### PR TITLE
KEP-4742: Copy topology labels from Node objects to Pods upon binding/scheduling

### DIFF
--- a/pkg/controlplane/apiserver/samples/generic/server/admission.go
+++ b/pkg/controlplane/apiserver/samples/generic/server/admission.go
@@ -30,7 +30,6 @@ import (
 	certsigning "k8s.io/kubernetes/plugin/pkg/admission/certificates/signing"
 	certsubjectrestriction "k8s.io/kubernetes/plugin/pkg/admission/certificates/subjectrestriction"
 	"k8s.io/kubernetes/plugin/pkg/admission/defaulttolerationseconds"
-	"k8s.io/kubernetes/plugin/pkg/admission/podtopologylabels"
 	"k8s.io/kubernetes/plugin/pkg/admission/serviceaccount"
 )
 
@@ -49,8 +48,6 @@ func DefaultOffAdmissionPlugins() sets.Set[string] {
 		certsubjectrestriction.PluginName,    // CertificateSubjectRestriction
 		validatingadmissionpolicy.PluginName, // ValidatingAdmissionPolicy
 		mutatingadmissionpolicy.PluginName,   // MutatingAdmissionPolicy
-		podtopologylabels.PluginName,         // PodTopologyLabels, only active when feature gate PodTopologyLabelsAdmission is enabled.
-		validatingadmissionpolicy.PluginName, // ValidatingAdmissionPolicy, only active when feature gate ValidatingAdmissionPolicy is enabled
 	)
 
 	return sets.New(options.AllOrderedPlugins...).Difference(defaultOnPlugins)

--- a/pkg/controlplane/apiserver/samples/generic/server/admission.go
+++ b/pkg/controlplane/apiserver/samples/generic/server/admission.go
@@ -30,6 +30,7 @@ import (
 	certsigning "k8s.io/kubernetes/plugin/pkg/admission/certificates/signing"
 	certsubjectrestriction "k8s.io/kubernetes/plugin/pkg/admission/certificates/subjectrestriction"
 	"k8s.io/kubernetes/plugin/pkg/admission/defaulttolerationseconds"
+	"k8s.io/kubernetes/plugin/pkg/admission/podtopologylabels"
 	"k8s.io/kubernetes/plugin/pkg/admission/serviceaccount"
 )
 
@@ -48,6 +49,8 @@ func DefaultOffAdmissionPlugins() sets.Set[string] {
 		certsubjectrestriction.PluginName,    // CertificateSubjectRestriction
 		validatingadmissionpolicy.PluginName, // ValidatingAdmissionPolicy
 		mutatingadmissionpolicy.PluginName,   // MutatingAdmissionPolicy
+		podtopologylabels.PluginName,         // PodTopologyLabels, only active when feature gate PodTopologyLabelsAdmission is enabled.
+		validatingadmissionpolicy.PluginName, // ValidatingAdmissionPolicy, only active when feature gate ValidatingAdmissionPolicy is enabled
 	)
 
 	return sets.New(options.AllOrderedPlugins...).Difference(defaultOnPlugins)

--- a/pkg/controlplane/apiserver/samples/generic/server/admission_test.go
+++ b/pkg/controlplane/apiserver/samples/generic/server/admission_test.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/kubernetes/plugin/pkg/admission/limitranger"
 	"k8s.io/kubernetes/plugin/pkg/admission/network/defaultingressclass"
 	"k8s.io/kubernetes/plugin/pkg/admission/nodetaint"
+	"k8s.io/kubernetes/plugin/pkg/admission/podtopologylabels"
 	podpriority "k8s.io/kubernetes/plugin/pkg/admission/priority"
 	"k8s.io/kubernetes/plugin/pkg/admission/runtimeclass"
 	"k8s.io/kubernetes/plugin/pkg/admission/security/podsecurity"
@@ -42,6 +43,7 @@ var intentionallyOffPlugins = sets.New[string](
 	runtimeclass.PluginName,                 // RuntimeClass
 	defaultingressclass.PluginName,          // DefaultIngressClass
 	podsecurity.PluginName,                  // PodSecurity
+	podtopologylabels.PluginName,            // PodTopologyLabels
 )
 
 func TestDefaultOffAdmissionPlugins(t *testing.T) {

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -1585,6 +1585,10 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 		{Version: version.MustParse("1.30"), Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // GA in 1.30; remove in 1.32
 	},
 
+	PodTopologyLabelsAdmission: {
+		{Version: version.MustParse("1.33"), Default: false, PreRelease: featuregate.Alpha},
+	},
+
 	PortForwardWebsockets: {
 		{Version: version.MustParse("1.30"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("1.31"), Default: true, PreRelease: featuregate.Beta},

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -970,8 +970,8 @@ const (
 	// alpha: v1.33
 	//
 	// Enables the PodTopologyLabelsAdmission admission plugin that mutates `pod/binding`
-	// requests by copying the `topology.k8s.io/{zone,region}` and `kubernetes.io/hostname`
-	// labels from the assigned Node object (in the Binding being admitted) onto the Binding
+	// requests by copying the `topology.k8s.io/{zone,region}` labels from the assigned
+	// Node object (in the Binding being admitted) onto the Binding
 	// so that it can be persisted onto the Pod object when the Pod is being scheduled.
 	// This allows workloads running in pods to understand the topology information of their assigned node.
 	// Enabling this feature also permits external schedulers to set labels on pods in an atomic

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -964,6 +964,16 @@ const (
 	// restore the old behavior. Please file issues if you hit issues and have to use this Feature Gate.
 	// The Feature Gate will be locked to true and then removed in +2 releases (1.35) if there are no bug reported
 	DisableCPUQuotaWithExclusiveCPUs featuregate.Feature = "DisableCPUQuotaWithExclusiveCPUs"
+
+	// owner: @munnerz
+	// kep: https://kep.k8s.io/4742
+	// alpha: v1.33
+	//
+	// Enables the PodTopologyLabelsAdmission admission plugin to automatically set node topology labels
+	// (i.e. those with the 'topology.k8s.io/' prefix on Node objects) onto Pod objects when they are
+	// bound/scheduled to a node.
+	// This allows workloads running in pods to understand the topology information of their assigned node.
+	PodTopologyLabelsAdmission featuregate.Feature = "PodTopologyLabelsAdmission"
 )
 
 // defaultVersionedKubernetesFeatureGates consists of all known Kubernetes-specific feature keys with VersionedSpecs.

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -969,10 +969,14 @@ const (
 	// kep: https://kep.k8s.io/4742
 	// alpha: v1.33
 	//
-	// Enables the PodTopologyLabelsAdmission admission plugin to automatically set node topology labels
-	// (i.e. those with the 'topology.k8s.io/' prefix on Node objects) onto Pod objects when they are
-	// bound/scheduled to a node.
+	// Enables the PodTopologyLabelsAdmission admission plugin that mutates `pod/binding`
+	// requests by copying the `topology.k8s.io/{zone,region}` and `kubernetes.io/hostname`
+	// labels from the assigned Node object (in the Binding being admitted) onto the Binding
+	// so that it can be persisted onto the Pod object when the Pod is being scheduled.
 	// This allows workloads running in pods to understand the topology information of their assigned node.
+	// Enabling this feature also permits external schedulers to set labels on pods in an atomic
+	// operation when scheduling a Pod by setting the `metadata.labels` field on the submitted Binding,
+	// similar to how `metadata.annotations` behaves.
 	PodTopologyLabelsAdmission featuregate.Feature = "PodTopologyLabelsAdmission"
 )
 

--- a/pkg/kubeapiserver/options/plugins.go
+++ b/pkg/kubeapiserver/options/plugins.go
@@ -46,6 +46,7 @@ import (
 	"k8s.io/kubernetes/plugin/pkg/admission/nodetaint"
 	"k8s.io/kubernetes/plugin/pkg/admission/podnodeselector"
 	"k8s.io/kubernetes/plugin/pkg/admission/podtolerationrestriction"
+	"k8s.io/kubernetes/plugin/pkg/admission/podtopologylabels"
 	podpriority "k8s.io/kubernetes/plugin/pkg/admission/priority"
 	"k8s.io/kubernetes/plugin/pkg/admission/runtimeclass"
 	"k8s.io/kubernetes/plugin/pkg/admission/security/podsecurity"
@@ -93,6 +94,7 @@ var AllOrderedPlugins = []string{
 	certsubjectrestriction.PluginName,       // CertificateSubjectRestriction
 	defaultingressclass.PluginName,          // DefaultIngressClass
 	denyserviceexternalips.PluginName,       // DenyServiceExternalIPs
+	podtopologylabels.PluginName,            // PodTopologyLabels
 
 	// new admission plugins should generally be inserted above here
 	// webhook, resourcequota, and deny plugins must go at the end
@@ -138,6 +140,7 @@ func RegisterAllAdmissionPlugins(plugins *admission.Plugins) {
 	certsigning.Register(plugins)
 	ctbattest.Register(plugins)
 	certsubjectrestriction.Register(plugins)
+	podtopologylabels.Register(plugins)
 }
 
 // DefaultOffAdmissionPlugins get admission plugins off by default for kube-apiserver.
@@ -162,6 +165,7 @@ func DefaultOffAdmissionPlugins() sets.Set[string] {
 		certsubjectrestriction.PluginName,       // CertificateSubjectRestriction
 		defaultingressclass.PluginName,          // DefaultIngressClass
 		podsecurity.PluginName,                  // PodSecurity
+		podtopologylabels.PluginName,            // PodTopologyLabels, only active when feature gate PodTopologyLabelsAdmission is enabled.
 		mutatingadmissionpolicy.PluginName,      // Mutatingadmissionpolicy, only active when feature gate MutatingAdmissionpolicy is enabled
 		validatingadmissionpolicy.PluginName,    // ValidatingAdmissionPolicy, only active when feature gate ValidatingAdmissionPolicy is enabled
 	)

--- a/pkg/registry/core/pod/storage/storage.go
+++ b/pkg/registry/core/pod/storage/storage.go
@@ -205,10 +205,10 @@ func (r *BindingREST) PreserveRequestObjectMetaSystemFieldsOnSubresourceCreate()
 	return true
 }
 
-// setPodHostAndAnnotations sets the given pod's host to 'machine' if and only if
-// the pod is unassigned and merges the provided annotations with those of the pod.
+// setPodNodeAndMetadata sets the given pod's nodeName to 'machine' if and only if
+// the pod is unassigned, and merges the provided annotations and labels with those of the pod.
 // Returns the current state of the pod, or an error.
-func (r *BindingREST) setPodHostAndAnnotations(ctx context.Context, podUID types.UID, podResourceVersion, podID, machine string, annotations, labels map[string]string, dryRun bool) (finalPod *api.Pod, err error) {
+func (r *BindingREST) setPodNodeAndMetadata(ctx context.Context, podUID types.UID, podResourceVersion, podID, machine string, annotations, labels map[string]string, dryRun bool) (finalPod *api.Pod, err error) {
 	podKey, err := r.store.KeyFunc(ctx, podID)
 	if err != nil {
 		return nil, err
@@ -284,7 +284,7 @@ func copyLabelsWithoutOverwriting(pod *api.Pod, labels map[string]string) {
 
 // assignPod assigns the given pod to the given machine.
 func (r *BindingREST) assignPod(ctx context.Context, podUID types.UID, podResourceVersion, podID string, machine string, annotations, labels map[string]string, dryRun bool) (err error) {
-	if _, err = r.setPodHostAndAnnotations(ctx, podUID, podResourceVersion, podID, machine, annotations, labels, dryRun); err != nil {
+	if _, err = r.setPodNodeAndMetadata(ctx, podUID, podResourceVersion, podID, machine, annotations, labels, dryRun); err != nil {
 		err = storeerr.InterpretGetError(err, api.Resource("pods"), podID)
 		err = storeerr.InterpretUpdateError(err, api.Resource("pods"), podID)
 		if _, ok := err.(*errors.StatusError); !ok {

--- a/pkg/registry/core/pod/storage/storage_test.go
+++ b/pkg/registry/core/pod/storage/storage_test.go
@@ -680,8 +680,8 @@ func TestEtcdCreateWithContainersNotFound(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	featuregatetesting.SetFeatureGateEmulationVersionDuringTest(t, utilfeature.DefaultFeatureGate, version.MustParse("1.32"))
-	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, kubefeatures.SetPodTopologyLabels, true)
+	featuregatetesting.SetFeatureGateEmulationVersionDuringTest(t, utilfeature.DefaultFeatureGate, version.MustParse("1.33"))
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, kubefeatures.PodTopologyLabelsAdmission, true)
 	// Suddenly, a wild scheduler appears:
 	_, err = bindingStorage.Create(ctx, "foo", &api.Binding{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/registry/core/pod/storage/storage_test.go
+++ b/pkg/registry/core/pod/storage/storage_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/version"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/generic"
 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
@@ -42,8 +43,11 @@ import (
 	apiserverstorage "k8s.io/apiserver/pkg/storage"
 	storeerr "k8s.io/apiserver/pkg/storage/errors"
 	etcd3testing "k8s.io/apiserver/pkg/storage/etcd3/testing"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	podtest "k8s.io/kubernetes/pkg/api/pod/testing"
 	api "k8s.io/kubernetes/pkg/apis/core"
+	kubefeatures "k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
 	"k8s.io/kubernetes/pkg/securitycontext"
 )
@@ -676,12 +680,15 @@ func TestEtcdCreateWithContainersNotFound(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
+	featuregatetesting.SetFeatureGateEmulationVersionDuringTest(t, utilfeature.DefaultFeatureGate, version.MustParse("1.32"))
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, kubefeatures.SetPodTopologyLabels, true)
 	// Suddenly, a wild scheduler appears:
 	_, err = bindingStorage.Create(ctx, "foo", &api.Binding{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:   metav1.NamespaceDefault,
 			Name:        "foo",
-			Annotations: map[string]string{"label1": "value1"},
+			Annotations: map[string]string{"annotation1": "value1"},
+			Labels:      map[string]string{"label1": "label-value1"},
 		},
 		Target: api.ObjectReference{Name: "machine"},
 	}, rest.ValidateAllObjectFunc, &metav1.CreateOptions{})
@@ -695,8 +702,11 @@ func TestEtcdCreateWithContainersNotFound(t *testing.T) {
 	}
 	pod := obj.(*api.Pod)
 
-	if !(pod.Annotations != nil && pod.Annotations["label1"] == "value1") {
+	if !(pod.Annotations != nil && pod.Annotations["annotation1"] == "value1") {
 		t.Fatalf("Pod annotations don't match the expected: %v", pod.Annotations)
+	}
+	if !(pod.Labels != nil && pod.Labels["label1"] == "label-value1") {
+		t.Fatalf("Pod labels don't match the expected: %v", pod.Labels)
 	}
 }
 

--- a/pkg/registry/core/pod/storage/storage_test.go
+++ b/pkg/registry/core/pod/storage/storage_test.go
@@ -34,7 +34,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/version"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/generic"
 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
@@ -680,7 +679,6 @@ func TestEtcdCreateWithContainersNotFound(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	featuregatetesting.SetFeatureGateEmulationVersionDuringTest(t, utilfeature.DefaultFeatureGate, version.MustParse("1.33"))
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, kubefeatures.PodTopologyLabelsAdmission, true)
 	// Suddenly, a wild scheduler appears:
 	_, err = bindingStorage.Create(ctx, "foo", &api.Binding{

--- a/plugin/pkg/admission/podtopologylabels/admission.go
+++ b/plugin/pkg/admission/podtopologylabels/admission.go
@@ -41,7 +41,7 @@ const PluginName = "PodTopologyLabels"
 // This configuration is used by kube-apiserver.
 // It is not exported to avoid any chance of accidentally mutating the variable.
 var defaultConfig = Config{
-	Labels: []string{"topology.k8s.io/zone", "topology.k8s.io/region", "kubernetes.io/hostname"},
+	Labels: []string{"topology.k8s.io/zone", "topology.k8s.io/region"},
 }
 
 // Register registers a plugin

--- a/plugin/pkg/admission/podtopologylabels/admission.go
+++ b/plugin/pkg/admission/podtopologylabels/admission.go
@@ -172,7 +172,7 @@ func (p *Plugin) admitPod(ctx context.Context, a admission.Attributes, o admissi
 	if pod.Labels == nil {
 		pod.Labels = make(map[string]string)
 	}
-	// avoid overwriting any existing labels on the Pod.
+	// overwrite any existing labels on the pod
 	mergeLabels(pod.Labels, labelsToCopy)
 
 	return nil
@@ -199,12 +199,9 @@ func (p *Plugin) topologyLabelsForNodeName(nodeName string) (map[string]string, 
 	return labels, nil
 }
 
-// mergeLabels merges new into existing, without overwriting existing keys.
+// mergeLabels merges new into existing, overwriting existing keys.
 func mergeLabels(existing, new map[string]string) {
 	for k, v := range new {
-		if _, exists := existing[k]; exists {
-			continue
-		}
 		existing[k] = v
 	}
 }

--- a/plugin/pkg/admission/podtopologylabels/admission.go
+++ b/plugin/pkg/admission/podtopologylabels/admission.go
@@ -1,0 +1,205 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package podtopologylabels
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"k8s.io/klog/v2"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apiserver/pkg/admission"
+	genericadmissioninitializer "k8s.io/apiserver/pkg/admission/initializer"
+	"k8s.io/client-go/informers"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/component-base/featuregate"
+	api "k8s.io/kubernetes/pkg/apis/core"
+	"k8s.io/kubernetes/pkg/features"
+)
+
+// PluginName is a string with the name of the plugin
+const PluginName = "PodTopologyLabels"
+
+// Register registers a plugin
+func Register(plugins *admission.Plugins) {
+	plugins.Register(PluginName, func(_ io.Reader) (admission.Interface, error) {
+		plugin := NewPodTopologyPlugin()
+		return plugin, nil
+	})
+}
+
+// NewPodTopologyPlugin initializes a Plugin
+func NewPodTopologyPlugin() *Plugin {
+	return &Plugin{
+		Handler: admission.NewHandler(admission.Create),
+		// Always copy zone and region labels.
+		labels: sets.New("topology.k8s.io/zone", "topology.k8s.io/region"),
+		// Also support copying arbitrary custom topology labels.
+		domains: sets.New("topology.k8s.io"),
+		// Copy any sub-domains of topology.k8s.io as well.
+		suffixes: sets.New(".topology.k8s.io"),
+	}
+}
+
+type Plugin struct {
+	*admission.Handler
+
+	nodeLister corev1listers.NodeLister
+
+	// explicit labels, list of domains or a list of domain
+	// suffixes to be copies to Pod objects being bound.
+	labels, domains, suffixes sets.Set[string]
+
+	enabled, inspectedFeatureGates bool
+}
+
+var _ admission.MutationInterface = &Plugin{}
+var _ genericadmissioninitializer.WantsExternalKubeInformerFactory = &Plugin{}
+var _ genericadmissioninitializer.WantsFeatures = &Plugin{}
+
+// InspectFeatureGates implements WantsFeatures.
+func (p *Plugin) InspectFeatureGates(featureGates featuregate.FeatureGate) {
+	p.enabled = featureGates.Enabled(features.PodTopologyLabelsAdmission)
+	p.inspectedFeatureGates = true
+}
+
+func (p *Plugin) SetExternalKubeInformerFactory(factory informers.SharedInformerFactory) {
+	nodeInformer := factory.Core().V1().Nodes()
+	p.nodeLister = nodeInformer.Lister()
+	p.SetReadyFunc(nodeInformer.Informer().HasSynced)
+}
+
+func (p *Plugin) ValidateInitialization() error {
+	if p.nodeLister == nil {
+		return fmt.Errorf("nodeLister not set")
+	}
+	if !p.inspectedFeatureGates {
+		return fmt.Errorf("feature gates not inspected")
+	}
+	return nil
+}
+
+func (p *Plugin) Admit(ctx context.Context, a admission.Attributes, o admission.ObjectInterfaces) (err error) {
+	if !p.enabled {
+		return nil
+	}
+	if shouldIgnore(a) {
+		return nil
+	}
+	// we need to wait for our caches to warm
+	if !p.WaitForReady() {
+		return admission.NewForbidden(a, fmt.Errorf("not yet ready to handle request"))
+	}
+
+	binding := a.GetObject().(*api.Binding)
+	// other fields are not set by the default scheduler for the binding target, so only check the Kind.
+	if binding.Target.Kind != "Node" {
+		klog.V(6).Info("Skipping Pod being bound to non-Node object type", "target", binding.Target.GroupVersionKind())
+		return nil
+	}
+
+	node, err := p.nodeLister.Get(binding.Target.Name)
+	if err != nil {
+		// Ignore NotFound errors to avoid risking breaking compatibility/behaviour.
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	// fast-path/short circuit if the node has no labels
+	if node.Labels == nil {
+		return nil
+	}
+
+	labelsToCopy := make(map[string]string)
+	for k, v := range node.Labels {
+		if !p.isTopologyLabel(k) {
+			continue
+		}
+		labelsToCopy[k] = v
+	}
+
+	if len(labelsToCopy) == 0 {
+		// fast-path/short circuit if the node has no topology labels
+		return nil
+	}
+
+	// copy the topology labels into the Binding's labels, as these are copied from the Binding
+	// to the Pod object being bound within the podBinding registry/store.
+	if binding.Labels == nil {
+		binding.Labels = make(map[string]string)
+	}
+	for k, v := range labelsToCopy {
+		if _, exists := binding.Labels[k]; exists {
+			// Don't overwrite labels on Binding resources as this could lead to unexpected
+			// behaviour if any schedulers rely on being able to explicitly set values themselves.
+			continue
+		}
+		binding.Labels[k] = v
+	}
+
+	return nil
+}
+
+func (p *Plugin) isTopologyLabel(key string) bool {
+	// First check explicit label keys.
+	if p.labels.Has(key) {
+		return true
+	}
+	// Check the domain portion of the label key, if present
+	domain, _, hasDomain := strings.Cut(key, "/")
+	if !hasDomain {
+		// fast-path if there is no / separator
+		return false
+	}
+	if p.domains.Has(domain) {
+		// check for explicit domains to copy
+		return true
+	}
+	for _, suffix := range p.suffixes.UnsortedList() {
+		// check if the domain has one of the suffixes that are to be copied
+		if strings.HasSuffix(domain, suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+func shouldIgnore(a admission.Attributes) bool {
+	resource := a.GetResource().GroupResource()
+	if resource != api.Resource("pods") {
+		return true
+	}
+	if a.GetSubresource() != "binding" {
+		// only run the checks below on the binding subresource
+		return true
+	}
+
+	obj := a.GetObject()
+	_, ok := obj.(*api.Binding)
+	if !ok {
+		klog.Errorf("expected Binding but got %s", a.GetKind().Kind)
+		return true
+	}
+
+	return false
+}

--- a/plugin/pkg/admission/podtopologylabels/admission_test.go
+++ b/plugin/pkg/admission/podtopologylabels/admission_test.go
@@ -89,7 +89,7 @@ func TestPodTopology(t *testing.T) {
 			existingBindingLabels: map[string]string{},
 		},
 		{
-			name: "does not overwrite existing topology labels on Binding objects",
+			name: "overwrites existing topology labels",
 			existingBindingLabels: map[string]string{
 				"topology.k8s.io/zone": "oldValue",
 			},
@@ -97,7 +97,7 @@ func TestPodTopology(t *testing.T) {
 				"topology.k8s.io/zone": "newValue",
 			},
 			expectedBindingLabels: map[string]string{
-				"topology.k8s.io/zone": "oldValue",
+				"topology.k8s.io/zone": "newValue",
 			},
 		},
 		{

--- a/plugin/pkg/admission/podtopologylabels/admission_test.go
+++ b/plugin/pkg/admission/podtopologylabels/admission_test.go
@@ -1,0 +1,174 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package podtopologylabels
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+
+	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/version"
+	"k8s.io/apiserver/pkg/admission"
+	genericadmissioninitializer "k8s.io/apiserver/pkg/admission/initializer"
+	admissiontesting "k8s.io/apiserver/pkg/admission/testing"
+	"k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	api "k8s.io/kubernetes/pkg/apis/core"
+	kubefeatures "k8s.io/kubernetes/pkg/features"
+)
+
+// TestPodTopology verifies the pod topology admission plugin works as expected.
+func TestPodTopology(t *testing.T) {
+	tests := []struct {
+		name                  string               // name of the test case.
+		bindingTarget         *api.ObjectReference // target being bound to. Defaults to a valid node with the provided labels.
+		targetNodeLabels      map[string]string    // list of labels set on the node being bound to.
+		existingBindingLabels map[string]string    // list of labels that are set on the Binding prior to admission (aka by the client/scheduler)
+		expectedBindingLabels map[string]string    // list of labels that we expect to be set on the Binding after admission.
+		featureDisabled       bool                 // configure whether the SetPodTopologyLabels feature gate should be disabled.
+	}{
+		{
+			name: "copies topology.k8s.io/zone and region labels to binding annotations",
+			targetNodeLabels: map[string]string{
+				"topology.k8s.io/zone":      "zone1",
+				"topology.k8s.io/region":    "region1",
+				"non-topology.k8s.io/label": "something", // verify we don't unexpectedly copy non topology.k8s.io labels.
+			},
+			expectedBindingLabels: map[string]string{
+				"topology.k8s.io/zone":   "zone1",
+				"topology.k8s.io/region": "region1",
+			},
+		},
+		{
+			name: "copies arbitrary topology labels",
+			targetNodeLabels: map[string]string{
+				"topology.k8s.io/arbitrary": "something",
+			},
+			expectedBindingLabels: map[string]string{
+				"topology.k8s.io/arbitrary": "something",
+			},
+		},
+		{
+			name: "copies topology labels that use a subdomain",
+			targetNodeLabels: map[string]string{
+				"something.topology.k8s.io/a-thing": "value",
+			},
+			expectedBindingLabels: map[string]string{
+				"something.topology.k8s.io/a-thing": "value",
+			},
+		},
+		{
+			name: "does not copy label keys that don't contain a / character",
+			targetNodeLabels: map[string]string{
+				"topology.k8s.io": "value",
+			},
+			existingBindingLabels: map[string]string{},
+		},
+		{
+			name: "does not overwrite existing topology labels on Binding objects",
+			existingBindingLabels: map[string]string{
+				"topology.k8s.io/zone": "oldValue",
+			},
+			targetNodeLabels: map[string]string{
+				"topology.k8s.io/zone": "newValue",
+			},
+			expectedBindingLabels: map[string]string{
+				"topology.k8s.io/zone": "oldValue",
+			},
+		},
+		{
+			name: "does nothing if the SetPodTopologyLabels feature gate is disabled",
+			targetNodeLabels: map[string]string{
+				"topology.k8s.io/zone":   "zone1",
+				"topology.k8s.io/region": "region1",
+			},
+			expectedBindingLabels: map[string]string{},
+			featureDisabled:       true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			namespace := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-ns"},
+			}
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "valid-test-node",
+					Labels: test.targetNodeLabels,
+				},
+			}
+			// Pod we bind during test cases.
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "testPod", Namespace: namespace.Name},
+				Spec:       corev1.PodSpec{},
+			}
+			featuregatetesting.SetFeatureGateEmulationVersionDuringTest(t, feature.DefaultFeatureGate, version.MustParse("1.33"))
+			featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, kubefeatures.PodTopologyLabelsAdmission,
+				!test.featureDisabled)
+			mockClient := fake.NewSimpleClientset(namespace, node, pod)
+			handler, informerFactory, err := newHandlerForTest(mockClient)
+			if err != nil {
+				t.Fatalf("unexpected error initializing handler: %v", err)
+			}
+			stopCh := make(chan struct{})
+			defer close(stopCh)
+			informerFactory.Start(stopCh)
+
+			target := test.bindingTarget
+			if target == nil {
+				target = &api.ObjectReference{
+					Kind: "Node",
+					Name: node.Name,
+				}
+			}
+			binding := &api.Binding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      pod.Name,
+					Namespace: pod.Namespace,
+					Labels:    test.existingBindingLabels,
+				},
+				Target: *target,
+			}
+			if err := admissiontesting.WithReinvocationTesting(t, handler).
+				Admit(context.TODO(), admission.NewAttributesRecord(binding, nil, api.Kind("Binding").WithVersion("version"), pod.Namespace, pod.Name, api.Resource("pods").WithVersion("version"), "binding", admission.Create, &metav1.CreateOptions{}, false, nil), nil); err != nil {
+				t.Errorf("failed running admission plugin: %v", err)
+			}
+			updatedBindingLabels := binding.Labels
+			if !apiequality.Semantic.DeepEqual(updatedBindingLabels, test.expectedBindingLabels) {
+				t.Errorf("Unexpected label values: %v", cmp.Diff(updatedBindingLabels, test.expectedBindingLabels))
+			}
+		})
+	}
+}
+
+// newHandlerForTest returns the admission controller configured for testing.
+func newHandlerForTest(c kubernetes.Interface) (*Plugin, informers.SharedInformerFactory, error) {
+	factory := informers.NewSharedInformerFactory(c, 5*time.Minute)
+	handler := NewPodTopologyPlugin()
+	pluginInitializer := genericadmissioninitializer.New(c, nil, factory, nil, feature.DefaultFeatureGate, nil, nil)
+	pluginInitializer.Initialize(handler)
+	return handler, factory, admission.ValidateInitialization(handler)
+}

--- a/plugin/pkg/admission/podtopologylabels/doc.go
+++ b/plugin/pkg/admission/podtopologylabels/doc.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package podtopologylabels is a plugin that mutates `pod/binding` requests
+// to set `topology.k8s.io` labels (including subdomains) from the Node object
+// referenced in the Binding to the Binding, which causes the Pod to also
+// have these values set.
+// If the binding target is NOT a Node object, no action is taken.
+// If the referenced Node object does not exist, no action is taken.
+package podtopologylabels // import "k8s.io/kubernetes/plugin/pkg/admission/podtopologylabels"

--- a/plugin/pkg/admission/podtopologylabels/doc.go
+++ b/plugin/pkg/admission/podtopologylabels/doc.go
@@ -15,10 +15,11 @@ limitations under the License.
 */
 
 // Package podtopologylabels is a plugin that mutates `pod/binding` requests
-// by copying the `topology.k8s.io/{zone,region}` and `kubernetes.io/hostname`
-// labels from the assigned Node object (in the Binding being admitted) onto
-// the Binding so that it can be persisted onto the Pod object when the Pod
-// is being scheduled.
+// by copying the `topology.k8s.io/{zone,region}` labels from the assigned Node
+// object (in the Binding being admitted) onto the Binding so that it can be
+// persisted onto the Pod object when the Pod is being scheduled.
+// Requests for the regular `pods` resource that set the `spec.nodeName` will
+// also trigger the plugin to copy the labels as described.
 // If the binding target is NOT a Node object, no action is taken.
 // If the referenced Node object does not exist, no action is taken.
 package podtopologylabels // import "k8s.io/kubernetes/plugin/pkg/admission/podtopologylabels"

--- a/plugin/pkg/admission/podtopologylabels/doc.go
+++ b/plugin/pkg/admission/podtopologylabels/doc.go
@@ -15,9 +15,10 @@ limitations under the License.
 */
 
 // Package podtopologylabels is a plugin that mutates `pod/binding` requests
-// to set `topology.k8s.io` labels (including subdomains) from the Node object
-// referenced in the Binding to the Binding, which causes the Pod to also
-// have these values set.
+// by copying the `topology.k8s.io/{zone,region}` and `kubernetes.io/hostname`
+// labels from the assigned Node object (in the Binding being admitted) onto
+// the Binding so that it can be persisted onto the Pod object when the Pod
+// is being scheduled.
 // If the binding target is NOT a Node object, no action is taken.
 // If the referenced Node object does not exist, no action is taken.
 package podtopologylabels // import "k8s.io/kubernetes/plugin/pkg/admission/podtopologylabels"

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -1075,6 +1075,12 @@
     lockToDefault: true
     preRelease: GA
     version: "1.30"
+- name: PodTopologyLabelsAdmission
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.33"
 - name: PortForwardWebsockets
   versionedSpecs:
   - default: false

--- a/test/integration/pods/pods_test.go
+++ b/test/integration/pods/pods_test.go
@@ -57,6 +57,28 @@ func TestPodTopologyLabels(t *testing.T) {
 				"topology.k8s.io/region": "region",
 			},
 		},
+		{
+			name: "subdomains of topology.k8s.io are not copied",
+			targetNodeLabels: map[string]string{
+				"sub.topology.k8s.io/zone": "zone",
+				"topology.k8s.io/region":   "region",
+			},
+			expectedPodLabels: map[string]string{
+				"topology.k8s.io/region": "region",
+			},
+		},
+		{
+			name: "custom topology.k8s.io labels are not copied",
+			targetNodeLabels: map[string]string{
+				"topology.k8s.io/custom": "thing",
+				"topology.k8s.io/zone":   "zone",
+				"topology.k8s.io/region": "region",
+			},
+			expectedPodLabels: map[string]string{
+				"topology.k8s.io/zone":   "zone",
+				"topology.k8s.io/region": "region",
+			},
+		},
 	}
 	// Enable the feature BEFORE starting the test server, as the admission plugin only checks feature gates
 	// on start up and not on each invocation at runtime.
@@ -70,8 +92,10 @@ func TestPodTopologyLabels_FeatureDisabled(t *testing.T) {
 		{
 			name: "does nothing when the feature is not enabled",
 			targetNodeLabels: map[string]string{
-				"topology.k8s.io/zone":   "zone",
-				"topology.k8s.io/region": "region",
+				"topology.k8s.io/zone":     "zone",
+				"topology.k8s.io/region":   "region",
+				"topology.k8s.io/custom":   "thing",
+				"sub.topology.k8s.io/zone": "zone",
 			},
 			expectedPodLabels: map[string]string{},
 		},


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

**NOTE:** whilst this PR does work as intended, I'm opening it here to enable a wider discussion on *how* we can achieve this in the least intrusive/disruptive way.

As per referenced issue (and KEP), there is a desire to plumb topology information about Node objects through to Pods as labels that can be consumed via the downward API.

There are a number of alternatives to do this, each with their own drawback (discussed in the linked issue and KEP).

This particular implementation extends how the `pods/binding` subresource works to achieve this. Instead of just copying *annotations* from Binding objects to Pods (current behaviour, which has been in place for ~the lifetime of the project) we now *also* copy Label values from the binding to the pod.

Additionally, this PR adds an admission plugin on the `pods/binding` subresource that attempts to read the referenced Node name when admitted Bindings, and appropriately copies label values from the referenced node to the binding (so it can be persisted atomically along with the assigned node name).

#### Which issue(s) this PR fixes:

Fixes #40610 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Automatically copy `topology.k8s.io/zone`, `topology.k8s.io/region` and `kubernetes.io/hostname` labels from Node objects to Pods when they are scheduled to a node (via the `pods/binding` endpoint) to allow applications that need to be explicitly aware of their assigned node topology to access this information via the downward API, rather than requiring permission to `get node` objects (exposing the entire API surface of the Node object to otherwise unprivileged workloads).
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/4742-node-topology-downward-api
- [Usage]: https://github.com/kubernetes/website/pull/49928
- [Other doc]: todo
```

/cc @thockin @docandrew @simonswine 