### PR TITLE
fix replicaset controller display old msg when `manageReplicasErr` changed

### DIFF
--- a/pkg/controller/replicaset/replica_set_utils.go
+++ b/pkg/controller/replicaset/replica_set_utils.go
@@ -118,6 +118,9 @@ func calculateStatus(rs *apps.ReplicaSet, filteredPods []*v1.Pod, manageReplicas
 		SetCondition(&newStatus, cond)
 	} else if manageReplicasErr == nil && failureCond != nil {
 		RemoveCondition(&newStatus, apps.ReplicaSetReplicaFailure)
+	} else if manageReplicasErr != nil {
+		// Update the condition message if the error message has changed.
+		UpdateCondition(&newStatus, apps.ReplicaSetReplicaFailure, manageReplicasErr.Error())
 	}
 
 	newStatus.Replicas = int32(len(filteredPods))
@@ -162,6 +165,20 @@ func SetCondition(status *apps.ReplicaSetStatus, condition apps.ReplicaSetCondit
 // RemoveCondition removes the condition with the provided type from the replicaset status.
 func RemoveCondition(status *apps.ReplicaSetStatus, condType apps.ReplicaSetConditionType) {
 	status.Conditions = filterOutCondition(status.Conditions, condType)
+}
+
+// UpdateCondition Updates the conditional message of the provided type.
+func UpdateCondition(status *apps.ReplicaSetStatus, condType apps.ReplicaSetConditionType, msg string) {
+	currentCond := GetCondition(*status, condType)
+	if currentCond == nil {
+		return
+	}
+	if currentCond.Message == msg {
+		return
+	}
+	newCond := NewReplicaSetCondition(condType, currentCond.Status, currentCond.Reason, msg)
+	status.Conditions = filterOutCondition(status.Conditions, condType)
+	status.Conditions = append(status.Conditions, newCond)
 }
 
 // filterOutCondition returns a new slice of replicaset conditions without conditions with the provided type.

--- a/pkg/controller/replicaset/replica_set_utils_test.go
+++ b/pkg/controller/replicaset/replica_set_utils_test.go
@@ -217,8 +217,9 @@ func TestCalculateStatusConditions(t *testing.T) {
 			fmt.Errorf("fake manageReplicasErr"),
 			[]apps.ReplicaSetCondition{
 				{
-					Type:   apps.ReplicaSetReplicaFailure,
-					Status: v1.ConditionTrue,
+					Type:    apps.ReplicaSetReplicaFailure,
+					Status:  v1.ConditionTrue,
+					Message: "fake manageReplicasErr",
 				},
 			},
 		},
@@ -230,6 +231,21 @@ func TestCalculateStatusConditions(t *testing.T) {
 			},
 			nil,
 			nil,
+		},
+		{
+			"manageReplicasErr != nil && failureCond != nil, failure msg updated",
+			replicaFailureRS,
+			[]*v1.Pod{
+				newPod("pod1", replicaFailureRS, v1.PodRunning, nil, true),
+			},
+			fmt.Errorf("new fake manageReplicasErr"),
+			[]apps.ReplicaSetCondition{
+				{
+					Type:    apps.ReplicaSetReplicaFailure,
+					Status:  v1.ConditionTrue,
+					Message: "new fake manageReplicasErr",
+				},
+			},
 		},
 	}
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
replicaset failure type condition should show the newest message, when `manageReplicasErr` changed

#### Which issue(s) this PR fixes:
Fixes #127081

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
replicaset failure type condition will show the newest error message
```
