### PR TITLE
Pod Lifecycle: propagate context to containerRuntime SyncPod

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2058,14 +2058,7 @@ func (kl *Kubelet) SyncPod(ctx context.Context, updateType kubetypes.SyncPodType
 	// Ensure the pod is being probed
 	kl.probeManager.AddPod(pod)
 
-	// TODO(#113606): use cancellation from the incoming context parameter, which comes from the pod worker.
-	// Currently, using cancellation from that context causes test failures. To remove this WithoutCancel,
-	// any wait.Interrupted errors need to be filtered from result and bypass the reasonCache - cancelling
-	// the context for SyncPod is a known and deliberate error, not a generic error.
-	// Use WithoutCancel instead of a new context.TODO() to propagate trace context
-	// Call the container runtime's SyncPod callback
-	sctx := context.WithoutCancel(ctx)
-	result := kl.containerRuntime.SyncPod(sctx, pod, podStatus, pullSecrets, kl.crashLoopBackOff)
+	result := kl.containerRuntime.SyncPod(ctx, pod, podStatus, pullSecrets, kl.crashLoopBackOff)
 	kl.reasonCache.Update(pod.UID, result)
 
 	for _, r := range result.SyncResults {

--- a/test/e2e/node/pods.go
+++ b/test/e2e/node/pods.go
@@ -234,6 +234,14 @@ var _ = SIGDescribe("Pods Extended", func() {
 				podClient.PodInterface,
 			)
 		})
+		ginkgo.It("should not return an error when any health probe fails", func(ctx context.Context) {
+			ginkgo.By("creating pods pod with container that restarts if health probe fails")
+			createAndTestPodRepeatedly(ctx,
+				3, 15,
+				podDelayDeleteScenario{client: podClient.PodInterface, waitRestarted: true},
+				podClient.PodInterface,
+			)
+		})
 	})
 
 	ginkgo.Describe("Pod Container lifecycle", func() {
@@ -883,15 +891,18 @@ type podFastDeleteScenario struct {
 	initContainer bool
 }
 
+type podDelayDeleteScenario struct {
+	client v1core.PodInterface
+
+	waitRestarted bool
+}
+
 func (s podFastDeleteScenario) Verifier(pod *v1.Pod) podScenarioVerifier {
 	return &podStartVerifier{}
 }
 
 func (s podFastDeleteScenario) IsLastEvent(event watch.Event) bool {
-	if event.Type == watch.Deleted {
-		return true
-	}
-	return false
+	return event.Type == watch.Deleted
 }
 
 func (s podFastDeleteScenario) Action(ctx context.Context, pod *v1.Pod) (podScenarioVerifier, string, error) {
@@ -909,7 +920,7 @@ func (s podFastDeleteScenario) Action(ctx context.Context, pod *v1.Pod) (podScen
 			}
 
 			return fmt.Errorf("pod %s on node %s has been created but is still in the Creating state", pod.Name, pod.Spec.NodeName)
-		}).WithPolling(50 * time.Millisecond).WithTimeout(30 * time.Second).Should(gomega.Succeed()); err != nil {
+		}).WithPolling(50 * time.Millisecond).WithTimeout(1 * time.Minute).Should(gomega.Succeed()); err != nil {
 			return nil, "", err
 		}
 		scenario = fmt.Sprintf("t=%s", time.Since(t))
@@ -1000,6 +1011,79 @@ func (s podFastDeleteScenario) Pod(worker, attempt int) *v1.Pod {
 			},
 		},
 	}
+}
+
+func (s podDelayDeleteScenario) Action(ctx context.Context, pod *v1.Pod) (podScenarioVerifier, string, error) {
+	var scenario string
+	if s.waitRestarted {
+		t := time.Now()
+		if err := framework.Gomega().Eventually(ctx, func(ctx context.Context) error {
+			pod, err := s.client.Get(ctx, pod.Name, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+
+			if pod.Status.ContainerStatuses != nil && pod.Status.ContainerStatuses[0].RestartCount == 1 {
+				return nil
+			}
+
+			return fmt.Errorf("pod %s on node %s has been created but not restart", pod.Name, pod.Spec.NodeName)
+		}).WithPolling(100 * time.Millisecond).WithTimeout(3 * time.Minute).Should(gomega.Succeed()); err != nil {
+			return nil, "", err
+		}
+		scenario = fmt.Sprintf("t=%s", time.Since(t))
+	}
+
+	return &podDeleteVerifier{pod: pod, waitCreated: true}, scenario, s.client.Delete(ctx, pod.Name, metav1.DeleteOptions{})
+}
+
+func (s podDelayDeleteScenario) Pod(worker, attempt int) *v1.Pod {
+	name := fmt.Sprintf("pod-terminate-status-%d-%d", worker, attempt)
+	value := strconv.Itoa(time.Now().Nanosecond())
+	one := int64(1)
+	terminationGracePeriodSeconds := int64(1)
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				"name": "foo",
+				"time": value,
+			},
+		},
+		Spec: v1.PodSpec{
+			RestartPolicy:                 v1.RestartPolicyAlways,
+			TerminationGracePeriodSeconds: &one,
+			Containers: []v1.Container{
+				{
+					Name:  "normal",
+					Image: imageutils.GetE2EImage(imageutils.BusyBox),
+					Command: []string{
+						"sleep", "1800",
+					},
+					Resources: v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("5m"),
+							v1.ResourceMemory: resource.MustParse("10Mi"),
+						},
+					},
+					StartupProbe: &v1.Probe{
+						ProbeHandler: v1.ProbeHandler{
+							Exec: &v1.ExecAction{
+								Command: []string{"/bin/false"},
+							},
+						},
+						FailureThreshold:              1,
+						PeriodSeconds:                 1,
+						TerminationGracePeriodSeconds: &terminationGracePeriodSeconds,
+					},
+				},
+			},
+		},
+	}
+}
+
+func (s podDelayDeleteScenario) IsLastEvent(event watch.Event) bool {
+	return event.Type == watch.Deleted
 }
 
 // podStartVerifier checks events for a given pod and looks for unexpected
@@ -1128,28 +1212,7 @@ func (v *podStartVerifier) Verify(event watch.Event) error {
 }
 
 func (v *podStartVerifier) VerifyFinal(scenario string, total time.Duration) (*v1.Pod, []error) {
-	var errs []error
-	pod := v.pod
-	if !v.hasTerminalPhase {
-		var names []string
-		for _, status := range pod.Status.ContainerStatuses {
-			if status.State.Running != nil {
-				names = append(names, status.Name)
-			}
-		}
-		switch {
-		case len(names) > 0:
-			errs = append(errs, fmt.Errorf("pod %s on node %s did not reach a terminal phase before being deleted but had running containers: phase=%s, running-containers=%s", pod.Name, pod.Spec.NodeName, pod.Status.Phase, strings.Join(names, ",")))
-			// If we don't wait for the container to be created, so don't need to verify it here.
-		case pod.Status.Phase != v1.PodPending && v.waitCreated:
-			errs = append(errs, fmt.Errorf("pod %s on node %s was not Pending but has no running containers: phase=%s", pod.Name, pod.Spec.NodeName, pod.Status.Phase))
-		}
-	}
-	if v.hasRunningContainers {
-		data, _ := json.MarshalIndent(pod.Status.ContainerStatuses, "", "  ")
-		errs = append(errs, fmt.Errorf("pod %s on node %s had running or unknown container status before being deleted:\n%s", pod.Name, pod.Spec.NodeName, string(data)))
-	}
-
+	pod, errs := verifyFinal(v.pod, v.hasTerminalPhase, v.hasRunningContainers, v.waitCreated)
 	framework.Logf("Pod %s on node %s %s total=%s run=%s execute=%s", pod.Name, pod.Spec.NodeName, scenario, total, v.completeDuration, v.duration)
 	return pod, errs
 }
@@ -1160,4 +1223,134 @@ func (v *podStartVerifier) VerifyFinal(scenario string, total time.Duration) (*v
 // If the command execution phase has been reached, then the Go standard library will return `signal: killed`.
 func isContextCanceled(message string) bool {
 	return strings.Contains(message, "context canceled") || strings.Contains(message, "signal: killed")
+}
+
+// podDeleteVerifier checks events for a given pod and looks for unexpected transitions.
+// It assumes that a running container was restarted due to any healthy probe.
+type podDeleteVerifier struct {
+	pod                  *v1.Pod
+	waitCreated          bool
+	hasContainers        bool
+	hasTerminated        bool
+	hasRunningContainers bool
+	hasTerminalPhase     bool
+	duration             time.Duration
+	completeDuration     time.Duration
+}
+
+// Verify takes successive watch events for a given pod and returns an error if the status is unexpected.
+// This verifier works for any pod which has 0 init containers and 1 regular container.
+func (v *podDeleteVerifier) Verify(event watch.Event) error {
+	var ok bool
+	pod, ok := event.Object.(*v1.Pod)
+	if !ok {
+		framework.Logf("Unexpected event object: %s %#v", event.Type, event.Object)
+		return nil
+	}
+	v.pod = pod
+
+	if len(pod.Status.ContainerStatuses) == 0 {
+		if v.hasContainers {
+			return fmt.Errorf("pod %s on node %s had incorrect containers: %#v", pod.Name, pod.Spec.NodeName, pod.Status.ContainerStatuses)
+		}
+		return nil
+	}
+	v.hasContainers = true
+	if len(pod.Status.ContainerStatuses) != 1 {
+		return fmt.Errorf("pod %s on node %s had incorrect containers: %#v", pod.Name, pod.Spec.NodeName, pod.Status.ContainerStatuses)
+	}
+
+	// If containerRuntime.SyncPod() returns an error,
+	// it is possible that the container state and the pod phase are inconsistent.
+	if !v.hasTerminated {
+		if status := e2epod.FindContainerStatusInPod(pod, "normal"); status != nil {
+			if status.State.Terminated != nil && pod.Status.Phase != v1.PodFailed {
+				return fmt.Errorf("pod %s on node %s had incorrect containers: %#v", pod.Name, pod.Spec.NodeName, pod.Status)
+			}
+		}
+	}
+
+	status := e2epod.FindContainerStatusInPod(pod, "normal")
+	if status == nil {
+		return fmt.Errorf("pod %s on node %s had incorrect containers: %#v", pod.Name, pod.Spec.NodeName, pod.Status)
+	}
+
+	t := status.State.Terminated
+	if v.hasTerminated {
+		if status.State.Waiting != nil || status.State.Running != nil {
+			return fmt.Errorf("pod %s on node %s was terminated and then changed state: %#v", pod.Name, pod.Spec.NodeName, status)
+		}
+		if t == nil {
+			return fmt.Errorf("pod %s on node %s was terminated and then had termination cleared: %#v", pod.Name, pod.Spec.NodeName, status)
+		}
+	}
+	var hasNoStartTime bool
+	v.hasRunningContainers = status.State.Waiting == nil && status.State.Terminated == nil
+	if t != nil {
+		if !t.FinishedAt.Time.IsZero() {
+			// If the pod is deleted while being created, its creation time is the starting point of Unix time.
+			if t.StartedAt.IsZero() || t.StartedAt.Time == time.Unix(0, 0) {
+				hasNoStartTime = true
+			} else {
+				v.duration = t.FinishedAt.Sub(t.StartedAt.Time)
+			}
+			v.completeDuration = t.FinishedAt.Sub(pod.CreationTimestamp.Time)
+		}
+
+		defer func() { v.hasTerminated = true }()
+		switch {
+		case pod.ObjectMeta.DeletionTimestamp != nil && t.ExitCode == 137 && t.Reason == "Error":
+			// expected, pod was force-killed after grace period
+		default:
+			data, _ := json.MarshalIndent(pod.Status, "", "  ")
+			framework.Logf("pod %s on node %s had incorrect final status:\n%s", pod.Name, pod.Spec.NodeName, string(data))
+			return fmt.Errorf("pod %s on node %s container unexpected exit code %d: start=%s end=%s reason=%s message=%s", pod.Name, pod.Spec.NodeName, t.ExitCode, t.StartedAt, t.FinishedAt, t.Reason, t.Message)
+		}
+		switch {
+		case v.duration > time.Hour:
+			// problem with status reporting
+			return fmt.Errorf("pod %s container %s on node %s had very long duration %s: start=%s end=%s", pod.Name, status.Name, pod.Spec.NodeName, v.duration, t.StartedAt, t.FinishedAt)
+		case hasNoStartTime:
+			// should never happen
+			return fmt.Errorf("pod %s container %s on node %s had finish time but not start time: end=%s", pod.Name, status.Name, pod.Spec.NodeName, t.FinishedAt)
+		}
+	}
+
+	if pod.Status.Phase == v1.PodFailed || pod.Status.Phase == v1.PodSucceeded {
+		v.hasTerminalPhase = true
+	} else if v.hasTerminalPhase {
+		return fmt.Errorf("pod %s on node %s was in a terminal phase and then reverted: %#v", pod.Name, pod.Spec.NodeName, pod.Status)
+	}
+	return nil
+}
+
+func (v *podDeleteVerifier) VerifyFinal(scenario string, total time.Duration) (*v1.Pod, []error) {
+	pod, errs := verifyFinal(v.pod, v.hasTerminalPhase, v.hasRunningContainers, v.waitCreated)
+	framework.Logf("Pod %s on node %s %s total=%s run=%s execute=%s", pod.Name, pod.Spec.NodeName, scenario, total, v.completeDuration, v.duration)
+	return pod, errs
+}
+
+func verifyFinal(pod *v1.Pod, hasTerminalPhase, hasRunningContainers, waitCreated bool) (*v1.Pod, []error) {
+	var errs []error
+	if !hasTerminalPhase {
+		var names []string
+		for _, status := range pod.Status.ContainerStatuses {
+			if status.State.Running != nil {
+				names = append(names, status.Name)
+			}
+		}
+		switch {
+		case len(names) > 0:
+			errs = append(errs, fmt.Errorf("pod %s on node %s did not reach a terminal phase before being deleted but had running containers: phase=%s, running-containers=%s", pod.Name, pod.Spec.NodeName, pod.Status.Phase, strings.Join(names, ",")))
+			// If we don't wait for the container to be created, so don't need to verify it here.
+		case pod.Status.Phase != v1.PodPending && waitCreated:
+			errs = append(errs, fmt.Errorf("pod %s on node %s was not Pending but has no running containers: phase=%s", pod.Name, pod.Spec.NodeName, pod.Status.Phase))
+		}
+	}
+	if hasRunningContainers {
+		data, _ := json.MarshalIndent(pod.Status.ContainerStatuses, "", "  ")
+		errs = append(errs, fmt.Errorf("pod %s on node %s had running or unknown container status before being deleted:\n%s", pod.Name, pod.Spec.NodeName, string(data)))
+	}
+
+	return pod, errs
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Due to the failure to correctly propagate the context to `SyncPod`, kubelet is unable to cancel the image pull action when deleting a pod.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #125050 #122905, and part of #113606

#### Special notes for your reviewer:
I discovered this issue while attempting to resolve #125050 and #122905.

The reason kubelet cannot cancel the image pull when deleting a pod is due to the failure to correctly propagate the context to `SyncPod`


>A few PRs block resolving this issue:

> The pod worker is being improved to periodically resync missing pods - moderate refactor that must be completed https://github.com/kubernetes/kubernetes/pull/113145
>If we were to propagate context into sync today, certain wait loops would return generic errors instead of context cancellation which would cause spurious errors - a refactor of the wait package that introduces new methods to handle this must be merged first https://github.com/kubernetes/kubernetes/pull/107826

>After these two issues merge, we can propagate context into Sync methods and add tests that verify pods with long lifecycle hooks are terminated quickly and long grace period deletions can be reduced, as well as stress tests that verify that we do not generate excessive errors. This issue tracks this final work.
>
According to #113606, once #113145 and #107826 are merged, we should be able to propagate the context to SyncPod. It appears that the prerequisites have now been fulfilled, so I will attempt to pass the context to SyncPod and resolve the test issues arising from it.

------

This is a simple modification that resolves the issue where we are unable to cancel container creation(deleting a pod during pod creation) during the pod creation process. I have added tests to cover scenarios that may break after the changes.

When propagating the context to `containerRuntime.SyncPod()`, if the context is canceled during container creation, the container runtime will return either a "**context canceled**" or "**signal: killed**" error(the latter error is returned by Go’s standard library when the `exec.CommandContext(ctx).Run()` call is interrupted by a context cancellation). I believe both of these errors are expected and acceptable outcomes.

Based on this, I have made the following test additions/modifications:

* **Modified pod rapid creation and deletion tests**: These tests now wait for pod creation to complete before verifying the expected pod event transitions（this includes checks for legacy issues, which I believe are still necessary).

* **Added new tests for rapid pod creation and deletion**: In this test, if the pod event contains "**context canceled**" or "**signal: killed**", we treat that as an expected result.

* **Added a delayed pod deletion test**: This test verifies whether the pod event transitions meet expectations when a pod needs to recreate its containers due to any health probe failures.

Additionally, the exists container lifecycle e2e tests can also cover this scenario to ensure that canceling the context does not interfere with the correct execution of lifecycle hooks.


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
