### PR TITLE
feat: introduce pInfo.GatingPlugin to filter out events more generally

### DIFF
--- a/pkg/scheduler/backend/queue/active_queue.go
+++ b/pkg/scheduler/backend/queue/active_queue.go
@@ -306,6 +306,8 @@ func (aq *activeQueue) unlockedPop(logger klog.Logger) (*framework.QueuedPodInfo
 	}
 	pInfo.UnschedulablePlugins.Clear()
 	pInfo.PendingPlugins.Clear()
+	pInfo.GatingPlugin = ""
+	pInfo.GatingPluginEvents = nil
 
 	return pInfo, nil
 }

--- a/pkg/scheduler/backend/queue/scheduling_queue.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue.go
@@ -579,9 +579,7 @@ func (p *PriorityQueue) runPreEnqueuePlugin(ctx context.Context, logger klog.Log
 		p.metricsRecorder.ObservePluginDurationAsync(preEnqueue, pl.Name(), s.Code().String(), p.clock.Since(startTime).Seconds())
 	}
 	if s.IsSuccess() {
-		// This plugin passed, remove it from the unschedulable plugins.
 		// No need to change GatingPlugin; it's overwritten by the next PreEnqueue plugin if they gate this pod, or it's overwritten with an empty string if all PreEnqueue plugins pass.
-		pInfo.UnschedulablePlugins.Delete(pl.Name())
 		return s
 	}
 	pInfo.UnschedulablePlugins.Insert(pl.Name())

--- a/pkg/scheduler/framework/interface.go
+++ b/pkg/scheduler/framework/interface.go
@@ -476,9 +476,14 @@ type QueueSortPlugin interface {
 // This is because such temporal errors cannot be resolved by specific cluster events,
 // and we have no choose but keep retrying scheduling until the failure is resolved.
 //
-// Plugins that make pod unschedulable (PreEnqueue, PreFilter, Filter, Reserve, and Permit plugins) should implement this interface,
+// Plugins that make pod unschedulable (PreEnqueue, PreFilter, Filter, Reserve, and Permit plugins) must implement this interface,
 // otherwise the default implementation will be used, which is less efficient in requeueing Pods rejected by the plugin.
-// And, if plugins other than above extension points support this interface, they are just ignored.
+//
+// Also, if EventsToRegister returns an empty list, that means the Pods failed by the plugin are not requeued by any events,
+// which doesn't make sense in most cases (very likely misuse)
+// since the pods rejected by the plugin could be stuck in the unschedulable pod pool forever.
+//
+// If plugins other than above extension points support this interface, they are just ignored.
 type EnqueueExtensions interface {
 	Plugin
 	// EventsToRegister returns a series of possible events that may cause a Pod

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -352,11 +352,16 @@ func New(ctx context.Context,
 		return nil, errors.New("at least one profile is required")
 	}
 
-	preEnqueuePluginMap := make(map[string][]framework.PreEnqueuePlugin)
+	preEnqueuePluginMap := make(map[string]map[string]framework.PreEnqueuePlugin)
 	queueingHintsPerProfile := make(internalqueue.QueueingHintMapPerProfile)
 	var returnErr error
 	for profileName, profile := range profiles {
-		preEnqueuePluginMap[profileName] = profile.PreEnqueuePlugins()
+		plugins := profile.PreEnqueuePlugins()
+		preEnqueuePluginMap[profileName] = make(map[string]framework.PreEnqueuePlugin, len(plugins))
+		for _, plugin := range plugins {
+			preEnqueuePluginMap[profileName][plugin.Name()] = plugin
+		}
+
 		queueingHintsPerProfile[profileName], err = buildQueueingHintMap(ctx, profile.EnqueueExtensions())
 		if err != nil {
 			returnErr = errors.Join(returnErr, err)

--- a/test/integration/scheduler/plugins/plugins_test.go
+++ b/test/integration/scheduler/plugins/plugins_test.go
@@ -41,6 +41,7 @@ import (
 	listersv1 "k8s.io/client-go/listers/core/v1"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	corev1helpers "k8s.io/component-helpers/scheduling/corev1"
+	"k8s.io/klog/v2"
 	configv1 "k8s.io/kube-scheduler/config/v1"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/scheduler"
@@ -2753,6 +2754,7 @@ func (pl *SchedulingGatesPluginWithEvents) Name() string {
 
 func (pl *SchedulingGatesPluginWithEvents) PreEnqueue(ctx context.Context, p *v1.Pod) *framework.Status {
 	pl.called++
+	klog.FromContext(ctx).Info("PreEnqueue is called", "pod", klog.KObj(p), "count", pl.called)
 	return pl.SchedulingGates.PreEnqueue(ctx, p)
 }
 
@@ -2773,6 +2775,7 @@ func (pl *SchedulingGatesPluginWOEvents) Name() string {
 
 func (pl *SchedulingGatesPluginWOEvents) PreEnqueue(ctx context.Context, p *v1.Pod) *framework.Status {
 	pl.called++
+	klog.FromContext(ctx).Info("PreEnqueue is called", "pod", klog.KObj(p), "count", pl.called)
 	return pl.SchedulingGates.PreEnqueue(ctx, p)
 }
 
@@ -2782,8 +2785,6 @@ func (pl *SchedulingGatesPluginWOEvents) EventsToRegister(_ context.Context) ([]
 
 // This test helps to verify registering nil events for PreEnqueue plugin works as expected.
 func TestPreEnqueuePluginEventsToRegister(t *testing.T) {
-	testContext := testutils.InitTestAPIServer(t, "preenqueue-plugin", nil)
-
 	num := func(pl framework.Plugin) int {
 		switch item := pl.(type) {
 		case *SchedulingGatesPluginWithEvents:
@@ -2830,6 +2831,7 @@ func TestPreEnqueuePluginEventsToRegister(t *testing.T) {
 			t.Run(tt.name+fmt.Sprintf(" queueHint(%v)", queueHintEnabled), func(t *testing.T) {
 				featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.SchedulerQueueingHints, queueHintEnabled)
 
+				testContext := testutils.InitTestAPIServer(t, "preenqueue-plugin", nil)
 				// use new plugin every time to clear counts
 				var plugin framework.PreEnqueuePlugin
 				if tt.withEvents {
@@ -2865,6 +2867,8 @@ func TestPreEnqueuePluginEventsToRegister(t *testing.T) {
 				)
 				defer teardown()
 
+				t.Log("Create the gated pod")
+
 				// Create a pod with schedulingGates.
 				gatedPod := st.MakePod().Name("p").Namespace(testContext.NS.Name).
 					SchedulingGates([]string{"foo"}).
@@ -2885,6 +2889,8 @@ func TestPreEnqueuePluginEventsToRegister(t *testing.T) {
 					return
 				}
 
+				t.Log("Create the pause pod")
+
 				// Create a best effort pod.
 				pausePod, err := testutils.CreatePausePod(testCtx.ClientSet, testutils.InitPausePod(&testutils.PausePodConfig{
 					Name:      "pause-pod",
@@ -2901,6 +2907,8 @@ func TestPreEnqueuePluginEventsToRegister(t *testing.T) {
 					t.Errorf("Expected the pod to be schedulable, but got: %v", err)
 					return
 				}
+
+				t.Log("Update the pause pod")
 
 				// Update the pod which will trigger the requeue logic if plugin registers the events.
 				pausePod, err = testCtx.ClientSet.CoreV1().Pods(pausePod.Namespace).Get(testCtx.Ctx, pausePod.Name, metav1.GetOptions{})
@@ -2924,6 +2932,8 @@ func TestPreEnqueuePluginEventsToRegister(t *testing.T) {
 					t.Errorf("Expected the preEnqueue plugin to be called %v, but got %v", tt.count, num(plugin))
 					return
 				}
+
+				t.Log("Remove the scheduling gate")
 
 				// Remove gated pod's scheduling gates.
 				gatedPod, err = testCtx.ClientSet.CoreV1().Pods(gatedPod.Namespace).Get(testCtx.Ctx, gatedPod.Name, metav1.GetOptions{})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

We have a short cut path for the scheduling gate, which is not ideal because we're basically trying to build our scheduler generic; not depend on any in-tree plugins at all.

This PR introduces `pInfo.GatingPlugin`, which indicates the plugin name gating this Pod right now. Also, we create a pre-calculated map for which plugin is interested in which events. 
With them, we can implement an early `continue`, which is similar to the current short cut, but not specific to the scheduling gate plugin; This short cut path now benefits all the other PreEnqueue plugins too.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Follow up of #125527
We discussed we ideally wanted to make it general.

#### Special notes for your reviewer:

Here's the scheduler-perf result. 

**master**

```json
    {
      "data": {
        "Average": 1033.690384826998,
        "Perc50": 1042.0894467055684,
        "Perc90": 1296.9310473639357,
        "Perc95": 1577.0437629644223,
        "Perc99": 1577.0437629644223
      },
      "unit": "pods/s",
      "labels": {
        "Metric": "SchedulingThroughput",
        "Name": "BenchmarkPerfScheduling/SchedulingWhileGated/1Node_10000GatedPods/namespace-5",
        "event": "not applicable",
        "extension_point": "not applicable",
        "plugin": "not applicable",
        "result": "not applicable"
      }
    },
    {
      "data": {
        "Average": 1068.7906572953373,
        "Perc50": 1076.0178436039005,
        "Perc90": 1375.026813022854,
        "Perc95": 1502.1168581823936,
        "Perc99": 1502.1168581823936
      },
      "unit": "pods/s",
      "labels": {
        "Metric": "SchedulingThroughput",
        "Name": "BenchmarkPerfScheduling/SchedulingWhileGated/1Node_10000GatedPods_QueueingHintsEnabled/namespace-5",
        "event": "not applicable",
        "extension_point": "not applicable",
        "plugin": "not applicable",
        "result": "not applicable"
      }
    },
```

**this branch**

```json
    {
      "data": {
        "Average": 1125.381883565056,
        "Perc50": 1063.7432906243237,
        "Perc90": 1238.9720202948656,
        "Perc95": 1760.1309819071496,
        "Perc99": 1760.1309819071496
      },
      "unit": "pods/s",
      "labels": {
        "Metric": "SchedulingThroughput",
        "Name": "BenchmarkPerfScheduling/SchedulingWhileGated/1Node_10000GatedPods/namespace-5",
        "event": "not applicable",
        "extension_point": "not applicable",
        "plugin": "not applicable",
        "result": "not applicable"
      }
    },
    {
      "data": {
        "Average": 1284.9195459589641,
        "Perc50": 1246.9339648710884,
        "Perc90": 1381.9668894552956,
        "Perc95": 1513.0076906180914,
        "Perc99": 1513.0076906180914
      },
      "unit": "pods/s",
      "labels": {
        "Metric": "SchedulingThroughput",
        "Name": "BenchmarkPerfScheduling/SchedulingWhileGated/1Node_10000GatedPods_QueueingHintsEnabled/namespace-5",
        "event": "not applicable",
        "extension_point": "not applicable",
        "plugin": "not applicable",
        "result": "not applicable"
      }
    },
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
