### PR TITLE
Add warning message for attach

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/attach/attach.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/attach/attach.go
@@ -307,6 +307,7 @@ func (o *AttachOptions) Run() error {
 	}
 
 	if !o.Quiet {
+		_, _ = fmt.Fprintln(o.ErrOut, "All commands and output from this session will be recorded in container logs, including credentials and sensitive information passed through the command prompt.")
 		fmt.Fprintln(o.ErrOut, "If you don't see a command prompt, try pressing enter.")
 	}
 	if err := t.Safe(o.AttachFunc(o, containerToAttach, t.Raw, sizeQueue)); err != nil {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/attach/attach_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/attach/attach_test.go
@@ -242,6 +242,7 @@ func TestAttach(t *testing.T) {
 		pod                                                         *corev1.Pod
 		remoteAttachErr                                             bool
 		expectedErr                                                 string
+		expectedErrOut                                              []string
 	}{
 		{
 			name:         "pod attach",
@@ -251,6 +252,10 @@ func TestAttach(t *testing.T) {
 			attachPath:   "/api/" + version + "/namespaces/test/pods/foo/attach",
 			pod:          attachPod(),
 			container:    "bar",
+			expectedErrOut: []string{
+				"All commands and output from this session will be recorded in container logs, including credentials and sensitive information passed through the command prompt.",
+				"If you don't see a command prompt, try pressing enter.",
+			},
 		},
 		{
 			name:            "pod attach error",
@@ -305,10 +310,11 @@ func TestAttach(t *testing.T) {
 			if test.remoteAttachErr {
 				remoteAttach.err = fmt.Errorf("attach error")
 			}
+			streams, _, _, errOut := genericiooptions.NewTestIOStreams()
 			options := &AttachOptions{
 				StreamOptions: exec.StreamOptions{
 					ContainerName: test.container,
-					IOStreams:     genericiooptions.NewTestIOStreamsDiscard(),
+					IOStreams:     streams,
 				},
 				Attach:        remoteAttach,
 				GetPodTimeout: 1000,
@@ -348,6 +354,14 @@ func TestAttach(t *testing.T) {
 			}
 			if remoteAttach.url.Query().Get("container") != "bar" {
 				t.Errorf("%s: Did not have query parameters: %s", test.name, remoteAttach.url.Query())
+			}
+			if test.expectedErrOut != nil {
+				for _, expect := range test.expectedErrOut {
+					if !strings.Contains(errOut.String(), expect) {
+						t.Errorf("%s: expected message %s not found, got: %s", test.name, expect, strings.ReplaceAll(errOut.String(), "\n", ""))
+						return
+					}
+				}
 			}
 		})
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/sig auth
/sig node
/sig security
/sig cli

#### What this PR does / why we need it:
Output warning message when user attaches to a container.
It applies when using the following commands( which internally execute `AttachFunc()`):

- `kubectl attach`
- `kubectl run -it`
- `kubectl debug -it`

e.g.
```bash
$ kubectl run -it mypod --image=busybox -- /bin/sh
All commands and output executed when attached to a container will be visible via pods/log.
If you don't see a command prompt, try pressing enter.
/ # 
```

#### Which issue(s) this PR fixes:
Fixes #123967
Related #125343

#### Does this PR introduce a user-facing change?

```release-note
Added a warning to `kubectl attach`, notifying / reminding users that commands and output are available via the `log` subresource of that Pod.
```
