### PR TITLE
KEP-4292: Add e2e test for custom profile in kubectl debug

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go
@@ -212,9 +212,7 @@ func (o *DebugOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&o.TargetContainer, "target", "", i18n.T("When using an ephemeral container, target processes in this container name."))
 	cmd.Flags().BoolVarP(&o.TTY, "tty", "t", o.TTY, i18n.T("Allocate a TTY for the debugging container."))
 	cmd.Flags().StringVar(&o.Profile, "profile", ProfileLegacy, i18n.T(`Options are "legacy", "general", "baseline", "netadmin", "restricted" or "sysadmin".`))
-	if !cmdutil.DebugCustomProfile.IsDisabled() {
-		cmd.Flags().StringVar(&o.CustomProfileFile, "custom", o.CustomProfileFile, i18n.T("Path to a JSON or YAML file containing a partial container spec to customize built-in debug profiles."))
-	}
+	cmd.Flags().StringVar(&o.CustomProfileFile, "custom", o.CustomProfileFile, i18n.T("Path to a JSON or YAML file containing a partial container spec to customize built-in debug profiles."))
 }
 
 // Complete finishes run-time initialization of debug.DebugOptions.

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
@@ -430,7 +430,6 @@ const (
 	OpenAPIV3Patch          FeatureGate = "KUBECTL_OPENAPIV3_PATCH"
 	RemoteCommandWebsockets FeatureGate = "KUBECTL_REMOTE_COMMAND_WEBSOCKETS"
 	PortForwardWebsockets   FeatureGate = "KUBECTL_PORT_FORWARD_WEBSOCKETS"
-	DebugCustomProfile      FeatureGate = "KUBECTL_DEBUG_CUSTOM_PROFILE"
 )
 
 // IsEnabled returns true iff environment variable is set to true.

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
@@ -430,7 +430,7 @@ const (
 	OpenAPIV3Patch          FeatureGate = "KUBECTL_OPENAPIV3_PATCH"
 	RemoteCommandWebsockets FeatureGate = "KUBECTL_REMOTE_COMMAND_WEBSOCKETS"
 	PortForwardWebsockets   FeatureGate = "KUBECTL_PORT_FORWARD_WEBSOCKETS"
-	// DebugCustomProfile should be dropped in 1.33
+	// DebugCustomProfile should be dropped in 1.34
 	DebugCustomProfile FeatureGate = "KUBECTL_DEBUG_CUSTOM_PROFILE"
 )
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
@@ -430,6 +430,8 @@ const (
 	OpenAPIV3Patch          FeatureGate = "KUBECTL_OPENAPIV3_PATCH"
 	RemoteCommandWebsockets FeatureGate = "KUBECTL_REMOTE_COMMAND_WEBSOCKETS"
 	PortForwardWebsockets   FeatureGate = "KUBECTL_PORT_FORWARD_WEBSOCKETS"
+	// DebugCustomProfile should be dropped in 1.33
+	DebugCustomProfile FeatureGate = "KUBECTL_DEBUG_CUSTOM_PROFILE"
 )
 
 // IsEnabled returns true iff environment variable is set to true.

--- a/test/e2e/kubectl/debug.go
+++ b/test/e2e/kubectl/debug.go
@@ -1,0 +1,188 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// OWNER = sig/cli
+
+package kubectl
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/wait"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2ekubectl "k8s.io/kubernetes/test/e2e/framework/kubectl"
+	testutils "k8s.io/kubernetes/test/utils"
+	imageutils "k8s.io/kubernetes/test/utils/image"
+	admissionapi "k8s.io/pod-security-admission/api"
+)
+
+var _ = SIGDescribe("kubectl debug", func() {
+	defer ginkgo.GinkgoRecover()
+	f := framework.NewDefaultFramework("kubectl-debug")
+	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
+
+	var ns string
+	var c clientset.Interface
+	ginkgo.BeforeEach(func() {
+		c = f.ClientSet
+		ns = f.Namespace.Name
+	})
+
+	ginkgo.Describe("custom profile", func() {
+		ginkgo.It("should be applied on static profiles on ephemeral container", func(ctx context.Context) {
+			debugPodName := "e2e-test-debug-custom-profile-pod-ephemeral"
+			customProfileImage := imageutils.GetE2EImage(imageutils.BusyBox)
+			ginkgo.By("running the image " + customProfileImage)
+			e2ekubectl.RunKubectlOrDie(ns,
+				"run", debugPodName,
+				"--image="+customProfileImage,
+				podRunningTimeoutArg,
+				"--labels=run="+debugPodName,
+				"--", "sh", "-c",
+				"sleep 3600")
+
+			ginkgo.By("verifying the pod " + debugPodName + " is running")
+			label := labels.SelectorFromSet(map[string]string{"run": debugPodName})
+			err := testutils.WaitForPodsWithLabelRunning(c, ns, label)
+			if err != nil {
+				framework.Failf("Failed getting pod %s: %v", debugPodName, err)
+			}
+
+			tmpDir, err := os.MkdirTemp("", "test-custom-profile-debug")
+			customProfileFile := "custom.yaml"
+			framework.ExpectNoError(err)
+			defer os.Remove(tmpDir) //nolint:errcheck
+			framework.ExpectNoError(os.WriteFile(filepath.Join(tmpDir, customProfileFile), []byte(`
+securityContext:
+  capabilities:
+    add:
+      - NET_ADMIN
+env:
+  - name: REQUIRED_ENV_VAR
+    value: value2
+`), os.FileMode(0755)))
+			ginkgo.By("verifying ephemeral container has correct fields")
+			e2ekubectl.RunKubectlOrDie(ns,
+				"debug",
+				debugPodName,
+				"--image="+imageutils.GetE2EImage(imageutils.Nginx),
+				"--container=debugger",
+				"--profile=general", // general profile sets capability to SYS_PTRACE and custom should overwrite it to NET_ADMIN
+				"--custom="+filepath.Join(tmpDir, customProfileFile),
+				"--", "sh", "-c",
+				"sleep 3600")
+
+			ginkgo.By("verifying the container debugger is running")
+			err = wait.PollUntilContextTimeout(ctx, 3*time.Second, 2*time.Minute, false, func(ctx context.Context) (bool, error) {
+				running := e2ekubectl.RunKubectlOrDie(ns, "get", "pod", debugPodName, "-o", "template", `--template={{if (exists . "status" "ephemeralContainerStatuses")}}{{range .status.ephemeralContainerStatuses}}{{if (and (eq .name "debugger") (exists . "state" "running"))}}true{{end}}{{end}}{{end}}`)
+				if running != "true" {
+					return false, nil
+				}
+				return true, nil
+			})
+			framework.ExpectNoError(err)
+			output := e2ekubectl.RunKubectlOrDie(ns, "get", "pod", debugPodName, "-o", "jsonpath={.spec.ephemeralContainers[*]}")
+			ginkgo.By("verifying NET_ADMIN is added")
+			if !strings.Contains(output, "NET_ADMIN") {
+				framework.Failf("failed to find the expected NET_ADMIN capability")
+			}
+			ginkgo.By("verifying SYS_PTRACE is overridden")
+			if strings.Contains(output, "SYS_PTRACE") {
+				framework.Failf("unexpected SYS_PTRACE capability")
+			}
+			ginkgo.By("verifying REQUIRED_ENV_VAR is added")
+			if !strings.Contains(output, "REQUIRED_ENV_VAR") {
+				framework.Failf("failed to find the expected REQUIRED_ENV_VAR environment variable")
+			}
+		})
+
+		ginkgo.It("should be applied on static profiles while copying from pod", func(ctx context.Context) {
+			debugPodName := "e2e-test-debug-custom-profile-pod"
+			customProfileImage := imageutils.GetE2EImage(imageutils.BusyBox)
+			ginkgo.By("running the image " + customProfileImage)
+			e2ekubectl.RunKubectlOrDie(ns,
+				"run", debugPodName,
+				"--image="+customProfileImage,
+				podRunningTimeoutArg,
+				"--labels=run="+debugPodName,
+				"--", "sh", "-c",
+				"sleep 3600")
+
+			ginkgo.By("verifying the pod " + debugPodName + " is running")
+			label := labels.SelectorFromSet(map[string]string{"run": debugPodName})
+			err := testutils.WaitForPodsWithLabelRunning(c, ns, label)
+			if err != nil {
+				framework.Failf("Failed getting pod %s: %v", debugPodName, err)
+			}
+
+			tmpDir, err := os.MkdirTemp("", "test-custom-profile-debug")
+			customProfileFile := "custom.yaml"
+			framework.ExpectNoError(err)
+			defer os.Remove(tmpDir) //nolint:errcheck
+			framework.ExpectNoError(os.WriteFile(filepath.Join(tmpDir, customProfileFile), []byte(`
+securityContext:
+  capabilities:
+    add:
+      - NET_ADMIN
+env:
+  - name: REQUIRED_ENV_VAR
+    value: value2
+`), os.FileMode(0755)))
+			ginkgo.By("verifying copied pod has correct fields")
+			e2ekubectl.RunKubectlOrDie(ns,
+				"debug",
+				debugPodName,
+				"--image="+imageutils.GetE2EImage(imageutils.Nginx),
+				"--copy-to=my-debugger",
+				"--profile=general", // general profile sets capability to SYS_PTRACE and custom should overwrite it to NET_ADMIN
+				"--custom="+filepath.Join(tmpDir, customProfileFile),
+				"--", "sh", "-c",
+				"sleep 3600")
+
+			ginkgo.By("verifying the container in pod my-debugger is running")
+			err = wait.PollUntilContextTimeout(ctx, 3*time.Second, 2*time.Minute, false, func(ctx context.Context) (bool, error) {
+				running := e2ekubectl.RunKubectlOrDie(ns, "get", "pod", "my-debugger", "-o", "template", fmt.Sprintf(`--template={{if (exists . "status" "containerStatuses")}}{{range .status.containerStatuses}}{{if (and (ne .name "%s") (exists . "state" "running"))}}true{{end}}{{end}}{{end}}`, debugPodName))
+				if running != "true" {
+					return false, nil
+				}
+				return true, nil
+			})
+			framework.ExpectNoError(err)
+			output := e2ekubectl.RunKubectlOrDie(ns, "get", "pod", "my-debugger", "-o", "jsonpath={.spec.containers[*]}")
+			ginkgo.By("verifying NET_ADMIN is added")
+			if !strings.Contains(output, "NET_ADMIN") {
+				framework.Failf("failed to find the expected NET_ADMIN capability")
+			}
+			ginkgo.By("verifying SYS_PTRACE is overridden")
+			if strings.Contains(output, "SYS_PTRACE") {
+				framework.Failf("unexpected SYS_PTRACE capability")
+			}
+			ginkgo.By("verifying REQUIRED_ENV_VAR is added")
+			if !strings.Contains(output, "REQUIRED_ENV_VAR") {
+				framework.Failf("failed to find the expected REQUIRED_ENV_VAR environment variable")
+			}
+		})
+	})
+})

--- a/test/e2e/kubectl/debug.go
+++ b/test/e2e/kubectl/debug.go
@@ -30,7 +30,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2ekubectl "k8s.io/kubernetes/test/e2e/framework/kubectl"
-	"k8s.io/kubernetes/test/e2e/framework/pod"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	testutils "k8s.io/kubernetes/test/utils"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 	admissionapi "k8s.io/pod-security-admission/api"
@@ -62,7 +62,7 @@ var _ = SIGDescribe("kubectl debug", func() {
 
 			ginkgo.By("verifying the pod " + debugPodName + " is running")
 			label := labels.SelectorFromSet(map[string]string{"run": debugPodName})
-			_, err := pod.WaitForPodsWithLabelRunningReady(ctx, c, ns, label, 1, framework.PodStartShortTimeout)
+			_, err := e2epod.WaitForPodsWithLabelRunningReady(ctx, c, ns, label, 1, framework.PodStartShortTimeout)
 			if err != nil {
 				framework.Failf("Failed getting pod %s: %v", debugPodName, err)
 			}
@@ -92,7 +92,7 @@ env:
 				"sleep 3600")
 
 			ginkgo.By("verifying the container debugger is running")
-			framework.ExpectNoError(pod.WaitForContainerRunning(ctx, c, ns, debugPodName, "debugger", framework.PodStartShortTimeout))
+			framework.ExpectNoError(e2epod.WaitForContainerRunning(ctx, c, ns, debugPodName, "debugger", framework.PodStartShortTimeout))
 			output := e2ekubectl.RunKubectlOrDie(ns, "get", "pod", debugPodName, "-o", "jsonpath={.spec.ephemeralContainers[*]}")
 			ginkgo.By("verifying NET_ADMIN is added")
 			gomega.Expect(output).To(gomega.ContainSubstring("NET_ADMIN"))
@@ -147,7 +147,7 @@ env:
 				"sleep 3600")
 
 			ginkgo.By("verifying the container in pod my-debugger is running")
-			framework.ExpectNoError(pod.WaitForContainerRunning(ctx, c, ns, "my-debugger", "debugger", framework.PodStartShortTimeout))
+			framework.ExpectNoError(e2epod.WaitForContainerRunning(ctx, c, ns, "my-debugger", "debugger", framework.PodStartShortTimeout))
 
 			output := e2ekubectl.RunKubectlOrDie(ns, "get", "pod", "my-debugger", "-o", "jsonpath={.spec.containers[*]}")
 			ginkgo.By("verifying NET_ADMIN is added")


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This PR adds e2e for custom profiling in kubectl debug as promised in enhancement as prerequisite for promotion to stable. 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Locking the feature custom profiling in kubectl debug to true.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
- [KEP]:  https://github.com/kubernetes/enhancements/tree/master/keps/sig-cli/4292-kubectl-debug-custom-profile
```
