### PR TITLE
add constants socket path to podresources

### DIFF
--- a/staging/src/k8s.io/kubelet/pkg/apis/podresources/v1/constants.go
+++ b/staging/src/k8s.io/kubelet/pkg/apis/podresources/v1/constants.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+const (
+	// Version means current version of the API supported by kubelet
+	Version = "v1"
+	// PodResourcesPath is the folder the Pod Resources is expecting sockets to be on
+	// Only privileged pods have access to this path
+	// Note: Placeholder until we find a "standard path"
+	PodResourcesPath = "/var/lib/kubelet/pod-resources/"
+	// PodResourcesSocket is the path of the Kubelet registry socket
+	PodResourcesSocket = PodResourcesPath + "kubelet.sock"
+
+	// PodResourcesPathWindows Avoid failed to run Kubelet: bad socketPath,
+	// must be an absolute path: /var/lib/kubelet/pod-resources/kubelet.sock
+	PodResourcesPathWindows = "\\var\\lib\\kubelet\\pod-resources\\"
+	// PodResourcesSocketWindows is the path of the Kubelet registry socket on windows
+	PodResourcesSocketWindows = PodResourcesPathWindows + "kubelet.sock"
+)

--- a/staging/src/k8s.io/kubelet/pkg/apis/podresources/v1alpha1/constants.go
+++ b/staging/src/k8s.io/kubelet/pkg/apis/podresources/v1alpha1/constants.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+const (
+	// Version means current version of the API supported by kubelet
+	Version = "v1alpha1"
+	// PodResourcesPath is the folder the Pod Resources is expecting sockets to be on
+	// Only privileged pods have access to this path
+	// Note: Placeholder until we find a "standard path"
+	PodResourcesPath = "/var/lib/kubelet/pod-resources/"
+	// PodResourcesSocket is the path of the Kubelet registry socket
+	PodResourcesSocket = PodResourcesPath + "kubelet.sock"
+
+	// PodResourcesPathWindows Avoid failed to run Kubelet: bad socketPath,
+	// must be an absolute path: /var/lib/kubelet/pod-resources/kubelet.sock
+	PodResourcesPathWindows = "\\var\\lib\\kubelet\\pod-resources\\"
+	// PodResourcesSocketWindows is the path of the Kubelet registry socket on windows
+	PodResourcesSocketWindows = PodResourcesPathWindows + "kubelet.sock"
+)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Current when i use PodResourcesLister API, we need handwriting a unixSocketPath "/var/lib/kubelet/pod-resources/kubelet.sock".


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://github.com/kubernetes/kubernetes/issues/127189

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add a default PodResourcesSocket const in api/pluginregistration/v1/constants.go file.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
