### PR TITLE
[FG:InPlacePodVerticalScaling] e2e node: Verify pod cgroups in resize test

### DIFF
--- a/test/e2e/common/node/framework/podresize/resize.go
+++ b/test/e2e/common/node/framework/podresize/resize.go
@@ -216,11 +216,34 @@ func VerifyPodContainersCgroupValues(ctx context.Context, f *framework.Framework
 
 	onCgroupv2 := cgroups.IsPodOnCgroupv2Node(f, pod)
 
+	var podCPURequestMilliValue, podCPULimitMilliValue, podMemoryLimitInBytes int64
 	var errs []error
 	for _, ci := range tcInfo {
 		tc := makeResizableContainer(ci)
 		errs = append(errs, cgroups.VerifyContainerCgroupValues(f, pod, &tc, onCgroupv2))
+
+		// TODO: Consider PodLevelResources feature and move this function to `cgroups` package.
+		// Accumulate container resources for verifying pod (PodLevelResources feature is not taken into account now)
+		podCPURequestMilliValue += tc.Resources.Requests.Cpu().MilliValue()
+		if podCPULimitMilliValue >= 0 {
+			if tc.Resources.Limits.Cpu().IsZero() {
+				podCPULimitMilliValue = -1
+			} else {
+				podCPULimitMilliValue += tc.Resources.Limits.Cpu().MilliValue()
+			}
+		}
+		if podMemoryLimitInBytes >= 0 {
+			if tc.Resources.Limits.Memory().IsZero() {
+				podMemoryLimitInBytes = -1
+			} else {
+				podMemoryLimitInBytes += tc.Resources.Limits.Memory().Value()
+			}
+		}
 	}
+
+	podResourceInfo := cgroups.BuildPodResourceInfo(podCPURequestMilliValue, podCPULimitMilliValue, podMemoryLimitInBytes)
+	errs = append(errs, cgroups.VerifyPodCgroups(ctx, f, pod, &podResourceInfo))
+
 	return utilerrors.NewAggregate(errs)
 }
 

--- a/test/e2e/common/node/pod_resize.go
+++ b/test/e2e/common/node/pod_resize.go
@@ -1043,9 +1043,6 @@ func doPodResizeTests(f *framework.Framework) {
 					MemPolicy: &noRestart,
 				},
 			},
-			patchString: fmt.Sprintf(`{"spec":{"containers":[
-						{"name":"c2", "resources":{"requests":{"memory":"%s"}}}
-					]}}`, increasedMem),
 			expected: []podresize.ResizableContainerInfo{
 				{
 					Name: "c1",
@@ -1318,7 +1315,7 @@ func doPodResizeMemoryLimitDecreaseTest(f *framework.Framework) {
 
 		tStamp := strconv.Itoa(time.Now().Nanosecond())
 		testPod = podresize.MakePodWithResizableContainers(f.Namespace.Name, "testpod", tStamp, original)
-		testPod = e2epod.MustMixinRestrictedPodSecurity(testPod)
+		cgroups.ConfigureHostPathForPodCgroup(testPod)
 
 		ginkgo.By("creating pod")
 		testPod = podClient.CreateSync(ctx, testPod)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup


#### What this PR does / why we need it:
Pod resize updates not only container cgroups but also pod cgroups. This fix adds verification for pod cgroups to resize tests.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
