### PR TITLE
EventedPLEG: Set Timestamp in PodStatus for Generic PLEG more accurate

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -1536,7 +1536,7 @@ func (m *kubeGenericRuntimeManager) GetPodStatus(ctx context.Context, uid kubety
 
 	sandboxStatuses := []*runtimeapi.PodSandboxStatus{}
 	containerStatuses := []*kubecontainer.Status{}
-	var timestamp time.Time
+	timestamp := time.Now()
 
 	podIPs := []string{}
 	for idx, podSandboxID := range podSandboxIDs {
@@ -1580,7 +1580,7 @@ func (m *kubeGenericRuntimeManager) GetPodStatus(ctx context.Context, uid kubety
 			} else {
 				// Get the statuses of all containers visible to the pod and
 				// timestamp from sandboxStatus.
-				timestamp = time.Unix(resp.Timestamp, 0)
+				timestamp = time.Unix(0, resp.Timestamp)
 				for _, cs := range resp.ContainersStatuses {
 					cStatus := m.convertToKubeContainerStatus(cs)
 					containerStatuses = append(containerStatuses, cStatus)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind cleanup
/kind sig-node

**What this PR does / why we need it:**
Ref: https://github.com/kubernetes/kubernetes/pull/127195#discussion_r1759704491
Timestamp returned by PodSandboxStatus should be more accurate. PR https://github.com/cri-o/cri-o/pull/8582 has already changed timestamp to nanoseconds so kubelet should change it.
BTW, timestamp is not return by runtime Containerd, we should set timestamp as now  in `GetPodStatus()` for Generic PLEG to set cache by `status.timestamp` regardless of whether EventedPLEG is enabled or not.

**Which issue(s) this PR fixes:**
Fixes https://github.com/kubernetes/kubernetes/issues/126414

**Special notes for your reviewer:**
Follow https://github.com/kubernetes/kubernetes/pull/124297

**Does this PR introduce a user-facing change?**
NONE

Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
NONE