### PR TITLE
Fail draplugin PublishResources without nodeName or kubeclient

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/draplugin.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/draplugin.go
@@ -55,7 +55,10 @@ type DRAPlugin interface {
 	// to the API server.
 	//
 	// The caller must not modify the content after the call.
-	PublishResources(ctx context.Context, resources Resources)
+	//
+	// Returns an error if KubeClient or NodeName options were not
+	// set in Start() to create the DRAPlugin instance.
+	PublishResources(ctx context.Context, resources Resources) error
 
 	// This unexported method ensures that we can modify the interface
 	// without causing an API break of the package
@@ -254,6 +257,9 @@ type draPlugin struct {
 // The context and/or DRAPlugin.Stop can be used to stop all background activity.
 // Stop also blocks. A logger can be stored in the context to add values or
 // a name to all log entries.
+//
+// If the plugin will be used to publish resources, [KubeClient] and [NodeName]
+// options are mandatory.
 func Start(ctx context.Context, nodeServer interface{}, opts ...Option) (result DRAPlugin, finalErr error) {
 	logger := klog.FromContext(ctx)
 	o := options{
@@ -365,8 +371,16 @@ func (d *draPlugin) Stop() {
 	d.wg.Wait()
 }
 
-// PublishResources implements [DRAPlugin.PublishResources].
-func (d *draPlugin) PublishResources(ctx context.Context, resources Resources) {
+// PublishResources implements [DRAPlugin.PublishResources]. Returns en error if
+// kubeClient or nodeName are unset.
+func (d *draPlugin) PublishResources(ctx context.Context, resources Resources) error {
+	if d.kubeClient == nil {
+		return errors.New("no KubeClient found to publish resources")
+	}
+	if d.nodeName == "" {
+		return errors.New("no NodeName was set to publish resources")
+	}
+
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
 
@@ -393,11 +407,13 @@ func (d *draPlugin) PublishResources(ctx context.Context, resources Resources) {
 		controllerLogger = klog.LoggerWithName(controllerLogger, "ResourceSlice controller")
 		controllerCtx = klog.NewContext(controllerCtx, controllerLogger)
 		d.resourceSliceController = resourceslice.StartController(controllerCtx, d.kubeClient, d.driverName, owner, driverResources)
-		return
+		return nil
 	}
 
 	// Inform running controller about new information.
 	d.resourceSliceController.Update(driverResources)
+
+	return nil
 }
 
 // RegistrationStatus implements [DRAPlugin.RegistrationStatus].

--- a/test/e2e/dra/test-driver/app/kubeletplugin.go
+++ b/test/e2e/dra/test-driver/app/kubeletplugin.go
@@ -182,7 +182,9 @@ func StartPlugin(ctx context.Context, cdiDir, driverName string, kubeClient kube
 		resources := kubeletplugin.Resources{
 			Devices: devices,
 		}
-		ex.d.PublishResources(ctx, resources)
+		if err := ex.d.PublishResources(ctx, resources); err != nil {
+			return nil, fmt.Errorf("start kubelet plugin: publish resources: %w", err)
+		}
 	} else if len(ex.fileOps.Devices) > 0 {
 		devices := make([]resourceapi.Device, len(ex.fileOps.Devices))
 		for i, deviceName := range sets.List(ex.deviceNames) {
@@ -194,7 +196,9 @@ func StartPlugin(ctx context.Context, cdiDir, driverName string, kubeClient kube
 		resources := kubeletplugin.Resources{
 			Devices: devices,
 		}
-		ex.d.PublishResources(ctx, resources)
+		if err := ex.d.PublishResources(ctx, resources); err != nil {
+			return nil, fmt.Errorf("start kubelet plugin: publish resources: %w", err)
+		}
 	}
 
 	return ex, nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

When DRAPlugin was instanciated via `draplugin.Start` without KubeClient or NodeName options - the `PublishResources` call should return an error to prevent:
- silent inaction when ResourceSliceController detects no KubeClient
- ResourceSlices from all nodes piling up in a blank-string-named pool
- ResourceSliceController failing to lookup owner UID
- API server refusing to accept OwnerReference with no name or UID

https://github.com/kubernetes/kubernetes/blob/f248c24456254d6e0668a424a31258e6d9e9c185/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/draplugin.go#L395

`->`

https://github.com/kubernetes/kubernetes/blob/f248c24456254d6e0668a424a31258e6d9e9c185/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/resourceslicecontroller.go#L114

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #127194

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
```
