### PR TITLE
fix: return copy of api version/info to avoid data race

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/version/version.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/version/version.go
@@ -467,13 +467,14 @@ func (v *Version) Info() *apimachineryversion.Info {
 	if v == nil {
 		return nil
 	}
+	result := v.info
 	// in case info is empty, or the major and minor in info is different from the actual major and minor
-	v.info.Major = itoa(v.Major())
-	v.info.Minor = itoa(v.Minor())
-	if v.info.GitVersion == "" {
-		v.info.GitVersion = v.String()
+	result.Major = itoa(v.Major())
+	result.Minor = itoa(v.Minor())
+	if result.GitVersion == "" {
+		result.GitVersion = v.String()
 	}
-	return &v.info
+	return &result
 }
 
 func itoa(i uint) string {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
/king regression

#### What this PR does / why we need it:
A data race was detected with golang race detector with Info() as it manipulates the internal Version. To remedy, return a copy of info.

#### Which issue(s) this PR fixes:


#### Special notes for your reviewer:
This is new in k8s 1.31 and was introduced in https://github.com/kubernetes/kubernetes/commit/4352c4ad2762#diff-f8b003ff625ac702e70a653181a893fcbd14b7bcf655c3d1d4d62842c37f8d56 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
