### PR TITLE
add OWNERS and README for zpages under component-base

### DIFF
--- a/staging/src/k8s.io/component-base/zpages/OWNERS
+++ b/staging/src/k8s.io/component-base/zpages/OWNERS
@@ -1,0 +1,9 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - sig-instrumentation-approvers
+  - logicalhan
+reviewers:
+  - sig-instrumentation-reviewers
+labels:
+  - sig/instrumentation

--- a/staging/src/k8s.io/component-base/zpages/README.md
+++ b/staging/src/k8s.io/component-base/zpages/README.md
@@ -1,0 +1,9 @@
+## z-pages
+
+## Purpose
+
+<!---
+TODO: Placeholder README. Add more details, KEP for z-pags here.
+--> 
+
+The purpose of this effort is to enhance the observability, troubleshooting, and debugging capabilities of core Kubernetes components by integrating with a suite of z-pages. This will provide a standardized, low-overhead way to expose internal component metrics, runtime statistics, and configuration details, enabling users to gain deeper insights into the behavior and performance of the core components.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind documentation

#### What this PR does / why we need it:
Adds a separate directory for z-pages under component-base.

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
- Issue: https://github.com/kubernetes/enhancements/issues/4827
- KEP: https://github.com/kubernetes/enhancements/pull/4830
- Discussion: [link](https://docs.google.com/document/d/1lJKbb9nLzJWnJgZdMxNv2CVAWFh24uuzoR0P-ZvWLUs/edit?usp=sharing) 

