### PR TITLE
Fix Typo in metrics docs

### DIFF
--- a/test/instrumentation/documentation/documentation.md
+++ b/test/instrumentation/documentation/documentation.md
@@ -1552,14 +1552,14 @@ Alpha metrics do not have any API guarantees. These metrics must be used at your
 	</ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">ephemeral_volume_controller_create_failures_total</div>
-	<div class="metric_help">Number of PersistenVolumeClaims creation requests</div>
+	<div class="metric_help">Number of PersistentVolumeClaims creation requests</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
 	</ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">ephemeral_volume_controller_create_total</div>
-	<div class="metric_help">Number of PersistenVolumeClaims creation requests</div>
+	<div class="metric_help">Number of PersistentVolumeClaims creation requests</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>


### PR DESCRIPTION
Fix typo Persisten -> Persistent in metrics docs.

I previously opened a PR in the website repo to change this, but I was made aware that I was editing the autogenerated output files directly and linked [here](https://kubernetes.io/docs/contribute/generate-ref-docs/metrics-reference/) .

The information at the link is perhaps not quite as clear as it could be, My undetstanding is that the change needs to be made in this repo, and then generate the docs and add to `website` repo. Is that correct?