### PR TITLE
remove redundant code

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/scheme.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/scheme.go
@@ -120,7 +120,6 @@ func (s *Scheme) Converter() *conversion.Converter {
 // TODO: there is discussion about removing unversioned and replacing it with objects that are manifest into
 // every version with particular schemas. Resolve this method at that point.
 func (s *Scheme) AddUnversionedTypes(version schema.GroupVersion, types ...Object) {
-	s.addObservedVersion(version)
 	s.AddKnownTypes(version, types...)
 	for _, obj := range types {
 		t := reflect.TypeOf(obj).Elem()

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/scheme.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/scheme.go
@@ -137,7 +137,6 @@ func (s *Scheme) AddUnversionedTypes(version schema.GroupVersion, types ...Objec
 // the struct becomes the "kind" field when encoding. Version may not be empty - use the
 // APIVersionInternal constant if you have a type that does not have a formal version.
 func (s *Scheme) AddKnownTypes(gv schema.GroupVersion, types ...Object) {
-	s.addObservedVersion(gv)
 	for _, obj := range types {
 		t := reflect.TypeOf(obj)
 		if t.Kind() != reflect.Pointer {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

As `addObservedVersion()` is already called in `AddKnownTypeWithName()`, we do not need to call `addObservedVersion()` before `AddKnownTypeWithName()`.