### PR TITLE
perf: optimize the `GetPodServiceMemberships` function

### DIFF
--- a/staging/src/k8s.io/endpointslice/util/controller_utils.go
+++ b/staging/src/k8s.io/endpointslice/util/controller_utils.go
@@ -61,11 +61,12 @@ func GetPodServiceMemberships(serviceLister v1listers.ServiceLister, pod *v1.Pod
 			// if the service has a nil selector this means selectors match nothing, not everything.
 			continue
 		}
-		key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(service)
-		if err != nil {
-			return nil, err
-		}
+
 		if labels.ValidatedSetSelector(service.Spec.Selector).Matches(labels.Set(pod.Labels)) {
+			key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(service)
+			if err != nil {
+				return nil, err
+			}
 			set.Insert(key)
 		}
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
If the service is not the pod's membership(service selector not match pod label), it seems unnecessary to get the `key`. And `cache.DeletionHandlingMetaNamespaceKeyFunc` needs to do reflection, it will do unnecessary operations

```
goos: darwin
goarch: arm64
pkg: k8s.io/endpointslice/util
BenchmarkGetPodServiceMemberships
BenchmarkGetPodServiceMemberships-8   	    9835	    119421 ns/op
```

after optimized:
```
goos: darwin
goarch: arm64
pkg: k8s.io/endpointslice/util
BenchmarkGetPodServiceMemberships
BenchmarkGetPodServiceMemberships-8   	   12853	     90160 ns/op
```


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
None
```

