### PR TITLE
refactor: Dynamic maxJitter value based on token TTL

### DIFF
--- a/pkg/kubelet/token/token_manager.go
+++ b/pkg/kubelet/token/token_manager.go
@@ -37,9 +37,8 @@ import (
 )
 
 const (
-	maxTTL    = 24 * time.Hour
-	gcPeriod  = time.Minute
-	maxJitter = 10 * time.Second
+	maxTTL   = 24 * time.Hour
+	gcPeriod = time.Minute
 )
 
 // NewManager returns a new token manager.
@@ -175,11 +174,19 @@ func (m *Manager) requiresRefresh(tr *authenticationv1.TokenRequest) bool {
 		klog.ErrorS(nil, "Expiration seconds was nil for token request", "tokenRequest", cpy)
 		return false
 	}
+
 	now := m.clock.Now()
 	exp := tr.Status.ExpirationTimestamp.Time
 	iat := exp.Add(-1 * time.Duration(*tr.Spec.ExpirationSeconds) * time.Second)
 
-	jitter := time.Duration(rand.Float64()*maxJitter.Seconds()) * time.Second
+	// maxJitter is set to the smaller of 10% of the token's lifetime or 5 minutes.
+	maxJitter := float64(*tr.Spec.ExpirationSeconds) / 10
+	if maxJitter > 300 {
+		maxJitter = 300
+	}
+
+	jitter := time.Duration(rand.Float64()*maxJitter) * time.Second
+
 	if now.After(iat.Add(maxTTL - jitter)) {
 		return true
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Dynamically calculates `maxJitter` based on token TTL to reduce synchronized token refresh traffic spikes. This change addresses the issue where fixed jitter values led to predictable and concentrated refresh requests.

#### Which issue(s) this PR fixes:
Fixes #124646

#### Special notes for your reviewer:
NONE

#### Does this PR introduce a user-facing change?
NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
NONE
