### PR TITLE
Improve Job Controller Performance

### DIFF
--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -767,6 +767,7 @@ func (jm *Controller) syncJob(ctx context.Context, key string) (rErr error) {
 	// if job was finished previously, we don't want to redo the termination
 	if util.IsJobFinished(&job) {
 		// The job shouldn't be marked as finished until all pod finalizers are removed.
+		// Cleaning pod finalizers one more time just in case.
 		jm.cleanupPodFinalizers(&job)
 		err := jm.podBackoffStore.removeBackoffRecord(key)
 		if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
/kind regression


#### What this PR does / why we need it:

Following up on this - https://github.com/kubernetes/kubernetes/issues/126510#issuecomment-2265947469

This PR helps improve the Job controller performance in sync path 

With this change, I have seen at least the update event handler sync path for job controller performance p99 increased by at least `128X` for cluster with `10k+ jobs`.

Cluster with similar load for Job Update event handler number w/o this change has `p99 13.02 ms` (vs) cluster w similar load for Job update event handler w this change has `p99 0.1024ms` i.e 12600% faster.

```
job_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="update",le="0.1"} 0
job_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="update",le="0.2"} 0
job_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="update",le="0.4"} 0
job_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="update",le="0.8"} 0
job_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="update",le="1.6"} 0
job_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="update",le="3.2"} 0
job_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="update",le="6.4"} 0
job_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="update",le="12.8"} 116917
job_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="update",le="25.6"} 291934
job_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="update",le="51.2"} 404434
job_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="update",le="102.4"} 589226
job_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="update",le="204.8"} 625432
job_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="update",le="409.6"} 633231
job_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="update",le="819.2"} 635917
job_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="update",le="1638.4"} 636703
job_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="update",le="3276.8"} 647305
job_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="update",le="6553.6"} 820939
job_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="update",le="13107.2"} 948647
job_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="update",le="26214.4"} 955181
job_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="update",le="52428.8"} 955999
job_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="update",le="+Inf"} 956053
job_controller_event_handling_duration_microseconds_sum{resource="jobs",type="update"} 2.148933816e+09
job_controller_event_handling_duration_microseconds_count{resource="jobs",type="update"} 956053
```



#### Comparing the update sync path of Job controller (vs) ttl-finished controller which pretty much acts on incoming job event handling notifications.

```
job_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="update",le="0.1"} 0
job_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="update",le="0.2"} 0
job_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="update",le="0.4"} 0
job_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="update",le="0.8"} 0
job_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="update",le="1.6"} 0
job_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="update",le="3.2"} 0
job_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="update",le="6.4"} 132254
job_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="update",le="12.8"} 384777
job_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="update",le="25.6"} 742505
job_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="update",le="51.2"} 850312
job_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="update",le="102.4"} 861308
job_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="update",le="204.8"} 863176
job_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="update",le="409.6"} 863448
job_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="update",le="819.2"} 863526
job_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="update",le="1638.4"} 863584
job_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="update",le="3276.8"} 863615
job_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="update",le="6553.6"} 863629
job_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="update",le="13107.2"} 863639
job_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="update",le="26214.4"} 863650
job_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="update",le="52428.8"} 863651
job_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="update",le="+Inf"} 863651

job_controller_event_handling_duration_microseconds_sum{resource="jobs",type="update"} 1.4756581e+07
job_controller_event_handling_duration_microseconds_count{resource="jobs",type="update"} 863651

```

```
ttl_after_finished_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="update",le="0.1"} 47818
ttl_after_finished_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="update",le="0.2"} 47818
ttl_after_finished_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="update",le="0.4"} 47818
ttl_after_finished_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="update",le="0.8"} 47818
ttl_after_finished_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="update",le="1.6"} 275487
ttl_after_finished_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="update",le="3.2"} 642007
ttl_after_finished_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="update",le="6.4"} 816296
ttl_after_finished_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="update",le="12.8"} 871174
ttl_after_finished_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="update",le="25.6"} 879438
ttl_after_finished_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="update",le="51.2"} 880307
ttl_after_finished_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="update",le="102.4"} 880444
ttl_after_finished_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="update",le="204.8"} 880559
ttl_after_finished_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="update",le="409.6"} 880621
ttl_after_finished_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="update",le="819.2"} 880648
ttl_after_finished_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="update",le="1638.4"} 880668
ttl_after_finished_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="update",le="3276.8"} 880679
ttl_after_finished_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="update",le="6553.6"} 880682
ttl_after_finished_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="update",le="13107.2"} 880683
ttl_after_finished_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="update",le="26214.4"} 880683
ttl_after_finished_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="update",le="52428.8"} 880684
ttl_after_finished_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="update",le="+Inf"} 880684
ttl_after_finished_controller_event_handling_duration_microseconds_sum{resource="jobs",type="update"} 2.706518e+06
ttl_after_finished_controller_event_handling_duration_microseconds_count{resource="jobs",type="update"} 880684

```

We can see that for  roughly handling around 880K update events,  two controllers p99 seems to be almost similar now 


i.e; p99 for `job update event handler` is b/w `0.0512 ms` and `0.1024ms` 
and  ttl-finished-controller update event handler is < `0.0512 ms` 



#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #126510



#### Special notes for your reviewer:

I haven't made changes to `job delete event handler`.  See the difference in performance b/w changes in `Job update handler` (VS) w/o changes in `job delete event handler`. See below data for `job delete event handler`  

 ```
 job_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="delete",le="0.1"} 0
job_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="delete",le="0.2"} 0
job_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="delete",le="0.4"} 0
job_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="delete",le="0.8"} 0
job_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="delete",le="1.6"} 0
job_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="delete",le="3.2"} 0
job_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="delete",le="6.4"} 0
job_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="delete",le="12.8"} 1
job_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="delete",le="25.6"} 114
job_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="delete",le="51.2"} 1229
job_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="delete",le="102.4"} 5322
job_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="delete",le="204.8"} 12645
job_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="delete",le="409.6"} 18345
job_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="delete",le="819.2"} 28267
job_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="delete",le="1638.4"} 41339
job_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="delete",le="3276.8"} 68261
job_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="delete",le="6553.6"} 92852
job_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="delete",le="13107.2"} 152230
job_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="delete",le="26214.4"} 178060
job_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="delete",le="52428.8"} 178870
job_controller_event_handling_duration_microseconds_bucket{resource="jobs",type="delete",le="+Inf"} 178896
job_controller_event_handling_duration_microseconds_sum{resource="jobs",type="delete"} 1.236442415e+09
job_controller_event_handling_duration_microseconds_count{resource="jobs",type="delete"} 178896

```

The p99 for `job delete event handler` for processing 178K notifications is roughly around `26.2144 ms` 

Performance has improved by approximately `255 times` when comparing `26.2144 ms` to `0.1024 ms` (though one is update and other is delete).


#### Thus with above data we can summarize that major bottleneck is  `cleanUpPodFinalizers` in sync path for Job controller and increases performance at least by double digit for 10k jobs or more and brings it closer to ttl-finished-controller handler duration time.


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Improve performance of the job controller when handling job update events.
```

