### PR TITLE
kubectl debug: warning message about legacy profile

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go
@@ -401,7 +401,7 @@ func (o *DebugOptions) Validate() error {
 
 	// Warning for legacy profile
 	if o.Profile == ProfileLegacy {
-		fmt.Fprintln(o.ErrOut, "Legacy profile is planned to be deprecated in the near future. It is recommended to specify other profiles such as \"--profile=general\".")
+		fmt.Fprintln(o.ErrOut, `Legacy profile is planned to be deprecated in the near future. It is recommended to specify other profiles such as "--profile=general".`)
 	}
 
 	return nil

--- a/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go
@@ -399,6 +399,11 @@ func (o *DebugOptions) Validate() error {
 		}
 	}
 
+	// Warning for legacy profile
+	if o.Profile == ProfileLegacy {
+		fmt.Fprintln(o.ErrOut, "Legacy profile is planned to be deprecated in the near future. It is recommended to specify other profiles such as \"--profile=general\".")
+	}
+
 	return nil
 }
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go
@@ -401,7 +401,7 @@ func (o *DebugOptions) Validate() error {
 
 	// Warning for legacy profile
 	if o.Profile == ProfileLegacy {
-		fmt.Fprintln(o.ErrOut, `Legacy profile is planned to be deprecated in the near future. It is recommended to specify other profiles such as "--profile=general".`)
+		fmt.Fprintln(o.ErrOut, `--profile=legacy is deprecated and will be removed in the future. It is recommended to explicitly specify a profile, for example "--profile=general".`)
 	}
 
 	return nil


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
As discussed in https://github.com/kubernetes/kubernetes/pull/123149#discussion_r1600979662 and described in [docs](https://kubernetes.io/docs/tasks/debug/debug-application/debug-running-pod/#debugging-profiles) , the `legacy` profile is planned to be deprecated.
In this PR, I've added a warning message about the `legacy` profile to inform users that the `legacy` profile is planned to be deprecated.


```bash
$ kubectl debug -it mypod --image busybox --target mypod -- sh
Targeting container "mypod". If you don't see processes from this container it may be because the container runtime doesn't support this feature.
Legacy profile is planned to be deprecated in the near future. It is recommended to specify other profiles such as "--profile=general".
```


#### Which issue(s) this PR fixes:


#### Special notes for your reviewer:
The `auto` profile is planned to be the default profile for `kubectl debug`.([KEP-1441](https://github.com/kubernetes/enhancements/tree/master/keps/sig-cli/1441-kubectl-debug#default-profile-and-automation-selection))
However, the `auto` profile is WIP( #120687 ) and not yet implemented.

IMO: We should change the default profile from `legacy` to `auto` and move `legacy` to deprecated after `auto` becomes ready. And I think showing this message is appropriate step while transitioning the `legacy` profile to deprecated and remove.

#### Does this PR introduce a user-facing change?

```release-note
Show a warning message to inform users that the `legacy` profile is planned to be deprecated.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
https://github.com/kubernetes/enhancements/tree/master/keps/sig-cli/1441-kubectl-debug#default-profile-and-automation-selection
```
