### PR TITLE
Add scheduler_perf test case for queueing hints memory leak scenario

### DIFF
--- a/test/integration/scheduler_perf/config/performance-config.yaml
+++ b/test/integration/scheduler_perf/config/performance-config.yaml
@@ -1383,3 +1383,39 @@
     params:
       gatedPods: 10000
       measurePods: 20000
+
+# This test case simulates the scheduling when pods selected to schedule have deletionTimestamp set.
+# There was a memory leak related to this path of code fixed in:
+# https://github.com/kubernetes/kubernetes/pull/126962
+# Main goal of this test case is to verify if InFlightEvents is empty after the test.
+- name: SchedulingDeletedPodsWithFinalizers
+  featureGates:
+    SchedulerQueueingHints: true
+  defaultPodTemplatePath: config/templates/light-pod.yaml
+  workloadTemplate:
+  - opcode: createNodes
+    countParam: $initNodes
+  - opcode: createPods
+    # Create pods with finalizers and delete them before they are scheduled.
+    # DeletionTimestamp field should be populated then, 
+    # but a few pods should still be chosen into the scheduling.
+    countParam: $deletingPods
+    podTemplatePath: config/templates/pod-with-finalizer.yaml
+    skipWaitToCompletion: true
+    deletePodsPerSecond: 100
+  - opcode: createPods
+    countParam: $measurePods
+    collectMetrics: true
+  workloads:
+  - name: 10Node_100DeletingPods
+    labels: [integration-test, fast]
+    params:
+      initNodes: 10
+      deletingPods: 100
+      measurePods: 10
+  - name: 1000Node_1000DeletingPods
+    labels: [performance, fast]
+    params:
+      initNodes: 1000
+      deletingPods: 1000
+      measurePods: 1000

--- a/test/integration/scheduler_perf/config/templates/pod-with-finalizer.yaml
+++ b/test/integration/scheduler_perf/config/templates/pod-with-finalizer.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  generateName: pod-
+  finalizers:
+  - test.k8s.io/finalizer
+spec:
+  containers:
+  - image: registry.k8s.io/pause:3.10
+    name: pause


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

This PR adds a test case, which is reproducing the issue fixed in #126962. By deleting not yet scheduled pods with finalizers, the `skipPodSchedule` function in scheduling cycle could be called for some of them. Main purpose of this case is to measure if inFlightEvents is empty at the end of the test, which is added in #127154. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #120622

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
