### PR TITLE
Make scheduler_perf integration tests shorter

### DIFF
--- a/test/integration/scheduler_perf/config/performance-config.yaml
+++ b/test/integration/scheduler_perf/config/performance-config.yaml
@@ -35,7 +35,7 @@
       initPods: 5
       measurePods: 10
   - name: 500Nodes
-    labels: [integration-test, fast]
+    labels: [fast]
     params:
       initNodes: 500
       initPods: 500
@@ -77,7 +77,7 @@
       initPods: 1
       measurePods: 4
   - name: 500Nodes
-    labels: [integration-test, fast]
+    labels: [fast]
     params:
       initNodes: 500
       initPods: 100
@@ -114,7 +114,7 @@
       initPods: 5
       measurePods: 10
   - name: 500Nodes
-    labels: [integration-test, fast]
+    labels: [fast]
     params:
       initNodes: 500
       initPods: 500
@@ -154,7 +154,7 @@
       initPods: 5
       measurePods: 10
   - name: 500Nodes
-    labels: [integration-test, performance, fast]
+    labels: [performance, fast]
     params:
       initNodes: 500
       initPods: 500
@@ -203,7 +203,7 @@
       initPods: 5
       measurePods: 10
   - name: 500Nodes
-    labels: [integration-test, performance, fast]
+    labels: [performance, fast]
     params:
       initNodes: 500
       initPods: 500
@@ -250,7 +250,7 @@
       initPods: 5
       measurePods: 10
   - name: 500Nodes
-    labels: [integration-test, performance, fast]
+    labels: [performance, fast]
     params:
       initNodes: 500
       initPods: 500
@@ -296,7 +296,7 @@
       initPods: 5
       measurePods: 10
   - name: 500Nodes
-    labels: [integration-test, fast]
+    labels: [fast]
     params:
       initNodes: 500
       initPods: 500
@@ -338,7 +338,7 @@
       initPods: 5
       measurePods: 10
   - name: 500Nodes
-    labels: [integration-test, performance, fast]
+    labels: [performance, fast]
     params:
       initNodes: 500
       initPods: 500
@@ -380,7 +380,7 @@
       initPods: 5
       measurePods: 10
   - name: 500Nodes
-    labels: [integration-test, fast]
+    labels: [fast]
     params:
       initNodes: 500
       initPods: 500
@@ -454,7 +454,7 @@
       initPods: 5
       measurePods: 10
   - name: 500Nodes
-    labels: [integration-test, fast]
+    labels: [fast]
     params:
       initNodes: 500
       initPods: 500
@@ -496,7 +496,7 @@
       initPods: 10
       measurePods: 10
   - name: 500Nodes
-    labels: [integration-test, fast]
+    labels: [fast]
     params:
       initNodes: 500
       initPods: 1000
@@ -538,7 +538,7 @@
       initPods: 10
       measurePods: 10
   - name: 500Nodes
-    labels: [integration-test, performance, fast]
+    labels: [performance, fast]
     params:
       initNodes: 500
       initPods: 1000
@@ -599,7 +599,7 @@
       initPods: 2
       measurePods: 10
   - name: 500Nodes
-    labels: [integration-test, performance, fast]
+    labels: [performance, fast]
     params:
       initNodes: 500
       initPods: 200
@@ -708,7 +708,7 @@
       initPods: 2
       measurePods: 10
   - name: 500Nodes/200InitPods
-    labels: [integration-test, fast]
+    labels: [fast]
     params:
       initNodes: 500
       initPods: 200
@@ -755,7 +755,7 @@
       initNodes: 10
       measurePods: 100
   - name: 1000Nodes
-    labels: [integration-test, fast]
+    labels: [fast]
     params:
       initNodes: 1000
       measurePods: 1000
@@ -1011,7 +1011,7 @@
       normalNodes: 4
       measurePods: 4
   - name: 500Nodes
-    labels: [integration-test, fast]
+    labels: [fast]
     params:
       taintNodes: 100
       normalNodes: 400


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

Unfortunately, the integration tests running in ci-kubernetes-integration-master have a timeout set to 10 minutes, so it's needed to remove the `integration-test` label from all mid-sized workloads. If it still would take too long, in the next PR I'll have to remove a few test cases from running as integration. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Probably #127178

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
