### PR TITLE
API emulation versioning honors cohabitating resources

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/storage/resource_encoding_config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/storage/resource_encoding_config.go
@@ -130,13 +130,24 @@ func emulatedStorageVersion(binaryVersionOfResource schema.GroupVersion, example
 	gvks, _, err := scheme.ObjectKinds(example)
 	if err != nil {
 		return schema.GroupVersion{}, err
-	} else if len(gvks) == 0 {
-		// Probably shouldn't happen if err is non-nil
+	}
+
+	var gvk schema.GroupVersionKind
+	for _, item := range gvks {
+		if item.Group != binaryVersionOfResource.Group {
+			continue
+		}
+
+		gvk = item
+		break
+	}
+
+	if len(gvk.Kind) == 0 {
 		return schema.GroupVersion{}, fmt.Errorf("object %T has no GVKs registered in scheme", example)
 	}
 
 	// VersionsForGroupKind returns versions in priority order
-	versions := scheme.VersionsForGroupKind(schema.GroupKind{Group: gvks[0].Group, Kind: gvks[0].Kind})
+	versions := scheme.VersionsForGroupKind(schema.GroupKind{Group: gvk.Group, Kind: gvk.Kind})
 
 	compatibilityVersion := effectiveVersion.MinCompatibilityVersion()
 
@@ -148,7 +159,7 @@ func emulatedStorageVersion(binaryVersionOfResource schema.GroupVersion, example
 		gvk := schema.GroupVersionKind{
 			Group:   gv.Group,
 			Version: gv.Version,
-			Kind:    gvks[0].Kind,
+			Kind:    gvk.Kind,
 		}
 
 		exampleOfGVK, err := scheme.New(gvk)

--- a/staging/src/k8s.io/apiserver/pkg/server/storage/storage_factory.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/storage/storage_factory.go
@@ -245,7 +245,7 @@ func (s *DefaultStorageFactory) NewConfig(groupResource schema.GroupResource, ex
 
 	var err error
 	if backwardCompatibleInterface, ok := s.ResourceEncodingConfig.(CompatibilityResourceEncodingConfig); ok {
-		codecConfig.StorageVersion, err = backwardCompatibleInterface.BackwardCompatibileStorageEncodingFor(groupResource, example)
+		codecConfig.StorageVersion, err = backwardCompatibleInterface.BackwardCompatibileStorageEncodingFor(chosenStorageResource, example)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind regression
/sig api-machinery


#### What this PR does / why we need it:
API emulation versioning seems break Cohabitating Resources overwriting. it seems a regression introduced in https://github.com/kubernetes/kubernetes/commit/403301bfdf2c7312591077827abd2e72f445a53a#diff-df88db6cbb681f73f6ac0a2979ce70b6d8f812e05c5064de760cd7d90d9b1f1bR248



#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #127232

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Fixes a 1.31 regression with API emulation versioning honors cohabitating resources
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```