### PR TITLE
With feature gate

### DIFF
--- a/test/e2e/network/service_cidrs.go
+++ b/test/e2e/network/service_cidrs.go
@@ -61,7 +61,7 @@ var _ = common.SIGDescribe(feature.ServiceCIDRs, framework.WithFeatureGate(featu
 
 	})
 
-	ginkgo.It("should create Services and servce on different Service CIDRs", func(ctx context.Context) {
+	ginkgo.It("should create Services and serve on different Service CIDRs", func(ctx context.Context) {
 		// create a new service CIDR
 		svcCIDR := &networkingv1beta1.ServiceCIDR{
 			ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/network/service_cidrs.go
+++ b/test/e2e/network/service_cidrs.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/test/e2e/feature"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
@@ -36,7 +37,7 @@ import (
 	admissionapi "k8s.io/pod-security-admission/api"
 )
 
-var _ = common.SIGDescribe(feature.ServiceCIDRs, func() {
+var _ = common.SIGDescribe(feature.ServiceCIDRs, framework.WithFeatureGate(features.MultiCIDRServiceAllocator), func() {
 
 	fr := framework.NewDefaultFramework("servicecidrs")
 	fr.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged


### PR DESCRIPTION

/kind cleanup
```release-note
NONE
```
Spotted by @adrianmoisey , the ServiceCIDR was wrongly using the `WithFeature` method instead the `WithFeatureGate`.

`WithFeature` means: "your cluster under test needs some extra configuration or characteristics to be able to run these tests"
however
`WithFeatureGate` means: "your cluster under test requires this feature to be enabled, e2e does not know about the features that are running, so is going to tag the test with the level of stability the feature gate has (alpha or beta)

