### PR TITLE
Fix invalid label use in validatingadmissionpolicy e2e

### DIFF
--- a/test/e2e/apimachinery/validatingadmissionpolicy.go
+++ b/test/e2e/apimachinery/validatingadmissionpolicy.go
@@ -367,8 +367,8 @@ var _ = SIGDescribe("ValidatingAdmissionPolicy [Privileged:ClusterAdmin]", func(
 					// If the warnings are empty, touch the policy to retry type checking
 					if len(policy.Status.TypeChecking.ExpressionWarnings) == 0 {
 						applyConfig := applyadmissionregistrationv1.ValidatingAdmissionPolicy(policy.Name).WithLabels(map[string]string{
-							"touched": time.Now().String(),
-							"random":  fmt.Sprintf("%d", rand.Int()),
+							"touched": fmt.Sprintf("a%d", time.Now().UnixMilli()),
+							"random":  fmt.Sprintf("a%d", rand.Int()),
 						})
 						_, err := client.AdmissionregistrationV1().ValidatingAdmissionPolicies().Apply(ctx, applyConfig, metav1.ApplyOptions{FieldManager: "validatingadmissionpolicy-e2e"})
 						return false, err


### PR DESCRIPTION
If this fallback code was hit, it would always fail due to invalid text
in a label.

Failure would surface as:

```
 [sig-api-machinery] ValidatingAdmissionPolicy [Privileged:ClusterAdmin] should type check a CRD [Suite:openshift/conformance/parallel] [Suite:k8s] expand_less
Run #0: Failed expand_less 	1s
{  fail [k8s.io/kubernetes/test/e2e/apimachinery/validatingadmissionpolicy.go:380]: wait for type checking: ValidatingAdmissionPolicy.admissionregistration.k8s.io "e2e-validating-admission-policy-9124.confused-crd-policy.example.com" is invalid: metadata.labels: Invalid value: "2024-09-09 06:17:56.154972722 +0000 UTC m=+0.729477367": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')
Error: exit with code 1
Ginkgo exit error 1: exit with code 1}
```


```release-note
NONE
```