### PR TITLE
Kubelet: DRA: fix testify errors

### DIFF
--- a/pkg/kubelet/cm/dra/claiminfo_test.go
+++ b/pkg/kubelet/cm/dra/claiminfo_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	resourceapi "k8s.io/api/resource/v1alpha3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -307,7 +308,7 @@ func TestClaimInfoHasPodReference(t *testing.T) {
 		},
 	} {
 		t.Run(test.description, func(t *testing.T) {
-			assert.Equal(t, test.claimInfo.hasPodReference(podUID), test.expectedResult)
+			assert.Equal(t, test.expectedResult, test.claimInfo.hasPodReference(podUID))
 		})
 	}
 }
@@ -401,7 +402,7 @@ func TestClaimInfoIsPrepared(t *testing.T) {
 		},
 	} {
 		t.Run(test.description, func(t *testing.T) {
-			assert.Equal(t, test.claimInfo.isPrepared(), test.expectedResult)
+			assert.Equal(t, test.expectedResult, test.claimInfo.isPrepared())
 		})
 	}
 }
@@ -440,7 +441,7 @@ func TestNewClaimInfoCache(t *testing.T) {
 				assert.Error(t, err)
 				return
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.NotNil(t, result)
 		})
 	}
@@ -494,7 +495,7 @@ func TestClaimInfoCacheWithLock(t *testing.T) {
 	} {
 		t.Run(test.description, func(t *testing.T) {
 			cache, err := newClaimInfoCache(t.TempDir(), "test-checkpoint")
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.NotNil(t, cache)
 			err = cache.withLock(test.funcGen(cache))
 			if test.wantErr {
@@ -554,7 +555,7 @@ func TestClaimInfoCacheWithRLock(t *testing.T) {
 	} {
 		t.Run(test.description, func(t *testing.T) {
 			cache, err := newClaimInfoCache(t.TempDir(), "test-checkpoint")
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.NotNil(t, cache)
 			err = cache.withRLock(test.funcGen(cache))
 			if test.wantErr {
@@ -583,7 +584,7 @@ func TestClaimInfoCacheAdd(t *testing.T) {
 	} {
 		t.Run(test.description, func(t *testing.T) {
 			cache, err := newClaimInfoCache(t.TempDir(), "test-checkpoint")
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.NotNil(t, cache)
 			cache.add(test.claimInfo)
 			assert.True(t, cache.contains(test.claimInfo.ClaimName, test.claimInfo.Namespace))
@@ -754,13 +755,13 @@ func TestSyncToCheckpoint(t *testing.T) {
 	} {
 		t.Run(test.description, func(t *testing.T) {
 			cache, err := newClaimInfoCache(test.stateDir, test.checkpointName)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			err = cache.syncToCheckpoint()
 			if test.wantErr {
 				assert.Error(t, err)
 				return
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		})
 	}
 }

--- a/pkg/kubelet/cm/dra/manager_test.go
+++ b/pkg/kubelet/cm/dra/manager_test.go
@@ -196,7 +196,7 @@ func TestNewManagerImpl(t *testing.T) {
 				return
 			}
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.NotNil(t, manager.cache)
 			assert.NotNil(t, manager.kubeClient)
 		})
@@ -355,7 +355,7 @@ func TestGetResources(t *testing.T) {
 	} {
 		t.Run(test.description, func(t *testing.T) {
 			manager, err := NewManagerImpl(kubeClient, t.TempDir(), "worker")
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			if test.claimInfo != nil {
 				manager.cache.add(test.claimInfo)
@@ -593,7 +593,7 @@ func TestPrepareResources(t *testing.T) {
 				return // PrepareResources returned an error so stopping the test case here
 			}
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			if test.wantResourceSkipped {
 				return // resource skipped so no need to continue
@@ -735,7 +735,7 @@ func TestUnprepareResources(t *testing.T) {
 				return // PrepareResources returned an error so stopping the test case here
 			}
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			if test.wantResourceSkipped {
 				return // resource skipped so no need to continue
@@ -859,7 +859,7 @@ func TestGetContainerClaimInfos(t *testing.T) {
 				return
 			}
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Len(t, claimInfos, 1)
 			assert.Equal(t, test.expectedClaimName, claimInfos[0].ClaimInfoState.ClaimName)
 		})

--- a/pkg/kubelet/cm/dra/plugin/plugin_test.go
+++ b/pkg/kubelet/cm/dra/plugin/plugin_test.go
@@ -223,7 +223,7 @@ func TestNewDRAPluginClient(t *testing.T) {
 				assert.Error(t, err)
 			} else {
 				assert.NotNil(t, client)
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 			}
 		})
 	}


### PR DESCRIPTION


#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

It fixes the following testify errors found by the [testify-lint](https://github.com/Antonboom/testifylint):

```
pkg/kubelet/cm/dra/claiminfo_test.go:310:4: expected-actual: need to reverse actual and expected values
pkg/kubelet/cm/dra/claiminfo_test.go:404:4: expected-actual: need to reverse actual and expected values
pkg/kubelet/cm/dra/manager_test.go:738:4: require-error: for error assertions use require
pkg/kubelet/cm/dra/manager_test.go:862:4: require-error: for error assertions use require
pkg/kubelet/cm/dra/claiminfo_test.go:757:4: require-error: for error assertions use require
pkg/kubelet/cm/dra/manager_test.go:199:4: require-error: for error assertions use require
pkg/kubelet/cm/dra/manager_test.go:596:4: require-error: for error assertions use require
pkg/kubelet/cm/dra/claiminfo_test.go:443:4: require-error: for error assertions use require
pkg/kubelet/cm/dra/claiminfo_test.go:497:4: require-error: for error assertions use require
pkg/kubelet/cm/dra/claiminfo_test.go:557:4: require-error: for error assertions use require
pkg/kubelet/cm/dra/claiminfo_test.go:586:4: require-error: for error assertions use require
pkg/kubelet/cm/dra/manager_test.go:358:4: require-error: for error assertions use require
pkg/kubelet/cm/dra/plugin/plugin_test.go:226:5: error-nil: use assert.NoError
```

#### Does this PR introduce a user-facing change?

```release-note
NONE
```