### PR TITLE
Fix go vet errors in e2e_node test files

### DIFF
--- a/test/e2e/framework/skipper/skipper.go
+++ b/test/e2e/framework/skipper/skipper.go
@@ -46,6 +46,9 @@ func Skipf(format string, args ...interface{}) {
 	panic("unreachable")
 }
 
+// Skip is an alias for ginkgo.Skip.
+var Skip = ginkgo.Skip
+
 // SkipUnlessAtLeast skips if the value is less than the minValue.
 func SkipUnlessAtLeast(value int, minValue int, message string) {
 	if value < minValue {

--- a/test/e2e_node/system_node_critical_test.go
+++ b/test/e2e_node/system_node_critical_test.go
@@ -18,6 +18,7 @@ package e2enode
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -90,8 +91,7 @@ var _ = SIGDescribe("SystemNodeCriticalPod", framework.WithSlow(), framework.Wit
 						return nil
 					}
 					msg := fmt.Sprintf("NodeCondition: %s not encountered yet", v1.NodeDiskPressure)
-					framework.Logf(msg)
-					return fmt.Errorf(msg)
+					return errors.New(msg)
 				}, time.Minute*2, time.Second*4).Should(gomega.Succeed())
 
 				ginkgo.By("check if it's running all the time")
@@ -100,7 +100,7 @@ var _ = SIGDescribe("SystemNodeCriticalPod", framework.WithSlow(), framework.Wit
 					if err == nil {
 						framework.Logf("mirror pod %q is running", mirrorPodName)
 					} else {
-						framework.Logf(err.Error())
+						framework.Logf("%s", err.Error())
 					}
 					return err
 				}, time.Minute*8, time.Second*4).ShouldNot(gomega.HaveOccurred())

--- a/test/e2e_node/util_sriov.go
+++ b/test/e2e_node/util_sriov.go
@@ -42,8 +42,8 @@ func requireSRIOVDevices() {
 
 	msg := "this test is meant to run on a system with at least one configured VF from SRIOV device"
 	if framework.TestContext.RequireDevices {
-		framework.Failf(msg)
+		framework.Fail(msg)
 	} else {
-		e2eskipper.Skipf(msg)
+		e2eskipper.Skip(msg)
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
related to issue https://github.com/kubernetes/kubernetes/issues/127191
Building of e2e_node.test binary is throwing below errors:
```
+ make cross
+++ [0909 18:02:50] Building go targets for linux/ppc64le
    k8s.io/apiextensions-apiserver (static)
    k8s.io/component-base/logs/kube-log-runner (static)
    k8s.io/kube-aggregator (static)
    k8s.io/kubernetes/cluster/gce/gci/mounter (static)
    k8s.io/kubernetes/cmd/kube-apiserver (static)
    k8s.io/kubernetes/cmd/kube-controller-manager (static)
    k8s.io/kubernetes/cmd/kube-proxy (static)
    k8s.io/kubernetes/cmd/kube-scheduler (static)
    k8s.io/kubernetes/cmd/kubeadm (static)
    k8s.io/kubernetes/cmd/kubelet (non-static)
+++ [0909 18:11:53] Building go targets for linux/ppc64le
    k8s.io/component-base/logs/kube-log-runner (static)
    k8s.io/kubernetes/cmd/kube-proxy (static)
    k8s.io/kubernetes/cmd/kubeadm (static)
    k8s.io/kubernetes/cmd/kubelet (non-static)
+++ [0909 18:12:15] Building go targets for linux/ppc64le
    k8s.io/kubernetes/cmd/kubectl (static)
    k8s.io/kubernetes/cmd/kubectl-convert (static)
+++ [0909 18:12:55] Building go targets for linux/ppc64le
    github.com/onsi/ginkgo/v2/ginkgo (non-static)
    k8s.io/kubernetes/test/conformance/image/go-runner (non-static)
    k8s.io/kubernetes/test/e2e/e2e.test (test)
+++ [0909 18:16:50] Building go targets for linux/ppc64le
    github.com/onsi/ginkgo/v2/ginkgo (non-static)
    k8s.io/kubernetes/cmd/kubemark (static)
    k8s.io/kubernetes/test/e2e_node/e2e_node.test (test)
# k8s.io/kubernetes/test/e2e_node
# [k8s.io/kubernetes/test/e2e_node]
test/e2e_node/util_sriov.go:45:19: non-constant format string in call to k8s.io/kubernetes/test/e2e/framework.Failf
test/e2e_node/util_sriov.go:47:20: non-constant format string in call to k8s.io/kubernetes/test/e2e/framework/skipper.Skipf
test/e2e_node/system_node_critical_test.go:93:21: non-constant format string in call to k8s.io/kubernetes/test/e2e/framework.Logf
test/e2e_node/system_node_critical_test.go:94:24: non-constant format string in call to fmt.Errorf
test/e2e_node/system_node_critical_test.go:103:22: non-constant format string in call to k8s.io/kubernetes/test/e2e/framework.Logf
!!! [0909 18:18:03] Call tree:
!!! [0909 18:18:03]  1: /home/prow/go/src/github.com/kubernetes/kubernetes/hack/lib/golang.sh:970 kube::golang::build_binaries_for_platform(...)
!!! [0909 18:18:03]  2: hack/make-rules/build.sh:28 kube::golang::build_binaries(...)
!!! [0909 18:18:03] Call tree:
!!! [0909 18:18:03]  1: hack/make-rules/build.sh:28 kube::golang::build_binaries(...)
make[1]: *** [Makefile:97: all] Error 1
make: *** [Makefile:494: cross] Error 1
```
This started occurring after golang commit `go version devel go1.24-de0aafa3c7 Wed Sep 4 20:42:05`