### PR TITLE
Promote Node lifecycle e2e test to Conformance

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -2267,6 +2267,15 @@
     be evicted if the taint is removed before toleration time ends.
   release: v1.16
   file: test/e2e/node/taints.go
+- testname: Node, resource lifecycle
+  codename: '[sig-node] Node Lifecycle should run through the lifecycle of a node
+    [Conformance]'
+  description: Creating and Reading a Node MUST succeed with required name retrieved.
+    Patching a Node MUST succeed with its new label found. Listing Nodes with a labelSelector
+    MUST succeed with only a single node found. Updating a Node MUST succeed with
+    its new label found. Deleting the Node MUST succeed and its deletion MUST be confirmed.
+  release: v1.32
+  file: test/e2e/node/node_lifecycle.go
 - testname: PodTemplate, delete a collection
   codename: '[sig-node] PodTemplates should delete a collection of pod templates [Conformance]'
   description: A set of Pod Templates is created with a label selector which MUST

--- a/test/e2e/node/node_lifecycle.go
+++ b/test/e2e/node/node_lifecycle.go
@@ -40,7 +40,15 @@ var _ = SIGDescribe("Node Lifecycle", func() {
 	f := framework.NewDefaultFramework("fake-node")
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 
-	ginkgo.It("should run through the lifecycle of a node", func(ctx context.Context) {
+	/*
+		Release: v1.32
+		Testname: Node, resource lifecycle
+		Description: Creating and Reading a Node MUST succeed with required name retrieved.
+		Patching a Node MUST succeed with its new label found. Listing Nodes with a labelSelector
+		MUST succeed with only a single node found. Updating a Node MUST succeed with
+		its new label found. Deleting the Node MUST succeed and its deletion MUST be confirmed.
+	*/
+	framework.ConformanceIt("should run through the lifecycle of a node", func(ctx context.Context) {
 		// the scope of this test only covers the api-server
 
 		nodeClient := f.ClientSet.CoreV1().Nodes()


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR promotes to Conformance the following endpoints in a recently added [e2e test](https://github.com/kubernetes/kubernetes/pull/126825):

- createCoreV1Node
- deleteCoreV1Node

#### Which issue(s) this PR fixes:

Fixes #126823

#### Testgrid Link:

[sig-release-master-blocking: should run through the lifecycle of a node](https://testgrid.k8s.io/sig-release-master-blocking#gce-cos-master-default&width=5&graph-metrics=test-duration-minutes&include-filter-by-regex=should.run.through.the.lifecycle.of.a.node)

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
/sig testing
/sig architecture
/area conformance