### PR TITLE
Partial cherrypick of #127271 to release-1.31 - use go1.22 runtime defaults

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,8 @@ module k8s.io/kubernetes
 
 go 1.22.0
 
+godebug default=go1.22
+
 require (
 	bitbucket.org/bertimus9/systemstat v0.5.0
 	github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab

--- a/go.work
+++ b/go.work
@@ -2,6 +2,8 @@
 
 go 1.22.0
 
+godebug default=go1.22
+
 use (
 	.
 	./staging/src/k8s.io/api

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -2,6 +2,8 @@ module k8s.io/kubernetes/hack/tools
 
 go 1.22.1
 
+godebug default=go1.22
+
 require (
 	github.com/aojea/sloppy-netparser v0.0.0-20210819225411-1b3bd8b3b975
 	github.com/cespare/prettybench v0.0.0-20150116022406-03b8cfe5406c

--- a/hack/tools/go.work
+++ b/hack/tools/go.work
@@ -3,4 +3,6 @@
 
 go 1.22.1
 
+godebug default=go1.22
+
 use .

--- a/staging/src/k8s.io/api/go.mod
+++ b/staging/src/k8s.io/api/go.mod
@@ -4,6 +4,8 @@ module k8s.io/api
 
 go 1.22.0
 
+godebug default=go1.22
+
 require (
 	github.com/gogo/protobuf v1.3.2
 	github.com/stretchr/testify v1.9.0

--- a/staging/src/k8s.io/apiextensions-apiserver/go.mod
+++ b/staging/src/k8s.io/apiextensions-apiserver/go.mod
@@ -4,6 +4,8 @@ module k8s.io/apiextensions-apiserver
 
 go 1.22.0
 
+godebug default=go1.22
+
 require (
 	github.com/emicklei/go-restful/v3 v3.11.0
 	github.com/gogo/protobuf v1.3.2

--- a/staging/src/k8s.io/apimachinery/go.mod
+++ b/staging/src/k8s.io/apimachinery/go.mod
@@ -4,6 +4,8 @@ module k8s.io/apimachinery
 
 go 1.22.0
 
+godebug default=go1.22
+
 require (
 	github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc

--- a/staging/src/k8s.io/apiserver/go.mod
+++ b/staging/src/k8s.io/apiserver/go.mod
@@ -4,6 +4,8 @@ module k8s.io/apiserver
 
 go 1.22.0
 
+godebug default=go1.22
+
 require (
 	github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a
 	github.com/coreos/go-oidc v2.2.1+incompatible

--- a/staging/src/k8s.io/cli-runtime/go.mod
+++ b/staging/src/k8s.io/cli-runtime/go.mod
@@ -4,6 +4,8 @@ module k8s.io/cli-runtime
 
 go 1.22.0
 
+godebug default=go1.22
+
 require (
 	github.com/google/gnostic-models v0.6.8
 	github.com/google/go-cmp v0.6.0

--- a/staging/src/k8s.io/client-go/go.mod
+++ b/staging/src/k8s.io/client-go/go.mod
@@ -4,6 +4,8 @@ module k8s.io/client-go
 
 go 1.22.0
 
+godebug default=go1.22
+
 require (
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da

--- a/staging/src/k8s.io/cloud-provider/go.mod
+++ b/staging/src/k8s.io/cloud-provider/go.mod
@@ -4,6 +4,8 @@ module k8s.io/cloud-provider
 
 go 1.22.0
 
+godebug default=go1.22
+
 require (
 	github.com/google/go-cmp v0.6.0
 	github.com/spf13/cobra v1.8.1

--- a/staging/src/k8s.io/cluster-bootstrap/go.mod
+++ b/staging/src/k8s.io/cluster-bootstrap/go.mod
@@ -4,6 +4,8 @@ module k8s.io/cluster-bootstrap
 
 go 1.22.0
 
+godebug default=go1.22
+
 require (
 	github.com/stretchr/testify v1.9.0
 	gopkg.in/square/go-jose.v2 v2.6.0

--- a/staging/src/k8s.io/code-generator/examples/go.mod
+++ b/staging/src/k8s.io/code-generator/examples/go.mod
@@ -4,6 +4,8 @@ module k8s.io/code-generator/examples
 
 go 1.22.0
 
+godebug default=go1.22
+
 require (
 	k8s.io/api v0.0.0
 	k8s.io/apimachinery v0.0.0

--- a/staging/src/k8s.io/code-generator/examples/go.work
+++ b/staging/src/k8s.io/code-generator/examples/go.work
@@ -3,4 +3,6 @@
 
 go 1.22.0
 
+godebug default=go1.22
+
 use .

--- a/staging/src/k8s.io/code-generator/go.mod
+++ b/staging/src/k8s.io/code-generator/go.mod
@@ -4,6 +4,8 @@ module k8s.io/code-generator
 
 go 1.22.0
 
+godebug default=go1.22
+
 require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/gogo/protobuf v1.3.2

--- a/staging/src/k8s.io/component-base/go.mod
+++ b/staging/src/k8s.io/component-base/go.mod
@@ -4,6 +4,8 @@ module k8s.io/component-base
 
 go 1.22.0
 
+godebug default=go1.22
+
 require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/go-logr/logr v1.4.2

--- a/staging/src/k8s.io/component-helpers/go.mod
+++ b/staging/src/k8s.io/component-helpers/go.mod
@@ -4,6 +4,8 @@ module k8s.io/component-helpers
 
 go 1.22.0
 
+godebug default=go1.22
+
 require (
 	github.com/google/go-cmp v0.6.0
 	github.com/stretchr/testify v1.9.0

--- a/staging/src/k8s.io/controller-manager/go.mod
+++ b/staging/src/k8s.io/controller-manager/go.mod
@@ -4,6 +4,8 @@ module k8s.io/controller-manager
 
 go 1.22.0
 
+godebug default=go1.22
+
 require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.9.0

--- a/staging/src/k8s.io/cri-api/go.mod
+++ b/staging/src/k8s.io/cri-api/go.mod
@@ -4,6 +4,8 @@ module k8s.io/cri-api
 
 go 1.22.0
 
+godebug default=go1.22
+
 require (
 	github.com/gogo/protobuf v1.3.2
 	github.com/stretchr/testify v1.9.0

--- a/staging/src/k8s.io/cri-client/go.mod
+++ b/staging/src/k8s.io/cri-client/go.mod
@@ -4,6 +4,8 @@ module k8s.io/cri-client
 
 go 1.22.0
 
+godebug default=go1.22
+
 require (
 	github.com/Microsoft/go-winio v0.6.0
 	github.com/fsnotify/fsnotify v1.7.0

--- a/staging/src/k8s.io/csi-translation-lib/go.mod
+++ b/staging/src/k8s.io/csi-translation-lib/go.mod
@@ -4,6 +4,8 @@ module k8s.io/csi-translation-lib
 
 go 1.22.0
 
+godebug default=go1.22
+
 require (
 	github.com/stretchr/testify v1.9.0
 	k8s.io/api v0.0.0

--- a/staging/src/k8s.io/dynamic-resource-allocation/go.mod
+++ b/staging/src/k8s.io/dynamic-resource-allocation/go.mod
@@ -4,6 +4,8 @@ module k8s.io/dynamic-resource-allocation
 
 go 1.22.0
 
+godebug default=go1.22
+
 require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/go-logr/logr v1.4.2

--- a/staging/src/k8s.io/endpointslice/go.mod
+++ b/staging/src/k8s.io/endpointslice/go.mod
@@ -4,6 +4,8 @@ module k8s.io/endpointslice
 
 go 1.22.0
 
+godebug default=go1.22
+
 require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/google/go-cmp v0.6.0

--- a/staging/src/k8s.io/kms/go.mod
+++ b/staging/src/k8s.io/kms/go.mod
@@ -4,6 +4,8 @@ module k8s.io/kms
 
 go 1.22.0
 
+godebug default=go1.22
+
 require (
 	github.com/gogo/protobuf v1.3.2
 	google.golang.org/grpc v1.65.0

--- a/staging/src/k8s.io/kms/internal/plugins/_mock/go.mod
+++ b/staging/src/k8s.io/kms/internal/plugins/_mock/go.mod
@@ -2,6 +2,8 @@ module k8s.io/kms/plugins/mock
 
 go 1.22.0
 
+godebug default=go1.22
+
 require (
 	github.com/ThalesIgnite/crypto11 v1.2.5
 	k8s.io/kms v0.0.0-00010101000000-000000000000

--- a/staging/src/k8s.io/kms/internal/plugins/_mock/go.work
+++ b/staging/src/k8s.io/kms/internal/plugins/_mock/go.work
@@ -3,4 +3,6 @@
 
 go 1.22.0
 
+godebug default=go1.22
+
 use .

--- a/staging/src/k8s.io/kube-aggregator/go.mod
+++ b/staging/src/k8s.io/kube-aggregator/go.mod
@@ -4,6 +4,8 @@ module k8s.io/kube-aggregator
 
 go 1.22.0
 
+godebug default=go1.22
+
 require (
 	github.com/emicklei/go-restful/v3 v3.11.0
 	github.com/gogo/protobuf v1.3.2

--- a/staging/src/k8s.io/kube-controller-manager/go.mod
+++ b/staging/src/k8s.io/kube-controller-manager/go.mod
@@ -4,6 +4,8 @@ module k8s.io/kube-controller-manager
 
 go 1.22.0
 
+godebug default=go1.22
+
 require (
 	k8s.io/apimachinery v0.0.0
 	k8s.io/cloud-provider v0.0.0

--- a/staging/src/k8s.io/kube-proxy/go.mod
+++ b/staging/src/k8s.io/kube-proxy/go.mod
@@ -4,6 +4,8 @@ module k8s.io/kube-proxy
 
 go 1.22.0
 
+godebug default=go1.22
+
 require (
 	k8s.io/apimachinery v0.0.0
 	k8s.io/component-base v0.0.0

--- a/staging/src/k8s.io/kube-scheduler/go.mod
+++ b/staging/src/k8s.io/kube-scheduler/go.mod
@@ -4,6 +4,8 @@ module k8s.io/kube-scheduler
 
 go 1.22.0
 
+godebug default=go1.22
+
 require (
 	github.com/google/go-cmp v0.6.0
 	k8s.io/api v0.0.0

--- a/staging/src/k8s.io/kubectl/go.mod
+++ b/staging/src/k8s.io/kubectl/go.mod
@@ -4,6 +4,8 @@ module k8s.io/kubectl
 
 go 1.22.0
 
+godebug default=go1.22
+
 require (
 	github.com/MakeNowJust/heredoc v1.0.0
 	github.com/chai2010/gettext-go v1.0.2

--- a/staging/src/k8s.io/kubelet/go.mod
+++ b/staging/src/k8s.io/kubelet/go.mod
@@ -4,6 +4,8 @@ module k8s.io/kubelet
 
 go 1.22.0
 
+godebug default=go1.22
+
 require (
 	github.com/emicklei/go-restful/v3 v3.11.0
 	github.com/gogo/protobuf v1.3.2

--- a/staging/src/k8s.io/metrics/go.mod
+++ b/staging/src/k8s.io/metrics/go.mod
@@ -4,6 +4,8 @@ module k8s.io/metrics
 
 go 1.22.0
 
+godebug default=go1.22
+
 require (
 	github.com/gogo/protobuf v1.3.2
 	github.com/stretchr/testify v1.9.0

--- a/staging/src/k8s.io/mount-utils/go.mod
+++ b/staging/src/k8s.io/mount-utils/go.mod
@@ -4,6 +4,8 @@ module k8s.io/mount-utils
 
 go 1.22.0
 
+godebug default=go1.22
+
 require (
 	github.com/moby/sys/mountinfo v0.7.1
 	github.com/opencontainers/runc v1.1.13

--- a/staging/src/k8s.io/pod-security-admission/go.mod
+++ b/staging/src/k8s.io/pod-security-admission/go.mod
@@ -4,6 +4,8 @@ module k8s.io/pod-security-admission
 
 go 1.22.0
 
+godebug default=go1.22
+
 require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/google/go-cmp v0.6.0

--- a/staging/src/k8s.io/sample-apiserver/go.mod
+++ b/staging/src/k8s.io/sample-apiserver/go.mod
@@ -4,6 +4,8 @@ module k8s.io/sample-apiserver
 
 go 1.22.0
 
+godebug default=go1.22
+
 require (
 	github.com/google/gofuzz v1.2.0
 	github.com/spf13/cobra v1.8.1

--- a/staging/src/k8s.io/sample-cli-plugin/go.mod
+++ b/staging/src/k8s.io/sample-cli-plugin/go.mod
@@ -4,6 +4,8 @@ module k8s.io/sample-cli-plugin
 
 go 1.22.0
 
+godebug default=go1.22
+
 require (
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/pflag v1.0.5

--- a/staging/src/k8s.io/sample-controller/go.mod
+++ b/staging/src/k8s.io/sample-controller/go.mod
@@ -4,6 +4,8 @@ module k8s.io/sample-controller
 
 go 1.22.0
 
+godebug default=go1.22
+
 require (
 	golang.org/x/time v0.3.0
 	k8s.io/api v0.0.0


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

Pick of godebug default commit from https://github.com/kubernetes/kubernetes/pull/127271 for https://github.com/kubernetes/release/issues/3650

#### What this PR does / why we need it:

Indicates runtime defaults should use go1.22-compatible behavior.

Related to https://github.com/kubernetes/enhancements/tree/master/keps/sig-release/3744-stay-on-supported-go-versions

/sig release architecture

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
