### PR TITLE
Remove Node endpoints from pending_eligible_endpoints.yaml

### DIFF
--- a/test/conformance/testdata/pending_eligible_endpoints.yaml
+++ b/test/conformance/testdata/pending_eligible_endpoints.yaml
@@ -1,8 +1,6 @@
 ---
 - createCoreV1NamespacedServiceAccountToken
-- createCoreV1Node
 - createStorageV1CSINode
-- deleteCoreV1Node
 - deleteStorageV1CollectionCSINode
 - deleteStorageV1CSINode
 - listStorageV1CSINode


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The promoted conformance test for Node endpoints covering +2 endpoints.

#### Which issue(s) this PR fixes:

Fixes #126823

#### Special notes for your reviewer:
Adds +2 endpoint test coverage (good for conformance)

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
/sig testing
/sig architecture
/area conformance