### PR TITLE
Apf fix watch panic handling

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/filters/priority-and-fairness_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/priority-and-fairness_test.go
@@ -41,6 +41,7 @@ import (
 	epmetrics "k8s.io/apiserver/pkg/endpoints/metrics"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/server/mux"
+	"k8s.io/apiserver/pkg/util/controlflow"
 	utilflowcontrol "k8s.io/apiserver/pkg/util/flowcontrol"
 	fq "k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing"
 	fcmetrics "k8s.io/apiserver/pkg/util/flowcontrol/metrics"
@@ -177,21 +178,20 @@ func newApfHandlerWithFilter(t *testing.T, flowControlFilter utilflowcontrol.Int
 		r = r.WithContext(apirequest.WithUser(r.Context(), &user.DefaultInfo{
 			Groups: []string{user.AllUnauthenticated},
 		}))
-		func() {
+		controlflow.TryFinally(func() {
+			apfHandler.ServeHTTP(w, r)
+			postExecute()
+		}, func() {
 			// the APF handler completes its run, either normally or
 			// with a panic, in either case, all APF book keeping must
 			// be completed by now. Also, whether the request is
 			// executed or rejected, we expect the counter to be zero.
 			// TODO: all test(s) using this filter must run
 			// serially to each other
-			defer func() {
-				if atomicReadOnlyExecuting != 0 {
-					t.Errorf("Wanted %d requests executing, got %d", 0, atomicReadOnlyExecuting)
-				}
-			}()
-			apfHandler.ServeHTTP(w, r)
-			postExecute()
-		}()
+			if atomicReadOnlyExecuting != 0 {
+				t.Errorf("Wanted %d requests executing, got %d", 0, atomicReadOnlyExecuting)
+			}
+		})
 	}), requestInfoFactory)
 
 	return handler
@@ -800,15 +800,15 @@ func TestPriorityAndFairnessWithPanicRecoveryAndTimeoutFilter(t *testing.T) {
 			response *http.Response
 			err      error
 		)
-		func() {
-			defer close(callerRoundTripDoneCh)
-
+		controlflow.TryFinally(func() {
 			t.Logf("Waiting for the request: %q to time out", rquestTimesOutPath)
 			response, err = requestGetter(rquestTimesOutPath)
 			if isClientTimeout(err) {
 				t.Fatalf("the client has unexpectedly timed out - request: %q error: %s", rquestTimesOutPath, err.Error())
 			}
-		}()
+		}, func() {
+			close(callerRoundTripDoneCh)
+		})
 
 		t.Logf("Waiting for the inner handler of the request: %q to complete", rquestTimesOutPath)
 		select {
@@ -877,14 +877,15 @@ func TestPriorityAndFairnessWithPanicRecoveryAndTimeoutFilter(t *testing.T) {
 			response *http.Response
 			err      error
 		)
-		func() {
-			defer close(callerRoundTripDoneCh)
+		controlflow.TryFinally(func() {
 			t.Logf("Waiting for the request: %q to time out", rquestTimesOutPath)
 			response, err = requestGetter(rquestTimesOutPath)
 			if isClientTimeout(err) {
 				t.Fatalf("the client has unexpectedly timed out - request: %q error: %s", rquestTimesOutPath, err.Error())
 			}
-		}()
+		}, func() {
+			close(callerRoundTripDoneCh)
+		})
 
 		t.Logf("Waiting for the inner handler of the request: %q to complete", rquestTimesOutPath)
 		select {
@@ -954,14 +955,15 @@ func TestPriorityAndFairnessWithPanicRecoveryAndTimeoutFilter(t *testing.T) {
 		// chance of a flake in ci, the cient waits long enough for the server to send a
 		// timeout response to the client.
 		var err error
-		func() {
-			defer close(callerRoundTripDoneCh)
+		controlflow.TryFinally(func() {
 			t.Logf("Waiting for the request: %q to time out", rquestTimesOutPath)
 			_, err = requestGetter(rquestTimesOutPath)
 			if isClientTimeout(err) {
 				t.Fatalf("the client has unexpectedly timed out - request: %q error: %s", rquestTimesOutPath, err.Error())
 			}
-		}()
+		}, func() {
+			close(callerRoundTripDoneCh)
+		})
 
 		t.Logf("Waiting for the inner handler of the request: %q to complete", rquestTimesOutPath)
 		select {

--- a/staging/src/k8s.io/apiserver/pkg/util/controlflow/fmt-stack.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/controlflow/fmt-stack.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controlflow
+
+import (
+	"fmt"
+	"runtime"
+)
+
+// FormatValueWithStack combines the string rendering of the given value
+// with a stack trace.
+func FormatValueWithStack(value any) string {
+	// Stack tracing code copied from apimachinery/pkg/util/runtime
+	const size = 64 << 10
+	stacktrace := make([]byte, size)
+	stacktrace = stacktrace[:runtime.Stack(stacktrace, false)]
+
+	return fmt.Sprintf("%v\n\n%s", value, string(stacktrace))
+}

--- a/staging/src/k8s.io/apiserver/pkg/util/controlflow/try-finally.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/controlflow/try-finally.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controlflow
+
+// TryFinally invokes `try` and then certainly invokes `finally` --- even if `try` panics.
+// The name comes from the analogous construct in Python.
+func TryFinally(try, finally func()) {
+	defer finally()
+	try()
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:
This PR (a) introduces and uses controlflow.TryFinally to make the control flow clearer and (b) simplifying and clarifying the signalling between the goroutine that the APF handler forks in the WATCH case and the main goroutine while also adding handling of the case of both goroutines panicking. Part (b) is structured as two commits: the first removes the relaying of a panic, the second restores the relay and handles all four panic/no-panic cases.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #127048 

#### Special notes for your reviewer:
For a version without introducing and using `controlflow.TryFinally`, see #127762.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
