### PR TITLE
chore:  add unit test to cover cohabitating resources in StorageFactory

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/apis/example2/install/install.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/example2/install/install.go
@@ -22,12 +22,14 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apiserver/pkg/apis/example"
+	"k8s.io/apiserver/pkg/apis/example2"
 	example2v1 "k8s.io/apiserver/pkg/apis/example2/v1"
 )
 
 // Install registers the API group and adds types to a scheme
 func Install(scheme *runtime.Scheme) {
 	utilruntime.Must(example.AddToScheme(scheme))
+	utilruntime.Must(example2.AddToScheme(scheme))
 	utilruntime.Must(example2v1.AddToScheme(scheme))
 	utilruntime.Must(scheme.SetVersionPriority(example2v1.SchemeGroupVersion))
 }


### PR DESCRIPTION
#### What type of PR is this?


Add one of the following kinds:
/kind cleanup

#### What this PR does / why we need it:
As https://github.com/kubernetes/kubernetes/pull/127239#issuecomment-2344672553 mentioned, this PR add some unit test to make sure cohabitating resources will not break again in future.

This PR is also a proof of pervious fix is valid, and it could suggests us that we can cherry-pick pervious fix back to v1.31 with confidence.

/triage accepted
/priority backlog
/assign @jpbetz

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

Because usage of cohabitating resources in kube-apiserver are relatively limited, so some use cases in the third-party extension API cannot be fully covered, so I use unit tests to cover the usage scenarios as much as possible.

before fix #127239 is merged, below cases was broken:
```
--- FAIL: TestConfigurableStorageFactory (0.00s)
    --- FAIL: TestConfigurableStorageFactory/config_resource_is_secondary_cohabitating_resources (0.00s)
        storage_factory_test.go:248: unexpected encoding version schema.GroupVersion{Group:"example2.apiserver.k8s.io", Version:"v1"}, but expected schema.GroupVersion{Group:"example.apiserver.k8s.io", Version:"v1"}
    --- FAIL: TestConfigurableStorageFactory/config_resource_is_primary_cohabitating_resources_and_not_enabled (0.00s)
        storage_factory_test.go:248: unexpected encoding version schema.GroupVersion{Group:"example.apiserver.k8s.io", Version:"v1"}, but expected schema.GroupVersion{Group:"example2.apiserver.k8s.io", Version:"v1"}
    --- FAIL: TestConfigurableStorageFactory/config_resource_is_secondary_cohabitating_resources_and_not_enabled (0.00s)
        storage_factory_test.go:248: unexpected encoding version schema.GroupVersion{Group:"example2.apiserver.k8s.io", Version:"v1"}, but expected schema.GroupVersion{Group:"example.apiserver.k8s.io", Version:"v1"}
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
