### PR TITLE
kubeadm: add default paths to 'upgrade diff'

### DIFF
--- a/cmd/kubeadm/app/cmd/upgrade/diff.go
+++ b/cmd/kubeadm/app/cmd/upgrade/diff.go
@@ -57,8 +57,11 @@ type diffFlags struct {
 // newCmdDiff returns the cobra command for `kubeadm upgrade diff`
 func newCmdDiff(out io.Writer) *cobra.Command {
 	flags := &diffFlags{
-		kubeConfigPath: constants.GetAdminKubeConfigPath(),
-		out:            out,
+		kubeConfigPath:                constants.GetAdminKubeConfigPath(),
+		out:                           out,
+		apiServerManifestPath:         constants.GetStaticPodFilepath(constants.KubeAPIServer, constants.GetStaticPodDirectory()),
+		controllerManagerManifestPath: constants.GetStaticPodFilepath(constants.KubeControllerManager, constants.GetStaticPodDirectory()),
+		schedulerManifestPath:         constants.GetStaticPodFilepath(constants.KubeScheduler, constants.GetStaticPodDirectory()),
 	}
 
 	cmd := &cobra.Command{
@@ -88,9 +91,6 @@ func newCmdDiff(out io.Writer) *cobra.Command {
 
 func validateManifestsPath(manifests ...string) (err error) {
 	for _, manifestPath := range manifests {
-		if len(manifestPath) == 0 {
-			return errors.New("empty manifest path")
-		}
 		s, err := os.Stat(manifestPath)
 		if err != nil {
 			if os.IsNotExist(err) {

--- a/cmd/kubeadm/app/cmd/upgrade/diff_test.go
+++ b/cmd/kubeadm/app/cmd/upgrade/diff_test.go
@@ -114,13 +114,6 @@ diff:
 			expectedError: true,
 		},
 		{
-			name:            "invalid: valid config but empty manifest path",
-			cfgPath:         testUpgradeDiffConfig,
-			setManifestPath: true,
-			manifestPath:    "",
-			expectedError:   true,
-		},
-		{
 			name:            "invalid: valid config but bad manifest path",
 			cfgPath:         testUpgradeDiffConfig,
 			setManifestPath: true,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

After the flags to control manifest paths were removed in https://github.com/kubernetes/kubernetes/commit/d62b797c16fdffa55a8e2fc95f04bf72c019be70 , the variables in diff.go remained empty and the validation fails with "empty manifest path".

Always populate the paths with the kubeadm defaults under /etc/kubernetes/manifest and remove the empty path validation.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubeadm/issues/3110

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
