### PR TITLE
proxy/conntrack: reconciler

### DIFF
--- a/pkg/proxy/conntrack/cleanup.go
+++ b/pkg/proxy/conntrack/cleanup.go
@@ -20,6 +20,8 @@ limitations under the License.
 package conntrack
 
 import (
+	"time"
+
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
 
@@ -27,88 +29,96 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/proxy"
-	proxyutil "k8s.io/kubernetes/pkg/proxy/util"
 	netutils "k8s.io/utils/net"
 )
 
-// CleanStaleEntries takes care of flushing stale conntrack entries for services and endpoints.
-func CleanStaleEntries(ct Interface, ipFamily v1.IPFamily, svcPortMap proxy.ServicePortMap,
-	serviceUpdateResult proxy.UpdateServiceMapResult, endpointsUpdateResult proxy.UpdateEndpointsMapResult) {
-	deleteStaleServiceConntrackEntries(ct, ipFamily, svcPortMap, serviceUpdateResult, endpointsUpdateResult)
-	deleteStaleEndpointConntrackEntries(ct, ipFamily, svcPortMap, endpointsUpdateResult)
-}
+// CleanStaleEntries scans conntrack table and removes any entries
+// for a service that do not correspond to a serving endpoint.
+func CleanStaleEntries(ct Interface, ipFamily v1.IPFamily,
+	svcPortMap proxy.ServicePortMap, endpointsMap proxy.EndpointsMap) {
 
-// deleteStaleServiceConntrackEntries takes care of flushing stale conntrack entries related
-// to UDP Service IPs. When a service has no endpoints and we drop traffic to it, conntrack
-// may create "black hole" entries for that IP+port. When the service gets endpoints we
-// need to delete those entries so further traffic doesn't get dropped.
-func deleteStaleServiceConntrackEntries(ct Interface, ipFamily v1.IPFamily, svcPortMap proxy.ServicePortMap, serviceUpdateResult proxy.UpdateServiceMapResult, endpointsUpdateResult proxy.UpdateEndpointsMapResult) {
+	start := time.Now()
+	klog.V(4).InfoS("Started to reconcile conntrack entries", "ipFamily", ipFamily)
+
+	entries, err := ct.ListEntries(ipFamilyMap[ipFamily])
+	if err != nil {
+		klog.ErrorS(err, "Failed to list conntrack entries")
+		return
+	}
+
+	// serviceIPEndpointIPs maps service IPs (ClusterIP, LoadBalancerIPs and ExternalIPs)
+	// to the set of serving endpoint IPs.
+	serviceIPEndpointIPs := make(map[string]sets.Set[string])
+	// serviceNodePortEndpointIPs maps service NodePort to the set of serving endpoint IPs.
+	serviceNodePortEndpointIPs := make(map[int]sets.Set[string])
+
+	for svcName, svc := range svcPortMap {
+		// we are only interested in UDP services
+		if svc.Protocol() != v1.ProtocolUDP {
+			continue
+		}
+
+		endpointIPs := sets.New[string]()
+		for _, endpoint := range endpointsMap[svcName] {
+			// We need to remove all the conntrack entries for a Service (IP or NodePort)
+			// that are not pointing to a serving endpoint.
+			// We map all the serving endpoint IPs to the service and clear all the conntrack
+			// entries which are destined for the service and are not DNATed to these endpoints.
+			// Changes to the service should not affect existing flows, so we do not take
+			// traffic policies, topology, or terminating status of the service into account.
+			// This ensures that the behavior of UDP services remains consistent with TCP
+			// services.
+			if endpoint.IsServing() {
+				endpointIPs.Insert(endpoint.IP())
+			}
+		}
+
+		serviceIPEndpointIPs[svc.ClusterIP().String()] = endpointIPs
+		for _, loadBalancerIP := range svc.LoadBalancerVIPs() {
+			serviceIPEndpointIPs[loadBalancerIP.String()] = endpointIPs
+		}
+		for _, externalIP := range svc.ExternalIPs() {
+			serviceIPEndpointIPs[externalIP.String()] = endpointIPs
+		}
+		if svc.NodePort() != 0 {
+			serviceNodePortEndpointIPs[svc.NodePort()] = endpointIPs
+		}
+	}
+
 	var filters []netlink.CustomConntrackFilter
-	conntrackCleanupServiceIPs := serviceUpdateResult.DeletedUDPClusterIPs
-	conntrackCleanupServiceNodePorts := sets.New[int]()
+	for _, entry := range entries {
+		// we only deal with UDP protocol entries
+		if entry.Forward.Protocol != unix.IPPROTO_UDP {
+			continue
+		}
 
-	// merge newly active services gathered from endpointsUpdateResult
-	// a UDP service that changes from 0 to non-0 endpoints is newly active.
-	for _, svcPortName := range endpointsUpdateResult.NewlyActiveUDPServices {
-		if svcInfo, ok := svcPortMap[svcPortName]; ok {
-			klog.V(4).InfoS("Newly-active UDP service may have stale conntrack entries", "servicePortName", svcPortName)
-			conntrackCleanupServiceIPs.Insert(svcInfo.ClusterIP().String())
-			for _, extIP := range svcInfo.ExternalIPs() {
-				conntrackCleanupServiceIPs.Insert(extIP.String())
+		origDst := entry.Forward.DstIP.String()
+		origPortDst := int(entry.Forward.DstPort)
+		replySrc := entry.Reverse.SrcIP.String()
+
+		// if the original destination (--orig-dst) of the entry is service IP (ClusterIP,
+		// LoadBalancerIPs or ExternalIPs) and the reply source (--reply-src) is not IP of
+		// any serving endpoint, we clear the entry.
+		if _, ok := serviceIPEndpointIPs[origDst]; ok {
+			if !serviceIPEndpointIPs[origDst].Has(replySrc) {
+				filters = append(filters, filterForNAT(origDst, replySrc, v1.ProtocolUDP))
 			}
-			for _, lbIP := range svcInfo.LoadBalancerVIPs() {
-				conntrackCleanupServiceIPs.Insert(lbIP.String())
-			}
-			nodePort := svcInfo.NodePort()
-			if svcInfo.Protocol() == v1.ProtocolUDP && nodePort != 0 {
-				conntrackCleanupServiceNodePorts.Insert(nodePort)
+		}
+
+		// if the original port destination (--orig-port-dst) of the flow is service
+		// NodePort and the reply source (--reply-src) is not IP of any serving endpoint,
+		// we clear the entry.
+		if _, ok := serviceNodePortEndpointIPs[origPortDst]; ok {
+			if !serviceNodePortEndpointIPs[origPortDst].Has(replySrc) {
+				filters = append(filters, filterForPortNAT(replySrc, origPortDst, v1.ProtocolUDP))
 			}
 		}
 	}
 
-	klog.V(4).InfoS("Deleting conntrack stale entries for services", "IPs", conntrackCleanupServiceIPs.UnsortedList())
-	for _, svcIP := range conntrackCleanupServiceIPs.UnsortedList() {
-		filters = append(filters, filterForIP(svcIP, v1.ProtocolUDP))
-	}
-	klog.V(4).InfoS("Deleting conntrack stale entries for services", "nodePorts", conntrackCleanupServiceNodePorts.UnsortedList())
-	for _, nodePort := range conntrackCleanupServiceNodePorts.UnsortedList() {
-		filters = append(filters, filterForPort(nodePort, v1.ProtocolUDP))
-	}
-
 	if n, err := ct.ClearEntries(ipFamilyMap[ipFamily], filters...); err != nil {
-		klog.ErrorS(err, "Failed to delete stale service connections")
+		klog.ErrorS(err, "Failed to clear all conntrack entries", "ipFamily", ipFamily, "entriesDeleted", n, "took", time.Since(start))
 	} else {
-		klog.V(4).InfoS("Deleted conntrack stale entries for services", "count", n)
-	}
-}
-
-// deleteStaleEndpointConntrackEntries takes care of flushing stale conntrack entries related
-// to UDP endpoints. After a UDP endpoint is removed we must flush any conntrack entries
-// for it so that if the same client keeps sending, the packets will get routed to a new endpoint.
-func deleteStaleEndpointConntrackEntries(ct Interface, ipFamily v1.IPFamily, svcPortMap proxy.ServicePortMap, endpointsUpdateResult proxy.UpdateEndpointsMapResult) {
-	var filters []netlink.CustomConntrackFilter
-	for _, epSvcPair := range endpointsUpdateResult.DeletedUDPEndpoints {
-		if svcInfo, ok := svcPortMap[epSvcPair.ServicePortName]; ok {
-			endpointIP := proxyutil.IPPart(epSvcPair.Endpoint)
-			nodePort := svcInfo.NodePort()
-			if nodePort != 0 {
-				filters = append(filters, filterForPortNAT(endpointIP, nodePort, v1.ProtocolUDP))
-
-			}
-			filters = append(filters, filterForNAT(svcInfo.ClusterIP().String(), endpointIP, v1.ProtocolUDP))
-			for _, extIP := range svcInfo.ExternalIPs() {
-				filters = append(filters, filterForNAT(extIP.String(), endpointIP, v1.ProtocolUDP))
-			}
-			for _, lbIP := range svcInfo.LoadBalancerVIPs() {
-				filters = append(filters, filterForNAT(lbIP.String(), endpointIP, v1.ProtocolUDP))
-			}
-		}
-	}
-
-	if n, err := ct.ClearEntries(ipFamilyMap[ipFamily], filters...); err != nil {
-		klog.ErrorS(err, "Failed to delete stale endpoint connections")
-	} else {
-		klog.V(4).InfoS("Deleted conntrack stale entries for endpoints", "count", n)
+		klog.V(4).InfoS("Finished reconciling conntrack entries", "ipFamily", ipFamily, "entriesDeleted", n, "took", time.Since(start))
 	}
 }
 
@@ -124,30 +134,6 @@ var protocolMap = map[v1.Protocol]uint8{
 	v1.ProtocolTCP:  unix.IPPROTO_TCP,
 	v1.ProtocolUDP:  unix.IPPROTO_UDP,
 	v1.ProtocolSCTP: unix.IPPROTO_SCTP,
-}
-
-// filterForIP returns *conntrackFilter to delete the conntrack entries for connections
-// specified by the destination IP (original direction).
-func filterForIP(ip string, protocol v1.Protocol) *conntrackFilter {
-	klog.V(4).InfoS("Adding conntrack filter for cleanup", "org-dst", ip, "protocol", protocol)
-	return &conntrackFilter{
-		protocol: protocolMap[protocol],
-		original: &connectionTuple{
-			dstIP: netutils.ParseIPSloppy(ip),
-		},
-	}
-}
-
-// filterForPort returns *conntrackFilter to delete the conntrack entries for connections
-// specified by the destination Port (original direction).
-func filterForPort(port int, protocol v1.Protocol) *conntrackFilter {
-	klog.V(4).InfoS("Adding conntrack filter for cleanup", "org-port-dst", port, "protocol", protocol)
-	return &conntrackFilter{
-		protocol: protocolMap[protocol],
-		original: &connectionTuple{
-			dstPort: uint16(port),
-		},
-	}
 }
 
 // filterForNAT returns *conntrackFilter to delete the conntrack entries for connections

--- a/pkg/proxy/conntrack/cleanup.go
+++ b/pkg/proxy/conntrack/cleanup.go
@@ -75,8 +75,10 @@ func deleteStaleServiceConntrackEntries(ct Interface, ipFamily v1.IPFamily, svcP
 		filters = append(filters, filterForPort(nodePort, v1.ProtocolUDP))
 	}
 
-	if err := ct.ClearEntries(ipFamilyMap[ipFamily], filters...); err != nil {
+	if n, err := ct.ClearEntries(ipFamilyMap[ipFamily], filters...); err != nil {
 		klog.ErrorS(err, "Failed to delete stale service connections")
+	} else {
+		klog.V(4).InfoS("Deleted conntrack stale entries for services", "count", n)
 	}
 }
 
@@ -103,8 +105,10 @@ func deleteStaleEndpointConntrackEntries(ct Interface, ipFamily v1.IPFamily, svc
 		}
 	}
 
-	if err := ct.ClearEntries(ipFamilyMap[ipFamily], filters...); err != nil {
+	if n, err := ct.ClearEntries(ipFamilyMap[ipFamily], filters...); err != nil {
 		klog.ErrorS(err, "Failed to delete stale endpoint connections")
+	} else {
+		klog.V(4).InfoS("Deleted conntrack stale entries for endpoints", "count", n)
 	}
 }
 

--- a/pkg/proxy/conntrack/conntrack.go
+++ b/pkg/proxy/conntrack/conntrack.go
@@ -29,6 +29,7 @@ import (
 
 // Interface for dealing with conntrack
 type Interface interface {
+	ListEntries(ipFamily uint8) ([]*netlink.ConntrackFlow, error)
 	// ClearEntries deletes conntrack entries for connections of the given IP family,
 	// filtered by the given filters.
 	ClearEntries(ipFamily uint8, filters ...netlink.CustomConntrackFilter) (int, error)
@@ -36,6 +37,7 @@ type Interface interface {
 
 // netlinkHandler allows consuming real and mockable implementation for testing.
 type netlinkHandler interface {
+	ConntrackTableList(netlink.ConntrackTableType, netlink.InetFamily) ([]*netlink.ConntrackFlow, error)
 	ConntrackDeleteFilters(netlink.ConntrackTableType, netlink.InetFamily, ...netlink.CustomConntrackFilter) (uint, error)
 }
 
@@ -54,6 +56,11 @@ func newConntracker(handler netlinkHandler) Interface {
 	return &conntracker{handler: handler}
 }
 
+// ListEntries list all conntrack entries for connections of the given IP family.
+func (ct *conntracker) ListEntries(ipFamily uint8) ([]*netlink.ConntrackFlow, error) {
+	return ct.handler.ConntrackTableList(netlink.ConntrackTable, netlink.InetFamily(ipFamily))
+}
+
 // ClearEntries deletes conntrack entries for connections of the given IP family,
 // filtered by the given filters.
 func (ct *conntracker) ClearEntries(ipFamily uint8, filters ...netlink.CustomConntrackFilter) (int, error) {
@@ -64,8 +71,7 @@ func (ct *conntracker) ClearEntries(ipFamily uint8, filters ...netlink.CustomCon
 
 	n, err := ct.handler.ConntrackDeleteFilters(netlink.ConntrackTable, netlink.InetFamily(ipFamily), filters...)
 	if err != nil {
-		return 0, fmt.Errorf("error deleting conntrack entries, error: %w", err)
+		return int(n), fmt.Errorf("error deleting conntrack entries, error: %w", err)
 	}
-	klog.V(4).InfoS("Cleared conntrack entries", "count", n)
 	return int(n), nil
 }

--- a/pkg/proxy/conntrack/conntrack.go
+++ b/pkg/proxy/conntrack/conntrack.go
@@ -31,7 +31,7 @@ import (
 type Interface interface {
 	// ClearEntries deletes conntrack entries for connections of the given IP family,
 	// filtered by the given filters.
-	ClearEntries(ipFamily uint8, filters ...netlink.CustomConntrackFilter) error
+	ClearEntries(ipFamily uint8, filters ...netlink.CustomConntrackFilter) (int, error)
 }
 
 // netlinkHandler allows consuming real and mockable implementation for testing.
@@ -56,16 +56,16 @@ func newConntracker(handler netlinkHandler) Interface {
 
 // ClearEntries deletes conntrack entries for connections of the given IP family,
 // filtered by the given filters.
-func (ct *conntracker) ClearEntries(ipFamily uint8, filters ...netlink.CustomConntrackFilter) error {
+func (ct *conntracker) ClearEntries(ipFamily uint8, filters ...netlink.CustomConntrackFilter) (int, error) {
 	if len(filters) == 0 {
 		klog.V(7).InfoS("no conntrack filters provided")
-		return nil
+		return 0, nil
 	}
 
 	n, err := ct.handler.ConntrackDeleteFilters(netlink.ConntrackTable, netlink.InetFamily(ipFamily), filters...)
 	if err != nil {
-		return fmt.Errorf("error deleting conntrack entries, error: %w", err)
+		return 0, fmt.Errorf("error deleting conntrack entries, error: %w", err)
 	}
 	klog.V(4).InfoS("Cleared conntrack entries", "count", n)
-	return nil
+	return int(n), nil
 }

--- a/pkg/proxy/conntrack/conntrack_test.go
+++ b/pkg/proxy/conntrack/conntrack_test.go
@@ -91,7 +91,8 @@ func TestConntracker_ClearEntries(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			handler := &fakeHandler{}
 			ct := newConntracker(handler)
-			require.NoError(t, ct.ClearEntries(tc.ipFamily, tc.filters...))
+			_, err := ct.ClearEntries(tc.ipFamily, tc.filters...)
+			require.NoError(t, err)
 			require.Equal(t, netlink.ConntrackTableType(netlink.ConntrackTable), handler.tableType)
 			require.Equal(t, netlink.InetFamily(tc.ipFamily), handler.ipFamily)
 			require.Equal(t, len(tc.filters), len(handler.filters))

--- a/pkg/proxy/conntrack/conntrack_test.go
+++ b/pkg/proxy/conntrack/conntrack_test.go
@@ -35,6 +35,10 @@ type fakeHandler struct {
 	filters   []*conntrackFilter
 }
 
+func (f *fakeHandler) ConntrackTableList(_ netlink.ConntrackTableType, _ netlink.InetFamily) ([]*netlink.ConntrackFlow, error) {
+	return nil, nil
+}
+
 func (f *fakeHandler) ConntrackDeleteFilters(tableType netlink.ConntrackTableType, family netlink.InetFamily, netlinkFilters ...netlink.CustomConntrackFilter) (uint, error) {
 	f.tableType = tableType
 	f.ipFamily = family
@@ -48,7 +52,6 @@ func (f *fakeHandler) ConntrackDeleteFilters(tableType netlink.ConntrackTableTyp
 var _ netlinkHandler = (*fakeHandler)(nil)
 
 func TestConntracker_ClearEntries(t *testing.T) {
-
 	testCases := []struct {
 		name     string
 		ipFamily uint8

--- a/pkg/proxy/conntrack/fake.go
+++ b/pkg/proxy/conntrack/fake.go
@@ -20,77 +20,42 @@ limitations under the License.
 package conntrack
 
 import (
-	"fmt"
-
 	"github.com/vishvananda/netlink"
-
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 // FakeInterface implements Interface by just recording entries that have been cleared.
 type FakeInterface struct {
-	ClearedIPs      sets.Set[string]
-	ClearedPorts    sets.Set[int]
-	ClearedNATs     map[string]string // origin -> dest
-	ClearedPortNATs map[int]string    // port -> dest
+	entries []*netlink.ConntrackFlow
 }
 
 var _ Interface = &FakeInterface{}
 
 // NewFake creates a new FakeInterface
 func NewFake() *FakeInterface {
-	fake := &FakeInterface{}
-	fake.Reset()
-	return fake
+	return &FakeInterface{entries: make([]*netlink.ConntrackFlow, 0)}
 }
 
-// Reset clears fake's sets/maps
-func (fake *FakeInterface) Reset() {
-	fake.ClearedIPs = sets.New[string]()
-	fake.ClearedPorts = sets.New[int]()
-	fake.ClearedNATs = make(map[string]string)
-	fake.ClearedPortNATs = make(map[int]string)
+// ListEntries is part of Interface
+func (fake *FakeInterface) ListEntries(_ uint8) ([]*netlink.ConntrackFlow, error) {
+	return fake.entries, nil
 }
 
 // ClearEntries is part of Interface
 func (fake *FakeInterface) ClearEntries(_ uint8, filters ...netlink.CustomConntrackFilter) (int, error) {
-	for _, anyFilter := range filters {
-		filter := anyFilter.(*conntrackFilter)
-		if filter.protocol != protocolMap[v1.ProtocolUDP] {
-			return 0, fmt.Errorf("FakeInterface currently only supports UDP")
-		}
-
-		// record IP and Port entries
-		if filter.original != nil && filter.reply == nil {
-			if filter.original.dstIP != nil {
-				fake.ClearedIPs.Insert(filter.original.dstIP.String())
-			}
-			if filter.original.dstPort != 0 {
-				fake.ClearedPorts.Insert(int(filter.original.dstPort))
+	var flows []*netlink.ConntrackFlow
+	before := len(fake.entries)
+	for _, flow := range fake.entries {
+		var matched bool
+		for _, filter := range filters {
+			matched = filter.MatchConntrackFlow(flow)
+			if matched {
+				break
 			}
 		}
-
-		// record NAT and NATPort entries
-		if filter.original != nil && filter.reply != nil {
-			if filter.original.dstIP != nil && filter.reply.srcIP != nil {
-				origin := filter.original.dstIP.String()
-				dest := filter.reply.srcIP.String()
-				if previous, exists := fake.ClearedNATs[origin]; exists && previous != dest {
-					return 0, fmt.Errorf("filter for NAT passed with same origin (%s), different destination (%s / %s)", origin, previous, dest)
-				}
-				fake.ClearedNATs[filter.original.dstIP.String()] = filter.reply.srcIP.String()
-			}
-
-			if filter.original.dstPort != 0 && filter.reply.srcIP != nil {
-				dest := filter.reply.srcIP.String()
-				port := int(filter.original.dstPort)
-				if previous, exists := fake.ClearedPortNATs[port]; exists && previous != dest {
-					return 0, fmt.Errorf("filter for PortNAT passed with same port (%d), different destination (%s / %s)", port, previous, dest)
-				}
-				fake.ClearedPortNATs[port] = dest
-			}
+		if !matched {
+			flows = append(flows, flow)
 		}
 	}
-	return 0, nil
+	fake.entries = flows
+	return before - len(fake.entries), nil
 }

--- a/pkg/proxy/conntrack/fake.go
+++ b/pkg/proxy/conntrack/fake.go
@@ -54,11 +54,11 @@ func (fake *FakeInterface) Reset() {
 }
 
 // ClearEntries is part of Interface
-func (fake *FakeInterface) ClearEntries(_ uint8, filters ...netlink.CustomConntrackFilter) error {
+func (fake *FakeInterface) ClearEntries(_ uint8, filters ...netlink.CustomConntrackFilter) (int, error) {
 	for _, anyFilter := range filters {
 		filter := anyFilter.(*conntrackFilter)
 		if filter.protocol != protocolMap[v1.ProtocolUDP] {
-			return fmt.Errorf("FakeInterface currently only supports UDP")
+			return 0, fmt.Errorf("FakeInterface currently only supports UDP")
 		}
 
 		// record IP and Port entries
@@ -77,7 +77,7 @@ func (fake *FakeInterface) ClearEntries(_ uint8, filters ...netlink.CustomConntr
 				origin := filter.original.dstIP.String()
 				dest := filter.reply.srcIP.String()
 				if previous, exists := fake.ClearedNATs[origin]; exists && previous != dest {
-					return fmt.Errorf("filter for NAT passed with same origin (%s), different destination (%s / %s)", origin, previous, dest)
+					return 0, fmt.Errorf("filter for NAT passed with same origin (%s), different destination (%s / %s)", origin, previous, dest)
 				}
 				fake.ClearedNATs[filter.original.dstIP.String()] = filter.reply.srcIP.String()
 			}
@@ -86,11 +86,11 @@ func (fake *FakeInterface) ClearEntries(_ uint8, filters ...netlink.CustomConntr
 				dest := filter.reply.srcIP.String()
 				port := int(filter.original.dstPort)
 				if previous, exists := fake.ClearedPortNATs[port]; exists && previous != dest {
-					return fmt.Errorf("filter for PortNAT passed with same port (%d), different destination (%s / %s)", port, previous, dest)
+					return 0, fmt.Errorf("filter for PortNAT passed with same port (%d), different destination (%s / %s)", port, previous, dest)
 				}
 				fake.ClearedPortNATs[port] = dest
 			}
 		}
 	}
-	return nil
+	return 0, nil
 }

--- a/pkg/proxy/endpointschangetracker_test.go
+++ b/pkg/proxy/endpointschangetracker_test.go
@@ -525,23 +525,21 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		// previousEndpointSlices and currentEndpointSlices are used to call appropriate
 		// handlers OnEndpointSlice* (based on whether corresponding values are nil
 		// or non-nil) and must be of equal length.
-		name                           string
-		previousEndpointSlices         []*discovery.EndpointSlice
-		currentEndpointSlices          []*discovery.EndpointSlice
-		previousEndpointsMap           map[ServicePortName][]*BaseEndpointInfo
-		expectedResult                 map[ServicePortName][]*BaseEndpointInfo
-		expectedDeletedUDPEndpoints    []ServiceEndpoint
-		expectedNewlyActiveUDPServices map[ServicePortName]bool
-		expectedLocalEndpoints         map[types.NamespacedName]int
-		expectedChangedEndpoints       sets.Set[types.NamespacedName]
+		name                             string
+		previousEndpointSlices           []*discovery.EndpointSlice
+		currentEndpointSlices            []*discovery.EndpointSlice
+		previousEndpointsMap             map[ServicePortName][]*BaseEndpointInfo
+		expectedResult                   map[ServicePortName][]*BaseEndpointInfo
+		expectedConntrackCleanupRequired bool
+		expectedLocalEndpoints           map[types.NamespacedName]int
+		expectedChangedEndpoints         sets.Set[types.NamespacedName]
 	}{{
-		name:                           "empty",
-		previousEndpointsMap:           map[ServicePortName][]*BaseEndpointInfo{},
-		expectedResult:                 map[ServicePortName][]*BaseEndpointInfo{},
-		expectedDeletedUDPEndpoints:    []ServiceEndpoint{},
-		expectedNewlyActiveUDPServices: map[ServicePortName]bool{},
-		expectedLocalEndpoints:         map[types.NamespacedName]int{},
-		expectedChangedEndpoints:       sets.New[types.NamespacedName](),
+		name:                             "empty",
+		previousEndpointsMap:             map[ServicePortName][]*BaseEndpointInfo{},
+		expectedResult:                   map[ServicePortName][]*BaseEndpointInfo{},
+		expectedConntrackCleanupRequired: false,
+		expectedLocalEndpoints:           map[types.NamespacedName]int{},
+		expectedChangedEndpoints:         sets.New[types.NamespacedName](),
 	}, {
 		name: "no change, unnamed port",
 		previousEndpointSlices: []*discovery.EndpointSlice{
@@ -560,10 +558,9 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{ip: "1.1.1.1", port: 11, endpoint: "1.1.1.1:11", isLocal: false, ready: true, serving: true, terminating: false},
 			},
 		},
-		expectedDeletedUDPEndpoints:    []ServiceEndpoint{},
-		expectedNewlyActiveUDPServices: map[ServicePortName]bool{},
-		expectedLocalEndpoints:         map[types.NamespacedName]int{},
-		expectedChangedEndpoints:       sets.New[types.NamespacedName](),
+		expectedConntrackCleanupRequired: false,
+		expectedLocalEndpoints:           map[types.NamespacedName]int{},
+		expectedChangedEndpoints:         sets.New[types.NamespacedName](),
 	}, {
 		name: "no change, named port, local",
 		previousEndpointSlices: []*discovery.EndpointSlice{
@@ -582,8 +579,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{ip: "1.1.1.1", port: 11, endpoint: "1.1.1.1:11", isLocal: true, ready: true, serving: true, terminating: false},
 			},
 		},
-		expectedDeletedUDPEndpoints:    []ServiceEndpoint{},
-		expectedNewlyActiveUDPServices: map[ServicePortName]bool{},
+		expectedConntrackCleanupRequired: false,
 		expectedLocalEndpoints: map[types.NamespacedName]int{
 			makeNSN("ns1", "ep1"): 1,
 		},
@@ -614,10 +610,9 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{ip: "1.1.1.2", port: 12, endpoint: "1.1.1.2:12", isLocal: false, ready: true, serving: true, terminating: false},
 			},
 		},
-		expectedDeletedUDPEndpoints:    []ServiceEndpoint{},
-		expectedNewlyActiveUDPServices: map[ServicePortName]bool{},
-		expectedLocalEndpoints:         map[types.NamespacedName]int{},
-		expectedChangedEndpoints:       sets.New[types.NamespacedName](),
+		expectedConntrackCleanupRequired: false,
+		expectedLocalEndpoints:           map[types.NamespacedName]int{},
+		expectedChangedEndpoints:         sets.New[types.NamespacedName](),
 	}, {
 		name: "no change, multiple slices, multiple ports, local",
 		previousEndpointSlices: []*discovery.EndpointSlice{
@@ -650,8 +645,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{ip: "1.1.1.3", port: 13, endpoint: "1.1.1.3:13", isLocal: false, ready: true, serving: true, terminating: false},
 			},
 		},
-		expectedDeletedUDPEndpoints:    []ServiceEndpoint{},
-		expectedNewlyActiveUDPServices: map[ServicePortName]bool{},
+		expectedConntrackCleanupRequired: false,
 		expectedLocalEndpoints: map[types.NamespacedName]int{
 			makeNSN("ns1", "ep1"): 1,
 		},
@@ -720,8 +714,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{ip: "2.2.2.2", port: 22, endpoint: "2.2.2.2:22", isLocal: true, ready: true, serving: true, terminating: false},
 			},
 		},
-		expectedDeletedUDPEndpoints:    []ServiceEndpoint{},
-		expectedNewlyActiveUDPServices: map[ServicePortName]bool{},
+		expectedConntrackCleanupRequired: false,
 		expectedLocalEndpoints: map[types.NamespacedName]int{
 			makeNSN("ns1", "ep1"): 2,
 			makeNSN("ns2", "ep2"): 1,
@@ -741,10 +734,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{ip: "1.1.1.1", port: 11, endpoint: "1.1.1.1:11", isLocal: true, ready: true, serving: true, terminating: false},
 			},
 		},
-		expectedDeletedUDPEndpoints: []ServiceEndpoint{},
-		expectedNewlyActiveUDPServices: map[ServicePortName]bool{
-			makeServicePortName("ns1", "ep1", "", v1.ProtocolUDP): true,
-		},
+		expectedConntrackCleanupRequired: true,
 		expectedLocalEndpoints: map[types.NamespacedName]int{
 			makeNSN("ns1", "ep1"): 1,
 		},
@@ -762,14 +752,10 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{ip: "1.1.1.1", port: 11, endpoint: "1.1.1.1:11", isLocal: true, ready: true, serving: true, terminating: false},
 			},
 		},
-		expectedResult: map[ServicePortName][]*BaseEndpointInfo{},
-		expectedDeletedUDPEndpoints: []ServiceEndpoint{{
-			Endpoint:        "1.1.1.1:11",
-			ServicePortName: makeServicePortName("ns1", "ep1", "", v1.ProtocolUDP),
-		}},
-		expectedNewlyActiveUDPServices: map[ServicePortName]bool{},
-		expectedLocalEndpoints:         map[types.NamespacedName]int{},
-		expectedChangedEndpoints:       sets.New(makeNSN("ns1", "ep1")),
+		expectedConntrackCleanupRequired: true,
+		expectedResult:                   map[ServicePortName][]*BaseEndpointInfo{},
+		expectedLocalEndpoints:           map[types.NamespacedName]int{},
+		expectedChangedEndpoints:         sets.New(makeNSN("ns1", "ep1")),
 	}, {
 		name: "add an IP and port",
 		previousEndpointSlices: []*discovery.EndpointSlice{
@@ -793,10 +779,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{ip: "1.1.1.2", port: 12, endpoint: "1.1.1.2:12", isLocal: true, ready: true, serving: true, terminating: false},
 			},
 		},
-		expectedDeletedUDPEndpoints: []ServiceEndpoint{},
-		expectedNewlyActiveUDPServices: map[ServicePortName]bool{
-			makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP): true,
-		},
+		expectedConntrackCleanupRequired: true,
 		expectedLocalEndpoints: map[types.NamespacedName]int{
 			makeNSN("ns1", "ep1"): 1,
 		},
@@ -824,19 +807,9 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{ip: "1.1.1.1", port: 11, endpoint: "1.1.1.1:11", isLocal: false, ready: true, serving: true, terminating: false},
 			},
 		},
-		expectedDeletedUDPEndpoints: []ServiceEndpoint{{
-			Endpoint:        "1.1.1.2:11",
-			ServicePortName: makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP),
-		}, {
-			Endpoint:        "1.1.1.1:12",
-			ServicePortName: makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP),
-		}, {
-			Endpoint:        "1.1.1.2:12",
-			ServicePortName: makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP),
-		}},
-		expectedNewlyActiveUDPServices: map[ServicePortName]bool{},
-		expectedLocalEndpoints:         map[types.NamespacedName]int{},
-		expectedChangedEndpoints:       sets.New(makeNSN("ns1", "ep1")),
+		expectedConntrackCleanupRequired: true,
+		expectedLocalEndpoints:           map[types.NamespacedName]int{},
+		expectedChangedEndpoints:         sets.New(makeNSN("ns1", "ep1")),
 	}, {
 		name: "add a slice to an endpoint",
 		previousEndpointSlices: []*discovery.EndpointSlice{
@@ -860,10 +833,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{ip: "1.1.1.2", port: 12, endpoint: "1.1.1.2:12", isLocal: true, ready: true, serving: true, terminating: false},
 			},
 		},
-		expectedDeletedUDPEndpoints: []ServiceEndpoint{},
-		expectedNewlyActiveUDPServices: map[ServicePortName]bool{
-			makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP): true,
-		},
+		expectedConntrackCleanupRequired: true,
 		expectedLocalEndpoints: map[types.NamespacedName]int{
 			makeNSN("ns1", "ep1"): 1,
 		},
@@ -891,13 +861,9 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{ip: "1.1.1.1", port: 11, endpoint: "1.1.1.1:11", isLocal: false, ready: true, serving: true, terminating: false},
 			},
 		},
-		expectedDeletedUDPEndpoints: []ServiceEndpoint{{
-			Endpoint:        "1.1.1.2:12",
-			ServicePortName: makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP),
-		}},
-		expectedNewlyActiveUDPServices: map[ServicePortName]bool{},
-		expectedLocalEndpoints:         map[types.NamespacedName]int{},
-		expectedChangedEndpoints:       sets.New(makeNSN("ns1", "ep1")),
+		expectedConntrackCleanupRequired: true,
+		expectedLocalEndpoints:           map[types.NamespacedName]int{},
+		expectedChangedEndpoints:         sets.New(makeNSN("ns1", "ep1")),
 	}, {
 		name: "rename a port",
 		previousEndpointSlices: []*discovery.EndpointSlice{
@@ -916,15 +882,9 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{ip: "1.1.1.1", port: 11, endpoint: "1.1.1.1:11", isLocal: false, ready: true, serving: true, terminating: false},
 			},
 		},
-		expectedDeletedUDPEndpoints: []ServiceEndpoint{{
-			Endpoint:        "1.1.1.1:11",
-			ServicePortName: makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP),
-		}},
-		expectedNewlyActiveUDPServices: map[ServicePortName]bool{
-			makeServicePortName("ns1", "ep1", "p11-2", v1.ProtocolUDP): true,
-		},
-		expectedLocalEndpoints:   map[types.NamespacedName]int{},
-		expectedChangedEndpoints: sets.New(makeNSN("ns1", "ep1")),
+		expectedConntrackCleanupRequired: true,
+		expectedLocalEndpoints:           map[types.NamespacedName]int{},
+		expectedChangedEndpoints:         sets.New(makeNSN("ns1", "ep1")),
 	}, {
 		name: "renumber a port",
 		previousEndpointSlices: []*discovery.EndpointSlice{
@@ -943,13 +903,9 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{ip: "1.1.1.1", port: 22, endpoint: "1.1.1.1:22", isLocal: false, ready: true, serving: true, terminating: false},
 			},
 		},
-		expectedDeletedUDPEndpoints: []ServiceEndpoint{{
-			Endpoint:        "1.1.1.1:11",
-			ServicePortName: makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP),
-		}},
-		expectedNewlyActiveUDPServices: map[ServicePortName]bool{},
-		expectedLocalEndpoints:         map[types.NamespacedName]int{},
-		expectedChangedEndpoints:       sets.New(makeNSN("ns1", "ep1")),
+		expectedConntrackCleanupRequired: true,
+		expectedLocalEndpoints:           map[types.NamespacedName]int{},
+		expectedChangedEndpoints:         sets.New(makeNSN("ns1", "ep1")),
 	}, {
 		name: "complex add and remove",
 		previousEndpointSlices: []*discovery.EndpointSlice{
@@ -1015,27 +971,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{ip: "4.4.4.4", port: 44, endpoint: "4.4.4.4:44", isLocal: true, ready: true, serving: true, terminating: false},
 			},
 		},
-		expectedDeletedUDPEndpoints: []ServiceEndpoint{{
-			Endpoint:        "2.2.2.2:22",
-			ServicePortName: makeServicePortName("ns2", "ep2", "p22", v1.ProtocolUDP),
-		}, {
-			Endpoint:        "2.2.2.22:22",
-			ServicePortName: makeServicePortName("ns2", "ep2", "p22", v1.ProtocolUDP),
-		}, {
-			Endpoint:        "2.2.2.3:23",
-			ServicePortName: makeServicePortName("ns2", "ep2", "p23", v1.ProtocolUDP),
-		}, {
-			Endpoint:        "4.4.4.5:44",
-			ServicePortName: makeServicePortName("ns4", "ep4", "p44", v1.ProtocolUDP),
-		}, {
-			Endpoint:        "4.4.4.6:45",
-			ServicePortName: makeServicePortName("ns4", "ep4", "p45", v1.ProtocolUDP),
-		}},
-		expectedNewlyActiveUDPServices: map[ServicePortName]bool{
-			makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP):  true,
-			makeServicePortName("ns1", "ep1", "p122", v1.ProtocolUDP): true,
-			makeServicePortName("ns3", "ep3", "p33", v1.ProtocolUDP):  true,
-		},
+		expectedConntrackCleanupRequired: true,
 		expectedLocalEndpoints: map[types.NamespacedName]int{
 			makeNSN("ns4", "ep4"): 1,
 		},
@@ -1054,12 +990,9 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{ip: "1.1.1.1", port: 11, endpoint: "1.1.1.1:11", isLocal: false, ready: true, serving: true, terminating: false},
 			},
 		},
-		expectedDeletedUDPEndpoints: []ServiceEndpoint{},
-		expectedNewlyActiveUDPServices: map[ServicePortName]bool{
-			makeServicePortName("ns1", "ep1", "", v1.ProtocolUDP): true,
-		},
-		expectedLocalEndpoints:   map[types.NamespacedName]int{},
-		expectedChangedEndpoints: sets.New(makeNSN("ns1", "ep1")),
+		expectedConntrackCleanupRequired: true,
+		expectedLocalEndpoints:           map[types.NamespacedName]int{},
+		expectedChangedEndpoints:         sets.New(makeNSN("ns1", "ep1")),
 	}, {
 		name: "change from ready to terminating pod",
 		previousEndpointSlices: []*discovery.EndpointSlice{
@@ -1078,10 +1011,9 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{ip: "1.1.1.1", port: 11, endpoint: "1.1.1.1:11", isLocal: false, ready: false, serving: true, terminating: true},
 			},
 		},
-		expectedDeletedUDPEndpoints:    []ServiceEndpoint{},
-		expectedNewlyActiveUDPServices: map[ServicePortName]bool{},
-		expectedLocalEndpoints:         map[types.NamespacedName]int{},
-		expectedChangedEndpoints:       sets.New(makeNSN("ns1", "ep1")),
+		expectedConntrackCleanupRequired: true,
+		expectedLocalEndpoints:           map[types.NamespacedName]int{},
+		expectedChangedEndpoints:         sets.New(makeNSN("ns1", "ep1")),
 	}, {
 		name: "change from terminating to empty pod",
 		previousEndpointSlices: []*discovery.EndpointSlice{
@@ -1095,14 +1027,10 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{ip: "1.1.1.1", port: 11, endpoint: "1.1.1.1:11", isLocal: false, ready: false, serving: true, terminating: true},
 			},
 		},
-		expectedResult: map[ServicePortName][]*BaseEndpointInfo{},
-		expectedDeletedUDPEndpoints: []ServiceEndpoint{{
-			Endpoint:        "1.1.1.1:11",
-			ServicePortName: makeServicePortName("ns1", "ep1", "", v1.ProtocolUDP),
-		}},
-		expectedNewlyActiveUDPServices: map[ServicePortName]bool{},
-		expectedLocalEndpoints:         map[types.NamespacedName]int{},
-		expectedChangedEndpoints:       sets.New(makeNSN("ns1", "ep1")),
+		expectedConntrackCleanupRequired: true,
+		expectedResult:                   map[ServicePortName][]*BaseEndpointInfo{},
+		expectedLocalEndpoints:           map[types.NamespacedName]int{},
+		expectedChangedEndpoints:         sets.New(makeNSN("ns1", "ep1")),
 	},
 	}
 
@@ -1147,36 +1075,9 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			if !result.UpdatedServices.Equal(tc.expectedChangedEndpoints) {
 				t.Errorf("[%d] expected changed endpoints %q, got %q", tci, tc.expectedChangedEndpoints.UnsortedList(), result.UpdatedServices.UnsortedList())
 			}
-			if len(result.DeletedUDPEndpoints) != len(tc.expectedDeletedUDPEndpoints) {
-				t.Errorf("[%d] expected %d staleEndpoints, got %d: %v", tci, len(tc.expectedDeletedUDPEndpoints), len(result.DeletedUDPEndpoints), result.DeletedUDPEndpoints)
+			if result.ConntrackCleanupRequired != tc.expectedConntrackCleanupRequired {
+				t.Errorf("[%d] expected conntrackCleanupRequired to be %t, got %t", tci, tc.expectedConntrackCleanupRequired, result.ConntrackCleanupRequired)
 			}
-			for _, x := range tc.expectedDeletedUDPEndpoints {
-				found := false
-				for _, stale := range result.DeletedUDPEndpoints {
-					if stale == x {
-						found = true
-						break
-					}
-				}
-				if !found {
-					t.Errorf("[%d] expected staleEndpoints[%v], but didn't find it: %v", tci, x, result.DeletedUDPEndpoints)
-				}
-			}
-			if len(result.NewlyActiveUDPServices) != len(tc.expectedNewlyActiveUDPServices) {
-				t.Errorf("[%d] expected %d newlyActiveUDPServices, got %d: %v", tci, len(tc.expectedNewlyActiveUDPServices), len(result.NewlyActiveUDPServices), result.NewlyActiveUDPServices)
-			}
-			for svcName := range tc.expectedNewlyActiveUDPServices {
-				found := false
-				for _, newSvcName := range result.NewlyActiveUDPServices {
-					if newSvcName == svcName {
-						found = true
-					}
-				}
-				if !found {
-					t.Errorf("[%d] expected newlyActiveUDPServices[%v], but didn't find it: %v", tci, svcName, result.NewlyActiveUDPServices)
-				}
-			}
-
 			localReadyEndpoints := fp.endpointsMap.LocalReadyEndpoints()
 			if !reflect.DeepEqual(localReadyEndpoints, tc.expectedLocalEndpoints) {
 				t.Errorf("[%d] expected local ready endpoints %v, got %v", tci, tc.expectedLocalEndpoints, localReadyEndpoints)

--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -1595,7 +1595,7 @@ func (proxier *Proxier) syncProxyRules() {
 	}
 
 	// Finish housekeeping, clear stale conntrack entries for UDP Services
-	conntrack.CleanStaleEntries(proxier.conntrack, proxier.ipFamily, proxier.svcPortMap, serviceUpdateResult, endpointUpdateResult)
+	conntrack.CleanStaleEntries(proxier.conntrack, proxier.ipFamily, proxier.svcPortMap, proxier.endpointsMap)
 }
 
 func (proxier *Proxier) writeServiceToEndpointRules(natRules proxyutil.LineBuffer, svcPortNameString string, svcInfo proxy.ServicePort, svcChain utiliptables.Chain, endpoints []proxy.Endpoint, args []string) {

--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -1594,8 +1594,10 @@ func (proxier *Proxier) syncProxyRules() {
 		proxier.logger.Error(err, "Error syncing healthcheck endpoints")
 	}
 
-	// Finish housekeeping, clear stale conntrack entries for UDP Services
-	conntrack.CleanStaleEntries(proxier.conntrack, proxier.ipFamily, proxier.svcPortMap, proxier.endpointsMap)
+	if endpointUpdateResult.ConntrackCleanupRequired {
+		// Finish housekeeping, clear stale conntrack entries for UDP Services
+		conntrack.CleanStaleEntries(proxier.conntrack, proxier.ipFamily, proxier.svcPortMap, proxier.endpointsMap)
+	}
 }
 
 func (proxier *Proxier) writeServiceToEndpointRules(natRules proxyutil.LineBuffer, svcPortNameString string, svcInfo proxy.ServicePort, svcChain utiliptables.Chain, endpoints []proxy.Endpoint, args []string) {

--- a/pkg/proxy/iptables/proxier_test.go
+++ b/pkg/proxy/iptables/proxier_test.go
@@ -2966,14 +2966,9 @@ func TestBuildServiceMapAddRemove(t *testing.T) {
 	for i := range services {
 		fp.OnServiceAdd(services[i])
 	}
-	result := fp.svcPortMap.Update(fp.serviceChanges)
+	fp.svcPortMap.Update(fp.serviceChanges)
 	if len(fp.svcPortMap) != 10 {
 		t.Errorf("expected service map length 10, got %v", fp.svcPortMap)
-	}
-
-	if len(result.DeletedUDPClusterIPs) != 0 {
-		// Services only added, so nothing stale yet
-		t.Errorf("expected stale UDP services length 0, got %d", len(result.DeletedUDPClusterIPs))
 	}
 
 	// The only-local-loadbalancer ones get added
@@ -3000,22 +2995,9 @@ func TestBuildServiceMapAddRemove(t *testing.T) {
 	fp.OnServiceDelete(services[2])
 	fp.OnServiceDelete(services[3])
 
-	result = fp.svcPortMap.Update(fp.serviceChanges)
+	fp.svcPortMap.Update(fp.serviceChanges)
 	if len(fp.svcPortMap) != 1 {
 		t.Errorf("expected service map length 1, got %v", fp.svcPortMap)
-	}
-
-	// All services but one were deleted. While you'd expect only the ClusterIPs
-	// from the three deleted services here, we still have the ClusterIP for
-	// the not-deleted service, because one of it's ServicePorts was deleted.
-	expectedStaleUDPServices := []string{"172.30.55.10", "172.30.55.4", "172.30.55.11", "172.30.55.12"}
-	if len(result.DeletedUDPClusterIPs) != len(expectedStaleUDPServices) {
-		t.Errorf("expected stale UDP services length %d, got %v", len(expectedStaleUDPServices), result.DeletedUDPClusterIPs.UnsortedList())
-	}
-	for _, ip := range expectedStaleUDPServices {
-		if !result.DeletedUDPClusterIPs.Has(ip) {
-			t.Errorf("expected stale UDP service service %s", ip)
-		}
 	}
 
 	healthCheckNodePorts = fp.svcPortMap.HealthCheckNodePorts()
@@ -3041,13 +3023,9 @@ func TestBuildServiceMapServiceHeadless(t *testing.T) {
 	)
 
 	// Headless service should be ignored
-	result := fp.svcPortMap.Update(fp.serviceChanges)
+	fp.svcPortMap.Update(fp.serviceChanges)
 	if len(fp.svcPortMap) != 0 {
 		t.Errorf("expected service map length 0, got %d", len(fp.svcPortMap))
-	}
-
-	if len(result.DeletedUDPClusterIPs) != 0 {
-		t.Errorf("expected stale UDP services length 0, got %d", len(result.DeletedUDPClusterIPs))
 	}
 
 	// No proxied services, so no healthchecks
@@ -3070,12 +3048,9 @@ func TestBuildServiceMapServiceTypeExternalName(t *testing.T) {
 		}),
 	)
 
-	result := fp.svcPortMap.Update(fp.serviceChanges)
+	fp.svcPortMap.Update(fp.serviceChanges)
 	if len(fp.svcPortMap) != 0 {
 		t.Errorf("expected service map length 0, got %v", fp.svcPortMap)
-	}
-	if len(result.DeletedUDPClusterIPs) != 0 {
-		t.Errorf("expected stale UDP services length 0, got %v", result.DeletedUDPClusterIPs)
 	}
 	// No proxied services, so no healthchecks
 	healthCheckNodePorts := fp.svcPortMap.HealthCheckNodePorts()
@@ -3111,13 +3086,9 @@ func TestBuildServiceMapServiceUpdate(t *testing.T) {
 
 	fp.OnServiceAdd(servicev1)
 
-	result := fp.svcPortMap.Update(fp.serviceChanges)
+	fp.svcPortMap.Update(fp.serviceChanges)
 	if len(fp.svcPortMap) != 2 {
 		t.Errorf("expected service map length 2, got %v", fp.svcPortMap)
-	}
-	if len(result.DeletedUDPClusterIPs) != 0 {
-		// Services only added, so nothing stale yet
-		t.Errorf("expected stale UDP services length 0, got %d", len(result.DeletedUDPClusterIPs))
 	}
 	healthCheckNodePorts := fp.svcPortMap.HealthCheckNodePorts()
 	if len(healthCheckNodePorts) != 0 {
@@ -3126,12 +3097,9 @@ func TestBuildServiceMapServiceUpdate(t *testing.T) {
 
 	// Change service to load-balancer
 	fp.OnServiceUpdate(servicev1, servicev2)
-	result = fp.svcPortMap.Update(fp.serviceChanges)
+	fp.svcPortMap.Update(fp.serviceChanges)
 	if len(fp.svcPortMap) != 2 {
 		t.Errorf("expected service map length 2, got %v", fp.svcPortMap)
-	}
-	if len(result.DeletedUDPClusterIPs) != 0 {
-		t.Errorf("expected stale UDP services length 0, got %v", result.DeletedUDPClusterIPs.UnsortedList())
 	}
 	healthCheckNodePorts = fp.svcPortMap.HealthCheckNodePorts()
 	if len(healthCheckNodePorts) != 1 {
@@ -3141,12 +3109,9 @@ func TestBuildServiceMapServiceUpdate(t *testing.T) {
 	// No change; make sure the service map stays the same and there are
 	// no health-check changes
 	fp.OnServiceUpdate(servicev2, servicev2)
-	result = fp.svcPortMap.Update(fp.serviceChanges)
+	fp.svcPortMap.Update(fp.serviceChanges)
 	if len(fp.svcPortMap) != 2 {
 		t.Errorf("expected service map length 2, got %v", fp.svcPortMap)
-	}
-	if len(result.DeletedUDPClusterIPs) != 0 {
-		t.Errorf("expected stale UDP services length 0, got %v", result.DeletedUDPClusterIPs.UnsortedList())
 	}
 	healthCheckNodePorts = fp.svcPortMap.HealthCheckNodePorts()
 	if len(healthCheckNodePorts) != 1 {
@@ -3155,13 +3120,9 @@ func TestBuildServiceMapServiceUpdate(t *testing.T) {
 
 	// And back to ClusterIP
 	fp.OnServiceUpdate(servicev2, servicev1)
-	result = fp.svcPortMap.Update(fp.serviceChanges)
+	fp.svcPortMap.Update(fp.serviceChanges)
 	if len(fp.svcPortMap) != 2 {
 		t.Errorf("expected service map length 2, got %v", fp.svcPortMap)
-	}
-	if len(result.DeletedUDPClusterIPs) != 0 {
-		// Services only added, so nothing stale yet
-		t.Errorf("expected stale UDP services length 0, got %d", len(result.DeletedUDPClusterIPs))
 	}
 	healthCheckNodePorts = fp.svcPortMap.HealthCheckNodePorts()
 	if len(healthCheckNodePorts) != 0 {

--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -932,7 +932,7 @@ func (proxier *Proxier) syncProxyRules() {
 	// We assume that if this was called, we really want to sync them,
 	// even if nothing changed in the meantime. In other words, callers are
 	// responsible for detecting no-op changes and not calling this function.
-	serviceUpdateResult := proxier.svcPortMap.Update(proxier.serviceChanges)
+	_ = proxier.svcPortMap.Update(proxier.serviceChanges)
 	endpointUpdateResult := proxier.endpointsMap.Update(proxier.endpointsChanges)
 
 	proxier.logger.V(3).Info("Syncing ipvs proxier rules")
@@ -1498,7 +1498,7 @@ func (proxier *Proxier) syncProxyRules() {
 	metrics.SyncProxyRulesNoLocalEndpointsTotal.WithLabelValues("external").Set(float64(proxier.serviceNoLocalEndpointsExternal.Len()))
 
 	// Finish housekeeping, clear stale conntrack entries for UDP Services
-	conntrack.CleanStaleEntries(proxier.conntrack, proxier.ipFamily, proxier.svcPortMap, serviceUpdateResult, endpointUpdateResult)
+	conntrack.CleanStaleEntries(proxier.conntrack, proxier.ipFamily, proxier.svcPortMap, proxier.endpointsMap)
 }
 
 // writeIptablesRules write all iptables rules to proxier.natRules or proxier.FilterRules that ipvs proxier needed

--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -1497,8 +1497,10 @@ func (proxier *Proxier) syncProxyRules() {
 	metrics.SyncProxyRulesNoLocalEndpointsTotal.WithLabelValues("internal").Set(float64(proxier.serviceNoLocalEndpointsInternal.Len()))
 	metrics.SyncProxyRulesNoLocalEndpointsTotal.WithLabelValues("external").Set(float64(proxier.serviceNoLocalEndpointsExternal.Len()))
 
-	// Finish housekeeping, clear stale conntrack entries for UDP Services
-	conntrack.CleanStaleEntries(proxier.conntrack, proxier.ipFamily, proxier.svcPortMap, proxier.endpointsMap)
+	if endpointUpdateResult.ConntrackCleanupRequired {
+		// Finish housekeeping, clear stale conntrack entries for UDP Services
+		conntrack.CleanStaleEntries(proxier.conntrack, proxier.ipFamily, proxier.svcPortMap, proxier.endpointsMap)
+	}
 }
 
 // writeIptablesRules write all iptables rules to proxier.natRules or proxier.FilterRules that ipvs proxier needed

--- a/pkg/proxy/ipvs/proxier_test.go
+++ b/pkg/proxy/ipvs/proxier_test.go
@@ -2517,14 +2517,9 @@ func TestBuildServiceMapAddRemove(t *testing.T) {
 	for i := range services {
 		fp.OnServiceAdd(services[i])
 	}
-	result := fp.svcPortMap.Update(fp.serviceChanges)
+	fp.svcPortMap.Update(fp.serviceChanges)
 	if len(fp.svcPortMap) != 12 {
 		t.Errorf("expected service map length 12, got %v", fp.svcPortMap)
-	}
-
-	if len(result.DeletedUDPClusterIPs) != 0 {
-		// Services only added, so nothing stale yet
-		t.Errorf("expected stale UDP services length 0, got %d", len(result.DeletedUDPClusterIPs))
 	}
 
 	// The only-local-loadbalancer ones get added
@@ -2551,24 +2546,10 @@ func TestBuildServiceMapAddRemove(t *testing.T) {
 	fp.OnServiceDelete(services[2])
 	fp.OnServiceDelete(services[3])
 
-	result = fp.svcPortMap.Update(fp.serviceChanges)
+	fp.svcPortMap.Update(fp.serviceChanges)
 	if len(fp.svcPortMap) != 1 {
 		t.Errorf("expected service map length 1, got %v", fp.svcPortMap)
 	}
-
-	// All services but one were deleted. While you'd expect only the ClusterIPs
-	// from the three deleted services here, we still have the ClusterIP for
-	// the not-deleted service, because one of it's ServicePorts was deleted.
-	expectedStaleUDPServices := []string{"172.16.55.10", "172.16.55.4", "172.16.55.11", "172.16.55.12"}
-	if len(result.DeletedUDPClusterIPs) != len(expectedStaleUDPServices) {
-		t.Errorf("expected stale UDP services length %d, got %v", len(expectedStaleUDPServices), result.DeletedUDPClusterIPs.UnsortedList())
-	}
-	for _, ip := range expectedStaleUDPServices {
-		if !result.DeletedUDPClusterIPs.Has(ip) {
-			t.Errorf("expected stale UDP service service %s", ip)
-		}
-	}
-
 	healthCheckNodePorts = fp.svcPortMap.HealthCheckNodePorts()
 	if len(healthCheckNodePorts) != 0 {
 		t.Errorf("expected 0 healthcheck ports, got %v", healthCheckNodePorts)
@@ -2600,13 +2581,9 @@ func TestBuildServiceMapServiceHeadless(t *testing.T) {
 	)
 
 	// Headless service should be ignored
-	result := fp.svcPortMap.Update(fp.serviceChanges)
+	fp.svcPortMap.Update(fp.serviceChanges)
 	if len(fp.svcPortMap) != 0 {
 		t.Errorf("expected service map length 0, got %d", len(fp.svcPortMap))
-	}
-
-	if len(result.DeletedUDPClusterIPs) != 0 {
-		t.Errorf("expected stale UDP services length 0, got %d", len(result.DeletedUDPClusterIPs))
 	}
 
 	// No proxied services, so no healthchecks
@@ -2632,12 +2609,9 @@ func TestBuildServiceMapServiceTypeExternalName(t *testing.T) {
 		}),
 	)
 
-	result := fp.svcPortMap.Update(fp.serviceChanges)
+	fp.svcPortMap.Update(fp.serviceChanges)
 	if len(fp.svcPortMap) != 0 {
 		t.Errorf("expected service map length 0, got %v", fp.svcPortMap)
-	}
-	if len(result.DeletedUDPClusterIPs) != 0 {
-		t.Errorf("expected stale UDP services length 0, got %v", result.DeletedUDPClusterIPs)
 	}
 
 	// No proxied services, so no healthchecks
@@ -2677,15 +2651,10 @@ func TestBuildServiceMapServiceUpdate(t *testing.T) {
 
 	fp.OnServiceAdd(servicev1)
 
-	result := fp.svcPortMap.Update(fp.serviceChanges)
+	fp.svcPortMap.Update(fp.serviceChanges)
 	if len(fp.svcPortMap) != 2 {
 		t.Errorf("expected service map length 2, got %v", fp.svcPortMap)
 	}
-	if len(result.DeletedUDPClusterIPs) != 0 {
-		// Services only added, so nothing stale yet
-		t.Errorf("expected stale UDP services length 0, got %d", len(result.DeletedUDPClusterIPs))
-	}
-
 	healthCheckNodePorts := fp.svcPortMap.HealthCheckNodePorts()
 	if len(healthCheckNodePorts) != 0 {
 		t.Errorf("expected healthcheck ports length 0, got %v", healthCheckNodePorts)
@@ -2693,12 +2662,9 @@ func TestBuildServiceMapServiceUpdate(t *testing.T) {
 
 	// Change service to load-balancer
 	fp.OnServiceUpdate(servicev1, servicev2)
-	result = fp.svcPortMap.Update(fp.serviceChanges)
+	fp.svcPortMap.Update(fp.serviceChanges)
 	if len(fp.svcPortMap) != 2 {
 		t.Errorf("expected service map length 2, got %v", fp.svcPortMap)
-	}
-	if len(result.DeletedUDPClusterIPs) != 0 {
-		t.Errorf("expected stale UDP services length 0, got %v", result.DeletedUDPClusterIPs.UnsortedList())
 	}
 
 	healthCheckNodePorts = fp.svcPortMap.HealthCheckNodePorts()
@@ -2709,12 +2675,9 @@ func TestBuildServiceMapServiceUpdate(t *testing.T) {
 	// No change; make sure the service map stays the same and there are
 	// no health-check changes
 	fp.OnServiceUpdate(servicev2, servicev2)
-	result = fp.svcPortMap.Update(fp.serviceChanges)
+	fp.svcPortMap.Update(fp.serviceChanges)
 	if len(fp.svcPortMap) != 2 {
 		t.Errorf("expected service map length 2, got %v", fp.svcPortMap)
-	}
-	if len(result.DeletedUDPClusterIPs) != 0 {
-		t.Errorf("expected stale UDP services length 0, got %v", result.DeletedUDPClusterIPs.UnsortedList())
 	}
 
 	healthCheckNodePorts = fp.svcPortMap.HealthCheckNodePorts()
@@ -2724,13 +2687,9 @@ func TestBuildServiceMapServiceUpdate(t *testing.T) {
 
 	// And back to ClusterIP
 	fp.OnServiceUpdate(servicev2, servicev1)
-	result = fp.svcPortMap.Update(fp.serviceChanges)
+	fp.svcPortMap.Update(fp.serviceChanges)
 	if len(fp.svcPortMap) != 2 {
 		t.Errorf("expected service map length 2, got %v", fp.svcPortMap)
-	}
-	if len(result.DeletedUDPClusterIPs) != 0 {
-		// Services only added, so nothing stale yet
-		t.Errorf("expected stale UDP services length 0, got %d", len(result.DeletedUDPClusterIPs))
 	}
 
 	healthCheckNodePorts = fp.svcPortMap.HealthCheckNodePorts()

--- a/pkg/proxy/ipvs/proxier_test.go
+++ b/pkg/proxy/ipvs/proxier_test.go
@@ -3127,22 +3127,20 @@ func Test_updateEndpointsMap(t *testing.T) {
 		// previousEndpoints and currentEndpoints are used to call appropriate
 		// handlers OnEndpoints* (based on whether corresponding values are nil
 		// or non-nil) and must be of equal length.
-		name                           string
-		previousEndpoints              []*discovery.EndpointSlice
-		currentEndpoints               []*discovery.EndpointSlice
-		oldEndpoints                   map[proxy.ServicePortName][]endpointExpectation
-		expectedResult                 map[proxy.ServicePortName][]endpointExpectation
-		expectedDeletedUDPEndpoints    []proxy.ServiceEndpoint
-		expectedNewlyActiveUDPServices map[proxy.ServicePortName]bool
-		expectedReadyEndpoints         map[types.NamespacedName]int
+		name                             string
+		previousEndpoints                []*discovery.EndpointSlice
+		currentEndpoints                 []*discovery.EndpointSlice
+		oldEndpoints                     map[proxy.ServicePortName][]endpointExpectation
+		expectedResult                   map[proxy.ServicePortName][]endpointExpectation
+		expectedConntrackCleanupRequired bool
+		expectedReadyEndpoints           map[types.NamespacedName]int
 	}{{
 		// Case[0]: nothing
-		name:                           "nothing",
-		oldEndpoints:                   map[proxy.ServicePortName][]endpointExpectation{},
-		expectedResult:                 map[proxy.ServicePortName][]endpointExpectation{},
-		expectedDeletedUDPEndpoints:    []proxy.ServiceEndpoint{},
-		expectedNewlyActiveUDPServices: map[proxy.ServicePortName]bool{},
-		expectedReadyEndpoints:         map[types.NamespacedName]int{},
+		name:                             "nothing",
+		oldEndpoints:                     map[proxy.ServicePortName][]endpointExpectation{},
+		expectedResult:                   map[proxy.ServicePortName][]endpointExpectation{},
+		expectedConntrackCleanupRequired: false,
+		expectedReadyEndpoints:           map[types.NamespacedName]int{},
 	}, {
 		// Case[1]: no change, named port, local
 		name:              "no change, named port, local",
@@ -3158,8 +3156,7 @@ func Test_updateEndpointsMap(t *testing.T) {
 				{endpoint: "1.1.1.1:11", isLocal: true},
 			},
 		},
-		expectedDeletedUDPEndpoints:    []proxy.ServiceEndpoint{},
-		expectedNewlyActiveUDPServices: map[proxy.ServicePortName]bool{},
+		expectedConntrackCleanupRequired: false,
 		expectedReadyEndpoints: map[types.NamespacedName]int{
 			makeNSN("ns1", "ep1"): 1,
 		},
@@ -3184,9 +3181,8 @@ func Test_updateEndpointsMap(t *testing.T) {
 				{endpoint: "1.1.1.2:12", isLocal: false},
 			},
 		},
-		expectedDeletedUDPEndpoints:    []proxy.ServiceEndpoint{},
-		expectedNewlyActiveUDPServices: map[proxy.ServicePortName]bool{},
-		expectedReadyEndpoints:         map[types.NamespacedName]int{},
+		expectedConntrackCleanupRequired: false,
+		expectedReadyEndpoints:           map[types.NamespacedName]int{},
 	}, {
 		// Case[3]: no change, multiple subsets, multiple ports, local
 		name:              "no change, multiple subsets, multiple ports, local",
@@ -3214,8 +3210,7 @@ func Test_updateEndpointsMap(t *testing.T) {
 				{endpoint: "1.1.1.3:13", isLocal: false},
 			},
 		},
-		expectedDeletedUDPEndpoints:    []proxy.ServiceEndpoint{},
-		expectedNewlyActiveUDPServices: map[proxy.ServicePortName]bool{},
+		expectedConntrackCleanupRequired: false,
 		expectedReadyEndpoints: map[types.NamespacedName]int{
 			makeNSN("ns1", "ep1"): 1,
 		},
@@ -3276,8 +3271,7 @@ func Test_updateEndpointsMap(t *testing.T) {
 				{endpoint: "2.2.2.2:22", isLocal: true},
 			},
 		},
-		expectedDeletedUDPEndpoints:    []proxy.ServiceEndpoint{},
-		expectedNewlyActiveUDPServices: map[proxy.ServicePortName]bool{},
+		expectedConntrackCleanupRequired: false,
 		expectedReadyEndpoints: map[types.NamespacedName]int{
 			makeNSN("ns1", "ep1"): 2,
 			makeNSN("ns2", "ep2"): 1,
@@ -3293,10 +3287,7 @@ func Test_updateEndpointsMap(t *testing.T) {
 				{endpoint: "1.1.1.1:11", isLocal: true},
 			},
 		},
-		expectedDeletedUDPEndpoints: []proxy.ServiceEndpoint{},
-		expectedNewlyActiveUDPServices: map[proxy.ServicePortName]bool{
-			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): true,
-		},
+		expectedConntrackCleanupRequired: true,
 		expectedReadyEndpoints: map[types.NamespacedName]int{
 			makeNSN("ns1", "ep1"): 1,
 		},
@@ -3310,13 +3301,9 @@ func Test_updateEndpointsMap(t *testing.T) {
 				{endpoint: "1.1.1.1:11", isLocal: true},
 			},
 		},
-		expectedResult: map[proxy.ServicePortName][]endpointExpectation{},
-		expectedDeletedUDPEndpoints: []proxy.ServiceEndpoint{{
-			Endpoint:        "1.1.1.1:11",
-			ServicePortName: makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP),
-		}},
-		expectedNewlyActiveUDPServices: map[proxy.ServicePortName]bool{},
-		expectedReadyEndpoints:         map[types.NamespacedName]int{},
+		expectedConntrackCleanupRequired: true,
+		expectedResult:                   map[proxy.ServicePortName][]endpointExpectation{},
+		expectedReadyEndpoints:           map[types.NamespacedName]int{},
 	}, {
 		// Case[7]: add an IP and port
 		name:              "add an IP and port",
@@ -3337,10 +3324,7 @@ func Test_updateEndpointsMap(t *testing.T) {
 				{endpoint: "1.1.1.2:12", isLocal: true},
 			},
 		},
-		expectedDeletedUDPEndpoints: []proxy.ServiceEndpoint{},
-		expectedNewlyActiveUDPServices: map[proxy.ServicePortName]bool{
-			makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP): true,
-		},
+		expectedConntrackCleanupRequired: true,
 		expectedReadyEndpoints: map[types.NamespacedName]int{
 			makeNSN("ns1", "ep1"): 1,
 		},
@@ -3364,18 +3348,8 @@ func Test_updateEndpointsMap(t *testing.T) {
 				{endpoint: "1.1.1.1:11", isLocal: false},
 			},
 		},
-		expectedDeletedUDPEndpoints: []proxy.ServiceEndpoint{{
-			Endpoint:        "1.1.1.2:11",
-			ServicePortName: makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP),
-		}, {
-			Endpoint:        "1.1.1.1:12",
-			ServicePortName: makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP),
-		}, {
-			Endpoint:        "1.1.1.2:12",
-			ServicePortName: makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP),
-		}},
-		expectedNewlyActiveUDPServices: map[proxy.ServicePortName]bool{},
-		expectedReadyEndpoints:         map[types.NamespacedName]int{},
+		expectedConntrackCleanupRequired: true,
+		expectedReadyEndpoints:           map[types.NamespacedName]int{},
 	}, {
 		// Case[9]: add a subset
 		name:              "add a subset",
@@ -3394,10 +3368,7 @@ func Test_updateEndpointsMap(t *testing.T) {
 				{endpoint: "1.1.1.2:12", isLocal: true},
 			},
 		},
-		expectedDeletedUDPEndpoints: []proxy.ServiceEndpoint{},
-		expectedNewlyActiveUDPServices: map[proxy.ServicePortName]bool{
-			makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP): true,
-		},
+		expectedConntrackCleanupRequired: true,
 		expectedReadyEndpoints: map[types.NamespacedName]int{
 			makeNSN("ns1", "ep1"): 1,
 		},
@@ -3419,12 +3390,8 @@ func Test_updateEndpointsMap(t *testing.T) {
 				{endpoint: "1.1.1.1:11", isLocal: false},
 			},
 		},
-		expectedDeletedUDPEndpoints: []proxy.ServiceEndpoint{{
-			Endpoint:        "1.1.1.2:12",
-			ServicePortName: makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP),
-		}},
-		expectedNewlyActiveUDPServices: map[proxy.ServicePortName]bool{},
-		expectedReadyEndpoints:         map[types.NamespacedName]int{},
+		expectedConntrackCleanupRequired: true,
+		expectedReadyEndpoints:           map[types.NamespacedName]int{},
 	}, {
 		// Case[11]: rename a port
 		name:              "rename a port",
@@ -3440,14 +3407,8 @@ func Test_updateEndpointsMap(t *testing.T) {
 				{endpoint: "1.1.1.1:11", isLocal: false},
 			},
 		},
-		expectedDeletedUDPEndpoints: []proxy.ServiceEndpoint{{
-			Endpoint:        "1.1.1.1:11",
-			ServicePortName: makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP),
-		}},
-		expectedNewlyActiveUDPServices: map[proxy.ServicePortName]bool{
-			makeServicePortName("ns1", "ep1", "p11-2", v1.ProtocolUDP): true,
-		},
-		expectedReadyEndpoints: map[types.NamespacedName]int{},
+		expectedConntrackCleanupRequired: true,
+		expectedReadyEndpoints:           map[types.NamespacedName]int{},
 	}, {
 		// Case[12]: renumber a port
 		name:              "renumber a port",
@@ -3463,12 +3424,8 @@ func Test_updateEndpointsMap(t *testing.T) {
 				{endpoint: "1.1.1.1:22", isLocal: false},
 			},
 		},
-		expectedDeletedUDPEndpoints: []proxy.ServiceEndpoint{{
-			Endpoint:        "1.1.1.1:11",
-			ServicePortName: makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP),
-		}},
-		expectedNewlyActiveUDPServices: map[proxy.ServicePortName]bool{},
-		expectedReadyEndpoints:         map[types.NamespacedName]int{},
+		expectedConntrackCleanupRequired: true,
+		expectedReadyEndpoints:           map[types.NamespacedName]int{},
 	}, {
 		// Case[13]: complex add and remove
 		name:              "complex add and remove",
@@ -3511,27 +3468,7 @@ func Test_updateEndpointsMap(t *testing.T) {
 				{endpoint: "4.4.4.4:44", isLocal: true},
 			},
 		},
-		expectedDeletedUDPEndpoints: []proxy.ServiceEndpoint{{
-			Endpoint:        "2.2.2.2:22",
-			ServicePortName: makeServicePortName("ns2", "ep2", "p22", v1.ProtocolUDP),
-		}, {
-			Endpoint:        "2.2.2.22:22",
-			ServicePortName: makeServicePortName("ns2", "ep2", "p22", v1.ProtocolUDP),
-		}, {
-			Endpoint:        "2.2.2.3:23",
-			ServicePortName: makeServicePortName("ns2", "ep2", "p23", v1.ProtocolUDP),
-		}, {
-			Endpoint:        "4.4.4.5:44",
-			ServicePortName: makeServicePortName("ns4", "ep4", "p44", v1.ProtocolUDP),
-		}, {
-			Endpoint:        "4.4.4.6:45",
-			ServicePortName: makeServicePortName("ns4", "ep4", "p45", v1.ProtocolUDP),
-		}},
-		expectedNewlyActiveUDPServices: map[proxy.ServicePortName]bool{
-			makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP):  true,
-			makeServicePortName("ns1", "ep1", "p122", v1.ProtocolUDP): true,
-			makeServicePortName("ns3", "ep3", "p33", v1.ProtocolUDP):  true,
-		},
+		expectedConntrackCleanupRequired: true,
 		expectedReadyEndpoints: map[types.NamespacedName]int{
 			makeNSN("ns4", "ep4"): 1,
 		},
@@ -3546,11 +3483,8 @@ func Test_updateEndpointsMap(t *testing.T) {
 				{endpoint: "1.1.1.1:11", isLocal: false},
 			},
 		},
-		expectedDeletedUDPEndpoints: []proxy.ServiceEndpoint{},
-		expectedNewlyActiveUDPServices: map[proxy.ServicePortName]bool{
-			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): true,
-		},
-		expectedReadyEndpoints: map[types.NamespacedName]int{},
+		expectedConntrackCleanupRequired: true,
+		expectedReadyEndpoints:           map[types.NamespacedName]int{},
 	},
 	}
 
@@ -3592,35 +3526,8 @@ func Test_updateEndpointsMap(t *testing.T) {
 			result := fp.endpointsMap.Update(fp.endpointsChanges)
 			newMap := fp.endpointsMap
 			checkEndpointExpectations(t, tci, newMap, tc.expectedResult)
-			if len(result.DeletedUDPEndpoints) != len(tc.expectedDeletedUDPEndpoints) {
-				t.Errorf("[%d] expected %d staleEndpoints, got %d: %v", tci, len(tc.expectedDeletedUDPEndpoints), len(result.DeletedUDPEndpoints), result.DeletedUDPEndpoints)
-			}
-			for _, x := range tc.expectedDeletedUDPEndpoints {
-				found := false
-				for _, stale := range result.DeletedUDPEndpoints {
-					if stale == x {
-						found = true
-						break
-					}
-				}
-				if !found {
-					t.Errorf("[%d] expected staleEndpoints[%v], but didn't find it: %v", tci, x, result.DeletedUDPEndpoints)
-				}
-			}
-			if len(result.NewlyActiveUDPServices) != len(tc.expectedNewlyActiveUDPServices) {
-				t.Errorf("[%d] expected %d staleServiceNames, got %d: %v", tci, len(tc.expectedNewlyActiveUDPServices), len(result.NewlyActiveUDPServices), result.NewlyActiveUDPServices)
-			}
-			for svcName := range tc.expectedNewlyActiveUDPServices {
-				found := false
-				for _, stale := range result.NewlyActiveUDPServices {
-					if stale == svcName {
-						found = true
-						break
-					}
-				}
-				if !found {
-					t.Errorf("[%d] expected staleServiceNames[%v], but didn't find it: %v", tci, svcName, result.NewlyActiveUDPServices)
-				}
+			if result.ConntrackCleanupRequired != tc.expectedConntrackCleanupRequired {
+				t.Errorf("[%d] expected conntrackCleanupRequired to be %t, got %t", tci, tc.expectedConntrackCleanupRequired, result.ConntrackCleanupRequired)
 			}
 			localReadyEndpoints := fp.endpointsMap.LocalReadyEndpoints()
 			if !reflect.DeepEqual(localReadyEndpoints, tc.expectedReadyEndpoints) {

--- a/pkg/proxy/nftables/proxier.go
+++ b/pkg/proxy/nftables/proxier.go
@@ -1838,8 +1838,10 @@ func (proxier *Proxier) syncProxyRules() {
 		proxier.logger.Error(err, "Error syncing healthcheck endpoints")
 	}
 
-	// Finish housekeeping, clear stale conntrack entries for UDP Services
-	conntrack.CleanStaleEntries(proxier.conntrack, proxier.ipFamily, proxier.svcPortMap, proxier.endpointsMap)
+	if endpointUpdateResult.ConntrackCleanupRequired {
+		// Finish housekeeping, clear stale conntrack entries for UDP Services
+		conntrack.CleanStaleEntries(proxier.conntrack, proxier.ipFamily, proxier.svcPortMap, proxier.endpointsMap)
+	}
 }
 
 func (proxier *Proxier) writeServiceToEndpointRules(tx *knftables.Transaction, svcInfo *servicePortInfo, svcChain string, endpoints []proxy.Endpoint) {

--- a/pkg/proxy/nftables/proxier.go
+++ b/pkg/proxy/nftables/proxier.go
@@ -1839,7 +1839,7 @@ func (proxier *Proxier) syncProxyRules() {
 	}
 
 	// Finish housekeeping, clear stale conntrack entries for UDP Services
-	conntrack.CleanStaleEntries(proxier.conntrack, proxier.ipFamily, proxier.svcPortMap, serviceUpdateResult, endpointUpdateResult)
+	conntrack.CleanStaleEntries(proxier.conntrack, proxier.ipFamily, proxier.svcPortMap, proxier.endpointsMap)
 }
 
 func (proxier *Proxier) writeServiceToEndpointRules(tx *knftables.Transaction, svcInfo *servicePortInfo, svcChain string, endpoints []proxy.Endpoint) {

--- a/pkg/proxy/nftables/proxier_test.go
+++ b/pkg/proxy/nftables/proxier_test.go
@@ -1969,22 +1969,20 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		// previousEndpoints and currentEndpoints are used to call appropriate
 		// handlers OnEndpoints* (based on whether corresponding values are nil
 		// or non-nil) and must be of equal length.
-		name                           string
-		previousEndpoints              []*discovery.EndpointSlice
-		currentEndpoints               []*discovery.EndpointSlice
-		oldEndpoints                   map[proxy.ServicePortName][]endpointExpectation
-		expectedResult                 map[proxy.ServicePortName][]endpointExpectation
-		expectedDeletedUDPEndpoints    []proxy.ServiceEndpoint
-		expectedNewlyActiveUDPServices map[proxy.ServicePortName]bool
-		expectedLocalEndpoints         map[types.NamespacedName]int
+		name                             string
+		previousEndpoints                []*discovery.EndpointSlice
+		currentEndpoints                 []*discovery.EndpointSlice
+		oldEndpoints                     map[proxy.ServicePortName][]endpointExpectation
+		expectedResult                   map[proxy.ServicePortName][]endpointExpectation
+		expectedConntrackCleanupRequired bool
+		expectedLocalEndpoints           map[types.NamespacedName]int
 	}{{
 		// Case[0]: nothing
-		name:                           "nothing",
-		oldEndpoints:                   map[proxy.ServicePortName][]endpointExpectation{},
-		expectedResult:                 map[proxy.ServicePortName][]endpointExpectation{},
-		expectedDeletedUDPEndpoints:    []proxy.ServiceEndpoint{},
-		expectedNewlyActiveUDPServices: map[proxy.ServicePortName]bool{},
-		expectedLocalEndpoints:         map[types.NamespacedName]int{},
+		name:                             "nothing",
+		oldEndpoints:                     map[proxy.ServicePortName][]endpointExpectation{},
+		expectedResult:                   map[proxy.ServicePortName][]endpointExpectation{},
+		expectedConntrackCleanupRequired: false,
+		expectedLocalEndpoints:           map[types.NamespacedName]int{},
 	}, {
 		// Case[1]: no change, named port, local
 		name:              "no change, named port, local",
@@ -2000,8 +1998,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{endpoint: "10.1.1.1:11", isLocal: true},
 			},
 		},
-		expectedDeletedUDPEndpoints:    []proxy.ServiceEndpoint{},
-		expectedNewlyActiveUDPServices: map[proxy.ServicePortName]bool{},
+		expectedConntrackCleanupRequired: false,
 		expectedLocalEndpoints: map[types.NamespacedName]int{
 			makeNSN("ns1", "ep1"): 1,
 		},
@@ -2026,9 +2023,8 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{endpoint: "10.1.1.2:12", isLocal: false},
 			},
 		},
-		expectedDeletedUDPEndpoints:    []proxy.ServiceEndpoint{},
-		expectedNewlyActiveUDPServices: map[proxy.ServicePortName]bool{},
-		expectedLocalEndpoints:         map[types.NamespacedName]int{},
+		expectedConntrackCleanupRequired: false,
+		expectedLocalEndpoints:           map[types.NamespacedName]int{},
 	}, {
 		// Case[3]: no change, multiple subsets, multiple ports, local
 		name:              "no change, multiple subsets, multiple ports, local",
@@ -2056,8 +2052,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{endpoint: "10.1.1.3:13", isLocal: false},
 			},
 		},
-		expectedDeletedUDPEndpoints:    []proxy.ServiceEndpoint{},
-		expectedNewlyActiveUDPServices: map[proxy.ServicePortName]bool{},
+		expectedConntrackCleanupRequired: false,
 		expectedLocalEndpoints: map[types.NamespacedName]int{
 			makeNSN("ns1", "ep1"): 1,
 		},
@@ -2118,8 +2113,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{endpoint: "10.2.2.2:22", isLocal: true},
 			},
 		},
-		expectedDeletedUDPEndpoints:    []proxy.ServiceEndpoint{},
-		expectedNewlyActiveUDPServices: map[proxy.ServicePortName]bool{},
+		expectedConntrackCleanupRequired: false,
 		expectedLocalEndpoints: map[types.NamespacedName]int{
 			makeNSN("ns1", "ep1"): 2,
 			makeNSN("ns2", "ep2"): 1,
@@ -2135,10 +2129,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{endpoint: "10.1.1.1:11", isLocal: true},
 			},
 		},
-		expectedDeletedUDPEndpoints: []proxy.ServiceEndpoint{},
-		expectedNewlyActiveUDPServices: map[proxy.ServicePortName]bool{
-			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): true,
-		},
+		expectedConntrackCleanupRequired: true,
 		expectedLocalEndpoints: map[types.NamespacedName]int{
 			makeNSN("ns1", "ep1"): 1,
 		},
@@ -2152,13 +2143,8 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{endpoint: "10.1.1.1:11", isLocal: true},
 			},
 		},
-		expectedResult: map[proxy.ServicePortName][]endpointExpectation{},
-		expectedDeletedUDPEndpoints: []proxy.ServiceEndpoint{{
-			Endpoint:        "10.1.1.1:11",
-			ServicePortName: makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP),
-		}},
-		expectedNewlyActiveUDPServices: map[proxy.ServicePortName]bool{},
-		expectedLocalEndpoints:         map[types.NamespacedName]int{},
+		expectedConntrackCleanupRequired: true,
+		expectedLocalEndpoints:           map[types.NamespacedName]int{},
 	}, {
 		// Case[7]: add an IP and port
 		name:              "add an IP and port",
@@ -2179,10 +2165,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{endpoint: "10.1.1.2:12", isLocal: true},
 			},
 		},
-		expectedDeletedUDPEndpoints: []proxy.ServiceEndpoint{},
-		expectedNewlyActiveUDPServices: map[proxy.ServicePortName]bool{
-			makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP): true,
-		},
+		expectedConntrackCleanupRequired: true,
 		expectedLocalEndpoints: map[types.NamespacedName]int{
 			makeNSN("ns1", "ep1"): 1,
 		},
@@ -2206,18 +2189,8 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{endpoint: "10.1.1.1:11", isLocal: false},
 			},
 		},
-		expectedDeletedUDPEndpoints: []proxy.ServiceEndpoint{{
-			Endpoint:        "10.1.1.2:11",
-			ServicePortName: makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP),
-		}, {
-			Endpoint:        "10.1.1.1:12",
-			ServicePortName: makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP),
-		}, {
-			Endpoint:        "10.1.1.2:12",
-			ServicePortName: makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP),
-		}},
-		expectedNewlyActiveUDPServices: map[proxy.ServicePortName]bool{},
-		expectedLocalEndpoints:         map[types.NamespacedName]int{},
+		expectedConntrackCleanupRequired: true,
+		expectedLocalEndpoints:           map[types.NamespacedName]int{},
 	}, {
 		// Case[9]: add a subset
 		name:              "add a subset",
@@ -2236,10 +2209,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{endpoint: "10.1.1.2:12", isLocal: true},
 			},
 		},
-		expectedDeletedUDPEndpoints: []proxy.ServiceEndpoint{},
-		expectedNewlyActiveUDPServices: map[proxy.ServicePortName]bool{
-			makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP): true,
-		},
+		expectedConntrackCleanupRequired: true,
 		expectedLocalEndpoints: map[types.NamespacedName]int{
 			makeNSN("ns1", "ep1"): 1,
 		},
@@ -2261,12 +2231,8 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{endpoint: "10.1.1.1:11", isLocal: false},
 			},
 		},
-		expectedDeletedUDPEndpoints: []proxy.ServiceEndpoint{{
-			Endpoint:        "10.1.1.2:12",
-			ServicePortName: makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP),
-		}},
-		expectedNewlyActiveUDPServices: map[proxy.ServicePortName]bool{},
-		expectedLocalEndpoints:         map[types.NamespacedName]int{},
+		expectedConntrackCleanupRequired: true,
+		expectedLocalEndpoints:           map[types.NamespacedName]int{},
 	}, {
 		// Case[11]: rename a port
 		name:              "rename a port",
@@ -2282,14 +2248,8 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{endpoint: "10.1.1.1:11", isLocal: false},
 			},
 		},
-		expectedDeletedUDPEndpoints: []proxy.ServiceEndpoint{{
-			Endpoint:        "10.1.1.1:11",
-			ServicePortName: makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP),
-		}},
-		expectedNewlyActiveUDPServices: map[proxy.ServicePortName]bool{
-			makeServicePortName("ns1", "ep1", "p11-2", v1.ProtocolUDP): true,
-		},
-		expectedLocalEndpoints: map[types.NamespacedName]int{},
+		expectedConntrackCleanupRequired: true,
+		expectedLocalEndpoints:           map[types.NamespacedName]int{},
 	}, {
 		// Case[12]: renumber a port
 		name:              "renumber a port",
@@ -2305,12 +2265,8 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{endpoint: "10.1.1.1:22", isLocal: false},
 			},
 		},
-		expectedDeletedUDPEndpoints: []proxy.ServiceEndpoint{{
-			Endpoint:        "10.1.1.1:11",
-			ServicePortName: makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP),
-		}},
-		expectedNewlyActiveUDPServices: map[proxy.ServicePortName]bool{},
-		expectedLocalEndpoints:         map[types.NamespacedName]int{},
+		expectedConntrackCleanupRequired: true,
+		expectedLocalEndpoints:           map[types.NamespacedName]int{},
 	}, {
 		// Case[13]: complex add and remove
 		name:              "complex add and remove",
@@ -2353,27 +2309,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{endpoint: "10.4.4.4:44", isLocal: true},
 			},
 		},
-		expectedDeletedUDPEndpoints: []proxy.ServiceEndpoint{{
-			Endpoint:        "10.2.2.2:22",
-			ServicePortName: makeServicePortName("ns2", "ep2", "p22", v1.ProtocolUDP),
-		}, {
-			Endpoint:        "10.2.2.22:22",
-			ServicePortName: makeServicePortName("ns2", "ep2", "p22", v1.ProtocolUDP),
-		}, {
-			Endpoint:        "10.2.2.3:23",
-			ServicePortName: makeServicePortName("ns2", "ep2", "p23", v1.ProtocolUDP),
-		}, {
-			Endpoint:        "10.4.4.5:44",
-			ServicePortName: makeServicePortName("ns4", "ep4", "p44", v1.ProtocolUDP),
-		}, {
-			Endpoint:        "10.4.4.6:45",
-			ServicePortName: makeServicePortName("ns4", "ep4", "p45", v1.ProtocolUDP),
-		}},
-		expectedNewlyActiveUDPServices: map[proxy.ServicePortName]bool{
-			makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP):  true,
-			makeServicePortName("ns1", "ep1", "p122", v1.ProtocolUDP): true,
-			makeServicePortName("ns3", "ep3", "p33", v1.ProtocolUDP):  true,
-		},
+		expectedConntrackCleanupRequired: true,
 		expectedLocalEndpoints: map[types.NamespacedName]int{
 			makeNSN("ns4", "ep4"): 1,
 		},
@@ -2388,11 +2324,8 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{endpoint: "10.1.1.1:11", isLocal: false},
 			},
 		},
-		expectedDeletedUDPEndpoints: []proxy.ServiceEndpoint{},
-		expectedNewlyActiveUDPServices: map[proxy.ServicePortName]bool{
-			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): true,
-		},
-		expectedLocalEndpoints: map[types.NamespacedName]int{},
+		expectedConntrackCleanupRequired: true,
+		expectedLocalEndpoints:           map[types.NamespacedName]int{},
 	},
 	}
 
@@ -2430,34 +2363,8 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			result := fp.endpointsMap.Update(fp.endpointsChanges)
 			newMap := fp.endpointsMap
 			checkEndpointExpectations(t, tci, newMap, tc.expectedResult)
-			if len(result.DeletedUDPEndpoints) != len(tc.expectedDeletedUDPEndpoints) {
-				t.Errorf("[%d] expected %d staleEndpoints, got %d: %v", tci, len(tc.expectedDeletedUDPEndpoints), len(result.DeletedUDPEndpoints), result.DeletedUDPEndpoints)
-			}
-			for _, x := range tc.expectedDeletedUDPEndpoints {
-				found := false
-				for _, stale := range result.DeletedUDPEndpoints {
-					if stale == x {
-						found = true
-						break
-					}
-				}
-				if !found {
-					t.Errorf("[%d] expected staleEndpoints[%v], but didn't find it: %v", tci, x, result.DeletedUDPEndpoints)
-				}
-			}
-			if len(result.NewlyActiveUDPServices) != len(tc.expectedNewlyActiveUDPServices) {
-				t.Errorf("[%d] expected %d staleServiceNames, got %d: %v", tci, len(tc.expectedNewlyActiveUDPServices), len(result.NewlyActiveUDPServices), result.NewlyActiveUDPServices)
-			}
-			for svcName := range tc.expectedNewlyActiveUDPServices {
-				found := false
-				for _, stale := range result.NewlyActiveUDPServices {
-					if stale == svcName {
-						found = true
-					}
-				}
-				if !found {
-					t.Errorf("[%d] expected staleServiceNames[%v], but didn't find it: %v", tci, svcName, result.NewlyActiveUDPServices)
-				}
+			if result.ConntrackCleanupRequired != tc.expectedConntrackCleanupRequired {
+				t.Errorf("[%d] expected conntrackCleanupRequired to be %t, got %t", tci, tc.expectedConntrackCleanupRequired, result.ConntrackCleanupRequired)
 			}
 			localReadyEndpoints := fp.endpointsMap.LocalReadyEndpoints()
 			if !reflect.DeepEqual(localReadyEndpoints, tc.expectedLocalEndpoints) {

--- a/pkg/proxy/servicechangetracker_test.go
+++ b/pkg/proxy/servicechangetracker_test.go
@@ -680,9 +680,6 @@ func TestServiceMapUpdateHeadless(t *testing.T) {
 	if len(result.UpdatedServices) != 0 {
 		t.Errorf("expected 0 updated services, got %d", len(result.UpdatedServices))
 	}
-	if len(result.DeletedUDPClusterIPs) != 0 {
-		t.Errorf("expected stale UDP services length 0, got %d", len(result.DeletedUDPClusterIPs))
-	}
 
 	// No proxied services, so no healthchecks
 	healthCheckNodePorts := fp.svcPortMap.HealthCheckNodePorts()
@@ -709,9 +706,6 @@ func TestUpdateServiceTypeExternalName(t *testing.T) {
 	}
 	if len(result.UpdatedServices) != 0 {
 		t.Errorf("expected 0 updated services, got %v", result.UpdatedServices)
-	}
-	if len(result.DeletedUDPClusterIPs) != 0 {
-		t.Errorf("expected stale UDP services length 0, got %v", result.DeletedUDPClusterIPs)
 	}
 
 	// No proxied services, so no healthchecks
@@ -782,10 +776,6 @@ func TestBuildServiceMapAddRemove(t *testing.T) {
 	if len(result.UpdatedServices) != len(services) {
 		t.Errorf("expected %d updated services, got %d", len(services), len(result.UpdatedServices))
 	}
-	if len(result.DeletedUDPClusterIPs) != 0 {
-		// Services only added, so nothing stale yet
-		t.Errorf("expected stale UDP services length 0, got %d", len(result.DeletedUDPClusterIPs))
-	}
 
 	// The only-local-loadbalancer ones get added
 	healthCheckNodePorts := fp.svcPortMap.HealthCheckNodePorts()
@@ -823,19 +813,6 @@ func TestBuildServiceMapAddRemove(t *testing.T) {
 	if len(healthCheckNodePorts) != 0 {
 		t.Errorf("expected 0 healthcheck ports, got %v", healthCheckNodePorts)
 	}
-
-	// All services but one were deleted. While you'd expect only the ClusterIPs
-	// from the three deleted services here, we still have the ClusterIP for
-	// the not-deleted service, because one of it's ServicePorts was deleted.
-	expectedDeletedUDPClusterIPs := []string{"172.16.55.10", "172.16.55.4", "172.16.55.11", "172.16.55.12"}
-	if len(result.DeletedUDPClusterIPs) != len(expectedDeletedUDPClusterIPs) {
-		t.Errorf("expected stale UDP services length %d, got %v", len(expectedDeletedUDPClusterIPs), result.DeletedUDPClusterIPs.UnsortedList())
-	}
-	for _, ip := range expectedDeletedUDPClusterIPs {
-		if !result.DeletedUDPClusterIPs.Has(ip) {
-			t.Errorf("expected stale UDP service service %s", ip)
-		}
-	}
 }
 
 func TestBuildServiceMapServiceUpdate(t *testing.T) {
@@ -871,10 +848,6 @@ func TestBuildServiceMapServiceUpdate(t *testing.T) {
 	if len(result.UpdatedServices) != 1 {
 		t.Errorf("expected 1 updated service, got %d", len(result.UpdatedServices))
 	}
-	if len(result.DeletedUDPClusterIPs) != 0 {
-		// Services only added, so nothing stale yet
-		t.Errorf("expected stale UDP services length 0, got %d", len(result.DeletedUDPClusterIPs))
-	}
 
 	healthCheckNodePorts := fp.svcPortMap.HealthCheckNodePorts()
 	if len(healthCheckNodePorts) != 0 {
@@ -889,9 +862,6 @@ func TestBuildServiceMapServiceUpdate(t *testing.T) {
 	}
 	if len(result.UpdatedServices) != 1 {
 		t.Errorf("expected 1 updated service, got %d", len(result.UpdatedServices))
-	}
-	if len(result.DeletedUDPClusterIPs) != 0 {
-		t.Errorf("expected stale UDP services length 0, got %v", result.DeletedUDPClusterIPs.UnsortedList())
 	}
 
 	healthCheckNodePorts = fp.svcPortMap.HealthCheckNodePorts()
@@ -909,9 +879,6 @@ func TestBuildServiceMapServiceUpdate(t *testing.T) {
 	if len(result.UpdatedServices) != 0 {
 		t.Errorf("expected 0 updated services, got %d", len(result.UpdatedServices))
 	}
-	if len(result.DeletedUDPClusterIPs) != 0 {
-		t.Errorf("expected stale UDP services length 0, got %v", result.DeletedUDPClusterIPs.UnsortedList())
-	}
 
 	healthCheckNodePorts = fp.svcPortMap.HealthCheckNodePorts()
 	if len(healthCheckNodePorts) != 1 {
@@ -926,10 +893,6 @@ func TestBuildServiceMapServiceUpdate(t *testing.T) {
 	}
 	if len(result.UpdatedServices) != 1 {
 		t.Errorf("expected 1 updated service, got %d", len(result.UpdatedServices))
-	}
-	if len(result.DeletedUDPClusterIPs) != 0 {
-		// Services only added, so nothing stale yet
-		t.Errorf("expected stale UDP services length 0, got %d", len(result.DeletedUDPClusterIPs))
 	}
 
 	healthCheckNodePorts = fp.svcPortMap.HealthCheckNodePorts()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR adds a reconciler for cleaning up stale conntrack entries which can blackhole UDP traffic.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #126130

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kube-proxy now reconciles Service/Endpoint changes with conntrack table and cleans up only stale UDP flow entries
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
