### PR TITLE
[KEP-2400] Swap: Fix misleading log about swap being on, even if it's actually off

### DIFF
--- a/pkg/kubelet/util/swap/swap_util.go
+++ b/pkg/kubelet/util/swap/swap_util.go
@@ -110,8 +110,12 @@ func isSwapOnAccordingToProcSwaps(procSwapsContent []byte) bool {
 	procSwapsLines := strings.Split(procSwapsStr, "\n")
 
 	// If there is more than one line (table headers) in /proc/swaps then swap is enabled
-	klog.InfoS("Swap is on", "/proc/swaps contents", procSwapsStr)
-	return len(procSwapsLines) > 1
+	isSwapOn := len(procSwapsLines) > 1
+	if isSwapOn {
+		klog.InfoS("Swap is on", "/proc/swaps contents", procSwapsStr)
+	}
+
+	return isSwapOn
 }
 
 // IsSwapOn detects whether swap in enabled on the system by inspecting


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:
Currently, a log is triggered about swap being on even if swap is off.
For example:
```
Sep 12 09:13:01 kubecontroller2 kubelet[6803]: I0912 09:13:01.618825    6803 swap_util.go:113] "Swap is on" /proc/swaps contents="Filename\t\t\t\tType\t\tSize\t\tUsed\t\tPriority"
```

After this commit, the log would be triggered only if swap is truly turned on.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/2400-node-swap/README.md#beta-1
```
