### PR TITLE
Automated cherry pick of #127239: API emulation versioning honors cohabitating resources

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/storage/resource_encoding_config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/storage/resource_encoding_config.go
@@ -130,13 +130,24 @@ func emulatedStorageVersion(binaryVersionOfResource schema.GroupVersion, example
 	gvks, _, err := scheme.ObjectKinds(example)
 	if err != nil {
 		return schema.GroupVersion{}, err
-	} else if len(gvks) == 0 {
-		// Probably shouldn't happen if err is non-nil
+	}
+
+	var gvk schema.GroupVersionKind
+	for _, item := range gvks {
+		if item.Group != binaryVersionOfResource.Group {
+			continue
+		}
+
+		gvk = item
+		break
+	}
+
+	if len(gvk.Kind) == 0 {
 		return schema.GroupVersion{}, fmt.Errorf("object %T has no GVKs registered in scheme", example)
 	}
 
 	// VersionsForGroupKind returns versions in priority order
-	versions := scheme.VersionsForGroupKind(schema.GroupKind{Group: gvks[0].Group, Kind: gvks[0].Kind})
+	versions := scheme.VersionsForGroupKind(schema.GroupKind{Group: gvk.Group, Kind: gvk.Kind})
 
 	compatibilityVersion := effectiveVersion.MinCompatibilityVersion()
 
@@ -148,7 +159,7 @@ func emulatedStorageVersion(binaryVersionOfResource schema.GroupVersion, example
 		gvk := schema.GroupVersionKind{
 			Group:   gv.Group,
 			Version: gv.Version,
-			Kind:    gvks[0].Kind,
+			Kind:    gvk.Kind,
 		}
 
 		exampleOfGVK, err := scheme.New(gvk)

--- a/staging/src/k8s.io/apiserver/pkg/server/storage/storage_factory.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/storage/storage_factory.go
@@ -245,7 +245,7 @@ func (s *DefaultStorageFactory) NewConfig(groupResource schema.GroupResource, ex
 
 	var err error
 	if backwardCompatibleInterface, ok := s.ResourceEncodingConfig.(CompatibilityResourceEncodingConfig); ok {
-		codecConfig.StorageVersion, err = backwardCompatibleInterface.BackwardCompatibileStorageEncodingFor(groupResource, example)
+		codecConfig.StorageVersion, err = backwardCompatibleInterface.BackwardCompatibileStorageEncodingFor(chosenStorageResource, example)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Cherry pick of #127239 on release-1.31.

#127239: API emulation versioning honors cohabitating resources

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixes a 1.31 regression with API emulation versioning honors cohabitating resources
```