### PR TITLE
WIP: KEP-267 Server Rotate Certificate

### DIFF
--- a/staging/src/k8s.io/cloud-provider/app/controllermanager.go
+++ b/staging/src/k8s.io/cloud-provider/app/controllermanager.go
@@ -369,7 +369,7 @@ func ControllerNames(controllerInitFuncConstructors map[string]ControllerInitFun
 
 var (
 	// ControllersDisabledByDefault is the controller disabled default when starting cloud-controller managers.
-	ControllersDisabledByDefault = sets.NewString()
+	ControllersDisabledByDefault = sets.NewString().Insert(names.CloudNodeCSRApprover)
 
 	// AllWebhooks represents the list of all webhook options configured in
 	// this package.  This is empty because no webhooks are currently
@@ -415,6 +415,13 @@ func StartCloudNodeLifecycleControllerWrapper(initContext ControllerInitContext,
 	}
 }
 
+// StartCloudNodeCSRApproverWrapper is used to take cloud config as input and start cloud node csr approver
+func StartCloudNodeCSRApproverWrapper(initContext ControllerInitContext, completedConfig *cloudcontrollerconfig.CompletedConfig, cloud cloudprovider.Interface) InitFunc {
+	return func(ctx context.Context, controllerContext genericcontrollermanager.ControllerContext) (controller.Interface, bool, error) {
+		return startCloudNodeCSRApprover(ctx, initContext, controllerContext, completedConfig, cloud)
+	}
+}
+
 // StartServiceControllerWrapper is used to take cloud config as input and start service controller
 func StartServiceControllerWrapper(initContext ControllerInitContext, completedConfig *cloudcontrollerconfig.CompletedConfig, cloud cloudprovider.Interface) InitFunc {
 	return func(ctx context.Context, controllerContext genericcontrollermanager.ControllerContext) (controller.Interface, bool, error) {
@@ -452,11 +459,11 @@ var DefaultInitFuncConstructors = map[string]ControllerInitFuncConstructor{
 		},
 		Constructor: StartServiceControllerWrapper,
 	},
-	names.NodeRouteController: {
+	names.CloudNodeCSRApprover: {
 		InitContext: ControllerInitContext{
-			ClientName: "route-controller",
+			ClientName: "node-csr-approver",
 		},
-		Constructor: StartRouteControllerWrapper,
+		Constructor: StartCloudNodeCSRApproverWrapper,
 	},
 }
 

--- a/staging/src/k8s.io/cloud-provider/controllers/nodecsrapprover/node_csr_approver.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/nodecsrapprover/node_csr_approver.go
@@ -1,0 +1,202 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodecsrapprover
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	certificatesinformers "k8s.io/client-go/informers/certificates/v1"
+	coreinformers "k8s.io/client-go/informers/core/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
+	certificateslisters "k8s.io/client-go/listers/certificates/v1"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/workqueue"
+	cloudprovider "k8s.io/cloud-provider"
+	"k8s.io/cloud-provider/names"
+	"k8s.io/klog/v2"
+	certutil "k8s.io/kubernetes/pkg/apis/certificates/v1"
+	"k8s.io/kubernetes/pkg/controller/certificates"
+	"k8s.io/kubernetes/pkg/proxy/apis/config/scheme"
+)
+
+const (
+	controllerName = names.CloudNodeCSRApprover
+)
+
+// Controller implements a node CSR approver by checking the new Node object against the cloud provider metadata.
+type Controller struct {
+	kubeClient clientset.Interface
+
+	csrLister certificateslisters.CertificateSigningRequestLister
+	csrSynced cache.InformerSynced
+
+	nodesLister corelisters.NodeLister
+	nodesSynced cache.InformerSynced
+	queue       workqueue.TypedRateLimitingInterface[string]
+
+	broadcaster record.EventBroadcaster
+	recorder    record.EventRecorder
+
+	cloud cloudprovider.Interface
+}
+
+// NewController creates a new Controller.
+func NewController(
+	csrInformer certificatesinformers.CertificateSigningRequestInformer,
+	nodeInformer coreinformers.NodeInformer,
+	kubeClient clientset.Interface,
+	cloud cloudprovider.Interface,
+) (*Controller, error) {
+
+	c := &Controller{
+		kubeClient:  kubeClient,
+		nodesLister: nodeInformer.Lister(),
+		nodesSynced: nodeInformer.Informer().HasSynced,
+		cloud:       cloud,
+		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
+			workqueue.DefaultTypedControllerRateLimiter[string](),
+			workqueue.TypedRateLimitingQueueConfig[string]{Name: controllerName},
+		),
+	}
+
+	// nolint: errcheck
+	csrSynced, _ := csrInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+			if err != nil {
+				return
+			}
+			c.queue.Add(key)
+		},
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(newObj)
+			if err != nil {
+				return
+			}
+			c.queue.Add(key)
+		},
+	})
+
+	c.csrLister = csrInformer.Lister()
+	c.csrSynced = csrSynced.HasSynced
+
+	return c, nil
+}
+
+func (c *Controller) processNextItem(ctx context.Context) bool {
+	key, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	defer c.queue.Done(key)
+
+	err := c.syncCSR(ctx, key)
+	c.handleErr(err, key)
+	return true
+}
+
+// handleErr checks if an error happened and makes sure we will retry later.
+func (c *Controller) handleErr(err error, key string) {
+	if err == nil {
+		c.queue.Forget(key)
+		return
+	}
+
+	// This controller retries 5 times if something goes wrong. After that, it stops trying.
+	if c.queue.NumRequeues(key) < 5 {
+		klog.Infof("Error syncing CertificateSigningRequest %v: %v", key, err)
+		c.queue.AddRateLimited(key)
+		return
+	}
+
+	c.queue.Forget(key)
+	runtime.HandleError(err)
+	klog.Infof("Dropping CertificateSigningRequest %q out of the queue: %v", key, err)
+}
+
+// Run begins watching and syncing.
+func (c *Controller) Run(ctx context.Context, workers int) {
+	defer runtime.HandleCrash()
+	defer c.queue.ShutDown()
+
+	c.broadcaster = record.NewBroadcaster(record.WithContext(ctx))
+	c.broadcaster.StartStructuredLogging(0)
+	c.broadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: c.kubeClient.CoreV1().Events("")})
+
+	c.recorder = c.broadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: controllerName})
+	defer c.broadcaster.Shutdown()
+
+	klog.Info("Starting Node CSR approver")
+	defer klog.Info("Shutting down Node CSR approver")
+
+	// Wait for all involved caches to be synced, before processing items from the queue is started
+	if !cache.WaitForCacheSync(ctx.Done(), c.nodesSynced, c.csrSynced) {
+		runtime.HandleError(fmt.Errorf("Timed out waiting for caches to sync"))
+		return
+	}
+
+	for i := 0; i < workers; i++ {
+		go wait.UntilWithContext(ctx, c.runWorker, time.Second)
+	}
+
+	<-ctx.Done()
+	klog.Info("Stopping Pod controller")
+}
+
+func (c *Controller) runWorker(ctx context.Context) {
+	for c.processNextItem(ctx) {
+	}
+}
+
+func (c *Controller) syncCSR(ctx context.Context, key string) error {
+	logger := klog.FromContext(ctx)
+	startTime := time.Now()
+	defer func() {
+		logger.V(4).Info("Finished syncing CSR", "key", key, "elapsedTime", time.Since(startTime))
+	}()
+
+	csr, err := c.csrLister.Get(key)
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			return err
+		}
+		return nil
+	}
+	if approved, denied := certificates.GetCertApprovalCondition(&csr.Status); approved || denied {
+		logger.V(4).Info("CSR does no need approval", "name", csr.Name, "approved", approved, "denied", denied)
+		return nil
+	}
+
+	x509cr, err := certutil.ParseCSR(csr.Spec.Request)
+	if err != nil {
+		return fmt.Errorf("unable to parse csr %q: %v", csr.Name, err)
+	}
+	hostnames := x509cr.DNSNames
+	ips := x509cr.IPAddresses
+	logger.V(4).Info("CSR", "hostnames", hostnames, "ipaddresses", ips)
+
+	return nil
+}

--- a/staging/src/k8s.io/cloud-provider/names/controller_names.go
+++ b/staging/src/k8s.io/cloud-provider/names/controller_names.go
@@ -51,6 +51,7 @@ const (
 	ServiceLBController          = "service-lb-controller"
 	NodeRouteController          = "node-route-controller"
 	CloudNodeLifecycleController = "cloud-node-lifecycle-controller"
+	CloudNodeCSRApprover         = "cloud-node-csr-approver"
 )
 
 // CCMControllerAliases returns a mapping of aliases to canonical controller names


### PR DESCRIPTION
/kind feature
```release-note
Graduate to GA RotateKubeletServerCertificate, introducing a new opt-in node CSR approver in the default cloud-controller-manager that uses the cloud provider API to validate the new Nodes Certificates Signing Requests and approve them.
```


```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/267
- [Usage]: https://kubernetes.io/docs/reference/access-authn-authz/kubelet-tls-bootstrapping/#certificate-rotation
```
