### PR TITLE
Fixed a possible `nil` pointer dereference if `gracePeriod` is `nil`

### DIFF
--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -3176,7 +3176,7 @@ func validateSleepAction(sleep *core.SleepAction, gracePeriod *int64, fldPath *f
 	// We allow gracePeriod to be nil here because the pod in which this SleepAction
 	// is defined might have an invalid grace period defined, and we don't want to
 	// flag another error here when the real problem will already be flagged.
-	if gracePeriod != nil && sleep.Seconds <= 0 || sleep.Seconds > *gracePeriod {
+	if gracePeriod != nil && (sleep.Seconds <= 0 || sleep.Seconds > *gracePeriod) {
 		invalidStr := fmt.Sprintf("must be greater than 0 and less than terminationGracePeriodSeconds (%d)", *gracePeriod)
 		allErrors = append(allErrors, field.Invalid(fldPath, sleep.Seconds, invalidStr))
 	}

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -24148,7 +24148,7 @@ func TestValidateSleepAction(t *testing.T) {
 	testCases := []struct {
 		name        string
 		action      *core.SleepAction
-		gracePeriod int64
+		gracePeriod *int64
 		expectErr   field.ErrorList
 	}{
 		{
@@ -24156,29 +24156,48 @@ func TestValidateSleepAction(t *testing.T) {
 			action: &core.SleepAction{
 				Seconds: 5,
 			},
-			gracePeriod: 30,
+			gracePeriod: func() *int64 {
+				v := int64(30)
+				return &v
+			}(),
 		},
 		{
 			name: "negative seconds",
 			action: &core.SleepAction{
 				Seconds: -1,
 			},
-			gracePeriod: 30,
-			expectErr:   field.ErrorList{field.Invalid(fldPath, -1, getInvalidStr(30))},
+			gracePeriod: func() *int64 {
+				v := int64(30)
+				return &v
+			}(),
+			expectErr: field.ErrorList{field.Invalid(fldPath, -1, getInvalidStr(30))},
 		},
 		{
 			name: "longer than gracePeriod",
 			action: &core.SleepAction{
 				Seconds: 5,
 			},
-			gracePeriod: 3,
-			expectErr:   field.ErrorList{field.Invalid(fldPath, 5, getInvalidStr(3))},
+			gracePeriod: func() *int64 {
+				v := int64(3)
+				return &v
+			}(),
+			expectErr: field.ErrorList{field.Invalid(fldPath, 5, getInvalidStr(3))},
+		},
+		{
+			name: "gracePeriod is nil",
+			action: &core.SleepAction{
+				Seconds: 5,
+			},
+			gracePeriod: func() *int64 {
+				return nil
+			}(),
+			expectErr: field.ErrorList{},
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			errs := validateSleepAction(tc.action, &tc.gracePeriod, fldPath)
+			errs := validateSleepAction(tc.action, tc.gracePeriod, fldPath)
 
 			if len(tc.expectErr) > 0 && len(errs) == 0 {
 				t.Errorf("Unexpected success")

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -24156,42 +24156,31 @@ func TestValidateSleepAction(t *testing.T) {
 			action: &core.SleepAction{
 				Seconds: 5,
 			},
-			gracePeriod: func() *int64 {
-				v := int64(30)
-				return &v
-			}(),
+			gracePeriod: ptr.To[int64](30),
 		},
 		{
 			name: "negative seconds",
 			action: &core.SleepAction{
 				Seconds: -1,
 			},
-			gracePeriod: func() *int64 {
-				v := int64(30)
-				return &v
-			}(),
-			expectErr: field.ErrorList{field.Invalid(fldPath, -1, getInvalidStr(30))},
+			gracePeriod: ptr.To[int64](30),
+			expectErr:   field.ErrorList{field.Invalid(fldPath, -1, getInvalidStr(30))},
 		},
 		{
 			name: "longer than gracePeriod",
 			action: &core.SleepAction{
 				Seconds: 5,
 			},
-			gracePeriod: func() *int64 {
-				v := int64(3)
-				return &v
-			}(),
-			expectErr: field.ErrorList{field.Invalid(fldPath, 5, getInvalidStr(3))},
+			gracePeriod: ptr.To[int64](3),
+			expectErr:   field.ErrorList{field.Invalid(fldPath, 5, getInvalidStr(3))},
 		},
 		{
 			name: "gracePeriod is nil",
 			action: &core.SleepAction{
 				Seconds: 5,
 			},
-			gracePeriod: func() *int64 {
-				return nil
-			}(),
-			expectErr: field.ErrorList{},
+			gracePeriod: nil,
+			expectErr:   field.ErrorList{},
 		},
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Bug fix

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
NONE
```release-note
Fix a nil pointer dereference in api server when gracePeriod was set to nil.
```
