### PR TITLE
Add integration test for VolumeZone in requeueing scenarios

### DIFF
--- a/pkg/scheduler/testing/wrappers.go
+++ b/pkg/scheduler/testing/wrappers.go
@@ -907,6 +907,23 @@ func (p *PersistentVolumeWrapper) NodeAffinityIn(key string, vals []string) *Per
 	return p
 }
 
+// Labels sets all {k,v} pair provided by `labels` to the pv.
+func (p *PersistentVolumeWrapper) Labels(labels map[string]string) *PersistentVolumeWrapper {
+	for k, v := range labels {
+		p.Label(k, v)
+	}
+	return p
+}
+
+// Label sets a {k,v} pair to the pv.
+func (p *PersistentVolumeWrapper) Label(k, v string) *PersistentVolumeWrapper {
+	if p.PersistentVolume.ObjectMeta.Labels == nil {
+		p.PersistentVolume.ObjectMeta.Labels = make(map[string]string)
+	}
+	p.PersistentVolume.ObjectMeta.Labels[k] = v
+	return p
+}
+
 // ResourceClaimWrapper wraps a ResourceClaim inside.
 type ResourceClaimWrapper struct{ resourceapi.ResourceClaim }
 

--- a/pkg/scheduler/testing/wrappers.go
+++ b/pkg/scheduler/testing/wrappers.go
@@ -22,6 +22,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1alpha3"
+	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -1130,4 +1131,35 @@ func (wrapper *ResourceSliceWrapper) Devices(names ...string) *ResourceSliceWrap
 func (wrapper *ResourceSliceWrapper) Device(name string, attrs map[resourceapi.QualifiedName]resourceapi.DeviceAttribute) *ResourceSliceWrapper {
 	wrapper.Spec.Devices = append(wrapper.Spec.Devices, resourceapi.Device{Name: name, Basic: &resourceapi.BasicDevice{Attributes: attrs}})
 	return wrapper
+}
+
+// StorageClassWrapper wraps a StorageClass inside.
+type StorageClassWrapper struct{ storagev1.StorageClass }
+
+// MakeStorageClass creates a StorageClass wrapper.
+func MakeStorageClass() *StorageClassWrapper {
+	return &StorageClassWrapper{}
+}
+
+// Obj returns the inner StorageClass.
+func (s *StorageClassWrapper) Obj() *storagev1.StorageClass {
+	return &s.StorageClass
+}
+
+// Name sets `n` as the name of the inner StorageClass.
+func (s *StorageClassWrapper) Name(n string) *StorageClassWrapper {
+	s.SetName(n)
+	return s
+}
+
+// VolumeBindingMode sets mode as the mode of the inner StorageClass.
+func (s *StorageClassWrapper) VolumeBindingMode(mode storagev1.VolumeBindingMode) *StorageClassWrapper {
+	s.StorageClass.VolumeBindingMode = &mode
+	return s
+}
+
+// Provisoner sets p as the provisioner of the inner StorageClass.
+func (s *StorageClassWrapper) Provisioner(p string) *StorageClassWrapper {
+	s.StorageClass.Provisioner = p
+	return s
 }

--- a/test/integration/scheduler/queue_test.go
+++ b/test/integration/scheduler/queue_test.go
@@ -896,6 +896,7 @@ func TestCoreResourceEnqueue(t *testing.T) {
 			},
 			pods: []*v1.Pod{
 				st.MakePod().Name("pod2").Container("image").PVC("pvc2").Obj(),
+				st.MakePod().Name("pod3").Container("image").PVC("pvc3").Obj(),
 			},
 			triggerFn: func(testCtx *testutils.TestContext) error {
 				pvc2 := st.MakePersistentVolumeClaim().
@@ -952,6 +953,7 @@ func TestCoreResourceEnqueue(t *testing.T) {
 			},
 			pods: []*v1.Pod{
 				st.MakePod().Name("pod2").Container("image").PVC("pvc2").Obj(),
+				st.MakePod().Name("pod3").Container("image").PVC("pvc3").Obj(),
 			},
 			triggerFn: func(testCtx *testutils.TestContext) error {
 				pvc2 := st.MakePersistentVolumeClaim().
@@ -1015,61 +1017,6 @@ func TestCoreResourceEnqueue(t *testing.T) {
 				return nil
 			},
 			wantRequeuedPods:          sets.New("pod2"),
-			enableSchedulingQueueHint: []bool{true},
-		},
-		{
-			name:         "Pod rejected with node by the VolumeZone plugin is not requeued when the unrelated PVC is added",
-			initialNodes: []*v1.Node{st.MakeNode().Name("fake-node").Label("node", "fake-node").Label(v1.LabelTopologyZone, "us-west1-a").Obj()},
-			initialPVs: []*v1.PersistentVolume{
-				st.MakePersistentVolume().
-					Name("pv1").
-					Labels(map[string]string{v1.LabelTopologyZone: "us-west1-a"}).
-					AccessModes([]v1.PersistentVolumeAccessMode{v1.ReadOnlyMany}).
-					Capacity(v1.ResourceList{v1.ResourceStorage: resource.MustParse("1Mi")}).
-					HostPathVolumeSource(&v1.HostPathVolumeSource{Path: "/tmp", Type: &volType}).
-					Obj(),
-				st.MakePersistentVolume().
-					Name("pv2").
-					Labels(map[string]string{v1.LabelTopologyZone: "us-east1"}).
-					AccessModes([]v1.PersistentVolumeAccessMode{v1.ReadOnlyMany}).
-					Capacity(v1.ResourceList{v1.ResourceStorage: resource.MustParse("1Mi")}).
-					HostPathVolumeSource(&v1.HostPathVolumeSource{Path: "/tmp", Type: &volType}).
-					Obj(),
-			},
-			initialPVCs: []*v1.PersistentVolumeClaim{
-				st.MakePersistentVolumeClaim().
-					Name("pvc1").
-					Annotation(volume.AnnBindCompleted, "true").
-					VolumeName("pv1").
-					AccessModes([]v1.PersistentVolumeAccessMode{v1.ReadWriteOncePod}).
-					Resources(v1.VolumeResourceRequirements{Requests: v1.ResourceList{v1.ResourceStorage: resource.MustParse("1Mi")}}).
-					Obj(),
-				st.MakePersistentVolumeClaim().
-					Name("pvc2").
-					Annotation(volume.AnnBindCompleted, "true").
-					AccessModes([]v1.PersistentVolumeAccessMode{v1.ReadWriteOncePod}).
-					Resources(v1.VolumeResourceRequirements{Requests: v1.ResourceList{v1.ResourceStorage: resource.MustParse("1Mi")}}).
-					Obj(),
-			},
-			initialPods: []*v1.Pod{
-				st.MakePod().Name("pod1").Container("image").PVC("pvc1").Node("fake-node").Obj(),
-			},
-			pods: []*v1.Pod{
-				st.MakePod().Name("pod2").Container("image").PVC("pvc2").Obj(),
-			},
-			triggerFn: func(testCtx *testutils.TestContext) error {
-				pvc3 := st.MakePersistentVolumeClaim().
-					Name("pvc3").
-					Annotation(volume.AnnBindCompleted, "true").
-					AccessModes([]v1.PersistentVolumeAccessMode{v1.ReadWriteOncePod}).
-					Resources(v1.VolumeResourceRequirements{Requests: v1.ResourceList{v1.ResourceStorage: resource.MustParse("1Mi")}}).
-					Obj()
-				if _, err := testCtx.ClientSet.CoreV1().PersistentVolumeClaims(testCtx.NS.Name).Create(testCtx.Ctx, pvc3, metav1.CreateOptions{}); err != nil {
-					return fmt.Errorf("failed to create pvc3: %w", err)
-				}
-				return nil
-			},
-			wantRequeuedPods:          sets.Set[string]{},
 			enableSchedulingQueueHint: []bool{true},
 		},
 	}

--- a/test/integration/scheduler/queue_test.go
+++ b/test/integration/scheduler/queue_test.go
@@ -189,7 +189,6 @@ func TestSchedulingGates(t *testing.T) {
 // TestCoreResourceEnqueue verify Pods failed by in-tree default plugins can be
 // moved properly upon their registered events.
 func TestCoreResourceEnqueue(t *testing.T) {
-	volType := v1.HostPathDirectoryOrCreate
 	tests := []struct {
 		name string
 		// initialNodes is the list of Nodes to be created at first.
@@ -769,7 +768,7 @@ func TestCoreResourceEnqueue(t *testing.T) {
 					Labels(map[string]string{v1.LabelTopologyZone: "us-west1-a"}).
 					AccessModes([]v1.PersistentVolumeAccessMode{v1.ReadOnlyMany}).
 					Capacity(v1.ResourceList{v1.ResourceStorage: resource.MustParse("1Mi")}).
-					HostPathVolumeSource(&v1.HostPathVolumeSource{Path: "/tmp", Type: &volType}).
+					HostPathVolumeSource(&v1.HostPathVolumeSource{Path: "/tmp", Type: ptr.To(v1.HostPathDirectoryOrCreate)}).
 					Obj(),
 			},
 			initialPVCs: []*v1.PersistentVolumeClaim{
@@ -798,7 +797,7 @@ func TestCoreResourceEnqueue(t *testing.T) {
 				pv2 := st.MakePersistentVolume().Name("pv2").Label(v1.LabelTopologyZone, "us-west1-a").
 					AccessModes([]v1.PersistentVolumeAccessMode{v1.ReadOnlyMany}).
 					Capacity(v1.ResourceList{v1.ResourceStorage: resource.MustParse("1Mi")}).
-					HostPathVolumeSource(&v1.HostPathVolumeSource{Path: "/tmp", Type: &volType}).
+					HostPathVolumeSource(&v1.HostPathVolumeSource{Path: "/tmp", Type: ptr.To(v1.HostPathDirectoryOrCreate)}).
 					Obj()
 				if _, err := testCtx.ClientSet.CoreV1().PersistentVolumes().Create(testCtx.Ctx, pv2, metav1.CreateOptions{}); err != nil {
 					return fmt.Errorf("failed to create pv2: %w", err)
@@ -817,14 +816,14 @@ func TestCoreResourceEnqueue(t *testing.T) {
 					Labels(map[string]string{v1.LabelTopologyZone: "us-west1-a"}).
 					AccessModes([]v1.PersistentVolumeAccessMode{v1.ReadOnlyMany}).
 					Capacity(v1.ResourceList{v1.ResourceStorage: resource.MustParse("1Mi")}).
-					HostPathVolumeSource(&v1.HostPathVolumeSource{Path: "/tmp", Type: &volType}).
+					HostPathVolumeSource(&v1.HostPathVolumeSource{Path: "/tmp", Type: ptr.To(v1.HostPathDirectoryOrCreate)}).
 					Obj(),
 				st.MakePersistentVolume().
 					Name("pv2").
 					Labels(map[string]string{v1.LabelTopologyZone: "us-east1"}).
 					AccessModes([]v1.PersistentVolumeAccessMode{v1.ReadOnlyMany}).
 					Capacity(v1.ResourceList{v1.ResourceStorage: resource.MustParse("1Mi")}).
-					HostPathVolumeSource(&v1.HostPathVolumeSource{Path: "/tmp", Type: &volType}).
+					HostPathVolumeSource(&v1.HostPathVolumeSource{Path: "/tmp", Type: ptr.To(v1.HostPathDirectoryOrCreate)}).
 					Obj(),
 			},
 			initialPVCs: []*v1.PersistentVolumeClaim{
@@ -853,7 +852,7 @@ func TestCoreResourceEnqueue(t *testing.T) {
 				pv2 := st.MakePersistentVolume().Name("pv2").Label(v1.LabelTopologyZone, "us-west1-a").
 					AccessModes([]v1.PersistentVolumeAccessMode{v1.ReadOnlyMany}).
 					Capacity(v1.ResourceList{v1.ResourceStorage: resource.MustParse("1Mi")}).
-					HostPathVolumeSource(&v1.HostPathVolumeSource{Path: "/tmp", Type: &volType}).
+					HostPathVolumeSource(&v1.HostPathVolumeSource{Path: "/tmp", Type: ptr.To(v1.HostPathDirectoryOrCreate)}).
 					Obj()
 				if _, err := testCtx.ClientSet.CoreV1().PersistentVolumes().Update(testCtx.Ctx, pv2, metav1.UpdateOptions{}); err != nil {
 					return fmt.Errorf("failed to update pv2: %w", err)
@@ -872,14 +871,14 @@ func TestCoreResourceEnqueue(t *testing.T) {
 					Labels(map[string]string{v1.LabelTopologyZone: "us-west1-a"}).
 					AccessModes([]v1.PersistentVolumeAccessMode{v1.ReadOnlyMany}).
 					Capacity(v1.ResourceList{v1.ResourceStorage: resource.MustParse("1Mi")}).
-					HostPathVolumeSource(&v1.HostPathVolumeSource{Path: "/tmp", Type: &volType}).
+					HostPathVolumeSource(&v1.HostPathVolumeSource{Path: "/tmp", Type: ptr.To(v1.HostPathDirectoryOrCreate)}).
 					Obj(),
 				st.MakePersistentVolume().
 					Name("pv2").
 					Labels(map[string]string{v1.LabelTopologyZone: "us-east1"}).
 					AccessModes([]v1.PersistentVolumeAccessMode{v1.ReadOnlyMany}).
 					Capacity(v1.ResourceList{v1.ResourceStorage: resource.MustParse("1Mi")}).
-					HostPathVolumeSource(&v1.HostPathVolumeSource{Path: "/tmp", Type: &volType}).
+					HostPathVolumeSource(&v1.HostPathVolumeSource{Path: "/tmp", Type: ptr.To(v1.HostPathDirectoryOrCreate)}).
 					Obj(),
 			},
 			initialPVCs: []*v1.PersistentVolumeClaim{
@@ -923,14 +922,14 @@ func TestCoreResourceEnqueue(t *testing.T) {
 					Labels(map[string]string{v1.LabelTopologyZone: "us-west1-a"}).
 					AccessModes([]v1.PersistentVolumeAccessMode{v1.ReadOnlyMany}).
 					Capacity(v1.ResourceList{v1.ResourceStorage: resource.MustParse("1Mi")}).
-					HostPathVolumeSource(&v1.HostPathVolumeSource{Path: "/tmp", Type: &volType}).
+					HostPathVolumeSource(&v1.HostPathVolumeSource{Path: "/tmp", Type: ptr.To(v1.HostPathDirectoryOrCreate)}).
 					Obj(),
 				st.MakePersistentVolume().
 					Name("pv2").
 					Labels(map[string]string{v1.LabelTopologyZone: "us-east1"}).
 					AccessModes([]v1.PersistentVolumeAccessMode{v1.ReadOnlyMany}).
 					Capacity(v1.ResourceList{v1.ResourceStorage: resource.MustParse("1Mi")}).
-					HostPathVolumeSource(&v1.HostPathVolumeSource{Path: "/tmp", Type: &volType}).
+					HostPathVolumeSource(&v1.HostPathVolumeSource{Path: "/tmp", Type: ptr.To(v1.HostPathDirectoryOrCreate)}).
 					Obj(),
 			},
 			initialPVCs: []*v1.PersistentVolumeClaim{
@@ -980,7 +979,7 @@ func TestCoreResourceEnqueue(t *testing.T) {
 					Labels(map[string]string{v1.LabelTopologyZone: "us-west1-a"}).
 					AccessModes([]v1.PersistentVolumeAccessMode{v1.ReadOnlyMany}).
 					Capacity(v1.ResourceList{v1.ResourceStorage: resource.MustParse("1Mi")}).
-					HostPathVolumeSource(&v1.HostPathVolumeSource{Path: "/tmp", Type: &volType}).
+					HostPathVolumeSource(&v1.HostPathVolumeSource{Path: "/tmp", Type: ptr.To(v1.HostPathDirectoryOrCreate)}).
 					Obj(),
 			},
 			initialPVCs: []*v1.PersistentVolumeClaim{
@@ -1028,14 +1027,14 @@ func TestCoreResourceEnqueue(t *testing.T) {
 					Labels(map[string]string{v1.LabelTopologyZone: "us-west1-a"}).
 					AccessModes([]v1.PersistentVolumeAccessMode{v1.ReadOnlyMany}).
 					Capacity(v1.ResourceList{v1.ResourceStorage: resource.MustParse("1Mi")}).
-					HostPathVolumeSource(&v1.HostPathVolumeSource{Path: "/tmp", Type: &volType}).
+					HostPathVolumeSource(&v1.HostPathVolumeSource{Path: "/tmp", Type: ptr.To(v1.HostPathDirectoryOrCreate)}).
 					Obj(),
 				st.MakePersistentVolume().
 					Name("pv2").
 					Labels(map[string]string{v1.LabelTopologyZone: "us-east1"}).
 					AccessModes([]v1.PersistentVolumeAccessMode{v1.ReadOnlyMany}).
 					Capacity(v1.ResourceList{v1.ResourceStorage: resource.MustParse("1Mi")}).
-					HostPathVolumeSource(&v1.HostPathVolumeSource{Path: "/tmp", Type: &volType}).
+					HostPathVolumeSource(&v1.HostPathVolumeSource{Path: "/tmp", Type: ptr.To(v1.HostPathDirectoryOrCreate)}).
 					Obj(),
 			},
 			initialPVCs: []*v1.PersistentVolumeClaim{
@@ -1065,7 +1064,7 @@ func TestCoreResourceEnqueue(t *testing.T) {
 					Labels(map[string]string{v1.LabelTopologyZone: "us-east1", "unrelated": "unrelated"}).
 					AccessModes([]v1.PersistentVolumeAccessMode{v1.ReadOnlyMany}).
 					Capacity(v1.ResourceList{v1.ResourceStorage: resource.MustParse("1Mi")}).
-					HostPathVolumeSource(&v1.HostPathVolumeSource{Path: "/tmp", Type: &volType}).
+					HostPathVolumeSource(&v1.HostPathVolumeSource{Path: "/tmp", Type: ptr.To(v1.HostPathDirectoryOrCreate)}).
 					Obj()
 				if _, err := testCtx.ClientSet.CoreV1().PersistentVolumes().Update(testCtx.Ctx, pv2, metav1.UpdateOptions{}); err != nil {
 					return fmt.Errorf("failed to update pv2: %w", err)

--- a/test/integration/scheduler/queue_test.go
+++ b/test/integration/scheduler/queue_test.go
@@ -1019,6 +1019,62 @@ func TestCoreResourceEnqueue(t *testing.T) {
 			wantRequeuedPods:          sets.New("pod2"),
 			enableSchedulingQueueHint: []bool{true},
 		},
+		{
+			name:         "Pod rejected with node by the VolumeZone plugin is not requeued when the PV is updated but the topology is same",
+			initialNodes: []*v1.Node{st.MakeNode().Name("fake-node").Label("node", "fake-node").Label(v1.LabelTopologyZone, "us-west1-a").Obj()},
+			initialPVs: []*v1.PersistentVolume{
+				st.MakePersistentVolume().
+					Name("pv1").
+					Labels(map[string]string{v1.LabelTopologyZone: "us-west1-a"}).
+					AccessModes([]v1.PersistentVolumeAccessMode{v1.ReadOnlyMany}).
+					Capacity(v1.ResourceList{v1.ResourceStorage: resource.MustParse("1Mi")}).
+					HostPathVolumeSource(&v1.HostPathVolumeSource{Path: "/tmp", Type: &volType}).
+					Obj(),
+				st.MakePersistentVolume().
+					Name("pv2").
+					Labels(map[string]string{v1.LabelTopologyZone: "us-east1"}).
+					AccessModes([]v1.PersistentVolumeAccessMode{v1.ReadOnlyMany}).
+					Capacity(v1.ResourceList{v1.ResourceStorage: resource.MustParse("1Mi")}).
+					HostPathVolumeSource(&v1.HostPathVolumeSource{Path: "/tmp", Type: &volType}).
+					Obj(),
+			},
+			initialPVCs: []*v1.PersistentVolumeClaim{
+				st.MakePersistentVolumeClaim().
+					Name("pvc1").
+					Annotation(volume.AnnBindCompleted, "true").
+					VolumeName("pv1").
+					AccessModes([]v1.PersistentVolumeAccessMode{v1.ReadWriteOncePod}).
+					Resources(v1.VolumeResourceRequirements{Requests: v1.ResourceList{v1.ResourceStorage: resource.MustParse("1Mi")}}).
+					Obj(),
+				st.MakePersistentVolumeClaim().
+					Name("pvc2").
+					Annotation(volume.AnnBindCompleted, "true").
+					VolumeName("pv2").
+					AccessModes([]v1.PersistentVolumeAccessMode{v1.ReadWriteOncePod}).
+					Resources(v1.VolumeResourceRequirements{Requests: v1.ResourceList{v1.ResourceStorage: resource.MustParse("1Mi")}}).
+					Obj(),
+			},
+			initialPods: []*v1.Pod{
+				st.MakePod().Name("pod1").Container("image").PVC("pvc1").Node("fake-node").Obj(),
+			},
+			pods: []*v1.Pod{
+				st.MakePod().Name("pod2").Container("image").PVC("pvc2").Obj(),
+			},
+			triggerFn: func(testCtx *testutils.TestContext) error {
+				pv2 := st.MakePersistentVolume().Name("pv2").
+					Labels(map[string]string{v1.LabelTopologyZone: "us-east1", "unrelated": "unrelated"}).
+					AccessModes([]v1.PersistentVolumeAccessMode{v1.ReadOnlyMany}).
+					Capacity(v1.ResourceList{v1.ResourceStorage: resource.MustParse("1Mi")}).
+					HostPathVolumeSource(&v1.HostPathVolumeSource{Path: "/tmp", Type: &volType}).
+					Obj()
+				if _, err := testCtx.ClientSet.CoreV1().PersistentVolumes().Update(testCtx.Ctx, pv2, metav1.UpdateOptions{}); err != nil {
+					return fmt.Errorf("failed to update pv2: %w", err)
+				}
+				return nil
+			},
+			wantRequeuedPods:          sets.Set[string]{},
+			enableSchedulingQueueHint: []bool{true},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Add the integration test for VolumeZone requeueing scenarios

#### Which issue(s) this PR fixes:
Part of #122305 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
None
```
