### PR TITLE
return gvk while decoding object for typed client new function added

### DIFF
--- a/staging/src/k8s.io/client-go/rest/request.go
+++ b/staging/src/k8s.io/client-go/rest/request.go
@@ -1520,21 +1520,29 @@ func (r Result) ContentType(contentType *string) Result {
 // If the returned object is of type Status and has .Status != StatusSuccess, the
 // additional information in Status will be used to enrich the error.
 func (r Result) Into(obj runtime.Object) error {
+	_, err := r.UpdateObjectAndGetGVK(obj)
+	return err
+}
+
+// UpdateObjectAndGetGVK stores the result into obj, if possible and returns gvk.
+// Because of the codec convention while using dynamic-client, it removes GVK from the object.
+// To restore GVK into the object it returns GVK.
+func (r Result) UpdateObjectAndGetGVK(obj runtime.Object) (*schema.GroupVersionKind, error) {
 	if r.err != nil {
 		// Check whether the result has a Status object in the body and prefer that.
-		return r.Error()
+		return nil, r.Error()
 	}
 	if r.decoder == nil {
-		return fmt.Errorf("serializer for %s doesn't exist", r.contentType)
+		return nil, fmt.Errorf("serializer for %s doesn't exist", r.contentType)
 	}
 	if len(r.body) == 0 {
-		return fmt.Errorf("0-length response with status code: %d and content type: %s",
+		return nil, fmt.Errorf("0-length response with status code: %d and content type: %s",
 			r.statusCode, r.contentType)
 	}
 
-	out, _, err := r.decoder.Decode(r.body, nil, obj)
+	out, gvk, err := r.decoder.Decode(r.body, nil, obj)
 	if err != nil || out == obj {
-		return err
+		return gvk, err
 	}
 	// if a different object is returned, see if it is Status and avoid double decoding
 	// the object.
@@ -1542,10 +1550,10 @@ func (r Result) Into(obj runtime.Object) error {
 	case *metav1.Status:
 		// any status besides StatusSuccess is considered an error.
 		if t.Status != metav1.StatusSuccess {
-			return errors.FromObject(t)
+			return gvk, errors.FromObject(t)
 		}
 	}
-	return nil
+	return gvk, nil
 }
 
 // WasCreated updates the provided bool pointer to whether the server returned


### PR DESCRIPTION
Signed-off-by: Hiranmoy Das Chowdhury <hiranmoy.das70@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind api-change
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
While getting or creating or patching or updating object using typed-client which is a dynamic client in controller-runtime repository, gvk found empty for that object because of the codec convention. And this is the minimal coding change and might be the optimal solution I found.
controller-runtime PR link: https://github.com/kubernetes-sigs/controller-runtime/pull/2943
#### Which issue(s) this PR fixes:
https://github.com/kubernetes/kubernetes/issues/80609
https://github.com/kubernetes/kubernetes/issues/3030

#### Does this PR introduce a user-facing change?
NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

