### PR TITLE
fix(e2e-node-tests): project and zone in the prerequisites check

### DIFF
--- a/hack/make-rules/test-e2e-node.sh
+++ b/hack/make-rules/test-e2e-node.sh
@@ -132,6 +132,7 @@ if [ "${remote}" = true ] && [ "${remote_mode}" = gce ] ; then
 
   # Get the compute zone
   zone=${ZONE:-"$(gcloud info --format='value(config.properties.compute.zone.value)')"}
+  zone=${zone// /}
   if [[ ${zone} == "" ]]; then
     echo "Could not find gcloud compute/zone when running: \`gcloud info --format='value(config.properties.compute.zone.value)'\`"
     exit 1
@@ -139,6 +140,7 @@ if [ "${remote}" = true ] && [ "${remote_mode}" = gce ] ; then
 
   # Get the compute project
   project=$(gcloud info --format='value(config.project)')
+  project=${project// /}
   if [[ ${project} == "" ]]; then
     echo "Could not find gcloud project when running: \`gcloud info --format='value(config.project)'\`"
     exit 1


### PR DESCRIPTION
/kind bug
/kind e2e


#### What this PR does / why we need it:
fix : e2e test on https://github.com/kubernetes/kubernetes/blob/master/hack/make-rules/test-e2e-node.sh#L134-L145 
 The compute project and zone in the prerequisites check are incorrectly calculated.

#### Which issue(s) this PR fixes:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes https://github.com/kubernetes/kubernetes/issues/127362.

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
no

```release-note
n/a
```

/sig node