### PR TITLE
Fix e2e tests tags

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -2656,7 +2656,7 @@
   file: test/e2e/common/node/expansion.go
 - testname: VolumeSubpathEnvExpansion, subpath with absolute path
   codename: '[sig-node] Variable Expansion should fail substituting values in a volume
-    subpath with absolute path [Slow] [Conformance]'
+    subpath with absolute path [Conformance]'
   description: Make sure a container's subpath can not be set using an expansion of
     environment variables when absolute path is supplied.
   release: v1.19

--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -2663,7 +2663,7 @@
   file: test/e2e/common/node/expansion.go
 - testname: VolumeSubpathEnvExpansion, subpath with backticks
   codename: '[sig-node] Variable Expansion should fail substituting values in a volume
-    subpath with backticks [Slow] [Conformance]'
+    subpath with backticks [Conformance]'
   description: Make sure a container's subpath can not be set using an expansion of
     environment variables when backticks are supplied.
   release: v1.19

--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -2670,7 +2670,7 @@
   file: test/e2e/common/node/expansion.go
 - testname: VolumeSubpathEnvExpansion, subpath test writes
   codename: '[sig-node] Variable Expansion should succeed in writing subpaths in container
-    [Slow] [Conformance]'
+    [Conformance]'
   description: "Verify that a subpath expansion can be used to write files into subpaths.
     1.\tvalid subpathexpr starts a container running 2.\ttest for valid subpath writes
     3.\tsuccessful expansion of the subpathexpr isn't required for volume cleanup"

--- a/test/e2e/cloud/gcp/network/kube_proxy_migration.go
+++ b/test/e2e/cloud/gcp/network/kube_proxy_migration.go
@@ -46,7 +46,7 @@ func kubeProxyDaemonSetExtraEnvs(enableKubeProxyDaemonSet bool) []string {
 	return []string{fmt.Sprintf("KUBE_PROXY_DAEMONSET=%v", enableKubeProxyDaemonSet)}
 }
 
-var _ = SIGDescribe("kube-proxy migration", feature.KubeProxyDaemonSetMigration, func() {
+var _ = SIGDescribe("kube-proxy migration", framework.WithSerial(), framework.WithDisruptive(), feature.KubeProxyDaemonSetMigration, func() {
 	f := framework.NewDefaultFramework("kube-proxy-ds-migration")
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 	upgradeTestFrameworks := upgrades.CreateUpgradeFrameworks(upgradeTests)

--- a/test/e2e/common/node/expansion.go
+++ b/test/e2e/common/node/expansion.go
@@ -153,7 +153,7 @@ var _ = SIGDescribe("Variable Expansion", func() {
 		Testname: VolumeSubpathEnvExpansion, subpath with backticks
 		Description: Make sure a container's subpath can not be set using an expansion of environment variables when backticks are supplied.
 	*/
-	framework.ConformanceIt("should fail substituting values in a volume subpath with backticks", f.WithSlow(), func(ctx context.Context) {
+	framework.ConformanceIt("should fail substituting values in a volume subpath with backticks", func(ctx context.Context) {
 
 		envVars := []v1.EnvVar{
 			{

--- a/test/e2e/common/node/expansion.go
+++ b/test/e2e/common/node/expansion.go
@@ -298,7 +298,7 @@ var _ = SIGDescribe("Variable Expansion", func() {
 		3.	successful expansion of the subpathexpr isn't required for volume cleanup
 
 	*/
-	framework.ConformanceIt("should succeed in writing subpaths in container", f.WithSlow(), func(ctx context.Context) {
+	framework.ConformanceIt("should succeed in writing subpaths in container", func(ctx context.Context) {
 
 		envVars := []v1.EnvVar{
 			{

--- a/test/e2e/common/node/expansion.go
+++ b/test/e2e/common/node/expansion.go
@@ -187,7 +187,7 @@ var _ = SIGDescribe("Variable Expansion", func() {
 		Testname: VolumeSubpathEnvExpansion, subpath with absolute path
 		Description: Make sure a container's subpath can not be set using an expansion of environment variables when absolute path is supplied.
 	*/
-	framework.ConformanceIt("should fail substituting values in a volume subpath with absolute path", f.WithSlow(), func(ctx context.Context) {
+	framework.ConformanceIt("should fail substituting values in a volume subpath with absolute path", func(ctx context.Context) {
 		absolutePath := "/tmp"
 		if framework.NodeOSDistroIs("windows") {
 			// Windows does not typically have a C:\tmp folder.


### PR DESCRIPTION

/kind cleanup
```release-note
NONE
```

Fix tags on some tests:
- kube-proxy migration should be disruptive and serial
- There are three conformance tests that are not slow (old criteria for slow is ~ 5 mins)


/sig testing
/assign @dims