### PR TITLE
kubectl: check version skew

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/version/skew_warning_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/version/skew_warning_test.go
@@ -17,14 +17,12 @@ limitations under the License.
 package version
 
 import (
-	"bytes"
-	apimachineryversion "k8s.io/apimachinery/pkg/version"
 	"testing"
+
+	apimachineryversion "k8s.io/apimachinery/pkg/version"
 )
 
 func TestPrintVersionSkewWarning(t *testing.T) {
-	output := &bytes.Buffer{}
-
 	testCases := []struct {
 		name              string
 		clientVersion     apimachineryversion.Info
@@ -82,14 +80,15 @@ func TestPrintVersionSkewWarning(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			output.Reset()
+			warningMessage, err := getVersionSkewWarning(tc.clientVersion, tc.serverVersion)
+			if err != nil {
+				t.Errorf("error: %s", err)
+			}
 
-			printVersionSkewWarning(output, tc.clientVersion, tc.serverVersion)
-
-			if tc.isWarningExpected && output.Len() == 0 {
-				t.Error("warning was expected, but not written to the output")
-			} else if !tc.isWarningExpected && output.Len() > 0 {
-				t.Errorf("warning was not expected, but was written to the output: %s", output.String())
+			if tc.isWarningExpected && warningMessage == "" {
+				t.Error("warning was expected")
+			} else if !tc.isWarningExpected && warningMessage != "" {
+				t.Errorf("warning was not expected. but got %s", warningMessage)
 			}
 		})
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/version/version_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/version/version_test.go
@@ -20,8 +20,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/spf13/cobra"
-
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
@@ -32,13 +30,18 @@ func TestNewCmdVersionClientVersion(t *testing.T) {
 	defer tf.Cleanup()
 	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	o := NewOptions(streams)
-	if err := o.Complete(tf, &cobra.Command{}, nil); err != nil {
+
+	cmd := NewCmdVersion(tf, streams)
+	cmd.Flags().Bool("warnings-as-errors", false, "")
+
+	if err := o.Complete(tf, cmd, nil); err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
 	if err := o.Validate(); err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
-	if err := o.Complete(tf, &cobra.Command{}, []string{"extraParameter0"}); err != nil {
+
+	if err := o.Complete(tf, cmd, []string{"extraParameter0"}); err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
 	if err := o.Validate(); !strings.Contains(err.Error(), "extra arguments") {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature 
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Add an flag for kubectl version which fails if the client version exceeds the supported minor version skew of +/-1
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes kubernetes/kubectl#1648

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add a flag to `kubectl version` that detects whether a client/server version mismatch is outside the officially supported range.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
