### PR TITLE
 Improve precision of Quantity export as float64

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"math"
 	"math/big"
 	"strconv"
 	"strings"
@@ -464,20 +463,29 @@ func (q *Quantity) CanonicalizeBytes(out []byte) (result, suffix []byte) {
 // lose precision. If the value of the quantity is outside the range of a float64
 // +Inf/-Inf will be returned.
 func (q *Quantity) AsApproximateFloat64() float64 {
-	var base float64
-	var exponent int
-	if q.d.Dec != nil {
-		base, _ = big.NewFloat(0).SetInt(q.d.Dec.UnscaledBig()).Float64()
-		exponent = int(-q.d.Dec.Scale())
+	infDec := q.AsDec()
+
+	var absScale int64
+	if infDec.Scale() < 0 {
+		absScale = int64(-infDec.Scale())
 	} else {
-		base = float64(q.i.value)
-		exponent = int(q.i.scale)
+		absScale = int64(infDec.Scale())
 	}
-	if exponent == 0 {
-		return base
+	pow10AbsScale := big.NewInt(10)
+	pow10AbsScale = pow10AbsScale.Exp(pow10AbsScale, big.NewInt(absScale), nil)
+
+	var resultBigFloat *big.Float
+	if infDec.Scale() < 0 {
+		resultBigInt := new(big.Int).Mul(infDec.UnscaledBig(), pow10AbsScale)
+		resultBigFloat = new(big.Float).SetInt(resultBigInt)
+	} else {
+		pow10AbsScaleFloat := new(big.Float).SetInt(pow10AbsScale)
+		resultBigFloat = new(big.Float).SetInt(infDec.UnscaledBig())
+		resultBigFloat = resultBigFloat.Quo(resultBigFloat, pow10AbsScaleFloat)
 	}
 
-	return base * math.Pow10(exponent)
+	result, _ := resultBigFloat.Float64()
+	return result
 }
 
 // AsInt64 returns a representation of the current value as an int64 if a fast conversion

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
@@ -1294,6 +1294,78 @@ func TestNegateRoundTrip(t *testing.T) {
 }
 
 func TestQuantityAsApproximateFloat64(t *testing.T) {
+	// NOTE: this table should be kept in sync with TestQuantityAsFloat64Slow
+	table := []struct {
+		in  Quantity
+		out float64
+	}{
+		{decQuantity(0, 0, DecimalSI), 0.0},
+		{decQuantity(0, 0, DecimalExponent), 0.0},
+		{decQuantity(0, 0, BinarySI), 0.0},
+
+		{decQuantity(1, 0, DecimalSI), 1},
+		{decQuantity(1, 0, DecimalExponent), 1},
+		{decQuantity(1, 0, BinarySI), 1},
+
+		// Binary suffixes
+		{decQuantity(1024, 0, BinarySI), 1024},
+		{decQuantity(8*1024, 0, BinarySI), 8 * 1024},
+		{decQuantity(7*1024*1024, 0, BinarySI), 7 * 1024 * 1024},
+		{decQuantity(7*1024*1024, 1, BinarySI), (7 * 1024 * 1024) * 10},
+		{decQuantity(7*1024*1024, 4, BinarySI), (7 * 1024 * 1024) * 10000},
+		{decQuantity(7*1024*1024, 8, BinarySI), (7 * 1024 * 1024) * 100000000},
+		{decQuantity(7*1024*1024, -1, BinarySI), (7 * 1024 * 1024) * math.Pow10(-1)}, // '* Pow10' and '/ float(10)' do not round the same way
+		{decQuantity(7*1024*1024, -8, BinarySI), (7 * 1024 * 1024) / float64(100000000)},
+
+		{decQuantity(1024, 0, DecimalSI), 1024},
+		{decQuantity(8*1024, 0, DecimalSI), 8 * 1024},
+		{decQuantity(7*1024*1024, 0, DecimalSI), 7 * 1024 * 1024},
+		{decQuantity(7*1024*1024, 1, DecimalSI), (7 * 1024 * 1024) * 10},
+		{decQuantity(7*1024*1024, 4, DecimalSI), (7 * 1024 * 1024) * 10000},
+		{decQuantity(7*1024*1024, 8, DecimalSI), (7 * 1024 * 1024) * 100000000},
+		{decQuantity(7*1024*1024, -1, DecimalSI), (7 * 1024 * 1024) * math.Pow10(-1)}, // '* Pow10' and '/ float(10)' do not round the same way
+		{decQuantity(7*1024*1024, -8, DecimalSI), (7 * 1024 * 1024) / float64(100000000)},
+
+		{decQuantity(1024, 0, DecimalExponent), 1024},
+		{decQuantity(8*1024, 0, DecimalExponent), 8 * 1024},
+		{decQuantity(7*1024*1024, 0, DecimalExponent), 7 * 1024 * 1024},
+		{decQuantity(7*1024*1024, 1, DecimalExponent), (7 * 1024 * 1024) * 10},
+		{decQuantity(7*1024*1024, 4, DecimalExponent), (7 * 1024 * 1024) * 10000},
+		{decQuantity(7*1024*1024, 8, DecimalExponent), (7 * 1024 * 1024) * 100000000},
+		{decQuantity(7*1024*1024, -1, DecimalExponent), (7 * 1024 * 1024) * math.Pow10(-1)}, // '* Pow10' and '/ float(10)' do not round the same way
+		{decQuantity(7*1024*1024, -8, DecimalExponent), (7 * 1024 * 1024) / float64(100000000)},
+
+		// very large numbers
+		{Quantity{d: maxAllowed, Format: DecimalSI}, math.MaxInt64},
+		{Quantity{d: maxAllowed, Format: BinarySI}, math.MaxInt64},
+		{decQuantity(12, 18, DecimalSI), 1.2e19},
+
+		// infinities caused due to float64 overflow
+		{decQuantity(12, 500, DecimalSI), math.Inf(0)},
+		{decQuantity(-12, 500, DecimalSI), math.Inf(-1)},
+	}
+
+	for i, item := range table {
+		t.Run(fmt.Sprintf("%s %s", item.in.Format, item.in.String()), func(t *testing.T) {
+			out := item.in.AsApproximateFloat64()
+			if out != item.out {
+				t.Fatalf("test %d expected %v, got %v", i+1, item.out, out)
+			}
+			if item.in.d.Dec != nil {
+				if i, ok := item.in.AsInt64(); ok {
+					q := intQuantity(i, 0, item.in.Format)
+					out := q.AsApproximateFloat64()
+					if out != item.out {
+						t.Fatalf("as int quantity: expected %v, got %v", item.out, out)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestQuantityAsFloat64Slow(t *testing.T) {
+	// NOTE: this table should be kept in sync with TestQuantityAsApproximateFloat64
 	table := []struct {
 		in  Quantity
 		out float64
@@ -1346,14 +1418,14 @@ func TestQuantityAsApproximateFloat64(t *testing.T) {
 
 	for i, item := range table {
 		t.Run(fmt.Sprintf("%s %s", item.in.Format, item.in.String()), func(t *testing.T) {
-			out := item.in.AsApproximateFloat64()
+			out := item.in.AsFloat64Slow()
 			if out != item.out {
 				t.Fatalf("test %d expected %v, got %v", i+1, item.out, out)
 			}
 			if item.in.d.Dec != nil {
 				if i, ok := item.in.AsInt64(); ok {
 					q := intQuantity(i, 0, item.in.Format)
-					out := q.AsApproximateFloat64()
+					out := q.AsFloat64Slow()
 					if out != item.out {
 						t.Fatalf("as int quantity: expected %v, got %v", item.out, out)
 					}
@@ -1388,6 +1460,40 @@ func TestStringQuantityAsApproximateFloat64(t *testing.T) {
 				if i, ok := in.AsInt64(); ok {
 					q := intQuantity(i, 0, in.Format)
 					out := q.AsApproximateFloat64()
+					if out != item.out {
+						t.Fatalf("as int quantity: expected %v, got %v", item.out, out)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestStringQuantityAsFloat64Slow(t *testing.T) {
+	table := []struct {
+		in  string
+		out float64
+	}{
+		{"2Ki", 2048},
+		{"1.1Ki", 1126.4e+0},
+		{"1Mi", 1.048576e+06},
+		{"2Gi", 2.147483648e+09},
+	}
+
+	for _, item := range table {
+		t.Run(item.in, func(t *testing.T) {
+			in, err := ParseQuantity(item.in)
+			if err != nil {
+				t.Fatal(err)
+			}
+			out := in.AsFloat64Slow()
+			if out != item.out {
+				t.Fatalf("expected %v, got %v", item.out, out)
+			}
+			if in.d.Dec != nil {
+				if i, ok := in.AsInt64(); ok {
+					q := intQuantity(i, 0, in.Format)
+					out := q.AsFloat64Slow()
 					if out != item.out {
 						t.Fatalf("as int quantity: expected %v, got %v", item.out, out)
 					}
@@ -1573,6 +1679,18 @@ func BenchmarkQuantityAsApproximateFloat64(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		q := values[i%len(values)]
 		if q.AsApproximateFloat64() == -1 {
+			b.Fatal(q)
+		}
+	}
+	b.StopTimer()
+}
+
+func BenchmarkQuantityAsFloat64Slow(b *testing.B) {
+	values := benchmarkQuantities()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		q := values[i%len(values)]
+		if q.AsFloat64Slow() == -1 {
 			b.Fatal(q)
 		}
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
@@ -1313,7 +1313,7 @@ func TestQuantityAsApproximateFloat64(t *testing.T) {
 		{decQuantity(7*1024*1024, 1, BinarySI), (7 * 1024 * 1024) * 10},
 		{decQuantity(7*1024*1024, 4, BinarySI), (7 * 1024 * 1024) * 10000},
 		{decQuantity(7*1024*1024, 8, BinarySI), (7 * 1024 * 1024) * 100000000},
-		{decQuantity(7*1024*1024, -1, BinarySI), (7 * 1024 * 1024) * math.Pow10(-1)}, // '* Pow10' and '/ float(10)' do not round the same way
+		{decQuantity(7*1024*1024, -1, BinarySI), (7 * 1024 * 1024) / float64(10)},
 		{decQuantity(7*1024*1024, -8, BinarySI), (7 * 1024 * 1024) / float64(100000000)},
 
 		{decQuantity(1024, 0, DecimalSI), 1024},
@@ -1322,7 +1322,7 @@ func TestQuantityAsApproximateFloat64(t *testing.T) {
 		{decQuantity(7*1024*1024, 1, DecimalSI), (7 * 1024 * 1024) * 10},
 		{decQuantity(7*1024*1024, 4, DecimalSI), (7 * 1024 * 1024) * 10000},
 		{decQuantity(7*1024*1024, 8, DecimalSI), (7 * 1024 * 1024) * 100000000},
-		{decQuantity(7*1024*1024, -1, DecimalSI), (7 * 1024 * 1024) * math.Pow10(-1)}, // '* Pow10' and '/ float(10)' do not round the same way
+		{decQuantity(7*1024*1024, -1, DecimalSI), (7 * 1024 * 1024) / float64(10)},
 		{decQuantity(7*1024*1024, -8, DecimalSI), (7 * 1024 * 1024) / float64(100000000)},
 
 		{decQuantity(1024, 0, DecimalExponent), 1024},
@@ -1331,7 +1331,7 @@ func TestQuantityAsApproximateFloat64(t *testing.T) {
 		{decQuantity(7*1024*1024, 1, DecimalExponent), (7 * 1024 * 1024) * 10},
 		{decQuantity(7*1024*1024, 4, DecimalExponent), (7 * 1024 * 1024) * 10000},
 		{decQuantity(7*1024*1024, 8, DecimalExponent), (7 * 1024 * 1024) * 100000000},
-		{decQuantity(7*1024*1024, -1, DecimalExponent), (7 * 1024 * 1024) * math.Pow10(-1)}, // '* Pow10' and '/ float(10)' do not round the same way
+		{decQuantity(7*1024*1024, -1, DecimalExponent), (7 * 1024 * 1024) / float64(10)},
 		{decQuantity(7*1024*1024, -8, DecimalExponent), (7 * 1024 * 1024) / float64(100000000)},
 
 		// very large numbers
@@ -1344,11 +1344,11 @@ func TestQuantityAsApproximateFloat64(t *testing.T) {
 		{decQuantity(-12, 500, DecimalSI), math.Inf(-1)},
 	}
 
-	for _, item := range table {
+	for i, item := range table {
 		t.Run(fmt.Sprintf("%s %s", item.in.Format, item.in.String()), func(t *testing.T) {
 			out := item.in.AsApproximateFloat64()
 			if out != item.out {
-				t.Fatalf("expected %v, got %v", item.out, out)
+				t.Fatalf("test %d expected %v, got %v", i+1, item.out, out)
 			}
 			if item.in.d.Dec != nil {
 				if i, ok := item.in.AsInt64(); ok {


### PR DESCRIPTION
This supersedes #119910, retaining the original commit and added another.  Reviewers: only the final state really matters.

The original comment was:

"""
This improves the precision of Quantity.AsApproximateFloat64, by way of example:

decQuantity(7*1024*1024, -1, BinarySI)
Before: 734003.2000000001,
After: 734003.2
"""

The performance delta was significant, so I moved the fix (by @intUnderflow) to a new method (AsFloat64Slow).  Users can trade-off accuracy for performance as they need.

```
$ go test ./staging/src/k8s.io/apimachinery/pkg/api/resource/ -bench=Float64
goos: linux
goarch: amd64
pkg: k8s.io/apimachinery/pkg/api/resource
cpu: Intel(R) Xeon(R) W-2135 CPU @ 3.70GHz
BenchmarkQuantityAsApproximateFloat64-6         95865672                11.44 ns/op
BenchmarkQuantityAsFloat64Slow-6                 2800825               430.2 ns/op
PASS
ok      k8s.io/apimachinery/pkg/api/resource    2.786s
```

/sig api-machinery
/kind feature
/kind api-change

```release-note
NONE
```
