### PR TITLE
feat(test): support KUBE_VERBOSE param

### DIFF
--- a/hack/make-rules/test-e2e-node.sh
+++ b/hack/make-rules/test-e2e-node.sh
@@ -14,6 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+KUBE_VERBOSE=${KUBE_VERBOSE:-1}
+if (( KUBE_VERBOSE > 4 )); then
+  set -x
+fi
 KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/../..
 source "${KUBE_ROOT}/hack/lib/init.sh"
 

--- a/hack/make-rules/test-integration.sh
+++ b/hack/make-rules/test-integration.sh
@@ -14,6 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+KUBE_VERBOSE=${KUBE_VERBOSE:-1}
+if (( KUBE_VERBOSE > 4 )); then
+  set -x
+fi
 set -o errexit
 set -o nounset
 set -o pipefail


### PR DESCRIPTION
/kind feature

#### What this PR does / why we need it:
support local troubleshooting  with "set -x" on : 
1. hack/make-rules/test-e2e-node.sh
2. hack/make-rules/test-integration.sh

#### Which issue(s) this PR fixes:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes https://github.com/kubernetes/kubernetes/issues/127367.

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
no

```release-note
n/a
```

/sig node