### PR TITLE
Tag sig-network e2e test correctly

### DIFF
--- a/test/e2e/cloud/gcp/network/kube_proxy_migration.go
+++ b/test/e2e/cloud/gcp/network/kube_proxy_migration.go
@@ -46,7 +46,7 @@ func kubeProxyDaemonSetExtraEnvs(enableKubeProxyDaemonSet bool) []string {
 	return []string{fmt.Sprintf("KUBE_PROXY_DAEMONSET=%v", enableKubeProxyDaemonSet)}
 }
 
-var _ = SIGDescribe("kube-proxy migration", feature.KubeProxyDaemonSetMigration, func() {
+var _ = SIGDescribe("kube-proxy migration", framework.WithSerial(), framework.WithDisruptive(), feature.KubeProxyDaemonSetMigration, func() {
 	f := framework.NewDefaultFramework("kube-proxy-ds-migration")
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 	upgradeTestFrameworks := upgrades.CreateUpgradeFrameworks(upgradeTests)

--- a/test/e2e/network/example_cluster_dns.go
+++ b/test/e2e/network/example_cluster_dns.go
@@ -59,7 +59,7 @@ try:
 except:
 	print('err')`
 
-var _ = common.SIGDescribe("ClusterDns", feature.Example, func() {
+var _ = common.SIGDescribe("ClusterDns", feature.Example, feature.NetworkingIPv4, func() {
 	f := framework.NewDefaultFramework("cluster-dns")
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 


### PR DESCRIPTION

/kind cleanup
```release-note
NONE
```

After working on refactoring the kind jobs expressions, some new tests started running and two of them were not tagged correctly:

- `ClusterDns [Feature:Example] should create pod that uses dns`: does not support IPv6, it also uses some images that are not present on the framework
- `kube-proxy migration [Feature:KubeProxyDaemonSetMigration] Downgrade kube-proxy from a DaemonSet to static pods should maintain a functioning cluster [Feature:KubeProxyDaemonSetDowngrade]` this test modify the kube-proxy impacting the cluter, so it should run serially and be also tagged as disruptive