### PR TITLE
Kubelet: DRA: fix golangci-lint findings

### DIFF
--- a/pkg/kubelet/cm/dra/claiminfo.go
+++ b/pkg/kubelet/cm/dra/claiminfo.go
@@ -115,12 +115,12 @@ func (info *ClaimInfo) isPrepared() bool {
 func newClaimInfoCache(stateDir, checkpointName string) (*claimInfoCache, error) {
 	checkpointer, err := state.NewCheckpointer(stateDir, checkpointName)
 	if err != nil {
-		return nil, fmt.Errorf("could not initialize checkpoint manager, please drain node and remove dra state file, err: %+v", err)
+		return nil, fmt.Errorf("could not initialize checkpoint manager, please drain node and remove dra state file, err: %w", err)
 	}
 
 	checkpoint, err := checkpointer.GetOrCreate()
 	if err != nil {
-		return nil, fmt.Errorf("error calling GetOrCreate() on checkpoint state: %v", err)
+		return nil, fmt.Errorf("error calling GetOrCreate() on checkpoint state: %w", err)
 	}
 
 	cache := &claimInfoCache{
@@ -182,9 +182,9 @@ func (cache *claimInfoCache) delete(claimName, namespace string) {
 // that is referenced by the pod with the given UID
 // This function is used indirectly by the status manager
 // to check if pod can enter termination status
-func (cache *claimInfoCache) hasPodReference(UID types.UID) bool {
+func (cache *claimInfoCache) hasPodReference(uid types.UID) bool {
 	for _, claimInfo := range cache.claimInfo {
-		if claimInfo.hasPodReference(UID) {
+		if claimInfo.hasPodReference(uid) {
 			return true
 		}
 	}

--- a/pkg/kubelet/cm/dra/manager.go
+++ b/pkg/kubelet/cm/dra/manager.go
@@ -70,7 +70,7 @@ type ManagerImpl struct {
 func NewManagerImpl(kubeClient clientset.Interface, stateFileDirectory string, nodeName types.NodeName) (*ManagerImpl, error) {
 	claimInfoCache, err := newClaimInfoCache(stateFileDirectory, draManagerStateFileName)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create claimInfo cache: %+v", err)
+		return nil, fmt.Errorf("failed to create claimInfo cache: %w", err)
 	}
 
 	// TODO: for now the reconcile period is not configurable.
@@ -158,7 +158,7 @@ func (m *ManagerImpl) PrepareResources(ctx context.Context, pod *v1.Pod) error {
 		logger.V(3).Info("Processing resource", "pod", klog.KObj(pod), "podClaim", podClaim.Name)
 		claimName, mustCheckOwner, err := resourceclaim.Name(pod, podClaim)
 		if err != nil {
-			return fmt.Errorf("prepare resource claim: %v", err)
+			return fmt.Errorf("prepare resource claim: %w", err)
 		}
 
 		if claimName == nil {
@@ -172,7 +172,7 @@ func (m *ManagerImpl) PrepareResources(ctx context.Context, pod *v1.Pod) error {
 			*claimName,
 			metav1.GetOptions{})
 		if err != nil {
-			return fmt.Errorf("failed to fetch ResourceClaim %s referenced by pod %s: %+v", *claimName, pod.Name, err)
+			return fmt.Errorf("failed to fetch ResourceClaim %s referenced by pod %s: %w", *claimName, pod.Name, err)
 		}
 
 		if mustCheckOwner {
@@ -489,10 +489,10 @@ func (m *ManagerImpl) unprepareResources(ctx context.Context, podUID types.UID, 
 
 // PodMightNeedToUnprepareResources returns true if the pod might need to
 // unprepare resources
-func (m *ManagerImpl) PodMightNeedToUnprepareResources(UID types.UID) bool {
+func (m *ManagerImpl) PodMightNeedToUnprepareResources(uid types.UID) bool {
 	m.cache.Lock()
 	defer m.cache.Unlock()
-	return m.cache.hasPodReference(UID)
+	return m.cache.hasPodReference(uid)
 }
 
 // GetContainerClaimInfos gets Container's ClaimInfo


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:

It fixes the following linter warnings:

```
$ _output/local/bin/golangci-lint run --config=/home/ed/go/src/k8s.io/kubernetes/hack/golangci-hints.yaml ./pkg/kubelet/cm/dra/...
pkg/kubelet/cm/dra/claiminfo.go:118:124: non-wrapping format verb for fmt.Errorf. Use `%w` to format errors (errorlint)
                return nil, fmt.Errorf("could not initialize checkpoint manager, please drain node and remove dra state file, err: %+v", err)
                                                                                                                                         ^
pkg/kubelet/cm/dra/claiminfo.go:123:81: non-wrapping format verb for fmt.Errorf. Use `%w` to format errors (errorlint)
                return nil, fmt.Errorf("error calling GetOrCreate() on checkpoint state: %v", err)
                                                                                              ^
pkg/kubelet/cm/dra/claiminfo.go:185:46: captLocal: `UID' should not be capitalized (gocritic)
func (cache *claimInfoCache) hasPodReference(UID types.UID) bool {
                                             ^
pkg/kubelet/cm/dra/manager.go:73:67: non-wrapping format verb for fmt.Errorf. Use `%w` to format errors (errorlint)
                return nil, fmt.Errorf("failed to create claimInfo cache: %+v", err)
                                                                                ^
pkg/kubelet/cm/dra/manager.go:161:52: non-wrapping format verb for fmt.Errorf. Use `%w` to format errors (errorlint)
                        return fmt.Errorf("prepare resource claim: %v", err)
                                                                        ^
pkg/kubelet/cm/dra/manager.go:175:106: non-wrapping format verb for fmt.Errorf. Use `%w` to format errors (errorlint)
                        return fmt.Errorf("failed to fetch ResourceClaim %s referenced by pod %s: %+v", *claimName, pod.Name, err)
                                                                                                                              ^
pkg/kubelet/cm/dra/manager.go:492:56: captLocal: `UID' should not be capitalized (gocritic)
func (m *ManagerImpl) PodMightNeedToUnprepareResources(UID types.UID) bool {
                                                       ^
pkg/kubelet/cm/dra/manager_test.go:136:15: Error return value of `os.RemoveAll` is not checked (errcheck)
                os.RemoveAll(socketName)
                            ^
pkg/kubelet/cm/dra/manager_test.go:163:13: Error return value of `s.Serve` is not checked (errcheck)
                go s.Serve(l)
                          ^
```

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
