### PR TITLE
[Scheduler] Retry pods with cluster events to unschedulable pod

### DIFF
--- a/pkg/kubelet/cm/devicemanager/manager.go
+++ b/pkg/kubelet/cm/devicemanager/manager.go
@@ -1040,7 +1040,7 @@ func (m *ManagerImpl) callGetPreferredAllocationIfAvailable(podUID, contName, re
 // the allocated capacity. This allows pods that have already been scheduled on
 // the node to pass GeneralPredicates admission checking even upon device plugin failure.
 func (m *ManagerImpl) sanitizeNodeAllocatable(node *schedulerframework.NodeInfo) {
-	var newAllocatableResource *schedulerframework.Resource
+	var newAllocatableResource *schedulerframework.ComputeResource
 	allocatableResource := node.Allocatable
 	if allocatableResource.ScalarResources == nil {
 		allocatableResource.ScalarResources = make(map[v1.ResourceName]int64)

--- a/pkg/scheduler/backend/cache/cache_test.go
+++ b/pkg/scheduler/backend/cache/cache_test.go
@@ -83,8 +83,8 @@ func (b *hostPortInfoBuilder) build() framework.HostPortInfo {
 	return res
 }
 
-func newNodeInfo(requestedResource *framework.Resource,
-	nonzeroRequest *framework.Resource,
+func newNodeInfo(requestedResource *framework.ComputeResource,
+	nonzeroRequest *framework.ComputeResource,
 	pods []*v1.Pod,
 	usedPorts framework.HostPortInfo,
 	imageStates map[string]*framework.ImageStateSummary,
@@ -120,11 +120,11 @@ func TestAssumePodScheduled(t *testing.T) {
 		name: "assumed one pod with resource request and used ports",
 		pods: []*v1.Pod{testPods[0]},
 		wNodeInfo: newNodeInfo(
-			&framework.Resource{
+			&framework.ComputeResource{
 				MilliCPU: 100,
 				Memory:   500,
 			},
-			&framework.Resource{
+			&framework.ComputeResource{
 				MilliCPU: 100,
 				Memory:   500,
 			},
@@ -136,11 +136,11 @@ func TestAssumePodScheduled(t *testing.T) {
 		name: "node requested resource are equal to the sum of the assumed pods requested resource, node contains host ports defined by pods",
 		pods: []*v1.Pod{testPods[1], testPods[2]},
 		wNodeInfo: newNodeInfo(
-			&framework.Resource{
+			&framework.ComputeResource{
 				MilliCPU: 300,
 				Memory:   1524,
 			},
-			&framework.Resource{
+			&framework.ComputeResource{
 				MilliCPU: 300,
 				Memory:   1524,
 			},
@@ -152,11 +152,11 @@ func TestAssumePodScheduled(t *testing.T) {
 		name: "assumed pod without resource request",
 		pods: []*v1.Pod{testPods[3]},
 		wNodeInfo: newNodeInfo(
-			&framework.Resource{
+			&framework.ComputeResource{
 				MilliCPU: 0,
 				Memory:   0,
 			},
-			&framework.Resource{
+			&framework.ComputeResource{
 				MilliCPU: schedutil.DefaultMilliCPURequest,
 				Memory:   schedutil.DefaultMemoryRequest,
 			},
@@ -168,12 +168,12 @@ func TestAssumePodScheduled(t *testing.T) {
 		name: "assumed one pod with extended resource",
 		pods: []*v1.Pod{testPods[4]},
 		wNodeInfo: newNodeInfo(
-			&framework.Resource{
+			&framework.ComputeResource{
 				MilliCPU:        100,
 				Memory:          500,
 				ScalarResources: map[v1.ResourceName]int64{"example.com/foo": 3},
 			},
-			&framework.Resource{
+			&framework.ComputeResource{
 				MilliCPU: 100,
 				Memory:   500,
 			},
@@ -185,12 +185,12 @@ func TestAssumePodScheduled(t *testing.T) {
 		name: "assumed two pods with extended resources",
 		pods: []*v1.Pod{testPods[4], testPods[5]},
 		wNodeInfo: newNodeInfo(
-			&framework.Resource{
+			&framework.ComputeResource{
 				MilliCPU:        300,
 				Memory:          1524,
 				ScalarResources: map[v1.ResourceName]int64{"example.com/foo": 8},
 			},
-			&framework.Resource{
+			&framework.ComputeResource{
 				MilliCPU: 300,
 				Memory:   1524,
 			},
@@ -202,11 +202,11 @@ func TestAssumePodScheduled(t *testing.T) {
 		name: "assumed pod with random invalid extended resource key",
 		pods: []*v1.Pod{testPods[6]},
 		wNodeInfo: newNodeInfo(
-			&framework.Resource{
+			&framework.ComputeResource{
 				MilliCPU: 100,
 				Memory:   500,
 			},
-			&framework.Resource{
+			&framework.ComputeResource{
 				MilliCPU: 100,
 				Memory:   500,
 			},
@@ -299,11 +299,11 @@ func TestExpirePod(t *testing.T) {
 			},
 			cleanupTime: now.Add(2 * defaultTTL),
 			wNodeInfo: newNodeInfo(
-				&framework.Resource{
+				&framework.ComputeResource{
 					MilliCPU: 400,
 					Memory:   2048,
 				},
-				&framework.Resource{
+				&framework.ComputeResource{
 					MilliCPU: 400,
 					Memory:   2048,
 				},
@@ -321,11 +321,11 @@ func TestExpirePod(t *testing.T) {
 			},
 			cleanupTime: now.Add(3 * defaultTTL),
 			wNodeInfo: newNodeInfo(
-				&framework.Resource{
+				&framework.ComputeResource{
 					MilliCPU: 100,
 					Memory:   500,
 				},
-				&framework.Resource{
+				&framework.ComputeResource{
 					MilliCPU: 100,
 					Memory:   500,
 				},
@@ -386,11 +386,11 @@ func TestAddPodWillConfirm(t *testing.T) {
 		podsToAssume: []*v1.Pod{testPods[0], testPods[1]},
 		podsToAdd:    []*v1.Pod{testPods[0]},
 		wNodeInfo: newNodeInfo(
-			&framework.Resource{
+			&framework.ComputeResource{
 				MilliCPU: 100,
 				Memory:   500,
 			},
-			&framework.Resource{
+			&framework.ComputeResource{
 				MilliCPU: 100,
 				Memory:   500,
 			},
@@ -499,11 +499,11 @@ func TestAddPodAlwaysUpdatesPodInfoInNodeInfo(t *testing.T) {
 		podsToAddAfterAssume: []*v1.Pod{p2},
 		nodeInfo: map[string]*framework.NodeInfo{
 			"node1": newNodeInfo(
-				&framework.Resource{
+				&framework.ComputeResource{
 					MilliCPU: 100,
 					Memory:   500,
 				},
-				&framework.Resource{
+				&framework.ComputeResource{
 					MilliCPU: 100,
 					Memory:   500,
 				},
@@ -555,11 +555,11 @@ func TestAddPodWillReplaceAssumed(t *testing.T) {
 		wNodeInfo: map[string]*framework.NodeInfo{
 			"assumed-node": nil,
 			"actual-node": newNodeInfo(
-				&framework.Resource{
+				&framework.ComputeResource{
 					MilliCPU: 200,
 					Memory:   500,
 				},
-				&framework.Resource{
+				&framework.ComputeResource{
 					MilliCPU: 200,
 					Memory:   500,
 				},
@@ -608,11 +608,11 @@ func TestAddPodAfterExpiration(t *testing.T) {
 	}{
 		pod: basePod,
 		wNodeInfo: newNodeInfo(
-			&framework.Resource{
+			&framework.ComputeResource{
 				MilliCPU: 100,
 				Memory:   500,
 			},
-			&framework.Resource{
+			&framework.ComputeResource{
 				MilliCPU: 100,
 				Memory:   500,
 			},
@@ -662,11 +662,11 @@ func TestUpdatePod(t *testing.T) {
 		podsToAdd:    []*v1.Pod{testPods[0]},
 		podsToUpdate: []*v1.Pod{testPods[0], testPods[1], testPods[0]},
 		wNodeInfo: []*framework.NodeInfo{newNodeInfo(
-			&framework.Resource{
+			&framework.ComputeResource{
 				MilliCPU: 200,
 				Memory:   1024,
 			},
-			&framework.Resource{
+			&framework.ComputeResource{
 				MilliCPU: 200,
 				Memory:   1024,
 			},
@@ -674,11 +674,11 @@ func TestUpdatePod(t *testing.T) {
 			newHostPortInfoBuilder().add("TCP", "127.0.0.1", 8080).build(),
 			make(map[string]*framework.ImageStateSummary),
 		), newNodeInfo(
-			&framework.Resource{
+			&framework.ComputeResource{
 				MilliCPU: 100,
 				Memory:   500,
 			},
-			&framework.Resource{
+			&framework.ComputeResource{
 				MilliCPU: 100,
 				Memory:   500,
 			},
@@ -806,11 +806,11 @@ func TestExpireAddUpdatePod(t *testing.T) {
 		podsToAdd:    []*v1.Pod{testPods[0]},
 		podsToUpdate: []*v1.Pod{testPods[0], testPods[1], testPods[0]},
 		wNodeInfo: []*framework.NodeInfo{newNodeInfo(
-			&framework.Resource{
+			&framework.ComputeResource{
 				MilliCPU: 200,
 				Memory:   1024,
 			},
-			&framework.Resource{
+			&framework.ComputeResource{
 				MilliCPU: 200,
 				Memory:   1024,
 			},
@@ -818,11 +818,11 @@ func TestExpireAddUpdatePod(t *testing.T) {
 			newHostPortInfoBuilder().add("TCP", "127.0.0.1", 8080).build(),
 			make(map[string]*framework.ImageStateSummary),
 		), newNodeInfo(
-			&framework.Resource{
+			&framework.ComputeResource{
 				MilliCPU: 100,
 				Memory:   500,
 			},
-			&framework.Resource{
+			&framework.ComputeResource{
 				MilliCPU: 100,
 				Memory:   500,
 			},
@@ -882,10 +882,10 @@ func TestEphemeralStorageResource(t *testing.T) {
 	}{
 		pod: podE,
 		wNodeInfo: newNodeInfo(
-			&framework.Resource{
+			&framework.ComputeResource{
 				EphemeralStorage: 500,
 			},
-			&framework.Resource{
+			&framework.ComputeResource{
 				MilliCPU: schedutil.DefaultMilliCPURequest,
 				Memory:   schedutil.DefaultMemoryRequest,
 			},
@@ -926,11 +926,11 @@ func TestRemovePod(t *testing.T) {
 		},
 	}
 	wNodeInfo := newNodeInfo(
-		&framework.Resource{
+		&framework.ComputeResource{
 			MilliCPU: 100,
 			Memory:   500,
 		},
-		&framework.Resource{
+		&framework.ComputeResource{
 			MilliCPU: 100,
 			Memory:   500,
 		},

--- a/pkg/scheduler/eventhandlers_test.go
+++ b/pkg/scheduler/eventhandlers_test.go
@@ -241,15 +241,15 @@ func TestPreCheckForNode(t *testing.T) {
 func TestAddAllEventHandlers(t *testing.T) {
 	tests := []struct {
 		name                   string
-		gvkMap                 map[framework.GVK]framework.ActionType
+		resourceMap            map[framework.Resource]framework.ActionType
 		enableDRA              bool
 		enableClassicDRA       bool
 		expectStaticInformers  map[reflect.Type]bool
 		expectDynamicInformers map[schema.GroupVersionResource]bool
 	}{
 		{
-			name:   "default handlers in framework",
-			gvkMap: map[framework.GVK]framework.ActionType{},
+			name:        "default handlers in framework",
+			resourceMap: map[framework.Resource]framework.ActionType{},
 			expectStaticInformers: map[reflect.Type]bool{
 				reflect.TypeOf(&v1.Pod{}):       true,
 				reflect.TypeOf(&v1.Node{}):      true,
@@ -259,7 +259,7 @@ func TestAddAllEventHandlers(t *testing.T) {
 		},
 		{
 			name: "DRA events disabled",
-			gvkMap: map[framework.GVK]framework.ActionType{
+			resourceMap: map[framework.Resource]framework.ActionType{
 				framework.PodSchedulingContext: framework.Add,
 				framework.ResourceClaim:        framework.Add,
 				framework.ResourceSlice:        framework.Add,
@@ -274,7 +274,7 @@ func TestAddAllEventHandlers(t *testing.T) {
 		},
 		{
 			name: "some DRA events enabled",
-			gvkMap: map[framework.GVK]framework.ActionType{
+			resourceMap: map[framework.Resource]framework.ActionType{
 				framework.PodSchedulingContext: framework.Add,
 				framework.ResourceClaim:        framework.Add,
 				framework.ResourceSlice:        framework.Add,
@@ -293,7 +293,7 @@ func TestAddAllEventHandlers(t *testing.T) {
 		},
 		{
 			name: "all DRA events enabled",
-			gvkMap: map[framework.GVK]framework.ActionType{
+			resourceMap: map[framework.Resource]framework.ActionType{
 				framework.PodSchedulingContext: framework.Add,
 				framework.ResourceClaim:        framework.Add,
 				framework.ResourceSlice:        framework.Add,
@@ -313,8 +313,8 @@ func TestAddAllEventHandlers(t *testing.T) {
 			expectDynamicInformers: map[schema.GroupVersionResource]bool{},
 		},
 		{
-			name: "add GVKs handlers defined in framework dynamically",
-			gvkMap: map[framework.GVK]framework.ActionType{
+			name: "add Resources handlers defined in framework dynamically",
+			resourceMap: map[framework.Resource]framework.ActionType{
 				"Pod":                               framework.Add | framework.Delete,
 				"PersistentVolume":                  framework.Delete,
 				"storage.k8s.io/CSIStorageCapacity": framework.Update,
@@ -329,8 +329,8 @@ func TestAddAllEventHandlers(t *testing.T) {
 			expectDynamicInformers: map[schema.GroupVersionResource]bool{},
 		},
 		{
-			name: "add GVKs handlers defined in plugins dynamically",
-			gvkMap: map[framework.GVK]framework.ActionType{
+			name: "add Resources handlers defined in plugins dynamically",
+			resourceMap: map[framework.Resource]framework.ActionType{
 				"daemonsets.v1.apps": framework.Add | framework.Delete,
 				"cronjobs.v1.batch":  framework.Delete,
 			},
@@ -345,8 +345,8 @@ func TestAddAllEventHandlers(t *testing.T) {
 			},
 		},
 		{
-			name: "add GVKs handlers defined in plugins dynamically, with one illegal GVK form",
-			gvkMap: map[framework.GVK]framework.ActionType{
+			name: "add Resources handlers defined in plugins dynamically, with one illegal Resource form",
+			resourceMap: map[framework.Resource]framework.ActionType{
 				"daemonsets.v1.apps":    framework.Add | framework.Delete,
 				"custommetrics.v1beta1": framework.Update,
 			},
@@ -392,7 +392,7 @@ func TestAddAllEventHandlers(t *testing.T) {
 				resourceClaimCache = assumecache.NewAssumeCache(logger, resourceClaimInformer, "ResourceClaim", "", nil)
 			}
 
-			if err := addAllEventHandlers(&testSched, informerFactory, dynInformerFactory, resourceClaimCache, tt.gvkMap); err != nil {
+			if err := addAllEventHandlers(&testSched, informerFactory, dynInformerFactory, resourceClaimCache, tt.resourceMap); err != nil {
 				t.Fatalf("Add event handlers failed, error = %v", err)
 			}
 

--- a/pkg/scheduler/framework/events.go
+++ b/pkg/scheduler/framework/events.go
@@ -40,31 +40,51 @@ const (
 
 var (
 	// AssignedPodAdd is the event when an assigned pod is added.
-	AssignedPodAdd = ClusterEvent{Resource: Pod, ActionType: Add, Label: "AssignedPodAdd"}
+	AssignedPodAdd = ClusterEvent{Resource: AssignedPod, ActionType: Add, Label: "AssignedPodAdd"}
 	// NodeAdd is the event when a new node is added to the cluster.
 	NodeAdd = ClusterEvent{Resource: Node, ActionType: Add, Label: "NodeAdd"}
 	// NodeDelete is the event when a node is deleted from the cluster.
 	NodeDelete = ClusterEvent{Resource: Node, ActionType: Delete, Label: "NodeDelete"}
 	// AssignedPodUpdate is the event when an assigned pod is updated.
-	AssignedPodUpdate = ClusterEvent{Resource: Pod, ActionType: Update, Label: "AssignedPodUpdate"}
+	AssignedPodUpdate = ClusterEvent{Resource: AssignedPod, ActionType: Update, Label: "AssignedPodUpdate"}
 	// UnscheduledPodAdd is the event when an unscheduled pod is added.
-	UnscheduledPodAdd = ClusterEvent{Resource: Pod, ActionType: Update, Label: "UnschedulablePodAdd"}
+	UnscheduledPodAdd = ClusterEvent{Resource: UnscheduledPod, ActionType: Add, Label: "UnscheduledPodAdd"}
 	// UnscheduledPodUpdate is the event when an unscheduled pod is updated.
-	UnscheduledPodUpdate = ClusterEvent{Resource: Pod, ActionType: Update, Label: "UnschedulablePodUpdate"}
+	UnscheduledPodUpdate = ClusterEvent{Resource: UnscheduledPod, ActionType: Update, Label: "UnscheduledPodUpdate"}
+	// PodItselfUpdate is the event when an unscheduled pod itself is updated.
+	PodItselfUpdate = ClusterEvent{Resource: PodItself, ActionType: Update, Label: "PodItselfUpdate"}
 	// UnscheduledPodDelete is the event when an unscheduled pod is deleted.
-	UnscheduledPodDelete = ClusterEvent{Resource: Pod, ActionType: Update, Label: "UnschedulablePodDelete"}
+	UnscheduledPodDelete = ClusterEvent{Resource: UnscheduledPod, ActionType: Delete, Label: "UnscheduledPodDelete"}
 	// assignedPodOtherUpdate is the event when an assigned pod got updated in fields that are not covered by UpdatePodXXX.
-	assignedPodOtherUpdate = ClusterEvent{Resource: Pod, ActionType: updatePodOther, Label: "AssignedPodUpdate"}
+	assignedPodOtherUpdate = ClusterEvent{Resource: AssignedPod, ActionType: updatePodOther, Label: "assignedPodOtherUpdate"}
+	// podItselfOtherUpdate is the event when an unscheduled pod itself got updated in fields that are not covered by UpdatePodXXX.
+	podItselfOtherUpdate = ClusterEvent{Resource: PodItself, ActionType: updatePodOther, Label: "podItselfOtherUpdate"}
+	// unscheduledPodOtherUpdate is the event when an unscheduled pod got updated in fields that are not covered by UpdatePodXXX.
+	unscheduledPodOtherUpdate = ClusterEvent{Resource: UnscheduledPod, ActionType: updatePodOther, Label: "unscheduledPodOtherUpdate"}
 	// AssignedPodDelete is the event when an assigned pod is deleted.
-	AssignedPodDelete = ClusterEvent{Resource: Pod, ActionType: Delete, Label: "AssignedPodDelete"}
-	// PodRequestScaledDown is the event when a pod's resource request is scaled down.
-	PodRequestScaledDown = ClusterEvent{Resource: Pod, ActionType: UpdatePodScaleDown, Label: "PodRequestScaledDown"}
-	// PodLabelChange is the event when a pod's label is changed.
-	PodLabelChange = ClusterEvent{Resource: Pod, ActionType: UpdatePodLabel, Label: "PodLabelChange"}
-	// PodTolerationChange is the event when a pod's toleration is changed.
-	PodTolerationChange = ClusterEvent{Resource: Pod, ActionType: UpdatePodTolerations, Label: "PodTolerationChange"}
-	// PodSchedulingGateEliminatedChange is the event when a pod's scheduling gate is changed.
-	PodSchedulingGateEliminatedChange = ClusterEvent{Resource: Pod, ActionType: UpdatePodSchedulingGatesEliminated, Label: "PodSchedulingGateChange"}
+	AssignedPodDelete = ClusterEvent{Resource: AssignedPod, ActionType: Delete, Label: "AssignedPodDelete"}
+	// AssignedPodRequestScaledDown is the event when a pod's resource request is scaled down.
+	AssignedPodRequestScaledDown = ClusterEvent{Resource: AssignedPod, ActionType: UpdatePodScaleDown, Label: "AssignedPodRequestScaledDown"}
+	// PodItselfRequestScaledDown is the event when an unscheduled pod itself has its resource request scaled down.
+	PodItselfRequestScaledDown = ClusterEvent{Resource: PodItself, ActionType: UpdatePodScaleDown, Label: "PodItselfRequestScaledDown"}
+	// UnscheduledPodRequestScaledDown is the event when an unscheduled pod has its resource request scaled down.
+	UnscheduledPodRequestScaledDown = ClusterEvent{Resource: UnscheduledPod, ActionType: UpdatePodScaleDown, Label: "UnscheduledPodRequestScaledDown"}
+	// AssignedPodLabelChange is the event when a AssignedPod's label is changed.
+	AssignedPodLabelChange = ClusterEvent{Resource: AssignedPod, ActionType: UpdatePodLabel, Label: "AssignedPodLabelChange"}
+	// PodItselfLabelChange is the event when an unscheduled pod itself has its label changed.
+	PodItselfLabelChange = ClusterEvent{Resource: PodItself, ActionType: UpdatePodLabel, Label: "PodItselfLabelChange"}
+	// UnscheduledPodLabelChange is the event when an unscheduled pod has its label changed.
+	UnscheduledPodLabelChange = ClusterEvent{Resource: UnscheduledPod, ActionType: UpdatePodLabel, Label: "UnscheduledPodLabelChange"}
+	// AssignedPodTolerationChange is the event when a AssignedPod's toleration is changed.
+	AssignedPodTolerationChange = ClusterEvent{Resource: AssignedPod, ActionType: UpdatePodTolerations, Label: "AssignedPodTolerationChange"}
+	// PodItselfTolerationChange is the event when an unscheduled pod itself has its toleration updated.
+	PodItselfTolerationChange = ClusterEvent{Resource: PodItself, ActionType: UpdatePodTolerations, Label: "PodItselfTolerationChange"}
+	// UnscheduledPodTolerationChange is the event when an unscheduled pod has its toleration updated.
+	UnscheduledPodTolerationChange = ClusterEvent{Resource: UnscheduledPod, ActionType: UpdatePodTolerations, Label: "UnscheduledPodTolerationChange"}
+	// PodItselfSchedulingGateEliminatedChange is the event when an unscheduled pod itself has its scheduling gate changed.
+	PodItselfSchedulingGateEliminatedChange = ClusterEvent{Resource: PodItself, ActionType: UpdatePodSchedulingGatesEliminated, Label: "PodItselfSchedulingGateEliminatedChange"}
+	// UnscheduledPodSchedulingGateEliminatedChange is the event when an unscheduled pod has its scheduling gate changed.
+	UnscheduledPodSchedulingGateEliminatedChange = ClusterEvent{Resource: UnscheduledPod, ActionType: UpdatePodSchedulingGatesEliminated, Label: "UnscheduledPodSchedulingGateEliminatedChange"}
 	// NodeSpecUnschedulableChange is the event when unschedulable node spec is changed.
 	NodeSpecUnschedulableChange = ClusterEvent{Resource: Node, ActionType: UpdateNodeTaint, Label: "NodeSpecUnschedulableChange"}
 	// NodeAllocatableChange is the event when node allocatable is changed.
@@ -113,13 +133,23 @@ var (
 		AssignedPodUpdate,
 		UnscheduledPodAdd,
 		UnscheduledPodUpdate,
+		PodItselfUpdate,
 		UnscheduledPodDelete,
 		assignedPodOtherUpdate,
+		podItselfOtherUpdate,
+		unscheduledPodOtherUpdate,
 		AssignedPodDelete,
-		PodRequestScaledDown,
-		PodLabelChange,
-		PodTolerationChange,
-		PodSchedulingGateEliminatedChange,
+		AssignedPodRequestScaledDown,
+		PodItselfRequestScaledDown,
+		UnscheduledPodRequestScaledDown,
+		AssignedPodLabelChange,
+		PodItselfLabelChange,
+		UnscheduledPodLabelChange,
+		AssignedPodTolerationChange,
+		PodItselfTolerationChange,
+		UnscheduledPodTolerationChange,
+		PodItselfSchedulingGateEliminatedChange,
+		UnscheduledPodSchedulingGateEliminatedChange,
 		NodeSpecUnschedulableChange,
 		NodeAllocatableChange,
 		NodeLabelChange,
@@ -145,7 +175,7 @@ var (
 
 // PodSchedulingPropertiesChange interprets the update of a pod and returns corresponding UpdatePodXYZ event(s).
 // Once we have other pod update events, we should update here as well.
-func PodSchedulingPropertiesChange(newPod *v1.Pod, oldPod *v1.Pod) (events []ClusterEvent) {
+func PodSchedulingPropertiesChange(newPod *v1.Pod, oldPod *v1.Pod, isSelf bool) (events []ClusterEvent) {
 	podChangeExtracters := []podChangeExtractor{
 		extractPodLabelsChange,
 		extractPodScaleDown,
@@ -154,24 +184,32 @@ func PodSchedulingPropertiesChange(newPod *v1.Pod, oldPod *v1.Pod) (events []Clu
 	}
 
 	for _, fn := range podChangeExtracters {
-		if event := fn(newPod, oldPod); event != nil {
+		if event := fn(newPod, oldPod, isSelf); event != nil {
 			events = append(events, *event)
 		}
 	}
 
 	if len(events) == 0 {
-		// When no specific event is found, we use AssignedPodOtherUpdate,
+		// When no specific event is found, we use PodOtherUpdate,
 		// which should only trigger plugins registering a general Pod/Update event.
-		events = append(events, assignedPodOtherUpdate)
+		if len(newPod.Spec.NodeName) != 0 {
+			events = append(events, assignedPodOtherUpdate)
+			return
+		}
+		if isSelf {
+			events = append(events, podItselfOtherUpdate)
+			return
+		}
+		events = append(events, unscheduledPodOtherUpdate)
 	}
 
 	return
 }
 
-type podChangeExtractor func(newNode *v1.Pod, oldNode *v1.Pod) *ClusterEvent
+type podChangeExtractor func(newNode *v1.Pod, oldNode *v1.Pod, isSelf bool) *ClusterEvent
 
 // extractPodScaleDown interprets the update of a pod and returns PodRequestScaledDown event if any pod's resource request(s) is scaled down.
-func extractPodScaleDown(newPod, oldPod *v1.Pod) *ClusterEvent {
+func extractPodScaleDown(newPod, oldPod *v1.Pod, isSelf bool) *ClusterEvent {
 	opt := resource.PodResourcesOptions{
 		InPlacePodVerticalScalingEnabled: utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling),
 	}
@@ -180,43 +218,59 @@ func extractPodScaleDown(newPod, oldPod *v1.Pod) *ClusterEvent {
 
 	for rName, oldReq := range oldPodRequests {
 		newReq, ok := newPodRequests[rName]
-		if !ok {
-			// The resource request of rName is removed.
-			return &PodRequestScaledDown
-		}
-
-		if oldReq.MilliValue() > newReq.MilliValue() {
-			// The resource request of rName is scaled down.
-			return &PodRequestScaledDown
+		if !ok || oldReq.MilliValue() > newReq.MilliValue() {
+			// The resource request of rName is removed or scaled down.
+			if len(oldPod.Spec.NodeName) != 0 {
+				return &AssignedPodRequestScaledDown
+			}
+			if isSelf {
+				return &PodItselfRequestScaledDown
+			}
+			return &UnscheduledPodRequestScaledDown
 		}
 	}
 
 	return nil
 }
 
-func extractPodLabelsChange(newPod *v1.Pod, oldPod *v1.Pod) *ClusterEvent {
+func extractPodLabelsChange(newPod *v1.Pod, oldPod *v1.Pod, isSelf bool) *ClusterEvent {
 	if isLabelChanged(newPod.GetLabels(), oldPod.GetLabels()) {
-		return &PodLabelChange
+		if len(oldPod.Spec.NodeName) != 0 {
+			return &AssignedPodLabelChange
+		}
+		if isSelf {
+			return &PodItselfLabelChange
+		}
+		return &UnscheduledPodLabelChange
 	}
 	return nil
 }
 
-func extractPodTolerationChange(newPod *v1.Pod, oldPod *v1.Pod) *ClusterEvent {
+func extractPodTolerationChange(newPod *v1.Pod, oldPod *v1.Pod, isSelf bool) *ClusterEvent {
 	if len(newPod.Spec.Tolerations) != len(oldPod.Spec.Tolerations) {
 		// A Pod got a new toleration.
 		// Due to API validation, the user can add, but cannot modify or remove tolerations.
 		// So, it's enough to just check the length of tolerations to notice the update.
 		// And, any updates in tolerations could make Pod schedulable.
-		return &PodTolerationChange
+		if len(oldPod.Spec.NodeName) != 0 {
+			return &AssignedPodTolerationChange
+		}
+		if isSelf {
+			return &PodItselfTolerationChange
+		}
+		return &UnscheduledPodTolerationChange
 	}
 
 	return nil
 }
 
-func extractPodSchedulingGateEliminatedChange(newPod *v1.Pod, oldPod *v1.Pod) *ClusterEvent {
+func extractPodSchedulingGateEliminatedChange(newPod *v1.Pod, oldPod *v1.Pod, isSelf bool) *ClusterEvent {
 	if len(newPod.Spec.SchedulingGates) == 0 && len(oldPod.Spec.SchedulingGates) != 0 {
 		// A scheduling gate on the pod is completely removed.
-		return &PodSchedulingGateEliminatedChange
+		if isSelf {
+			return &PodItselfSchedulingGateEliminatedChange
+		}
+		return &UnscheduledPodSchedulingGateEliminatedChange
 	}
 
 	return nil

--- a/pkg/scheduler/framework/plugins/interpodaffinity/plugin.go
+++ b/pkg/scheduler/framework/plugins/interpodaffinity/plugin.go
@@ -77,7 +77,7 @@ func (pl *InterPodAffinity) EventsToRegister(_ context.Context) ([]framework.Clu
 		// an unschedulable Pod schedulable.
 		// - Add. An unschedulable Pod may fail due to violating pod-affinity constraints,
 		// adding an assigned Pod may make it schedulable.
-		{Event: framework.ClusterEvent{Resource: framework.Pod, ActionType: framework.Add | framework.UpdatePodLabel | framework.Delete}, QueueingHintFn: pl.isSchedulableAfterPodChange},
+		{Event: framework.ClusterEvent{Resource: framework.AssignedPod, ActionType: framework.Add | framework.UpdatePodLabel | framework.Delete}, QueueingHintFn: pl.isSchedulableAfterPodChange},
 		{Event: framework.ClusterEvent{Resource: framework.Node, ActionType: nodeActionType}, QueueingHintFn: pl.isSchedulableAfterNodeChange},
 	}, nil
 }

--- a/pkg/scheduler/framework/plugins/nodeports/node_ports.go
+++ b/pkg/scheduler/framework/plugins/nodeports/node_ports.go
@@ -127,7 +127,7 @@ func (pl *NodePorts) EventsToRegister(_ context.Context) ([]framework.ClusterEve
 
 	return []framework.ClusterEventWithHint{
 		// Due to immutable fields `spec.containers[*].ports`, pod update events are ignored.
-		{Event: framework.ClusterEvent{Resource: framework.Pod, ActionType: framework.Delete}, QueueingHintFn: pl.isSchedulableAfterPodDeleted},
+		{Event: framework.ClusterEvent{Resource: framework.AssignedPod, ActionType: framework.Delete}, QueueingHintFn: pl.isSchedulableAfterPodDeleted},
 		// We don't need the QueueingHintFn here because the scheduling of Pods will be always retried with backoff when this Event happens.
 		// (the same as Queue)
 		{Event: framework.ClusterEvent{Resource: framework.Node, ActionType: nodeActionType}},

--- a/pkg/scheduler/framework/plugins/noderesources/fit.go
+++ b/pkg/scheduler/framework/plugins/noderesources/fit.go
@@ -100,7 +100,7 @@ func (f *Fit) ScoreExtensions() framework.ScoreExtensions {
 
 // preFilterState computed at PreFilter and used at Filter.
 type preFilterState struct {
-	framework.Resource
+	framework.ComputeResource
 }
 
 // Clone the prefilter state.
@@ -337,7 +337,7 @@ func (f *Fit) isSchedulableAfterPodScaleDown(targetPod, originalPod, modifiedPod
 	}
 
 	// the other pod was scheduled, so modification or deletion may free up some resources.
-	originalMaxResourceReq, modifiedMaxResourceReq := &framework.Resource{}, &framework.Resource{}
+	originalMaxResourceReq, modifiedMaxResourceReq := &framework.ComputeResource{}, &framework.ComputeResource{}
 	originalMaxResourceReq.SetMaxResource(resource.PodRequests(originalPod, resource.PodResourcesOptions{InPlacePodVerticalScalingEnabled: f.enableInPlacePodVerticalScaling}))
 	modifiedMaxResourceReq.SetMaxResource(resource.PodRequests(modifiedPod, resource.PodResourcesOptions{InPlacePodVerticalScalingEnabled: f.enableInPlacePodVerticalScaling}))
 

--- a/pkg/scheduler/framework/plugins/noderesources/fit_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/fit_test.go
@@ -68,7 +68,7 @@ func makeAllocatableResources(milliCPU, memory, pods, extendedA, storage, hugePa
 	}
 }
 
-func newResourcePod(usage ...framework.Resource) *v1.Pod {
+func newResourcePod(usage ...framework.ComputeResource) *v1.Pod {
 	var containers []v1.Container
 	for _, req := range usage {
 		rl := v1.ResourceList{
@@ -95,7 +95,7 @@ func newResourcePod(usage ...framework.Resource) *v1.Pod {
 	}
 }
 
-func newResourceInitPod(pod *v1.Pod, usage ...framework.Resource) *v1.Pod {
+func newResourceInitPod(pod *v1.Pod, usage ...framework.ComputeResource) *v1.Pod {
 	pod.Spec.InitContainers = newResourcePod(usage...).Spec.Containers
 	return pod
 }
@@ -129,14 +129,14 @@ func TestEnoughRequests(t *testing.T) {
 		{
 			pod: &v1.Pod{},
 			nodeInfo: framework.NewNodeInfo(
-				newResourcePod(framework.Resource{MilliCPU: 10, Memory: 20})),
+				newResourcePod(framework.ComputeResource{MilliCPU: 10, Memory: 20})),
 			name:                      "no resources requested always fits",
 			wantInsufficientResources: []InsufficientResource{},
 		},
 		{
-			pod: newResourcePod(framework.Resource{MilliCPU: 1, Memory: 1}),
+			pod: newResourcePod(framework.ComputeResource{MilliCPU: 1, Memory: 1}),
 			nodeInfo: framework.NewNodeInfo(
-				newResourcePod(framework.Resource{MilliCPU: 10, Memory: 20})),
+				newResourcePod(framework.ComputeResource{MilliCPU: 10, Memory: 20})),
 			name:       "too many resources fails",
 			wantStatus: framework.NewStatus(framework.Unschedulable, getErrReason(v1.ResourceCPU), getErrReason(v1.ResourceMemory)),
 			wantInsufficientResources: []InsufficientResource{
@@ -145,9 +145,9 @@ func TestEnoughRequests(t *testing.T) {
 			},
 		},
 		{
-			pod: newResourceInitPod(newResourcePod(framework.Resource{MilliCPU: 1, Memory: 1}), framework.Resource{MilliCPU: 3, Memory: 1}),
+			pod: newResourceInitPod(newResourcePod(framework.ComputeResource{MilliCPU: 1, Memory: 1}), framework.ComputeResource{MilliCPU: 3, Memory: 1}),
 			nodeInfo: framework.NewNodeInfo(
-				newResourcePod(framework.Resource{MilliCPU: 8, Memory: 19})),
+				newResourcePod(framework.ComputeResource{MilliCPU: 8, Memory: 19})),
 			name:       "too many resources fails due to init container cpu",
 			wantStatus: framework.NewStatus(framework.Unschedulable, getErrReason(v1.ResourceCPU)),
 			wantInsufficientResources: []InsufficientResource{
@@ -155,9 +155,9 @@ func TestEnoughRequests(t *testing.T) {
 			},
 		},
 		{
-			pod: newResourceInitPod(newResourcePod(framework.Resource{MilliCPU: 1, Memory: 1}), framework.Resource{MilliCPU: 3, Memory: 1}, framework.Resource{MilliCPU: 2, Memory: 1}),
+			pod: newResourceInitPod(newResourcePod(framework.ComputeResource{MilliCPU: 1, Memory: 1}), framework.ComputeResource{MilliCPU: 3, Memory: 1}, framework.ComputeResource{MilliCPU: 2, Memory: 1}),
 			nodeInfo: framework.NewNodeInfo(
-				newResourcePod(framework.Resource{MilliCPU: 8, Memory: 19})),
+				newResourcePod(framework.ComputeResource{MilliCPU: 8, Memory: 19})),
 			name:       "too many resources fails due to highest init container cpu",
 			wantStatus: framework.NewStatus(framework.Unschedulable, getErrReason(v1.ResourceCPU)),
 			wantInsufficientResources: []InsufficientResource{
@@ -165,9 +165,9 @@ func TestEnoughRequests(t *testing.T) {
 			},
 		},
 		{
-			pod: newResourceInitPod(newResourcePod(framework.Resource{MilliCPU: 1, Memory: 1}), framework.Resource{MilliCPU: 1, Memory: 3}),
+			pod: newResourceInitPod(newResourcePod(framework.ComputeResource{MilliCPU: 1, Memory: 1}), framework.ComputeResource{MilliCPU: 1, Memory: 3}),
 			nodeInfo: framework.NewNodeInfo(
-				newResourcePod(framework.Resource{MilliCPU: 9, Memory: 19})),
+				newResourcePod(framework.ComputeResource{MilliCPU: 9, Memory: 19})),
 			name:       "too many resources fails due to init container memory",
 			wantStatus: framework.NewStatus(framework.Unschedulable, getErrReason(v1.ResourceMemory)),
 			wantInsufficientResources: []InsufficientResource{
@@ -175,9 +175,9 @@ func TestEnoughRequests(t *testing.T) {
 			},
 		},
 		{
-			pod: newResourceInitPod(newResourcePod(framework.Resource{MilliCPU: 1, Memory: 1}), framework.Resource{MilliCPU: 1, Memory: 3}, framework.Resource{MilliCPU: 1, Memory: 2}),
+			pod: newResourceInitPod(newResourcePod(framework.ComputeResource{MilliCPU: 1, Memory: 1}), framework.ComputeResource{MilliCPU: 1, Memory: 3}, framework.ComputeResource{MilliCPU: 1, Memory: 2}),
 			nodeInfo: framework.NewNodeInfo(
-				newResourcePod(framework.Resource{MilliCPU: 9, Memory: 19})),
+				newResourcePod(framework.ComputeResource{MilliCPU: 9, Memory: 19})),
 			name:       "too many resources fails due to highest init container memory",
 			wantStatus: framework.NewStatus(framework.Unschedulable, getErrReason(v1.ResourceMemory)),
 			wantInsufficientResources: []InsufficientResource{
@@ -185,30 +185,30 @@ func TestEnoughRequests(t *testing.T) {
 			},
 		},
 		{
-			pod: newResourceInitPod(newResourcePod(framework.Resource{MilliCPU: 1, Memory: 1}), framework.Resource{MilliCPU: 1, Memory: 1}),
+			pod: newResourceInitPod(newResourcePod(framework.ComputeResource{MilliCPU: 1, Memory: 1}), framework.ComputeResource{MilliCPU: 1, Memory: 1}),
 			nodeInfo: framework.NewNodeInfo(
-				newResourcePod(framework.Resource{MilliCPU: 9, Memory: 19})),
+				newResourcePod(framework.ComputeResource{MilliCPU: 9, Memory: 19})),
 			name:                      "init container fits because it's the max, not sum, of containers and init containers",
 			wantInsufficientResources: []InsufficientResource{},
 		},
 		{
-			pod: newResourceInitPod(newResourcePod(framework.Resource{MilliCPU: 1, Memory: 1}), framework.Resource{MilliCPU: 1, Memory: 1}, framework.Resource{MilliCPU: 1, Memory: 1}),
+			pod: newResourceInitPod(newResourcePod(framework.ComputeResource{MilliCPU: 1, Memory: 1}), framework.ComputeResource{MilliCPU: 1, Memory: 1}, framework.ComputeResource{MilliCPU: 1, Memory: 1}),
 			nodeInfo: framework.NewNodeInfo(
-				newResourcePod(framework.Resource{MilliCPU: 9, Memory: 19})),
+				newResourcePod(framework.ComputeResource{MilliCPU: 9, Memory: 19})),
 			name:                      "multiple init containers fit because it's the max, not sum, of containers and init containers",
 			wantInsufficientResources: []InsufficientResource{},
 		},
 		{
-			pod: newResourcePod(framework.Resource{MilliCPU: 1, Memory: 1}),
+			pod: newResourcePod(framework.ComputeResource{MilliCPU: 1, Memory: 1}),
 			nodeInfo: framework.NewNodeInfo(
-				newResourcePod(framework.Resource{MilliCPU: 5, Memory: 5})),
+				newResourcePod(framework.ComputeResource{MilliCPU: 5, Memory: 5})),
 			name:                      "both resources fit",
 			wantInsufficientResources: []InsufficientResource{},
 		},
 		{
-			pod: newResourcePod(framework.Resource{MilliCPU: 2, Memory: 1}),
+			pod: newResourcePod(framework.ComputeResource{MilliCPU: 2, Memory: 1}),
 			nodeInfo: framework.NewNodeInfo(
-				newResourcePod(framework.Resource{MilliCPU: 9, Memory: 5})),
+				newResourcePod(framework.ComputeResource{MilliCPU: 9, Memory: 5})),
 			name:       "one resource memory fits",
 			wantStatus: framework.NewStatus(framework.Unschedulable, getErrReason(v1.ResourceCPU)),
 			wantInsufficientResources: []InsufficientResource{
@@ -216,9 +216,9 @@ func TestEnoughRequests(t *testing.T) {
 			},
 		},
 		{
-			pod: newResourcePod(framework.Resource{MilliCPU: 1, Memory: 2}),
+			pod: newResourcePod(framework.ComputeResource{MilliCPU: 1, Memory: 2}),
 			nodeInfo: framework.NewNodeInfo(
-				newResourcePod(framework.Resource{MilliCPU: 5, Memory: 19})),
+				newResourcePod(framework.ComputeResource{MilliCPU: 5, Memory: 19})),
 			name:       "one resource cpu fits",
 			wantStatus: framework.NewStatus(framework.Unschedulable, getErrReason(v1.ResourceMemory)),
 			wantInsufficientResources: []InsufficientResource{
@@ -226,36 +226,36 @@ func TestEnoughRequests(t *testing.T) {
 			},
 		},
 		{
-			pod: newResourcePod(framework.Resource{MilliCPU: 5, Memory: 1}),
+			pod: newResourcePod(framework.ComputeResource{MilliCPU: 5, Memory: 1}),
 			nodeInfo: framework.NewNodeInfo(
-				newResourcePod(framework.Resource{MilliCPU: 5, Memory: 19})),
+				newResourcePod(framework.ComputeResource{MilliCPU: 5, Memory: 19})),
 			name:                      "equal edge case",
 			wantInsufficientResources: []InsufficientResource{},
 		},
 		{
-			pod: newResourceInitPod(newResourcePod(framework.Resource{MilliCPU: 4, Memory: 1}), framework.Resource{MilliCPU: 5, Memory: 1}),
+			pod: newResourceInitPod(newResourcePod(framework.ComputeResource{MilliCPU: 4, Memory: 1}), framework.ComputeResource{MilliCPU: 5, Memory: 1}),
 			nodeInfo: framework.NewNodeInfo(
-				newResourcePod(framework.Resource{MilliCPU: 5, Memory: 19})),
+				newResourcePod(framework.ComputeResource{MilliCPU: 5, Memory: 19})),
 			name:                      "equal edge case for init container",
 			wantInsufficientResources: []InsufficientResource{},
 		},
 		{
-			pod:                       newResourcePod(framework.Resource{ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 1}}),
-			nodeInfo:                  framework.NewNodeInfo(newResourcePod(framework.Resource{})),
+			pod:                       newResourcePod(framework.ComputeResource{ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 1}}),
+			nodeInfo:                  framework.NewNodeInfo(newResourcePod(framework.ComputeResource{})),
 			name:                      "extended resource fits",
 			wantInsufficientResources: []InsufficientResource{},
 		},
 		{
-			pod:                       newResourceInitPod(newResourcePod(framework.Resource{}), framework.Resource{ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 1}}),
-			nodeInfo:                  framework.NewNodeInfo(newResourcePod(framework.Resource{})),
+			pod:                       newResourceInitPod(newResourcePod(framework.ComputeResource{}), framework.ComputeResource{ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 1}}),
+			nodeInfo:                  framework.NewNodeInfo(newResourcePod(framework.ComputeResource{})),
 			name:                      "extended resource fits for init container",
 			wantInsufficientResources: []InsufficientResource{},
 		},
 		{
 			pod: newResourcePod(
-				framework.Resource{MilliCPU: 1, Memory: 1, ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 10}}),
+				framework.ComputeResource{MilliCPU: 1, Memory: 1, ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 10}}),
 			nodeInfo: framework.NewNodeInfo(
-				newResourcePod(framework.Resource{MilliCPU: 0, Memory: 0, ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 0}})),
+				newResourcePod(framework.ComputeResource{MilliCPU: 0, Memory: 0, ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 0}})),
 			name:       "extended resource capacity enforced",
 			wantStatus: framework.NewStatus(framework.Unschedulable, getErrReason(extendedResourceA)),
 			wantInsufficientResources: []InsufficientResource{
@@ -263,10 +263,10 @@ func TestEnoughRequests(t *testing.T) {
 			},
 		},
 		{
-			pod: newResourceInitPod(newResourcePod(framework.Resource{}),
-				framework.Resource{MilliCPU: 1, Memory: 1, ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 10}}),
+			pod: newResourceInitPod(newResourcePod(framework.ComputeResource{}),
+				framework.ComputeResource{MilliCPU: 1, Memory: 1, ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 10}}),
 			nodeInfo: framework.NewNodeInfo(
-				newResourcePod(framework.Resource{MilliCPU: 0, Memory: 0, ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 0}})),
+				newResourcePod(framework.ComputeResource{MilliCPU: 0, Memory: 0, ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 0}})),
 			name:       "extended resource capacity enforced for init container",
 			wantStatus: framework.NewStatus(framework.Unschedulable, getErrReason(extendedResourceA)),
 			wantInsufficientResources: []InsufficientResource{
@@ -275,9 +275,9 @@ func TestEnoughRequests(t *testing.T) {
 		},
 		{
 			pod: newResourcePod(
-				framework.Resource{MilliCPU: 1, Memory: 1, ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 1}}),
+				framework.ComputeResource{MilliCPU: 1, Memory: 1, ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 1}}),
 			nodeInfo: framework.NewNodeInfo(
-				newResourcePod(framework.Resource{MilliCPU: 0, Memory: 0, ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 5}})),
+				newResourcePod(framework.ComputeResource{MilliCPU: 0, Memory: 0, ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 5}})),
 			name:       "extended resource allocatable enforced",
 			wantStatus: framework.NewStatus(framework.Unschedulable, getErrReason(extendedResourceA)),
 			wantInsufficientResources: []InsufficientResource{
@@ -285,10 +285,10 @@ func TestEnoughRequests(t *testing.T) {
 			},
 		},
 		{
-			pod: newResourceInitPod(newResourcePod(framework.Resource{}),
-				framework.Resource{MilliCPU: 1, Memory: 1, ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 1}}),
+			pod: newResourceInitPod(newResourcePod(framework.ComputeResource{}),
+				framework.ComputeResource{MilliCPU: 1, Memory: 1, ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 1}}),
 			nodeInfo: framework.NewNodeInfo(
-				newResourcePod(framework.Resource{MilliCPU: 0, Memory: 0, ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 5}})),
+				newResourcePod(framework.ComputeResource{MilliCPU: 0, Memory: 0, ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 5}})),
 			name:       "extended resource allocatable enforced for init container",
 			wantStatus: framework.NewStatus(framework.Unschedulable, getErrReason(extendedResourceA)),
 			wantInsufficientResources: []InsufficientResource{
@@ -297,10 +297,10 @@ func TestEnoughRequests(t *testing.T) {
 		},
 		{
 			pod: newResourcePod(
-				framework.Resource{MilliCPU: 1, Memory: 1, ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 3}},
-				framework.Resource{MilliCPU: 1, Memory: 1, ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 3}}),
+				framework.ComputeResource{MilliCPU: 1, Memory: 1, ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 3}},
+				framework.ComputeResource{MilliCPU: 1, Memory: 1, ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 3}}),
 			nodeInfo: framework.NewNodeInfo(
-				newResourcePod(framework.Resource{MilliCPU: 0, Memory: 0, ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 2}})),
+				newResourcePod(framework.ComputeResource{MilliCPU: 0, Memory: 0, ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 2}})),
 			name:       "extended resource allocatable enforced for multiple containers",
 			wantStatus: framework.NewStatus(framework.Unschedulable, getErrReason(extendedResourceA)),
 			wantInsufficientResources: []InsufficientResource{
@@ -308,20 +308,20 @@ func TestEnoughRequests(t *testing.T) {
 			},
 		},
 		{
-			pod: newResourceInitPod(newResourcePod(framework.Resource{}),
-				framework.Resource{MilliCPU: 1, Memory: 1, ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 3}},
-				framework.Resource{MilliCPU: 1, Memory: 1, ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 3}}),
+			pod: newResourceInitPod(newResourcePod(framework.ComputeResource{}),
+				framework.ComputeResource{MilliCPU: 1, Memory: 1, ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 3}},
+				framework.ComputeResource{MilliCPU: 1, Memory: 1, ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 3}}),
 			nodeInfo: framework.NewNodeInfo(
-				newResourcePod(framework.Resource{MilliCPU: 0, Memory: 0, ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 2}})),
+				newResourcePod(framework.ComputeResource{MilliCPU: 0, Memory: 0, ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 2}})),
 			name:                      "extended resource allocatable admits multiple init containers",
 			wantInsufficientResources: []InsufficientResource{},
 		},
 		{
-			pod: newResourceInitPod(newResourcePod(framework.Resource{}),
-				framework.Resource{MilliCPU: 1, Memory: 1, ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 6}},
-				framework.Resource{MilliCPU: 1, Memory: 1, ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 3}}),
+			pod: newResourceInitPod(newResourcePod(framework.ComputeResource{}),
+				framework.ComputeResource{MilliCPU: 1, Memory: 1, ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 6}},
+				framework.ComputeResource{MilliCPU: 1, Memory: 1, ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 3}}),
 			nodeInfo: framework.NewNodeInfo(
-				newResourcePod(framework.Resource{MilliCPU: 0, Memory: 0, ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 2}})),
+				newResourcePod(framework.ComputeResource{MilliCPU: 0, Memory: 0, ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 2}})),
 			name:       "extended resource allocatable enforced for multiple init containers",
 			wantStatus: framework.NewStatus(framework.Unschedulable, getErrReason(extendedResourceA)),
 			wantInsufficientResources: []InsufficientResource{
@@ -330,9 +330,9 @@ func TestEnoughRequests(t *testing.T) {
 		},
 		{
 			pod: newResourcePod(
-				framework.Resource{MilliCPU: 1, Memory: 1, ScalarResources: map[v1.ResourceName]int64{extendedResourceB: 1}}),
+				framework.ComputeResource{MilliCPU: 1, Memory: 1, ScalarResources: map[v1.ResourceName]int64{extendedResourceB: 1}}),
 			nodeInfo: framework.NewNodeInfo(
-				newResourcePod(framework.Resource{MilliCPU: 0, Memory: 0})),
+				newResourcePod(framework.ComputeResource{MilliCPU: 0, Memory: 0})),
 			name:       "extended resource allocatable enforced for unknown resource",
 			wantStatus: framework.NewStatus(framework.Unschedulable, getErrReason(extendedResourceB)),
 			wantInsufficientResources: []InsufficientResource{
@@ -340,10 +340,10 @@ func TestEnoughRequests(t *testing.T) {
 			},
 		},
 		{
-			pod: newResourceInitPod(newResourcePod(framework.Resource{}),
-				framework.Resource{MilliCPU: 1, Memory: 1, ScalarResources: map[v1.ResourceName]int64{extendedResourceB: 1}}),
+			pod: newResourceInitPod(newResourcePod(framework.ComputeResource{}),
+				framework.ComputeResource{MilliCPU: 1, Memory: 1, ScalarResources: map[v1.ResourceName]int64{extendedResourceB: 1}}),
 			nodeInfo: framework.NewNodeInfo(
-				newResourcePod(framework.Resource{MilliCPU: 0, Memory: 0})),
+				newResourcePod(framework.ComputeResource{MilliCPU: 0, Memory: 0})),
 			name:       "extended resource allocatable enforced for unknown resource for init container",
 			wantStatus: framework.NewStatus(framework.Unschedulable, getErrReason(extendedResourceB)),
 			wantInsufficientResources: []InsufficientResource{
@@ -352,9 +352,9 @@ func TestEnoughRequests(t *testing.T) {
 		},
 		{
 			pod: newResourcePod(
-				framework.Resource{MilliCPU: 1, Memory: 1, ScalarResources: map[v1.ResourceName]int64{kubernetesIOResourceA: 10}}),
+				framework.ComputeResource{MilliCPU: 1, Memory: 1, ScalarResources: map[v1.ResourceName]int64{kubernetesIOResourceA: 10}}),
 			nodeInfo: framework.NewNodeInfo(
-				newResourcePod(framework.Resource{MilliCPU: 0, Memory: 0})),
+				newResourcePod(framework.ComputeResource{MilliCPU: 0, Memory: 0})),
 			name:       "kubernetes.io resource capacity enforced",
 			wantStatus: framework.NewStatus(framework.Unschedulable, getErrReason(kubernetesIOResourceA)),
 			wantInsufficientResources: []InsufficientResource{
@@ -362,10 +362,10 @@ func TestEnoughRequests(t *testing.T) {
 			},
 		},
 		{
-			pod: newResourceInitPod(newResourcePod(framework.Resource{}),
-				framework.Resource{MilliCPU: 1, Memory: 1, ScalarResources: map[v1.ResourceName]int64{kubernetesIOResourceB: 10}}),
+			pod: newResourceInitPod(newResourcePod(framework.ComputeResource{}),
+				framework.ComputeResource{MilliCPU: 1, Memory: 1, ScalarResources: map[v1.ResourceName]int64{kubernetesIOResourceB: 10}}),
 			nodeInfo: framework.NewNodeInfo(
-				newResourcePod(framework.Resource{MilliCPU: 0, Memory: 0})),
+				newResourcePod(framework.ComputeResource{MilliCPU: 0, Memory: 0})),
 			name:       "kubernetes.io resource capacity enforced for init container",
 			wantStatus: framework.NewStatus(framework.Unschedulable, getErrReason(kubernetesIOResourceB)),
 			wantInsufficientResources: []InsufficientResource{
@@ -374,9 +374,9 @@ func TestEnoughRequests(t *testing.T) {
 		},
 		{
 			pod: newResourcePod(
-				framework.Resource{MilliCPU: 1, Memory: 1, ScalarResources: map[v1.ResourceName]int64{hugePageResourceA: 10}}),
+				framework.ComputeResource{MilliCPU: 1, Memory: 1, ScalarResources: map[v1.ResourceName]int64{hugePageResourceA: 10}}),
 			nodeInfo: framework.NewNodeInfo(
-				newResourcePod(framework.Resource{MilliCPU: 0, Memory: 0, ScalarResources: map[v1.ResourceName]int64{hugePageResourceA: 0}})),
+				newResourcePod(framework.ComputeResource{MilliCPU: 0, Memory: 0, ScalarResources: map[v1.ResourceName]int64{hugePageResourceA: 0}})),
 			name:       "hugepages resource capacity enforced",
 			wantStatus: framework.NewStatus(framework.Unschedulable, getErrReason(hugePageResourceA)),
 			wantInsufficientResources: []InsufficientResource{
@@ -384,10 +384,10 @@ func TestEnoughRequests(t *testing.T) {
 			},
 		},
 		{
-			pod: newResourceInitPod(newResourcePod(framework.Resource{}),
-				framework.Resource{MilliCPU: 1, Memory: 1, ScalarResources: map[v1.ResourceName]int64{hugePageResourceA: 10}}),
+			pod: newResourceInitPod(newResourcePod(framework.ComputeResource{}),
+				framework.ComputeResource{MilliCPU: 1, Memory: 1, ScalarResources: map[v1.ResourceName]int64{hugePageResourceA: 10}}),
 			nodeInfo: framework.NewNodeInfo(
-				newResourcePod(framework.Resource{MilliCPU: 0, Memory: 0, ScalarResources: map[v1.ResourceName]int64{hugePageResourceA: 0}})),
+				newResourcePod(framework.ComputeResource{MilliCPU: 0, Memory: 0, ScalarResources: map[v1.ResourceName]int64{hugePageResourceA: 0}})),
 			name:       "hugepages resource capacity enforced for init container",
 			wantStatus: framework.NewStatus(framework.Unschedulable, getErrReason(hugePageResourceA)),
 			wantInsufficientResources: []InsufficientResource{
@@ -396,10 +396,10 @@ func TestEnoughRequests(t *testing.T) {
 		},
 		{
 			pod: newResourcePod(
-				framework.Resource{MilliCPU: 1, Memory: 1, ScalarResources: map[v1.ResourceName]int64{hugePageResourceA: 3}},
-				framework.Resource{MilliCPU: 1, Memory: 1, ScalarResources: map[v1.ResourceName]int64{hugePageResourceA: 3}}),
+				framework.ComputeResource{MilliCPU: 1, Memory: 1, ScalarResources: map[v1.ResourceName]int64{hugePageResourceA: 3}},
+				framework.ComputeResource{MilliCPU: 1, Memory: 1, ScalarResources: map[v1.ResourceName]int64{hugePageResourceA: 3}}),
 			nodeInfo: framework.NewNodeInfo(
-				newResourcePod(framework.Resource{MilliCPU: 0, Memory: 0, ScalarResources: map[v1.ResourceName]int64{hugePageResourceA: 2}})),
+				newResourcePod(framework.ComputeResource{MilliCPU: 0, Memory: 0, ScalarResources: map[v1.ResourceName]int64{hugePageResourceA: 2}})),
 			name:       "hugepages resource allocatable enforced for multiple containers",
 			wantStatus: framework.NewStatus(framework.Unschedulable, getErrReason(hugePageResourceA)),
 			wantInsufficientResources: []InsufficientResource{
@@ -408,8 +408,8 @@ func TestEnoughRequests(t *testing.T) {
 		},
 		{
 			pod: newResourcePod(
-				framework.Resource{MilliCPU: 1, Memory: 1, ScalarResources: map[v1.ResourceName]int64{extendedResourceB: 1}}),
-			nodeInfo: framework.NewNodeInfo(newResourcePod(framework.Resource{MilliCPU: 0, Memory: 0})),
+				framework.ComputeResource{MilliCPU: 1, Memory: 1, ScalarResources: map[v1.ResourceName]int64{extendedResourceB: 1}}),
+			nodeInfo: framework.NewNodeInfo(newResourcePod(framework.ComputeResource{MilliCPU: 0, Memory: 0})),
 			args: config.NodeResourcesFitArgs{
 				IgnoredResources: []string{"example.com/bbb"},
 			},
@@ -418,19 +418,19 @@ func TestEnoughRequests(t *testing.T) {
 		},
 		{
 			pod: newResourceOverheadPod(
-				newResourcePod(framework.Resource{MilliCPU: 1, Memory: 1}),
+				newResourcePod(framework.ComputeResource{MilliCPU: 1, Memory: 1}),
 				v1.ResourceList{v1.ResourceCPU: resource.MustParse("3m"), v1.ResourceMemory: resource.MustParse("13")},
 			),
-			nodeInfo:                  framework.NewNodeInfo(newResourcePod(framework.Resource{MilliCPU: 5, Memory: 5})),
+			nodeInfo:                  framework.NewNodeInfo(newResourcePod(framework.ComputeResource{MilliCPU: 5, Memory: 5})),
 			name:                      "resources + pod overhead fits",
 			wantInsufficientResources: []InsufficientResource{},
 		},
 		{
 			pod: newResourceOverheadPod(
-				newResourcePod(framework.Resource{MilliCPU: 1, Memory: 1}),
+				newResourcePod(framework.ComputeResource{MilliCPU: 1, Memory: 1}),
 				v1.ResourceList{v1.ResourceCPU: resource.MustParse("1m"), v1.ResourceMemory: resource.MustParse("15")},
 			),
-			nodeInfo:   framework.NewNodeInfo(newResourcePod(framework.Resource{MilliCPU: 5, Memory: 5})),
+			nodeInfo:   framework.NewNodeInfo(newResourcePod(framework.ComputeResource{MilliCPU: 5, Memory: 5})),
 			name:       "requests + overhead does not fit for memory",
 			wantStatus: framework.NewStatus(framework.Unschedulable, getErrReason(v1.ResourceMemory)),
 			wantInsufficientResources: []InsufficientResource{
@@ -439,14 +439,14 @@ func TestEnoughRequests(t *testing.T) {
 		},
 		{
 			pod: newResourcePod(
-				framework.Resource{
+				framework.ComputeResource{
 					MilliCPU: 1,
 					Memory:   1,
 					ScalarResources: map[v1.ResourceName]int64{
 						extendedResourceB:     1,
 						kubernetesIOResourceA: 1,
 					}}),
-			nodeInfo: framework.NewNodeInfo(newResourcePod(framework.Resource{MilliCPU: 0, Memory: 0})),
+			nodeInfo: framework.NewNodeInfo(newResourcePod(framework.ComputeResource{MilliCPU: 0, Memory: 0})),
 			args: config.NodeResourcesFitArgs{
 				IgnoredResourceGroups: []string{"example.com"},
 			},
@@ -464,24 +464,24 @@ func TestEnoughRequests(t *testing.T) {
 		},
 		{
 			pod: newResourcePod(
-				framework.Resource{
+				framework.ComputeResource{
 					MilliCPU: 1,
 					Memory:   1,
 					ScalarResources: map[v1.ResourceName]int64{
 						extendedResourceA: 0,
 					}}),
-			nodeInfo: framework.NewNodeInfo(newResourcePod(framework.Resource{
+			nodeInfo: framework.NewNodeInfo(newResourcePod(framework.ComputeResource{
 				MilliCPU: 0, Memory: 0, ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 6}})),
 			name:                      "skip checking extended resource request with quantity zero via resource groups",
 			wantInsufficientResources: []InsufficientResource{},
 		},
 		{
 			pod: newResourcePod(
-				framework.Resource{
+				framework.ComputeResource{
 					ScalarResources: map[v1.ResourceName]int64{
 						extendedResourceA: 1,
 					}}),
-			nodeInfo: framework.NewNodeInfo(newResourcePod(framework.Resource{
+			nodeInfo: framework.NewNodeInfo(newResourcePod(framework.ComputeResource{
 				MilliCPU: 20, Memory: 30, ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 1}})),
 			name:                      "skip checking resource request with quantity zero",
 			wantInsufficientResources: []InsufficientResource{},
@@ -553,25 +553,25 @@ func TestNotEnoughRequests(t *testing.T) {
 	}{
 		{
 			pod:        &v1.Pod{},
-			nodeInfo:   framework.NewNodeInfo(newResourcePod(framework.Resource{MilliCPU: 10, Memory: 20})),
+			nodeInfo:   framework.NewNodeInfo(newResourcePod(framework.ComputeResource{MilliCPU: 10, Memory: 20})),
 			name:       "even without specified resources, predicate fails when there's no space for additional pod",
 			wantStatus: framework.NewStatus(framework.Unschedulable, "Too many pods"),
 		},
 		{
-			pod:        newResourcePod(framework.Resource{MilliCPU: 1, Memory: 1}),
-			nodeInfo:   framework.NewNodeInfo(newResourcePod(framework.Resource{MilliCPU: 5, Memory: 5})),
+			pod:        newResourcePod(framework.ComputeResource{MilliCPU: 1, Memory: 1}),
+			nodeInfo:   framework.NewNodeInfo(newResourcePod(framework.ComputeResource{MilliCPU: 5, Memory: 5})),
 			name:       "even if both resources fit, predicate fails when there's no space for additional pod",
 			wantStatus: framework.NewStatus(framework.Unschedulable, "Too many pods"),
 		},
 		{
-			pod:        newResourcePod(framework.Resource{MilliCPU: 5, Memory: 1}),
-			nodeInfo:   framework.NewNodeInfo(newResourcePod(framework.Resource{MilliCPU: 5, Memory: 19})),
+			pod:        newResourcePod(framework.ComputeResource{MilliCPU: 5, Memory: 1}),
+			nodeInfo:   framework.NewNodeInfo(newResourcePod(framework.ComputeResource{MilliCPU: 5, Memory: 19})),
 			name:       "even for equal edge case, predicate fails when there's no space for additional pod",
 			wantStatus: framework.NewStatus(framework.Unschedulable, "Too many pods"),
 		},
 		{
-			pod:        newResourceInitPod(newResourcePod(framework.Resource{MilliCPU: 5, Memory: 1}), framework.Resource{MilliCPU: 5, Memory: 1}),
-			nodeInfo:   framework.NewNodeInfo(newResourcePod(framework.Resource{MilliCPU: 5, Memory: 19})),
+			pod:        newResourceInitPod(newResourcePod(framework.ComputeResource{MilliCPU: 5, Memory: 1}), framework.ComputeResource{MilliCPU: 5, Memory: 1}),
+			nodeInfo:   framework.NewNodeInfo(newResourcePod(framework.ComputeResource{MilliCPU: 5, Memory: 19})),
 			name:       "even for equal edge case, predicate fails when there's no space for additional pod due to init container",
 			wantStatus: framework.NewStatus(framework.Unschedulable, "Too many pods"),
 		},
@@ -611,28 +611,28 @@ func TestStorageRequests(t *testing.T) {
 		wantStatus *framework.Status
 	}{
 		{
-			pod: newResourcePod(framework.Resource{MilliCPU: 1, Memory: 1}),
+			pod: newResourcePod(framework.ComputeResource{MilliCPU: 1, Memory: 1}),
 			nodeInfo: framework.NewNodeInfo(
-				newResourcePod(framework.Resource{MilliCPU: 2, Memory: 10})),
+				newResourcePod(framework.ComputeResource{MilliCPU: 2, Memory: 10})),
 			name: "empty storage requested, and pod fits",
 		},
 		{
-			pod: newResourcePod(framework.Resource{EphemeralStorage: 25}),
+			pod: newResourcePod(framework.ComputeResource{EphemeralStorage: 25}),
 			nodeInfo: framework.NewNodeInfo(
-				newResourcePod(framework.Resource{MilliCPU: 2, Memory: 2})),
+				newResourcePod(framework.ComputeResource{MilliCPU: 2, Memory: 2})),
 			name:       "storage ephemeral local storage request exceeds allocatable",
 			wantStatus: framework.NewStatus(framework.Unschedulable, getErrReason(v1.ResourceEphemeralStorage)),
 		},
 		{
-			pod: newResourceInitPod(newResourcePod(framework.Resource{EphemeralStorage: 5})),
+			pod: newResourceInitPod(newResourcePod(framework.ComputeResource{EphemeralStorage: 5})),
 			nodeInfo: framework.NewNodeInfo(
-				newResourcePod(framework.Resource{MilliCPU: 2, Memory: 2, EphemeralStorage: 10})),
+				newResourcePod(framework.ComputeResource{MilliCPU: 2, Memory: 2, EphemeralStorage: 10})),
 			name: "ephemeral local storage is sufficient",
 		},
 		{
-			pod: newResourcePod(framework.Resource{EphemeralStorage: 10}),
+			pod: newResourcePod(framework.ComputeResource{EphemeralStorage: 10}),
 			nodeInfo: framework.NewNodeInfo(
-				newResourcePod(framework.Resource{MilliCPU: 2, Memory: 2})),
+				newResourcePod(framework.ComputeResource{MilliCPU: 2, Memory: 2})),
 			name: "pod fits",
 		},
 	}
@@ -1250,14 +1250,14 @@ func Test_isSchedulableAfterNodeChange(t *testing.T) {
 			expectedErr:  true,
 		},
 		"skip-queue-on-node-add-without-sufficient-resources": {
-			pod: newResourcePod(framework.Resource{Memory: 2}),
+			pod: newResourcePod(framework.ComputeResource{Memory: 2}),
 			newObj: st.MakeNode().Capacity(map[v1.ResourceName]string{
 				v1.ResourceMemory: "1",
 			}).Obj(),
 			expectedHint: framework.QueueSkip,
 		},
 		"skip-queue-on-node-add-without-required-resource-type": {
-			pod: newResourcePod(framework.Resource{
+			pod: newResourcePod(framework.ComputeResource{
 				ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 1}},
 			),
 			newObj: st.MakeNode().Capacity(map[v1.ResourceName]string{
@@ -1266,7 +1266,7 @@ func Test_isSchedulableAfterNodeChange(t *testing.T) {
 			expectedHint: framework.QueueSkip,
 		},
 		"queue-on-node-add-with-sufficient-resources": {
-			pod: newResourcePod(framework.Resource{
+			pod: newResourcePod(framework.ComputeResource{
 				Memory:          2,
 				ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 1},
 			}),
@@ -1285,7 +1285,7 @@ func Test_isSchedulableAfterNodeChange(t *testing.T) {
 		// 	expectedHint: framework.QueueSkip,
 		// },
 		"skip-queue-on-node-changes-from-suitable-to-unsuitable": {
-			pod: newResourcePod(framework.Resource{
+			pod: newResourcePod(framework.ComputeResource{
 				Memory:          2,
 				ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 1},
 			}),
@@ -1300,7 +1300,7 @@ func Test_isSchedulableAfterNodeChange(t *testing.T) {
 			expectedHint: framework.QueueSkip,
 		},
 		"queue-on-node-changes-from-unsuitable-to-suitable": {
-			pod: newResourcePod(framework.Resource{
+			pod: newResourcePod(framework.ComputeResource{
 				Memory:          2,
 				ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 1},
 			}),

--- a/pkg/scheduler/framework/plugins/noderesources/fit_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/fit_test.go
@@ -1096,24 +1096,25 @@ func TestEventsToRegister(t *testing.T) {
 			name:                            "Register events with InPlacePodVerticalScaling feature enabled",
 			enableInPlacePodVerticalScaling: true,
 			expectedClusterEvents: []framework.ClusterEventWithHint{
-				{Event: framework.ClusterEvent{Resource: "Pod", ActionType: framework.UpdatePodScaleDown | framework.Delete}},
-				{Event: framework.ClusterEvent{Resource: "Node", ActionType: framework.Add | framework.UpdateNodeAllocatable | framework.UpdateNodeTaint | framework.UpdateNodeLabel}},
+				{Event: framework.ClusterEvent{Resource: framework.AssignedPod, ActionType: framework.UpdatePodScaleDown | framework.Delete}},
+				{Event: framework.ClusterEvent{Resource: framework.Node, ActionType: framework.Add | framework.UpdateNodeAllocatable | framework.UpdateNodeTaint | framework.UpdateNodeLabel}},
+				{Event: framework.ClusterEvent{Resource: framework.PodItself, ActionType: framework.UpdatePodScaleDown}},
 			},
 		},
 		{
 			name:                      "Register events with SchedulingQueueHint feature enabled",
 			enableSchedulingQueueHint: true,
 			expectedClusterEvents: []framework.ClusterEventWithHint{
-				{Event: framework.ClusterEvent{Resource: "Pod", ActionType: framework.Delete}},
-				{Event: framework.ClusterEvent{Resource: "Node", ActionType: framework.Add | framework.UpdateNodeAllocatable}},
+				{Event: framework.ClusterEvent{Resource: framework.AssignedPod, ActionType: framework.Delete}},
+				{Event: framework.ClusterEvent{Resource: framework.Node, ActionType: framework.Add | framework.UpdateNodeAllocatable}},
 			},
 		},
 		{
 			name:                            "Register events with InPlacePodVerticalScaling feature disabled",
 			enableInPlacePodVerticalScaling: false,
 			expectedClusterEvents: []framework.ClusterEventWithHint{
-				{Event: framework.ClusterEvent{Resource: "Pod", ActionType: framework.Delete}},
-				{Event: framework.ClusterEvent{Resource: "Node", ActionType: framework.Add | framework.UpdateNodeAllocatable | framework.UpdateNodeTaint | framework.UpdateNodeLabel}},
+				{Event: framework.ClusterEvent{Resource: framework.AssignedPod, ActionType: framework.Delete}},
+				{Event: framework.ClusterEvent{Resource: framework.Node, ActionType: framework.Add | framework.UpdateNodeAllocatable | framework.UpdateNodeTaint | framework.UpdateNodeLabel}},
 			},
 		},
 	}

--- a/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable.go
+++ b/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable.go
@@ -65,10 +65,10 @@ func (pl *NodeUnschedulable) EventsToRegister(_ context.Context) ([]framework.Cl
 		// When QueueingHint is enabled, we don't use preCheck and we don't need to register UpdateNodeLabel event.
 		{Event: framework.ClusterEvent{Resource: framework.Node, ActionType: framework.Add | framework.UpdateNodeTaint}, QueueingHintFn: pl.isSchedulableAfterNodeChange},
 		// When the QueueingHint feature is enabled,
-		// the scheduling queue uses Pod/Update Queueing Hint
+		// the scheduling queue uses PodItself/Update Queueing Hint
 		// to determine whether a Pod's update makes the Pod schedulable or not.
 		// https://github.com/kubernetes/kubernetes/pull/122234
-		{Event: framework.ClusterEvent{Resource: framework.Pod, ActionType: framework.UpdatePodTolerations}, QueueingHintFn: pl.isSchedulableAfterPodTolerationChange},
+		{Event: framework.ClusterEvent{Resource: framework.PodItself, ActionType: framework.UpdatePodTolerations}, QueueingHintFn: pl.isSchedulableAfterPodTolerationChange},
 	}, nil
 }
 

--- a/pkg/scheduler/framework/plugins/nodevolumelimits/csi.go
+++ b/pkg/scheduler/framework/plugins/nodevolumelimits/csi.go
@@ -85,7 +85,7 @@ func (pl *CSILimits) EventsToRegister(_ context.Context) ([]framework.ClusterEve
 		// We don't register any `QueueingHintFn` intentionally
 		// because any new CSINode could make pods that were rejected by CSI volumes schedulable.
 		{Event: framework.ClusterEvent{Resource: framework.CSINode, ActionType: framework.Add}},
-		{Event: framework.ClusterEvent{Resource: framework.Pod, ActionType: framework.Delete}, QueueingHintFn: pl.isSchedulableAfterPodDeleted},
+		{Event: framework.ClusterEvent{Resource: framework.AssignedPod, ActionType: framework.Delete}, QueueingHintFn: pl.isSchedulableAfterPodDeleted},
 		{Event: framework.ClusterEvent{Resource: framework.PersistentVolumeClaim, ActionType: framework.Add}, QueueingHintFn: pl.isSchedulableAfterPVCAdded},
 	}, nil
 }

--- a/pkg/scheduler/framework/plugins/schedulinggates/scheduling_gates.go
+++ b/pkg/scheduler/framework/plugins/schedulinggates/scheduling_gates.go
@@ -63,12 +63,12 @@ func (pl *SchedulingGates) EventsToRegister(_ context.Context) ([]framework.Clus
 		return nil, nil
 	}
 	// When the QueueingHint feature is enabled,
-	// the scheduling queue uses Pod/Update Queueing Hint
+	// the scheduling queue uses PodItself/Update Queueing Hint
 	// to determine whether a Pod's update makes the Pod schedulable or not.
 	// https://github.com/kubernetes/kubernetes/pull/122234
 	return []framework.ClusterEventWithHint{
 		// Pods can be more schedulable once it's gates are removed
-		{Event: framework.ClusterEvent{Resource: framework.Pod, ActionType: framework.UpdatePodSchedulingGatesEliminated}, QueueingHintFn: pl.isSchedulableAfterUpdatePodSchedulingGatesEliminated},
+		{Event: framework.ClusterEvent{Resource: framework.PodItself, ActionType: framework.UpdatePodSchedulingGatesEliminated}, QueueingHintFn: pl.isSchedulableAfterUpdatePodSchedulingGatesEliminated},
 	}, nil
 }
 

--- a/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration.go
+++ b/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration.go
@@ -64,10 +64,10 @@ func (pl *TaintToleration) EventsToRegister(_ context.Context) ([]framework.Clus
 			// When the QueueingHint feature is enabled, preCheck is eliminated and we don't need additional UpdateNodeLabel.
 			{Event: framework.ClusterEvent{Resource: framework.Node, ActionType: framework.Add | framework.UpdateNodeTaint}, QueueingHintFn: pl.isSchedulableAfterNodeChange},
 			// When the QueueingHint feature is enabled,
-			// the scheduling queue uses Pod/Update Queueing Hint
+			// the scheduling queue uses PodItself/Update Queueing Hint
 			// to determine whether a Pod's update makes the Pod schedulable or not.
 			// https://github.com/kubernetes/kubernetes/pull/122234
-			{Event: framework.ClusterEvent{Resource: framework.Pod, ActionType: framework.UpdatePodTolerations}, QueueingHintFn: pl.isSchedulableAfterPodTolerationChange},
+			{Event: framework.ClusterEvent{Resource: framework.PodItself, ActionType: framework.UpdatePodTolerations}, QueueingHintFn: pl.isSchedulableAfterPodTolerationChange},
 		}, nil
 	}
 

--- a/pkg/scheduler/framework/plugins/volumerestrictions/volume_restrictions.go
+++ b/pkg/scheduler/framework/plugins/volumerestrictions/volume_restrictions.go
@@ -334,7 +334,7 @@ func (pl *VolumeRestrictions) EventsToRegister(_ context.Context) ([]framework.C
 		// Pods may fail to schedule because of volumes conflicting with other pods on same node.
 		// Once running pods are deleted and volumes have been released, the unschedulable pod will be schedulable.
 		// Due to immutable fields `spec.volumes`, pod update events are ignored.
-		{Event: framework.ClusterEvent{Resource: framework.Pod, ActionType: framework.Delete}, QueueingHintFn: pl.isSchedulableAfterPodDeleted},
+		{Event: framework.ClusterEvent{Resource: framework.AssignedPod, ActionType: framework.Delete}, QueueingHintFn: pl.isSchedulableAfterPodDeleted},
 		// A new Node may make a pod schedulable.
 		// We intentionally don't set QueueingHint since all Node/Add events could make Pods schedulable.
 		{Event: framework.ClusterEvent{Resource: framework.Node, ActionType: nodeActionType}},

--- a/pkg/scheduler/framework/types_test.go
+++ b/pkg/scheduler/framework/types_test.go
@@ -41,12 +41,12 @@ func TestNewResource(t *testing.T) {
 	tests := []struct {
 		name         string
 		resourceList v1.ResourceList
-		expected     *Resource
+		expected     *ComputeResource
 	}{
 		{
 			name:         "empty resource",
 			resourceList: map[v1.ResourceName]resource.Quantity{},
-			expected:     &Resource{},
+			expected:     &ComputeResource{},
 		},
 		{
 			name: "complex resource",
@@ -58,7 +58,7 @@ func TestNewResource(t *testing.T) {
 				"scalar.test/" + "scalar1":          *resource.NewQuantity(1, resource.DecimalSI),
 				v1.ResourceHugePagesPrefix + "test": *resource.NewQuantity(2, resource.BinarySI),
 			},
-			expected: &Resource{
+			expected: &ComputeResource{
 				MilliCPU:         4,
 				Memory:           2000,
 				EphemeralStorage: 5000,
@@ -80,22 +80,22 @@ func TestNewResource(t *testing.T) {
 
 func TestResourceClone(t *testing.T) {
 	tests := []struct {
-		resource *Resource
-		expected *Resource
+		resource *ComputeResource
+		expected *ComputeResource
 	}{
 		{
-			resource: &Resource{},
-			expected: &Resource{},
+			resource: &ComputeResource{},
+			expected: &ComputeResource{},
 		},
 		{
-			resource: &Resource{
+			resource: &ComputeResource{
 				MilliCPU:         4,
 				Memory:           2000,
 				EphemeralStorage: 5000,
 				AllowedPodNumber: 80,
 				ScalarResources:  map[v1.ResourceName]int64{"scalar.test/scalar1": 1, "hugepages-test": 2},
 			},
-			expected: &Resource{
+			expected: &ComputeResource{
 				MilliCPU:         4,
 				Memory:           2000,
 				EphemeralStorage: 5000,
@@ -119,21 +119,21 @@ func TestResourceClone(t *testing.T) {
 
 func TestResourceAddScalar(t *testing.T) {
 	tests := []struct {
-		resource       *Resource
+		resource       *ComputeResource
 		scalarName     v1.ResourceName
 		scalarQuantity int64
-		expected       *Resource
+		expected       *ComputeResource
 	}{
 		{
-			resource:       &Resource{},
+			resource:       &ComputeResource{},
 			scalarName:     "scalar1",
 			scalarQuantity: 100,
-			expected: &Resource{
+			expected: &ComputeResource{
 				ScalarResources: map[v1.ResourceName]int64{"scalar1": 100},
 			},
 		},
 		{
-			resource: &Resource{
+			resource: &ComputeResource{
 				MilliCPU:         4,
 				Memory:           2000,
 				EphemeralStorage: 5000,
@@ -142,7 +142,7 @@ func TestResourceAddScalar(t *testing.T) {
 			},
 			scalarName:     "scalar2",
 			scalarQuantity: 200,
-			expected: &Resource{
+			expected: &ComputeResource{
 				MilliCPU:         4,
 				Memory:           2000,
 				EphemeralStorage: 5000,
@@ -164,25 +164,25 @@ func TestResourceAddScalar(t *testing.T) {
 
 func TestSetMaxResource(t *testing.T) {
 	tests := []struct {
-		resource     *Resource
+		resource     *ComputeResource
 		resourceList v1.ResourceList
-		expected     *Resource
+		expected     *ComputeResource
 	}{
 		{
-			resource: &Resource{},
+			resource: &ComputeResource{},
 			resourceList: map[v1.ResourceName]resource.Quantity{
 				v1.ResourceCPU:              *resource.NewScaledQuantity(4, -3),
 				v1.ResourceMemory:           *resource.NewQuantity(2000, resource.BinarySI),
 				v1.ResourceEphemeralStorage: *resource.NewQuantity(5000, resource.BinarySI),
 			},
-			expected: &Resource{
+			expected: &ComputeResource{
 				MilliCPU:         4,
 				Memory:           2000,
 				EphemeralStorage: 5000,
 			},
 		},
 		{
-			resource: &Resource{
+			resource: &ComputeResource{
 				MilliCPU:         4,
 				Memory:           4000,
 				EphemeralStorage: 5000,
@@ -195,7 +195,7 @@ func TestSetMaxResource(t *testing.T) {
 				"scalar.test/scalar1":               *resource.NewQuantity(4, resource.DecimalSI),
 				v1.ResourceHugePagesPrefix + "test": *resource.NewQuantity(5, resource.BinarySI),
 			},
-			expected: &Resource{
+			expected: &ComputeResource{
 				MilliCPU:         4,
 				Memory:           4000,
 				EphemeralStorage: 7000,
@@ -241,21 +241,21 @@ func TestNewNodeInfo(t *testing.T) {
 	}
 
 	expected := &NodeInfo{
-		Requested: &Resource{
+		Requested: &ComputeResource{
 			MilliCPU:         300,
 			Memory:           1524,
 			EphemeralStorage: 0,
 			AllowedPodNumber: 0,
 			ScalarResources:  map[v1.ResourceName]int64(nil),
 		},
-		NonZeroRequested: &Resource{
+		NonZeroRequested: &ComputeResource{
 			MilliCPU:         300,
 			Memory:           1524,
 			EphemeralStorage: 0,
 			AllowedPodNumber: 0,
 			ScalarResources:  map[v1.ResourceName]int64(nil),
 		},
-		Allocatable: &Resource{},
+		Allocatable: &ComputeResource{},
 		Generation:  2,
 		UsedPorts: HostPortInfo{
 			"127.0.0.1": map[ProtocolPort]struct{}{
@@ -346,9 +346,9 @@ func TestNodeInfoClone(t *testing.T) {
 	}{
 		{
 			nodeInfo: &NodeInfo{
-				Requested:        &Resource{},
-				NonZeroRequested: &Resource{},
-				Allocatable:      &Resource{},
+				Requested:        &ComputeResource{},
+				NonZeroRequested: &ComputeResource{},
+				Allocatable:      &ComputeResource{},
 				Generation:       2,
 				UsedPorts: HostPortInfo{
 					"127.0.0.1": map[ProtocolPort]struct{}{
@@ -420,9 +420,9 @@ func TestNodeInfoClone(t *testing.T) {
 				},
 			},
 			expected: &NodeInfo{
-				Requested:        &Resource{},
-				NonZeroRequested: &Resource{},
-				Allocatable:      &Resource{},
+				Requested:        &ComputeResource{},
+				NonZeroRequested: &ComputeResource{},
+				Allocatable:      &ComputeResource{},
 				Generation:       2,
 				UsedPorts: HostPortInfo{
 					"127.0.0.1": map[ProtocolPort]struct{}{
@@ -646,21 +646,21 @@ func TestNodeInfoAddPod(t *testing.T) {
 				Name: "test-node",
 			},
 		},
-		Requested: &Resource{
+		Requested: &ComputeResource{
 			MilliCPU:         2300,
 			Memory:           209716700, //1500 + 200MB in initContainers
 			EphemeralStorage: 0,
 			AllowedPodNumber: 0,
 			ScalarResources:  map[v1.ResourceName]int64(nil),
 		},
-		NonZeroRequested: &Resource{
+		NonZeroRequested: &ComputeResource{
 			MilliCPU:         2300,
 			Memory:           419431900, //200MB(initContainers) + 200MB(default memory value) + 1500 specified in requests/overhead
 			EphemeralStorage: 0,
 			AllowedPodNumber: 0,
 			ScalarResources:  map[v1.ResourceName]int64(nil),
 		},
-		Allocatable: &Resource{},
+		Allocatable: &ComputeResource{},
 		Generation:  2,
 		UsedPorts: HostPortInfo{
 			"127.0.0.1": map[ProtocolPort]struct{}{
@@ -872,21 +872,21 @@ func TestNodeInfoRemovePod(t *testing.T) {
 						Name: "test-node",
 					},
 				},
-				Requested: &Resource{
+				Requested: &ComputeResource{
 					MilliCPU:         1300,
 					Memory:           2524,
 					EphemeralStorage: 0,
 					AllowedPodNumber: 0,
 					ScalarResources:  map[v1.ResourceName]int64(nil),
 				},
-				NonZeroRequested: &Resource{
+				NonZeroRequested: &ComputeResource{
 					MilliCPU:         1300,
 					Memory:           2524,
 					EphemeralStorage: 0,
 					AllowedPodNumber: 0,
 					ScalarResources:  map[v1.ResourceName]int64(nil),
 				},
-				Allocatable: &Resource{},
+				Allocatable: &ComputeResource{},
 				Generation:  2,
 				UsedPorts: HostPortInfo{
 					"127.0.0.1": map[ProtocolPort]struct{}{
@@ -1023,21 +1023,21 @@ func TestNodeInfoRemovePod(t *testing.T) {
 						Name: "test-node",
 					},
 				},
-				Requested: &Resource{
+				Requested: &ComputeResource{
 					MilliCPU:         700,
 					Memory:           1524,
 					EphemeralStorage: 0,
 					AllowedPodNumber: 0,
 					ScalarResources:  map[v1.ResourceName]int64(nil),
 				},
-				NonZeroRequested: &Resource{
+				NonZeroRequested: &ComputeResource{
 					MilliCPU:         700,
 					Memory:           1524,
 					EphemeralStorage: 0,
 					AllowedPodNumber: 0,
 					ScalarResources:  map[v1.ResourceName]int64(nil),
 				},
-				Allocatable: &Resource{},
+				Allocatable: &ComputeResource{},
 				Generation:  3,
 				UsedPorts: HostPortInfo{
 					"127.0.0.1": map[ProtocolPort]struct{}{
@@ -1549,7 +1549,7 @@ func TestCalculatePodResourcesWithResize(t *testing.T) {
 		requests           v1.ResourceList
 		allocatedResources v1.ResourceList
 		resizeStatus       v1.PodResizeStatus
-		expectedResource   Resource
+		expectedResource   ComputeResource
 		expectedNon0CPU    int64
 		expectedNon0Mem    int64
 	}{
@@ -1558,7 +1558,7 @@ func TestCalculatePodResourcesWithResize(t *testing.T) {
 			requests:           v1.ResourceList{v1.ResourceCPU: cpu500m, v1.ResourceMemory: mem500M},
 			allocatedResources: v1.ResourceList{v1.ResourceCPU: cpu500m, v1.ResourceMemory: mem500M},
 			resizeStatus:       "",
-			expectedResource:   Resource{MilliCPU: cpu500m.MilliValue(), Memory: mem500M.Value()},
+			expectedResource:   ComputeResource{MilliCPU: cpu500m.MilliValue(), Memory: mem500M.Value()},
 			expectedNon0CPU:    cpu500m.MilliValue(),
 			expectedNon0Mem:    mem500M.Value(),
 		},
@@ -1567,7 +1567,7 @@ func TestCalculatePodResourcesWithResize(t *testing.T) {
 			requests:           v1.ResourceList{v1.ResourceCPU: cpu500m, v1.ResourceMemory: mem500M},
 			allocatedResources: v1.ResourceList{v1.ResourceCPU: cpu500m, v1.ResourceMemory: mem500M},
 			resizeStatus:       v1.PodResizeStatusInProgress,
-			expectedResource:   Resource{MilliCPU: cpu500m.MilliValue(), Memory: mem500M.Value()},
+			expectedResource:   ComputeResource{MilliCPU: cpu500m.MilliValue(), Memory: mem500M.Value()},
 			expectedNon0CPU:    cpu500m.MilliValue(),
 			expectedNon0Mem:    mem500M.Value(),
 		},
@@ -1576,7 +1576,7 @@ func TestCalculatePodResourcesWithResize(t *testing.T) {
 			requests:           v1.ResourceList{v1.ResourceCPU: cpu700m, v1.ResourceMemory: mem800M},
 			allocatedResources: v1.ResourceList{v1.ResourceCPU: cpu500m, v1.ResourceMemory: mem500M},
 			resizeStatus:       v1.PodResizeStatusDeferred,
-			expectedResource:   Resource{MilliCPU: cpu700m.MilliValue(), Memory: mem800M.Value()},
+			expectedResource:   ComputeResource{MilliCPU: cpu700m.MilliValue(), Memory: mem800M.Value()},
 			expectedNon0CPU:    cpu700m.MilliValue(),
 			expectedNon0Mem:    mem800M.Value(),
 		},
@@ -1585,7 +1585,7 @@ func TestCalculatePodResourcesWithResize(t *testing.T) {
 			requests:           v1.ResourceList{v1.ResourceCPU: cpu700m, v1.ResourceMemory: mem800M},
 			allocatedResources: v1.ResourceList{v1.ResourceCPU: cpu500m, v1.ResourceMemory: mem500M},
 			resizeStatus:       v1.PodResizeStatusInfeasible,
-			expectedResource:   Resource{MilliCPU: cpu500m.MilliValue(), Memory: mem500M.Value()},
+			expectedResource:   ComputeResource{MilliCPU: cpu500m.MilliValue(), Memory: mem500M.Value()},
 			expectedNon0CPU:    cpu500m.MilliValue(),
 			expectedNon0Mem:    mem500M.Value(),
 		},

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -374,7 +374,7 @@ func New(ctx context.Context,
 	sched.NextPod = podQueue.Pop
 	sched.applyDefaultHandlers()
 
-	if err = addAllEventHandlers(sched, informerFactory, dynInformerFactory, resourceClaimCache, unionedGVKs(queueingHintsPerProfile)); err != nil {
+	if err = addAllEventHandlers(sched, informerFactory, dynInformerFactory, resourceClaimCache, unionedResources(queueingHintsPerProfile)); err != nil {
 		return nil, fmt.Errorf("adding event handlers: %w", err)
 	}
 
@@ -555,18 +555,18 @@ func buildExtenders(logger klog.Logger, extenders []schedulerapi.Extender, profi
 
 type FailureHandlerFn func(ctx context.Context, fwk framework.Framework, podInfo *framework.QueuedPodInfo, status *framework.Status, nominatingInfo *framework.NominatingInfo, start time.Time)
 
-func unionedGVKs(queueingHintsPerProfile internalqueue.QueueingHintMapPerProfile) map[framework.GVK]framework.ActionType {
-	gvkMap := make(map[framework.GVK]framework.ActionType)
+func unionedResources(queueingHintsPerProfile internalqueue.QueueingHintMapPerProfile) map[framework.Resource]framework.ActionType {
+	resourceMap := make(map[framework.Resource]framework.ActionType)
 	for _, queueingHints := range queueingHintsPerProfile {
 		for evt := range queueingHints {
-			if _, ok := gvkMap[evt.Resource]; ok {
-				gvkMap[evt.Resource] |= evt.ActionType
+			if _, ok := resourceMap[evt.Resource]; ok {
+				resourceMap[evt.Resource] |= evt.ActionType
 			} else {
-				gvkMap[evt.Resource] = evt.ActionType
+				resourceMap[evt.Resource] = evt.ActionType
 			}
 		}
 	}
-	return gvkMap
+	return resourceMap
 }
 
 // newPodInformer creates a shared index informer that returns only non-terminal pods.

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -425,10 +425,18 @@ func buildQueueingHintMap(ctx context.Context, es []framework.EnqueueExtensions)
 				}
 			}
 
-			queueingHintMap[event.Event] = append(queueingHintMap[event.Event], &internalqueue.QueueingHintFunction{
+			qHintFn := &internalqueue.QueueingHintFunction{
 				PluginName:     e.Name(),
 				QueueingHintFn: fn,
-			})
+			}
+
+			if event.Event.Resource == framework.Pod {
+				for _, se := range framework.UnrollPodEvent(event.Event) {
+					queueingHintMap[se] = append(queueingHintMap[se], qHintFn)
+				}
+				continue
+			}
+			queueingHintMap[event.Event] = append(queueingHintMap[event.Event], qHintFn)
 		}
 		if registerNodeAdded && !registerNodeTaintUpdated {
 			// Temporally fix for the issue https://github.com/kubernetes/kubernetes/issues/109437

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -792,12 +792,12 @@ func Test_buildQueueingHintMap(t *testing.T) {
 	}
 }
 
-// Test_UnionedGVKs tests UnionedGVKs worked with buildQueueingHintMap.
-func Test_UnionedGVKs(t *testing.T) {
+// Test_UnionedResources tests UnionedResources worked with buildQueueingHintMap.
+func Test_UnionedResources(t *testing.T) {
 	tests := []struct {
 		name                            string
 		plugins                         schedulerapi.PluginSet
-		want                            map[framework.GVK]framework.ActionType
+		want                            map[framework.Resource]framework.ActionType
 		enableInPlacePodVerticalScaling bool
 		enableSchedulerQueueingHints    bool
 	}{
@@ -811,7 +811,7 @@ func Test_UnionedGVKs(t *testing.T) {
 				},
 				Disabled: []schedulerapi.Plugin{{Name: "*"}}, // disable default plugins
 			},
-			want: map[framework.GVK]framework.ActionType{
+			want: map[framework.Resource]framework.ActionType{
 				framework.AssignedPod:           framework.All,
 				framework.UnscheduledPod:        framework.All,
 				framework.PodItself:             framework.All,
@@ -837,7 +837,7 @@ func Test_UnionedGVKs(t *testing.T) {
 				},
 				Disabled: []schedulerapi.Plugin{{Name: "*"}}, // disable default plugins
 			},
-			want: map[framework.GVK]framework.ActionType{
+			want: map[framework.Resource]framework.ActionType{
 				framework.Node: framework.Add | framework.UpdateNodeTaint, // When Node/Add is registered, Node/UpdateNodeTaint is automatically registered.
 			},
 		},
@@ -851,7 +851,7 @@ func Test_UnionedGVKs(t *testing.T) {
 				},
 				Disabled: []schedulerapi.Plugin{{Name: "*"}}, // disable default plugins
 			},
-			want: map[framework.GVK]framework.ActionType{
+			want: map[framework.Resource]framework.ActionType{
 				framework.AssignedPod:    framework.Add,
 				framework.UnscheduledPod: framework.Add,
 				framework.PodItself:      framework.Add,
@@ -868,7 +868,7 @@ func Test_UnionedGVKs(t *testing.T) {
 				},
 				Disabled: []schedulerapi.Plugin{{Name: "*"}}, // disable default plugins
 			},
-			want: map[framework.GVK]framework.ActionType{
+			want: map[framework.Resource]framework.ActionType{
 				framework.AssignedPod:    framework.Add,
 				framework.UnscheduledPod: framework.Add,
 				framework.PodItself:      framework.Add,
@@ -885,12 +885,12 @@ func Test_UnionedGVKs(t *testing.T) {
 				},
 				Disabled: []schedulerapi.Plugin{{Name: "*"}}, // disable default plugins
 			},
-			want: map[framework.GVK]framework.ActionType{},
+			want: map[framework.Resource]framework.ActionType{},
 		},
 		{
 			name:    "plugins with default profile (No feature gate enabled)",
 			plugins: schedulerapi.PluginSet{Enabled: defaults.PluginsV1.MultiPoint.Enabled},
-			want: map[framework.GVK]framework.ActionType{
+			want: map[framework.Resource]framework.ActionType{
 				framework.AssignedPod:           framework.Add | framework.UpdatePodLabel | framework.Delete,
 				framework.Node:                  framework.Add | framework.UpdateNodeAllocatable | framework.UpdateNodeLabel | framework.UpdateNodeTaint | framework.Delete,
 				framework.CSINode:               framework.All - framework.Delete,
@@ -904,7 +904,7 @@ func Test_UnionedGVKs(t *testing.T) {
 		{
 			name:    "plugins with default profile (InPlacePodVerticalScaling: enabled)",
 			plugins: schedulerapi.PluginSet{Enabled: defaults.PluginsV1.MultiPoint.Enabled},
-			want: map[framework.GVK]framework.ActionType{
+			want: map[framework.Resource]framework.ActionType{
 				framework.AssignedPod:           framework.Add | framework.UpdatePodLabel | framework.UpdatePodScaleDown | framework.Delete,
 				framework.PodItself:             framework.UpdatePodScaleDown,
 				framework.Node:                  framework.Add | framework.UpdateNodeAllocatable | framework.UpdateNodeLabel | framework.UpdateNodeTaint | framework.Delete,
@@ -920,7 +920,7 @@ func Test_UnionedGVKs(t *testing.T) {
 		{
 			name:    "plugins with default profile (queueingHint/InPlacePodVerticalScaling: enabled)",
 			plugins: schedulerapi.PluginSet{Enabled: defaults.PluginsV1.MultiPoint.Enabled},
-			want: map[framework.GVK]framework.ActionType{
+			want: map[framework.Resource]framework.ActionType{
 				framework.AssignedPod:           framework.Add | framework.UpdatePodLabel | framework.UpdatePodScaleDown | framework.Delete,
 				framework.PodItself:             framework.UpdatePodTolerations | framework.UpdatePodSchedulingGatesEliminated | framework.UpdatePodScaleDown,
 				framework.Node:                  framework.Add | framework.UpdateNodeAllocatable | framework.UpdateNodeLabel | framework.UpdateNodeTaint | framework.Delete,
@@ -968,7 +968,7 @@ func Test_UnionedGVKs(t *testing.T) {
 			queueingHintsPerProfile := internalqueue.QueueingHintMapPerProfile{
 				"default": queueingHintMap,
 			}
-			got := unionedGVKs(queueingHintsPerProfile)
+			got := unionedResources(queueingHintsPerProfile)
 
 			if diff := cmp.Diff(tt.want, got); diff != "" {
 				t.Errorf("Unexpected eventToPlugin map (-want,+got):%s", diff)

--- a/test/integration/scheduler/plugins/plugins_test.go
+++ b/test/integration/scheduler/plugins/plugins_test.go
@@ -2629,7 +2629,7 @@ func (pl *SchedulingGatesPluginWithEvents) PreEnqueue(ctx context.Context, p *v1
 
 func (pl *SchedulingGatesPluginWithEvents) EventsToRegister(_ context.Context) ([]framework.ClusterEventWithHint, error) {
 	return []framework.ClusterEventWithHint{
-		{Event: framework.ClusterEvent{Resource: framework.Pod, ActionType: framework.Update}},
+		{Event: framework.ClusterEvent{Resource: framework.PodItself, ActionType: framework.Update}},
 	}, nil
 }
 
@@ -2685,9 +2685,11 @@ func TestPreEnqueuePluginEventsToRegister(t *testing.T) {
 			expectedScheduled: []bool{true, false},
 		},
 		{
-			name:              "preEnqueue plugin with event registered",
-			withEvents:        true,
-			count:             3,
+			name:       "preEnqueue plugin with event registered",
+			withEvents: true,
+			// Update an assigned pod will not trigger the schedulingGate plugin
+			// So we still expect 2 here (gatedPod created and pausePod created)
+			count:             2,
 			queueHintEnabled:  []bool{false, true},
 			expectedScheduled: []bool{true, true},
 		},

--- a/test/integration/scheduler/queue_test.go
+++ b/test/integration/scheduler/queue_test.go
@@ -974,7 +974,7 @@ func TestCoreResourceEnqueue(t *testing.T) {
 
 	for _, tt := range tests {
 		if len(tt.wantRequeuedPodsByQHint) == 0 {
-			t.Fatalf("case[%s] didn't set expect result properly", tt.name)
+			t.Fatalf("case[%s]: wantRequeuedPodsByQHint must be set", tt.name)
 		}
 		for featureEnabled, wantedPods := range tt.wantRequeuedPodsByQHint {
 			t.Run(fmt.Sprintf("%s [SchedulerQueueingHints enabled: %v]", tt.name, featureEnabled), func(t *testing.T) {

--- a/test/integration/scheduler/queue_test.go
+++ b/test/integration/scheduler/queue_test.go
@@ -841,7 +841,7 @@ func TestCoreResourceEnqueue(t *testing.T) {
 			},
 		},
 		{
-			name: "Pods with PodTopologySpread should be requeued when a Node with a topology label is deleted (QHint: enabled)",
+			name: "Pods with PodTopologySpread should be requeued when a Node with a topology label is deleted",
 			initialNodes: []*v1.Node{
 				st.MakeNode().Name("fake-node1").Label("node", "fake-node").Obj(),
 				st.MakeNode().Name("fake-node2").Label("zone", "fake-node").Obj(),
@@ -857,40 +857,17 @@ func TestCoreResourceEnqueue(t *testing.T) {
 			},
 			triggerFn: func(testCtx *testutils.TestContext) error {
 				// Trigger an NodeTaint delete event.
-				// It should requeue pod4 only because this node only has zone label, and doesn't have node label that pod3 requires.
+				// It should requeue pod4 only when QHint is enabled because this node only has zone label, and doesn't have node label that pod3 requires.
+				// It should requeue both pod3 and pod4 when QHint is disabled because PodTopologySpread subscribes to Node/delete events .
 				if err := testCtx.ClientSet.CoreV1().Nodes().Delete(testCtx.Ctx, "fake-node2", metav1.DeleteOptions{}); err != nil {
 					return fmt.Errorf("failed to update node: %w", err)
 				}
 				return nil
 			},
-			wantRequeuedPods:          sets.New("pod4"),
-			enableSchedulingQueueHint: []bool{true},
-		},
-		{
-			name: "Pods with PodTopologySpread should be requeued when a Node with a topology label is deleted (QHint: disabled)",
-			initialNodes: []*v1.Node{
-				st.MakeNode().Name("fake-node1").Label("node", "fake-node").Obj(),
-				st.MakeNode().Name("fake-node2").Label("zone", "fake-node").Obj(),
+			wantRequeuedPodsByQHint: map[bool]sets.Set[string]{
+				false: sets.New("pod3", "pod4"),
+				true:  sets.New("pod4"),
 			},
-			initialPods: []*v1.Pod{
-				st.MakePod().Name("pod1").Label("key1", "val").SpreadConstraint(1, "node", v1.DoNotSchedule, st.MakeLabelSelector().Exists("key1").Obj(), nil, nil, nil, nil).Container("image").Node("fake-node1").Obj(),
-				st.MakePod().Name("pod2").Label("key1", "val").SpreadConstraint(1, "zone", v1.DoNotSchedule, st.MakeLabelSelector().Exists("key1").Obj(), nil, nil, nil, nil).Container("image").Node("fake-node2").Obj(),
-			},
-			pods: []*v1.Pod{
-				// - Pod3 and Pod4 will be rejected by the PodTopologySpread plugin.
-				st.MakePod().Name("pod3").Label("key1", "val").SpreadConstraint(1, "node", v1.DoNotSchedule, st.MakeLabelSelector().Exists("key1").Obj(), ptr.To(int32(3)), nil, nil, nil).Container("image").Obj(),
-				st.MakePod().Name("pod4").Label("key1", "val").SpreadConstraint(1, "zone", v1.DoNotSchedule, st.MakeLabelSelector().Exists("key1").Obj(), ptr.To(int32(3)), nil, nil, nil).Container("image").Obj(),
-			},
-			triggerFn: func(testCtx *testutils.TestContext) error {
-				// Trigger an NodeTaint delete event.
-				// It should requeue both pod3 and pod4 only because PodTopologySpread subscribes to Node/delete events.
-				if err := testCtx.ClientSet.CoreV1().Nodes().Delete(testCtx.Ctx, "fake-node2", metav1.DeleteOptions{}); err != nil {
-					return fmt.Errorf("failed to update node: %w", err)
-				}
-				return nil
-			},
-			wantRequeuedPods:          sets.New("pod3", "pod4"),
-			enableSchedulingQueueHint: []bool{false},
 		},
 		{
 			name: "Pods with PodTopologySpread should be requeued when a NodeTaint of a Node with a topology label has been updated",
@@ -996,7 +973,9 @@ func TestCoreResourceEnqueue(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-
+		if len(tt.wantRequeuedPodsByQHint) == 0 {
+			t.Fatalf("case[%s] didn't set expect result properly", tt.name)
+		}
 		for featureEnabled, wantedPods := range tt.wantRequeuedPodsByQHint {
 			t.Run(fmt.Sprintf("%s [SchedulerQueueingHints enabled: %v]", tt.name, featureEnabled), func(t *testing.T) {
 				featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.SchedulerQueueingHints, featureEnabled)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature 

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Currently, we don't trigger requeueing with cluster events to unschedulable Pods. It's OK for in-tree plugins, but not OK for out-of-tree plugins that could change the scheduling results with unscheduled Pods state.

This pr does the following things:

1.  Adding three new different gvks: `AssignedPod` , `UnscheduledPod` and `PodItself`
2. Trigger `MoveAllToActiveOrBackoffQueue` when unscheduledPod Add/Update/Delete events happens.
3. The original GVK `Pod` will be treated as a collection of three new gvk.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #127290

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The scheduler starts to use unscheduledPod Add/Update/Delete event to determine whether the event can make other unscheduled Pods schedulable.
Previously, when unscheduled Pods are added/updated, the scheduler only checks if the added/updated pod can be schedulable. But, actually this event could also make other pods schedulable when there are out-tree plugins registered.
Now, when an unscheduled Pod is added/updated/deleted, the scheduling queue checks with QueueingHint(s) whether the event may make the current unscheduled pods in schedulingQueue schedulable, and requeues them to activeQ/backoffQ if at least one QueueingHint(s) return Queue. 

Plugins **have to** register unscheduledPod Add/Update/Delete event if the rejection from them could be resolved by adding/updating/deleting another unscheduled pod.
Plugins **should** use refined QHint functions for Pod/Update and UnscheduledPod/Update events, and are  recommend registering specific Pod GVKs instead of general Pod GVK.

Example: suppose you develop a custom plugin to schedule pods with the `foo=bar` label and only start scheduling when there are two or more pods with this label in the queue.
Given a pod with `foo=bar` label will be schedulable if another pod with `foo=bar` label is added, or another unscheduled pod was added the label `foo=bar`, this plugin would register unscheduledPod Add/Update event.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
