### PR TITLE
Automated cherry pick of #127151: Remove `socat` and `ebtables` from kubeadm preflight checks

### DIFF
--- a/cmd/kubeadm/app/preflight/checks_linux.go
+++ b/cmd/kubeadm/app/preflight/checks_linux.go
@@ -82,9 +82,7 @@ func addExecChecks(checks []Checker, execer utilsexec.Interface) []Checker {
 		InPathCheck{executable: "iptables", mandatory: true, exec: execer},
 		InPathCheck{executable: "mount", mandatory: true, exec: execer},
 		InPathCheck{executable: "nsenter", mandatory: true, exec: execer},
-		InPathCheck{executable: "ebtables", mandatory: false, exec: execer},
 		InPathCheck{executable: "ethtool", mandatory: false, exec: execer},
-		InPathCheck{executable: "socat", mandatory: false, exec: execer},
 		InPathCheck{executable: "tc", mandatory: false, exec: execer},
 		InPathCheck{executable: "touch", mandatory: false, exec: execer})
 	return checks


### PR DESCRIPTION
Cherry pick of #127151 on release-1.28.

#127151: Remove `socat` and `ebtables` from kubeadm preflight checks

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
kubeadm: removed `socat` and `ebtables` from kubeadm preflight checks
```