### PR TITLE
Add instanceExistsGracePeriod to cloud-node-lifecycle-controller

### DIFF
--- a/api/api-rules/violation_exceptions.list
+++ b/api/api-rules/violation_exceptions.list
@@ -131,6 +131,7 @@ API rule violation: names_match,k8s.io/cloud-provider/config/v1alpha1,KubeCloudS
 API rule violation: names_match,k8s.io/cloud-provider/config/v1alpha1,KubeCloudSharedConfiguration,ClusterName
 API rule violation: names_match,k8s.io/cloud-provider/config/v1alpha1,KubeCloudSharedConfiguration,ConfigureCloudRoutes
 API rule violation: names_match,k8s.io/cloud-provider/config/v1alpha1,KubeCloudSharedConfiguration,ExternalCloudVolumePlugin
+API rule violation: names_match,k8s.io/cloud-provider/config/v1alpha1,KubeCloudSharedConfiguration,InstanceExistsGracePeriod
 API rule violation: names_match,k8s.io/cloud-provider/config/v1alpha1,KubeCloudSharedConfiguration,NodeMonitorPeriod
 API rule violation: names_match,k8s.io/cloud-provider/config/v1alpha1,KubeCloudSharedConfiguration,NodeSyncPeriod
 API rule violation: names_match,k8s.io/cloud-provider/config/v1alpha1,KubeCloudSharedConfiguration,RouteReconciliationPeriod

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -57165,6 +57165,12 @@ func schema_k8sio_cloud_provider_config_v1alpha1_KubeCloudSharedConfiguration(re
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Duration"),
 						},
 					},
+					"InstanceExistsGracePeriod": {
+						SchemaProps: spec.SchemaProps{
+							Description: "InstanceExistsGracePeriod is the period after Node creation that CloudNodeLifecycleController will assume the cloud instance exists.",
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Duration"),
+						},
+					},
 					"ClusterName": {
 						SchemaProps: spec.SchemaProps{
 							Description: "clusterName is the instance prefix for the cluster.",
@@ -57211,7 +57217,7 @@ func schema_k8sio_cloud_provider_config_v1alpha1_KubeCloudSharedConfiguration(re
 						},
 					},
 				},
-				Required: []string{"CloudProvider", "ExternalCloudVolumePlugin", "UseServiceAccountCredentials", "AllowUntaggedCloud", "RouteReconciliationPeriod", "NodeMonitorPeriod", "ClusterName", "ClusterCIDR", "AllocateNodeCIDRs", "CIDRAllocatorType", "ConfigureCloudRoutes", "NodeSyncPeriod"},
+				Required: []string{"CloudProvider", "ExternalCloudVolumePlugin", "UseServiceAccountCredentials", "AllowUntaggedCloud", "RouteReconciliationPeriod", "NodeMonitorPeriod", "InstanceExistsGracePeriod", "ClusterName", "ClusterCIDR", "AllocateNodeCIDRs", "CIDRAllocatorType", "ConfigureCloudRoutes", "NodeSyncPeriod"},
 			},
 		},
 		Dependencies: []string{

--- a/staging/src/k8s.io/cloud-provider/app/core.go
+++ b/staging/src/k8s.io/cloud-provider/app/core.go
@@ -67,6 +67,7 @@ func startCloudNodeLifecycleController(ctx context.Context, initContext Controll
 		completedConfig.ClientBuilder.ClientOrDie(initContext.ClientName),
 		cloud,
 		completedConfig.ComponentConfig.KubeCloudShared.NodeMonitorPeriod.Duration,
+		completedConfig.ComponentConfig.KubeCloudShared.InstanceExistsGracePeriod.Duration,
 	)
 	if err != nil {
 		klog.Warningf("failed to start cloud node lifecycle controller: %s", err)

--- a/staging/src/k8s.io/cloud-provider/config/types.go
+++ b/staging/src/k8s.io/cloud-provider/config/types.go
@@ -67,6 +67,8 @@ type KubeCloudSharedConfiguration struct {
 	RouteReconciliationPeriod metav1.Duration
 	// nodeMonitorPeriod is the period for syncing NodeStatus in CloudNodeLifecycleController.
 	NodeMonitorPeriod metav1.Duration
+	// InstanceExistsGracePeriod is the period after Node creation that CloudNodeLifecycleController will assume the cloud instance exists.
+	InstanceExistsGracePeriod metav1.Duration
 	// clusterName is the instance prefix for the cluster.
 	ClusterName string
 	// clusterCIDR is CIDR Range for Pods in cluster.

--- a/staging/src/k8s.io/cloud-provider/config/v1alpha1/types.go
+++ b/staging/src/k8s.io/cloud-provider/config/v1alpha1/types.go
@@ -63,6 +63,8 @@ type KubeCloudSharedConfiguration struct {
 	RouteReconciliationPeriod metav1.Duration
 	// nodeMonitorPeriod is the period for syncing NodeStatus in NodeController.
 	NodeMonitorPeriod metav1.Duration
+	// InstanceExistsGracePeriod is the period after Node creation that CloudNodeLifecycleController will assume the cloud instance exists.
+	InstanceExistsGracePeriod metav1.Duration
 	// clusterName is the instance prefix for the cluster.
 	ClusterName string
 	// clusterCIDR is CIDR Range for Pods in cluster.

--- a/staging/src/k8s.io/cloud-provider/config/v1alpha1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/cloud-provider/config/v1alpha1/zz_generated.conversion.go
@@ -154,6 +154,7 @@ func autoConvert_v1alpha1_KubeCloudSharedConfiguration_To_config_KubeCloudShared
 	out.AllowUntaggedCloud = in.AllowUntaggedCloud
 	out.RouteReconciliationPeriod = in.RouteReconciliationPeriod
 	out.NodeMonitorPeriod = in.NodeMonitorPeriod
+	out.InstanceExistsGracePeriod = in.InstanceExistsGracePeriod
 	out.ClusterName = in.ClusterName
 	out.ClusterCIDR = in.ClusterCIDR
 	out.AllocateNodeCIDRs = in.AllocateNodeCIDRs
@@ -174,6 +175,7 @@ func autoConvert_config_KubeCloudSharedConfiguration_To_v1alpha1_KubeCloudShared
 	out.AllowUntaggedCloud = in.AllowUntaggedCloud
 	out.RouteReconciliationPeriod = in.RouteReconciliationPeriod
 	out.NodeMonitorPeriod = in.NodeMonitorPeriod
+	out.InstanceExistsGracePeriod = in.InstanceExistsGracePeriod
 	out.ClusterName = in.ClusterName
 	out.ClusterCIDR = in.ClusterCIDR
 	out.AllocateNodeCIDRs = in.AllocateNodeCIDRs

--- a/staging/src/k8s.io/cloud-provider/config/v1alpha1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/cloud-provider/config/v1alpha1/zz_generated.deepcopy.go
@@ -78,6 +78,7 @@ func (in *KubeCloudSharedConfiguration) DeepCopyInto(out *KubeCloudSharedConfigu
 	out.CloudProvider = in.CloudProvider
 	out.RouteReconciliationPeriod = in.RouteReconciliationPeriod
 	out.NodeMonitorPeriod = in.NodeMonitorPeriod
+	out.InstanceExistsGracePeriod = in.InstanceExistsGracePeriod
 	if in.ConfigureCloudRoutes != nil {
 		in, out := &in.ConfigureCloudRoutes, &out.ConfigureCloudRoutes
 		*out = new(bool)

--- a/staging/src/k8s.io/cloud-provider/config/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/cloud-provider/config/zz_generated.deepcopy.go
@@ -78,6 +78,7 @@ func (in *KubeCloudSharedConfiguration) DeepCopyInto(out *KubeCloudSharedConfigu
 	out.CloudProvider = in.CloudProvider
 	out.RouteReconciliationPeriod = in.RouteReconciliationPeriod
 	out.NodeMonitorPeriod = in.NodeMonitorPeriod
+	out.InstanceExistsGracePeriod = in.InstanceExistsGracePeriod
 	out.NodeSyncPeriod = in.NodeSyncPeriod
 	return
 }

--- a/staging/src/k8s.io/cloud-provider/options/kubecloudshared.go
+++ b/staging/src/k8s.io/cloud-provider/options/kubecloudshared.go
@@ -60,6 +60,8 @@ func (o *KubeCloudSharedOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&o.RouteReconciliationPeriod.Duration, "route-reconciliation-period", o.RouteReconciliationPeriod.Duration, "The period for reconciling routes created for Nodes by cloud provider.")
 	fs.DurationVar(&o.NodeMonitorPeriod.Duration, "node-monitor-period", o.NodeMonitorPeriod.Duration,
 		fmt.Sprintf("The period for syncing NodeStatus in %s.", names.CloudNodeLifecycleController))
+	fs.DurationVar(&o.InstanceExistsGracePeriod.Duration, "instance-exists-grace-period", o.InstanceExistsGracePeriod.Duration,
+		fmt.Sprintf("Period after Node creation during which %s will assume the cloud instance exists.", names.CloudNodeLifecycleController))
 	fs.StringVar(&o.ClusterName, "cluster-name", o.ClusterName, "The instance prefix for the cluster.")
 	fs.StringVar(&o.ClusterCIDR, "cluster-cidr", o.ClusterCIDR, "CIDR Range for Pods in cluster. Only used when --allocate-node-cidrs=true; if false, this option will be ignored.")
 	fs.BoolVar(&o.AllocateNodeCIDRs, "allocate-node-cidrs", false, "Should CIDRs for Pods be allocated and set on the cloud provider. Requires --cluster-cidr.")

--- a/staging/src/k8s.io/cloud-provider/options/options_test.go
+++ b/staging/src/k8s.io/cloud-provider/options/options_test.go
@@ -84,6 +84,7 @@ func TestDefaultFlags(t *testing.T) {
 			KubeCloudSharedConfiguration: &cpconfig.KubeCloudSharedConfiguration{
 				RouteReconciliationPeriod: metav1.Duration{Duration: 10 * time.Second},
 				NodeMonitorPeriod:         metav1.Duration{Duration: 5 * time.Second},
+				InstanceExistsGracePeriod: metav1.Duration{}, // zero
 				ClusterName:               "kubernetes",
 				ClusterCIDR:               "",
 				AllocateNodeCIDRs:         false,
@@ -202,6 +203,7 @@ func TestAddFlags(t *testing.T) {
 		"--use-service-account-credentials=false",
 		"--concurrent-node-syncs=5",
 		"--webhooks=foo,bar,-baz",
+		"--instance-exists-grace-period=30s",
 	}
 	err = fs.Parse(args)
 	if err != nil {
@@ -243,6 +245,7 @@ func TestAddFlags(t *testing.T) {
 			KubeCloudSharedConfiguration: &cpconfig.KubeCloudSharedConfiguration{
 				RouteReconciliationPeriod: metav1.Duration{Duration: 30 * time.Second},
 				NodeMonitorPeriod:         metav1.Duration{Duration: 5 * time.Second},
+				InstanceExistsGracePeriod: metav1.Duration{Duration: 30 * time.Second},
 				ClusterName:               "k8s",
 				ClusterCIDR:               "1.2.3.4/24",
 				AllocateNodeCIDRs:         true,
@@ -410,6 +413,7 @@ func TestCreateConfig(t *testing.T) {
 			KubeCloudShared: cpconfig.KubeCloudSharedConfiguration{
 				RouteReconciliationPeriod: metav1.Duration{Duration: 30 * time.Second},
 				NodeMonitorPeriod:         metav1.Duration{Duration: 5 * time.Second},
+				InstanceExistsGracePeriod: metav1.Duration{}, // zero
 				ClusterName:               "k8s",
 				ClusterCIDR:               "1.2.3.4/24",
 				AllocateNodeCIDRs:         true,
@@ -551,6 +555,7 @@ func TestCreateConfigWithoutWebHooks(t *testing.T) {
 			KubeCloudShared: cpconfig.KubeCloudSharedConfiguration{
 				RouteReconciliationPeriod: metav1.Duration{Duration: 30 * time.Second},
 				NodeMonitorPeriod:         metav1.Duration{Duration: 5 * time.Second},
+				InstanceExistsGracePeriod: metav1.Duration{}, // zero
 				ClusterName:               "k8s",
 				ClusterCIDR:               "1.2.3.4/24",
 				AllocateNodeCIDRs:         true,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

On some cloud providers (like AWS), a recently-created `Node`'s corresponding cloud instance may not be found in the cloud provider for a (short) period of time. In most cases, `ec2:DescribeInstances` appears to be strongly-consistent -- but it is not. EKS has seen a small number of cases where the controller will delete a `Node` that *does* exist, and (depending on the orchestrator being used) manual action is usually needed to recover from this.

This adds a configurable "grace period" after `Node` creation, during which the cloud-node-lifecycle-controller will not delete the `Node`. The default behavior is unchanged.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

I can handle this in cloud-provider-aws with something like this: https://github.com/kubernetes/cloud-provider-aws/pull/1024

But I'd prefer for it to be in the controller, as `InstancesV2.InstanceExists` may be used in other contexts where this grace period doesn't make sense.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The cloud-node-lifecycle-controller has a new option, `instanceExistsGracePeriod`, for handling eventually-consistent cloud providers.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
