### PR TITLE
bug(nodeunschedulable): register missing Pod event for NodeUnschedulable plugin

### DIFF
--- a/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable_test.go
+++ b/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable_test.go
@@ -23,6 +23,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/feature"
+	st "k8s.io/kubernetes/pkg/scheduler/testing"
 	"k8s.io/kubernetes/test/utils/ktesting"
 )
 
@@ -96,14 +97,14 @@ func TestIsSchedulableAfterNodeChange(t *testing.T) {
 		expectedErr    bool
 	}{
 		{
-			name:         "backoff-wrong-new-object",
+			name:         "error-wrong-new-object",
 			pod:          &v1.Pod{},
 			newObj:       "not-a-node",
 			expectedHint: framework.Queue,
 			expectedErr:  true,
 		},
 		{
-			name: "backoff-wrong-old-object",
+			name: "error-wrong-old-object",
 			pod:  &v1.Pod{},
 			newObj: &v1.Node{
 				Spec: v1.NodeSpec{
@@ -177,6 +178,67 @@ func TestIsSchedulableAfterNodeChange(t *testing.T) {
 			logger, _ := ktesting.NewTestContext(t)
 			pl := &NodeUnschedulable{}
 			got, err := pl.isSchedulableAfterNodeChange(logger, testCase.pod, testCase.oldObj, testCase.newObj)
+			if err != nil && !testCase.expectedErr {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if got != testCase.expectedHint {
+				t.Errorf("isSchedulableAfterNodeChange() = %v, want %v", got, testCase.expectedHint)
+			}
+		})
+	}
+}
+
+func TestIsSchedulableAfterPodTolerationChange(t *testing.T) {
+	testCases := []struct {
+		name           string
+		pod            *v1.Pod
+		oldObj, newObj interface{}
+		expectedHint   framework.QueueingHint
+		expectedErr    bool
+	}{
+		{
+			name:         "error-wrong-new-object",
+			pod:          &v1.Pod{},
+			newObj:       "not-a-pod",
+			expectedHint: framework.Queue,
+			expectedErr:  true,
+		},
+		{
+			name:         "error-wrong-old-object",
+			pod:          &v1.Pod{},
+			newObj:       &v1.Pod{},
+			oldObj:       "not-a-pod",
+			expectedHint: framework.Queue,
+			expectedErr:  true,
+		},
+		{
+			name:         "skip-different-pod-update",
+			pod:          st.MakePod().UID("uid").Obj(),
+			newObj:       st.MakePod().UID("different-uid").Toleration(v1.TaintNodeUnschedulable).Obj(),
+			oldObj:       st.MakePod().UID("different-uid").Obj(),
+			expectedHint: framework.QueueSkip,
+		},
+		{
+			name:         "queue-when-the-unsched-pod-gets-toleration",
+			pod:          st.MakePod().UID("uid").Obj(),
+			newObj:       st.MakePod().UID("uid").Toleration(v1.TaintNodeUnschedulable).Obj(),
+			oldObj:       st.MakePod().UID("uid").Obj(),
+			expectedHint: framework.Queue,
+		},
+		{
+			name:         "skip-when-the-unsched-pod-gets-unrelated-toleration",
+			pod:          st.MakePod().UID("uid").Obj(),
+			newObj:       st.MakePod().UID("uid").Toleration("unrelated-key").Obj(),
+			oldObj:       st.MakePod().UID("uid").Obj(),
+			expectedHint: framework.QueueSkip,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			logger, _ := ktesting.NewTestContext(t)
+			pl := &NodeUnschedulable{}
+			got, err := pl.isSchedulableAfterPodTolerationChange(logger, testCase.pod, testCase.oldObj, testCase.newObj)
 			if err != nil && !testCase.expectedErr {
 				t.Errorf("unexpected error: %v", err)
 			}

--- a/pkg/scheduler/framework/types.go
+++ b/pkg/scheduler/framework/types.go
@@ -69,7 +69,8 @@ const (
 	UpdatePodLabel
 	// UpdatePodScaleDown is an update for pod's scale down (i.e., any resource request is reduced).
 	UpdatePodScaleDown
-	// UpdatePodTolerations is an update for pod's tolerations.
+	// UpdatePodTolerations is an addition for pod's tolerations.
+	// (Due to API validation, we can add, but cannot modify or remove tolerations.)
 	UpdatePodTolerations
 	// UpdatePodSchedulingGatesEliminated is an update for pod's scheduling gates, which eliminates all scheduling gates in the Pod.
 	UpdatePodSchedulingGatesEliminated


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR fixes two bugs in NodeUnschedulable:
1. Pods rejected by NodeUnschedulable could be schedulable when the Pods get the toleration for NodeUnschedulable taint. But, it doesn't register any Pod events. This is a bug that is only valid when QHint is enabled because when QHint is disabled, we requeue unsched Pods with any kind of updates to them. 
2. In https://github.com/kubernetes/kubernetes/pull/127220, I forgot to add `Node/UpdateNodeLabel` like other plugins. As the added comment says, we should always add `Node/UpdateNodeLabel` and `Node/UpdteNodeTaint` when the plugin uses `Node/Add`. 


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixes the bug in NodeUnschedulable that only happens with QHint enabled, 
which the scheduler might miss some updates for the Pods rejected by NodeUnschedulable plugin and put the Pods in the queue for a longer time than needed.
```

(It doesn't mention the second bug intentionally because it's just made and isn't released.)

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
