### PR TITLE
Code cleanup: functions to convert cgroup v1's cpu.shares and v2's cpu.weight to avoid code duplications

### DIFF
--- a/pkg/kubelet/cm/cgroup_manager_linux.go
+++ b/pkg/kubelet/cm/cgroup_manager_linux.go
@@ -32,6 +32,7 @@ import (
 	libcontainerconfigs "github.com/opencontainers/runc/libcontainer/configs"
 	"k8s.io/klog/v2"
 	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
+	"k8s.io/kubernetes/pkg/kubelet/cm/util"
 
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -268,10 +269,8 @@ func getCPUWeight(cpuShares *uint64) uint64 {
 	if cpuShares == nil {
 		return 0
 	}
-	if *cpuShares >= 262144 {
-		return 10000
-	}
-	return 1 + ((*cpuShares-2)*9999)/262142
+
+	return util.CPUSharesToCPUWeight(*cpuShares)
 }
 
 var (

--- a/pkg/kubelet/cm/cgroup_manager_linux_test.go
+++ b/pkg/kubelet/cm/cgroup_manager_linux_test.go
@@ -23,6 +23,8 @@ import (
 	"path"
 	"reflect"
 	"testing"
+
+	"k8s.io/kubernetes/pkg/kubelet/cm/util"
 )
 
 // TestNewCgroupName tests confirms that #68416 is fixed
@@ -206,7 +208,7 @@ func TestCpuSharesToCPUWeight(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		if actual := cpuSharesToCPUWeight(testCase.cpuShares); actual != testCase.expectedCpuWeight {
+		if actual := util.CPUSharesToCPUWeight(testCase.cpuShares); actual != testCase.expectedCpuWeight {
 			t.Errorf("cpuShares: %v, expectedCpuWeight: %v, actualCpuWeight: %v",
 				testCase.cpuShares, testCase.expectedCpuWeight, actual)
 		}
@@ -245,7 +247,7 @@ func TestCpuWeightToCPUShares(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		if actual := cpuWeightToCPUShares(testCase.cpuWeight); actual != testCase.expectedCpuShares {
+		if actual := util.CPUWeightToCPUShares(testCase.cpuWeight); actual != testCase.expectedCpuShares {
 			t.Errorf("cpuWeight: %v, expectedCpuShares: %v, actualCpuShares: %v",
 				testCase.cpuWeight, testCase.expectedCpuShares, actual)
 		}

--- a/pkg/kubelet/cm/cgroup_manager_linux_test.go
+++ b/pkg/kubelet/cm/cgroup_manager_linux_test.go
@@ -20,6 +20,7 @@ limitations under the License.
 package cm
 
 import (
+	"github.com/stretchr/testify/require"
 	"path"
 	"reflect"
 	"testing"
@@ -208,7 +209,11 @@ func TestCpuSharesToCPUWeight(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		if actual := util.CPUSharesToCPUWeight(testCase.cpuShares); actual != testCase.expectedCpuWeight {
+		actual, err := util.CPUSharesToCPUWeight(testCase.cpuShares)
+		req := require.New(t)
+		req.NoError(err)
+
+		if actual != testCase.expectedCpuWeight {
 			t.Errorf("cpuShares: %v, expectedCpuWeight: %v, actualCpuWeight: %v",
 				testCase.cpuShares, testCase.expectedCpuWeight, actual)
 		}
@@ -247,7 +252,11 @@ func TestCpuWeightToCPUShares(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		if actual := util.CPUWeightToCPUShares(testCase.cpuWeight); actual != testCase.expectedCpuShares {
+		actual, err := util.CPUWeightToCPUShares(testCase.cpuWeight)
+		req := require.New(t)
+		req.NoError(err)
+
+		if actual != testCase.expectedCpuShares {
 			t.Errorf("cpuWeight: %v, expectedCpuShares: %v, actualCpuShares: %v",
 				testCase.cpuWeight, testCase.expectedCpuShares, actual)
 		}

--- a/pkg/kubelet/cm/cgroup_v2_manager_linux.go
+++ b/pkg/kubelet/cm/cgroup_v2_manager_linux.go
@@ -124,7 +124,7 @@ func (c *cgroupV2impl) getCgroupCPUConfig(cgroupPath string) (*ResourceConfig, e
 	if errWeight != nil {
 		return nil, fmt.Errorf("failed to read CPU weight for cgroup %v: %w", cgroupPath, errWeight)
 	}
-	cpuShares := cpuWeightToCPUShares(cpuWeight)
+	cpuShares := cmutil.CPUWeightToCPUShares(cpuWeight)
 	return &ResourceConfig{CPUShares: &cpuShares, CPUQuota: &cpuLimit, CPUPeriod: &cpuPeriod}, nil
 }
 
@@ -162,16 +162,4 @@ func readUnifiedControllers(path string) (sets.Set[string], error) {
 func (c *cgroupV2impl) buildCgroupUnifiedPath(name CgroupName) string {
 	cgroupFsAdaptedName := c.Name(name)
 	return path.Join(cmutil.CgroupRoot, cgroupFsAdaptedName)
-}
-
-// Convert cgroup v1 cpu.shares value to cgroup v2 cpu.weight
-// https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/2254-cgroup-v2#phase-1-convert-from-cgroups-v1-settings-to-v2
-func cpuSharesToCPUWeight(cpuShares uint64) uint64 {
-	return uint64((((cpuShares - 2) * 9999) / 262142) + 1)
-}
-
-// Convert cgroup v2 cpu.weight value to cgroup v1 cpu.shares
-// https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/2254-cgroup-v2#phase-1-convert-from-cgroups-v1-settings-to-v2
-func cpuWeightToCPUShares(cpuWeight uint64) uint64 {
-	return uint64((((cpuWeight - 1) * 262142) / 9999) + 2)
 }

--- a/pkg/kubelet/cm/cgroup_v2_manager_linux.go
+++ b/pkg/kubelet/cm/cgroup_v2_manager_linux.go
@@ -124,7 +124,10 @@ func (c *cgroupV2impl) getCgroupCPUConfig(cgroupPath string) (*ResourceConfig, e
 	if errWeight != nil {
 		return nil, fmt.Errorf("failed to read CPU weight for cgroup %v: %w", cgroupPath, errWeight)
 	}
-	cpuShares := cmutil.CPUWeightToCPUShares(cpuWeight)
+	cpuShares, err := cmutil.CPUWeightToCPUShares(cpuWeight)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert cgroup v1 CPU weight %d to v2 CPU shares: %w", cpuWeight, err)
+	}
 	return &ResourceConfig{CPUShares: &cpuShares, CPUQuota: &cpuLimit, CPUPeriod: &cpuPeriod}, nil
 }
 

--- a/pkg/kubelet/cm/container_manager_linux_test.go
+++ b/pkg/kubelet/cm/container_manager_linux_test.go
@@ -21,6 +21,7 @@ package cm
 
 import (
 	"errors"
+	pointer "k8s.io/utils/ptr"
 	"os"
 	"path"
 	"testing"
@@ -127,16 +128,21 @@ func TestCgroupMountValidationMultipleSubsystem(t *testing.T) {
 }
 
 func TestGetCpuWeight(t *testing.T) {
-	assert.Equal(t, uint64(0), getCPUWeight(nil))
+	weight, err := getCPUWeight(nil)
+	req := require.New(t)
+	req.NoError(err)
+	req.Equal(uint64(0), weight)
 
-	v := uint64(2)
-	assert.Equal(t, uint64(1), getCPUWeight(&v))
+	weight, err = getCPUWeight(pointer.To(uint64(2)))
+	req.NoError(err)
+	req.Equal(uint64(1), weight)
 
-	v = uint64(262144)
-	assert.Equal(t, uint64(10000), getCPUWeight(&v))
+	weight, err = getCPUWeight(pointer.To(uint64(262144)))
+	req.NoError(err)
+	req.Equal(uint64(10000), weight)
 
-	v = uint64(1000000000)
-	assert.Equal(t, uint64(10000), getCPUWeight(&v))
+	_, err = getCPUWeight(pointer.To(uint64(1000000000)))
+	req.Error(err)
 }
 
 func TestSoftRequirementsValidationSuccess(t *testing.T) {

--- a/pkg/kubelet/cm/util/cgroups.go
+++ b/pkg/kubelet/cm/util/cgroups.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package util
 
+import "fmt"
+
 const (
 	minCPUShares = uint64(2)
 	maxCPUShares = uint64(262144)
@@ -25,26 +27,34 @@ const (
 
 // Convert cgroup v1 cpu.shares value to cgroup v2 cpu.weight
 // https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/2254-cgroup-v2#phase-1-convert-from-cgroups-v1-settings-to-v2
-func CPUSharesToCPUWeight(cpuShares uint64) uint64 {
-	if cpuShares <= minCPUShares {
-		return minCPUWeight
-	}
-	if cpuShares >= maxCPUShares {
-		return maxCPUWeight
+func CPUSharesToCPUWeight(cpuShares uint64) (uint64, error) {
+	if err := checkBoundaries(cpuShares, minCPUShares, maxCPUShares); err != nil {
+		return 0, fmt.Errorf("CPU shares %s", err.Error())
 	}
 
-	return (((cpuShares - 2) * 9999) / 262142) + 1
+	return (((cpuShares - 2) * 9999) / 262142) + 1, nil
 }
 
 // Convert cgroup v2 cpu.weight value to cgroup v1 cpu.shares
 // https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/2254-cgroup-v2#phase-1-convert-from-cgroups-v1-settings-to-v2
-func CPUWeightToCPUShares(cpuWeight uint64) uint64 {
-	if cpuWeight <= minCPUWeight {
-		return minCPUShares
-	}
-	if cpuWeight >= maxCPUWeight {
-		return maxCPUShares
+func CPUWeightToCPUShares(cpuWeight uint64) (uint64, error) {
+	if err := checkBoundaries(cpuWeight, minCPUWeight, maxCPUWeight); err != nil {
+		return 0, fmt.Errorf("CPU weight %s", err.Error())
 	}
 
-	return (((cpuWeight - 1) * 262142) / 9999) + 2
+	return (((cpuWeight - 1) * 262142) / 9999) + 2, nil
+}
+
+func checkBoundaries(valueToValidate, minAllowed, maxAllowed uint64) error {
+	if valueToValidate <= 0 {
+		return fmt.Errorf("must be greater than zero, but equals to %d", valueToValidate)
+	}
+	if valueToValidate < minAllowed {
+		return fmt.Errorf("must be greater than or equal to %d, but equals to %d", minAllowed, valueToValidate)
+	}
+	if valueToValidate > maxAllowed {
+		return fmt.Errorf("must be less than or equal to %d, but equals to %d", maxAllowed, valueToValidate)
+	}
+
+	return nil
 }

--- a/pkg/kubelet/cm/util/cgroups.go
+++ b/pkg/kubelet/cm/util/cgroups.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+// Convert cgroup v1 cpu.shares value to cgroup v2 cpu.weight
+// https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/2254-cgroup-v2#phase-1-convert-from-cgroups-v1-settings-to-v2
+func CPUSharesToCPUWeight(cpuShares uint64) uint64 {
+	return uint64((((cpuShares - 2) * 9999) / 262142) + 1)
+}
+
+// Convert cgroup v2 cpu.weight value to cgroup v1 cpu.shares
+// https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/2254-cgroup-v2#phase-1-convert-from-cgroups-v1-settings-to-v2
+func CPUWeightToCPUShares(cpuWeight uint64) uint64 {
+	return uint64((((cpuWeight - 1) * 262142) / 9999) + 2)
+}

--- a/pkg/kubelet/cm/util/cgroups.go
+++ b/pkg/kubelet/cm/util/cgroups.go
@@ -16,14 +16,35 @@ limitations under the License.
 
 package util
 
+const (
+	minCPUShares = uint64(2)
+	maxCPUShares = uint64(262144)
+	minCPUWeight = uint64(1)
+	maxCPUWeight = uint64(10000)
+)
+
 // Convert cgroup v1 cpu.shares value to cgroup v2 cpu.weight
 // https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/2254-cgroup-v2#phase-1-convert-from-cgroups-v1-settings-to-v2
 func CPUSharesToCPUWeight(cpuShares uint64) uint64 {
+	if cpuShares <= minCPUShares {
+		return minCPUWeight
+	}
+	if cpuShares >= maxCPUShares {
+		return maxCPUWeight
+	}
+
 	return (((cpuShares - 2) * 9999) / 262142) + 1
 }
 
 // Convert cgroup v2 cpu.weight value to cgroup v1 cpu.shares
 // https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/2254-cgroup-v2#phase-1-convert-from-cgroups-v1-settings-to-v2
 func CPUWeightToCPUShares(cpuWeight uint64) uint64 {
+	if cpuWeight <= minCPUWeight {
+		return minCPUShares
+	}
+	if cpuWeight >= maxCPUWeight {
+		return maxCPUShares
+	}
+
 	return (((cpuWeight - 1) * 262142) / 9999) + 2
 }

--- a/pkg/kubelet/cm/util/cgroups.go
+++ b/pkg/kubelet/cm/util/cgroups.go
@@ -19,11 +19,11 @@ package util
 // Convert cgroup v1 cpu.shares value to cgroup v2 cpu.weight
 // https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/2254-cgroup-v2#phase-1-convert-from-cgroups-v1-settings-to-v2
 func CPUSharesToCPUWeight(cpuShares uint64) uint64 {
-	return uint64((((cpuShares - 2) * 9999) / 262142) + 1)
+	return (((cpuShares - 2) * 9999) / 262142) + 1
 }
 
 // Convert cgroup v2 cpu.weight value to cgroup v1 cpu.shares
 // https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/2254-cgroup-v2#phase-1-convert-from-cgroups-v1-settings-to-v2
 func CPUWeightToCPUShares(cpuWeight uint64) uint64 {
-	return uint64((((cpuWeight - 1) * 262142) / 9999) + 2)
+	return (((cpuWeight - 1) * 262142) / 9999) + 2
 }

--- a/pkg/kubelet/cm/util/cgroups_test.go
+++ b/pkg/kubelet/cm/util/cgroups_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestInvalidCPUSharesToCPUWeight(t *testing.T) {
+	req := require.New(t)
+	_, err := CPUSharesToCPUWeight(0)
+	req.Error(err)
+
+	_, err = CPUSharesToCPUWeight(minCPUShares - 1)
+	req.Error(err)
+
+	_, err = CPUSharesToCPUWeight(maxCPUShares + 1)
+	req.Error(err)
+}
+
+func TestInvalidCPUWeightToCPUShares(t *testing.T) {
+	req := require.New(t)
+	_, err := CPUWeightToCPUShares(0)
+	req.Error(err)
+
+	_, err = CPUWeightToCPUShares(minCPUWeight - 1)
+	req.Error(err)
+
+	_, err = CPUWeightToCPUShares(maxCPUWeight + 1)
+	req.Error(err)
+}
+
+func TestValidCPUSharesToCPUWeight(t *testing.T) {
+	req := require.New(t)
+	weight, err := CPUSharesToCPUWeight(123)
+	req.NoError(err)
+	req.Equal(uint64(5), weight)
+
+	weight, err = CPUSharesToCPUWeight(12345)
+	req.NoError(err)
+	req.Equal(uint64(471), weight)
+}
+
+func TestValidCPUWeightToCPUShares(t *testing.T) {
+	req := require.New(t)
+	weight, err := CPUWeightToCPUShares(123)
+	req.NoError(err)
+	req.Equal(uint64(3200), weight)
+
+	weight, err = CPUWeightToCPUShares(1234)
+	req.NoError(err)
+	req.Equal(uint64(32327), weight)
+}

--- a/test/e2e_node/node_container_manager_test.go
+++ b/test/e2e_node/node_container_manager_test.go
@@ -33,6 +33,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
 	"k8s.io/kubernetes/pkg/kubelet/cm"
+	"k8s.io/kubernetes/pkg/kubelet/cm/util"
 	"k8s.io/kubernetes/pkg/kubelet/stats/pidlimit"
 	admissionapi "k8s.io/pod-security-admission/api"
 
@@ -212,11 +213,6 @@ func destroyTemporaryCgroupsForReservation(cgroupManager cm.CgroupManager) error
 	return cgroupManager.Destroy(cgroupConfig)
 }
 
-// convertSharesToWeight converts from cgroup v1 cpu.shares to cgroup v2 cpu.weight
-func convertSharesToWeight(shares int64) int64 {
-	return 1 + ((shares-2)*9999)/262142
-}
-
 func runTest(ctx context.Context, f *framework.Framework) error {
 	var oldCfg *kubeletconfig.KubeletConfiguration
 	subsystems, err := cm.GetCgroupSubsystems()
@@ -327,7 +323,7 @@ func runTest(ctx context.Context, f *framework.Framework) error {
 		shares := int64(cm.MilliCPUToShares(allocatableCPU.MilliValue()))
 		if IsCgroup2UnifiedMode() {
 			// convert to the cgroup v2 cpu.weight value
-			if err := expectFileValToEqual(filepath.Join(subsystems.MountPoints["cpu"], cgroupName, "cpu.weight"), convertSharesToWeight(shares), 10); err != nil {
+			if err := expectFileValToEqual(filepath.Join(subsystems.MountPoints["cpu"], cgroupName, "cpu.weight"), int64(util.CPUSharesToCPUWeight(uint64(shares))), 10); err != nil {
 				return err
 			}
 		} else {
@@ -373,7 +369,7 @@ func runTest(ctx context.Context, f *framework.Framework) error {
 	kubeReservedCPU := resource.MustParse(currentConfig.KubeReserved[string(v1.ResourceCPU)])
 	shares := int64(cm.MilliCPUToShares(kubeReservedCPU.MilliValue()))
 	if IsCgroup2UnifiedMode() {
-		if err := expectFileValToEqual(filepath.Join(subsystems.MountPoints["cpu"], cgroupPath, "cpu.weight"), convertSharesToWeight(shares), 10); err != nil {
+		if err := expectFileValToEqual(filepath.Join(subsystems.MountPoints["cpu"], cgroupPath, "cpu.weight"), int64(util.CPUSharesToCPUWeight(uint64(shares))), 10); err != nil {
 			return err
 		}
 	} else {
@@ -402,7 +398,7 @@ func runTest(ctx context.Context, f *framework.Framework) error {
 	systemReservedCPU := resource.MustParse(currentConfig.SystemReserved[string(v1.ResourceCPU)])
 	shares = int64(cm.MilliCPUToShares(systemReservedCPU.MilliValue()))
 	if IsCgroup2UnifiedMode() {
-		if err := expectFileValToEqual(filepath.Join(subsystems.MountPoints["cpu"], cgroupPath, "cpu.weight"), convertSharesToWeight(shares), 10); err != nil {
+		if err := expectFileValToEqual(filepath.Join(subsystems.MountPoints["cpu"], cgroupPath, "cpu.weight"), int64(util.CPUSharesToCPUWeight(uint64(shares))), 10); err != nil {
 			return err
 		}
 	} else {

--- a/test/e2e_node/node_container_manager_test.go
+++ b/test/e2e_node/node_container_manager_test.go
@@ -323,7 +323,11 @@ func runTest(ctx context.Context, f *framework.Framework) error {
 		shares := int64(cm.MilliCPUToShares(allocatableCPU.MilliValue()))
 		if IsCgroup2UnifiedMode() {
 			// convert to the cgroup v2 cpu.weight value
-			if err := expectFileValToEqual(filepath.Join(subsystems.MountPoints["cpu"], cgroupName, "cpu.weight"), int64(util.CPUSharesToCPUWeight(uint64(shares))), 10); err != nil {
+			cpuShares, err := util.CPUSharesToCPUWeight(uint64(shares))
+			if err != nil {
+				return err
+			}
+			if err := expectFileValToEqual(filepath.Join(subsystems.MountPoints["cpu"], cgroupName, "cpu.weight"), int64(cpuShares), 10); err != nil {
 				return err
 			}
 		} else {
@@ -369,7 +373,11 @@ func runTest(ctx context.Context, f *framework.Framework) error {
 	kubeReservedCPU := resource.MustParse(currentConfig.KubeReserved[string(v1.ResourceCPU)])
 	shares := int64(cm.MilliCPUToShares(kubeReservedCPU.MilliValue()))
 	if IsCgroup2UnifiedMode() {
-		if err := expectFileValToEqual(filepath.Join(subsystems.MountPoints["cpu"], cgroupPath, "cpu.weight"), int64(util.CPUSharesToCPUWeight(uint64(shares))), 10); err != nil {
+		cpuShares, err := util.CPUSharesToCPUWeight(uint64(shares))
+		if err != nil {
+			return err
+		}
+		if err := expectFileValToEqual(filepath.Join(subsystems.MountPoints["cpu"], cgroupPath, "cpu.weight"), int64(cpuShares), 10); err != nil {
 			return err
 		}
 	} else {
@@ -398,7 +406,11 @@ func runTest(ctx context.Context, f *framework.Framework) error {
 	systemReservedCPU := resource.MustParse(currentConfig.SystemReserved[string(v1.ResourceCPU)])
 	shares = int64(cm.MilliCPUToShares(systemReservedCPU.MilliValue()))
 	if IsCgroup2UnifiedMode() {
-		if err := expectFileValToEqual(filepath.Join(subsystems.MountPoints["cpu"], cgroupPath, "cpu.weight"), int64(util.CPUSharesToCPUWeight(uint64(shares))), 10); err != nil {
+		cpuShares, err := util.CPUSharesToCPUWeight(uint64(shares))
+		if err != nil {
+			return err
+		}
+		if err := expectFileValToEqual(filepath.Join(subsystems.MountPoints["cpu"], cgroupPath, "cpu.weight"), int64(cpuShares), 10); err != nil {
 			return err
 		}
 	} else {


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/sig node

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
As can be seen here [1], there's a known formula to convert between cgroup's v1's cpu.shares and v2's cpu.weight.

This formula is currently duplicated across the codebase although we already have utility functions that perform this calculation. This PR removes these duplications and expose the utility functions. In addition, these functions are now generic, eliminating the need for unnecessary back-and-forth type conversions.

[1] https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/2254-cgroup-v2#phase-1-convert-from-cgroups-v1-settings-to-v2

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

