### PR TITLE
Fine grain QueueHints for NodeAffinity plugin

### DIFF
--- a/pkg/scheduler/framework/plugins/nodeaffinity/node_affinity_test.go
+++ b/pkg/scheduler/framework/plugins/nodeaffinity/node_affinity_test.go
@@ -1297,6 +1297,13 @@ func Test_isSchedulableAfterNodeChange(t *testing.T) {
 			newObj:       st.MakeNode().Label("foo", "bar").Obj(),
 			expectedHint: framework.Queue,
 		},
+		"skip-unrelated-change-that-keeps-pod-schedulable": {
+			args:         &config.NodeAffinityArgs{},
+			pod:          podWithNodeAffinity.Obj(),
+			oldObj:       st.MakeNode().Label("foo", "bar").Obj(),
+			newObj:       st.MakeNode().Capacity(nil).Label("foo", "bar").Obj(),
+			expectedHint: framework.QueueSkip,
+		},
 		"skip-queue-on-add-scheduler-enforced-node-affinity": {
 			args: &config.NodeAffinityArgs{
 				AddedAffinity: &v1.NodeAffinity{

--- a/pkg/scheduler/framework/types.go
+++ b/pkg/scheduler/framework/types.go
@@ -146,7 +146,7 @@ const (
 
 type ClusterEventWithHint struct {
 	Event ClusterEvent
-	// QueueingHintFn is executed for the plugin rejected by this plugin when the above Event happens,
+	// QueueingHintFn is executed for the Pod rejected by this plugin when the above Event happens,
 	// and filters out events to reduce useless retry of Pod's scheduling.
 	// It's an optional field. If not set,
 	// the scheduling of Pods will be always retried with backoff when this Event happens.


### PR DESCRIPTION
Skip queue on unrelated change that keeps pod schedulable when QueueHints are enabled.

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
Part of #127405

#### Special notes for your reviewer:

Executed the following tests:

- make test WHAT="pkg/scheduler/..." KUBE_TIMEOUT="-timeout=600s" GOFLAGS="-count=1"
- make test-integration WHAT=./test/integration/scheduler_perf KUBE_TEST_ARGS=-use-testing-log
- make test-integration WHAT=./test/integration/scheduler

#### Does this PR introduce a user-facing change?
```release-note
Improve Node QueueHint in the NodeAffinty plugin by ignoring unrelated changes that keep pods unschedulable.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:


