### PR TITLE
Promote e2e test for VolumeAttachmentStatus Endpoints +3 Endpoints

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -3592,6 +3592,17 @@
     was configured with a subpath.
   release: v1.12
   file: test/e2e/storage/subpath.go
+- testname: VolumeAttachment, apply changes to a volumeattachment status
+  codename: '[sig-storage] VolumeAttachment Conformance should apply changes to a
+    volumeattachment status [Conformance]'
+  description: Creating an initial VolumeAttachment MUST succeed. Patching a VolumeAttachment
+    MUST succeed with its new label found. Reading VolumeAttachment status MUST succeed
+    with its attached status being false. Patching the VolumeAttachment status MUST
+    succeed with its attached status being true. Updating the VolumeAttachment status
+    MUST succeed with its attached status being false. Deleting a VolumeAttachment
+    MUST succeed and it MUST be confirmed.
+  release: v1.32
+  file: test/e2e/storage/volume_attachment.go
 - testname: VolumeAttachment, lifecycle
   codename: '[sig-storage] VolumeAttachment Conformance should run through the lifecycle
     of a VolumeAttachment [Conformance]'

--- a/test/e2e/storage/volume_attachment.go
+++ b/test/e2e/storage/volume_attachment.go
@@ -167,7 +167,17 @@ var _ = utils.SIGDescribe("VolumeAttachment", func() {
 			framework.ExpectNoError(err, "Timeout while waiting to confirm deletion of all VolumeAttachments")
 		})
 
-		ginkgo.It("should apply changes to a volumeattachment status", func(ctx context.Context) {
+		/*
+			Release: v1.32
+			Testname: VolumeAttachment, apply changes to a volumeattachment status
+			Description: Creating an initial VolumeAttachment MUST succeed. Patching a VolumeAttachment
+			MUST succeed with its new label found. Reading VolumeAttachment status MUST succeed
+			with its attached status being false. Patching the VolumeAttachment status MUST
+			succeed with its attached status being true. Updating the VolumeAttachment status
+			MUST succeed with its attached status being false. Deleting a VolumeAttachment
+			MUST succeed and it MUST be confirmed.
+		*/
+		framework.ConformanceIt("should apply changes to a volumeattachment status", func(ctx context.Context) {
 
 			vaClient := f.ClientSet.StorageV1().VolumeAttachments()
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR promotes to Conformance the following endpoints in a recently added [e2e test](https://pr.k8s.io/126827):
- patchStorageV1VolumeAttachmentStatus
- readStorageV1VolumeAttachmentStatus
- replaceStorageV1VolumeAttachmentStatus

#### Which issue(s) this PR fixes:

Fixes #126826

#### Special notes for your reviewer:

- Adds +3 endpoint test coverage (good for conformance)
- Links for e2e test progress on [Testgrid](https://testgrid.k8s.io/sig-release-master-blocking#gce-cos-master-default&width=5&graph-metrics=test-duration-minutes&include-filter-by-regex=should.apply.changes.to.a.volumeattachment.status) and [K8s Triage](https://storage.googleapis.com/k8s-triage/index.html?test=should.apply.changes.to.a.volumeattachment.status)

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
/sig testing
/sig architecture
/area conformance