### PR TITLE
endpointsLeasesResourceLock and configMapsLeasesResourceLock  has been removed

### DIFF
--- a/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/interface.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/interface.go
@@ -35,74 +35,8 @@ const (
 	endpointsResourceLock             = "endpoints"
 	configMapsResourceLock            = "configmaps"
 	LeasesResourceLock                = "leases"
-	// When using endpointsLeasesResourceLock, you need to ensure that
-	// API Priority & Fairness is configured with non-default flow-schema
-	// that will catch the necessary operations on leader-election related
-	// endpoint objects.
-	//
-	// The example of such flow scheme could look like this:
-	//   apiVersion: flowcontrol.apiserver.k8s.io/v1beta2
-	//   kind: FlowSchema
-	//   metadata:
-	//     name: my-leader-election
-	//   spec:
-	//     distinguisherMethod:
-	//       type: ByUser
-	//     matchingPrecedence: 200
-	//     priorityLevelConfiguration:
-	//       name: leader-election   # reference the <leader-election> PL
-	//     rules:
-	//     - resourceRules:
-	//       - apiGroups:
-	//         - ""
-	//         namespaces:
-	//         - '*'
-	//         resources:
-	//         - endpoints
-	//         verbs:
-	//         - get
-	//         - create
-	//         - update
-	//       subjects:
-	//       - kind: ServiceAccount
-	//         serviceAccount:
-	//           name: '*'
-	//           namespace: kube-system
-	endpointsLeasesResourceLock = "endpointsleases"
-	// When using configMapsLeasesResourceLock, you need to ensure that
-	// API Priority & Fairness is configured with non-default flow-schema
-	// that will catch the necessary operations on leader-election related
-	// configmap objects.
-	//
-	// The example of such flow scheme could look like this:
-	//   apiVersion: flowcontrol.apiserver.k8s.io/v1beta2
-	//   kind: FlowSchema
-	//   metadata:
-	//     name: my-leader-election
-	//   spec:
-	//     distinguisherMethod:
-	//       type: ByUser
-	//     matchingPrecedence: 200
-	//     priorityLevelConfiguration:
-	//       name: leader-election   # reference the <leader-election> PL
-	//     rules:
-	//     - resourceRules:
-	//       - apiGroups:
-	//         - ""
-	//         namespaces:
-	//         - '*'
-	//         resources:
-	//         - configmaps
-	//         verbs:
-	//         - get
-	//         - create
-	//         - update
-	//       subjects:
-	//       - kind: ServiceAccount
-	//         serviceAccount:
-	//           name: '*'
-	//           namespace: kube-system
-	configMapsLeasesResourceLock = "configmapsleases"
+	endpointsLeasesResourceLock       = "endpointsleases"
+	configMapsLeasesResourceLock      = "configmapsleases"
 )
 
 // LeaderElectionRecord is the record that is stored in the leader election annotation.
@@ -177,9 +111,9 @@ func New(lockType string, ns string, name string, coreClient corev1.CoreV1Interf
 	}
 	switch lockType {
 	case endpointsResourceLock:
-		return nil, fmt.Errorf("endpoints lock is removed, migrate to %s (using version v0.27.x)", endpointsLeasesResourceLock)
+		return nil, fmt.Errorf("endpoints lock is removed, migrate to %s", LeasesResourceLock)
 	case configMapsResourceLock:
-		return nil, fmt.Errorf("configmaps lock is removed, migrate to %s (using version v0.27.x)", configMapsLeasesResourceLock)
+		return nil, fmt.Errorf("configmaps lock is removed, migrate to %s", LeasesResourceLock)
 	case LeasesResourceLock:
 		return leaseLock, nil
 	case endpointsLeasesResourceLock:


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
endpointsLeasesResourceLock and configMapsLeasesResourceLock  has been removed，need migrate to  LeasesResourceLock


#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
NONE