### PR TITLE
Run staging verify scripts from the main make verify

### DIFF
--- a/hack/lib/util.sh
+++ b/hack/lib/util.sh
@@ -828,6 +828,18 @@ function kube::util::read-array {
   fi
 }
 
+# kube::util::run-in
+# Changes directory to "$1", runs the rest of the arguments, and restores the initial directory
+# Returns 1 if a directory change fails, the result of running the arguments otherwise
+function kube::util::run-in {
+  pushd "$1" > /dev/null || return 1
+  shift
+  "$@"
+  local result=$?
+  popd > /dev/null || return 1
+  return $result
+}
+
 # Some useful colors.
 if [[ -z "${color_start-}" ]]; then
   declare -r color_start="\033["

--- a/hack/make-rules/verify.sh
+++ b/hack/make-rules/verify.sh
@@ -14,12 +14,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Indirect calls through kube::util::run-in aren't interpreted
+# shellcheck disable=SC2317
+
 set -o errexit
 set -o nounset
 set -o pipefail
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/../..
-source "${KUBE_ROOT}/hack/lib/util.sh"
+source "${KUBE_ROOT}/hack/lib/init.sh"
+
+kube::golang::setup_env
 
 # If KUBE_JUNIT_REPORT_DIR is unset, and ARTIFACTS is set, then have them match.
 if [[ -z "${KUBE_JUNIT_REPORT_DIR:-}" && -n "${ARTIFACTS:-}" ]]; then
@@ -142,7 +147,7 @@ function run-cmd {
     juLog -output="${output}" -class="verify" -name="${testname}" -fail="^ERROR: " "$@"
     tr=$?
   fi
-  return ${tr}
+  return "${tr}"
 }
 
 # Collect Failed tests in this Array , initialize it to nil
@@ -164,6 +169,10 @@ function run-checks {
   local t
   for t in ${pattern}
   do
+    if [ "$t" = "$pattern" ]; then
+      # The pattern didn't match any files
+      continue
+    fi
     local check_name
     check_name="$(basename "${t}")"
     if [[ -n ${WHAT:-} ]]; then
@@ -190,7 +199,7 @@ function run-checks {
     else
       echo -e "${color_red}FAILED${color_norm}   ${check_name}\t${elapsed}s"
       ret=1
-      FAILED_TESTS+=("${t}")
+      FAILED_TESTS+=("${base}/${t}")
     fi
   done
 }
@@ -220,9 +229,17 @@ if ${QUICK} ; then
   echo "Running in quick mode (QUICK=true). Only fast checks will run."
 fi
 
+export API_KNOWN_VIOLATIONS_DIR="${KUBE_ROOT}"/api/api-rules
 ret=0
-run-checks "${KUBE_ROOT}/hack/verify-*.sh" bash
-run-checks "${KUBE_ROOT}/hack/verify-*.py" python3
+modules=() # Pacify shellcheck
+kube::util::read-array modules < <(go list -f '{{.Dir}}' -m)
+for module in "${modules[@]}"; do
+  base=${module%/go.mod}
+  if [ -d "$base/hack" ]; then
+    kube::util::run-in "$base" run-checks "hack/verify-*.sh" bash
+    kube::util::run-in "$base" run-checks "hack/verify-*.py" python3
+  fi
+done
 missing-target-checks
 
 if [[ ${ret} -eq 1 ]]; then

--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/hack/update-codegen.sh
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/hack/update-codegen.sh
@@ -19,7 +19,7 @@ set -o nounset
 set -o pipefail
 
 SCRIPT_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
-CODEGEN_PKG=${CODEGEN_PKG:-$(cd "${SCRIPT_ROOT}"; ls -d -1 ./vendor/k8s.io/code-generator 2>/dev/null || echo ../code-generator)}
+CODEGEN_PKG=${CODEGEN_PKG:-$(cd "${SCRIPT_ROOT}"; ls -d -1 ./vendor/k8s.io/code-generator 2>/dev/null || echo ../../../code-generator)}
 
 source "${CODEGEN_PKG}/kube_codegen.sh"
 

--- a/staging/src/k8s.io/code-generator/examples/hack/verify-codegen.sh
+++ b/staging/src/k8s.io/code-generator/examples/hack/verify-codegen.sh
@@ -35,7 +35,7 @@ cp -a "${DIFFROOT}"/* "${TMP_DIFFROOT}"
 "${SCRIPT_ROOT}/hack/update-codegen.sh"
 echo "diffing ${DIFFROOT} against freshly generated codegen"
 ret=0
-diff -Naupr "${DIFFROOT}" "${TMP_DIFFROOT}" || ret=$?
+diff -Naupr -x.gitignore "${DIFFROOT}" "${TMP_DIFFROOT}" || ret=$?
 if [[ $ret -eq 0 ]]; then
   echo "${DIFFROOT} up to date."
 else


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

`make update` runs code generation throughout the tree, but `make verify` only verifies code generation in the main project, excluding staging projects. This means that code generation bugs can go undetected.

This fixes that by running all verification scripts in `hack` directories in all the modules.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
