### PR TITLE
[FG:InPlacePodVerticalScaling] kubelet: Add VPA start, finished, and failure events, while optimizing vpa errors

### DIFF
--- a/pkg/kubelet/container/sync_result.go
+++ b/pkg/kubelet/container/sync_result.go
@@ -45,6 +45,8 @@ var (
 	ErrConfigPodSandbox = errors.New("ConfigPodSandboxError")
 	// ErrKillPodSandbox returned when runtime failed to stop pod's sandbox.
 	ErrKillPodSandbox = errors.New("KillPodSandboxError")
+	// ErrResizePodSandbox returned when runtime failed to resize pod's sandbox.
+	ErrResizePodSandbox = errors.New("ResizePodSandboxError")
 )
 
 // SyncAction indicates different kind of actions in SyncPod() and KillPod(). Now there are only actions
@@ -68,6 +70,8 @@ const (
 	ConfigPodSandbox SyncAction = "ConfigPodSandbox"
 	// KillPodSandbox action
 	KillPodSandbox SyncAction = "KillPodSandbox"
+	// ResizePodSandbox action
+	ResizePodSandbox SyncAction = "ResizePodSandbox"
 )
 
 // SyncResult is the result of sync action.

--- a/pkg/kubelet/events/event.go
+++ b/pkg/kubelet/events/event.go
@@ -34,6 +34,9 @@ const (
 	FailedToCreatePodContainer     = "FailedCreatePodContainer"
 	FailedToMakePodDataDirectories = "Failed"
 	NetworkNotReady                = "NetworkNotReady"
+	StartingVerticalScalingPod     = "StartingVerticalScalingPod"
+	FailedToVerticalScalingPod     = "FailedVerticalScalingPod"
+	FinishedVerticalScalingPod     = "FinishedVerticalScalingPod"
 )
 
 // Image event reason list


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
When we perform vertical scaling on Pods, we want users to be notified of the start, completion, or failure of the vertical scaling operation through events. While fixed the issue where kubecontainer.PodSyncResult was not effective in the higher-level function(SyncPod) because it was passed by value instead of by reference.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
No issue

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
None

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
yes, when performing vertical scaling of pods, users will receive event notifications related to the pods.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
