### PR TITLE
feat: Added net.ipv4.tcp_rmem and net.ipv4.tcp_wmem into safe sysctl list

### DIFF
--- a/pkg/kubelet/sysctl/safe_sysctls.go
+++ b/pkg/kubelet/sysctl/safe_sysctls.go
@@ -60,6 +60,12 @@ var safeSysctls = []sysctl{
 		name:   "net.ipv4.tcp_keepalive_probes",
 		kernel: utilkernel.TCPKeepAliveProbesNamespacedKernelVersion,
 	},
+	{
+		name: "net.ipv4.tcp_rmem",
+	},
+	{
+		name: "net.ipv4.tcp_wmem",
+	},
 }
 
 // SafeSysctlAllowlist returns the allowlist of safe sysctls and safe sysctl patterns (ending in *).

--- a/pkg/kubelet/sysctl/safe_sysctls.go
+++ b/pkg/kubelet/sysctl/safe_sysctls.go
@@ -61,10 +61,12 @@ var safeSysctls = []sysctl{
 		kernel: utilkernel.TCPKeepAliveProbesNamespacedKernelVersion,
 	},
 	{
-		name: "net.ipv4.tcp_rmem",
+		name:   "net.ipv4.tcp_rmem",
+		kernel: utilkernel.TCPReceiveMemoryNamespacedKernelVersion,
 	},
 	{
-		name: "net.ipv4.tcp_wmem",
+		name:   "net.ipv4.tcp_wmem",
+		kernel: utilkernel.TCPTransmitMemoryNamespacedKernelVersion,
 	},
 }
 

--- a/pkg/kubelet/sysctl/safe_sysctls_test.go
+++ b/pkg/kubelet/sysctl/safe_sysctls_test.go
@@ -41,6 +41,8 @@ func Test_getSafeSysctlAllowlist(t *testing.T) {
 				"net.ipv4.tcp_syncookies",
 				"net.ipv4.ping_group_range",
 				"net.ipv4.ip_unprivileged_port_start",
+				"net.ipv4.tcp_rmem",
+				"net.ipv4.tcp_wmem",
 			},
 		},
 		{
@@ -56,6 +58,8 @@ func Test_getSafeSysctlAllowlist(t *testing.T) {
 				"net.ipv4.ping_group_range",
 				"net.ipv4.ip_unprivileged_port_start",
 				"net.ipv4.ip_local_reserved_ports",
+				"net.ipv4.tcp_rmem",
+				"net.ipv4.tcp_wmem",
 			},
 		},
 		{
@@ -75,6 +79,8 @@ func Test_getSafeSysctlAllowlist(t *testing.T) {
 				"net.ipv4.tcp_fin_timeout",
 				"net.ipv4.tcp_keepalive_intvl",
 				"net.ipv4.tcp_keepalive_probes",
+				"net.ipv4.tcp_rmem",
+				"net.ipv4.tcp_wmem",
 			},
 		},
 	}

--- a/pkg/kubelet/sysctl/safe_sysctls_test.go
+++ b/pkg/kubelet/sysctl/safe_sysctls_test.go
@@ -41,8 +41,6 @@ func Test_getSafeSysctlAllowlist(t *testing.T) {
 				"net.ipv4.tcp_syncookies",
 				"net.ipv4.ping_group_range",
 				"net.ipv4.ip_unprivileged_port_start",
-				"net.ipv4.tcp_rmem",
-				"net.ipv4.tcp_wmem",
 			},
 		},
 		{
@@ -58,8 +56,6 @@ func Test_getSafeSysctlAllowlist(t *testing.T) {
 				"net.ipv4.ping_group_range",
 				"net.ipv4.ip_unprivileged_port_start",
 				"net.ipv4.ip_local_reserved_ports",
-				"net.ipv4.tcp_rmem",
-				"net.ipv4.tcp_wmem",
 			},
 		},
 		{

--- a/pkg/util/kernel/constants.go
+++ b/pkg/util/kernel/constants.go
@@ -54,3 +54,11 @@ const TmpfsNoswapSupportKernelVersion = "6.4"
 // nftables mode with by default. This is not directly related to any specific kernel
 // commit; see https://issues.k8s.io/122743#issuecomment-1893922424
 const NFTablesKubeProxyKernelVersion = "5.13"
+
+// TCPReceiveMemoryNamespacedKernelVersion is the kernel version in which net.ipv4.tcp_rmem was namespaced(netns).
+// (ref: https://github.com/torvalds/linux/commit/356d1833b638bd465672aefeb71def3ab93fc17d)
+const TCPReceiveMemoryNamespacedKernelVersion = "4.15"
+
+// TCPTransmitMemoryNamespacedKernelVersion is the kernel version in which net.ipv4.tcp_wmem was namespaced(netns).
+// (ref: https://github.com/torvalds/linux/commit/356d1833b638bd465672aefeb71def3ab93fc17d)
+const TCPTransmitMemoryNamespacedKernelVersion = "4.15"

--- a/staging/src/k8s.io/pod-security-admission/policy/check_sysctls.go
+++ b/staging/src/k8s.io/pod-security-admission/policy/check_sysctls.go
@@ -47,6 +47,8 @@ spec.securityContext.sysctls[*].name
 'net.ipv4.tcp_fin_timeout'
 'net.ipv4.tcp_keepalive_intvl'
 'net.ipv4.tcp_keepalive_probes'
+'net.ipv4.tcp_rmem'
+'net.ipv4.tcp_wmem'
 
 */
 
@@ -104,6 +106,10 @@ var (
 		"net.ipv4.tcp_keepalive_intvl",
 		"net.ipv4.tcp_keepalive_probes",
 	)
+	sysctlsAllowedV1Dot30 = sets.NewString(
+		"net.ipv4.tcp_rmem",
+		"net.ipv4.tcp_wmem",
+	)
 )
 
 func sysctlsV1Dot0(podMetadata *metav1.ObjectMeta, podSpec *corev1.PodSpec) CheckResult {
@@ -116,6 +122,10 @@ func sysctlsV1Dot27(podMetadata *metav1.ObjectMeta, podSpec *corev1.PodSpec) Che
 
 func sysctlsV1Dot29(podMetadata *metav1.ObjectMeta, podSpec *corev1.PodSpec) CheckResult {
 	return sysctls(podMetadata, podSpec, sysctlsAllowedV1Dot29)
+}
+
+func sysctlsV1Dot30(podMetadata *metav1.ObjectMeta, podSpec *corev1.PodSpec) CheckResult {
+	return sysctls(podMetadata, podSpec, sysctlsAllowedV1Dot30)
 }
 
 func sysctls(podMetadata *metav1.ObjectMeta, podSpec *corev1.PodSpec, sysctls_allowed_set sets.String) CheckResult {

--- a/staging/src/k8s.io/pod-security-admission/policy/check_sysctls.go
+++ b/staging/src/k8s.io/pod-security-admission/policy/check_sysctls.go
@@ -90,30 +90,19 @@ var (
 		"net.ipv4.ping_group_range",
 		"net.ipv4.ip_unprivileged_port_start",
 	)
-	sysctlsAllowedV1Dot27 = sets.NewString(
-		"kernel.shm_rmid_forced",
-		"net.ipv4.ip_local_port_range",
-		"net.ipv4.tcp_syncookies",
-		"net.ipv4.ping_group_range",
-		"net.ipv4.ip_unprivileged_port_start",
+	sysctlsAllowedV1Dot27 = sysctlsAllowedV1Dot0.Union(sets.NewString(
 		"net.ipv4.ip_local_reserved_ports",
-	)
-	sysctlsAllowedV1Dot29 = sets.NewString(
-		"kernel.shm_rmid_forced",
-		"net.ipv4.ip_local_port_range",
-		"net.ipv4.tcp_syncookies",
-		"net.ipv4.ping_group_range",
-		"net.ipv4.ip_unprivileged_port_start",
-		"net.ipv4.ip_local_reserved_ports",
+	))
+	sysctlsAllowedV1Dot29 = sysctlsAllowedV1Dot27.Union(sets.NewString(
 		"net.ipv4.tcp_keepalive_time",
 		"net.ipv4.tcp_fin_timeout",
 		"net.ipv4.tcp_keepalive_intvl",
 		"net.ipv4.tcp_keepalive_probes",
-	)
-	sysctlsAllowedV1Dot32 = sets.NewString(
+	))
+	sysctlsAllowedV1Dot32 = sysctlsAllowedV1Dot29.Union(sets.NewString(
 		"net.ipv4.tcp_rmem",
 		"net.ipv4.tcp_wmem",
-	)
+	))
 )
 
 func sysctlsV1Dot0(podMetadata *metav1.ObjectMeta, podSpec *corev1.PodSpec) CheckResult {

--- a/staging/src/k8s.io/pod-security-admission/policy/check_sysctls.go
+++ b/staging/src/k8s.io/pod-security-admission/policy/check_sysctls.go
@@ -74,6 +74,10 @@ func CheckSysctls() Check {
 				MinimumVersion: api.MajorMinorVersion(1, 29),
 				CheckPod:       sysctlsV1Dot29,
 			},
+			{
+				MinimumVersion: api.MajorMinorVersion(1, 32),
+				CheckPod:       sysctlsV1Dot32,
+			},
 		},
 	}
 }
@@ -106,7 +110,7 @@ var (
 		"net.ipv4.tcp_keepalive_intvl",
 		"net.ipv4.tcp_keepalive_probes",
 	)
-	sysctlsAllowedV1Dot30 = sets.NewString(
+	sysctlsAllowedV1Dot32 = sets.NewString(
 		"net.ipv4.tcp_rmem",
 		"net.ipv4.tcp_wmem",
 	)
@@ -124,8 +128,8 @@ func sysctlsV1Dot29(podMetadata *metav1.ObjectMeta, podSpec *corev1.PodSpec) Che
 	return sysctls(podMetadata, podSpec, sysctlsAllowedV1Dot29)
 }
 
-func sysctlsV1Dot30(podMetadata *metav1.ObjectMeta, podSpec *corev1.PodSpec) CheckResult {
-	return sysctls(podMetadata, podSpec, sysctlsAllowedV1Dot30)
+func sysctlsV1Dot32(podMetadata *metav1.ObjectMeta, podSpec *corev1.PodSpec) CheckResult {
+	return sysctls(podMetadata, podSpec, sysctlsAllowedV1Dot32)
 }
 
 func sysctls(podMetadata *metav1.ObjectMeta, podSpec *corev1.PodSpec, sysctls_allowed_set sets.String) CheckResult {

--- a/staging/src/k8s.io/pod-security-admission/policy/check_sysctls_test.go
+++ b/staging/src/k8s.io/pod-security-admission/policy/check_sysctls_test.go
@@ -267,7 +267,7 @@ func TestSysctls_1_29(t *testing.T) {
 	}
 }
 
-func TestSysctls_1_30(t *testing.T) {
+func TestSysctls_1_32(t *testing.T) {
 	tests := []struct {
 		name         string
 		pod          *corev1.Pod
@@ -308,7 +308,7 @@ func TestSysctls_1_30(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			result := sysctlsV1Dot30(&tc.pod.ObjectMeta, &tc.pod.Spec)
+			result := sysctlsV1Dot32(&tc.pod.ObjectMeta, &tc.pod.Spec)
 			if !tc.allowed {
 				if result.Allowed {
 					t.Fatal("expected disallowed")

--- a/staging/src/k8s.io/pod-security-admission/test/fixtures_sysctls.go
+++ b/staging/src/k8s.io/pod-security-admission/test/fixtures_sysctls.go
@@ -157,7 +157,7 @@ func init() {
 		fixtureDataV1Dot29,
 	)
 
-	fixtureDataV1Dot30 := fixtureGenerator{
+	fixtureDataV1Dot32 := fixtureGenerator{
 		expectErrorSubstring: "forbidden sysctl",
 		generatePass: func(p *corev1.Pod) []*corev1.Pod {
 			if p.Spec.SecurityContext == nil {
@@ -188,7 +188,7 @@ func init() {
 		},
 	}
 	registerFixtureGenerator(
-		fixtureKey{level: api.LevelBaseline, version: api.MajorMinorVersion(1, 29), check: "sysctls"},
-		fixtureDataV1Dot30,
+		fixtureKey{level: api.LevelBaseline, version: api.MajorMinorVersion(1, 32), check: "sysctls"},
+		fixtureDataV1Dot32,
 	)
 }

--- a/staging/src/k8s.io/pod-security-admission/test/run.go
+++ b/staging/src/k8s.io/pod-security-admission/test/run.go
@@ -37,7 +37,7 @@ import (
 )
 
 const (
-	newestMinorVersionToTest            = 31
+	newestMinorVersionToTest            = 32
 	podOSBasedRestrictionEnabledVersion = 29
 )
 

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/fail/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/fail/apparmorprofile0.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: unconfined
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/fail/apparmorprofile1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/fail/apparmorprofile1.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/initcontainer1: unconfined
+  name: apparmorprofile1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/fail/capabilities_baseline0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/fail/capabilities_baseline0.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_baseline0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      capabilities:
+        add:
+        - NET_RAW
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      capabilities: {}
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/fail/capabilities_baseline1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/fail/capabilities_baseline1.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_baseline1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      capabilities: {}
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      capabilities:
+        add:
+        - NET_RAW
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/fail/capabilities_baseline2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/fail/capabilities_baseline2.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_baseline2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      capabilities:
+        add:
+        - chown
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      capabilities: {}
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/fail/capabilities_baseline3.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/fail/capabilities_baseline3.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_baseline3
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      capabilities:
+        add:
+        - CAP_CHOWN
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      capabilities: {}
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/fail/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/fail/hostnamespaces0.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+  hostIPC: true
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/fail/hostnamespaces1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/fail/hostnamespaces1.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+  hostNetwork: true
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/fail/hostnamespaces2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/fail/hostnamespaces2.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+  hostPID: true
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/fail/hostpathvolumes0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/fail/hostpathvolumes0.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostpathvolumes0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+  volumes:
+  - emptyDir: {}
+    name: volume-emptydir
+  - hostPath:
+      path: /a
+    name: volume-hostpath

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/fail/hostpathvolumes1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/fail/hostpathvolumes1.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostpathvolumes1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+  volumes:
+  - hostPath:
+      path: /a
+    name: volume-hostpath-a
+  - hostPath:
+      path: /b
+    name: volume-hostpath-b

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/fail/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/fail/hostports0.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/fail/hostports1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/fail/hostports1.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/fail/hostports2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/fail/hostports2.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    - containerPort: 12347
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    - containerPort: 12348

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/fail/privileged0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/fail/privileged0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: privileged0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      privileged: true
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext: {}
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/fail/privileged1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/fail/privileged1.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: privileged1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext: {}
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      privileged: true
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/fail/procmount0.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: procmount0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      procMount: Unmasked
+  hostUsers: false
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext: {}
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/fail/procmount1.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: procmount1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext: {}
+  hostUsers: false
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      procMount: Unmasked
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/fail/seccompprofile_baseline0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/fail/seccompprofile_baseline0.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_baseline0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext: {}
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext: {}
+  securityContext:
+    seccompProfile:
+      type: Unconfined

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/fail/seccompprofile_baseline1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/fail/seccompprofile_baseline1.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_baseline1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      seccompProfile:
+        type: Unconfined
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext: {}
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/fail/seccompprofile_baseline2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/fail/seccompprofile_baseline2.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_baseline2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext: {}
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      seccompProfile:
+        type: Unconfined
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/fail/selinuxoptions0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/fail/selinuxoptions0.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      seLinuxOptions: {}
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      seLinuxOptions: {}
+  securityContext:
+    seLinuxOptions:
+      type: somevalue

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/fail/selinuxoptions1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/fail/selinuxoptions1.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      seLinuxOptions:
+        type: somevalue
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      seLinuxOptions: {}
+  securityContext:
+    seLinuxOptions: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/fail/selinuxoptions2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/fail/selinuxoptions2.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      seLinuxOptions: {}
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      seLinuxOptions:
+        type: somevalue
+  securityContext:
+    seLinuxOptions: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/fail/selinuxoptions3.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/fail/selinuxoptions3.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions3
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      seLinuxOptions: {}
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      seLinuxOptions: {}
+  securityContext:
+    seLinuxOptions:
+      user: somevalue

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/fail/selinuxoptions4.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/fail/selinuxoptions4.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions4
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      seLinuxOptions: {}
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      seLinuxOptions: {}
+  securityContext:
+    seLinuxOptions:
+      role: somevalue

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/fail/sysctls0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/fail/sysctls0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sysctls0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+  securityContext:
+    sysctls:
+    - name: othersysctl
+      value: other

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/fail/windowshostprocess0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/fail/windowshostprocess0.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: windowshostprocess0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      windowsOptions: {}
+  hostNetwork: true
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      windowsOptions: {}
+  securityContext:
+    windowsOptions:
+      hostProcess: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/fail/windowshostprocess1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/fail/windowshostprocess1.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: windowshostprocess1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      windowsOptions:
+        hostProcess: true
+  hostNetwork: true
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      windowsOptions:
+        hostProcess: true
+  securityContext:
+    windowsOptions: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/pass/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/pass/apparmorprofile0.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: localhost/foo
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/pass/base.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/pass/base.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: base
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/pass/capabilities_baseline0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/pass/capabilities_baseline0.yaml
@@ -1,0 +1,44 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_baseline0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      capabilities:
+        add:
+        - AUDIT_WRITE
+        - CHOWN
+        - DAC_OVERRIDE
+        - FOWNER
+        - FSETID
+        - KILL
+        - MKNOD
+        - NET_BIND_SERVICE
+        - SETFCAP
+        - SETGID
+        - SETPCAP
+        - SETUID
+        - SYS_CHROOT
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      capabilities:
+        add:
+        - AUDIT_WRITE
+        - CHOWN
+        - DAC_OVERRIDE
+        - FOWNER
+        - FSETID
+        - KILL
+        - MKNOD
+        - NET_BIND_SERVICE
+        - SETFCAP
+        - SETGID
+        - SETPCAP
+        - SETUID
+        - SYS_CHROOT
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/pass/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/pass/hostports0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/pass/privileged0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/pass/privileged0.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: privileged0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      privileged: false
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      privileged: false
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/pass/procmount0.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: procmount0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      procMount: Default
+  hostUsers: false
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      procMount: Default
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/pass/seccompprofile_baseline0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/pass/seccompprofile_baseline0.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_baseline0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      seccompProfile:
+        type: RuntimeDefault
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext: {}
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/pass/selinuxoptions0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/pass/selinuxoptions0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext: {}
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      seLinuxOptions: {}
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/pass/selinuxoptions1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/pass/selinuxoptions1.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      seLinuxOptions:
+        level: somevalue
+        type: container_init_t
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      seLinuxOptions:
+        type: container_kvm_t
+  securityContext:
+    seLinuxOptions:
+      type: container_t

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/pass/sysctls0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/pass/sysctls0.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sysctls0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/pass/sysctls1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.32/pass/sysctls1.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sysctls1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+  securityContext:
+    sysctls:
+    - name: net.ipv4.tcp_rmem
+      value: 4096 87380 16777216
+    - name: net.ipv4.tcp_wmem
+      value: 4096 65536 16777216

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/allowprivilegeescalation0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/allowprivilegeescalation0.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: allowprivilegeescalation0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: true
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/allowprivilegeescalation1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/allowprivilegeescalation1.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: allowprivilegeescalation1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: true
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/allowprivilegeescalation2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/allowprivilegeescalation2.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: allowprivilegeescalation2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/allowprivilegeescalation3.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/allowprivilegeescalation3.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: allowprivilegeescalation3
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/apparmorprofile0.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: unconfined
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/apparmorprofile1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/apparmorprofile1.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/initcontainer1: unconfined
+  name: apparmorprofile1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/capabilities_baseline0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/capabilities_baseline0.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_baseline0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - NET_RAW
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/capabilities_baseline1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/capabilities_baseline1.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_baseline1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - NET_RAW
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/capabilities_baseline2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/capabilities_baseline2.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_baseline2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - chown
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/capabilities_baseline3.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/capabilities_baseline3.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_baseline3
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - CAP_CHOWN
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/capabilities_restricted0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/capabilities_restricted0.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_restricted0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities: {}
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/capabilities_restricted1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/capabilities_restricted1.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_restricted1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities: {}
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/capabilities_restricted2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/capabilities_restricted2.yaml
@@ -1,0 +1,97 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_restricted2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - SYS_TIME
+        - SYS_MODULE
+        - SYS_RAWIO
+        - SYS_PACCT
+        - SYS_ADMIN
+        - SYS_NICE
+        - SYS_RESOURCE
+        - SYS_TIME
+        - SYS_TTY_CONFIG
+        - MKNOD
+        - AUDIT_WRITE
+        - AUDIT_CONTROL
+        - MAC_OVERRIDE
+        - MAC_ADMIN
+        - NET_ADMIN
+        - SYSLOG
+        - CHOWN
+        - NET_RAW
+        - DAC_OVERRIDE
+        - FOWNER
+        - DAC_READ_SEARCH
+        - FSETID
+        - KILL
+        - SETGID
+        - SETUID
+        - LINUX_IMMUTABLE
+        - NET_BIND_SERVICE
+        - NET_BROADCAST
+        - IPC_LOCK
+        - IPC_OWNER
+        - SYS_CHROOT
+        - SYS_PTRACE
+        - SYS_BOOT
+        - LEASE
+        - SETFCAP
+        - WAKE_ALARM
+        - BLOCK_SUSPEND
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - SYS_TIME
+        - SYS_MODULE
+        - SYS_RAWIO
+        - SYS_PACCT
+        - SYS_ADMIN
+        - SYS_NICE
+        - SYS_RESOURCE
+        - SYS_TIME
+        - SYS_TTY_CONFIG
+        - MKNOD
+        - AUDIT_WRITE
+        - AUDIT_CONTROL
+        - MAC_OVERRIDE
+        - MAC_ADMIN
+        - NET_ADMIN
+        - SYSLOG
+        - CHOWN
+        - NET_RAW
+        - DAC_OVERRIDE
+        - FOWNER
+        - DAC_READ_SEARCH
+        - FSETID
+        - KILL
+        - SETGID
+        - SETUID
+        - LINUX_IMMUTABLE
+        - NET_BIND_SERVICE
+        - NET_BROADCAST
+        - IPC_LOCK
+        - IPC_OWNER
+        - SYS_CHROOT
+        - SYS_PTRACE
+        - SYS_BOOT
+        - LEASE
+        - SETFCAP
+        - WAKE_ALARM
+        - BLOCK_SUSPEND
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/capabilities_restricted3.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/capabilities_restricted3.yaml
@@ -1,0 +1,53 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_restricted3
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - AUDIT_WRITE
+        - CHOWN
+        - DAC_OVERRIDE
+        - FOWNER
+        - FSETID
+        - KILL
+        - MKNOD
+        - NET_BIND_SERVICE
+        - SETFCAP
+        - SETGID
+        - SETPCAP
+        - SETUID
+        - SYS_CHROOT
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - AUDIT_WRITE
+        - CHOWN
+        - DAC_OVERRIDE
+        - FOWNER
+        - FSETID
+        - KILL
+        - MKNOD
+        - NET_BIND_SERVICE
+        - SETFCAP
+        - SETGID
+        - SETPCAP
+        - SETUID
+        - SYS_CHROOT
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/hostnamespaces0.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  hostIPC: true
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/hostnamespaces1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/hostnamespaces1.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  hostNetwork: true
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/hostnamespaces2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/hostnamespaces2.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  hostPID: true
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/hostpathvolumes0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/hostpathvolumes0.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostpathvolumes0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - emptyDir: {}
+    name: volume-emptydir
+  - hostPath:
+      path: /a
+    name: volume-hostpath

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/hostpathvolumes1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/hostpathvolumes1.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostpathvolumes1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - hostPath:
+      path: /a
+    name: volume-hostpath-a
+  - hostPath:
+      path: /b
+    name: volume-hostpath-b

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/hostports0.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/hostports1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/hostports1.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/hostports2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/hostports2.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    - containerPort: 12347
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    - containerPort: 12348
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/privileged0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/privileged0.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: privileged0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      capabilities:
+        drop:
+        - ALL
+      privileged: true
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/privileged1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/privileged1.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: privileged1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      capabilities:
+        drop:
+        - ALL
+      privileged: true
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/procmount0.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: procmount0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      procMount: Unmasked
+  hostUsers: false
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/procmount1.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: procmount1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  hostUsers: false
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      procMount: Unmasked
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/restrictedvolumes0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/restrictedvolumes0.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - gcePersistentDisk:
+      pdName: test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/restrictedvolumes1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/restrictedvolumes1.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - awsElasticBlockStore:
+      volumeID: test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/restrictedvolumes10.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/restrictedvolumes10.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes10
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - flocker:
+      datasetName: test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/restrictedvolumes11.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/restrictedvolumes11.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes11
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - fc:
+      wwids:
+      - test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/restrictedvolumes12.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/restrictedvolumes12.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes12
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - azureFile:
+      secretName: test
+      shareName: test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/restrictedvolumes13.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/restrictedvolumes13.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes13
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - name: volume1
+    vsphereVolume:
+      volumePath: test

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/restrictedvolumes14.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/restrictedvolumes14.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes14
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - name: volume1
+    quobyte:
+      registry: localhost:1234
+      volume: test

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/restrictedvolumes15.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/restrictedvolumes15.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes15
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - azureDisk:
+      diskName: test
+      diskURI: https://test.blob.core.windows.net/test/test.vhd
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/restrictedvolumes16.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/restrictedvolumes16.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes16
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - name: volume1
+    portworxVolume:
+      fsType: ext4
+      volumeID: test

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/restrictedvolumes17.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/restrictedvolumes17.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes17
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - name: volume1
+    scaleIO:
+      gateway: localhost
+      secretRef: null
+      system: test
+      volumeName: test

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/restrictedvolumes18.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/restrictedvolumes18.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes18
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - name: volume1
+    storageos:
+      volumeName: test

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/restrictedvolumes19.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/restrictedvolumes19.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes19
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - hostPath:
+      path: /dev/null
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/restrictedvolumes2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/restrictedvolumes2.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - gitRepo:
+      repository: github.com/kubernetes/kubernetes
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/restrictedvolumes3.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/restrictedvolumes3.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes3
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - name: volume1
+    nfs:
+      path: /test
+      server: test

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/restrictedvolumes4.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/restrictedvolumes4.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes4
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - iscsi:
+      iqn: iqn.2001-04.com.example:storage.kube.sys1.xyz
+      lun: 0
+      targetPortal: test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/restrictedvolumes5.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/restrictedvolumes5.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes5
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - glusterfs:
+      endpoints: test
+      path: test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/restrictedvolumes6.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/restrictedvolumes6.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes6
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - name: volume1
+    rbd:
+      image: test
+      monitors:
+      - test

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/restrictedvolumes7.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/restrictedvolumes7.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes7
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - flexVolume:
+      driver: test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/restrictedvolumes8.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/restrictedvolumes8.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes8
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - cinder:
+      volumeID: test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/restrictedvolumes9.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/restrictedvolumes9.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes9
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - cephfs:
+      monitors:
+      - test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/runasnonroot0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/runasnonroot0.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasnonroot0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/runasnonroot1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/runasnonroot1.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasnonroot1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: false
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/runasnonroot2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/runasnonroot2.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasnonroot2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsNonRoot: false
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/runasnonroot3.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/runasnonroot3.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasnonroot3
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsNonRoot: false
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/runasuser0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/runasuser0.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasuser0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 0
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/runasuser1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/runasuser1.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasuser1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsUser: 0
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/runasuser2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/runasuser2.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasuser2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsUser: 0
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/seccompprofile_baseline0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/seccompprofile_baseline0.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_baseline0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: Unconfined

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/seccompprofile_baseline1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/seccompprofile_baseline1.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_baseline1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seccompProfile:
+        type: Unconfined
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/seccompprofile_baseline2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/seccompprofile_baseline2.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_baseline2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seccompProfile:
+        type: Unconfined
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/seccompprofile_restricted0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/seccompprofile_restricted0.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_restricted0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/seccompprofile_restricted1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/seccompprofile_restricted1.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_restricted1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: Unconfined

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/seccompprofile_restricted2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/seccompprofile_restricted2.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_restricted2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seccompProfile:
+        type: RuntimeDefault
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/seccompprofile_restricted3.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/seccompprofile_restricted3.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_restricted3
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seccompProfile:
+        type: RuntimeDefault
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/seccompprofile_restricted4.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/seccompprofile_restricted4.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_restricted4
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seccompProfile:
+        type: RuntimeDefault
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seccompProfile:
+        type: Unconfined
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/selinuxoptions0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/selinuxoptions0.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions: {}
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions: {}
+  securityContext:
+    runAsNonRoot: true
+    seLinuxOptions:
+      type: somevalue
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/selinuxoptions1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/selinuxoptions1.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions:
+        type: somevalue
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions: {}
+  securityContext:
+    runAsNonRoot: true
+    seLinuxOptions: {}
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/selinuxoptions2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/selinuxoptions2.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions: {}
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions:
+        type: somevalue
+  securityContext:
+    runAsNonRoot: true
+    seLinuxOptions: {}
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/selinuxoptions3.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/selinuxoptions3.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions3
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions: {}
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions: {}
+  securityContext:
+    runAsNonRoot: true
+    seLinuxOptions:
+      user: somevalue
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/selinuxoptions4.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/selinuxoptions4.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions4
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions: {}
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions: {}
+  securityContext:
+    runAsNonRoot: true
+    seLinuxOptions:
+      role: somevalue
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/sysctls0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/sysctls0.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sysctls0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+    sysctls:
+    - name: othersysctl
+      value: other

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/windowshostprocess0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/windowshostprocess0.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: windowshostprocess0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      windowsOptions: {}
+  hostNetwork: true
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      windowsOptions: {}
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+    windowsOptions:
+      hostProcess: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/windowshostprocess1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/fail/windowshostprocess1.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: windowshostprocess1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      windowsOptions:
+        hostProcess: true
+  hostNetwork: true
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      windowsOptions:
+        hostProcess: true
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+    windowsOptions: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/pass/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/pass/apparmorprofile0.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: localhost/foo
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/pass/base.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/pass/base.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: base
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/pass/base_linux.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/pass/base_linux.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: base_linux
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  os:
+    name: linux
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/pass/base_windows.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/pass/base_windows.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: base_windows
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+  os:
+    name: windows
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/pass/capabilities_restricted0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/pass/capabilities_restricted0.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_restricted0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - NET_BIND_SERVICE
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - NET_BIND_SERVICE
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/pass/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/pass/hostports0.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/pass/privileged0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/pass/privileged0.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: privileged0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      privileged: false
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      privileged: false
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/pass/procmount0.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: procmount0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      procMount: Default
+  hostUsers: false
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      procMount: Default
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/pass/restrictedvolumes0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/pass/restrictedvolumes0.yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - name: volume0
+  - emptyDir: {}
+    name: volume1
+  - name: volume2
+    secret:
+      secretName: test
+  - name: volume3
+    persistentVolumeClaim:
+      claimName: test
+  - downwardAPI:
+      items:
+      - fieldRef:
+          fieldPath: metadata.labels
+        path: labels
+    name: volume4
+  - configMap:
+      name: test
+    name: volume5
+  - name: volume6
+    projected:
+      sources: []

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/pass/runasnonroot0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/pass/runasnonroot0.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasnonroot0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/pass/runasnonroot1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/pass/runasnonroot1.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasnonroot1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsNonRoot: true
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsNonRoot: true
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/pass/runasuser0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/pass/runasuser0.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasuser0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsUser: 1000
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsUser: 1000
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/pass/seccompprofile_restricted0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/pass/seccompprofile_restricted0.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_restricted0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/pass/seccompprofile_restricted1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/pass/seccompprofile_restricted1.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_restricted1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      localhostProfile: testing
+      type: Localhost

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/pass/seccompprofile_restricted2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/pass/seccompprofile_restricted2.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_restricted2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seccompProfile:
+        type: RuntimeDefault
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seccompProfile:
+        localhostProfile: testing
+        type: Localhost
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/pass/selinuxoptions0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/pass/selinuxoptions0.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions: {}
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/pass/selinuxoptions1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/pass/selinuxoptions1.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions:
+        level: somevalue
+        type: container_init_t
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions:
+        type: container_kvm_t
+  securityContext:
+    runAsNonRoot: true
+    seLinuxOptions:
+      type: container_t
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/pass/sysctls0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/pass/sysctls0.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sysctls0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/pass/sysctls1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.32/pass/sysctls1.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sysctls1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+    sysctls:
+    - name: net.ipv4.tcp_rmem
+      value: 4096 87380 16777216
+    - name: net.ipv4.tcp_wmem
+      value: 4096 65536 16777216


### PR DESCRIPTION
This is based on @nikzayn's https://github.com/kubernetes/kubernetes/pull/125270. Feel free to close this PR if you want to continue to work on the original one.

Fixes https://github.com/kubernetes/kubernetes/issues/125234

> This PR adds the net.ipv4.tcp_rmem and net.ipv4.tcp_wmem into safe sysctl list because to handle thousands of concurrent connections used by Cassandra, DataStax recommends these settings to optimize the Linux network stack.


```release-note
Allow pods to use the `net.ipv4.tcp_rmem` and `net.ipv4.tcp_wmem` sysctl by default
when the kernel version is 4.15 or higher. With the kernel 4.15 the sysctl became namespaced.
Pod Security admission allows these sysctl in v1.32+ versions of the baseline and restricted policies.
```

- [x] Website sync: https://github.com/kubernetes/website/pull/48008