### PR TITLE
apiserver/authconfig: make CEL compiler shareable

### DIFF
--- a/pkg/kubeapiserver/authorizer/config.go
+++ b/pkg/kubeapiserver/authorizer/config.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apiserver/pkg/apis/apiserver/load"
 	"k8s.io/apiserver/pkg/apis/apiserver/validation"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
+	authorizationcel "k8s.io/apiserver/pkg/authorization/cel"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	versionedinformers "k8s.io/client-go/informers"
 	resourceinformers "k8s.io/client-go/informers/resource/v1alpha3"
@@ -72,6 +73,8 @@ type Config struct {
 // New returns the right sort of union of multiple authorizer.Authorizer objects
 // based on the authorizationMode or an error.
 // stopCh is used to shut down config reload goroutines when the server is shutting down.
+//
+// Note: the cel compiler construction depends on feature gates and the compatibility version to be initialized.
 func (config Config) New(ctx context.Context, serverID string) (authorizer.Authorizer, authorizer.RuleResolver, error) {
 	if len(config.AuthorizationConfiguration.Authorizers) == 0 {
 		return nil, nil, fmt.Errorf("at least one authorization mode must be passed")
@@ -82,6 +85,7 @@ func (config Config) New(ctx context.Context, serverID string) (authorizer.Autho
 		apiServerID:      serverID,
 		lastLoadedConfig: config.AuthorizationConfiguration,
 		reloadInterval:   time.Minute,
+		compiler:         authorizationcel.NewDefaultCompiler(),
 	}
 
 	seenTypes := sets.New[authzconfig.AuthorizerType]()
@@ -156,15 +160,15 @@ func GetNameForAuthorizerMode(mode string) string {
 	return strings.ToLower(mode)
 }
 
-func LoadAndValidateFile(configFile string, requireNonWebhookTypes sets.Set[authzconfig.AuthorizerType]) (*authzconfig.AuthorizationConfiguration, error) {
+func LoadAndValidateFile(configFile string, compiler authorizationcel.Compiler, requireNonWebhookTypes sets.Set[authzconfig.AuthorizerType]) (*authzconfig.AuthorizationConfiguration, error) {
 	data, err := os.ReadFile(configFile)
 	if err != nil {
 		return nil, err
 	}
-	return LoadAndValidateData(data, requireNonWebhookTypes)
+	return LoadAndValidateData(data, compiler, requireNonWebhookTypes)
 }
 
-func LoadAndValidateData(data []byte, requireNonWebhookTypes sets.Set[authzconfig.AuthorizerType]) (*authzconfig.AuthorizationConfiguration, error) {
+func LoadAndValidateData(data []byte, compiler authorizationcel.Compiler, requireNonWebhookTypes sets.Set[authzconfig.AuthorizerType]) (*authzconfig.AuthorizationConfiguration, error) {
 	// load the file and check for errors
 	authorizationConfiguration, err := load.LoadFromData(data)
 	if err != nil {
@@ -172,7 +176,7 @@ func LoadAndValidateData(data []byte, requireNonWebhookTypes sets.Set[authzconfi
 	}
 
 	// validate the file and return any error
-	if errors := validation.ValidateAuthorizationConfiguration(nil, authorizationConfiguration,
+	if errors := validation.ValidateAuthorizationConfiguration(compiler, nil, authorizationConfiguration,
 		sets.NewString(modes.AuthorizationModeChoices...),
 		sets.NewString(repeatableAuthorizerTypes...),
 	); len(errors) != 0 {

--- a/pkg/kubeapiserver/authorizer/config.go
+++ b/pkg/kubeapiserver/authorizer/config.go
@@ -177,8 +177,8 @@ func LoadAndValidateData(data []byte, compiler authorizationcel.Compiler, requir
 
 	// validate the file and return any error
 	if errors := validation.ValidateAuthorizationConfiguration(compiler, nil, authorizationConfiguration,
-		sets.NewString(modes.AuthorizationModeChoices...),
-		sets.NewString(repeatableAuthorizerTypes...),
+		sets.New(modes.AuthorizationModeChoices...),
+		sets.New(repeatableAuthorizerTypes...),
 	); len(errors) != 0 {
 		return nil, errors.ToAggregate()
 	}

--- a/pkg/kubeapiserver/authorizer/reload.go
+++ b/pkg/kubeapiserver/authorizer/reload.go
@@ -32,7 +32,7 @@ import (
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	"k8s.io/apiserver/pkg/authorization/authorizerfactory"
-	"k8s.io/apiserver/pkg/authorization/cel"
+	authorizationcel "k8s.io/apiserver/pkg/authorization/cel"
 	authorizationmetrics "k8s.io/apiserver/pkg/authorization/metrics"
 	"k8s.io/apiserver/pkg/authorization/union"
 	"k8s.io/apiserver/pkg/server/options/authorizationconfig/metrics"
@@ -61,6 +61,7 @@ type reloadableAuthorizerResolver struct {
 	nodeAuthorizer *node.NodeAuthorizer
 	rbacAuthorizer *rbac.RBACAuthorizer
 	abacAuthorizer abac.PolicyList
+	compiler       authorizationcel.Compiler // non-nil and shared across reloads.
 
 	lastLoadedLock   sync.Mutex
 	lastLoadedConfig *authzconfig.AuthorizationConfiguration
@@ -148,7 +149,8 @@ func (r *reloadableAuthorizerResolver) newForConfig(authzConfig *authzconfig.Aut
 				decisionOnError,
 				configuredAuthorizer.Webhook.MatchConditions,
 				configuredAuthorizer.Name,
-				kubeapiserverWebhookMetrics{WebhookMetrics: webhookmetrics.NewWebhookMetrics(), MatcherMetrics: cel.NewMatcherMetrics()},
+				kubeapiserverWebhookMetrics{WebhookMetrics: webhookmetrics.NewWebhookMetrics(), MatcherMetrics: authorizationcel.NewMatcherMetrics()},
+				r.compiler,
 			)
 			if err != nil {
 				return nil, nil, err
@@ -175,7 +177,7 @@ type kubeapiserverWebhookMetrics struct {
 	// kube-apiserver does report webhook metrics
 	webhookmetrics.WebhookMetrics
 	// kube-apiserver does report matchCondition metrics
-	cel.MatcherMetrics
+	authorizationcel.MatcherMetrics
 }
 
 // runReload starts checking the config file for changes and reloads the authorizer when it changes.
@@ -214,7 +216,7 @@ func (r *reloadableAuthorizerResolver) checkFile(ctx context.Context) {
 	klog.InfoS("found new authorization config data")
 	r.lastReadData = data
 
-	config, err := LoadAndValidateData(data, r.requireNonWebhookTypes)
+	config, err := LoadAndValidateData(data, r.compiler, r.requireNonWebhookTypes)
 	if err != nil {
 		klog.ErrorS(err, "reloading authorization config")
 		metrics.RecordAuthorizationConfigAutomaticReloadFailure(r.apiServerID)

--- a/pkg/kubeapiserver/options/authentication.go
+++ b/pkg/kubeapiserver/options/authentication.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/apiserver/pkg/apis/apiserver/install"
 	apiservervalidation "k8s.io/apiserver/pkg/apis/apiserver/validation"
 	"k8s.io/apiserver/pkg/authentication/authenticator"
+	authenticationcel "k8s.io/apiserver/pkg/authentication/cel"
 	genericfeatures "k8s.io/apiserver/pkg/features"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/apiserver/pkg/server/egressselector"
@@ -574,7 +575,7 @@ func (o *BuiltInAuthenticationOptions) ToAuthenticationConfig() (kubeauthenticat
 		}
 	}
 
-	if err := apiservervalidation.ValidateAuthenticationConfiguration(ret.AuthenticationConfig, ret.ServiceAccountIssuers).ToAggregate(); err != nil {
+	if err := apiservervalidation.ValidateAuthenticationConfiguration(authenticationcel.NewDefaultCompiler(), ret.AuthenticationConfig, ret.ServiceAccountIssuers).ToAggregate(); err != nil {
 		return kubeauthenticator.Config{}, err
 	}
 
@@ -756,7 +757,7 @@ func (o *BuiltInAuthenticationOptions) ApplyTo(
 					return
 				}
 
-				validationErrs := apiservervalidation.ValidateAuthenticationConfiguration(authConfig, authenticatorConfig.ServiceAccountIssuers)
+				validationErrs := apiservervalidation.ValidateAuthenticationConfiguration(authenticationcel.NewDefaultCompiler(), authConfig, authenticatorConfig.ServiceAccountIssuers)
 				if !reflect.DeepEqual(originalFileAnonymousConfig, authConfig.Anonymous) {
 					validationErrs = append(validationErrs, field.Forbidden(field.NewPath("anonymous"), "changed from initial configuration file"))
 				}

--- a/pkg/kubeapiserver/options/authorization.go
+++ b/pkg/kubeapiserver/options/authorization.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"time"
 
+	authorizationcel "k8s.io/apiserver/pkg/authorization/cel"
 	genericfeatures "k8s.io/apiserver/pkg/features"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 
@@ -118,7 +119,7 @@ func (o *BuiltInAuthorizationOptions) Validate() []error {
 		}
 
 		// load/validate kube-apiserver authz config with no opinion about required modes
-		_, err := authorizer.LoadAndValidateFile(o.AuthorizationConfigurationFile, nil)
+		_, err := authorizer.LoadAndValidateFile(o.AuthorizationConfigurationFile, authorizationcel.NewDefaultCompiler(), nil)
 		if err != nil {
 			return append(allErrors, err)
 		}
@@ -236,7 +237,7 @@ func (o *BuiltInAuthorizationOptions) ToAuthorizationConfig(versionedInformerFac
 			return nil, fmt.Errorf("--%s can not be specified when --%s or --authorization-webhook-* flags are defined", authorizationConfigFlag, authorizationModeFlag)
 		}
 		// load/validate kube-apiserver authz config with no opinion about required modes
-		authorizationConfiguration, err = authorizer.LoadAndValidateFile(o.AuthorizationConfigurationFile, nil)
+		authorizationConfiguration, err = authorizer.LoadAndValidateFile(o.AuthorizationConfigurationFile, authorizationcel.NewDefaultCompiler(), nil)
 		if err != nil {
 			return nil, err
 		}

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/validation/validation.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/validation/validation.go
@@ -613,7 +613,7 @@ func compileUserCELExpression(compiler authenticationcel.Compiler, expression au
 }
 
 // ValidateAuthorizationConfiguration validates a given AuthorizationConfiguration.
-func ValidateAuthorizationConfiguration(compiler authorizationcel.Compiler, fldPath *field.Path, c *api.AuthorizationConfiguration, knownTypes sets.String, repeatableTypes sets.String) field.ErrorList {
+func ValidateAuthorizationConfiguration(compiler authorizationcel.Compiler, fldPath *field.Path, c *api.AuthorizationConfiguration, knownTypes sets.Set[string], repeatableTypes sets.Set[string]) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if len(c.Authorizers) == 0 {
@@ -630,7 +630,7 @@ func ValidateAuthorizationConfiguration(compiler authorizationcel.Compiler, fldP
 			continue
 		}
 		if !knownTypes.Has(aType) {
-			allErrs = append(allErrs, field.NotSupported(fldPath.Child("type"), aType, knownTypes.List()))
+			allErrs = append(allErrs, field.NotSupported(fldPath.Child("type"), aType, sets.List(knownTypes)))
 			continue
 		}
 		if seenAuthorizerTypes.Has(aType) && !repeatableTypes.Has(aType) {

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/validation/validation.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/validation/validation.go
@@ -38,14 +38,13 @@ import (
 	authenticationcel "k8s.io/apiserver/pkg/authentication/cel"
 	authorizationcel "k8s.io/apiserver/pkg/authorization/cel"
 	"k8s.io/apiserver/pkg/cel"
-	"k8s.io/apiserver/pkg/cel/environment"
 	"k8s.io/apiserver/pkg/features"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/util/cert"
 )
 
 // ValidateAuthenticationConfiguration validates a given AuthenticationConfiguration.
-func ValidateAuthenticationConfiguration(c *api.AuthenticationConfiguration, disallowedIssuers []string) field.ErrorList {
+func ValidateAuthenticationConfiguration(compiler authenticationcel.Compiler, c *api.AuthenticationConfiguration, disallowedIssuers []string) field.ErrorList {
 	root := field.NewPath("jwt")
 	var allErrs field.ErrorList
 
@@ -62,7 +61,7 @@ func ValidateAuthenticationConfiguration(c *api.AuthenticationConfiguration, dis
 	seenDiscoveryURLs := sets.New[string]()
 	for i, a := range c.JWT {
 		fldPath := root.Index(i)
-		_, errs := validateJWTAuthenticator(a, fldPath, sets.New(disallowedIssuers...), utilfeature.DefaultFeatureGate.Enabled(features.StructuredAuthenticationConfiguration))
+		_, errs := validateJWTAuthenticator(compiler, a, fldPath, sets.New(disallowedIssuers...), utilfeature.DefaultFeatureGate.Enabled(features.StructuredAuthenticationConfiguration))
 		allErrs = append(allErrs, errs...)
 
 		if seenIssuers.Has(a.Issuer.URL) {
@@ -93,15 +92,13 @@ func ValidateAuthenticationConfiguration(c *api.AuthenticationConfiguration, dis
 // CompileAndValidateJWTAuthenticator validates a given JWTAuthenticator and returns a CELMapper with the compiled
 // CEL expressions for claim mappings and validation rules.
 // This is exported for use in oidc package.
-func CompileAndValidateJWTAuthenticator(authenticator api.JWTAuthenticator, disallowedIssuers []string) (authenticationcel.CELMapper, field.ErrorList) {
-	return validateJWTAuthenticator(authenticator, nil, sets.New(disallowedIssuers...), utilfeature.DefaultFeatureGate.Enabled(features.StructuredAuthenticationConfiguration))
+func CompileAndValidateJWTAuthenticator(compiler authenticationcel.Compiler, authenticator api.JWTAuthenticator, disallowedIssuers []string) (authenticationcel.CELMapper, field.ErrorList) {
+	return validateJWTAuthenticator(compiler, authenticator, nil, sets.New(disallowedIssuers...), utilfeature.DefaultFeatureGate.Enabled(features.StructuredAuthenticationConfiguration))
 }
 
-func validateJWTAuthenticator(authenticator api.JWTAuthenticator, fldPath *field.Path, disallowedIssuers sets.Set[string], structuredAuthnFeatureEnabled bool) (authenticationcel.CELMapper, field.ErrorList) {
+func validateJWTAuthenticator(compiler authenticationcel.Compiler, authenticator api.JWTAuthenticator, fldPath *field.Path, disallowedIssuers sets.Set[string], structuredAuthnFeatureEnabled bool) (authenticationcel.CELMapper, field.ErrorList) {
 	var allErrs field.ErrorList
 
-	// strictCost is set to true which enables the strict cost for CEL validation.
-	compiler := authenticationcel.NewCompiler(environment.MustBaseEnvSet(environment.DefaultCompatibilityVersion(), true))
 	state := &validationState{}
 
 	allErrs = append(allErrs, validateIssuer(authenticator.Issuer, disallowedIssuers, fldPath.Child("issuer"), structuredAuthnFeatureEnabled)...)
@@ -616,7 +613,7 @@ func compileUserCELExpression(compiler authenticationcel.Compiler, expression au
 }
 
 // ValidateAuthorizationConfiguration validates a given AuthorizationConfiguration.
-func ValidateAuthorizationConfiguration(fldPath *field.Path, c *api.AuthorizationConfiguration, knownTypes sets.String, repeatableTypes sets.String) field.ErrorList {
+func ValidateAuthorizationConfiguration(compiler authorizationcel.Compiler, fldPath *field.Path, c *api.AuthorizationConfiguration, knownTypes sets.String, repeatableTypes sets.String) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if len(c.Authorizers) == 0 {
@@ -657,7 +654,7 @@ func ValidateAuthorizationConfiguration(fldPath *field.Path, c *api.Authorizatio
 				allErrs = append(allErrs, field.Required(fldPath.Child("webhook"), "required when type=Webhook"))
 				continue
 			}
-			allErrs = append(allErrs, ValidateWebhookConfiguration(fldPath, a.Webhook)...)
+			allErrs = append(allErrs, ValidateWebhookConfiguration(compiler, fldPath, a.Webhook)...)
 		default:
 			if a.Webhook != nil {
 				allErrs = append(allErrs, field.Invalid(fldPath.Child("webhook"), "non-null", "may only be specified when type=Webhook"))
@@ -668,7 +665,7 @@ func ValidateAuthorizationConfiguration(fldPath *field.Path, c *api.Authorizatio
 	return allErrs
 }
 
-func ValidateWebhookConfiguration(fldPath *field.Path, c *api.WebhookConfiguration) field.ErrorList {
+func ValidateWebhookConfiguration(compiler authorizationcel.Compiler, fldPath *field.Path, c *api.WebhookConfiguration) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if c.Timeout.Duration == 0 {
@@ -740,7 +737,7 @@ func ValidateWebhookConfiguration(fldPath *field.Path, c *api.WebhookConfigurati
 		allErrs = append(allErrs, field.NotSupported(fldPath.Child("connectionInfo", "type"), c.ConnectionInfo, []string{api.AuthorizationWebhookConnectionInfoTypeInCluster, api.AuthorizationWebhookConnectionInfoTypeKubeConfigFile}))
 	}
 
-	_, errs := compileMatchConditions(c.MatchConditions, fldPath, utilfeature.DefaultFeatureGate.Enabled(features.StructuredAuthorizationConfiguration))
+	_, errs := compileMatchConditions(compiler, c.MatchConditions, fldPath, utilfeature.DefaultFeatureGate.Enabled(features.StructuredAuthorizationConfiguration))
 	allErrs = append(allErrs, errs...)
 
 	return allErrs
@@ -748,11 +745,11 @@ func ValidateWebhookConfiguration(fldPath *field.Path, c *api.WebhookConfigurati
 
 // ValidateAndCompileMatchConditions validates a given webhook's matchConditions.
 // This is exported for use in authz package.
-func ValidateAndCompileMatchConditions(matchConditions []api.WebhookMatchCondition) (*authorizationcel.CELMatcher, field.ErrorList) {
-	return compileMatchConditions(matchConditions, nil, utilfeature.DefaultFeatureGate.Enabled(features.StructuredAuthorizationConfiguration))
+func ValidateAndCompileMatchConditions(compiler authorizationcel.Compiler, matchConditions []api.WebhookMatchCondition) (*authorizationcel.CELMatcher, field.ErrorList) {
+	return compileMatchConditions(compiler, matchConditions, nil, utilfeature.DefaultFeatureGate.Enabled(features.StructuredAuthorizationConfiguration))
 }
 
-func compileMatchConditions(matchConditions []api.WebhookMatchCondition, fldPath *field.Path, structuredAuthzFeatureEnabled bool) (*authorizationcel.CELMatcher, field.ErrorList) {
+func compileMatchConditions(compiler authorizationcel.Compiler, matchConditions []api.WebhookMatchCondition, fldPath *field.Path, structuredAuthzFeatureEnabled bool) (*authorizationcel.CELMatcher, field.ErrorList) {
 	var allErrs field.ErrorList
 	// should fail when match conditions are used without feature enabled
 	if len(matchConditions) > 0 && !structuredAuthzFeatureEnabled {
@@ -763,8 +760,6 @@ func compileMatchConditions(matchConditions []api.WebhookMatchCondition, fldPath
 		return nil, allErrs
 	}
 
-	// strictCost is set to true which enables the strict cost for CEL validation.
-	compiler := authorizationcel.NewCompiler(environment.MustBaseEnvSet(environment.DefaultCompatibilityVersion(), true))
 	seenExpressions := sets.NewString()
 	var compilationResults []authorizationcel.CompilationResult
 	var usesFieldSelector, usesLabelSelector bool

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/validation/validation_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/validation/validation_test.go
@@ -1680,8 +1680,8 @@ type (
 		name            string
 		configuration   api.AuthorizationConfiguration
 		expectedErrList field.ErrorList
-		knownTypes      sets.String
-		repeatableTypes sets.String
+		knownTypes      sets.Set[string]
+		repeatableTypes sets.Set[string]
 	}
 )
 
@@ -1704,8 +1704,8 @@ func TestValidateAuthorizationConfiguration(t *testing.T) {
 				Authorizers: []api.AuthorizerConfiguration{},
 			},
 			expectedErrList: field.ErrorList{field.Required(field.NewPath("authorizers"), "at least one authorization mode must be defined")},
-			knownTypes:      sets.NewString(),
-			repeatableTypes: sets.NewString(),
+			knownTypes:      sets.New[string](),
+			repeatableTypes: sets.New[string](),
 		},
 		{
 			name: "type and name are required if an authorizer is defined",
@@ -1715,8 +1715,8 @@ func TestValidateAuthorizationConfiguration(t *testing.T) {
 				},
 			},
 			expectedErrList: field.ErrorList{field.Required(field.NewPath("type"), "")},
-			knownTypes:      sets.NewString(string("Webhook")),
-			repeatableTypes: sets.NewString(string("Webhook")),
+			knownTypes:      sets.New("Webhook"),
+			repeatableTypes: sets.New("Webhook"),
 		},
 		{
 			name: "authorizer names should be of non-zero length",
@@ -1729,8 +1729,8 @@ func TestValidateAuthorizationConfiguration(t *testing.T) {
 				},
 			},
 			expectedErrList: field.ErrorList{field.Required(field.NewPath("name"), "")},
-			knownTypes:      sets.NewString(string("Foo")),
-			repeatableTypes: sets.NewString(string("Webhook")),
+			knownTypes:      sets.New("Foo"),
+			repeatableTypes: sets.New("Webhook"),
 		},
 		{
 			name: "authorizer names should be unique",
@@ -1747,8 +1747,8 @@ func TestValidateAuthorizationConfiguration(t *testing.T) {
 				},
 			},
 			expectedErrList: field.ErrorList{field.Duplicate(field.NewPath("name"), "foo")},
-			knownTypes:      sets.NewString(string("Foo"), string("Bar")),
-			repeatableTypes: sets.NewString(string("Webhook")),
+			knownTypes:      sets.New("Foo", "Bar"),
+			repeatableTypes: sets.New("Webhook"),
 		},
 		{
 			name: "authorizer names should be DNS1123 labels",
@@ -1761,8 +1761,8 @@ func TestValidateAuthorizationConfiguration(t *testing.T) {
 				},
 			},
 			expectedErrList: field.ErrorList{},
-			knownTypes:      sets.NewString(string("Foo")),
-			repeatableTypes: sets.NewString(string("Webhook")),
+			knownTypes:      sets.New("Foo"),
+			repeatableTypes: sets.New("Webhook"),
 		},
 		{
 			name: "authorizer names should be DNS1123 subdomains",
@@ -1775,8 +1775,8 @@ func TestValidateAuthorizationConfiguration(t *testing.T) {
 				},
 			},
 			expectedErrList: field.ErrorList{},
-			knownTypes:      sets.NewString(string("Foo")),
-			repeatableTypes: sets.NewString(string("Webhook")),
+			knownTypes:      sets.New("Foo"),
+			repeatableTypes: sets.New("Webhook"),
 		},
 		{
 			name: "authorizer names should not be invalid DNS1123 labels or subdomains",
@@ -1789,8 +1789,8 @@ func TestValidateAuthorizationConfiguration(t *testing.T) {
 				},
 			},
 			expectedErrList: field.ErrorList{field.Invalid(field.NewPath("name"), "FOO.example.domain", "")},
-			knownTypes:      sets.NewString(string("Foo")),
-			repeatableTypes: sets.NewString(string("Webhook")),
+			knownTypes:      sets.New("Foo"),
+			repeatableTypes: sets.New("Webhook"),
 		},
 		{
 			name: "bare minimum configuration with Webhook",
@@ -1814,8 +1814,8 @@ func TestValidateAuthorizationConfiguration(t *testing.T) {
 				},
 			},
 			expectedErrList: field.ErrorList{},
-			knownTypes:      sets.NewString(string("Webhook")),
-			repeatableTypes: sets.NewString(string("Webhook")),
+			knownTypes:      sets.New("Webhook"),
+			repeatableTypes: sets.New("Webhook"),
 		},
 		{
 			name: "bare minimum configuration with Webhook and MatchConditions",
@@ -1847,8 +1847,8 @@ func TestValidateAuthorizationConfiguration(t *testing.T) {
 				},
 			},
 			expectedErrList: field.ErrorList{},
-			knownTypes:      sets.NewString(string("Webhook")),
-			repeatableTypes: sets.NewString(string("Webhook")),
+			knownTypes:      sets.New("Webhook"),
+			repeatableTypes: sets.New("Webhook"),
 		},
 		{
 			name: "bare minimum configuration with multiple webhooks",
@@ -1887,8 +1887,8 @@ func TestValidateAuthorizationConfiguration(t *testing.T) {
 				},
 			},
 			expectedErrList: field.ErrorList{},
-			knownTypes:      sets.NewString(string("Webhook")),
-			repeatableTypes: sets.NewString(string("Webhook")),
+			knownTypes:      sets.New("Webhook"),
+			repeatableTypes: sets.New("Webhook"),
 		},
 		{
 			name: "configuration with unknown types",
@@ -1900,8 +1900,8 @@ func TestValidateAuthorizationConfiguration(t *testing.T) {
 				},
 			},
 			expectedErrList: field.ErrorList{field.NotSupported(field.NewPath("type"), "Foo", []string{"..."})},
-			knownTypes:      sets.NewString(string("Webhook")),
-			repeatableTypes: sets.NewString(string("Webhook")),
+			knownTypes:      sets.New("Webhook"),
+			repeatableTypes: sets.New("Webhook"),
 		},
 		{
 			name: "configuration with not repeatable types",
@@ -1918,8 +1918,8 @@ func TestValidateAuthorizationConfiguration(t *testing.T) {
 				},
 			},
 			expectedErrList: field.ErrorList{field.Duplicate(field.NewPath("type"), "Foo")},
-			knownTypes:      sets.NewString(string("Foo")),
-			repeatableTypes: sets.NewString(string("Webhook")),
+			knownTypes:      sets.New("Foo"),
+			repeatableTypes: sets.New("Webhook"),
 		},
 		{
 			name: "when type=Webhook, webhook needs to be defined",
@@ -1932,8 +1932,8 @@ func TestValidateAuthorizationConfiguration(t *testing.T) {
 				},
 			},
 			expectedErrList: field.ErrorList{field.Required(field.NewPath("webhook"), "required when type=Webhook")},
-			knownTypes:      sets.NewString(string("Webhook")),
-			repeatableTypes: sets.NewString(string("Webhook")),
+			knownTypes:      sets.New("Webhook"),
+			repeatableTypes: sets.New("Webhook"),
 		},
 		{
 			name: "when type!=Webhook, webhooks needs to be nil",
@@ -1947,8 +1947,8 @@ func TestValidateAuthorizationConfiguration(t *testing.T) {
 				},
 			},
 			expectedErrList: field.ErrorList{field.Invalid(field.NewPath("webhook"), "non-null", "may only be specified when type=Webhook")},
-			knownTypes:      sets.NewString(string("Foo")),
-			repeatableTypes: sets.NewString(string("Webhook")),
+			knownTypes:      sets.New("Foo"),
+			repeatableTypes: sets.New("Webhook"),
 		},
 		{
 			name: "timeout should be specified",
@@ -1971,8 +1971,8 @@ func TestValidateAuthorizationConfiguration(t *testing.T) {
 				},
 			},
 			expectedErrList: field.ErrorList{field.Required(field.NewPath("timeout"), "")},
-			knownTypes:      sets.NewString(string("Webhook")),
-			repeatableTypes: sets.NewString(string("Webhook")),
+			knownTypes:      sets.New("Webhook"),
+			repeatableTypes: sets.New("Webhook"),
 		},
 		//
 		{
@@ -1997,8 +1997,8 @@ func TestValidateAuthorizationConfiguration(t *testing.T) {
 				},
 			},
 			expectedErrList: field.ErrorList{field.Required(field.NewPath("timeout"), "")},
-			knownTypes:      sets.NewString(string("Webhook")),
-			repeatableTypes: sets.NewString(string("Webhook")),
+			knownTypes:      sets.New("Webhook"),
+			repeatableTypes: sets.New("Webhook"),
 		},
 		{
 			name: "timeout shouldn't be negative",
@@ -2022,8 +2022,8 @@ func TestValidateAuthorizationConfiguration(t *testing.T) {
 				},
 			},
 			expectedErrList: field.ErrorList{field.Invalid(field.NewPath("timeout"), time.Duration(-30*time.Second).String(), "must be > 0s and <= 30s")},
-			knownTypes:      sets.NewString(string("Webhook")),
-			repeatableTypes: sets.NewString(string("Webhook")),
+			knownTypes:      sets.New("Webhook"),
+			repeatableTypes: sets.New("Webhook"),
 		},
 		{
 			name: "timeout shouldn't be greater than 30seconds",
@@ -2047,8 +2047,8 @@ func TestValidateAuthorizationConfiguration(t *testing.T) {
 				},
 			},
 			expectedErrList: field.ErrorList{field.Invalid(field.NewPath("timeout"), time.Duration(60*time.Second).String(), "must be > 0s and <= 30s")},
-			knownTypes:      sets.NewString(string("Webhook")),
-			repeatableTypes: sets.NewString(string("Webhook")),
+			knownTypes:      sets.New("Webhook"),
+			repeatableTypes: sets.New("Webhook"),
 		},
 		{
 			name: "authorizedTTL should be defined ",
@@ -2071,8 +2071,8 @@ func TestValidateAuthorizationConfiguration(t *testing.T) {
 				},
 			},
 			expectedErrList: field.ErrorList{field.Required(field.NewPath("authorizedTTL"), "")},
-			knownTypes:      sets.NewString(string("Webhook")),
-			repeatableTypes: sets.NewString(string("Webhook")),
+			knownTypes:      sets.New("Webhook"),
+			repeatableTypes: sets.New("Webhook"),
 		},
 		{
 			name: "authorizedTTL shouldn't be negative",
@@ -2096,8 +2096,8 @@ func TestValidateAuthorizationConfiguration(t *testing.T) {
 				},
 			},
 			expectedErrList: field.ErrorList{field.Invalid(field.NewPath("authorizedTTL"), time.Duration(-30*time.Second).String(), "must be > 0s")},
-			knownTypes:      sets.NewString(string("Webhook")),
-			repeatableTypes: sets.NewString(string("Webhook")),
+			knownTypes:      sets.New("Webhook"),
+			repeatableTypes: sets.New("Webhook"),
 		},
 		{
 			name: "unauthorizedTTL should be defined ",
@@ -2120,8 +2120,8 @@ func TestValidateAuthorizationConfiguration(t *testing.T) {
 				},
 			},
 			expectedErrList: field.ErrorList{field.Required(field.NewPath("unauthorizedTTL"), "")},
-			knownTypes:      sets.NewString(string("Webhook")),
-			repeatableTypes: sets.NewString(string("Webhook")),
+			knownTypes:      sets.New("Webhook"),
+			repeatableTypes: sets.New("Webhook"),
 		},
 		{
 			name: "unauthorizedTTL shouldn't be negative",
@@ -2145,8 +2145,8 @@ func TestValidateAuthorizationConfiguration(t *testing.T) {
 				},
 			},
 			expectedErrList: field.ErrorList{field.Invalid(field.NewPath("unauthorizedTTL"), time.Duration(-30*time.Second).String(), "must be > 0s")},
-			knownTypes:      sets.NewString(string("Webhook")),
-			repeatableTypes: sets.NewString(string("Webhook")),
+			knownTypes:      sets.New("Webhook"),
+			repeatableTypes: sets.New("Webhook"),
 		},
 		{
 			name: "SAR should be defined",
@@ -2169,8 +2169,8 @@ func TestValidateAuthorizationConfiguration(t *testing.T) {
 				},
 			},
 			expectedErrList: field.ErrorList{field.Required(field.NewPath("subjectAccessReviewVersion"), "")},
-			knownTypes:      sets.NewString(string("Webhook")),
-			repeatableTypes: sets.NewString(string("Webhook")),
+			knownTypes:      sets.New("Webhook"),
+			repeatableTypes: sets.New("Webhook"),
 		},
 		{
 			name: "SAR should be one of v1 and v1beta1",
@@ -2194,8 +2194,8 @@ func TestValidateAuthorizationConfiguration(t *testing.T) {
 				},
 			},
 			expectedErrList: field.ErrorList{field.NotSupported(field.NewPath("subjectAccessReviewVersion"), "v2beta1", []string{"v1", "v1beta1"})},
-			knownTypes:      sets.NewString(string("Webhook")),
-			repeatableTypes: sets.NewString(string("Webhook")),
+			knownTypes:      sets.New("Webhook"),
+			repeatableTypes: sets.New("Webhook"),
 		},
 		{
 			name: "MatchConditionSAR should be defined",
@@ -2219,8 +2219,8 @@ func TestValidateAuthorizationConfiguration(t *testing.T) {
 				},
 			},
 			expectedErrList: field.ErrorList{field.Required(field.NewPath("matchConditionSubjectAccessReviewVersion"), "")},
-			knownTypes:      sets.NewString(string("Webhook")),
-			repeatableTypes: sets.NewString(string("Webhook")),
+			knownTypes:      sets.New("Webhook"),
+			repeatableTypes: sets.New("Webhook"),
 		},
 		{
 			name: "MatchConditionSAR must not be anything other than v1",
@@ -2244,8 +2244,8 @@ func TestValidateAuthorizationConfiguration(t *testing.T) {
 				},
 			},
 			expectedErrList: field.ErrorList{field.NotSupported(field.NewPath("matchConditionSubjectAccessReviewVersion"), "v1beta1", []string{"v1"})},
-			knownTypes:      sets.NewString(string("Webhook")),
-			repeatableTypes: sets.NewString(string("Webhook")),
+			knownTypes:      sets.New("Webhook"),
+			repeatableTypes: sets.New("Webhook"),
 		},
 		{
 			name: "failurePolicy should be defined",
@@ -2268,8 +2268,8 @@ func TestValidateAuthorizationConfiguration(t *testing.T) {
 				},
 			},
 			expectedErrList: field.ErrorList{field.Required(field.NewPath("failurePolicy"), "")},
-			knownTypes:      sets.NewString(string("Webhook")),
-			repeatableTypes: sets.NewString(string("Webhook")),
+			knownTypes:      sets.New("Webhook"),
+			repeatableTypes: sets.New("Webhook"),
 		},
 		{
 			name: "failurePolicy should be one of \"NoOpinion\" or \"Deny\"",
@@ -2293,8 +2293,8 @@ func TestValidateAuthorizationConfiguration(t *testing.T) {
 				},
 			},
 			expectedErrList: field.ErrorList{field.NotSupported(field.NewPath("failurePolicy"), "AlwaysAllow", []string{"NoOpinion", "Deny"})},
-			knownTypes:      sets.NewString(string("Webhook")),
-			repeatableTypes: sets.NewString(string("Webhook")),
+			knownTypes:      sets.New("Webhook"),
+			repeatableTypes: sets.New("Webhook"),
 		},
 		{
 			name: "connectionInfo should be defined",
@@ -2315,8 +2315,8 @@ func TestValidateAuthorizationConfiguration(t *testing.T) {
 				},
 			},
 			expectedErrList: field.ErrorList{field.Required(field.NewPath("connectionInfo"), "")},
-			knownTypes:      sets.NewString(string("Webhook")),
-			repeatableTypes: sets.NewString(string("Webhook")),
+			knownTypes:      sets.New("Webhook"),
+			repeatableTypes: sets.New("Webhook"),
 		},
 		{
 			name: "connectionInfo should be one of InClusterConfig or KubeConfigFile",
@@ -2342,8 +2342,8 @@ func TestValidateAuthorizationConfiguration(t *testing.T) {
 			expectedErrList: field.ErrorList{
 				field.NotSupported(field.NewPath("connectionInfo"), api.WebhookConnectionInfo{Type: "ExternalClusterConfig"}, []string{"InClusterConfig", "KubeConfigFile"}),
 			},
-			knownTypes:      sets.NewString(string("Webhook")),
-			repeatableTypes: sets.NewString(string("Webhook")),
+			knownTypes:      sets.New("Webhook"),
+			repeatableTypes: sets.New("Webhook"),
 		},
 		{
 			name: "if connectionInfo=InClusterConfig, then kubeConfigFile should be nil",
@@ -2370,8 +2370,8 @@ func TestValidateAuthorizationConfiguration(t *testing.T) {
 			expectedErrList: field.ErrorList{
 				field.Invalid(field.NewPath("connectionInfo", "kubeConfigFile"), "", "can only be set when type=KubeConfigFile"),
 			},
-			knownTypes:      sets.NewString(string("Webhook")),
-			repeatableTypes: sets.NewString(string("Webhook")),
+			knownTypes:      sets.New("Webhook"),
+			repeatableTypes: sets.New("Webhook"),
 		},
 		{
 			name: "if connectionInfo=KubeConfigFile, then KubeConfigFile should be defined",
@@ -2395,8 +2395,8 @@ func TestValidateAuthorizationConfiguration(t *testing.T) {
 				},
 			},
 			expectedErrList: field.ErrorList{field.Required(field.NewPath("kubeConfigFile"), "")},
-			knownTypes:      sets.NewString(string("Webhook")),
-			repeatableTypes: sets.NewString(string("Webhook")),
+			knownTypes:      sets.New("Webhook"),
+			repeatableTypes: sets.New("Webhook"),
 		},
 		{
 			name: "if connectionInfo=KubeConfigFile, then KubeConfigFile should be defined, must be an absolute path, should exist, shouldn't be a symlink",
@@ -2421,8 +2421,8 @@ func TestValidateAuthorizationConfiguration(t *testing.T) {
 				},
 			},
 			expectedErrList: field.ErrorList{field.Invalid(field.NewPath("kubeConfigFile"), badKubeConfigFile, "must be an absolute path")},
-			knownTypes:      sets.NewString(string("Webhook")),
-			repeatableTypes: sets.NewString(string("Webhook")),
+			knownTypes:      sets.New("Webhook"),
+			repeatableTypes: sets.New("Webhook"),
 		},
 		{
 			name: "if connectionInfo=KubeConfigFile, an existent file needs to be passed",
@@ -2447,8 +2447,8 @@ func TestValidateAuthorizationConfiguration(t *testing.T) {
 				},
 			},
 			expectedErrList: field.ErrorList{},
-			knownTypes:      sets.NewString(string("Webhook")),
-			repeatableTypes: sets.NewString(string("Webhook")),
+			knownTypes:      sets.New("Webhook"),
+			repeatableTypes: sets.New("Webhook"),
 		},
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/validation/validation_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/validation/validation_test.go
@@ -34,16 +34,12 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	api "k8s.io/apiserver/pkg/apis/apiserver"
 	authenticationcel "k8s.io/apiserver/pkg/authentication/cel"
-	"k8s.io/apiserver/pkg/cel/environment"
+	authorizationcel "k8s.io/apiserver/pkg/authorization/cel"
 	"k8s.io/apiserver/pkg/features"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	certutil "k8s.io/client-go/util/cert"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/utils/pointer"
-)
-
-var (
-	compiler = authenticationcel.NewCompiler(environment.MustBaseEnvSet(environment.DefaultCompatibilityVersion(), true))
 )
 
 func TestValidateAuthenticationConfiguration(t *testing.T) {
@@ -619,7 +615,7 @@ func TestValidateAuthenticationConfiguration(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			got := ValidateAuthenticationConfiguration(tt.in, tt.disallowedIssuers).ToAggregate()
+			got := ValidateAuthenticationConfiguration(authenticationcel.NewDefaultCompiler(), tt.in, tt.disallowedIssuers).ToAggregate()
 			if d := cmp.Diff(tt.want, errString(got)); d != "" {
 				t.Fatalf("AuthenticationConfiguration validation mismatch (-want +got):\n%s", d)
 			}
@@ -1044,7 +1040,7 @@ func TestValidateClaimValidationRules(t *testing.T) {
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			state := &validationState{}
-			got := validateClaimValidationRules(compiler, state, tt.in, fldPath, tt.structuredAuthnFeatureEnabled).ToAggregate()
+			got := validateClaimValidationRules(authenticationcel.NewDefaultCompiler(), state, tt.in, fldPath, tt.structuredAuthnFeatureEnabled).ToAggregate()
 			if d := cmp.Diff(tt.want, errString(got)); d != "" {
 				t.Fatalf("ClaimValidationRules validation mismatch (-want +got):\n%s", d)
 			}
@@ -1572,7 +1568,7 @@ func TestValidateClaimMappings(t *testing.T) {
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			state := &validationState{usesEmailVerifiedClaim: tt.usesEmailVerifiedClaim}
-			got := validateClaimMappings(compiler, state, tt.in, fldPath, tt.structuredAuthnFeatureEnabled).ToAggregate()
+			got := validateClaimMappings(authenticationcel.NewDefaultCompiler(), state, tt.in, fldPath, tt.structuredAuthnFeatureEnabled).ToAggregate()
 			if d := cmp.Diff(tt.want, errString(got)); d != "" {
 				fmt.Println(errString(got))
 				t.Fatalf("ClaimMappings validation mismatch (-want +got):\n%s", d)
@@ -1661,7 +1657,7 @@ func TestValidateUserValidationRules(t *testing.T) {
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			state := &validationState{}
-			got := validateUserValidationRules(compiler, state, tt.in, fldPath, tt.structuredAuthnFeatureEnabled).ToAggregate()
+			got := validateUserValidationRules(authenticationcel.NewDefaultCompiler(), state, tt.in, fldPath, tt.structuredAuthnFeatureEnabled).ToAggregate()
 			if d := cmp.Diff(tt.want, errString(got)); d != "" {
 				t.Fatalf("UserValidationRules validation mismatch (-want +got):\n%s", d)
 			}
@@ -2458,7 +2454,7 @@ func TestValidateAuthorizationConfiguration(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			errList := ValidateAuthorizationConfiguration(nil, &test.configuration, test.knownTypes, test.repeatableTypes)
+			errList := ValidateAuthorizationConfiguration(authorizationcel.NewDefaultCompiler(), nil, &test.configuration, test.knownTypes, test.repeatableTypes)
 			if len(errList) != len(test.expectedErrList) {
 				t.Errorf("expected %d errs, got %d, errors %v", len(test.expectedErrList), len(errList), errList)
 			}
@@ -2568,7 +2564,7 @@ func TestValidateAndCompileMatchConditions(t *testing.T) {
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.StructuredAuthorizationConfiguration, tt.featureEnabled)
-			celMatcher, errList := ValidateAndCompileMatchConditions(tt.matchConditions)
+			celMatcher, errList := ValidateAndCompileMatchConditions(authorizationcel.NewDefaultCompiler(), tt.matchConditions)
 			if len(tt.expectedErr) == 0 && len(tt.matchConditions) > 0 && len(errList) == 0 && celMatcher == nil {
 				t.Errorf("celMatcher should not be nil when there are matchCondition and no error returned")
 			}

--- a/staging/src/k8s.io/apiserver/pkg/authentication/cel/compile.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/cel/compile.go
@@ -39,6 +39,12 @@ type compiler struct {
 	varEnvs map[string]*environment.EnvSet
 }
 
+// NewDefaultCompiler returns a new Compiler following the default compatibility version.
+// Note: the compiler construction depends on feature gates and the compatibility version to be initialized.
+func NewDefaultCompiler() Compiler {
+	return NewCompiler(environment.MustBaseEnvSet(environment.DefaultCompatibilityVersion(), true))
+}
+
 // NewCompiler returns a new Compiler.
 func NewCompiler(env *environment.EnvSet) Compiler {
 	return &compiler{

--- a/staging/src/k8s.io/apiserver/pkg/authentication/cel/compile_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/cel/compile_test.go
@@ -23,7 +23,6 @@ import (
 
 	authenticationv1 "k8s.io/api/authentication/v1"
 	apiservercel "k8s.io/apiserver/pkg/cel"
-	"k8s.io/apiserver/pkg/cel/environment"
 )
 
 func TestCompileClaimsExpression(t *testing.T) {
@@ -57,12 +56,10 @@ func TestCompileClaimsExpression(t *testing.T) {
 		},
 	}
 
-	compiler := NewCompiler(environment.MustBaseEnvSet(environment.DefaultCompatibilityVersion(), true))
-
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			for _, expressionAccessor := range tc.expressionAccessors {
-				_, err := compiler.CompileClaimsExpression(expressionAccessor)
+				_, err := NewDefaultCompiler().CompileClaimsExpression(expressionAccessor)
 				if err != nil {
 					t.Errorf("unexpected error: %v", err)
 				}
@@ -86,12 +83,10 @@ func TestCompileUserExpression(t *testing.T) {
 		},
 	}
 
-	compiler := NewCompiler(environment.MustBaseEnvSet(environment.DefaultCompatibilityVersion(), true))
-
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			for _, expressionAccessor := range tc.expressionAccessors {
-				_, err := compiler.CompileUserExpression(expressionAccessor)
+				_, err := NewDefaultCompiler().CompileUserExpression(expressionAccessor)
 				if err != nil {
 					t.Errorf("unexpected error: %v", err)
 				}
@@ -135,12 +130,10 @@ func TestCompileClaimsExpressionError(t *testing.T) {
 		},
 	}
 
-	compiler := NewCompiler(environment.MustBaseEnvSet(environment.DefaultCompatibilityVersion(), true))
-
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			for _, expressionAccessor := range tc.expressionAccessors {
-				_, err := compiler.CompileClaimsExpression(expressionAccessor)
+				_, err := NewDefaultCompiler().CompileClaimsExpression(expressionAccessor)
 				if err == nil {
 					t.Errorf("expected error but got nil")
 				}
@@ -205,12 +198,10 @@ func TestCompileUserExpressionError(t *testing.T) {
 		},
 	}
 
-	compiler := NewCompiler(environment.MustBaseEnvSet(environment.DefaultCompatibilityVersion(), true))
-
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			for _, expressionAccessor := range tc.expressionAccessors {
-				_, err := compiler.CompileUserExpression(expressionAccessor)
+				_, err := NewDefaultCompiler().CompileUserExpression(expressionAccessor)
 				if err == nil {
 					t.Errorf("expected error but got nil")
 				}

--- a/staging/src/k8s.io/apiserver/pkg/authorization/cel/compile.go
+++ b/staging/src/k8s.io/apiserver/pkg/authorization/cel/compile.go
@@ -65,6 +65,12 @@ type compiler struct {
 	envSet *environment.EnvSet
 }
 
+// NewDefaultCompiler returns a new Compiler following the default compatibility version.
+// Note: the compiler construction depends on feature gates and the compatibility version to be initialized.
+func NewDefaultCompiler() Compiler {
+	return NewCompiler(environment.MustBaseEnvSet(environment.DefaultCompatibilityVersion(), true))
+}
+
 // NewCompiler returns a new Compiler.
 func NewCompiler(env *environment.EnvSet) Compiler {
 	return &compiler{

--- a/staging/src/k8s.io/apiserver/pkg/authorization/cel/compile_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/authorization/cel/compile_test.go
@@ -25,7 +25,6 @@ import (
 	v1 "k8s.io/api/authorization/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apiservercel "k8s.io/apiserver/pkg/cel"
-	"k8s.io/apiserver/pkg/cel/environment"
 	genericfeatures "k8s.io/apiserver/pkg/features"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
@@ -100,7 +99,10 @@ func TestCompileCELExpression(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.AuthorizeWithSelectors, tc.authorizeWithSelectorsEnabled)
-			compiler := NewCompiler(environment.MustBaseEnvSet(environment.DefaultCompatibilityVersion(), true))
+
+			// create new compiler because it depends on the feature gate
+			compiler := NewDefaultCompiler()
+
 			_, err := compiler.CompileCELExpression(&SubjectAccessReviewMatchCondition{
 				Expression: tc.expression,
 			})

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/metrics_test.go
@@ -122,7 +122,7 @@ func TestAuthorizerMetrics(t *testing.T) {
 			defer server.Close()
 
 			fakeAuthzMetrics := &fakeAuthorizerMetrics{}
-			wh, err := newV1Authorizer(server.URL, scenario.clientCert, scenario.clientKey, scenario.clientCA, 0, fakeAuthzMetrics, []apiserver.WebhookMatchCondition{}, "")
+			wh, err := newV1Authorizer(server.URL, scenario.clientCert, scenario.clientKey, scenario.clientCA, 0, fakeAuthzMetrics, cel.NewDefaultCompiler(), []apiserver.WebhookMatchCondition{}, "")
 			if err != nil {
 				t.Error("failed to create client")
 				return

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/webhook.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/webhook.go
@@ -82,8 +82,8 @@ type WebhookAuthorizer struct {
 }
 
 // NewFromInterface creates a WebhookAuthorizer using the given subjectAccessReview client
-func NewFromInterface(subjectAccessReview authorizationv1client.AuthorizationV1Interface, authorizedTTL, unauthorizedTTL time.Duration, retryBackoff wait.Backoff, decisionOnError authorizer.Decision, metrics metrics.AuthorizerMetrics) (*WebhookAuthorizer, error) {
-	return newWithBackoff(&subjectAccessReviewV1Client{subjectAccessReview.RESTClient()}, authorizedTTL, unauthorizedTTL, retryBackoff, decisionOnError, nil, metrics, "")
+func NewFromInterface(subjectAccessReview authorizationv1client.AuthorizationV1Interface, authorizedTTL, unauthorizedTTL time.Duration, retryBackoff wait.Backoff, decisionOnError authorizer.Decision, metrics metrics.AuthorizerMetrics, compiler authorizationcel.Compiler) (*WebhookAuthorizer, error) {
+	return newWithBackoff(&subjectAccessReviewV1Client{subjectAccessReview.RESTClient()}, authorizedTTL, unauthorizedTTL, retryBackoff, decisionOnError, nil, metrics, compiler, "")
 }
 
 // New creates a new WebhookAuthorizer from the provided kubeconfig file.
@@ -105,18 +105,18 @@ func NewFromInterface(subjectAccessReview authorizationv1client.AuthorizationV1I
 //
 // For additional HTTP configuration, refer to the kubeconfig documentation
 // https://kubernetes.io/docs/user-guide/kubeconfig-file/.
-func New(config *rest.Config, version string, authorizedTTL, unauthorizedTTL time.Duration, retryBackoff wait.Backoff, decisionOnError authorizer.Decision, matchConditions []apiserver.WebhookMatchCondition, name string, metrics metrics.AuthorizerMetrics) (*WebhookAuthorizer, error) {
+func New(config *rest.Config, version string, authorizedTTL, unauthorizedTTL time.Duration, retryBackoff wait.Backoff, decisionOnError authorizer.Decision, matchConditions []apiserver.WebhookMatchCondition, name string, metrics metrics.AuthorizerMetrics, compiler authorizationcel.Compiler) (*WebhookAuthorizer, error) {
 	subjectAccessReview, err := subjectAccessReviewInterfaceFromConfig(config, version, retryBackoff)
 	if err != nil {
 		return nil, err
 	}
-	return newWithBackoff(subjectAccessReview, authorizedTTL, unauthorizedTTL, retryBackoff, decisionOnError, matchConditions, metrics, name)
+	return newWithBackoff(subjectAccessReview, authorizedTTL, unauthorizedTTL, retryBackoff, decisionOnError, matchConditions, metrics, compiler, name)
 }
 
 // newWithBackoff allows tests to skip the sleep.
-func newWithBackoff(subjectAccessReview subjectAccessReviewer, authorizedTTL, unauthorizedTTL time.Duration, retryBackoff wait.Backoff, decisionOnError authorizer.Decision, matchConditions []apiserver.WebhookMatchCondition, am metrics.AuthorizerMetrics, name string) (*WebhookAuthorizer, error) {
+func newWithBackoff(subjectAccessReview subjectAccessReviewer, authorizedTTL, unauthorizedTTL time.Duration, retryBackoff wait.Backoff, decisionOnError authorizer.Decision, matchConditions []apiserver.WebhookMatchCondition, am metrics.AuthorizerMetrics, compiler authorizationcel.Compiler, name string) (*WebhookAuthorizer, error) {
 	// compile all expressions once in validation and save the results to be used for eval later
-	cm, fieldErr := apiservervalidation.ValidateAndCompileMatchConditions(matchConditions)
+	cm, fieldErr := apiservervalidation.ValidateAndCompileMatchConditions(compiler, matchConditions)
 	if err := fieldErr.ToAggregate(); err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/webhook_v1beta1_test.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/webhook_v1beta1_test.go
@@ -41,6 +41,7 @@ import (
 	authzconfig "k8s.io/apiserver/pkg/apis/apiserver"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
+	authorizationcel "k8s.io/apiserver/pkg/authorization/cel"
 	webhookutil "k8s.io/apiserver/pkg/util/webhook"
 	v1 "k8s.io/client-go/tools/clientcmd/api/v1"
 )
@@ -197,7 +198,7 @@ current-context: default
 			if err != nil {
 				return fmt.Errorf("error building sar client: %v", err)
 			}
-			_, err = newWithBackoff(sarClient, 0, 0, testRetryBackoff, authorizer.DecisionNoOpinion, []authzconfig.WebhookMatchCondition{}, noopAuthorizerMetrics(), "")
+			_, err = newWithBackoff(sarClient, 0, 0, testRetryBackoff, authorizer.DecisionNoOpinion, []authzconfig.WebhookMatchCondition{}, noopAuthorizerMetrics(), authorizationcel.NewDefaultCompiler(), "")
 			return err
 		}()
 		if err != nil && !tt.wantErr {
@@ -340,7 +341,7 @@ func newV1beta1Authorizer(callbackURL string, clientCert, clientKey, ca []byte, 
 	if err != nil {
 		return nil, fmt.Errorf("error building sar client: %v", err)
 	}
-	return newWithBackoff(sarClient, cacheTime, cacheTime, testRetryBackoff, authorizer.DecisionNoOpinion, []authzconfig.WebhookMatchCondition{}, noopAuthorizerMetrics(), "")
+	return newWithBackoff(sarClient, cacheTime, cacheTime, testRetryBackoff, authorizer.DecisionNoOpinion, []authzconfig.WebhookMatchCondition{}, noopAuthorizerMetrics(), authorizationcel.NewDefaultCompiler(), "")
 }
 
 func TestV1beta1TLSConfig(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

/kind cleanup

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

The CEL compiler construction is quite heavy. It is done now during creation of every delegated authorizer although the compiler is static. We see it showing up in pprof in code that creates a number of authorizers. This PR makes the compiler passed down explicitly in authn/z config validation and added to the delegated authorizer configuration passed to the delegate authorizer constructor. This was higher level code can use a shared copy.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```