### PR TITLE
Improve error messages in feature gate linter

### DIFF
--- a/test/featuregates_linter/cmd/feature_gates.go
+++ b/test/featuregates_linter/cmd/feature_gates.go
@@ -212,11 +212,24 @@ func verifyFeatureDeletionOnly(newFeatureList []featureInfo, oldFeatureList []fe
 		if !found {
 			newFeatures = append(newFeatures, f.Name)
 		} else if !reflect.DeepEqual(*oldSpecs, f) {
-			return fmt.Errorf("feature %s changed with diff: %s", f.Name, cmp.Diff(*oldSpecs, f))
+			return fmt.Errorf(
+				"feature %s has been modified in the unversioned feature list.\n"+
+					"Only feature deletion is allowed for unversioned features.\n"+
+					"All feature updates should be migrated to versioned feature gates.\n"+
+					"Please remove this feature from staging/src/k8s.io/apiserver/pkg/features/kube_features.go\n"+
+					"and ensure it is properly migrated to the versioned feature gate.\n"+
+					"For more information, see: https://github.com/kubernetes/kubernetes/issues/125031\n\n"+
+					"Diff: %s", f.Name, cmp.Diff(*oldSpecs, f))
 		}
 	}
 	if len(newFeatures) > 0 {
-		return fmt.Errorf("new features added to FeatureSpec map! %v\nPlease add new features through VersionedSpecs map ONLY! ", newFeatures)
+		return fmt.Errorf(
+			"new features added to unversioned FeatureSpec map: %v\n"+
+				"Only feature deletion is allowed for unversioned features.\n"+
+				"Please add new features through VersionedSpecs map ONLY.\n"+
+				"Remove these features from staging/src/k8s.io/apiserver/pkg/features/kube_features.go\n"+
+				"and ensure they are properly added to the versioned feature gate.\n"+
+				"For more information, see: https://github.com/kubernetes/kubernetes/issues/125031", newFeatures)
 	}
 	return nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Versioned feature gate lint error need to provide clear directions on what to do:
```
found 41 features in FeatureSpecMap var defaultKubernetesFeatureGates in file: /Users/omera/Desktop/PersonlRepos/kubernetes/pkg/features/kube_features.go
found 2 features in FeatureSpecMap var defaultKubernetesFeatureGates in file: /Users/omera/Desktop/PersonlRepos/kubernetes/staging/src/k8s.io/apiextensions-apiserver/pkg/features/kube_features.go
found 30 features in FeatureSpecMap var defaultKubernetesFeatureGates in file: /Users/omera/Desktop/PersonlRepos/kubernetes/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
found 3 features in FeatureSpecMap of func featureGates in file: /Users/omera/Desktop/PersonlRepos/kubernetes/staging/src/k8s.io/component-base/logs/api/v1/kube_features.go
found 1 features in FeatureSpecMap of func featureGates in file: /Users/omera/Desktop/PersonlRepos/kubernetes/staging/src/k8s.io/component-base/metrics/features/kube_features.go
found 1 features in FeatureSpecMap var cloudPublicFeatureGates in file: /Users/omera/Desktop/PersonlRepos/kubernetes/staging/src/k8s.io/controller-manager/pkg/features/kube_features.go
panic: feature RetryGenerateName has been modified in the unversioned feature list.
        Only feature deletion is allowed for unversioned features.
        All feature updates should be migrated to versioned feature gates.
        Please remove this feature from staging/src/k8s.io/apiserver/pkg/features/kube_features.go
        and ensure it is properly migrated to the versioned feature gate.
        For more information, see: https://github.com/kubernetes/kubernetes/issues/125031

        Diff:   cmd.featureInfo{
                Name:     "RetryGenerateName",
                FullName: "",
                VersionedSpecs: []cmd.featureSpec{
                        {
                                Default:       true,
        -                       LockToDefault: true,
        +                       LockToDefault: false,
        -                       PreRelease:    "GA",
        +                       PreRelease:    "Beta",
                                Version:       "",
                        },
                },
          }


goroutine 1 [running]:
k8s.io/kubernetes/test/featuregates_linter/cmd.updateFeatureListFunc(0x1400018cd00?, {0x104c55209?, 0x4?, 0x104c551b9?})
        /Users/omera/Desktop/PersonlRepos/kubernetes/test/featuregates_linter/cmd/feature_gates.go:108 +0xa0
github.com/spf13/cobra.(*Command).execute(0x1400019e608, {0x104ef0c80, 0x0, 0x0})
        /Users/omera/Desktop/PersonlRepos/kubernetes/vendor/github.com/spf13/cobra/command.go:989 +0x81c
github.com/spf13/cobra.(*Command).ExecuteC(0x104ec6b20)
        /Users/omera/Desktop/PersonlRepos/kubernetes/vendor/github.com/spf13/cobra/command.go:1117 +0x344
github.com/spf13/cobra.(*Command).Execute(...)
        /Users/omera/Desktop/PersonlRepos/kubernetes/vendor/github.com/spf13/cobra/command.go:1041
k8s.io/kubernetes/test/featuregates_linter/cmd.Execute()
        /Users/omera/Desktop/PersonlRepos/kubernetes/test/featuregates_linter/cmd/root.go:32 +0x24
main.main()
        /Users/omera/Desktop/PersonlRepos/kubernetes/test/featuregates_linter/main.go:22 +0x1c
exit status 2
```
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #127476

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
