### PR TITLE
Add GroupLister interface to discovery GroupManager

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/discovery/root.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/discovery/root.go
@@ -17,6 +17,7 @@ limitations under the License.
 package discovery
 
 import (
+	"context"
 	"net/http"
 	"sync"
 
@@ -33,10 +34,19 @@ import (
 // GroupManager is an interface that allows dynamic mutation of the existing webservice to handle
 // API groups being added or removed.
 type GroupManager interface {
+	GroupLister
+
 	AddGroup(apiGroup metav1.APIGroup)
 	RemoveGroup(groupName string)
 	ServeHTTP(resp http.ResponseWriter, req *http.Request)
 	WebService() *restful.WebService
+}
+
+// GroupLister knows how to list APIGroups for discovery.
+type GroupLister interface {
+	// Groups returns APIGroups for discovery, filling in ServerAddressByClientCIDRs
+	// based on data in req.
+	Groups(ctx context.Context, req *http.Request) ([]metav1.APIGroup, error)
 }
 
 // rootAPIsHandler creates a webservice serving api group discovery.
@@ -94,24 +104,40 @@ func (s *rootAPIsHandler) RemoveGroup(groupName string) {
 	}
 }
 
-func (s *rootAPIsHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
+func (s *rootAPIsHandler) Groups(ctx context.Context, req *http.Request) ([]metav1.APIGroup, error) {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
+
+	return s.groupsLocked(ctx, req), nil
+}
+
+// groupsLocked returns the APIGroupList discovery information for this handler.
+// The caller must hold the lock before invoking this method to avoid data races.
+func (s *rootAPIsHandler) groupsLocked(ctx context.Context, req *http.Request) []metav1.APIGroup {
+	clientIP := utilnet.GetClientIP(req)
+	serverCIDR := s.addresses.ServerAddressByClientCIDRs(clientIP)
 
 	orderedGroups := []metav1.APIGroup{}
 	for _, groupName := range s.apiGroupNames {
 		orderedGroups = append(orderedGroups, s.apiGroups[groupName])
 	}
 
-	clientIP := utilnet.GetClientIP(req)
-	serverCIDR := s.addresses.ServerAddressByClientCIDRs(clientIP)
 	groups := make([]metav1.APIGroup, len(orderedGroups))
 	for i := range orderedGroups {
 		groups[i] = orderedGroups[i]
 		groups[i].ServerAddressByClientCIDRs = serverCIDR
 	}
 
-	responsewriters.WriteObjectNegotiated(s.serializer, negotiation.DefaultEndpointRestrictions, schema.GroupVersion{}, resp, req, http.StatusOK, &metav1.APIGroupList{Groups: groups}, false)
+	return groups
+}
+
+func (s *rootAPIsHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+
+	groupList := metav1.APIGroupList{Groups: s.groupsLocked(req.Context(), req)}
+
+	responsewriters.WriteObjectNegotiated(s.serializer, negotiation.DefaultEndpointRestrictions, schema.GroupVersion{}, resp, req, http.StatusOK, &groupList, false)
 }
 
 func (s *rootAPIsHandler) restfulHandle(req *restful.Request, resp *restful.Response) {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/discovery/root_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/discovery/root_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package discovery
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -172,6 +173,13 @@ func TestDiscoveryOrdering(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+
+	// Check if internal groups listers returns the same group.
+	groups, err := handler.Groups(context.TODO(), &http.Request{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assert.Len(t, groups, 6)
 
 	assert.Len(t, groupList.Groups, 6)
 	assert.Equal(t, "x", groupList.Groups[0].Name)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

While creating a custom API server implementation (full on DIY mode using control plane package) we ran into an issue where we need programmatically get all current groups, registered in groupManager. We are adding a simple Lister sub-interface to list groups current registered. 

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Extend discovery GroupManager with Group lister interface
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
