### PR TITLE
fix: enable compares rule from testifylint in module k8s.io/client-go

### DIFF
--- a/staging/src/k8s.io/client-go/discovery/cached/memory/memcache_test.go
+++ b/staging/src/k8s.io/client-go/discovery/cached/memory/memcache_test.go
@@ -445,8 +445,8 @@ func TestOpenAPIMemCache(t *testing.T) {
 					continue
 				}
 
-				assert.True(t, reflect.ValueOf(paths).Pointer() == reflect.ValueOf(pathsAgain).Pointer())
-				assert.True(t, reflect.ValueOf(original).Pointer() == reflect.ValueOf(schemaAgain).Pointer())
+				assert.Equal(t, reflect.ValueOf(paths).Pointer(), reflect.ValueOf(pathsAgain).Pointer())
+				assert.Equal(t, reflect.ValueOf(original).Pointer(), reflect.ValueOf(schemaAgain).Pointer())
 
 				// Invalidate and try again. This time pointers should not be equal
 				client.Invalidate()
@@ -461,8 +461,8 @@ func TestOpenAPIMemCache(t *testing.T) {
 					continue
 				}
 
-				assert.True(t, reflect.ValueOf(paths).Pointer() != reflect.ValueOf(pathsAgain).Pointer())
-				assert.True(t, reflect.ValueOf(original).Pointer() != reflect.ValueOf(schemaAgain).Pointer())
+				assert.NotEqual(t, reflect.ValueOf(paths).Pointer(), reflect.ValueOf(pathsAgain).Pointer())
+				assert.NotEqual(t, reflect.ValueOf(original).Pointer(), reflect.ValueOf(schemaAgain).Pointer())
 				assert.Equal(t, original, schemaAgain)
 			}
 		})

--- a/staging/src/k8s.io/client-go/discovery/discovery_client_test.go
+++ b/staging/src/k8s.io/client-go/discovery/discovery_client_test.go
@@ -2425,9 +2425,9 @@ func TestAggregatedServerGroupsAndResources(t *testing.T) {
 				"%s: Expected GVKs (%s), got (%s)", test.name, expectedGroupNames.List(), actualGroupNames.List())
 			// If the core V1 group is returned from /api, it should be the first group.
 			if expectedGroupNames.Has("") {
-				assert.True(t, len(apiGroups) > 0)
+				assert.NotEmpty(t, apiGroups)
 				actualFirstGroup := apiGroups[0]
-				assert.True(t, len(actualFirstGroup.Versions) > 0)
+				assert.NotEmpty(t, actualFirstGroup.Versions)
 				actualFirstGroupVersion := actualFirstGroup.Versions[0].GroupVersion
 				assert.Equal(t, "v1", actualFirstGroupVersion)
 			}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This fixes [compares](https://github.com/Antonboom/testifylint?tab=readme-ov-file#compares) rule from [testifylint](https://github.com/Antonboom/testifylint) in module k8s.io/client-go