### PR TITLE
fix: enable compares rule from testifylint in module k8s.io/apiserver

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/named_certificates_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/named_certificates_test.go
@@ -236,7 +236,7 @@ NextTest:
 			for name, cert := range certMap {
 				x509Certs, err := x509.ParseCertificates(cert.Certificate[0])
 				assert.NoError(t, err, "%d - invalid certificate for %q", i, name)
-				assert.True(t, len(x509Certs) > 0, "%d - expected at least one x509 cert in tls cert for %q", i, name)
+				assert.NotEmpty(t, x509Certs, "%d - expected at least one x509 cert in tls cert for %q", i, name)
 				got[name] = bySignature[x509CertSignature(x509Certs[0])]
 			}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig testing

#### What this PR does / why we need it:

This fixes [compares](https://github.com/Antonboom/testifylint?tab=readme-ov-file#compares) rule from [testifylint](https://github.com/Antonboom/testifylint) in module k8s.io/apiserver
