### PR TITLE
fix: enable blank-import rule from testifylint

### DIFF
--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -239,7 +239,6 @@ linters-settings: # please keep this alphabetized
   testifylint:
     enable-all: true
     disable:  # TODO: remove each disabled rule and fix it
-      - blank-import
       - compares
       - error-is-as
       - error-nil

--- a/hack/golangci.yaml.in
+++ b/hack/golangci.yaml.in
@@ -212,7 +212,6 @@ linters-settings: # please keep this alphabetized
     enable-all: true
     {{- if .Base}}
     disable:  # TODO: remove each disabled rule and fix it
-      - blank-import
       - compares
       - error-is-as
       - error-nil


### PR DESCRIPTION
#### What type of PR is this?

/area test
/kind cleanup
/priority backlog
/sig testing

#### What this PR does / why we need it:

This enables [blank-import](https://github.com/Antonboom/testifylint?tab=readme-ov-file#blank-import) rule from [testifylint](https://github.com/Antonboom/testifylint) at `hack/golangci.yaml` level
