### PR TITLE
fix: enable contains rule from testifylint in module `k8s.io/kubectl`

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait_test.go
@@ -232,7 +232,7 @@ func createUnstructured(t *testing.T, config string) *unstructured.Unstructured 
 	t.Helper()
 	result := map[string]interface{}{}
 
-	require.False(t, strings.Contains(config, "\t"), "Yaml %s cannot contain tabs", config)
+	require.NotContains(t, config, "\t", "Yaml %s cannot contain tabs", config)
 	require.NoError(t, yaml.Unmarshal([]byte(config), &result), "Could not parse config:\n\n%s\n", config)
 
 	return &unstructured.Unstructured{


### PR DESCRIPTION
#### What type of PR is this?

/area test
/kind cleanup
/priority backlog
/sig testing

#### What this PR does / why we need it:

This fixes [contains](https://github.com/Antonboom/testifylint?tab=readme-ov-file#contains) rule from [testifylint](https://github.com/Antonboom/testifylint) in module `k8s.io/kubectl`

