### PR TITLE
fix: enable contains rule from testifylint in module `k8s.io/kubernetes`

### DIFF
--- a/pkg/kubelet/cm/devicemanager/manager_test.go
+++ b/pkg/kubelet/cm/devicemanager/manager_test.go
@@ -2011,7 +2011,7 @@ func TestFeatureGateResourceHealthStatus(t *testing.T) {
 		{ID: "dev2", Health: pluginapi.Unhealthy},
 	})
 	// update chan no data
-	assert.Empty(t, len(testManager.update), 0)
+	assert.Empty(t, testManager.update, 0)
 
 	// update chan receive pod1
 	var wg sync.WaitGroup

--- a/pkg/kubelet/container/cache_test.go
+++ b/pkg/kubelet/container/cache_test.go
@@ -35,7 +35,7 @@ func TestCacheNotInitialized(t *testing.T) {
 	cache := newTestCache()
 	// If the global timestamp is not set, always return nil.
 	d := cache.getIfNewerThan(types.UID("1234"), time.Time{})
-	assert.True(t, d == nil, "should return nil since cache is not initialized")
+	assert.Equal(t, d, nil, "should return nil since cache is not initialized")
 }
 
 func getTestPodIDAndStatus(numContainers int) (types.UID, *PodStatus) {
@@ -178,9 +178,9 @@ func TestDelete(t *testing.T) {
 
 func verifyNotification(t *testing.T, ch chan *data, expectNotification bool) {
 	if expectNotification {
-		assert.True(t, len(ch) > 0, "Did not receive notification")
+		assert.Positive(t, ch, "Did not receive notification")
 	} else {
-		assert.True(t, len(ch) < 1, "Should not have triggered the notification")
+		assert.Less(t, len(ch), 1, "Should not have triggered the notification")
 	}
 	// Drain the channel.
 	for i := 0; i < len(ch); i++ {

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -527,7 +527,7 @@ func TestHandlePodCleanupsPerQOS(t *testing.T) {
 	// done within a goroutine and can get called multiple times, so the
 	// Destroy() count in not deterministic on the actual number.
 	// https://github.com/kubernetes/kubernetes/blob/29fdbb065b5e0d195299eb2d260b975cbc554673/pkg/kubelet/kubelet_pods.go#L2006
-	assert.True(t, destroyCount >= 1, "Expect 1 or more destroys")
+	assert.GreaterOrEqual(t, destroyCount, 1, "Expect 1 or more destroys")
 }
 
 func TestDispatchWorkOfCompletedPod(t *testing.T) {

--- a/pkg/kubelet/kubelet_volumes_test.go
+++ b/pkg/kubelet/kubelet_volumes_test.go
@@ -390,7 +390,7 @@ func TestVolumeAttachAndMountControllerDisabled(t *testing.T) {
 	for _, name := range expectedPodVolumes {
 		assert.Contains(t, podVolumes, name, "Volumes for pod %+v", pod)
 	}
-	assert.True(t, testKubelet.volumePlugin.GetNewAttacherCallCount() >= 1, "Expected plugin NewAttacher to be called at least once")
+	assert.GreaterOrEqual(t, testKubelet.volumePlugin.GetNewAttacherCallCount(), 1, "Expected plugin NewAttacher to be called at least once")
 	assert.NoError(t, volumetest.VerifyWaitForAttachCallCount(
 		1 /* expectedWaitForAttachCallCount */, testKubelet.volumePlugin))
 	assert.NoError(t, volumetest.VerifyAttachCallCount(
@@ -454,7 +454,7 @@ func TestVolumeUnmountAndDetachControllerDisabled(t *testing.T) {
 		assert.Contains(t, podVolumes, name, "Volumes for pod %+v", pod)
 	}
 
-	assert.True(t, testKubelet.volumePlugin.GetNewAttacherCallCount() >= 1, "Expected plugin NewAttacher to be called at least once")
+	assert.GreaterOrEqual(t, testKubelet.volumePlugin.GetNewAttacherCallCount(), 1, "Expected plugin NewAttacher to be called at least once")
 	assert.NoError(t, volumetest.VerifyWaitForAttachCallCount(
 		1 /* expectedWaitForAttachCallCount */, testKubelet.volumePlugin))
 	assert.NoError(t, volumetest.VerifyAttachCallCount(
@@ -486,7 +486,7 @@ func TestVolumeUnmountAndDetachControllerDisabled(t *testing.T) {
 
 	// Verify volumes detached and no longer reported as in use
 	assert.NoError(t, waitForVolumeDetach(v1.UniqueVolumeName("fake/fake-device"), kubelet.volumeManager))
-	assert.True(t, testKubelet.volumePlugin.GetNewAttacherCallCount() >= 1, "Expected plugin NewAttacher to be called at least once")
+	assert.GreaterOrEqual(t, testKubelet.volumePlugin.GetNewAttacherCallCount(), 1, "Expected plugin NewAttacher to be called at least once")
 	assert.NoError(t, volumetest.VerifyDetachCallCount(
 		1 /* expectedDetachCallCount */, testKubelet.volumePlugin))
 }
@@ -566,7 +566,7 @@ func TestVolumeAttachAndMountControllerEnabled(t *testing.T) {
 	for _, name := range expectedPodVolumes {
 		assert.Contains(t, podVolumes, name, "Volumes for pod %+v", pod)
 	}
-	assert.True(t, testKubelet.volumePlugin.GetNewAttacherCallCount() >= 1, "Expected plugin NewAttacher to be called at least once")
+	assert.GreaterOrEqual(t, testKubelet.volumePlugin.GetNewAttacherCallCount(), 1, "Expected plugin NewAttacher to be called at least once")
 	assert.NoError(t, volumetest.VerifyWaitForAttachCallCount(
 		1 /* expectedWaitForAttachCallCount */, testKubelet.volumePlugin))
 	assert.NoError(t, volumetest.VerifyZeroAttachCalls(testKubelet.volumePlugin))
@@ -654,7 +654,7 @@ func TestVolumeUnmountAndDetachControllerEnabled(t *testing.T) {
 		assert.Contains(t, podVolumes, name, "Volumes for pod %+v", pod)
 	}
 
-	assert.True(t, testKubelet.volumePlugin.GetNewAttacherCallCount() >= 1, "Expected plugin NewAttacher to be called at least once")
+	assert.GreaterOrEqual(t, testKubelet.volumePlugin.GetNewAttacherCallCount(), 1, "Expected plugin NewAttacher to be called at least once")
 	assert.NoError(t, volumetest.VerifyWaitForAttachCallCount(
 		1 /* expectedWaitForAttachCallCount */, testKubelet.volumePlugin))
 	assert.NoError(t, volumetest.VerifyZeroAttachCalls(testKubelet.volumePlugin))
@@ -684,7 +684,7 @@ func TestVolumeUnmountAndDetachControllerEnabled(t *testing.T) {
 
 	// Verify volumes detached and no longer reported as in use
 	assert.NoError(t, waitForVolumeDetach(v1.UniqueVolumeName("fake/fake-device"), kubelet.volumeManager))
-	assert.True(t, testKubelet.volumePlugin.GetNewAttacherCallCount() >= 1, "Expected plugin NewAttacher to be called at least once")
+	assert.GreaterOrEqual(t, testKubelet.volumePlugin.GetNewAttacherCallCount(), 1, "Expected plugin NewAttacher to be called at least once")
 	assert.NoError(t, volumetest.VerifyZeroDetachCallCount(testKubelet.volumePlugin))
 }
 

--- a/pkg/kubelet/prober/results/results_manager_test.go
+++ b/pkg/kubelet/prober/results/results_manager_test.go
@@ -39,7 +39,7 @@ func TestCacheOperations(t *testing.T) {
 
 	m.Set(setID, Success, &corev1.Pod{})
 	result, found := m.Get(setID)
-	assert.True(t, result == Success, "set result")
+	assert.Equal(t, result, Success, "set result")
 	assert.True(t, found, "set result found")
 
 	m.Remove(setID)

--- a/pkg/kubelet/status/status_manager_test.go
+++ b/pkg/kubelet/status/status_manager_test.go
@@ -683,10 +683,10 @@ func TestTerminatePod(t *testing.T) {
 	t.Logf("we expect the container statuses to have changed to terminated")
 	newStatus := expectPodStatus(t, syncer, testPod)
 	for i := range newStatus.ContainerStatuses {
-		assert.False(t, newStatus.ContainerStatuses[i].State.Terminated == nil, "expected containers to be terminated")
+		assert.NotEqual(t, newStatus.ContainerStatuses[i].State.Terminated, nil, "expected containers to be terminated")
 	}
 	for i := range newStatus.InitContainerStatuses {
-		assert.False(t, newStatus.InitContainerStatuses[i].State.Terminated == nil, "expected init containers to be terminated")
+		assert.NotEqual(t, newStatus.InitContainerStatuses[i].State.Terminated, nil, "expected init containers to be terminated")
 	}
 
 	expectUnknownState := v1.ContainerState{Terminated: &v1.ContainerStateTerminated{Reason: kubecontainer.ContainerReasonStatusUnknown, Message: "The container could not be located when the pod was terminated", ExitCode: 137}}
@@ -765,13 +765,13 @@ func TestTerminatePodWaiting(t *testing.T) {
 	t.Logf("we expect the container statuses to have changed to terminated")
 	newStatus := expectPodStatus(t, syncer, testPod)
 	for _, container := range newStatus.ContainerStatuses {
-		assert.False(t, container.State.Terminated == nil, "expected containers to be terminated")
+		assert.NotEqual(t, container.State.Terminated, nil, "expected containers to be terminated")
 	}
 	for _, container := range newStatus.InitContainerStatuses[:2] {
-		assert.False(t, container.State.Terminated == nil, "expected init containers to be terminated")
+		assert.NotEqual(t, container.State.Terminated, nil, "expected init containers to be terminated")
 	}
 	for _, container := range newStatus.InitContainerStatuses[2:] {
-		assert.False(t, container.State.Waiting == nil, "expected init containers to be waiting")
+		assert.NotEqual(t, container.State.Waiting, nil, "expected init containers to be waiting")
 	}
 
 	expectUnknownState := v1.ContainerState{Terminated: &v1.ContainerStateTerminated{Reason: kubecontainer.ContainerReasonStatusUnknown, Message: "The container could not be located when the pod was terminated", ExitCode: 137}}

--- a/pkg/kubelet/userns/userns_manager_test.go
+++ b/pkg/kubelet/userns/userns_manager_test.go
@@ -122,9 +122,9 @@ func TestUserNsManagerAllocate(t *testing.T) {
 		allocated, length, err = m.allocateOne(types.UID(fmt.Sprintf("%d", i)))
 		assert.Equal(t, userNsLength, int(length), "length is not the expected. iter: %v", i)
 		assert.NoError(t, err)
-		assert.True(t, allocated >= minimumMappingUID)
+		assert.GreaterOrEqual(t, allocated, minimumMappingUID)
 		// The last ID of the userns range (allocated+userNsLength) should be within bounds.
-		assert.True(t, allocated <= minimumMappingUID+mappingLen-userNsLength)
+		assert.LessOrEqual(t, allocated, minimumMappingUID+mappingLen-userNsLength)
 		allocs = append(allocs, allocated)
 	}
 	for i, v := range allocs {


### PR DESCRIPTION
#### What type of PR is this?

/area test
/kind cleanup
/priority backlog
/sig testing

#### What this PR does / why we need it:

This fixes [contains](https://github.com/Antonboom/testifylint?tab=readme-ov-file#contains) rule from [testifylint](https://github.com/Antonboom/testifylint) in module `k8s.io/kubernetes`

