### PR TITLE
fix: enable error-is-as rule from testifylint in module `k8s.io/client-go`

### DIFF
--- a/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection_test.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection_test.go
@@ -937,7 +937,7 @@ func TestLeaderElectionConfigValidation(t *testing.T) {
 	lock.LockConfig = resourceLockConfig
 	lec.Lock = lock
 	_, err = NewLeaderElector(lec)
-	assert.Error(t, err, fmt.Errorf("Lock identity is empty"))
+	assert.EqualError(t, err, "Lock identity is empty")
 }
 
 func assertEqualEvents(t *testing.T, expected []string, actual <-chan string) {


### PR DESCRIPTION
#### What type of PR is this?

/area test
/kind cleanup
/priority backlog
/sig testing

#### What this PR does / why we need it:

This fixes [error-is-as](https://github.com/Antonboom/testifylint?tab=readme-ov-file#error-is-as) rule from [testifylint](https://github.com/Antonboom/testifylint) in module `k8s.io/client-go`

