### PR TITLE
fix: enable error-is-as rule from testifylint in module `k8s.io/apiserver`

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/proxy/streamtunnel_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/proxy/streamtunnel_test.go
@@ -19,7 +19,6 @@ package proxy
 import (
 	"bytes"
 	"crypto/rand"
-	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -304,7 +303,7 @@ func TestTunnelingResponseWriter_DelegateResponseWriter(t *testing.T) {
 	trw.hijacked = true
 	_, err = trw.Write(expectedWrite)
 	assert.Error(t, err, "Writing to ResponseWriter after Hijack() is an error")
-	assert.True(t, errors.Is(err, http.ErrHijacked), "Hijacked error returned if writing after hijacked")
+	require.ErrorIs(t, err, http.ErrHijacked, "Hijacked error returned if writing after hijacked")
 	// Validate WriteHeader().
 	trw = &tunnelingResponseWriter{w: &mockResponseWriter{}}
 	expectedStatusCode := 201


### PR DESCRIPTION
#### What type of PR is this?

/area test
/kind cleanup
/priority backlog
/sig testing

#### What this PR does / why we need it:

This fixes [error-is-as](https://github.com/Antonboom/testifylint?tab=readme-ov-file#error-is-as) rule from [testifylint](https://github.com/Antonboom/testifylint) in module `k8s.io/apiserver`

