### PR TITLE
Use generics for conditions to match all types derived from string.

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/conditions.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/conditions.go
@@ -70,13 +70,14 @@ func SetStatusCondition(conditions *[]metav1.Condition, newCondition metav1.Cond
 // RemoveStatusCondition removes the corresponding conditionType from conditions if present. Returns
 // true if it was present and got removed.
 // conditions must be non-nil.
-func RemoveStatusCondition(conditions *[]metav1.Condition, conditionType string) (removed bool) {
+func RemoveStatusCondition[T ~string](conditions *[]metav1.Condition, conditionType T) (removed bool) {
 	if conditions == nil || len(*conditions) == 0 {
 		return false
 	}
+	condTypeStr := string(conditionType)
 	newConditions := make([]metav1.Condition, 0, len(*conditions)-1)
 	for _, condition := range *conditions {
-		if condition.Type != conditionType {
+		if condition.Type != condTypeStr {
 			newConditions = append(newConditions, condition)
 		}
 	}
@@ -88,9 +89,10 @@ func RemoveStatusCondition(conditions *[]metav1.Condition, conditionType string)
 }
 
 // FindStatusCondition finds the conditionType in conditions.
-func FindStatusCondition(conditions []metav1.Condition, conditionType string) *metav1.Condition {
+func FindStatusCondition[T ~string](conditions []metav1.Condition, conditionType T) *metav1.Condition {
+	condTypeStr := string(conditionType)
 	for i := range conditions {
-		if conditions[i].Type == conditionType {
+		if conditions[i].Type == condTypeStr {
 			return &conditions[i]
 		}
 	}
@@ -99,19 +101,20 @@ func FindStatusCondition(conditions []metav1.Condition, conditionType string) *m
 }
 
 // IsStatusConditionTrue returns true when the conditionType is present and set to `metav1.ConditionTrue`
-func IsStatusConditionTrue(conditions []metav1.Condition, conditionType string) bool {
-	return IsStatusConditionPresentAndEqual(conditions, conditionType, metav1.ConditionTrue)
+func IsStatusConditionTrue[T ~string](conditions []metav1.Condition, conditionType T) bool {
+	return IsStatusConditionPresentAndEqual[T](conditions, conditionType, metav1.ConditionTrue)
 }
 
 // IsStatusConditionFalse returns true when the conditionType is present and set to `metav1.ConditionFalse`
-func IsStatusConditionFalse(conditions []metav1.Condition, conditionType string) bool {
-	return IsStatusConditionPresentAndEqual(conditions, conditionType, metav1.ConditionFalse)
+func IsStatusConditionFalse[T ~string](conditions []metav1.Condition, conditionType T) bool {
+	return IsStatusConditionPresentAndEqual[T](conditions, conditionType, metav1.ConditionFalse)
 }
 
 // IsStatusConditionPresentAndEqual returns true when conditionType is present and equal to status.
-func IsStatusConditionPresentAndEqual(conditions []metav1.Condition, conditionType string, status metav1.ConditionStatus) bool {
+func IsStatusConditionPresentAndEqual[T ~string](conditions []metav1.Condition, conditionType T, status metav1.ConditionStatus) bool {
+	condTypeStr := string(conditionType)
 	for _, condition := range conditions {
-		if condition.Type == conditionType {
+		if condition.Type == condTypeStr {
 			return condition.Status == status
 		}
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Currently, methods related to setting/removing/finding conditions operate with condition type string, whereas most condition _types_ are declared as a custom type assignable to string ([PVC](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/api/core/v1/types.go#L612), [Pod](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/api/core/v1/types.go#L3205), [Node](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/api/core/v1/types.go#L6222) etc). This leads to constant casting to string on the call site ([1](https://github.com/k8up-io/k8up/blob/7713061e17d84f541ad18ed0fcb23f8c2e140fb0/api/v1/status.go#L30), [2](https://github.com/smartxworks/virtink/blob/318e476909cb479a61e7a0ae31f00695a1009ea4/pkg/controller/vmm_webhook.go#L112), [3](https://github.com/aws/aws-application-networking-k8s/blob/cde77632fea38e46055b9f19291db38b82be25dd/pkg/k8s/policyhelper/policy.go#L243), [4](https://github.com/grafana/tempo-operator/blob/c39140e6c2b2351ce1baffb88c1cf06a6ad93445/internal/status/monolithic.go#L100), [5](https://github.com/openshift-kni/lifecycle-agent/blob/40315766ef501b72a75a9944cba5b9e853ae6c5c/controllers/ibu_controller.go#L252) etc):

```go
RemoveStatusCondition(&conditions, string(corev1.PodReady))
```

This patch introduces a type constraint `~string` so casting on the call site is unnecessary (see the added tests).

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
If a condition type is defined as a type assignable to string, then casting condition type to string is unnecessary when calling meta.*StatusCondition functions.

```

