### PR TITLE
kcm should use the controller name constants

### DIFF
--- a/cmd/kube-controller-manager/app/apps.go
+++ b/cmd/kube-controller-manager/app/apps.go
@@ -43,6 +43,7 @@ func newDaemonSetControllerDescriptor() *ControllerDescriptor {
 func startDaemonSetController(ctx context.Context, controllerContext ControllerContext, controllerName string) (controller.Interface, bool, error) {
 	dsc, err := daemon.NewDaemonSetsController(
 		ctx,
+		controllerName,
 		controllerContext.InformerFactory.Apps().V1().DaemonSets(),
 		controllerContext.InformerFactory.Apps().V1().ControllerRevisions(),
 		controllerContext.InformerFactory.Core().V1().Pods(),
@@ -67,6 +68,7 @@ func newStatefulSetControllerDescriptor() *ControllerDescriptor {
 func startStatefulSetController(ctx context.Context, controllerContext ControllerContext, controllerName string) (controller.Interface, bool, error) {
 	go statefulset.NewStatefulSetController(
 		ctx,
+		controllerName,
 		controllerContext.InformerFactory.Core().V1().Pods(),
 		controllerContext.InformerFactory.Apps().V1().StatefulSets(),
 		controllerContext.InformerFactory.Core().V1().PersistentVolumeClaims(),
@@ -87,6 +89,7 @@ func newReplicaSetControllerDescriptor() *ControllerDescriptor {
 func startReplicaSetController(ctx context.Context, controllerContext ControllerContext, controllerName string) (controller.Interface, bool, error) {
 	go replicaset.NewReplicaSetController(
 		ctx,
+		controllerName,
 		controllerContext.InformerFactory.Apps().V1().ReplicaSets(),
 		controllerContext.InformerFactory.Core().V1().Pods(),
 		controllerContext.ClientBuilder.ClientOrDie("replicaset-controller"),
@@ -106,6 +109,7 @@ func newDeploymentControllerDescriptor() *ControllerDescriptor {
 func startDeploymentController(ctx context.Context, controllerContext ControllerContext, controllerName string) (controller.Interface, bool, error) {
 	dc, err := deployment.NewDeploymentController(
 		ctx,
+		controllerName,
 		controllerContext.InformerFactory.Apps().V1().Deployments(),
 		controllerContext.InformerFactory.Apps().V1().ReplicaSets(),
 		controllerContext.InformerFactory.Core().V1().Pods(),

--- a/cmd/kube-controller-manager/app/autoscaling.go
+++ b/cmd/kube-controller-manager/app/autoscaling.go
@@ -60,10 +60,10 @@ func startHorizontalPodAutoscalerControllerWithRESTClient(ctx context.Context, c
 		custom_metrics.NewForConfig(clientConfig, controllerContext.RESTMapper, apiVersionsGetter),
 		external_metrics.NewForConfigOrDie(clientConfig),
 	)
-	return startHPAControllerWithMetricsClient(ctx, controllerContext, metricsClient)
+	return startHPAControllerWithMetricsClient(ctx, controllerName, controllerContext, metricsClient)
 }
 
-func startHPAControllerWithMetricsClient(ctx context.Context, controllerContext ControllerContext, metricsClient metrics.MetricsClient) (controller.Interface, bool, error) {
+func startHPAControllerWithMetricsClient(ctx context.Context, controllerName string, controllerContext ControllerContext, metricsClient metrics.MetricsClient) (controller.Interface, bool, error) {
 
 	hpaClient := controllerContext.ClientBuilder.ClientOrDie("horizontal-pod-autoscaler")
 	hpaClientConfig := controllerContext.ClientBuilder.ConfigOrDie("horizontal-pod-autoscaler")
@@ -78,6 +78,7 @@ func startHPAControllerWithMetricsClient(ctx context.Context, controllerContext 
 
 	go podautoscaler.NewHorizontalController(
 		ctx,
+		controllerName,
 		hpaClient.CoreV1(),
 		scaleClient,
 		hpaClient.AutoscalingV2(),

--- a/cmd/kube-controller-manager/app/batch.go
+++ b/cmd/kube-controller-manager/app/batch.go
@@ -40,6 +40,7 @@ func newJobControllerDescriptor() *ControllerDescriptor {
 func startJobController(ctx context.Context, controllerContext ControllerContext, controllerName string) (controller.Interface, bool, error) {
 	jobController, err := job.NewController(
 		ctx,
+		controllerName,
 		controllerContext.InformerFactory.Core().V1().Pods(),
 		controllerContext.InformerFactory.Batch().V1().Jobs(),
 		controllerContext.ClientBuilder.ClientOrDie("job-controller"),
@@ -60,7 +61,10 @@ func newCronJobControllerDescriptor() *ControllerDescriptor {
 }
 
 func startCronJobController(ctx context.Context, controllerContext ControllerContext, controllerName string) (controller.Interface, bool, error) {
-	cj2c, err := cronjob.NewControllerV2(ctx, controllerContext.InformerFactory.Batch().V1().Jobs(),
+	cj2c, err := cronjob.NewControllerV2(
+		ctx,
+		controllerName,
+		controllerContext.InformerFactory.Batch().V1().Jobs(),
 		controllerContext.InformerFactory.Batch().V1().CronJobs(),
 		controllerContext.ClientBuilder.ClientOrDie("cronjob-controller"),
 	)

--- a/cmd/kube-controller-manager/app/bootstrap.go
+++ b/cmd/kube-controller-manager/app/bootstrap.go
@@ -35,6 +35,7 @@ func newBootstrapSignerControllerDescriptor() *ControllerDescriptor {
 }
 func startBootstrapSignerController(ctx context.Context, controllerContext ControllerContext, controllerName string) (controller.Interface, bool, error) {
 	bsc, err := bootstrap.NewSigner(
+		controllerName,
 		controllerContext.ClientBuilder.ClientOrDie("bootstrap-signer"),
 		controllerContext.InformerFactory.Core().V1().Secrets(),
 		controllerContext.InformerFactory.Core().V1().ConfigMaps(),
@@ -57,6 +58,7 @@ func newTokenCleanerControllerDescriptor() *ControllerDescriptor {
 }
 func startTokenCleanerController(ctx context.Context, controllerContext ControllerContext, controllerName string) (controller.Interface, bool, error) {
 	tcc, err := bootstrap.NewTokenCleaner(
+		controllerName,
 		controllerContext.ClientBuilder.ClientOrDie("token-cleaner"),
 		controllerContext.InformerFactory.Core().V1().Secrets(),
 		bootstrap.DefaultTokenCleanerOptions(),

--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -728,7 +728,7 @@ func StartController(ctx context.Context, controllerCtx ControllerContext, contr
 
 	time.Sleep(wait.Jitter(controllerCtx.ComponentConfig.Generic.ControllerStartInterval.Duration, ControllerStartJitter))
 
-	logger.V(1).Info("Starting controller", "controller", controllerName)
+	logger.V(1).Info("Initializing controller", "controller", controllerName)
 
 	initFunc := controllerDescriptor.GetInitFunc()
 	ctrl, started, err := initFunc(klog.NewContext(ctx, klog.LoggerWithName(logger, controllerName)), controllerCtx, controllerName)

--- a/cmd/kube-controller-manager/app/core_test.go
+++ b/cmd/kube-controller-manager/app/core_test.go
@@ -147,7 +147,7 @@ func TestController_DiscoveryError(t *testing.T) {
 			}
 		}
 		_, _, err := startModifiedNamespaceController(
-			context.TODO(), ctx, testClientset, testClientBuilder.ConfigOrDie("namespace-controller"))
+			context.TODO(), "namespace-controller", ctx, testClientset, testClientBuilder.ConfigOrDie("namespace-controller"))
 		if test.expectedErr != (err != nil) {
 			t.Errorf("Namespace Controller test failed for use case: %v", name)
 		}

--- a/cmd/kube-controller-manager/app/discovery.go
+++ b/cmd/kube-controller-manager/app/discovery.go
@@ -39,6 +39,7 @@ func newEndpointSliceControllerDescriptor() *ControllerDescriptor {
 func startEndpointSliceController(ctx context.Context, controllerContext ControllerContext, controllerName string) (controller.Interface, bool, error) {
 	go endpointslicecontroller.NewController(
 		ctx,
+		controllerName,
 		controllerContext.InformerFactory.Core().V1().Pods(),
 		controllerContext.InformerFactory.Core().V1().Services(),
 		controllerContext.InformerFactory.Core().V1().Nodes(),
@@ -61,6 +62,7 @@ func newEndpointSliceMirroringControllerDescriptor() *ControllerDescriptor {
 func startEndpointSliceMirroringController(ctx context.Context, controllerContext ControllerContext, controllerName string) (controller.Interface, bool, error) {
 	go endpointslicemirroringcontroller.NewController(
 		ctx,
+		controllerName,
 		controllerContext.InformerFactory.Core().V1().Endpoints(),
 		controllerContext.InformerFactory.Discovery().V1().EndpointSlices(),
 		controllerContext.InformerFactory.Core().V1().Services(),

--- a/cmd/kube-controller-manager/app/networking.go
+++ b/cmd/kube-controller-manager/app/networking.go
@@ -40,6 +40,7 @@ func newServiceCIDRsControllerDescriptor() *ControllerDescriptor {
 func startServiceCIDRsController(ctx context.Context, controllerContext ControllerContext, controllerName string) (controller.Interface, bool, error) {
 	go servicecidrs.NewController(
 		ctx,
+		controllerName,
 		controllerContext.InformerFactory.Networking().V1beta1().ServiceCIDRs(),
 		controllerContext.InformerFactory.Networking().V1beta1().IPAddresses(),
 		controllerContext.ClientBuilder.ClientOrDie("service-cidrs-controller"),

--- a/cmd/kube-controller-manager/app/policy.go
+++ b/cmd/kube-controller-manager/app/policy.go
@@ -48,6 +48,7 @@ func startDisruptionController(ctx context.Context, controllerContext Controller
 
 	go disruption.NewDisruptionController(
 		ctx,
+		controllerName,
 		controllerContext.InformerFactory.Core().V1().Pods(),
 		controllerContext.InformerFactory.Policy().V1().PodDisruptionBudgets(),
 		controllerContext.InformerFactory.Core().V1().ReplicationControllers(),

--- a/cmd/kube-controller-manager/app/rbac.go
+++ b/cmd/kube-controller-manager/app/rbac.go
@@ -34,6 +34,7 @@ func newClusterRoleAggregrationControllerDescriptor() *ControllerDescriptor {
 
 func startClusterRoleAggregationController(ctx context.Context, controllerContext ControllerContext, controllerName string) (controller.Interface, bool, error) {
 	go clusterroleaggregation.NewClusterRoleAggregation(
+		controllerName,
 		controllerContext.InformerFactory.Rbac().V1().ClusterRoles(),
 		controllerContext.ClientBuilder.ClientOrDie("clusterrole-aggregation-controller").RbacV1(),
 	).Run(ctx, 5)

--- a/cmd/kube-controller-manager/app/validatingadmissionpolicystatus.go
+++ b/cmd/kube-controller-manager/app/validatingadmissionpolicystatus.go
@@ -49,6 +49,7 @@ func startValidatingAdmissionPolicyStatusController(ctx context.Context, control
 		RestMapper:     controllerContext.RESTMapper,
 	}
 	c, err := validatingadmissionpolicystatus.NewController(
+		controllerName,
 		controllerContext.InformerFactory.Admissionregistration().V1().ValidatingAdmissionPolicies(),
 		controllerContext.ClientBuilder.ClientOrDie(names.ValidatingAdmissionPolicyStatusController).AdmissionregistrationV1().ValidatingAdmissionPolicies(),
 		typeChecker,

--- a/cmd/kube-controller-manager/names/controller_names.go
+++ b/cmd/kube-controller-manager/names/controller_names.go
@@ -33,10 +33,10 @@ package names
 // The following places should use the controller name constants, when:
 //  1. defining a new app.ControllerDescriptor so it can be used in app.NewControllerDescriptors or app.KnownControllers:
 //  2. used anywhere inside the controller itself:
-//     2.1. [TODO] logging should use a canonical controller name when referencing a controller (Eg. Starting X, Shutting down X)
+//     2.1. logging should use a canonical controller name when referencing a controller (Eg. Starting X, Shutting down X)
 //     2.2. [TODO] emitted events should have an EventSource.Component set to the controller name (usually when initializing an EventRecorder)
 //     2.3. [TODO] registering ControllerManagerMetrics with ControllerStarted and ControllerStopped
-//     2.4. [TODO] calling WaitForNamedCacheSync
+//     2.4. calling WaitForNamedCacheSync
 //  3. defining controller options for "--help" command or generated documentation
 //     3.1. controller name should be used to create a pflag.FlagSet when registering controller options (the name is rendered in a controller flag group header) in options.KubeControllerManagerOptions
 //     3.2. when defined flag's help mentions a controller name

--- a/pkg/controller/bootstrap/bootstrapsigner_test.go
+++ b/pkg/controller/bootstrap/bootstrapsigner_test.go
@@ -40,7 +40,7 @@ func newSigner() (*Signer, *fake.Clientset, coreinformers.SecretInformer, corein
 	informers := informers.NewSharedInformerFactory(fake.NewSimpleClientset(), controller.NoResyncPeriodFunc())
 	secrets := informers.Core().V1().Secrets()
 	configMaps := informers.Core().V1().ConfigMaps()
-	bsc, err := NewSigner(cl, secrets, configMaps, options)
+	bsc, err := NewSigner("bootstrap-signer-controller", cl, secrets, configMaps, options)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}

--- a/pkg/controller/bootstrap/tokencleaner_test.go
+++ b/pkg/controller/bootstrap/tokencleaner_test.go
@@ -36,7 +36,7 @@ func newTokenCleaner() (*TokenCleaner, *fake.Clientset, coreinformers.SecretInfo
 	cl := fake.NewSimpleClientset()
 	informerFactory := informers.NewSharedInformerFactory(cl, options.SecretResync)
 	secrets := informerFactory.Core().V1().Secrets()
-	tcc, err := NewTokenCleaner(cl, secrets, options)
+	tcc, err := NewTokenCleaner("token-cleaner-controller", cl, secrets, options)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/pkg/controller/clusterroleaggregation/clusterroleaggregation_controller.go
+++ b/pkg/controller/clusterroleaggregation/clusterroleaggregation_controller.go
@@ -43,6 +43,7 @@ import (
 
 // ClusterRoleAggregationController is a controller to combine cluster roles
 type ClusterRoleAggregationController struct {
+	controllerName     string
 	clusterRoleClient  rbacclient.ClusterRolesGetter
 	clusterRoleLister  rbaclisters.ClusterRoleLister
 	clusterRolesSynced cache.InformerSynced
@@ -52,8 +53,9 @@ type ClusterRoleAggregationController struct {
 }
 
 // NewClusterRoleAggregation creates a new controller
-func NewClusterRoleAggregation(clusterRoleInformer rbacinformers.ClusterRoleInformer, clusterRoleClient rbacclient.ClusterRolesGetter) *ClusterRoleAggregationController {
+func NewClusterRoleAggregation(controllerName string, clusterRoleInformer rbacinformers.ClusterRoleInformer, clusterRoleClient rbacclient.ClusterRolesGetter) *ClusterRoleAggregationController {
 	c := &ClusterRoleAggregationController{
+		controllerName:     controllerName,
 		clusterRoleClient:  clusterRoleClient,
 		clusterRoleLister:  clusterRoleInformer.Lister(),
 		clusterRolesSynced: clusterRoleInformer.Informer().HasSynced,
@@ -191,10 +193,10 @@ func (c *ClusterRoleAggregationController) Run(ctx context.Context, workers int)
 	defer c.queue.ShutDown()
 
 	logger := klog.FromContext(ctx)
-	logger.Info("Starting ClusterRoleAggregator controller")
-	defer logger.Info("Shutting down ClusterRoleAggregator controller")
+	logger.Info("Starting controller", "controller", c.controllerName)
+	defer logger.Info("Shutting down controller", "controller", c.controllerName)
 
-	if !cache.WaitForNamedCacheSync("ClusterRoleAggregator", ctx.Done(), c.clusterRolesSynced) {
+	if !cache.WaitForNamedCacheSync(c.controllerName, ctx.Done(), c.clusterRolesSynced) {
 		return
 	}
 

--- a/pkg/controller/cronjob/cronjob_controllerv2_test.go
+++ b/pkg/controller/cronjob/cronjob_controllerv2_test.go
@@ -1645,7 +1645,7 @@ func TestControllerV2UpdateCronJob(t *testing.T) {
 			defer cancel()
 			kubeClient := fake.NewSimpleClientset()
 			sharedInformers := informers.NewSharedInformerFactory(kubeClient, controller.NoResyncPeriodFunc())
-			jm, err := NewControllerV2(ctx, sharedInformers.Batch().V1().Jobs(), sharedInformers.Batch().V1().CronJobs(), kubeClient)
+			jm, err := NewControllerV2(ctx, "cronjob-controller", sharedInformers.Batch().V1().Jobs(), sharedInformers.Batch().V1().CronJobs(), kubeClient)
 			if err != nil {
 				t.Errorf("unexpected error %v", err)
 				return
@@ -1753,7 +1753,7 @@ func TestControllerV2GetJobsToBeReconciled(t *testing.T) {
 			for _, job := range tt.jobs {
 				sharedInformers.Batch().V1().Jobs().Informer().GetIndexer().Add(job)
 			}
-			jm, err := NewControllerV2(ctx, sharedInformers.Batch().V1().Jobs(), sharedInformers.Batch().V1().CronJobs(), kubeClient)
+			jm, err := NewControllerV2(ctx, "cronjob-controller", sharedInformers.Batch().V1().Jobs(), sharedInformers.Batch().V1().CronJobs(), kubeClient)
 			if err != nil {
 				t.Errorf("unexpected error %v", err)
 				return
@@ -1860,7 +1860,7 @@ func TestControllerV2CleanupFinishedJobs(t *testing.T) {
 				_ = informerFactory.Batch().V1().Jobs().Informer().GetIndexer().Add(job)
 			}
 
-			jm, err := NewControllerV2(ctx, informerFactory.Batch().V1().Jobs(), informerFactory.Batch().V1().CronJobs(), client)
+			jm, err := NewControllerV2(ctx, "cronjob-controller", informerFactory.Batch().V1().Jobs(), informerFactory.Batch().V1().CronJobs(), client)
 			if err != nil {
 				t.Errorf("unexpected error %v", err)
 				return
@@ -1912,7 +1912,7 @@ func TestControllerV2JobAlreadyExistsButNotInActiveStatus(t *testing.T) {
 	informerFactory := informers.NewSharedInformerFactory(client, controller.NoResyncPeriodFunc())
 	_ = informerFactory.Batch().V1().CronJobs().Informer().GetIndexer().Add(cjCopy)
 
-	jm, err := NewControllerV2(ctx, informerFactory.Batch().V1().Jobs(), informerFactory.Batch().V1().CronJobs(), client)
+	jm, err := NewControllerV2(ctx, "cronjob-controller", informerFactory.Batch().V1().Jobs(), informerFactory.Batch().V1().CronJobs(), client)
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
@@ -1969,7 +1969,7 @@ func TestControllerV2JobAlreadyExistsButDifferentOwner(t *testing.T) {
 	informerFactory := informers.NewSharedInformerFactory(client, controller.NoResyncPeriodFunc())
 	_ = informerFactory.Batch().V1().CronJobs().Informer().GetIndexer().Add(cjCopy)
 
-	jm, err := NewControllerV2(ctx, informerFactory.Batch().V1().Jobs(), informerFactory.Batch().V1().CronJobs(), client)
+	jm, err := NewControllerV2(ctx, "cronjob-controller", informerFactory.Batch().V1().Jobs(), informerFactory.Batch().V1().CronJobs(), client)
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}

--- a/pkg/controller/daemon/daemon_controller_test.go
+++ b/pkg/controller/daemon/daemon_controller_test.go
@@ -317,6 +317,7 @@ func newTestController(ctx context.Context, initialObjects ...runtime.Object) (*
 
 	dsc, err := NewDaemonSetsController(
 		ctx,
+		"daemonset-controller",
 		informerFactory.Apps().V1().DaemonSets(),
 		informerFactory.Apps().V1().ControllerRevisions(),
 		informerFactory.Core().V1().Pods(),
@@ -490,6 +491,7 @@ func TestExpectationsOnRecreate(t *testing.T) {
 	f := informers.NewSharedInformerFactory(client, controller.NoResyncPeriodFunc())
 	dsc, err := NewDaemonSetsController(
 		ctx,
+		"daemonset-controller",
 		f.Apps().V1().DaemonSets(),
 		f.Apps().V1().ControllerRevisions(),
 		f.Core().V1().Pods(),

--- a/pkg/controller/deployment/deployment_controller_test.go
+++ b/pkg/controller/deployment/deployment_controller_test.go
@@ -186,7 +186,7 @@ func newFixture(t testing.TB) *fixture {
 func (f *fixture) newController(ctx context.Context) (*DeploymentController, informers.SharedInformerFactory, error) {
 	f.client = fake.NewSimpleClientset(f.objects...)
 	informers := informers.NewSharedInformerFactory(f.client, controller.NoResyncPeriodFunc())
-	c, err := NewDeploymentController(ctx, informers.Apps().V1().Deployments(), informers.Apps().V1().ReplicaSets(), informers.Core().V1().Pods(), f.client)
+	c, err := NewDeploymentController(ctx, "deployment-controller", informers.Apps().V1().Deployments(), informers.Apps().V1().ReplicaSets(), informers.Core().V1().Pods(), f.client)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/controller/deployment/recreate_test.go
+++ b/pkg/controller/deployment/recreate_test.go
@@ -67,7 +67,7 @@ func TestScaleDownOldReplicaSets(t *testing.T) {
 		kc := fake.NewSimpleClientset(expected...)
 		informers := informers.NewSharedInformerFactory(kc, controller.NoResyncPeriodFunc())
 		_, ctx := ktesting.NewTestContext(t)
-		c, err := NewDeploymentController(ctx, informers.Apps().V1().Deployments(), informers.Apps().V1().ReplicaSets(), informers.Core().V1().Pods(), kc)
+		c, err := NewDeploymentController(ctx, "deployment-controller", informers.Apps().V1().Deployments(), informers.Apps().V1().ReplicaSets(), informers.Core().V1().Pods(), kc)
 		if err != nil {
 			t.Fatalf("error creating Deployment controller: %v", err)
 		}

--- a/pkg/controller/deployment/sync_test.go
+++ b/pkg/controller/deployment/sync_test.go
@@ -414,7 +414,7 @@ func TestDeploymentController_cleanupDeployment(t *testing.T) {
 
 		fake := &fake.Clientset{}
 		informers := informers.NewSharedInformerFactory(fake, controller.NoResyncPeriodFunc())
-		controller, err := NewDeploymentController(ctx, informers.Apps().V1().Deployments(), informers.Apps().V1().ReplicaSets(), informers.Core().V1().Pods(), fake)
+		controller, err := NewDeploymentController(ctx, "deployment-controller", informers.Apps().V1().Deployments(), informers.Apps().V1().ReplicaSets(), informers.Core().V1().Pods(), fake)
 		if err != nil {
 			t.Fatalf("error creating Deployment controller: %v", err)
 		}
@@ -550,7 +550,7 @@ func TestDeploymentController_cleanupDeploymentOrder(t *testing.T) {
 
 		fake := &fake.Clientset{}
 		informers := informers.NewSharedInformerFactory(fake, controller.NoResyncPeriodFunc())
-		controller, err := NewDeploymentController(ctx, informers.Apps().V1().Deployments(), informers.Apps().V1().ReplicaSets(), informers.Core().V1().Pods(), fake)
+		controller, err := NewDeploymentController(ctx, "deployment-controller", informers.Apps().V1().Deployments(), informers.Apps().V1().ReplicaSets(), informers.Core().V1().Pods(), fake)
 		if err != nil {
 			t.Fatalf("error creating Deployment controller: %v", err)
 		}

--- a/pkg/controller/disruption/disruption_test.go
+++ b/pkg/controller/disruption/disruption_test.go
@@ -167,6 +167,7 @@ func newFakeDisruptionControllerWithTime(ctx context.Context, now time.Time) (*d
 
 	dc := NewDisruptionControllerInternal(
 		ctx,
+		"disruption-controller",
 		informerFactory.Core().V1().Pods(),
 		informerFactory.Policy().V1().PodDisruptionBudgets(),
 		informerFactory.Core().V1().ReplicationControllers(),

--- a/pkg/controller/endpoint/endpoints_controller_test.go
+++ b/pkg/controller/endpoint/endpoints_controller_test.go
@@ -228,7 +228,7 @@ type endpointController struct {
 func newController(ctx context.Context, url string, batchPeriod time.Duration) *endpointController {
 	client := clientset.NewForConfigOrDie(&restclient.Config{Host: url, ContentConfig: restclient.ContentConfig{GroupVersion: &schema.GroupVersion{Group: "", Version: "v1"}, ContentType: runtime.ContentTypeJSON}})
 	informerFactory := informers.NewSharedInformerFactory(client, controllerpkg.NoResyncPeriodFunc())
-	endpoints := NewEndpointController(ctx, informerFactory.Core().V1().Pods(), informerFactory.Core().V1().Services(),
+	endpoints := NewEndpointController(ctx, "endpoint-controller", informerFactory.Core().V1().Pods(), informerFactory.Core().V1().Services(),
 		informerFactory.Core().V1().Endpoints(), client, batchPeriod)
 	endpoints.podsSynced = alwaysReady
 	endpoints.servicesSynced = alwaysReady
@@ -247,6 +247,7 @@ func newFakeController(ctx context.Context, batchPeriod time.Duration) (*fake.Cl
 
 	eController := NewEndpointController(
 		ctx,
+		"endpoint-controller",
 		informerFactory.Core().V1().Pods(),
 		informerFactory.Core().V1().Services(),
 		informerFactory.Core().V1().Endpoints(),

--- a/pkg/controller/endpointslice/endpointslice_controller_test.go
+++ b/pkg/controller/endpointslice/endpointslice_controller_test.go
@@ -99,6 +99,7 @@ func newController(t *testing.T, nodeNames []string, batchPeriod time.Duration) 
 	_, ctx := ktesting.NewTestContext(t)
 	esController := NewController(
 		ctx,
+		"endpointslice-controller",
 		informerFactory.Core().V1().Pods(),
 		informerFactory.Core().V1().Services(),
 		nodeInformer,
@@ -397,7 +398,7 @@ func TestSyncServiceEndpointSlicePendingDeletion(t *testing.T) {
 			OwnerReferences: []metav1.OwnerReference{*ownerRef},
 			Labels: map[string]string{
 				discovery.LabelServiceName: serviceName,
-				discovery.LabelManagedBy:   controllerName,
+				discovery.LabelManagedBy:   controllerQualifiedName,
 			},
 			DeletionTimestamp: &deletedTs,
 		},
@@ -442,7 +443,7 @@ func TestSyncServiceEndpointSliceLabelSelection(t *testing.T) {
 			OwnerReferences: []metav1.OwnerReference{*ownerRef},
 			Labels: map[string]string{
 				discovery.LabelServiceName: serviceName,
-				discovery.LabelManagedBy:   controllerName,
+				discovery.LabelManagedBy:   controllerQualifiedName,
 			},
 		},
 		AddressType: discovery.AddressTypeIPv4,
@@ -453,7 +454,7 @@ func TestSyncServiceEndpointSliceLabelSelection(t *testing.T) {
 			OwnerReferences: []metav1.OwnerReference{*ownerRef},
 			Labels: map[string]string{
 				discovery.LabelServiceName: serviceName,
-				discovery.LabelManagedBy:   controllerName,
+				discovery.LabelManagedBy:   controllerQualifiedName,
 			},
 		},
 		AddressType: discovery.AddressTypeIPv4,
@@ -472,7 +473,7 @@ func TestSyncServiceEndpointSliceLabelSelection(t *testing.T) {
 			Namespace: ns,
 			Labels: map[string]string{
 				discovery.LabelServiceName: "something-else",
-				discovery.LabelManagedBy:   controllerName,
+				discovery.LabelManagedBy:   controllerQualifiedName,
 			},
 		},
 		AddressType: discovery.AddressTypeIPv4,
@@ -529,7 +530,7 @@ func TestOnEndpointSliceUpdate(t *testing.T) {
 			Namespace: ns,
 			Labels: map[string]string{
 				discovery.LabelServiceName: serviceName,
-				discovery.LabelManagedBy:   controllerName,
+				discovery.LabelManagedBy:   controllerQualifiedName,
 			},
 		},
 		AddressType: discovery.AddressTypeIPv4,
@@ -1750,7 +1751,7 @@ func TestSyncServiceStaleInformer(t *testing.T) {
 					Generation: testcase.informerGenerationNumber,
 					Labels: map[string]string{
 						discovery.LabelServiceName: serviceName,
-						discovery.LabelManagedBy:   controllerName,
+						discovery.LabelManagedBy:   controllerQualifiedName,
 					},
 				},
 				AddressType: discovery.AddressTypeIPv4,
@@ -1977,7 +1978,7 @@ func TestUpdateNode(t *testing.T) {
 					Namespace: "ns",
 					Labels: map[string]string{
 						discovery.LabelServiceName: "svc",
-						discovery.LabelManagedBy:   controllerName,
+						discovery.LabelManagedBy:   controllerQualifiedName,
 					},
 				},
 				Endpoints: []discovery.Endpoint{

--- a/pkg/controller/endpointslicemirroring/endpointslicemirroring_controller_test.go
+++ b/pkg/controller/endpointslicemirroring/endpointslicemirroring_controller_test.go
@@ -55,6 +55,7 @@ func newController(ctx context.Context, batchPeriod time.Duration) (*fake.Client
 
 	esController := NewController(
 		ctx,
+		"endpointslice-mirroring-controller",
 		informerFactory.Core().V1().Endpoints(),
 		informerFactory.Discovery().V1().EndpointSlices(),
 		informerFactory.Core().V1().Services(),

--- a/pkg/controller/garbagecollector/garbagecollector_test.go
+++ b/pkg/controller/garbagecollector/garbagecollector_test.go
@@ -103,7 +103,7 @@ func TestGarbageCollectorConstruction(t *testing.T) {
 	alwaysStarted := make(chan struct{})
 	close(alwaysStarted)
 	logger, tCtx := ktesting.NewTestContext(t)
-	gc, err := NewGarbageCollector(tCtx, client, metadataClient, rm, map[schema.GroupResource]struct{}{},
+	gc, err := NewGarbageCollector(tCtx, "garbage-collector-controller", client, metadataClient, rm, map[schema.GroupResource]struct{}{},
 		informerfactory.NewInformerFactory(sharedInformers, metadataInformers), alwaysStarted)
 	if err != nil {
 		t.Fatal(err)
@@ -222,7 +222,7 @@ func setupGC(t *testing.T, config *restclient.Config) garbageCollector {
 	sharedInformers := informers.NewSharedInformerFactory(client, 0)
 	alwaysStarted := make(chan struct{})
 	close(alwaysStarted)
-	gc, err := NewGarbageCollector(ctx, client, metadataClient, &testRESTMapper{testrestmapper.TestOnlyStaticRESTMapper(legacyscheme.Scheme)}, ignoredResources, sharedInformers, alwaysStarted)
+	gc, err := NewGarbageCollector(ctx, "garbage-collector-controller", client, metadataClient, &testRESTMapper{testrestmapper.TestOnlyStaticRESTMapper(legacyscheme.Scheme)}, ignoredResources, sharedInformers, alwaysStarted)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -909,7 +909,7 @@ func TestGarbageCollectorSync(t *testing.T) {
 	defer tCtx.Cancel("test has completed")
 	alwaysStarted := make(chan struct{})
 	close(alwaysStarted)
-	gc, err := NewGarbageCollector(tCtx, client, metadataClient, rm, map[schema.GroupResource]struct{}{}, sharedInformers, alwaysStarted)
+	gc, err := NewGarbageCollector(tCtx, "garbage-collector-controller", client, metadataClient, rm, map[schema.GroupResource]struct{}{}, sharedInformers, alwaysStarted)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/controller/job/job_controller_test.go
+++ b/pkg/controller/job/job_controller_test.go
@@ -131,7 +131,7 @@ func newControllerFromClient(ctx context.Context, t *testing.T, kubeClient clien
 func newControllerFromClientWithClock(ctx context.Context, t *testing.T, kubeClient clientset.Interface, resyncPeriod controller.ResyncPeriodFunc, clock clock.WithTicker) (*Controller, informers.SharedInformerFactory) {
 	t.Helper()
 	sharedInformers := informers.NewSharedInformerFactory(kubeClient, resyncPeriod())
-	jm, err := newControllerWithClock(ctx, sharedInformers.Core().V1().Pods(), sharedInformers.Batch().V1().Jobs(), kubeClient, clock)
+	jm, err := newControllerWithClock(ctx, "job-controller", sharedInformers.Core().V1().Pods(), sharedInformers.Batch().V1().Jobs(), kubeClient, clock)
 	if err != nil {
 		t.Fatalf("Error creating Job controller: %v", err)
 	}
@@ -6655,7 +6655,7 @@ func TestWatchOrphanPods(t *testing.T) {
 	t.Cleanup(cancel)
 	clientset := fake.NewClientset()
 	sharedInformers := informers.NewSharedInformerFactory(clientset, controller.NoResyncPeriodFunc())
-	manager, err := NewController(ctx, sharedInformers.Core().V1().Pods(), sharedInformers.Batch().V1().Jobs(), clientset)
+	manager, err := NewController(ctx, "job-controller", sharedInformers.Core().V1().Pods(), sharedInformers.Batch().V1().Jobs(), clientset)
 	if err != nil {
 		t.Fatalf("Error creating Job controller: %v", err)
 	}
@@ -6726,7 +6726,7 @@ func TestSyncOrphanPod(t *testing.T) {
 	_, ctx := ktesting.NewTestContext(t)
 	clientset := fake.NewClientset()
 	sharedInformers := informers.NewSharedInformerFactory(clientset, controller.NoResyncPeriodFunc())
-	manager, err := NewController(ctx, sharedInformers.Core().V1().Pods(), sharedInformers.Batch().V1().Jobs(), clientset)
+	manager, err := NewController(ctx, "job-controller", sharedInformers.Core().V1().Pods(), sharedInformers.Batch().V1().Jobs(), clientset)
 	if err != nil {
 		t.Fatalf("Error creating Job controller: %v", err)
 	}
@@ -7639,7 +7639,7 @@ func TestFinalizersRemovedExpectations(t *testing.T) {
 	_, ctx := ktesting.NewTestContext(t)
 	clientset := fake.NewClientset()
 	sharedInformers := informers.NewSharedInformerFactory(clientset, controller.NoResyncPeriodFunc())
-	manager, err := NewController(ctx, sharedInformers.Core().V1().Pods(), sharedInformers.Batch().V1().Jobs(), clientset)
+	manager, err := NewController(ctx, "job-controller", sharedInformers.Core().V1().Pods(), sharedInformers.Batch().V1().Jobs(), clientset)
 	if err != nil {
 		t.Fatalf("Error creating Job controller: %v", err)
 	}
@@ -7743,7 +7743,7 @@ func TestFinalizerCleanup(t *testing.T) {
 
 	clientset := fake.NewClientset()
 	sharedInformers := informers.NewSharedInformerFactory(clientset, controller.NoResyncPeriodFunc())
-	manager, err := NewController(ctx, sharedInformers.Core().V1().Pods(), sharedInformers.Batch().V1().Jobs(), clientset)
+	manager, err := NewController(ctx, "job-controller", sharedInformers.Core().V1().Pods(), sharedInformers.Batch().V1().Jobs(), clientset)
 	if err != nil {
 		t.Fatalf("Error creating Job controller: %v", err)
 	}

--- a/pkg/controller/nodelifecycle/node_lifecycle_controller_test.go
+++ b/pkg/controller/nodelifecycle/node_lifecycle_controller_test.go
@@ -141,6 +141,7 @@ func newNodeLifecycleControllerFromClient(
 
 	nc, err := NewNodeLifecycleController(
 		ctx,
+		"node-lifecycle-controller",
 		leaseInformer,
 		factory.Core().V1().Pods(),
 		nodeInformer,

--- a/pkg/controller/podautoscaler/horizontal_test.go
+++ b/pkg/controller/podautoscaler/horizontal_test.go
@@ -770,6 +770,7 @@ func (tc *testCase) setupController(t *testing.T) (*HorizontalController, inform
 	tCtx := ktesting.Init(t)
 	hpaController := NewHorizontalController(
 		tCtx,
+		"horizontal-pod-autoscaler-controller",
 		eventClient.CoreV1(),
 		testScaleClient,
 		testClient.AutoscalingV2(),
@@ -5262,6 +5263,7 @@ func TestMultipleHPAs(t *testing.T) {
 	tCtx := ktesting.Init(t)
 	hpaController := NewHorizontalController(
 		tCtx,
+		"horizontal-pod-autoscaler-controller",
 		testClient.CoreV1(),
 		testScaleClient,
 		testClient.AutoscalingV2(),

--- a/pkg/controller/podgc/gc_controller_test.go
+++ b/pkg/controller/podgc/gc_controller_test.go
@@ -53,7 +53,7 @@ func NewFromClient(ctx context.Context, kubeClient clientset.Interface, terminat
 	informerFactory := informers.NewSharedInformerFactory(kubeClient, controller.NoResyncPeriodFunc())
 	podInformer := informerFactory.Core().V1().Pods()
 	nodeInformer := informerFactory.Core().V1().Nodes()
-	controller := NewPodGC(ctx, kubeClient, podInformer, nodeInformer, terminatedPodThreshold)
+	controller := NewPodGC(ctx, "pod-garbage-collector-controller", kubeClient, podInformer, nodeInformer, terminatedPodThreshold)
 	controller.podListerSynced = alwaysReady
 	return controller, podInformer, nodeInformer
 }

--- a/pkg/controller/replicaset/replica_set_test.go
+++ b/pkg/controller/replicaset/replica_set_test.go
@@ -67,6 +67,7 @@ func testNewReplicaSetControllerFromClient(tb testing.TB, client clientset.Inter
 	tCtx := ktesting.Init(tb)
 	ret := NewReplicaSetController(
 		tCtx,
+		"replicaset-controller",
 		informers.Apps().V1().ReplicaSets(),
 		informers.Core().V1().Pods(),
 		client,
@@ -631,6 +632,7 @@ func TestWatchControllers(t *testing.T) {
 	tCtx := ktesting.Init(t)
 	manager := NewReplicaSetController(
 		tCtx,
+		"replicaset-controller",
 		informers.Apps().V1().ReplicaSets(),
 		informers.Core().V1().Pods(),
 		client,
@@ -1198,6 +1200,7 @@ func TestExpectationsOnRecreate(t *testing.T) {
 	logger := tCtx.Logger()
 	manager := NewReplicaSetController(
 		tCtx,
+		"replicaset-controller",
 		f.Apps().V1().ReplicaSets(),
 		f.Core().V1().Pods(),
 		client,

--- a/pkg/controller/replication/replication_controller.go
+++ b/pkg/controller/replication/replication_controller.go
@@ -50,11 +50,11 @@ type ReplicationManager struct {
 }
 
 // NewReplicationManager configures a replication manager with the specified event recorder
-func NewReplicationManager(ctx context.Context, podInformer coreinformers.PodInformer, rcInformer coreinformers.ReplicationControllerInformer, kubeClient clientset.Interface, burstReplicas int) *ReplicationManager {
+func NewReplicationManager(ctx context.Context, controllerName string, podInformer coreinformers.PodInformer, rcInformer coreinformers.ReplicationControllerInformer, kubeClient clientset.Interface, burstReplicas int) *ReplicationManager {
 	logger := klog.FromContext(ctx)
 	eventBroadcaster := record.NewBroadcaster(record.WithContext(ctx))
 	return &ReplicationManager{
-		*replicaset.NewBaseController(logger, informerAdapter{rcInformer}, podInformer, clientsetAdapter{kubeClient}, burstReplicas,
+		*replicaset.NewBaseController(logger, controllerName, informerAdapter{rcInformer}, podInformer, clientsetAdapter{kubeClient}, burstReplicas,
 			v1.SchemeGroupVersion.WithKind("ReplicationController"),
 			"replication_controller",
 			"replicationmanager",

--- a/pkg/controller/resourceclaim/controller_test.go
+++ b/pkg/controller/resourceclaim/controller_test.go
@@ -390,7 +390,7 @@ func TestSyncHandler(t *testing.T) {
 			claimInformer := informerFactory.Resource().V1alpha3().ResourceClaims()
 			templateInformer := informerFactory.Resource().V1alpha3().ResourceClaimTemplates()
 
-			ec, err := NewController(tCtx.Logger(), tc.adminAccessEnabled, fakeKubeClient, podInformer, claimInformer, templateInformer)
+			ec, err := NewController(tCtx.Logger(), "resourceclaim-controller", tc.adminAccessEnabled, fakeKubeClient, podInformer, claimInformer, templateInformer)
 			if err != nil {
 				t.Fatalf("error creating ephemeral controller : %v", err)
 			}
@@ -465,7 +465,7 @@ func TestResourceClaimEventHandler(t *testing.T) {
 	templateInformer := informerFactory.Resource().V1alpha3().ResourceClaimTemplates()
 	claimClient := fakeKubeClient.ResourceV1alpha3().ResourceClaims(testNamespace)
 
-	_, err := NewController(tCtx.Logger(), false /* admin access */, fakeKubeClient, podInformer, claimInformer, templateInformer)
+	_, err := NewController(tCtx.Logger(), "resourceclaim-controller", false /* admin access */, fakeKubeClient, podInformer, claimInformer, templateInformer)
 	tCtx.ExpectNoError(err, "creating ephemeral controller")
 
 	informerFactory.Start(tCtx.Done())

--- a/pkg/controller/resourcequota/resource_quota_controller_test.go
+++ b/pkg/controller/resourcequota/resource_quota_controller_test.go
@@ -115,6 +115,7 @@ func setupQuotaController(t *testing.T, kubeClient kubernetes.Interface, lister 
 	alwaysStarted := make(chan struct{})
 	close(alwaysStarted)
 	resourceQuotaControllerOptions := &ControllerOptions{
+		ControllerName:            "resourcequota-controller",
 		QuotaClient:               kubeClient.CoreV1(),
 		ResourceQuotaInformer:     informerFactory.Core().V1().ResourceQuotas(),
 		ResyncPeriod:              controller.NoResyncPeriodFunc,

--- a/pkg/controller/serviceaccount/legacy_serviceaccount_token_cleaner_test.go
+++ b/pkg/controller/serviceaccount/legacy_serviceaccount_token_cleaner_test.go
@@ -386,7 +386,7 @@ func TestLegacyServiceAccountTokenCleanUp(t *testing.T) {
 				SyncInterval:  30 * time.Second,
 				CleanUpPeriod: tc.LegacyTokenCleanUpPeriod,
 			}
-			cleaner, _ := NewLegacySATokenCleaner(saInformer, secretInformer, podInformer, client, testingclock.NewFakeClock(time.Now().UTC()), options)
+			cleaner, _ := NewLegacySATokenCleaner("legacy-serviceaccount-token-cleaner-controller", saInformer, secretInformer, podInformer, client, testingclock.NewFakeClock(time.Now().UTC()), options)
 
 			if tc.ExistingServiceAccount != nil {
 				serviceAccounts.Add(tc.ExistingServiceAccount)

--- a/pkg/controller/serviceaccount/serviceaccounts_controller_test.go
+++ b/pkg/controller/serviceaccount/serviceaccounts_controller_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/informers"
@@ -162,6 +162,7 @@ func TestServiceAccountCreation(t *testing.T) {
 		saInformer := informers.Core().V1().ServiceAccounts()
 		nsInformer := informers.Core().V1().Namespaces()
 		controller, err := NewServiceAccountsController(
+			"serviceaccount-controller",
 			saInformer,
 			nsInformer,
 			client,

--- a/pkg/controller/servicecidrs/servicecidrs_controller_test.go
+++ b/pkg/controller/servicecidrs/servicecidrs_controller_test.go
@@ -67,6 +67,7 @@ func newController(ctx context.Context, t *testing.T, cidrs []*networkingapiv1be
 	}
 	controller := NewController(
 		ctx,
+		"service-cidr-controller",
 		serviceCIDRInformer,
 		ipAddressInformer,
 		client)

--- a/pkg/controller/statefulset/stateful_set_test.go
+++ b/pkg/controller/statefulset/stateful_set_test.go
@@ -922,6 +922,7 @@ func newFakeStatefulSetController(ctx context.Context, initialObjects ...runtime
 	ssu := newFakeStatefulSetStatusUpdater(informerFactory.Apps().V1().StatefulSets())
 	ssc := NewStatefulSetController(
 		ctx,
+		"statufset-controller",
 		informerFactory.Core().V1().Pods(),
 		informerFactory.Apps().V1().StatefulSets(),
 		informerFactory.Core().V1().PersistentVolumeClaims(),

--- a/pkg/controller/storageversiongc/gc_controller_test.go
+++ b/pkg/controller/storageversiongc/gc_controller_test.go
@@ -38,7 +38,7 @@ func setupController(ctx context.Context, clientset kubernetes.Interface) {
 	leaseInformer := informerFactory.Coordination().V1().Leases()
 	storageVersionInformer := informerFactory.Internal().V1alpha1().StorageVersions()
 
-	controller := NewStorageVersionGC(ctx, clientset, leaseInformer, storageVersionInformer)
+	controller := NewStorageVersionGC(ctx, "storage-version-migrator-controller", clientset, leaseInformer, storageVersionInformer)
 	go controller.Run(context.Background())
 	informerFactory.Start(nil)
 }

--- a/pkg/controller/storageversionmigrator/resourceversion.go
+++ b/pkg/controller/storageversionmigrator/resourceversion.go
@@ -122,7 +122,7 @@ func (rv *ResourceVersionController) Run(ctx context.Context) {
 	defer rv.queue.ShutDown()
 
 	logger := klog.FromContext(ctx)
-	logger.Info("Starting", "controller", ResourceVersionControllerName)
+	logger.Info("Starting controller", "controller", ResourceVersionControllerName)
 	defer logger.Info("Shutting down", "controller", ResourceVersionControllerName)
 
 	if !cache.WaitForNamedCacheSync(ResourceVersionControllerName, ctx.Done(), rv.svmSynced) {

--- a/pkg/controller/storageversionmigrator/storageversionmigrator.go
+++ b/pkg/controller/storageversionmigrator/storageversionmigrator.go
@@ -129,7 +129,7 @@ func (svmc *SVMController) Run(ctx context.Context) {
 	defer svmc.queue.ShutDown()
 
 	logger := klog.FromContext(ctx)
-	logger.Info("Starting", "controller", svmc.controllerName)
+	logger.Info("Starting controller", "controller", svmc.controllerName)
 	defer logger.Info("Shutting down", "controller", svmc.controllerName)
 
 	if !cache.WaitForNamedCacheSync(svmc.controllerName, ctx.Done(), svmc.svmSynced) {

--- a/pkg/controller/tainteviction/taint_eviction_test.go
+++ b/pkg/controller/tainteviction/taint_eviction_test.go
@@ -97,7 +97,7 @@ func setupNewController(ctx context.Context, fakeClientSet *fake.Clientset) (*Co
 	informerFactory := informers.NewSharedInformerFactory(fakeClientSet, 0)
 	podIndexer := informerFactory.Core().V1().Pods().Informer().GetIndexer()
 	nodeIndexer := informerFactory.Core().V1().Nodes().Informer().GetIndexer()
-	mgr, _ := New(ctx, fakeClientSet, informerFactory.Core().V1().Pods(), informerFactory.Core().V1().Nodes(), "taint-eviction-controller")
+	mgr, _ := New(ctx, "taint-eviction-controller", fakeClientSet, informerFactory.Core().V1().Pods(), informerFactory.Core().V1().Nodes())
 	mgr.podListerSynced = alwaysReady
 	mgr.nodeListerSynced = alwaysReady
 	mgr.getPodsAssignedToNode = getPodsAssignedToNode(ctx, fakeClientSet)

--- a/pkg/controller/validatingadmissionpolicystatus/controller_test.go
+++ b/pkg/controller/validatingadmissionpolicystatus/controller_test.go
@@ -106,6 +106,7 @@ func TestTypeChecking(t *testing.T) {
 				RestMapper:     testrestmapper.TestOnlyStaticRESTMapper(scheme.Scheme),
 			}
 			controller, err := NewController(
+				"validatingadmissionpolicy-status-controller",
 				informerFactory.Admissionregistration().V1().ValidatingAdmissionPolicies(),
 				client.AdmissionregistrationV1().ValidatingAdmissionPolicies(),
 				typeChecker,

--- a/pkg/controller/volume/attachdetach/attach_detach_controller_test.go
+++ b/pkg/controller/volume/attachdetach/attach_detach_controller_test.go
@@ -50,6 +50,7 @@ func createADC(t testing.TB, tCtx ktesting.TContext, fakeKubeClient *fake.Client
 
 	adcObj, err := NewAttachDetachController(
 		tCtx,
+		"persistentvolume-attach-detach-controller",
 		fakeKubeClient,
 		informerFactory.Core().V1().Pods(),
 		informerFactory.Core().V1().Nodes(),
@@ -291,6 +292,7 @@ func attachDetachRecoveryTestCase(t *testing.T, extraPods1 []*v1.Pod, extraPods2
 	logger, tCtx := ktesting.NewTestContext(t)
 	adcObj, err := NewAttachDetachController(
 		tCtx,
+		"persistentvolume-attach-detach-controller",
 		fakeKubeClient,
 		informerFactory.Core().V1().Pods(),
 		informerFactory.Core().V1().Nodes(),

--- a/pkg/controller/volume/ephemeral/controller_test.go
+++ b/pkg/controller/volume/ephemeral/controller_test.go
@@ -145,7 +145,7 @@ func TestSyncHandler(t *testing.T) {
 			podInformer := informerFactory.Core().V1().Pods()
 			pvcInformer := informerFactory.Core().V1().PersistentVolumeClaims()
 
-			c, err := NewController(ctx, fakeKubeClient, podInformer, pvcInformer)
+			c, err := NewController(ctx, "persistentvolume-expander-controller", fakeKubeClient, podInformer, pvcInformer)
 			if err != nil {
 				t.Fatalf("error creating ephemeral controller : %v", err)
 			}

--- a/pkg/controller/volume/expand/expand_controller_test.go
+++ b/pkg/controller/volume/expand/expand_controller_test.go
@@ -108,7 +108,7 @@ func TestSyncHandler(t *testing.T) {
 		}
 		allPlugins := []volume.VolumePlugin{}
 		translator := csitrans.New()
-		expc, err := NewExpandController(tCtx, fakeKubeClient, pvcInformer, allPlugins, translator, csimigration.NewPluginManager(translator, utilfeature.DefaultFeatureGate))
+		expc, err := NewExpandController(tCtx, "persistentvolume-expander-controller", fakeKubeClient, pvcInformer, allPlugins, translator, csimigration.NewPluginManager(translator, utilfeature.DefaultFeatureGate))
 		if err != nil {
 			t.Fatalf("error creating expand controller : %v", err)
 		}

--- a/pkg/controller/volume/persistentvolume/framework_test.go
+++ b/pkg/controller/volume/persistentvolume/framework_test.go
@@ -224,6 +224,7 @@ func newTestController(ctx context.Context, kubeClient clientset.Interface, info
 		informerFactory = informers.NewSharedInformerFactory(kubeClient, controller.NoResyncPeriodFunc())
 	}
 	params := ControllerParameters{
+		ControllerName:            "persistentvolume-binder-controller",
 		KubeClient:                kubeClient,
 		SyncPeriod:                5 * time.Second,
 		VolumePlugins:             []volume.VolumePlugin{},

--- a/pkg/controller/volume/persistentvolume/pv_controller.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller.go
@@ -141,6 +141,7 @@ type CSIMigratedPluginManager interface {
 // cache.Controllers that watch PersistentVolume and PersistentVolumeClaim
 // changes.
 type PersistentVolumeController struct {
+	controllerName     string
 	volumeLister       corelisters.PersistentVolumeLister
 	volumeListerSynced cache.InformerSynced
 	claimLister        corelisters.PersistentVolumeClaimLister

--- a/pkg/controller/volume/pvcprotection/pvc_protection_controller_test.go
+++ b/pkg/controller/volume/pvcprotection/pvc_protection_controller_test.go
@@ -513,7 +513,7 @@ func TestPVCProtectionController(t *testing.T) {
 
 		// Create the controller
 		logger, _ := ktesting.NewTestContext(t)
-		ctrl, err := NewPVCProtectionController(logger, pvcInformer, podInformer, client)
+		ctrl, err := NewPVCProtectionController(logger, "persistentvolumeclaim-protection-controller", pvcInformer, podInformer, client)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/pkg/controller/volume/pvprotection/pv_protection_controller_test.go
+++ b/pkg/controller/volume/pvprotection/pv_protection_controller_test.go
@@ -210,7 +210,7 @@ func TestPVProtectionController(t *testing.T) {
 
 		// Create the controller
 		logger, _ := ktesting.NewTestContext(t)
-		ctrl := NewPVProtectionController(logger, pvInformer, client)
+		ctrl := NewPVProtectionController(logger, "persistentvolume-protection-controller", pvInformer, client)
 
 		// Start the test by simulating an event
 		if test.updatedPV != nil {

--- a/test/e2e_node/services/namespace_controller.go
+++ b/test/e2e_node/services/namespace_controller.go
@@ -76,12 +76,12 @@ func (n *NamespaceController) Start(ctx context.Context) error {
 
 	nc := namespacecontroller.NewNamespaceController(
 		ctx,
+		"namespace-controller",
 		client,
 		metadataClient,
 		discoverResourcesFn,
 		informerFactory.Core().V1().Namespaces(),
-		ncResyncPeriod, v1.FinalizerKubernetes,
-	)
+		ncResyncPeriod, v1.FinalizerKubernetes)
 	informerFactory.Start(n.stopCh)
 	go nc.Run(ctx, ncConcurrency)
 	return nil

--- a/test/integration/apiserver/peerproxy/peer_proxy_test.go
+++ b/test/integration/apiserver/peerproxy/peer_proxy_test.go
@@ -219,7 +219,7 @@ func setupStorageVersionGC(ctx context.Context, kubeClientSet *kubernetes.Client
 	go leaseInformer.Informer().Run(ctx.Done())
 	go storageVersionInformer.Informer().Run(ctx.Done())
 
-	controller := storageversiongc.NewStorageVersionGC(ctx, kubeClientSet, leaseInformer, storageVersionInformer)
+	controller := storageversiongc.NewStorageVersionGC(ctx, "storage-version-migrator-controller", kubeClientSet, leaseInformer, storageVersionInformer)
 	go controller.Run(ctx)
 }
 

--- a/test/integration/cronjob/cronjob_test.go
+++ b/test/integration/cronjob/cronjob_test.go
@@ -48,11 +48,11 @@ func setup(ctx context.Context, t *testing.T) (kubeapiservertesting.TearDownFunc
 	}
 	resyncPeriod := 12 * time.Hour
 	informerSet := informers.NewSharedInformerFactory(clientset.NewForConfigOrDie(restclient.AddUserAgent(config, "cronjob-informers")), resyncPeriod)
-	cjc, err := cronjob.NewControllerV2(ctx, informerSet.Batch().V1().Jobs(), informerSet.Batch().V1().CronJobs(), clientSet)
+	cjc, err := cronjob.NewControllerV2(ctx, "cronjob-controller", informerSet.Batch().V1().Jobs(), informerSet.Batch().V1().CronJobs(), clientSet)
 	if err != nil {
 		t.Fatalf("Error creating CronJob controller: %v", err)
 	}
-	jc, err := job.NewController(ctx, informerSet.Core().V1().Pods(), informerSet.Batch().V1().Jobs(), clientSet)
+	jc, err := job.NewController(ctx, "job-controller", informerSet.Core().V1().Pods(), informerSet.Batch().V1().Jobs(), clientSet)
 	if err != nil {
 		t.Fatalf("Error creating Job controller: %v", err)
 	}

--- a/test/integration/daemonset/daemonset_test.go
+++ b/test/integration/daemonset/daemonset_test.go
@@ -83,6 +83,7 @@ func setupWithServerSetup(t *testing.T, serverSetup framework.TestServerSetup) (
 	informers := informers.NewSharedInformerFactory(clientset.NewForConfigOrDie(restclient.AddUserAgent(config, "daemonset-informers")), resyncPeriod)
 	dc, err := daemon.NewDaemonSetsController(
 		tCtx,
+		"daemonset-controller",
 		informers.Apps().V1().DaemonSets(),
 		informers.Apps().V1().ControllerRevisions(),
 		informers.Core().V1().Pods(),

--- a/test/integration/deployment/util.go
+++ b/test/integration/deployment/util.go
@@ -115,6 +115,7 @@ func dcSetup(ctx context.Context, t *testing.T) (kubeapiservertesting.TearDownFu
 
 	dc, err := deployment.NewDeploymentController(
 		ctx,
+		"deployment-controller",
 		informers.Apps().V1().Deployments(),
 		informers.Apps().V1().ReplicaSets(),
 		informers.Core().V1().Pods(),
@@ -125,6 +126,7 @@ func dcSetup(ctx context.Context, t *testing.T) (kubeapiservertesting.TearDownFu
 	}
 	rm := replicaset.NewReplicaSetController(
 		ctx,
+		"replicaset-controller",
 		informers.Apps().V1().ReplicaSets(),
 		informers.Core().V1().Pods(),
 		clientset.NewForConfigOrDie(restclient.AddUserAgent(config, "replicaset-controller")),

--- a/test/integration/disruption/disruption_test.go
+++ b/test/integration/disruption/disruption_test.go
@@ -97,6 +97,7 @@ func setup(ctx context.Context, t *testing.T) (*kubeapiservertesting.TestServer,
 
 	pdbc := disruption.NewDisruptionControllerInternal(
 		ctx,
+		"disruption-controller",
 		informers.Core().V1().Pods(),
 		informers.Policy().V1().PodDisruptionBudgets(),
 		informers.Core().V1().ReplicationControllers(),

--- a/test/integration/dualstack/dualstack_endpoints_test.go
+++ b/test/integration/dualstack/dualstack_endpoints_test.go
@@ -91,6 +91,7 @@ func TestDualStackEndpoints(t *testing.T) {
 
 	epController := endpoint.NewEndpointController(
 		tCtx,
+		"endpoint-controller",
 		informers.Core().V1().Pods(),
 		informers.Core().V1().Services(),
 		informers.Core().V1().Endpoints(),
@@ -99,6 +100,7 @@ func TestDualStackEndpoints(t *testing.T) {
 
 	epsController := endpointslice.NewController(
 		tCtx,
+		"endpointslice-controller",
 		informers.Core().V1().Pods(),
 		informers.Core().V1().Services(),
 		informers.Core().V1().Nodes(),

--- a/test/integration/endpoints/endpoints_test.go
+++ b/test/integration/endpoints/endpoints_test.go
@@ -54,6 +54,7 @@ func TestEndpointUpdates(t *testing.T) {
 	tCtx := ktesting.Init(t)
 	epController := endpoint.NewEndpointController(
 		tCtx,
+		"endpoint-controller",
 		informers.Core().V1().Pods(),
 		informers.Core().V1().Services(),
 		informers.Core().V1().Endpoints(),
@@ -178,6 +179,7 @@ func TestEndpointWithMultiplePodUpdates(t *testing.T) {
 	tCtx := ktesting.Init(t)
 	epController := endpoint.NewEndpointController(
 		tCtx,
+		"endpoint-controller",
 		informers.Core().V1().Pods(),
 		informers.Core().V1().Services(),
 		informers.Core().V1().Endpoints(),
@@ -321,6 +323,7 @@ func TestExternalNameToClusterIPTransition(t *testing.T) {
 	tCtx := ktesting.Init(t)
 	epController := endpoint.NewEndpointController(
 		tCtx,
+		"endpoint-controller",
 		informers.Core().V1().Pods(),
 		informers.Core().V1().Services(),
 		informers.Core().V1().Endpoints(),
@@ -430,6 +433,7 @@ func TestEndpointWithTerminatingPod(t *testing.T) {
 	tCtx := ktesting.Init(t)
 	epController := endpoint.NewEndpointController(
 		tCtx,
+		"endpoint-controller",
 		informers.Core().V1().Pods(),
 		informers.Core().V1().Services(),
 		informers.Core().V1().Endpoints(),
@@ -623,6 +627,7 @@ func TestEndpointTruncate(t *testing.T) {
 	tCtx := ktesting.Init(t)
 	epController := endpoint.NewEndpointController(
 		tCtx,
+		"endpoint-controller",
 		informers.Core().V1().Pods(),
 		informers.Core().V1().Services(),
 		informers.Core().V1().Endpoints(),

--- a/test/integration/endpointslice/endpointslicemirroring_test.go
+++ b/test/integration/endpointslice/endpointslicemirroring_test.go
@@ -54,6 +54,7 @@ func TestEndpointSliceMirroring(t *testing.T) {
 
 	epController := endpoint.NewEndpointController(
 		tCtx,
+		"endpoint-controller",
 		informers.Core().V1().Pods(),
 		informers.Core().V1().Services(),
 		informers.Core().V1().Endpoints(),
@@ -62,6 +63,7 @@ func TestEndpointSliceMirroring(t *testing.T) {
 
 	epsController := endpointslice.NewController(
 		tCtx,
+		"endpointslice-controller",
 		informers.Core().V1().Pods(),
 		informers.Core().V1().Services(),
 		informers.Core().V1().Nodes(),
@@ -72,6 +74,7 @@ func TestEndpointSliceMirroring(t *testing.T) {
 
 	epsmController := endpointslicemirroring.NewController(
 		tCtx,
+		"endpointslice-mirroring-controller",
 		informers.Core().V1().Endpoints(),
 		informers.Discovery().V1().EndpointSlices(),
 		informers.Core().V1().Services(),
@@ -327,6 +330,7 @@ func TestEndpointSliceMirroringUpdates(t *testing.T) {
 	tCtx := ktesting.Init(t)
 	epsmController := endpointslicemirroring.NewController(
 		tCtx,
+		"endpointslice-mirroring-controller",
 		informers.Core().V1().Endpoints(),
 		informers.Discovery().V1().EndpointSlices(),
 		informers.Core().V1().Services(),
@@ -502,6 +506,7 @@ func TestEndpointSliceMirroringSelectorTransition(t *testing.T) {
 	tCtx := ktesting.Init(t)
 	epsmController := endpointslicemirroring.NewController(
 		tCtx,
+		"endpointslice-mirroring-controller",
 		informers.Core().V1().Endpoints(),
 		informers.Discovery().V1().EndpointSlices(),
 		informers.Core().V1().Services(),

--- a/test/integration/endpointslice/endpointsliceterminating_test.go
+++ b/test/integration/endpointslice/endpointsliceterminating_test.go
@@ -119,6 +119,7 @@ func TestEndpointSliceTerminating(t *testing.T) {
 			tCtx := ktesting.Init(t)
 			epsController := endpointslice.NewController(
 				tCtx,
+				"endpointslice-controller",
 				informers.Core().V1().Pods(),
 				informers.Core().V1().Services(),
 				informers.Core().V1().Nodes(),

--- a/test/integration/evictions/evictions_test.go
+++ b/test/integration/evictions/evictions_test.go
@@ -682,6 +682,7 @@ func rmSetup(ctx context.Context, t *testing.T) (kubeapiservertesting.TearDownFu
 
 	rm := disruption.NewDisruptionController(
 		ctx,
+		"disruption-controller",
 		informers.Core().V1().Pods(),
 		informers.Policy().V1().PodDisruptionBudgets(),
 		informers.Core().V1().ReplicationControllers(),

--- a/test/integration/garbagecollector/garbage_collector_test.go
+++ b/test/integration/garbagecollector/garbage_collector_test.go
@@ -278,6 +278,7 @@ func setupWithServer(t *testing.T, result *kubeapiservertesting.TestServer, work
 
 	gc, err := garbagecollector.NewGarbageCollector(
 		tCtx,
+		"garbage-collector-controller",
 		clientSet,
 		metadataClient,
 		restMapper,

--- a/test/integration/job/job_test.go
+++ b/test/integration/job/job_test.go
@@ -4493,7 +4493,7 @@ func createJobControllerWithSharedInformers(tb testing.TB, restConfig *restclien
 	clientSet := clientset.NewForConfigOrDie(restclient.AddUserAgent(restConfig, "job-controller"))
 	_, ctx := ktesting.NewTestContext(tb)
 	ctx, cancel := context.WithCancel(ctx)
-	jc, err := jobcontroller.NewController(ctx, informerSet.Core().V1().Pods(), informerSet.Batch().V1().Jobs(), clientSet)
+	jc, err := jobcontroller.NewController(ctx, "job-controller", informerSet.Core().V1().Pods(), informerSet.Batch().V1().Jobs(), clientSet)
 	if err != nil {
 		tb.Fatalf("Error creating Job controller: %v", err)
 	}

--- a/test/integration/namespace/ns_conditions_test.go
+++ b/test/integration/namespace/ns_conditions_test.go
@@ -197,6 +197,7 @@ func namespaceLifecycleSetup(t *testing.T) (context.Context, kubeapiservertestin
 	_, ctx := ktesting.NewTestContext(t)
 	controller := namespace.NewNamespaceController(
 		ctx,
+		"namespace-controller",
 		clientSet,
 		metadataClient,
 		discoverResourcesFn,

--- a/test/integration/node/lifecycle_test.go
+++ b/test/integration/node/lifecycle_test.go
@@ -127,6 +127,7 @@ func TestEvictionForNoExecuteTaintAddedByUser(t *testing.T) {
 			// Start NodeLifecycleController for taint.
 			nc, err := nodelifecycle.NewNodeLifecycleController(
 				testCtx.Ctx,
+				"node-lifecycle-controller",
 				externalInformers.Coordination().V1().Leases(),
 				externalInformers.Core().V1().Pods(),
 				externalInformers.Core().V1().Nodes(),
@@ -155,10 +156,10 @@ func TestEvictionForNoExecuteTaintAddedByUser(t *testing.T) {
 			if test.startStandaloneTaintEvictionController {
 				tm, _ := tainteviction.New(
 					testCtx.Ctx,
+					names.TaintEvictionController,
 					testCtx.ClientSet,
 					externalInformers.Core().V1().Pods(),
 					externalInformers.Core().V1().Nodes(),
-					names.TaintEvictionController,
 				)
 				go tm.Run(testCtx.Ctx)
 			}
@@ -339,6 +340,7 @@ func TestTaintBasedEvictions(t *testing.T) {
 			// Start NodeLifecycleController for taint.
 			nc, err := nodelifecycle.NewNodeLifecycleController(
 				testCtx.Ctx,
+				"node-lifecycle-controller",
 				externalInformers.Coordination().V1().Leases(),
 				externalInformers.Core().V1().Pods(),
 				externalInformers.Core().V1().Nodes(),
@@ -367,10 +369,10 @@ func TestTaintBasedEvictions(t *testing.T) {
 			if test.enableSeparateTaintEvictionController {
 				tm, _ := tainteviction.New(
 					testCtx.Ctx,
+					names.TaintEvictionController,
 					testCtx.ClientSet,
 					externalInformers.Core().V1().Pods(),
 					externalInformers.Core().V1().Nodes(),
-					names.TaintEvictionController,
 				)
 				go tm.Run(testCtx.Ctx)
 			}

--- a/test/integration/podgc/podgc_test.go
+++ b/test/integration/podgc/podgc_test.go
@@ -379,6 +379,7 @@ func setup(t *testing.T, name string) *testutils.TestContext {
 	externalInformers := informers.NewSharedInformerFactory(testCtx.ClientSet, time.Second)
 
 	podgc := podgc.NewPodGCInternal(testCtx.Ctx,
+		"pod-garbage-collector-controller",
 		testCtx.ClientSet,
 		externalInformers.Core().V1().Pods(),
 		externalInformers.Core().V1().Nodes(),

--- a/test/integration/quota/quota_test.go
+++ b/test/integration/quota/quota_test.go
@@ -81,6 +81,7 @@ func TestQuota(t *testing.T) {
 	informers := informers.NewSharedInformerFactory(clientset, controller.NoResyncPeriodFunc())
 	rm := replicationcontroller.NewReplicationManager(
 		ctx,
+		"replicationcontroller-controller",
 		informers.Core().V1().Pods(),
 		informers.Core().V1().ReplicationControllers(),
 		clientset,
@@ -310,6 +311,7 @@ plugins:
 	informers := informers.NewSharedInformerFactory(clientset, controller.NoResyncPeriodFunc())
 	rm := replicationcontroller.NewReplicationManager(
 		tCtx,
+		"replicationcontroller-controller",
 		informers.Core().V1().Pods(),
 		informers.Core().V1().ReplicationControllers(),
 		clientset,
@@ -436,6 +438,7 @@ plugins:
 	informers := informers.NewSharedInformerFactory(clientset, controller.NoResyncPeriodFunc())
 	rm := replicationcontroller.NewReplicationManager(
 		tCtx,
+		"replicationcontroller-controller",
 		informers.Core().V1().Pods(),
 		informers.Core().V1().ReplicationControllers(),
 		clientset,

--- a/test/integration/replicaset/replicaset_test.go
+++ b/test/integration/replicaset/replicaset_test.go
@@ -133,6 +133,7 @@ func rmSetup(t *testing.T) (context.Context, kubeapiservertesting.TearDownFunc, 
 
 	rm := replicaset.NewReplicaSetController(
 		tCtx,
+		"replicaset-controller",
 		informers.Apps().V1().ReplicaSets(),
 		informers.Core().V1().Pods(),
 		clientset.NewForConfigOrDie(restclient.AddUserAgent(config, "replicaset-controller")),

--- a/test/integration/replicationcontroller/replicationcontroller_test.go
+++ b/test/integration/replicationcontroller/replicationcontroller_test.go
@@ -126,6 +126,7 @@ func rmSetup(t *testing.T) (context.Context, kubeapiservertesting.TearDownFunc, 
 
 	rm := replication.NewReplicationManager(
 		tCtx,
+		"replicationcontroller-controller",
 		informers.Core().V1().Pods(),
 		informers.Core().V1().ReplicationControllers(),
 		clientset.NewForConfigOrDie(restclient.AddUserAgent(config, "replication-controller")),

--- a/test/integration/scheduler/taint/taint_test.go
+++ b/test/integration/scheduler/taint/taint_test.go
@@ -80,6 +80,7 @@ func TestTaintNodeByCondition(t *testing.T) {
 	// Start NodeLifecycleController for taint.
 	nc, err := nodelifecycle.NewNodeLifecycleController(
 		testCtx.Ctx,
+		"node-lifecycle-controller",
 		externalInformers.Coordination().V1().Leases(),
 		externalInformers.Core().V1().Pods(),
 		externalInformers.Core().V1().Nodes(),

--- a/test/integration/service/service_test.go
+++ b/test/integration/service/service_test.go
@@ -314,6 +314,7 @@ func Test_TransitionsForTrafficDistribution(t *testing.T) {
 	defer ctx.Cancel("test has completed")
 	epsController := endpointslice.NewController(
 		ctx,
+		"endpointslice-controller",
 		informers.Core().V1().Pods(),
 		informers.Core().V1().Services(),
 		informers.Core().V1().Nodes(),

--- a/test/integration/serviceaccount/legacy_service_account_token_clean_up_test.go
+++ b/test/integration/serviceaccount/legacy_service_account_token_clean_up_test.go
@@ -343,6 +343,7 @@ func patchSecret(ctx context.Context, c clientset.Interface, t *testing.T, lastU
 
 func startLegacyServiceAccountTokenCleaner(ctx context.Context, client clientset.Interface, fakeClock clock.Clock, informers clientinformers.SharedInformerFactory) {
 	legacySATokenCleaner, _ := serviceaccountcontroller.NewLegacySATokenCleaner(
+		"legacy-serviceaccount-token-cleaner-controller",
 		informers.Core().V1().ServiceAccounts(),
 		informers.Core().V1().Secrets(),
 		informers.Core().V1().Pods(),

--- a/test/integration/serviceaccount/service_account_test.go
+++ b/test/integration/serviceaccount/service_account_test.go
@@ -406,6 +406,7 @@ func startServiceAccountTestServerAndWaitForCaches(ctx context.Context, t *testi
 	go tokenController.Run(ctx, 1)
 
 	serviceAccountController, err := serviceaccountcontroller.NewServiceAccountsController(
+		"serviceaccount-controller",
 		informers.Core().V1().ServiceAccounts(),
 		informers.Core().V1().Namespaces(),
 		rootClientset,

--- a/test/integration/servicecidr/migration_test.go
+++ b/test/integration/servicecidr/migration_test.go
@@ -77,6 +77,7 @@ func TestMigrateServiceCIDR(t *testing.T) {
 	// ServiceCIDR controller
 	go servicecidrs.NewController(
 		tCtx,
+		"service-cidr-controller",
 		informers1.Networking().V1beta1().ServiceCIDRs(),
 		informers1.Networking().V1beta1().IPAddresses(),
 		client1,
@@ -216,6 +217,7 @@ func TestMigrateServiceCIDR(t *testing.T) {
 	informers2 := informers.NewSharedInformerFactory(client2, resyncPeriod)
 	go servicecidrs.NewController(
 		tCtx2,
+		"service-cidr-controller",
 		informers2.Networking().V1beta1().ServiceCIDRs(),
 		informers2.Networking().V1beta1().IPAddresses(),
 		client2,

--- a/test/integration/servicecidr/servicecidr_test.go
+++ b/test/integration/servicecidr/servicecidr_test.go
@@ -63,6 +63,7 @@ func TestServiceAllocNewServiceCIDR(t *testing.T) {
 	informerFactory := informers.NewSharedInformerFactory(client, resyncPeriod)
 	go servicecidrs.NewController(
 		ctx,
+		"service-cidr-controller",
 		informerFactory.Networking().V1beta1().ServiceCIDRs(),
 		informerFactory.Networking().V1beta1().IPAddresses(),
 		client,
@@ -165,6 +166,7 @@ func TestServiceCIDRDeletion(t *testing.T) {
 	informerFactory := informers.NewSharedInformerFactory(client, resyncPeriod)
 	go servicecidrs.NewController(
 		ctx,
+		"service-cidr-controller",
 		informerFactory.Networking().V1beta1().ServiceCIDRs(),
 		informerFactory.Networking().V1beta1().IPAddresses(),
 		client,

--- a/test/integration/statefulset/statefulset_test.go
+++ b/test/integration/statefulset/statefulset_test.go
@@ -393,6 +393,7 @@ func TestStatefulSetStatusWithPodFail(t *testing.T) {
 	informers := informers.NewSharedInformerFactory(clientset.NewForConfigOrDie(restclient.AddUserAgent(config, "statefulset-informers")), resyncPeriod)
 	ssc := statefulset.NewStatefulSetController(
 		tCtx,
+		"statefulset-controller",
 		informers.Core().V1().Pods(),
 		informers.Apps().V1().StatefulSets(),
 		informers.Core().V1().PersistentVolumeClaims(),

--- a/test/integration/statefulset/util.go
+++ b/test/integration/statefulset/util.go
@@ -178,6 +178,7 @@ func scSetup(t *testing.T) (context.Context, kubeapiservertesting.TearDownFunc, 
 
 	sc := statefulset.NewStatefulSetController(
 		tCtx,
+		"statefulset-controller",
 		informers.Core().V1().Pods(),
 		informers.Apps().V1().StatefulSets(),
 		informers.Core().V1().PersistentVolumeClaims(),

--- a/test/integration/storageversion/gc_test.go
+++ b/test/integration/storageversion/gc_test.go
@@ -65,7 +65,7 @@ func TestStorageVersionGarbageCollection(t *testing.T) {
 	storageVersionInformer := informers.Internal().V1alpha1().StorageVersions()
 
 	_, ctx := ktesting.NewTestContext(t)
-	controller := storageversiongc.NewStorageVersionGC(ctx, kubeclient, leaseInformer, storageVersionInformer)
+	controller := storageversiongc.NewStorageVersionGC(ctx, "storage-version-migrator-controller", kubeclient, leaseInformer, storageVersionInformer)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/test/integration/ttlcontroller/ttlcontroller_test.go
+++ b/test/integration/ttlcontroller/ttlcontroller_test.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -139,7 +139,7 @@ func TestTTLAnnotations(t *testing.T) {
 	testClient, informers := createClientAndInformers(t, server)
 	nodeInformer := informers.Core().V1().Nodes()
 	_, ctx := ktesting.NewTestContext(t)
-	ttlc := ttl.NewTTLController(ctx, nodeInformer, testClient)
+	ttlc := ttl.NewTTLController(ctx, "ttl-controller", nodeInformer, testClient)
 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()

--- a/test/integration/util/util.go
+++ b/test/integration/util/util.go
@@ -132,7 +132,7 @@ func CreateResourceClaimController(ctx context.Context, tb ktesting.TB, clientSe
 	podInformer := informerFactory.Core().V1().Pods()
 	claimInformer := informerFactory.Resource().V1alpha3().ResourceClaims()
 	claimTemplateInformer := informerFactory.Resource().V1alpha3().ResourceClaimTemplates()
-	claimController, err := resourceclaim.NewController(klog.FromContext(ctx), true /* admin access */, clientSet, podInformer, claimInformer, claimTemplateInformer)
+	claimController, err := resourceclaim.NewController(klog.FromContext(ctx), "resourceclaim-controller", true /* admin access */, clientSet, podInformer, claimInformer, claimTemplateInformer)
 	if err != nil {
 		tb.Fatalf("Error creating claim controller: %v", err)
 	}
@@ -203,6 +203,7 @@ func CreateGCController(ctx context.Context, tb ktesting.TB, restConfig restclie
 	close(alwaysStarted)
 	gc, err := garbagecollector.NewGarbageCollector(
 		ctx,
+		"garbage-collector-controller",
 		clientSet,
 		metadataClient,
 		restMapper,
@@ -237,6 +238,7 @@ func CreateNamespaceController(ctx context.Context, tb ktesting.TB, restConfig r
 	discoverResourcesFn := clientSet.Discovery().ServerPreferredNamespacedResources
 	controller := namespace.NewNamespaceController(
 		ctx,
+		"namespace-controller",
 		clientSet,
 		metadataClient,
 		discoverResourcesFn,
@@ -673,6 +675,7 @@ func InitDisruptionController(t *testing.T, testCtx *TestContext) *disruption.Di
 
 	dc := disruption.NewDisruptionController(
 		testCtx.Ctx,
+		"disruption-controller",
 		informers.Core().V1().Pods(),
 		informers.Policy().V1().PodDisruptionBudgets(),
 		informers.Core().V1().ReplicationControllers(),

--- a/test/integration/volume/attach_detach_test.go
+++ b/test/integration/volume/attach_detach_test.go
@@ -350,6 +350,7 @@ func createAdClients(ctx context.Context, t *testing.T, server *kubeapiservertes
 	informers := clientgoinformers.NewSharedInformerFactory(testClient, resyncPeriod)
 	ctrl, err := attachdetach.NewAttachDetachController(
 		ctx,
+		"persistentvolume-attach-detach-controller",
 		testClient,
 		informers.Core().V1().Pods(),
 		informers.Core().V1().Nodes(),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

A follow-up of https://github.com/kubernetes/kubernetes/pull/120371

1. logging should use a canonical controller name when referencing a controller (Eg. Starting X, Shutting down X)
2. calling WaitForNamedCacheSync

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related-to https://github.com/kubernetes/kubernetes/pull/120371

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
All controllers in kcm used the controller name constants when
1. logging should use a canonical controller name when referencing a controller (Eg. Starting X, Shutting down X)
2. calling WaitForNamedCacheSync
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
