### PR TITLE
feat(kubectl) Add proxy-url command line option to kubectl

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go
@@ -58,6 +58,7 @@ const (
 	flagTimeout            = "request-timeout"
 	flagCacheDir           = "cache-dir"
 	flagDisableCompression = "disable-compression"
+	flagProxyURL           = "proxy-url"
 )
 
 // RESTClientGetter is an interface that the ConfigFlags describe to provide an easier way to mock for commands
@@ -101,6 +102,7 @@ type ConfigFlags struct {
 	Password           *string
 	Timeout            *string
 	DisableCompression *bool
+	ProxyURL           *string
 	// If non-nil, wrap config function can transform the Config
 	// before it is returned in ToRESTConfig function.
 	WrapConfigFn func(*rest.Config) *rest.Config
@@ -232,6 +234,11 @@ func (f *ConfigFlags) toRawKubeConfigLoader() clientcmd.ClientConfig {
 	if f.Password == nil {
 		return &clientConfig{clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, overrides)}
 	}
+
+	if f.ProxyURL != nil {
+		overrides.ClusterInfo.ProxyURL = *f.ProxyURL
+	}
+
 	return &clientConfig{clientcmd.NewInteractiveDeferredLoadingClientConfig(loadingRules, overrides, os.Stdin)}
 }
 
@@ -410,6 +417,9 @@ func (f *ConfigFlags) AddFlags(flags *pflag.FlagSet) {
 	if f.DisableCompression != nil {
 		flags.BoolVar(f.DisableCompression, flagDisableCompression, *f.DisableCompression, "If true, opt-out of response compression for all requests to the server")
 	}
+	if f.ProxyURL != nil {
+		flags.StringVar(f.ProxyURL, flagProxyURL, *f.ProxyURL, "If provided, this URL will be used to connect via proxy")
+	}
 }
 
 // WithDeprecatedPasswordFlag enables the username and password config flags
@@ -467,6 +477,7 @@ func NewConfigFlags(usePersistentConfig bool) *ConfigFlags {
 		BearerToken:        utilpointer.String(""),
 		Impersonate:        utilpointer.String(""),
 		ImpersonateUID:     utilpointer.String(""),
+		ProxyURL:           utilpointer.String(""),
 		ImpersonateGroup:   &impersonateGroup,
 		DisableCompression: &disableCompression,
 

--- a/test/cmd/get.sh
+++ b/test/cmd/get.sh
@@ -533,3 +533,19 @@ __EOF__
   set +o nounset
   set +o errexit
 }
+
+run_kubectl_proxy_url_tests() {
+  set -o nounset
+
+  kube::log::status "Testing kubectl --proxy-url=socks5://127.0.0.1:12345"
+
+  # Port 12345 is unreachable so the command will fail.
+  output_message=$(kubectl --proxy-url=socks5://127.0.0.1:12345 get pods --v=9 2>&1 )
+
+  set -o errexit
+
+  kube::test::if_has_string "${output_message}" "Dial to tcp:127.0.0.1:12345"
+
+  set +o nounset
+  set +o errexit
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Golang doesn't support HTTPS_PROXY for localhost addresses as noted in https://github.com/kubernetes/kubectl/issues/1653. Avoids the need to statically set proxy urls for each of the clusters defined in a config file.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/kubernetes/kubectl/issues/1655

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Adds proxy-url flag to kubectl. If provided, this URL will be used to connect via proxy.

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
