### PR TITLE
Wire in Discovery Group lister into APIExtension server

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/apiserver.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/apiserver.go
@@ -107,6 +107,9 @@ type CustomResourceDefinitions struct {
 
 	// provided for easier embedding
 	Informers externalinformers.SharedInformerFactory
+
+	// DiscoveryGroupLister is used to list the groups that are available for discovery.
+	DiscoveryGroupLister discovery.GroupLister
 }
 
 // Complete fills in any fields not set that are required to have valid data. It's mutating the receiver.
@@ -177,9 +180,13 @@ func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget)
 		delegate:  delegateHandler,
 	}
 	groupDiscoveryHandler := &groupDiscoveryHandler{
-		discovery: map[string]*discovery.APIGroupHandler{},
-		delegate:  delegateHandler,
+		discovery:       map[string]*discovery.APIGroupHandler{},
+		discoveryGroups: map[string]metav1.APIGroup{},
+		delegate:        delegateHandler,
 	}
+
+	s.DiscoveryGroupLister = groupDiscoveryHandler
+
 	establishingController := establish.NewEstablishingController(s.Informers.Apiextensions().V1().CustomResourceDefinitions(), crdClient.ApiextensionsV1())
 	crdHandler, err := NewCustomResourceDefinitionHandler(
 		versionDiscoveryHandler,

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_discovery_controller.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_discovery_controller.go
@@ -246,7 +246,8 @@ func (c *DiscoveryController) sync(version schema.GroupVersion) error {
 		// apiVersionsForDiscovery after it put in the right ordered
 		PreferredVersion: apiVersionsForDiscovery[0],
 	}
-	c.groupHandler.setDiscovery(version.Group, discovery.NewAPIGroupHandler(Codecs, apiGroup))
+
+	c.groupHandler.setDiscovery(version.Group, discovery.NewAPIGroupHandler(Codecs, apiGroup), apiGroup)
 
 	if !foundVersion {
 		c.versionHandler.unsetDiscovery(version)

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_discovery_controller_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_discovery_controller_test.go
@@ -18,6 +18,7 @@ package apiserver
 
 import (
 	"context"
+	"net/http"
 	"testing"
 	"time"
 
@@ -248,7 +249,8 @@ func setup() *testEnvironment {
 			discovery: make(map[schema.GroupVersion]*discovery.APIVersionHandler),
 		},
 		groupDiscoveryHandler: groupDiscoveryHandler{
-			discovery: make(map[string]*discovery.APIGroupHandler),
+			discovery:       make(map[string]*discovery.APIGroupHandler),
+			discoveryGroups: make(map[string]metav1.APIGroup),
 		},
 	}
 
@@ -374,6 +376,10 @@ func TestMultipleCRDSameVersion(t *testing.T) {
 	}
 	err = env.FakeResourceManager.WaitForActions(ctx, 1*time.Second)
 	require.NoError(t, err)
+
+	groups, err := env.groupDiscoveryHandler.Groups(ctx, &http.Request{})
+	require.NoError(t, err)
+	require.Len(t, groups, 1)
 }
 
 // Tests that if a CRD is deleted at runtime, the discovery controller will


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

With [change](https://github.com/kubernetes/kubernetes/pull/127524) merged before, this uses the same discovery interface and extends the API-extension server CRD struct with Groups lister. This will enable users to write your aggregation server using these 2 interfaces (easy to query groups served by both core api-servers)

The long-term goal is to be able to write your own implementation of the aggregation server, which would conform to the API-extension server interface (not yet existing). This would enable generic control plane providers to create their own flavoured aggregation servers where API-Services might be implemented differently or even without them all altogether.  In the end this enable users to use K8S in more composable way (with/without APIServices, RBAC, Core resources, etc). Currently if using existing API-Aggregation server its very hard to disable APIServices implementation without layers of layers of hacks). 

/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Wire in group lister into custom resource definition struct into api-extension server.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
