### PR TITLE
integrate kubelet with the systemd watchdog

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -1658,6 +1658,7 @@ After=network-online.target
 [Service]
 Restart=always
 RestartSec=10
+WatchdogSec=30s
 EnvironmentFile=${kubelet_env_file}
 ExecStart=${kubelet_bin} \$KUBELET_OPTS
 

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -749,6 +749,16 @@ const (
 	//
 	// Enables the image volume source.
 	ImageVolume featuregate.Feature = "ImageVolume"
+
+	// owner: @zhifei92
+	// beta: v1.32
+	//
+	// Enables the systemd watchdog for the kubelet. When enabled, the kubelet will
+	// periodically notify the systemd watchdog to indicate that it is still alive.
+	// This can help prevent the system from restarting the kubelet if it becomes
+	// unresponsive. The feature gate is enabled by default, but should only be used
+	// if the system supports the systemd watchdog feature and has it configured properly.
+	SystemdWatchdog = featuregate.Feature("SystemdWatchdog")
 )
 
 func init() {

--- a/pkg/features/versioned_kube_features.go
+++ b/pkg/features/versioned_kube_features.go
@@ -696,6 +696,10 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 		{Version: version.MustParse("1.31"), Default: false, PreRelease: featuregate.Alpha},
 	},
 
+	SystemdWatchdog: {
+		{Version: version.MustParse("1.32"), Default: true, PreRelease: featuregate.Beta},
+	},
+
 	TopologyAwareHints: {
 		{Version: version.MustParse("1.21"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("1.23"), Default: false, PreRelease: featuregate.Beta},

--- a/pkg/kubelet/watchdog/types.go
+++ b/pkg/kubelet/watchdog/types.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package watchdog
+
+import "net/http"
+
+// HealthChecker defines the interface of health checkers.
+type HealthChecker interface {
+	Start()
+}
+
+// syncLoopHealthChecker contains the health check method for syncLoop.
+type syncLoopHealthChecker interface {
+	SyncLoopHealthCheck(req *http.Request) error
+}

--- a/pkg/kubelet/watchdog/watchdog_linux.go
+++ b/pkg/kubelet/watchdog/watchdog_linux.go
@@ -1,0 +1,158 @@
+//go:build linux
+// +build linux
+
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package watchdog
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/coreos/go-systemd/v22/daemon"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apiserver/pkg/server/healthz"
+	"k8s.io/klog/v2"
+)
+
+// WatchdogClient defines the interface for interacting with the systemd watchdog.
+type WatchdogClient interface {
+	SdWatchdogEnabled(unsetEnvironment bool) (time.Duration, error)
+	SdNotify(unsetEnvironment bool) (bool, error)
+}
+
+// DefaultWatchdogClient implements the WatchdogClient interface using the actual systemd daemon functions.
+type DefaultWatchdogClient struct{}
+
+var _ WatchdogClient = &DefaultWatchdogClient{}
+
+func (d *DefaultWatchdogClient) SdWatchdogEnabled(unsetEnvironment bool) (time.Duration, error) {
+	return daemon.SdWatchdogEnabled(unsetEnvironment)
+}
+
+func (d *DefaultWatchdogClient) SdNotify(unsetEnvironment bool) (bool, error) {
+	return daemon.SdNotify(unsetEnvironment, daemon.SdNotifyWatchdog)
+}
+
+// Option defines optional parameters for initializing the healthChecker
+// structure.
+type Option func(*healthChecker)
+
+func WithWatchdogClient(watchdog WatchdogClient) Option {
+	return func(hc *healthChecker) {
+		hc.watchdog = watchdog
+	}
+}
+
+type healthChecker struct {
+	checkers     []healthz.HealthChecker
+	retryBackoff wait.Backoff
+	interval     time.Duration
+	watchdog     WatchdogClient
+}
+
+var _ HealthChecker = &healthChecker{}
+
+const minimalNotifyInterval = time.Second
+
+// NewHealthChecker creates a new HealthChecker instance.
+// This function initializes the health checker and configures its behavior based on the status of the systemd watchdog.
+// If the watchdog is not enabled, the function returns an error.
+func NewHealthChecker(syncLoop syncLoopHealthChecker, opts ...Option) (HealthChecker, error) {
+	hc := &healthChecker{
+		watchdog: &DefaultWatchdogClient{},
+	}
+	for _, o := range opts {
+		o(hc)
+	}
+
+	// get watchdog information
+	watchdogVal, err := hc.watchdog.SdWatchdogEnabled(false)
+	if err != nil {
+		// Failed to get watchdog configuration information.
+		// This occurs when we want to start the watchdog but the configuration is incorrect,
+		// for example, the time is not configured correctly.
+		return nil, fmt.Errorf("configure watchdog: %w", err)
+	}
+	if watchdogVal == 0 {
+		klog.InfoS("Systemd watchdog is not enabled")
+		return &healthChecker{}, nil
+	}
+	if watchdogVal <= minimalNotifyInterval {
+		return nil, fmt.Errorf("configure watchdog timeout too small: %v", watchdogVal)
+	}
+
+	// The health checks performed by checkers are the same as those for "/healthz".
+	checkers := []healthz.HealthChecker{
+		healthz.PingHealthz,
+		healthz.LogHealthz,
+		healthz.NamedCheck("syncloop", syncLoop.SyncLoopHealthCheck),
+	}
+	retryBackoff := wait.Backoff{
+		Duration: time.Second,
+		Factor:   2.0,
+		Jitter:   0.1,
+		Steps:    2,
+	}
+	hc.checkers = checkers
+	hc.retryBackoff = retryBackoff
+	hc.interval = watchdogVal / 2
+
+	return hc, nil
+}
+
+func (hc *healthChecker) Start() {
+	if hc.interval <= 0 {
+		klog.InfoS("Systemd watchdog is not enabled or the interval is invalid, so health checking will not be started.")
+		return
+	}
+	klog.InfoS("Starting systemd watchdog with interval", "interval", hc.interval)
+
+	go wait.Forever(func() {
+		if err := hc.doCheck(); err != nil {
+			klog.ErrorS(err, "Do not notify watchdog this iteration as the kubelet is reportedly not healthy")
+			return
+		}
+
+		err := wait.ExponentialBackoff(hc.retryBackoff, func() (bool, error) {
+			ack, err := hc.watchdog.SdNotify(false)
+			if err != nil {
+				klog.V(5).InfoS("Failed to notify systemd watchdog, retrying", "error", err)
+				return false, nil
+			}
+			if !ack {
+				return false, fmt.Errorf("failed to notify systemd watchdog, notification not supported - (i.e. NOTIFY_SOCKET is unset)")
+			}
+
+			klog.V(5).InfoS("Watchdog plugin notified", "acknowledgment", ack, "state", daemon.SdNotifyWatchdog)
+			return true, nil
+		})
+		if err != nil {
+			klog.ErrorS(err, "Failed to notify watchdog")
+		}
+	}, hc.interval)
+}
+
+func (hc *healthChecker) doCheck() error {
+	for _, hc := range hc.checkers {
+		if err := hc.Check(nil); err != nil {
+			return fmt.Errorf("checker %s failed: %w", hc.Name(), err)
+		}
+	}
+	return nil
+}

--- a/pkg/kubelet/watchdog/watchdog_linux_test.go
+++ b/pkg/kubelet/watchdog/watchdog_linux_test.go
@@ -1,0 +1,180 @@
+//go:build linux
+// +build linux
+
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package watchdog
+
+import (
+	"bytes"
+	"errors"
+	"flag"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"k8s.io/klog/v2"
+)
+
+// Mock syncLoopHealthChecker
+type mockSyncLoopHealthChecker struct {
+	healthCheckErr error
+}
+
+func (m *mockSyncLoopHealthChecker) SyncLoopHealthCheck(req *http.Request) error {
+	return m.healthCheckErr
+}
+
+// Mock WatchdogClient
+type mockWatchdogClient struct {
+	enabledVal time.Duration
+	enabledErr error
+	notifyAck  bool
+	notifyErr  error
+}
+
+func (m *mockWatchdogClient) SdWatchdogEnabled(unsetEnvironment bool) (time.Duration, error) {
+	return m.enabledVal, m.enabledErr
+}
+
+func (m *mockWatchdogClient) SdNotify(unsetEnvironment bool) (bool, error) {
+	return m.notifyAck, m.notifyErr
+}
+
+const (
+	interval      = 4 * time.Second
+	intervalSmall = 1 * time.Second
+)
+
+// TestNewHealthChecker tests the NewHealthChecker function.
+func TestNewHealthChecker(t *testing.T) {
+	// Test cases
+	tests := []struct {
+		name        string
+		mockEnabled time.Duration
+		mockErr     error
+		wantErr     bool
+	}{
+		{"Watchdog enabled", interval, nil, false},
+		{"Watchdog not enabled", 0, nil, false},
+		{"Watchdog enabled with error", interval, errors.New("mock error"), true},
+		{"Watchdog timeout too small", intervalSmall, nil, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := &mockWatchdogClient{
+				enabledVal: tt.mockEnabled,
+				enabledErr: tt.mockErr,
+			}
+
+			_, err := NewHealthChecker(&mockSyncLoopHealthChecker{}, WithWatchdogClient(mockClient))
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewHealthChecker() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestHealthCheckerStart tests the Start method of the healthChecker.
+func TestHealthCheckerStart(t *testing.T) {
+	// Test cases
+	tests := []struct {
+		name           string
+		enabledVal     time.Duration
+		healthCheckErr error
+		notifyAck      bool
+		notifyErr      error
+		expectedLogs   []string
+	}{
+		{
+			name:           "Watchdog enabled and notify succeeds",
+			enabledVal:     interval,
+			healthCheckErr: nil,
+			notifyAck:      true,
+			notifyErr:      nil,
+			expectedLogs:   []string{"Starting systemd watchdog with interval", "Watchdog plugin notified"},
+		},
+		{
+			name:           "Watchdog enabled and notify fails, notification not supported",
+			enabledVal:     interval,
+			healthCheckErr: nil,
+			notifyAck:      false,
+			notifyErr:      nil,
+			expectedLogs:   []string{"Starting systemd watchdog with interval", "Failed to notify watchdog", "notification not supported"},
+		},
+		{
+			name:           "Watchdog enabled and notify fails, transmission failed",
+			enabledVal:     interval,
+			healthCheckErr: nil,
+			notifyAck:      false,
+			notifyErr:      errors.New("mock notify error"),
+			expectedLogs:   []string{"Starting systemd watchdog with interval", "Failed to notify watchdog"},
+		},
+		{
+			name:           "Watchdog enabled and health check fails",
+			enabledVal:     interval,
+			healthCheckErr: errors.New("mock healthy error"),
+			notifyAck:      true,
+			notifyErr:      nil,
+			expectedLogs:   []string{"Starting systemd watchdog with interval", "Do not notify watchdog this iteration as the kubelet is reportedly not healthy"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Capture logs
+			var logBuffer bytes.Buffer
+			flags := &flag.FlagSet{}
+			klog.InitFlags(flags)
+			if err := flags.Set("v", "5"); err != nil {
+				t.Fatal(err)
+			}
+			klog.LogToStderr(false)
+			klog.SetOutput(&logBuffer)
+
+			// Mock SdWatchdogEnabled to return a valid value
+			mockClient := &mockWatchdogClient{
+				enabledVal: tt.enabledVal,
+				notifyAck:  tt.notifyAck,
+				notifyErr:  tt.notifyErr,
+			}
+
+			// Create a healthChecker
+			hc, err := NewHealthChecker(&mockSyncLoopHealthChecker{healthCheckErr: tt.healthCheckErr}, WithWatchdogClient(mockClient))
+			if err != nil {
+				t.Fatalf("NewHealthChecker() failed: %v", err)
+			}
+
+			// Start the health checker
+			hc.Start()
+
+			// Wait for a short period to allow the health check to run
+			time.Sleep(2 * interval)
+
+			// Check logs to verify the health check ran
+			klog.Flush()
+			logs := logBuffer.String()
+			for _, expectedLog := range tt.expectedLogs {
+				if !strings.Contains(logs, expectedLog) {
+					t.Errorf("Expected log '%s' not found in logs: %s", expectedLog, logs)
+				}
+			}
+		})
+	}
+}

--- a/pkg/kubelet/watchdog/watchdog_unsupported.go
+++ b/pkg/kubelet/watchdog/watchdog_unsupported.go
@@ -1,0 +1,33 @@
+//go:build !linux
+// +build !linux
+
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package watchdog
+
+type healthCheckerUnsupported struct{}
+
+var _ HealthChecker = &healthCheckerUnsupported{}
+
+// NewHealthChecker creates a fake one here
+func NewHealthChecker(_ syncLoopHealthChecker) (HealthChecker, error) {
+	return &healthCheckerUnsupported{}, nil
+}
+
+func (ow *healthCheckerUnsupported) Start() {
+	return
+}

--- a/test/featuregates_linter/test_data/versioned_feature_list.yaml
+++ b/test/featuregates_linter/test_data/versioned_feature_list.yaml
@@ -1218,6 +1218,12 @@
     lockToDefault: false
     preRelease: Alpha
     version: "1.31"
+- name: SystemdWatchdog
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.32"
 - name: TopologyAwareHints
   versionedSpecs:
   - default: false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Related issue #127460

Utilize the `systemd watchdog` capability to restart the kubelet when the kubelet health check fails, and limit the maximum number of restarts within a given time period. This can enhance the reliability of the kubelet to some extent.

Example of  `systemd unit config`:

```
WatchdogSec=30s
Restart=on-failure
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #127460

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added kubelet support for systemd watchdog integration. With this enabled, systemd can automatically recover a hung kubelet.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
