### PR TITLE
Do not return error where it's not needed

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/fixtures/resources.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/fixtures/resources.go
@@ -381,7 +381,7 @@ func waitForCRDReady(crd *apiextensionsv1.CustomResourceDefinition, apiExtension
 	if err != nil {
 		return nil, err
 	}
-	return v1CRD, err
+	return v1CRD, nil
 }
 
 // CreateNewV1CustomResourceDefinitionWatchUnsafe creates the CRD and makes sure
@@ -404,7 +404,7 @@ func CreateNewV1CustomResourceDefinitionWatchUnsafe(v1CRD *apiextensionsv1.Custo
 		}
 	}
 
-	return v1CRD, err
+	return v1CRD, nil
 }
 
 // CreateNewV1CustomResourceDefinition creates the given CRD and makes sure its watch cache is primed on the server.


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/sig api-machinery 

#### What this PR does / why we need it:
While looking into [this flake](https://github.com/kubernetes/kubernetes/issues/127519) I've noticed we're unnecessarily returning error where one should never be returned. I doubt the problems from that issues is in any way related with this fix, but I figured out we might want to get it straightened out :wink: 

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
/assign @sttts 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
