### PR TITLE
Reuse CreateTestCRD helper for kubectl e2e

### DIFF
--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -1235,7 +1235,7 @@ metadata:
 
 		ginkgo.It("should detect unknown metadata fields in both the root and embedded object of a CR", func(ctx context.Context) {
 			ginkgo.By("prepare CRD with x-kubernetes-embedded-resource: true")
-			opt := func(crd *apiextensionsv1.CustomResourceDefinition) {
+			testCRD, err := crd.CreateTestCRD(f, func(crd *apiextensionsv1.CustomResourceDefinition) {
 				props := &apiextensionsv1.JSONSchemaProps{}
 				if err := yaml.Unmarshal(schemaFooEmbedded, props); err != nil {
 					framework.Failf("failed to unmarshal schema: %v", err)
@@ -1250,10 +1250,7 @@ metadata:
 						},
 					},
 				}
-			}
-
-			group := fmt.Sprintf("%s.example.com", f.BaseName)
-			testCRD, err := crd.CreateMultiVersionTestCRD(f, group, opt)
+			})
 			if err != nil {
 				framework.Failf("failed to create test CRD: %v", err)
 			}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/sig cli

#### What this PR does / why we need it:
While looking into https://github.com/kubernetes/kubernetes/issues/127519 I've noticed we're copy&pasting code from `CreateMultiVersionTestCRD` so I've decided to fix it, which will also make it easier to track the calls next time.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
/assign @ardaguclu 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
