### PR TITLE
feat(test-e2e): support custom network and subnet on remote e2e mode

### DIFF
--- a/hack/make-rules/test-e2e-node.sh
+++ b/hack/make-rules/test-e2e-node.sh
@@ -110,6 +110,8 @@ if [ "${remote}" = true ] && [ "${remote_mode}" = gce ] ; then
   gubernator=${GUBERNATOR:-"false"}
   instance_type=${INSTANCE_TYPE:-""}
   node_env="${NODE_ENV:-""}"
+  network="${NETWORK:-""}"
+  subnet="${SUBNET:-""}"
   image_config_file=${IMAGE_CONFIG_FILE:-""}
   image_config_dir=${IMAGE_CONFIG_DIR:-""}
   use_dockerized_build=${USE_DOCKERIZED_BUILD:-"false"}
@@ -196,6 +198,12 @@ if [ "${remote}" = true ] && [ "${remote_mode}" = gce ] ; then
   if [[ -n ${instance_type} ]]; then
     echo "Instance Type: ${instance_type}"
   fi
+  if [[ -n ${network} ]]; then
+    echo "Network: ${network}"
+  fi
+  if [[ -n ${subnet} ]]; then
+    echo "Subnet: ${subnet}"
+  fi
   echo "Kubelet Config File: ${kubelet_config_file}"
 
   # Invoke the runner
@@ -206,6 +214,7 @@ if [ "${remote}" = true ] && [ "${remote_mode}" = gce ] ; then
     --image-project="${image_project}" --instance-name-prefix="${instance_prefix}" \
     --delete-instances="${delete_instances}" --test_args="${test_args}" --instance-metadata="${metadata}" \
     --image-config-file="${image_config_file}" --system-spec-name="${system_spec_name}" \
+    --network="${network}" --subnet="${subnet}" \
     --runtime-config="${runtime_config}" --preemptible-instances="${preemptible_instances}" \
     --ssh-user="${ssh_user}" --ssh-key="${ssh_key}" --ssh-options="${ssh_options}" \
     --image-config-dir="${image_config_dir}" --node-env="${node_env}" \

--- a/test/e2e_node/remote/gce/gce_runner.go
+++ b/test/e2e_node/remote/gce/gce_runner.go
@@ -75,6 +75,8 @@ var instanceMetadata = flag.String("instance-metadata", "", "key/value metadata 
 var imageProject = flag.String("image-project", "", "gce project the hosts live in  (gce)")
 var instanceType = flag.String("instance-type", "e2-medium", "GCP Machine type to use for test")
 var preemptibleInstances = flag.Bool("preemptible-instances", false, "If true, gce instances will be configured to be preemptible  (gce)")
+var network = flag.String("network", "", "Specifies the network that the VM instance are a part of")
+var subnet = flag.String("subnet", "", "Specifies the subnet that the VM instance are a part of")
 
 func init() {
 	flag.Var(&nodeEnvs, "node-env", "An environment variable passed to instance as metadata, e.g. when '--node-env=PATH=/usr/bin' is specified, there will be an extra instance metadata 'PATH=/usr/bin'.")
@@ -512,6 +514,12 @@ func (g *GCERunner) createGCEInstance(imageConfig *internalGCEImage) (string, er
 	createArgs = append(createArgs, "--machine-type="+g.machineType(imageConfig.machine))
 	createArgs = append(createArgs, "--create-disk="+strings.Join(diskArgs, ","))
 	createArgs = append(createArgs, "--service-account="+serviceAccount)
+	if len(*network) > 0 {
+		createArgs = append(createArgs, "--network="+*network)
+	}
+	if len(*subnet) > 0 {
+		createArgs = append(createArgs, "--subnet="+*subnet)
+	}
 	if *preemptibleInstances {
 		createArgs = append(createArgs, "--preemptible")
 	}


### PR DESCRIPTION
/kind feature

#### What this PR does / why we need it:
The default network is not always a viable option, as it may already be saturated or unavailable for use.
Allowing the use of custom networks will improve flexibility.


#### Which issue(s) this PR fixes:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes https://github.com/kubernetes/kubernetes/issues/127567.

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
no

```release-note
Support specifying a custom network parameter when running e2e-node-tests with the remote option.
```

/sig node