### PR TITLE
pkg/api(s): drop pointer wrapper functions

### DIFF
--- a/pkg/api/job/warnings_test.go
+++ b/pkg/api/job/warnings_test.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/kubernetes/pkg/apis/batch"
 	"k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/test/utils/ktesting"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 var (
@@ -50,21 +50,21 @@ func TestWarningsForJobSpec(t *testing.T) {
 	}{
 		"valid NonIndexed": {
 			spec: &batch.JobSpec{
-				CompletionMode: completionModePtr(batch.NonIndexedCompletion),
+				CompletionMode: ptr.To(batch.NonIndexedCompletion),
 				Template:       validPodTemplate,
 			},
 		},
 		"NondIndexed with high completions and parallelism": {
 			spec: &batch.JobSpec{
-				CompletionMode: completionModePtr(batch.NonIndexedCompletion),
+				CompletionMode: ptr.To(batch.NonIndexedCompletion),
 				Template:       validPodTemplate,
-				Parallelism:    pointer.Int32(1_000_000_000),
-				Completions:    pointer.Int32(1_000_000_000),
+				Parallelism:    ptr.To[int32](1_000_000_000),
+				Completions:    ptr.To[int32](1_000_000_000),
 			},
 		},
 		"invalid PodTemplate": {
 			spec: &batch.JobSpec{
-				CompletionMode: completionModePtr(batch.NonIndexedCompletion),
+				CompletionMode: ptr.To(batch.NonIndexedCompletion),
 				Template: core.PodTemplateSpec{
 					Spec: core.PodSpec{ImagePullSecrets: []core.LocalObjectReference{{Name: ""}}},
 				},
@@ -73,33 +73,33 @@ func TestWarningsForJobSpec(t *testing.T) {
 		},
 		"valid Indexed low completions low parallelism": {
 			spec: &batch.JobSpec{
-				CompletionMode: completionModePtr(batch.IndexedCompletion),
-				Completions:    pointer.Int32(10_000),
-				Parallelism:    pointer.Int32(10_000),
+				CompletionMode: ptr.To(batch.IndexedCompletion),
+				Completions:    ptr.To[int32](10_000),
+				Parallelism:    ptr.To[int32](10_000),
 				Template:       validPodTemplate,
 			},
 		},
 		"valid Indexed high completions low parallelism": {
 			spec: &batch.JobSpec{
-				CompletionMode: completionModePtr(batch.IndexedCompletion),
-				Completions:    pointer.Int32(1000_000_000),
-				Parallelism:    pointer.Int32(10_000),
+				CompletionMode: ptr.To(batch.IndexedCompletion),
+				Completions:    ptr.To[int32](1000_000_000),
+				Parallelism:    ptr.To[int32](10_000),
 				Template:       validPodTemplate,
 			},
 		},
 		"valid Indexed medium completions medium parallelism": {
 			spec: &batch.JobSpec{
-				CompletionMode: completionModePtr(batch.IndexedCompletion),
-				Completions:    pointer.Int32(100_000),
-				Parallelism:    pointer.Int32(100_000),
+				CompletionMode: ptr.To(batch.IndexedCompletion),
+				Completions:    ptr.To[int32](100_000),
+				Parallelism:    ptr.To[int32](100_000),
 				Template:       validPodTemplate,
 			},
 		},
 		"invalid Indexed high completions high parallelism": {
 			spec: &batch.JobSpec{
-				CompletionMode: completionModePtr(batch.IndexedCompletion),
-				Completions:    pointer.Int32(100_001),
-				Parallelism:    pointer.Int32(10_001),
+				CompletionMode: ptr.To(batch.IndexedCompletion),
+				Completions:    ptr.To[int32](100_001),
+				Parallelism:    ptr.To[int32](10_001),
 				Template:       validPodTemplate,
 			},
 			wantWarningsCount: 1,
@@ -114,8 +114,4 @@ func TestWarningsForJobSpec(t *testing.T) {
 			}
 		})
 	}
-}
-
-func completionModePtr(m batch.CompletionMode) *batch.CompletionMode {
-	return &m
 }

--- a/pkg/apis/admissionregistration/validation/validation_test.go
+++ b/pkg/apis/admissionregistration/validation/validation_test.go
@@ -32,13 +32,8 @@ import (
 	"k8s.io/apiserver/pkg/features"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/kubernetes/pkg/apis/admissionregistration"
+	"k8s.io/utils/ptr"
 )
-
-func ptr[T any](v T) *T { return &v }
-
-func strPtr(s string) *string { return &s }
-
-func int32Ptr(i int32) *int32 { return &i }
 
 func newValidatingWebhookConfiguration(hooks []admissionregistration.ValidatingWebhook, defaultAdmissionReviewVersions bool) *admissionregistration.ValidatingWebhookConfiguration {
 	// If the test case did not specify an AdmissionReviewVersions, default it so the test passes as
@@ -60,7 +55,7 @@ func TestValidateValidatingWebhookConfiguration(t *testing.T) {
 	noSideEffect := admissionregistration.SideEffectClassNone
 	unknownSideEffect := admissionregistration.SideEffectClassUnknown
 	validClientConfig := admissionregistration.WebhookClientConfig{
-		URL: strPtr("https://example.com"),
+		URL: ptr.To("https://example.com"),
 	}
 	tests := []struct {
 		name          string
@@ -380,7 +375,7 @@ func TestValidateValidatingWebhookConfiguration(t *testing.T) {
 					Name:      "n",
 					Port:      443,
 				},
-				URL: strPtr("example.com/k8s/webhook"),
+				URL: ptr.To("example.com/k8s/webhook"),
 			},
 		},
 		}, true),
@@ -390,7 +385,7 @@ func TestValidateValidatingWebhookConfiguration(t *testing.T) {
 		config: newValidatingWebhookConfiguration([]admissionregistration.ValidatingWebhook{{
 			Name: "webhook.k8s.io",
 			ClientConfig: admissionregistration.WebhookClientConfig{
-				URL: strPtr(""),
+				URL: ptr.To(""),
 			},
 		},
 		}, true),
@@ -400,7 +395,7 @@ func TestValidateValidatingWebhookConfiguration(t *testing.T) {
 		config: newValidatingWebhookConfiguration([]admissionregistration.ValidatingWebhook{{
 			Name: "webhook.k8s.io",
 			ClientConfig: admissionregistration.WebhookClientConfig{
-				URL: strPtr("http://example.com"),
+				URL: ptr.To("http://example.com"),
 			},
 		},
 		}, true),
@@ -410,7 +405,7 @@ func TestValidateValidatingWebhookConfiguration(t *testing.T) {
 		config: newValidatingWebhookConfiguration([]admissionregistration.ValidatingWebhook{{
 			Name: "webhook.k8s.io",
 			ClientConfig: admissionregistration.WebhookClientConfig{
-				URL: strPtr("https:///fancy/webhook"),
+				URL: ptr.To("https:///fancy/webhook"),
 			},
 		},
 		}, true),
@@ -420,7 +415,7 @@ func TestValidateValidatingWebhookConfiguration(t *testing.T) {
 		config: newValidatingWebhookConfiguration([]admissionregistration.ValidatingWebhook{{
 			Name: "webhook.k8s.io",
 			ClientConfig: admissionregistration.WebhookClientConfig{
-				URL: strPtr("https://example.com/#bookmark"),
+				URL: ptr.To("https://example.com/#bookmark"),
 			},
 		},
 		}, true),
@@ -430,7 +425,7 @@ func TestValidateValidatingWebhookConfiguration(t *testing.T) {
 		config: newValidatingWebhookConfiguration([]admissionregistration.ValidatingWebhook{{
 			Name: "webhook.k8s.io",
 			ClientConfig: admissionregistration.WebhookClientConfig{
-				URL: strPtr("https://example.com?arg=value"),
+				URL: ptr.To("https://example.com?arg=value"),
 			},
 		},
 		}, true),
@@ -440,7 +435,7 @@ func TestValidateValidatingWebhookConfiguration(t *testing.T) {
 		config: newValidatingWebhookConfiguration([]admissionregistration.ValidatingWebhook{{
 			Name: "webhook.k8s.io",
 			ClientConfig: admissionregistration.WebhookClientConfig{
-				URL: strPtr("https://harry.potter@example.com/"),
+				URL: ptr.To("https://harry.potter@example.com/"),
 			},
 		},
 		}, true),
@@ -450,7 +445,7 @@ func TestValidateValidatingWebhookConfiguration(t *testing.T) {
 		config: newValidatingWebhookConfiguration([]admissionregistration.ValidatingWebhook{{
 			Name: "webhook.k8s.io",
 			ClientConfig: admissionregistration.WebhookClientConfig{
-				URL: strPtr("arg#backwards=thisis?html.index/port:host//:https"),
+				URL: ptr.To("arg#backwards=thisis?html.index/port:host//:https"),
 			},
 		},
 		}, true),
@@ -463,7 +458,7 @@ func TestValidateValidatingWebhookConfiguration(t *testing.T) {
 				Service: &admissionregistration.ServiceReference{
 					Namespace: "ns",
 					Name:      "n",
-					Path:      strPtr("foo/"),
+					Path:      ptr.To("foo/"),
 					Port:      443,
 				},
 			},
@@ -478,7 +473,7 @@ func TestValidateValidatingWebhookConfiguration(t *testing.T) {
 				Service: &admissionregistration.ServiceReference{
 					Namespace: "ns",
 					Name:      "n",
-					Path:      strPtr("/"),
+					Path:      ptr.To("/"),
 					Port:      443,
 				},
 			},
@@ -494,7 +489,7 @@ func TestValidateValidatingWebhookConfiguration(t *testing.T) {
 				Service: &admissionregistration.ServiceReference{
 					Namespace: "ns",
 					Name:      "n",
-					Path:      strPtr("/foo"),
+					Path:      ptr.To("/foo"),
 					Port:      443,
 				},
 			},
@@ -510,7 +505,7 @@ func TestValidateValidatingWebhookConfiguration(t *testing.T) {
 				Service: &admissionregistration.ServiceReference{
 					Namespace: "ns",
 					Name:      "n",
-					Path:      strPtr("//"),
+					Path:      ptr.To("//"),
 					Port:      443,
 				},
 			},
@@ -526,7 +521,7 @@ func TestValidateValidatingWebhookConfiguration(t *testing.T) {
 				Service: &admissionregistration.ServiceReference{
 					Namespace: "ns",
 					Name:      "n",
-					Path:      strPtr("/foo//bar/"),
+					Path:      ptr.To("/foo//bar/"),
 					Port:      443,
 				},
 			},
@@ -542,7 +537,7 @@ func TestValidateValidatingWebhookConfiguration(t *testing.T) {
 				Service: &admissionregistration.ServiceReference{
 					Namespace: "ns",
 					Name:      "n",
-					Path:      strPtr("/foo/bar//"),
+					Path:      ptr.To("/foo/bar//"),
 					Port:      443,
 				},
 			},
@@ -558,7 +553,7 @@ func TestValidateValidatingWebhookConfiguration(t *testing.T) {
 				Service: &admissionregistration.ServiceReference{
 					Namespace: "ns",
 					Name:      "n",
-					Path:      strPtr("/apis/foo.bar/v1alpha1/--bad"),
+					Path:      ptr.To("/apis/foo.bar/v1alpha1/--bad"),
 					Port:      443,
 				},
 			},
@@ -575,7 +570,7 @@ func TestValidateValidatingWebhookConfiguration(t *testing.T) {
 					Service: &admissionregistration.ServiceReference{
 						Namespace: "ns",
 						Name:      "n",
-						Path:      strPtr("https://apis/foo.bar"),
+						Path:      ptr.To("https://apis/foo.bar"),
 						Port:      0,
 					},
 				},
@@ -592,7 +587,7 @@ func TestValidateValidatingWebhookConfiguration(t *testing.T) {
 					Service: &admissionregistration.ServiceReference{
 						Namespace: "ns",
 						Name:      "n",
-						Path:      strPtr("https://apis/foo.bar"),
+						Path:      ptr.To("https://apis/foo.bar"),
 						Port:      65536,
 					},
 				},
@@ -606,7 +601,7 @@ func TestValidateValidatingWebhookConfiguration(t *testing.T) {
 			Name:           "webhook.k8s.io",
 			ClientConfig:   validClientConfig,
 			SideEffects:    &unknownSideEffect,
-			TimeoutSeconds: int32Ptr(31),
+			TimeoutSeconds: ptr.To[int32](31),
 		},
 		}, true),
 		expectedError: `webhooks[0].timeoutSeconds: Invalid value: 31: the timeout value must be between 1 and 30 seconds`,
@@ -616,7 +611,7 @@ func TestValidateValidatingWebhookConfiguration(t *testing.T) {
 			Name:           "webhook.k8s.io",
 			ClientConfig:   validClientConfig,
 			SideEffects:    &unknownSideEffect,
-			TimeoutSeconds: int32Ptr(0),
+			TimeoutSeconds: ptr.To[int32](0),
 		},
 		}, true),
 		expectedError: `webhooks[0].timeoutSeconds: Invalid value: 0: the timeout value must be between 1 and 30 seconds`,
@@ -626,7 +621,7 @@ func TestValidateValidatingWebhookConfiguration(t *testing.T) {
 			Name:           "webhook.k8s.io",
 			ClientConfig:   validClientConfig,
 			SideEffects:    &unknownSideEffect,
-			TimeoutSeconds: int32Ptr(-1),
+			TimeoutSeconds: ptr.To[int32](-1),
 		},
 		}, true),
 		expectedError: `webhooks[0].timeoutSeconds: Invalid value: -1: the timeout value must be between 1 and 30 seconds`,
@@ -636,17 +631,17 @@ func TestValidateValidatingWebhookConfiguration(t *testing.T) {
 			Name:           "webhook.k8s.io",
 			ClientConfig:   validClientConfig,
 			SideEffects:    &noSideEffect,
-			TimeoutSeconds: int32Ptr(1),
+			TimeoutSeconds: ptr.To[int32](1),
 		}, {
 			Name:           "webhook2.k8s.io",
 			ClientConfig:   validClientConfig,
 			SideEffects:    &noSideEffect,
-			TimeoutSeconds: int32Ptr(15),
+			TimeoutSeconds: ptr.To[int32](15),
 		}, {
 			Name:           "webhook3.k8s.io",
 			ClientConfig:   validClientConfig,
 			SideEffects:    &noSideEffect,
-			TimeoutSeconds: int32Ptr(30),
+			TimeoutSeconds: ptr.To[int32](30),
 		},
 		}, true),
 	}, {
@@ -841,7 +836,7 @@ func TestValidateValidatingWebhookConfigurationUpdate(t *testing.T) {
 	noSideEffect := admissionregistration.SideEffectClassNone
 	unknownSideEffect := admissionregistration.SideEffectClassUnknown
 	validClientConfig := admissionregistration.WebhookClientConfig{
-		URL: strPtr("https://example.com"),
+		URL: ptr.To("https://example.com"),
 	}
 	tests := []struct {
 		name          string
@@ -1037,7 +1032,7 @@ func TestValidateMutatingWebhookConfiguration(t *testing.T) {
 	noSideEffect := admissionregistration.SideEffectClassNone
 	unknownSideEffect := admissionregistration.SideEffectClassUnknown
 	validClientConfig := admissionregistration.WebhookClientConfig{
-		URL: strPtr("https://example.com"),
+		URL: ptr.To("https://example.com"),
 	}
 	tests := []struct {
 		name          string
@@ -1357,7 +1352,7 @@ func TestValidateMutatingWebhookConfiguration(t *testing.T) {
 					Name:      "n",
 					Port:      443,
 				},
-				URL: strPtr("example.com/k8s/webhook"),
+				URL: ptr.To("example.com/k8s/webhook"),
 			},
 		},
 		}, true),
@@ -1367,7 +1362,7 @@ func TestValidateMutatingWebhookConfiguration(t *testing.T) {
 		config: newMutatingWebhookConfiguration([]admissionregistration.MutatingWebhook{{
 			Name: "webhook.k8s.io",
 			ClientConfig: admissionregistration.WebhookClientConfig{
-				URL: strPtr(""),
+				URL: ptr.To(""),
 			},
 		},
 		}, true),
@@ -1377,7 +1372,7 @@ func TestValidateMutatingWebhookConfiguration(t *testing.T) {
 		config: newMutatingWebhookConfiguration([]admissionregistration.MutatingWebhook{{
 			Name: "webhook.k8s.io",
 			ClientConfig: admissionregistration.WebhookClientConfig{
-				URL: strPtr("http://example.com"),
+				URL: ptr.To("http://example.com"),
 			},
 		},
 		}, true),
@@ -1387,7 +1382,7 @@ func TestValidateMutatingWebhookConfiguration(t *testing.T) {
 		config: newMutatingWebhookConfiguration([]admissionregistration.MutatingWebhook{{
 			Name: "webhook.k8s.io",
 			ClientConfig: admissionregistration.WebhookClientConfig{
-				URL: strPtr("https:///fancy/webhook"),
+				URL: ptr.To("https:///fancy/webhook"),
 			},
 		},
 		}, true),
@@ -1397,7 +1392,7 @@ func TestValidateMutatingWebhookConfiguration(t *testing.T) {
 		config: newMutatingWebhookConfiguration([]admissionregistration.MutatingWebhook{{
 			Name: "webhook.k8s.io",
 			ClientConfig: admissionregistration.WebhookClientConfig{
-				URL: strPtr("https://example.com/#bookmark"),
+				URL: ptr.To("https://example.com/#bookmark"),
 			},
 		},
 		}, true),
@@ -1407,7 +1402,7 @@ func TestValidateMutatingWebhookConfiguration(t *testing.T) {
 		config: newMutatingWebhookConfiguration([]admissionregistration.MutatingWebhook{{
 			Name: "webhook.k8s.io",
 			ClientConfig: admissionregistration.WebhookClientConfig{
-				URL: strPtr("https://example.com?arg=value"),
+				URL: ptr.To("https://example.com?arg=value"),
 			},
 		},
 		}, true),
@@ -1417,7 +1412,7 @@ func TestValidateMutatingWebhookConfiguration(t *testing.T) {
 		config: newMutatingWebhookConfiguration([]admissionregistration.MutatingWebhook{{
 			Name: "webhook.k8s.io",
 			ClientConfig: admissionregistration.WebhookClientConfig{
-				URL: strPtr("https://harry.potter@example.com/"),
+				URL: ptr.To("https://harry.potter@example.com/"),
 			},
 		},
 		}, true),
@@ -1427,7 +1422,7 @@ func TestValidateMutatingWebhookConfiguration(t *testing.T) {
 		config: newMutatingWebhookConfiguration([]admissionregistration.MutatingWebhook{{
 			Name: "webhook.k8s.io",
 			ClientConfig: admissionregistration.WebhookClientConfig{
-				URL: strPtr("arg#backwards=thisis?html.index/port:host//:https"),
+				URL: ptr.To("arg#backwards=thisis?html.index/port:host//:https"),
 			},
 		},
 		}, true),
@@ -1440,7 +1435,7 @@ func TestValidateMutatingWebhookConfiguration(t *testing.T) {
 				Service: &admissionregistration.ServiceReference{
 					Namespace: "ns",
 					Name:      "n",
-					Path:      strPtr("foo/"),
+					Path:      ptr.To("foo/"),
 					Port:      443,
 				},
 			},
@@ -1455,7 +1450,7 @@ func TestValidateMutatingWebhookConfiguration(t *testing.T) {
 				Service: &admissionregistration.ServiceReference{
 					Namespace: "ns",
 					Name:      "n",
-					Path:      strPtr("/"),
+					Path:      ptr.To("/"),
 					Port:      443,
 				},
 			},
@@ -1471,7 +1466,7 @@ func TestValidateMutatingWebhookConfiguration(t *testing.T) {
 				Service: &admissionregistration.ServiceReference{
 					Namespace: "ns",
 					Name:      "n",
-					Path:      strPtr("/foo"),
+					Path:      ptr.To("/foo"),
 					Port:      443,
 				},
 			},
@@ -1487,7 +1482,7 @@ func TestValidateMutatingWebhookConfiguration(t *testing.T) {
 				Service: &admissionregistration.ServiceReference{
 					Namespace: "ns",
 					Name:      "n",
-					Path:      strPtr("//"),
+					Path:      ptr.To("//"),
 					Port:      443,
 				},
 			},
@@ -1503,7 +1498,7 @@ func TestValidateMutatingWebhookConfiguration(t *testing.T) {
 				Service: &admissionregistration.ServiceReference{
 					Namespace: "ns",
 					Name:      "n",
-					Path:      strPtr("/foo//bar/"),
+					Path:      ptr.To("/foo//bar/"),
 					Port:      443,
 				},
 			},
@@ -1519,7 +1514,7 @@ func TestValidateMutatingWebhookConfiguration(t *testing.T) {
 				Service: &admissionregistration.ServiceReference{
 					Namespace: "ns",
 					Name:      "n",
-					Path:      strPtr("/foo/bar//"),
+					Path:      ptr.To("/foo/bar//"),
 					Port:      443,
 				},
 			},
@@ -1535,7 +1530,7 @@ func TestValidateMutatingWebhookConfiguration(t *testing.T) {
 				Service: &admissionregistration.ServiceReference{
 					Namespace: "ns",
 					Name:      "n",
-					Path:      strPtr("/apis/foo.bar/v1alpha1/--bad"),
+					Path:      ptr.To("/apis/foo.bar/v1alpha1/--bad"),
 					Port:      443,
 				},
 			},
@@ -1552,7 +1547,7 @@ func TestValidateMutatingWebhookConfiguration(t *testing.T) {
 					Service: &admissionregistration.ServiceReference{
 						Namespace: "ns",
 						Name:      "n",
-						Path:      strPtr("https://apis/foo.bar"),
+						Path:      ptr.To("https://apis/foo.bar"),
 						Port:      0,
 					},
 				},
@@ -1569,7 +1564,7 @@ func TestValidateMutatingWebhookConfiguration(t *testing.T) {
 					Service: &admissionregistration.ServiceReference{
 						Namespace: "ns",
 						Name:      "n",
-						Path:      strPtr("https://apis/foo.bar"),
+						Path:      ptr.To("https://apis/foo.bar"),
 						Port:      65536,
 					},
 				},
@@ -1583,7 +1578,7 @@ func TestValidateMutatingWebhookConfiguration(t *testing.T) {
 			Name:           "webhook.k8s.io",
 			ClientConfig:   validClientConfig,
 			SideEffects:    &unknownSideEffect,
-			TimeoutSeconds: int32Ptr(31),
+			TimeoutSeconds: ptr.To[int32](31),
 		},
 		}, true),
 		expectedError: `webhooks[0].timeoutSeconds: Invalid value: 31: the timeout value must be between 1 and 30 seconds`,
@@ -1593,7 +1588,7 @@ func TestValidateMutatingWebhookConfiguration(t *testing.T) {
 			Name:           "webhook.k8s.io",
 			ClientConfig:   validClientConfig,
 			SideEffects:    &unknownSideEffect,
-			TimeoutSeconds: int32Ptr(0),
+			TimeoutSeconds: ptr.To[int32](0),
 		},
 		}, true),
 		expectedError: `webhooks[0].timeoutSeconds: Invalid value: 0: the timeout value must be between 1 and 30 seconds`,
@@ -1603,7 +1598,7 @@ func TestValidateMutatingWebhookConfiguration(t *testing.T) {
 			Name:           "webhook.k8s.io",
 			ClientConfig:   validClientConfig,
 			SideEffects:    &unknownSideEffect,
-			TimeoutSeconds: int32Ptr(-1),
+			TimeoutSeconds: ptr.To[int32](-1),
 		},
 		}, true),
 		expectedError: `webhooks[0].timeoutSeconds: Invalid value: -1: the timeout value must be between 1 and 30 seconds`,
@@ -1613,17 +1608,17 @@ func TestValidateMutatingWebhookConfiguration(t *testing.T) {
 			Name:           "webhook.k8s.io",
 			ClientConfig:   validClientConfig,
 			SideEffects:    &noSideEffect,
-			TimeoutSeconds: int32Ptr(1),
+			TimeoutSeconds: ptr.To[int32](1),
 		}, {
 			Name:           "webhook2.k8s.io",
 			ClientConfig:   validClientConfig,
 			SideEffects:    &noSideEffect,
-			TimeoutSeconds: int32Ptr(15),
+			TimeoutSeconds: ptr.To[int32](15),
 		}, {
 			Name:           "webhook3.k8s.io",
 			ClientConfig:   validClientConfig,
 			SideEffects:    &noSideEffect,
-			TimeoutSeconds: int32Ptr(30),
+			TimeoutSeconds: ptr.To[int32](30),
 		},
 		}, true),
 	}, {
@@ -1818,7 +1813,7 @@ func TestValidateMutatingWebhookConfigurationUpdate(t *testing.T) {
 	unknownSideEffect := admissionregistration.SideEffectClassUnknown
 	noSideEffect := admissionregistration.SideEffectClassNone
 	validClientConfig := admissionregistration.WebhookClientConfig{
-		URL: strPtr("https://example.com"),
+		URL: ptr.To("https://example.com"),
 	}
 	tests := []struct {
 		name          string
@@ -3532,7 +3527,7 @@ func TestValidateValidatingAdmissionPolicyBinding(t *testing.T) {
 				PolicyName: "xyzlimit-scale.example.com",
 				ParamRef: &admissionregistration.ParamRef{
 					Name:                    "xyzlimit-scale-setting.example.com",
-					ParameterNotFoundAction: ptr(admissionregistration.DenyAction),
+					ParameterNotFoundAction: ptr.To(admissionregistration.DenyAction),
 				},
 				MatchResources: &admissionregistration.MatchResources{
 					MatchPolicy: func() *admissionregistration.MatchPolicyType {
@@ -3553,7 +3548,7 @@ func TestValidateValidatingAdmissionPolicyBinding(t *testing.T) {
 				PolicyName: "xyzlimit-scale.example.com",
 				ParamRef: &admissionregistration.ParamRef{
 					Name:                    "xyzlimit-scale-setting.example.com",
-					ParameterNotFoundAction: ptr(admissionregistration.DenyAction),
+					ParameterNotFoundAction: ptr.To(admissionregistration.DenyAction),
 				},
 				MatchResources: &admissionregistration.MatchResources{
 					ResourceRules: []admissionregistration.NamedRuleWithOperations{{
@@ -3608,7 +3603,7 @@ func TestValidateValidatingAdmissionPolicyBinding(t *testing.T) {
 				PolicyName: "xyzlimit-scale.example.com",
 				ParamRef: &admissionregistration.ParamRef{
 					Name:                    "xyzlimit-scale-setting.example.com",
-					ParameterNotFoundAction: ptr(admissionregistration.DenyAction),
+					ParameterNotFoundAction: ptr.To(admissionregistration.DenyAction),
 				}, MatchResources: &admissionregistration.MatchResources{
 					ResourceRules: []admissionregistration.NamedRuleWithOperations{{
 						RuleWithOperations: admissionregistration.RuleWithOperations{
@@ -3634,7 +3629,7 @@ func TestValidateValidatingAdmissionPolicyBinding(t *testing.T) {
 				PolicyName: "xyzlimit-scale.example.com",
 				ParamRef: &admissionregistration.ParamRef{
 					Name:                    "xyzlimit-scale-setting.example.com",
-					ParameterNotFoundAction: ptr(admissionregistration.DenyAction),
+					ParameterNotFoundAction: ptr.To(admissionregistration.DenyAction),
 				}, MatchResources: &admissionregistration.MatchResources{
 					ResourceRules: []admissionregistration.NamedRuleWithOperations{{
 						RuleWithOperations: admissionregistration.RuleWithOperations{
@@ -3660,7 +3655,7 @@ func TestValidateValidatingAdmissionPolicyBinding(t *testing.T) {
 				PolicyName: "xyzlimit-scale.example.com",
 				ParamRef: &admissionregistration.ParamRef{
 					Name:                    "xyzlimit-scale-setting.example.com",
-					ParameterNotFoundAction: ptr(admissionregistration.DenyAction),
+					ParameterNotFoundAction: ptr.To(admissionregistration.DenyAction),
 				},
 				ValidationActions: []admissionregistration.ValidationAction{admissionregistration.Deny},
 				MatchResources: &admissionregistration.MatchResources{
@@ -3688,7 +3683,7 @@ func TestValidateValidatingAdmissionPolicyBinding(t *testing.T) {
 				PolicyName: "xyzlimit-scale.example.com",
 				ParamRef: &admissionregistration.ParamRef{
 					Name:                    "xyzlimit-scale-setting.example.com",
-					ParameterNotFoundAction: ptr(admissionregistration.DenyAction),
+					ParameterNotFoundAction: ptr.To(admissionregistration.DenyAction),
 				},
 				ValidationActions: []admissionregistration.ValidationAction{admissionregistration.Deny},
 				MatchResources: &admissionregistration.MatchResources{
@@ -3725,7 +3720,7 @@ func TestValidateValidatingAdmissionPolicyBinding(t *testing.T) {
 				PolicyName: "xyzlimit-scale.example.com",
 				ParamRef: &admissionregistration.ParamRef{
 					Name:                    "xyzlimit-scale-setting.example.com",
-					ParameterNotFoundAction: ptr(admissionregistration.DenyAction),
+					ParameterNotFoundAction: ptr.To(admissionregistration.DenyAction),
 				},
 				ValidationActions: []admissionregistration.ValidationAction{admissionregistration.Deny},
 				MatchResources: &admissionregistration.MatchResources{
@@ -3753,7 +3748,7 @@ func TestValidateValidatingAdmissionPolicyBinding(t *testing.T) {
 				PolicyName: "xyzlimit-scale.example.com",
 				ParamRef: &admissionregistration.ParamRef{
 					Name:                    "xyzlimit-scale-setting.example.com",
-					ParameterNotFoundAction: ptr(admissionregistration.DenyAction),
+					ParameterNotFoundAction: ptr.To(admissionregistration.DenyAction),
 				},
 				ValidationActions: []admissionregistration.ValidationAction{admissionregistration.Deny},
 				MatchResources: &admissionregistration.MatchResources{
@@ -3781,7 +3776,7 @@ func TestValidateValidatingAdmissionPolicyBinding(t *testing.T) {
 				PolicyName: "xyzlimit-scale.example.com",
 				ParamRef: &admissionregistration.ParamRef{
 					Name:                    "xyzlimit-scale-setting.example.com",
-					ParameterNotFoundAction: ptr(admissionregistration.DenyAction),
+					ParameterNotFoundAction: ptr.To(admissionregistration.DenyAction),
 				},
 				ValidationActions: []admissionregistration.ValidationAction{admissionregistration.Deny},
 				MatchResources: &admissionregistration.MatchResources{
@@ -3818,7 +3813,7 @@ func TestValidateValidatingAdmissionPolicyBinding(t *testing.T) {
 				PolicyName: "xyzlimit-scale.example.com",
 				ParamRef: &admissionregistration.ParamRef{
 					Name:                    "xyzlimit-scale-setting.example.com",
-					ParameterNotFoundAction: ptr(admissionregistration.DenyAction),
+					ParameterNotFoundAction: ptr.To(admissionregistration.DenyAction),
 				},
 				ValidationActions: []admissionregistration.ValidationAction{admissionregistration.Deny},
 				MatchResources: &admissionregistration.MatchResources{
@@ -3846,7 +3841,7 @@ func TestValidateValidatingAdmissionPolicyBinding(t *testing.T) {
 				PolicyName: "xyzlimit-scale.example.com",
 				ParamRef: &admissionregistration.ParamRef{
 					Name:                    "xyzlimit-scale-setting.example.com",
-					ParameterNotFoundAction: ptr(admissionregistration.DenyAction),
+					ParameterNotFoundAction: ptr.To(admissionregistration.DenyAction),
 				},
 				ValidationActions: []admissionregistration.ValidationAction{admissionregistration.Deny},
 				MatchResources: &admissionregistration.MatchResources{
@@ -3874,7 +3869,7 @@ func TestValidateValidatingAdmissionPolicyBinding(t *testing.T) {
 				PolicyName: "xyzlimit-scale.example.com",
 				ParamRef: &admissionregistration.ParamRef{
 					Name:                    "xyzlimit-scale-setting.example.com",
-					ParameterNotFoundAction: ptr(admissionregistration.DenyAction),
+					ParameterNotFoundAction: ptr.To(admissionregistration.DenyAction),
 				},
 				ValidationActions: []admissionregistration.ValidationAction{admissionregistration.Deny, admissionregistration.Deny},
 			},
@@ -3890,7 +3885,7 @@ func TestValidateValidatingAdmissionPolicyBinding(t *testing.T) {
 				PolicyName: "xyzlimit-scale.example.com",
 				ParamRef: &admissionregistration.ParamRef{
 					Name:                    "xyzlimit-scale-setting.example.com",
-					ParameterNotFoundAction: ptr(admissionregistration.DenyAction),
+					ParameterNotFoundAction: ptr.To(admissionregistration.DenyAction),
 				},
 				ValidationActions: []admissionregistration.ValidationAction{admissionregistration.ValidationAction("illegal")},
 			},
@@ -3912,7 +3907,7 @@ func TestValidateValidatingAdmissionPolicyBinding(t *testing.T) {
 							"label": "value",
 						},
 					},
-					ParameterNotFoundAction: ptr(admissionregistration.DenyAction),
+					ParameterNotFoundAction: ptr.To(admissionregistration.DenyAction),
 				},
 			},
 		},
@@ -3943,7 +3938,7 @@ func TestValidateValidatingAdmissionPolicyBinding(t *testing.T) {
 				ValidationActions: []admissionregistration.ValidationAction{admissionregistration.Deny},
 				ParamRef: &admissionregistration.ParamRef{
 					Name:                    "xyzlimit-scale-setting.example.com",
-					ParameterNotFoundAction: ptr(admissionregistration.ParameterNotFoundActionType("invalid")),
+					ParameterNotFoundAction: ptr.To(admissionregistration.ParameterNotFoundActionType("invalid")),
 				},
 			},
 		},
@@ -3958,7 +3953,7 @@ func TestValidateValidatingAdmissionPolicyBinding(t *testing.T) {
 				PolicyName:        "xyzlimit-scale.example.com",
 				ValidationActions: []admissionregistration.ValidationAction{admissionregistration.Deny},
 				ParamRef: &admissionregistration.ParamRef{
-					ParameterNotFoundAction: ptr(admissionregistration.DenyAction),
+					ParameterNotFoundAction: ptr.To(admissionregistration.DenyAction),
 				},
 			},
 		},
@@ -3998,7 +3993,7 @@ func TestValidateValidatingAdmissionPolicyBindingUpdate(t *testing.T) {
 				PolicyName: "xyzlimit-scale.example.com",
 				ParamRef: &admissionregistration.ParamRef{
 					Name:                    "xyzlimit-scale-setting.example.com",
-					ParameterNotFoundAction: ptr(admissionregistration.DenyAction),
+					ParameterNotFoundAction: ptr.To(admissionregistration.DenyAction),
 				},
 				ValidationActions: []admissionregistration.ValidationAction{admissionregistration.Deny},
 				MatchResources: &admissionregistration.MatchResources{
@@ -4033,7 +4028,7 @@ func TestValidateValidatingAdmissionPolicyBindingUpdate(t *testing.T) {
 				PolicyName: "xyzlimit-scale.example.com",
 				ParamRef: &admissionregistration.ParamRef{
 					Name:                    "xyzlimit-scale-setting.example.com",
-					ParameterNotFoundAction: ptr(admissionregistration.DenyAction),
+					ParameterNotFoundAction: ptr.To(admissionregistration.DenyAction),
 				},
 				ValidationActions: []admissionregistration.ValidationAction{admissionregistration.Deny},
 				MatchResources: &admissionregistration.MatchResources{
@@ -4070,7 +4065,7 @@ func TestValidateValidatingAdmissionPolicyBindingUpdate(t *testing.T) {
 				PolicyName: "xyzlimit-scale.example.com",
 				ParamRef: &admissionregistration.ParamRef{
 					Name:                    "xyzlimit-scale-setting.example.com",
-					ParameterNotFoundAction: ptr(admissionregistration.DenyAction),
+					ParameterNotFoundAction: ptr.To(admissionregistration.DenyAction),
 				},
 				ValidationActions: []admissionregistration.ValidationAction{admissionregistration.Deny},
 				MatchResources: &admissionregistration.MatchResources{

--- a/pkg/apis/batch/v1/defaults.go
+++ b/pkg/apis/batch/v1/defaults.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/kubernetes/pkg/features"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func addDefaultingFuncs(scheme *runtime.Scheme) error {
@@ -35,17 +35,17 @@ func SetDefaults_Job(obj *batchv1.Job) {
 	// For a non-parallel job, you can leave both `.spec.completions` and
 	// `.spec.parallelism` unset.  When both are unset, both are defaulted to 1.
 	if obj.Spec.Completions == nil && obj.Spec.Parallelism == nil {
-		obj.Spec.Completions = utilpointer.Int32(1)
-		obj.Spec.Parallelism = utilpointer.Int32(1)
+		obj.Spec.Completions = ptr.To[int32](1)
+		obj.Spec.Parallelism = ptr.To[int32](1)
 	}
 	if obj.Spec.Parallelism == nil {
-		obj.Spec.Parallelism = utilpointer.Int32(1)
+		obj.Spec.Parallelism = ptr.To[int32](1)
 	}
 	if obj.Spec.BackoffLimit == nil {
 		if obj.Spec.BackoffLimitPerIndex != nil {
-			obj.Spec.BackoffLimit = utilpointer.Int32(math.MaxInt32)
+			obj.Spec.BackoffLimit = ptr.To[int32](math.MaxInt32)
 		} else {
-			obj.Spec.BackoffLimit = utilpointer.Int32(6)
+			obj.Spec.BackoffLimit = ptr.To[int32](6)
 		}
 	}
 	labels := obj.Spec.Template.Labels
@@ -57,7 +57,7 @@ func SetDefaults_Job(obj *batchv1.Job) {
 		obj.Spec.CompletionMode = &mode
 	}
 	if obj.Spec.Suspend == nil {
-		obj.Spec.Suspend = utilpointer.Bool(false)
+		obj.Spec.Suspend = ptr.To(false)
 	}
 	if obj.Spec.PodFailurePolicy != nil {
 		for _, rule := range obj.Spec.PodFailurePolicy.Rules {
@@ -73,14 +73,14 @@ func SetDefaults_Job(obj *batchv1.Job) {
 	if utilfeature.DefaultFeatureGate.Enabled(features.JobPodReplacementPolicy) {
 		if obj.Spec.PodReplacementPolicy == nil {
 			if obj.Spec.PodFailurePolicy != nil {
-				obj.Spec.PodReplacementPolicy = podReplacementPolicyPtr(batchv1.Failed)
+				obj.Spec.PodReplacementPolicy = ptr.To(batchv1.Failed)
 			} else {
-				obj.Spec.PodReplacementPolicy = podReplacementPolicyPtr(batchv1.TerminatingOrFailed)
+				obj.Spec.PodReplacementPolicy = ptr.To(batchv1.TerminatingOrFailed)
 			}
 		}
 	}
 	if obj.Spec.ManualSelector == nil {
-		obj.Spec.ManualSelector = utilpointer.Bool(false)
+		obj.Spec.ManualSelector = ptr.To(false)
 	}
 }
 
@@ -89,16 +89,12 @@ func SetDefaults_CronJob(obj *batchv1.CronJob) {
 		obj.Spec.ConcurrencyPolicy = batchv1.AllowConcurrent
 	}
 	if obj.Spec.Suspend == nil {
-		obj.Spec.Suspend = utilpointer.Bool(false)
+		obj.Spec.Suspend = ptr.To(false)
 	}
 	if obj.Spec.SuccessfulJobsHistoryLimit == nil {
-		obj.Spec.SuccessfulJobsHistoryLimit = utilpointer.Int32(3)
+		obj.Spec.SuccessfulJobsHistoryLimit = ptr.To[int32](3)
 	}
 	if obj.Spec.FailedJobsHistoryLimit == nil {
-		obj.Spec.FailedJobsHistoryLimit = utilpointer.Int32(1)
+		obj.Spec.FailedJobsHistoryLimit = ptr.To[int32](1)
 	}
-}
-
-func podReplacementPolicyPtr(obj batchv1.PodReplacementPolicy) *batchv1.PodReplacementPolicy {
-	return &obj
 }

--- a/pkg/apis/batch/v1/defaults_test.go
+++ b/pkg/apis/batch/v1/defaults_test.go
@@ -32,7 +32,7 @@ import (
 	_ "k8s.io/kubernetes/pkg/apis/batch/install"
 	_ "k8s.io/kubernetes/pkg/apis/core/install"
 	"k8s.io/kubernetes/pkg/features"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	. "k8s.io/kubernetes/pkg/apis/batch/v1"
 )
@@ -93,12 +93,12 @@ func TestSetDefaultJob(t *testing.T) {
 			},
 			expected: &batchv1.Job{
 				Spec: batchv1.JobSpec{
-					Completions:    pointer.Int32(1),
-					Parallelism:    pointer.Int32(1),
-					BackoffLimit:   pointer.Int32(6),
-					CompletionMode: completionModePtr(batchv1.NonIndexedCompletion),
-					Suspend:        pointer.Bool(false),
-					ManualSelector: pointer.Bool(false),
+					Completions:    ptr.To[int32](1),
+					Parallelism:    ptr.To[int32](1),
+					BackoffLimit:   ptr.To[int32](6),
+					CompletionMode: ptr.To(batchv1.NonIndexedCompletion),
+					Suspend:        ptr.To(false),
+					ManualSelector: ptr.To(false),
 					PodFailurePolicy: &batchv1.PodFailurePolicy{
 						Rules: []batchv1.PodFailurePolicyRule{
 							{
@@ -161,13 +161,13 @@ func TestSetDefaultJob(t *testing.T) {
 			},
 			expected: &batchv1.Job{
 				Spec: batchv1.JobSpec{
-					Completions:          pointer.Int32(1),
-					Parallelism:          pointer.Int32(1),
-					BackoffLimit:         pointer.Int32(6),
-					CompletionMode:       completionModePtr(batchv1.NonIndexedCompletion),
-					Suspend:              pointer.Bool(false),
-					PodReplacementPolicy: podReplacementPtr(batchv1.Failed),
-					ManualSelector:       pointer.Bool(false),
+					Completions:          ptr.To[int32](1),
+					Parallelism:          ptr.To[int32](1),
+					BackoffLimit:         ptr.To[int32](6),
+					CompletionMode:       ptr.To(batchv1.NonIndexedCompletion),
+					Suspend:              ptr.To(false),
+					PodReplacementPolicy: ptr.To(batchv1.Failed),
+					ManualSelector:       ptr.To(false),
 					PodFailurePolicy: &batchv1.PodFailurePolicy{
 						Rules: []batchv1.PodFailurePolicyRule{
 							{
@@ -194,13 +194,13 @@ func TestSetDefaultJob(t *testing.T) {
 			},
 			expected: &batchv1.Job{
 				Spec: batchv1.JobSpec{
-					Completions:          pointer.Int32(1),
-					Parallelism:          pointer.Int32(1),
-					BackoffLimit:         pointer.Int32(6),
-					CompletionMode:       completionModePtr(batchv1.NonIndexedCompletion),
-					Suspend:              pointer.Bool(false),
-					PodReplacementPolicy: podReplacementPtr(batchv1.TerminatingOrFailed),
-					ManualSelector:       pointer.Bool(false),
+					Completions:          ptr.To[int32](1),
+					Parallelism:          ptr.To[int32](1),
+					BackoffLimit:         ptr.To[int32](6),
+					CompletionMode:       ptr.To(batchv1.NonIndexedCompletion),
+					Suspend:              ptr.To(false),
+					PodReplacementPolicy: ptr.To(batchv1.TerminatingOrFailed),
+					ManualSelector:       ptr.To(false),
 				},
 			},
 			expectLabels:               true,
@@ -216,12 +216,12 @@ func TestSetDefaultJob(t *testing.T) {
 			},
 			expected: &batchv1.Job{
 				Spec: batchv1.JobSpec{
-					Completions:    pointer.Int32(1),
-					Parallelism:    pointer.Int32(1),
-					BackoffLimit:   pointer.Int32(6),
-					CompletionMode: completionModePtr(batchv1.NonIndexedCompletion),
-					Suspend:        pointer.Bool(false),
-					ManualSelector: pointer.Bool(false),
+					Completions:    ptr.To[int32](1),
+					Parallelism:    ptr.To[int32](1),
+					BackoffLimit:   ptr.To[int32](6),
+					CompletionMode: ptr.To(batchv1.NonIndexedCompletion),
+					Suspend:        ptr.To(false),
+					ManualSelector: ptr.To(false),
 				},
 			},
 			expectLabels: true,
@@ -236,12 +236,12 @@ func TestSetDefaultJob(t *testing.T) {
 			},
 			expected: &batchv1.Job{
 				Spec: batchv1.JobSpec{
-					Completions:    pointer.Int32(1),
-					Parallelism:    pointer.Int32(1),
-					BackoffLimit:   pointer.Int32(6),
-					CompletionMode: completionModePtr(batchv1.NonIndexedCompletion),
-					Suspend:        pointer.Bool(false),
-					ManualSelector: pointer.Bool(false),
+					Completions:    ptr.To[int32](1),
+					Parallelism:    ptr.To[int32](1),
+					BackoffLimit:   ptr.To[int32](6),
+					CompletionMode: ptr.To(batchv1.NonIndexedCompletion),
+					Suspend:        ptr.To(false),
+					ManualSelector: ptr.To(false),
 				},
 			},
 			expectLabels: true,
@@ -249,7 +249,7 @@ func TestSetDefaultJob(t *testing.T) {
 		"suspend set, everything else is defaulted": {
 			original: &batchv1.Job{
 				Spec: batchv1.JobSpec{
-					Suspend: pointer.Bool(true),
+					Suspend: ptr.To(true),
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{Labels: defaultLabels},
 					},
@@ -257,12 +257,12 @@ func TestSetDefaultJob(t *testing.T) {
 			},
 			expected: &batchv1.Job{
 				Spec: batchv1.JobSpec{
-					Completions:    pointer.Int32(1),
-					Parallelism:    pointer.Int32(1),
-					BackoffLimit:   pointer.Int32(6),
-					CompletionMode: completionModePtr(batchv1.NonIndexedCompletion),
-					Suspend:        pointer.Bool(true),
-					ManualSelector: pointer.Bool(false),
+					Completions:    ptr.To[int32](1),
+					Parallelism:    ptr.To[int32](1),
+					BackoffLimit:   ptr.To[int32](6),
+					CompletionMode: ptr.To(batchv1.NonIndexedCompletion),
+					Suspend:        ptr.To(true),
+					ManualSelector: ptr.To(false),
 				},
 			},
 			expectLabels: true,
@@ -280,19 +280,19 @@ func TestSetDefaultJob(t *testing.T) {
 			},
 			expected: &batchv1.Job{
 				Spec: batchv1.JobSpec{
-					Completions:    pointer.Int32(1),
-					Parallelism:    pointer.Int32(1),
-					BackoffLimit:   pointer.Int32(6),
-					CompletionMode: completionModePtr(batchv1.NonIndexedCompletion),
-					Suspend:        pointer.Bool(false),
-					ManualSelector: pointer.Bool(false),
+					Completions:    ptr.To[int32](1),
+					Parallelism:    ptr.To[int32](1),
+					BackoffLimit:   ptr.To[int32](6),
+					CompletionMode: ptr.To(batchv1.NonIndexedCompletion),
+					Suspend:        ptr.To(false),
+					ManualSelector: ptr.To(false),
 				},
 			},
 		},
 		"WQ: Parallelism explicitly 0 and completions unset -> BackoffLimit is defaulted": {
 			original: &batchv1.Job{
 				Spec: batchv1.JobSpec{
-					Parallelism: pointer.Int32(0),
+					Parallelism: ptr.To[int32](0),
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{Labels: defaultLabels},
 					},
@@ -300,11 +300,11 @@ func TestSetDefaultJob(t *testing.T) {
 			},
 			expected: &batchv1.Job{
 				Spec: batchv1.JobSpec{
-					Parallelism:    pointer.Int32(0),
-					BackoffLimit:   pointer.Int32(6),
-					CompletionMode: completionModePtr(batchv1.NonIndexedCompletion),
-					Suspend:        pointer.Bool(false),
-					ManualSelector: pointer.Bool(false),
+					Parallelism:    ptr.To[int32](0),
+					BackoffLimit:   ptr.To[int32](6),
+					CompletionMode: ptr.To(batchv1.NonIndexedCompletion),
+					Suspend:        ptr.To(false),
+					ManualSelector: ptr.To(false),
 				},
 			},
 			expectLabels: true,
@@ -312,7 +312,7 @@ func TestSetDefaultJob(t *testing.T) {
 		"WQ: Parallelism explicitly 2 and completions unset -> BackoffLimit is defaulted": {
 			original: &batchv1.Job{
 				Spec: batchv1.JobSpec{
-					Parallelism: pointer.Int32(2),
+					Parallelism: ptr.To[int32](2),
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{Labels: defaultLabels},
 					},
@@ -320,11 +320,11 @@ func TestSetDefaultJob(t *testing.T) {
 			},
 			expected: &batchv1.Job{
 				Spec: batchv1.JobSpec{
-					Parallelism:    pointer.Int32(2),
-					BackoffLimit:   pointer.Int32(6),
-					CompletionMode: completionModePtr(batchv1.NonIndexedCompletion),
-					Suspend:        pointer.Bool(false),
-					ManualSelector: pointer.Bool(false),
+					Parallelism:    ptr.To[int32](2),
+					BackoffLimit:   ptr.To[int32](6),
+					CompletionMode: ptr.To(batchv1.NonIndexedCompletion),
+					Suspend:        ptr.To(false),
+					ManualSelector: ptr.To(false),
 				},
 			},
 			expectLabels: true,
@@ -332,7 +332,7 @@ func TestSetDefaultJob(t *testing.T) {
 		"Completions explicitly 2 and others unset -> parallelism and BackoffLimit are defaulted": {
 			original: &batchv1.Job{
 				Spec: batchv1.JobSpec{
-					Completions: pointer.Int32(2),
+					Completions: ptr.To[int32](2),
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{Labels: defaultLabels},
 					},
@@ -340,12 +340,12 @@ func TestSetDefaultJob(t *testing.T) {
 			},
 			expected: &batchv1.Job{
 				Spec: batchv1.JobSpec{
-					Completions:    pointer.Int32(2),
-					Parallelism:    pointer.Int32(1),
-					BackoffLimit:   pointer.Int32(6),
-					CompletionMode: completionModePtr(batchv1.NonIndexedCompletion),
-					Suspend:        pointer.Bool(false),
-					ManualSelector: pointer.Bool(false),
+					Completions:    ptr.To[int32](2),
+					Parallelism:    ptr.To[int32](1),
+					BackoffLimit:   ptr.To[int32](6),
+					CompletionMode: ptr.To(batchv1.NonIndexedCompletion),
+					Suspend:        ptr.To(false),
+					ManualSelector: ptr.To(false),
 				},
 			},
 			expectLabels: true,
@@ -353,7 +353,7 @@ func TestSetDefaultJob(t *testing.T) {
 		"BackoffLimit explicitly 5 and others unset -> parallelism and completions are defaulted": {
 			original: &batchv1.Job{
 				Spec: batchv1.JobSpec{
-					BackoffLimit: pointer.Int32(5),
+					BackoffLimit: ptr.To[int32](5),
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{Labels: defaultLabels},
 					},
@@ -361,12 +361,12 @@ func TestSetDefaultJob(t *testing.T) {
 			},
 			expected: &batchv1.Job{
 				Spec: batchv1.JobSpec{
-					Completions:    pointer.Int32(1),
-					Parallelism:    pointer.Int32(1),
-					BackoffLimit:   pointer.Int32(5),
-					CompletionMode: completionModePtr(batchv1.NonIndexedCompletion),
-					Suspend:        pointer.Bool(false),
-					ManualSelector: pointer.Bool(false),
+					Completions:    ptr.To[int32](1),
+					Parallelism:    ptr.To[int32](1),
+					BackoffLimit:   ptr.To[int32](5),
+					CompletionMode: ptr.To(batchv1.NonIndexedCompletion),
+					Suspend:        ptr.To(false),
+					ManualSelector: ptr.To(false),
 				},
 			},
 			expectLabels: true,
@@ -374,13 +374,13 @@ func TestSetDefaultJob(t *testing.T) {
 		"All set -> no change": {
 			original: &batchv1.Job{
 				Spec: batchv1.JobSpec{
-					Completions:          pointer.Int32(8),
-					Parallelism:          pointer.Int32(9),
-					BackoffLimit:         pointer.Int32(10),
-					CompletionMode:       completionModePtr(batchv1.NonIndexedCompletion),
-					Suspend:              pointer.Bool(false),
-					PodReplacementPolicy: podReplacementPtr(batchv1.TerminatingOrFailed),
-					ManualSelector:       pointer.Bool(false),
+					Completions:          ptr.To[int32](8),
+					Parallelism:          ptr.To[int32](9),
+					BackoffLimit:         ptr.To[int32](10),
+					CompletionMode:       ptr.To(batchv1.NonIndexedCompletion),
+					Suspend:              ptr.To(false),
+					PodReplacementPolicy: ptr.To(batchv1.TerminatingOrFailed),
+					ManualSelector:       ptr.To(false),
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{Labels: defaultLabels},
 					},
@@ -388,13 +388,13 @@ func TestSetDefaultJob(t *testing.T) {
 			},
 			expected: &batchv1.Job{
 				Spec: batchv1.JobSpec{
-					Completions:          pointer.Int32(8),
-					Parallelism:          pointer.Int32(9),
-					BackoffLimit:         pointer.Int32(10),
-					CompletionMode:       completionModePtr(batchv1.NonIndexedCompletion),
-					Suspend:              pointer.Bool(false),
-					PodReplacementPolicy: podReplacementPtr(batchv1.TerminatingOrFailed),
-					ManualSelector:       pointer.Bool(false),
+					Completions:          ptr.To[int32](8),
+					Parallelism:          ptr.To[int32](9),
+					BackoffLimit:         ptr.To[int32](10),
+					CompletionMode:       ptr.To(batchv1.NonIndexedCompletion),
+					Suspend:              ptr.To(false),
+					PodReplacementPolicy: ptr.To(batchv1.TerminatingOrFailed),
+					ManualSelector:       ptr.To(false),
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{Labels: defaultLabels},
 					},
@@ -405,13 +405,13 @@ func TestSetDefaultJob(t *testing.T) {
 		"All set, flipped -> no change": {
 			original: &batchv1.Job{
 				Spec: batchv1.JobSpec{
-					Completions:          pointer.Int32(11),
-					Parallelism:          pointer.Int32(10),
-					BackoffLimit:         pointer.Int32(9),
-					CompletionMode:       completionModePtr(batchv1.IndexedCompletion),
-					Suspend:              pointer.Bool(true),
-					PodReplacementPolicy: podReplacementPtr(batchv1.Failed),
-					ManualSelector:       pointer.Bool(true),
+					Completions:          ptr.To[int32](11),
+					Parallelism:          ptr.To[int32](10),
+					BackoffLimit:         ptr.To[int32](9),
+					CompletionMode:       ptr.To(batchv1.IndexedCompletion),
+					Suspend:              ptr.To(true),
+					PodReplacementPolicy: ptr.To(batchv1.Failed),
+					ManualSelector:       ptr.To(true),
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{Labels: defaultLabels},
 					},
@@ -419,13 +419,13 @@ func TestSetDefaultJob(t *testing.T) {
 			},
 			expected: &batchv1.Job{
 				Spec: batchv1.JobSpec{
-					Completions:          pointer.Int32(11),
-					Parallelism:          pointer.Int32(10),
-					BackoffLimit:         pointer.Int32(9),
-					CompletionMode:       completionModePtr(batchv1.IndexedCompletion),
-					Suspend:              pointer.Bool(true),
-					PodReplacementPolicy: podReplacementPtr(batchv1.Failed),
-					ManualSelector:       pointer.Bool(true),
+					Completions:          ptr.To[int32](11),
+					Parallelism:          ptr.To[int32](10),
+					BackoffLimit:         ptr.To[int32](9),
+					CompletionMode:       ptr.To(batchv1.IndexedCompletion),
+					Suspend:              ptr.To(true),
+					PodReplacementPolicy: ptr.To(batchv1.Failed),
+					ManualSelector:       ptr.To(true),
 				},
 			},
 			expectLabels: true,
@@ -433,25 +433,25 @@ func TestSetDefaultJob(t *testing.T) {
 		"BackoffLimitPerIndex specified, but no BackoffLimit -> default BackoffLimit to max int32": {
 			original: &batchv1.Job{
 				Spec: batchv1.JobSpec{
-					Completions:          pointer.Int32(11),
-					Parallelism:          pointer.Int32(10),
-					BackoffLimitPerIndex: pointer.Int32(1),
-					CompletionMode:       completionModePtr(batchv1.IndexedCompletion),
+					Completions:          ptr.To[int32](11),
+					Parallelism:          ptr.To[int32](10),
+					BackoffLimitPerIndex: ptr.To[int32](1),
+					CompletionMode:       ptr.To(batchv1.IndexedCompletion),
 					Template:             validPodTemplateSpec,
-					Suspend:              pointer.Bool(true),
-					ManualSelector:       pointer.Bool(false),
+					Suspend:              ptr.To(true),
+					ManualSelector:       ptr.To(false),
 				},
 			},
 			expected: &batchv1.Job{
 				Spec: batchv1.JobSpec{
-					Completions:          pointer.Int32(11),
-					Parallelism:          pointer.Int32(10),
-					BackoffLimit:         pointer.Int32(math.MaxInt32),
-					BackoffLimitPerIndex: pointer.Int32(1),
-					CompletionMode:       completionModePtr(batchv1.IndexedCompletion),
+					Completions:          ptr.To[int32](11),
+					Parallelism:          ptr.To[int32](10),
+					BackoffLimit:         ptr.To[int32](math.MaxInt32),
+					BackoffLimitPerIndex: ptr.To[int32](1),
+					CompletionMode:       ptr.To(batchv1.IndexedCompletion),
 					Template:             validPodTemplateSpec,
-					Suspend:              pointer.Bool(true),
-					ManualSelector:       pointer.Bool(false),
+					Suspend:              ptr.To(true),
+					ManualSelector:       ptr.To(false),
 				},
 			},
 			expectLabels: true,
@@ -459,26 +459,26 @@ func TestSetDefaultJob(t *testing.T) {
 		"BackoffLimitPerIndex and BackoffLimit specified -> no change": {
 			original: &batchv1.Job{
 				Spec: batchv1.JobSpec{
-					Completions:          pointer.Int32(11),
-					Parallelism:          pointer.Int32(10),
-					BackoffLimit:         pointer.Int32(3),
-					BackoffLimitPerIndex: pointer.Int32(1),
-					CompletionMode:       completionModePtr(batchv1.IndexedCompletion),
+					Completions:          ptr.To[int32](11),
+					Parallelism:          ptr.To[int32](10),
+					BackoffLimit:         ptr.To[int32](3),
+					BackoffLimitPerIndex: ptr.To[int32](1),
+					CompletionMode:       ptr.To(batchv1.IndexedCompletion),
 					Template:             validPodTemplateSpec,
-					Suspend:              pointer.Bool(true),
-					ManualSelector:       pointer.Bool(true),
+					Suspend:              ptr.To(true),
+					ManualSelector:       ptr.To(true),
 				},
 			},
 			expected: &batchv1.Job{
 				Spec: batchv1.JobSpec{
-					Completions:          pointer.Int32(11),
-					Parallelism:          pointer.Int32(10),
-					BackoffLimit:         pointer.Int32(3),
-					BackoffLimitPerIndex: pointer.Int32(1),
-					CompletionMode:       completionModePtr(batchv1.IndexedCompletion),
+					Completions:          ptr.To[int32](11),
+					Parallelism:          ptr.To[int32](10),
+					BackoffLimit:         ptr.To[int32](3),
+					BackoffLimitPerIndex: ptr.To[int32](1),
+					CompletionMode:       ptr.To(batchv1.IndexedCompletion),
 					Template:             validPodTemplateSpec,
-					Suspend:              pointer.Bool(true),
-					ManualSelector:       pointer.Bool(true),
+					Suspend:              ptr.To(true),
+					ManualSelector:       ptr.To(true),
 				},
 			},
 			expectLabels: true,
@@ -567,9 +567,9 @@ func TestSetDefaultCronJob(t *testing.T) {
 			expected: &batchv1.CronJob{
 				Spec: batchv1.CronJobSpec{
 					ConcurrencyPolicy:          batchv1.AllowConcurrent,
-					Suspend:                    pointer.Bool(false),
-					SuccessfulJobsHistoryLimit: pointer.Int32(3),
-					FailedJobsHistoryLimit:     pointer.Int32(1),
+					Suspend:                    ptr.To(false),
+					SuccessfulJobsHistoryLimit: ptr.To[int32](3),
+					FailedJobsHistoryLimit:     ptr.To[int32](1),
 				},
 			},
 		},
@@ -577,17 +577,17 @@ func TestSetDefaultCronJob(t *testing.T) {
 			original: &batchv1.CronJob{
 				Spec: batchv1.CronJobSpec{
 					ConcurrencyPolicy:          batchv1.ForbidConcurrent,
-					Suspend:                    pointer.Bool(true),
-					SuccessfulJobsHistoryLimit: pointer.Int32(5),
-					FailedJobsHistoryLimit:     pointer.Int32(5),
+					Suspend:                    ptr.To(true),
+					SuccessfulJobsHistoryLimit: ptr.To[int32](5),
+					FailedJobsHistoryLimit:     ptr.To[int32](5),
 				},
 			},
 			expected: &batchv1.CronJob{
 				Spec: batchv1.CronJobSpec{
 					ConcurrencyPolicy:          batchv1.ForbidConcurrent,
-					Suspend:                    pointer.Bool(true),
-					SuccessfulJobsHistoryLimit: pointer.Int32(5),
-					FailedJobsHistoryLimit:     pointer.Int32(5),
+					Suspend:                    ptr.To(true),
+					SuccessfulJobsHistoryLimit: ptr.To[int32](5),
+					FailedJobsHistoryLimit:     ptr.To[int32](5),
 				},
 			},
 		},
@@ -615,12 +615,4 @@ func TestSetDefaultCronJob(t *testing.T) {
 			t.Errorf("%s: got different failedJobsHistoryLimit than expected: %v %v", name, *actual.Spec.FailedJobsHistoryLimit, *expected.Spec.FailedJobsHistoryLimit)
 		}
 	}
-}
-
-func completionModePtr(m batchv1.CompletionMode) *batchv1.CompletionMode {
-	return &m
-}
-
-func podReplacementPtr(m batchv1.PodReplacementPolicy) *batchv1.PodReplacementPolicy {
-	return &m
 }

--- a/pkg/apis/batch/validation/validation_test.go
+++ b/pkg/apis/batch/validation/validation_test.go
@@ -34,7 +34,6 @@ import (
 	"k8s.io/kubernetes/pkg/apis/batch"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	corevalidation "k8s.io/kubernetes/pkg/apis/core/validation"
-	"k8s.io/utils/pointer"
 	"k8s.io/utils/ptr"
 )
 
@@ -118,7 +117,7 @@ func TestValidateJob(t *testing.T) {
 				ObjectMeta: validJobObjectMeta,
 				Spec: batch.JobSpec{
 					Selector:       validGeneratedSelector,
-					CompletionMode: completionModePtr(batch.IndexedCompletion),
+					CompletionMode: ptr.To(batch.IndexedCompletion),
 					Completions:    ptr.To[int32](10),
 					Template:       validPodTemplateSpecForGeneratedRestartPolicyNever,
 					SuccessPolicy: &batch.SuccessPolicy{
@@ -158,14 +157,14 @@ func TestValidateJob(t *testing.T) {
 						}, {
 							Action: batch.PodFailurePolicyActionCount,
 							OnExitCodes: &batch.PodFailurePolicyOnExitCodesRequirement{
-								ContainerName: pointer.String("ctr"),
+								ContainerName: ptr.To("ctr"),
 								Operator:      batch.PodFailurePolicyOnExitCodesOpIn,
 								Values:        []int32{1, 2, 3},
 							},
 						}, {
 							Action: batch.PodFailurePolicyActionIgnore,
 							OnExitCodes: &batch.PodFailurePolicyOnExitCodesRequirement{
-								ContainerName: pointer.String("def"),
+								ContainerName: ptr.To("def"),
 								Operator:      batch.PodFailurePolicyOnExitCodesOpIn,
 								Values:        []int32{4},
 							},
@@ -184,11 +183,11 @@ func TestValidateJob(t *testing.T) {
 			job: batch.Job{
 				ObjectMeta: validJobObjectMeta,
 				Spec: batch.JobSpec{
-					CompletionMode:       completionModePtr(batch.IndexedCompletion),
-					Completions:          pointer.Int32(2),
-					BackoffLimitPerIndex: pointer.Int32(1),
+					CompletionMode:       ptr.To(batch.IndexedCompletion),
+					Completions:          ptr.To[int32](2),
+					BackoffLimitPerIndex: ptr.To[int32](1),
 					Selector:             validGeneratedSelector,
-					ManualSelector:       pointer.Bool(true),
+					ManualSelector:       ptr.To(true),
 					Template:             validPodTemplateSpecForGeneratedRestartPolicyNever,
 					PodFailurePolicy: &batch.PodFailurePolicy{
 						Rules: []batch.PodFailurePolicyRule{{
@@ -213,7 +212,7 @@ func TestValidateJob(t *testing.T) {
 				},
 				Spec: batch.JobSpec{
 					Selector:       validManualSelector,
-					ManualSelector: pointer.Bool(true),
+					ManualSelector: ptr.To(true),
 					Template:       validPodTemplateSpecForManual,
 				},
 			},
@@ -287,7 +286,7 @@ func TestValidateJob(t *testing.T) {
 				Spec: batch.JobSpec{
 					Selector:       validGeneratedSelector,
 					Template:       validPodTemplateSpecForGenerated,
-					CompletionMode: completionModePtr(batch.NonIndexedCompletion),
+					CompletionMode: ptr.To(batch.NonIndexedCompletion),
 				},
 			},
 		},
@@ -302,9 +301,9 @@ func TestValidateJob(t *testing.T) {
 				Spec: batch.JobSpec{
 					Selector:       validGeneratedSelector,
 					Template:       validPodTemplateSpecForGenerated,
-					CompletionMode: completionModePtr(batch.IndexedCompletion),
-					Completions:    pointer.Int32(2),
-					Parallelism:    pointer.Int32(100000),
+					CompletionMode: ptr.To(batch.IndexedCompletion),
+					Completions:    ptr.To[int32](2),
+					Parallelism:    ptr.To[int32](100000),
 				},
 			},
 		},
@@ -312,11 +311,11 @@ func TestValidateJob(t *testing.T) {
 			job: batch.Job{
 				ObjectMeta: validJobObjectMeta,
 				Spec: batch.JobSpec{
-					Completions:          pointer.Int32(100_000),
-					Parallelism:          pointer.Int32(100_000),
-					MaxFailedIndexes:     pointer.Int32(100_000),
-					BackoffLimitPerIndex: pointer.Int32(1),
-					CompletionMode:       completionModePtr(batch.IndexedCompletion),
+					Completions:          ptr.To[int32](100_000),
+					Parallelism:          ptr.To[int32](100_000),
+					MaxFailedIndexes:     ptr.To[int32](100_000),
+					BackoffLimitPerIndex: ptr.To[int32](1),
+					CompletionMode:       ptr.To(batch.IndexedCompletion),
 					Selector:             validGeneratedSelector,
 					Template:             validPodTemplateSpecForGenerated,
 				},
@@ -327,11 +326,11 @@ func TestValidateJob(t *testing.T) {
 			job: batch.Job{
 				ObjectMeta: validJobObjectMeta,
 				Spec: batch.JobSpec{
-					Completions:          pointer.Int32(1_000_000_000),
-					Parallelism:          pointer.Int32(10_000),
-					MaxFailedIndexes:     pointer.Int32(10_000),
-					BackoffLimitPerIndex: pointer.Int32(1),
-					CompletionMode:       completionModePtr(batch.IndexedCompletion),
+					Completions:          ptr.To[int32](1_000_000_000),
+					Parallelism:          ptr.To[int32](10_000),
+					MaxFailedIndexes:     ptr.To[int32](10_000),
+					BackoffLimitPerIndex: ptr.To[int32](1),
+					CompletionMode:       ptr.To(batch.IndexedCompletion),
 					Selector:             validGeneratedSelector,
 					Template:             validPodTemplateSpecForGenerated,
 				},
@@ -458,7 +457,7 @@ func TestValidateJob(t *testing.T) {
 				ObjectMeta: validJobObjectMeta,
 				Spec: batch.JobSpec{
 					Selector:       validGeneratedSelector,
-					CompletionMode: completionModePtr(batch.IndexedCompletion),
+					CompletionMode: ptr.To(batch.IndexedCompletion),
 					Completions:    ptr.To[int32](5),
 					Template:       validPodTemplateSpecForGeneratedRestartPolicyNever,
 					SuccessPolicy:  &batch.SuccessPolicy{},
@@ -471,7 +470,7 @@ func TestValidateJob(t *testing.T) {
 				ObjectMeta: validJobObjectMeta,
 				Spec: batch.JobSpec{
 					Selector:       validGeneratedSelector,
-					CompletionMode: completionModePtr(batch.IndexedCompletion),
+					CompletionMode: ptr.To(batch.IndexedCompletion),
 					Completions:    ptr.To[int32](5),
 					Template:       validPodTemplateSpecForGeneratedRestartPolicyNever,
 					SuccessPolicy: &batch.SuccessPolicy{
@@ -489,7 +488,7 @@ func TestValidateJob(t *testing.T) {
 				ObjectMeta: validJobObjectMeta,
 				Spec: batch.JobSpec{
 					Selector:       validGeneratedSelector,
-					CompletionMode: completionModePtr(batch.IndexedCompletion),
+					CompletionMode: ptr.To(batch.IndexedCompletion),
 					Completions:    ptr.To[int32](5),
 					Template:       validPodTemplateSpecForGeneratedRestartPolicyNever,
 					SuccessPolicy: &batch.SuccessPolicy{
@@ -506,7 +505,7 @@ func TestValidateJob(t *testing.T) {
 				ObjectMeta: validJobObjectMeta,
 				Spec: batch.JobSpec{
 					Selector:       validGeneratedSelector,
-					CompletionMode: completionModePtr(batch.IndexedCompletion),
+					CompletionMode: ptr.To(batch.IndexedCompletion),
 					Completions:    ptr.To[int32](5),
 					Template:       validPodTemplateSpecForGeneratedRestartPolicyNever,
 					SuccessPolicy: &batch.SuccessPolicy{
@@ -523,7 +522,7 @@ func TestValidateJob(t *testing.T) {
 				ObjectMeta: validJobObjectMeta,
 				Spec: batch.JobSpec{
 					Selector:       validGeneratedSelector,
-					CompletionMode: completionModePtr(batch.IndexedCompletion),
+					CompletionMode: ptr.To(batch.IndexedCompletion),
 					Completions:    ptr.To[int32](5),
 					Template:       validPodTemplateSpecForGeneratedRestartPolicyNever,
 					SuccessPolicy: &batch.SuccessPolicy{
@@ -540,7 +539,7 @@ func TestValidateJob(t *testing.T) {
 				ObjectMeta: validJobObjectMeta,
 				Spec: batch.JobSpec{
 					Selector:       validGeneratedSelector,
-					CompletionMode: completionModePtr(batch.IndexedCompletion),
+					CompletionMode: ptr.To(batch.IndexedCompletion),
 					Completions:    ptr.To[int32](5),
 					Template:       validPodTemplateSpecForGeneratedRestartPolicyNever,
 					SuccessPolicy: &batch.SuccessPolicy{
@@ -557,7 +556,7 @@ func TestValidateJob(t *testing.T) {
 				ObjectMeta: validJobObjectMeta,
 				Spec: batch.JobSpec{
 					Selector:       validGeneratedSelector,
-					CompletionMode: completionModePtr(batch.IndexedCompletion),
+					CompletionMode: ptr.To(batch.IndexedCompletion),
 					Completions:    ptr.To[int32](5),
 					Template:       validPodTemplateSpecForGeneratedRestartPolicyNever,
 					SuccessPolicy: &batch.SuccessPolicy{
@@ -575,7 +574,7 @@ func TestValidateJob(t *testing.T) {
 				ObjectMeta: validJobObjectMeta,
 				Spec: batch.JobSpec{
 					Selector:       validGeneratedSelector,
-					CompletionMode: completionModePtr(batch.IndexedCompletion),
+					CompletionMode: ptr.To(batch.IndexedCompletion),
 					Completions:    ptr.To[int32](5),
 					Template:       validPodTemplateSpecForGeneratedRestartPolicyNever,
 					SuccessPolicy: &batch.SuccessPolicy{
@@ -807,7 +806,7 @@ func TestValidateJob(t *testing.T) {
 						Rules: []batch.PodFailurePolicyRule{{
 							Action: batch.PodFailurePolicyActionFailJob,
 							OnExitCodes: &batch.PodFailurePolicyOnExitCodesRequirement{
-								ContainerName: pointer.String("ctr"),
+								ContainerName: ptr.To("ctr"),
 								Operator:      batch.PodFailurePolicyOnExitCodesOpIn,
 								Values:        []int32{1, 2, 3},
 							},
@@ -850,14 +849,14 @@ func TestValidateJob(t *testing.T) {
 						Rules: []batch.PodFailurePolicyRule{{
 							Action: batch.PodFailurePolicyActionIgnore,
 							OnExitCodes: &batch.PodFailurePolicyOnExitCodesRequirement{
-								ContainerName: pointer.String("ctr"),
+								ContainerName: ptr.To("ctr"),
 								Operator:      batch.PodFailurePolicyOnExitCodesOpIn,
 								Values:        []int32{1, 2, 3},
 							},
 						}, {
 							Action: batch.PodFailurePolicyActionFailJob,
 							OnExitCodes: &batch.PodFailurePolicyOnExitCodesRequirement{
-								ContainerName: pointer.String("xyz"),
+								ContainerName: ptr.To("xyz"),
 								Operator:      batch.PodFailurePolicyOnExitCodesOpIn,
 								Values:        []int32{5, 6, 7},
 							},
@@ -877,7 +876,7 @@ func TestValidateJob(t *testing.T) {
 						Rules: []batch.PodFailurePolicyRule{{
 							Action: "UnknownAction",
 							OnExitCodes: &batch.PodFailurePolicyOnExitCodesRequirement{
-								ContainerName: pointer.String("ctr"),
+								ContainerName: ptr.To("ctr"),
 								Operator:      batch.PodFailurePolicyOnExitCodesOpIn,
 								Values:        []int32{1, 2, 3},
 							},
@@ -1005,7 +1004,7 @@ func TestValidateJob(t *testing.T) {
 			job: batch.Job{
 				ObjectMeta: validJobObjectMeta,
 				Spec: batch.JobSpec{
-					PodReplacementPolicy: (*batch.PodReplacementPolicy)(pointer.String("")),
+					PodReplacementPolicy: (*batch.PodReplacementPolicy)(ptr.To("")),
 					Selector:             validGeneratedSelector,
 					Template:             validPodTemplateSpecForGeneratedRestartPolicyNever,
 				},
@@ -1053,7 +1052,7 @@ func TestValidateJob(t *testing.T) {
 					UID:       types.UID("1a2b3c"),
 				},
 				Spec: batch.JobSpec{
-					BackoffLimit: pointer.Int32(-1),
+					BackoffLimit: ptr.To[int32](-1),
 					Selector:     validGeneratedSelector,
 					Template:     validPodTemplateSpecForGenerated,
 				},
@@ -1064,7 +1063,7 @@ func TestValidateJob(t *testing.T) {
 			job: batch.Job{
 				ObjectMeta: validJobObjectMeta,
 				Spec: batch.JobSpec{
-					BackoffLimitPerIndex: pointer.Int32(1),
+					BackoffLimitPerIndex: ptr.To[int32](1),
 					Selector:             validGeneratedSelector,
 					Template:             validPodTemplateSpecForGenerated,
 				},
@@ -1075,8 +1074,8 @@ func TestValidateJob(t *testing.T) {
 			job: batch.Job{
 				ObjectMeta: validJobObjectMeta,
 				Spec: batch.JobSpec{
-					BackoffLimitPerIndex: pointer.Int32(-1),
-					CompletionMode:       completionModePtr(batch.IndexedCompletion),
+					BackoffLimitPerIndex: ptr.To[int32](-1),
+					CompletionMode:       ptr.To(batch.IndexedCompletion),
 					Selector:             validGeneratedSelector,
 					Template:             validPodTemplateSpecForGenerated,
 				},
@@ -1087,10 +1086,10 @@ func TestValidateJob(t *testing.T) {
 			job: batch.Job{
 				ObjectMeta: validJobObjectMeta,
 				Spec: batch.JobSpec{
-					Completions:          pointer.Int32(10),
-					MaxFailedIndexes:     pointer.Int32(11),
-					BackoffLimitPerIndex: pointer.Int32(1),
-					CompletionMode:       completionModePtr(batch.IndexedCompletion),
+					Completions:          ptr.To[int32](10),
+					MaxFailedIndexes:     ptr.To[int32](11),
+					BackoffLimitPerIndex: ptr.To[int32](1),
+					CompletionMode:       ptr.To(batch.IndexedCompletion),
 					Selector:             validGeneratedSelector,
 					Template:             validPodTemplateSpecForGenerated,
 				},
@@ -1101,9 +1100,9 @@ func TestValidateJob(t *testing.T) {
 			job: batch.Job{
 				ObjectMeta: validJobObjectMeta,
 				Spec: batch.JobSpec{
-					Completions:          pointer.Int32(100_001),
-					BackoffLimitPerIndex: pointer.Int32(1),
-					CompletionMode:       completionModePtr(batch.IndexedCompletion),
+					Completions:          ptr.To[int32](100_001),
+					BackoffLimitPerIndex: ptr.To[int32](1),
+					CompletionMode:       ptr.To(batch.IndexedCompletion),
 					Selector:             validGeneratedSelector,
 					Template:             validPodTemplateSpecForGenerated,
 				},
@@ -1114,11 +1113,11 @@ func TestValidateJob(t *testing.T) {
 			job: batch.Job{
 				ObjectMeta: validJobObjectMeta,
 				Spec: batch.JobSpec{
-					Completions:          pointer.Int32(100_001),
-					Parallelism:          pointer.Int32(50_000),
-					BackoffLimitPerIndex: pointer.Int32(1),
-					MaxFailedIndexes:     pointer.Int32(1),
-					CompletionMode:       completionModePtr(batch.IndexedCompletion),
+					Completions:          ptr.To[int32](100_001),
+					Parallelism:          ptr.To[int32](50_000),
+					BackoffLimitPerIndex: ptr.To[int32](1),
+					MaxFailedIndexes:     ptr.To[int32](1),
+					CompletionMode:       ptr.To(batch.IndexedCompletion),
 					Selector:             validGeneratedSelector,
 					Template:             validPodTemplateSpecForGenerated,
 				},
@@ -1129,10 +1128,10 @@ func TestValidateJob(t *testing.T) {
 			job: batch.Job{
 				ObjectMeta: validJobObjectMeta,
 				Spec: batch.JobSpec{
-					Completions:          pointer.Int32(100_001),
-					BackoffLimitPerIndex: pointer.Int32(1),
-					MaxFailedIndexes:     pointer.Int32(100_001),
-					CompletionMode:       completionModePtr(batch.IndexedCompletion),
+					Completions:          ptr.To[int32](100_001),
+					BackoffLimitPerIndex: ptr.To[int32](1),
+					MaxFailedIndexes:     ptr.To[int32](100_001),
+					CompletionMode:       ptr.To(batch.IndexedCompletion),
 					Selector:             validGeneratedSelector,
 					Template:             validPodTemplateSpecForGenerated,
 				},
@@ -1143,10 +1142,10 @@ func TestValidateJob(t *testing.T) {
 			job: batch.Job{
 				ObjectMeta: validJobObjectMeta,
 				Spec: batch.JobSpec{
-					Completions:          pointer.Int32(100_001),
-					BackoffLimitPerIndex: pointer.Int32(1),
-					MaxFailedIndexes:     pointer.Int32(50_000),
-					CompletionMode:       completionModePtr(batch.IndexedCompletion),
+					Completions:          ptr.To[int32](100_001),
+					BackoffLimitPerIndex: ptr.To[int32](1),
+					MaxFailedIndexes:     ptr.To[int32](50_000),
+					CompletionMode:       ptr.To(batch.IndexedCompletion),
 					Selector:             validGeneratedSelector,
 					Template:             validPodTemplateSpecForGenerated,
 				},
@@ -1157,9 +1156,9 @@ func TestValidateJob(t *testing.T) {
 			job: batch.Job{
 				ObjectMeta: validJobObjectMeta,
 				Spec: batch.JobSpec{
-					BackoffLimitPerIndex: pointer.Int32(1),
-					MaxFailedIndexes:     pointer.Int32(-1),
-					CompletionMode:       completionModePtr(batch.IndexedCompletion),
+					BackoffLimitPerIndex: ptr.To[int32](1),
+					MaxFailedIndexes:     ptr.To[int32](-1),
+					CompletionMode:       ptr.To(batch.IndexedCompletion),
 					Selector:             validGeneratedSelector,
 					Template:             validPodTemplateSpecForGenerated,
 				},
@@ -1170,8 +1169,8 @@ func TestValidateJob(t *testing.T) {
 			job: batch.Job{
 				ObjectMeta: validJobObjectMeta,
 				Spec: batch.JobSpec{
-					MaxFailedIndexes: pointer.Int32(1),
-					CompletionMode:   completionModePtr(batch.IndexedCompletion),
+					MaxFailedIndexes: ptr.To[int32](1),
+					CompletionMode:   ptr.To(batch.IndexedCompletion),
 					Selector:         validGeneratedSelector,
 					Template:         validPodTemplateSpecForGenerated,
 				},
@@ -1230,7 +1229,7 @@ func TestValidateJob(t *testing.T) {
 				},
 				Spec: batch.JobSpec{
 					Selector:       validManualSelector,
-					ManualSelector: pointer.Bool(true),
+					ManualSelector: ptr.To(true),
 					Template: api.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{"y": "z"},
@@ -1250,7 +1249,7 @@ func TestValidateJob(t *testing.T) {
 				},
 				Spec: batch.JobSpec{
 					Selector:       validManualSelector,
-					ManualSelector: pointer.Bool(true),
+					ManualSelector: ptr.To(true),
 					Template: api.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{"controller-uid": "4d5e6f"},
@@ -1270,7 +1269,7 @@ func TestValidateJob(t *testing.T) {
 				},
 				Spec: batch.JobSpec{
 					Selector:       validManualSelector,
-					ManualSelector: pointer.Bool(true),
+					ManualSelector: ptr.To(true),
 					Template: api.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: validManualSelector.MatchLabels,
@@ -1290,7 +1289,7 @@ func TestValidateJob(t *testing.T) {
 				},
 				Spec: batch.JobSpec{
 					Selector:       validManualSelector,
-					ManualSelector: pointer.Bool(true),
+					ManualSelector: ptr.To(true),
 					Template: api.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: validManualSelector.MatchLabels,
@@ -1326,7 +1325,7 @@ func TestValidateJob(t *testing.T) {
 				Spec: batch.JobSpec{
 					Selector:       validGeneratedSelector,
 					Template:       validPodTemplateSpecForGenerated,
-					CompletionMode: completionModePtr(batch.IndexedCompletion),
+					CompletionMode: ptr.To(batch.IndexedCompletion),
 				},
 			},
 			opts: JobValidationOptions{RequirePrefixedLabels: true},
@@ -1341,9 +1340,9 @@ func TestValidateJob(t *testing.T) {
 				Spec: batch.JobSpec{
 					Selector:       validGeneratedSelector,
 					Template:       validPodTemplateSpecForGenerated,
-					CompletionMode: completionModePtr(batch.IndexedCompletion),
-					Completions:    pointer.Int32(2),
-					Parallelism:    pointer.Int32(100001),
+					CompletionMode: ptr.To(batch.IndexedCompletion),
+					Completions:    ptr.To[int32](2),
+					Parallelism:    ptr.To[int32](100001),
 				},
 			},
 			opts: JobValidationOptions{RequirePrefixedLabels: true},
@@ -1501,16 +1500,16 @@ func TestValidateJobUpdate(t *testing.T) {
 				Spec: batch.JobSpec{
 					Selector:                validGeneratedSelector,
 					Template:                validPodTemplateSpecForGenerated,
-					Parallelism:             pointer.Int32(5),
-					ActiveDeadlineSeconds:   pointer.Int64(2),
-					TTLSecondsAfterFinished: pointer.Int32(1),
+					Parallelism:             ptr.To[int32](5),
+					ActiveDeadlineSeconds:   ptr.To[int64](2),
+					TTLSecondsAfterFinished: ptr.To[int32](1),
 				},
 			},
 			update: func(job *batch.Job) {
-				job.Spec.Parallelism = pointer.Int32(2)
-				job.Spec.ActiveDeadlineSeconds = pointer.Int64(3)
-				job.Spec.TTLSecondsAfterFinished = pointer.Int32(2)
-				job.Spec.ManualSelector = pointer.Bool(true)
+				job.Spec.Parallelism = ptr.To[int32](2)
+				job.Spec.ActiveDeadlineSeconds = ptr.To[int64](3)
+				job.Spec.TTLSecondsAfterFinished = ptr.To[int32](2)
+				job.Spec.ManualSelector = ptr.To(true)
 			},
 		},
 		"invalid attempt to set managedBy field": {
@@ -1555,7 +1554,7 @@ func TestValidateJobUpdate(t *testing.T) {
 				},
 			},
 			update: func(job *batch.Job) {
-				job.Spec.Completions = pointer.Int32(1)
+				job.Spec.Completions = ptr.To[int32](1)
 			},
 			err: &field.Error{
 				Type:  field.ErrorTypeInvalid,
@@ -1582,7 +1581,7 @@ func TestValidateJobUpdate(t *testing.T) {
 			old: batch.Job{
 				ObjectMeta: metav1.ObjectMeta{Name: "abc", Namespace: metav1.NamespaceDefault},
 				Spec: batch.JobSpec{
-					CompletionMode: completionModePtr(batch.IndexedCompletion),
+					CompletionMode: ptr.To(batch.IndexedCompletion),
 					Completions:    ptr.To[int32](5),
 					Selector:       validGeneratedSelector,
 					Template:       validPodTemplateSpecForGeneratedRestartPolicyNever,
@@ -1604,7 +1603,7 @@ func TestValidateJobUpdate(t *testing.T) {
 			old: batch.Job{
 				ObjectMeta: metav1.ObjectMeta{Name: "abc", Namespace: metav1.NamespaceDefault},
 				Spec: batch.JobSpec{
-					CompletionMode: completionModePtr(batch.IndexedCompletion),
+					CompletionMode: ptr.To(batch.IndexedCompletion),
 					Completions:    ptr.To[int32](5),
 					Selector:       validGeneratedSelector,
 					Template:       validPodTemplateSpecForGeneratedRestartPolicyNever,
@@ -1629,7 +1628,7 @@ func TestValidateJobUpdate(t *testing.T) {
 			old: batch.Job{
 				ObjectMeta: metav1.ObjectMeta{Name: "abc", Namespace: metav1.NamespaceDefault},
 				Spec: batch.JobSpec{
-					CompletionMode: completionModePtr(batch.IndexedCompletion),
+					CompletionMode: ptr.To(batch.IndexedCompletion),
 					Completions:    ptr.To[int32](5),
 					Selector:       validGeneratedSelector,
 					Template:       validPodTemplateSpecForGeneratedRestartPolicyNever,
@@ -1734,12 +1733,12 @@ func TestValidateJobUpdate(t *testing.T) {
 				Spec: batch.JobSpec{
 					Selector:       validGeneratedSelector,
 					Template:       validPodTemplateSpecForGeneratedRestartPolicyNever,
-					Completions:    pointer.Int32(3),
-					CompletionMode: completionModePtr(batch.IndexedCompletion),
+					Completions:    ptr.To[int32](3),
+					CompletionMode: ptr.To(batch.IndexedCompletion),
 				},
 			},
 			update: func(job *batch.Job) {
-				job.Spec.BackoffLimitPerIndex = pointer.Int32(1)
+				job.Spec.BackoffLimitPerIndex = ptr.To[int32](1)
 			},
 			err: &field.Error{
 				Type:  field.ErrorTypeInvalid,
@@ -1752,9 +1751,9 @@ func TestValidateJobUpdate(t *testing.T) {
 				Spec: batch.JobSpec{
 					Selector:             validGeneratedSelector,
 					Template:             validPodTemplateSpecForGeneratedRestartPolicyNever,
-					Completions:          pointer.Int32(3),
-					CompletionMode:       completionModePtr(batch.IndexedCompletion),
-					BackoffLimitPerIndex: pointer.Int32(1),
+					Completions:          ptr.To[int32](3),
+					CompletionMode:       ptr.To(batch.IndexedCompletion),
+					BackoffLimitPerIndex: ptr.To[int32](1),
 				},
 			},
 			update: func(job *batch.Job) {
@@ -1771,13 +1770,13 @@ func TestValidateJobUpdate(t *testing.T) {
 				Spec: batch.JobSpec{
 					Selector:             validGeneratedSelector,
 					Template:             validPodTemplateSpecForGeneratedRestartPolicyNever,
-					Completions:          pointer.Int32(3),
-					CompletionMode:       completionModePtr(batch.IndexedCompletion),
-					BackoffLimitPerIndex: pointer.Int32(1),
+					Completions:          ptr.To[int32](3),
+					CompletionMode:       ptr.To(batch.IndexedCompletion),
+					BackoffLimitPerIndex: ptr.To[int32](1),
 				},
 			},
 			update: func(job *batch.Job) {
-				job.Spec.BackoffLimitPerIndex = pointer.Int32(2)
+				job.Spec.BackoffLimitPerIndex = ptr.To[int32](2)
 			},
 			err: &field.Error{
 				Type:  field.ErrorTypeInvalid,
@@ -1790,13 +1789,13 @@ func TestValidateJobUpdate(t *testing.T) {
 				Spec: batch.JobSpec{
 					Selector:             validGeneratedSelector,
 					Template:             validPodTemplateSpecForGeneratedRestartPolicyNever,
-					Completions:          pointer.Int32(3),
-					CompletionMode:       completionModePtr(batch.IndexedCompletion),
-					BackoffLimitPerIndex: pointer.Int32(1),
+					Completions:          ptr.To[int32](3),
+					CompletionMode:       ptr.To(batch.IndexedCompletion),
+					BackoffLimitPerIndex: ptr.To[int32](1),
 				},
 			},
 			update: func(job *batch.Job) {
-				job.Spec.MaxFailedIndexes = pointer.Int32(1)
+				job.Spec.MaxFailedIndexes = ptr.To[int32](1)
 			},
 		},
 		"unset max failed indexes": {
@@ -1805,10 +1804,10 @@ func TestValidateJobUpdate(t *testing.T) {
 				Spec: batch.JobSpec{
 					Selector:             validGeneratedSelector,
 					Template:             validPodTemplateSpecForGeneratedRestartPolicyNever,
-					Completions:          pointer.Int32(3),
-					CompletionMode:       completionModePtr(batch.IndexedCompletion),
-					BackoffLimitPerIndex: pointer.Int32(1),
-					MaxFailedIndexes:     pointer.Int32(1),
+					Completions:          ptr.To[int32](3),
+					CompletionMode:       ptr.To(batch.IndexedCompletion),
+					BackoffLimitPerIndex: ptr.To[int32](1),
+					MaxFailedIndexes:     ptr.To[int32](1),
 				},
 			},
 			update: func(job *batch.Job) {
@@ -1821,14 +1820,14 @@ func TestValidateJobUpdate(t *testing.T) {
 				Spec: batch.JobSpec{
 					Selector:             validGeneratedSelector,
 					Template:             validPodTemplateSpecForGeneratedRestartPolicyNever,
-					Completions:          pointer.Int32(3),
-					CompletionMode:       completionModePtr(batch.IndexedCompletion),
-					BackoffLimitPerIndex: pointer.Int32(1),
-					MaxFailedIndexes:     pointer.Int32(1),
+					Completions:          ptr.To[int32](3),
+					CompletionMode:       ptr.To(batch.IndexedCompletion),
+					BackoffLimitPerIndex: ptr.To[int32](1),
+					MaxFailedIndexes:     ptr.To[int32](1),
 				},
 			},
 			update: func(job *batch.Job) {
-				job.Spec.MaxFailedIndexes = pointer.Int32(2)
+				job.Spec.MaxFailedIndexes = ptr.To[int32](2)
 			},
 		},
 		"immutable pod template": {
@@ -1837,8 +1836,8 @@ func TestValidateJobUpdate(t *testing.T) {
 				Spec: batch.JobSpec{
 					Selector:       validGeneratedSelector,
 					Template:       validPodTemplateSpecForGenerated,
-					Completions:    pointer.Int32(3),
-					CompletionMode: completionModePtr(batch.IndexedCompletion),
+					Completions:    ptr.To[int32](3),
+					CompletionMode: ptr.To(batch.IndexedCompletion),
 				},
 			},
 			update: func(job *batch.Job) {
@@ -1855,12 +1854,12 @@ func TestValidateJobUpdate(t *testing.T) {
 				Spec: batch.JobSpec{
 					Selector:       validGeneratedSelector,
 					Template:       validPodTemplateSpecForGenerated,
-					CompletionMode: completionModePtr(batch.IndexedCompletion),
-					Completions:    pointer.Int32(2),
+					CompletionMode: ptr.To(batch.IndexedCompletion),
+					Completions:    ptr.To[int32](2),
 				},
 			},
 			update: func(job *batch.Job) {
-				job.Spec.CompletionMode = completionModePtr(batch.NonIndexedCompletion)
+				job.Spec.CompletionMode = ptr.To(batch.NonIndexedCompletion)
 			},
 			err: &field.Error{
 				Type:  field.ErrorTypeInvalid,
@@ -1873,12 +1872,12 @@ func TestValidateJobUpdate(t *testing.T) {
 				Spec: batch.JobSpec{
 					Selector:       validGeneratedSelector,
 					Template:       validPodTemplateSpecForGenerated,
-					CompletionMode: completionModePtr(batch.NonIndexedCompletion),
-					Completions:    pointer.Int32(2),
+					CompletionMode: ptr.To(batch.NonIndexedCompletion),
+					Completions:    ptr.To[int32](2),
 				},
 			},
 			update: func(job *batch.Job) {
-				job.Spec.Completions = pointer.Int32(4)
+				job.Spec.Completions = ptr.To[int32](4)
 			},
 			err: &field.Error{
 				Type:  field.ErrorTypeInvalid,
@@ -2127,14 +2126,14 @@ func TestValidateJobUpdate(t *testing.T) {
 				Spec: batch.JobSpec{
 					Selector:       validGeneratedSelector,
 					Template:       validPodTemplateSpecForGenerated,
-					Completions:    pointer.Int32(1),
-					Parallelism:    pointer.Int32(1),
-					CompletionMode: completionModePtr(batch.IndexedCompletion),
+					Completions:    ptr.To[int32](1),
+					Parallelism:    ptr.To[int32](1),
+					CompletionMode: ptr.To(batch.IndexedCompletion),
 				},
 			},
 			update: func(job *batch.Job) {
-				job.Spec.Completions = pointer.Int32(2)
-				job.Spec.Parallelism = pointer.Int32(2)
+				job.Spec.Completions = ptr.To[int32](2)
+				job.Spec.Parallelism = ptr.To[int32](2)
 			},
 		},
 		"previous parallelism != previous completions, new parallelism == new completions": {
@@ -2143,14 +2142,14 @@ func TestValidateJobUpdate(t *testing.T) {
 				Spec: batch.JobSpec{
 					Selector:       validGeneratedSelector,
 					Template:       validPodTemplateSpecForGenerated,
-					Completions:    pointer.Int32(1),
-					Parallelism:    pointer.Int32(2),
-					CompletionMode: completionModePtr(batch.IndexedCompletion),
+					Completions:    ptr.To[int32](1),
+					Parallelism:    ptr.To[int32](2),
+					CompletionMode: ptr.To(batch.IndexedCompletion),
 				},
 			},
 			update: func(job *batch.Job) {
-				job.Spec.Completions = pointer.Int32(3)
-				job.Spec.Parallelism = pointer.Int32(3)
+				job.Spec.Completions = ptr.To[int32](3)
+				job.Spec.Parallelism = ptr.To[int32](3)
 			},
 		},
 		"indexed job updating completions and parallelism to different values is invalid": {
@@ -2159,14 +2158,14 @@ func TestValidateJobUpdate(t *testing.T) {
 				Spec: batch.JobSpec{
 					Selector:       validGeneratedSelector,
 					Template:       validPodTemplateSpecForGenerated,
-					Completions:    pointer.Int32(1),
-					Parallelism:    pointer.Int32(1),
-					CompletionMode: completionModePtr(batch.IndexedCompletion),
+					Completions:    ptr.To[int32](1),
+					Parallelism:    ptr.To[int32](1),
+					CompletionMode: ptr.To(batch.IndexedCompletion),
 				},
 			},
 			update: func(job *batch.Job) {
-				job.Spec.Completions = pointer.Int32(2)
-				job.Spec.Parallelism = pointer.Int32(3)
+				job.Spec.Completions = ptr.To[int32](2)
+				job.Spec.Parallelism = ptr.To[int32](3)
 			},
 			err: &field.Error{
 				Type:  field.ErrorTypeInvalid,
@@ -2179,14 +2178,14 @@ func TestValidateJobUpdate(t *testing.T) {
 				Spec: batch.JobSpec{
 					Selector:       validGeneratedSelector,
 					Template:       validPodTemplateSpecForGenerated,
-					Completions:    pointer.Int32(1),
-					Parallelism:    pointer.Int32(1),
-					CompletionMode: completionModePtr(batch.IndexedCompletion),
+					Completions:    ptr.To[int32](1),
+					Parallelism:    ptr.To[int32](1),
+					CompletionMode: ptr.To(batch.IndexedCompletion),
 				},
 			},
 			update: func(job *batch.Job) {
 				job.Spec.Completions = nil
-				job.Spec.Parallelism = pointer.Int32(3)
+				job.Spec.Parallelism = ptr.To[int32](3)
 			},
 			err: &field.Error{
 				Type:  field.ErrorTypeRequired,
@@ -2199,14 +2198,14 @@ func TestValidateJobUpdate(t *testing.T) {
 				Spec: batch.JobSpec{
 					Selector:       validGeneratedSelector,
 					Template:       validPodTemplateSpecForGenerated,
-					Completions:    pointer.Int32(2),
-					Parallelism:    pointer.Int32(2),
-					CompletionMode: completionModePtr(batch.IndexedCompletion),
+					Completions:    ptr.To[int32](2),
+					Parallelism:    ptr.To[int32](2),
+					CompletionMode: ptr.To(batch.IndexedCompletion),
 				},
 			},
 			update: func(job *batch.Job) {
-				job.Spec.Completions = pointer.Int32(2)
-				job.Spec.Parallelism = pointer.Int32(1)
+				job.Spec.Completions = ptr.To[int32](2)
+				job.Spec.Parallelism = ptr.To[int32](1)
 			},
 		},
 		"indexed job with completions unchanged, parallelism increased higher than completions": {
@@ -2215,14 +2214,14 @@ func TestValidateJobUpdate(t *testing.T) {
 				Spec: batch.JobSpec{
 					Selector:       validGeneratedSelector,
 					Template:       validPodTemplateSpecForGenerated,
-					Completions:    pointer.Int32(2),
-					Parallelism:    pointer.Int32(2),
-					CompletionMode: completionModePtr(batch.IndexedCompletion),
+					Completions:    ptr.To[int32](2),
+					Parallelism:    ptr.To[int32](2),
+					CompletionMode: ptr.To(batch.IndexedCompletion),
 				},
 			},
 			update: func(job *batch.Job) {
-				job.Spec.Completions = pointer.Int32(2)
-				job.Spec.Parallelism = pointer.Int32(3)
+				job.Spec.Completions = ptr.To[int32](2)
+				job.Spec.Parallelism = ptr.To[int32](3)
 			},
 		},
 	}
@@ -2263,7 +2262,7 @@ func TestValidateJobUpdateStatus(t *testing.T) {
 					Active:      1,
 					Succeeded:   2,
 					Failed:      3,
-					Terminating: pointer.Int32(4),
+					Terminating: ptr.To[int32](4),
 				},
 			},
 			update: batch.Job{
@@ -2276,8 +2275,8 @@ func TestValidateJobUpdateStatus(t *testing.T) {
 					Active:      2,
 					Succeeded:   3,
 					Failed:      4,
-					Ready:       pointer.Int32(1),
-					Terminating: pointer.Int32(4),
+					Ready:       ptr.To[int32](1),
+					Terminating: ptr.To[int32](4),
 				},
 			},
 		},
@@ -2318,7 +2317,7 @@ func TestValidateJobUpdateStatus(t *testing.T) {
 					Active:      1,
 					Succeeded:   2,
 					Failed:      3,
-					Terminating: pointer.Int32(4),
+					Terminating: ptr.To[int32](4),
 				},
 			},
 			update: batch.Job{
@@ -2331,8 +2330,8 @@ func TestValidateJobUpdateStatus(t *testing.T) {
 					Active:      -1,
 					Succeeded:   -2,
 					Failed:      -3,
-					Ready:       pointer.Int32(-1),
-					Terminating: pointer.Int32(-2),
+					Ready:       ptr.To[int32](-1),
+					Terminating: ptr.To[int32](-2),
 				},
 			},
 			wantErrs: field.ErrorList{
@@ -2782,7 +2781,7 @@ func TestValidateCronJob(t *testing.T) {
 				ConcurrencyPolicy: batch.AllowConcurrent,
 				JobTemplate: batch.JobTemplateSpec{
 					Spec: batch.JobSpec{
-						ManualSelector: pointer.Bool(true),
+						ManualSelector: ptr.To(true),
 						Template:       validPodTemplateSpec,
 					},
 				},
@@ -3047,7 +3046,7 @@ func TestValidateCronJobSpec(t *testing.T) {
 			},
 			new: &batch.CronJobSpec{
 				Schedule:          "0 * * * *",
-				TimeZone:          pointer.String("America/New_York"),
+				TimeZone:          ptr.To("America/New_York"),
 				ConcurrencyPolicy: batch.AllowConcurrent,
 				JobTemplate: batch.JobTemplateSpec{
 					Spec: batch.JobSpec{
@@ -3069,7 +3068,7 @@ func TestValidateCronJobSpec(t *testing.T) {
 			},
 			new: &batch.CronJobSpec{
 				Schedule:          "0 * * * *",
-				TimeZone:          pointer.String("broken"),
+				TimeZone:          ptr.To("broken"),
 				ConcurrencyPolicy: batch.AllowConcurrent,
 				JobTemplate: batch.JobTemplateSpec{
 					Spec: batch.JobSpec{
@@ -3082,7 +3081,7 @@ func TestValidateCronJobSpec(t *testing.T) {
 		"old timeZone and new timeZone are valid": {
 			old: &batch.CronJobSpec{
 				Schedule:          "0 * * * *",
-				TimeZone:          pointer.String("America/New_York"),
+				TimeZone:          ptr.To("America/New_York"),
 				ConcurrencyPolicy: batch.AllowConcurrent,
 				JobTemplate: batch.JobTemplateSpec{
 					Spec: batch.JobSpec{
@@ -3092,7 +3091,7 @@ func TestValidateCronJobSpec(t *testing.T) {
 			},
 			new: &batch.CronJobSpec{
 				Schedule:          "0 * * * *",
-				TimeZone:          pointer.String("America/Chicago"),
+				TimeZone:          ptr.To("America/Chicago"),
 				ConcurrencyPolicy: batch.AllowConcurrent,
 				JobTemplate: batch.JobTemplateSpec{
 					Spec: batch.JobSpec{
@@ -3104,7 +3103,7 @@ func TestValidateCronJobSpec(t *testing.T) {
 		"old timeZone is valid, but new timeZone is invalid": {
 			old: &batch.CronJobSpec{
 				Schedule:          "0 * * * *",
-				TimeZone:          pointer.String("America/New_York"),
+				TimeZone:          ptr.To("America/New_York"),
 				ConcurrencyPolicy: batch.AllowConcurrent,
 				JobTemplate: batch.JobTemplateSpec{
 					Spec: batch.JobSpec{
@@ -3114,7 +3113,7 @@ func TestValidateCronJobSpec(t *testing.T) {
 			},
 			new: &batch.CronJobSpec{
 				Schedule:          "0 * * * *",
-				TimeZone:          pointer.String("broken"),
+				TimeZone:          ptr.To("broken"),
 				ConcurrencyPolicy: batch.AllowConcurrent,
 				JobTemplate: batch.JobTemplateSpec{
 					Spec: batch.JobSpec{
@@ -3127,7 +3126,7 @@ func TestValidateCronJobSpec(t *testing.T) {
 		"old timeZone and new timeZone are invalid, but unchanged": {
 			old: &batch.CronJobSpec{
 				Schedule:          "0 * * * *",
-				TimeZone:          pointer.String("broken"),
+				TimeZone:          ptr.To("broken"),
 				ConcurrencyPolicy: batch.AllowConcurrent,
 				JobTemplate: batch.JobTemplateSpec{
 					Spec: batch.JobSpec{
@@ -3137,7 +3136,7 @@ func TestValidateCronJobSpec(t *testing.T) {
 			},
 			new: &batch.CronJobSpec{
 				Schedule:          "0 * * * *",
-				TimeZone:          pointer.String("broken"),
+				TimeZone:          ptr.To("broken"),
 				ConcurrencyPolicy: batch.AllowConcurrent,
 				JobTemplate: batch.JobTemplateSpec{
 					Spec: batch.JobSpec{
@@ -3149,7 +3148,7 @@ func TestValidateCronJobSpec(t *testing.T) {
 		"old timeZone and new timeZone are invalid, but different": {
 			old: &batch.CronJobSpec{
 				Schedule:          "0 * * * *",
-				TimeZone:          pointer.String("broken"),
+				TimeZone:          ptr.To("broken"),
 				ConcurrencyPolicy: batch.AllowConcurrent,
 				JobTemplate: batch.JobTemplateSpec{
 					Spec: batch.JobSpec{
@@ -3159,7 +3158,7 @@ func TestValidateCronJobSpec(t *testing.T) {
 			},
 			new: &batch.CronJobSpec{
 				Schedule:          "0 * * * *",
-				TimeZone:          pointer.String("still broken"),
+				TimeZone:          ptr.To("still broken"),
 				ConcurrencyPolicy: batch.AllowConcurrent,
 				JobTemplate: batch.JobTemplateSpec{
 					Spec: batch.JobSpec{
@@ -3172,7 +3171,7 @@ func TestValidateCronJobSpec(t *testing.T) {
 		"old timeZone is invalid, but new timeZone is valid": {
 			old: &batch.CronJobSpec{
 				Schedule:          "0 * * * *",
-				TimeZone:          pointer.String("broken"),
+				TimeZone:          ptr.To("broken"),
 				ConcurrencyPolicy: batch.AllowConcurrent,
 				JobTemplate: batch.JobTemplateSpec{
 					Spec: batch.JobSpec{
@@ -3182,7 +3181,7 @@ func TestValidateCronJobSpec(t *testing.T) {
 			},
 			new: &batch.CronJobSpec{
 				Schedule:          "0 * * * *",
-				TimeZone:          pointer.String("America/New_York"),
+				TimeZone:          ptr.To("America/New_York"),
 				ConcurrencyPolicy: batch.AllowConcurrent,
 				JobTemplate: batch.JobTemplateSpec{
 					Spec: batch.JobSpec{
@@ -3201,10 +3200,6 @@ func TestValidateCronJobSpec(t *testing.T) {
 			t.Errorf("expected error for %s but got nil", k)
 		}
 	}
-}
-
-func completionModePtr(m batch.CompletionMode) *batch.CompletionMode {
-	return &m
 }
 
 func TestTimeZones(t *testing.T) {

--- a/pkg/apis/discovery/validation/validation_test.go
+++ b/pkg/apis/discovery/validation/validation_test.go
@@ -25,7 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/discovery"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestValidateEndpointSlice(t *testing.T) {
@@ -44,12 +44,12 @@ func TestValidateEndpointSlice(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.String("http"),
-					Protocol: protocolPtr(api.ProtocolTCP),
+					Name:     ptr.To("http"),
+					Protocol: ptr.To(api.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: generateIPAddresses(1),
-					Hostname:  utilpointer.String("valid-123"),
+					Hostname:  ptr.To("valid-123"),
 				}},
 			},
 		},
@@ -59,12 +59,12 @@ func TestValidateEndpointSlice(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeIPv6,
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.String("http"),
-					Protocol: protocolPtr(api.ProtocolTCP),
+					Name:     ptr.To("http"),
+					Protocol: ptr.To(api.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: []string{"a00:100::4"},
-					Hostname:  utilpointer.String("valid-123"),
+					Hostname:  ptr.To("valid-123"),
 				}},
 			},
 		},
@@ -74,12 +74,12 @@ func TestValidateEndpointSlice(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeFQDN,
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.String("http"),
-					Protocol: protocolPtr(api.ProtocolTCP),
+					Name:     ptr.To("http"),
+					Protocol: ptr.To(api.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: []string{"foo.example.com", "example.com", "example.com.", "hyphens-are-good.example.com"},
-					Hostname:  utilpointer.String("valid-123"),
+					Hostname:  ptr.To("valid-123"),
 				}},
 			},
 		},
@@ -89,18 +89,18 @@ func TestValidateEndpointSlice(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.String("tcp"),
-					Protocol: protocolPtr(api.ProtocolTCP),
+					Name:     ptr.To("tcp"),
+					Protocol: ptr.To(api.ProtocolTCP),
 				}, {
-					Name:     utilpointer.String("udp"),
-					Protocol: protocolPtr(api.ProtocolUDP),
+					Name:     ptr.To("udp"),
+					Protocol: ptr.To(api.ProtocolUDP),
 				}, {
-					Name:     utilpointer.String("sctp"),
-					Protocol: protocolPtr(api.ProtocolSCTP),
+					Name:     ptr.To("sctp"),
+					Protocol: ptr.To(api.ProtocolSCTP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: generateIPAddresses(1),
-					Hostname:  utilpointer.String("valid-123"),
+					Hostname:  ptr.To("valid-123"),
 				}},
 			},
 		},
@@ -110,25 +110,25 @@ func TestValidateEndpointSlice(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
-					Name:        utilpointer.String("one"),
-					Protocol:    protocolPtr(api.ProtocolTCP),
-					AppProtocol: utilpointer.String("HTTP"),
+					Name:        ptr.To("one"),
+					Protocol:    ptr.To(api.ProtocolTCP),
+					AppProtocol: ptr.To("HTTP"),
 				}, {
-					Name:        utilpointer.String("two"),
-					Protocol:    protocolPtr(api.ProtocolTCP),
-					AppProtocol: utilpointer.String("https"),
+					Name:        ptr.To("two"),
+					Protocol:    ptr.To(api.ProtocolTCP),
+					AppProtocol: ptr.To("https"),
 				}, {
-					Name:        utilpointer.String("three"),
-					Protocol:    protocolPtr(api.ProtocolTCP),
-					AppProtocol: utilpointer.String("my-protocol"),
+					Name:        ptr.To("three"),
+					Protocol:    ptr.To(api.ProtocolTCP),
+					AppProtocol: ptr.To("my-protocol"),
 				}, {
-					Name:        utilpointer.String("four"),
-					Protocol:    protocolPtr(api.ProtocolTCP),
-					AppProtocol: utilpointer.String("example.com/custom-protocol"),
+					Name:        ptr.To("four"),
+					Protocol:    ptr.To(api.ProtocolTCP),
+					AppProtocol: ptr.To("example.com/custom-protocol"),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: generateIPAddresses(1),
-					Hostname:  utilpointer.String("valid-123"),
+					Hostname:  ptr.To("valid-123"),
 				}},
 			},
 		},
@@ -138,11 +138,11 @@ func TestValidateEndpointSlice(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.String(""),
-					Protocol: protocolPtr(api.ProtocolTCP),
+					Name:     ptr.To(""),
+					Protocol: ptr.To(api.ProtocolTCP),
 				}, {
-					Name:     utilpointer.String("http"),
-					Protocol: protocolPtr(api.ProtocolTCP),
+					Name:     ptr.To("http"),
+					Protocol: ptr.To(api.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: generateIPAddresses(1),
@@ -155,8 +155,8 @@ func TestValidateEndpointSlice(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.String(strings.Repeat("a", 63)),
-					Protocol: protocolPtr(api.ProtocolTCP),
+					Name:     ptr.To(strings.Repeat("a", 63)),
+					Protocol: ptr.To(api.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: generateIPAddresses(1),
@@ -195,8 +195,8 @@ func TestValidateEndpointSlice(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.String("http"),
-					Protocol: protocolPtr(api.ProtocolTCP),
+					Name:     ptr.To("http"),
+					Protocol: ptr.To(api.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: generateIPAddresses(maxAddresses),
@@ -209,8 +209,8 @@ func TestValidateEndpointSlice(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.String("http"),
-					Protocol: protocolPtr(api.ProtocolTCP),
+					Name:     ptr.To("http"),
+					Protocol: ptr.To(api.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses:          generateIPAddresses(1),
@@ -224,8 +224,8 @@ func TestValidateEndpointSlice(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.String("http"),
-					Protocol: protocolPtr(api.ProtocolTCP),
+					Name:     ptr.To("http"),
+					Protocol: ptr.To(api.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: generateIPAddresses(1),
@@ -243,11 +243,11 @@ func TestValidateEndpointSlice(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.String(""),
-					Protocol: protocolPtr(api.ProtocolTCP),
+					Name:     ptr.To(""),
+					Protocol: ptr.To(api.ProtocolTCP),
 				}, {
-					Name:     utilpointer.String(""),
-					Protocol: protocolPtr(api.ProtocolTCP),
+					Name:     ptr.To(""),
+					Protocol: ptr.To(api.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{},
 			},
@@ -258,8 +258,8 @@ func TestValidateEndpointSlice(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.String("aCapital"),
-					Protocol: protocolPtr(api.ProtocolTCP),
+					Name:     ptr.To("aCapital"),
+					Protocol: ptr.To(api.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{},
 			},
@@ -270,8 +270,8 @@ func TestValidateEndpointSlice(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.String("almost_valid"),
-					Protocol: protocolPtr(api.ProtocolTCP),
+					Name:     ptr.To("almost_valid"),
+					Protocol: ptr.To(api.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{},
 			},
@@ -282,8 +282,8 @@ func TestValidateEndpointSlice(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.String(strings.Repeat("a", 64)),
-					Protocol: protocolPtr(api.ProtocolTCP),
+					Name:     ptr.To(strings.Repeat("a", 64)),
+					Protocol: ptr.To(api.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{},
 			},
@@ -294,8 +294,8 @@ func TestValidateEndpointSlice(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.String("http"),
-					Protocol: protocolPtr(api.Protocol("foo")),
+					Name:     ptr.To("http"),
+					Protocol: ptr.To(api.Protocol("foo")),
 				}},
 			},
 		},
@@ -322,8 +322,8 @@ func TestValidateEndpointSlice(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.String("http"),
-					Protocol: protocolPtr(api.ProtocolTCP),
+					Name:     ptr.To("http"),
+					Protocol: ptr.To(api.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: generateIPAddresses(0),
@@ -336,8 +336,8 @@ func TestValidateEndpointSlice(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.String("http"),
-					Protocol: protocolPtr(api.ProtocolTCP),
+					Name:     ptr.To("http"),
+					Protocol: ptr.To(api.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: generateIPAddresses(maxAddresses + 1),
@@ -350,8 +350,8 @@ func TestValidateEndpointSlice(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.String("http"),
-					Protocol: protocolPtr(api.ProtocolTCP),
+					Name:     ptr.To("http"),
+					Protocol: ptr.To(api.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses:          generateIPAddresses(1),
@@ -365,8 +365,8 @@ func TestValidateEndpointSlice(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.String("http"),
-					Protocol: protocolPtr(api.ProtocolTCP),
+					Name:     ptr.To("http"),
+					Protocol: ptr.To(api.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses:          generateIPAddresses(1),
@@ -380,12 +380,12 @@ func TestValidateEndpointSlice(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.String("http"),
-					Protocol: protocolPtr(api.ProtocolTCP),
+					Name:     ptr.To("http"),
+					Protocol: ptr.To(api.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: generateIPAddresses(1),
-					Hostname:  utilpointer.String("--INVALID"),
+					Hostname:  ptr.To("--INVALID"),
 				}},
 			},
 		},
@@ -398,12 +398,12 @@ func TestValidateEndpointSlice(t *testing.T) {
 				},
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.String("http"),
-					Protocol: protocolPtr(api.ProtocolTCP),
+					Name:     ptr.To("http"),
+					Protocol: ptr.To(api.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: generateIPAddresses(1),
-					Hostname:  utilpointer.String("valid-123"),
+					Hostname:  ptr.To("valid-123"),
 				}},
 			},
 		},
@@ -413,12 +413,12 @@ func TestValidateEndpointSlice(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.String("http"),
-					Protocol: protocolPtr(api.ProtocolTCP),
+					Name:     ptr.To("http"),
+					Protocol: ptr.To(api.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: []string{"123.456.789.012"},
-					Hostname:  utilpointer.String("valid-123"),
+					Hostname:  ptr.To("valid-123"),
 				}},
 			},
 		},
@@ -428,12 +428,12 @@ func TestValidateEndpointSlice(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.String("http"),
-					Protocol: protocolPtr(api.ProtocolTCP),
+					Name:     ptr.To("http"),
+					Protocol: ptr.To(api.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: []string{"123.456.789.012", "2001:4860:4860::8888"},
-					Hostname:  utilpointer.String("valid-123"),
+					Hostname:  ptr.To("valid-123"),
 				}},
 			},
 		},
@@ -443,12 +443,12 @@ func TestValidateEndpointSlice(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeIPv6,
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.String("http"),
-					Protocol: protocolPtr(api.ProtocolTCP),
+					Name:     ptr.To("http"),
+					Protocol: ptr.To(api.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: []string{"123.456.789.012", "2001:4860:4860:defg"},
-					Hostname:  utilpointer.String("valid-123"),
+					Hostname:  ptr.To("valid-123"),
 				}},
 			},
 		},
@@ -458,12 +458,12 @@ func TestValidateEndpointSlice(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeFQDN,
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.String("http"),
-					Protocol: protocolPtr(api.ProtocolTCP),
+					Name:     ptr.To("http"),
+					Protocol: ptr.To(api.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: []string{"foo.*", "FOO.example.com", "underscores_are_bad.example.com", "*.example.com"},
-					Hostname:  utilpointer.String("valid-123"),
+					Hostname:  ptr.To("valid-123"),
 				}},
 			},
 		},
@@ -473,13 +473,13 @@ func TestValidateEndpointSlice(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
-					Name:        utilpointer.String("http"),
-					Protocol:    protocolPtr(api.ProtocolTCP),
-					AppProtocol: utilpointer.String("--"),
+					Name:        ptr.To("http"),
+					Protocol:    ptr.To(api.ProtocolTCP),
+					AppProtocol: ptr.To("--"),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: generateIPAddresses(1),
-					Hostname:  utilpointer.String("valid-123"),
+					Hostname:  ptr.To("valid-123"),
 				}},
 			},
 		},
@@ -489,8 +489,8 @@ func TestValidateEndpointSlice(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.String("http"),
-					Protocol: protocolPtr(api.ProtocolTCP),
+					Name:     ptr.To("http"),
+					Protocol: ptr.To(api.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: generateIPAddresses(1),
@@ -506,8 +506,8 @@ func TestValidateEndpointSlice(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.String("http"),
-					Protocol: protocolPtr(api.ProtocolTCP),
+					Name:     ptr.To("http"),
+					Protocol: ptr.To(api.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: generateIPAddresses(1),
@@ -527,8 +527,8 @@ func TestValidateEndpointSlice(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.String("http"),
-					Protocol: protocolPtr(api.ProtocolTCP),
+					Name:     ptr.To("http"),
+					Protocol: ptr.To(api.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: generateIPAddresses(1),
@@ -558,8 +558,8 @@ func TestValidateEndpointSlice(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.String("http"),
-					Protocol: protocolPtr(api.ProtocolTCP),
+					Name:     ptr.To("http"),
+					Protocol: ptr.To(api.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses:          generateIPAddresses(1),
@@ -573,12 +573,12 @@ func TestValidateEndpointSlice(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.String("http"),
-					Protocol: protocolPtr(api.ProtocolTCP),
+					Name:     ptr.To("http"),
+					Protocol: ptr.To(api.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: []string{"127.0.0.1"},
-					Hostname:  utilpointer.String("valid-123"),
+					Hostname:  ptr.To("valid-123"),
 				}},
 			},
 		},
@@ -588,12 +588,12 @@ func TestValidateEndpointSlice(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeIPv6,
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.String("http"),
-					Protocol: protocolPtr(api.ProtocolTCP),
+					Name:     ptr.To("http"),
+					Protocol: ptr.To(api.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: []string{"fe80::9656:d028:8652:66b6"},
-					Hostname:  utilpointer.String("valid-123"),
+					Hostname:  ptr.To("valid-123"),
 				}},
 			},
 		},
@@ -626,12 +626,12 @@ func TestValidateEndpointSliceCreate(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.String("http"),
-					Protocol: protocolPtr(api.ProtocolTCP),
+					Name:     ptr.To("http"),
+					Protocol: ptr.To(api.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: generateIPAddresses(1),
-					Hostname:  utilpointer.String("valid-123"),
+					Hostname:  ptr.To("valid-123"),
 				}},
 			},
 		},
@@ -641,13 +641,13 @@ func TestValidateEndpointSliceCreate(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.String("http"),
-					Protocol: protocolPtr(api.ProtocolTCP),
+					Name:     ptr.To("http"),
+					Protocol: ptr.To(api.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: generateIPAddresses(1),
-					Hostname:  utilpointer.String("valid-123"),
-					NodeName:  utilpointer.String("valid-node-name"),
+					Hostname:  ptr.To("valid-123"),
+					NodeName:  ptr.To("valid-node-name"),
 				}},
 			},
 		},
@@ -659,13 +659,13 @@ func TestValidateEndpointSliceCreate(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.String("http"),
-					Protocol: protocolPtr(api.ProtocolTCP),
+					Name:     ptr.To("http"),
+					Protocol: ptr.To(api.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: generateIPAddresses(1),
-					Hostname:  utilpointer.String("valid-123"),
-					NodeName:  utilpointer.String("INvalid-node-name"),
+					Hostname:  ptr.To("valid-123"),
+					NodeName:  ptr.To("INvalid-node-name"),
 				}},
 			},
 		},
@@ -675,8 +675,8 @@ func TestValidateEndpointSliceCreate(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressType("IP"),
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.String("http"),
-					Protocol: protocolPtr(api.ProtocolTCP),
+					Name:     ptr.To("http"),
+					Protocol: ptr.To(api.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: generateIPAddresses(1),
@@ -689,8 +689,8 @@ func TestValidateEndpointSliceCreate(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressType("other"),
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.String("http"),
-					Protocol: protocolPtr(api.ProtocolTCP),
+					Name:     ptr.To("http"),
+					Protocol: ptr.To(api.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: generateIPAddresses(1),
@@ -744,7 +744,7 @@ func TestValidateEndpointSliceUpdate(t *testing.T) {
 				AddressType: discovery.AddressTypeIPv4,
 				Endpoints: []discovery.Endpoint{{
 					Addresses: []string{"10.1.2.3"},
-					NodeName:  utilpointer.String("INVALID foo"),
+					NodeName:  ptr.To("INVALID foo"),
 				}},
 			},
 			expectedErrors: 1,
@@ -781,8 +781,8 @@ func TestValidateEndpointSliceUpdate(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.String(""),
-					Protocol: protocolPtr(api.Protocol("invalid")),
+					Name:     ptr.To(""),
+					Protocol: ptr.To(api.Protocol("invalid")),
 				}},
 			},
 			expectedErrors: 1,
@@ -801,16 +801,12 @@ func TestValidateEndpointSliceUpdate(t *testing.T) {
 
 // Test helpers
 
-func protocolPtr(protocol api.Protocol) *api.Protocol {
-	return &protocol
-}
-
 func generatePorts(n int) []discovery.EndpointPort {
 	ports := []discovery.EndpointPort{}
 	for i := 0; i < n; i++ {
 		ports = append(ports, discovery.EndpointPort{
-			Name:     utilpointer.String(fmt.Sprintf("http-%d", i)),
-			Protocol: protocolPtr(api.ProtocolTCP),
+			Name:     ptr.To(fmt.Sprintf("http-%d", i)),
+			Protocol: ptr.To(api.ProtocolTCP),
 		})
 	}
 	return ports


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The new k8s.io/utils/ptr package provides generic wrapper functions, which can be used instead of type-specific pointer wrapper functions. This replaces the latter with the former, and migrates other uses of the deprecated pointer package to ptr in affacted files.

See https://github.com/kubernetes/utils/pull/283 for details.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
