### PR TITLE
chore: disable require-error rule from testifylint

### DIFF
--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -185,3 +185,5 @@ linters-settings: # please keep this alphabetized
       - "all"
   testifylint:
     enable-all: true
+    disable:  # TODO: remove each disabled rule and fix it
+      - require-error

--- a/hack/golangci-strict.yaml
+++ b/hack/golangci-strict.yaml
@@ -225,3 +225,5 @@ linters-settings: # please keep this alphabetized
       - "all"
   testifylint:
     enable-all: true
+    disable:  # TODO: remove each disabled rule and fix it
+      - require-error

--- a/hack/golangci.yaml.in
+++ b/hack/golangci.yaml.in
@@ -210,8 +210,8 @@ linters-settings: # please keep this alphabetized
   {{- end}}
   testifylint:
     enable-all: true
-    {{- if .Base}}
     disable:  # TODO: remove each disabled rule and fix it
+    {{- if .Base}}
       - compares
       - error-is-as
       - error-nil
@@ -219,5 +219,5 @@ linters-settings: # please keep this alphabetized
       - float-compare
       - go-require
       - nil-compare
-      - require-error
     {{- end}}
+      - require-error


### PR DESCRIPTION
#### What type of PR is this?

/area test
/assign @thockin 
/kind cleanup
/priority backlog
/sig testing

#### What this PR does / why we need it:

The use of the [require-error](https://github.com/Antonboom/testifylint?tab=readme-ov-file#require-error) rule in golangci-lint hints is asking for changes when other rules are being applied in the base. It needs to be reactivated in a second time when all other rules are already active.

