### PR TITLE
fix(e2e-node-tests):  duplicate flag "--runtime-config" when calling run_remote.go on test-e2e-node.sh

### DIFF
--- a/hack/make-rules/test-e2e-node.sh
+++ b/hack/make-rules/test-e2e-node.sh
@@ -202,7 +202,7 @@ if [ "${remote}" = true ] && [ "${remote_mode}" = gce ] ; then
   go run test/e2e_node/runner/remote/run_remote.go  --vmodule=*=4 --ssh-env="gce" \
     --zone="${zone}" --project="${project}" --gubernator="${gubernator}" \
     --hosts="${hosts}" --images="${images}" --cleanup="${cleanup}" \
-    --results-dir="${artifacts}" --ginkgo-flags="${ginkgoflags}" --runtime-config="${runtime_config}" \
+    --results-dir="${artifacts}" --ginkgo-flags="${ginkgoflags}" \
     --image-project="${image_project}" --instance-name-prefix="${instance_prefix}" \
     --delete-instances="${delete_instances}" --test_args="${test_args}" --instance-metadata="${metadata}" \
     --image-config-file="${image_config_file}" --system-spec-name="${system_spec_name}" \


### PR DESCRIPTION
/kind bug
/kind e2e


#### What this PR does / why we need it:
fix : remove duplicate flag "--runtime-config" when calling run_remote.go on test-e2e-node.sh

#### Which issue(s) this PR fixes:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes https://github.com/kubernetes/kubernetes/issues/127596.

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
no

```release-note
n/a
```

/sig node