### PR TITLE
bugfix: initialize secondary range registry with the right value

### DIFF
--- a/pkg/registry/core/rest/storage_core.go
+++ b/pkg/registry/core/rest/storage_core.go
@@ -440,7 +440,7 @@ func (c *Config) newServiceIPAllocators() (registries rangeRegistries, primaryCl
 					if err != nil {
 						return nil, err
 					}
-					rangeRegistry.Range = serviceClusterIPRange.String()
+					rangeRegistry.Range = c.Services.SecondaryClusterIPRange.String()
 					if len(rangeRegistry.ResourceVersion) == 0 {
 						klog.Infof("kube-apiserver started with IP allocator and dual write enabled but bitmap allocator does not exist, recreating it ...")
 						err := etcd.CreateOrUpdate(rangeRegistry)


### PR DESCRIPTION
When MultiCIDRServiceAllocator feature is enabled, we added an additional feature gate DisableAllocatorDualWrite that allows to enable a mirror behavior on the old allocator to deal with problems during cluster upgrades.

During the implementation the secondary range of the legacy allocator was initialized with the valuye of the primary range, hence, when a Service tried to allocate a new IP on the secondary range, it succeded in the new ip allocator but failed when it tried to allocate the same IP on the legacy allocator, since it has a different range.

/kind bug
Fixes #127588

```release-note
fix a bug with dual stack clusters using the beta feature MultiCIDRServiceAllocator can not create dual stack Services or Services with IPs on the secondary range. User that want to use this feature in 1.30 with dual stack clusters can workaround the issue by setting the feature gate DisableAllocatorDualWrite to true
```

