### PR TITLE
Fix: use reflect.DeepEqual for comparing merge keys

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch.go
@@ -952,7 +952,7 @@ func mergeKeyValueEqual(left, right interface{}, mergeKey string) (bool, error) 
 	if !ok {
 		return false, mergepatch.ErrNoMergeKey(typedRight, mergeKey)
 	}
-	return mergeKeyLeft == mergeKeyRight, nil
+	return reflect.DeepEqual(mergeKeyLeft, mergeKeyRight), nil
 }
 
 // extractKey trims the prefix and return the original key

--- a/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch.go
@@ -490,7 +490,7 @@ func index(l []interface{}, valToLookUp interface{}, mergeKey string, kind refle
 	}
 
 	for i, v := range l {
-		if getValFn(valToLookUp) == getValFn(v) {
+		if reflect.DeepEqual(getValFn(valToLookUp), getValFn(v)) {
 			return i
 		}
 	}
@@ -1659,7 +1659,7 @@ func findMapInSliceBasedOnKeyValue(m []interface{}, key string, value interface{
 		}
 
 		valueToMatch, ok := typedV[key]
-		if ok && valueToMatch == value {
+		if ok && reflect.DeepEqual(valueToMatch, value) {
 			return typedV, k, true, nil
 		}
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch_test.go
@@ -1266,6 +1266,61 @@ testCases:
 
 var strategicMergePatchRawTestCases = []StrategicMergePatchRawTestCase{
 	{
+		Description: "diff level array",
+		StrategicMergePatchRawTestCaseData: StrategicMergePatchRawTestCaseData{
+			Original: []byte(`
+mergingList:
+- name: hello1
+- name: hello2
+`),
+			Current: []byte(`
+mergingList:
+- name: hello1
+- name: hello2
+`),
+			Modified: []byte(`
+mergingList:
+- name: hello1
+- name: 
+    first: hello2
+`),
+			TwoWay: []byte(`
+$setElementOrder/mergingList:
+- name: hello1
+- name:
+    first: hello2
+mergingList:
+- name:
+    first: hello2
+- $patch: delete
+  name: hello2
+`),
+			ThreeWay: []byte(`
+$setElementOrder/mergingList:
+- name: hello1
+- name:
+    first: hello2
+mergingList:
+- name:
+    first: hello2
+- $patch: delete
+  name: hello2
+`),
+			TwoWayResult: []byte(`
+mergingList:
+- name: hello1
+- name:
+    first: hello2
+`),
+			Result: []byte(`
+mergingList:
+- name: hello1
+- name:
+    first: hello2
+`),
+		},
+	},
+	{
 		Description: "nested patch merge with empty list",
 		StrategicMergePatchRawTestCaseData: StrategicMergePatchRawTestCaseData{
 			Original: []byte(`

--- a/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch_test.go
@@ -1266,7 +1266,7 @@ testCases:
 
 var strategicMergePatchRawTestCases = []StrategicMergePatchRawTestCase{
 	{
-		Description: "diff level array",
+		Description: "different level of values with same key in array",
 		StrategicMergePatchRawTestCaseData: StrategicMergePatchRawTestCaseData{
 			Original: []byte(`
 mergingList:


### PR DESCRIPTION
Fixes #127056 

#### What type of PR is this?
/kind bug


#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
Fixes #127056 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NONE
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
