### PR TITLE
Automated cherry pick of #127491: kubeadm: check whether the peer URL for the added etcd member already exists when the MemberAddAsLearner/MemberAdd fails

### DIFF
--- a/cmd/kubeadm/app/util/etcd/etcd.go
+++ b/cmd/kubeadm/app/util/etcd/etcd.go
@@ -404,28 +404,18 @@ func (c *Client) addMember(name string, peerAddrs string, isLearner bool) ([]Mem
 	var (
 		lastError   error
 		respMembers []*etcdserverpb.Member
-		learnerID   uint64
 		resp        *clientv3.MemberAddResponse
 	)
 	err = wait.ExponentialBackoff(etcdBackoff, func() (bool, error) {
 		ctx, cancel := context.WithTimeout(context.Background(), etcdTimeout)
 		defer cancel()
 		if isLearner {
-			// if learnerID is set, it means the etcd member is already added successfully.
-			if learnerID == 0 {
-				klog.V(1).Info("[etcd] Adding etcd member as learner")
-				resp, err = cli.MemberAddAsLearner(ctx, []string{peerAddrs})
-				if err != nil {
-					lastError = err
-					return false, nil
-				}
-				learnerID = resp.Member.ID
-			}
-			respMembers = resp.Members
-			return true, nil
+			klog.V(1).Infof("[etcd] Adding etcd member %q as learner", peerAddrs)
+			resp, err = cli.MemberAddAsLearner(ctx, []string{peerAddrs})
+		} else {
+			klog.V(1).Infof("[etcd] Adding etcd member %q", peerAddrs)
+			resp, err = cli.MemberAdd(ctx, []string{peerAddrs})
 		}
-
-		resp, err = cli.MemberAdd(ctx, []string{peerAddrs})
 		if err == nil {
 			respMembers = resp.Members
 			return true, nil


### PR DESCRIPTION
Cherry pick of #127491 on release-1.28.

#127491: kubeadm: check whether the peer URL for the added etcd member already exists when the MemberAddAsLearner/MemberAdd fails

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
kubeadm: when adding new control plane nodes with "kubeamd join", ensure that the etcd member addition is performed only if a given member URL does not already exist in the list of members. Similarly, on "kubeadm reset" only remove an etcd member if its ID exists.
```