### PR TITLE
Stop setting GO111MODULE=off in tests

### DIFF
--- a/hack/jenkins/benchmark-dockerized.sh
+++ b/hack/jenkins/benchmark-dockerized.sh
@@ -42,14 +42,9 @@ export KUBE_ROOT
 
 export PATH=${GOPATH}/bin:${PWD}/third_party/etcd:/usr/local/go/bin:${PATH}
 
-# Until all GOPATH references are removed from all build scripts as well,
-# explicitly disable module mode to avoid picking up user-set GO111MODULE preferences.
-# As individual scripts make use of go modules, they can explicitly set GO111MODULE=on
-export GO111MODULE=off
-
 # Install tools we need
-GO111MODULE=on go -C "${KUBE_ROOT}/hack/tools" install github.com/cespare/prettybench
-GO111MODULE=on go -C "${KUBE_ROOT}/hack/tools" install gotest.tools/gotestsum
+go -C "${KUBE_ROOT}/hack/tools" install github.com/cespare/prettybench
+go -C "${KUBE_ROOT}/hack/tools" install gotest.tools/gotestsum
 
 # Disable the Go race detector.
 export KUBE_RACE=" "

--- a/hack/jenkins/test-dockerized.sh
+++ b/hack/jenkins/test-dockerized.sh
@@ -26,13 +26,8 @@ set -o xtrace
 
 export PATH=${GOPATH}/bin:${PWD}/third_party/etcd:/usr/local/go/bin:${PATH}
 
-# Until all GOPATH references are removed from all build scripts as well,
-# explicitly disable module mode to avoid picking up user-set GO111MODULE preferences.
-# As individual scripts make use of go modules, they can explicitly set GO111MODULE=on
-export GO111MODULE=off
-
 # Install tools we need
-GO111MODULE=on go -C "./hack/tools" install gotest.tools/gotestsum
+go -C "./hack/tools" install gotest.tools/gotestsum
 
 # Disable coverage report
 export KUBE_COVER="n"


### PR DESCRIPTION
#127606 brought this to light - we should no longer need to set GO111MODULE=off

/kind cleanup

```release-note
NONE
```
