### PR TITLE
Increase the readability of the test preconditions and double check that all test pods are really unschedulable.

### DIFF
--- a/test/integration/scheduler/queue_test.go
+++ b/test/integration/scheduler/queue_test.go
@@ -956,7 +956,8 @@ func TestCoreResourceEnqueue(t *testing.T) {
 
 				// Wait for the tt.pods to be present in the scheduling active queue.
 				if err := wait.PollUntilContextTimeout(ctx, time.Millisecond*200, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
-					return len(testCtx.Scheduler.SchedulingQueue.PodsInActiveQ()) == len(tt.pods), nil
+					pendingPods, _ := testCtx.Scheduler.SchedulingQueue.PendingPods()
+					return len(pendingPods) == len(tt.pods) && len(testCtx.Scheduler.SchedulingQueue.PodsInActiveQ()) == len(tt.pods), nil
 				}); err != nil {
 					t.Fatal(err)
 				}

--- a/test/integration/scheduler/queue_test.go
+++ b/test/integration/scheduler/queue_test.go
@@ -970,14 +970,15 @@ func TestCoreResourceEnqueue(t *testing.T) {
 				}
 				// Wait for the tt.pods to be still present in the scheduling (unschedulable) queue.
 				if err := wait.PollUntilContextTimeout(ctx, time.Millisecond*200, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
+					activePodsCount := len(testCtx.Scheduler.SchedulingQueue.PodsInActiveQ())
+					if activePodsCount > 0 {
+						return false, fmt.Errorf("Active queue was expected to be empty, but found %v Pods", activePodsCount)
+					}
+
 					pendingPods, _ := testCtx.Scheduler.SchedulingQueue.PendingPods()
 					return len(pendingPods) == len(tt.pods), nil
 				}); err != nil {
 					t.Fatal(err)
-				}
-				activePodsCount := len(testCtx.Scheduler.SchedulingQueue.PodsInActiveQ())
-				if activePodsCount > 0 {
-					t.Fatalf("Active queue was expected to be empty, but found %v Pods", activePodsCount)
 				}
 
 				t.Log("finished initial schedulings for all Pods, will trigger triggerFn")


### PR DESCRIPTION

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
Increase the readability of the test preconditions and double check that all test pods are really unschedulable.

#### Which issue(s) this PR fixes:

Part of #127405

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```