### PR TITLE
Add local reference to hcs structs in windows cri stats test

### DIFF
--- a/pkg/kubelet/stats/cri_stats_provider_windows_test.go
+++ b/pkg/kubelet/stats/cri_stats_provider_windows_test.go
@@ -39,9 +39,24 @@ type fakeNetworkStatsProvider struct {
 	containers []containerStats
 }
 
+// NetworkStats holds the network statistics for a container
+type fakeNetworkStats struct {
+	BytesReceived          uint64
+	BytesSent              uint64
+	PacketsReceived        uint64
+	PacketsSent            uint64
+	DroppedPacketsIncoming uint64
+	DroppedPacketsOutgoing uint64
+	EndpointId             string
+	InstanceId             string
+}
+
+type fakeContainerProperties struct {
+	ID string
+}
 type containerStats struct {
-	container hcsshim.ContainerProperties
-	hcsStats  []hcsshim.NetworkStats
+	container fakeContainerProperties
+	hcsStats  []fakeNetworkStats
 }
 
 func (s fakeNetworkStatsProvider) GetHNSEndpointStats(endpointName string) (*hcsshim.HNSEndpointStats, error) {
@@ -105,9 +120,9 @@ func Test_criStatsProvider_listContainerNetworkStats(t *testing.T) {
 			fields: fakeNetworkStatsProvider{
 				containers: []containerStats{
 					{
-						container: hcsshim.ContainerProperties{
+						container: fakeContainerProperties{
 							ID: "c1",
-						}, hcsStats: []hcsshim.NetworkStats{
+						}, hcsStats: []fakeNetworkStats{
 							{
 								BytesReceived: 1,
 								BytesSent:     10,
@@ -117,9 +132,9 @@ func Test_criStatsProvider_listContainerNetworkStats(t *testing.T) {
 						},
 					},
 					{
-						container: hcsshim.ContainerProperties{
+						container: fakeContainerProperties{
 							ID: "c2",
-						}, hcsStats: []hcsshim.NetworkStats{
+						}, hcsStats: []fakeNetworkStats{
 							{
 								BytesReceived: 2,
 								BytesSent:     20,
@@ -170,9 +185,9 @@ func Test_criStatsProvider_listContainerNetworkStats(t *testing.T) {
 			fields: fakeNetworkStatsProvider{
 				containers: []containerStats{
 					{
-						container: hcsshim.ContainerProperties{
+						container: fakeContainerProperties{
 							ID: "c1",
-						}, hcsStats: []hcsshim.NetworkStats{
+						}, hcsStats: []fakeNetworkStats{
 							{
 								BytesReceived: 1,
 								BytesSent:     10,
@@ -182,9 +197,9 @@ func Test_criStatsProvider_listContainerNetworkStats(t *testing.T) {
 						},
 					},
 					{
-						container: hcsshim.ContainerProperties{
+						container: fakeContainerProperties{
 							ID: "c2",
-						}, hcsStats: []hcsshim.NetworkStats{
+						}, hcsStats: []fakeNetworkStats{
 							{
 								BytesReceived: 2,
 								BytesSent:     20,
@@ -194,9 +209,9 @@ func Test_criStatsProvider_listContainerNetworkStats(t *testing.T) {
 						},
 					},
 					{
-						container: hcsshim.ContainerProperties{
+						container: fakeContainerProperties{
 							ID: "c3",
-						}, hcsStats: []hcsshim.NetworkStats{
+						}, hcsStats: []fakeNetworkStats{
 							{
 								BytesReceived: 3,
 								BytesSent:     30,
@@ -262,9 +277,9 @@ func Test_criStatsProvider_listContainerNetworkStats(t *testing.T) {
 			fields: fakeNetworkStatsProvider{
 				containers: []containerStats{
 					{
-						container: hcsshim.ContainerProperties{
+						container: fakeContainerProperties{
 							ID: "c1",
-						}, hcsStats: []hcsshim.NetworkStats{
+						}, hcsStats: []fakeNetworkStats{
 							{
 								BytesReceived: 1,
 								BytesSent:     10,
@@ -280,9 +295,9 @@ func Test_criStatsProvider_listContainerNetworkStats(t *testing.T) {
 						},
 					},
 					{
-						container: hcsshim.ContainerProperties{
+						container: fakeContainerProperties{
 							ID: "c2",
-						}, hcsStats: []hcsshim.NetworkStats{
+						}, hcsStats: []fakeNetworkStats{
 							{
 								BytesReceived: 2,
 								BytesSent:     20,
@@ -333,9 +348,9 @@ func Test_criStatsProvider_listContainerNetworkStats(t *testing.T) {
 			fields: fakeNetworkStatsProvider{
 				containers: []containerStats{
 					{
-						container: hcsshim.ContainerProperties{
+						container: fakeContainerProperties{
 							ID: "c1",
-						}, hcsStats: []hcsshim.NetworkStats{
+						}, hcsStats: []fakeNetworkStats{
 							{
 								BytesReceived: 1,
 								BytesSent:     10,
@@ -351,9 +366,9 @@ func Test_criStatsProvider_listContainerNetworkStats(t *testing.T) {
 						},
 					},
 					{
-						container: hcsshim.ContainerProperties{
+						container: fakeContainerProperties{
 							ID: "c2",
-						}, hcsStats: []hcsshim.NetworkStats{
+						}, hcsStats: []fakeNetworkStats{
 							{
 								BytesReceived: 2,
 								BytesSent:     20,


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This is part of the efforts to remove importing whole of hcsshim for only a small subset of references. This commit aims are removing references to hcsshim for two hcs structures (ContainerProperties, NetworkState\s) that are used in only ONE single test file

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
