### PR TITLE
feature(dra): support publishing larger numbers of devices in multiple ResourceSlice objects

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/resourceslicecontroller_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/resourceslicecontroller_test.go
@@ -17,6 +17,9 @@ limitations under the License.
 package resourceslice
 
 import (
+	"fmt"
+	"sort"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -28,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 	"k8s.io/klog/v2/ktesting"
 	"k8s.io/utils/ptr"
 )
@@ -41,91 +45,54 @@ func TestControllerSyncPool(t *testing.T) {
 		poolName       = "pool"
 		poolName1      = "pool-1"
 		deviceName     = "device"
+		resourceSlice  = "resource-slice"
 		resourceSlice1 = "resource-slice-1"
 		resourceSlice2 = "resource-slice-2"
 		resourceSlice3 = "resource-slice-3"
 	)
 
 	testCases := map[string]struct {
-		nodeUID                types.UID
+		nodeUID types.UID
+		// initialObjects is a list of initial resource slices to be used in the test.
 		initialObjects         []runtime.Object
+		initialOtherObjects    []runtime.Object
 		poolName               string
 		inputDriverResources   *DriverResources
 		expectedResourceSlices []resourceapi.ResourceSlice
+		// expectedResourceSliceTotalCount is the expected total count of resource slice.
+		expectedResourceSliceTotalCount int
+		// expectedResourceSliceChangeCount is the expected count of
+		// resource slice changes (created or deleted).
+		expectedResourceSliceChangeCount int
 	}{
-		"single-resourceslice-existing": {
-			nodeUID: nodeUID,
-			initialObjects: []runtime.Object{
-				newResourceSlice(resourceSlice1, node, driveName, poolName, 1),
-			},
-			poolName: poolName,
-			inputDriverResources: &DriverResources{
-				Pools: map[string]Pool{
-					poolName: {
-						Devices: []resourceapi.Device{
-							{
-								Name: deviceName,
-							},
-						},
-					},
-				},
-			},
-			expectedResourceSlices: []resourceapi.ResourceSlice{
-				*newExpectResourceSlice(resourceSlice1, node, string(nodeUID), driveName, poolName, deviceName, false, 1),
-			},
-		},
-		"single-resourceslice-existing-with-nodeUID-empty": {
-			nodeUID: "",
-			initialObjects: []runtime.Object{
-				newNode(node, nodeUID),
-				newResourceSlice(resourceSlice1, node, driveName, poolName, 1),
-			},
-			poolName: poolName,
-			inputDriverResources: &DriverResources{
-				Pools: map[string]Pool{
-					poolName: {
-						Devices: []resourceapi.Device{
-							{
-								Name: deviceName,
-							},
-						},
-					},
-				},
-			},
-			expectedResourceSlices: []resourceapi.ResourceSlice{
-				*newExpectResourceSlice(resourceSlice1, node, string(nodeUID), driveName, poolName, deviceName, false, 1),
-			},
-		},
-		"multiple-resourceslices-existing": {
-			nodeUID: nodeUID,
-			initialObjects: []runtime.Object{
-				newResourceSlice(resourceSlice1, node, driveName, poolName, 1),
-				newResourceSlice(resourceSlice2, node, driveName, poolName, 1),
-				newResourceSlice(resourceSlice3, node, driveName, poolName, 1),
-			},
-			poolName: poolName,
-			inputDriverResources: &DriverResources{
-				Pools: map[string]Pool{
-					poolName: {
-						Devices: []resourceapi.Device{
-							{
-								Name: deviceName,
-							},
-						},
-					},
-				},
-			},
-			expectedResourceSlices: []resourceapi.ResourceSlice{
-				*newExpectResourceSlice(resourceSlice1, node, string(nodeUID), driveName, poolName, deviceName, false, 1),
-			},
-		},
-		"no-resourceslices-existing": {
+		"no-resourceslices-existing-with-no-devices": {
 			nodeUID:        nodeUID,
 			initialObjects: []runtime.Object{},
 			poolName:       poolName,
 			inputDriverResources: &DriverResources{
 				Pools: map[string]Pool{
 					poolName: {
+						Devices: []resourceapi.Device{},
+					},
+				},
+			},
+			expectedResourceSlices: []resourceapi.ResourceSlice{
+				*MakeResourceSlice().Name(node+"-"+driveName+"-0").GenerateName(node+"-"+driveName+"-").
+					OwnerReferences(node, string(nodeUID)).NodeName(node).
+					Driver(driveName).Devices([]resourceapi.Device{}).
+					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 1, ResourceSliceCount: 1}).Obj(),
+			},
+			expectedResourceSliceTotalCount:  1,
+			expectedResourceSliceChangeCount: 1,
+		},
+		"no-resourceslices-existing-with-one-device": {
+			nodeUID:        nodeUID,
+			initialObjects: []runtime.Object{},
+			poolName:       poolName,
+			inputDriverResources: &DriverResources{
+				Pools: map[string]Pool{
+					poolName: {
+						Generation: 1,
 						Devices: []resourceapi.Device{
 							{
 								Name: deviceName,
@@ -135,15 +102,225 @@ func TestControllerSyncPool(t *testing.T) {
 				},
 			},
 			expectedResourceSlices: []resourceapi.ResourceSlice{
-				*newExpectResourceSlice(node+"-"+driveName+"-", node, string(nodeUID), driveName, poolName, deviceName, true, 0),
+				*MakeResourceSlice().Name(node+"-"+driveName+"-0").GenerateName(node+"-"+driveName+"-").
+					OwnerReferences(node, string(nodeUID)).NodeName(node).
+					Driver(driveName).Devices([]resourceapi.Device{{Name: deviceName}}).
+					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 2, ResourceSliceCount: 1}).Obj(),
 			},
+			expectedResourceSliceTotalCount:  1,
+			expectedResourceSliceChangeCount: 1,
 		},
-		"single-resourceslice-existing-with-different-resource-pool-generation": {
+		"no-resourceslice-existing-with-mismatching-resource-pool-name": {
+			nodeUID:        nodeUID,
+			initialObjects: []runtime.Object{},
+			poolName:       poolName,
+			inputDriverResources: &DriverResources{
+				Pools: map[string]Pool{
+					poolName1: {
+						Generation: 1,
+						Devices: []resourceapi.Device{
+							{
+								Name: deviceName,
+							},
+						},
+					},
+				},
+			},
+			expectedResourceSlices:           nil,
+			expectedResourceSliceTotalCount:  0,
+			expectedResourceSliceChangeCount: 0,
+		},
+		"single-resourceslice-existing-with-one-device": {
 			nodeUID: nodeUID,
 			initialObjects: []runtime.Object{
-				newResourceSlice(resourceSlice1, node, driveName, poolName, 2),
-				newResourceSlice(resourceSlice2, node, driveName, poolName, 1),
-				newResourceSlice(resourceSlice3, node, driveName, poolName, 1),
+				// no devices
+				MakeResourceSlice().Name(resourceSlice1).UID(resourceSlice1).
+					OwnerReferences(node, string(nodeUID)).NodeName(node).
+					Driver(driveName).Devices([]resourceapi.Device{}).
+					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 1, ResourceSliceCount: 1}).Obj(),
+			},
+			poolName: poolName,
+			inputDriverResources: &DriverResources{
+				Pools: map[string]Pool{
+					poolName: {
+						Devices: []resourceapi.Device{
+							{
+								Name: deviceName,
+							},
+						},
+					},
+				},
+			},
+			expectedResourceSlices: []resourceapi.ResourceSlice{
+				*MakeResourceSlice().Name(resourceSlice1).UID(resourceSlice1).
+					OwnerReferences(node, string(nodeUID)).NodeName(node).
+					Driver(driveName).Devices([]resourceapi.Device{{Name: deviceName}}).
+					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 1, ResourceSliceCount: 1}).Obj(),
+			},
+			expectedResourceSliceTotalCount:  1,
+			expectedResourceSliceChangeCount: 0,
+		},
+		"single-resourceslice-existing-with-nodeUID-empty": {
+			nodeUID: "",
+			initialObjects: []runtime.Object{
+				// no devices
+				MakeResourceSlice().Name(resourceSlice1).UID(resourceSlice1).
+					NodeName(node).
+					Driver(driveName).Devices([]resourceapi.Device{}).
+					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 1, ResourceSliceCount: 1}).Obj(),
+			},
+			initialOtherObjects: []runtime.Object{
+				newNode(node, nodeUID),
+			},
+			poolName: poolName,
+			inputDriverResources: &DriverResources{
+				Pools: map[string]Pool{
+					poolName: {
+						Devices: []resourceapi.Device{
+							{
+								Name: deviceName,
+							},
+						},
+					},
+				},
+			},
+			expectedResourceSlices: []resourceapi.ResourceSlice{
+				*MakeResourceSlice().Name(resourceSlice1).UID(resourceSlice1).
+					OwnerReferences(node, string(nodeUID)).NodeName(node).
+					Driver(driveName).Devices([]resourceapi.Device{{Name: deviceName}}).
+					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 1, ResourceSliceCount: 1}).Obj(),
+			},
+			expectedResourceSliceTotalCount:  1,
+			expectedResourceSliceChangeCount: 0,
+		},
+		"single-resourceslice-existing-with-mismatching-resource-pool-name": {
+			nodeUID: nodeUID,
+			initialObjects: []runtime.Object{
+				// no devices
+				MakeResourceSlice().Name(resourceSlice1).UID(resourceSlice1).
+					OwnerReferences(node, string(nodeUID)).NodeName(node).
+					Driver(driveName).Devices([]resourceapi.Device{}).
+					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 1, ResourceSliceCount: 1}).Obj(),
+			},
+			poolName: poolName,
+			inputDriverResources: &DriverResources{
+				Pools: map[string]Pool{
+					poolName1: {
+						Generation: 1,
+						Devices: []resourceapi.Device{
+							{
+								Name: deviceName,
+							},
+						},
+					},
+				},
+			},
+			expectedResourceSlices:           nil,
+			expectedResourceSliceTotalCount:  0,
+			expectedResourceSliceChangeCount: -1,
+		},
+		"single-resourceslice-with-more-than-128-devices-with-no-device": {
+			nodeUID: nodeUID,
+			initialObjects: []runtime.Object{
+				// no devices
+				MakeResourceSlice().Name(resourceSlice1).UID(resourceSlice1).
+					OwnerReferences(node, string(nodeUID)).NodeName(node).
+					Driver(driveName).Devices([]resourceapi.Device{}).
+					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 1, ResourceSliceCount: 1}).Obj(),
+			},
+			poolName: poolName,
+			inputDriverResources: &DriverResources{
+				Pools: map[string]Pool{
+					poolName: {
+						// We need to synchronize a total of 128 + 10 devices
+						// The naming convention for the devices follows the pattern from "device-000000" to "device-000137"
+						Devices: generateDevices(0, resourceapi.ResourceSliceMaxDevices+10),
+					},
+				},
+			},
+			expectedResourceSlices:           generateExpectedResourceSlices(resourceSlice, node, string(nodeUID), driveName, poolName, resourceapi.ResourceSliceMaxDevices+10, 2, 1),
+			expectedResourceSliceTotalCount:  2,
+			expectedResourceSliceChangeCount: 1,
+		},
+		"single-resourceslices-with-more-than-128-devices-with-noneeded-device": {
+			nodeUID: nodeUID,
+			initialObjects: []runtime.Object{
+				// 10 noneeded devices, we have to remove those devices
+				// The naming convention for the devices follows the pattern from "device-000300" to "device-000309"
+				MakeResourceSlice().Name(resourceSlice1).UID(resourceSlice1).
+					OwnerReferences(node, string(nodeUID)).NodeName(node).
+					Driver(driveName).Devices(generateDevices(300, 10)).
+					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 1, ResourceSliceCount: 1}).Obj(),
+			},
+			poolName: poolName,
+			inputDriverResources: &DriverResources{
+				Pools: map[string]Pool{
+					poolName: {
+						// We need to synchronize a total of 128*2 + 10 devices
+						// The naming convention for the devices follows the pattern from "device-000000" to "device-000265"
+						Devices: generateDevices(0, resourceapi.ResourceSliceMaxDevices*2+10),
+					},
+				},
+			},
+			expectedResourceSlices:           generateExpectedResourceSlices(resourceSlice, node, string(nodeUID), driveName, poolName, resourceapi.ResourceSliceMaxDevices*2+10, 2, 1),
+			expectedResourceSliceTotalCount:  3,
+			expectedResourceSliceChangeCount: 2,
+		},
+		"multiple-resourceslices-existing": {
+			nodeUID: nodeUID,
+			initialObjects: []runtime.Object{
+				MakeResourceSlice().Name(resourceSlice1).UID(resourceSlice1).
+					OwnerReferences(node, string(nodeUID)).NodeName(node).
+					Driver(driveName).Devices([]resourceapi.Device{}).
+					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 1, ResourceSliceCount: 1}).Obj(),
+				MakeResourceSlice().Name(resourceSlice2).UID(resourceSlice2).
+					OwnerReferences(node, string(nodeUID)).NodeName(node).
+					Driver(driveName).Devices([]resourceapi.Device{}).
+					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 1, ResourceSliceCount: 1}).Obj(),
+				MakeResourceSlice().Name(resourceSlice3).UID(resourceSlice3).
+					OwnerReferences(node, string(nodeUID)).NodeName(node).
+					Driver(driveName).Devices([]resourceapi.Device{}).
+					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 1, ResourceSliceCount: 1}).Obj(),
+			},
+			poolName: poolName,
+			inputDriverResources: &DriverResources{
+				Pools: map[string]Pool{
+					poolName: {
+						Devices: []resourceapi.Device{
+							{
+								Name: deviceName,
+							},
+						},
+					},
+				},
+			},
+			expectedResourceSlices: []resourceapi.ResourceSlice{
+				*MakeResourceSlice().Name(resourceSlice1).UID(resourceSlice1).
+					OwnerReferences(node, string(nodeUID)).NodeName(node).
+					Driver(driveName).Devices([]resourceapi.Device{{Name: deviceName}}).
+					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 2, ResourceSliceCount: 1}).Obj(),
+			},
+			expectedResourceSliceTotalCount:  1,
+			expectedResourceSliceChangeCount: -2,
+		},
+		"multiple-resourceslice-existing-with-different-resource-pool-generation": {
+			nodeUID: nodeUID,
+			initialObjects: []runtime.Object{
+				// no devices
+				MakeResourceSlice().Name(resourceSlice1).UID(resourceSlice1).
+					OwnerReferences(node, string(nodeUID)).NodeName(node).
+					Driver(driveName).Devices([]resourceapi.Device{}).
+					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 1, ResourceSliceCount: 1}).Obj(),
+				// no devices
+				MakeResourceSlice().Name(resourceSlice2).UID(resourceSlice2).
+					OwnerReferences(node, string(nodeUID)).NodeName(node).
+					Driver(driveName).Devices([]resourceapi.Device{}).
+					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 2, ResourceSliceCount: 1}).Obj(),
+				// no devices
+				MakeResourceSlice().Name(resourceSlice3).UID(resourceSlice3).
+					OwnerReferences(node, string(nodeUID)).NodeName(node).
+					Driver(driveName).Devices([]resourceapi.Device{}).
+					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 1, ResourceSliceCount: 1}).Obj(),
 			},
 			poolName: poolName,
 			inputDriverResources: &DriverResources{
@@ -159,35 +336,197 @@ func TestControllerSyncPool(t *testing.T) {
 				},
 			},
 			expectedResourceSlices: []resourceapi.ResourceSlice{
-				*newExpectResourceSlice(resourceSlice1, node, string(nodeUID), driveName, poolName, deviceName, false, 3),
+				*MakeResourceSlice().Name(resourceSlice2).UID(resourceSlice2).
+					OwnerReferences(node, string(nodeUID)).NodeName(node).
+					Driver(driveName).Devices([]resourceapi.Device{{Name: deviceName}}).
+					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 4, ResourceSliceCount: 1}).Obj(),
 			},
+			expectedResourceSliceTotalCount:  1,
+			expectedResourceSliceChangeCount: -2,
 		},
-		"single-resourceslice-existing-with-mismatching-resource-pool-name": {
+		"multiple-resourceslices-with-more-than-128-devices-with-no-device": {
 			nodeUID: nodeUID,
 			initialObjects: []runtime.Object{
-				newResourceSlice(resourceSlice1, node, driveName, poolName, 1),
+				// no devices
+				MakeResourceSlice().Name(resourceSlice1).UID(resourceSlice1).
+					OwnerReferences(node, string(nodeUID)).NodeName(node).
+					Driver(driveName).Devices([]resourceapi.Device{}).
+					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 1, ResourceSliceCount: 1}).Obj(),
+				// no devices
+				MakeResourceSlice().Name(resourceSlice2).UID(resourceSlice2).
+					OwnerReferences(node, string(nodeUID)).NodeName(node).
+					Driver(driveName).Devices([]resourceapi.Device{}).
+					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 1, ResourceSliceCount: 1}).Obj(),
 			},
 			poolName: poolName,
 			inputDriverResources: &DriverResources{
 				Pools: map[string]Pool{
-					poolName1: {
-						Generation: 1,
-						Devices: []resourceapi.Device{
-							{
-								Name: deviceName,
-							},
-						},
+					poolName: {
+						// We need to synchronize a total of 128*2 + 10 devices
+						// The naming convention for the devices follows the pattern from "device-000000" to "device-000265"
+						Devices: generateDevices(0, resourceapi.ResourceSliceMaxDevices*2+10),
 					},
 				},
 			},
-			expectedResourceSlices: nil,
+			expectedResourceSlices:           generateExpectedResourceSlices(resourceSlice, node, string(nodeUID), driveName, poolName, resourceapi.ResourceSliceMaxDevices*2+10, 2, 2),
+			expectedResourceSliceTotalCount:  3,
+			expectedResourceSliceChangeCount: 1,
+		},
+		"multiple-resourceslices-with-more-than-128-devices-with-needed-device-and-noneeded-device": {
+			nodeUID: nodeUID,
+			initialObjects: []runtime.Object{
+				// 20 needed devices, we have to keep those devices
+				// The naming convention for the devices follows the pattern from "device-000010" to "device-000029"
+				MakeResourceSlice().Name(resourceSlice1).UID(resourceSlice1).
+					OwnerReferences(node, string(nodeUID)).NodeName(node).
+					Driver(driveName).Devices(generateDevices(10, 20)).
+					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 1, ResourceSliceCount: 1}).Obj(),
+				// 10 noneeded devices, we have to remove those devices
+				// The naming convention for the devices follows the pattern from "device-000300" to "device-000309"
+				MakeResourceSlice().Name(resourceSlice2).UID(resourceSlice2).
+					OwnerReferences(node, string(nodeUID)).NodeName(node).
+					Driver(driveName).Devices(generateDevices(300, 10)).
+					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 1, ResourceSliceCount: 1}).Obj(),
+			},
+			poolName: poolName,
+			inputDriverResources: &DriverResources{
+				Pools: map[string]Pool{
+					poolName: {
+						// We need to synchronize a total of 128*2 + 10 devices
+						// The naming convention for the devices follows the pattern from "device-000000" to "device-000265"
+						Devices: generateDevices(0, resourceapi.ResourceSliceMaxDevices*2+10),
+					},
+				},
+			},
+			expectedResourceSlices:           generateExpectedResourceSlices(resourceSlice, node, string(nodeUID), driveName, poolName, resourceapi.ResourceSliceMaxDevices*2+10, 2, 2),
+			expectedResourceSliceTotalCount:  3,
+			expectedResourceSliceChangeCount: 1,
+		},
+		"multiple-resourceslices-with-more-than-128-devices-with-needed-device-and-noneeded-device-and-no-device": {
+			nodeUID: nodeUID,
+			initialObjects: []runtime.Object{
+				// 50 needed devices, we have to keep those devices
+				// The naming convention for the devices follows the pattern from "device-000010" to "device-000059"
+				MakeResourceSlice().Name(resourceSlice1).UID(resourceSlice1).
+					OwnerReferences(node, string(nodeUID)).NodeName(node).
+					Driver(driveName).Devices(generateDevices(10, 50)).
+					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 1, ResourceSliceCount: 1}).Obj(),
+				// 80 noneeded devices, we have to remove those devices
+				// The naming convention for the devices follows the pattern from "device-000400" to "device-000479"
+				MakeResourceSlice().Name(resourceSlice2).UID(resourceSlice2).
+					OwnerReferences(node, string(nodeUID)).NodeName(node).
+					Driver(driveName).Devices(generateDevices(400, 80)).
+					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 1, ResourceSliceCount: 1}).Obj(),
+				// no devices
+				MakeResourceSlice().Name(resourceSlice3).UID(resourceSlice3).
+					OwnerReferences(node, string(nodeUID)).NodeName(node).
+					Driver(driveName).Devices([]resourceapi.Device{}).
+					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 1, ResourceSliceCount: 1}).Obj(),
+			},
+			poolName: poolName,
+			inputDriverResources: &DriverResources{
+				Pools: map[string]Pool{
+					poolName: {
+						// We need to synchronize a total of 128*3 + 10 devices
+						// The naming convention for the devices follows the pattern from "device-000000" to "device-000393"
+						Devices: generateDevices(0, resourceapi.ResourceSliceMaxDevices*3+10),
+					},
+				},
+			},
+			expectedResourceSlices:           generateExpectedResourceSlices(resourceSlice, node, string(nodeUID), driveName, poolName, resourceapi.ResourceSliceMaxDevices*3+10, 2, 3),
+			expectedResourceSliceTotalCount:  4,
+			expectedResourceSliceChangeCount: 1,
+		},
+		"multiple-resourceslices-with-no-devices": {
+			nodeUID: nodeUID,
+			initialObjects: []runtime.Object{
+				// 50 needed devices, we have to keep those devices
+				// The naming convention for the devices follows the pattern from "device-000010" to "device-000059"
+				MakeResourceSlice().Name(resourceSlice1).UID(resourceSlice1).
+					OwnerReferences(node, string(nodeUID)).NodeName(node).
+					Driver(driveName).Devices(generateDevices(10, 50)).
+					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 1, ResourceSliceCount: 1}).Obj(),
+				// 80 noneeded devices, we have to remove those devices
+				// The naming convention for the devices follows the pattern from "device-000300" to "device-000379"
+				MakeResourceSlice().Name(resourceSlice2).UID(resourceSlice2).
+					OwnerReferences(node, string(nodeUID)).NodeName(node).
+					Driver(driveName).Devices(generateDevices(300, 80)).
+					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 1, ResourceSliceCount: 1}).Obj(),
+				// no devices
+				MakeResourceSlice().Name(resourceSlice3).UID(resourceSlice3).
+					OwnerReferences(node, string(nodeUID)).NodeName(node).
+					Driver(driveName).Devices([]resourceapi.Device{}).
+					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 1, ResourceSliceCount: 1}).Obj(),
+			},
+			poolName: poolName,
+			inputDriverResources: &DriverResources{
+				Pools: map[string]Pool{
+					poolName: {
+						Devices: []resourceapi.Device{},
+					},
+				},
+			},
+			expectedResourceSlices: []resourceapi.ResourceSlice{
+				*MakeResourceSlice().Name(resourceSlice1).UID(resourceSlice1).
+					OwnerReferences(node, string(nodeUID)).NodeName(node).
+					Driver(driveName).Devices([]resourceapi.Device{}).
+					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 2, ResourceSliceCount: 1}).Obj(),
+			},
+			expectedResourceSliceTotalCount:  1,
+			expectedResourceSliceChangeCount: -2,
+		},
+		"no-resourceslices-with-more-than-128-devices-one": {
+			nodeUID:        nodeUID,
+			initialObjects: []runtime.Object{},
+			poolName:       poolName,
+			inputDriverResources: &DriverResources{
+				Pools: map[string]Pool{
+					poolName: {
+						Generation: 1,
+						// We need to synchronize a total of 128*2 + 10 devices
+						// The naming convention for the devices follows the pattern from "device-000000" to "device-000265"
+						Devices: generateDevices(0, resourceapi.ResourceSliceMaxDevices*2+10),
+					},
+				},
+			},
+			expectedResourceSlices:           generateExpectedResourceSlices(resourceSlice, node, string(nodeUID), driveName, poolName, resourceapi.ResourceSliceMaxDevices*2+10, 2, 0),
+			expectedResourceSliceTotalCount:  3,
+			expectedResourceSliceChangeCount: 3,
+		},
+		"no-resourceslices-with-more-than-128-devices-two": {
+			nodeUID:        nodeUID,
+			initialObjects: []runtime.Object{},
+			poolName:       poolName,
+			inputDriverResources: &DriverResources{
+				Pools: map[string]Pool{
+					poolName: {
+						Generation: 1,
+						// We need to synchronize a total of 128*3 + 10 devices
+						// The naming convention for the devices follows the pattern from "device-000000" to "device-000393"
+						Devices: generateDevices(0, resourceapi.ResourceSliceMaxDevices*3+10),
+					},
+				},
+			},
+			expectedResourceSlices:           generateExpectedResourceSlices(resourceSlice, node, string(nodeUID), driveName, poolName, resourceapi.ResourceSliceMaxDevices*3+10, 2, 0),
+			expectedResourceSliceTotalCount:  4,
+			expectedResourceSliceChangeCount: 4,
 		},
 	}
 
 	for name, test := range testCases {
 		t.Run(name, func(t *testing.T) {
 			_, ctx := ktesting.NewTestContext(t)
-			kubeClient := fake.NewSimpleClientset(test.initialObjects...)
+			inputObjects := make([]runtime.Object, 0, len(test.initialObjects)+len(test.initialOtherObjects))
+			for _, initialOtherObject := range test.initialOtherObjects {
+				inputObjects = append(inputObjects, initialOtherObject.DeepCopyObject())
+			}
+			for _, initialObject := range test.initialObjects {
+				if _, ok := initialObject.(*resourceapi.ResourceSlice); !ok {
+					t.Fatalf("test.initialObjects have to be of type *resourceapi.ResourceSlice")
+				}
+				inputObjects = append(inputObjects, initialObject.DeepCopyObject())
+			}
+			kubeClient := createTestClient(inputObjects...)
 			owner := Owner{
 				APIVersion: "v1",
 				Kind:       "Node",
@@ -203,9 +542,25 @@ func TestControllerSyncPool(t *testing.T) {
 			// Check ResourceSlices
 			resourceSlices, err := kubeClient.ResourceV1alpha3().ResourceSlices().List(ctx, metav1.ListOptions{})
 			require.NoError(t, err, "list resource slices")
-			assert.Equal(t, test.expectedResourceSlices, resourceSlices.Items, "unexpected ResourceSlices")
+
+			sortResourceSlices(test.expectedResourceSlices)
+			sortResourceSlices(resourceSlices.Items)
+			assert.Equal(t, test.expectedResourceSlices, resourceSlices.Items)
+			resourceSlicesLen := len(resourceSlices.Items)
+			initResourceSliceLen := len(test.initialObjects)
+			assert.Equal(t, test.expectedResourceSliceTotalCount, resourceSlicesLen)
+			assert.Equal(t, test.expectedResourceSliceChangeCount, resourceSlicesLen-initResourceSliceLen)
 		})
 	}
+}
+
+func sortResourceSlices(slices []resourceapi.ResourceSlice) {
+	sort.Slice(slices, func(i, j int) bool {
+		if len(slices[i].Name) == 0 && len(slices[j].Name) == 0 {
+			return slices[i].ObjectMeta.GenerateName < slices[j].ObjectMeta.GenerateName
+		}
+		return slices[i].Name < slices[j].Name
+	})
 }
 
 func newNode(name string, uid types.UID) *v1.Node {
@@ -217,54 +572,170 @@ func newNode(name string, uid types.UID) *v1.Node {
 	}
 }
 
-func newResourceSlice(name, nodeName, driveName, poolName string, poolGeneration int64) *resourceapi.ResourceSlice {
-	return &resourceapi.ResourceSlice{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-			UID:  types.UID(name),
-		},
-		Spec: resourceapi.ResourceSliceSpec{
-			NodeName: nodeName,
-			Driver:   driveName,
-			Pool: resourceapi.ResourcePool{
-				Name:               poolName,
-				ResourceSliceCount: 1,
-				Generation:         poolGeneration,
+func createTestClient(objects ...runtime.Object) *fake.Clientset {
+	fakeClient := fake.NewSimpleClientset(objects...)
+	fakeClient.PrependReactor("create", "resourceslices", createResourceSliceReactor())
+	return fakeClient
+}
+
+// createResourceSliceReactor implements the logic required for the GenerateName field to work when using
+// the fake client. Add it with client.PrependReactor to your fake client.
+func createResourceSliceReactor() func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+	nameCounter := 0
+	var mutex sync.Mutex
+	return func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+		mutex.Lock()
+		defer mutex.Unlock()
+		resourceslice := action.(k8stesting.CreateAction).GetObject().(*resourceapi.ResourceSlice)
+		if resourceslice.Name == "" && resourceslice.GenerateName != "" {
+			resourceslice.Name = fmt.Sprintf("%s%d", resourceslice.GenerateName, nameCounter)
+		}
+		nameCounter++
+		return false, nil, nil
+	}
+}
+
+// ResourceSliceWrapper wraps a ResourceSlice.
+type ResourceSliceWrapper struct {
+	resourceapi.ResourceSlice
+}
+
+// MakeResourceSlice creates a wrapper for a ResourceSlice.
+func MakeResourceSlice() *ResourceSliceWrapper {
+	return &ResourceSliceWrapper{
+		resourceapi.ResourceSlice{
+			ObjectMeta: metav1.ObjectMeta{},
+			Spec: resourceapi.ResourceSliceSpec{
+				Pool:    resourceapi.ResourcePool{},
+				Devices: []resourceapi.Device{},
 			},
 		},
 	}
 }
 
-func newExpectResourceSlice(name, nodeName, nodeUID, driveName, poolName, deviceName string, generateName bool, poolGeneration int64) *resourceapi.ResourceSlice {
-	resourceSlice := &resourceapi.ResourceSlice{
-		ObjectMeta: metav1.ObjectMeta{
-			OwnerReferences: []metav1.OwnerReference{
-				{
-					APIVersion: "v1",
-					Kind:       "Node",
-					Name:       nodeName,
-					UID:        types.UID(nodeUID),
-					Controller: ptr.To(true),
-				},
-			},
+// Obj returns the inner ResourceSlice.
+func (r *ResourceSliceWrapper) Obj() *resourceapi.ResourceSlice {
+	return &r.ResourceSlice
+}
+
+// Name sets the value of ResourceSlice.ObjectMeta.Name
+func (r *ResourceSliceWrapper) Name(name string) *ResourceSliceWrapper {
+	r.ObjectMeta.Name = name
+	return r
+}
+
+// GenerateName sets the value of ResourceSlice.ObjectMeta.GenerateName
+func (r *ResourceSliceWrapper) GenerateName(generateName string) *ResourceSliceWrapper {
+	r.ObjectMeta.GenerateName = generateName
+	return r
+}
+
+// UID sets the value of ResourceSlice.ObjectMeta.UID
+func (r *ResourceSliceWrapper) UID(uid string) *ResourceSliceWrapper {
+	r.ObjectMeta.UID = types.UID(uid)
+	return r
+}
+
+// OwnerReferences sets the value of ResourceSlice.ObjectMeta.OwnerReferences
+func (r *ResourceSliceWrapper) OwnerReferences(nodeName, nodeUID string) *ResourceSliceWrapper {
+	r.ObjectMeta.OwnerReferences = []metav1.OwnerReference{
+		{
+			APIVersion: "v1",
+			Kind:       "Node",
+			Name:       nodeName,
+			UID:        types.UID(nodeUID),
+			Controller: ptr.To(true),
 		},
-		Spec: resourceapi.ResourceSliceSpec{
-			NodeName: nodeName,
-			Driver:   driveName,
-			Pool: resourceapi.ResourcePool{
-				Name:               poolName,
-				ResourceSliceCount: 1,
-				Generation:         poolGeneration,
-			},
-			Devices: []resourceapi.Device{{Name: deviceName}},
-		},
+	}
+	return r
+}
+
+// Driver sets the value of ResourceSlice.Spec.Driver
+func (r *ResourceSliceWrapper) Driver(driver string) *ResourceSliceWrapper {
+	r.Spec.Driver = driver
+	return r
+}
+
+// Pool sets the value of ResourceSlice.Spec.Pool
+func (r *ResourceSliceWrapper) Pool(pool resourceapi.ResourcePool) *ResourceSliceWrapper {
+	r.Spec.Pool = pool
+	return r
+}
+
+// NodeName sets the value of ResourceSlice.Spec.NodeName
+func (r *ResourceSliceWrapper) NodeName(nodeName string) *ResourceSliceWrapper {
+	r.Spec.NodeName = nodeName
+	return r
+}
+
+// NodeSelector sets the value of ResourceSlice.Spec.NodeSelector
+func (r *ResourceSliceWrapper) NodeSelector(nodeSelector *v1.NodeSelector) *ResourceSliceWrapper {
+	r.Spec.NodeSelector = nodeSelector
+	return r
+}
+
+// AllNodes sets the value of ResourceSlice.Spec.AllNodes
+func (r *ResourceSliceWrapper) AllNodes(allNodes bool) *ResourceSliceWrapper {
+	r.Spec.AllNodes = allNodes
+	return r
+}
+
+// Devices sets the value of ResourceSlice.Spec.Devices
+func (r *ResourceSliceWrapper) Devices(devices []resourceapi.Device) *ResourceSliceWrapper {
+	r.Spec.Devices = devices
+	return r
+}
+
+// generateExpectedResourceSlices generates the expected ResourceSlice objects for a given test case.
+func generateExpectedResourceSlices(baseName, nodeName, nodeUID, driveName, poolName string, totalDevices, generation int, initialSlices int) []resourceapi.ResourceSlice {
+	var slices []resourceapi.ResourceSlice
+	maxDevices := 128
+	resourceSliceCount := (totalDevices + maxDevices - 1) / maxDevices
+	// Initialize the slices array to ensure that its length is large enough
+	for i := 1; i <= initialSlices; i++ {
+		slice := MakeResourceSlice().Name(fmt.Sprintf("%s-%d", baseName, i)).UID(fmt.Sprintf("%s-%d", baseName, i)).
+			OwnerReferences(nodeName, string(nodeUID)).NodeName(nodeName).
+			Driver(driveName).Devices([]resourceapi.Device{}).
+			Pool(resourceapi.ResourcePool{Name: poolName, Generation: 1}).Obj()
+		slices = append(slices, *slice)
 	}
 
-	if generateName {
-		resourceSlice.ObjectMeta.GenerateName = name
-	} else {
-		resourceSlice.ObjectMeta.Name = name
-		resourceSlice.ObjectMeta.UID = types.UID(name)
+	// Add additional slices if needed
+	if resourceSliceCount > initialSlices {
+		for i := 0; i < resourceSliceCount-initialSlices; i++ {
+			slice := MakeResourceSlice().Name(fmt.Sprintf(nodeName+"-"+driveName+"-%d", i)).GenerateName(nodeName+"-"+driveName+"-").
+				OwnerReferences(nodeName, string(nodeUID)).NodeName(nodeName).
+				Driver(driveName).Devices([]resourceapi.Device{}).
+				Pool(resourceapi.ResourcePool{Name: poolName, Generation: 1}).Obj()
+			slices = append(slices, *slice)
+		}
 	}
-	return resourceSlice
+	// Generate a list of devices and ensure that the device names are consecutive
+	currentDeviceIndex := 0
+	for i := 0; i < resourceSliceCount; i++ {
+		start := i * maxDevices
+		end := start + maxDevices
+		if end > totalDevices {
+			end = totalDevices
+		}
+		devices := generateDevices(currentDeviceIndex, end-start)
+		slices[i].Spec.Devices = devices
+		slices[i].Spec.Pool.ResourceSliceCount = int64(resourceSliceCount)
+		slices[i].Spec.Pool.Generation = int64(generation)
+		currentDeviceIndex += end - start
+	}
+	return slices
+}
+
+// generateDevices generates a list of devices with consecutive names.
+// The number of devices generated is determined by the total number of devices
+// divided by the number of slices.
+func generateDevices(startIndex int, count int) []resourceapi.Device {
+	devices := make([]resourceapi.Device, count)
+	for i := 0; i < count; i++ {
+		// Generate a unique device name using the index
+		deviceName := fmt.Sprintf("device-%06d", startIndex+i)
+		devices[i] = resourceapi.Device{Name: deviceName}
+	}
+	return devices
 }


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
- support publishing larger numbers of devices in multiple ResourceSlice objects
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/126837

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
support publishing larger numbers of devices in multiple ResourceSlice objects
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
