### PR TITLE
kubeadm: fix a bug where the RemoveMember function did not return the correct member list when the member to be removed did not exist

### DIFF
--- a/cmd/kubeadm/app/util/etcd/etcd.go
+++ b/cmd/kubeadm/app/util/etcd/etcd.go
@@ -347,18 +347,19 @@ func (c *Client) ListMembers() ([]Member, error) {
 
 // RemoveMember notifies an etcd cluster to remove an existing member
 func (c *Client) RemoveMember(id uint64) ([]Member, error) {
-	// Remove an existing member from the cluster
-	var lastError error
-	var resp *clientv3.MemberRemoveResponse
-	err := wait.PollUntilContextTimeout(context.Background(), constants.EtcdAPICallRetryInterval, constants.EtcdAPICallTimeout,
-		true, func(_ context.Context) (bool, error) {
-			cli, err := c.newEtcdClient(c.Endpoints)
-			if err != nil {
-				lastError = err
-				return false, nil
-			}
-			defer func() { _ = cli.Close() }()
+	cli, err := c.newEtcdClient(c.Endpoints)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = cli.Close() }()
 
+	// Remove an existing member from the cluster
+	var (
+		lastError   error
+		respMembers []*etcdserverpb.Member
+	)
+	err = wait.PollUntilContextTimeout(context.Background(), constants.EtcdAPICallRetryInterval, constants.EtcdAPICallTimeout,
+		true, func(_ context.Context) (bool, error) {
 			ctx, cancel := context.WithTimeout(context.Background(), etcdTimeout)
 			defer cancel()
 
@@ -378,16 +379,22 @@ func (c *Client) RemoveMember(id uint64) ([]Member, error) {
 			}
 			if !found {
 				klog.V(5).Infof("Member %s was not found; assuming it was already removed", strconv.FormatUint(id, 16))
+				respMembers = listResp.Members
 				return true, nil
 			}
 
-			resp, err = cli.MemberRemove(ctx, id)
+			resp, err := cli.MemberRemove(ctx, id)
 			if err == nil {
+				respMembers = resp.Members
 				return true, nil
 			}
 			if errors.Is(rpctypes.ErrMemberNotFound, err) {
 				klog.V(5).Infof("Member was already removed, because member %s was not found", strconv.FormatUint(id, 16))
-				return true, nil
+				listResp, err = cli.MemberList(ctx)
+				if err == nil {
+					respMembers = listResp.Members
+					return true, nil
+				}
 			}
 			klog.V(5).Infof("Failed to remove etcd member: %v", err)
 			lastError = err
@@ -399,11 +406,8 @@ func (c *Client) RemoveMember(id uint64) ([]Member, error) {
 
 	// Returns the updated list of etcd members
 	ret := []Member{}
-	if resp != nil {
-		for _, m := range resp.Members {
-			ret = append(ret, Member{Name: m.Name, PeerURL: m.PeerURLs[0]})
-		}
-
+	for _, m := range respMembers {
+		ret = append(ret, Member{Name: m.Name, PeerURL: m.PeerURLs[0]})
 	}
 
 	return ret, nil
@@ -484,7 +488,6 @@ func (c *Client) addMember(name string, peerAddrs string, isLearner bool) ([]Mem
 			// call out to MemberList to fetch all the members before returning.
 			if errors.Is(err, rpctypes.ErrPeerURLExist) {
 				klog.V(5).Info("The peer URL for the added etcd member already exists. Fetching the existing etcd members")
-				var listResp *clientv3.MemberListResponse
 				listResp, err = cli.MemberList(ctx)
 				if err == nil {
 					respMembers = listResp.Members


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
kubeadm: fix a bug where the `RemoveMember` function did not return the correct member list when the member to be removed did not exist

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
We don't actually use the member list returned by `RemoveMember`, just to print debug messages:
https://github.com/kubernetes/kubernetes/blob/9770283c137e73169a8e6f94abdf3e15f1f8cc4d/cmd/kubeadm/app/phases/etcd/local.go#L129-L133

So the cherry-pick doesn't seem to make much sense.


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: fix wrong member list reported when removing an etcd member
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
