### PR TITLE
Automated cherry pick of #127102: Clean up Node authorizer's non-thread-safe method names
#127098: Make Node authorizer's index authoritative for unauthorized calls

### DIFF
--- a/plugin/pkg/auth/authorizer/node/graph.go
+++ b/plugin/pkg/auth/authorizer/node/graph.go
@@ -139,21 +139,21 @@ var vertexTypes = map[vertexType]string{
 }
 
 // must be called under a write lock
-func (g *Graph) getOrCreateVertex_locked(vertexType vertexType, namespace, name string) *namedVertex {
-	if vertex, exists := g.getVertex_rlocked(vertexType, namespace, name); exists {
+func (g *Graph) getOrCreateVertexLocked(vertexType vertexType, namespace, name string) *namedVertex {
+	if vertex, exists := g.getVertexRLocked(vertexType, namespace, name); exists {
 		return vertex
 	}
-	return g.createVertex_locked(vertexType, namespace, name)
+	return g.createVertexLocked(vertexType, namespace, name)
 }
 
 // must be called under a read lock
-func (g *Graph) getVertex_rlocked(vertexType vertexType, namespace, name string) (*namedVertex, bool) {
+func (g *Graph) getVertexRLocked(vertexType vertexType, namespace, name string) (*namedVertex, bool) {
 	vertex, exists := g.vertices[vertexType][namespace][name]
 	return vertex, exists
 }
 
 // must be called under a write lock
-func (g *Graph) createVertex_locked(vertexType vertexType, namespace, name string) *namedVertex {
+func (g *Graph) createVertexLocked(vertexType vertexType, namespace, name string) *namedVertex {
 	typedVertices, exists := g.vertices[vertexType]
 	if !exists {
 		typedVertices = namespaceVertexMapping{}
@@ -174,8 +174,8 @@ func (g *Graph) createVertex_locked(vertexType vertexType, namespace, name strin
 }
 
 // must be called under write lock
-func (g *Graph) deleteVertex_locked(vertexType vertexType, namespace, name string) {
-	vertex, exists := g.getVertex_rlocked(vertexType, namespace, name)
+func (g *Graph) deleteVertexLocked(vertexType vertexType, namespace, name string) {
+	vertex, exists := g.getVertexRLocked(vertexType, namespace, name)
 	if !exists {
 		return
 	}
@@ -202,25 +202,25 @@ func (g *Graph) deleteVertex_locked(vertexType vertexType, namespace, name strin
 	})
 
 	// remove the vertex
-	g.removeVertex_locked(vertex)
+	g.removeVertexLocked(vertex)
 
 	// remove neighbors that are now edgeless
 	for _, neighbor := range neighborsToRemove {
-		g.removeVertex_locked(neighbor.(*namedVertex))
+		g.removeVertexLocked(neighbor.(*namedVertex))
 	}
 
 	// remove edges from destination indexes for neighbors that dropped outbound edges
 	for _, edge := range edgesToRemoveFromIndexes {
-		g.removeEdgeFromDestinationIndex_locked(edge)
+		g.removeEdgeFromDestinationIndexLocked(edge)
 	}
 }
 
 // must be called under write lock
 // deletes edges from a given vertex type to a specific vertex
 // will delete each orphaned "from" vertex, but will never delete the "to" vertex
-func (g *Graph) deleteEdges_locked(fromType, toType vertexType, toNamespace, toName string) {
+func (g *Graph) deleteEdgesLocked(fromType, toType vertexType, toNamespace, toName string) {
 	// get the "to" side
-	toVert, exists := g.getVertex_rlocked(toType, toNamespace, toName)
+	toVert, exists := g.getVertexRLocked(toType, toNamespace, toName)
 	if !exists {
 		return
 	}
@@ -244,18 +244,18 @@ func (g *Graph) deleteEdges_locked(fromType, toType vertexType, toNamespace, toN
 
 	// clean up orphaned verts
 	for _, v := range neighborsToRemove {
-		g.removeVertex_locked(v)
+		g.removeVertexLocked(v)
 	}
 
 	// remove edges and decrement destination indexes for neighbors that dropped outbound edges
 	for _, edge := range edgesToRemove {
 		g.graph.RemoveEdge(edge)
-		g.removeEdgeFromDestinationIndex_locked(edge)
+		g.removeEdgeFromDestinationIndexLocked(edge)
 	}
 }
 
-// A fastpath for recomputeDestinationIndex_locked for "removing edge" case.
-func (g *Graph) removeEdgeFromDestinationIndex_locked(e graph.Edge) {
+// A fastpath for recomputeDestinationIndexLocked for "removing edge" case.
+func (g *Graph) removeEdgeFromDestinationIndexLocked(e graph.Edge) {
 	n := e.From()
 	// don't maintain indices for nodes with few edges
 	edgeCount := g.graph.Degree(n)
@@ -274,13 +274,13 @@ func (g *Graph) removeEdgeFromDestinationIndex_locked(e graph.Edge) {
 	}
 }
 
-// A fastpath for recomputeDestinationIndex_locked for "adding edge case".
-func (g *Graph) addEdgeToDestinationIndex_locked(e graph.Edge) {
+// A fastpath for recomputeDestinationIndexLocked for "adding edge case".
+func (g *Graph) addEdgeToDestinationIndexLocked(e graph.Edge) {
 	n := e.From()
 	index := g.destinationEdgeIndex[n.ID()]
 	if index == nil {
 		// There is no index, use the full index computation method
-		g.recomputeDestinationIndex_locked(n)
+		g.recomputeDestinationIndexLocked(n)
 		return
 	}
 	// fast-add the new edge to an existing index
@@ -290,9 +290,9 @@ func (g *Graph) addEdgeToDestinationIndex_locked(e graph.Edge) {
 }
 
 // must be called under write lock
-// removeVertex_locked removes the specified vertex from the graph and from the maintained indices.
+// removeVertexLocked removes the specified vertex from the graph and from the maintained indices.
 // It does nothing to indexes of neighbor vertices.
-func (g *Graph) removeVertex_locked(v *namedVertex) {
+func (g *Graph) removeVertexLocked(v *namedVertex) {
 	g.graph.RemoveNode(v)
 	delete(g.destinationEdgeIndex, v.ID())
 	delete(g.vertices[v.vertexType][v.namespace], v.name)
@@ -302,8 +302,8 @@ func (g *Graph) removeVertex_locked(v *namedVertex) {
 }
 
 // must be called under write lock
-// recomputeDestinationIndex_locked recomputes the index of destination ids for the specified vertex
-func (g *Graph) recomputeDestinationIndex_locked(n graph.Node) {
+// recomputeDestinationIndexLocked recomputes the index of destination ids for the specified vertex
+func (g *Graph) recomputeDestinationIndexLocked(n graph.Node) {
 	// don't maintain indices for nodes with few edges
 	edgeCount := g.graph.Degree(n)
 	if edgeCount < g.destinationEdgeThreshold {
@@ -345,9 +345,9 @@ func (g *Graph) AddPod(pod *corev1.Pod) {
 	g.lock.Lock()
 	defer g.lock.Unlock()
 
-	g.deleteVertex_locked(podVertexType, pod.Namespace, pod.Name)
-	podVertex := g.getOrCreateVertex_locked(podVertexType, pod.Namespace, pod.Name)
-	nodeVertex := g.getOrCreateVertex_locked(nodeVertexType, "", pod.Spec.NodeName)
+	g.deleteVertexLocked(podVertexType, pod.Namespace, pod.Name)
+	podVertex := g.getOrCreateVertexLocked(podVertexType, pod.Namespace, pod.Name)
+	nodeVertex := g.getOrCreateVertexLocked(nodeVertexType, "", pod.Spec.NodeName)
 	g.graph.SetEdge(newDestinationEdge(podVertex, nodeVertex, nodeVertex))
 
 	// Short-circuit adding edges to other resources for mirror pods.
@@ -362,25 +362,25 @@ func (g *Graph) AddPod(pod *corev1.Pod) {
 	//
 	// ref https://github.com/kubernetes/kubernetes/issues/58790
 	if len(pod.Spec.ServiceAccountName) > 0 {
-		serviceAccountVertex := g.getOrCreateVertex_locked(serviceAccountVertexType, pod.Namespace, pod.Spec.ServiceAccountName)
+		serviceAccountVertex := g.getOrCreateVertexLocked(serviceAccountVertexType, pod.Namespace, pod.Spec.ServiceAccountName)
 		e := newDestinationEdge(serviceAccountVertex, podVertex, nodeVertex)
 		g.graph.SetEdge(e)
-		g.addEdgeToDestinationIndex_locked(e)
+		g.addEdgeToDestinationIndexLocked(e)
 	}
 
 	podutil.VisitPodSecretNames(pod, func(secret string) bool {
-		secretVertex := g.getOrCreateVertex_locked(secretVertexType, pod.Namespace, secret)
+		secretVertex := g.getOrCreateVertexLocked(secretVertexType, pod.Namespace, secret)
 		e := newDestinationEdge(secretVertex, podVertex, nodeVertex)
 		g.graph.SetEdge(e)
-		g.addEdgeToDestinationIndex_locked(e)
+		g.addEdgeToDestinationIndexLocked(e)
 		return true
 	})
 
 	podutil.VisitPodConfigmapNames(pod, func(configmap string) bool {
-		configmapVertex := g.getOrCreateVertex_locked(configMapVertexType, pod.Namespace, configmap)
+		configmapVertex := g.getOrCreateVertexLocked(configMapVertexType, pod.Namespace, configmap)
 		e := newDestinationEdge(configmapVertex, podVertex, nodeVertex)
 		g.graph.SetEdge(e)
-		g.addEdgeToDestinationIndex_locked(e)
+		g.addEdgeToDestinationIndexLocked(e)
 		return true
 	})
 
@@ -392,10 +392,10 @@ func (g *Graph) AddPod(pod *corev1.Pod) {
 			claimName = ephemeral.VolumeClaimName(pod, &v)
 		}
 		if claimName != "" {
-			pvcVertex := g.getOrCreateVertex_locked(pvcVertexType, pod.Namespace, claimName)
+			pvcVertex := g.getOrCreateVertexLocked(pvcVertexType, pod.Namespace, claimName)
 			e := newDestinationEdge(pvcVertex, podVertex, nodeVertex)
 			g.graph.SetEdge(e)
-			g.addEdgeToDestinationIndex_locked(e)
+			g.addEdgeToDestinationIndexLocked(e)
 		}
 	}
 
@@ -406,10 +406,10 @@ func (g *Graph) AddPod(pod *corev1.Pod) {
 		// still needs to be created, nil that intentionally no claim
 		// was created and never will be because it isn't needed.
 		if err == nil && claimName != nil {
-			claimVertex := g.getOrCreateVertex_locked(resourceClaimVertexType, pod.Namespace, *claimName)
+			claimVertex := g.getOrCreateVertexLocked(resourceClaimVertexType, pod.Namespace, *claimName)
 			e := newDestinationEdge(claimVertex, podVertex, nodeVertex)
 			g.graph.SetEdge(e)
-			g.addEdgeToDestinationIndex_locked(e)
+			g.addEdgeToDestinationIndexLocked(e)
 		}
 	}
 }
@@ -420,7 +420,7 @@ func (g *Graph) DeletePod(name, namespace string) {
 	}()
 	g.lock.Lock()
 	defer g.lock.Unlock()
-	g.deleteVertex_locked(podVertexType, namespace, name)
+	g.deleteVertexLocked(podVertexType, namespace, name)
 }
 
 // AddPV sets up edges for the following relationships:
@@ -437,18 +437,18 @@ func (g *Graph) AddPV(pv *corev1.PersistentVolume) {
 	defer g.lock.Unlock()
 
 	// clear existing edges
-	g.deleteVertex_locked(pvVertexType, "", pv.Name)
+	g.deleteVertexLocked(pvVertexType, "", pv.Name)
 
 	// if we have a pvc, establish new edges
 	if pv.Spec.ClaimRef != nil {
-		pvVertex := g.getOrCreateVertex_locked(pvVertexType, "", pv.Name)
+		pvVertex := g.getOrCreateVertexLocked(pvVertexType, "", pv.Name)
 
 		// since we don't know the other end of the pvc -> pod -> node chain (or it may not even exist yet), we can't decorate these edges with kubernetes node info
-		g.graph.SetEdge(simple.Edge{F: pvVertex, T: g.getOrCreateVertex_locked(pvcVertexType, pv.Spec.ClaimRef.Namespace, pv.Spec.ClaimRef.Name)})
+		g.graph.SetEdge(simple.Edge{F: pvVertex, T: g.getOrCreateVertexLocked(pvcVertexType, pv.Spec.ClaimRef.Namespace, pv.Spec.ClaimRef.Name)})
 		pvutil.VisitPVSecretNames(pv, func(namespace, secret string, kubeletVisible bool) bool {
 			// This grants access to the named secret in the same namespace as the bound PVC
 			if kubeletVisible {
-				g.graph.SetEdge(simple.Edge{F: g.getOrCreateVertex_locked(secretVertexType, namespace, secret), T: pvVertex})
+				g.graph.SetEdge(simple.Edge{F: g.getOrCreateVertexLocked(secretVertexType, namespace, secret), T: pvVertex})
 			}
 			return true
 		})
@@ -461,7 +461,7 @@ func (g *Graph) DeletePV(name string) {
 	}()
 	g.lock.Lock()
 	defer g.lock.Unlock()
-	g.deleteVertex_locked(pvVertexType, "", name)
+	g.deleteVertexLocked(pvVertexType, "", name)
 }
 
 // AddVolumeAttachment sets up edges for the following relationships:
@@ -476,12 +476,12 @@ func (g *Graph) AddVolumeAttachment(attachmentName, nodeName string) {
 	defer g.lock.Unlock()
 
 	// clear existing edges
-	g.deleteVertex_locked(vaVertexType, "", attachmentName)
+	g.deleteVertexLocked(vaVertexType, "", attachmentName)
 
 	// if we have a node, establish new edges
 	if len(nodeName) > 0 {
-		vaVertex := g.getOrCreateVertex_locked(vaVertexType, "", attachmentName)
-		nodeVertex := g.getOrCreateVertex_locked(nodeVertexType, "", nodeName)
+		vaVertex := g.getOrCreateVertexLocked(vaVertexType, "", attachmentName)
+		nodeVertex := g.getOrCreateVertexLocked(nodeVertexType, "", nodeName)
 		g.graph.SetEdge(newDestinationEdge(vaVertex, nodeVertex, nodeVertex))
 	}
 }
@@ -492,7 +492,7 @@ func (g *Graph) DeleteVolumeAttachment(name string) {
 	}()
 	g.lock.Lock()
 	defer g.lock.Unlock()
-	g.deleteVertex_locked(vaVertexType, "", name)
+	g.deleteVertexLocked(vaVertexType, "", name)
 }
 
 // AddResourceSlice sets up edges for the following relationships:
@@ -507,12 +507,12 @@ func (g *Graph) AddResourceSlice(sliceName, nodeName string) {
 	defer g.lock.Unlock()
 
 	// clear existing edges
-	g.deleteVertex_locked(sliceVertexType, "", sliceName)
+	g.deleteVertexLocked(sliceVertexType, "", sliceName)
 
 	// if we have a node, establish new edges
 	if len(nodeName) > 0 {
-		sliceVertex := g.getOrCreateVertex_locked(sliceVertexType, "", sliceName)
-		nodeVertex := g.getOrCreateVertex_locked(nodeVertexType, "", nodeName)
+		sliceVertex := g.getOrCreateVertexLocked(sliceVertexType, "", sliceName)
+		nodeVertex := g.getOrCreateVertexLocked(nodeVertexType, "", nodeName)
 		g.graph.SetEdge(newDestinationEdge(sliceVertex, nodeVertex, nodeVertex))
 	}
 }
@@ -523,5 +523,5 @@ func (g *Graph) DeleteResourceSlice(sliceName string) {
 	}()
 	g.lock.Lock()
 	defer g.lock.Unlock()
-	g.deleteVertex_locked(sliceVertexType, "", sliceName)
+	g.deleteVertexLocked(sliceVertexType, "", sliceName)
 }

--- a/plugin/pkg/auth/authorizer/node/graph_test.go
+++ b/plugin/pkg/auth/authorizer/node/graph_test.go
@@ -30,7 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-func TestDeleteEdges_locked(t *testing.T) {
+func TestDeleteEdgesLocked(t *testing.T) {
 	cases := []struct {
 		desc        string
 		fromType    vertexType
@@ -49,16 +49,16 @@ func TestDeleteEdges_locked(t *testing.T) {
 			toName:      "node1",
 			start: func() *Graph {
 				g := NewGraph()
-				g.getOrCreateVertex_locked(configMapVertexType, "namespace1", "configmap2")
-				nodeVertex := g.getOrCreateVertex_locked(nodeVertexType, "", "node1")
-				configmapVertex := g.getOrCreateVertex_locked(configMapVertexType, "namespace1", "configmap1")
+				g.getOrCreateVertexLocked(configMapVertexType, "namespace1", "configmap2")
+				nodeVertex := g.getOrCreateVertexLocked(nodeVertexType, "", "node1")
+				configmapVertex := g.getOrCreateVertexLocked(configMapVertexType, "namespace1", "configmap1")
 				g.graph.SetEdge(newDestinationEdge(configmapVertex, nodeVertex, nodeVertex))
 				return g
 			}(),
 			expect: func() *Graph {
 				g := NewGraph()
-				g.getOrCreateVertex_locked(configMapVertexType, "namespace1", "configmap2")
-				g.getOrCreateVertex_locked(nodeVertexType, "", "node1")
+				g.getOrCreateVertexLocked(configMapVertexType, "namespace1", "configmap2")
+				g.getOrCreateVertexLocked(nodeVertexType, "", "node1")
 				return g
 			}(),
 		},
@@ -71,18 +71,18 @@ func TestDeleteEdges_locked(t *testing.T) {
 			toName:      "node2",
 			start: func() *Graph {
 				g := NewGraph()
-				nodeVertex1 := g.getOrCreateVertex_locked(nodeVertexType, "", "node1")
-				nodeVertex2 := g.getOrCreateVertex_locked(nodeVertexType, "", "node2")
-				configmapVertex := g.getOrCreateVertex_locked(configMapVertexType, "namespace1", "configmap1")
+				nodeVertex1 := g.getOrCreateVertexLocked(nodeVertexType, "", "node1")
+				nodeVertex2 := g.getOrCreateVertexLocked(nodeVertexType, "", "node2")
+				configmapVertex := g.getOrCreateVertexLocked(configMapVertexType, "namespace1", "configmap1")
 				g.graph.SetEdge(newDestinationEdge(configmapVertex, nodeVertex1, nodeVertex1))
 				g.graph.SetEdge(newDestinationEdge(configmapVertex, nodeVertex2, nodeVertex2))
 				return g
 			}(),
 			expect: func() *Graph {
 				g := NewGraph()
-				nodeVertex1 := g.getOrCreateVertex_locked(nodeVertexType, "", "node1")
-				g.getOrCreateVertex_locked(nodeVertexType, "", "node2")
-				configmapVertex := g.getOrCreateVertex_locked(configMapVertexType, "namespace1", "configmap1")
+				nodeVertex1 := g.getOrCreateVertexLocked(nodeVertexType, "", "node1")
+				g.getOrCreateVertexLocked(nodeVertexType, "", "node2")
+				configmapVertex := g.getOrCreateVertexLocked(configMapVertexType, "namespace1", "configmap1")
 				g.graph.SetEdge(newDestinationEdge(configmapVertex, nodeVertex1, nodeVertex1))
 				return g
 			}(),
@@ -95,14 +95,14 @@ func TestDeleteEdges_locked(t *testing.T) {
 			toName:      "node1",
 			start: func() *Graph {
 				g := NewGraph()
-				g.getOrCreateVertex_locked(nodeVertexType, "", "node1")
-				g.getOrCreateVertex_locked(configMapVertexType, "namespace1", "configmap1")
+				g.getOrCreateVertexLocked(nodeVertexType, "", "node1")
+				g.getOrCreateVertexLocked(configMapVertexType, "namespace1", "configmap1")
 				return g
 			}(),
 			expect: func() *Graph {
 				g := NewGraph()
-				g.getOrCreateVertex_locked(nodeVertexType, "", "node1")
-				g.getOrCreateVertex_locked(configMapVertexType, "namespace1", "configmap1")
+				g.getOrCreateVertexLocked(nodeVertexType, "", "node1")
+				g.getOrCreateVertexLocked(configMapVertexType, "namespace1", "configmap1")
 				return g
 			}(),
 		},
@@ -114,12 +114,12 @@ func TestDeleteEdges_locked(t *testing.T) {
 			toName:      "node1",
 			start: func() *Graph {
 				g := NewGraph()
-				g.getOrCreateVertex_locked(configMapVertexType, "namespace1", "configmap1")
+				g.getOrCreateVertexLocked(configMapVertexType, "namespace1", "configmap1")
 				return g
 			}(),
 			expect: func() *Graph {
 				g := NewGraph()
-				g.getOrCreateVertex_locked(configMapVertexType, "namespace1", "configmap1")
+				g.getOrCreateVertexLocked(configMapVertexType, "namespace1", "configmap1")
 				return g
 			}(),
 		},
@@ -131,19 +131,19 @@ func TestDeleteEdges_locked(t *testing.T) {
 			toName:      "node1",
 			start: func() *Graph {
 				g := NewGraph()
-				g.getOrCreateVertex_locked(nodeVertexType, "", "node1")
+				g.getOrCreateVertexLocked(nodeVertexType, "", "node1")
 				return g
 			}(),
 			expect: func() *Graph {
 				g := NewGraph()
-				g.getOrCreateVertex_locked(nodeVertexType, "", "node1")
+				g.getOrCreateVertexLocked(nodeVertexType, "", "node1")
 				return g
 			}(),
 		},
 	}
 	for _, c := range cases {
 		t.Run(c.desc, func(t *testing.T) {
-			c.start.deleteEdges_locked(c.fromType, c.toType, c.toNamespace, c.toName)
+			c.start.deleteEdgesLocked(c.fromType, c.toType, c.toNamespace, c.toName)
 
 			// Note: We assert on substructures (graph.Nodes(), graph.Edges()) because the graph tracks
 			// freed IDs for reuse, which results in an irrelevant inequality between start and expect.

--- a/plugin/pkg/auth/authorizer/node/graph_test.go
+++ b/plugin/pkg/auth/authorizer/node/graph_test.go
@@ -52,7 +52,7 @@ func TestDeleteEdgesLocked(t *testing.T) {
 				g.getOrCreateVertexLocked(configMapVertexType, "namespace1", "configmap2")
 				nodeVertex := g.getOrCreateVertexLocked(nodeVertexType, "", "node1")
 				configmapVertex := g.getOrCreateVertexLocked(configMapVertexType, "namespace1", "configmap1")
-				g.graph.SetEdge(newDestinationEdge(configmapVertex, nodeVertex, nodeVertex))
+				g.addEdgeLocked(configmapVertex, nodeVertex, nodeVertex)
 				return g
 			}(),
 			expect: func() *Graph {
@@ -74,8 +74,8 @@ func TestDeleteEdgesLocked(t *testing.T) {
 				nodeVertex1 := g.getOrCreateVertexLocked(nodeVertexType, "", "node1")
 				nodeVertex2 := g.getOrCreateVertexLocked(nodeVertexType, "", "node2")
 				configmapVertex := g.getOrCreateVertexLocked(configMapVertexType, "namespace1", "configmap1")
-				g.graph.SetEdge(newDestinationEdge(configmapVertex, nodeVertex1, nodeVertex1))
-				g.graph.SetEdge(newDestinationEdge(configmapVertex, nodeVertex2, nodeVertex2))
+				g.addEdgeLocked(configmapVertex, nodeVertex1, nodeVertex1)
+				g.addEdgeLocked(configmapVertex, nodeVertex2, nodeVertex2)
 				return g
 			}(),
 			expect: func() *Graph {
@@ -83,7 +83,7 @@ func TestDeleteEdgesLocked(t *testing.T) {
 				nodeVertex1 := g.getOrCreateVertexLocked(nodeVertexType, "", "node1")
 				g.getOrCreateVertexLocked(nodeVertexType, "", "node2")
 				configmapVertex := g.getOrCreateVertexLocked(configMapVertexType, "namespace1", "configmap1")
-				g.graph.SetEdge(newDestinationEdge(configmapVertex, nodeVertex1, nodeVertex1))
+				g.addEdgeLocked(configmapVertex, nodeVertex1, nodeVertex1)
 				return g
 			}(),
 		},
@@ -343,4 +343,559 @@ func TestIndex(t *testing.T) {
 		"configmap:ns/cm3":      {"node:node1=1", "node:node2=1", "node:node3=1"},
 		"serviceAccount:ns/sa1": {"node:node1=1", "node:node2=1", "node:node3=1"},
 	})
+}
+
+func TestIndex2(t *testing.T) {
+	NewTestGraph := func() *Graph {
+		g := NewGraph()
+		g.destinationEdgeThreshold = 3
+		return g
+	}
+
+	pod := func(podName, nodeName, saName string, volumes []corev1.Volume, resourceClaims []corev1.PodResourceClaim) *corev1.Pod {
+		p := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: podName, Namespace: "ns", UID: types.UID(fmt.Sprintf("pod%suid", podName))},
+			Spec: corev1.PodSpec{
+				NodeName: nodeName,
+			},
+		}
+		if saName != "" {
+			p.Spec.ServiceAccountName = saName
+		}
+		if volumes != nil {
+			p.Spec.Volumes = volumes
+		}
+		if resourceClaims != nil {
+			p.Spec.ResourceClaims = resourceClaims
+		}
+		return p
+	}
+
+	podWithSAAndCMs := func(podName, nodeName string) *corev1.Pod {
+		cm := func(name string) corev1.Volume {
+			return corev1.Volume{Name: name, VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: name}}}}
+		}
+		return pod(podName, nodeName, "sa1", []corev1.Volume{
+			cm("cm1"),
+			cm("cm2"),
+			cm("cm3"),
+		}, nil)
+	}
+
+	podWithSecrets := func(podName, nodeName string) *corev1.Pod {
+		secret := func(name string) corev1.Volume {
+			return corev1.Volume{Name: name, VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: name}}}
+		}
+		return pod(podName, nodeName, "", []corev1.Volume{
+			secret("s1"),
+			secret("s2"),
+			secret("s3"),
+		}, nil)
+	}
+
+	podWithPVCs := func(podName, nodeName string) *corev1.Pod {
+		pvc := func(name string) corev1.Volume {
+			return corev1.Volume{Name: name, VolumeSource: corev1.VolumeSource{PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: name}}}
+		}
+		return pod(podName, nodeName, "", []corev1.Volume{
+			pvc("pvc1"),
+			pvc("pvc2"),
+			pvc("pvc3"),
+		}, nil)
+	}
+
+	podWithResourceClaims := func(podName, nodeName string) *corev1.Pod {
+		rc := func(name string) corev1.PodResourceClaim {
+			return corev1.PodResourceClaim{ResourceClaimName: &name}
+		}
+		return pod(podName, nodeName, "", nil, []corev1.PodResourceClaim{
+			rc("rc1"),
+			rc("rc2"),
+			rc("rc3"),
+		})
+	}
+
+	pv := func(pvName, pvcName, secretName string) *corev1.PersistentVolume {
+		pv := &corev1.PersistentVolume{
+			ObjectMeta: metav1.ObjectMeta{Name: pvName, UID: types.UID(fmt.Sprintf("pv%suid", pvName))},
+			Spec: corev1.PersistentVolumeSpec{
+				ClaimRef: &corev1.ObjectReference{
+					Name:      pvcName,
+					Namespace: "ns",
+				},
+			},
+		}
+		if secretName != "" {
+			pv.Spec.PersistentVolumeSource = corev1.PersistentVolumeSource{
+				CSI: &corev1.CSIPersistentVolumeSource{
+					NodePublishSecretRef: &corev1.SecretReference{
+						Name:      secretName,
+						Namespace: "ns",
+					},
+				},
+			}
+		}
+		return pv
+	}
+
+	toString := func(g *Graph, id int) string {
+		for _, namespaceName := range g.vertices {
+			for _, nameVertex := range namespaceName {
+				for _, vertex := range nameVertex {
+					if vertex.id == id {
+						return vertex.String()
+					}
+				}
+			}
+		}
+		return ""
+	}
+	expectGraph := func(t *testing.T, g *Graph, expect map[string][]string) {
+		t.Helper()
+		actual := map[string][]string{}
+		for _, node := range g.graph.Nodes() {
+			sortedTo := []string{}
+			for _, to := range g.graph.From(node) {
+				sortedTo = append(sortedTo, toString(g, to.ID()))
+			}
+			sort.Strings(sortedTo)
+			actual[toString(g, node.ID())] = sortedTo
+		}
+		if !reflect.DeepEqual(expect, actual) {
+			e, _ := json.MarshalIndent(expect, "", "  ")
+			a, _ := json.MarshalIndent(actual, "", "  ")
+			t.Errorf("expected graph:\n%s\ngot:\n%s", string(e), string(a))
+		}
+	}
+	expectIndex := func(t *testing.T, g *Graph, expect map[string][]string) {
+		t.Helper()
+		actual := map[string][]string{}
+		for from, to := range g.destinationEdgeIndex {
+			sortedValues := []string{}
+			for member, count := range to.members {
+				sortedValues = append(sortedValues, fmt.Sprintf("%s=%d", toString(g, member), count))
+			}
+			sort.Strings(sortedValues)
+			actual[toString(g, from)] = sortedValues
+		}
+		if !reflect.DeepEqual(expect, actual) {
+			e, _ := json.MarshalIndent(expect, "", "  ")
+			a, _ := json.MarshalIndent(actual, "", "  ")
+			t.Errorf("expected index:\n%s\ngot:\n%s", string(e), string(a))
+		}
+	}
+
+	cases := []struct {
+		desc             string
+		startingGraph    *Graph
+		graphTransformer func(*Graph)
+		expectedGraph    map[string][]string
+		expectedIndex    map[string][]string
+	}{
+		{
+			desc:             "empty graph",
+			startingGraph:    NewTestGraph(),
+			graphTransformer: func(_ *Graph) {},
+			expectedGraph:    map[string][]string{},
+			expectedIndex:    map[string][]string{},
+		},
+		{
+			desc:          "outdeg below destination edge index threshold",
+			startingGraph: NewTestGraph(),
+			graphTransformer: func(g *Graph) {
+				g.AddPod(podWithSAAndCMs("pod1", "node1"))
+				g.AddPod(podWithSAAndCMs("pod2", "node2"))
+			},
+			expectedGraph: map[string][]string{
+				"node:node1":            {},
+				"node:node2":            {},
+				"pod:ns/pod1":           {"node:node1"},
+				"pod:ns/pod2":           {"node:node2"},
+				"configmap:ns/cm1":      {"pod:ns/pod1", "pod:ns/pod2"},
+				"configmap:ns/cm2":      {"pod:ns/pod1", "pod:ns/pod2"},
+				"configmap:ns/cm3":      {"pod:ns/pod1", "pod:ns/pod2"},
+				"serviceAccount:ns/sa1": {"pod:ns/pod1", "pod:ns/pod2"},
+			},
+			expectedIndex: map[string][]string{},
+		},
+		{
+			desc: "index built for configmaps and serviceaccounts",
+			startingGraph: func() *Graph {
+				g := NewTestGraph()
+				g.AddPod(podWithSAAndCMs("pod1", "node1"))
+				g.AddPod(podWithSAAndCMs("pod2", "node2"))
+				return g
+			}(),
+			graphTransformer: func(g *Graph) {
+				g.AddPod(podWithSAAndCMs("pod3", "node3"))
+			},
+			expectedGraph: map[string][]string{
+				"node:node1":            {},
+				"node:node2":            {},
+				"node:node3":            {},
+				"pod:ns/pod1":           {"node:node1"},
+				"pod:ns/pod2":           {"node:node2"},
+				"pod:ns/pod3":           {"node:node3"},
+				"configmap:ns/cm1":      {"pod:ns/pod1", "pod:ns/pod2", "pod:ns/pod3"},
+				"configmap:ns/cm2":      {"pod:ns/pod1", "pod:ns/pod2", "pod:ns/pod3"},
+				"configmap:ns/cm3":      {"pod:ns/pod1", "pod:ns/pod2", "pod:ns/pod3"},
+				"serviceAccount:ns/sa1": {"pod:ns/pod1", "pod:ns/pod2", "pod:ns/pod3"},
+			},
+			expectedIndex: map[string][]string{
+				"configmap:ns/cm1":      {"node:node1=1", "node:node2=1", "node:node3=1"},
+				"configmap:ns/cm2":      {"node:node1=1", "node:node2=1", "node:node3=1"},
+				"configmap:ns/cm3":      {"node:node1=1", "node:node2=1", "node:node3=1"},
+				"serviceAccount:ns/sa1": {"node:node1=1", "node:node2=1", "node:node3=1"},
+			},
+		},
+		{
+			desc: "no index for configmaps and serviceaccounts - dropping below threshold",
+			startingGraph: func() *Graph {
+				g := NewTestGraph()
+				g.AddPod(podWithSAAndCMs("pod1", "node1"))
+				g.AddPod(podWithSAAndCMs("pod2", "node2"))
+				g.AddPod(podWithSAAndCMs("pod3", "node3"))
+				return g
+			}(),
+			graphTransformer: func(g *Graph) {
+				g.DeletePod("pod1", "ns")
+			},
+			expectedGraph: map[string][]string{
+				"node:node2":            {},
+				"node:node3":            {},
+				"pod:ns/pod2":           {"node:node2"},
+				"pod:ns/pod3":           {"node:node3"},
+				"configmap:ns/cm1":      {"pod:ns/pod2", "pod:ns/pod3"},
+				"configmap:ns/cm2":      {"pod:ns/pod2", "pod:ns/pod3"},
+				"configmap:ns/cm3":      {"pod:ns/pod2", "pod:ns/pod3"},
+				"serviceAccount:ns/sa1": {"pod:ns/pod2", "pod:ns/pod3"},
+			},
+			expectedIndex: map[string][]string{},
+		},
+		{
+			desc: "removing pod but staying above threshold",
+			startingGraph: func() *Graph {
+				g := NewTestGraph()
+				g.AddPod(podWithSAAndCMs("pod1", "node1"))
+				g.AddPod(podWithSAAndCMs("pod2", "node2"))
+				g.AddPod(podWithSAAndCMs("pod3", "node3"))
+				g.AddPod(podWithSAAndCMs("pod4", "node1"))
+				return g
+			}(),
+			graphTransformer: func(g *Graph) {
+				g.DeletePod("pod1", "ns")
+			},
+			expectedGraph: map[string][]string{
+				"node:node1":            {},
+				"node:node2":            {},
+				"node:node3":            {},
+				"pod:ns/pod2":           {"node:node2"},
+				"pod:ns/pod3":           {"node:node3"},
+				"pod:ns/pod4":           {"node:node1"},
+				"configmap:ns/cm1":      {"pod:ns/pod2", "pod:ns/pod3", "pod:ns/pod4"},
+				"configmap:ns/cm2":      {"pod:ns/pod2", "pod:ns/pod3", "pod:ns/pod4"},
+				"configmap:ns/cm3":      {"pod:ns/pod2", "pod:ns/pod3", "pod:ns/pod4"},
+				"serviceAccount:ns/sa1": {"pod:ns/pod2", "pod:ns/pod3", "pod:ns/pod4"},
+			},
+			expectedIndex: map[string][]string{
+				"configmap:ns/cm1":      {"node:node1=1", "node:node2=1", "node:node3=1"},
+				"configmap:ns/cm2":      {"node:node1=1", "node:node2=1", "node:node3=1"},
+				"configmap:ns/cm3":      {"node:node1=1", "node:node2=1", "node:node3=1"},
+				"serviceAccount:ns/sa1": {"node:node1=1", "node:node2=1", "node:node3=1"},
+			},
+		},
+		{
+			desc: "index built for secrets",
+			startingGraph: func() *Graph {
+				g := NewTestGraph()
+				g.AddPod(podWithSecrets("pod1", "node1"))
+				g.AddPod(podWithSecrets("pod2", "node2"))
+				return g
+			}(),
+			graphTransformer: func(g *Graph) {
+				g.AddPod(podWithSecrets("pod3", "node3"))
+			},
+			expectedGraph: map[string][]string{
+				"node:node1":   {},
+				"node:node2":   {},
+				"node:node3":   {},
+				"pod:ns/pod1":  {"node:node1"},
+				"pod:ns/pod2":  {"node:node2"},
+				"pod:ns/pod3":  {"node:node3"},
+				"secret:ns/s1": {"pod:ns/pod1", "pod:ns/pod2", "pod:ns/pod3"},
+				"secret:ns/s2": {"pod:ns/pod1", "pod:ns/pod2", "pod:ns/pod3"},
+				"secret:ns/s3": {"pod:ns/pod1", "pod:ns/pod2", "pod:ns/pod3"},
+			},
+			expectedIndex: map[string][]string{
+				"secret:ns/s1": {"node:node1=1", "node:node2=1", "node:node3=1"},
+				"secret:ns/s2": {"node:node1=1", "node:node2=1", "node:node3=1"},
+				"secret:ns/s3": {"node:node1=1", "node:node2=1", "node:node3=1"},
+			},
+		},
+		{
+			desc: "no index for secrets - dropping below threshold",
+			startingGraph: func() *Graph {
+				g := NewTestGraph()
+				g.AddPod(podWithSecrets("pod1", "node1"))
+				g.AddPod(podWithSecrets("pod2", "node2"))
+				g.AddPod(podWithSecrets("pod3", "node3"))
+				return g
+			}(),
+			graphTransformer: func(g *Graph) {
+				g.DeletePod("pod1", "ns")
+			},
+			expectedGraph: map[string][]string{
+				"node:node2":   {},
+				"node:node3":   {},
+				"pod:ns/pod2":  {"node:node2"},
+				"pod:ns/pod3":  {"node:node3"},
+				"secret:ns/s1": {"pod:ns/pod2", "pod:ns/pod3"},
+				"secret:ns/s2": {"pod:ns/pod2", "pod:ns/pod3"},
+				"secret:ns/s3": {"pod:ns/pod2", "pod:ns/pod3"},
+			},
+			expectedIndex: map[string][]string{},
+		},
+		{
+			desc: "index built for pvcs",
+			startingGraph: func() *Graph {
+				g := NewTestGraph()
+				g.AddPod(podWithPVCs("pod1", "node1"))
+				g.AddPod(podWithPVCs("pod2", "node2"))
+				return g
+			}(),
+			graphTransformer: func(g *Graph) {
+				g.AddPod(podWithPVCs("pod3", "node3"))
+			},
+			expectedGraph: map[string][]string{
+				"node:node1":  {},
+				"node:node2":  {},
+				"node:node3":  {},
+				"pod:ns/pod1": {"node:node1"},
+				"pod:ns/pod2": {"node:node2"},
+				"pod:ns/pod3": {"node:node3"},
+				"pvc:ns/pvc1": {"pod:ns/pod1", "pod:ns/pod2", "pod:ns/pod3"},
+				"pvc:ns/pvc2": {"pod:ns/pod1", "pod:ns/pod2", "pod:ns/pod3"},
+				"pvc:ns/pvc3": {"pod:ns/pod1", "pod:ns/pod2", "pod:ns/pod3"},
+			},
+			expectedIndex: map[string][]string{
+				"pvc:ns/pvc1": {"node:node1=1", "node:node2=1", "node:node3=1"},
+				"pvc:ns/pvc2": {"node:node1=1", "node:node2=1", "node:node3=1"},
+				"pvc:ns/pvc3": {"node:node1=1", "node:node2=1", "node:node3=1"},
+			},
+		},
+		{
+			desc: "no index for pvcs - dropping below threshold",
+			startingGraph: func() *Graph {
+				g := NewTestGraph()
+				g.AddPod(podWithPVCs("pod1", "node1"))
+				g.AddPod(podWithPVCs("pod2", "node2"))
+				g.AddPod(podWithPVCs("pod3", "node3"))
+				return g
+			}(),
+			graphTransformer: func(g *Graph) {
+				g.DeletePod("pod1", "ns")
+			},
+			expectedGraph: map[string][]string{
+				"node:node2":  {},
+				"node:node3":  {},
+				"pod:ns/pod2": {"node:node2"},
+				"pod:ns/pod3": {"node:node3"},
+				"pvc:ns/pvc1": {"pod:ns/pod2", "pod:ns/pod3"},
+				"pvc:ns/pvc2": {"pod:ns/pod2", "pod:ns/pod3"},
+				"pvc:ns/pvc3": {"pod:ns/pod2", "pod:ns/pod3"},
+			},
+			expectedIndex: map[string][]string{},
+		},
+		{
+			desc:          "index built for resourceclaims",
+			startingGraph: NewTestGraph(),
+			graphTransformer: func(g *Graph) {
+				g.AddPod(podWithResourceClaims("pod1", "node1"))
+				g.AddPod(podWithResourceClaims("pod2", "node2"))
+				g.AddPod(podWithResourceClaims("pod3", "node3"))
+			},
+			expectedGraph: map[string][]string{
+				"node:node1":           {},
+				"node:node2":           {},
+				"node:node3":           {},
+				"pod:ns/pod1":          {"node:node1"},
+				"pod:ns/pod2":          {"node:node2"},
+				"pod:ns/pod3":          {"node:node3"},
+				"resourceclaim:ns/rc1": {"pod:ns/pod1", "pod:ns/pod2", "pod:ns/pod3"},
+				"resourceclaim:ns/rc2": {"pod:ns/pod1", "pod:ns/pod2", "pod:ns/pod3"},
+				"resourceclaim:ns/rc3": {"pod:ns/pod1", "pod:ns/pod2", "pod:ns/pod3"},
+			},
+			expectedIndex: map[string][]string{
+				"resourceclaim:ns/rc1": {"node:node1=1", "node:node2=1", "node:node3=1"},
+				"resourceclaim:ns/rc2": {"node:node1=1", "node:node2=1", "node:node3=1"},
+				"resourceclaim:ns/rc3": {"node:node1=1", "node:node2=1", "node:node3=1"},
+			},
+		},
+		{
+			desc: "no index for resourceclaims - dropping below threshold",
+			startingGraph: func() *Graph {
+				g := NewTestGraph()
+				g.AddPod(podWithResourceClaims("pod1", "node1"))
+				g.AddPod(podWithResourceClaims("pod2", "node2"))
+				g.AddPod(podWithResourceClaims("pod3", "node3"))
+				return g
+			}(),
+			graphTransformer: func(g *Graph) {
+				g.DeletePod("pod1", "ns")
+			},
+			expectedGraph: map[string][]string{
+				"node:node2":           {},
+				"node:node3":           {},
+				"pod:ns/pod2":          {"node:node2"},
+				"pod:ns/pod3":          {"node:node3"},
+				"resourceclaim:ns/rc1": {"pod:ns/pod2", "pod:ns/pod3"},
+				"resourceclaim:ns/rc2": {"pod:ns/pod2", "pod:ns/pod3"},
+				"resourceclaim:ns/rc3": {"pod:ns/pod2", "pod:ns/pod3"},
+			},
+			expectedIndex: map[string][]string{},
+		},
+		{
+			desc:          "resourceslices adding",
+			startingGraph: NewTestGraph(),
+			graphTransformer: func(g *Graph) {
+				g.AddResourceSlice("s1", "node1")
+				g.AddResourceSlice("s2", "node2")
+				g.AddResourceSlice("s3", "node3")
+			},
+			expectedGraph: map[string][]string{
+				"node:node1":       {},
+				"node:node2":       {},
+				"node:node3":       {},
+				"resourceslice:s1": {"node:node1"},
+				"resourceslice:s2": {"node:node2"},
+				"resourceslice:s3": {"node:node3"},
+			},
+			expectedIndex: map[string][]string{},
+		},
+		{
+			desc: "resourceslices deleting",
+			startingGraph: func() *Graph {
+				g := NewTestGraph()
+				g.AddResourceSlice("s1", "node1")
+				g.AddResourceSlice("s2", "node2")
+				g.AddResourceSlice("s3", "node3")
+				return g
+			}(),
+			graphTransformer: func(g *Graph) {
+				g.DeleteResourceSlice("s1")
+			},
+			expectedGraph: map[string][]string{
+				"node:node2":       {},
+				"node:node3":       {},
+				"resourceslice:s2": {"node:node2"},
+				"resourceslice:s3": {"node:node3"},
+			},
+			expectedIndex: map[string][]string{},
+		},
+		{
+			desc:          "volumeattachments adding",
+			startingGraph: NewTestGraph(),
+			graphTransformer: func(g *Graph) {
+				g.AddVolumeAttachment("va1", "node1")
+				g.AddVolumeAttachment("va2", "node2")
+				g.AddVolumeAttachment("va3", "node3")
+			},
+			expectedGraph: map[string][]string{
+				"node:node1":           {},
+				"node:node2":           {},
+				"node:node3":           {},
+				"volumeattachment:va1": {"node:node1"},
+				"volumeattachment:va2": {"node:node2"},
+				"volumeattachment:va3": {"node:node3"},
+			},
+			expectedIndex: map[string][]string{},
+		},
+		{
+			desc: "volumeattachments deleting",
+			startingGraph: func() *Graph {
+				g := NewTestGraph()
+				g.AddVolumeAttachment("va1", "node1")
+				g.AddVolumeAttachment("va2", "node2")
+				g.AddVolumeAttachment("va3", "node3")
+				return g
+			}(),
+			graphTransformer: func(g *Graph) {
+				g.DeleteVolumeAttachment("va1")
+			},
+			expectedGraph: map[string][]string{
+				"node:node2":           {},
+				"node:node3":           {},
+				"volumeattachment:va2": {"node:node2"},
+				"volumeattachment:va3": {"node:node3"},
+			},
+			expectedIndex: map[string][]string{},
+		},
+		{
+			desc:          "persistentvolumes adding",
+			startingGraph: NewTestGraph(),
+			graphTransformer: func(g *Graph) {
+				g.AddPV(pv("pv1", "pvc1", ""))
+				g.AddPV(pv("pv2", "pvc2", ""))
+				g.AddPV(pv("pv3", "pvc3", ""))
+			},
+			expectedGraph: map[string][]string{
+				"pv:pv1":      {"pvc:ns/pvc1"},
+				"pv:pv2":      {"pvc:ns/pvc2"},
+				"pv:pv3":      {"pvc:ns/pvc3"},
+				"pvc:ns/pvc1": {},
+				"pvc:ns/pvc2": {},
+				"pvc:ns/pvc3": {},
+			},
+			expectedIndex: map[string][]string{},
+		},
+		{
+			desc: "persistentvolumes deleting",
+			startingGraph: func() *Graph {
+				g := NewTestGraph()
+				g.AddPV(pv("pv1", "pvc1", ""))
+				g.AddPV(pv("pv2", "pvc2", ""))
+				g.AddPV(pv("pv3", "pvc3", ""))
+				return g
+			}(),
+			graphTransformer: func(g *Graph) {
+				g.DeletePV("pv1")
+			},
+			expectedGraph: map[string][]string{
+				"pv:pv2":      {"pvc:ns/pvc2"},
+				"pv:pv3":      {"pvc:ns/pvc3"},
+				"pvc:ns/pvc2": {},
+				"pvc:ns/pvc3": {},
+			},
+			expectedIndex: map[string][]string{},
+		},
+		{
+			desc:          "persistentvolumes with secrets",
+			startingGraph: NewTestGraph(),
+			graphTransformer: func(g *Graph) {
+				g.AddPV(pv("pv1", "pvc1", "s1"))
+				g.AddPV(pv("pv2", "pvc2", "s2"))
+				g.AddPV(pv("pv3", "pvc3", "s3"))
+			},
+			expectedGraph: map[string][]string{
+				"pv:pv1":       {"pvc:ns/pvc1"},
+				"pv:pv2":       {"pvc:ns/pvc2"},
+				"pv:pv3":       {"pvc:ns/pvc3"},
+				"pvc:ns/pvc1":  {},
+				"pvc:ns/pvc2":  {},
+				"pvc:ns/pvc3":  {},
+				"secret:ns/s1": {"pv:pv1"},
+				"secret:ns/s2": {"pv:pv2"},
+				"secret:ns/s3": {"pv:pv3"},
+			},
+			expectedIndex: map[string][]string{},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			tc.graphTransformer(tc.startingGraph)
+			expectGraph(t, tc.startingGraph, tc.expectedGraph)
+			expectIndex(t, tc.startingGraph, tc.expectedIndex)
+		})
+	}
 }

--- a/plugin/pkg/auth/authorizer/node/node_authorizer.go
+++ b/plugin/pkg/auth/authorizer/node/node_authorizer.go
@@ -448,12 +448,12 @@ func (r *NodeAuthorizer) hasPathFrom(nodeName string, startingType vertexType, s
 	r.graph.lock.RLock()
 	defer r.graph.lock.RUnlock()
 
-	nodeVertex, exists := r.graph.getVertex_rlocked(nodeVertexType, "", nodeName)
+	nodeVertex, exists := r.graph.getVertexRLocked(nodeVertexType, "", nodeName)
 	if !exists {
 		return false, fmt.Errorf("unknown node '%s' cannot get %s %s/%s", nodeName, vertexTypes[startingType], startingNamespace, startingName)
 	}
 
-	startingVertex, exists := r.graph.getVertex_rlocked(startingType, startingNamespace, startingName)
+	startingVertex, exists := r.graph.getVertexRLocked(startingType, startingNamespace, startingName)
 	if !exists {
 		return false, fmt.Errorf("node '%s' cannot get unknown %s %s/%s", nodeName, vertexTypes[startingType], startingNamespace, startingName)
 	}


### PR DESCRIPTION
Cherry pick of #127102 #127098 on release-1.31.

#127102: Clean up Node authorizer's non-thread-safe method names
#127098: Make Node authorizer's index authoritative for unauthorized calls

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```