### PR TITLE
fix: enable formatter rule from testifylint in module test/utils

### DIFF
--- a/test/utils/image/csi_manifests_test.go
+++ b/test/utils/image/csi_manifests_test.go
@@ -61,5 +61,5 @@ func TestCSIImageConfigs(t *testing.T) {
 		assert.NotEmpty(t, config.version, "version")
 		actualImages.Insert(config.name)
 	}
-	assert.ElementsMatch(t, expectedImages, actualImages.UnsortedList(), "found these images: %+v", configs)
+	assert.ElementsMatchf(t, expectedImages, actualImages.UnsortedList(), "found these images: %+v", configs)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?


/area test
/kind cleanup
/sig testing


#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
This fixes [formatter](https://github.com/Antonboom/testifylint?tab=readme-ov-file#formatter) rule from [testifylint](https://github.com/Antonboom/testifylint) in module test/utils
