### PR TITLE
DRA resourceclaims: maintain metric of total and allocated claims

### DIFF
--- a/pkg/controller/resourceclaim/metrics/metrics.go
+++ b/pkg/controller/resourceclaim/metrics/metrics.go
@@ -45,6 +45,22 @@ var (
 			Help:           "Number of ResourceClaims creation request failures",
 			StabilityLevel: metrics.ALPHA,
 		})
+	// NumResourceClaims tracks the current number of ResourceClaims.
+	NumResourceClaims = metrics.NewGauge(
+		&metrics.GaugeOpts{
+			Subsystem:      ResourceClaimSubsystem,
+			Name:           "resource_claims",
+			Help:           "Number of ResourceClaims",
+			StabilityLevel: metrics.ALPHA,
+		})
+	// NumAllocatedResourceClaims tracks the current number of allocated ResourceClaims.
+	NumAllocatedResourceClaims = metrics.NewGauge(
+		&metrics.GaugeOpts{
+			Subsystem:      ResourceClaimSubsystem,
+			Name:           "allocated_resource_claims",
+			Help:           "Number of allocated ResourceClaims",
+			StabilityLevel: metrics.ALPHA,
+		})
 )
 
 var registerMetrics sync.Once
@@ -54,5 +70,7 @@ func RegisterMetrics() {
 	registerMetrics.Do(func() {
 		legacyregistry.MustRegister(ResourceClaimCreateAttempts)
 		legacyregistry.MustRegister(ResourceClaimCreateFailures)
+		legacyregistry.MustRegister(NumResourceClaims)
+		legacyregistry.MustRegister(NumAllocatedResourceClaims)
 	})
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

These metrics can provide insights into ResourceClaim usage. The total count is redundant because the apiserver also provides count of resources, but having it in the same sub-system next to the count of allocated claims might be more discoverable and helps monitor the controller itself.

#### Which issue(s) this PR fixes:

Related-to: https://github.com/kubernetes/enhancements/pull/4869

#### Special notes for your reviewer:

/hold

Let's wait for [the KEP update](https://github.com/kubernetes/enhancements/pull/4869) to get reviewed, too.

#### Does this PR introduce a user-facing change?
```release-note
DRA: the resource claim controller now maintains metrics about the total number of ResourceClaims and the number of allocated ResourceClaims.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/4381
```
