### PR TITLE
Make sleepOp duration parametrizable in scheduler_perf

### DIFF
--- a/test/integration/scheduler_perf/config/performance-config.yaml
+++ b/test/integration/scheduler_perf/config/performance-config.yaml
@@ -1450,7 +1450,7 @@
     skipWaitToCompletion: true
     # Wait to make sure gated pods are enqueued in scheduler.
   - opcode: sleep
-    duration: 5s
+    durationParam: $sleepDuration
     # Create pods that will be gradually deleted after being scheduled.
   - opcode: createPods
     countParam: $deletingPods
@@ -1471,6 +1471,7 @@
       gatedPods: 10
       deletingPods: 10
       measurePods: 10
+      sleepDuration: 1s
   - name: 1Node_10000GatedPods
     labels: [performance, short]
     threshold: 130
@@ -1478,6 +1479,7 @@
       gatedPods: 10000
       deletingPods: 20000
       measurePods: 20000
+      sleepDuration: 5s
 
 - name: SchedulingGatedPodsWithPodAffinityImpactForThroughput
   defaultPodTemplatePath: config/templates/pod-with-label.yaml
@@ -1491,7 +1493,7 @@
     skipWaitToCompletion: true
   - opcode: sleep
     # To produce a stable scheduler_perf result, here we make sure all gated Pods are stored in the scheduling queue.
-    duration: 5s
+    durationParam: $sleepDuration
   - opcode: createPods
     # The scheduling of those Pods will result in many cluster events (AssignedPodAdded)
     # and each of them will be processed by the scheduling queue.
@@ -1504,12 +1506,14 @@
     params:
       gatedPods: 10
       measurePods: 10
+      sleepDuration: 1s
   - name: 1Node_10000GatedPods
     labels: [performance, short]
     threshold: 110
     params:
       gatedPods: 10000
       measurePods: 20000
+      sleepDuration: 5s
 
 # This test case simulates the scheduling when pods selected to schedule have deletionTimestamp set.
 # There was a memory leak related to this path of code fixed in:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

Allow to set sleepOp duration using parameter. It can reduce testing time for smaller workloads.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
