### PR TITLE
fix plugin probe init race causing erroneous volume unmounts

### DIFF
--- a/pkg/volume/flexvolume/probe.go
+++ b/pkg/volume/flexvolume/probe.go
@@ -33,7 +33,7 @@ import (
 )
 
 type flexVolumeProber struct {
-	mutex          sync.RWMutex
+	mutex          sync.Mutex
 	pluginDir      string         // Flexvolume driver directory
 	runner         exec.Interface // Interface to use for execing flex calls
 	watcher        utilfs.FSWatcher

--- a/pkg/volume/flexvolume/probe.go
+++ b/pkg/volume/flexvolume/probe.go
@@ -40,6 +40,7 @@ type flexVolumeProber struct {
 	factory        PluginFactory
 	fs             utilfs.Filesystem
 	probeAllNeeded bool
+	probeAllOnce   sync.Once
 	eventsMap      map[string]volume.ProbeOperation // the key is the driver directory path, the value is the corresponding operation
 }
 
@@ -55,7 +56,7 @@ func GetDynamicPluginProber(pluginDir string, runner exec.Interface) volume.Dyna
 }
 
 func (prober *flexVolumeProber) Init() error {
-	prober.testAndSetProbeAllNeeded(true)
+	prober.probeAllNeeded = true
 	prober.eventsMap = map[string]volume.ProbeOperation{}
 
 	if err := prober.createPluginDir(); err != nil {
@@ -68,23 +69,18 @@ func (prober *flexVolumeProber) Init() error {
 	return nil
 }
 
-// If probeAllNeeded is true, probe all pluginDir
+// If we haven't yet done so, probe all pluginDir
 // else probe events in eventsMap
 func (prober *flexVolumeProber) Probe() (events []volume.ProbeEvent, err error) {
-	prober.mutex.RLock()
-	if prober.probeAllNeeded {
-		prober.mutex.RUnlock()
-		prober.mutex.Lock()
-		// check again, if multiple readers got through the first if, only one should probeAll
-		if prober.probeAllNeeded {
-			events, err = prober.probeAll()
-			prober.probeAllNeeded = false
-			prober.mutex.Unlock()
-			return
-		}
-		prober.mutex.Unlock()
+	probedAll := false
+	prober.probeAllOnce.Do(func() {
+		events, err = prober.probeAll()
+		probedAll = true
+		prober.probeAllNeeded = false
+	})
+	if probedAll {
+		return events, err
 	}
-	prober.mutex.RUnlock()
 	return prober.probeMap()
 }
 
@@ -286,11 +282,4 @@ func (prober *flexVolumeProber) createPluginDir() error {
 	}
 
 	return nil
-}
-
-func (prober *flexVolumeProber) testAndSetProbeAllNeeded(newval bool) (oldval bool) {
-	prober.mutex.Lock()
-	defer prober.mutex.Unlock()
-	oldval, prober.probeAllNeeded = prober.probeAllNeeded, newval
-	return
 }

--- a/pkg/volume/flexvolume/probe_test.go
+++ b/pkg/volume/flexvolume/probe_test.go
@@ -21,6 +21,8 @@ import (
 	"path/filepath"
 	goruntime "runtime"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/fsnotify/fsnotify"
@@ -325,6 +327,47 @@ func TestProberSuccessAndError(t *testing.T) {
 	assert.Equal(t, volume.ProbeAddOrUpdate, events[0].Op)
 	assert.Equal(t, driverName, events[0].PluginName)
 	assert.Error(t, err)
+}
+
+// TestProberMultiThreaded tests the code path of many callers calling FindPluginBySpec/FindPluginByName
+// which then calls refreshProbedPlugins which then calls prober.Probe() and ensures that the prober is thread safe
+func TestProberMultiThreaded(t *testing.T) {
+	// Arrange
+	_, _, _, prober := initTestEnvironment(t)
+	totalEvents := atomic.Int32{}
+	totalErrors := atomic.Int32{}
+	pluginNameMutex := sync.RWMutex{}
+	var pluginName string
+	var wg sync.WaitGroup
+
+	// Act
+	for i := 0; i < 100; i++ {
+		go func() {
+			defer wg.Done()
+			events, err := prober.Probe()
+			for _, event := range events {
+				if event.Op == volume.ProbeAddOrUpdate {
+					pluginNameMutex.Lock()
+					pluginName = event.Plugin.GetPluginName()
+					pluginNameMutex.Unlock()
+				}
+			}
+			// this fails if ProbeAll is not complete before the next call comes in but we have assumed that it has
+			pluginNameMutex.RLock()
+			assert.Equal(t, "fake-driver", pluginName)
+			pluginNameMutex.RUnlock()
+			totalEvents.Add(int32(len(events)))
+			if err != nil {
+				totalErrors.Add(1)
+			}
+		}()
+		wg.Add(1)
+	}
+	wg.Wait()
+
+	// Assert
+	assert.Equal(t, int32(1), totalEvents.Load())
+	assert.Equal(t, int32(0), totalErrors.Load())
 }
 
 // Installs a mock driver (an empty file) in the mock fs.

--- a/pkg/volume/plugins_test.go
+++ b/pkg/volume/plugins_test.go
@@ -17,6 +17,10 @@ limitations under the License.
 package volume
 
 import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
@@ -164,4 +168,63 @@ func Test_ValidatePodTemplate(t *testing.T) {
 	if got := ValidateRecyclerPodTemplate(pod); got == nil {
 		t.Errorf("isPodTemplateValid(%v) returned (%v), want (%v)", pod.String(), got, "Error: pod specification does not contain any volume(s).")
 	}
+}
+
+// TestVolumePluginMultiThreaded tests FindPluginByName/FindPluginBySpec in a multi-threaded environment.
+// If these are called by different threads at the same time, they should still be able to reconcile the plugins
+// and return the same results (no missing plugin)
+func TestVolumePluginMultiThreaded(t *testing.T) {
+	vpm := VolumePluginMgr{}
+	var prober DynamicPluginProber = &fakeProber{events: []ProbeEvent{{PluginName: testPluginName, Op: ProbeAddOrUpdate, Plugin: &testPlugins{}}}}
+	err := vpm.InitPlugins([]VolumePlugin{}, prober, nil)
+	require.NoError(t, err)
+
+	volumeSpec := &Spec{}
+	totalErrors := atomic.Int32{}
+	var wg sync.WaitGroup
+
+	for i := 0; i < 100; i++ {
+		go func() {
+			defer wg.Done()
+			_, err := vpm.FindPluginByName(testPluginName)
+			if err != nil {
+				totalErrors.Add(1)
+			}
+		}()
+		wg.Add(1)
+	}
+	wg.Wait()
+
+	assert.Equal(t, int32(0), totalErrors.Load())
+
+	for i := 0; i < 100; i++ {
+		go func() {
+			defer wg.Done()
+			_, err := vpm.FindPluginBySpec(volumeSpec)
+			if err != nil {
+				totalErrors.Add(1)
+			}
+		}()
+		wg.Add(1)
+	}
+	wg.Wait()
+
+	assert.Equal(t, int32(0), totalErrors.Load())
+}
+
+type fakeProber struct {
+	events         []ProbeEvent
+	firstExecution atomic.Bool
+}
+
+func (prober *fakeProber) Init() error {
+	prober.firstExecution.Store(true)
+	return nil
+}
+
+func (prober *fakeProber) Probe() (events []ProbeEvent, err error) {
+	if prober.firstExecution.CompareAndSwap(true, false) {
+		return prober.events, nil
+	}
+	return []ProbeEvent{}, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
After upgrading from 1.27 to 1.28, we noticed that on kubelet restart, some pods would sometimes incorrectly get their volumes unmounted with the error:
`
E0926 13:39:38.676490 3845949 kubelet.go:1949] "Unable to attach or mount volumes for pod; skipping pod" err="unmounted volumes=[artifact kube-api-access-rrq9m], unattached volumes=[], failed to process volumes=[artifact]: failed to get Plugin from volumeSpec for volume \"artifact\" err=no volume plugin matched"
`
along with previous errors:
`
13:29:36.094274 3707146 desired_state_of_world_populator.go:330] "Failed to add volume to desiredStateOfWorld" err="failed to get Plugin from volumeSpec for volume \"artifact\" err=no volume plugin matched" pod="vt-agkogkakis/vtickets-service-translator-5d5bccb84f-w2tpz" volumeName="artifact" volumeSpecName="artifact"
`
And then soon after would follow `operationExecutor.UnmountVolume started for volume` 

When we turned off the feature flag `NewVolumeManagerReconstruction`, these would not occur. 

Taking a closer look here, I found two places that were not thread-safe. The reason this did not occur before (before the flag was on by default) is because the new volume manager would call [reconstructVolumes](https://github.com/kubernetes/kubernetes/blob/5ebd0da6ccb156bee76783394df120bbac6f0d4d/pkg/kubelet/volumemanager/reconciler/reconciler.go#L25) which calls `reconstructVolume` which calls [FindPluginByName](https://github.com/kubernetes/kubernetes/blob/5ebd0da6ccb156bee76783394df120bbac6f0d4d/pkg/kubelet/volumemanager/reconciler/reconstruct_common.go#L264). The old reconstruction flow did not do this. This new flow would be in a race with DSOW [AddPodToVolume, which calls FindPluginBySpec](https://github.com/kubernetes/kubernetes/blob/5ebd0da6ccb156bee76783394df120bbac6f0d4d/pkg/kubelet/volumemanager/cache/desired_state_of_world.go#L270). 


The first race is in the `Probe()` method, which sets `probeAllNeeded=false` _before_ `probeAll` finishes, so threads running right after that flag is switched but before `probeAll` finishes would see no plugins.

The second race is in `FindPluginBySpec`/`FindPluginByName`, where they call `Probe()` and then iterate over the events and add the plugins to their map. However, if two threads were to enter here, one would get events from `Probe()` and the other wouldn't, and while the first is adding the plugins to the map, the other would simply assume there are no plugins, so a lock is needed here


This is easily reproducible by repeatedly restarting kubelet when there are pods on the node that have flex volumes, and grepping for `no volume plugin matched`. In my test example, my node had 100+ pods and I ran `while sleep 20; do date && systemctl restart kubelet ; done` - only took a few minutes to get a hit


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixes a race condition that could result in erroneous volume unmounts for flex volume plugins on kubelet restart

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
