### PR TITLE
fix: use `ErrorContains(t, err` instead of `Contains(t, err.Error()`

### DIFF
--- a/cmd/gotemplate/gotemplate_test.go
+++ b/cmd/gotemplate/gotemplate_test.go
@@ -70,7 +70,7 @@ func TestGenerate(t *testing.T) {
 				require.NoError(t, err, "expand template")
 				require.Equal(t, tt.expected, out.String())
 			} else {
-				require.Contains(t, err.Error(), tt.expectedErr)
+				require.ErrorContains(t, err, tt.expectedErr)
 			}
 		})
 	}

--- a/cmd/kube-proxy/app/options_test.go
+++ b/cmd/kube-proxy/app/options_test.go
@@ -315,7 +315,7 @@ func TestLoadConfigFailures(t *testing.T) {
 			_, err := options.loadConfig([]byte(config))
 
 			require.Error(t, err, tc.name)
-			require.Contains(t, err.Error(), tc.expErr)
+			require.ErrorContains(t, err, tc.expErr)
 
 			if tc.checkFn != nil {
 				require.True(t, tc.checkFn(err), tc.name)

--- a/cmd/kube-scheduler/app/options/options_test.go
+++ b/cmd/kube-scheduler/app/options/options_test.go
@@ -933,7 +933,7 @@ profiles:
 			if err != nil {
 				if tc.expectedError != "" || tc.checkErrFn != nil {
 					if tc.expectedError != "" {
-						assert.Contains(t, err.Error(), tc.expectedError)
+						assert.ErrorContains(t, err, tc.expectedError)
 					}
 					if tc.checkErrFn != nil {
 						assert.True(t, tc.checkErrFn(err), "got error: %v", err)

--- a/cmd/kubelet/app/server_test.go
+++ b/cmd/kubelet/app/server_test.go
@@ -315,7 +315,7 @@ port: 123
 					require.NoError(t, err, "failed to merge kubelet drop-in configs")
 				} else {
 					require.Error(t, err)
-					require.Contains(t, err.Error(), test.expectMergeError)
+					require.ErrorContains(t, err, test.expectMergeError)
 				}
 			}
 

--- a/pkg/controller/podautoscaler/replica_calculator_test.go
+++ b/pkg/controller/podautoscaler/replica_calculator_test.go
@@ -362,7 +362,7 @@ func (tc *replicaCalcTestCase) runTest(t *testing.T) {
 
 		if tc.expectedError != nil {
 			require.Error(t, err, "there should be an error calculating the replica count")
-			assert.Contains(t, err.Error(), tc.expectedError.Error(), "the error message should have contained the expected error message")
+			assert.ErrorContains(t, err, tc.expectedError.Error(), "the error message should have contained the expected error message")
 			return
 		}
 		require.NoError(t, err, "there should not have been an error calculating the replica count")
@@ -412,7 +412,7 @@ func (tc *replicaCalcTestCase) runTest(t *testing.T) {
 
 	if tc.expectedError != nil {
 		require.Error(t, err, "there should be an error calculating the replica count")
-		assert.Contains(t, err.Error(), tc.expectedError.Error(), "the error message should have contained the expected error message")
+		assert.ErrorContains(t, err, tc.expectedError.Error(), "the error message should have contained the expected error message")
 		return
 	}
 	require.NoError(t, err, "there should not have been an error calculating the replica count")

--- a/pkg/kubelet/cm/cpumanager/state/state_checkpoint_test.go
+++ b/pkg/kubelet/cm/cpumanager/state/state_checkpoint_test.go
@@ -224,8 +224,8 @@ func TestCheckpointStateRestore(t *testing.T) {
 				require.NoError(t, err)
 			} else {
 				require.Error(t, err)
-				require.Contains(t, err.Error(), "could not restore state from checkpoint")
-				require.Contains(t, err.Error(), tc.expectedError)
+				require.ErrorContains(t, err, "could not restore state from checkpoint")
+				require.ErrorContains(t, err, tc.expectedError)
 				return
 			}
 

--- a/pkg/kubelet/cm/dra/manager_test.go
+++ b/pkg/kubelet/cm/dra/manager_test.go
@@ -597,7 +597,7 @@ func TestPrepareResources(t *testing.T) {
 			if test.expectedErrMsg != "" {
 				assert.Error(t, err)
 				if err != nil {
-					assert.Contains(t, err.Error(), test.expectedErrMsg)
+					assert.ErrorContains(t, err, test.expectedErrMsg)
 				}
 				return // PrepareResources returned an error so stopping the test case here
 			}
@@ -739,7 +739,7 @@ func TestUnprepareResources(t *testing.T) {
 			if test.expectedErrMsg != "" {
 				assert.Error(t, err)
 				if err != nil {
-					assert.Contains(t, err.Error(), test.expectedErrMsg)
+					assert.ErrorContains(t, err, test.expectedErrMsg)
 				}
 				return // PrepareResources returned an error so stopping the test case here
 			}
@@ -863,7 +863,7 @@ func TestGetContainerClaimInfos(t *testing.T) {
 			if test.expectedErrMsg != "" {
 				assert.Error(t, err)
 				if err != nil {
-					assert.Contains(t, err.Error(), test.expectedErrMsg)
+					assert.ErrorContains(t, err, test.expectedErrMsg)
 				}
 				return
 			}

--- a/pkg/kubelet/cm/memorymanager/state/state_checkpoint_test.go
+++ b/pkg/kubelet/cm/memorymanager/state/state_checkpoint_test.go
@@ -134,7 +134,7 @@ func TestCheckpointStateRestore(t *testing.T) {
 			restoredState, err := NewCheckpointState(testingDir, testingCheckpoint, "static")
 			if strings.TrimSpace(tc.expectedError) != "" {
 				assert.Error(t, err)
-				assert.Contains(t, err.Error(), "could not restore state from checkpoint: "+tc.expectedError)
+				assert.ErrorContains(t, err, "could not restore state from checkpoint: "+tc.expectedError)
 			} else {
 				assert.NoError(t, err, "unexpected error while creating checkpointState")
 				// compare state after restoration with the one expected

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_linux_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_linux_test.go
@@ -780,7 +780,7 @@ func TestGenerateLinuxConfigSupplementalGroupsPolicy(t *testing.T) {
 			} else {
 				assert.NotEmpty(t, err, "Unexpected success")
 				assert.Empty(t, actual, "Unexpected non empty value")
-				assert.Contains(t, err.Error(), tc.expectedErrMsg, "Error for %s", tc.name)
+				assert.ErrorContainsf(t, err, tc.expectedErrMsg, "Error for %s", tc.name)
 			}
 		})
 	}

--- a/pkg/kubelet/volumemanager/reconciler/reconciler_test.go
+++ b/pkg/kubelet/volumemanager/reconciler/reconciler_test.go
@@ -1142,7 +1142,7 @@ func Test_GenerateMapVolumeFunc_Plugin_Not_Found(t *testing.T) {
 			err := oex.MountVolume(waitForAttachTimeout, volumeToMount, asw, false)
 			// Assert
 			if assert.Error(t, err) {
-				assert.Contains(t, err.Error(), tc.expectedErrMsg)
+				assert.ErrorContains(t, err, tc.expectedErrMsg)
 			}
 		})
 	}
@@ -1184,7 +1184,7 @@ func Test_GenerateUnmapVolumeFunc_Plugin_Not_Found(t *testing.T) {
 			err := oex.UnmountVolume(volumeToUnmount, asw, "" /* podsDir */)
 			// Assert
 			if assert.Error(t, err) {
-				assert.Contains(t, err.Error(), tc.expectedErrMsg)
+				assert.ErrorContains(t, err, tc.expectedErrMsg)
 			}
 		})
 	}
@@ -1225,7 +1225,7 @@ func Test_GenerateUnmapDeviceFunc_Plugin_Not_Found(t *testing.T) {
 			err := oex.UnmountDevice(deviceToDetach, asw, hostutil)
 			// Assert
 			if assert.Error(t, err) {
-				assert.Contains(t, err.Error(), tc.expectedErrMsg)
+				assert.ErrorContains(t, err, tc.expectedErrMsg)
 			}
 		})
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/versioning_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/versioning_test.go
@@ -124,7 +124,7 @@ func TestInternalVersionIsHandlerVersion(t *testing.T) {
 				return false, nil
 			}
 
-			assert.Contains(t, err.Error(), "apiVersion")
+			assert.ErrorContains(t, err, "apiVersion")
 			return true, nil
 		})
 		assert.NoError(t, err)

--- a/staging/src/k8s.io/apiserver/pkg/audit/policy/reader_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/audit/policy/reader_test.go
@@ -123,7 +123,7 @@ func TestParsePolicyWithNoVersionOrKind(t *testing.T) {
 	defer os.Remove(f)
 
 	_, err = LoadPolicyFromFile(f)
-	assert.Contains(t, err.Error(), "unknown group version field")
+	assert.ErrorContains(t, err, "unknown group version field")
 }
 
 func TestParsePolicyWithUnknownField(t *testing.T) {

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/event_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/event_test.go
@@ -17,11 +17,12 @@ limitations under the License.
 package etcd3
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.etcd.io/etcd/api/v3/mvccpb"
 	clientv3 "go.etcd.io/etcd/client/v3"
-	"testing"
 )
 
 func TestParseEvent(t *testing.T) {
@@ -100,7 +101,7 @@ func TestParseEvent(t *testing.T) {
 			actualEvent, err := parseEvent(tc.etcdEvent)
 			if tc.expectedErr != "" {
 				require.Error(t, err)
-				assert.Contains(t, err.Error(), tc.expectedErr)
+				assert.ErrorContains(t, err, tc.expectedErr)
 			} else {
 				require.NoError(t, err)
 				assert.Equal(t, tc.expectedEvent, actualEvent)


### PR DESCRIPTION
#### What type of PR is this?

/area test
/kind cleanup
/priority backlog
/sig testing

#### What this PR does / why we need it:

This remplaces  `Contains(t, err.Error()` by  `ErrorContains(t, err`  as it is simpler to read and safer as err is checked for nullity before `err.Error()` being called.

