### PR TITLE
KEP-4358: Promote Custom Resource Field Selectors to GA

### DIFF
--- a/pkg/features/versioned_kube_features.go
+++ b/pkg/features/versioned_kube_features.go
@@ -122,6 +122,7 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 	apiextensionsfeatures.CustomResourceFieldSelectors: {
 		{Version: version.MustParse("1.30"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("1.31"), Default: true, PreRelease: featuregate.Beta},
+		{Version: version.MustParse("1.32"), Default: true, LockToDefault: true, PreRelease: featuregate.GA},
 	},
 
 	DevicePluginCDIDevices: {

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/testing/testserver.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/testing/testserver.go
@@ -124,7 +124,11 @@ func StartTestServer(t Logger, _ *TestServerInstanceOptions, customFlags []strin
 	fs := pflag.NewFlagSet("test", pflag.PanicOnError)
 
 	featureGate := utilfeature.DefaultMutableFeatureGate
+
+	// Configure the effective version.
 	effectiveVersion := utilversion.DefaultKubeEffectiveVersion()
+	effectiveVersion.SetEmulationVersion(featureGate.EmulationVersion())
+
 	utilversion.DefaultComponentGlobalsRegistry.Reset()
 	utilruntime.Must(utilversion.DefaultComponentGlobalsRegistry.Register(utilversion.DefaultKubeComponent, effectiveVersion, featureGate))
 	s := options.NewCustomResourceDefinitionsServerOptions(os.Stdout, os.Stderr)

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/features/kube_features.go
@@ -66,5 +66,6 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 	CustomResourceFieldSelectors: {
 		{Version: version.MustParse("1.30"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("1.31"), Default: true, PreRelease: featuregate.Beta},
+		{Version: version.MustParse("1.32"), Default: true, LockToDefault: true, PreRelease: featuregate.GA},
 	},
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/strategy_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/strategy_test.go
@@ -26,6 +26,7 @@ import (
 	apiextensionsfeatures "k8s.io/apiextensions-apiserver/pkg/features"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/util/version"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 )
@@ -307,6 +308,7 @@ func TestSelectableFields(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
+		featuregatetesting.SetFeatureGateEmulationVersionDuringTest(t, utilfeature.DefaultFeatureGate, version.MustParse("1.31"))
 		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, apiextensionsfeatures.CustomResourceFieldSelectors, true)
 		t.Run(tc.name, func(t *testing.T) {
 			strategy := customResourceStrategy{selectableFieldSet: prepareSelectableFields(tc.selectableFields)}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition/strategy_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition/strategy_test.go
@@ -28,6 +28,7 @@ import (
 	apiextensionsfeatures "k8s.io/apiextensions-apiserver/pkg/features"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apimachinery/pkg/util/version"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/utils/pointer"
@@ -1299,6 +1300,7 @@ func TestDropDisabledFields(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateEmulationVersionDuringTest(t, utilfeature.DefaultFeatureGate, version.MustParse("1.31"))
 			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, apiextensionsfeatures.CRDValidationRatcheting, tc.enableRatcheting)
 			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, apiextensionsfeatures.CustomResourceFieldSelectors, tc.enableSelectableFields)
 			old := tc.oldCRD.DeepCopy()

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/fieldselector_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/fieldselector_test.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -200,8 +201,6 @@ func (sf selectableFieldTestCase) Name() string {
 
 func TestSelectableFields(t *testing.T) {
 	_, ctx := ktesting.NewTestContext(t)
-
-	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, apiextensionsfeatures.CustomResourceFieldSelectors, true)
 	tearDown, apiExtensionClient, dynamicClient, err := fixtures.StartDefaultServerWithClients(t)
 	if err != nil {
 		t.Fatal(err)
@@ -497,7 +496,6 @@ func testDeleteCollection(ctx context.Context, t *testing.T, tcs []selectableFie
 
 func TestFieldSelectorOpenAPI(t *testing.T) {
 	_, ctx := ktesting.NewTestContext(t)
-	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, apiextensionsfeatures.CustomResourceFieldSelectors, true)
 	tearDown, config, _, err := fixtures.StartDefaultServer(t)
 	if err != nil {
 		t.Fatal(err)
@@ -595,6 +593,7 @@ func TestFieldSelectorOpenAPI(t *testing.T) {
 
 func TestFieldSelectorDropFields(t *testing.T) {
 	_, ctx := ktesting.NewTestContext(t)
+	featuregatetesting.SetFeatureGateEmulationVersionDuringTest(t, utilfeature.DefaultFeatureGate, version.MustParse("1.31"))
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, apiextensionsfeatures.CustomResourceFieldSelectors, false)
 	tearDown, apiExtensionClient, _, err := fixtures.StartDefaultServerWithClients(t)
 	if err != nil {
@@ -676,6 +675,7 @@ func TestFieldSelectorDropFields(t *testing.T) {
 }
 
 func TestFieldSelectorDisablement(t *testing.T) {
+	featuregatetesting.SetFeatureGateEmulationVersionDuringTest(t, utilfeature.DefaultFeatureGate, version.MustParse("1.31"))
 	_, ctx := ktesting.NewTestContext(t)
 	tearDown, config, _, err := fixtures.StartDefaultServer(t)
 	if err != nil {

--- a/test/e2e/apimachinery/crd_selectable_fields.go
+++ b/test/e2e/apimachinery/crd_selectable_fields.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	apiextensionsfeatures "k8s.io/apiextensions-apiserver/pkg/features"
 	"k8s.io/apiextensions-apiserver/test/integration/fixtures"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -42,7 +41,7 @@ import (
 	"github.com/onsi/ginkgo/v2"
 )
 
-var _ = SIGDescribe("CustomResourceFieldSelectors [Privileged:ClusterAdmin]", framework.WithFeatureGate(apiextensionsfeatures.CustomResourceFieldSelectors), func() {
+var _ = SIGDescribe("CustomResourceFieldSelectors [Privileged:ClusterAdmin]", func() {
 
 	f := framework.NewDefaultFramework("crd-selectable-fields")
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged

--- a/test/featuregates_linter/test_data/versioned_feature_list.yaml
+++ b/test/featuregates_linter/test_data/versioned_feature_list.yaml
@@ -272,6 +272,10 @@
     lockToDefault: false
     preRelease: Beta
     version: "1.31"
+  - default: true
+    lockToDefault: true
+    preRelease: GA
+    version: "1.32"
 - name: DevicePluginCDIDevices
   versionedSpecs:
   - default: false


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

https://github.com/kubernetes/enhancements/issues/4358

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

-->
```release-note
Promoted `CustomResourceFieldSelectors` to stable; the feature is enabled by default. `--feature-gates=CustomResourceFieldSelectors=true` not needed on kube-apiserver binaries and will be removed in a future release.
```

