### PR TITLE
fix: unnecessary fmt.Sprintf in assertions

### DIFF
--- a/pkg/security/apparmor/validate_test.go
+++ b/pkg/security/apparmor/validate_test.go
@@ -18,7 +18,6 @@ package apparmor
 
 import (
 	"errors"
-	"fmt"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
@@ -71,9 +70,9 @@ func TestValidateValidHost(t *testing.T) {
 	for _, test := range tests {
 		err := v.Validate(getPodWithProfile(test.profile))
 		if test.expectValid {
-			assert.NoError(t, err, "Pod with profile %q should be valid", test.profile)
+			assert.NoErrorf(t, err, "Pod with profile %q should be valid", test.profile)
 		} else {
-			assert.Error(t, err, fmt.Sprintf("Pod with profile %q should trigger a validation error", test.profile))
+			assert.Errorf(t, err, "Pod with profile %q should trigger a validation error", test.profile)
 		}
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/area test
/kind cleanup
/sig testing



#### What this PR does / why we need it:

Code simplification， and Unnecessary fmt.Sprintf in assertions
