### PR TITLE
fix: enable error-nil and nil-compare rules from testifylint in module `k8s.io/cri-client`

### DIFF
--- a/staging/src/k8s.io/cri-client/pkg/util/util_unix_test.go
+++ b/staging/src/k8s.io/cri-client/pkg/util/util_unix_test.go
@@ -62,10 +62,10 @@ func TestParseEndpoint(t *testing.T) {
 		protocol, addr, err := parseEndpoint(test.endpoint)
 		assert.Equal(t, test.expectedProtocol, protocol)
 		if test.expectError {
-			assert.NotNil(t, err, "Expect error during parsing %q", test.endpoint)
+			assert.Error(t, err, "Expect error during parsing %q", test.endpoint)
 			continue
 		}
-		assert.Nil(t, err, "Expect no error during parsing %q", test.endpoint)
+		assert.NoError(t, err, "Expect no error during parsing %q", test.endpoint)
 		assert.Equal(t, test.expectedAddr, addr)
 	}
 
@@ -109,10 +109,10 @@ func TestGetAddressAndDialer(t *testing.T) {
 		// just test addr and err
 		addr, _, err := GetAddressAndDialer(test.endpoint)
 		if test.expectError {
-			assert.NotNil(t, err, "expected error during parsing %s", test.endpoint)
+			assert.Error(t, err, "expected error during parsing %s", test.endpoint)
 			continue
 		}
-		assert.Nil(t, err, "expected no error during parsing %s", test.endpoint)
+		assert.NoError(t, err, "expected no error during parsing %s", test.endpoint)
 		assert.Equal(t, test.expectedAddr, addr)
 	}
 }

--- a/staging/src/k8s.io/cri-client/pkg/utils_test.go
+++ b/staging/src/k8s.io/cri-client/pkg/utils_test.go
@@ -102,7 +102,7 @@ func TestVerifySandboxStatus(t *testing.T) {
 		if actual != nil {
 			assert.EqualError(t, actual, status.expected.Error())
 		} else {
-			assert.Nil(t, status.expected)
+			assert.NoError(t, status.expected)
 		}
 	}
 }
@@ -175,7 +175,7 @@ func TestVerifyContainerStatus(t *testing.T) {
 		if actual != nil {
 			assert.EqualError(t, actual, status.expected.Error())
 		} else {
-			assert.Nil(t, status.expected)
+			assert.NoError(t, status.expected)
 		}
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/area test
/kind cleanup
/priority backlog
/sig testing

#### What this PR does / why we need it:

This fixes [error-nil](https://github.com/Antonboom/testifylint?tab=readme-ov-file#error-nil) and [nil-compare](https://github.com/Antonboom/testifylint?tab=readme-ov-file#nil-compare) rules from [testifylint](https://github.com/Antonboom/testifylint) in module `k8s.io/apiserver`

