### PR TITLE
fix: enable expected-actual rule from testifylint in module `k8s.io/kubelet`

### DIFF
--- a/staging/src/k8s.io/kubelet/pkg/cri/streaming/request_cache_test.go
+++ b/staging/src/k8s.io/kubelet/pkg/cri/streaming/request_cache_test.go
@@ -71,7 +71,7 @@ func TestInsert(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	require.NoError(t, WriteError(err, recorder))
 	errResponse := recorder.Result()
-	assert.Equal(t, errResponse.StatusCode, http.StatusTooManyRequests)
+	assert.Equal(t, http.StatusTooManyRequests, errResponse.StatusCode)
 	assert.Equal(t, strconv.Itoa(int(cacheTTL.Seconds())), errResponse.Header.Get("Retry-After"))
 
 	assertCacheSize(t, c, maxInFlight)


### PR DESCRIPTION
#### What type of PR is this?

/area test
/kind cleanup
/priority backlog
/sig testing

#### What this PR does / why we need it:

This fixes [expected-actual](https://github.com/Antonboom/testifylint?tab=readme-ov-file#expected-actual) rule from [testifylint](https://github.com/Antonboom/testifylint) in module `k8s.io/kubelet`

