### PR TITLE
fix: enable expected-actual rule from testifylint in module `k8s.io/kubectl`

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/util/prune/prune_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/prune/prune_test.go
@@ -144,7 +144,7 @@ func TestParsePruneResources(t *testing.T) {
 		if tc.err {
 			assert.NotEmptyf(t, err, "parsePruneResources error expected but not fired")
 		} else {
-			assert.Equal(t, actual, tc.expected, "parsePruneResources failed expected %v actual %v", tc.expected, actual)
+			assert.Equalf(t, tc.expected, actual, "parsePruneResources failed expected %v actual %v", tc.expected, actual)
 		}
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/area test
/kind cleanup
/priority backlog
/sig testing

#### What this PR does / why we need it:

This fixes [expected-actual](https://github.com/Antonboom/testifylint?tab=readme-ov-file#expected-actual) rule from [testifylint](https://github.com/Antonboom/testifylint) in module `k8s.io/kubectl`

