### PR TITLE
fix: enable expected-actual rule from testifylint in module `k8s.io/endpointslice`

### DIFF
--- a/staging/src/k8s.io/endpointslice/utils_test.go
+++ b/staging/src/k8s.io/endpointslice/utils_test.go
@@ -881,7 +881,7 @@ func TestSetEndpointSliceLabels(t *testing.T) {
 			logger, _ := ktesting.NewTestContext(t)
 			svc := tc.updateSvc(service)
 			labels, updated := setEndpointSliceLabels(logger, tc.epSlice, &svc, controllerName)
-			assert.EqualValues(t, updated, tc.expectedUpdate)
+			assert.EqualValues(t, tc.expectedUpdate, updated)
 			assert.EqualValues(t, tc.expectedLabels, labels)
 		})
 	}


### PR DESCRIPTION
#### What type of PR is this?

/area test
/kind cleanup
/priority backlog
/sig testing

#### What this PR does / why we need it:

This fixes [expected-actual](https://github.com/Antonboom/testifylint?tab=readme-ov-file#expected-actual) rule from [testifylint](https://github.com/Antonboom/testifylint) in module `k8s.io/endpointslice`

