### PR TITLE
fix: enable expected-actual rule from testifylint in module `k8s.io/cli-runtime`

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/resource/visitor_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/visitor_test.go
@@ -153,7 +153,7 @@ func TestVisitorHttpGet(t *testing.T) {
 			actualBytes, actualErr := readHttpWithRetries(tt.httpRetries, tt.args.duration, tt.args.u, tt.args.attempts)
 
 			if tt.isNotNil {
-				assert.Nil(t, actualErr)
+				assert.NoError(t, actualErr)
 				assert.NotNil(t, actualBytes)
 			} else {
 				if tt.expectedErr != nil {


### PR DESCRIPTION
#### What type of PR is this?

/area test
/kind cleanup
/priority backlog
/sig testing

#### What this PR does / why we need it:

This fixes [expected-actual](https://github.com/Antonboom/testifylint?tab=readme-ov-file#expected-actual) rule from [testifylint](https://github.com/Antonboom/testifylint) in module `k8s.io/cli-runtime`

