### PR TITLE
fix: enable expected-actual rule from testifylint in module `k8s.io/client-go`

### DIFF
--- a/staging/src/k8s.io/client-go/discovery/cached/disk/cached_discovery_test.go
+++ b/staging/src/k8s.io/client-go/discovery/cached/disk/cached_discovery_test.go
@@ -57,35 +57,35 @@ func TestCachedDiscoveryClient_Fresh(t *testing.T) {
 
 	cdc.ServerGroups()
 	assert.True(cdc.Fresh(), "should be fresh after groups call without cache")
-	assert.Equal(c.groupCalls, 1)
+	assert.Equal(1, c.groupCalls)
 
 	cdc.ServerGroups()
 	assert.True(cdc.Fresh(), "should be fresh after another groups call")
-	assert.Equal(c.groupCalls, 1)
+	assert.Equal(1, c.groupCalls)
 
 	cdc.ServerGroupsAndResources()
 	assert.True(cdc.Fresh(), "should be fresh after resources call")
-	assert.Equal(c.resourceCalls, 1)
+	assert.Equal(1, c.resourceCalls)
 
 	cdc.ServerGroupsAndResources()
 	assert.True(cdc.Fresh(), "should be fresh after another resources call")
-	assert.Equal(c.resourceCalls, 1)
+	assert.Equal(1, c.resourceCalls)
 
 	cdc = newCachedDiscoveryClient(&c, d, 60*time.Second)
 	cdc.ServerGroups()
 	assert.False(cdc.Fresh(), "should NOT be fresh after recreation with existing groups cache")
-	assert.Equal(c.groupCalls, 1)
+	assert.Equal(1, c.groupCalls)
 
 	cdc.ServerGroupsAndResources()
 	assert.False(cdc.Fresh(), "should NOT be fresh after recreation with existing resources cache")
-	assert.Equal(c.resourceCalls, 1)
+	assert.Equal(1, c.resourceCalls)
 
 	cdc.Invalidate()
 	assert.True(cdc.Fresh(), "should be fresh after cache invalidation")
 
 	cdc.ServerGroupsAndResources()
 	assert.True(cdc.Fresh(), "should ignore existing resources cache after invalidation")
-	assert.Equal(c.resourceCalls, 2)
+	assert.Equal(2, c.resourceCalls)
 }
 
 func TestNewCachedDiscoveryClient_TTL(t *testing.T) {
@@ -98,12 +98,12 @@ func TestNewCachedDiscoveryClient_TTL(t *testing.T) {
 	c := fakeDiscoveryClient{}
 	cdc := newCachedDiscoveryClient(&c, d, 1*time.Nanosecond)
 	cdc.ServerGroups()
-	assert.Equal(c.groupCalls, 1)
+	assert.Equal(1, c.groupCalls)
 
 	time.Sleep(1 * time.Second)
 
 	cdc.ServerGroups()
-	assert.Equal(c.groupCalls, 2)
+	assert.Equal(2, c.groupCalls)
 }
 
 func TestNewCachedDiscoveryClient_PathPerm(t *testing.T) {

--- a/staging/src/k8s.io/client-go/features/envvar_test.go
+++ b/staging/src/k8s.io/client-go/features/envvar_test.go
@@ -148,7 +148,7 @@ func TestEnvVarFeatureGates(t *testing.T) {
 			}
 			for expectedFeature, expectedValue := range scenario.expectedFeaturesState {
 				actualValue := target.Enabled(expectedFeature)
-				require.Equal(t, actualValue, expectedValue, "expected feature=%v, to be=%v, not=%v", expectedFeature, expectedValue, actualValue)
+				require.Equal(t, expectedValue, actualValue, "expected feature=%v, to be=%v, not=%v", expectedFeature, expectedValue, actualValue)
 			}
 
 			enabledViaEnvVarInternalMap := target.enabledViaEnvVar.Load().(map[Feature]bool)

--- a/staging/src/k8s.io/client-go/restmapper/discovery_test.go
+++ b/staging/src/k8s.io/client-go/restmapper/discovery_test.go
@@ -257,8 +257,8 @@ func TestDeferredDiscoveryRESTMapper_CacheMiss(t *testing.T) {
 	})
 	assert.NoError(err)
 	assert.True(cdc.fresh, "should be fresh after a cache-miss")
-	assert.Equal(cdc.invalidateCalls, 1, "should have called Invalidate() once")
-	assert.Equal(gvk.Kind, "Foo")
+	assert.Equal(1, cdc.invalidateCalls, "should have called Invalidate() once")
+	assert.Equal("Foo", gvk.Kind)
 
 	gvk, err = m.KindFor(schema.GroupVersionResource{
 		Group:    "a",
@@ -266,7 +266,7 @@ func TestDeferredDiscoveryRESTMapper_CacheMiss(t *testing.T) {
 		Resource: "foo",
 	})
 	assert.NoError(err)
-	assert.Equal(cdc.invalidateCalls, 1, "should NOT have called Invalidate() again")
+	assert.Equal(1, cdc.invalidateCalls, "should NOT have called Invalidate() again")
 
 	gvk, err = m.KindFor(schema.GroupVersionResource{
 		Group:    "a",
@@ -274,7 +274,7 @@ func TestDeferredDiscoveryRESTMapper_CacheMiss(t *testing.T) {
 		Resource: "bar",
 	})
 	assert.Error(err)
-	assert.Equal(cdc.invalidateCalls, 1, "should NOT have called Invalidate() again after another cache-miss, but with fresh==true")
+	assert.Equal(1, cdc.invalidateCalls, "should NOT have called Invalidate() again after another cache-miss, but with fresh==true")
 
 	cdc.fresh = false
 	gvk, err = m.KindFor(schema.GroupVersionResource{
@@ -283,7 +283,7 @@ func TestDeferredDiscoveryRESTMapper_CacheMiss(t *testing.T) {
 		Resource: "bar",
 	})
 	assert.Error(err)
-	assert.Equal(cdc.invalidateCalls, 2, "should HAVE called Invalidate() again after another cache-miss, but with fresh==false")
+	assert.Equal(2, cdc.invalidateCalls, "should HAVE called Invalidate() again after another cache-miss, but with fresh==false")
 }
 
 func TestGetAPIGroupResources(t *testing.T) {

--- a/staging/src/k8s.io/client-go/testing/fixture_test.go
+++ b/staging/src/k8s.io/client-go/testing/fixture_test.go
@@ -19,12 +19,12 @@ package testing
 import (
 	"fmt"
 	"math/rand"
-	"sigs.k8s.io/structured-merge-diff/v4/typed"
 	"strconv"
 	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/structured-merge-diff/v4/typed"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -297,7 +297,7 @@ func TestApplyCreate(t *testing.T) {
 		t.Fatalf("Failed to create a resource with apply: %v", err)
 	}
 	cm := configMap.(*v1.ConfigMap)
-	assert.Equal(t, cm.Data, map[string]string{"k": "v"})
+	assert.Equal(t, map[string]string{"k": "v"}, cm.Data)
 }
 
 func TestApplyNoMeta(t *testing.T) {

--- a/staging/src/k8s.io/client-go/util/consistencydetector/data_consistency_detector_test.go
+++ b/staging/src/k8s.io/client-go/util/consistencydetector/data_consistency_detector_test.go
@@ -221,8 +221,8 @@ func TestDataConsistencyChecker(t *testing.T) {
 				CheckDataConsistency(ctx, "", scenario.lastSyncedResourceVersion, fakeLister.List, scenario.requestOptions, retrievedItemsFunc)
 			}
 
-			require.Equal(t, fakeLister.counter, scenario.expectedListRequests)
-			require.Equal(t, fakeLister.requestOptions, scenario.expectedRequestOptions)
+			require.Equal(t, scenario.expectedListRequests, fakeLister.counter)
+			require.Equal(t, scenario.expectedRequestOptions, fakeLister.requestOptions)
 		})
 	}
 }

--- a/staging/src/k8s.io/client-go/util/consistencydetector/list_data_consistency_detector_test.go
+++ b/staging/src/k8s.io/client-go/util/consistencydetector/list_data_consistency_detector_test.go
@@ -133,7 +133,7 @@ func TestCheckListFromCacheDataConsistencyIfRequestedInternalHappyPath(t *testin
 
 			require.Equal(t, 1, fakeLister.counter)
 			require.Len(t, fakeLister.requestOptions, 1)
-			require.Equal(t, fakeLister.requestOptions[0], scenario.expectedRequestOptions)
+			require.Equal(t, scenario.expectedRequestOptions, fakeLister.requestOptions[0])
 		})
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/area test
/kind cleanup
/priority backlog
/sig testing

#### What this PR does / why we need it:

This fixes [expected-actual](https://github.com/Antonboom/testifylint?tab=readme-ov-file#expected-actual) rule from [testifylint](https://github.com/Antonboom/testifylint) in module `k8s.io/client-go`

