### PR TITLE
fix: enable expected-actual rule from testifylint in module `k8s.io/apiserver`

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/attributes_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/attributes_test.go
@@ -30,13 +30,13 @@ func TestAddAnnotation(t *testing.T) {
 	attr.AddAnnotation("foo.admission.k8s.io/key1", "value1")
 	attr.AddAnnotation("foo.admission.k8s.io/key2", "value2")
 	annotations := attr.getAnnotations(auditinternal.LevelMetadata)
-	assert.Equal(t, annotations["foo.admission.k8s.io/key1"], "value1")
+	assert.Equal(t, "value1", annotations["foo.admission.k8s.io/key1"])
 
 	// test overwrite
 	assert.Error(t, attr.AddAnnotation("foo.admission.k8s.io/key1", "value1-overwrite"),
 		"admission annotations should not be allowd to be overwritten")
 	annotations = attr.getAnnotations(auditinternal.LevelMetadata)
-	assert.Equal(t, annotations["foo.admission.k8s.io/key1"], "value1", "admission annotations should not be overwritten")
+	assert.Equal(t, "value1", annotations["foo.admission.k8s.io/key1"], "admission annotations should not be overwritten")
 
 	// test invalid plugin names
 	var testCases = map[string]string{
@@ -49,17 +49,16 @@ func TestAddAnnotation(t *testing.T) {
 		err := attr.AddAnnotation(invalidKey, "value-foo")
 		assert.Error(t, err)
 		annotations = attr.getAnnotations(auditinternal.LevelMetadata)
-		assert.Equal(t, annotations[invalidKey], "", name+": invalid pluginName is not allowed ")
+		assert.Equal(t, "", annotations[invalidKey], name+": invalid pluginName is not allowed ")
 	}
 
 	// test all saved annotations
 	assert.Equal(
 		t,
-		annotations,
 		map[string]string{
 			"foo.admission.k8s.io/key1": "value1",
 			"foo.admission.k8s.io/key2": "value2",
-		},
+		}, annotations,
 		"unexpected final annotations",
 	)
 }

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/admission_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/admission_test.go
@@ -602,7 +602,7 @@ func TestDefinitionDoesntMatch(t *testing.T) {
 				nil, matchingParams,
 				admission.Create), &admission.RuntimeObjectInterfaces{}),
 		`Denied`)
-	require.Equal(t, numCompiles, 1)
+	require.Equal(t, 1, numCompiles)
 }
 
 func TestReconfigureBinding(t *testing.T) {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/discovery/aggregated/handler_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/discovery/aggregated/handler_test.go
@@ -470,7 +470,7 @@ func TestMultipleSources(t *testing.T) {
 	_, _, initialDocument := fetchPath(defaultManager, "application/json", discoveryPath, "")
 
 	require.Len(t, initialDocument.Items, len(expectedResult))
-	require.Equal(t, initialDocument.Items, expectedResult)
+	require.Equal(t, expectedResult, initialDocument.Items)
 }
 
 // Shows that if you have multiple sources including Default source using
@@ -674,11 +674,11 @@ func TestVersionSortingNoPriority(t *testing.T) {
 	versions := decoded.Items[0].Versions
 
 	// Ensure that v1 is sorted before v1alpha1
-	assert.Equal(t, versions[0].Version, "v2")
-	assert.Equal(t, versions[1].Version, "v1")
-	assert.Equal(t, versions[2].Version, "v2beta1")
-	assert.Equal(t, versions[3].Version, "v1beta1")
-	assert.Equal(t, versions[4].Version, "v1alpha1")
+	assert.Equal(t, "v2", versions[0].Version)
+	assert.Equal(t, "v1", versions[1].Version)
+	assert.Equal(t, "v2beta1", versions[2].Version)
+	assert.Equal(t, "v1beta1", versions[3].Version)
+	assert.Equal(t, "v1alpha1", versions[4].Version)
 }
 
 func TestVersionSortingWithPriority(t *testing.T) {
@@ -699,8 +699,8 @@ func TestVersionSortingWithPriority(t *testing.T) {
 	versions := decoded.Items[0].Versions
 
 	// Ensure that reverse alpha sort order can be overridden by setting group version priorities.
-	assert.Equal(t, versions[0].Version, "v1alpha1")
-	assert.Equal(t, versions[1].Version, "v1")
+	assert.Equal(t, "v1alpha1", versions[0].Version)
+	assert.Equal(t, "v1", versions[1].Version)
 }
 
 // if two apiservices declare conflicting priorities for their group priority, take the higher one.
@@ -726,8 +726,8 @@ func TestGroupVersionSortingConflictingPriority(t *testing.T) {
 	groups := decoded.Items
 
 	// Ensure that reverse alpha sort order can be overridden by setting group version priorities.
-	assert.Equal(t, groups[0].Name, "test")
-	assert.Equal(t, groups[1].Name, "default")
+	assert.Equal(t, "test", groups[0].Name)
+	assert.Equal(t, "default", groups[1].Name)
 }
 
 // Show that the GroupPriorityMinimum is not sticky if a higher group version is removed
@@ -756,8 +756,8 @@ func TestStatelessGroupPriorityMinimum(t *testing.T) {
 	// Expect v1alpha1's group priority to be used and sort it first in the list
 	response, _, decoded := fetchPath(manager, "application/json", discoveryPath, "")
 	assert.Equal(t, http.StatusOK, response.StatusCode, "response should be 200 OK")
-	assert.Equal(t, decoded.Items[0].Name, "experimental.example.com")
-	assert.Equal(t, decoded.Items[1].Name, "stable.example.com")
+	assert.Equal(t, "experimental.example.com", decoded.Items[0].Name)
+	assert.Equal(t, "stable.example.com", decoded.Items[1].Name)
 
 	// Remove v1alpha1 and expect the new lower priority to take hold
 	manager.RemoveGroupVersion(metav1.GroupVersion{Group: experimentalGroup, Version: "v1alpha1"})
@@ -765,6 +765,6 @@ func TestStatelessGroupPriorityMinimum(t *testing.T) {
 	response, _, decoded = fetchPath(manager, "application/json", discoveryPath, "")
 	assert.Equal(t, http.StatusOK, response.StatusCode, "response should be 200 OK")
 
-	assert.Equal(t, decoded.Items[0].Name, "stable.example.com")
-	assert.Equal(t, decoded.Items[1].Name, "experimental.example.com")
+	assert.Equal(t, "stable.example.com", decoded.Items[0].Name)
+	assert.Equal(t, "experimental.example.com", decoded.Items[1].Name)
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/mux/pathrecorder_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/mux/pathrecorder_test.go
@@ -48,24 +48,24 @@ func TestUnregisterHandlers(t *testing.T) {
 	assert.Contains(t, c.ListedPaths(), "/nonswagger")
 
 	resp, _ := http.Get(s.URL + "/nonswagger")
-	assert.Equal(t, first, 1)
-	assert.Equal(t, resp.StatusCode, http.StatusOK)
+	assert.Equal(t, 1, first)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 	c.Unregister("/nonswagger")
 	assert.NotContains(t, c.ListedPaths(), "/nonswagger")
 
 	resp, _ = http.Get(s.URL + "/nonswagger")
-	assert.Equal(t, first, 1)
-	assert.Equal(t, resp.StatusCode, http.StatusNotFound)
+	assert.Equal(t, 1, first)
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
 
 	c.HandleFunc("/nonswagger", func(http.ResponseWriter, *http.Request) {
 		second = second + 1
 	})
 	assert.Contains(t, c.ListedPaths(), "/nonswagger")
 	resp, _ = http.Get(s.URL + "/nonswagger")
-	assert.Equal(t, first, 1)
-	assert.Equal(t, second, 1)
-	assert.Equal(t, resp.StatusCode, http.StatusOK)
+	assert.Equal(t, 1, first)
+	assert.Equal(t, 1, second)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
 
 func TestPrefixHandlers(t *testing.T) {
@@ -103,10 +103,10 @@ func TestPrefixHandlers(t *testing.T) {
 
 	resp, _ := http.Get(s.URL + "/fallthrough")
 	assert.Equal(t, 1, fallThroughCount)
-	assert.Equal(t, resp.StatusCode, http.StatusOK)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	resp, _ = http.Get(s.URL + "/publicPrefix")
 	assert.Equal(t, 2, fallThroughCount)
-	assert.Equal(t, resp.StatusCode, http.StatusOK)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 	http.Get(s.URL + "/publicPrefix/")
 	assert.Equal(t, 1, publicPrefixCount)


### PR DESCRIPTION
#### What type of PR is this?

/area test
/kind cleanup
/priority backlog
/sig testing

#### What this PR does / why we need it:

This fixes [expected-actual](https://github.com/Antonboom/testifylint?tab=readme-ov-file#expected-actual) rule from [testifylint](https://github.com/Antonboom/testifylint) in module `k8s.io/apiserver`

