### PR TITLE
fix: enable expected-actual rule from testifylint in module `k8s.io/apimachinery`

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/helpers_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/helpers_test.go
@@ -178,7 +178,7 @@ func TestSetNestedStringSlice(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, obj["x"], 3)
 	assert.Len(t, obj["x"].(map[string]interface{})["z"], 1)
-	assert.Equal(t, obj["x"].(map[string]interface{})["z"].([]interface{})[0], "bar")
+	assert.Equal(t, "bar", obj["x"].(map[string]interface{})["z"].([]interface{})[0])
 }
 
 func TestSetNestedSlice(t *testing.T) {
@@ -193,7 +193,7 @@ func TestSetNestedSlice(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, obj["x"], 3)
 	assert.Len(t, obj["x"].(map[string]interface{})["z"], 1)
-	assert.Equal(t, obj["x"].(map[string]interface{})["z"].([]interface{})[0], "bar")
+	assert.Equal(t, "bar", obj["x"].(map[string]interface{})["z"].([]interface{})[0])
 }
 
 func TestSetNestedStringMap(t *testing.T) {
@@ -208,7 +208,7 @@ func TestSetNestedStringMap(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, obj["x"], 3)
 	assert.Len(t, obj["x"].(map[string]interface{})["z"], 1)
-	assert.Equal(t, obj["x"].(map[string]interface{})["z"].(map[string]interface{})["b"], "bar")
+	assert.Equal(t, "bar", obj["x"].(map[string]interface{})["z"].(map[string]interface{})["b"])
 }
 
 func TestSetNestedMap(t *testing.T) {
@@ -223,5 +223,5 @@ func TestSetNestedMap(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, obj["x"], 3)
 	assert.Len(t, obj["x"].(map[string]interface{})["z"], 1)
-	assert.Equal(t, obj["x"].(map[string]interface{})["z"].(map[string]interface{})["b"], "bar")
+	assert.Equal(t, "bar", obj["x"].(map[string]interface{})["z"].(map[string]interface{})["b"])
 }

--- a/staging/src/k8s.io/apimachinery/pkg/util/managedfields/internal/typeconverter_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/managedfields/internal/typeconverter_test.go
@@ -287,7 +287,7 @@ func TestIndexModels(t *testing.T) {
 		resultNames[k] = *v.TypeRef.NamedType
 	}
 
-	require.Equal(t, resultNames, map[schema.GroupVersionKind]string{
+	require.Equal(t, map[schema.GroupVersionKind]string{
 		{
 			Group:   "mygroup",
 			Version: "v1",
@@ -313,5 +313,5 @@ func TestIndexModels(t *testing.T) {
 			Version: "v3",
 			Kind:    "MyOtherKind",
 		}: "def3",
-	})
+	}, resultNames)
 }


### PR DESCRIPTION
#### What type of PR is this?

/area test
/kind cleanup
/priority backlog
/sig testing

#### What this PR does / why we need it:

This fixes [expected-actual](https://github.com/Antonboom/testifylint?tab=readme-ov-file#expected-actual) rule from [testifylint](https://github.com/Antonboom/testifylint) in module `k8s.io/apimachinery`

