### PR TITLE
kubectl debug: Display a warning message that the debug container's capabilities may not work with a non-root user

### DIFF
--- a/hack/testdata/pod-run-as-non-root.yaml
+++ b/hack/testdata/pod-run-as-non-root.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    run: target
+  name: target
+spec:
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 1000
+    runAsNonRoot: true
+  containers:
+  - image: busybox
+    name: target
+    command: ["/bin/sh", "-c", "sleep 100"]

--- a/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go
@@ -75,6 +75,10 @@ var (
 		            debugging utilities without restarting the pod.
 		* Node: Create a new pod that runs in the node's host namespaces and can access
 		        the node's filesystem.
+
+		Note: When a non-root user is configured for the entire target Pod, some capabilities granted 
+		by debug profile may not work. Please consider using "--custom" with a custom profile 
+		that specifies "securityContext.runAsUser: 0".
 `))
 
 	debugExample = templates.Examples(i18n.T(`
@@ -475,18 +479,6 @@ func (o *DebugOptions) visitNode(ctx context.Context, node *corev1.Node) (*corev
 //
 // visitPod returns a pod and debug container name for subsequent attach, if applicable.
 func (o *DebugOptions) visitPod(ctx context.Context, pod *corev1.Pod) (*corev1.Pod, string, error) {
-	// Display warning message if some capabilities are set by profile and non-root user is specified in .Spec.SecurityContext.RunAsUser.(#1650)
-	if o.Profile == ProfileGeneral || o.Profile == ProfileNetadmin || o.Profile == ProfileSysadmin ||
-		(o.CustomProfile != nil && o.CustomProfile.SecurityContext != nil &&
-			((o.CustomProfile.SecurityContext.Privileged != nil && *o.CustomProfile.SecurityContext.Privileged) ||
-				(o.CustomProfile.SecurityContext.Capabilities != nil && len(o.CustomProfile.SecurityContext.Capabilities.Add) != 0))) {
-		if pod.Spec.SecurityContext.RunAsUser != nil && *pod.Spec.SecurityContext.RunAsUser != 0 {
-			if o.CustomProfile == nil ||
-				(o.CustomProfile.SecurityContext.RunAsUser == nil || *o.CustomProfile.SecurityContext.RunAsUser != 0) {
-				fmt.Fprintln(o.ErrOut, `Warning: Non-root user is specified for the entire target Pod and some capabilities granted by debug profile may not work. Please consider using "--custom" with the custom profile specifying "securityContext.runAsUser: 0".`)
-			}
-		}
-	}
 	if len(o.CopyTo) > 0 {
 		return o.debugByCopy(ctx, pod)
 	}
@@ -506,6 +498,8 @@ func (o *DebugOptions) debugByEphemeralContainer(ctx context.Context, pod *corev
 		return nil, "", err
 	}
 	klog.V(2).Infof("new ephemeral container: %#v", debugContainer)
+
+	o.displayWarning((*corev1.Container)(&debugContainer.EphemeralContainerCommon), pod)
 
 	debugJS, err := json.Marshal(debugPod)
 	if err != nil {
@@ -623,6 +617,16 @@ func (o *DebugOptions) debugByCopy(ctx context.Context, pod *corev1.Pod) (*corev
 	if err != nil {
 		return nil, "", err
 	}
+
+	var debugContainer *corev1.Container
+	for i := range copied.Spec.Containers {
+		if copied.Spec.Containers[i].Name == dc {
+			debugContainer = &copied.Spec.Containers[i]
+			break
+		}
+	}
+	o.displayWarning(debugContainer, copied)
+
 	created, err := o.podClient.Pods(copied.Namespace).Create(ctx, copied, metav1.CreateOptions{})
 	if err != nil {
 		return nil, "", err
@@ -634,6 +638,21 @@ func (o *DebugOptions) debugByCopy(ctx context.Context, pod *corev1.Pod) (*corev
 		}
 	}
 	return created, dc, nil
+}
+
+func (o *DebugOptions) displayWarning(container *corev1.Container, pod *corev1.Pod) {
+	if container != nil {
+		// Display warning message if some capabilities are set by profile and non-root user is specified in .Spec.SecurityContext.RunAsUser.(#1650)
+		if container.SecurityContext != nil &&
+			((container.SecurityContext.Privileged != nil && *container.SecurityContext.Privileged) ||
+				(container.SecurityContext.Capabilities != nil && len(container.SecurityContext.Capabilities.Add) != 0)) {
+			if pod.Spec.SecurityContext.RunAsUser != nil && *pod.Spec.SecurityContext.RunAsUser != 0 {
+				if container.SecurityContext.RunAsUser == nil || *container.SecurityContext.RunAsUser != 0 {
+					_, _ = fmt.Fprintln(o.ErrOut, `Warning: Non-root user is configured for the entire target Pod, and some capabilities granted by debug profile may not work. Please consider using "--custom" with a custom profile that specifies "securityContext.runAsUser: 0".`)
+				}
+			}
+		}
+	}
 }
 
 // generateDebugContainer returns a debugging pod and an EphemeralContainer suitable for use as a debug container

--- a/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go
@@ -645,20 +645,20 @@ func (o *DebugOptions) displayWarning(container *corev1.Container, pod *corev1.P
 		return
 	}
 
+	if pod.Spec.SecurityContext.RunAsUser == nil || *pod.Spec.SecurityContext.RunAsUser == 0 {
+		return
+	}
+
 	if container.SecurityContext == nil {
+		return
+	}
+
+	if container.SecurityContext.RunAsUser != nil && *container.SecurityContext.RunAsUser == 0 {
 		return
 	}
 
 	if (container.SecurityContext.Privileged == nil || !*container.SecurityContext.Privileged) &&
 		(container.SecurityContext.Capabilities == nil || len(container.SecurityContext.Capabilities.Add) == 0) {
-		return
-	}
-
-	if pod.Spec.SecurityContext.RunAsUser == nil || *pod.Spec.SecurityContext.RunAsUser == 0 {
-		return
-	}
-
-	if container.SecurityContext.RunAsUser != nil && *container.SecurityContext.RunAsUser == 0 {
 		return
 	}
 

--- a/test/cmd/legacy-script.sh
+++ b/test/cmd/legacy-script.sh
@@ -1048,6 +1048,7 @@ runTests() {
     record_command run_kubectl_debug_restricted_tests
     record_command run_kubectl_debug_netadmin_tests
     record_command run_kubectl_debug_custom_profile_tests
+    record_command run_kubectl_debug_warning_tests
   fi
   if kube::test::if_supports_resource "${nodes}" ; then
     record_command run_kubectl_debug_node_tests


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig cli

#### What this PR does / why we need it:

When users debug a Pod using `kubectl debug`(Ephemeral Container or Copy Pod), the debug container's capabilities granted by debugging profile may not work as expected if a non-root user is specified in Pod's `.Spec.SecurityContext.RunAsUser` field.
As discussed in [#1650](https://github.com/kubernetes/kubectl/issues/1650) , we should inform users about this in specific situations like this:

```bash
$ kubectl debug run-as-user-1000 --target=test --image=busybox --profile=sysadmin
Targeting container "test". If you don't see processes from this container it may be because the container runtime doesn't support this feature.
Warning: Non-root user is specified for the entire target Pod and some capabilities granted by debug profile may not work. Please consider using "--custom" with the custom profile specifying "securityContext.runAsUser: 0".
Defaulting debug container name to debugger-r58ml.
```

The cases where the warning message is displayed is as follows:

|  | Root Pod<br>`pod.spec.securityContext.runAsUser=nil or 0` | Non-Root Container of Root Pod<br>`pod.spec.securityContext.runAsUser=nil or 0)`<br>and<br> `pod.spec.containers[].securityContext.runAsUser≠0(e.g. =1000)` | Non-Root Pod<br>`pod.spec.securityContext.runAsUser≠0(e.g. =1000)` |
| :--- | :--- | :--- | :--- |
| no profile<br>(legacy profile) |  |  |  |
| general profile |  |  | warning |
| sysadmin profile |  |  | warning |
| netadmin profile |  |  | warning |
| custom profile <br>specifying privileged and not root user |  |  | warning |
| custom profile<br>specifying privileged and root user |  |  |  |
| custom profile <br>  specifying some capabilities and not <br> root user |  |  | warning |
| custom profile <br>specifying some capabilities and root user |  |  |  |


#### Which issue(s) this PR fixes:
[#1650](https://github.com/kubernetes/kubectl/issues/1650)

#### Special notes for your reviewer:
Please review the warning message and suggest any improvements.

#### Does this PR introduce a user-facing change?

```release-note
Show a warning message to inform users that the debug container's capabilities granted by debugging profile may not work as expected if a non-root user is specified in target Pod's `.Spec.SecurityContext.RunAsUser` field.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```