### PR TITLE
fix: enable contains rule from testifylint in module k8s.io/client-go

### DIFF
--- a/staging/src/k8s.io/client-go/transport/websocket/roundtripper_test.go
+++ b/staging/src/k8s.io/client-go/transport/websocket/roundtripper_test.go
@@ -22,7 +22,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"strings"
 	"testing"
 	"time"
 
@@ -70,7 +69,7 @@ func TestWebSocketRoundTripper_RoundTripperFails(t *testing.T) {
 		// Bad handshake means websocket server will not completely initialize.
 		_, err := webSocketServerStreams(req, w)
 		require.Error(t, err)
-		assert.True(t, strings.Contains(err.Error(), "websocket server finished before becoming ready"))
+		assert.Contains(t, err.Error(), "websocket server finished before becoming ready")
 	}))
 	defer websocketServer.Close()
 
@@ -87,8 +86,8 @@ func TestWebSocketRoundTripper_RoundTripperFails(t *testing.T) {
 	_, err = rt.RoundTrip(req)
 	// Ensure a "bad handshake" error is returned, since requested protocol is not supported.
 	require.Error(t, err)
-	assert.True(t, strings.Contains(err.Error(), "websocket: bad handshake"))
-	assert.True(t, strings.Contains(err.Error(), "403 Forbidden"))
+	assert.Contains(t, err.Error(), "websocket: bad handshake")
+	assert.Contains(t, err.Error(), "403 Forbidden")
 	assert.True(t, httpstream.IsUpgradeFailure(err))
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/area test
/kind cleanup
/sig testing

#### What this PR does / why we need it:

This fixes [contains](https://github.com/Antonboom/testifylint?tab=readme-ov-file#contains) rule from [testifylint](https://github.com/Antonboom/testifylint) in module k8s.io/client-go
