### PR TITLE
kubectl: support creating immutable secrets and configmaps

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_configmap.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_configmap.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/kubectl/pkg/util/hash"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
+	"k8s.io/utils/ptr"
 )
 
 var (
@@ -89,6 +90,8 @@ type ConfigMapOptions struct {
 	EnvFileSources []string
 	// AppendHash; if true, derive a hash from the ConfigMap and append it to the name
 	AppendHash bool
+	// Immutable; if true, the ConfigMap will be immutable (optional)
+	Immutable bool
 
 	FieldManager     string
 	CreateAnnotation bool
@@ -137,6 +140,7 @@ func NewCmdCreateConfigMap(f cmdutil.Factory, ioStreams genericiooptions.IOStrea
 	cmd.Flags().StringArrayVar(&o.LiteralSources, "from-literal", o.LiteralSources, "Specify a key and literal value to insert in configmap (i.e. mykey=somevalue)")
 	cmd.Flags().StringSliceVar(&o.EnvFileSources, "from-env-file", o.EnvFileSources, "Specify the path to a file to read lines of key=val pairs to create a configmap.")
 	cmd.Flags().BoolVar(&o.AppendHash, "append-hash", o.AppendHash, "Append a hash of the configmap to its name.")
+	cmd.Flags().BoolVar(&o.Immutable, "immutable", o.Immutable, "Create immutable configmap.")
 
 	cmdutil.AddFieldManagerFlagVar(cmd, &o.FieldManager, "kubectl-create")
 
@@ -271,6 +275,9 @@ func (o *ConfigMapOptions) createConfigMap() (*corev1.ConfigMap, error) {
 			return nil, err
 		}
 		configMap.Name = fmt.Sprintf("%s-%s", configMap.Name, hash)
+	}
+	if o.Immutable {
+		configMap.Immutable = ptr.To[bool](true)
 	}
 
 	return configMap, nil

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_configmap_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_configmap_test.go
@@ -25,6 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 )
 
 func TestCreateConfigMap(t *testing.T) {
@@ -32,6 +33,7 @@ func TestCreateConfigMap(t *testing.T) {
 		configMapName string
 		configMapType string
 		appendHash    bool
+		immutable     bool
 		fromLiteral   []string
 		fromFile      []string
 		fromEnvFile   []string
@@ -67,6 +69,22 @@ func TestCreateConfigMap(t *testing.T) {
 				},
 				Data:       map[string]string{},
 				BinaryData: map[string][]byte{},
+			},
+		},
+		"create_foo_immutable_configmap": {
+			configMapName: "foo",
+			immutable:     true,
+			expected: &corev1.ConfigMap{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: corev1.SchemeGroupVersion.String(),
+					Kind:       "ConfigMap",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo",
+				},
+				Data:       map[string]string{},
+				BinaryData: map[string][]byte{},
+				Immutable:  ptr.To[bool](true),
 			},
 		},
 		"create_foo_type_configmap": {
@@ -431,6 +449,7 @@ func TestCreateConfigMap(t *testing.T) {
 				Name:           test.configMapName,
 				Type:           test.configMapType,
 				AppendHash:     test.appendHash,
+				Immutable:      test.immutable,
 				FileSources:    test.fromFile,
 				LiteralSources: test.fromLiteral,
 				EnvFileSources: test.fromEnvFile,

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/kubectl/pkg/util/hash"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
+	"k8s.io/utils/ptr"
 )
 
 // NewCmdCreateSecret groups subcommands to create various types of secrets.
@@ -115,6 +116,8 @@ type CreateSecretOptions struct {
 	EnvFileSources []string
 	// AppendHash; if true, derive a hash from the Secret data and type and append it to the name
 	AppendHash bool
+	// Immutable; if true, the Secret will be immutable (optional)
+	Immutable bool
 
 	FieldManager     string
 	CreateAnnotation bool
@@ -163,6 +166,7 @@ func NewCmdCreateSecretGeneric(f cmdutil.Factory, ioStreams genericiooptions.IOS
 	cmd.Flags().StringSliceVar(&o.EnvFileSources, "from-env-file", o.EnvFileSources, "Specify the path to a file to read lines of key=val pairs to create a secret.")
 	cmd.Flags().StringVar(&o.Type, "type", o.Type, i18n.T("The type of secret to create"))
 	cmd.Flags().BoolVar(&o.AppendHash, "append-hash", o.AppendHash, "Append a hash of the secret to its name.")
+	cmd.Flags().BoolVar(&o.Immutable, "immutable", o.Immutable, "Create immutable secret.")
 
 	cmdutil.AddFieldManagerFlagVar(cmd, &o.FieldManager, "kubectl-create")
 
@@ -286,6 +290,9 @@ func (o *CreateSecretOptions) createSecret() (*corev1.Secret, error) {
 			return nil, err
 		}
 		secret.Name = fmt.Sprintf("%s-%s", secret.Name, hash)
+	}
+	if o.Immutable {
+		secret.Immutable = ptr.To[bool](true)
 	}
 
 	return secret, nil

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret_docker.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret_docker.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/kubectl/pkg/util/hash"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
+	"k8s.io/utils/ptr"
 )
 
 var (
@@ -103,6 +104,8 @@ type CreateSecretDockerRegistryOptions struct {
 	Server string
 	// AppendHash; if true, derive a hash from the Secret and append it to the name
 	AppendHash bool
+	// Immutable; if true, the Secret will be immutable (optional)
+	Immutable bool
 
 	FieldManager     string
 	CreateAnnotation bool
@@ -153,6 +156,7 @@ func NewCmdCreateSecretDockerRegistry(f cmdutil.Factory, ioStreams genericioopti
 	cmd.Flags().StringVar(&o.Email, "docker-email", o.Email, i18n.T("Email for Docker registry"))
 	cmd.Flags().StringVar(&o.Server, "docker-server", o.Server, i18n.T("Server location for Docker registry"))
 	cmd.Flags().BoolVar(&o.AppendHash, "append-hash", o.AppendHash, "Append a hash of the secret to its name.")
+	cmd.Flags().BoolVar(&o.Immutable, "immutable", o.Immutable, "Create immutable secret.")
 	cmd.Flags().StringSliceVar(&o.FileSources, "from-file", o.FileSources, "Key files can be specified using their file path, "+
 		"in which case a default name of "+corev1.DockerConfigJsonKey+" will be given to them, "+
 		"or optionally with a name and file path, in which case the given name will be used. "+
@@ -282,6 +286,9 @@ func (o *CreateSecretDockerRegistryOptions) createSecretDockerRegistry() (*corev
 			return nil, err
 		}
 		secretDockerRegistry.Name = fmt.Sprintf("%s-%s", secretDockerRegistry.Name, hash)
+	}
+	if o.Immutable {
+		secretDockerRegistry.Immutable = ptr.To[bool](true)
 	}
 	return secretDockerRegistry, nil
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret_docker_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret_docker_test.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
+	"k8s.io/utils/ptr"
 )
 
 func TestCreateSecretDockerRegistry(t *testing.T) {
@@ -47,6 +48,7 @@ func TestCreateSecretDockerRegistry(t *testing.T) {
 		dockerPassword           string
 		dockerServer             string
 		appendHash               bool
+		immutable                bool
 		expected                 *corev1.Secret
 		expectErr                bool
 	}{
@@ -121,6 +123,7 @@ func TestCreateSecretDockerRegistry(t *testing.T) {
 			dockerEmail:              "",
 			dockerServer:             server,
 			appendHash:               true,
+			immutable:                true,
 			expected: &corev1.Secret{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: corev1.SchemeGroupVersion.String(),
@@ -133,6 +136,7 @@ func TestCreateSecretDockerRegistry(t *testing.T) {
 				Data: map[string][]byte{
 					corev1.DockerConfigJsonKey: secretDataNoEmail,
 				},
+				Immutable: ptr.To[bool](true),
 			},
 			expectErr: false,
 		},
@@ -170,6 +174,7 @@ func TestCreateSecretDockerRegistry(t *testing.T) {
 				Password:   test.dockerPassword,
 				Server:     test.dockerServer,
 				AppendHash: test.appendHash,
+				Immutable:  test.immutable,
 			}
 			err := secretDockerRegistryOptions.Validate()
 			if err == nil {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret_test.go
@@ -25,6 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 )
 
 func TestCreateSecretObject(t *testing.T) {
@@ -56,6 +57,7 @@ func TestCreateSecretGeneric(t *testing.T) {
 		fromFile    []string
 		fromEnvFile []string
 		appendHash  bool
+		immutable   bool
 		setup       func(t *testing.T, secretGenericOptions *CreateSecretOptions) func()
 
 		expected  *corev1.Secret
@@ -86,6 +88,21 @@ func TestCreateSecretGeneric(t *testing.T) {
 					Name: "foo-949tdgdkgg",
 				},
 				Data: map[string][]byte{},
+			},
+		},
+		"create_secret_foo_immutable": {
+			secretName: "foo",
+			immutable:  true,
+			expected: &corev1.Secret{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: corev1.SchemeGroupVersion.String(),
+					Kind:       "Secret",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo",
+				},
+				Immutable: ptr.To[bool](true),
+				Data:      map[string][]byte{},
 			},
 		},
 		"create_secret_foo_type": {
@@ -507,6 +524,7 @@ func TestCreateSecretGeneric(t *testing.T) {
 				Name:           test.secretName,
 				Type:           test.secretType,
 				AppendHash:     test.appendHash,
+				Immutable:      test.immutable,
 				FileSources:    test.fromFile,
 				LiteralSources: test.fromLiteral,
 				EnvFileSources: test.fromEnvFile,

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret_tls.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret_tls.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/kubectl/pkg/util/hash"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
+	"k8s.io/utils/ptr"
 )
 
 var (
@@ -63,6 +64,8 @@ type CreateSecretTLSOptions struct {
 	Cert string
 	// AppendHash; if true, derive a hash from the Secret and append it to the name
 	AppendHash bool
+	// Immutable; if true, the Secret will be immutable (optional)
+	Immutable bool
 
 	FieldManager     string
 	CreateAnnotation bool
@@ -110,6 +113,7 @@ func NewCmdCreateSecretTLS(f cmdutil.Factory, ioStreams genericiooptions.IOStrea
 	cmd.Flags().StringVar(&o.Cert, "cert", o.Cert, i18n.T("Path to PEM encoded public key certificate."))
 	cmd.Flags().StringVar(&o.Key, "key", o.Key, i18n.T("Path to private key associated with given certificate."))
 	cmd.Flags().BoolVar(&o.AppendHash, "append-hash", o.AppendHash, "Append a hash of the secret to its name.")
+	cmd.Flags().BoolVar(&o.Immutable, "immutable", o.Immutable, "Create immutable secret.")
 
 	cmdutil.AddFieldManagerFlagVar(cmd, &o.FieldManager, "kubectl-create")
 
@@ -234,6 +238,9 @@ func (o *CreateSecretTLSOptions) createSecretTLS() (*corev1.Secret, error) {
 			return nil, err
 		}
 		secretTLS.Name = fmt.Sprintf("%s-%s", secretTLS.Name, hash)
+	}
+	if o.Immutable {
+		secretTLS.Immutable = ptr.To[bool](true)
 	}
 
 	return secretTLS, nil

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret_tls_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret_tls_test.go
@@ -24,6 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 )
 
 var rsaCertPEM = `-----BEGIN CERTIFICATE-----
@@ -96,6 +97,7 @@ func TestCreateSecretTLS(t *testing.T) {
 		tlsKey        string
 		tlsCert       string
 		appendHash    bool
+		immutable     bool
 		expected      *corev1.Secret
 		expectErr     bool
 	}{
@@ -124,6 +126,7 @@ func TestCreateSecretTLS(t *testing.T) {
 			tlsKey:        validKeyPath,
 			tlsCert:       validCertPath,
 			appendHash:    true,
+			immutable:     true,
 			expected: &corev1.Secret{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: corev1.SchemeGroupVersion.String(),
@@ -137,6 +140,7 @@ func TestCreateSecretTLS(t *testing.T) {
 					corev1.TLSPrivateKeyKey: []byte(rsaKeyPEM),
 					corev1.TLSCertKey:       []byte(rsaCertPEM),
 				},
+				Immutable: ptr.To[bool](true),
 			},
 			expectErr: false,
 		},
@@ -168,6 +172,7 @@ func TestCreateSecretTLS(t *testing.T) {
 				Key:        test.tlsKey,
 				Cert:       test.tlsCert,
 				AppendHash: test.appendHash,
+				Immutable:  test.immutable,
 			}
 			secretTLS, err := secretTLSOptions.createSecretTLS()
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

The PR adds support for creating immutable Secrets and ConfigMaps to `kubectl`.

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/kubectl/issues/1698

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added support for creating immutable Secrets and ConfigMaps to `kubectl`.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
