### PR TITLE
kube-apiserver: Support structured and contextual logging

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -138,10 +138,11 @@ cluster's shared state through which all other components interact.`,
 
 // Run runs the specified APIServer.  This should never exit.
 func Run(ctx context.Context, opts options.CompletedOptions) error {
+	logger := klog.FromContext(ctx)
 	// To help debugging, immediately log version
-	klog.Infof("Version: %+v", utilversion.Get())
+	logger.Info("Version information", "version", utilversion.Get())
 
-	klog.InfoS("Golang settings", "GOGC", os.Getenv("GOGC"), "GOMAXPROCS", os.Getenv("GOMAXPROCS"), "GOTRACEBACK", os.Getenv("GOTRACEBACK"))
+	logger.Info("Golang settings", "GOGC", os.Getenv("GOGC"), "GOMAXPROCS", os.Getenv("GOMAXPROCS"), "GOTRACEBACK", os.Getenv("GOTRACEBACK"))
 
 	config, err := NewConfig(opts)
 	if err != nil {

--- a/cmd/kube-apiserver/app/testing/testserver.go
+++ b/cmd/kube-apiserver/app/testing/testserver.go
@@ -170,6 +170,7 @@ func StartTestServer(t ktesting.TB, instanceOptions *TestServerInstanceOptions, 
 		return result, fmt.Errorf("failed to create temp dir: %v", err)
 	}
 
+	logger := klog.FromContext(tCtx)
 	var errCh chan error
 	tearDown := func() {
 		// Cancel is stopping apiserver and cleaning up
@@ -181,7 +182,7 @@ func StartTestServer(t ktesting.TB, instanceOptions *TestServerInstanceOptions, 
 		if errCh != nil {
 			err, ok := <-errCh
 			if ok && err != nil {
-				klog.Errorf("Failed to shutdown test server clearly: %v", err)
+				logger.Error(err, "Failed to shutdown test server clearly")
 			}
 		}
 		os.RemoveAll(result.TmpDir)

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -158,6 +158,7 @@ linters-settings: # please keep this alphabetized
           contextual k8s.io/sample-apiserver/.*
           contextual k8s.io/sample-cli-plugin/.*
           contextual k8s.io/sample-controller/.*
+          contextual k8s.io/kubernetes/cmd/kube-apiserver/.*
           contextual k8s.io/kubernetes/cmd/kube-proxy/.*
           contextual k8s.io/kubernetes/cmd/kube-scheduler/.*
           contextual k8s.io/kubernetes/pkg/controller/.*

--- a/hack/golangci-strict.yaml
+++ b/hack/golangci-strict.yaml
@@ -204,6 +204,7 @@ linters-settings: # please keep this alphabetized
           contextual k8s.io/sample-apiserver/.*
           contextual k8s.io/sample-cli-plugin/.*
           contextual k8s.io/sample-controller/.*
+          contextual k8s.io/kubernetes/cmd/kube-apiserver/.*
           contextual k8s.io/kubernetes/cmd/kube-proxy/.*
           contextual k8s.io/kubernetes/cmd/kube-scheduler/.*
           contextual k8s.io/kubernetes/pkg/controller/.*

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -206,6 +206,7 @@ linters-settings: # please keep this alphabetized
           contextual k8s.io/sample-apiserver/.*
           contextual k8s.io/sample-cli-plugin/.*
           contextual k8s.io/sample-controller/.*
+          contextual k8s.io/kubernetes/cmd/kube-apiserver/.*
           contextual k8s.io/kubernetes/cmd/kube-proxy/.*
           contextual k8s.io/kubernetes/cmd/kube-scheduler/.*
           contextual k8s.io/kubernetes/pkg/controller/.*

--- a/hack/logcheck.conf
+++ b/hack/logcheck.conf
@@ -42,6 +42,7 @@ contextual k8s.io/kube-scheduler/.*
 contextual k8s.io/sample-apiserver/.*
 contextual k8s.io/sample-cli-plugin/.*
 contextual k8s.io/sample-controller/.*
+contextual k8s.io/kubernetes/cmd/kube-apiserver/.*
 contextual k8s.io/kubernetes/cmd/kube-proxy/.*
 contextual k8s.io/kubernetes/cmd/kube-scheduler/.*
 contextual k8s.io/kubernetes/pkg/controller/.*


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
I implemented the support for structured and contextual logging in kube-apiserver, following the guideline:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/migration-to-structured-logging.md

In addition, I've modified the log messages based on the following guideline:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/migration-to-structured-logging.md#remove-string-formatting-from-log-message

I've confirmed that they pass the [logcheck](https://github.com/kubernetes-sigs/logtools/tree/main/logcheck) tests.
You can run logcheck with `make test` or `make logcheck`
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
I've confirm that they pass the logcheck tests.
```
$GOPATH/bin/logcheck -check-contextual ./cmd/kube-apiserver/...
```
```
$GOPATH/bin/logcheck -check-structured ./cmd/kube-apiserver/...
```
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
