### PR TITLE
fix: unnecessary fmt.Sprintf in assertions (pkg/proxier)

### DIFF
--- a/pkg/proxy/ipvs/proxier_test.go
+++ b/pkg/proxy/ipvs/proxier_test.go
@@ -4811,7 +4811,7 @@ func TestTestInternalTrafficPolicyE2E(t *testing.T) {
 			realServers1, rsErr1 := ipvs.GetRealServers(virtualServers1[0])
 			assert.NoError(t, rsErr1, "Expected no error getting real servers")
 
-			assert.Len(t, realServers1, tc.expectLocalRealServerNum, fmt.Sprintf("Expected %d real servers", tc.expectLocalRealServerNum))
+			assert.Lenf(t, realServers1, tc.expectLocalRealServerNum, "Expected %d real servers", tc.expectLocalRealServerNum)
 			for i := 0; i < tc.expectLocalRealServerNum; i++ {
 				assert.Equal(t, realServers1[i].String(), tc.expectLocalRealServers[i])
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/area test
/kind cleanup
/sig testing

#### What this PR does / why we need it:
Code simplification， and unnecessary fmt.Sprintf in assertions