### PR TITLE
kube-controller-manager: Support structured and contextual loging.

### DIFF
--- a/cmd/genkubedocs/gen_kube_docs.go
+++ b/cmd/genkubedocs/gen_kube_docs.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -34,6 +35,7 @@ import (
 )
 
 func main() {
+	ctx := context.Background()
 	// use os.Args instead of "flags" because "flags" will mess up the man pages!
 	path := ""
 	module := ""
@@ -58,7 +60,7 @@ func main() {
 		doc.GenMarkdownTree(apiserver, outDir)
 	case "kube-controller-manager":
 		// generate docs for kube-controller-manager
-		controllermanager := cmapp.NewControllerManagerCommand()
+		controllermanager := cmapp.NewControllerManagerCommand(ctx)
 		doc.GenMarkdownTree(controllermanager, outDir)
 	case "kube-proxy":
 		// generate docs for kube-proxy

--- a/cmd/genman/gen_kube_man.go
+++ b/cmd/genman/gen_kube_man.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -38,6 +39,7 @@ import (
 )
 
 func main() {
+	ctx := context.Background()
 	// use os.Args instead of "flags" because "flags" will mess up the man pages!
 	path := "docs/man/man1"
 	module := ""
@@ -69,7 +71,7 @@ func main() {
 		}
 	case "kube-controller-manager":
 		// generate manpage for kube-controller-manager
-		controllermanager := cmapp.NewControllerManagerCommand()
+		controllermanager := cmapp.NewControllerManagerCommand(ctx)
 		genMarkdown(controllermanager, "", outDir)
 		for _, c := range controllermanager.Commands() {
 			genMarkdown(c, "kube-controller-manager", outDir)

--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -99,7 +99,7 @@ const (
 )
 
 // NewControllerManagerCommand creates a *cobra.Command object with default parameters
-func NewControllerManagerCommand() *cobra.Command {
+func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 	s, err := options.NewKubeControllerManagerOptions()
 	if err != nil {
 		klog.Background().Error(err, "Unable to initialize command options")
@@ -155,7 +155,7 @@ controller, and serviceaccounts controller.`,
 	}
 
 	fs := cmd.Flags()
-	namedFlagSets := s.Flags(KnownControllers(), ControllersDisabledByDefault(), ControllerAliases())
+	namedFlagSets := s.Flags(ctx, KnownControllers(), ControllersDisabledByDefault(), ControllerAliases())
 	verflag.AddFlags(namedFlagSets.FlagSet("global"))
 	globalflag.AddGlobalFlags(namedFlagSets.FlagSet("global"), cmd.Name(), logs.SkipLoggingConfigurationFlags())
 	for _, f := range namedFlagSets.FlagSets {

--- a/cmd/kube-controller-manager/app/options/options.go
+++ b/cmd/kube-controller-manager/app/options/options.go
@@ -18,6 +18,7 @@ limitations under the License.
 package options
 
 import (
+	"context"
 	"fmt"
 	"net"
 
@@ -249,7 +250,8 @@ func NewDefaultComponentConfig() (kubectrlmgrconfig.KubeControllerManagerConfigu
 }
 
 // Flags returns flags for a specific KubeController by section name
-func (s *KubeControllerManagerOptions) Flags(allControllers []string, disabledByDefaultControllers []string, controllerAliases map[string]string) cliflag.NamedFlagSets {
+func (s *KubeControllerManagerOptions) Flags(ctx context.Context, allControllers []string, disabledByDefaultControllers []string, controllerAliases map[string]string) cliflag.NamedFlagSets {
+	logger := klog.FromContext(ctx)
 	fss := cliflag.NamedFlagSets{}
 	s.Generic.AddFlags(&fss, allControllers, disabledByDefaultControllers, controllerAliases)
 	s.KubeCloudShared.AddFlags(fss.FlagSet("generic"))
@@ -298,7 +300,7 @@ func (s *KubeControllerManagerOptions) Flags(allControllers []string, disabledBy
 			// it turns out that there are some integration tests that start multiple control plane components which
 			// share global DefaultFeatureGate/DefaultMutableFeatureGate variables.
 			// in those cases, the above call will fail (FG already registered and cannot be overridden), and the error will be logged.
-			klog.Errorf("unable to set %s feature gate, err: %v", clientgofeaturegate.WatchListClient, err)
+			logger.Error(err, "Unable to set feature gate", "featureGate", clientgofeaturegate.WatchListClient)
 		}
 	}
 

--- a/cmd/kube-controller-manager/app/options/options_test.go
+++ b/cmd/kube-controller-manager/app/options/options_test.go
@@ -50,6 +50,8 @@ import (
 	cmconfig "k8s.io/controller-manager/config"
 	cmoptions "k8s.io/controller-manager/options"
 	migration "k8s.io/controller-manager/pkg/leadermigration/options"
+	"k8s.io/klog/v2/ktesting"
+	_ "k8s.io/klog/v2/ktesting/init"
 	kubecontrollerconfig "k8s.io/kubernetes/cmd/kube-controller-manager/app/config"
 	kubectrlmgrconfig "k8s.io/kubernetes/pkg/controller/apis/config"
 	csrsigningconfig "k8s.io/kubernetes/pkg/controller/certificates/signer/config"
@@ -1469,9 +1471,10 @@ func TestControllerManagerAliases(t *testing.T) {
 }
 
 func TestWatchListClientFlagUsage(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
 	fs := pflag.NewFlagSet("addflagstest", pflag.ContinueOnError)
 	s, _ := NewKubeControllerManagerOptions()
-	for _, f := range s.Flags([]string{""}, []string{""}, nil).FlagSets {
+	for _, f := range s.Flags(ctx, []string{""}, []string{""}, nil).FlagSets {
 		fs.AddFlagSet(f)
 	}
 
@@ -1480,13 +1483,14 @@ func TestWatchListClientFlagUsage(t *testing.T) {
 }
 
 func TestWatchListClientFlagChange(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
 	fs := pflag.NewFlagSet("addflagstest", pflag.ContinueOnError)
 	s, err := NewKubeControllerManagerOptions()
 	if err != nil {
 		t.Fatal(fmt.Errorf("NewKubeControllerManagerOptions failed with %w", err))
 	}
 
-	for _, f := range s.Flags([]string{""}, []string{""}, nil).FlagSets {
+	for _, f := range s.Flags(ctx, []string{""}, []string{""}, nil).FlagSets {
 		fs.AddFlagSet(f)
 	}
 
@@ -1531,6 +1535,7 @@ func assertWatchListCommandLineDefaultValue(t *testing.T, fs *pflag.FlagSet) {
 }
 
 func setupControllerManagerFlagSet(t *testing.T) (*pflag.FlagSet, *KubeControllerManagerOptions) {
+	_, ctx := ktesting.NewTestContext(t)
 	fs := pflag.NewFlagSet("addflagstest", pflag.ContinueOnError)
 	s, err := NewKubeControllerManagerOptions()
 	if err != nil {
@@ -1553,7 +1558,7 @@ func setupControllerManagerFlagSet(t *testing.T) (*pflag.FlagSet, *KubeControlle
 	utilruntime.Must(componentGlobalsRegistry.Register(basecompatibility.DefaultKubeComponent, verKube, fg))
 	s.ComponentGlobalsRegistry = componentGlobalsRegistry
 
-	for _, f := range s.Flags([]string{""}, []string{""}, nil).FlagSets {
+	for _, f := range s.Flags(ctx, []string{""}, []string{""}, nil).FlagSets {
 		fs.AddFlagSet(f)
 	}
 	return fs, s

--- a/cmd/kube-controller-manager/app/testing/testserver.go
+++ b/cmd/kube-controller-manager/app/testing/testserver.go
@@ -97,7 +97,7 @@ func StartTestServer(ctx context.Context, customFlags []string) (result TestServ
 		return TestServer{}, err
 	}
 	all, disabled, aliases := app.KnownControllers(), app.ControllersDisabledByDefault(), app.ControllerAliases()
-	namedFlagSets := s.Flags(all, disabled, aliases)
+	namedFlagSets := s.Flags(ctx, all, disabled, aliases)
 	for _, f := range namedFlagSets.FlagSets {
 		fs.AddFlagSet(f)
 	}

--- a/cmd/kube-controller-manager/controller-manager.go
+++ b/cmd/kube-controller-manager/controller-manager.go
@@ -21,6 +21,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"os"
 	_ "time/tzdata" // for CronJob Time Zone support
 
@@ -32,7 +33,8 @@ import (
 )
 
 func main() {
-	command := app.NewControllerManagerCommand()
+	ctx := context.Background()
+	command := app.NewControllerManagerCommand(ctx)
 	code := cli.Run(command)
 	os.Exit(code)
 }

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -167,6 +167,7 @@ linters-settings: # please keep this alphabetized
           contextual k8s.io/sample-apiserver/.*
           contextual k8s.io/sample-cli-plugin/.*
           contextual k8s.io/sample-controller/.*
+          contextual k8s.io/kubernetes/cmd/kube-controller-manager/.*
           contextual k8s.io/kubernetes/cmd/kube-proxy/.*
           contextual k8s.io/kubernetes/cmd/kube-scheduler/.*
           contextual k8s.io/kubernetes/pkg/controller/.*

--- a/hack/golangci-strict.yaml
+++ b/hack/golangci-strict.yaml
@@ -213,6 +213,7 @@ linters-settings: # please keep this alphabetized
           contextual k8s.io/sample-apiserver/.*
           contextual k8s.io/sample-cli-plugin/.*
           contextual k8s.io/sample-controller/.*
+          contextual k8s.io/kubernetes/cmd/kube-controller-manager/.*
           contextual k8s.io/kubernetes/cmd/kube-proxy/.*
           contextual k8s.io/kubernetes/cmd/kube-scheduler/.*
           contextual k8s.io/kubernetes/pkg/controller/.*

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -215,6 +215,7 @@ linters-settings: # please keep this alphabetized
           contextual k8s.io/sample-apiserver/.*
           contextual k8s.io/sample-cli-plugin/.*
           contextual k8s.io/sample-controller/.*
+          contextual k8s.io/kubernetes/cmd/kube-controller-manager/.*
           contextual k8s.io/kubernetes/cmd/kube-proxy/.*
           contextual k8s.io/kubernetes/cmd/kube-scheduler/.*
           contextual k8s.io/kubernetes/pkg/controller/.*

--- a/hack/logcheck.conf
+++ b/hack/logcheck.conf
@@ -44,6 +44,7 @@ contextual k8s.io/kube-scheduler/.*
 contextual k8s.io/sample-apiserver/.*
 contextual k8s.io/sample-cli-plugin/.*
 contextual k8s.io/sample-controller/.*
+contextual k8s.io/kubernetes/cmd/kube-controller-manager/.*
 contextual k8s.io/kubernetes/cmd/kube-proxy/.*
 contextual k8s.io/kubernetes/cmd/kube-scheduler/.*
 contextual k8s.io/kubernetes/pkg/controller/.*


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
I implemented the support for structured and contextual logging in kube-controller-manager, following the guideline:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/migration-to-structured-logging.md

In addition, I've modified the log messages based on the following guideline:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/migration-to-structured-logging.md#remove-string-formatting-from-log-message

I've confirmed that they pass the [logcheck](https://github.com/kubernetes-sigs/logtools/tree/main/logcheck) tests.
You can run logcheck with `make test` or `make logcheck`


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
I've confirm that they pass the logcheck tests.
```
$GOPATH/bin/logcheck -check-contextual ./cmd/kube-controller-manager/...
```
```
$GOPATH/bin/logcheck -check-structured ./cmd/kube-controller-manager/...
```
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
