### PR TITLE
Wait other finalizers on Foreground deletion

### DIFF
--- a/pkg/controller/garbagecollector/garbagecollector.go
+++ b/pkg/controller/garbagecollector/garbagecollector.go
@@ -472,7 +472,7 @@ func (gc *GarbageCollector) classifyReferences(ctx context.Context, item *node, 
 		if err != nil {
 			return nil, nil, nil, err
 		}
-		if ownerAccessor.GetDeletionTimestamp() != nil && hasDeleteDependentsFinalizer(ownerAccessor) {
+		if ownerAccessor.GetDeletionTimestamp() != nil && hasDeleteDependentsFinalizer(ownerAccessor) && len(ownerAccessor.GetFinalizers()) == 1 {
 			waitingForDependentsDeletion = append(waitingForDependentsDeletion, reference)
 		} else {
 			solid = append(solid, reference)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Background:
Currently Foreground cascading deletion try to delete child object at almost the same time.
Which causing the issue when controlling deletion order between some objects like: https://github.com/kubernetes-sigs/cluster-api/issues/4085
Which is from current behavior is when the parent object has Foreground finalizer, GC controller ignores other finalizers.

From me, it's misunderstanding behavior (looks bug) from the name "Foreground deletion" and should fix to proceed child objects when only Foreground finalizer is existing (=other finalizer is done).


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Foreground cascading deletion waits other finalizers
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
