### PR TITLE
hack: configure Go environments where necessary

### DIFF
--- a/hack/verify-featuregates.sh
+++ b/hack/verify-featuregates.sh
@@ -26,6 +26,8 @@ set -o pipefail
 KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 source "${KUBE_ROOT}/hack/lib/init.sh"
 
+kube::golang::setup_env
+
 cd "${KUBE_ROOT}"
 
 go run test/featuregates_linter/main.go feature-gates verify

--- a/hack/verify-testing-import.sh
+++ b/hack/verify-testing-import.sh
@@ -28,6 +28,8 @@ KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 source "${KUBE_ROOT}/hack/lib/init.sh"
 cd "${KUBE_ROOT}"
 
+kube::golang::setup_env
+
 RELEASE_BIN_PKGS=(
   "${KUBE_ROOT}/cmd/cloud-controller-manager"
   "${KUBE_ROOT}/cmd/kube-apiserver"

--- a/test/conformance/spec-to-yaml.sh
+++ b/test/conformance/spec-to-yaml.sh
@@ -22,5 +22,9 @@ set -o pipefail
 KUBE_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd -P)
 cd "${KUBE_ROOT}"
 
+source "${KUBE_ROOT}/hack/lib/init.sh"
+
+kube::golang::setup_env
+
 # convert dumped spec (see dump-spec.sh) to conformance.yaml
 go run ./test/conformance/walk.go --source="${KUBE_ROOT}" ./_output/specsummaries.json > ./_output/conformance.yaml


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

These scripts rely on the system's default `go`; this changes that using `kube::golang::setup_env` so that the appropriate `go` is used when the system's isn't sufficient.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
