### PR TITLE
[KEP-2400]: Remove the NodeSwap feature gate usages and mark as GA

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -835,15 +835,13 @@ func run(ctx context.Context, s *options.KubeletServer, kubeDeps *kubelet.Depend
 			return fmt.Errorf("topology manager policy options %v require feature gates %q enabled",
 				s.TopologyManagerPolicyOptions, features.TopologyManagerPolicyOptions)
 		}
-		if utilfeature.DefaultFeatureGate.Enabled(features.NodeSwap) {
-			if !isCgroup2UnifiedMode() && s.MemorySwap.SwapBehavior == kubelettypes.LimitedSwap {
-				// This feature is not supported for cgroupv1 so we are failing early.
-				return fmt.Errorf("swap feature is enabled and LimitedSwap but it is only supported with cgroupv2")
-			}
-			if !s.FailSwapOn && s.MemorySwap.SwapBehavior == "" {
-				// This is just a log because we are using a default of NoSwap.
-				klog.InfoS("NoSwap is set due to memorySwapBehavior not specified", "memorySwapBehavior", s.MemorySwap.SwapBehavior, "FailSwapOn", s.FailSwapOn)
-			}
+		if !isCgroup2UnifiedMode() && s.MemorySwap.SwapBehavior == kubelettypes.LimitedSwap {
+			// This feature is not supported for cgroupv1 so we are failing early.
+			return fmt.Errorf("swap feature is enabled and LimitedSwap but it is only supported with cgroupv2")
+		}
+		if !s.FailSwapOn && s.MemorySwap.SwapBehavior == "" {
+			// This is just a log because we are using a default of NoSwap.
+			klog.InfoS("NoSwap is set due to memorySwapBehavior not specified", "memorySwapBehavior", s.MemorySwap.SwapBehavior, "FailSwapOn", s.FailSwapOn)
 		}
 
 		kubeDeps.ContainerManager, err = cm.NewContainerManager(

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -498,6 +498,7 @@ const (
 	// alpha: v1.22
 	// beta1: v1.28 (default=false)
 	// beta2: v.1.30 (default=true)
+	// GA: v1.32
 
 	// Permits kubelet to run with swap enabled.
 	NodeSwap featuregate.Feature = "NodeSwap"

--- a/pkg/features/versioned_kube_features.go
+++ b/pkg/features/versioned_kube_features.go
@@ -469,6 +469,7 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 		{Version: version.MustParse("1.22"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("1.28"), Default: false, PreRelease: featuregate.Beta},
 		{Version: version.MustParse("1.30"), Default: true, PreRelease: featuregate.Beta},
+		{Version: version.MustParse("1.32"), Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.34
 	},
 
 	PDBUnhealthyPodEvictionPolicy: {

--- a/pkg/kubelet/apis/config/validation/validation.go
+++ b/pkg/kubelet/apis/config/validation/validation.go
@@ -190,17 +190,13 @@ func ValidateKubeletConfiguration(kc *kubeletconfig.KubeletConfiguration, featur
 			allErrors = append(allErrors, fmt.Errorf("invalid configuration: Specifying shutdownGracePeriodByPodPriority requires feature gate GracefulNodeShutdownBasedOnPodPriority"))
 		}
 	}
-	if localFeatureGate.Enabled(features.NodeSwap) {
-		switch kc.MemorySwap.SwapBehavior {
-		case "":
-		case kubetypes.NoSwap:
-		case kubetypes.LimitedSwap:
-		default:
-			allErrors = append(allErrors, fmt.Errorf("invalid configuration: memorySwap.swapBehavior %q must be one of: \"\", %q or %q", kc.MemorySwap.SwapBehavior, kubetypes.LimitedSwap, kubetypes.NoSwap))
-		}
-	}
-	if !localFeatureGate.Enabled(features.NodeSwap) && kc.MemorySwap != (kubeletconfig.MemorySwapConfiguration{}) {
-		allErrors = append(allErrors, fmt.Errorf("invalid configuration: memorySwap.swapBehavior cannot be set when NodeSwap feature flag is disabled"))
+
+	switch kc.MemorySwap.SwapBehavior {
+	case "":
+	case kubetypes.NoSwap:
+	case kubetypes.LimitedSwap:
+	default:
+		allErrors = append(allErrors, fmt.Errorf("invalid configuration: memorySwap.swapBehavior %q must be one of: \"\", %q or %q", kc.MemorySwap.SwapBehavior, kubetypes.LimitedSwap, kubetypes.NoSwap))
 	}
 
 	uniqueEnforcements := sets.Set[string]{}

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go
@@ -175,11 +175,6 @@ func (m *kubeGenericRuntimeManager) configureContainerSwapResources(lcr *runtime
 		}
 	}
 
-	if !utilfeature.DefaultFeatureGate.Enabled(kubefeatures.NodeSwap) {
-		swapConfigurationHelper.ConfigureNoSwap(lcr)
-		return
-	}
-
 	if kubelettypes.IsCriticalPod(pod) {
 		swapConfigurationHelper.ConfigureNoSwap(lcr)
 		return

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_linux_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_linux_test.go
@@ -1029,7 +1029,6 @@ func TestGenerateLinuxContainerResourcesWithSwap(t *testing.T) {
 		cgroupVersion               CgroupVersion
 		qosClass                    v1.PodQOSClass
 		swapDisabledOnNode          bool
-		nodeSwapFeatureGateEnabled  bool
 		swapBehavior                string
 		addContainerWithoutRequests bool
 		addGuaranteedContainer      bool
@@ -1037,59 +1036,44 @@ func TestGenerateLinuxContainerResourcesWithSwap(t *testing.T) {
 	}{
 		// With cgroup v1
 		{
-			name:                       "cgroups v1, LimitedSwap, Burstable QoS",
-			cgroupVersion:              cgroupV1,
-			qosClass:                   v1.PodQOSBurstable,
-			nodeSwapFeatureGateEnabled: true,
-			swapBehavior:               types.LimitedSwap,
+			name:          "cgroups v1, LimitedSwap, Burstable QoS",
+			cgroupVersion: cgroupV1,
+			qosClass:      v1.PodQOSBurstable,
+			swapBehavior:  types.LimitedSwap,
 		},
 		{
-			name:                       "cgroups v1, LimitedSwap, Best-effort QoS",
-			cgroupVersion:              cgroupV1,
-			qosClass:                   v1.PodQOSBestEffort,
-			nodeSwapFeatureGateEnabled: true,
-			swapBehavior:               types.LimitedSwap,
-		},
-
-		// With feature gate turned off
-		{
-			name:                       "NodeSwap feature gate turned off, cgroups v2, LimitedSwap",
-			cgroupVersion:              cgroupV2,
-			qosClass:                   v1.PodQOSBurstable,
-			nodeSwapFeatureGateEnabled: false,
-			swapBehavior:               types.LimitedSwap,
+			name:          "cgroups v1, LimitedSwap, Best-effort QoS",
+			cgroupVersion: cgroupV1,
+			qosClass:      v1.PodQOSBestEffort,
+			swapBehavior:  types.LimitedSwap,
 		},
 
 		// With no swapBehavior, NoSwap should be the default
 		{
-			name:                       "With no swapBehavior - NoSwap should be the default",
-			cgroupVersion:              cgroupV2,
-			qosClass:                   v1.PodQOSBestEffort,
-			nodeSwapFeatureGateEnabled: true,
-			swapBehavior:               "",
+			name:          "With no swapBehavior - NoSwap should be the default",
+			cgroupVersion: cgroupV2,
+			qosClass:      v1.PodQOSBestEffort,
+			swapBehavior:  "",
 		},
 
 		// With Guaranteed and Best-effort QoS
 		{
-			name:                       "Best-effort QoS, cgroups v2, NoSwap",
-			cgroupVersion:              cgroupV2,
-			qosClass:                   v1.PodQOSBestEffort,
-			nodeSwapFeatureGateEnabled: true,
-			swapBehavior:               "NoSwap",
+			name:          "Best-effort QoS, cgroups v2, NoSwap",
+			cgroupVersion: cgroupV2,
+			qosClass:      v1.PodQOSBestEffort,
+			swapBehavior:  "NoSwap",
 		},
 		{
-			name:                       "Best-effort QoS, cgroups v2, LimitedSwap",
-			cgroupVersion:              cgroupV2,
-			qosClass:                   v1.PodQOSBurstable,
-			nodeSwapFeatureGateEnabled: true,
-			swapBehavior:               types.LimitedSwap,
+			name:          "Best-effort QoS, cgroups v2, LimitedSwap",
+			cgroupVersion: cgroupV2,
+			qosClass:      v1.PodQOSBurstable,
+			swapBehavior:  types.LimitedSwap,
 		},
 		{
-			name:                       "Guaranteed QoS, cgroups v2, LimitedSwap",
-			cgroupVersion:              cgroupV2,
-			qosClass:                   v1.PodQOSGuaranteed,
-			nodeSwapFeatureGateEnabled: true,
-			swapBehavior:               types.LimitedSwap,
+			name:          "Guaranteed QoS, cgroups v2, LimitedSwap",
+			cgroupVersion: cgroupV2,
+			qosClass:      v1.PodQOSGuaranteed,
+			swapBehavior:  types.LimitedSwap,
 		},
 
 		// With a "guaranteed" container (when memory requests equal to limits)
@@ -1097,7 +1081,6 @@ func TestGenerateLinuxContainerResourcesWithSwap(t *testing.T) {
 			name:                        "Burstable QoS, cgroups v2, LimitedSwap, with a guaranteed container",
 			cgroupVersion:               cgroupV2,
 			qosClass:                    v1.PodQOSBurstable,
-			nodeSwapFeatureGateEnabled:  true,
 			swapBehavior:                types.LimitedSwap,
 			addContainerWithoutRequests: false,
 			addGuaranteedContainer:      true,
@@ -1108,7 +1091,6 @@ func TestGenerateLinuxContainerResourcesWithSwap(t *testing.T) {
 			name:                        "Burstable QoS, cgroups v2, LimitedSwap",
 			cgroupVersion:               cgroupV2,
 			qosClass:                    v1.PodQOSBurstable,
-			nodeSwapFeatureGateEnabled:  true,
 			swapBehavior:                types.LimitedSwap,
 			addContainerWithoutRequests: false,
 			addGuaranteedContainer:      false,
@@ -1117,65 +1099,49 @@ func TestGenerateLinuxContainerResourcesWithSwap(t *testing.T) {
 			name:                        "Burstable QoS, cgroups v2, LimitedSwap, with a container with no requests",
 			cgroupVersion:               cgroupV2,
 			qosClass:                    v1.PodQOSBurstable,
-			nodeSwapFeatureGateEnabled:  true,
 			swapBehavior:                types.LimitedSwap,
 			addContainerWithoutRequests: true,
 			addGuaranteedContainer:      false,
 		},
 		// All the above examples with Swap disabled on node
 		{
-			name:                       "Swap disabled on node, cgroups v1, LimitedSwap, Burstable QoS",
-			swapDisabledOnNode:         true,
-			cgroupVersion:              cgroupV1,
-			qosClass:                   v1.PodQOSBurstable,
-			nodeSwapFeatureGateEnabled: true,
-			swapBehavior:               types.LimitedSwap,
+			name:               "Swap disabled on node, cgroups v1, LimitedSwap, Burstable QoS",
+			swapDisabledOnNode: true,
+			cgroupVersion:      cgroupV1,
+			qosClass:           v1.PodQOSBurstable,
+			swapBehavior:       types.LimitedSwap,
 		},
 		{
-			name:                       "Swap disabled on node, cgroups v1, LimitedSwap, Best-effort QoS",
-			swapDisabledOnNode:         true,
-			cgroupVersion:              cgroupV1,
-			qosClass:                   v1.PodQOSBestEffort,
-			nodeSwapFeatureGateEnabled: true,
-			swapBehavior:               types.LimitedSwap,
-		},
-
-		// With feature gate turned off
-		{
-			name:                       "Swap disabled on node, NodeSwap feature gate turned off, cgroups v2, LimitedSwap",
-			swapDisabledOnNode:         true,
-			cgroupVersion:              cgroupV2,
-			qosClass:                   v1.PodQOSBurstable,
-			nodeSwapFeatureGateEnabled: false,
-			swapBehavior:               types.LimitedSwap,
+			name:               "Swap disabled on node, cgroups v1, LimitedSwap, Best-effort QoS",
+			swapDisabledOnNode: true,
+			cgroupVersion:      cgroupV1,
+			qosClass:           v1.PodQOSBestEffort,
+			swapBehavior:       types.LimitedSwap,
 		},
 
 		// With no swapBehavior, NoSwap should be the default
 		{
-			name:                       "Swap disabled on node, With no swapBehavior - NoSwap should be the default",
-			swapDisabledOnNode:         true,
-			cgroupVersion:              cgroupV2,
-			qosClass:                   v1.PodQOSBestEffort,
-			nodeSwapFeatureGateEnabled: true,
-			swapBehavior:               "",
+			name:               "Swap disabled on node, With no swapBehavior - NoSwap should be the default",
+			swapDisabledOnNode: true,
+			cgroupVersion:      cgroupV2,
+			qosClass:           v1.PodQOSBestEffort,
+			swapBehavior:       "",
 		},
 
 		// With Guaranteed and Best-effort QoS
 		{
-			name:                       "Swap disabled on node, Best-effort QoS, cgroups v2, LimitedSwap",
-			swapDisabledOnNode:         true,
-			cgroupVersion:              cgroupV2,
-			qosClass:                   v1.PodQOSBurstable,
-			nodeSwapFeatureGateEnabled: true,
-			swapBehavior:               types.LimitedSwap,
+			name:               "Swap disabled on node, Best-effort QoS, cgroups v2, LimitedSwap",
+			swapDisabledOnNode: true,
+			cgroupVersion:      cgroupV2,
+			qosClass:           v1.PodQOSBurstable,
+			swapBehavior:       types.LimitedSwap,
 		},
 		{
-			name:                       "Swap disabled on node, Guaranteed QoS, cgroups v2, LimitedSwap",
-			swapDisabledOnNode:         true,
-			cgroupVersion:              cgroupV2,
-			qosClass:                   v1.PodQOSGuaranteed,
-			nodeSwapFeatureGateEnabled: true,
-			swapBehavior:               types.LimitedSwap,
+			name:               "Swap disabled on node, Guaranteed QoS, cgroups v2, LimitedSwap",
+			swapDisabledOnNode: true,
+			cgroupVersion:      cgroupV2,
+			qosClass:           v1.PodQOSGuaranteed,
+			swapBehavior:       types.LimitedSwap,
 		},
 
 		// With a "guaranteed" container (when memory requests equal to limits)
@@ -1184,7 +1150,6 @@ func TestGenerateLinuxContainerResourcesWithSwap(t *testing.T) {
 			swapDisabledOnNode:          true,
 			cgroupVersion:               cgroupV2,
 			qosClass:                    v1.PodQOSBurstable,
-			nodeSwapFeatureGateEnabled:  true,
 			swapBehavior:                types.LimitedSwap,
 			addContainerWithoutRequests: false,
 			addGuaranteedContainer:      true,
@@ -1196,7 +1161,6 @@ func TestGenerateLinuxContainerResourcesWithSwap(t *testing.T) {
 			swapDisabledOnNode:          true,
 			cgroupVersion:               cgroupV2,
 			qosClass:                    v1.PodQOSBurstable,
-			nodeSwapFeatureGateEnabled:  true,
 			swapBehavior:                types.LimitedSwap,
 			addContainerWithoutRequests: false,
 			addGuaranteedContainer:      false,
@@ -1206,7 +1170,6 @@ func TestGenerateLinuxContainerResourcesWithSwap(t *testing.T) {
 			swapDisabledOnNode:          true,
 			cgroupVersion:               cgroupV2,
 			qosClass:                    v1.PodQOSBurstable,
-			nodeSwapFeatureGateEnabled:  true,
 			swapBehavior:                types.LimitedSwap,
 			addContainerWithoutRequests: true,
 			addGuaranteedContainer:      false,
@@ -1214,18 +1177,16 @@ func TestGenerateLinuxContainerResourcesWithSwap(t *testing.T) {
 
 		// When the pod is considered critical, disallow swap access
 		{
-			name:                       "Best-effort QoS, cgroups v2, LimitedSwap, critical pod",
-			cgroupVersion:              cgroupV2,
-			qosClass:                   v1.PodQOSBurstable,
-			nodeSwapFeatureGateEnabled: true,
-			swapBehavior:               types.LimitedSwap,
-			isCriticalPod:              true,
+			name:          "Best-effort QoS, cgroups v2, LimitedSwap, critical pod",
+			cgroupVersion: cgroupV2,
+			qosClass:      v1.PodQOSBurstable,
+			swapBehavior:  types.LimitedSwap,
+			isCriticalPod: true,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			setCgroupVersionDuringTest(tc.cgroupVersion)
 			defer setSwapControllerAvailableDuringTest(!tc.swapDisabledOnNode)()
-			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.NodeSwap, tc.nodeSwapFeatureGateEnabled)
 			m.memorySwapBehavior = tc.swapBehavior
 
 			var resourceReqsC1, resourceReqsC2 v1.ResourceRequirements

--- a/test/e2e_node/swap_test.go
+++ b/test/e2e_node/swap_test.go
@@ -37,7 +37,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
-	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/types"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
@@ -60,10 +59,6 @@ var _ = SIGDescribe("Swap", "[LinuxOnly]", nodefeature.Swap, framework.WithSeria
 	f := framework.NewDefaultFramework("swap-qos")
 	addAfterEachForCleaningUpPods(f)
 	f.NamespacePodSecurityLevel = admissionapi.LevelBaseline
-
-	ginkgo.BeforeEach(func() {
-		gomega.Expect(isSwapFeatureGateEnabled()).To(gomega.BeTrueBecause("NodeSwap feature should be on"))
-	})
 
 	f.Context(framework.WithNodeConformance(), func() {
 
@@ -384,11 +379,6 @@ func runPodAndWaitUntilScheduled(f *framework.Framework, pod *v1.Pod) *v1.Pod {
 	gomega.ExpectWithOffset(1, isReady).To(gomega.BeTrueBecause("pod %+v was expected to be ready", pod))
 
 	return pod
-}
-
-func isSwapFeatureGateEnabled() bool {
-	ginkgo.By("figuring if NodeSwap feature gate is turned on")
-	return e2eskipper.IsFeatureGateEnabled(features.NodeSwap)
 }
 
 func isPodCgroupV2(f *framework.Framework, pod *v1.Pod) bool {


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Removes the NodeSwap feature gate usages and mark it as GA.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/2400-node-swap/README.md
```
