### PR TITLE
Ensure consistent UTC handling for CronJob scheduling

### DIFF
--- a/pkg/controller/cronjob/utils.go
+++ b/pkg/controller/cronjob/utils.go
@@ -100,7 +100,11 @@ func deleteFromActiveList(cj *batchv1.CronJob, uid types.UID) {
 //   - error in an edge case where the schedule specification is grammatically correct,
 //     but logically doesn't make sense (31st day for months with only 30 days, for example).
 func mostRecentScheduleTime(cj *batchv1.CronJob, now time.Time, schedule cron.Schedule, includeStartingDeadlineSeconds bool) (time.Time, *time.Time, missedSchedulesType, error) {
-	earliestTime := cj.ObjectMeta.CreationTimestamp.Time
+    // Convert 'now' to UTC to ensure consistent time comparisons
+    now = now.UTC()
+    earliestTime := cj.ObjectMeta.CreationTimestamp.Time
+	// Convert 'earliestTime' to UTC to match 'now' and 'schedule' time zones
+    earliestTime = earliestTime.UTC()
 	missedSchedules := noneMissed
 	if cj.Status.LastScheduleTime != nil {
 		earliestTime = cj.Status.LastScheduleTime.Time


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR fixes a bug in the CronJob controller where the time calculations for scheduling jobs do not account for time zone differences, potentially causing jobs to be scheduled at incorrect times.

The issue occurs in the mostRecentScheduleTime function, where the now and earliestTime variables are in the local time zone (e.g., KST), but the cron.Schedule object interprets times in UTC. This mismatch can lead to incorrect calculations of missed schedules and cause CronJobs to start jobs earlier or later than intended.

By converting now and earliestTime to UTC before performing time comparisons and calculations, we ensure that all time values are in the same time zone, which fixes the scheduling discrepancies.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #127678 

#### Special notes for your reviewer:
- This change ensures consistent time zone handling within the CronJob controller by converting now and earliestTime to UTC
- It addresses scenarios where the controller might incorrectly determine that there are missed schedules due to time zone discrepancies.
- I can't be entirely sure if this change will resolve the issue I'm currently facing, but I believe it to be a meaningful fix.

I would appreciate your thoughts on this.


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
