### PR TITLE
fix: apply usestdlibvars linter with golangci strict and hints

### DIFF
--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -92,6 +92,7 @@ linters:
     - stylecheck
     - testifylint
     - unused
+    - usestdlibvars
 
 linters-settings: # please keep this alphabetized
   custom:

--- a/hack/golangci-strict.yaml
+++ b/hack/golangci-strict.yaml
@@ -135,6 +135,7 @@ linters:
     - stylecheck
     - testifylint
     - unused
+    - usestdlibvars
   disable:
     # https://github.com/kubernetes/kubernetes/issues/117288#issuecomment-1507008359
     - errcheck

--- a/hack/golangci.yaml.in
+++ b/hack/golangci.yaml.in
@@ -150,6 +150,9 @@ linters:
     - stylecheck
     - testifylint
     - unused
+  {{- if not .Base }}
+    - usestdlibvars
+  {{- end}}
   {{- if .Strict}}
   disable:
     # https://github.com/kubernetes/kubernetes/issues/117288#issuecomment-1507008359


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/priority backlog
/sig testing

#### What this PR does / why we need it:

`usestdlibvars` is a linter that detect the possibility to use variables/constants from the Go standard library.

This applies usestdlibvars linter with golangci strict and hints.

By default, it will force the use of `http.MethodXX` and `http.StatusXX` instead of there plain text value.

<!--
Signed-off-by: Matthieu MOREL <matthieu.morel35@gmail.com>
-->