### PR TITLE
Automated cherry pick of #123233: Fix daemonset to ensure old unhealthy pods are counted

### DIFF
--- a/pkg/controller/daemon/update.go
+++ b/pkg/controller/daemon/update.go
@@ -99,6 +99,7 @@ func (dsc *DaemonSetsController) rollingUpdate(ctx context.Context, ds *apps.Dae
 						allowedReplacementPods = make([]string, 0, len(nodeToDaemonPods))
 					}
 					allowedReplacementPods = append(allowedReplacementPods, oldPod.Name)
+					numUnavailable++
 				case numUnavailable >= maxUnavailable:
 					// no point considering any other candidates
 					continue


### PR DESCRIPTION
Cherry pick of #123233 on release-1.29.

#123233: Fix daemonset to ensure old unhealthy pods are counted

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Ensure daemonset controller to count old unhealthy pods towards max unavailable budget
```