### PR TITLE
Print tested command only once

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -585,7 +585,9 @@ func StartCmdAndStreamOutput(cmd *exec.Cmd) (stdout, stderr io.ReadCloser, err e
 	if err != nil {
 		return
 	}
-	Logf("Asynchronously running '%s %s'", cmd.Path, strings.Join(cmd.Args, " "))
+	// cmd.Args contains command itself as 0th argument, so it's sufficient to
+	// print 1st and latter arguments
+	Logf("Asynchronously running '%s %s'", cmd.Path, strings.Join(cmd.Args[1:], " "))
 	err = cmd.Start()
 	return
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/sig testing

#### What this PR does / why we need it:
I've noticed this when trying to change the command under tests, when I passed `--kubectl-path=$(pwd)/_output/local/bin/linux/amd64/kubectl` I got:
```
Asynchronously running '/home/user/workspace/k8s/src/k8s.io/kubernetes/_output/local/bin/linux/amd64/kubectl - /home/user/workspace/k8s/src/k8s.io/kubernetes/_output/local/bin/linux/amd64/kubectl ...
```
as pointed above the path to `kubectl` is printed twice, that's because `cmd.Args` as the first argument has the actual executed binary. 

This PR, leave the full path, to show which kubectl we are running during tests, but skips the first argument, which usually is just `kubectl`, but in case like the one described above duplicates pretty long path.

#### Special notes for your reviewer:
/assign @pohly 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
