### PR TITLE
Fix deleted UDP endpoint detection

### DIFF
--- a/pkg/proxy/endpointschangetracker.go
+++ b/pkg/proxy/endpointschangetracker.go
@@ -308,7 +308,8 @@ func detectStaleConntrackEntries(oldEndpointsMap, newEndpointsMap EndpointsMap, 
 			// serving to not serving. If it did change stale entries for the old
 			// endpoint have to be cleared.
 			for i := range newEndpointsMap[svcPortName] {
-				if newEndpointsMap[svcPortName][i].String() == ep.String() {
+				if newEndpointsMap[svcPortName][i].String() == ep.String() &&
+					newEndpointsMap[svcPortName][i].IsServing() == ep.IsServing() {
 					deleted = false
 					break
 				}


### PR DESCRIPTION
#### What this PR does / why we need it:
Stale UDP endpoint detection got broken in 1.29 as part of #119394; I [incorrectly argued](https://github.com/kubernetes/kubernetes/pull/119394#discussion_r1313364450) that we could remove an `IsServing()` check, which had the result that now when a UDP endpoint goes from Serving to not-Serving we don't delete the conntrack entry for it. (We only do so if it goes directly from Serving to non-existent.)

(I'm not sure what I was thinking in the linked comment, but the endpoints maps obviously contain non-serving endpoints, since there wouldn't be any point in having the `IsServing` method if they didn't.)

#### Which issue(s) this PR fixes:
Fixes #125467
(which was merged into the larger-scope conntrack cleanup rewrite bug, but this part of it can be fixed and backported separately)

#### Does this PR introduce a user-facing change?
```release-note
Fixes a regression introduced in 1.29 where conntrack entries for UDP connections
to deleted pods did not get cleaned up correctly, which could (among other things)
cause DNS problems when DNS pods were restarted.
```

/kind bug
/kind regression
/sig network
/priority important-soon
/triage accepted
/assign @aojea @aroradaman 