### PR TITLE
Fix Storage e2e test `should assign default SC to PVCs that have no SC set`

### DIFF
--- a/test/e2e/storage/pvc_storageclass.go
+++ b/test/e2e/storage/pvc_storageclass.go
@@ -18,172 +18,152 @@ package storage
 
 import (
 	"context"
-	"fmt"
 	"time"
+
+	"k8s.io/klog/v2"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
-
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	storageutil "k8s.io/kubernetes/pkg/apis/storage/util"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2epv "k8s.io/kubernetes/test/e2e/framework/pv"
-	"k8s.io/kubernetes/test/e2e/storage/testsuites"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
 	admissionapi "k8s.io/pod-security-admission/api"
 )
 
-var _ = utils.SIGDescribe("Persistent Volume Claim and StorageClass", func() {
-	f := framework.NewDefaultFramework("pvc-retroactive-storageclass")
+var _ = utils.SIGDescribe("Retroactive StorageClass Assignment", func() {
+	f := framework.NewDefaultFramework("retroactive-storageclass")
 	f.NamespacePodSecurityLevel = admissionapi.LevelBaseline
 
 	var (
 		client    clientset.Interface
 		namespace string
-		prefixPVC string
-		prefixSC  string
-		t         testsuites.StorageClassTest
-		pvc       *v1.PersistentVolumeClaim
-		err       error
 	)
 
 	ginkgo.BeforeEach(func() {
 		client = f.ClientSet
 		namespace = f.Namespace.Name
-		prefixPVC = "retro-pvc-"
-		prefixSC = "retro"
-		t = testsuites.StorageClassTest{
-			Timeouts:  f.Timeouts,
-			ClaimSize: "1Gi",
-		}
 	})
 
-	f.Describe("Retroactive StorageClass assignment", framework.WithSerial(), framework.WithDisruptive(), func() {
-		ginkgo.It("should assign default SC to PVCs that have no SC set", func(ctx context.Context) {
+	f.It("should assign default StorageClass to PVCs retroactively", f.WithDisruptive(), f.WithSerial(), func(ctx context.Context) {
+		defaultSCs, err := getDefaultStorageClasses(ctx, client)
+		framework.ExpectNoError(err, "Failed to get default StorageClasses")
 
-			// Temporarily set all default storage classes as non-default
-			restoreClasses := temporarilyUnsetDefaultClasses(ctx, client)
-			defer restoreClasses()
-
-			// Create PVC with nil SC
-			pvcObj := e2epv.MakePersistentVolumeClaim(e2epv.PersistentVolumeClaimConfig{
-				NamePrefix: prefixPVC,
-				ClaimSize:  t.ClaimSize,
-				VolumeMode: &t.VolumeMode,
-			}, namespace)
-			pvc, err = client.CoreV1().PersistentVolumeClaims(pvcObj.Namespace).Create(ctx, pvcObj, metav1.CreateOptions{})
-			framework.ExpectNoError(err, "Error creating PVC")
-			defer func(pvc *v1.PersistentVolumeClaim) {
-				// Remove test PVC
-				err := client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Delete(ctx, pvc.Name, metav1.DeleteOptions{})
-				framework.ExpectNoError(err, "Error cleaning up PVC")
-			}(pvc)
-
-			// Create custom default SC
-			storageClass := testsuites.SetupStorageClass(ctx, client, makeStorageClass(prefixSC))
-
-			// Wait for PVC to get updated with the new default SC
-			pvc, err = waitForPVCStorageClass(ctx, client, namespace, pvc.Name, storageClass.Name, f.Timeouts.ClaimBound)
-			framework.ExpectNoError(err, "Error updating PVC with the correct storage class")
-
-			// Create PV with specific class
-			pv := e2epv.MakePersistentVolume(e2epv.PersistentVolumeConfig{
-				NamePrefix:       "pv-",
-				StorageClassName: storageClass.Name,
-				VolumeMode:       pvc.Spec.VolumeMode,
-				PVSource: v1.PersistentVolumeSource{
-					HostPath: &v1.HostPathVolumeSource{
-						Path: "/tmp/test",
-					},
-				},
-			})
-			_, err = e2epv.CreatePV(ctx, client, f.Timeouts, pv)
-			framework.ExpectNoError(err, "Error creating pv %v", err)
-			ginkgo.DeferCleanup(e2epv.DeletePersistentVolume, client, pv.Name)
-
-			// Verify the PVC is bound and has the new default SC
-			claimNames := []string{pvc.Name}
-			err = e2epv.WaitForPersistentVolumeClaimsPhase(ctx, v1.ClaimBound, client, namespace, claimNames, 2*time.Second /* Poll */, t.Timeouts.ClaimProvisionShort, false)
-			framework.ExpectNoError(err)
-			updatedPVC, err := client.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, pvc.Name, metav1.GetOptions{})
-			framework.ExpectNoError(err)
-			gomega.Expect(*updatedPVC.Spec.StorageClassName).To(gomega.Equal(storageClass.Name), "Expected PVC %v to have StorageClass %v, but it has StorageClass %v instead", updatedPVC.Name, prefixSC, updatedPVC.Spec.StorageClassName)
-			framework.Logf("Success - PersistentVolumeClaim %s got updated retroactively with StorageClass %v", updatedPVC.Name, storageClass.Name)
+		ginkgo.DeferCleanup(func(cleanupContext context.Context) {
+			// Restore existing default StorageClasses at the end of the test
+			for _, sc := range defaultSCs {
+				setStorageClassDefault(cleanupContext, client, sc.Name, "true")
+			}
 		})
+
+		// Unset all default StorageClasses
+		for _, sc := range defaultSCs {
+			klog.InfoS("Unsetting default StorageClass", "StorageClass", sc.Name)
+			setStorageClassDefault(ctx, client, sc.Name, "false")
+		}
+
+		// Ensure no default StorageClasses exist
+		if len(defaultSCs) > 0 {
+			ensureNoDefaultStorageClasses(ctx, client)
+		}
+
+		// Create a PVC with nil StorageClass
+		pvc := createPVC(ctx, client, namespace)
+		ginkgo.DeferCleanup(func(cleanupContext context.Context) {
+			err := client.CoreV1().PersistentVolumeClaims(namespace).Delete(ctx, pvc.Name, *metav1.NewDeleteOptions(0))
+			framework.ExpectNoError(err, "Error deleting PVC")
+		})
+
+		// Create a default StorageClass
+		sc := createDefaultStorageClass(ctx, client)
+		ginkgo.DeferCleanup(func(cleanupContext context.Context) {
+			deleteStorageClass(cleanupContext, client, sc.Name)
+		})
+
+		// Verify that the PVC is assigned the default StorageClass
+		gomega.Eventually(ctx, framework.GetObject(client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get, pvc.Name, metav1.GetOptions{})).
+			WithPolling(framework.Poll).
+			WithTimeout(2*time.Minute).
+			Should(gomega.HaveField("Spec.StorageClassName", gomega.Equal(&sc.Name)),
+				"failed to wait for PVC to have the storageclass %s", sc.Name)
 	})
 })
 
-func makeStorageClass(prefixSC string) *storagev1.StorageClass {
-	return &storagev1.StorageClass{
+func getDefaultStorageClasses(ctx context.Context, client clientset.Interface) ([]storagev1.StorageClass, error) {
+	scList, err := client.StorageV1().StorageClasses().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	var defaultSCs []storagev1.StorageClass
+	for _, sc := range scList.Items {
+		if sc.Annotations[storageutil.IsDefaultStorageClassAnnotation] == "true" {
+			defaultSCs = append(defaultSCs, sc)
+		}
+	}
+	return defaultSCs, nil
+}
+
+func setStorageClassDefault(ctx context.Context, client clientset.Interface, scName string, isDefault string) {
+	sc, err := client.StorageV1().StorageClasses().Get(ctx, scName, metav1.GetOptions{})
+	framework.ExpectNoError(err, "Error getting StorageClass")
+
+	if sc.Annotations == nil {
+		sc.Annotations = make(map[string]string)
+	}
+	sc.Annotations[storageutil.IsDefaultStorageClassAnnotation] = isDefault
+
+	_, err = client.StorageV1().StorageClasses().Update(ctx, sc, metav1.UpdateOptions{})
+	framework.ExpectNoError(err, "Error updating StorageClass")
+}
+
+func ensureNoDefaultStorageClasses(ctx context.Context, client clientset.Interface) {
+	gomega.Eventually(ctx, func() (int, error) {
+		defaultSCs, err := getDefaultStorageClasses(ctx, client)
+		if err != nil {
+			return 0, err
+		}
+		return len(defaultSCs), nil
+	}).WithPolling(framework.Poll).WithTimeout(2*time.Minute).
+		Should(gomega.BeZero(), "Expected no default StorageClasses")
+}
+
+func createPVC(ctx context.Context, client clientset.Interface, namespace string) *v1.PersistentVolumeClaim {
+	ginkgo.By("Creating a PVC")
+
+	c := e2epv.PersistentVolumeClaimConfig{
+		Name: "test-pvc",
+	}
+
+	pvcObj := e2epv.MakePersistentVolumeClaim(c, namespace)
+	pvc, err := client.CoreV1().PersistentVolumeClaims(pvcObj.Namespace).Create(ctx, pvcObj, metav1.CreateOptions{})
+	framework.ExpectNoError(err, "Error creating PVC")
+
+	return pvc
+}
+
+func createDefaultStorageClass(ctx context.Context, client clientset.Interface) *storagev1.StorageClass {
+	ginkgo.By("Creating a default StorageClass")
+
+	c := &storagev1.StorageClass{
 		TypeMeta: metav1.TypeMeta{
 			Kind: "StorageClass",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: prefixSC,
+			Name: "test-default-sc",
 			Annotations: map[string]string{
 				storageutil.IsDefaultStorageClassAnnotation: "true",
 			},
 		},
 		Provisioner: "fake-1",
 	}
-}
 
-func temporarilyUnsetDefaultClasses(ctx context.Context, client clientset.Interface) func() {
-	classes, err := client.StorageV1().StorageClasses().List(ctx, metav1.ListOptions{})
-	framework.ExpectNoError(err)
+	sc, err := client.StorageV1().StorageClasses().Create(ctx, c, metav1.CreateOptions{})
+	framework.ExpectNoError(err, "Error creating StorageClass")
 
-	changedClasses := make(map[string]bool)
-
-	for _, sc := range classes.Items {
-		if sc.Annotations[storageutil.IsDefaultStorageClassAnnotation] == "true" {
-			changedClasses[sc.GetName()] = true
-			sc.Annotations[storageutil.IsDefaultStorageClassAnnotation] = "false"
-			_, err := client.StorageV1().StorageClasses().Update(ctx, &sc, metav1.UpdateOptions{})
-			framework.ExpectNoError(err)
-		}
-	}
-
-	return func() {
-		classes, err = client.StorageV1().StorageClasses().List(ctx, metav1.ListOptions{})
-		framework.ExpectNoError(err)
-		for _, sc := range classes.Items {
-			if _, found := changedClasses[sc.GetName()]; found {
-				sc.Annotations[storageutil.IsDefaultStorageClassAnnotation] = "true"
-				_, err := client.StorageV1().StorageClasses().Update(ctx, &sc, metav1.UpdateOptions{})
-				framework.ExpectNoError(err)
-			}
-		}
-	}
-
-}
-
-func waitForPVCStorageClass(ctx context.Context, c clientset.Interface, namespace, pvcName, scName string, timeout time.Duration) (*v1.PersistentVolumeClaim, error) {
-	var watchedPVC *v1.PersistentVolumeClaim
-
-	err := wait.PollUntilContextTimeout(ctx, 1*time.Second, timeout, false, func(ctx context.Context) (bool, error) {
-		var err error
-		watchedPVC, err = c.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, pvcName, metav1.GetOptions{})
-		if err != nil {
-			return true, err
-		}
-
-		if watchedPVC.Spec.StorageClassName == nil {
-			return false, nil // Poll until PVC has correct SC
-		}
-		if watchedPVC.Spec.StorageClassName != nil && *watchedPVC.Spec.StorageClassName != scName {
-			framework.Logf("PersistentVolumeClaim %s has unexpected StorageClass %v, expected StorageClass is: %v", watchedPVC.Name, *watchedPVC.Spec.StorageClassName, scName)
-			return false, nil // Log unexpected SC and continue poll (something might be changing default SC)
-		}
-		return true, nil // Correct SC name found on PVC
-	})
-
-	if err != nil {
-		return watchedPVC, fmt.Errorf("error waiting for claim %s to have StorageClass set to %s: %w", pvcName, scName, err)
-	}
-
-	return watchedPVC, nil
+	return sc
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug
/kind failing-test


#### What this PR does / why we need it:

This PR fixes a failing storage e2e test and generally improves the maintainability of this code path. 

The existing implementation is prone to race conditions and flakes quite often. Specifically, the following is problematic: https://github.com/kubernetes/kubernetes/blob/005f184ab631e52195ed6d129969ff3914d51c98/test/e2e/storage/pvc_storageclass.go#L68-L70 the test should unset default StorageClasses *before* creating a PVC/PV. However, the existing logic is incorrectly under a `defer` and this results in a default StorageClass being available at a point in time where the test expects there to be no default StorageClasses.

See the linked issue for more context.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes  https://github.com/kubernetes/kubernetes/issues/126829

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
N/A
```