### PR TITLE
Fix bug in Makefile example for running integration tests

### DIFF
--- a/build/root/Makefile
+++ b/build/root/Makefile
@@ -203,7 +203,7 @@ define TEST_IT_HELP_INFO
 # Example:
 #   make test-integration
 #   make test-integration WHAT=./test/integration/kubelet GOFLAGS="-v -coverpkg=./pkg/kubelet/..." KUBE_COVER="y"
-#   make test-integration WHAT=./test/integration/pods GOFLAGS="-v" KUBE_TEST_ARGS='-run ^TestPodUpdateActiveDeadlineSeconds$$'
+#   make test-integration WHAT=./test/integration/pods GOFLAGS="-v" KUBE_TEST_ARGS='-run ^TestPodUpdateActiveDeadlineSeconds$'
 endef
 .PHONY: test-integration
 ifeq ($(PRINT_HELP),y)


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

Fix a bug in the example Makefile command to run a particular integration test. There's an extra `$` in the regex causing it to not match any tests.

A single `$` character should be used in a regular expression to assert the match must occur at the end of a string or just before a newline (e.g. `abc$` will match `abc` but not `abc123`).

In the example in the Makefile, there's a `$` characters are used, so the first $ is treated as a literal character, causing the expression not match any integration test.

#### Which issue(s) this PR fixes:


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```