### PR TITLE
fix: enable formatter.require-f-funcs from `testifylint`

### DIFF
--- a/cluster/gce/gci/audit_policy_test.go
+++ b/cluster/gce/gci/audit_policy_test.go
@@ -41,7 +41,7 @@ func init() {
 
 func TestCreateMasterAuditPolicy(t *testing.T) {
 	baseDir, err := os.MkdirTemp("", "configure-helper-test") // cleaned up by c.tearDown()
-	require.NoError(t, err, "Failed to create temp directory")
+	require.NoErrorf(t, err, "Failed to create temp directory")
 
 	policyFile := filepath.Join(baseDir, "audit_policy.yaml")
 	c := ManifestTestCase{
@@ -60,7 +60,7 @@ func TestCreateMasterAuditPolicy(t *testing.T) {
 	)
 
 	policy, err := auditpolicy.LoadPolicyFromFile(policyFile)
-	require.NoError(t, err, "Failed to load generated policy.")
+	require.NoErrorf(t, err, "Failed to load generated policy.")
 
 	// Users for test cases
 	var (
@@ -181,9 +181,9 @@ func (t *auditTester) testResources(level audit.Level, usrVerbRes ...interface{}
 			t.Fatalf("Invalid test argument: %+v", arg)
 		}
 	}
-	require.NotEmpty(t, verbs, "testcases must have a verb")
-	require.NotEmpty(t, users, "testcases must have a user")
-	require.NotEmpty(t, resources, "resource testcases must have a resource")
+	require.NotEmptyf(t, verbs, "testcases must have a verb")
+	require.NotEmptyf(t, users, "testcases must have a user")
+	require.NotEmptyf(t, resources, "resource testcases must have a resource")
 
 	for _, usr := range users {
 		for _, verb := range verbs {

--- a/cmd/gotemplate/gotemplate_test.go
+++ b/cmd/gotemplate/gotemplate_test.go
@@ -59,15 +59,15 @@ func TestGenerate(t *testing.T) {
 			tmp := t.TempDir()
 			for fileName, fileContent := range tt.files {
 				err := os.WriteFile(path.Join(tmp, fileName), []byte(fileContent), 0666)
-				require.NoError(t, err, "create input file")
+				require.NoErrorf(t, err, "create input file")
 			}
 			defer os.Chdir(cwd)
-			require.NoError(t, os.Chdir(tmp), "change into tmp directory")
+			require.NoErrorf(t, os.Chdir(tmp), "change into tmp directory")
 			in := strings.NewReader(tt.in)
 			var out bytes.Buffer
 			err := generate(in, &out, tt.data)
 			if tt.expectedErr == "" {
-				require.NoError(t, err, "expand template")
+				require.NoErrorf(t, err, "expand template")
 				require.Equal(t, tt.expected, out.String())
 			} else {
 				require.ErrorContains(t, err, tt.expectedErr)

--- a/cmd/kube-scheduler/app/options/options_test.go
+++ b/cmd/kube-scheduler/app/options/options_test.go
@@ -936,7 +936,7 @@ profiles:
 						assert.ErrorContains(t, err, tc.expectedError)
 					}
 					if tc.checkErrFn != nil {
-						assert.True(t, tc.checkErrFn(err), "got error: %v", err)
+						assert.Truef(t, tc.checkErrFn(err), "got error: %v", err)
 					}
 					return
 				}

--- a/cmd/kubeadm/app/cmd/certs_test.go
+++ b/cmd/kubeadm/app/cmd/certs_test.go
@@ -353,7 +353,7 @@ func TestRunGenCSR(t *testing.T) {
 	}
 
 	err := runGenCSR(nil, &config)
-	require.NoError(t, err, "expected runGenCSR to not fail")
+	require.NoErrorf(t, err, "expected runGenCSR to not fail")
 
 	t.Log("The command generates key and CSR files in the configured --cert-dir")
 	for _, name := range expectedCertificates {
@@ -627,9 +627,9 @@ kubernetesVersion: %s`,
 			assert.Len(t, info.CertificateAuthorities, len(caCerts))
 			for _, cert := range info.Certificates {
 				if tc.brokenCertName == cert.Name {
-					assert.True(t, cert.Missing, "expected certificate to be missing")
+					assert.Truef(t, cert.Missing, "expected certificate to be missing")
 				} else {
-					assert.False(t, cert.Missing, "expected certificate to be present")
+					assert.Falsef(t, cert.Missing, "expected certificate to be present")
 				}
 			}
 		default:

--- a/cmd/prune-junit-xml/prunexml_test.go
+++ b/cmd/prune-junit-xml/prunexml_test.go
@@ -63,7 +63,7 @@ func TestPruneXML(t *testing.T) {
 	writer := bufio.NewWriter(&output)
 	_ = streamXML(writer, suites)
 	_ = writer.Flush()
-	assert.Equal(t, outputXML, string(output.Bytes()), "xml was not pruned correctly")
+	assert.Equalf(t, outputXML, string(output.Bytes()), "xml was not pruned correctly")
 }
 
 func TestPruneTESTS(t *testing.T) {
@@ -114,5 +114,5 @@ func TestPruneTESTS(t *testing.T) {
 	writer := bufio.NewWriter(&output)
 	_ = streamXML(writer, suites)
 	_ = writer.Flush()
-	assert.Equal(t, outputXML, string(output.Bytes()), "tests in xml was not pruned correctly")
+	assert.Equalf(t, outputXML, string(output.Bytes()), "tests in xml was not pruned correctly")
 }

--- a/cmd/yamlfmt/yamlfmt_test.go
+++ b/cmd/yamlfmt/yamlfmt_test.go
@@ -48,5 +48,5 @@ labels:
 	writer := bufio.NewWriter(&output)
 	_ = streamYaml(writer, &indent, node)
 	_ = writer.Flush()
-	assert.Equal(t, outputYaml, string(output.Bytes()), "yaml was not formatted correctly")
+	assert.Equalf(t, outputYaml, string(output.Bytes()), "yaml was not formatted correctly")
 }

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -185,3 +185,6 @@ linters-settings: # please keep this alphabetized
       - "all"
   testifylint:
     enable-all: true
+    formatter:
+      # To require f-assertions if format string is used.
+      require-f-funcs: true

--- a/hack/golangci-strict.yaml
+++ b/hack/golangci-strict.yaml
@@ -224,6 +224,9 @@ linters-settings: # please keep this alphabetized
     checks:
       - "all"
   testifylint:
-    enable-all: true
     disable:  # TODO: remove each disabled rule and fix it
       - require-error
+    enable-all: true
+    formatter:
+      # To require f-assertions if format string is used.
+      require-f-funcs: true

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -237,8 +237,11 @@ linters-settings: # please keep this alphabetized
     checks:
       - "ST1019"   # Importing the same package multiple times
   testifylint:
-    enable-all: true
     disable:  # TODO: remove each disabled rule and fix it
       - float-compare
       - go-require
       - require-error
+    enable-all: true
+    formatter:
+      # To require f-assertions if format string is used.
+      require-f-funcs: true

--- a/hack/golangci.yaml.in
+++ b/hack/golangci.yaml.in
@@ -209,7 +209,6 @@ linters-settings: # please keep this alphabetized
       - "ST1019"   # Importing the same package multiple times
   {{- end}}
   testifylint:
-    enable-all: true
     {{- if not .Hints }}
     disable:  # TODO: remove each disabled rule and fix it
       {{- if .Base }}
@@ -218,3 +217,7 @@ linters-settings: # please keep this alphabetized
       {{- end}}
       - require-error
     {{- end}}
+    enable-all: true
+    formatter:
+      # To require f-assertions if format string is used.
+      require-f-funcs: true

--- a/pkg/api/pod/util_test.go
+++ b/pkg/api/pod/util_test.go
@@ -781,21 +781,21 @@ func TestDropAppArmor(t *testing.T) {
 			}
 
 			DropDisabledPodFields(newPod, newPod)
-			require.Equal(t, &test.pod, newPod, "unchanged pod should never be mutated")
+			require.Equalf(t, &test.pod, newPod, "unchanged pod should never be mutated")
 
 			DropDisabledPodFields(newPod, nil)
-			assert.Equal(t, &test.pod, newPod, "pod should not be mutated when both feature gates are enabled")
+			assert.Equalf(t, &test.pod, newPod, "pod should not be mutated when both feature gates are enabled")
 
 			expectAnnotations := test.hasAnnotations
-			assert.Equal(t, expectAnnotations, appArmorAnnotationsInUse(newPod.Annotations), "AppArmor annotations expectation")
+			assert.Equalf(t, expectAnnotations, appArmorAnnotationsInUse(newPod.Annotations), "AppArmor annotations expectation")
 			if expectAnnotations == test.hasAnnotations {
-				assert.Equal(t, test.pod.Annotations, newPod.Annotations, "annotations should not be mutated")
+				assert.Equalf(t, test.pod.Annotations, newPod.Annotations, "annotations should not be mutated")
 			}
 
 			expectFields := test.hasFields
-			assert.Equal(t, expectFields, appArmorFieldsInUse(&newPod.Spec), "AppArmor fields expectation")
+			assert.Equalf(t, expectFields, appArmorFieldsInUse(&newPod.Spec), "AppArmor fields expectation")
 			if expectFields == test.hasFields {
-				assert.Equal(t, &test.pod.Spec, &newPod.Spec, "PodSpec should not be mutated")
+				assert.Equalf(t, &test.pod.Spec, &newPod.Spec, "PodSpec should not be mutated")
 			}
 		})
 

--- a/pkg/api/v1/pod/util_test.go
+++ b/pkg/api/v1/pod/util_test.go
@@ -801,11 +801,11 @@ func TestGetContainerStatus(t *testing.T) {
 
 	for _, test := range tests {
 		resultStatus, exists := GetContainerStatus(test.status, test.name)
-		assert.Equal(t, test.expected.status, resultStatus, "GetContainerStatus: "+test.desc)
-		assert.Equal(t, test.expected.exists, exists, "GetContainerStatus: "+test.desc)
+		assert.Equalf(t, test.expected.status, resultStatus, "GetContainerStatus: "+test.desc)
+		assert.Equalf(t, test.expected.exists, exists, "GetContainerStatus: "+test.desc)
 
 		resultStatus = GetExistingContainerStatus(test.status, test.name)
-		assert.Equal(t, test.expected.status, resultStatus, "GetExistingContainerStatus: "+test.desc)
+		assert.Equalf(t, test.expected.status, resultStatus, "GetExistingContainerStatus: "+test.desc)
 	}
 }
 
@@ -851,8 +851,8 @@ func TestGetIndexOfContainerStatus(t *testing.T) {
 
 	for _, test := range tests {
 		idx, exists := GetIndexOfContainerStatus(testStatus, test.containerName)
-		assert.Equal(t, test.expectedExists, exists, "GetIndexOfContainerStatus: "+test.desc)
-		assert.Equal(t, test.expectedIndex, idx, "GetIndexOfContainerStatus: "+test.desc)
+		assert.Equalf(t, test.expectedExists, exists, "GetIndexOfContainerStatus: "+test.desc)
+		assert.Equalf(t, test.expectedIndex, idx, "GetIndexOfContainerStatus: "+test.desc)
 	}
 }
 
@@ -918,7 +918,7 @@ func TestUpdatePodCondition(t *testing.T) {
 	for _, test := range tests {
 		resultStatus := UpdatePodCondition(test.status, &test.conditions)
 
-		assert.Equal(t, test.expected, resultStatus, test.desc)
+		assert.Equalf(t, test.expected, resultStatus, test.desc)
 	}
 }
 
@@ -957,7 +957,7 @@ func TestGetContainersReadyCondition(t *testing.T) {
 
 	for _, test := range tests {
 		containersReadyCondition := GetContainersReadyCondition(test.podStatus)
-		assert.Equal(t, test.expectedCondition, containersReadyCondition, test.desc)
+		assert.Equalf(t, test.expectedCondition, containersReadyCondition, test.desc)
 	}
 }
 
@@ -1012,6 +1012,6 @@ func TestIsContainersReadyConditionTrue(t *testing.T) {
 
 	for _, test := range tests {
 		isContainersReady := IsContainersReadyConditionTrue(test.podStatus)
-		assert.Equal(t, test.expected, isContainersReady, test.desc)
+		assert.Equalf(t, test.expected, isContainersReady, test.desc)
 	}
 }

--- a/pkg/api/v1/resource/helpers_test.go
+++ b/pkg/api/v1/resource/helpers_test.go
@@ -110,7 +110,7 @@ func TestGetResourceRequest(t *testing.T) {
 	as := assert.New(t)
 	for idx, tc := range cases {
 		actual := GetResourceRequest(tc.pod, tc.resourceName)
-		as.Equal(tc.expectedValue, actual, "expected test case [%d] %v: to return %q; got %q instead", idx, tc.cName, tc.expectedValue, actual)
+		as.Equalf(tc.expectedValue, actual, "expected test case [%d] %v: to return %q; got %q instead", idx, tc.cName, tc.expectedValue, actual)
 	}
 }
 
@@ -260,10 +260,10 @@ func TestExtractResourceValue(t *testing.T) {
 	for idx, tc := range cases {
 		actual, err := ExtractResourceValueByContainerName(tc.fs, tc.pod, tc.cName)
 		if tc.expectedError != nil {
-			require.EqualError(t, err, tc.expectedError.Error(), "expected test case [%d] to fail with error %v; got %v", idx, tc.expectedError, err)
+			require.EqualErrorf(t, err, tc.expectedError.Error(), "expected test case [%d] to fail with error %v; got %v", idx, tc.expectedError, err)
 		} else {
-			require.NoError(t, err, "expected test case [%d] to not return an error; got %v", idx, err)
-			as.Equal(tc.expectedValue, actual, "expected test case [%d] to return %q; got %q instead", idx, tc.expectedValue, actual)
+			require.NoErrorf(t, err, "expected test case [%d] to not return an error; got %v", idx, err)
+			as.Equalf(tc.expectedValue, actual, "expected test case [%d] to return %q; got %q instead", idx, tc.expectedValue, actual)
 		}
 	}
 }

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -22659,7 +22659,7 @@ func TestValidateSeccompAnnotationAndField(t *testing.T) {
 			},
 		},
 		validation: func(t *testing.T, desc string, allErrs field.ErrorList, pod *v1.Pod) {
-			require.NotNil(t, allErrs, desc)
+			require.NotNilf(t, allErrs, desc)
 		},
 	}, {
 		description: "Field type default and annotation does not match",
@@ -22678,7 +22678,7 @@ func TestValidateSeccompAnnotationAndField(t *testing.T) {
 			},
 		},
 		validation: func(t *testing.T, desc string, allErrs field.ErrorList, pod *v1.Pod) {
-			require.NotNil(t, allErrs, desc)
+			require.NotNilf(t, allErrs, desc)
 		},
 	}, {
 		description: "Field type localhost and annotation does not match",
@@ -22698,7 +22698,7 @@ func TestValidateSeccompAnnotationAndField(t *testing.T) {
 			},
 		},
 		validation: func(t *testing.T, desc string, allErrs field.ErrorList, pod *v1.Pod) {
-			require.NotNil(t, allErrs, desc)
+			require.NotNilf(t, allErrs, desc)
 		},
 	}, {
 		description: "Field type localhost and localhost/ prefixed annotation does not match",
@@ -22718,7 +22718,7 @@ func TestValidateSeccompAnnotationAndField(t *testing.T) {
 			},
 		},
 		validation: func(t *testing.T, desc string, allErrs field.ErrorList, pod *v1.Pod) {
-			require.NotNil(t, allErrs, desc)
+			require.NotNilf(t, allErrs, desc)
 		},
 	}, {
 		description: "Field type unconfined and annotation does not match (container)",
@@ -22740,7 +22740,7 @@ func TestValidateSeccompAnnotationAndField(t *testing.T) {
 			},
 		},
 		validation: func(t *testing.T, desc string, allErrs field.ErrorList, pod *v1.Pod) {
-			require.NotNil(t, allErrs, desc)
+			require.NotNilf(t, allErrs, desc)
 		},
 	}, {
 		description: "Field type default and annotation does not match (container)",
@@ -22762,7 +22762,7 @@ func TestValidateSeccompAnnotationAndField(t *testing.T) {
 			},
 		},
 		validation: func(t *testing.T, desc string, allErrs field.ErrorList, pod *v1.Pod) {
-			require.NotNil(t, allErrs, desc)
+			require.NotNilf(t, allErrs, desc)
 		},
 	}, {
 		description: "Field type localhost and annotation does not match (container)",
@@ -22785,7 +22785,7 @@ func TestValidateSeccompAnnotationAndField(t *testing.T) {
 			},
 		},
 		validation: func(t *testing.T, desc string, allErrs field.ErrorList, pod *v1.Pod) {
-			require.NotNil(t, allErrs, desc)
+			require.NotNilf(t, allErrs, desc)
 		},
 	}, {
 		description: "Field type localhost and localhost/ prefixed annotation does not match (container)",
@@ -22808,7 +22808,7 @@ func TestValidateSeccompAnnotationAndField(t *testing.T) {
 			},
 		},
 		validation: func(t *testing.T, desc string, allErrs field.ErrorList, pod *v1.Pod) {
-			require.NotNil(t, allErrs, desc)
+			require.NotNilf(t, allErrs, desc)
 		},
 	}, {
 		description: "Nil errors must not be appended (pod)",
@@ -22830,7 +22830,7 @@ func TestValidateSeccompAnnotationAndField(t *testing.T) {
 			},
 		},
 		validation: func(t *testing.T, desc string, allErrs field.ErrorList, pod *v1.Pod) {
-			require.Empty(t, allErrs, desc)
+			require.Emptyf(t, allErrs, desc)
 		},
 	}, {
 		description: "Nil errors must not be appended (container)",
@@ -22852,7 +22852,7 @@ func TestValidateSeccompAnnotationAndField(t *testing.T) {
 			},
 		},
 		validation: func(t *testing.T, desc string, allErrs field.ErrorList, pod *v1.Pod) {
-			require.Empty(t, allErrs, desc)
+			require.Emptyf(t, allErrs, desc)
 		},
 	},
 	} {
@@ -22935,7 +22935,7 @@ func TestValidateSeccompAnnotationsAndFieldsMatch(t *testing.T) {
 
 	for i, test := range tests {
 		err := validateSeccompAnnotationsAndFieldsMatch(test.annotationValue, test.seccompField, test.fldPath)
-		assert.Equal(t, test.expectedErr, err, "TestCase[%d]: %s", i, test.description)
+		assert.Equalf(t, test.expectedErr, err, "TestCase[%d]: %s", i, test.description)
 	}
 }
 
@@ -23021,7 +23021,7 @@ func TestValidatePodTemplateSpecSeccomp(t *testing.T) {
 
 	for i, test := range tests {
 		err := ValidatePodTemplateSpec(test.spec, rootFld, PodValidationOptions{})
-		assert.Equal(t, test.expectedErr, err, "TestCase[%d]: %s", i, test.description)
+		assert.Equalf(t, test.expectedErr, err, "TestCase[%d]: %s", i, test.description)
 	}
 }
 
@@ -23724,7 +23724,7 @@ func TestValidateAppArmorProfileFormat(t *testing.T) {
 	for _, test := range tests {
 		err := ValidateAppArmorProfileFormat(test.profile)
 		if test.expectValid {
-			assert.NoError(t, err, "Profile %s should be valid", test.profile)
+			assert.NoErrorf(t, err, "Profile %s should be valid", test.profile)
 		} else {
 			assert.Errorf(t, err, "Profile %s should not be valid", test.profile)
 		}

--- a/pkg/apis/discovery/v1beta1/conversion_test.go
+++ b/pkg/apis/discovery/v1beta1/conversion_test.go
@@ -135,11 +135,11 @@ func TestEndpointZoneConverstion(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			convertedInternal := discovery.Endpoint{}
 			require.NoError(t, Convert_v1beta1_Endpoint_To_discovery_Endpoint(&tc.external, &convertedInternal, nil))
-			assert.Equal(t, tc.internal, convertedInternal, "v1beta1.Endpoint -> discovery.Endpoint")
+			assert.Equalf(t, tc.internal, convertedInternal, "v1beta1.Endpoint -> discovery.Endpoint")
 
 			convertedV1beta1 := v1beta1.Endpoint{}
 			require.NoError(t, Convert_discovery_Endpoint_To_v1beta1_Endpoint(&tc.internal, &convertedV1beta1, nil))
-			assert.Equal(t, tc.external, convertedV1beta1, "discovery.Endpoint -> v1beta1.Endpoint")
+			assert.Equalf(t, tc.external, convertedV1beta1, "discovery.Endpoint -> v1beta1.Endpoint")
 		})
 	}
 }

--- a/pkg/apis/extensions/v1beta1/conversion_test.go
+++ b/pkg/apis/extensions/v1beta1/conversion_test.go
@@ -97,12 +97,12 @@ func TestIngressBackendConversion(t *testing.T) {
 			convertedInternal := networking.IngressSpec{}
 			require.NoError(t,
 				Convert_v1beta1_IngressSpec_To_networking_IngressSpec(&test.external, &convertedInternal, nil))
-			assert.Equal(t, test.internal, convertedInternal, "v1beta1.IngressSpec -> networking.IngressSpec")
+			assert.Equalf(t, test.internal, convertedInternal, "v1beta1.IngressSpec -> networking.IngressSpec")
 
 			convertedV1beta1 := v1beta1.IngressSpec{}
 			require.NoError(t,
 				Convert_networking_IngressSpec_To_v1beta1_IngressSpec(&test.internal, &convertedV1beta1, nil))
-			assert.Equal(t, test.external, convertedV1beta1, "networking.IngressSpec -> v1beta1.IngressSpec")
+			assert.Equalf(t, test.external, convertedV1beta1, "networking.IngressSpec -> v1beta1.IngressSpec")
 		})
 	}
 }

--- a/pkg/apis/flowcontrol/validation/validation_test.go
+++ b/pkg/apis/flowcontrol/validation/validation_test.go
@@ -1289,7 +1289,7 @@ func TestValidateNonResourceURLPath(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			err := ValidateNonResourceURLPath(testCase.path, field.NewPath(""))
-			assert.Equal(t, testCase.expectingError, err != nil,
+			assert.Equalf(t, testCase.expectingError, err != nil,
 				"actual error: %v", err)
 		})
 	}

--- a/pkg/apis/networking/v1beta1/conversion_test.go
+++ b/pkg/apis/networking/v1beta1/conversion_test.go
@@ -97,12 +97,12 @@ func TestIngressBackendConversion(t *testing.T) {
 			convertedInternal := networking.IngressSpec{}
 			require.NoError(t,
 				Convert_v1beta1_IngressSpec_To_networking_IngressSpec(&test.external, &convertedInternal, nil))
-			assert.Equal(t, test.internal, convertedInternal, "v1beta1.IngressSpec -> networking.IngressSpec")
+			assert.Equalf(t, test.internal, convertedInternal, "v1beta1.IngressSpec -> networking.IngressSpec")
 
 			convertedV1beta1 := v1beta1.IngressSpec{}
 			require.NoError(t,
 				Convert_networking_IngressSpec_To_v1beta1_IngressSpec(&test.internal, &convertedV1beta1, nil))
-			assert.Equal(t, test.external, convertedV1beta1, "networking.IngressSpec -> v1beta1.IngressSpec")
+			assert.Equalf(t, test.external, convertedV1beta1, "networking.IngressSpec -> v1beta1.IngressSpec")
 		})
 	}
 }

--- a/pkg/apis/node/v1alpha1/conversion_test.go
+++ b/pkg/apis/node/v1alpha1/conversion_test.go
@@ -124,12 +124,12 @@ func TestRuntimeClassConversion(t *testing.T) {
 			convertedInternal := &node.RuntimeClass{}
 			require.NoError(t,
 				Convert_v1alpha1_RuntimeClass_To_node_RuntimeClass(test.external, convertedInternal, nil))
-			assert.Equal(t, test.internal, convertedInternal, "external -> internal")
+			assert.Equalf(t, test.internal, convertedInternal, "external -> internal")
 
 			convertedV1alpha1 := &v1alpha1.RuntimeClass{}
 			require.NoError(t,
 				Convert_node_RuntimeClass_To_v1alpha1_RuntimeClass(test.internal, convertedV1alpha1, nil))
-			assert.Equal(t, test.external, convertedV1alpha1, "internal -> external")
+			assert.Equalf(t, test.external, convertedV1alpha1, "internal -> external")
 		})
 	}
 }

--- a/pkg/controller/endpoint/endpoints_tracker_test.go
+++ b/pkg/controller/endpoint/endpoints_tracker_test.go
@@ -41,13 +41,13 @@ func TestStaleEndpointsTracker(t *testing.T) {
 		}},
 	}
 
-	assert.False(t, tracker.IsStale(endpoints), "IsStale should return false before the endpoint is staled")
+	assert.Falsef(t, tracker.IsStale(endpoints), "IsStale should return false before the endpoint is staled")
 
 	tracker.Stale(endpoints)
-	assert.True(t, tracker.IsStale(endpoints), "IsStale should return true after the endpoint is staled")
+	assert.Truef(t, tracker.IsStale(endpoints), "IsStale should return true after the endpoint is staled")
 
 	endpoints.ResourceVersion = "2"
-	assert.False(t, tracker.IsStale(endpoints), "IsStale should return false after the endpoint is updated")
+	assert.Falsef(t, tracker.IsStale(endpoints), "IsStale should return false after the endpoint is updated")
 
 	tracker.Delete(endpoints.Namespace, endpoints.Name)
 	assert.Empty(t, tracker.staleResourceVersionByEndpoints)

--- a/pkg/controller/podautoscaler/horizontal_test.go
+++ b/pkg/controller/podautoscaler/horizontal_test.go
@@ -374,12 +374,12 @@ func (tc *testCase) prepareTestClient(t *testing.T) (*fake.Clientset, *metricsfa
 			defer tc.Unlock()
 
 			obj := action.(core.UpdateAction).GetObject().(*autoscalingv2.HorizontalPodAutoscaler)
-			assert.Equal(t, namespace, obj.Namespace, "the HPA namespace should be as expected")
-			assert.Equal(t, hpaName, obj.Name, "the HPA name should be as expected")
-			assert.Equal(t, tc.expectedDesiredReplicas, obj.Status.DesiredReplicas, "the desired replica count reported in the object status should be as expected")
+			assert.Equalf(t, namespace, obj.Namespace, "the HPA namespace should be as expected")
+			assert.Equalf(t, hpaName, obj.Name, "the HPA name should be as expected")
+			assert.Equalf(t, tc.expectedDesiredReplicas, obj.Status.DesiredReplicas, "the desired replica count reported in the object status should be as expected")
 			if tc.verifyCPUCurrent {
-				if utilization := findCpuUtilization(obj.Status.CurrentMetrics); assert.NotNil(t, utilization, "the reported CPU utilization percentage should be non-nil") {
-					assert.Equal(t, tc.CPUCurrent, *utilization, "the report CPU utilization percentage should be as expected")
+				if utilization := findCpuUtilization(obj.Status.CurrentMetrics); assert.NotNilf(t, utilization, "the reported CPU utilization percentage should be non-nil") {
+					assert.Equalf(t, tc.CPUCurrent, *utilization, "the report CPU utilization percentage should be as expected")
 				}
 			}
 			actualConditions := obj.Status.Conditions
@@ -394,7 +394,7 @@ func (tc *testCase) prepareTestClient(t *testing.T) (*fake.Clientset, *metricsfa
 				actualConditions[i].Message = ""
 				actualConditions[i].LastTransitionTime = metav1.Time{}
 			}
-			assert.Equal(t, tc.expectedConditions, actualConditions, "the status conditions should have been as expected")
+			assert.Equalf(t, tc.expectedConditions, actualConditions, "the status conditions should have been as expected")
 			tc.statusUpdated = true
 			// Every time we reconcile HPA object we are updating status.
 			return true, obj, nil
@@ -472,7 +472,7 @@ func (tc *testCase) prepareTestClient(t *testing.T) (*fake.Clientset, *metricsfa
 
 		obj := action.(core.UpdateAction).GetObject().(*autoscalingv1.Scale)
 		replicas := action.(core.UpdateAction).GetObject().(*autoscalingv1.Scale).Spec.Replicas
-		assert.Equal(t, tc.expectedDesiredReplicas, replicas, "the replica count of the RC should be as expected")
+		assert.Equalf(t, tc.expectedDesiredReplicas, replicas, "the replica count of the RC should be as expected")
 		tc.scaleUpdated = true
 		return true, obj, nil
 	})
@@ -483,7 +483,7 @@ func (tc *testCase) prepareTestClient(t *testing.T) (*fake.Clientset, *metricsfa
 
 		obj := action.(core.UpdateAction).GetObject().(*autoscalingv1.Scale)
 		replicas := action.(core.UpdateAction).GetObject().(*autoscalingv1.Scale).Spec.Replicas
-		assert.Equal(t, tc.expectedDesiredReplicas, replicas, "the replica count of the deployment should be as expected")
+		assert.Equalf(t, tc.expectedDesiredReplicas, replicas, "the replica count of the deployment should be as expected")
 		tc.scaleUpdated = true
 		return true, obj, nil
 	})
@@ -494,7 +494,7 @@ func (tc *testCase) prepareTestClient(t *testing.T) (*fake.Clientset, *metricsfa
 
 		obj := action.(core.UpdateAction).GetObject().(*autoscalingv1.Scale)
 		replicas := action.(core.UpdateAction).GetObject().(*autoscalingv1.Scale).Spec.Replicas
-		assert.Equal(t, tc.expectedDesiredReplicas, replicas, "the replica count of the replicaset should be as expected")
+		assert.Equalf(t, tc.expectedDesiredReplicas, replicas, "the replica count of the replicaset should be as expected")
 		tc.scaleUpdated = true
 		return true, obj, nil
 	})
@@ -564,8 +564,8 @@ func (tc *testCase) prepareTestClient(t *testing.T) (*fake.Clientset, *metricsfa
 			metrics := &cmapi.MetricValueList{}
 
 			// multiple objects
-			assert.Equal(t, "pods", getForAction.GetResource().Resource, "the type of object that we requested multiple metrics for should have been pods")
-			assert.Equal(t, "qps", getForAction.GetMetricName(), "the metric name requested should have been qps, as specified in the metric spec")
+			assert.Equalf(t, "pods", getForAction.GetResource().Resource, "the type of object that we requested multiple metrics for should have been pods")
+			assert.Equalf(t, "qps", getForAction.GetMetricName(), "the metric name requested should have been qps, as specified in the metric spec")
 
 			for i, level := range tc.reportedLevels {
 				podMetric := cmapi.MetricValue{
@@ -605,8 +605,8 @@ func (tc *testCase) prepareTestClient(t *testing.T) (*fake.Clientset, *metricsfa
 				}
 			}
 		}
-		assert.NotNil(t, matchedTarget, "this request should have matched one of the metric specs")
-		assert.Equal(t, "qps", getForAction.GetMetricName(), "the metric name requested should have been qps, as specified in the metric spec")
+		assert.NotNilf(t, matchedTarget, "this request should have matched one of the metric specs")
+		assert.Equalf(t, "qps", getForAction.GetMetricName(), "the metric name requested should have been qps, as specified in the metric spec")
 
 		metrics.Items = []cmapi.MetricValue{
 			{
@@ -639,7 +639,7 @@ func (tc *testCase) prepareTestClient(t *testing.T) (*fake.Clientset, *metricsfa
 
 		metrics := &emapi.ExternalMetricValueList{}
 
-		assert.Equal(t, "qps", listAction.GetResource().Resource, "the metric name requested should have been qps, as specified in the metric spec")
+		assert.Equalf(t, "qps", listAction.GetResource().Resource, "the metric name requested should have been qps, as specified in the metric spec")
 
 		for _, level := range tc.reportedLevels {
 			metric := emapi.ExternalMetricValue{
@@ -679,10 +679,10 @@ func (tc *testCase) verifyResults(t *testing.T, m *mockMonitor) {
 	tc.Lock()
 	defer tc.Unlock()
 
-	assert.Equal(t, tc.specReplicas != tc.expectedDesiredReplicas, tc.scaleUpdated, "the scale should only be updated if we expected a change in replicas")
-	assert.True(t, tc.statusUpdated, "the status should have been updated")
+	assert.Equalf(t, tc.specReplicas != tc.expectedDesiredReplicas, tc.scaleUpdated, "the scale should only be updated if we expected a change in replicas")
+	assert.Truef(t, tc.statusUpdated, "the status should have been updated")
 	if tc.verifyEvents {
-		assert.Equal(t, tc.specReplicas != tc.expectedDesiredReplicas, tc.eventCreated, "an event should have been created only if we expected a change in replicas")
+		assert.Equalf(t, tc.specReplicas != tc.expectedDesiredReplicas, tc.eventCreated, "an event should have been created only if we expected a change in replicas")
 	}
 
 	tc.verifyRecordedMetric(t, m)
@@ -692,8 +692,8 @@ func (tc *testCase) verifyRecordedMetric(t *testing.T, m *mockMonitor) {
 	// First, wait for the reconciliation completed at least once.
 	m.waitUntilRecorded(t)
 
-	assert.Equal(t, tc.expectedReportedReconciliationActionLabel, m.reconciliationActionLabels[0], "the reconciliation action should be recorded in monitor expectedly")
-	assert.Equal(t, tc.expectedReportedReconciliationErrorLabel, m.reconciliationErrorLabels[0], "the reconciliation error should be recorded in monitor expectedly")
+	assert.Equalf(t, tc.expectedReportedReconciliationActionLabel, m.reconciliationActionLabels[0], "the reconciliation action should be recorded in monitor expectedly")
+	assert.Equalf(t, tc.expectedReportedReconciliationErrorLabel, m.reconciliationErrorLabels[0], "the reconciliation error should be recorded in monitor expectedly")
 
 	if len(tc.expectedReportedMetricComputationActionLabels) != len(m.metricComputationActionLabels) {
 		t.Fatalf("the metric computation actions for %d types should be recorded, but actually only %d was recorded", len(tc.expectedReportedMetricComputationActionLabels), len(m.metricComputationActionLabels))
@@ -707,14 +707,14 @@ func (tc *testCase) verifyRecordedMetric(t *testing.T, m *mockMonitor) {
 		if !ok {
 			t.Fatalf("the metric computation action should be recorded with metricType %s, but actually nothing was recorded", metricType)
 		}
-		assert.Equal(t, l, m.metricComputationActionLabels[metricType][0], "the metric computation action should be recorded in monitor expectedly")
+		assert.Equalf(t, l, m.metricComputationActionLabels[metricType][0], "the metric computation action should be recorded in monitor expectedly")
 	}
 	for metricType, l := range tc.expectedReportedMetricComputationErrorLabels {
 		_, ok := m.metricComputationErrorLabels[metricType]
 		if !ok {
 			t.Fatalf("the metric computation error should be recorded with metricType %s, but actually nothing was recorded", metricType)
 		}
-		assert.Equal(t, l, m.metricComputationErrorLabels[metricType][0], "the metric computation error should be recorded in monitor expectedly")
+		assert.Equalf(t, l, m.metricComputationErrorLabels[metricType][0], "the metric computation error should be recorded in monitor expectedly")
 	}
 }
 
@@ -757,7 +757,7 @@ func (tc *testCase) setupController(t *testing.T) (*HorizontalController, inform
 					tc.expectedDesiredReplicas,
 					(int64(tc.reportedLevels[0])*100)/tc.reportedCPURequests[0].MilliValue(), tc.specReplicas), obj.Message)
 			default:
-				assert.False(t, true, "Unexpected event: %s / %s", obj.Reason, obj.Message)
+				assert.Falsef(t, true, "Unexpected event: %s / %s", obj.Reason, obj.Message)
 			}
 		}
 		tc.eventCreated = true
@@ -3838,8 +3838,8 @@ func TestConvertDesiredReplicasWithRules(t *testing.T) {
 				ctc.currentReplicas, ctc.expectedDesiredReplicas, ctc.hpaMinReplicas, ctc.hpaMaxReplicas,
 			)
 
-			assert.Equal(t, ctc.expectedConvertedDesiredReplicas, actualConvertedDesiredReplicas, ctc.annotation)
-			assert.Equal(t, ctc.expectedCondition, actualCondition, ctc.annotation)
+			assert.Equalf(t, ctc.expectedConvertedDesiredReplicas, actualConvertedDesiredReplicas, ctc.annotation)
+			assert.Equalf(t, ctc.expectedCondition, actualCondition, ctc.annotation)
 		})
 	}
 }
@@ -4511,8 +4511,8 @@ func TestScalingWithRules(t *testing.T) {
 			}
 
 			replicas, condition, _ := hc.convertDesiredReplicasWithBehaviorRate(arg)
-			assert.Equal(t, tc.expectedReplicas, replicas, "expected replicas do not match with converted replicas")
-			assert.Equal(t, tc.expectedCondition, condition, "HPA condition does not match with expected condition")
+			assert.Equalf(t, tc.expectedReplicas, replicas, "expected replicas do not match with converted replicas")
+			assert.Equalf(t, tc.expectedCondition, condition, "HPA condition does not match with expected condition")
 		})
 	}
 
@@ -4647,13 +4647,13 @@ func TestStoreScaleEvents(t *testing.T) {
 			gotReplicasChangeUp := getReplicasChangePerPeriod(60, hcUp.scaleUpEvents[tc.key])
 			assert.Equal(t, tc.expectedReplicasChange, gotReplicasChangeUp)
 			hcUp.storeScaleEvent(behaviorUp, tc.key, 10, 10+tc.replicaChange)
-			if !assert.Len(t, hcUp.scaleUpEvents[tc.key], len(tc.newScaleEvents), "up: scale events differ in length") {
+			if !assert.Lenf(t, hcUp.scaleUpEvents[tc.key], len(tc.newScaleEvents), "up: scale events differ in length") {
 				return
 			}
 			for i, gotEvent := range hcUp.scaleUpEvents[tc.key] {
 				expEvent := tc.newScaleEvents[i]
-				assert.Equal(t, expEvent.replicaChange, gotEvent.replicaChange, "up: idx:%v replicaChange", i)
-				assert.Equal(t, expEvent.outdated, gotEvent.outdated, "up: idx:%v outdated", i)
+				assert.Equalf(t, expEvent.replicaChange, gotEvent.replicaChange, "up: idx:%v replicaChange", i)
+				assert.Equalf(t, expEvent.outdated, gotEvent.outdated, "up: idx:%v outdated", i)
 			}
 			// testing scale down
 			var behaviorDown *autoscalingv2.HorizontalPodAutoscalerBehavior
@@ -4670,13 +4670,13 @@ func TestStoreScaleEvents(t *testing.T) {
 			gotReplicasChangeDown := getReplicasChangePerPeriod(60, hcDown.scaleDownEvents[tc.key])
 			assert.Equal(t, tc.expectedReplicasChange, gotReplicasChangeDown)
 			hcDown.storeScaleEvent(behaviorDown, tc.key, 10, 10-tc.replicaChange)
-			if !assert.Len(t, hcDown.scaleDownEvents[tc.key], len(tc.newScaleEvents), "down: scale events differ in length") {
+			if !assert.Lenf(t, hcDown.scaleDownEvents[tc.key], len(tc.newScaleEvents), "down: scale events differ in length") {
 				return
 			}
 			for i, gotEvent := range hcDown.scaleDownEvents[tc.key] {
 				expEvent := tc.newScaleEvents[i]
-				assert.Equal(t, expEvent.replicaChange, gotEvent.replicaChange, "down: idx:%v replicaChange", i)
-				assert.Equal(t, expEvent.outdated, gotEvent.outdated, "down: idx:%v outdated", i)
+				assert.Equalf(t, expEvent.replicaChange, gotEvent.replicaChange, "down: idx:%v replicaChange", i)
+				assert.Equalf(t, expEvent.outdated, gotEvent.outdated, "down: idx:%v outdated", i)
 			}
 		})
 	}
@@ -4884,14 +4884,14 @@ func TestNormalizeDesiredReplicasWithBehavior(t *testing.T) {
 				},
 			}
 			r, _, _ := hc.stabilizeRecommendationWithBehaviors(arg)
-			assert.Equal(t, tc.expectedStabilizedReplicas, r, "expected replicas do not match")
+			assert.Equalf(t, tc.expectedStabilizedReplicas, r, "expected replicas do not match")
 			if tc.expectedRecommendations != nil {
-				if !assert.Len(t, hc.recommendations[tc.key], len(tc.expectedRecommendations), "stored recommendations differ in length") {
+				if !assert.Lenf(t, hc.recommendations[tc.key], len(tc.expectedRecommendations), "stored recommendations differ in length") {
 					return
 				}
 				for i, r := range hc.recommendations[tc.key] {
 					expectedRecommendation := tc.expectedRecommendations[i]
-					assert.Equal(t, expectedRecommendation.recommendation, r.recommendation, "stored recommendation differs at position %d", i)
+					assert.Equalf(t, expectedRecommendation.recommendation, r.recommendation, "stored recommendation differs at position %d", i)
 				}
 			}
 		})
@@ -5248,7 +5248,7 @@ func TestMultipleHPAs(t *testing.T) {
 	testClient.AddReactor("update", "horizontalpodautoscalers", func(action core.Action) (handled bool, ret runtime.Object, err error) {
 		handled, obj, err := func() (handled bool, ret *autoscalingv2.HorizontalPodAutoscaler, err error) {
 			obj := action.(core.UpdateAction).GetObject().(*autoscalingv2.HorizontalPodAutoscaler)
-			assert.Equal(t, testNamespace, obj.Namespace, "the HPA namespace should be as expected")
+			assert.Equalf(t, testNamespace, obj.Namespace, "the HPA namespace should be as expected")
 
 			return true, obj, nil
 		}()
@@ -5293,5 +5293,5 @@ func TestMultipleHPAs(t *testing.T) {
 		}
 	}
 
-	assert.Len(t, processedHPA, hpaCount, "Expected to process all HPAs")
+	assert.Lenf(t, processedHPA, hpaCount, "Expected to process all HPAs")
 }

--- a/pkg/controller/podautoscaler/metrics/client_test.go
+++ b/pkg/controller/podautoscaler/metrics/client_test.go
@@ -123,8 +123,8 @@ func (tc *restClientTestCase) prepareTestClient(t *testing.T) (*metricsfake.Clie
 	} else if isExternal {
 		fakeEMClient.AddReactor("list", "*", func(action core.Action) (handled bool, ret runtime.Object, err error) {
 			listAction := action.(core.ListAction)
-			assert.Equal(t, tc.metricName, listAction.GetResource().Resource, "the metric requested should have matched the one specified.")
-			assert.Equal(t, tc.metricLabelSelector, listAction.GetListRestrictions().Labels, "the metric selector should have matched the one specified")
+			assert.Equalf(t, tc.metricName, listAction.GetResource().Resource, "the metric requested should have matched the one specified.")
+			assert.Equalf(t, tc.metricLabelSelector, listAction.GetListRestrictions().Labels, "the metric selector should have matched the one specified")
 
 			metrics := emapi.ExternalMetricValueList{}
 			for _, metricPoint := range tc.reportedMetricPoints {
@@ -141,12 +141,12 @@ func (tc *restClientTestCase) prepareTestClient(t *testing.T) (*metricsfake.Clie
 	} else {
 		fakeCMClient.AddReactor("get", "*", func(action core.Action) (handled bool, ret runtime.Object, err error) {
 			getForAction := action.(cmfake.GetForAction)
-			assert.Equal(t, tc.metricName, getForAction.GetMetricName(), "the metric requested should have matched the one specified")
+			assert.Equalf(t, tc.metricName, getForAction.GetMetricName(), "the metric requested should have matched the one specified")
 
 			if getForAction.GetName() == "*" {
 				// multiple objects
 				metrics := cmapi.MetricValueList{}
-				assert.Equal(t, "pods", getForAction.GetResource().Resource, "type of object that we requested multiple metrics for should have been pods")
+				assert.Equalf(t, "pods", getForAction.GetResource().Resource, "type of object that we requested multiple metrics for should have been pods")
 
 				for i, metricPoint := range tc.reportedMetricPoints {
 					timestamp := offsetTimestampBy(metricPoint.timestamp)
@@ -170,7 +170,7 @@ func (tc *restClientTestCase) prepareTestClient(t *testing.T) (*metricsfake.Clie
 			} else {
 				name := getForAction.GetName()
 				mapper := testrestmapper.TestOnlyStaticRESTMapper(legacyscheme.Scheme)
-				assert.NotNil(t, tc.singleObject, "should have only requested a single-object metric when we asked for metrics for a single object")
+				assert.NotNilf(t, tc.singleObject, "should have only requested a single-object metric when we asked for metrics for a single object")
 				gk := schema.FromAPIVersionAndKind(tc.singleObject.APIVersion, tc.singleObject.Kind).GroupKind()
 				mapping, err := mapper.RESTMapping(gk)
 				if err != nil {
@@ -178,8 +178,8 @@ func (tc *restClientTestCase) prepareTestClient(t *testing.T) (*metricsfake.Clie
 				}
 				groupResource := mapping.Resource.GroupResource()
 
-				assert.Equal(t, groupResource.String(), getForAction.GetResource().Resource, "should have requested metrics for the resource matching the GroupKind passed in")
-				assert.Equal(t, tc.singleObject.Name, name, "should have requested metrics for the object matching the name passed in")
+				assert.Equalf(t, groupResource.String(), getForAction.GetResource().Resource, "should have requested metrics for the resource matching the GroupKind passed in")
+				assert.Equalf(t, tc.singleObject.Name, name, "should have requested metrics for the object matching the name passed in")
 				metricPoint := tc.reportedMetricPoints[0]
 				timestamp := offsetTimestampBy(metricPoint.timestamp)
 
@@ -210,12 +210,12 @@ func (tc *restClientTestCase) prepareTestClient(t *testing.T) (*metricsfake.Clie
 
 func (tc *restClientTestCase) verifyResults(t *testing.T, metrics PodMetricsInfo, timestamp time.Time, err error) {
 	if tc.desiredError != nil {
-		require.Error(t, err, "there should be an error retrieving the metrics")
-		assert.Contains(t, fmt.Sprintf("%v", err), fmt.Sprintf("%v", tc.desiredError), "the error message should be as expected")
+		require.Errorf(t, err, "there should be an error retrieving the metrics")
+		assert.Containsf(t, fmt.Sprintf("%v", err), fmt.Sprintf("%v", tc.desiredError), "the error message should be as expected")
 		return
 	}
-	require.NoError(t, err, "there should be no error retrieving the metrics")
-	assert.NotNil(t, metrics, "there should be metrics returned")
+	require.NoErrorf(t, err, "there should be no error retrieving the metrics")
+	assert.NotNilf(t, metrics, "there should be metrics returned")
 
 	if len(metrics) != len(tc.desiredMetricValues) {
 		t.Errorf("Not equal:\nexpected: %v\nactual: %v", tc.desiredMetricValues, metrics)
@@ -231,7 +231,7 @@ func (tc *restClientTestCase) verifyResults(t *testing.T, metrics PodMetricsInfo
 	}
 
 	targetTimestamp := offsetTimestampBy(tc.targetTimestamp)
-	assert.True(t, targetTimestamp.Equal(timestamp), "the timestamp should be as expected (%s) but was %s", targetTimestamp, timestamp)
+	assert.Truef(t, targetTimestamp.Equal(timestamp), "the timestamp should be as expected (%s) but was %s", targetTimestamp, timestamp)
 }
 
 func (tc *restClientTestCase) runTest(t *testing.T) {

--- a/pkg/controller/podautoscaler/metrics/utilization_test.go
+++ b/pkg/controller/podautoscaler/metrics/utilization_test.go
@@ -39,15 +39,15 @@ func (tc *resourceUtilizationRatioTestCase) runTest(t *testing.T) {
 	actualUtilizationRatio, actualCurrentUtilization, actualRawAverageValue, actualErr := GetResourceUtilizationRatio(tc.metrics, tc.requests, tc.targetUtilization)
 
 	if tc.expectedErr != nil {
-		require.Error(t, actualErr, "there should be an error getting the utilization ratio")
-		assert.Contains(t, fmt.Sprintf("%v", actualErr), fmt.Sprintf("%v", tc.expectedErr), "the error message should be as expected")
+		require.Errorf(t, actualErr, "there should be an error getting the utilization ratio")
+		assert.Containsf(t, fmt.Sprintf("%v", actualErr), fmt.Sprintf("%v", tc.expectedErr), "the error message should be as expected")
 		return
 	}
 
-	require.NoError(t, actualErr, "there should be no error retrieving the utilization ratio")
-	assert.Equal(t, tc.expectedUtilizationRatio, actualUtilizationRatio, "the utilization ratios should be as expected")
-	assert.Equal(t, tc.expectedCurrentUtilization, actualCurrentUtilization, "the current utilization should be as expected")
-	assert.Equal(t, tc.expectedRawAverageValue, actualRawAverageValue, "the raw average value should be as expected")
+	require.NoErrorf(t, actualErr, "there should be no error retrieving the utilization ratio")
+	assert.Equalf(t, tc.expectedUtilizationRatio, actualUtilizationRatio, "the utilization ratios should be as expected")
+	assert.Equalf(t, tc.expectedCurrentUtilization, actualCurrentUtilization, "the current utilization should be as expected")
+	assert.Equalf(t, tc.expectedRawAverageValue, actualRawAverageValue, "the raw average value should be as expected")
 }
 
 type metricUsageRatioTestCase struct {
@@ -61,8 +61,8 @@ type metricUsageRatioTestCase struct {
 func (tc *metricUsageRatioTestCase) runTest(t *testing.T) {
 	actualUsageRatio, actualCurrentUsage := GetMetricUsageRatio(tc.metrics, tc.targetUsage)
 
-	assert.Equal(t, tc.expectedUsageRatio, actualUsageRatio, "the usage ratios should be as expected")
-	assert.Equal(t, tc.expectedCurrentUsage, actualCurrentUsage, "the current usage should be as expected")
+	assert.Equalf(t, tc.expectedUsageRatio, actualUsageRatio, "the usage ratios should be as expected")
+	assert.Equalf(t, tc.expectedCurrentUsage, actualCurrentUsage, "the current usage should be as expected")
 }
 
 func TestGetResourceUtilizationRatioBaseCase(t *testing.T) {

--- a/pkg/controller/podautoscaler/replica_calculator_test.go
+++ b/pkg/controller/podautoscaler/replica_calculator_test.go
@@ -232,13 +232,13 @@ func (tc *replicaCalcTestCase) prepareTestCMClient(t *testing.T) *cmfake.FakeCus
 			return true, nil, fmt.Errorf("no custom metrics specified in test client")
 		}
 
-		assert.Equal(t, tc.metric.name, getForAction.GetMetricName(), "the metric requested should have matched the one specified")
+		assert.Equalf(t, tc.metric.name, getForAction.GetMetricName(), "the metric requested should have matched the one specified")
 
 		if getForAction.GetName() == "*" {
 			metrics := cmapi.MetricValueList{}
 
 			// multiple objects
-			assert.Equal(t, "pods", getForAction.GetResource().Resource, "the type of object that we requested multiple metrics for should have been pods")
+			assert.Equalf(t, "pods", getForAction.GetResource().Resource, "the type of object that we requested multiple metrics for should have been pods")
 
 			for i, level := range tc.metric.levels {
 				podMetric := cmapi.MetricValue{
@@ -261,7 +261,7 @@ func (tc *replicaCalcTestCase) prepareTestCMClient(t *testing.T) *cmfake.FakeCus
 		name := getForAction.GetName()
 		mapper := testrestmapper.TestOnlyStaticRESTMapper(legacyscheme.Scheme)
 		metrics := &cmapi.MetricValueList{}
-		assert.NotNil(t, tc.metric.singleObject, "should have only requested a single-object metric when calling GetObjectMetricReplicas")
+		assert.NotNilf(t, tc.metric.singleObject, "should have only requested a single-object metric when calling GetObjectMetricReplicas")
 		gk := schema.FromAPIVersionAndKind(tc.metric.singleObject.APIVersion, tc.metric.singleObject.Kind).GroupKind()
 		mapping, err := mapper.RESTMapping(gk)
 		if err != nil {
@@ -269,8 +269,8 @@ func (tc *replicaCalcTestCase) prepareTestCMClient(t *testing.T) *cmfake.FakeCus
 		}
 		groupResource := mapping.Resource.GroupResource()
 
-		assert.Equal(t, groupResource.String(), getForAction.GetResource().Resource, "should have requested metrics for the resource matching the GroupKind passed in")
-		assert.Equal(t, tc.metric.singleObject.Name, name, "should have requested metrics for the object matching the name passed in")
+		assert.Equalf(t, groupResource.String(), getForAction.GetResource().Resource, "should have requested metrics for the resource matching the GroupKind passed in")
+		assert.Equalf(t, tc.metric.singleObject.Name, name, "should have requested metrics for the object matching the name passed in")
 
 		metrics.Items = []cmapi.MetricValue{
 			{
@@ -304,13 +304,13 @@ func (tc *replicaCalcTestCase) prepareTestEMClient(t *testing.T) *emfake.FakeExt
 			return true, nil, fmt.Errorf("no external metrics specified in test client")
 		}
 
-		assert.Equal(t, tc.metric.name, listAction.GetResource().Resource, "the metric requested should have matched the one specified")
+		assert.Equalf(t, tc.metric.name, listAction.GetResource().Resource, "the metric requested should have matched the one specified")
 
 		selector, err := metav1.LabelSelectorAsSelector(tc.metric.selector)
 		if err != nil {
 			return true, nil, fmt.Errorf("failed to convert label selector specified in test client")
 		}
-		assert.Equal(t, selector, listAction.GetListRestrictions().Labels, "the metric selector should have matched the one specified")
+		assert.Equalf(t, selector, listAction.GetListRestrictions().Labels, "the metric selector should have matched the one specified")
 
 		metrics := emapi.ExternalMetricValueList{}
 
@@ -355,21 +355,21 @@ func (tc *replicaCalcTestCase) runTest(t *testing.T) {
 	selector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{
 		MatchLabels: map[string]string{"name": podNamePrefix},
 	})
-	require.NoError(t, err, "something went horribly wrong...")
+	require.NoErrorf(t, err, "something went horribly wrong...")
 
 	if tc.resource != nil {
 		outReplicas, outUtilization, outRawValue, outTimestamp, err := replicaCalc.GetResourceReplicas(context.TODO(), tc.currentReplicas, tc.resource.targetUtilization, tc.resource.name, testNamespace, selector, tc.container)
 
 		if tc.expectedError != nil {
-			require.Error(t, err, "there should be an error calculating the replica count")
-			assert.ErrorContains(t, err, tc.expectedError.Error(), "the error message should have contained the expected error message")
+			require.Errorf(t, err, "there should be an error calculating the replica count")
+			assert.ErrorContainsf(t, err, tc.expectedError.Error(), "the error message should have contained the expected error message")
 			return
 		}
-		require.NoError(t, err, "there should not have been an error calculating the replica count")
-		assert.Equal(t, tc.expectedReplicas, outReplicas, "replicas should be as expected")
-		assert.Equal(t, tc.resource.expectedUtilization, outUtilization, "utilization should be as expected")
-		assert.Equal(t, tc.resource.expectedValue, outRawValue, "raw value should be as expected")
-		assert.True(t, tc.timestamp.Equal(outTimestamp), "timestamp should be as expected")
+		require.NoErrorf(t, err, "there should not have been an error calculating the replica count")
+		assert.Equalf(t, tc.expectedReplicas, outReplicas, "replicas should be as expected")
+		assert.Equalf(t, tc.resource.expectedUtilization, outUtilization, "utilization should be as expected")
+		assert.Equalf(t, tc.resource.expectedValue, outRawValue, "raw value should be as expected")
+		assert.Truef(t, tc.timestamp.Equal(outTimestamp), "timestamp should be as expected")
 		return
 	}
 
@@ -411,14 +411,14 @@ func (tc *replicaCalcTestCase) runTest(t *testing.T) {
 	}
 
 	if tc.expectedError != nil {
-		require.Error(t, err, "there should be an error calculating the replica count")
-		assert.ErrorContains(t, err, tc.expectedError.Error(), "the error message should have contained the expected error message")
+		require.Errorf(t, err, "there should be an error calculating the replica count")
+		assert.ErrorContainsf(t, err, tc.expectedError.Error(), "the error message should have contained the expected error message")
 		return
 	}
-	require.NoError(t, err, "there should not have been an error calculating the replica count")
-	assert.Equal(t, tc.expectedReplicas, outReplicas, "replicas should be as expected")
-	assert.Equal(t, tc.metric.expectedUsage, outUsage, "usage should be as expected")
-	assert.True(t, tc.timestamp.Equal(outTimestamp), "timestamp should be as expected")
+	require.NoErrorf(t, err, "there should not have been an error calculating the replica count")
+	assert.Equalf(t, tc.expectedReplicas, outReplicas, "replicas should be as expected")
+	assert.Equalf(t, tc.metric.expectedUsage, outUsage, "usage should be as expected")
+	assert.Truef(t, tc.timestamp.Equal(outTimestamp), "timestamp should be as expected")
 }
 func makePodMetricLevels(containerMetric ...int64) [][]int64 {
 	metrics := make([][]int64, len(containerMetric))
@@ -2101,8 +2101,8 @@ func TestCalculatePodRequests(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			requests, err := calculatePodRequests(tc.pods, tc.container, tc.resource)
-			assert.Equal(t, tc.expectedRequests, requests, "requests should be as expected")
-			assert.Equal(t, tc.expectedError, err, "error should be as expected")
+			assert.Equalf(t, tc.expectedRequests, requests, "requests should be as expected")
+			assert.Equalf(t, tc.expectedError, err, "error should be as expected")
 		})
 	}
 }

--- a/pkg/controller/resourceclaim/controller_test.go
+++ b/pkg/controller/resourceclaim/controller_test.go
@@ -498,7 +498,7 @@ func TestSyncHandler(t *testing.T) {
 				}
 				actualStatuses[pod.Name] = pod.Status.ResourceClaimStatuses
 			}
-			assert.Equal(t, tc.expectedStatuses, actualStatuses, "pod resource claim statuses")
+			assert.Equalf(t, tc.expectedStatuses, actualStatuses, "pod resource claim statuses")
 
 			scheduling, err := fakeKubeClient.ResourceV1alpha3().PodSchedulingContexts("").List(ctx, metav1.ListOptions{})
 			if err != nil {

--- a/pkg/controller/ttl/ttl_controller_test.go
+++ b/pkg/controller/ttl/ttl_controller_test.go
@@ -86,9 +86,9 @@ func TestPatchNode(t *testing.T) {
 			continue
 		}
 		actions := fakeClient.Actions()
-		assert.Len(t, actions, 1, "unexpected actions: %#v", actions)
+		assert.Lenf(t, actions, 1, "unexpected actions: %#v", actions)
 		patchAction := actions[0].(core.PatchActionImpl)
-		assert.Equal(t, testCase.patch, string(patchAction.Patch), "%d: unexpected patch: %s", i, string(patchAction.Patch))
+		assert.Equalf(t, testCase.patch, string(patchAction.Patch), "%d: unexpected patch: %s", i, string(patchAction.Patch))
 	}
 }
 
@@ -145,11 +145,11 @@ func TestUpdateNodeIfNeeded(t *testing.T) {
 		}
 		actions := fakeClient.Actions()
 		if testCase.patch == "" {
-			assert.Empty(t, actions, "unexpected actions")
+			assert.Emptyf(t, actions, "unexpected actions")
 		} else {
-			assert.Len(t, actions, 1, "unexpected actions: %#v", actions)
+			assert.Lenf(t, actions, 1, "unexpected actions: %#v", actions)
 			patchAction := actions[0].(core.PatchActionImpl)
-			assert.Equal(t, testCase.patch, string(patchAction.Patch), "%d: unexpected patch: %s", i, string(patchAction.Patch))
+			assert.Equalf(t, testCase.patch, string(patchAction.Patch), "%d: unexpected patch: %s", i, string(patchAction.Patch))
 		}
 	}
 }
@@ -242,7 +242,7 @@ func TestDesiredTTL(t *testing.T) {
 		if testCase.deleteNode {
 			ttlController.deleteNode(&v1.Node{})
 		}
-		assert.Equal(t, testCase.expectedTTL, ttlController.getDesiredTTLSeconds(),
+		assert.Equalf(t, testCase.expectedTTL, ttlController.getDesiredTTLSeconds(),
 			"%d: unexpected ttl: %d", i, ttlController.getDesiredTTLSeconds())
 	}
 }

--- a/pkg/kubelet/cadvisor/util_test.go
+++ b/pkg/kubelet/cadvisor/util_test.go
@@ -55,5 +55,5 @@ func TestCapacityFromMachineInfoWithHugePagesEnable(t *testing.T) {
 }
 
 func TestCrioSocket(t *testing.T) {
-	assert.True(t, strings.HasSuffix(crio.CrioSocket, CrioSocketSuffix), "CrioSocketSuffix in this package must be a suffix of the one in github.com/google/cadvisor/container/crio/client.go")
+	assert.Truef(t, strings.HasSuffix(crio.CrioSocket, CrioSocketSuffix), "CrioSocketSuffix in this package must be a suffix of the one in github.com/google/cadvisor/container/crio/client.go")
 }

--- a/pkg/kubelet/cm/container_manager_linux_test.go
+++ b/pkg/kubelet/cm/container_manager_linux_test.go
@@ -68,9 +68,9 @@ func TestCgroupMountValidationSuccess(t *testing.T) {
 	f, err := validateSystemRequirements(fakeContainerMgrMountInt())
 	assert.NoError(t, err)
 	if cgroups.IsCgroup2UnifiedMode() {
-		assert.True(t, f.cpuHardcapping, "cpu hardcapping is expected to be enabled")
+		assert.Truef(t, f.cpuHardcapping, "cpu hardcapping is expected to be enabled")
 	} else {
-		assert.False(t, f.cpuHardcapping, "cpu hardcapping is expected to be disabled")
+		assert.Falsef(t, f.cpuHardcapping, "cpu hardcapping is expected to be disabled")
 	}
 }
 
@@ -170,7 +170,7 @@ func TestSoftRequirementsValidationSuccess(t *testing.T) {
 		})
 	f, err := validateSystemRequirements(mountInt)
 	assert.NoError(t, err)
-	assert.True(t, f.cpuHardcapping, "cpu hardcapping is expected to be enabled")
+	assert.Truef(t, f.cpuHardcapping, "cpu hardcapping is expected to be enabled")
 }
 
 func TestGetCapacity(t *testing.T) {

--- a/pkg/kubelet/cm/devicemanager/manager_test.go
+++ b/pkg/kubelet/cm/devicemanager/manager_test.go
@@ -155,8 +155,8 @@ func TestDevicePluginReRegistration(t *testing.T) {
 			capacity, allocatable, _ := m.GetCapacity()
 			resourceCapacity := capacity[v1.ResourceName(testResourceName)]
 			resourceAllocatable := allocatable[v1.ResourceName(testResourceName)]
-			require.Equal(t, resourceCapacity.Value(), resourceAllocatable.Value(), "capacity should equal to allocatable")
-			require.Equal(t, int64(2), resourceAllocatable.Value(), "Devices are not updated.")
+			require.Equalf(t, resourceCapacity.Value(), resourceAllocatable.Value(), "capacity should equal to allocatable")
+			require.Equalf(t, int64(2), resourceAllocatable.Value(), "Devices are not updated.")
 
 			p2 := plugin.NewDevicePluginStub(devs, pluginSocketName+".new", testResourceName, preStartContainerFlag, getPreferredAllocationFlag)
 			err = p2.Start()
@@ -171,8 +171,8 @@ func TestDevicePluginReRegistration(t *testing.T) {
 			capacity, allocatable, _ = m.GetCapacity()
 			resourceCapacity = capacity[v1.ResourceName(testResourceName)]
 			resourceAllocatable = allocatable[v1.ResourceName(testResourceName)]
-			require.Equal(t, resourceCapacity.Value(), resourceAllocatable.Value(), "capacity should equal to allocatable")
-			require.Equal(t, int64(2), resourceAllocatable.Value(), "Devices shouldn't change.")
+			require.Equalf(t, resourceCapacity.Value(), resourceAllocatable.Value(), "capacity should equal to allocatable")
+			require.Equalf(t, int64(2), resourceAllocatable.Value(), "Devices shouldn't change.")
 
 			// Test the scenario that a plugin re-registers with different devices.
 			p3 := plugin.NewDevicePluginStub(devsForRegistration, pluginSocketName+".third", testResourceName, preStartContainerFlag, getPreferredAllocationFlag)
@@ -188,8 +188,8 @@ func TestDevicePluginReRegistration(t *testing.T) {
 			capacity, allocatable, _ = m.GetCapacity()
 			resourceCapacity = capacity[v1.ResourceName(testResourceName)]
 			resourceAllocatable = allocatable[v1.ResourceName(testResourceName)]
-			require.Equal(t, resourceCapacity.Value(), resourceAllocatable.Value(), "capacity should equal to allocatable")
-			require.Equal(t, int64(1), resourceAllocatable.Value(), "Devices of plugin previously registered should be removed.")
+			require.Equalf(t, resourceCapacity.Value(), resourceAllocatable.Value(), "capacity should equal to allocatable")
+			require.Equalf(t, int64(1), resourceAllocatable.Value(), "Devices of plugin previously registered should be removed.")
 			p2.Stop()
 			p3.Stop()
 			cleanup(t, m, p1)
@@ -229,8 +229,8 @@ func TestDevicePluginReRegistrationProbeMode(t *testing.T) {
 	capacity, allocatable, _ := m.GetCapacity()
 	resourceCapacity := capacity[v1.ResourceName(testResourceName)]
 	resourceAllocatable := allocatable[v1.ResourceName(testResourceName)]
-	require.Equal(t, resourceCapacity.Value(), resourceAllocatable.Value(), "capacity should equal to allocatable")
-	require.Equal(t, int64(2), resourceAllocatable.Value(), "Devices are not updated.")
+	require.Equalf(t, resourceCapacity.Value(), resourceAllocatable.Value(), "capacity should equal to allocatable")
+	require.Equalf(t, int64(2), resourceAllocatable.Value(), "Devices are not updated.")
 
 	p2 := plugin.NewDevicePluginStub(devs, pluginSocketName+".new", testResourceName, false, false)
 	err = p2.Start()
@@ -245,8 +245,8 @@ func TestDevicePluginReRegistrationProbeMode(t *testing.T) {
 	capacity, allocatable, _ = m.GetCapacity()
 	resourceCapacity = capacity[v1.ResourceName(testResourceName)]
 	resourceAllocatable = allocatable[v1.ResourceName(testResourceName)]
-	require.Equal(t, resourceCapacity.Value(), resourceAllocatable.Value(), "capacity should equal to allocatable")
-	require.Equal(t, int64(2), resourceAllocatable.Value(), "Devices are not updated.")
+	require.Equalf(t, resourceCapacity.Value(), resourceAllocatable.Value(), "capacity should equal to allocatable")
+	require.Equalf(t, int64(2), resourceAllocatable.Value(), "Devices are not updated.")
 
 	// Test the scenario that a plugin re-registers with different devices.
 	p3 := plugin.NewDevicePluginStub(devsForRegistration, pluginSocketName+".third", testResourceName, false, false)
@@ -262,8 +262,8 @@ func TestDevicePluginReRegistrationProbeMode(t *testing.T) {
 	capacity, allocatable, _ = m.GetCapacity()
 	resourceCapacity = capacity[v1.ResourceName(testResourceName)]
 	resourceAllocatable = allocatable[v1.ResourceName(testResourceName)]
-	require.Equal(t, resourceCapacity.Value(), resourceAllocatable.Value(), "capacity should equal to allocatable")
-	require.Equal(t, int64(1), resourceAllocatable.Value(), "Devices of previous registered should be removed")
+	require.Equalf(t, resourceCapacity.Value(), resourceAllocatable.Value(), "capacity should equal to allocatable")
+	require.Equalf(t, int64(1), resourceAllocatable.Value(), "Devices of previous registered should be removed")
 	p2.Stop()
 	p3.Stop()
 	cleanup(t, m, p1)
@@ -1960,7 +1960,7 @@ func sortContainerStatuses(statuses []v1.ContainerStatus) {
 
 func TestFeatureGateResourceHealthStatus(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "checkpoint")
-	require.NoError(t, err, "err should be nil")
+	require.NoErrorf(t, err, "err should be nil")
 	defer func() {
 		err = os.RemoveAll(tmpDir)
 		if err != nil {
@@ -1968,7 +1968,7 @@ func TestFeatureGateResourceHealthStatus(t *testing.T) {
 		}
 	}()
 	ckm, err := checkpointmanager.NewCheckpointManager(tmpDir)
-	require.NoError(t, err, "err should be nil")
+	require.NoErrorf(t, err, "err should be nil")
 	resourceName := "domain1.com/resource1"
 	existDevices := map[string]DeviceInstances{}
 	resourceNameMap := make(map[string]pluginapi.Device)

--- a/pkg/kubelet/cm/devicemanager/pod_devices_test.go
+++ b/pkg/kubelet/cm/devicemanager/pod_devices_test.go
@@ -46,16 +46,16 @@ func TestGetContainerDevices(t *testing.T) {
 
 	resContDevices := podDevices.getContainerDevices(podID, contID)
 	contDevices, ok := resContDevices[resourceName1]
-	require.True(t, ok, "resource %q not present", resourceName1)
+	require.Truef(t, ok, "resource %q not present", resourceName1)
 
 	for devID, plugInfo := range contDevices {
 		nodes := plugInfo.GetTopology().GetNodes()
-		require.Equal(t, len(nodes), len(devices), "Incorrect container devices: %v - %v (nodes %v)", devices, contDevices, nodes)
+		require.Equalf(t, len(nodes), len(devices), "Incorrect container devices: %v - %v (nodes %v)", devices, contDevices, nodes)
 
 		for _, node := range plugInfo.GetTopology().GetNodes() {
 			dev, ok := devices[node.ID]
-			require.True(t, ok, "NUMA id %v doesn't exist in result", node.ID)
-			require.Equal(t, devID, dev[0], "Can't find device %s in result", dev[0])
+			require.Truef(t, ok, "NUMA id %v doesn't exist in result", node.ID)
+			require.Equalf(t, devID, dev[0], "Can't find device %s in result", dev[0])
 		}
 	}
 }

--- a/pkg/kubelet/cm/dra/state/checkpointer_test.go
+++ b/pkg/kubelet/cm/dra/state/checkpointer_test.go
@@ -215,29 +215,29 @@ func TestCheckpointGetOrCreate(t *testing.T) {
 
 	// create checkpoint manager for testing
 	cpm, err := checkpointmanager.NewCheckpointManager(testingDir)
-	require.NoError(t, err, "could not create testing checkpoint manager")
+	require.NoErrorf(t, err, "could not create testing checkpoint manager")
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
 			// ensure there is no previous checkpoint
-			require.NoError(t, cpm.RemoveCheckpoint(testingCheckpoint), "could not remove testing checkpoint")
+			require.NoErrorf(t, cpm.RemoveCheckpoint(testingCheckpoint), "could not remove testing checkpoint")
 
 			// prepare checkpoint for testing
 			if strings.TrimSpace(tc.checkpointContent) != "" {
 				mock := &testutil.MockCheckpoint{Content: tc.checkpointContent}
-				require.NoError(t, cpm.CreateCheckpoint(testingCheckpoint, mock), "could not create testing checkpoint")
+				require.NoErrorf(t, cpm.CreateCheckpoint(testingCheckpoint, mock), "could not create testing checkpoint")
 			}
 
 			checkpointer, err := NewCheckpointer(testingDir, testingCheckpoint)
-			require.NoError(t, err, "could not create testing checkpointer")
+			require.NoErrorf(t, err, "could not create testing checkpointer")
 
 			checkpoint, err := checkpointer.GetOrCreate()
 			if strings.TrimSpace(tc.expectedError) != "" {
 				assert.ErrorContains(t, err, tc.expectedError)
 			} else {
-				require.NoError(t, err, "unexpected error")
+				require.NoErrorf(t, err, "unexpected error")
 				stateList, err := checkpoint.GetClaimInfoStateList()
-				require.NoError(t, err, "could not get data entries from checkpoint")
+				require.NoErrorf(t, err, "could not get data entries from checkpoint")
 				require.NoError(t, err)
 				assert.Equal(t, tc.expectedClaimInfoStateList, stateList)
 			}
@@ -369,25 +369,25 @@ func TestCheckpointStateStore(t *testing.T) {
 	}
 
 	cpm, err := checkpointmanager.NewCheckpointManager(testingDir)
-	require.NoError(t, err, "could not create testing checkpoint manager")
-	require.NoError(t, cpm.RemoveCheckpoint(testingCheckpoint), "could not remove testing checkpoint")
+	require.NoErrorf(t, err, "could not create testing checkpoint manager")
+	require.NoErrorf(t, cpm.RemoveCheckpoint(testingCheckpoint), "could not remove testing checkpoint")
 
 	cs, err := NewCheckpointer(testingDir, testingCheckpoint)
-	require.NoError(t, err, "could not create testing checkpointState instance")
+	require.NoErrorf(t, err, "could not create testing checkpointState instance")
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
 			checkpoint, err := NewCheckpoint(tc.claimInfoStateList)
-			require.NoError(t, err, "could not create Checkpoint")
+			require.NoErrorf(t, err, "could not create Checkpoint")
 
 			err = cs.Store(checkpoint)
-			require.NoError(t, err, "could not store checkpoint")
+			require.NoErrorf(t, err, "could not store checkpoint")
 
 			err = cpm.GetCheckpoint(testingCheckpoint, checkpoint)
-			require.NoError(t, err, "could not get checkpoint")
+			require.NoErrorf(t, err, "could not get checkpoint")
 
 			checkpointContent, err := checkpoint.MarshalCheckpoint()
-			require.NoError(t, err, "could not Marshal Checkpoint")
+			require.NoErrorf(t, err, "could not Marshal Checkpoint")
 			assert.Equal(t, tc.expectedCheckpointContent, string(checkpointContent))
 		})
 	}

--- a/pkg/kubelet/cm/memorymanager/state/state_checkpoint_test.go
+++ b/pkg/kubelet/cm/memorymanager/state/state_checkpoint_test.go
@@ -34,11 +34,11 @@ const testingCheckpoint = "memorymanager_checkpoint_test"
 func assertStateEqual(t *testing.T, restoredState, expectedState State) {
 	expectedMachineState := expectedState.GetMachineState()
 	restoredMachineState := restoredState.GetMachineState()
-	assert.Equal(t, expectedMachineState, restoredMachineState, "expected MachineState does not equal to restored one")
+	assert.Equalf(t, expectedMachineState, restoredMachineState, "expected MachineState does not equal to restored one")
 
 	expectedMemoryAssignments := expectedState.GetMemoryAssignments()
 	restoredMemoryAssignments := restoredState.GetMemoryAssignments()
-	assert.Equal(t, expectedMemoryAssignments, restoredMemoryAssignments, "state memory assignments mismatch")
+	assert.Equalf(t, expectedMemoryAssignments, restoredMemoryAssignments, "state memory assignments mismatch")
 }
 
 func TestCheckpointStateRestore(t *testing.T) {
@@ -118,17 +118,17 @@ func TestCheckpointStateRestore(t *testing.T) {
 
 	// create checkpoint manager for testing
 	cpm, err := checkpointmanager.NewCheckpointManager(testingDir)
-	assert.NoError(t, err, "could not create testing checkpoint manager")
+	assert.NoErrorf(t, err, "could not create testing checkpoint manager")
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
 			// ensure there is no previous checkpoint
-			assert.NoError(t, cpm.RemoveCheckpoint(testingCheckpoint), "could not remove testing checkpoint")
+			assert.NoErrorf(t, cpm.RemoveCheckpoint(testingCheckpoint), "could not remove testing checkpoint")
 
 			// prepare checkpoint for testing
 			if strings.TrimSpace(tc.checkpointContent) != "" {
 				checkpoint := &testutil.MockCheckpoint{Content: tc.checkpointContent}
-				assert.NoError(t, cpm.CreateCheckpoint(testingCheckpoint, checkpoint), "could not create testing checkpoint")
+				assert.NoErrorf(t, cpm.CreateCheckpoint(testingCheckpoint, checkpoint), "could not create testing checkpoint")
 			}
 
 			restoredState, err := NewCheckpointState(testingDir, testingCheckpoint, "static")
@@ -136,7 +136,7 @@ func TestCheckpointStateRestore(t *testing.T) {
 				assert.Error(t, err)
 				assert.ErrorContains(t, err, "could not restore state from checkpoint: "+tc.expectedError)
 			} else {
-				assert.NoError(t, err, "unexpected error while creating checkpointState")
+				assert.NoErrorf(t, err, "unexpected error while creating checkpointState")
 				// compare state after restoration with the one expected
 				assertStateEqual(t, restoredState, tc.expectedState)
 			}
@@ -180,12 +180,12 @@ func TestCheckpointStateStore(t *testing.T) {
 	defer os.RemoveAll(testingDir)
 
 	cpm, err := checkpointmanager.NewCheckpointManager(testingDir)
-	assert.NoError(t, err, "could not create testing checkpoint manager")
+	assert.NoErrorf(t, err, "could not create testing checkpoint manager")
 
-	assert.NoError(t, cpm.RemoveCheckpoint(testingCheckpoint), "could not remove testing checkpoint")
+	assert.NoErrorf(t, cpm.RemoveCheckpoint(testingCheckpoint), "could not remove testing checkpoint")
 
 	cs1, err := NewCheckpointState(testingDir, testingCheckpoint, "static")
-	assert.NoError(t, err, "could not create testing checkpointState instance")
+	assert.NoErrorf(t, err, "could not create testing checkpointState instance")
 
 	// set values of cs1 instance so they are stored in checkpoint and can be read by cs2
 	cs1.SetMachineState(expectedState.machineState)
@@ -193,7 +193,7 @@ func TestCheckpointStateStore(t *testing.T) {
 
 	// restore checkpoint with previously stored values
 	cs2, err := NewCheckpointState(testingDir, testingCheckpoint, "static")
-	assert.NoError(t, err, "could not create testing checkpointState instance")
+	assert.NoErrorf(t, err, "could not create testing checkpointState instance")
 
 	assertStateEqual(t, cs2, expectedState)
 }
@@ -299,26 +299,26 @@ func TestCheckpointStateHelpers(t *testing.T) {
 	defer os.RemoveAll(testingDir)
 
 	cpm, err := checkpointmanager.NewCheckpointManager(testingDir)
-	assert.NoError(t, err, "could not create testing checkpoint manager")
+	assert.NoErrorf(t, err, "could not create testing checkpoint manager")
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
 			// ensure there is no previous checkpoint
-			assert.NoError(t, cpm.RemoveCheckpoint(testingCheckpoint), "could not remove testing checkpoint")
+			assert.NoErrorf(t, cpm.RemoveCheckpoint(testingCheckpoint), "could not remove testing checkpoint")
 
 			state, err := NewCheckpointState(testingDir, testingCheckpoint, "static")
-			assert.NoError(t, err, "could not create testing checkpoint manager")
+			assert.NoErrorf(t, err, "could not create testing checkpoint manager")
 
 			state.SetMachineState(tc.machineState)
-			assert.Equal(t, tc.machineState, state.GetMachineState(), "machine state inconsistent")
+			assert.Equalf(t, tc.machineState, state.GetMachineState(), "machine state inconsistent")
 
 			for pod := range tc.assignments {
 				for container, blocks := range tc.assignments[pod] {
 					state.SetMemoryBlocks(pod, container, blocks)
-					assert.Equal(t, blocks, state.GetMemoryBlocks(pod, container), "memory block inconsistent")
+					assert.Equalf(t, blocks, state.GetMemoryBlocks(pod, container), "memory block inconsistent")
 
 					state.Delete(pod, container)
-					assert.Nil(t, state.GetMemoryBlocks(pod, container), "deleted container still existing in state")
+					assert.Nilf(t, state.GetMemoryBlocks(pod, container), "deleted container still existing in state")
 				}
 			}
 		})
@@ -370,14 +370,14 @@ func TestCheckpointStateClear(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
 			state, err := NewCheckpointState(testingDir, testingCheckpoint, "static")
-			assert.NoError(t, err, "could not create testing checkpoint manager")
+			assert.NoErrorf(t, err, "could not create testing checkpoint manager")
 
 			state.SetMachineState(tc.machineState)
 			state.SetMemoryAssignments(tc.assignments)
 
 			state.ClearState()
-			assert.Equal(t, NUMANodeMap{}, state.GetMachineState(), "cleared state with non-empty machine state")
-			assert.Equal(t, ContainerMemoryAssignments{}, state.GetMemoryAssignments(), "cleared state with non-empty memory assignments")
+			assert.Equalf(t, NUMANodeMap{}, state.GetMachineState(), "cleared state with non-empty machine state")
+			assert.Equalf(t, ContainerMemoryAssignments{}, state.GetMemoryAssignments(), "cleared state with non-empty memory assignments")
 		})
 	}
 }

--- a/pkg/kubelet/cm/node_container_manager_linux_test.go
+++ b/pkg/kubelet/cm/node_container_manager_linux_test.go
@@ -108,8 +108,8 @@ func TestNodeAllocatableReservationForScheduling(t *testing.T) {
 		}
 		for k, v := range cm.GetNodeAllocatableReservation() {
 			expected, exists := tc.expected[k]
-			assert.True(t, exists, "test case %d expected resource %q", idx+1, k)
-			assert.Equal(t, expected.MilliValue(), v.MilliValue(), "test case %d failed for resource %q", idx+1, k)
+			assert.Truef(t, exists, "test case %d expected resource %q", idx+1, k)
+			assert.Equalf(t, expected.MilliValue(), v.MilliValue(), "test case %d failed for resource %q", idx+1, k)
 		}
 	}
 
@@ -167,8 +167,8 @@ func TestNodeAllocatableReservationForScheduling(t *testing.T) {
 		}
 		for k, v := range cm.GetNodeAllocatableReservation() {
 			expected, exists := tc.expected[k]
-			assert.True(t, exists, "test case %d expected resource %q", idx+1, k)
-			assert.Equal(t, expected.MilliValue(), v.MilliValue(), "test case %d failed for resource %q", idx+1, k)
+			assert.Truef(t, exists, "test case %d expected resource %q", idx+1, k)
+			assert.Equalf(t, expected.MilliValue(), v.MilliValue(), "test case %d failed for resource %q", idx+1, k)
 		}
 	}
 }
@@ -254,7 +254,7 @@ func TestNodeAllocatableForEnforcement(t *testing.T) {
 		for k, v := range cm.GetNodeAllocatableAbsolute() {
 			expected, exists := tc.expected[k]
 			assert.True(t, exists)
-			assert.Equal(t, expected.MilliValue(), v.MilliValue(), "test case %d failed for resource %q", idx+1, k)
+			assert.Equalf(t, expected.MilliValue(), v.MilliValue(), "test case %d failed for resource %q", idx+1, k)
 		}
 	}
 }

--- a/pkg/kubelet/config/common_test.go
+++ b/pkg/kubelet/config/common_test.go
@@ -290,7 +290,7 @@ func TestStaticPodNameGenerate(t *testing.T) {
 		},
 	}
 	for _, c := range testCases {
-		assert.Equal(t, c.expected, generatePodName(c.podName, c.nodeName), "wrong pod name generated")
+		assert.Equalf(t, c.expected, generatePodName(c.podName, c.nodeName), "wrong pod name generated")
 		pod := podtest.MakePod("")
 		pod.Name = c.podName
 		if c.overwrite != "" {
@@ -304,7 +304,7 @@ func TestStaticPodNameGenerate(t *testing.T) {
 					specNameErrored = true
 				}
 			}
-			assert.NotEmpty(t, specNameErrored, "expecting error")
+			assert.NotEmptyf(t, specNameErrored, "expecting error")
 		} else {
 			for _, err := range errs {
 				if err.Field == "metadata.name" {

--- a/pkg/kubelet/container/cache_test.go
+++ b/pkg/kubelet/container/cache_test.go
@@ -35,7 +35,7 @@ func TestCacheNotInitialized(t *testing.T) {
 	cache := newTestCache()
 	// If the global timestamp is not set, always return nil.
 	d := cache.getIfNewerThan(types.UID("1234"), time.Time{})
-	assert.Nil(t, d, "should return nil since cache is not initialized")
+	assert.Nilf(t, d, "should return nil since cache is not initialized")
 }
 
 func getTestPodIDAndStatus(numContainers int) (types.UID, *PodStatus) {
@@ -100,7 +100,7 @@ func TestGetIfNewerThanWhenPodExists(t *testing.T) {
 		cache.UpdateTime(c.cacheTime)
 		cache.Set(podID, status, nil, c.modified)
 		d := cache.getIfNewerThan(podID, timestamp)
-		assert.Equal(t, c.expected, d != nil, "test[%d]", i)
+		assert.Equalf(t, c.expected, d != nil, "test[%d]", i)
 	}
 }
 
@@ -125,7 +125,7 @@ func TestGetPodNewerThanWhenPodDoesNotExist(t *testing.T) {
 	}
 	for i, c := range cases {
 		d := cache.getIfNewerThan(podID, c.timestamp)
-		assert.Equal(t, c.expected, d != nil, "test[%d]", i)
+		assert.Equalf(t, c.expected, d != nil, "test[%d]", i)
 	}
 }
 
@@ -145,8 +145,8 @@ func TestCacheSetAndGet(t *testing.T) {
 		// Read back the status and error stored in cache and make sure they
 		// match the original ones.
 		actualStatus, actualErr := cache.Get(podID)
-		assert.Equal(t, status, actualStatus, "test[%d]", i)
-		assert.Equal(t, c.error, actualErr, "test[%d]", i)
+		assert.Equalf(t, status, actualStatus, "test[%d]", i)
+		assert.Equalf(t, c.error, actualErr, "test[%d]", i)
 	}
 }
 
@@ -178,9 +178,9 @@ func TestDelete(t *testing.T) {
 
 func verifyNotification(t *testing.T, ch chan *data, expectNotification bool) {
 	if expectNotification {
-		assert.NotEmpty(t, ch, "Did not receive notification")
+		assert.NotEmptyf(t, ch, "Did not receive notification")
 	} else {
-		assert.Empty(t, ch, "Should not have triggered the notification")
+		assert.Emptyf(t, ch, "Should not have triggered the notification")
 	}
 	// Drain the channel.
 	for i := 0; i < len(ch); i++ {

--- a/pkg/kubelet/container/helpers_test.go
+++ b/pkg/kubelet/container/helpers_test.go
@@ -636,7 +636,7 @@ func TestMakePortMappings(t *testing.T) {
 
 	for i, tt := range tests {
 		actual := MakePortMappings(tt.container)
-		assert.Equal(t, tt.expectedPortMappings, actual, "[%d]", i)
+		assert.Equalf(t, tt.expectedPortMappings, actual, "[%d]", i)
 	}
 }
 
@@ -670,7 +670,7 @@ func TestHashContainer(t *testing.T) {
 		}
 
 		hashVal := HashContainer(&container)
-		assert.Equal(t, tc.expectedHash, hashVal, "the hash value here should not be changed.")
+		assert.Equalf(t, tc.expectedHash, hashVal, "the hash value here should not be changed.")
 	}
 }
 
@@ -694,7 +694,7 @@ func TestShouldRecordEvent(t *testing.T) {
 
 	var nilObj *v1.ObjectReference = nil
 	_, actual = innerEventRecorder.shouldRecordEvent(nilObj)
-	assert.False(t, actual, "should not panic if the typed nil was used, see https://github.com/kubernetes/kubernetes/issues/95552")
+	assert.Falsef(t, actual, "should not panic if the typed nil was used, see https://github.com/kubernetes/kubernetes/issues/95552")
 }
 
 func TestHasWindowsHostProcessContainer(t *testing.T) {
@@ -984,8 +984,8 @@ func TestHashContainerWithoutResources(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			containerCopy := tc.container.DeepCopy()
 			hash := HashContainer(tc.container)
-			assert.Equal(t, tc.expectedHash, hash, "[%s]", tc.name)
-			assert.Equal(t, containerCopy, tc.container, "[%s]", tc.name)
+			assert.Equalf(t, tc.expectedHash, hash, "[%s]", tc.name)
+			assert.Equalf(t, containerCopy, tc.container, "[%s]", tc.name)
 		})
 	}
 }

--- a/pkg/kubelet/eviction/helpers_test.go
+++ b/pkg/kubelet/eviction/helpers_test.go
@@ -3457,7 +3457,7 @@ func TestStatsNotFoundForPod(t *testing.T) {
 		},
 	} {
 		t.Run(test.description, func(t *testing.T) {
-			assert.Equal(t, 0, test.compFunc(statsFn)(pod1, pod2), "unexpected default result")
+			assert.Equalf(t, 0, test.compFunc(statsFn)(pod1, pod2), "unexpected default result")
 		})
 	}
 }

--- a/pkg/kubelet/images/image_manager_test.go
+++ b/pkg/kubelet/images/image_manager_test.go
@@ -469,23 +469,23 @@ func TestPullAndListImageWithPodAnnotations(t *testing.T) {
 
 		_, _, err := puller.EnsureImageExists(ctx, nil, pod, container.Image, nil, nil, "", container.ImagePullPolicy)
 		fakeRuntime.AssertCalls(c.expected[0].calls)
-		assert.Equal(t, c.expected[0].err, err, "tick=%d", 0)
+		assert.Equalf(t, c.expected[0].err, err, "tick=%d", 0)
 		assert.Equal(t, c.expected[0].shouldRecordStartedPullingTime, fakePodPullingTimeRecorder.startedPullingRecorded)
 		assert.Equal(t, c.expected[0].shouldRecordFinishedPullingTime, fakePodPullingTimeRecorder.finishedPullingRecorded)
 
 		images, _ := fakeRuntime.ListImages(ctx)
-		assert.Len(t, images, 1, "ListImages() count")
+		assert.Lenf(t, images, 1, "ListImages() count")
 
 		image := images[0]
-		assert.Equal(t, "missing_image:latest", image.ID, "Image ID")
-		assert.Equal(t, "", image.Spec.RuntimeHandler, "image.Spec.RuntimeHandler not empty", "ImageID", image.ID)
+		assert.Equalf(t, "missing_image:latest", image.ID, "Image ID")
+		assert.Equalf(t, "", image.Spec.RuntimeHandler, "image.Spec.RuntimeHandler not empty", "ImageID", image.ID)
 
 		expectedAnnotations := []Annotation{
 			{
 				Name:  "kubernetes.io/runtimehandler",
 				Value: "handler_name",
 			}}
-		assert.Equal(t, expectedAnnotations, image.Spec.Annotations, "image spec annotations")
+		assert.Equalf(t, expectedAnnotations, image.Spec.Annotations, "image spec annotations")
 	})
 }
 
@@ -526,26 +526,26 @@ func TestPullAndListImageWithRuntimeHandlerInImageCriAPIFeatureGate(t *testing.T
 
 		_, _, err := puller.EnsureImageExists(ctx, nil, pod, container.Image, nil, nil, runtimeHandler, container.ImagePullPolicy)
 		fakeRuntime.AssertCalls(c.expected[0].calls)
-		assert.Equal(t, c.expected[0].err, err, "tick=%d", 0)
+		assert.Equalf(t, c.expected[0].err, err, "tick=%d", 0)
 		assert.Equal(t, c.expected[0].shouldRecordStartedPullingTime, fakePodPullingTimeRecorder.startedPullingRecorded)
 		assert.Equal(t, c.expected[0].shouldRecordFinishedPullingTime, fakePodPullingTimeRecorder.finishedPullingRecorded)
 
 		images, _ := fakeRuntime.ListImages(ctx)
-		assert.Len(t, images, 1, "ListImages() count")
+		assert.Lenf(t, images, 1, "ListImages() count")
 
 		image := images[0]
-		assert.Equal(t, "missing_image:latest", image.ID, "Image ID")
+		assert.Equalf(t, "missing_image:latest", image.ID, "Image ID")
 
 		// when RuntimeClassInImageCriAPI feature gate is enabled, check runtime
 		// handler information for every image in the ListImages() response
-		assert.Equal(t, runtimeHandler, image.Spec.RuntimeHandler, "runtime handler returned not as expected", "Image ID", image)
+		assert.Equalf(t, runtimeHandler, image.Spec.RuntimeHandler, "runtime handler returned not as expected", "Image ID", image)
 
 		expectedAnnotations := []Annotation{
 			{
 				Name:  "kubernetes.io/runtimehandler",
 				Value: "handler_name",
 			}}
-		assert.Equal(t, expectedAnnotations, image.Spec.Annotations, "image spec annotations")
+		assert.Equalf(t, expectedAnnotations, image.Spec.Annotations, "image spec annotations")
 	})
 }
 

--- a/pkg/kubelet/kubelet_node_status_test.go
+++ b/pkg/kubelet/kubelet_node_status_test.go
@@ -328,17 +328,17 @@ func TestUpdateNewNodeStatus(t *testing.T) {
 			updatedNode, err := applyNodeStatusPatch(&existingNode, actions[1].(core.PatchActionImpl).GetPatch())
 			assert.NoError(t, err)
 			for i, cond := range updatedNode.Status.Conditions {
-				assert.False(t, cond.LastHeartbeatTime.IsZero(), "LastHeartbeatTime for %v condition is zero", cond.Type)
-				assert.False(t, cond.LastTransitionTime.IsZero(), "LastTransitionTime for %v condition is zero", cond.Type)
+				assert.Falsef(t, cond.LastHeartbeatTime.IsZero(), "LastHeartbeatTime for %v condition is zero", cond.Type)
+				assert.Falsef(t, cond.LastTransitionTime.IsZero(), "LastTransitionTime for %v condition is zero", cond.Type)
 				updatedNode.Status.Conditions[i].LastHeartbeatTime = metav1.Time{}
 				updatedNode.Status.Conditions[i].LastTransitionTime = metav1.Time{}
 			}
 
 			// Version skew workaround. See: https://github.com/kubernetes/kubernetes/issues/16961
-			assert.Equal(t, v1.NodeReady, updatedNode.Status.Conditions[len(updatedNode.Status.Conditions)-1].Type,
+			assert.Equalf(t, v1.NodeReady, updatedNode.Status.Conditions[len(updatedNode.Status.Conditions)-1].Type,
 				"NotReady should be last")
 			assert.Len(t, updatedNode.Status.Images, len(expectedImageList))
-			assert.True(t, apiequality.Semantic.DeepEqual(expectedNode, updatedNode), "%s", cmp.Diff(expectedNode, updatedNode))
+			assert.Truef(t, apiequality.Semantic.DeepEqual(expectedNode, updatedNode), "%s", cmp.Diff(expectedNode, updatedNode))
 		})
 	}
 }
@@ -523,17 +523,17 @@ func TestUpdateExistingNodeStatus(t *testing.T) {
 	for i, cond := range updatedNode.Status.Conditions {
 		old := metav1.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC).Time
 		// Expect LastHearbeat to be updated to Now, while LastTransitionTime to be the same.
-		assert.NotEqual(t, old, cond.LastHeartbeatTime.Rfc3339Copy().UTC(), "LastHeartbeatTime for condition %v", cond.Type)
-		assert.EqualValues(t, old, cond.LastTransitionTime.Rfc3339Copy().UTC(), "LastTransitionTime for condition %v", cond.Type)
+		assert.NotEqualf(t, old, cond.LastHeartbeatTime.Rfc3339Copy().UTC(), "LastHeartbeatTime for condition %v", cond.Type)
+		assert.EqualValuesf(t, old, cond.LastTransitionTime.Rfc3339Copy().UTC(), "LastTransitionTime for condition %v", cond.Type)
 
 		updatedNode.Status.Conditions[i].LastHeartbeatTime = metav1.Time{}
 		updatedNode.Status.Conditions[i].LastTransitionTime = metav1.Time{}
 	}
 
 	// Version skew workaround. See: https://github.com/kubernetes/kubernetes/issues/16961
-	assert.Equal(t, v1.NodeReady, updatedNode.Status.Conditions[len(updatedNode.Status.Conditions)-1].Type,
+	assert.Equalf(t, v1.NodeReady, updatedNode.Status.Conditions[len(updatedNode.Status.Conditions)-1].Type,
 		"NodeReady should be the last condition")
-	assert.True(t, apiequality.Semantic.DeepEqual(expectedNode, updatedNode), "%s", cmp.Diff(expectedNode, updatedNode))
+	assert.Truef(t, apiequality.Semantic.DeepEqual(expectedNode, updatedNode), "%s", cmp.Diff(expectedNode, updatedNode))
 }
 
 func TestUpdateExistingNodeStatusTimeout(t *testing.T) {
@@ -722,18 +722,18 @@ func TestUpdateNodeStatusWithRuntimeStateError(t *testing.T) {
 		require.Equal(t, "status", actions[1].GetSubresource())
 
 		updatedNode, err := kubeClient.CoreV1().Nodes().Get(ctx, testKubeletHostname, metav1.GetOptions{})
-		require.NoError(t, err, "can't apply node status patch")
+		require.NoErrorf(t, err, "can't apply node status patch")
 
 		for i, cond := range updatedNode.Status.Conditions {
-			assert.False(t, cond.LastHeartbeatTime.IsZero(), "LastHeartbeatTime for %v condition is zero", cond.Type)
-			assert.False(t, cond.LastTransitionTime.IsZero(), "LastTransitionTime for %v condition  is zero", cond.Type)
+			assert.Falsef(t, cond.LastHeartbeatTime.IsZero(), "LastHeartbeatTime for %v condition is zero", cond.Type)
+			assert.Falsef(t, cond.LastTransitionTime.IsZero(), "LastTransitionTime for %v condition  is zero", cond.Type)
 			updatedNode.Status.Conditions[i].LastHeartbeatTime = metav1.Time{}
 			updatedNode.Status.Conditions[i].LastTransitionTime = metav1.Time{}
 		}
 
 		// Version skew workaround. See: https://github.com/kubernetes/kubernetes/issues/16961
 		lastIndex := len(updatedNode.Status.Conditions) - 1
-		assert.Equal(t, v1.NodeReady, updatedNode.Status.Conditions[lastIndex].Type, "NodeReady should be the last condition")
+		assert.Equalf(t, v1.NodeReady, updatedNode.Status.Conditions[lastIndex].Type, "NodeReady should be the last condition")
 		assert.NotEmpty(t, updatedNode.Status.Conditions[lastIndex].Message)
 
 		updatedNode.Status.Conditions[lastIndex].Message = ""
@@ -744,7 +744,7 @@ func TestUpdateNodeStatusWithRuntimeStateError(t *testing.T) {
 			LastHeartbeatTime:  metav1.Time{},
 			LastTransitionTime: metav1.Time{},
 		}
-		assert.True(t, apiequality.Semantic.DeepEqual(expectedNode, updatedNode), "%s", cmp.Diff(expectedNode, updatedNode))
+		assert.Truef(t, apiequality.Semantic.DeepEqual(expectedNode, updatedNode), "%s", cmp.Diff(expectedNode, updatedNode))
 	}
 
 	// TODO(random-liu): Refactor the unit test to be table driven test.
@@ -962,10 +962,10 @@ func TestUpdateNodeStatusWithLease(t *testing.T) {
 		cond.LastHeartbeatTime = cond.LastHeartbeatTime.Rfc3339Copy()
 		cond.LastTransitionTime = cond.LastTransitionTime.Rfc3339Copy()
 	}
-	assert.True(t, apiequality.Semantic.DeepEqual(expectedNode, updatedNode), "%s", cmp.Diff(expectedNode, updatedNode))
+	assert.Truef(t, apiequality.Semantic.DeepEqual(expectedNode, updatedNode), "%s", cmp.Diff(expectedNode, updatedNode))
 
 	// Version skew workaround. See: https://github.com/kubernetes/kubernetes/issues/16961
-	assert.Equal(t, v1.NodeReady, updatedNode.Status.Conditions[len(updatedNode.Status.Conditions)-1].Type,
+	assert.Equalf(t, v1.NodeReady, updatedNode.Status.Conditions[len(updatedNode.Status.Conditions)-1].Type,
 		"NodeReady should be the last condition")
 
 	// Update node status again when nothing is changed (except heartbeat time).
@@ -991,7 +991,7 @@ func TestUpdateNodeStatusWithLease(t *testing.T) {
 	for i, cond := range expectedNode.Status.Conditions {
 		expectedNode.Status.Conditions[i].LastHeartbeatTime = metav1.NewTime(cond.LastHeartbeatTime.Time.Add(time.Minute)).Rfc3339Copy()
 	}
-	assert.True(t, apiequality.Semantic.DeepEqual(expectedNode, updatedNode), "%s", cmp.Diff(expectedNode, updatedNode))
+	assert.Truef(t, apiequality.Semantic.DeepEqual(expectedNode, updatedNode), "%s", cmp.Diff(expectedNode, updatedNode))
 
 	// Update node status again when nothing is changed (except heartbeat time).
 	// Do not report node status if it is within the duration of nodeStatusReportFrequency.
@@ -1027,27 +1027,27 @@ func TestUpdateNodeStatusWithLease(t *testing.T) {
 	require.NoError(t, err)
 	memCapacity := updatedNode.Status.Capacity[v1.ResourceMemory]
 	updatedMemoryCapacity, _ := (&memCapacity).AsInt64()
-	assert.Equal(t, newMemoryCapacity, updatedMemoryCapacity, "Memory capacity")
+	assert.Equalf(t, newMemoryCapacity, updatedMemoryCapacity, "Memory capacity")
 
 	now = metav1.NewTime(clock.Now()).Rfc3339Copy()
 	for _, cond := range updatedNode.Status.Conditions {
 		// Expect LastHearbeat updated, while LastTransitionTime unchanged.
-		assert.Equal(t, now, cond.LastHeartbeatTime.Rfc3339Copy(),
+		assert.Equalf(t, now, cond.LastHeartbeatTime.Rfc3339Copy(),
 			"LastHeartbeatTime for condition %v", cond.Type)
-		assert.Equal(t, now, metav1.NewTime(cond.LastTransitionTime.Time.Add(time.Minute+20*time.Second)).Rfc3339Copy(),
+		assert.Equalf(t, now, metav1.NewTime(cond.LastTransitionTime.Time.Add(time.Minute+20*time.Second)).Rfc3339Copy(),
 			"LastTransitionTime for condition %v", cond.Type)
 	}
 
 	// Update node status when changing pod CIDR.
 	// Report node status if it is still within the duration of nodeStatusReportFrequency.
 	clock.Step(10 * time.Second)
-	assert.Equal(t, "", kubelet.runtimeState.podCIDR(), "Pod CIDR should be empty")
+	assert.Equalf(t, "", kubelet.runtimeState.podCIDR(), "Pod CIDR should be empty")
 	podCIDRs := []string{"10.0.0.0/24", "2000::/10"}
 	updatedNode.Spec.PodCIDR = podCIDRs[0]
 	updatedNode.Spec.PodCIDRs = podCIDRs
 	kubeClient.ReactionChain = fake.NewSimpleClientset(&v1.NodeList{Items: []v1.Node{*updatedNode}}).ReactionChain
 	assert.NoError(t, kubelet.updateNodeStatus(ctx))
-	assert.Equal(t, strings.Join(podCIDRs, ","), kubelet.runtimeState.podCIDR(), "Pod CIDR should be updated now")
+	assert.Equalf(t, strings.Join(podCIDRs, ","), kubelet.runtimeState.podCIDR(), "Pod CIDR should be updated now")
 	// 2 more action (There were 7 actions before).
 	actions = kubeClient.Actions()
 	assert.Len(t, actions, 9)
@@ -1057,7 +1057,7 @@ func TestUpdateNodeStatusWithLease(t *testing.T) {
 	// Update node status when keeping the pod CIDR.
 	// Do not report node status if it is within the duration of nodeStatusReportFrequency.
 	clock.Step(10 * time.Second)
-	assert.Equal(t, strings.Join(podCIDRs, ","), kubelet.runtimeState.podCIDR(), "Pod CIDR should already be updated")
+	assert.Equalf(t, strings.Join(podCIDRs, ","), kubelet.runtimeState.podCIDR(), "Pod CIDR should already be updated")
 
 	assert.NoError(t, kubelet.updateNodeStatus(ctx))
 	// Only 1 more action (There were 9 actions before).
@@ -1154,14 +1154,14 @@ func TestUpdateNodeStatusAndVolumesInUseWithNodeLease(t *testing.T) {
 
 				updatedNode, err := applyNodeStatusPatch(tc.existingNode, patchAction.GetPatch())
 				require.NoError(t, err)
-				assert.True(t, apiequality.Semantic.DeepEqual(tc.expectedNode, updatedNode), "%s", cmp.Diff(tc.expectedNode, updatedNode))
+				assert.Truef(t, apiequality.Semantic.DeepEqual(tc.expectedNode, updatedNode), "%s", cmp.Diff(tc.expectedNode, updatedNode))
 			} else {
 				assert.Len(t, actions, 1)
 				assert.IsType(t, core.GetActionImpl{}, actions[0])
 			}
 
 			reportedInUse := fakeVolumeManager.GetVolumesReportedInUse()
-			assert.True(t, apiequality.Semantic.DeepEqual(tc.expectedReportedInUse, reportedInUse), "%s", cmp.Diff(tc.expectedReportedInUse, reportedInUse))
+			assert.Truef(t, apiequality.Semantic.DeepEqual(tc.expectedReportedInUse, reportedInUse), "%s", cmp.Diff(tc.expectedReportedInUse, reportedInUse))
 		})
 	}
 }
@@ -1549,10 +1549,10 @@ func TestTryRegisterWithApiServer(t *testing.T) {
 			addNotImplatedReaction(kubeClient)
 
 			result := kubelet.tryRegisterWithAPIServer(tc.newNode)
-			require.Equal(t, tc.expectedResult, result, "test [%s]", tc.name)
+			require.Equalf(t, tc.expectedResult, result, "test [%s]", tc.name)
 
 			actions := kubeClient.Actions()
-			assert.Len(t, actions, tc.expectedActions, "test [%s]", tc.name)
+			assert.Lenf(t, actions, tc.expectedActions, "test [%s]", tc.name)
 
 			if tc.testSavedNode {
 				var savedNode *v1.Node
@@ -1572,7 +1572,7 @@ func TestTryRegisterWithApiServer(t *testing.T) {
 				}
 
 				actualCMAD, _ := strconv.ParseBool(savedNode.Annotations[util.ControllerManagedAttachAnnotation])
-				assert.Equal(t, tc.savedNodeCMAD, actualCMAD, "test [%s]", tc.name)
+				assert.Equalf(t, tc.savedNodeCMAD, actualCMAD, "test [%s]", tc.name)
 			}
 		})
 	}
@@ -1646,7 +1646,7 @@ func TestUpdateNewNodeStatusTooLargeReservation(t *testing.T) {
 
 	updatedNode, err := applyNodeStatusPatch(&existingNode, actions[0].(core.PatchActionImpl).GetPatch())
 	assert.NoError(t, err)
-	assert.True(t, apiequality.Semantic.DeepEqual(expectedNode.Status.Allocatable, updatedNode.Status.Allocatable), "%s", cmp.Diff(expectedNode.Status.Allocatable, updatedNode.Status.Allocatable))
+	assert.Truef(t, apiequality.Semantic.DeepEqual(expectedNode.Status.Allocatable, updatedNode.Status.Allocatable), "%s", cmp.Diff(expectedNode.Status.Allocatable, updatedNode.Status.Allocatable))
 }
 
 func TestUpdateDefaultLabels(t *testing.T) {
@@ -1949,8 +1949,8 @@ func TestUpdateDefaultLabels(t *testing.T) {
 		kubelet := testKubelet.kubelet
 
 		needsUpdate := kubelet.updateDefaultLabels(tc.initialNode, tc.existingNode)
-		assert.Equal(t, tc.needsUpdate, needsUpdate, tc.name)
-		assert.Equal(t, tc.finalLabels, tc.existingNode.Labels, tc.name)
+		assert.Equalf(t, tc.needsUpdate, needsUpdate, tc.name)
+		assert.Equalf(t, tc.finalLabels, tc.existingNode.Labels, tc.name)
 	}
 }
 
@@ -2158,8 +2158,8 @@ func TestUpdateDefaultResources(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(T *testing.T) {
 			needsUpdate := updateDefaultResources(tc.initialNode, tc.existingNode)
-			assert.Equal(t, tc.needsUpdate, needsUpdate, tc.name)
-			assert.Equal(t, tc.expectedNode, tc.existingNode, tc.name)
+			assert.Equalf(t, tc.needsUpdate, needsUpdate, tc.name)
+			assert.Equalf(t, tc.expectedNode, tc.existingNode, tc.name)
 		})
 	}
 }
@@ -2450,8 +2450,8 @@ func TestReconcileHugePageResource(t *testing.T) {
 			kubelet := testKubelet.kubelet
 
 			needsUpdate := kubelet.reconcileHugePageResource(tc.initialNode, tc.existingNode)
-			assert.Equal(t, tc.needsUpdate, needsUpdate, tc.name)
-			assert.Equal(t, tc.expectedNode, tc.existingNode, tc.name)
+			assert.Equalf(t, tc.needsUpdate, needsUpdate, tc.name)
+			assert.Equalf(t, tc.expectedNode, tc.existingNode, tc.name)
 		})
 	}
 
@@ -2638,8 +2638,8 @@ func TestReconcileExtendedResource(t *testing.T) {
 		kubelet := testKubelet.kubelet
 
 		needsUpdate := kubelet.reconcileExtendedResource(tc.initialNode, tc.existingNode)
-		assert.Equal(t, tc.needsUpdate, needsUpdate, tc.name)
-		assert.Equal(t, tc.expectedNode, tc.existingNode, tc.name)
+		assert.Equalf(t, tc.needsUpdate, needsUpdate, tc.name)
+		assert.Equalf(t, tc.expectedNode, tc.existingNode, tc.name)
 	}
 
 }
@@ -2774,7 +2774,7 @@ func TestRegisterWithApiServerWithTaint(t *testing.T) {
 		Effect: v1.TaintEffectNoSchedule,
 	}
 
-	require.True(t,
+	require.Truef(t,
 		taintutil.TaintExists(got.Spec.Taints, unschedulableTaint),
 		"test unschedulable taint for TaintNodesByCondition")
 }
@@ -2928,9 +2928,9 @@ func TestNodeStatusHasChanged(t *testing.T) {
 			originalStatusCopy := tc.originalStatus.DeepCopy()
 			statusCopy := tc.status.DeepCopy()
 			changed := nodeStatusHasChanged(tc.originalStatus, tc.status)
-			assert.Equal(t, tc.expectChange, changed, "Expect node status change to be %t, but got %t.", tc.expectChange, changed)
-			assert.True(t, apiequality.Semantic.DeepEqual(originalStatusCopy, tc.originalStatus), "%s", cmp.Diff(originalStatusCopy, tc.originalStatus))
-			assert.True(t, apiequality.Semantic.DeepEqual(statusCopy, tc.status), "%s", cmp.Diff(statusCopy, tc.status))
+			assert.Equalf(t, tc.expectChange, changed, "Expect node status change to be %t, but got %t.", tc.expectChange, changed)
+			assert.Truef(t, apiequality.Semantic.DeepEqual(originalStatusCopy, tc.originalStatus), "%s", cmp.Diff(originalStatusCopy, tc.originalStatus))
+			assert.Truef(t, apiequality.Semantic.DeepEqual(statusCopy, tc.status), "%s", cmp.Diff(statusCopy, tc.status))
 		})
 	}
 }
@@ -3084,7 +3084,7 @@ func TestUpdateNodeAddresses(t *testing.T) {
 			updatedNode, err := applyNodeStatusPatch(oldNode, patchAction.GetPatch())
 			require.NoError(t, err)
 
-			assert.True(t, apiequality.Semantic.DeepEqual(updatedNode, expectedNode), "%s", cmp.Diff(expectedNode, updatedNode))
+			assert.Truef(t, apiequality.Semantic.DeepEqual(updatedNode, expectedNode), "%s", cmp.Diff(expectedNode, updatedNode))
 		})
 	}
 }

--- a/pkg/kubelet/kubelet_pods_linux_test.go
+++ b/pkg/kubelet/kubelet_pods_linux_test.go
@@ -268,7 +268,7 @@ func TestMakeMounts(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			assert.Equal(t, tc.expectedMounts, mounts, "mounts of container %+v", tc.container)
+			assert.Equalf(t, tc.expectedMounts, mounts, "mounts of container %+v", tc.container)
 		})
 	}
 }
@@ -499,7 +499,7 @@ func TestMakeBlockVolumes(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			assert.Equal(t, tc.expectedDevices, blkVolumes, "devices of container %+v", tc.container)
+			assert.Equalf(t, tc.expectedDevices, blkVolumes, "devices of container %+v", tc.container)
 		})
 	}
 }

--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -179,12 +179,12 @@ fe00::2	ip6-allrouters
 	for _, testCase := range testCases {
 		t.Run(testCase.hostsFileName, func(t *testing.T) {
 			tmpdir, err := writeHostsFile(testCase.hostsFileName, testCase.rawHostsFileContent)
-			require.NoError(t, err, "could not create a temp hosts file")
+			require.NoErrorf(t, err, "could not create a temp hosts file")
 			defer os.RemoveAll(tmpdir)
 
 			actualContent, fileReadErr := nodeHostsFileContent(filepath.Join(tmpdir, testCase.hostsFileName), testCase.hostAliases)
-			require.NoError(t, fileReadErr, "could not create read hosts file")
-			assert.Equal(t, testCase.expectedHostsFileContent, string(actualContent), "hosts file content not expected")
+			require.NoErrorf(t, fileReadErr, "could not create read hosts file")
+			assert.Equalf(t, testCase.expectedHostsFileContent, string(actualContent), "hosts file content not expected")
 		})
 	}
 }
@@ -298,7 +298,7 @@ fd00::6	podFoo.domainFoo	podFoo
 
 	for _, testCase := range testCases {
 		actualContent := managedHostsFileContent(testCase.hostIPs, testCase.hostName, testCase.hostDomainName, testCase.hostAliases)
-		assert.Equal(t, testCase.expectedContent, string(actualContent), "hosts file content not expected")
+		assert.Equalf(t, testCase.expectedContent, string(actualContent), "hosts file content not expected")
 	}
 }
 
@@ -320,7 +320,7 @@ func TestRunInContainerNoSuchPod(t *testing.T) {
 		containerName,
 		[]string{"ls"})
 	assert.Error(t, err)
-	assert.Nil(t, output, "output should be nil")
+	assert.Nilf(t, output, "output should be nil")
 }
 
 func TestRunInContainer(t *testing.T) {
@@ -351,11 +351,11 @@ func TestRunInContainer(t *testing.T) {
 		}
 		cmd := []string{"ls"}
 		actualOutput, err := kubelet.RunInContainer(ctx, "podFoo_nsFoo", "", "containerFoo", cmd)
-		assert.Equal(t, containerID, fakeCommandRunner.ContainerID, "(testError=%v) ID", testError)
-		assert.Equal(t, cmd, fakeCommandRunner.Cmd, "(testError=%v) command", testError)
+		assert.Equalf(t, containerID, fakeCommandRunner.ContainerID, "(testError=%v) ID", testError)
+		assert.Equalf(t, cmd, fakeCommandRunner.Cmd, "(testError=%v) command", testError)
 		// this isn't 100% foolproof as a bug in a real CommandRunner where it fails to copy to stdout/stderr wouldn't be caught by this test
-		assert.Equal(t, "foo", string(actualOutput), "(testError=%v) output", testError)
-		assert.Equal(t, err, testError, "(testError=%v) err", testError)
+		assert.Equalf(t, "foo", string(actualOutput), "(testError=%v) output", testError)
+		assert.Equalf(t, err, testError, "(testError=%v) err", testError)
 	}
 }
 
@@ -2042,13 +2042,13 @@ func TestMakeEnvironmentVariables(t *testing.T) {
 				assert.Equal(t, "", tc.expectedEvent)
 			}
 			if tc.expectedError {
-				assert.Error(t, err, tc.name)
+				assert.Errorf(t, err, tc.name)
 			} else {
-				assert.NoError(t, err, "[%s]", tc.name)
+				assert.NoErrorf(t, err, "[%s]", tc.name)
 
 				sort.Sort(envs(result))
 				sort.Sort(envs(tc.expectedEnvs))
-				assert.Equal(t, tc.expectedEnvs, result, "[%s] env entries", tc.name)
+				assert.Equalf(t, tc.expectedEnvs, result, "[%s] env entries", tc.name)
 			}
 		})
 
@@ -2307,7 +2307,7 @@ func TestPodPhaseWithRestartAlways(t *testing.T) {
 	}
 	for _, test := range tests {
 		status := getPhase(test.pod, test.pod.Status.ContainerStatuses, test.podIsTerminal)
-		assert.Equal(t, test.status, status, "[test %s]", test.test)
+		assert.Equalf(t, test.status, status, "[test %s]", test.test)
 	}
 }
 
@@ -2410,7 +2410,7 @@ func TestPodPhaseWithRestartAlwaysInitContainers(t *testing.T) {
 	for _, test := range tests {
 		statusInfo := append(test.pod.Status.InitContainerStatuses[:], test.pod.Status.ContainerStatuses[:]...)
 		status := getPhase(test.pod, statusInfo, false)
-		assert.Equal(t, test.status, status, "[test %s]", test.test)
+		assert.Equalf(t, test.status, status, "[test %s]", test.test)
 	}
 }
 
@@ -2622,7 +2622,7 @@ func TestPodPhaseWithRestartAlwaysRestartableInitContainers(t *testing.T) {
 	for _, test := range tests {
 		statusInfo := append(test.pod.Status.InitContainerStatuses[:], test.pod.Status.ContainerStatuses[:]...)
 		status := getPhase(test.pod, statusInfo, test.podIsTerminal)
-		assert.Equal(t, test.status, status, "[test %s]", test.test)
+		assert.Equalf(t, test.status, status, "[test %s]", test.test)
 	}
 }
 
@@ -2722,7 +2722,7 @@ func TestPodPhaseWithRestartNever(t *testing.T) {
 	}
 	for _, test := range tests {
 		status := getPhase(test.pod, test.pod.Status.ContainerStatuses, false)
-		assert.Equal(t, test.status, status, "[test %s]", test.test)
+		assert.Equalf(t, test.status, status, "[test %s]", test.test)
 	}
 }
 
@@ -2825,7 +2825,7 @@ func TestPodPhaseWithRestartNeverInitContainers(t *testing.T) {
 	for _, test := range tests {
 		statusInfo := append(test.pod.Status.InitContainerStatuses[:], test.pod.Status.ContainerStatuses[:]...)
 		status := getPhase(test.pod, statusInfo, false)
-		assert.Equal(t, test.status, status, "[test %s]", test.test)
+		assert.Equalf(t, test.status, status, "[test %s]", test.test)
 	}
 }
 
@@ -3024,7 +3024,7 @@ func TestPodPhaseWithRestartNeverRestartableInitContainers(t *testing.T) {
 	for _, test := range tests {
 		statusInfo := append(test.pod.Status.InitContainerStatuses[:], test.pod.Status.ContainerStatuses[:]...)
 		status := getPhase(test.pod, statusInfo, false)
-		assert.Equal(t, test.status, status, "[test %s]", test.test)
+		assert.Equalf(t, test.status, status, "[test %s]", test.test)
 	}
 }
 
@@ -3137,7 +3137,7 @@ func TestPodPhaseWithRestartOnFailure(t *testing.T) {
 	}
 	for _, test := range tests {
 		status := getPhase(test.pod, test.pod.Status.ContainerStatuses, false)
-		assert.Equal(t, test.status, status, "[test %s]", test.test)
+		assert.Equalf(t, test.status, status, "[test %s]", test.test)
 	}
 }
 
@@ -3230,7 +3230,7 @@ func TestConvertToAPIContainerStatuses(t *testing.T) {
 				test.isInitContainer,
 			)
 			for i, status := range containerStatuses {
-				assert.Equal(t, test.expected[i], status, "[test %s]", test.name)
+				assert.Equalf(t, test.expected[i], status, "[test %s]", test.name)
 			}
 		})
 	}
@@ -3933,10 +3933,10 @@ func TestGetExec(t *testing.T) {
 
 			redirect, err := kubelet.GetExec(ctx, tc.podFullName, podUID, tc.container, tc.command, remotecommand.Options{})
 			if tc.expectError {
-				assert.Error(t, err, description)
+				assert.Errorf(t, err, description)
 			} else {
-				assert.NoError(t, err, description)
-				assert.Equal(t, containertest.FakeHost, redirect.Host, description+": redirect")
+				assert.NoErrorf(t, err, description)
+				assert.Equalf(t, containertest.FakeHost, redirect.Host, description+": redirect")
 			}
 		})
 	}
@@ -3988,10 +3988,10 @@ func TestGetPortForward(t *testing.T) {
 
 		redirect, err := kubelet.GetPortForward(ctx, tc.podName, podNamespace, podUID, portforward.V4Options{})
 		if tc.expectError {
-			assert.Error(t, err, description)
+			assert.Errorf(t, err, description)
 		} else {
-			assert.NoError(t, err, description)
-			assert.Equal(t, containertest.FakeHost, redirect.Host, description+": redirect")
+			assert.NoErrorf(t, err, description)
+			assert.Equalf(t, containertest.FakeHost, redirect.Host, description+": redirect")
 		}
 	}
 }

--- a/pkg/kubelet/kubelet_resources_test.go
+++ b/pkg/kubelet/kubelet_resources_test.go
@@ -69,9 +69,9 @@ func TestPodResourceLimitsDefaulting(t *testing.T) {
 	as := assert.New(t)
 	for idx, tc := range cases {
 		actual, _, err := tk.kubelet.defaultPodLimitsForDownwardAPI(tc.pod, nil)
-		as.NoError(err, "failed to default pod limits: %v", err)
+		as.NoErrorf(err, "failed to default pod limits: %v", err)
 		if !apiequality.Semantic.DeepEqual(tc.expected, actual) {
-			as.Fail("test case [%d] failed.  Expected: %+v, Got: %+v", idx, tc.expected, actual)
+			as.Failf("test case [%d] failed.", "Expected: %+v, Got: %+v", idx, tc.expected, actual)
 		}
 	}
 }

--- a/pkg/kubelet/kubelet_volumes_test.go
+++ b/pkg/kubelet/kubelet_volumes_test.go
@@ -90,13 +90,13 @@ func TestListVolumesForPod(t *testing.T) {
 	podName := util.GetUniquePodName(pod)
 
 	volumesToReturn, volumeExsit := kubelet.ListVolumesForPod(types.UID(podName))
-	assert.True(t, volumeExsit, "expected to find volumes for pod %q", podName)
+	assert.Truef(t, volumeExsit, "expected to find volumes for pod %q", podName)
 
 	outerVolumeSpecName1 := "vol1"
-	assert.NotNil(t, volumesToReturn[outerVolumeSpecName1], "key %s", outerVolumeSpecName1)
+	assert.NotNilf(t, volumesToReturn[outerVolumeSpecName1], "key %s", outerVolumeSpecName1)
 
 	outerVolumeSpecName2 := "vol2"
-	assert.NotNil(t, volumesToReturn[outerVolumeSpecName2], "key %s", outerVolumeSpecName2)
+	assert.NotNilf(t, volumesToReturn[outerVolumeSpecName2], "key %s", outerVolumeSpecName2)
 }
 
 func TestPodVolumesExist(t *testing.T) {
@@ -210,7 +210,7 @@ func TestPodVolumesExist(t *testing.T) {
 
 	for _, pod := range pods {
 		podVolumesExist := kubelet.podVolumesExist(pod.UID)
-		assert.True(t, podVolumesExist, "pod %q", pod.UID)
+		assert.Truef(t, podVolumesExist, "pod %q", pod.UID)
 	}
 }
 
@@ -386,11 +386,11 @@ func TestVolumeAttachAndMountControllerDisabled(t *testing.T) {
 		util.GetUniquePodName(pod))
 
 	expectedPodVolumes := []string{"vol1"}
-	assert.Len(t, podVolumes, len(expectedPodVolumes), "Volumes for pod %+v", pod)
+	assert.Lenf(t, podVolumes, len(expectedPodVolumes), "Volumes for pod %+v", pod)
 	for _, name := range expectedPodVolumes {
-		assert.Contains(t, podVolumes, name, "Volumes for pod %+v", pod)
+		assert.Containsf(t, podVolumes, name, "Volumes for pod %+v", pod)
 	}
-	assert.GreaterOrEqual(t, testKubelet.volumePlugin.GetNewAttacherCallCount(), 1, "Expected plugin NewAttacher to be called at least once")
+	assert.GreaterOrEqualf(t, testKubelet.volumePlugin.GetNewAttacherCallCount(), 1, "Expected plugin NewAttacher to be called at least once")
 	assert.NoError(t, volumetest.VerifyWaitForAttachCallCount(
 		1 /* expectedWaitForAttachCallCount */, testKubelet.volumePlugin))
 	assert.NoError(t, volumetest.VerifyAttachCallCount(
@@ -449,12 +449,12 @@ func TestVolumeUnmountAndDetachControllerDisabled(t *testing.T) {
 		util.GetUniquePodName(pod))
 
 	expectedPodVolumes := []string{"vol1"}
-	assert.Len(t, podVolumes, len(expectedPodVolumes), "Volumes for pod %+v", pod)
+	assert.Lenf(t, podVolumes, len(expectedPodVolumes), "Volumes for pod %+v", pod)
 	for _, name := range expectedPodVolumes {
-		assert.Contains(t, podVolumes, name, "Volumes for pod %+v", pod)
+		assert.Containsf(t, podVolumes, name, "Volumes for pod %+v", pod)
 	}
 
-	assert.GreaterOrEqual(t, testKubelet.volumePlugin.GetNewAttacherCallCount(), 1, "Expected plugin NewAttacher to be called at least once")
+	assert.GreaterOrEqualf(t, testKubelet.volumePlugin.GetNewAttacherCallCount(), 1, "Expected plugin NewAttacher to be called at least once")
 	assert.NoError(t, volumetest.VerifyWaitForAttachCallCount(
 		1 /* expectedWaitForAttachCallCount */, testKubelet.volumePlugin))
 	assert.NoError(t, volumetest.VerifyAttachCallCount(
@@ -478,7 +478,7 @@ func TestVolumeUnmountAndDetachControllerDisabled(t *testing.T) {
 	podVolumes = kubelet.volumeManager.GetMountedVolumesForPod(
 		util.GetUniquePodName(pod))
 
-	assert.Empty(t, podVolumes,
+	assert.Emptyf(t, podVolumes,
 		"Expected volumes to be unmounted and detached. But some volumes are still mounted: %#v", podVolumes)
 
 	assert.NoError(t, volumetest.VerifyTearDownCallCount(
@@ -486,7 +486,7 @@ func TestVolumeUnmountAndDetachControllerDisabled(t *testing.T) {
 
 	// Verify volumes detached and no longer reported as in use
 	assert.NoError(t, waitForVolumeDetach(v1.UniqueVolumeName("fake/fake-device"), kubelet.volumeManager))
-	assert.GreaterOrEqual(t, testKubelet.volumePlugin.GetNewAttacherCallCount(), 1, "Expected plugin NewAttacher to be called at least once")
+	assert.GreaterOrEqualf(t, testKubelet.volumePlugin.GetNewAttacherCallCount(), 1, "Expected plugin NewAttacher to be called at least once")
 	assert.NoError(t, volumetest.VerifyDetachCallCount(
 		1 /* expectedDetachCallCount */, testKubelet.volumePlugin))
 }
@@ -559,14 +559,14 @@ func TestVolumeAttachAndMountControllerEnabled(t *testing.T) {
 		util.GetUniquePodName(pod))
 	allPodVolumes := kubelet.volumeManager.GetPossiblyMountedVolumesForPod(
 		util.GetUniquePodName(pod))
-	assert.Equal(t, podVolumes, allPodVolumes, "GetMountedVolumesForPod and GetPossiblyMountedVolumesForPod should return the same volumes")
+	assert.Equalf(t, podVolumes, allPodVolumes, "GetMountedVolumesForPod and GetPossiblyMountedVolumesForPod should return the same volumes")
 
 	expectedPodVolumes := []string{"vol1"}
-	assert.Len(t, podVolumes, len(expectedPodVolumes), "Volumes for pod %+v", pod)
+	assert.Lenf(t, podVolumes, len(expectedPodVolumes), "Volumes for pod %+v", pod)
 	for _, name := range expectedPodVolumes {
-		assert.Contains(t, podVolumes, name, "Volumes for pod %+v", pod)
+		assert.Containsf(t, podVolumes, name, "Volumes for pod %+v", pod)
 	}
-	assert.GreaterOrEqual(t, testKubelet.volumePlugin.GetNewAttacherCallCount(), 1, "Expected plugin NewAttacher to be called at least once")
+	assert.GreaterOrEqualf(t, testKubelet.volumePlugin.GetNewAttacherCallCount(), 1, "Expected plugin NewAttacher to be called at least once")
 	assert.NoError(t, volumetest.VerifyWaitForAttachCallCount(
 		1 /* expectedWaitForAttachCallCount */, testKubelet.volumePlugin))
 	assert.NoError(t, volumetest.VerifyZeroAttachCalls(testKubelet.volumePlugin))
@@ -646,15 +646,15 @@ func TestVolumeUnmountAndDetachControllerEnabled(t *testing.T) {
 		util.GetUniquePodName(pod))
 	allPodVolumes := kubelet.volumeManager.GetPossiblyMountedVolumesForPod(
 		util.GetUniquePodName(pod))
-	assert.Equal(t, podVolumes, allPodVolumes, "GetMountedVolumesForPod and GetPossiblyMountedVolumesForPod should return the same volumes")
+	assert.Equalf(t, podVolumes, allPodVolumes, "GetMountedVolumesForPod and GetPossiblyMountedVolumesForPod should return the same volumes")
 
 	expectedPodVolumes := []string{"vol1"}
-	assert.Len(t, podVolumes, len(expectedPodVolumes), "Volumes for pod %+v", pod)
+	assert.Lenf(t, podVolumes, len(expectedPodVolumes), "Volumes for pod %+v", pod)
 	for _, name := range expectedPodVolumes {
-		assert.Contains(t, podVolumes, name, "Volumes for pod %+v", pod)
+		assert.Containsf(t, podVolumes, name, "Volumes for pod %+v", pod)
 	}
 
-	assert.GreaterOrEqual(t, testKubelet.volumePlugin.GetNewAttacherCallCount(), 1, "Expected plugin NewAttacher to be called at least once")
+	assert.GreaterOrEqualf(t, testKubelet.volumePlugin.GetNewAttacherCallCount(), 1, "Expected plugin NewAttacher to be called at least once")
 	assert.NoError(t, volumetest.VerifyWaitForAttachCallCount(
 		1 /* expectedWaitForAttachCallCount */, testKubelet.volumePlugin))
 	assert.NoError(t, volumetest.VerifyZeroAttachCalls(testKubelet.volumePlugin))
@@ -674,9 +674,9 @@ func TestVolumeUnmountAndDetachControllerEnabled(t *testing.T) {
 		util.GetUniquePodName(pod))
 	allPodVolumes = kubelet.volumeManager.GetPossiblyMountedVolumesForPod(
 		util.GetUniquePodName(pod))
-	assert.Equal(t, podVolumes, allPodVolumes, "GetMountedVolumesForPod and GetPossiblyMountedVolumesForPod should return the same volumes")
+	assert.Equalf(t, podVolumes, allPodVolumes, "GetMountedVolumesForPod and GetPossiblyMountedVolumesForPod should return the same volumes")
 
-	assert.Empty(t, podVolumes,
+	assert.Emptyf(t, podVolumes,
 		"Expected volumes to be unmounted and detached. But some volumes are still mounted")
 
 	assert.NoError(t, volumetest.VerifyTearDownCallCount(
@@ -684,7 +684,7 @@ func TestVolumeUnmountAndDetachControllerEnabled(t *testing.T) {
 
 	// Verify volumes detached and no longer reported as in use
 	assert.NoError(t, waitForVolumeDetach(v1.UniqueVolumeName("fake/fake-device"), kubelet.volumeManager))
-	assert.GreaterOrEqual(t, testKubelet.volumePlugin.GetNewAttacherCallCount(), 1, "Expected plugin NewAttacher to be called at least once")
+	assert.GreaterOrEqualf(t, testKubelet.volumePlugin.GetNewAttacherCallCount(), 1, "Expected plugin NewAttacher to be called at least once")
 	assert.NoError(t, volumetest.VerifyZeroDetachCallCount(testKubelet.volumePlugin))
 }
 

--- a/pkg/kubelet/kuberuntime/helpers_linux_test.go
+++ b/pkg/kubelet/kuberuntime/helpers_linux_test.go
@@ -305,10 +305,10 @@ func TestGetSeccompProfile(t *testing.T) {
 	for i, test := range tests {
 		seccompProfile, err := m.getSeccompProfile(test.annotation, test.containerName, test.podSc, test.containerSc, false)
 		if test.expectedError != "" {
-			assert.EqualError(t, err, test.expectedError, "TestCase[%d]: %s", i, test.description)
+			assert.EqualErrorf(t, err, test.expectedError, "TestCase[%d]: %s", i, test.description)
 		} else {
-			assert.NoError(t, err, "TestCase[%d]: %s", i, test.description)
-			assert.Equal(t, test.expectedProfile, seccompProfile, "TestCase[%d]: %s", i, test.description)
+			assert.NoErrorf(t, err, "TestCase[%d]: %s", i, test.description)
+			assert.Equalf(t, test.expectedProfile, seccompProfile, "TestCase[%d]: %s", i, test.description)
 		}
 	}
 }
@@ -405,10 +405,10 @@ func TestGetSeccompProfileDefaultSeccomp(t *testing.T) {
 	for i, test := range tests {
 		seccompProfile, err := m.getSeccompProfile(test.annotation, test.containerName, test.podSc, test.containerSc, true)
 		if test.expectedError != "" {
-			assert.EqualError(t, err, test.expectedError, "TestCase[%d]: %s", i, test.description)
+			assert.EqualErrorf(t, err, test.expectedError, "TestCase[%d]: %s", i, test.description)
 		} else {
-			assert.NoError(t, err, "TestCase[%d]: %s", i, test.description)
-			assert.Equal(t, test.expectedProfile, seccompProfile, "TestCase[%d]: %s", i, test.description)
+			assert.NoErrorf(t, err, "TestCase[%d]: %s", i, test.description)
+			assert.Equalf(t, test.expectedProfile, seccompProfile, "TestCase[%d]: %s", i, test.description)
 		}
 	}
 }

--- a/pkg/kubelet/kuberuntime/helpers_test.go
+++ b/pkg/kubelet/kuberuntime/helpers_test.go
@@ -94,7 +94,7 @@ func TestIsInitContainerFailed(t *testing.T) {
 	}
 	for i, test := range tests {
 		isFailed := isInitContainerFailed(test.status)
-		assert.Equal(t, test.isFailed, isFailed, "TestCase[%d]: %s", i, test.description)
+		assert.Equalf(t, test.isFailed, isFailed, "TestCase[%d]: %s", i, test.description)
 	}
 }
 
@@ -279,14 +279,14 @@ func TestGetImageUser(t *testing.T) {
 		i.Images[test.originalImage.name].Uid = test.originalImage.uid
 
 		uid, username, err := m.getImageUser(ctx, test.originalImage.name)
-		assert.NoError(t, err, "TestCase[%d]", j)
+		assert.NoErrorf(t, err, "TestCase[%d]", j)
 
 		if test.expectedImageUserValues.uid == (*int64)(nil) {
-			assert.Equal(t, test.expectedImageUserValues.uid, uid, "TestCase[%d]", j)
+			assert.Equalf(t, test.expectedImageUserValues.uid, uid, "TestCase[%d]", j)
 		} else {
-			assert.Equal(t, test.expectedImageUserValues.uid, *uid, "TestCase[%d]", j)
+			assert.Equalf(t, test.expectedImageUserValues.uid, *uid, "TestCase[%d]", j)
 		}
-		assert.Equal(t, test.expectedImageUserValues.username, username, "TestCase[%d]", j)
+		assert.Equalf(t, test.expectedImageUserValues.username, username, "TestCase[%d]", j)
 	}
 }
 
@@ -436,8 +436,8 @@ func TestGetAppArmorProfile(t *testing.T) {
 				assert.NoError(t, err)
 			}
 
-			assert.Equal(t, test.expectedProfile, actual, "AppArmor profile")
-			assert.Equal(t, test.expectedOldProfile, actualOld, "old (deprecated) profile string")
+			assert.Equalf(t, test.expectedProfile, actual, "AppArmor profile")
+			assert.Equalf(t, test.expectedOldProfile, actualOld, "old (deprecated) profile string")
 		})
 	}
 }

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_linux_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_linux_test.go
@@ -115,9 +115,9 @@ func TestGenerateContainerConfig(t *testing.T) {
 	expectedConfig := makeExpectedConfig(m, pod, 0, false)
 	containerConfig, _, err := m.generateContainerConfig(ctx, &pod.Spec.Containers[0], pod, 0, "", pod.Spec.Containers[0].Image, []string{}, nil, nil)
 	assert.NoError(t, err)
-	assert.Equal(t, expectedConfig, containerConfig, "generate container config for kubelet runtime v1.")
-	assert.Equal(t, runAsUser, containerConfig.GetLinux().GetSecurityContext().GetRunAsUser().GetValue(), "RunAsUser should be set")
-	assert.Equal(t, runAsGroup, containerConfig.GetLinux().GetSecurityContext().GetRunAsGroup().GetValue(), "RunAsGroup should be set")
+	assert.Equalf(t, expectedConfig, containerConfig, "generate container config for kubelet runtime v1.")
+	assert.Equalf(t, runAsUser, containerConfig.GetLinux().GetSecurityContext().GetRunAsUser().GetValue(), "RunAsUser should be set")
+	assert.Equalf(t, runAsGroup, containerConfig.GetLinux().GetSecurityContext().GetRunAsGroup().GetValue(), "RunAsGroup should be set")
 
 	runAsRoot := int64(0)
 	runAsNonRootTrue := true
@@ -157,7 +157,7 @@ func TestGenerateContainerConfig(t *testing.T) {
 	podWithContainerSecurityContext.Spec.Containers[0].SecurityContext.RunAsNonRoot = &runAsNonRootTrue
 
 	_, _, err = m.generateContainerConfig(ctx, &podWithContainerSecurityContext.Spec.Containers[0], podWithContainerSecurityContext, 0, "", podWithContainerSecurityContext.Spec.Containers[0].Image, []string{}, nil, nil)
-	assert.Error(t, err, "RunAsNonRoot should fail for non-numeric username")
+	assert.Errorf(t, err, "RunAsNonRoot should fail for non-numeric username")
 }
 
 func TestGenerateLinuxContainerConfigResources(t *testing.T) {
@@ -230,10 +230,10 @@ func TestGenerateLinuxContainerConfigResources(t *testing.T) {
 
 		linuxConfig, err := m.generateLinuxContainerConfig(&pod.Spec.Containers[0], pod, new(int64), "", nil, false)
 		assert.NoError(t, err)
-		assert.Equal(t, test.expected.CpuPeriod, linuxConfig.GetResources().CpuPeriod, test.name)
-		assert.Equal(t, test.expected.CpuQuota, linuxConfig.GetResources().CpuQuota, test.name)
-		assert.Equal(t, test.expected.CpuShares, linuxConfig.GetResources().CpuShares, test.name)
-		assert.Equal(t, test.expected.MemoryLimitInBytes, linuxConfig.GetResources().MemoryLimitInBytes, test.name)
+		assert.Equalf(t, test.expected.CpuPeriod, linuxConfig.GetResources().CpuPeriod, test.name)
+		assert.Equalf(t, test.expected.CpuQuota, linuxConfig.GetResources().CpuQuota, test.name)
+		assert.Equalf(t, test.expected.CpuShares, linuxConfig.GetResources().CpuShares, test.name)
+		assert.Equalf(t, test.expected.MemoryLimitInBytes, linuxConfig.GetResources().MemoryLimitInBytes, test.name)
 	}
 }
 
@@ -470,9 +470,9 @@ func TestGenerateContainerConfigWithMemoryQoSEnforced(t *testing.T) {
 	for _, test := range tests {
 		linuxConfig, err := m.generateLinuxContainerConfig(&test.pod.Spec.Containers[0], test.pod, new(int64), "", nil, true)
 		assert.NoError(t, err)
-		assert.Equal(t, test.expected.containerConfig, linuxConfig, test.name)
-		assert.Equal(t, linuxConfig.GetResources().GetUnified()["memory.min"], strconv.FormatInt(test.expected.memoryLow, 10), test.name)
-		assert.Equal(t, linuxConfig.GetResources().GetUnified()["memory.high"], strconv.FormatInt(test.expected.memoryHigh, 10), test.name)
+		assert.Equalf(t, test.expected.containerConfig, linuxConfig, test.name)
+		assert.Equalf(t, linuxConfig.GetResources().GetUnified()["memory.min"], strconv.FormatInt(test.expected.memoryLow, 10), test.name)
+		assert.Equalf(t, linuxConfig.GetResources().GetUnified()["memory.high"], strconv.FormatInt(test.expected.memoryHigh, 10), test.name)
 	}
 }
 
@@ -778,8 +778,8 @@ func TestGenerateLinuxConfigSupplementalGroupsPolicy(t *testing.T) {
 				assert.Emptyf(t, err, "Unexpected error")
 				assert.EqualValuesf(t, tc.expected, actual.SecurityContext.SupplementalGroupsPolicy, "SupplementalGroupPolicy for %s", tc.name)
 			} else {
-				assert.NotEmpty(t, err, "Unexpected success")
-				assert.Empty(t, actual, "Unexpected non empty value")
+				assert.NotEmptyf(t, err, "Unexpected success")
+				assert.Emptyf(t, actual, "Unexpected non empty value")
 				assert.ErrorContainsf(t, err, tc.expectedErrMsg, "Error for %s", tc.name)
 			}
 		})
@@ -986,9 +986,9 @@ func TestGenerateLinuxContainerResourcesWithSwap(t *testing.T) {
 		for _, r := range resources {
 			switch cgroupVersion {
 			case cgroupV1:
-				assert.Equal(t, int64(0), r.MemorySwapLimitInBytes, msg)
+				assert.Equalf(t, int64(0), r.MemorySwapLimitInBytes, msg)
 			case cgroupV2:
-				assert.NotContains(t, r.Unified, cm.Cgroup2MaxSwapFilename, msg)
+				assert.NotContainsf(t, r.Unified, cm.Cgroup2MaxSwapFilename, msg)
 			}
 		}
 	}
@@ -999,9 +999,9 @@ func TestGenerateLinuxContainerResourcesWithSwap(t *testing.T) {
 		for _, r := range resources {
 			switch cgroupVersion {
 			case cgroupV1:
-				assert.Equal(t, r.MemoryLimitInBytes, r.MemorySwapLimitInBytes, msg)
+				assert.Equalf(t, r.MemoryLimitInBytes, r.MemorySwapLimitInBytes, msg)
 			case cgroupV2:
-				assert.Equal(t, "0", r.Unified[cm.Cgroup2MaxSwapFilename], msg)
+				assert.Equalf(t, "0", r.Unified[cm.Cgroup2MaxSwapFilename], msg)
 			}
 		}
 	}
@@ -1011,9 +1011,9 @@ func TestGenerateLinuxContainerResourcesWithSwap(t *testing.T) {
 
 		switch cgroupVersion {
 		case cgroupV1:
-			assert.Equal(t, resources.MemoryLimitInBytes+swapBytesExpected, resources.MemorySwapLimitInBytes, msg)
+			assert.Equalf(t, resources.MemoryLimitInBytes+swapBytesExpected, resources.MemorySwapLimitInBytes, msg)
 		case cgroupV2:
-			assert.Equal(t, fmt.Sprintf("%d", swapBytesExpected), resources.Unified[cm.Cgroup2MaxSwapFilename], msg)
+			assert.Equalf(t, fmt.Sprintf("%d", swapBytesExpected), resources.Unified[cm.Cgroup2MaxSwapFilename], msg)
 		}
 	}
 
@@ -1259,7 +1259,7 @@ func TestGenerateLinuxContainerResourcesWithSwap(t *testing.T) {
 
 			if tc.isCriticalPod {
 				pod.Spec.Priority = ptr.To(scheduling.SystemCriticalPriority)
-				assert.True(t, types.IsCriticalPod(pod), "pod is expected to be critical")
+				assert.Truef(t, types.IsCriticalPod(pod), "pod is expected to be critical")
 			}
 
 			resourcesC1 := m.generateLinuxContainerResources(pod, &pod.Spec.Containers[0], false)

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_test.go
@@ -230,7 +230,7 @@ func TestToKubeContainerStatus(t *testing.T) {
 		},
 	} {
 		actual := toKubeContainerStatus(test.input, cid.Type)
-		assert.Equal(t, test.expected, actual, desc)
+		assert.Equalf(t, test.expected, actual, desc)
 	}
 }
 
@@ -364,7 +364,7 @@ func TestToKubeContainerStatusWithResources(t *testing.T) {
 				t.Skip("Skip failing test on Windows.")
 			}
 			actual := toKubeContainerStatus(test.input, cid.Type)
-			assert.Equal(t, test.expected, actual, desc)
+			assert.Equalf(t, test.expected, actual, desc)
 		})
 	}
 }
@@ -448,7 +448,7 @@ func TestToKubeContainerStatusWithUser(t *testing.T) {
 				User:      test.input,
 			}
 			actual := toKubeContainerStatus(cStatus, cid.Type)
-			assert.EqualValues(t, test.expected, actual.User, desc)
+			assert.EqualValuesf(t, test.expected, actual.User, desc)
 		})
 	}
 }
@@ -756,15 +756,15 @@ func TestRestartCountByLogDir(t *testing.T) {
 		},
 	} {
 		tempDirPath, err := os.MkdirTemp("", "test-restart-count-")
-		assert.NoError(t, err, "create tempdir error")
+		assert.NoErrorf(t, err, "create tempdir error")
 		defer os.RemoveAll(tempDirPath)
 		for _, filename := range tc.filenames {
 			err = os.WriteFile(filepath.Join(tempDirPath, filename), []byte("a log line"), 0600)
-			assert.NoError(t, err, "could not write log file")
+			assert.NoErrorf(t, err, "could not write log file")
 		}
 		count, err := calcRestartCountByLogDir(tempDirPath)
 		if assert.NoError(t, err) {
-			assert.Equal(t, count, tc.restartCount, "count %v should equal restartCount %v", count, tc.restartCount)
+			assert.Equalf(t, count, tc.restartCount, "count %v should equal restartCount %v", count, tc.restartCount)
 		}
 	}
 }

--- a/pkg/kubelet/kuberuntime/kuberuntime_gc_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_gc_test.go
@@ -477,7 +477,7 @@ func TestUnknownStateContainerGC(t *testing.T) {
 	err = m.containerGC.evictContainers(ctx, defaultGCPolicy, true, false)
 	assert.NoError(t, err)
 
-	assert.Contains(t, fakeRuntime.GetCalls(), "StopContainer", "RemoveContainer",
+	assert.Containsf(t, fakeRuntime.GetCalls(), "StopContainer", "RemoveContainer",
 		"container in unknown state should be stopped before being removed")
 
 	remain, err := fakeRuntime.ListContainers(ctx, nil)

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -130,7 +130,7 @@ func makeAndSetFakePod(t *testing.T, m *kubeGenericRuntimeManager, fakeRuntime *
 // makeFakePodSandbox creates a fake pod sandbox based on a sandbox template.
 func makeFakePodSandbox(t *testing.T, m *kubeGenericRuntimeManager, template sandboxTemplate) *apitest.FakePodSandbox {
 	config, err := m.generatePodSandboxConfig(template.pod, template.attempt)
-	assert.NoError(t, err, "generatePodSandboxConfig for sandbox template %+v", template)
+	assert.NoErrorf(t, err, "generatePodSandboxConfig for sandbox template %+v", template)
 
 	podSandboxID := apitest.BuildSandboxName(config.Metadata)
 	podSandBoxStatus := &apitest.FakePodSandbox{
@@ -172,10 +172,10 @@ func makeFakePodSandboxes(t *testing.T, m *kubeGenericRuntimeManager, templates 
 func makeFakeContainer(t *testing.T, m *kubeGenericRuntimeManager, template containerTemplate) *apitest.FakeContainer {
 	ctx := context.Background()
 	sandboxConfig, err := m.generatePodSandboxConfig(template.pod, template.sandboxAttempt)
-	assert.NoError(t, err, "generatePodSandboxConfig for container template %+v", template)
+	assert.NoErrorf(t, err, "generatePodSandboxConfig for container template %+v", template)
 
 	containerConfig, _, err := m.generateContainerConfig(ctx, template.container, template.pod, template.attempt, "", template.container.Image, []string{}, nil, nil)
-	assert.NoError(t, err, "generateContainerConfig for container template %+v", template)
+	assert.NoErrorf(t, err, "generateContainerConfig for container template %+v", template)
 
 	podSandboxID := apitest.BuildSandboxName(sandboxConfig.Metadata)
 	containerID := apitest.BuildContainerName(containerConfig.Metadata, podSandboxID)
@@ -282,7 +282,7 @@ func verifyContainerStatuses(t *testing.T, runtime *apitest.FakeRuntimeService, 
 	}
 	sort.Sort(cRecordList(expected))
 	sort.Sort(cRecordList(actual))
-	assert.Equal(t, expected, actual, desc)
+	assert.Equalf(t, expected, actual, desc)
 }
 
 func TestNewKubeRuntimeManager(t *testing.T) {
@@ -1230,7 +1230,7 @@ func verifyActions(t *testing.T, expected, actual *podActions, desc string) {
 			actual.ContainersToKill[k] = info
 		}
 	}
-	assert.Equal(t, expected, actual, desc)
+	assert.Equalf(t, expected, actual, desc)
 }
 
 func TestComputePodActionsWithInitContainers(t *testing.T) {
@@ -2604,16 +2604,16 @@ func TestUpdatePodContainerResources(t *testing.T) {
 		}
 		fakeRuntime.Called = []string{}
 		err := m.updatePodContainerResources(pod, tc.resourceName, containersToUpdate)
-		assert.NoError(t, err, dsc)
+		assert.NoErrorf(t, err, dsc)
 
 		if tc.invokeUpdateResources {
-			assert.Contains(t, fakeRuntime.Called, "UpdateContainerResources", dsc)
+			assert.Containsf(t, fakeRuntime.Called, "UpdateContainerResources", dsc)
 		}
 		for idx := range pod.Spec.Containers {
-			assert.Equal(t, tc.expectedCurrentLimits[idx].Memory().Value(), containersToUpdate[idx].currentContainerResources.memoryLimit, dsc)
-			assert.Equal(t, tc.expectedCurrentRequests[idx].Memory().Value(), containersToUpdate[idx].currentContainerResources.memoryRequest, dsc)
-			assert.Equal(t, tc.expectedCurrentLimits[idx].Cpu().MilliValue(), containersToUpdate[idx].currentContainerResources.cpuLimit, dsc)
-			assert.Equal(t, tc.expectedCurrentRequests[idx].Cpu().MilliValue(), containersToUpdate[idx].currentContainerResources.cpuRequest, dsc)
+			assert.Equalf(t, tc.expectedCurrentLimits[idx].Memory().Value(), containersToUpdate[idx].currentContainerResources.memoryLimit, dsc)
+			assert.Equalf(t, tc.expectedCurrentRequests[idx].Memory().Value(), containersToUpdate[idx].currentContainerResources.memoryRequest, dsc)
+			assert.Equalf(t, tc.expectedCurrentLimits[idx].Cpu().MilliValue(), containersToUpdate[idx].currentContainerResources.cpuLimit, dsc)
+			assert.Equalf(t, tc.expectedCurrentRequests[idx].Cpu().MilliValue(), containersToUpdate[idx].currentContainerResources.cpuRequest, dsc)
 		}
 	}
 }
@@ -2679,7 +2679,7 @@ func TestToKubeContainerImageVolumes(t *testing.T) {
 		if tc.expectedError != nil {
 			require.EqualError(t, err, tc.expectedError.Error())
 		} else {
-			require.NoError(t, err, desc)
+			require.NoErrorf(t, err, desc)
 		}
 		assert.Equal(t, tc.expectedImageVolumes, imageVolumes)
 	}
@@ -2740,7 +2740,7 @@ func TestGetImageVolumes(t *testing.T) {
 		if tc.expectedError != nil {
 			require.EqualError(t, err, tc.expectedError.Error())
 		} else {
-			require.NoError(t, err, desc)
+			require.NoErrorf(t, err, desc)
 		}
 		assert.Equal(t, tc.expectedImageVolumePulls, imageVolumePulls)
 	}

--- a/pkg/kubelet/kuberuntime/kuberuntime_sandbox_linux_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_sandbox_linux_test.go
@@ -167,8 +167,8 @@ func TestApplySandboxResources(t *testing.T) {
 		setCgroupVersionDuringTest(test.cgroupVersion)
 
 		m.applySandboxResources(test.pod, config)
-		assert.Equal(t, test.expectedResource, config.Linux.Resources, "TestCase[%d]: %s", i, test.description)
-		assert.Equal(t, test.expectedOverhead, config.Linux.Overhead, "TestCase[%d]: %s", i, test.description)
+		assert.Equalf(t, test.expectedResource, config.Linux.Resources, "TestCase[%d]: %s", i, test.description)
+		assert.Equalf(t, test.expectedOverhead, config.Linux.Overhead, "TestCase[%d]: %s", i, test.description)
 	}
 }
 
@@ -257,7 +257,7 @@ func TestGeneratePodSandboxLinuxConfigSupplementalGroupsPolicy(t *testing.T) {
 			assert.Containsf(t, err.Error(), test.expectedErrMsg, "TestCase[%d]: %s", i, test.description)
 		} else {
 			actualPolicy := config.SecurityContext.SupplementalGroupsPolicy.String()
-			assert.EqualValues(t, test.expected, actualPolicy, "TestCase[%d]: %s", i, test.description)
+			assert.EqualValuesf(t, test.expected, actualPolicy, "TestCase[%d]: %s", i, test.description)
 		}
 	}
 }

--- a/pkg/kubelet/kuberuntime/kuberuntime_sandbox_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_sandbox_test.go
@@ -133,7 +133,7 @@ func TestGeneratePodSandboxLinuxConfigSeccomp(t *testing.T) {
 	for i, test := range tests {
 		config, _ := m.generatePodSandboxLinuxConfig(test.pod)
 		actualProfile := config.SecurityContext.Seccomp.ProfileType.String()
-		assert.EqualValues(t, test.expectedProfile, actualProfile, "TestCase[%d]: %s", i, test.description)
+		assert.EqualValuesf(t, test.expectedProfile, actualProfile, "TestCase[%d]: %s", i, test.description)
 	}
 }
 

--- a/pkg/kubelet/kuberuntime/security_context_others_test.go
+++ b/pkg/kubelet/kuberuntime/security_context_others_test.go
@@ -142,9 +142,9 @@ func TestVerifyRunAsNonRoot(t *testing.T) {
 		pod.Spec.Containers[0].SecurityContext = test.sc
 		err := verifyRunAsNonRoot(pod, &pod.Spec.Containers[0], test.uid, test.username)
 		if test.fail {
-			assert.Error(t, err, test.desc)
+			assert.Errorf(t, err, test.desc)
 		} else {
-			assert.NoError(t, err, test.desc)
+			assert.NoErrorf(t, err, test.desc)
 		}
 	}
 }

--- a/pkg/kubelet/logs/container_log_manager_test.go
+++ b/pkg/kubelet/logs/container_log_manager_test.go
@@ -371,11 +371,11 @@ func TestCompressLog(t *testing.T) {
 	c := &containerLogManager{osInterface: container.RealOS{}}
 	require.NoError(t, c.compressLog(testLog))
 	_, err = os.Stat(testLog + compressSuffix)
-	assert.NoError(t, err, "log should be compressed")
+	assert.NoErrorf(t, err, "log should be compressed")
 	_, err = os.Stat(testLog + tmpSuffix)
-	assert.Error(t, err, "temporary log should be renamed")
+	assert.Errorf(t, err, "temporary log should be renamed")
 	_, err = os.Stat(testLog)
-	assert.Error(t, err, "original log should be removed")
+	assert.Errorf(t, err, "original log should be removed")
 
 	rc, err := UncompressLog(testLog + compressSuffix)
 	require.NoError(t, err)

--- a/pkg/kubelet/network/dns/dns_test.go
+++ b/pkg/kubelet/network/dns/dns_test.go
@@ -102,11 +102,11 @@ func TestParseResolvConf(t *testing.T) {
 		ns, srch, opts, err := parseResolvConf(strings.NewReader(tc.data))
 		if !tc.isErr {
 			require.NoError(t, err)
-			assert.EqualValues(t, tc.nameservers, ns, "test case [%d]: name servers", i)
-			assert.EqualValues(t, tc.searches, srch, "test case [%d] searches", i)
-			assert.EqualValues(t, sets.New[string](tc.options...), sets.New[string](opts...), "test case [%d] options", i)
+			assert.EqualValuesf(t, tc.nameservers, ns, "test case [%d]: name servers", i)
+			assert.EqualValuesf(t, tc.searches, srch, "test case [%d] searches", i)
+			assert.EqualValuesf(t, sets.New[string](tc.options...), sets.New[string](opts...), "test case [%d] options", i)
 		} else {
-			require.Error(t, err, "tc.searches %v", tc.searches)
+			require.Errorf(t, err, "tc.searches %v", tc.searches)
 		}
 	}
 }
@@ -225,11 +225,11 @@ func TestFormDNSSearchFitsLimits(t *testing.T) {
 	for i, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			dnsSearch := configurer.formDNSSearchFitsLimits(tc.hostNames, pod)
-			assert.EqualValues(t, tc.resultSearch, dnsSearch, "test [%d]", i)
+			assert.EqualValuesf(t, tc.resultSearch, dnsSearch, "test [%d]", i)
 			for _, expectedEvent := range tc.events {
 				expected := fmt.Sprintf("%s %s %s", v1.EventTypeWarning, "DNSConfigForming", expectedEvent)
 				event := fetchEvent(recorder)
-				assert.Equal(t, expected, event, "test [%d]", i)
+				assert.Equalf(t, expected, event, "test [%d]", i)
 			}
 		})
 	}
@@ -284,7 +284,7 @@ func TestFormDNSNameserversFitsLimits(t *testing.T) {
 
 	for _, tc := range testCases {
 		appliedNameservers := configurer.formDNSNameserversFitsLimits(tc.nameservers, pod)
-		assert.EqualValues(t, tc.expectedNameserver, appliedNameservers, tc.desc)
+		assert.EqualValuesf(t, tc.expectedNameserver, appliedNameservers, tc.desc)
 		event := fetchEvent(recorder)
 		if tc.expectedEvent && len(event) == 0 {
 			t.Errorf("%s: formDNSNameserversFitsLimits(%v) expected event, got no event.", tc.desc, tc.nameservers)

--- a/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux_test.go
+++ b/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux_test.go
@@ -373,9 +373,9 @@ func TestManager(t *testing.T) {
 					t.Errorf("unexpected error message. Got: %s want %s", err.Error(), tc.expectedError.Error())
 				}
 			} else {
-				assert.NoError(t, err, "expected manager.Start() to not return error")
-				assert.True(t, fakeDbus.didInhibitShutdown, "expected that manager inhibited shutdown")
-				assert.NoError(t, manager.ShutdownStatus(), "expected that manager does not return error since shutdown is not active")
+				assert.NoErrorf(t, err, "expected manager.Start() to not return error")
+				assert.Truef(t, fakeDbus.didInhibitShutdown, "expected that manager inhibited shutdown")
+				assert.NoErrorf(t, manager.ShutdownStatus(), "expected that manager does not return error since shutdown is not active")
 				assert.True(t, manager.Admit(nil).Admit)
 
 				// Send fake shutdown event
@@ -397,10 +397,10 @@ func TestManager(t *testing.T) {
 					}
 				}
 
-				assert.Error(t, manager.ShutdownStatus(), "expected that manager returns error since shutdown is active")
+				assert.Errorf(t, manager.ShutdownStatus(), "expected that manager returns error since shutdown is active")
 				assert.False(t, manager.Admit(nil).Admit)
 				assert.Equal(t, tc.expectedPodToGracePeriodOverride, killedPodsToGracePeriods)
-				assert.Equal(t, tc.expectedDidOverrideInhibitDelay, fakeDbus.didOverrideInhibitDelay, "override system inhibit delay differs")
+				assert.Equalf(t, tc.expectedDidOverrideInhibitDelay, fakeDbus.didOverrideInhibitDelay, "override system inhibit delay differs")
 				if tc.expectedPodStatuses != nil {
 					for _, pod := range tc.activePods {
 						if diff := cmp.Diff(tc.expectedPodStatuses[pod.Name], pod.Status, cmpopts.IgnoreFields(v1.PodCondition{}, "LastProbeTime", "LastTransitionTime")); diff != "" {

--- a/pkg/kubelet/nodestatus/setters_test.go
+++ b/pkg/kubelet/nodestatus/setters_test.go
@@ -670,10 +670,10 @@ func TestNodeAddress(t *testing.T) {
 				return
 			}
 
-			assert.True(t, apiequality.Semantic.DeepEqual(testCase.expectedAddresses, existingNode.Status.Addresses),
+			assert.Truef(t, apiequality.Semantic.DeepEqual(testCase.expectedAddresses, existingNode.Status.Addresses),
 				"Diff: %s", cmp.Diff(testCase.expectedAddresses, existingNode.Status.Addresses))
 			if testCase.expectedAnnotations != nil {
-				assert.True(t, apiequality.Semantic.DeepEqual(testCase.expectedAnnotations, existingNode.Annotations),
+				assert.Truef(t, apiequality.Semantic.DeepEqual(testCase.expectedAnnotations, existingNode.Annotations),
 					"Diff: %s", cmp.Diff(testCase.expectedAnnotations, existingNode.Annotations))
 			}
 		})
@@ -758,7 +758,7 @@ func TestNodeAddress_NoCloudProvider(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 
-			assert.True(t, apiequality.Semantic.DeepEqual(testCase.expectedAddresses, existingNode.Status.Addresses),
+			assert.Truef(t, apiequality.Semantic.DeepEqual(testCase.expectedAddresses, existingNode.Status.Addresses),
 				"Diff: %s", cmp.Diff(testCase.expectedAddresses, existingNode.Status.Addresses))
 		})
 	}
@@ -1240,7 +1240,7 @@ func TestMachineInfo(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			// check expected node
-			assert.True(t, apiequality.Semantic.DeepEqual(tc.expectNode, tc.node),
+			assert.Truef(t, apiequality.Semantic.DeepEqual(tc.expectNode, tc.node),
 				"Diff: %s", cmp.Diff(tc.expectNode, tc.node))
 			// check expected events
 			require.Equal(t, len(tc.expectEvents), len(events))
@@ -1392,7 +1392,7 @@ func TestVersionInfo(t *testing.T) {
 			err := setter(ctx, tc.node)
 			require.Equal(t, tc.expectError, err)
 			// check expected node
-			assert.True(t, apiequality.Semantic.DeepEqual(tc.expectNode, tc.node),
+			assert.Truef(t, apiequality.Semantic.DeepEqual(tc.expectNode, tc.node),
 				"Diff: %s", cmp.Diff(tc.expectNode, tc.node))
 		})
 	}
@@ -1472,7 +1472,7 @@ func TestImages(t *testing.T) {
 			if err == nil {
 				expectNode.Status.Images = makeExpectedImageList(tc.imageList, tc.maxImages, MaxNamesPerImageInNodeStatus)
 			}
-			assert.True(t, apiequality.Semantic.DeepEqual(expectNode, node),
+			assert.Truef(t, apiequality.Semantic.DeepEqual(expectNode, node),
 				"Diff: %s", cmp.Diff(expectNode, node))
 		})
 	}
@@ -1649,7 +1649,7 @@ func TestReadyCondition(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			// check expected condition
-			assert.True(t, apiequality.Semantic.DeepEqual(tc.expectConditions, tc.node.Status.Conditions),
+			assert.Truef(t, apiequality.Semantic.DeepEqual(tc.expectConditions, tc.node.Status.Conditions),
 				"Diff: %s", cmp.Diff(tc.expectConditions, tc.node.Status.Conditions))
 			// check expected events
 			require.Equal(t, len(tc.expectEvents), len(events))
@@ -1771,7 +1771,7 @@ func TestMemoryPressureCondition(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			// check expected condition
-			assert.True(t, apiequality.Semantic.DeepEqual(tc.expectConditions, tc.node.Status.Conditions),
+			assert.Truef(t, apiequality.Semantic.DeepEqual(tc.expectConditions, tc.node.Status.Conditions),
 				"Diff: %s", cmp.Diff(tc.expectConditions, tc.node.Status.Conditions))
 			// check expected events
 			require.Equal(t, len(tc.expectEvents), len(events))
@@ -1893,7 +1893,7 @@ func TestPIDPressureCondition(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			// check expected condition
-			assert.True(t, apiequality.Semantic.DeepEqual(tc.expectConditions, tc.node.Status.Conditions),
+			assert.Truef(t, apiequality.Semantic.DeepEqual(tc.expectConditions, tc.node.Status.Conditions),
 				"Diff: %s", cmp.Diff(tc.expectConditions, tc.node.Status.Conditions))
 			// check expected events
 			require.Equal(t, len(tc.expectEvents), len(events))
@@ -2015,7 +2015,7 @@ func TestDiskPressureCondition(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			// check expected condition
-			assert.True(t, apiequality.Semantic.DeepEqual(tc.expectConditions, tc.node.Status.Conditions),
+			assert.Truef(t, apiequality.Semantic.DeepEqual(tc.expectConditions, tc.node.Status.Conditions),
 				"Diff: %s", cmp.Diff(tc.expectConditions, tc.node.Status.Conditions))
 			// check expected events
 			require.Equal(t, len(tc.expectEvents), len(events))
@@ -2072,7 +2072,7 @@ func TestVolumesInUse(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			// check expected volumes
-			assert.True(t, apiequality.Semantic.DeepEqual(tc.expectVolumesInUse, tc.node.Status.VolumesInUse),
+			assert.Truef(t, apiequality.Semantic.DeepEqual(tc.expectVolumesInUse, tc.node.Status.VolumesInUse),
 				"Diff: %s", cmp.Diff(tc.expectVolumesInUse, tc.node.Status.VolumesInUse))
 		})
 	}

--- a/pkg/kubelet/pleg/generic_test.go
+++ b/pkg/kubelet/pleg/generic_test.go
@@ -140,7 +140,7 @@ func TestRelisting(t *testing.T) {
 	// changed.
 	pleg.Relist()
 	actual = getEventsFromChannel(ch)
-	assert.Empty(t, actual, "no container has changed, event length should be 0")
+	assert.Emptyf(t, actual, "no container has changed, event length should be 0")
 
 	runtime.AllPodList = []*containertest.FakePod{
 		{Pod: &kubecontainer.Pod{
@@ -228,7 +228,7 @@ func TestEventChannelFull(t *testing.T) {
 	}
 	// event channel is full, discard events
 	actual = getEventsFromChannel(ch)
-	assert.Len(t, actual, 4, "channel length should be 4")
+	assert.Lenf(t, actual, 4, "channel length should be 4")
 	assert.Subsetf(t, allEvents, actual, "actual events should in all events")
 }
 
@@ -377,8 +377,8 @@ func TestRelistWithCache(t *testing.T) {
 	for i, c := range cases {
 		testStr := fmt.Sprintf("test[%d]", i)
 		actualStatus, actualErr := pleg.cache.Get(c.pod.ID)
-		assert.Equal(t, c.status, actualStatus, testStr)
-		assert.Equal(t, c.error, actualErr, testStr)
+		assert.Equalf(t, c.status, actualStatus, testStr)
+		assert.Equalf(t, c.error, actualErr, testStr)
 	}
 	// pleg should not generate any event for pods[1] because of the error.
 	assert.Exactly(t, []*PodLifecycleEvent{events[0]}, actualEvents)
@@ -398,8 +398,8 @@ func TestRelistWithCache(t *testing.T) {
 	for i, c := range cases {
 		testStr := fmt.Sprintf("test[%d]", i)
 		actualStatus, actualErr := pleg.cache.Get(c.pod.ID)
-		assert.Equal(t, c.status, actualStatus, testStr)
-		assert.Equal(t, c.error, actualErr, testStr)
+		assert.Equalf(t, c.status, actualStatus, testStr)
+		assert.Equalf(t, c.error, actualErr, testStr)
 	}
 	// Now that we are able to query status for pods[1], pleg should generate an event.
 	assert.Exactly(t, []*PodLifecycleEvent{events[1]}, actualEvents)
@@ -430,25 +430,25 @@ func TestHealthy(t *testing.T) {
 	// pleg should initially be unhealthy
 	pleg, _, clock := testPleg.pleg, testPleg.runtime, testPleg.clock
 	ok, _ := pleg.Healthy()
-	assert.False(t, ok, "pleg should be unhealthy")
+	assert.Falsef(t, ok, "pleg should be unhealthy")
 
 	// Advance the clock without any relisting.
 	clock.Step(time.Minute * 10)
 	ok, _ = pleg.Healthy()
-	assert.False(t, ok, "pleg should be unhealthy")
+	assert.Falsef(t, ok, "pleg should be unhealthy")
 
 	// Relist and than advance the time by 1 minute. pleg should be healthy
 	// because this is within the allowed limit.
 	pleg.Relist()
 	clock.Step(time.Minute * 1)
 	ok, _ = pleg.Healthy()
-	assert.True(t, ok, "pleg should be healthy")
+	assert.Truef(t, ok, "pleg should be healthy")
 
 	// Advance by relistThreshold without any relisting. pleg should be unhealthy
 	// because it has been longer than relistThreshold since a relist occurred.
 	clock.Step(pleg.relistDuration.RelistThreshold)
 	ok, _ = pleg.Healthy()
-	assert.False(t, ok, "pleg should be unhealthy")
+	assert.Falsef(t, ok, "pleg should be unhealthy")
 }
 
 func TestRelistWithReinspection(t *testing.T) {
@@ -633,8 +633,8 @@ func TestRelistIPChange(t *testing.T) {
 		pleg.Relist()
 		actualEvents := getEventsFromChannel(ch)
 		actualStatus, actualErr := pleg.cache.Get(pod.ID)
-		assert.Equal(t, status, actualStatus, tc.name)
-		assert.NoError(t, actualErr, tc.name)
+		assert.Equalf(t, status, actualStatus, tc.name)
+		assert.NoErrorf(t, actualErr, tc.name)
 		assert.Exactly(t, []*PodLifecycleEvent{event}, actualEvents)
 
 		// Clear the IP address and mark the container terminated
@@ -658,8 +658,8 @@ func TestRelistIPChange(t *testing.T) {
 		// the way to the event
 		statusCopy := *status
 		statusCopy.IPs = tc.podIPs
-		assert.Equal(t, &statusCopy, actualStatus, tc.name)
-		require.NoError(t, actualErr, tc.name)
+		assert.Equalf(t, &statusCopy, actualStatus, tc.name)
+		require.NoErrorf(t, actualErr, tc.name)
 		assert.Exactly(t, []*PodLifecycleEvent{event}, actualEvents)
 	}
 }

--- a/pkg/kubelet/pod/pod_manager_test.go
+++ b/pkg/kubelet/pod/pod_manager_test.go
@@ -116,17 +116,17 @@ func verify(t *testing.T, pm *basicManager, isMirror bool, expectedPod *v1.Pod) 
 	if isMirror {
 		inputPod, ok := pm.mirrorPodByUID[kubetypes.MirrorPodUID(expectedPod.UID)]
 		assert.True(t, ok)
-		assert.Empty(t, cmp.Diff(expectedPod, inputPod), "MirrorPodByUID map verification failed.")
+		assert.Emptyf(t, cmp.Diff(expectedPod, inputPod), "MirrorPodByUID map verification failed.")
 		inputPod, ok = pm.mirrorPodByFullName[fullName]
 		assert.True(t, ok)
-		assert.Empty(t, cmp.Diff(expectedPod, inputPod), "MirrorPodByFullName map verification failed.")
+		assert.Emptyf(t, cmp.Diff(expectedPod, inputPod), "MirrorPodByFullName map verification failed.")
 	} else {
 		inputPod, ok := pm.podByUID[kubetypes.ResolvedPodUID(expectedPod.UID)]
 		assert.True(t, ok)
-		assert.Empty(t, cmp.Diff(expectedPod, inputPod), "PodByUID map verification failed.")
+		assert.Emptyf(t, cmp.Diff(expectedPod, inputPod), "PodByUID map verification failed.")
 		inputPod, ok = pm.podByFullName[fullName]
 		assert.True(t, ok)
-		assert.Empty(t, cmp.Diff(expectedPod, inputPod), "PodByFullName map verification failed.")
+		assert.Emptyf(t, cmp.Diff(expectedPod, inputPod), "PodByFullName map verification failed.")
 	}
 }
 
@@ -203,36 +203,36 @@ func TestGetSetPods(t *testing.T) {
 			podManager := NewBasicPodManager()
 			podManager.SetPods(test.podList)
 			actualPods := podManager.GetPods()
-			assert.Empty(t, cmp.Diff(test.expectPods, actualPods, sortOpt), "actualPods and expectPods differ")
+			assert.Emptyf(t, cmp.Diff(test.expectPods, actualPods, sortOpt), "actualPods and expectPods differ")
 
 			uid := podManager.TranslatePodUID(test.wantPod.UID)
-			assert.Equal(t, kubetypes.ResolvedPodUID(test.expectUID), uid, "unable to translate pod UID")
+			assert.Equalf(t, kubetypes.ResolvedPodUID(test.expectUID), uid, "unable to translate pod UID")
 
 			fullName := fmt.Sprintf("%s_%s", test.wantPod.Name, test.wantPod.Namespace)
 			actualPod, ok := podManager.GetPodByFullName(fullName)
 			assert.True(t, ok)
-			assert.Empty(t, cmp.Diff(test.expectPod, actualPod), "actualPod by full name and expectGetPod differ")
+			assert.Emptyf(t, cmp.Diff(test.expectPod, actualPod), "actualPod by full name and expectGetPod differ")
 
 			actualPod, ok = podManager.GetPodByName(test.wantPod.Namespace, test.wantPod.Name)
 			assert.True(t, ok)
-			assert.Empty(t, cmp.Diff(test.expectPod, actualPod), "actualPod by name and expectGetPod differ")
+			assert.Emptyf(t, cmp.Diff(test.expectPod, actualPod), "actualPod by name and expectGetPod differ")
 
 			actualPod, ok = podManager.GetPodByUID(test.wantUID)
 			assert.True(t, ok)
-			assert.Empty(t, cmp.Diff(test.expectPod, actualPod), "actualPod and expectGetPod differ")
+			assert.Emptyf(t, cmp.Diff(test.expectPod, actualPod), "actualPod and expectGetPod differ")
 
 			podToMirror, mirrorToPod := podManager.GetUIDTranslations()
-			assert.Empty(t, cmp.Diff(test.expectPodToMirrorMap, podToMirror), "podToMirror and expectPodToMirror differ")
-			assert.Empty(t, cmp.Diff(test.expectMirrorToPodMap, mirrorToPod), "mirrorToPod and expectMirrorToPod differ")
+			assert.Emptyf(t, cmp.Diff(test.expectPodToMirrorMap, podToMirror), "podToMirror and expectPodToMirror differ")
+			assert.Emptyf(t, cmp.Diff(test.expectMirrorToPodMap, mirrorToPod), "mirrorToPod and expectMirrorToPod differ")
 
 			actualPod, ok = podManager.GetMirrorPodByPod(test.wantPod)
 			assert.Equal(t, test.expectedMirrorPod != nil, ok)
-			assert.Empty(t, cmp.Diff(test.expectedMirrorPod, actualPod), "actualPod and expectShouldBeMirrorPod differ")
+			assert.Emptyf(t, cmp.Diff(test.expectedMirrorPod, actualPod), "actualPod and expectShouldBeMirrorPod differ")
 
 			actualPod, actualMirrorPod, isMirrorPod := podManager.GetPodAndMirrorPod(test.wantPod)
 			assert.Equal(t, test.isMirrorPod, isMirrorPod)
-			assert.Empty(t, cmp.Diff(test.expectPod, actualPod), "actualPod and expectGetPod differ")
-			assert.Empty(t, cmp.Diff(test.expectedMirrorPod, actualMirrorPod), "actualMirrorPod and shouldBeMirrorPod differ")
+			assert.Emptyf(t, cmp.Diff(test.expectPod, actualPod), "actualPod and expectGetPod differ")
+			assert.Emptyf(t, cmp.Diff(test.expectedMirrorPod, actualMirrorPod), "actualMirrorPod and shouldBeMirrorPod differ")
 
 			isMirrorPod = IsMirrorPodOf(test.wantPod, mirrorPod)
 			assert.Equal(t, test.isMirrorPod, isMirrorPod)
@@ -240,7 +240,7 @@ func TestGetSetPods(t *testing.T) {
 			if test.isMirrorPod {
 				actualPod, ok = podManager.GetPodByMirrorPod(test.wantPod)
 				assert.Equal(t, test.expectedMirrorPod != nil, ok)
-				assert.Empty(t, cmp.Diff(test.expectPod, actualPod), "actualPod by name and expectGetPod differ")
+				assert.Emptyf(t, cmp.Diff(test.expectPod, actualPod), "actualPod by name and expectGetPod differ")
 			}
 		})
 	}
@@ -287,10 +287,10 @@ func TestRemovePods(t *testing.T) {
 			actualPods1 := podManager.GetPods()
 			actualPods2, actualMirrorPods, orphanedMirrorPodFullnames := podManager.GetPodsAndMirrorPods()
 			// Check if the actual pods and mirror pods match the expected ones.
-			assert.Empty(t, cmp.Diff(actualPods1, actualPods2, sortOpt), "actualPods by GetPods() and GetPodsAndMirrorPods() differ")
-			assert.Empty(t, cmp.Diff(test.expectPods, actualPods1, sortOpt), "actualPods and expectPods differ")
-			assert.Empty(t, cmp.Diff(test.expectMirrorPods, actualMirrorPods, sortOpt), "actualMirrorPods and expectMirrorPods differ")
-			assert.Empty(t, cmp.Diff(test.expectOrphanedMirrorPodFullnames, orphanedMirrorPodFullnames), "orphanedMirrorPodFullnames and expectOrphanedMirrorPodFullnames differ")
+			assert.Emptyf(t, cmp.Diff(actualPods1, actualPods2, sortOpt), "actualPods by GetPods() and GetPodsAndMirrorPods() differ")
+			assert.Emptyf(t, cmp.Diff(test.expectPods, actualPods1, sortOpt), "actualPods and expectPods differ")
+			assert.Emptyf(t, cmp.Diff(test.expectMirrorPods, actualMirrorPods, sortOpt), "actualMirrorPods and expectMirrorPods differ")
+			assert.Emptyf(t, cmp.Diff(test.expectOrphanedMirrorPodFullnames, orphanedMirrorPodFullnames), "orphanedMirrorPodFullnames and expectOrphanedMirrorPodFullnames differ")
 		})
 	}
 }

--- a/pkg/kubelet/prober/results/results_manager_test.go
+++ b/pkg/kubelet/prober/results/results_manager_test.go
@@ -35,16 +35,16 @@ func TestCacheOperations(t *testing.T) {
 	setID := kubecontainer.ContainerID{Type: "test", ID: "set"}
 
 	_, found := m.Get(unsetID)
-	assert.False(t, found, "unset result found")
+	assert.Falsef(t, found, "unset result found")
 
 	m.Set(setID, Success, &corev1.Pod{})
 	result, found := m.Get(setID)
-	assert.Equal(t, Success, result, "set result")
-	assert.True(t, found, "set result found")
+	assert.Equalf(t, Success, result, "set result")
+	assert.Truef(t, found, "set result found")
 
 	m.Remove(setID)
 	_, found = m.Get(setID)
-	assert.False(t, found, "removed result found")
+	assert.Falsef(t, found, "removed result found")
 }
 
 func TestUpdates(t *testing.T) {

--- a/pkg/kubelet/runtimeclass/runtimeclass_manager_test.go
+++ b/pkg/kubelet/runtimeclass/runtimeclass_manager_test.go
@@ -50,7 +50,7 @@ func TestLookupRuntimeHandler(t *testing.T) {
 		t.Run(fmt.Sprintf("%q->%q(err:%v)", tname, test.expected, test.expectError), func(t *testing.T) {
 			handler, err := manager.LookupRuntimeHandler(test.rcn)
 			if test.expectError {
-				assert.Error(t, err, "handler=%q", handler)
+				assert.Errorf(t, err, "handler=%q", handler)
 			} else {
 				assert.NoError(t, err)
 				assert.Equal(t, test.expected, handler)

--- a/pkg/kubelet/stats/cadvisor_stats_provider_test.go
+++ b/pkg/kubelet/stats/cadvisor_stats_provider_test.go
@@ -618,11 +618,11 @@ func TestImageFsStatsCustomResponse(t *testing.T) {
 		provider := newCadvisorStatsProvider(mockCadvisor, &fakeResourceAnalyzer{}, mockRuntime, nil, NewFakeHostStatsProvider())
 		stats, containerfs, err := provider.ImageFsStats(ctx)
 		if tc.shouldErr {
-			require.Error(t, err, desc)
+			require.Errorf(t, err, desc)
 			assert.Nil(t, stats)
 			assert.Nil(t, containerfs)
 		} else {
-			assert.NoError(t, err, desc)
+			assert.NoErrorf(t, err, desc)
 		}
 	}
 }

--- a/pkg/kubelet/stats/cri_stats_provider_test.go
+++ b/pkg/kubelet/stats/cri_stats_provider_test.go
@@ -1263,11 +1263,11 @@ func TestGetContainerUsageNanoCores(t *testing.T) {
 
 		// Update the cache and get the latest value.
 		real := provider.getAndUpdateContainerUsageNanoCores(test.stats)
-		assert.Equal(t, test.expected, real, test.desc)
+		assert.Equalf(t, test.expected, real, test.desc)
 
 		// After the update, the cached value should be up-to-date
 		cached = provider.getContainerUsageNanoCores(test.stats)
-		assert.Equal(t, test.expected, cached, test.desc)
+		assert.Equalf(t, test.expected, cached, test.desc)
 	}
 }
 

--- a/pkg/kubelet/stats/helper_test.go
+++ b/pkg/kubelet/stats/helper_test.go
@@ -79,7 +79,8 @@ func TestCustomMetrics(t *testing.T) {
 			},
 		},
 	}
-	assert.Contains(t, cadvisorInfoToUserDefinedMetrics(&cInfo),
+	definedMetrics := cadvisorInfoToUserDefinedMetrics(&cInfo)
+	assert.Contains(t, definedMetrics,
 		statsapi.UserDefinedMetric{
 			UserDefinedMetricDescriptor: statsapi.UserDefinedMetricDescriptor{
 				Name:  "qos",
@@ -88,7 +89,8 @@ func TestCustomMetrics(t *testing.T) {
 			},
 			Time:  metav1.NewTime(timestamp2),
 			Value: 100,
-		},
+		})
+	assert.Contains(t, definedMetrics,
 		statsapi.UserDefinedMetric{
 			UserDefinedMetricDescriptor: statsapi.UserDefinedMetricDescriptor{
 				Name:  "cpuLoad",

--- a/pkg/kubelet/stats/provider_test.go
+++ b/pkg/kubelet/stats/provider_test.go
@@ -420,72 +420,72 @@ func testTime(base time.Time, seed int) time.Time {
 
 func checkNetworkStats(t *testing.T, label string, seed int, stats *statsapi.NetworkStats) {
 	assert.NotNil(t, stats)
-	assert.EqualValues(t, testTime(timestamp, seed).Unix(), stats.Time.Time.Unix(), label+".Net.Time")
-	assert.EqualValues(t, "eth0", stats.Name, "default interface name is not eth0")
-	assert.EqualValues(t, seed+offsetNetRxBytes, *stats.RxBytes, label+".Net.RxBytes")
-	assert.EqualValues(t, seed+offsetNetRxErrors, *stats.RxErrors, label+".Net.RxErrors")
-	assert.EqualValues(t, seed+offsetNetTxBytes, *stats.TxBytes, label+".Net.TxBytes")
-	assert.EqualValues(t, seed+offsetNetTxErrors, *stats.TxErrors, label+".Net.TxErrors")
+	assert.EqualValuesf(t, testTime(timestamp, seed).Unix(), stats.Time.Time.Unix(), label+".Net.Time")
+	assert.EqualValuesf(t, "eth0", stats.Name, "default interface name is not eth0")
+	assert.EqualValuesf(t, seed+offsetNetRxBytes, *stats.RxBytes, label+".Net.RxBytes")
+	assert.EqualValuesf(t, seed+offsetNetRxErrors, *stats.RxErrors, label+".Net.RxErrors")
+	assert.EqualValuesf(t, seed+offsetNetTxBytes, *stats.TxBytes, label+".Net.TxBytes")
+	assert.EqualValuesf(t, seed+offsetNetTxErrors, *stats.TxErrors, label+".Net.TxErrors")
 
-	assert.Len(t, stats.Interfaces, 2, "network interfaces should contain 2 elements")
+	assert.Lenf(t, stats.Interfaces, 2, "network interfaces should contain 2 elements")
 
-	assert.EqualValues(t, "eth0", stats.Interfaces[0].Name, "default interface name is not eth0")
-	assert.EqualValues(t, seed+offsetNetRxBytes, *stats.Interfaces[0].RxBytes, label+".Net.TxErrors")
-	assert.EqualValues(t, seed+offsetNetRxErrors, *stats.Interfaces[0].RxErrors, label+".Net.TxErrors")
-	assert.EqualValues(t, seed+offsetNetTxBytes, *stats.Interfaces[0].TxBytes, label+".Net.TxErrors")
-	assert.EqualValues(t, seed+offsetNetTxErrors, *stats.Interfaces[0].TxErrors, label+".Net.TxErrors")
+	assert.EqualValuesf(t, "eth0", stats.Interfaces[0].Name, "default interface name is not eth0")
+	assert.EqualValuesf(t, seed+offsetNetRxBytes, *stats.Interfaces[0].RxBytes, label+".Net.TxErrors")
+	assert.EqualValuesf(t, seed+offsetNetRxErrors, *stats.Interfaces[0].RxErrors, label+".Net.TxErrors")
+	assert.EqualValuesf(t, seed+offsetNetTxBytes, *stats.Interfaces[0].TxBytes, label+".Net.TxErrors")
+	assert.EqualValuesf(t, seed+offsetNetTxErrors, *stats.Interfaces[0].TxErrors, label+".Net.TxErrors")
 
-	assert.EqualValues(t, "cbr0", stats.Interfaces[1].Name, "cbr0 interface name is not cbr0")
-	assert.EqualValues(t, 100, *stats.Interfaces[1].RxBytes, label+".Net.TxErrors")
-	assert.EqualValues(t, 100, *stats.Interfaces[1].RxErrors, label+".Net.TxErrors")
-	assert.EqualValues(t, 100, *stats.Interfaces[1].TxBytes, label+".Net.TxErrors")
-	assert.EqualValues(t, 100, *stats.Interfaces[1].TxErrors, label+".Net.TxErrors")
+	assert.EqualValuesf(t, "cbr0", stats.Interfaces[1].Name, "cbr0 interface name is not cbr0")
+	assert.EqualValuesf(t, 100, *stats.Interfaces[1].RxBytes, label+".Net.TxErrors")
+	assert.EqualValuesf(t, 100, *stats.Interfaces[1].RxErrors, label+".Net.TxErrors")
+	assert.EqualValuesf(t, 100, *stats.Interfaces[1].TxBytes, label+".Net.TxErrors")
+	assert.EqualValuesf(t, 100, *stats.Interfaces[1].TxErrors, label+".Net.TxErrors")
 
 }
 
 func checkCPUStats(t *testing.T, label string, seed int, stats *statsapi.CPUStats) {
-	require.NotNil(t, stats.Time, label+".CPU.Time")
-	require.NotNil(t, stats.UsageNanoCores, label+".CPU.UsageNanoCores")
-	require.NotNil(t, stats.UsageNanoCores, label+".CPU.UsageCoreSeconds")
-	assert.EqualValues(t, testTime(timestamp, seed).Unix(), stats.Time.Time.Unix(), label+".CPU.Time")
-	assert.EqualValues(t, seed+offsetCPUUsageCores, *stats.UsageNanoCores, label+".CPU.UsageCores")
-	assert.EqualValues(t, seed+offsetCPUUsageCoreSeconds, *stats.UsageCoreNanoSeconds, label+".CPU.UsageCoreSeconds")
+	require.NotNilf(t, stats.Time, label+".CPU.Time")
+	require.NotNilf(t, stats.UsageNanoCores, label+".CPU.UsageNanoCores")
+	require.NotNilf(t, stats.UsageNanoCores, label+".CPU.UsageCoreSeconds")
+	assert.EqualValuesf(t, testTime(timestamp, seed).Unix(), stats.Time.Time.Unix(), label+".CPU.Time")
+	assert.EqualValuesf(t, seed+offsetCPUUsageCores, *stats.UsageNanoCores, label+".CPU.UsageCores")
+	assert.EqualValuesf(t, seed+offsetCPUUsageCoreSeconds, *stats.UsageCoreNanoSeconds, label+".CPU.UsageCoreSeconds")
 }
 
 func checkMemoryStats(t *testing.T, label string, seed int, info cadvisorapiv2.ContainerInfo, stats *statsapi.MemoryStats) {
-	assert.EqualValues(t, testTime(timestamp, seed).Unix(), stats.Time.Time.Unix(), label+".Mem.Time")
-	assert.EqualValues(t, seed+offsetMemUsageBytes, *stats.UsageBytes, label+".Mem.UsageBytes")
-	assert.EqualValues(t, seed+offsetMemWorkingSetBytes, *stats.WorkingSetBytes, label+".Mem.WorkingSetBytes")
-	assert.EqualValues(t, seed+offsetMemRSSBytes, *stats.RSSBytes, label+".Mem.RSSBytes")
-	assert.EqualValues(t, seed+offsetMemPageFaults, *stats.PageFaults, label+".Mem.PageFaults")
-	assert.EqualValues(t, seed+offsetMemMajorPageFaults, *stats.MajorPageFaults, label+".Mem.MajorPageFaults")
+	assert.EqualValuesf(t, testTime(timestamp, seed).Unix(), stats.Time.Time.Unix(), label+".Mem.Time")
+	assert.EqualValuesf(t, seed+offsetMemUsageBytes, *stats.UsageBytes, label+".Mem.UsageBytes")
+	assert.EqualValuesf(t, seed+offsetMemWorkingSetBytes, *stats.WorkingSetBytes, label+".Mem.WorkingSetBytes")
+	assert.EqualValuesf(t, seed+offsetMemRSSBytes, *stats.RSSBytes, label+".Mem.RSSBytes")
+	assert.EqualValuesf(t, seed+offsetMemPageFaults, *stats.PageFaults, label+".Mem.PageFaults")
+	assert.EqualValuesf(t, seed+offsetMemMajorPageFaults, *stats.MajorPageFaults, label+".Mem.MajorPageFaults")
 	if !info.Spec.HasMemory || isMemoryUnlimited(info.Spec.Memory.Limit) {
-		assert.Nil(t, stats.AvailableBytes, label+".Mem.AvailableBytes")
+		assert.Nilf(t, stats.AvailableBytes, label+".Mem.AvailableBytes")
 	} else {
 		expected := info.Spec.Memory.Limit - *stats.WorkingSetBytes
-		assert.EqualValues(t, expected, *stats.AvailableBytes, label+".Mem.AvailableBytes")
+		assert.EqualValuesf(t, expected, *stats.AvailableBytes, label+".Mem.AvailableBytes")
 	}
 }
 
 func checkSwapStats(t *testing.T, label string, seed int, info cadvisorapiv2.ContainerInfo, stats *statsapi.SwapStats) {
 	label += ".Swap"
 
-	assert.EqualValues(t, testTime(timestamp, seed).Unix(), stats.Time.Time.Unix(), label+".Time")
-	assert.EqualValues(t, seed+offsetMemSwapUsageBytes, *stats.SwapUsageBytes, label+".SwapUsageBytes")
+	assert.EqualValuesf(t, testTime(timestamp, seed).Unix(), stats.Time.Time.Unix(), label+".Time")
+	assert.EqualValuesf(t, seed+offsetMemSwapUsageBytes, *stats.SwapUsageBytes, label+".SwapUsageBytes")
 
 	if !info.Spec.HasMemory || isMemoryUnlimited(info.Spec.Memory.SwapLimit) {
-		assert.Nil(t, stats.SwapAvailableBytes, label+".SwapAvailableBytes")
+		assert.Nilf(t, stats.SwapAvailableBytes, label+".SwapAvailableBytes")
 	} else {
 		expected := info.Spec.Memory.Limit - *stats.SwapUsageBytes
-		assert.EqualValues(t, expected, *stats.SwapAvailableBytes, label+".AvailableBytes")
+		assert.EqualValuesf(t, expected, *stats.SwapAvailableBytes, label+".AvailableBytes")
 	}
 }
 
 func checkFsStats(t *testing.T, label string, seed int, stats *statsapi.FsStats) {
-	assert.EqualValues(t, seed+offsetFsCapacity, *stats.CapacityBytes, label+".CapacityBytes")
-	assert.EqualValues(t, seed+offsetFsAvailable, *stats.AvailableBytes, label+".AvailableBytes")
-	assert.EqualValues(t, seed+offsetFsInodes, *stats.Inodes, label+".Inodes")
-	assert.EqualValues(t, seed+offsetFsInodesFree, *stats.InodesFree, label+".InodesFree")
+	assert.EqualValuesf(t, seed+offsetFsCapacity, *stats.CapacityBytes, label+".CapacityBytes")
+	assert.EqualValuesf(t, seed+offsetFsAvailable, *stats.AvailableBytes, label+".AvailableBytes")
+	assert.EqualValuesf(t, seed+offsetFsInodes, *stats.Inodes, label+".Inodes")
+	assert.EqualValuesf(t, seed+offsetFsInodesFree, *stats.InodesFree, label+".InodesFree")
 }
 
 func checkEphemeralStats(t *testing.T, label string, containerSeeds []int, volumeSeeds []int, containerLogStats []*volume.Metrics, stats *statsapi.FsStats) {
@@ -509,8 +509,8 @@ func checkEphemeralStats(t *testing.T, label string, containerSeeds []int, volum
 		usedBytes += int(logStats.Used.Value())
 		inodeUsage += int(logStats.InodesUsed.Value())
 	}
-	assert.EqualValues(t, usedBytes, int(*stats.UsedBytes), label+".UsedBytes")
-	assert.EqualValues(t, inodeUsage, int(*stats.InodesUsed), label+".InodesUsed")
+	assert.EqualValuesf(t, usedBytes, int(*stats.UsedBytes), label+".UsedBytes")
+	assert.EqualValuesf(t, inodeUsage, int(*stats.InodesUsed), label+".InodesUsed")
 }
 
 type fakeResourceAnalyzer struct {

--- a/pkg/kubelet/types/types_test.go
+++ b/pkg/kubelet/types/types_test.go
@@ -172,7 +172,7 @@ func TestSortStatusesOfInitContainers(t *testing.T) {
 	for _, data := range tests {
 		pod.Spec.InitContainers = data.containers
 		result := SortStatusesOfInitContainers(&pod, data.statusMap)
-		require.Equal(t, result, data.expectStatuses, "Unexpected result from SortStatusesOfInitContainers: %v", result)
+		require.Equalf(t, result, data.expectStatuses, "Unexpected result from SortStatusesOfInitContainers: %v", result)
 	}
 }
 

--- a/pkg/kubelet/userns/userns_manager_switch_test.go
+++ b/pkg/kubelet/userns/userns_manager_switch_test.go
@@ -48,7 +48,7 @@ func TestMakeUserNsManagerSwitch(t *testing.T) {
 	for _, podUID := range pods {
 		pod := v1.Pod{ObjectMeta: metav1.ObjectMeta{UID: podUID}}
 		_, err := m.GetOrCreateUserNamespaceMappings(&pod, "")
-		require.NoError(t, err, "failed to record userns range for pod %v", podUID)
+		require.NoErrorf(t, err, "failed to record userns range for pod %v", podUID)
 	}
 
 	// Test re-init works when the feature gate is disabled and there were some
@@ -60,7 +60,7 @@ func TestMakeUserNsManagerSwitch(t *testing.T) {
 	// The feature gate is off, no pods should be allocated.
 	for _, pod := range pods {
 		ok := m2.podAllocated(pod)
-		assert.False(t, ok, "pod %q should not be allocated", pod)
+		assert.Falsef(t, ok, "pod %q should not be allocated", pod)
 	}
 }
 
@@ -83,7 +83,7 @@ func TestGetOrCreateUserNamespaceMappingsSwitch(t *testing.T) {
 	for _, podUID := range pods {
 		pod := v1.Pod{ObjectMeta: metav1.ObjectMeta{UID: podUID}}
 		_, err := m.GetOrCreateUserNamespaceMappings(&pod, "")
-		require.NoError(t, err, "failed to record userns range for pod %v", podUID)
+		require.NoErrorf(t, err, "failed to record userns range for pod %v", podUID)
 	}
 
 	// Test no-op when the feature gate is disabled and there were some
@@ -97,8 +97,8 @@ func TestGetOrCreateUserNamespaceMappingsSwitch(t *testing.T) {
 		pod := v1.Pod{ObjectMeta: metav1.ObjectMeta{UID: podUID}}
 		userns, err := m2.GetOrCreateUserNamespaceMappings(&pod, "")
 
-		assert.NoError(t, err, "failed to record userns range for pod %v", podUID)
-		assert.Nil(t, userns, "userns range should be nil for pod %v", podUID)
+		assert.NoErrorf(t, err, "failed to record userns range for pod %v", podUID)
+		assert.Nilf(t, userns, "userns range should be nil for pod %v", podUID)
 	}
 }
 
@@ -120,7 +120,7 @@ func TestCleanupOrphanedPodUsernsAllocationsSwitch(t *testing.T) {
 	for _, podUID := range pods {
 		pod := v1.Pod{ObjectMeta: metav1.ObjectMeta{UID: podUID}}
 		_, err := m.GetOrCreateUserNamespaceMappings(&pod, "")
-		require.NoError(t, err, "failed to record userns range for pod %v", podUID)
+		require.NoErrorf(t, err, "failed to record userns range for pod %v", podUID)
 	}
 
 	// Test cleanup works when the feature gate is disabled and there were some
@@ -132,6 +132,6 @@ func TestCleanupOrphanedPodUsernsAllocationsSwitch(t *testing.T) {
 	// The feature gate is off, no pods should be allocated.
 	for _, pod := range append(listPods, pods...) {
 		ok := m.podAllocated(pod)
-		assert.False(t, ok, "pod %q should not be allocated", pod)
+		assert.Falsef(t, ok, "pod %q should not be allocated", pod)
 	}
 }

--- a/pkg/kubelet/userns/userns_manager_test.go
+++ b/pkg/kubelet/userns/userns_manager_test.go
@@ -97,13 +97,13 @@ func TestUserNsManagerAllocate(t *testing.T) {
 
 	allocated, length, err := m.allocateOne("one")
 	assert.NoError(t, err)
-	assert.Equal(t, userNsLength, int(length), "m.isSet(%d).length=%v", allocated, length)
-	assert.True(t, m.isSet(allocated), "m.isSet(%d)", allocated)
+	assert.Equalf(t, userNsLength, int(length), "m.isSet(%d).length=%v", allocated, length)
+	assert.Truef(t, m.isSet(allocated), "m.isSet(%d)", allocated)
 
 	allocated2, length2, err := m.allocateOne("two")
 	assert.NoError(t, err)
-	assert.NotEqual(t, allocated, allocated2, "allocated != allocated2")
-	assert.Equal(t, length, length2, "length == length2")
+	assert.NotEqualf(t, allocated, allocated2, "allocated != allocated2")
+	assert.Equalf(t, length, length2, "length == length2")
 
 	// verify that re-adding the same pod with the same settings won't fail
 	err = m.record("two", allocated2, length2)
@@ -114,13 +114,13 @@ func TestUserNsManagerAllocate(t *testing.T) {
 
 	m.Release("one")
 	m.Release("two")
-	assert.False(t, m.isSet(allocated), "m.isSet(%d)", allocated)
-	assert.False(t, m.isSet(allocated2), "m.nsSet(%d)", allocated2)
+	assert.Falsef(t, m.isSet(allocated), "m.isSet(%d)", allocated)
+	assert.Falsef(t, m.isSet(allocated2), "m.nsSet(%d)", allocated2)
 
 	var allocs []uint32
 	for i := 0; i < 1000; i++ {
 		allocated, length, err = m.allocateOne(types.UID(fmt.Sprintf("%d", i)))
-		assert.Equal(t, userNsLength, int(length), "length is not the expected. iter: %v", i)
+		assert.Equalf(t, userNsLength, int(length), "length is not the expected. iter: %v", i)
 		assert.NoError(t, err)
 		assert.GreaterOrEqual(t, allocated, uint32(minimumMappingUID))
 		// The last ID of the userns range (allocated+userNsLength) should be within bounds.
@@ -128,14 +128,14 @@ func TestUserNsManagerAllocate(t *testing.T) {
 		allocs = append(allocs, allocated)
 	}
 	for i, v := range allocs {
-		assert.True(t, m.isSet(v), "m.isSet(%d) should be true", v)
+		assert.Truef(t, m.isSet(v), "m.isSet(%d) should be true", v)
 		m.Release(types.UID(fmt.Sprintf("%d", i)))
-		assert.False(t, m.isSet(v), "m.isSet(%d) should be false", v)
+		assert.Falsef(t, m.isSet(v), "m.isSet(%d) should be false", v)
 
 		err = m.record(types.UID(fmt.Sprintf("%d", i)), v, userNsLength)
 		assert.NoError(t, err)
 		m.Release(types.UID(fmt.Sprintf("%d", i)))
-		assert.False(t, m.isSet(v), "m.isSet(%d) should be false", v)
+		assert.Falsef(t, m.isSet(v), "m.isSet(%d) should be false", v)
 	}
 }
 
@@ -443,12 +443,12 @@ func TestCleanupOrphanedPodUsernsAllocations(t *testing.T) {
 
 			for _, pod := range tc.podSetAfterCleanup {
 				ok := m.podAllocated(pod)
-				assert.True(t, ok, "pod %q should be allocated", pod)
+				assert.Truef(t, ok, "pod %q should be allocated", pod)
 			}
 
 			for _, pod := range tc.podUnsetAfterCleanup {
 				ok := m.podAllocated(pod)
-				assert.False(t, ok, "pod %q should not be allocated", pod)
+				assert.Falsef(t, ok, "pod %q should not be allocated", pod)
 			}
 		})
 	}

--- a/pkg/kubelet/util/manager/cache_based_manager_test.go
+++ b/pkg/kubelet/util/manager/cache_based_manager_test.go
@@ -99,7 +99,7 @@ func TestSecretStore(t *testing.T) {
 
 	// Adds don't issue Get requests.
 	actions := fakeClient.Actions()
-	assert.Empty(t, actions, "unexpected actions")
+	assert.Emptyf(t, actions, "unexpected actions")
 	// Should issue Get request
 	store.Get("ns1", "name1")
 	// Shouldn't issue Get request, as secret is not registered
@@ -108,10 +108,10 @@ func TestSecretStore(t *testing.T) {
 	store.Get("ns3", "name3")
 
 	actions = fakeClient.Actions()
-	assert.Len(t, actions, 2, "unexpected actions")
+	assert.Lenf(t, actions, 2, "unexpected actions")
 
 	for _, a := range actions {
-		assert.True(t, a.Matches("get", "secrets"), "unexpected actions: %#v", a)
+		assert.Truef(t, a.Matches("get", "secrets"), "unexpected actions: %#v", a)
 	}
 
 	checkObject(t, store, "ns1", "name1", true)
@@ -169,10 +169,10 @@ func TestSecretStoreGetAlwaysRefresh(t *testing.T) {
 	}
 	wg.Wait()
 	actions := fakeClient.Actions()
-	assert.Len(t, actions, 100, "unexpected actions")
+	assert.Lenf(t, actions, 100, "unexpected actions")
 
 	for _, a := range actions {
-		assert.True(t, a.Matches("get", "secrets"), "unexpected actions: %#v", a)
+		assert.Truef(t, a.Matches("get", "secrets"), "unexpected actions: %#v", a)
 	}
 }
 
@@ -197,7 +197,7 @@ func TestSecretStoreGetNeverRefresh(t *testing.T) {
 	wg.Wait()
 	actions := fakeClient.Actions()
 	// Only first Get, should forward the Get request.
-	assert.Len(t, actions, 10, "unexpected actions")
+	assert.Lenf(t, actions, 10, "unexpected actions")
 }
 
 func TestCustomTTL(t *testing.T) {
@@ -220,24 +220,24 @@ func TestCustomTTL(t *testing.T) {
 	ttlExists = true
 	store.Get("ns", "name")
 	actions := fakeClient.Actions()
-	assert.Len(t, actions, 1, "unexpected actions")
+	assert.Lenf(t, actions, 1, "unexpected actions")
 	fakeClient.ClearActions()
 
 	// Set 5-minute ttl and see if this works.
 	ttl = time.Duration(5) * time.Minute
 	store.Get("ns", "name")
 	actions = fakeClient.Actions()
-	assert.Empty(t, actions, "unexpected actions")
+	assert.Emptyf(t, actions, "unexpected actions")
 	// Still no effect after 4 minutes.
 	fakeClock.Step(4 * time.Minute)
 	store.Get("ns", "name")
 	actions = fakeClient.Actions()
-	assert.Empty(t, actions, "unexpected actions")
+	assert.Emptyf(t, actions, "unexpected actions")
 	// Now it should have an effect.
 	fakeClock.Step(time.Minute)
 	store.Get("ns", "name")
 	actions = fakeClient.Actions()
-	assert.Len(t, actions, 1, "unexpected actions")
+	assert.Lenf(t, actions, 1, "unexpected actions")
 	fakeClient.ClearActions()
 
 	// Now remove the custom ttl and see if that works.
@@ -245,12 +245,12 @@ func TestCustomTTL(t *testing.T) {
 	fakeClock.Step(55 * time.Second)
 	store.Get("ns", "name")
 	actions = fakeClient.Actions()
-	assert.Empty(t, actions, "unexpected action")
+	assert.Emptyf(t, actions, "unexpected action")
 	// Pass the minute and it should be triggered now.
 	fakeClock.Step(5 * time.Second)
 	store.Get("ns", "name")
 	actions = fakeClient.Actions()
-	assert.Len(t, actions, 1, "unexpected actions")
+	assert.Lenf(t, actions, 1, "unexpected actions")
 }
 
 func TestParseNodeAnnotation(t *testing.T) {
@@ -402,7 +402,7 @@ func TestCacheInvalidation(t *testing.T) {
 	store.Get("ns1", "s10")
 	store.Get("ns1", "s2")
 	actions := fakeClient.Actions()
-	assert.Len(t, actions, 3, "unexpected number of actions")
+	assert.Lenf(t, actions, 3, "unexpected number of actions")
 	fakeClient.ClearActions()
 
 	// Update a pod with a new secret.
@@ -421,7 +421,7 @@ func TestCacheInvalidation(t *testing.T) {
 	store.Get("ns1", "s20")
 	store.Get("ns1", "s3")
 	actions = fakeClient.Actions()
-	assert.Len(t, actions, 2, "unexpected actions")
+	assert.Lenf(t, actions, 2, "unexpected actions")
 	fakeClient.ClearActions()
 
 	// Create a new pod that is refencing the first three secrets - those should
@@ -433,7 +433,7 @@ func TestCacheInvalidation(t *testing.T) {
 	store.Get("ns1", "s20")
 	store.Get("ns1", "s3")
 	actions = fakeClient.Actions()
-	assert.Len(t, actions, 3, "unexpected actions")
+	assert.Lenf(t, actions, 3, "unexpected actions")
 	fakeClient.ClearActions()
 }
 

--- a/pkg/kubelet/util/manager/watch_based_manager_test.go
+++ b/pkg/kubelet/util/manager/watch_based_manager_test.go
@@ -195,7 +195,7 @@ func TestSecretCacheMultipleRegistrations(t *testing.T) {
 		store.DeleteReference("ns", "name", types.UID(fmt.Sprintf("pod-%d", i)))
 	}
 	actions := fakeClient.Actions()
-	assert.Len(t, actions, 2, "unexpected actions")
+	assert.Lenf(t, actions, 2, "unexpected actions")
 
 	// Final delete also doesn't trigger any action.
 	store.DeleteReference("ns", "name", "pod")
@@ -204,7 +204,7 @@ func TestSecretCacheMultipleRegistrations(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 	actions = fakeClient.Actions()
-	assert.Len(t, actions, 2, "unexpected actions")
+	assert.Lenf(t, actions, 2, "unexpected actions")
 }
 
 func TestImmutableSecretStopsTheReflector(t *testing.T) {

--- a/pkg/kubelet/util/util_unix_test.go
+++ b/pkg/kubelet/util/util_unix_test.go
@@ -42,10 +42,10 @@ func TestLocalEndpoint(t *testing.T) {
 	for _, test := range tests {
 		fullPath, err := LocalEndpoint(test.path, test.file)
 		if test.expectError {
-			assert.Error(t, err, "expected error")
+			assert.Errorf(t, err, "expected error")
 			continue
 		}
-		assert.NoError(t, err, "expected no error")
+		assert.NoErrorf(t, err, "expected no error")
 		assert.Equal(t, test.expectedFullPath, fullPath)
 	}
 }

--- a/pkg/proxy/apis/config/validation/validation_test.go
+++ b/pkg/proxy/apis/config/validation/validation_test.go
@@ -185,9 +185,9 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 			testCase.mutateConfigFunc(config)
 			errs := Validate(config)
 			if len(testCase.expectedErrs) == 0 {
-				assert.Equal(t, field.ErrorList{}, errs, "expected no validation errors")
+				assert.Equalf(t, field.ErrorList{}, errs, "expected no validation errors")
 			} else {
-				assert.Equal(t, testCase.expectedErrs, errs, "did not get expected validation errors")
+				assert.Equalf(t, testCase.expectedErrs, errs, "did not get expected validation errors")
 			}
 		})
 	}
@@ -215,7 +215,7 @@ func TestValidateKubeProxyIPTablesConfiguration(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			errs := validateKubeProxyIPTablesConfiguration(testCase.config, newPath.Child("KubeIPTablesConfiguration"))
-			assert.Equal(t, testCase.expectedErrs, errs, "did not get expected validation errors")
+			assert.Equalf(t, testCase.expectedErrs, errs, "did not get expected validation errors")
 		})
 	}
 }
@@ -255,7 +255,7 @@ func TestValidateKubeProxyIPVSConfiguration(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			errs := validateKubeProxyIPVSConfiguration(testCase.config, newPath.Child("KubeIPVSConfiguration"))
-			assert.Equal(t, testCase.expectedErrs, errs, "did not get expected validation errors")
+			assert.Equalf(t, testCase.expectedErrs, errs, "did not get expected validation errors")
 		})
 	}
 }
@@ -409,7 +409,7 @@ func TestValidateKubeProxyLinuxConfiguration(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			errs := validateKubeProxyLinuxConfiguration(testCase.config, newPath.Child("KubeProxyLinuxConfiguration"))
-			assert.Equal(t, testCase.expectedErrs, errs, "did not get expected validation errors")
+			assert.Equalf(t, testCase.expectedErrs, errs, "did not get expected validation errors")
 		})
 	}
 }
@@ -451,7 +451,7 @@ func testValidateProxyModeLinux(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			errs := validateProxyMode(testCase.mode, newPath)
-			assert.Equal(t, testCase.expectedErrs, errs, "did not get expected validation errors")
+			assert.Equalf(t, testCase.expectedErrs, errs, "did not get expected validation errors")
 		})
 	}
 }
@@ -491,7 +491,7 @@ func testValidateProxyModeWindows(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			errs := validateProxyMode(testCase.mode, newPath)
-			assert.Equal(t, testCase.expectedErrs, errs, "did not get expected validation errors")
+			assert.Equalf(t, testCase.expectedErrs, errs, "did not get expected validation errors")
 		})
 	}
 }
@@ -517,7 +517,7 @@ func TestValidateClientConnectionConfiguration(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			errs := validateClientConnectionConfiguration(testCase.ccc, newPath)
-			assert.Equal(t, testCase.expectedErrs, errs, "did not get expected validation errors")
+			assert.Equalf(t, testCase.expectedErrs, errs, "did not get expected validation errors")
 		})
 	}
 }
@@ -561,9 +561,9 @@ func TestValidateHostPort(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			errs := validateHostPort(testCase.ip, newPath.Child("HealthzBindAddress"))
 			if len(testCase.expectedErrs) == 0 {
-				assert.Equal(t, field.ErrorList{}, errs, "expected no validation errors")
+				assert.Equalf(t, field.ErrorList{}, errs, "expected no validation errors")
 			} else {
-				assert.Equal(t, testCase.expectedErrs, errs, "did not get expected validation errors")
+				assert.Equalf(t, testCase.expectedErrs, errs, "did not get expected validation errors")
 			}
 		})
 	}
@@ -651,9 +651,9 @@ func TestValidateKubeProxyNodePortAddress(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			errs := validateKubeProxyNodePortAddress(testCase.addresses, newPath.Child("NodePortAddresses"))
 			if len(testCase.expectedErrs) == 0 {
-				assert.Equal(t, field.ErrorList{}, errs, "expected no validation errors")
+				assert.Equalf(t, field.ErrorList{}, errs, "expected no validation errors")
 			} else {
-				assert.Equal(t, testCase.expectedErrs, errs, "did not get expected validation errors")
+				assert.Equalf(t, testCase.expectedErrs, errs, "did not get expected validation errors")
 			}
 		})
 	}
@@ -730,9 +730,9 @@ func TestValidateKubeProxyExcludeCIDRs(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			errs := validateIPVSExcludeCIDRs(testCase.addresses, newPath.Child("ExcludeCIDRS"))
 			if len(testCase.expectedErrs) == 0 {
-				assert.Equal(t, field.ErrorList{}, errs, "expected no validation errors")
+				assert.Equalf(t, field.ErrorList{}, errs, "expected no validation errors")
 			} else {
-				assert.Equal(t, testCase.expectedErrs, errs, "did not get expected validation errors")
+				assert.Equalf(t, testCase.expectedErrs, errs, "did not get expected validation errors")
 			}
 		})
 	}

--- a/pkg/proxy/iptables/proxier_test.go
+++ b/pkg/proxy/iptables/proxier_test.go
@@ -5815,7 +5815,7 @@ func TestSyncProxyRulesLargeClusterMode(t *testing.T) {
 	fp.syncProxyRules()
 
 	svc4Endpoint, numEndpoints, _ := countEndpointsAndComments(fp.iptablesData.String(), "10.4.0.1")
-	assert.Equal(t, "-A KUBE-SEP-SU5STNODRYEWJAUF -m tcp -p tcp -j DNAT --to-destination 10.4.0.1:8082", svc4Endpoint, "svc4 endpoint was not created")
+	assert.Equalf(t, "-A KUBE-SEP-SU5STNODRYEWJAUF -m tcp -p tcp -j DNAT --to-destination 10.4.0.1:8082", svc4Endpoint, "svc4 endpoint was not created")
 	// should only sync svc4
 	if numEndpoints != 1 {
 		t.Errorf("Found wrong number of endpoints after svc4 creation: expected %d, got %d", 1, numEndpoints)
@@ -5828,24 +5828,24 @@ func TestSyncProxyRulesLargeClusterMode(t *testing.T) {
 	fp.syncProxyRules()
 
 	svc4Endpoint, numEndpoints, _ = countEndpointsAndComments(fp.iptablesData.String(), "10.4.0.1")
-	assert.Equal(t, "", svc4Endpoint, "svc4 endpoint was still created!")
+	assert.Equalf(t, "", svc4Endpoint, "svc4 endpoint was still created!")
 	// should only sync svc4, and shouldn't output its endpoints
 	if numEndpoints != 0 {
 		t.Errorf("Found wrong number of endpoints after service deletion: expected %d, got %d", 0, numEndpoints)
 	}
-	assert.NotContains(t, fp.iptablesData.String(), "-X ", "iptables data unexpectedly contains chain deletions")
+	assert.NotContainsf(t, fp.iptablesData.String(), "-X ", "iptables data unexpectedly contains chain deletions")
 
 	// But resyncing after a long-enough delay will delete the stale chains
 	fp.lastIPTablesCleanup = time.Now().Add(-fp.syncPeriod).Add(-1)
 	fp.syncProxyRules()
 
 	svc4Endpoint, numEndpoints, _ = countEndpointsAndComments(fp.iptablesData.String(), "10.4.0.1")
-	assert.Equal(t, "", svc4Endpoint, "svc4 endpoint was still created!")
+	assert.Equalf(t, "", svc4Endpoint, "svc4 endpoint was still created!")
 	if numEndpoints != 0 {
 		t.Errorf("Found wrong number of endpoints after delayed resync: expected %d, got %d", 0, numEndpoints)
 	}
-	assert.Contains(t, fp.iptablesData.String(), "-X KUBE-SVC-EBDQOQU5SJFXRIL3", "iptables data does not contain chain deletion")
-	assert.Contains(t, fp.iptablesData.String(), "-X KUBE-SEP-SU5STNODRYEWJAUF", "iptables data does not contain endpoint deletions")
+	assert.Containsf(t, fp.iptablesData.String(), "-X KUBE-SVC-EBDQOQU5SJFXRIL3", "iptables data does not contain chain deletion")
+	assert.Containsf(t, fp.iptablesData.String(), "-X KUBE-SEP-SU5STNODRYEWJAUF", "iptables data does not contain endpoint deletions")
 
 	// force a full sync and count
 	fp.forceSyncProxyRules()

--- a/pkg/proxy/ipvs/proxier_test.go
+++ b/pkg/proxy/ipvs/proxier_test.go
@@ -4407,14 +4407,14 @@ func TestEndpointSliceE2E(t *testing.T) {
 	// Ensure that Proxier updates ipvs appropriately after EndpointSlice update
 	assert.NotNil(t, fp.ipsetList["KUBE-LOOP-BACK"])
 	activeEntries1 := fp.ipsetList["KUBE-LOOP-BACK"].activeEntries
-	assert.Equal(t, 1, activeEntries1.Len(), "Expected 1 active entry in KUBE-LOOP-BACK")
-	assert.True(t, activeEntries1.Has("10.0.1.1,tcp:80,10.0.1.1"), "Expected activeEntries to reference first (local) pod")
+	assert.Equalf(t, 1, activeEntries1.Len(), "Expected 1 active entry in KUBE-LOOP-BACK")
+	assert.Truef(t, activeEntries1.Has("10.0.1.1,tcp:80,10.0.1.1"), "Expected activeEntries to reference first (local) pod")
 	virtualServers1, vsErr1 := ipvs.GetVirtualServers()
-	assert.NoError(t, vsErr1, "Expected no error getting virtual servers")
-	assert.Len(t, virtualServers1, 1, "Expected 1 virtual server")
+	assert.NoErrorf(t, vsErr1, "Expected no error getting virtual servers")
+	assert.Lenf(t, virtualServers1, 1, "Expected 1 virtual server")
 	realServers1, rsErr1 := ipvs.GetRealServers(virtualServers1[0])
-	assert.NoError(t, rsErr1, "Expected no error getting real servers")
-	assert.Len(t, realServers1, 3, "Expected 3 real servers")
+	assert.NoErrorf(t, rsErr1, "Expected no error getting real servers")
+	assert.Lenf(t, realServers1, 3, "Expected 3 real servers")
 	assert.Equal(t, "10.0.1.1:80", realServers1[0].String())
 	assert.Equal(t, "10.0.1.2:80", realServers1[1].String())
 	assert.Equal(t, "10.0.1.3:80", realServers1[2].String())
@@ -4425,13 +4425,13 @@ func TestEndpointSliceE2E(t *testing.T) {
 	// Ensure that Proxier updates ipvs appropriately after EndpointSlice delete
 	assert.NotNil(t, fp.ipsetList["KUBE-LOOP-BACK"])
 	activeEntries2 := fp.ipsetList["KUBE-LOOP-BACK"].activeEntries
-	assert.Equal(t, 0, activeEntries2.Len(), "Expected 0 active entries in KUBE-LOOP-BACK")
+	assert.Equalf(t, 0, activeEntries2.Len(), "Expected 0 active entries in KUBE-LOOP-BACK")
 	virtualServers2, vsErr2 := ipvs.GetVirtualServers()
-	assert.NoError(t, vsErr2, "Expected no error getting virtual servers")
-	assert.Len(t, virtualServers2, 1, "Expected 1 virtual server")
+	assert.NoErrorf(t, vsErr2, "Expected no error getting virtual servers")
+	assert.Lenf(t, virtualServers2, 1, "Expected 1 virtual server")
 	realServers2, rsErr2 := ipvs.GetRealServers(virtualServers2[0])
-	assert.NoError(t, rsErr2, "Expected no error getting real servers")
-	assert.Empty(t, realServers2, "Expected 0 real servers")
+	assert.NoErrorf(t, rsErr2, "Expected no error getting real servers")
+	assert.Emptyf(t, realServers2, "Expected 0 real servers")
 }
 
 func TestHealthCheckNodePortE2E(t *testing.T) {
@@ -4464,8 +4464,8 @@ func TestHealthCheckNodePortE2E(t *testing.T) {
 	// Ensure that Proxier updates ipvs appropriately after service's being created
 	assert.NotNil(t, fp.ipsetList["KUBE-HEALTH-CHECK-NODE-PORT"])
 	activeEntries1 := fp.ipsetList["KUBE-HEALTH-CHECK-NODE-PORT"].activeEntries
-	assert.Equal(t, 1, activeEntries1.Len(), "Expected 1 active entry in KUBE-HEALTH-CHECK-NODE-PORT")
-	assert.True(t, activeEntries1.Has("30000"), "Expected activeEntries to reference hc node port in spec")
+	assert.Equalf(t, 1, activeEntries1.Len(), "Expected 1 active entry in KUBE-HEALTH-CHECK-NODE-PORT")
+	assert.Truef(t, activeEntries1.Has("30000"), "Expected activeEntries to reference hc node port in spec")
 
 	// Update health check node port in the spec
 	newSvc := svc
@@ -4476,8 +4476,8 @@ func TestHealthCheckNodePortE2E(t *testing.T) {
 	// Ensure that Proxier updates ipvs appropriately after service's being updated
 	assert.NotNil(t, fp.ipsetList["KUBE-HEALTH-CHECK-NODE-PORT"])
 	activeEntries2 := fp.ipsetList["KUBE-HEALTH-CHECK-NODE-PORT"].activeEntries
-	assert.Equal(t, 1, activeEntries2.Len(), "Expected 1 active entry in KUBE-HEALTH-CHECK-NODE-PORT")
-	assert.True(t, activeEntries2.Has("30001"), "Expected activeEntries to reference updated hc node port in spec")
+	assert.Equalf(t, 1, activeEntries2.Len(), "Expected 1 active entry in KUBE-HEALTH-CHECK-NODE-PORT")
+	assert.Truef(t, activeEntries2.Has("30001"), "Expected activeEntries to reference updated hc node port in spec")
 
 	fp.OnServiceDelete(&svc)
 	fp.syncProxyRules()
@@ -4485,7 +4485,7 @@ func TestHealthCheckNodePortE2E(t *testing.T) {
 	// Ensure that Proxier updates ipvs appropriately after EndpointSlice delete
 	assert.NotNil(t, fp.ipsetList["KUBE-HEALTH-CHECK-NODE-PORT"])
 	activeEntries3 := fp.ipsetList["KUBE-HEALTH-CHECK-NODE-PORT"].activeEntries
-	assert.Equal(t, 0, activeEntries3.Len(), "Expected 0 active entries in KUBE-HEALTH-CHECK-NODE-PORT")
+	assert.Equalf(t, 0, activeEntries3.Len(), "Expected 0 active entries in KUBE-HEALTH-CHECK-NODE-PORT")
 }
 
 // Test_HealthCheckNodePortWhenTerminating tests that health check node ports are not enabled when all local endpoints are terminating
@@ -4798,18 +4798,18 @@ func TestTestInternalTrafficPolicyE2E(t *testing.T) {
 		activeEntries1 := fp.ipsetList["KUBE-LOOP-BACK"].activeEntries
 
 		if tc.expectLocalEntries {
-			assert.Equal(t, 1, activeEntries1.Len(), "Expected 1 active entry in KUBE-LOOP-BACK")
+			assert.Equalf(t, 1, activeEntries1.Len(), "Expected 1 active entry in KUBE-LOOP-BACK")
 		} else {
-			assert.Equal(t, 0, activeEntries1.Len(), "Expected no active entry in KUBE-LOOP-BACK")
+			assert.Equalf(t, 0, activeEntries1.Len(), "Expected no active entry in KUBE-LOOP-BACK")
 		}
 
 		if tc.expectVirtualServer {
 			virtualServers1, vsErr1 := ipvs.GetVirtualServers()
-			assert.NoError(t, vsErr1, "Expected no error getting virtual servers")
+			assert.NoErrorf(t, vsErr1, "Expected no error getting virtual servers")
 
-			assert.Len(t, virtualServers1, 1, "Expected 1 virtual server")
+			assert.Lenf(t, virtualServers1, 1, "Expected 1 virtual server")
 			realServers1, rsErr1 := ipvs.GetRealServers(virtualServers1[0])
-			assert.NoError(t, rsErr1, "Expected no error getting real servers")
+			assert.NoErrorf(t, rsErr1, "Expected no error getting real servers")
 
 			assert.Lenf(t, realServers1, tc.expectLocalRealServerNum, "Expected %d real servers", tc.expectLocalRealServerNum)
 			for i := 0; i < tc.expectLocalRealServerNum; i++ {
@@ -4823,13 +4823,13 @@ func TestTestInternalTrafficPolicyE2E(t *testing.T) {
 		// Ensure that Proxier updates ipvs appropriately after EndpointSlice delete
 		assert.NotNil(t, fp.ipsetList["KUBE-LOOP-BACK"])
 		activeEntries3 := fp.ipsetList["KUBE-LOOP-BACK"].activeEntries
-		assert.Equal(t, 0, activeEntries3.Len(), "Expected 0 active entries in KUBE-LOOP-BACK")
+		assert.Equalf(t, 0, activeEntries3.Len(), "Expected 0 active entries in KUBE-LOOP-BACK")
 		virtualServers2, vsErr2 := ipvs.GetVirtualServers()
-		assert.NoError(t, vsErr2, "Expected no error getting virtual servers")
-		assert.Len(t, virtualServers2, 1, "Expected 1 virtual server")
+		assert.NoErrorf(t, vsErr2, "Expected no error getting virtual servers")
+		assert.Lenf(t, virtualServers2, 1, "Expected 1 virtual server")
 		realServers2, rsErr2 := ipvs.GetRealServers(virtualServers2[0])
-		assert.NoError(t, rsErr2, "Expected no error getting real servers")
-		assert.Empty(t, realServers2, "Expected 0 real servers")
+		assert.NoErrorf(t, rsErr2, "Expected no error getting real servers")
+		assert.Emptyf(t, realServers2, "Expected 0 real servers")
 	}
 }
 
@@ -4938,15 +4938,15 @@ func Test_EndpointSliceReadyAndTerminatingCluster(t *testing.T) {
 	// Ensure that Proxier updates ipvs appropriately after EndpointSlice update
 	assert.NotNil(t, fp.ipsetList["KUBE-LOOP-BACK"])
 	activeEntries1 := fp.ipsetList["KUBE-LOOP-BACK"].activeEntries
-	assert.Equal(t, 4, activeEntries1.Len(), "Expected 4 active entry in KUBE-LOOP-BACK")
-	assert.True(t, activeEntries1.Has("10.0.1.1,tcp:80,10.0.1.1"), "Expected activeEntries to reference first pod")
-	assert.True(t, activeEntries1.Has("10.0.1.2,tcp:80,10.0.1.2"), "Expected activeEntries to reference second pod")
-	assert.True(t, activeEntries1.Has("10.0.1.3,tcp:80,10.0.1.3"), "Expected activeEntries to reference third pod")
-	assert.True(t, activeEntries1.Has("10.0.1.4,tcp:80,10.0.1.4"), "Expected activeEntries to reference fourth pod")
+	assert.Equalf(t, 4, activeEntries1.Len(), "Expected 4 active entry in KUBE-LOOP-BACK")
+	assert.Truef(t, activeEntries1.Has("10.0.1.1,tcp:80,10.0.1.1"), "Expected activeEntries to reference first pod")
+	assert.Truef(t, activeEntries1.Has("10.0.1.2,tcp:80,10.0.1.2"), "Expected activeEntries to reference second pod")
+	assert.Truef(t, activeEntries1.Has("10.0.1.3,tcp:80,10.0.1.3"), "Expected activeEntries to reference third pod")
+	assert.Truef(t, activeEntries1.Has("10.0.1.4,tcp:80,10.0.1.4"), "Expected activeEntries to reference fourth pod")
 
 	virtualServers, vsErr := ipvs.GetVirtualServers()
-	assert.NoError(t, vsErr, "Expected no error getting virtual servers")
-	assert.Len(t, virtualServers, 2, "Expected 2 virtual server")
+	assert.NoErrorf(t, vsErr, "Expected no error getting virtual servers")
+	assert.Lenf(t, virtualServers, 2, "Expected 2 virtual server")
 
 	var clusterIPServer, externalIPServer *utilipvs.VirtualServer
 	for _, virtualServer := range virtualServers {
@@ -4961,16 +4961,16 @@ func Test_EndpointSliceReadyAndTerminatingCluster(t *testing.T) {
 
 	// clusterIP should route to cluster-wide ready endpoints
 	realServers1, rsErr1 := ipvs.GetRealServers(clusterIPServer)
-	assert.NoError(t, rsErr1, "Expected no error getting real servers")
-	assert.Len(t, realServers1, 3, "Expected 3 real servers")
+	assert.NoErrorf(t, rsErr1, "Expected no error getting real servers")
+	assert.Lenf(t, realServers1, 3, "Expected 3 real servers")
 	assert.Equal(t, "10.0.1.1:80", realServers1[0].String())
 	assert.Equal(t, "10.0.1.2:80", realServers1[1].String())
 	assert.Equal(t, "10.0.1.5:80", realServers1[2].String())
 
 	// externalIP should route to cluster-wide ready endpoints
 	realServers2, rsErr2 := ipvs.GetRealServers(externalIPServer)
-	assert.NoError(t, rsErr2, "Expected no error getting real servers")
-	assert.Len(t, realServers2, 3, "Expected 3 real servers")
+	assert.NoErrorf(t, rsErr2, "Expected no error getting real servers")
+	assert.Lenf(t, realServers2, 3, "Expected 3 real servers")
 	assert.Equal(t, "10.0.1.1:80", realServers2[0].String())
 	assert.Equal(t, "10.0.1.2:80", realServers2[1].String())
 	assert.Equal(t, "10.0.1.5:80", realServers1[2].String())
@@ -4981,11 +4981,11 @@ func Test_EndpointSliceReadyAndTerminatingCluster(t *testing.T) {
 	// Ensure that Proxier updates ipvs appropriately after EndpointSlice delete
 	assert.NotNil(t, fp.ipsetList["KUBE-LOOP-BACK"])
 	activeEntries2 := fp.ipsetList["KUBE-LOOP-BACK"].activeEntries
-	assert.Equal(t, 0, activeEntries2.Len(), "Expected 0 active entries in KUBE-LOOP-BACK")
+	assert.Equalf(t, 0, activeEntries2.Len(), "Expected 0 active entries in KUBE-LOOP-BACK")
 
 	virtualServers, vsErr = ipvs.GetVirtualServers()
-	assert.NoError(t, vsErr, "Expected no error getting virtual servers")
-	assert.Len(t, virtualServers, 2, "Expected 2 virtual server")
+	assert.NoErrorf(t, vsErr, "Expected no error getting virtual servers")
+	assert.Lenf(t, virtualServers, 2, "Expected 2 virtual server")
 
 	for _, virtualServer := range virtualServers {
 		if virtualServer.Address.String() == "172.20.1.1" {
@@ -4998,12 +4998,12 @@ func Test_EndpointSliceReadyAndTerminatingCluster(t *testing.T) {
 	}
 
 	realServers1, rsErr1 = ipvs.GetRealServers(clusterIPServer)
-	assert.NoError(t, rsErr1, "Expected no error getting real servers")
-	assert.Empty(t, realServers1, "Expected 0 real servers")
+	assert.NoErrorf(t, rsErr1, "Expected no error getting real servers")
+	assert.Emptyf(t, realServers1, "Expected 0 real servers")
 
 	realServers2, rsErr2 = ipvs.GetRealServers(externalIPServer)
-	assert.NoError(t, rsErr2, "Expected no error getting real servers")
-	assert.Empty(t, realServers2, "Expected 0 real servers")
+	assert.NoErrorf(t, rsErr2, "Expected no error getting real servers")
+	assert.Emptyf(t, realServers2, "Expected 0 real servers")
 }
 
 // Test_EndpointSliceReadyAndTerminatingLocal tests that when there are local ready and ready + terminating
@@ -5111,15 +5111,15 @@ func Test_EndpointSliceReadyAndTerminatingLocal(t *testing.T) {
 	// Ensure that Proxier updates ipvs appropriately after EndpointSlice update
 	assert.NotNil(t, fp.ipsetList["KUBE-LOOP-BACK"])
 	activeEntries1 := fp.ipsetList["KUBE-LOOP-BACK"].activeEntries
-	assert.Equal(t, 4, activeEntries1.Len(), "Expected 3 active entry in KUBE-LOOP-BACK")
-	assert.True(t, activeEntries1.Has("10.0.1.1,tcp:80,10.0.1.1"), "Expected activeEntries to reference first (local) pod")
-	assert.True(t, activeEntries1.Has("10.0.1.2,tcp:80,10.0.1.2"), "Expected activeEntries to reference second (local) pod")
-	assert.True(t, activeEntries1.Has("10.0.1.3,tcp:80,10.0.1.3"), "Expected activeEntries to reference second (local) pod")
-	assert.True(t, activeEntries1.Has("10.0.1.4,tcp:80,10.0.1.4"), "Expected activeEntries to reference second (local) pod")
+	assert.Equalf(t, 4, activeEntries1.Len(), "Expected 3 active entry in KUBE-LOOP-BACK")
+	assert.Truef(t, activeEntries1.Has("10.0.1.1,tcp:80,10.0.1.1"), "Expected activeEntries to reference first (local) pod")
+	assert.Truef(t, activeEntries1.Has("10.0.1.2,tcp:80,10.0.1.2"), "Expected activeEntries to reference second (local) pod")
+	assert.Truef(t, activeEntries1.Has("10.0.1.3,tcp:80,10.0.1.3"), "Expected activeEntries to reference second (local) pod")
+	assert.Truef(t, activeEntries1.Has("10.0.1.4,tcp:80,10.0.1.4"), "Expected activeEntries to reference second (local) pod")
 
 	virtualServers, vsErr := ipvs.GetVirtualServers()
-	assert.NoError(t, vsErr, "Expected no error getting virtual servers")
-	assert.Len(t, virtualServers, 2, "Expected 2 virtual server")
+	assert.NoErrorf(t, vsErr, "Expected no error getting virtual servers")
+	assert.Lenf(t, virtualServers, 2, "Expected 2 virtual server")
 
 	var clusterIPServer, externalIPServer *utilipvs.VirtualServer
 	for _, virtualServer := range virtualServers {
@@ -5134,16 +5134,16 @@ func Test_EndpointSliceReadyAndTerminatingLocal(t *testing.T) {
 
 	// clusterIP should route to cluster-wide ready endpoints
 	realServers1, rsErr1 := ipvs.GetRealServers(clusterIPServer)
-	assert.NoError(t, rsErr1, "Expected no error getting real servers")
-	assert.Len(t, realServers1, 3, "Expected 3 real servers")
+	assert.NoErrorf(t, rsErr1, "Expected no error getting real servers")
+	assert.Lenf(t, realServers1, 3, "Expected 3 real servers")
 	assert.Equal(t, "10.0.1.1:80", realServers1[0].String())
 	assert.Equal(t, "10.0.1.2:80", realServers1[1].String())
 	assert.Equal(t, "10.0.1.5:80", realServers1[2].String())
 
 	// externalIP should route to local ready + non-terminating endpoints if they exist
 	realServers2, rsErr2 := ipvs.GetRealServers(externalIPServer)
-	assert.NoError(t, rsErr2, "Expected no error getting real servers")
-	assert.Len(t, realServers2, 2, "Expected 2 real servers")
+	assert.NoErrorf(t, rsErr2, "Expected no error getting real servers")
+	assert.Lenf(t, realServers2, 2, "Expected 2 real servers")
 	assert.Equal(t, "10.0.1.1:80", realServers2[0].String())
 	assert.Equal(t, "10.0.1.2:80", realServers2[1].String())
 
@@ -5153,11 +5153,11 @@ func Test_EndpointSliceReadyAndTerminatingLocal(t *testing.T) {
 	// Ensure that Proxier updates ipvs appropriately after EndpointSlice delete
 	assert.NotNil(t, fp.ipsetList["KUBE-LOOP-BACK"])
 	activeEntries2 := fp.ipsetList["KUBE-LOOP-BACK"].activeEntries
-	assert.Equal(t, 0, activeEntries2.Len(), "Expected 0 active entries in KUBE-LOOP-BACK")
+	assert.Equalf(t, 0, activeEntries2.Len(), "Expected 0 active entries in KUBE-LOOP-BACK")
 
 	virtualServers, vsErr = ipvs.GetVirtualServers()
-	assert.NoError(t, vsErr, "Expected no error getting virtual servers")
-	assert.Len(t, virtualServers, 2, "Expected 2 virtual server")
+	assert.NoErrorf(t, vsErr, "Expected no error getting virtual servers")
+	assert.Lenf(t, virtualServers, 2, "Expected 2 virtual server")
 
 	for _, virtualServer := range virtualServers {
 		if virtualServer.Address.String() == "172.20.1.1" {
@@ -5170,12 +5170,12 @@ func Test_EndpointSliceReadyAndTerminatingLocal(t *testing.T) {
 	}
 
 	realServers1, rsErr1 = ipvs.GetRealServers(clusterIPServer)
-	assert.NoError(t, rsErr1, "Expected no error getting real servers")
-	assert.Empty(t, realServers1, "Expected 0 real servers")
+	assert.NoErrorf(t, rsErr1, "Expected no error getting real servers")
+	assert.Emptyf(t, realServers1, "Expected 0 real servers")
 
 	realServers2, rsErr2 = ipvs.GetRealServers(externalIPServer)
-	assert.NoError(t, rsErr2, "Expected no error getting real servers")
-	assert.Empty(t, realServers2, "Expected 0 real servers")
+	assert.NoErrorf(t, rsErr2, "Expected no error getting real servers")
+	assert.Emptyf(t, realServers2, "Expected 0 real servers")
 }
 
 // Test_EndpointSliceOnlyReadyTerminatingCluster tests that when there are only ready terminating
@@ -5283,14 +5283,14 @@ func Test_EndpointSliceOnlyReadyAndTerminatingCluster(t *testing.T) {
 	// Ensure that Proxier updates ipvs appropriately after EndpointSlice update
 	assert.NotNil(t, fp.ipsetList["KUBE-LOOP-BACK"])
 	activeEntries1 := fp.ipsetList["KUBE-LOOP-BACK"].activeEntries
-	assert.Equal(t, 3, activeEntries1.Len(), "Expected 3 active entry in KUBE-LOOP-BACK")
-	assert.True(t, activeEntries1.Has("10.0.1.1,tcp:80,10.0.1.1"), "Expected activeEntries to reference first (local) pod")
-	assert.True(t, activeEntries1.Has("10.0.1.2,tcp:80,10.0.1.2"), "Expected activeEntries to reference second (local) pod")
-	assert.True(t, activeEntries1.Has("10.0.1.3,tcp:80,10.0.1.3"), "Expected activeEntries to reference second (local) pod")
+	assert.Equalf(t, 3, activeEntries1.Len(), "Expected 3 active entry in KUBE-LOOP-BACK")
+	assert.Truef(t, activeEntries1.Has("10.0.1.1,tcp:80,10.0.1.1"), "Expected activeEntries to reference first (local) pod")
+	assert.Truef(t, activeEntries1.Has("10.0.1.2,tcp:80,10.0.1.2"), "Expected activeEntries to reference second (local) pod")
+	assert.Truef(t, activeEntries1.Has("10.0.1.3,tcp:80,10.0.1.3"), "Expected activeEntries to reference second (local) pod")
 
 	virtualServers, vsErr := ipvs.GetVirtualServers()
-	assert.NoError(t, vsErr, "Expected no error getting virtual servers")
-	assert.Len(t, virtualServers, 2, "Expected 2 virtual server")
+	assert.NoErrorf(t, vsErr, "Expected no error getting virtual servers")
+	assert.Lenf(t, virtualServers, 2, "Expected 2 virtual server")
 
 	var clusterIPServer, externalIPServer *utilipvs.VirtualServer
 	for _, virtualServer := range virtualServers {
@@ -5305,16 +5305,16 @@ func Test_EndpointSliceOnlyReadyAndTerminatingCluster(t *testing.T) {
 
 	// clusterIP should fall back to cluster-wide ready + terminating endpoints
 	realServers1, rsErr1 := ipvs.GetRealServers(clusterIPServer)
-	assert.NoError(t, rsErr1, "Expected no error getting real servers")
-	assert.Len(t, realServers1, 3, "Expected 1 real servers")
+	assert.NoErrorf(t, rsErr1, "Expected no error getting real servers")
+	assert.Lenf(t, realServers1, 3, "Expected 1 real servers")
 	assert.Equal(t, "10.0.1.1:80", realServers1[0].String())
 	assert.Equal(t, "10.0.1.2:80", realServers1[1].String())
 	assert.Equal(t, "10.0.1.4:80", realServers1[2].String())
 
 	// externalIP should fall back to ready + terminating endpoints
 	realServers2, rsErr2 := ipvs.GetRealServers(externalIPServer)
-	assert.NoError(t, rsErr2, "Expected no error getting real servers")
-	assert.Len(t, realServers2, 3, "Expected 2 real servers")
+	assert.NoErrorf(t, rsErr2, "Expected no error getting real servers")
+	assert.Lenf(t, realServers2, 3, "Expected 2 real servers")
 	assert.Equal(t, "10.0.1.1:80", realServers2[0].String())
 	assert.Equal(t, "10.0.1.2:80", realServers2[1].String())
 	assert.Equal(t, "10.0.1.4:80", realServers2[2].String())
@@ -5325,11 +5325,11 @@ func Test_EndpointSliceOnlyReadyAndTerminatingCluster(t *testing.T) {
 	// Ensure that Proxier updates ipvs appropriately after EndpointSlice delete
 	assert.NotNil(t, fp.ipsetList["KUBE-LOOP-BACK"])
 	activeEntries2 := fp.ipsetList["KUBE-LOOP-BACK"].activeEntries
-	assert.Equal(t, 0, activeEntries2.Len(), "Expected 0 active entries in KUBE-LOOP-BACK")
+	assert.Equalf(t, 0, activeEntries2.Len(), "Expected 0 active entries in KUBE-LOOP-BACK")
 
 	virtualServers, vsErr = ipvs.GetVirtualServers()
-	assert.NoError(t, vsErr, "Expected no error getting virtual servers")
-	assert.Len(t, virtualServers, 2, "Expected 2 virtual server")
+	assert.NoErrorf(t, vsErr, "Expected no error getting virtual servers")
+	assert.Lenf(t, virtualServers, 2, "Expected 2 virtual server")
 
 	for _, virtualServer := range virtualServers {
 		if virtualServer.Address.String() == "172.20.1.1" {
@@ -5342,12 +5342,12 @@ func Test_EndpointSliceOnlyReadyAndTerminatingCluster(t *testing.T) {
 	}
 
 	realServers1, rsErr1 = ipvs.GetRealServers(clusterIPServer)
-	assert.NoError(t, rsErr1, "Expected no error getting real servers")
-	assert.Empty(t, realServers1, "Expected 0 real servers")
+	assert.NoErrorf(t, rsErr1, "Expected no error getting real servers")
+	assert.Emptyf(t, realServers1, "Expected 0 real servers")
 
 	realServers2, rsErr2 = ipvs.GetRealServers(externalIPServer)
-	assert.NoError(t, rsErr2, "Expected no error getting real servers")
-	assert.Empty(t, realServers2, "Expected 0 real servers")
+	assert.NoErrorf(t, rsErr2, "Expected no error getting real servers")
+	assert.Emptyf(t, realServers2, "Expected 0 real servers")
 }
 
 // Test_EndpointSliceOnlyReadyTerminatingLocal tests that when there are only local ready terminating
@@ -5455,14 +5455,14 @@ func Test_EndpointSliceOnlyReadyAndTerminatingLocal(t *testing.T) {
 	// Ensure that Proxier updates ipvs appropriately after EndpointSlice update
 	assert.NotNil(t, fp.ipsetList["KUBE-LOOP-BACK"])
 	activeEntries1 := fp.ipsetList["KUBE-LOOP-BACK"].activeEntries
-	assert.Equal(t, 3, activeEntries1.Len(), "Expected 3 active entry in KUBE-LOOP-BACK")
-	assert.True(t, activeEntries1.Has("10.0.1.1,tcp:80,10.0.1.1"), "Expected activeEntries to reference first (local) pod")
-	assert.True(t, activeEntries1.Has("10.0.1.2,tcp:80,10.0.1.2"), "Expected activeEntries to reference second (local) pod")
-	assert.True(t, activeEntries1.Has("10.0.1.3,tcp:80,10.0.1.3"), "Expected activeEntries to reference second (local) pod")
+	assert.Equalf(t, 3, activeEntries1.Len(), "Expected 3 active entry in KUBE-LOOP-BACK")
+	assert.Truef(t, activeEntries1.Has("10.0.1.1,tcp:80,10.0.1.1"), "Expected activeEntries to reference first (local) pod")
+	assert.Truef(t, activeEntries1.Has("10.0.1.2,tcp:80,10.0.1.2"), "Expected activeEntries to reference second (local) pod")
+	assert.Truef(t, activeEntries1.Has("10.0.1.3,tcp:80,10.0.1.3"), "Expected activeEntries to reference second (local) pod")
 
 	virtualServers, vsErr := ipvs.GetVirtualServers()
-	assert.NoError(t, vsErr, "Expected no error getting virtual servers")
-	assert.Len(t, virtualServers, 2, "Expected 2 virtual server")
+	assert.NoErrorf(t, vsErr, "Expected no error getting virtual servers")
+	assert.Lenf(t, virtualServers, 2, "Expected 2 virtual server")
 
 	var clusterIPServer, externalIPServer *utilipvs.VirtualServer
 	for _, virtualServer := range virtualServers {
@@ -5477,14 +5477,14 @@ func Test_EndpointSliceOnlyReadyAndTerminatingLocal(t *testing.T) {
 
 	// clusterIP should route to cluster-wide Ready endpoints
 	realServers1, rsErr1 := ipvs.GetRealServers(clusterIPServer)
-	assert.NoError(t, rsErr1, "Expected no error getting real servers")
-	assert.Len(t, realServers1, 1, "Expected 1 real servers")
+	assert.NoErrorf(t, rsErr1, "Expected no error getting real servers")
+	assert.Lenf(t, realServers1, 1, "Expected 1 real servers")
 	assert.Equal(t, "10.0.1.5:80", realServers1[0].String())
 
 	// externalIP should fall back to local ready + terminating endpoints
 	realServers2, rsErr2 := ipvs.GetRealServers(externalIPServer)
-	assert.NoError(t, rsErr2, "Expected no error getting real servers")
-	assert.Len(t, realServers2, 2, "Expected 2 real servers")
+	assert.NoErrorf(t, rsErr2, "Expected no error getting real servers")
+	assert.Lenf(t, realServers2, 2, "Expected 2 real servers")
 	assert.Equal(t, "10.0.1.1:80", realServers2[0].String())
 	assert.Equal(t, "10.0.1.2:80", realServers2[1].String())
 
@@ -5494,11 +5494,11 @@ func Test_EndpointSliceOnlyReadyAndTerminatingLocal(t *testing.T) {
 	// Ensure that Proxier updates ipvs appropriately after EndpointSlice delete
 	assert.NotNil(t, fp.ipsetList["KUBE-LOOP-BACK"])
 	activeEntries2 := fp.ipsetList["KUBE-LOOP-BACK"].activeEntries
-	assert.Equal(t, 0, activeEntries2.Len(), "Expected 0 active entries in KUBE-LOOP-BACK")
+	assert.Equalf(t, 0, activeEntries2.Len(), "Expected 0 active entries in KUBE-LOOP-BACK")
 
 	virtualServers, vsErr = ipvs.GetVirtualServers()
-	assert.NoError(t, vsErr, "Expected no error getting virtual servers")
-	assert.Len(t, virtualServers, 2, "Expected 2 virtual server")
+	assert.NoErrorf(t, vsErr, "Expected no error getting virtual servers")
+	assert.Lenf(t, virtualServers, 2, "Expected 2 virtual server")
 
 	for _, virtualServer := range virtualServers {
 		if virtualServer.Address.String() == "172.20.1.1" {
@@ -5511,12 +5511,12 @@ func Test_EndpointSliceOnlyReadyAndTerminatingLocal(t *testing.T) {
 	}
 
 	realServers1, rsErr1 = ipvs.GetRealServers(clusterIPServer)
-	assert.NoError(t, rsErr1, "Expected no error getting real servers")
-	assert.Empty(t, realServers1, "Expected 0 real servers")
+	assert.NoErrorf(t, rsErr1, "Expected no error getting real servers")
+	assert.Emptyf(t, realServers1, "Expected 0 real servers")
 
 	realServers2, rsErr2 = ipvs.GetRealServers(externalIPServer)
-	assert.NoError(t, rsErr2, "Expected no error getting real servers")
-	assert.Empty(t, realServers2, "Expected 0 real servers")
+	assert.NoErrorf(t, rsErr2, "Expected no error getting real servers")
+	assert.Emptyf(t, realServers2, "Expected 0 real servers")
 }
 
 func TestIpIsValidForSet(t *testing.T) {

--- a/pkg/registry/core/pod/strategy_test.go
+++ b/pkg/registry/core/pod/strategy_test.go
@@ -2430,11 +2430,11 @@ func TestApplyAppArmorVersionSkew(t *testing.T) {
 			test.validation(t, test.pod)
 
 			if test.expectWarning {
-				if assert.NotEmpty(t, warnings.warnings, "expect warnings") {
+				if assert.NotEmptyf(t, warnings.warnings, "expect warnings") {
 					assert.Contains(t, warnings.warnings[0], `deprecated since v1.30; use the "appArmorProfile" field instead`)
 				}
 			} else {
-				assert.Empty(t, warnings.warnings, "shouldn't emit a warning")
+				assert.Emptyf(t, warnings.warnings, "shouldn't emit a warning")
 			}
 		})
 	}

--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
@@ -1127,13 +1127,13 @@ func (tc *testContext) verify(t *testing.T, expected result, initialObjects []me
 func (tc *testContext) listAll(t *testing.T) (objects []metav1.Object) {
 	t.Helper()
 	claims, err := tc.client.ResourceV1alpha3().ResourceClaims("").List(tc.ctx, metav1.ListOptions{})
-	require.NoError(t, err, "list claims")
+	require.NoErrorf(t, err, "list claims")
 	for _, claim := range claims.Items {
 		claim := claim
 		objects = append(objects, &claim)
 	}
 	schedulings, err := tc.client.ResourceV1alpha3().PodSchedulingContexts("").List(tc.ctx, metav1.ListOptions{})
-	require.NoError(t, err, "list pod scheduling")
+	require.NoErrorf(t, err, "list pod scheduling")
 	for _, scheduling := range schedulings.Items {
 		scheduling := scheduling
 		objects = append(objects, &scheduling)
@@ -1263,15 +1263,15 @@ func setup(t *testing.T, nodes []*v1.Node, claims []*resourceapi.ResourceClaim, 
 	// get triggered.
 	for _, claim := range claims {
 		_, err := tc.client.ResourceV1alpha3().ResourceClaims(claim.Namespace).Create(tc.ctx, claim, metav1.CreateOptions{})
-		require.NoError(t, err, "create resource claim")
+		require.NoErrorf(t, err, "create resource claim")
 	}
 	for _, class := range classes {
 		_, err := tc.client.ResourceV1alpha3().DeviceClasses().Create(tc.ctx, class, metav1.CreateOptions{})
-		require.NoError(t, err, "create resource class")
+		require.NoErrorf(t, err, "create resource class")
 	}
 	for _, scheduling := range schedulings {
 		_, err := tc.client.ResourceV1alpha3().PodSchedulingContexts(scheduling.Namespace).Create(tc.ctx, scheduling, metav1.CreateOptions{})
-		require.NoError(t, err, "create pod scheduling")
+		require.NoErrorf(t, err, "create pod scheduling")
 	}
 
 	tc.informerFactory.Start(tc.ctx.Done())
@@ -1483,9 +1483,9 @@ func Test_isSchedulableAfterClaimChange(t *testing.T) {
 				}
 
 				// Eventually the assume cache will have it, too.
-				require.EventuallyWithT(t, func(t *assert.CollectT) {
+				require.EventuallyWithTf(t, func(t *assert.CollectT) {
 					cachedClaim, err := testCtx.claimAssumeCache.Get(claimKey)
-					require.NoError(t, err, "retrieve claim")
+					require.NoErrorf(t, err, "retrieve claim")
 					if cachedClaim.(*resourceapi.ResourceClaim).ResourceVersion != claim.ResourceVersion {
 						t.Errorf("cached claim not updated yet")
 					}

--- a/pkg/scheduler/framework/plugins/noderesources/requested_to_capacity_ratio_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/requested_to_capacity_ratio_test.go
@@ -210,7 +210,7 @@ func TestBrokenLinearFunction(t *testing.T) {
 		t.Run(fmt.Sprintf("case_%d", i), func(t *testing.T) {
 			function := helper.BuildBrokenLinearFunction(test.points)
 			for _, assertion := range test.assertions {
-				assert.InDelta(t, assertion.expected, function(assertion.p), 0.1, "points=%v, p=%d", test.points, assertion.p)
+				assert.InDeltaf(t, assertion.expected, function(assertion.p), 0.1, "points=%v, p=%d", test.points, assertion.p)
 			}
 		})
 	}

--- a/pkg/security/apparmor/validate_test.go
+++ b/pkg/security/apparmor/validate_test.go
@@ -96,7 +96,7 @@ func TestValidateValidHost(t *testing.T) {
 			},
 		},
 	}
-	assert.NoError(t, v.Validate(pod), "Multi-container pod should validate")
+	assert.NoErrorf(t, v.Validate(pod), "Multi-container pod should validate")
 }
 
 func getPodWithProfile(profile string) *v1.Pod {

--- a/pkg/util/filesystem/util_test.go
+++ b/pkg/util/filesystem/util_test.go
@@ -82,7 +82,7 @@ func TestIsUnixDomainSocket(t *testing.T) {
 		} else {
 			assert.NoErrorf(t, err, "Unexpected error invoking IsUnixDomainSocket for %s", test.label)
 		}
-		assert.Equal(t, result, test.expectSocket, "Unexpected result from IsUnixDomainSocket: %v for %s", result, test.label)
+		assert.Equalf(t, result, test.expectSocket, "Unexpected result from IsUnixDomainSocket: %v for %s", result, test.label)
 	}
 }
 

--- a/pkg/util/oom/oom_linux_test.go
+++ b/pkg/util/oom/oom_linux_test.go
@@ -103,5 +103,5 @@ func TestOOMScoreAdjContainer(t *testing.T) {
 
 func TestPidListerFailure(t *testing.T) {
 	_, err := getPids("/does/not/exist")
-	assert.True(t, cgroups.IsNotFound(err) || os.IsNotExist(err), "expected getPids to return not exists error. Got %v", err)
+	assert.Truef(t, cgroups.IsNotFound(err) || os.IsNotExist(err), "expected getPids to return not exists error. Got %v", err)
 }

--- a/pkg/util/tolerations/tolerations_test.go
+++ b/pkg/util/tolerations/tolerations_test.go
@@ -169,11 +169,11 @@ func TestIsSuperset(t *testing.T) {
 	}}
 
 	assertSuperset := func(t *testing.T, super, sub string) {
-		assert.True(t, isSuperset(tolerations[super], tolerations[sub]),
+		assert.Truef(t, isSuperset(tolerations[super], tolerations[sub]),
 			"%s should be a superset of %s", super, sub)
 	}
 	assertNotSuperset := func(t *testing.T, super, sub string) {
-		assert.False(t, isSuperset(tolerations[super], tolerations[sub]),
+		assert.Falsef(t, isSuperset(tolerations[super], tolerations[sub]),
 			"%s should NOT be a superset of %s", super, sub)
 	}
 	contains := func(ss []string, s string) bool {
@@ -306,7 +306,7 @@ func TestMergeTolerations(t *testing.T) {
 			actual := MergeTolerations(getTolerations(test.a), getTolerations(test.b))
 			require.Len(t, actual, len(test.expected))
 			for i, expect := range getTolerations(test.expected) {
-				assert.Equal(t, expect, actual[i], "expected[%d] = %s", i, test.expected[i])
+				assert.Equalf(t, expect, actual[i], "expected[%d] = %s", i, test.expected[i])
 			}
 		})
 	}
@@ -341,7 +341,7 @@ func TestFuzzed(t *testing.T) {
 			gen.TolerationSeconds = utilpointer.Int64Ptr(r.Int63n(10))
 		}
 		// Ensure only valid tolerations are generated.
-		require.NoError(t, validation.ValidateTolerations([]api.Toleration{gen}, field.NewPath("")).ToAggregate(), "%#v", gen)
+		require.NoErrorf(t, validation.ValidateTolerations([]api.Toleration{gen}, field.NewPath("")).ToAggregate(), "%#v", gen)
 		return gen
 	}
 	genTolerations := func() []api.Toleration {
@@ -377,7 +377,7 @@ func TestFuzzed(t *testing.T) {
 			whitelist := append(genTolerations(), genToleration()) // Non-empty
 			if VerifyAgainstWhitelist(input, whitelist) {
 				for _, tol := range input {
-					require.True(t, isContained(tol, whitelist), debugMsg(input, whitelist))
+					require.Truef(t, isContained(tol, whitelist), debugMsg(input, whitelist))
 				}
 			} else {
 				uncontained := false
@@ -387,7 +387,7 @@ func TestFuzzed(t *testing.T) {
 						break
 					}
 				}
-				require.True(t, uncontained, debugMsg(input, whitelist))
+				require.Truef(t, uncontained, debugMsg(input, whitelist))
 			}
 		}
 	})
@@ -398,7 +398,7 @@ func TestFuzzed(t *testing.T) {
 			b := genTolerations()
 			result := MergeTolerations(a, b)
 			for _, tol := range append(a, b...) {
-				require.True(t, isContained(tol, result), debugMsg(a, b, result))
+				require.Truef(t, isContained(tol, result), debugMsg(a, b, result))
 			}
 		}
 	})

--- a/pkg/volume/csi/csi_mounter_test.go
+++ b/pkg/volume/csi/csi_mounter_test.go
@@ -1172,7 +1172,7 @@ func TestIsCorruptedDir(t *testing.T) {
 
 	for i, test := range tests {
 		isCorruptedDir := isCorruptedDir(test.dir)
-		assert.Equal(t, test.expectedResult, isCorruptedDir, "TestCase[%d]: %s", i, test.desc)
+		assert.Equalf(t, test.expectedResult, isCorruptedDir, "TestCase[%d]: %s", i, test.desc)
 	}
 }
 

--- a/pkg/volume/util/operationexecutor/operation_generator_test.go
+++ b/pkg/volume/util/operationexecutor/operation_generator_test.go
@@ -88,7 +88,7 @@ func TestOperationGenerator_GenerateUnmapVolumeFunc_PluginName(t *testing.T) {
 
 		storageOperationDurationSecondsMetricAfter, _ := testutil.GetHistogramMetricCount(m)
 		metricValueDiff := storageOperationDurationSecondsMetricAfter - storageOperationDurationSecondsMetricBefore
-		assert.Equal(t, uint64(1), metricValueDiff, tc.name)
+		assert.Equalf(t, uint64(1), metricValueDiff, tc.name)
 	}
 }
 

--- a/plugin/pkg/admission/serviceaccount/admission_test.go
+++ b/plugin/pkg/admission/serviceaccount/admission_test.go
@@ -969,7 +969,7 @@ func TestAddImagePullSecrets(t *testing.T) {
 		t.Errorf("Unexpected error: %v", err)
 	}
 
-	assert.EqualValues(t, expected, pod.Spec.ImagePullSecrets, "expected %v, got %v", expected, pod.Spec.ImagePullSecrets)
+	assert.EqualValuesf(t, expected, pod.Spec.ImagePullSecrets, "expected %v, got %v", expected, pod.Spec.ImagePullSecrets)
 
 	pod.Spec.ImagePullSecrets[1] = api.LocalObjectReference{Name: "baz"}
 	if !reflect.DeepEqual(originalSA, sa) {

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/validation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/validation_test.go
@@ -4381,8 +4381,8 @@ func TestRatcheting(t *testing.T) {
 				WithRatcheting(common.NewCorrelatedObject(c.newObj, c.oldObj, &model.Structural{Structural: c.schema})),
 			)
 
-			require.Len(t, errs, len(c.errors), "must have expected number of errors")
-			require.Len(t, recorder.Warnings(), len(c.warnings), "must have expected number of warnings")
+			require.Lenf(t, errs, len(c.errors), "must have expected number of errors")
+			require.Lenf(t, recorder.Warnings(), len(c.warnings), "must have expected number of warnings")
 
 			// Check that the expected errors were raised
 			for _, expectedErr := range c.errors {
@@ -4394,7 +4394,7 @@ func TestRatcheting(t *testing.T) {
 					}
 				}
 
-				assert.True(t, found, "expected error %q not found", expectedErr)
+				assert.Truef(t, found, "expected error %q not found", expectedErr)
 			}
 
 			// Check that the ratcheting disabled errors were raised as warnings
@@ -4406,7 +4406,7 @@ func TestRatcheting(t *testing.T) {
 						break
 					}
 				}
-				assert.True(t, found, "expected warning %q not found", expectedWarning)
+				assert.Truef(t, found, "expected warning %q not found", expectedWarning)
 			}
 
 		})

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/builder/builder_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/builder/builder_test.go
@@ -330,7 +330,7 @@ func TestCRDRouteParameterBuilder(t *testing.T) {
 		}
 		swagger, err := BuildOpenAPIV2(testNamespacedCRD, testCRDVersion, Options{V2: true})
 		require.NoError(t, err)
-		require.Equal(t, len(testCase.paths), len(swagger.Paths.Paths), testCase.scope)
+		require.Equalf(t, len(testCase.paths), len(swagger.Paths.Paths), string(testCase.scope))
 		for path, expected := range testCase.paths {
 			t.Run(path, func(t *testing.T) {
 				path, ok := swagger.Paths.Paths[path]

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/finalization_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/finalization_test.go
@@ -90,7 +90,7 @@ func TestFinalization(t *testing.T) {
 	// Check that the object is actually gone.
 	_, err = noxuResourceClient.Get(context.TODO(), name, metav1.GetOptions{})
 	require.Error(t, err)
-	require.True(t, errors.IsNotFound(err), "%#v", err)
+	require.Truef(t, errors.IsNotFound(err), "%#v", err)
 }
 
 func TestFinalizationAndDeletion(t *testing.T) {

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/helpers_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/helpers_test.go
@@ -83,7 +83,7 @@ func TestNestedFieldNoCopy(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, target, res)
 	target["foo"] = "baz"
-	assert.Equal(t, target["foo"], res.(map[string]interface{})["foo"], "result should be a reference to the expected item")
+	assert.Equalf(t, target["foo"], res.(map[string]interface{})["foo"], "result should be a reference to the expected item")
 
 	// case 2: field exists and is nil
 	res, exists, err = NestedFieldNoCopy(obj, "a", "c")
@@ -141,7 +141,7 @@ func TestNestedFieldCopy(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, target, res)
 	target["foo"] = "baz"
-	assert.NotEqual(t, target["foo"], res.(map[string]interface{})["foo"], "result should be a copy of the expected item")
+	assert.NotEqualf(t, target["foo"], res.(map[string]interface{})["foo"], "result should be a copy of the expected item")
 
 	// case 2: field exists and is nil
 	res, exists, err = NestedFieldCopy(obj, "a", "c")

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured_conversion_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured_conversion_test.go
@@ -251,7 +251,7 @@ func TestUnstructuredToObjectConversion(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			defer func() {
 				v := recover()
-				assert.Equal(t, testCase.expectPanic, v != nil, "unexpected panic")
+				assert.Equalf(t, testCase.expectPanic, v != nil, "unexpected panic")
 			}()
 			outObject := testCase.convertingObject.DeepCopyObject()
 			// Convert by specifying destination object
@@ -438,7 +438,7 @@ func TestUnstructuredToGVConversion(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			defer func() {
 				v := recover()
-				assert.Equal(t, testCase.expectPanic, v != nil, "unexpected panic")
+				assert.Equalf(t, testCase.expectPanic, v != nil, "unexpected panic")
 			}()
 			// Convert by specifying destination object
 			outObject, err := scheme.ConvertToVersion(testCase.unstructuredToConvert, testCase.targetGV)

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/converter_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/converter_test.go
@@ -975,7 +975,7 @@ func TestCustomToUnstructured(t *testing.T) {
 			})
 			require.NoError(t, err)
 			for field, fieldResult := range result {
-				assert.Equal(t, tc.Expected, fieldResult, field)
+				assert.Equalf(t, tc.Expected, fieldResult, field)
 			}
 		})
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning/versioning_unstructured_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning/versioning_unstructured_test.go
@@ -332,7 +332,7 @@ func TestDecodeUnstructured(t *testing.T) {
 			return
 		}
 		assert.NoError(t, err)
-		assert.Equal(t, testCase.expectedOut, actualObj, "%v failed", testCase.name)
-		assert.Equal(t, testCase.expectedGVKOfSerializedData, actualSerializedGVK, "%v failed", testCase.name)
+		assert.Equalf(t, testCase.expectedOut, actualObj, "%v failed", testCase.name)
+		assert.Equalf(t, testCase.expectedGVKOfSerializedData, actualSerializedGVK, "%v failed", testCase.name)
 	}
 }

--- a/staging/src/k8s.io/apimachinery/pkg/util/httpstream/wsstream/conn_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/httpstream/wsstream/conn_test.go
@@ -375,7 +375,7 @@ func TestIsWebSocketRequestWithStreamCloseProtocol(t *testing.T) {
 			req.Header.Add(key, value)
 		}
 		actual := IsWebSocketRequestWithStreamCloseProtocol(req)
-		assert.Equal(t, test.expected, actual, "%s: expected (%t), got (%t)", name, test.expected, actual)
+		assert.Equalf(t, test.expected, actual, "%s: expected (%t), got (%t)", name, test.expected, actual)
 	}
 }
 
@@ -412,7 +412,7 @@ func TestProtocolSupportsStreamClose(t *testing.T) {
 
 	for name, test := range tests {
 		actual := protocolSupportsStreamClose(test.protocol)
-		assert.Equal(t, test.expected, actual,
+		assert.Equalf(t, test.expected, actual,
 			"%s: expected (%t), got (%t)", name, test.expected, actual)
 	}
 }

--- a/staging/src/k8s.io/apimachinery/pkg/watch/mux_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/watch/mux_test.go
@@ -217,10 +217,10 @@ func TestBroadcasterWatchAfterShutdown(t *testing.T) {
 	m.Shutdown()
 
 	_, err := m.Watch()
-	assert.EqualError(t, err, "broadcaster already stopped", "Watch should report error id broadcaster is shutdown")
+	assert.EqualErrorf(t, err, "broadcaster already stopped", "Watch should report error id broadcaster is shutdown")
 
 	_, err = m.WatchWithPrefix([]Event{event1, event2})
-	assert.EqualError(t, err, "broadcaster already stopped", "WatchWithPrefix should report error id broadcaster is shutdown")
+	assert.EqualErrorf(t, err, "broadcaster already stopped", "WatchWithPrefix should report error id broadcaster is shutdown")
 }
 
 func TestBroadcasterSendEventAfterShutdown(t *testing.T) {
@@ -239,11 +239,11 @@ func TestBroadcasterSendEventAfterShutdown(t *testing.T) {
 	t.Log("Sending event")
 
 	err := m.Action(event.Type, event.Object)
-	assert.EqualError(t, err, "broadcaster already stopped", "ActionOrDrop should report error id broadcaster is shutdown")
+	assert.EqualErrorf(t, err, "broadcaster already stopped", "ActionOrDrop should report error id broadcaster is shutdown")
 
 	sendOnClosed, err := m.ActionOrDrop(event.Type, event.Object)
-	assert.False(t, sendOnClosed, "ActionOrDrop should return false if broadcaster is already shutdown")
-	assert.EqualError(t, err, "broadcaster already stopped", "ActionOrDrop should report error id broadcaster is shutdown")
+	assert.Falsef(t, sendOnClosed, "ActionOrDrop should return false if broadcaster is already shutdown")
+	assert.EqualErrorf(t, err, "broadcaster already stopped", "ActionOrDrop should report error id broadcaster is shutdown")
 }
 
 // Test this since we see usage patterns where the broadcaster and watchers are

--- a/staging/src/k8s.io/apiserver/pkg/admission/attributes_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/attributes_test.go
@@ -33,10 +33,10 @@ func TestAddAnnotation(t *testing.T) {
 	assert.Equal(t, "value1", annotations["foo.admission.k8s.io/key1"])
 
 	// test overwrite
-	assert.Error(t, attr.AddAnnotation("foo.admission.k8s.io/key1", "value1-overwrite"),
+	assert.Errorf(t, attr.AddAnnotation("foo.admission.k8s.io/key1", "value1-overwrite"),
 		"admission annotations should not be allowd to be overwritten")
 	annotations = attr.getAnnotations(auditinternal.LevelMetadata)
-	assert.Equal(t, "value1", annotations["foo.admission.k8s.io/key1"], "admission annotations should not be overwritten")
+	assert.Equalf(t, "value1", annotations["foo.admission.k8s.io/key1"], "admission annotations should not be overwritten")
 
 	// test invalid plugin names
 	var testCases = map[string]string{
@@ -49,11 +49,11 @@ func TestAddAnnotation(t *testing.T) {
 		err := attr.AddAnnotation(invalidKey, "value-foo")
 		assert.Error(t, err)
 		annotations = attr.getAnnotations(auditinternal.LevelMetadata)
-		assert.Equal(t, "", annotations[invalidKey], name+": invalid pluginName is not allowed ")
+		assert.Equalf(t, "", annotations[invalidKey], name+": invalid pluginName is not allowed ")
 	}
 
 	// test all saved annotations
-	assert.Equal(
+	assert.Equalf(
 		t,
 		map[string]string{
 			"foo.admission.k8s.io/key1": "value1",

--- a/staging/src/k8s.io/apiserver/pkg/admission/audit_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/audit_test.go
@@ -149,19 +149,19 @@ func TestWithAudit(t *testing.T) {
 		auditHandler := WithAudit(handler)
 		a := attributes()
 
-		assert.Equal(t, handler.Handles(Create), auditHandler.Handles(Create), tcName+": WithAudit decorator should not effect the return value")
+		assert.Equalf(t, handler.Handles(Create), auditHandler.Handles(Create), tcName+": WithAudit decorator should not effect the return value")
 
 		mutator, ok := handler.(MutationInterface)
 		require.True(t, ok)
 		auditMutator, ok := auditHandler.(MutationInterface)
 		require.True(t, ok)
-		assert.Equal(t, mutator.Admit(ctx, a, nil), auditMutator.Admit(ctx, a, nil), tcName+": WithAudit decorator should not effect the return value")
+		assert.Equalf(t, mutator.Admit(ctx, a, nil), auditMutator.Admit(ctx, a, nil), tcName+": WithAudit decorator should not effect the return value")
 
 		validator, ok := handler.(ValidationInterface)
 		require.True(t, ok)
 		auditValidator, ok := auditHandler.(ValidationInterface)
 		require.True(t, ok)
-		assert.Equal(t, validator.Validate(ctx, a, nil), auditValidator.Validate(ctx, a, nil), tcName+": WithAudit decorator should not effect the return value")
+		assert.Equalf(t, validator.Validate(ctx, a, nil), auditValidator.Validate(ctx, a, nil), tcName+": WithAudit decorator should not effect the return value")
 
 		annotations := make(map[string]string, len(tc.admitAnnotations)+len(tc.validateAnnotations))
 		for k, v := range tc.admitAnnotations {
@@ -171,9 +171,9 @@ func TestWithAudit(t *testing.T) {
 			annotations[k] = v
 		}
 		if len(annotations) == 0 {
-			assert.Nil(t, ae.Annotations, tcName+": unexptected annotations set in audit event")
+			assert.Nilf(t, ae.Annotations, tcName+": unexptected annotations set in audit event")
 		} else {
-			assert.Equal(t, annotations, ae.Annotations, tcName+": unexptected annotations set in audit event")
+			assert.Equalf(t, annotations, ae.Annotations, tcName+": unexptected annotations set in audit event")
 		}
 	}
 }
@@ -203,7 +203,7 @@ func TestWithAuditConcurrency(t *testing.T) {
 			require.True(t, ok)
 			auditMutator, ok := auditHandler.(MutationInterface)
 			require.True(t, ok)
-			assert.Equal(t, mutator.Admit(ctx, a, nil), auditMutator.Admit(ctx, a, nil), "WithAudit decorator should not effect the return value")
+			assert.Equalf(t, mutator.Admit(ctx, a, nil), auditMutator.Admit(ctx, a, nil), "WithAudit decorator should not effect the return value")
 		}()
 	}
 	wg.Wait()

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/dispatcher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/dispatcher_test.go
@@ -48,7 +48,7 @@ func TestMutationAnnotationValue(t *testing.T) {
 
 	for _, tc := range tcs {
 		actual, err := mutationAnnotationValue(tc.config, tc.webhook, tc.mutated)
-		assert.NoError(t, err, "unexpected error")
+		assert.NoErrorf(t, err, "unexpected error")
 		if actual != tc.expected {
 			t.Errorf("composed mutation annotation value doesn't match, want: %s, got: %s", tc.expected, actual)
 		}
@@ -103,9 +103,9 @@ func TestJSONPatchAnnotationValue(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			jsonPatch, err := jsonpatch.DecodePatch(tc.patch)
-			assert.NoError(t, err, "unexpected error decode patch")
+			assert.NoErrorf(t, err, "unexpected error decode patch")
 			actual, err := jsonPatchAnnotationValue(tc.config, tc.webhook, jsonPatch)
-			assert.NoError(t, err, "unexpected error getting json patch annotation")
+			assert.NoErrorf(t, err, "unexpected error getting json patch annotation")
 			if actual != tc.expected {
 				t.Errorf("composed patch annotation value doesn't match, want: %s, got: %s", tc.expected, actual)
 			}

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/plugin_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/plugin_test.go
@@ -184,9 +184,9 @@ func TestAdmit(t *testing.T) {
 				return
 			}
 			if len(tt.ExpectAnnotations) == 0 {
-				assert.Empty(t, fakeAttr.GetAnnotations(auditinternal.LevelMetadata), tt.Name+": annotations not set as expected.")
+				assert.Emptyf(t, fakeAttr.GetAnnotations(auditinternal.LevelMetadata), tt.Name+": annotations not set as expected.")
 			} else {
-				assert.Equal(t, tt.ExpectAnnotations, fakeAttr.GetAnnotations(auditinternal.LevelMetadata), tt.Name+": annotations not set as expected.")
+				assert.Equalf(t, tt.ExpectAnnotations, fakeAttr.GetAnnotations(auditinternal.LevelMetadata), tt.Name+": annotations not set as expected.")
 			}
 			reinvocationCtx := fakeAttr.Attributes.GetReinvocationContext()
 			reinvocationCtx.SetIsReinvoke()

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/plugin_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/plugin_test.go
@@ -155,9 +155,9 @@ func TestValidate(t *testing.T) {
 			continue
 		}
 		if len(tt.ExpectAnnotations) == 0 {
-			assert.Empty(t, fakeAttr.GetAnnotations(auditinternal.LevelMetadata), tt.Name+": annotations not set as expected.")
+			assert.Emptyf(t, fakeAttr.GetAnnotations(auditinternal.LevelMetadata), tt.Name+": annotations not set as expected.")
 		} else {
-			assert.Equal(t, tt.ExpectAnnotations, fakeAttr.GetAnnotations(auditinternal.LevelMetadata), tt.Name+": annotations not set as expected.")
+			assert.Equalf(t, tt.ExpectAnnotations, fakeAttr.GetAnnotations(auditinternal.LevelMetadata), tt.Name+": annotations not set as expected.")
 		}
 	}
 }
@@ -341,9 +341,9 @@ func TestValidatePanicHandling(t *testing.T) {
 			continue
 		}
 		if len(tt.ExpectAnnotations) == 0 {
-			assert.Empty(t, fakeAttr.GetAnnotations(auditinternal.LevelMetadata), tt.Name+": annotations not set as expected.")
+			assert.Emptyf(t, fakeAttr.GetAnnotations(auditinternal.LevelMetadata), tt.Name+": annotations not set as expected.")
 		} else {
-			assert.Equal(t, tt.ExpectAnnotations, fakeAttr.GetAnnotations(auditinternal.LevelMetadata), tt.Name+": annotations not set as expected.")
+			assert.Equalf(t, tt.ExpectAnnotations, fakeAttr.GetAnnotations(auditinternal.LevelMetadata), tt.Name+": annotations not set as expected.")
 		}
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/audit/policy/checker_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/audit/policy/checker_test.go
@@ -186,8 +186,8 @@ func test(t *testing.T, req string, expLevel audit.Level, policyStages, expOmitS
 	}
 	require.Contains(t, attrs, req)
 	auditConfig := NewPolicyRuleEvaluator(&policy).EvaluatePolicyRule(attrs[req])
-	assert.Equal(t, expLevel, auditConfig.Level, "request:%s rules:%s", req, strings.Join(ruleNames, ","))
-	assert.True(t, stageEqual(expOmitStages, auditConfig.OmitStages), "request:%s rules:%s, expected stages: %v, actual stages: %v",
+	assert.Equalf(t, expLevel, auditConfig.Level, "request:%s rules:%s", req, strings.Join(ruleNames, ","))
+	assert.Truef(t, stageEqual(expOmitStages, auditConfig.OmitStages), "request:%s rules:%s, expected stages: %v, actual stages: %v",
 		req, strings.Join(ruleNames, ","), expOmitStages, auditConfig.OmitStages)
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/discovery/aggregated/handler_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/discovery/aggregated/handler_test.go
@@ -160,15 +160,15 @@ func TestBasicResponse(t *testing.T) {
 	response, body, decoded := fetchPath(manager, "application/json", discoveryPath, "")
 
 	jsonFormatted, err := json.Marshal(&apis)
-	require.NoError(t, err, "json marshal should always succeed")
+	require.NoErrorf(t, err, "json marshal should always succeed")
 
-	assert.Equal(t, http.StatusOK, response.StatusCode, "response should be 200 OK")
-	assert.Equal(t, "application/json;g=apidiscovery.k8s.io;v=v2;as=APIGroupDiscoveryList", response.Header.Get("Content-Type"), "Content-Type response header should be as requested in Accept header if supported")
-	assert.NotEmpty(t, response.Header.Get("ETag"), "E-Tag should be set")
+	assert.Equalf(t, http.StatusOK, response.StatusCode, "response should be 200 OK")
+	assert.Equalf(t, "application/json;g=apidiscovery.k8s.io;v=v2;as=APIGroupDiscoveryList", response.Header.Get("Content-Type"), "Content-Type response header should be as requested in Accept header if supported")
+	assert.NotEmptyf(t, response.Header.Get("ETag"), "E-Tag should be set")
 
-	assert.NoError(t, err, "decode should always succeed")
-	assert.EqualValues(t, &apis, decoded, "decoded value should equal input")
-	assert.Equal(t, string(jsonFormatted)+"\n", string(body), "response should be the api group list")
+	assert.NoErrorf(t, err, "decode should always succeed")
+	assert.EqualValuesf(t, &apis, decoded, "decoded value should equal input")
+	assert.Equalf(t, string(jsonFormatted)+"\n", string(body), "response should be the api group list")
 }
 
 // Test that protobuf is outputted correctly
@@ -179,10 +179,10 @@ func TestBasicResponseProtobuf(t *testing.T) {
 	manager.SetGroups(apis.Items)
 
 	response, _, decoded := fetchPath(manager, "application/vnd.kubernetes.protobuf", discoveryPath, "")
-	assert.Equal(t, http.StatusOK, response.StatusCode, "response should be 200 OK")
-	assert.Equal(t, "application/vnd.kubernetes.protobuf;g=apidiscovery.k8s.io;v=v2;as=APIGroupDiscoveryList", response.Header.Get("Content-Type"), "Content-Type response header should be as requested in Accept header if supported")
-	assert.NotEmpty(t, response.Header.Get("ETag"), "E-Tag should be set")
-	assert.EqualValues(t, &apis, decoded, "decoded value should equal input")
+	assert.Equalf(t, http.StatusOK, response.StatusCode, "response should be 200 OK")
+	assert.Equalf(t, "application/vnd.kubernetes.protobuf;g=apidiscovery.k8s.io;v=v2;as=APIGroupDiscoveryList", response.Header.Get("Content-Type"), "Content-Type response header should be as requested in Accept header if supported")
+	assert.NotEmptyf(t, response.Header.Get("ETag"), "E-Tag should be set")
+	assert.EqualValuesf(t, &apis, decoded, "decoded value should equal input")
 }
 
 // V2Beta1 should still be served
@@ -202,15 +202,15 @@ func TestV2Beta1SkewSupport(t *testing.T) {
 	response, body, decoded := fetchPathV2Beta1(manager, "application/json", discoveryPath, "")
 
 	jsonFormatted, err := json.Marshal(v2beta1apis)
-	require.NoError(t, err, "json marshal should always succeed")
+	require.NoErrorf(t, err, "json marshal should always succeed")
 
-	assert.Equal(t, http.StatusOK, response.StatusCode, "response should be 200 OK")
-	assert.Equal(t, "application/json;g=apidiscovery.k8s.io;v=v2beta1;as=APIGroupDiscoveryList", response.Header.Get("Content-Type"), "Content-Type response header should be as requested in Accept header if supported")
-	assert.NotEmpty(t, response.Header.Get("ETag"), "E-Tag should be set")
+	assert.Equalf(t, http.StatusOK, response.StatusCode, "response should be 200 OK")
+	assert.Equalf(t, "application/json;g=apidiscovery.k8s.io;v=v2beta1;as=APIGroupDiscoveryList", response.Header.Get("Content-Type"), "Content-Type response header should be as requested in Accept header if supported")
+	assert.NotEmptyf(t, response.Header.Get("ETag"), "E-Tag should be set")
 
-	assert.NoError(t, err, "decode should always succeed")
-	assert.EqualValues(t, v2beta1apis, decoded, "decoded value should equal input")
-	assert.Equal(t, string(jsonFormatted)+"\n", string(body), "response should be the api group list")
+	assert.NoErrorf(t, err, "decode should always succeed")
+	assert.EqualValuesf(t, v2beta1apis, decoded, "decoded value should equal input")
+	assert.Equalf(t, string(jsonFormatted)+"\n", string(body), "response should be the api group list")
 }
 
 // Test that an etag associated with the service only depends on the apiresources
@@ -228,9 +228,9 @@ func TestEtagConsistent(t *testing.T) {
 	res1_initial, _, _ := fetchPath(manager1, "application/json", discoveryPath, "")
 	res2_initial, _, _ := fetchPath(manager2, "application/json", discoveryPath, "")
 
-	assert.NotEmpty(t, res1_initial.Header.Get("ETag"), "Etag should be populated")
-	assert.NotEmpty(t, res2_initial.Header.Get("ETag"), "Etag should be populated")
-	assert.Equal(t, res1_initial.Header.Get("ETag"), res2_initial.Header.Get("ETag"), "etag should be deterministic")
+	assert.NotEmptyf(t, res1_initial.Header.Get("ETag"), "Etag should be populated")
+	assert.NotEmptyf(t, res2_initial.Header.Get("ETag"), "Etag should be populated")
+	assert.Equalf(t, res1_initial.Header.Get("ETag"), res2_initial.Header.Get("ETag"), "etag should be deterministic")
 
 	// Then add one service to only one.
 	// Make sure etag is changed, but other is the same
@@ -244,10 +244,10 @@ func TestEtagConsistent(t *testing.T) {
 	res1_addedToOne, _, _ := fetchPath(manager1, "application/json", discoveryPath, "")
 	res2_addedToOne, _, _ := fetchPath(manager2, "application/json", discoveryPath, "")
 
-	assert.NotEmpty(t, res1_addedToOne.Header.Get("ETag"), "Etag should be populated")
-	assert.NotEmpty(t, res2_addedToOne.Header.Get("ETag"), "Etag should be populated")
-	assert.NotEqual(t, res1_initial.Header.Get("ETag"), res1_addedToOne.Header.Get("ETag"), "ETag should be changed since version was added")
-	assert.Equal(t, res2_initial.Header.Get("ETag"), res2_addedToOne.Header.Get("ETag"), "ETag should be unchanged since data was unchanged")
+	assert.NotEmptyf(t, res1_addedToOne.Header.Get("ETag"), "Etag should be populated")
+	assert.NotEmptyf(t, res2_addedToOne.Header.Get("ETag"), "Etag should be populated")
+	assert.NotEqualf(t, res1_initial.Header.Get("ETag"), res1_addedToOne.Header.Get("ETag"), "ETag should be changed since version was added")
+	assert.Equalf(t, res2_initial.Header.Get("ETag"), res2_addedToOne.Header.Get("ETag"), "ETag should be unchanged since data was unchanged")
 
 	// Then add service to other one
 	// Make sure etag is the same
@@ -260,10 +260,10 @@ func TestEtagConsistent(t *testing.T) {
 	res1_addedToBoth, _, _ := fetchPath(manager1, "application/json", discoveryPath, "")
 	res2_addedToBoth, _, _ := fetchPath(manager2, "application/json", discoveryPath, "")
 
-	assert.NotEmpty(t, res1_addedToOne.Header.Get("ETag"), "Etag should be populated")
-	assert.NotEmpty(t, res2_addedToOne.Header.Get("ETag"), "Etag should be populated")
-	assert.Equal(t, res1_addedToBoth.Header.Get("ETag"), res2_addedToBoth.Header.Get("ETag"), "ETags should be equal since content is equal")
-	assert.NotEqual(t, res2_initial.Header.Get("ETag"), res2_addedToBoth.Header.Get("ETag"), "ETag should be changed since data was changed")
+	assert.NotEmptyf(t, res1_addedToOne.Header.Get("ETag"), "Etag should be populated")
+	assert.NotEmptyf(t, res2_addedToOne.Header.Get("ETag"), "Etag should be populated")
+	assert.Equalf(t, res1_addedToBoth.Header.Get("ETag"), res2_addedToBoth.Header.Get("ETag"), "ETags should be equal since content is equal")
+	assert.NotEqualf(t, res2_initial.Header.Get("ETag"), res2_addedToBoth.Header.Get("ETag"), "ETag should be changed since data was changed")
 
 	// Remove the group version from both. Initial E-Tag should be restored
 	for _, group := range apis.Items {
@@ -282,10 +282,10 @@ func TestEtagConsistent(t *testing.T) {
 	res1_removeFromBoth, _, _ := fetchPath(manager1, "application/json", discoveryPath, "")
 	res2_removeFromBoth, _, _ := fetchPath(manager2, "application/json", discoveryPath, "")
 
-	assert.NotEmpty(t, res1_addedToOne.Header.Get("ETag"), "Etag should be populated")
-	assert.NotEmpty(t, res2_addedToOne.Header.Get("ETag"), "Etag should be populated")
-	assert.Equal(t, res1_removeFromBoth.Header.Get("ETag"), res2_removeFromBoth.Header.Get("ETag"), "ETags should be equal since content is equal")
-	assert.Equal(t, res1_initial.Header.Get("ETag"), res1_removeFromBoth.Header.Get("ETag"), "ETag should be equal to initial value since added content was removed")
+	assert.NotEmptyf(t, res1_addedToOne.Header.Get("ETag"), "Etag should be populated")
+	assert.NotEmptyf(t, res2_addedToOne.Header.Get("ETag"), "Etag should be populated")
+	assert.Equalf(t, res1_removeFromBoth.Header.Get("ETag"), res2_removeFromBoth.Header.Get("ETag"), "ETags should be equal since content is equal")
+	assert.Equalf(t, res1_initial.Header.Get("ETag"), res1_removeFromBoth.Header.Get("ETag"), "ETag should be equal to initial value since added content was removed")
 }
 
 // Test that if a request comes in with an If-None-Match header with an incorrect
@@ -297,15 +297,15 @@ func TestEtagNonMatching(t *testing.T) {
 
 	// fetch the document once
 	initial, _, _ := fetchPath(manager, "application/json", discoveryPath, "")
-	assert.NotEmpty(t, initial.Header.Get("ETag"), "ETag should be populated")
+	assert.NotEmptyf(t, initial.Header.Get("ETag"), "ETag should be populated")
 
 	// Send another request with a wrong e-tag. The same response should
 	// get sent again
 	second, _, _ := fetchPath(manager, "application/json", discoveryPath, "wrongetag")
 
-	assert.Equal(t, http.StatusOK, initial.StatusCode, "response should be 200 OK")
-	assert.Equal(t, http.StatusOK, second.StatusCode, "response should be 200 OK")
-	assert.Equal(t, initial.Header.Get("ETag"), second.Header.Get("ETag"), "ETag of both requests should be equal")
+	assert.Equalf(t, http.StatusOK, initial.StatusCode, "response should be 200 OK")
+	assert.Equalf(t, http.StatusOK, second.StatusCode, "response should be 200 OK")
+	assert.Equalf(t, initial.Header.Get("ETag"), second.Header.Get("ETag"), "ETag of both requests should be equal")
 }
 
 // Test that if a request comes in with an If-None-Match header with a correct
@@ -317,17 +317,17 @@ func TestEtagMatching(t *testing.T) {
 
 	// fetch the document once
 	initial, initialBody, _ := fetchPath(manager, "application/json", discoveryPath, "")
-	assert.NotEmpty(t, initial.Header.Get("ETag"), "ETag should be populated")
-	assert.NotEmpty(t, initialBody, "body should not be empty")
+	assert.NotEmptyf(t, initial.Header.Get("ETag"), "ETag should be populated")
+	assert.NotEmptyf(t, initialBody, "body should not be empty")
 
 	// Send another request with a wrong e-tag. The same response should
 	// get sent again
 	second, secondBody, _ := fetchPath(manager, "application/json", discoveryPath, initial.Header.Get("ETag"))
 
-	assert.Equal(t, http.StatusOK, initial.StatusCode, "initial response should be 200 OK")
-	assert.Equal(t, http.StatusNotModified, second.StatusCode, "second response should be 304 Not Modified")
-	assert.Equal(t, initial.Header.Get("ETag"), second.Header.Get("ETag"), "ETag of both requests should be equal")
-	assert.Empty(t, secondBody, "body should be empty when returning 304 Not Modified")
+	assert.Equalf(t, http.StatusOK, initial.StatusCode, "initial response should be 200 OK")
+	assert.Equalf(t, http.StatusNotModified, second.StatusCode, "second response should be 304 Not Modified")
+	assert.Equalf(t, initial.Header.Get("ETag"), second.Header.Get("ETag"), "ETag of both requests should be equal")
+	assert.Emptyf(t, secondBody, "body should be empty when returning 304 Not Modified")
 }
 
 // Test that if a request comes in with an If-None-Match header with an old
@@ -339,8 +339,8 @@ func TestEtagOutdated(t *testing.T) {
 
 	// fetch the document once
 	initial, initialBody, _ := fetchPath(manager, "application/json", discoveryPath, "")
-	assert.NotEmpty(t, initial.Header.Get("ETag"), "ETag should be populated")
-	assert.NotEmpty(t, initialBody, "body should not be empty")
+	assert.NotEmptyf(t, initial.Header.Get("ETag"), "ETag should be populated")
+	assert.NotEmptyf(t, initialBody, "body should not be empty")
 
 	// Then add some services so the etag changes
 	apis = fuzzAPIGroups(1, 3, 14)
@@ -353,10 +353,10 @@ func TestEtagOutdated(t *testing.T) {
 	// Send another request with the old e-tag. Response should not be 304 Not Modified
 	second, secondBody, _ := fetchPath(manager, "application/json", discoveryPath, initial.Header.Get("ETag"))
 
-	assert.Equal(t, http.StatusOK, initial.StatusCode, "initial response should be 200 OK")
-	assert.Equal(t, http.StatusOK, second.StatusCode, "second response should be 304 Not Modified")
-	assert.NotEqual(t, initial.Header.Get("ETag"), second.Header.Get("ETag"), "ETag of both requests should be unequal since contents differ")
-	assert.NotEmpty(t, secondBody, "body should be not empty when returning 304 Not Modified")
+	assert.Equalf(t, http.StatusOK, initial.StatusCode, "initial response should be 200 OK")
+	assert.Equalf(t, http.StatusOK, second.StatusCode, "second response should be 304 Not Modified")
+	assert.NotEqualf(t, initial.Header.Get("ETag"), second.Header.Get("ETag"), "ETag of both requests should be unequal since contents differ")
+	assert.NotEmptyf(t, secondBody, "body should be not empty when returning 304 Not Modified")
 }
 
 // Test that an api service can be added or removed
@@ -382,10 +382,10 @@ func TestAddRemove(t *testing.T) {
 
 	_, _, secondDocument := fetchPath(manager, "application/json", discoveryPath, "")
 
-	require.NotNil(t, initialDocument, "initial document should parse")
-	require.NotNil(t, secondDocument, "second document should parse")
-	assert.Len(t, initialDocument.Items, len(apis.Items), "initial document should have set number of groups")
-	assert.Empty(t, secondDocument.Items, "second document should have no groups")
+	require.NotNilf(t, initialDocument, "initial document should parse")
+	require.NotNilf(t, secondDocument, "second document should parse")
+	assert.Lenf(t, initialDocument.Items, len(apis.Items), "initial document should have set number of groups")
+	assert.Emptyf(t, secondDocument.Items, "second document should have no groups")
 }
 
 // Show that updating an existing service replaces and does not add the entry
@@ -401,7 +401,7 @@ func TestUpdateService(t *testing.T) {
 
 	_, _, initialDocument := fetchPath(manager, "application/json", discoveryPath, "")
 
-	assert.Equal(t, initialDocument, &apis, "should have returned expected document")
+	assert.Equalf(t, initialDocument, &apis, "should have returned expected document")
 
 	b, err := json.Marshal(apis)
 	if err != nil {
@@ -421,8 +421,8 @@ func TestUpdateService(t *testing.T) {
 	}
 
 	_, _, secondDocument := fetchPath(manager, "application/json", discoveryPath, "")
-	assert.Equal(t, secondDocument, &newapis, "should have returned expected document")
-	assert.NotEqual(t, secondDocument, initialDocument, "should have returned expected document")
+	assert.Equalf(t, secondDocument, &newapis, "should have returned expected document")
+	assert.NotEqualf(t, secondDocument, initialDocument, "should have returned expected document")
 }
 
 func TestMultipleSources(t *testing.T) {
@@ -537,11 +537,11 @@ func TestConcurrentRequests(t *testing.T) {
 				response, body, document := fetchPath(manager, "application/json", discoveryPath, usedEtag)
 
 				if usedEtag != "" {
-					assert.Equal(t, http.StatusNotModified, response.StatusCode, "response should be Not Modified if etag was used")
-					assert.Empty(t, body, "body should be empty if etag used")
+					assert.Equalf(t, http.StatusNotModified, response.StatusCode, "response should be Not Modified if etag was used")
+					assert.Emptyf(t, body, "body should be empty if etag used")
 				} else {
-					assert.Equal(t, http.StatusOK, response.StatusCode, "response should be OK if etag was unused")
-					assert.Equal(t, &apis, document, "document should be equal")
+					assert.Equalf(t, http.StatusOK, response.StatusCode, "response should be OK if etag was unused")
+					assert.Equalf(t, &apis, document, "document should be equal")
 				}
 
 				etag = response.Header.Get("ETag")
@@ -601,7 +601,7 @@ func TestAbuse(t *testing.T) {
 						// Send a request and try to remove a group someone else
 						// might have added
 						_, _, document := fetchPath(manager, "application/json", discoveryPath, "")
-						assert.NotNil(t, document, "manager should always succeed in returning a document")
+						assert.NotNilf(t, document, "manager should always succeed in returning a document")
 
 						if len(document.Items) > 0 {
 							manager.RemoveGroupVersion(metav1.GroupVersion{
@@ -634,10 +634,10 @@ func TestAbuse(t *testing.T) {
 
 				if response.StatusCode == http.StatusNotModified {
 					assert.Equal(t, etag, response.Header.Get("ETag"))
-					assert.Empty(t, body, "body should be empty if etag used")
+					assert.Emptyf(t, body, "body should be empty if etag used")
 					assert.Nil(t, document)
 				} else {
-					assert.Equal(t, http.StatusOK, response.StatusCode, "response should be OK if etag was unused")
+					assert.Equalf(t, http.StatusOK, response.StatusCode, "response should be OK if etag was unused")
 					assert.NotNil(t, document)
 				}
 
@@ -669,7 +669,7 @@ func TestVersionSortingNoPriority(t *testing.T) {
 	})
 
 	response, _, decoded := fetchPath(manager, "application/json", discoveryPath, "")
-	assert.Equal(t, http.StatusOK, response.StatusCode, "response should be 200 OK")
+	assert.Equalf(t, http.StatusOK, response.StatusCode, "response should be 200 OK")
 
 	versions := decoded.Items[0].Versions
 
@@ -694,7 +694,7 @@ func TestVersionSortingWithPriority(t *testing.T) {
 	manager.SetGroupVersionPriority(metav1.GroupVersion{Group: "default", Version: "v1alpha1"}, 1000, 200)
 
 	response, _, decoded := fetchPath(manager, "application/json", discoveryPath, "")
-	assert.Equal(t, http.StatusOK, response.StatusCode, "response should be 200 OK")
+	assert.Equalf(t, http.StatusOK, response.StatusCode, "response should be 200 OK")
 
 	versions := decoded.Items[0].Versions
 
@@ -721,7 +721,7 @@ func TestGroupVersionSortingConflictingPriority(t *testing.T) {
 	manager.SetGroupVersionPriority(metav1.GroupVersion{Group: "test", Version: "v1alpha1"}, 2000, 100)
 
 	response, _, decoded := fetchPath(manager, "application/json", discoveryPath, "")
-	assert.Equal(t, http.StatusOK, response.StatusCode, "response should be 200 OK")
+	assert.Equalf(t, http.StatusOK, response.StatusCode, "response should be 200 OK")
 
 	groups := decoded.Items
 
@@ -755,7 +755,7 @@ func TestStatelessGroupPriorityMinimum(t *testing.T) {
 
 	// Expect v1alpha1's group priority to be used and sort it first in the list
 	response, _, decoded := fetchPath(manager, "application/json", discoveryPath, "")
-	assert.Equal(t, http.StatusOK, response.StatusCode, "response should be 200 OK")
+	assert.Equalf(t, http.StatusOK, response.StatusCode, "response should be 200 OK")
 	assert.Equal(t, "experimental.example.com", decoded.Items[0].Name)
 	assert.Equal(t, "stable.example.com", decoded.Items[1].Name)
 
@@ -763,7 +763,7 @@ func TestStatelessGroupPriorityMinimum(t *testing.T) {
 	manager.RemoveGroupVersion(metav1.GroupVersion{Group: experimentalGroup, Version: "v1alpha1"})
 
 	response, _, decoded = fetchPath(manager, "application/json", discoveryPath, "")
-	assert.Equal(t, http.StatusOK, response.StatusCode, "response should be 200 OK")
+	assert.Equalf(t, http.StatusOK, response.StatusCode, "response should be 200 OK")
 
 	assert.Equal(t, "stable.example.com", decoded.Items[0].Name)
 	assert.Equal(t, "experimental.example.com", decoded.Items[1].Name)

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authorization_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authorization_test.go
@@ -289,8 +289,8 @@ func TestAuditAnnotation(t *testing.T) {
 		ae := audit.AuditEventFrom(req.Context())
 		req.RemoteAddr = "127.0.0.1"
 		handler.ServeHTTP(httptest.NewRecorder(), req)
-		assert.Equal(t, tc.decisionAnnotation, ae.Annotations[decisionAnnotationKey], k+": unexpected decision annotation")
-		assert.Equal(t, tc.reasonAnnotation, ae.Annotations[reasonAnnotationKey], k+": unexpected reason annotation")
+		assert.Equalf(t, tc.decisionAnnotation, ae.Annotations[decisionAnnotationKey], k+": unexpected decision annotation")
+		assert.Equalf(t, tc.reasonAnnotation, ae.Annotations[reasonAnnotationKey], k+": unexpected reason annotation")
 	}
 
 }

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/rest/streamer_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/rest/streamer_test.go
@@ -159,12 +159,12 @@ func TestInputStreamRedirects(t *testing.T) {
 		}
 	}))
 	loc, err := url.Parse(s.URL)
-	require.NoError(t, err, "Error parsing server URL")
+	require.NoErrorf(t, err, "Error parsing server URL")
 
 	streamer := &LocationStreamer{
 		Location:        loc,
 		RedirectChecker: PreventRedirects,
 	}
 	_, _, _, err = streamer.InputStream(context.Background(), "", "")
-	assert.Error(t, err, "Redirect should trigger an error")
+	assert.Errorf(t, err, "Redirect should trigger an error")
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/named_certificates_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/named_certificates_test.go
@@ -235,12 +235,12 @@ NextTest:
 			got := map[string]int{}
 			for name, cert := range certMap {
 				x509Certs, err := x509.ParseCertificates(cert.Certificate[0])
-				assert.NoError(t, err, "%d - invalid certificate for %q", i, name)
-				assert.NotEmpty(t, x509Certs, "%d - expected at least one x509 cert in tls cert for %q", i, name)
+				assert.NoErrorf(t, err, "%d - invalid certificate for %q", i, name)
+				assert.NotEmptyf(t, x509Certs, "%d - expected at least one x509 cert in tls cert for %q", i, name)
 				got[name] = bySignature[x509CertSignature(x509Certs[0])]
 			}
 
-			assert.EqualValues(t, test.expected, got, "%d - wrong certificate map", i)
+			assert.EqualValuesf(t, test.expected, got, "%d - wrong certificate map", i)
 		}
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/options/audit_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/audit_test.go
@@ -156,9 +156,9 @@ func TestAuditValidOptions(t *testing.T) {
 			fs := pflag.NewFlagSet("Test", pflag.PanicOnError)
 			options.AddFlags(fs)
 			require.NoError(t, fs.Parse(nil))
-			assert.Equal(t, tc.options(), options, "Flag defaults should match default options.")
+			assert.Equalf(t, tc.options(), options, "Flag defaults should match default options.")
 
-			assert.Empty(t, options.Validate(), "Options should be valid.")
+			assert.Emptyf(t, options.Validate(), "Options should be valid.")
 			config := &server.Config{}
 			require.NoError(t, options.ApplyTo(config))
 			if tc.expected == "" {
@@ -168,7 +168,7 @@ func TestAuditValidOptions(t *testing.T) {
 			}
 
 			w, err := options.LogOptions.getWriter()
-			require.NoError(t, err, "Writer creation should not fail.")
+			require.NoErrorf(t, err, "Writer creation should not fail.")
 
 			// Don't check writer if logging is disabled.
 			if w == nil {
@@ -260,7 +260,7 @@ func TestAuditInvalidOptions(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			options := tc.options()
 			require.NotNil(t, options)
-			assert.NotEmpty(t, options.Validate(), "Options should be invalid.")
+			assert.NotEmptyf(t, options.Validate(), "Options should be invalid.")
 		})
 	}
 }
@@ -272,8 +272,8 @@ func makeTmpWebhookConfig(t *testing.T) string {
 		},
 	}
 	f, err := ioutil.TempFile("", "k8s_audit_webhook_test_")
-	require.NoError(t, err, "creating temp file")
-	require.NoError(t, stdjson.NewEncoder(f).Encode(config), "writing webhook kubeconfig")
+	require.NoErrorf(t, err, "creating temp file")
+	require.NoErrorf(t, stdjson.NewEncoder(f).Encode(config), "writing webhook kubeconfig")
 	require.NoError(t, f.Close())
 	return f.Name()
 }
@@ -290,8 +290,8 @@ func makeTmpPolicy(t *testing.T) string {
 		},
 	}
 	f, err := ioutil.TempFile("", "k8s_audit_policy_test_")
-	require.NoError(t, err, "creating temp file")
-	require.NoError(t, stdjson.NewEncoder(f).Encode(pol), "writing policy file")
+	require.NoErrorf(t, err, "creating temp file")
+	require.NoErrorf(t, stdjson.NewEncoder(f).Encode(pol), "writing policy file")
 	require.NoError(t, f.Close())
 	return f.Name()
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
@@ -2018,7 +2018,7 @@ func TestWaitUntilWatchCacheFreshAndForceAllEvents(t *testing.T) {
 				ResourceVersion:   "105",
 			},
 			verifyBackingStore: func(t *testing.T, s *dummyStorage) {
-				require.NotEqual(t, 0, s.getRequestWatchProgressCounter(), "expected store.RequestWatchProgressCounter to be > 0. It looks like watch progress wasn't requested!")
+				require.NotEqualf(t, 0, s.getRequestWatchProgressCounter(), "expected store.RequestWatchProgressCounter to be > 0. It looks like watch progress wasn't requested!")
 			},
 		},
 
@@ -2053,7 +2053,7 @@ func TestWaitUntilWatchCacheFreshAndForceAllEvents(t *testing.T) {
 				return s
 			}(),
 			verifyBackingStore: func(t *testing.T, s *dummyStorage) {
-				require.NotEqual(t, 0, s.getRequestWatchProgressCounter(), "expected store.RequestWatchProgressCounter to be > 0. It looks like watch progress wasn't requested!")
+				require.NotEqualf(t, 0, s.getRequestWatchProgressCounter(), "expected store.RequestWatchProgressCounter to be > 0. It looks like watch progress wasn't requested!")
 			},
 		},
 
@@ -2088,7 +2088,7 @@ func TestWaitUntilWatchCacheFreshAndForceAllEvents(t *testing.T) {
 				return s
 			}(),
 			verifyBackingStore: func(t *testing.T, s *dummyStorage) {
-				require.NotEqual(t, 0, s.getRequestWatchProgressCounter(), "expected store.RequestWatchProgressCounter to be > 0. It looks like watch progress wasn't requested!")
+				require.NotEqualf(t, 0, s.getRequestWatchProgressCounter(), "expected store.RequestWatchProgressCounter to be > 0. It looks like watch progress wasn't requested!")
 			},
 		},
 	}
@@ -2115,7 +2115,7 @@ func TestWaitUntilWatchCacheFreshAndForceAllEvents(t *testing.T) {
 			}
 
 			w, err := cacher.Watch(context.Background(), "pods/ns", scenario.opts)
-			require.NoError(t, err, "failed to create watch: %v")
+			require.NoErrorf(t, err, "failed to create watch: %v")
 			defer w.Stop()
 			var expectedErr *apierrors.StatusError
 			if !errors.As(storage.NewTooLargeResourceVersionError(105, 100, resourceVersionTooHighRetrySeconds), &expectedErr) {
@@ -2136,10 +2136,10 @@ func TestWaitUntilWatchCacheFreshAndForceAllEvents(t *testing.T) {
 
 			go func(t *testing.T) {
 				err := cacher.watchCache.Add(makeTestPodDetails("pod1", 105, "node1", map[string]string{"label": "value1"}))
-				require.NoError(t, err, "failed adding a pod to the watchCache")
+				require.NoErrorf(t, err, "failed adding a pod to the watchCache")
 			}(t)
 			w, err = cacher.Watch(context.Background(), "pods/ns", scenario.opts)
-			require.NoError(t, err, "failed to create watch: %v")
+			require.NoErrorf(t, err, "failed to create watch: %v")
 			defer w.Stop()
 			verifyEvents(t, w, []watch.Event{
 				{
@@ -2264,7 +2264,7 @@ func TestWatchListIsSynchronisedWhenNoEventsFromStoreReceived(t *testing.T) {
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.WatchList, true)
 	backingStorage := &dummyStorage{}
 	cacher, _, err := newTestCacher(backingStorage)
-	require.NoError(t, err, "failed to create cacher")
+	require.NoErrorf(t, err, "failed to create cacher")
 	defer cacher.Stop()
 
 	if !utilfeature.DefaultFeatureGate.Enabled(features.ResilientWatchCacheInitialization) {
@@ -2280,7 +2280,7 @@ func TestWatchListIsSynchronisedWhenNoEventsFromStoreReceived(t *testing.T) {
 		SendInitialEvents: pointer.Bool(true),
 	}
 	w, err := cacher.Watch(context.Background(), "pods/ns", opts)
-	require.NoError(t, err, "failed to create watch: %v")
+	require.NoErrorf(t, err, "failed to create watch: %v")
 	defer w.Stop()
 
 	verifyEvents(t, w, []watch.Event{
@@ -2495,7 +2495,7 @@ func TestGetWatchCacheResourceVersion(t *testing.T) {
 		t.Run(scenario.name, func(t *testing.T) {
 			backingStorage := &dummyStorage{}
 			cacher, _, err := newTestCacher(backingStorage)
-			require.NoError(t, err, "couldn't create cacher")
+			require.NoErrorf(t, err, "couldn't create cacher")
 			defer cacher.Stop()
 
 			parsedResourceVersion := 0
@@ -2506,7 +2506,7 @@ func TestGetWatchCacheResourceVersion(t *testing.T) {
 
 			actualResourceVersion, err := cacher.getWatchCacheResourceVersion(context.TODO(), uint64(parsedResourceVersion), scenario.opts)
 			require.NoError(t, err)
-			require.Equal(t, uint64(scenario.expectedWatchResourceVersion), actualResourceVersion, "received unexpected ResourceVersion")
+			require.Equalf(t, uint64(scenario.expectedWatchResourceVersion), actualResourceVersion, "received unexpected ResourceVersion")
 		})
 	}
 }
@@ -2689,7 +2689,7 @@ func TestGetBookmarkAfterResourceVersionLockedFunc(t *testing.T) {
 		t.Run(scenario.name, func(t *testing.T) {
 			backingStorage := &dummyStorage{}
 			cacher, _, err := newTestCacher(backingStorage)
-			require.NoError(t, err, "couldn't create cacher")
+			require.NoErrorf(t, err, "couldn't create cacher")
 
 			defer cacher.Stop()
 
@@ -2711,7 +2711,7 @@ func TestGetBookmarkAfterResourceVersionLockedFunc(t *testing.T) {
 			cacher.watchCache.RLock()
 			defer cacher.watchCache.RUnlock()
 			getBookMarkResourceVersion := getBookMarkFn()
-			require.Equal(t, uint64(scenario.expectedBookmarkResourceVersion), getBookMarkResourceVersion, "received unexpected ResourceVersion")
+			require.Equalf(t, uint64(scenario.expectedBookmarkResourceVersion), getBookMarkResourceVersion, "received unexpected ResourceVersion")
 		})
 	}
 }

--- a/staging/src/k8s.io/apiserver/plugin/pkg/audit/buffered/buffered_test.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/audit/buffered/buffered_test.go
@@ -61,7 +61,7 @@ func TestBatchedBackendCollectEvents(t *testing.T) {
 	t.Log("Max batch size encountered.")
 	backend.ProcessEvents(newEvents(batchSize + 1)...)
 	batch := backend.collectEvents(nil, nil)
-	assert.Len(t, batch, batchSize, "Expected full batch")
+	assert.Lenf(t, batch, batchSize, "Expected full batch")
 
 	t.Log("Partial batch should hang until timer expires.")
 	backend.ProcessEvents(newEvents(1)...)
@@ -80,7 +80,7 @@ func TestBatchedBackendCollectEvents(t *testing.T) {
 
 	tc <- time.Now() // Trigger "timeout"
 	wg.Wait()
-	assert.Len(t, batch, 2, "Expected partial batch")
+	assert.Lenf(t, batch, 2, "Expected partial batch")
 
 	t.Log("Collected events should be delivered when stop channel is closed.")
 	backend.ProcessEvents(newEvents(3)...)
@@ -98,7 +98,7 @@ func TestBatchedBackendCollectEvents(t *testing.T) {
 
 	close(stopCh)
 	wg.Wait()
-	assert.Len(t, batch, 3, "Expected partial batch")
+	assert.Lenf(t, batch, 3, "Expected partial batch")
 }
 
 func TestUnbatchedBackendCollectEvents(t *testing.T) {
@@ -109,12 +109,12 @@ func TestUnbatchedBackendCollectEvents(t *testing.T) {
 	t.Log("Max batch size encountered.")
 	backend.ProcessEvents(newEvents(3)...)
 	batch := backend.collectEvents(nil, nil)
-	assert.Len(t, batch, 1, "Expected single event")
+	assert.Lenf(t, batch, 1, "Expected single event")
 
 	t.Log("Queue should always be drained.")
 	for len(backend.buffer) > 0 {
 		batch = backend.collectEvents(nil, nil)
-		assert.Len(t, batch, 1, "Expected single event")
+		assert.Lenf(t, batch, 1, "Expected single event")
 	}
 
 	t.Log("Collection should hault when stop channel is closed.")
@@ -127,7 +127,7 @@ func TestUnbatchedBackendCollectEvents(t *testing.T) {
 	}()
 	close(stopCh)
 	wg.Wait()
-	assert.Empty(t, batch, "Empty final batch")
+	assert.Emptyf(t, batch, "Empty final batch")
 }
 
 func TestBufferedBackendProcessEventsAfterStop(t *testing.T) {
@@ -142,7 +142,7 @@ func TestBufferedBackendProcessEventsAfterStop(t *testing.T) {
 	backend.ProcessEvents(newEvents(1)...)
 	batch := backend.collectEvents(infiniteTimeCh, wait.NeverStop)
 
-	require.Empty(t, batch, "processed events after the backed has been stopped")
+	require.Emptyf(t, batch, "processed events after the backed has been stopped")
 }
 
 func TestBufferedBackendProcessEventsBufferFull(t *testing.T) {
@@ -154,7 +154,7 @@ func TestBufferedBackendProcessEventsBufferFull(t *testing.T) {
 
 	backend.ProcessEvents(newEvents(2)...)
 
-	require.Len(t, backend.buffer, 1, "buffed contains more elements than it should")
+	require.Lenf(t, backend.buffer, 1, "buffed contains more elements than it should")
 }
 
 func TestBufferedBackendShutdownWaitsForDelegatedCalls(t *testing.T) {
@@ -207,7 +207,7 @@ func TestDelegateProcessEvents(t *testing.T) {
 			wg := sync.WaitGroup{}
 			delegate := &fake.Backend{
 				OnRequest: func(events []*auditinternal.Event) {
-					assert.Len(t, events, config.MaxBatchSize, "Unexpected batch")
+					assert.Lenf(t, events, config.MaxBatchSize, "Unexpected batch")
 					wg.Done()
 				},
 			}

--- a/staging/src/k8s.io/apiserver/plugin/pkg/audit/webhook/webhook_test.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/audit/webhook/webhook_test.go
@@ -86,7 +86,7 @@ func (t *testWebhookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// In a goroutine, can't call Fatal.
-	assert.NoError(t.t, err, "failed to read request body")
+	assert.NoErrorf(t.t, err, "failed to read request body")
 	http.Error(w, err.Error(), http.StatusInternalServerError)
 }
 
@@ -97,7 +97,7 @@ func newWebhook(t *testing.T, endpoint string, groupVersion schema.GroupVersion)
 		},
 	}
 	f, err := ioutil.TempFile("", "k8s_audit_webhook_test_")
-	require.NoError(t, err, "creating temp file")
+	require.NoErrorf(t, err, "creating temp file")
 
 	defer func() {
 		f.Close()
@@ -105,7 +105,7 @@ func newWebhook(t *testing.T, endpoint string, groupVersion schema.GroupVersion)
 	}()
 
 	// NOTE(ericchiang): Do we need to use a proper serializer?
-	require.NoError(t, stdjson.NewEncoder(f).Encode(config), "writing kubeconfig")
+	require.NoErrorf(t, stdjson.NewEncoder(f).Encode(config), "writing kubeconfig")
 
 	retryBackoff := wait.Backoff{
 		Duration: 500 * time.Millisecond,
@@ -114,7 +114,7 @@ func newWebhook(t *testing.T, endpoint string, groupVersion schema.GroupVersion)
 		Steps:    5,
 	}
 	b, err := NewBackend(f.Name(), groupVersion, retryBackoff, nil)
-	require.NoError(t, err, "initializing backend")
+	require.NoErrorf(t, err, "initializing backend")
 
 	return b.(*backend)
 }

--- a/staging/src/k8s.io/client-go/discovery/cached/disk/cached_discovery_test.go
+++ b/staging/src/k8s.io/client-go/discovery/cached/disk/cached_discovery_test.go
@@ -53,38 +53,38 @@ func TestCachedDiscoveryClient_Fresh(t *testing.T) {
 
 	c := fakeDiscoveryClient{}
 	cdc := newCachedDiscoveryClient(&c, d, 60*time.Second)
-	assert.True(cdc.Fresh(), "should be fresh after creation")
+	assert.Truef(cdc.Fresh(), "should be fresh after creation")
 
 	cdc.ServerGroups()
-	assert.True(cdc.Fresh(), "should be fresh after groups call without cache")
+	assert.Truef(cdc.Fresh(), "should be fresh after groups call without cache")
 	assert.Equal(1, c.groupCalls)
 
 	cdc.ServerGroups()
-	assert.True(cdc.Fresh(), "should be fresh after another groups call")
+	assert.Truef(cdc.Fresh(), "should be fresh after another groups call")
 	assert.Equal(1, c.groupCalls)
 
 	cdc.ServerGroupsAndResources()
-	assert.True(cdc.Fresh(), "should be fresh after resources call")
+	assert.Truef(cdc.Fresh(), "should be fresh after resources call")
 	assert.Equal(1, c.resourceCalls)
 
 	cdc.ServerGroupsAndResources()
-	assert.True(cdc.Fresh(), "should be fresh after another resources call")
+	assert.Truef(cdc.Fresh(), "should be fresh after another resources call")
 	assert.Equal(1, c.resourceCalls)
 
 	cdc = newCachedDiscoveryClient(&c, d, 60*time.Second)
 	cdc.ServerGroups()
-	assert.False(cdc.Fresh(), "should NOT be fresh after recreation with existing groups cache")
+	assert.Falsef(cdc.Fresh(), "should NOT be fresh after recreation with existing groups cache")
 	assert.Equal(1, c.groupCalls)
 
 	cdc.ServerGroupsAndResources()
-	assert.False(cdc.Fresh(), "should NOT be fresh after recreation with existing resources cache")
+	assert.Falsef(cdc.Fresh(), "should NOT be fresh after recreation with existing resources cache")
 	assert.Equal(1, c.resourceCalls)
 
 	cdc.Invalidate()
-	assert.True(cdc.Fresh(), "should be fresh after cache invalidation")
+	assert.Truef(cdc.Fresh(), "should be fresh after cache invalidation")
 
 	cdc.ServerGroupsAndResources()
-	assert.True(cdc.Fresh(), "should ignore existing resources cache after invalidation")
+	assert.Truef(cdc.Fresh(), "should ignore existing resources cache after invalidation")
 	assert.Equal(2, c.resourceCalls)
 }
 
@@ -369,17 +369,17 @@ func TestCachedDiscoveryClientUnaggregatedServerGroups(t *testing.T) {
 		// Discovery groups cached in servergroups.json file.
 		numFound, err := numFilesFound(discoCache, "servergroups.json")
 		assert.NoError(t, err)
-		assert.Equal(t, 1, numFound,
+		assert.Equalf(t, 1, numFound,
 			"%s: expected 1 discovery cache file servergroups.json found, got %d", test.name, numFound)
 		// Test expected groups returned by server groups.
 		expectedGroupNames := sets.NewString(test.expectedGroupNames...)
 		actualGroupNames := sets.NewString(groupNamesFromList(apiGroupList)...)
-		assert.True(t, expectedGroupNames.Equal(actualGroupNames),
+		assert.Truef(t, expectedGroupNames.Equal(actualGroupNames),
 			"%s: Expected groups (%s), got (%s)", test.name, expectedGroupNames.List(), actualGroupNames.List())
 		// Test the expected group versions for the aggregated discovery is correct.
 		expectedGroupVersions := sets.NewString(test.expectedGroupVersions...)
 		actualGroupVersions := sets.NewString(groupVersionsFromGroups(apiGroupList)...)
-		assert.True(t, expectedGroupVersions.Equal(actualGroupVersions),
+		assert.Truef(t, expectedGroupVersions.Equal(actualGroupVersions),
 			"%s: Expected group/versions (%s), got (%s)", test.name, expectedGroupVersions.List(), actualGroupVersions.List())
 	}
 }
@@ -660,22 +660,22 @@ func TestCachedDiscoveryClientAggregatedServerGroups(t *testing.T) {
 		// Discovery groups cached in servergroups.json file.
 		numFound, err := numFilesFound(discoCache, "servergroups.json")
 		assert.NoError(t, err)
-		assert.Equal(t, 1, numFound,
+		assert.Equalf(t, 1, numFound,
 			"%s: expected 1 discovery cache file servergroups.json found, got %d", test.name, numFound)
 		// Test expected groups returned by server groups.
 		expectedGroupNames := sets.NewString(test.expectedGroupNames...)
 		actualGroupNames := sets.NewString(groupNamesFromList(apiGroupList)...)
-		assert.True(t, expectedGroupNames.Equal(actualGroupNames),
+		assert.Truef(t, expectedGroupNames.Equal(actualGroupNames),
 			"%s: Expected groups (%s), got (%s)", test.name, expectedGroupNames.List(), actualGroupNames.List())
 		// Test the expected group versions for the aggregated discovery is correct.
 		expectedGroupVersions := sets.NewString(test.expectedGroupVersions...)
 		actualGroupVersions := sets.NewString(groupVersionsFromGroups(apiGroupList)...)
-		assert.True(t, expectedGroupVersions.Equal(actualGroupVersions),
+		assert.Truef(t, expectedGroupVersions.Equal(actualGroupVersions),
 			"%s: Expected group/versions (%s), got (%s)", test.name, expectedGroupVersions.List(), actualGroupVersions.List())
 		// Test the groups preferred version is correct.
 		expectedPreferredVersions := sets.NewString(test.expectedPreferredVersions...)
 		actualPreferredVersions := sets.NewString(preferredVersionsFromList(apiGroupList)...)
-		assert.True(t, expectedPreferredVersions.Equal(actualPreferredVersions),
+		assert.Truef(t, expectedPreferredVersions.Equal(actualPreferredVersions),
 			"%s: Expected preferred group/version (%s), got (%s)", test.name, expectedPreferredVersions.List(), actualPreferredVersions.List())
 	}
 }

--- a/staging/src/k8s.io/client-go/discovery/cached/memory/memcache_test.go
+++ b/staging/src/k8s.io/client-go/discovery/cached/memory/memcache_test.go
@@ -610,12 +610,12 @@ func TestMemCacheGroupsAndMaybeResources(t *testing.T) {
 		// Test the expected groups are returned for the aggregated format.
 		expectedGroupNames := sets.NewString(test.expectedGroupNames...)
 		actualGroupNames := sets.NewString(groupNamesFromList(apiGroupList)...)
-		assert.True(t, expectedGroupNames.Equal(actualGroupNames),
+		assert.Truef(t, expectedGroupNames.Equal(actualGroupNames),
 			"%s: Expected groups (%s), got (%s)", test.name, expectedGroupNames.List(), actualGroupNames.List())
 		// Test the expected group versions for the aggregated discovery is correct.
 		expectedGroupVersions := sets.NewString(test.expectedGroupVersions...)
 		actualGroupVersions := sets.NewString(groupVersionsFromGroups(apiGroupList)...)
-		assert.True(t, expectedGroupVersions.Equal(actualGroupVersions),
+		assert.Truef(t, expectedGroupVersions.Equal(actualGroupVersions),
 			"%s: Expected group/versions (%s), got (%s)", test.name, expectedGroupVersions.List(), actualGroupVersions.List())
 		// Invalidate the cache and retrieve the server groups and resources again.
 		memClient.Invalidate()
@@ -626,7 +626,7 @@ func TestMemCacheGroupsAndMaybeResources(t *testing.T) {
 		assert.False(t, memClient.receivedAggregatedDiscovery)
 		// Test the expected groups are returned for the aggregated format.
 		actualGroupNames = sets.NewString(groupNamesFromList(apiGroupList)...)
-		assert.True(t, expectedGroupNames.Equal(actualGroupNames),
+		assert.Truef(t, expectedGroupNames.Equal(actualGroupNames),
 			"%s: Expected after invalidation groups (%s), got (%s)", test.name, expectedGroupNames.List(), actualGroupNames.List())
 	}
 }
@@ -1136,12 +1136,12 @@ func TestAggregatedMemCacheGroupsAndMaybeResources(t *testing.T) {
 		// Test the expected groups are returned for the aggregated format.
 		expectedGroupNames := sets.NewString(test.expectedGroupNames...)
 		actualGroupNames := sets.NewString(groupNamesFromList(apiGroupList)...)
-		assert.True(t, expectedGroupNames.Equal(actualGroupNames),
+		assert.Truef(t, expectedGroupNames.Equal(actualGroupNames),
 			"%s: Expected groups (%s), got (%s)", test.name, expectedGroupNames.List(), actualGroupNames.List())
 		// Test the expected group versions for the aggregated discovery is correct.
 		expectedGroupVersions := sets.NewString(test.expectedGroupVersions...)
 		actualGroupVersions := sets.NewString(groupVersionsFromGroups(apiGroupList)...)
-		assert.True(t, expectedGroupVersions.Equal(actualGroupVersions),
+		assert.Truef(t, expectedGroupVersions.Equal(actualGroupVersions),
 			"%s: Expected group/versions (%s), got (%s)", test.name, expectedGroupVersions.List(), actualGroupVersions.List())
 		// Test the resources are correct.
 		expectedGVKs := sets.NewString(test.expectedGVKs...)
@@ -1150,12 +1150,12 @@ func TestAggregatedMemCacheGroupsAndMaybeResources(t *testing.T) {
 			resources = append(resources, resourceList)
 		}
 		actualGVKs := sets.NewString(groupVersionKinds(resources)...)
-		assert.True(t, expectedGVKs.Equal(actualGVKs),
+		assert.Truef(t, expectedGVKs.Equal(actualGVKs),
 			"%s: Expected GVKs (%s), got (%s)", test.name, expectedGVKs.List(), actualGVKs.List())
 		// Test the returned failed GroupVersions are correct.
 		expectedFailedGVs := sets.NewString(test.expectedFailedGVs...)
 		actualFailedGVs := sets.NewString(failedGroupVersions(failedGVs)...)
-		assert.True(t, expectedFailedGVs.Equal(actualFailedGVs),
+		assert.Truef(t, expectedFailedGVs.Equal(actualFailedGVs),
 			"%s: Expected Failed GroupVersions (%s), got (%s)", test.name, expectedFailedGVs.List(), actualFailedGVs.List())
 		// Invalidate the cache and retrieve the server groups again.
 		memClient.Invalidate()
@@ -1165,7 +1165,7 @@ func TestAggregatedMemCacheGroupsAndMaybeResources(t *testing.T) {
 		require.NoError(t, err)
 		// Test the expected groups are returned for the aggregated format.
 		actualGroupNames = sets.NewString(groupNamesFromList(apiGroupList)...)
-		assert.True(t, expectedGroupNames.Equal(actualGroupNames),
+		assert.Truef(t, expectedGroupNames.Equal(actualGroupNames),
 			"%s: Expected after invalidation groups (%s), got (%s)", test.name, expectedGroupNames.List(), actualGroupNames.List())
 	}
 }
@@ -1430,17 +1430,17 @@ func TestMemCacheAggregatedServerGroups(t *testing.T) {
 		// Test the expected groups are returned for the aggregated format.
 		expectedGroupNames := sets.NewString(test.expectedGroupNames...)
 		actualGroupNames := sets.NewString(groupNamesFromList(apiGroupList)...)
-		assert.True(t, expectedGroupNames.Equal(actualGroupNames),
+		assert.Truef(t, expectedGroupNames.Equal(actualGroupNames),
 			"%s: Expected groups (%s), got (%s)", test.name, expectedGroupNames.List(), actualGroupNames.List())
 		// Test the expected group versions for the aggregated discovery is correct.
 		expectedGroupVersions := sets.NewString(test.expectedGroupVersions...)
 		actualGroupVersions := sets.NewString(groupVersionsFromGroups(apiGroupList)...)
-		assert.True(t, expectedGroupVersions.Equal(actualGroupVersions),
+		assert.Truef(t, expectedGroupVersions.Equal(actualGroupVersions),
 			"%s: Expected group/versions (%s), got (%s)", test.name, expectedGroupVersions.List(), actualGroupVersions.List())
 		// Test the groups preferred version is correct.
 		expectedPreferredVersions := sets.NewString(test.expectedPreferredVersions...)
 		actualPreferredVersions := sets.NewString(preferredVersionsFromList(apiGroupList)...)
-		assert.True(t, expectedPreferredVersions.Equal(actualPreferredVersions),
+		assert.Truef(t, expectedPreferredVersions.Equal(actualPreferredVersions),
 			"%s: Expected preferred group/version (%s), got (%s)", test.name, expectedPreferredVersions.List(), actualPreferredVersions.List())
 		// Invalidate the cache and retrieve the server groups again.
 		memCacheClient.Invalidate()
@@ -1449,7 +1449,7 @@ func TestMemCacheAggregatedServerGroups(t *testing.T) {
 		require.NoError(t, err)
 		// Test the expected groups are returned for the aggregated format.
 		actualGroupNames = sets.NewString(groupNamesFromList(apiGroupList)...)
-		assert.True(t, expectedGroupNames.Equal(actualGroupNames),
+		assert.Truef(t, expectedGroupNames.Equal(actualGroupNames),
 			"%s: Expected after invalidation groups (%s), got (%s)", test.name, expectedGroupNames.List(), actualGroupNames.List())
 	}
 }

--- a/staging/src/k8s.io/client-go/discovery/discovery_client_test.go
+++ b/staging/src/k8s.io/client-go/discovery/discovery_client_test.go
@@ -1328,17 +1328,17 @@ func TestAggregatedServerGroups(t *testing.T) {
 		// Test the expected groups are returned for the aggregated format.
 		expectedGroupNames := sets.NewString(test.expectedGroupNames...)
 		actualGroupNames := sets.NewString(groupNamesFromList(apiGroupList)...)
-		assert.True(t, expectedGroupNames.Equal(actualGroupNames),
+		assert.Truef(t, expectedGroupNames.Equal(actualGroupNames),
 			"%s: Expected groups (%s), got (%s)", test.name, expectedGroupNames.List(), actualGroupNames.List())
 		// Test the expected group versions for the aggregated discovery is correct.
 		expectedGroupVersions := sets.NewString(test.expectedGroupVersions...)
 		actualGroupVersions := sets.NewString(groupVersionsFromGroups(apiGroupList)...)
-		assert.True(t, expectedGroupVersions.Equal(actualGroupVersions),
+		assert.Truef(t, expectedGroupVersions.Equal(actualGroupVersions),
 			"%s: Expected group/versions (%s), got (%s)", test.name, expectedGroupVersions.List(), actualGroupVersions.List())
 		// Test the groups preferred version is correct.
 		expectedPreferredVersions := sets.NewString(test.expectedPreferredVersions...)
 		actualPreferredVersions := sets.NewString(preferredVersionsFromList(apiGroupList)...)
-		assert.True(t, expectedPreferredVersions.Equal(actualPreferredVersions),
+		assert.Truef(t, expectedPreferredVersions.Equal(actualPreferredVersions),
 			"%s: Expected preferred group/version (%s), got (%s)", test.name, expectedPreferredVersions.List(), actualPreferredVersions.List())
 	}
 }
@@ -2413,7 +2413,7 @@ func TestAggregatedServerGroupsAndResources(t *testing.T) {
 				require.Error(t, err)
 				expectedFailedGVs := sets.NewString(test.expectedFailedGVs...)
 				actualFailedGVs := sets.NewString(failedGroupVersions(err)...)
-				assert.True(t, expectedFailedGVs.Equal(actualFailedGVs),
+				assert.Truef(t, expectedFailedGVs.Equal(actualFailedGVs),
 					"%s: Expected Failed GVs (%s), got (%s)", test.name, expectedFailedGVs, actualFailedGVs)
 			} else {
 				require.NoError(t, err)
@@ -2421,7 +2421,7 @@ func TestAggregatedServerGroupsAndResources(t *testing.T) {
 			// Test the expected groups are returned for the aggregated format.
 			expectedGroupNames := sets.NewString(test.expectedGroupNames...)
 			actualGroupNames := sets.NewString(groupNames(apiGroups)...)
-			assert.True(t, expectedGroupNames.Equal(actualGroupNames),
+			assert.Truef(t, expectedGroupNames.Equal(actualGroupNames),
 				"%s: Expected GVKs (%s), got (%s)", test.name, expectedGroupNames.List(), actualGroupNames.List())
 			// If the core V1 group is returned from /api, it should be the first group.
 			if expectedGroupNames.Has("") {
@@ -2434,12 +2434,12 @@ func TestAggregatedServerGroupsAndResources(t *testing.T) {
 			// Test the expected group/versions are returned from the aggregated discovery.
 			expectedGroupVersions := sets.NewString(test.expectedGroupVersions...)
 			actualGroupVersions := sets.NewString(groupVersions(resources)...)
-			assert.True(t, expectedGroupVersions.Equal(actualGroupVersions),
+			assert.Truef(t, expectedGroupVersions.Equal(actualGroupVersions),
 				"%s: Expected GroupVersions(%s), got (%s)", test.name, expectedGroupVersions.List(), actualGroupVersions.List())
 			// Test the expected GVKs are returned from the aggregated discovery.
 			expectedGVKs := sets.NewString(test.expectedGVKs...)
 			actualGVKs := sets.NewString(groupVersionKinds(resources)...)
-			assert.True(t, expectedGVKs.Equal(actualGVKs),
+			assert.Truef(t, expectedGVKs.Equal(actualGVKs),
 				"%s: Expected GVKs (%s), got (%s)", test.name, expectedGVKs.List(), actualGVKs.List())
 		}
 	}
@@ -2565,12 +2565,12 @@ func TestAggregatedServerGroupsAndResourcesWithErrors(t *testing.T) {
 		// First check the returned groups
 		expectedGroups := sets.NewString(test.expectedGroups...)
 		actualGroups := sets.NewString(groupNames(apiGroups)...)
-		assert.True(t, expectedGroups.Equal(actualGroups),
+		assert.Truef(t, expectedGroups.Equal(actualGroups),
 			"%s: Expected GVKs (%s), got (%s)", test.name, expectedGroups.List(), actualGroups.List())
 		// Next check the returned resources
 		expectedGVKs := sets.NewString(test.expectedResources...)
 		actualGVKs := sets.NewString(groupVersionKinds(resources)...)
-		assert.True(t, expectedGVKs.Equal(actualGVKs),
+		assert.Truef(t, expectedGVKs.Equal(actualGVKs),
 			"%s: Expected GVKs (%s), got (%s)", test.name, expectedGVKs.List(), actualGVKs.List())
 	}
 }
@@ -3171,7 +3171,7 @@ func TestAggregatedServerPreferredResources(t *testing.T) {
 			require.Error(t, err)
 			expectedFailedGVs := sets.NewString(test.expectedFailedGVs...)
 			actualFailedGVs := sets.NewString(failedGroupVersions(err)...)
-			assert.True(t, expectedFailedGVs.Equal(actualFailedGVs),
+			assert.Truef(t, expectedFailedGVs.Equal(actualFailedGVs),
 				"%s: Expected Failed GVs (%s), got (%s)", test.name, expectedFailedGVs, actualFailedGVs)
 		} else {
 			require.NoError(t, err)
@@ -3179,7 +3179,7 @@ func TestAggregatedServerPreferredResources(t *testing.T) {
 		// Test the expected preferred GVKs are returned from the aggregated discovery.
 		expectedGVKs := sets.NewString(test.expectedGVKs...)
 		actualGVKs := sets.NewString(groupVersionKinds(resources)...)
-		assert.True(t, expectedGVKs.Equal(actualGVKs),
+		assert.Truef(t, expectedGVKs.Equal(actualGVKs),
 			"%s: Expected GVKs (%s), got (%s)", test.name, expectedGVKs.List(), actualGVKs.List())
 	}
 }

--- a/staging/src/k8s.io/client-go/openapi3/root_test.go
+++ b/staging/src/k8s.io/client-go/openapi3/root_test.go
@@ -160,7 +160,7 @@ func TestOpenAPIV3Root_GVSpec(t *testing.T) {
 			require.NoError(t, err)
 			for _, path := range test.expectedPaths {
 				if _, found := gvSpec.Paths.Paths[path]; !found {
-					assert.True(t, found, "expected path not found (%s)\n", path)
+					assert.Truef(t, found, "expected path not found (%s)\n", path)
 				}
 			}
 		})
@@ -219,7 +219,7 @@ func TestOpenAPIV3Root_GVSpecAsMap(t *testing.T) {
 			for _, path := range test.expectedPaths {
 				pathsMap := gvSpecAsMap["paths"]
 				if _, found := pathsMap.(map[string]interface{})[path]; !found {
-					assert.True(t, found, "expected path not found (%s)\n", path)
+					assert.Truef(t, found, "expected path not found (%s)\n", path)
 				}
 			}
 		})
@@ -260,7 +260,7 @@ func TestOpenAPIV3Root_GroupVersionToPath(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			actualPath := gvToAPIPath(test.groupVersion)
-			assert.Equal(t, test.expectedPath, actualPath, "expected API path (%s), got (%s)",
+			assert.Equalf(t, test.expectedPath, actualPath, "expected API path (%s), got (%s)",
 				test.expectedPath, actualPath)
 		})
 	}
@@ -307,10 +307,10 @@ func TestOpenAPIV3Root_PathToGroupVersion(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			actualGV, err := pathToGroupVersion(test.path)
 			if test.expectedErr {
-				require.Error(t, err, "should have received error for path: %s", test.path)
+				require.Errorf(t, err, "should have received error for path: %s", test.path)
 			} else {
-				require.NoError(t, err, "expected no error, got (%v)", err)
-				assert.Equal(t, test.expectedGV, actualGV, "expected GroupVersion (%s), got (%s)",
+				require.NoErrorf(t, err, "expected no error, got (%v)", err)
+				assert.Equalf(t, test.expectedGV, actualGV, "expected GroupVersion (%s), got (%s)",
 					test.expectedGV, actualGV)
 			}
 		})

--- a/staging/src/k8s.io/client-go/rest/request_test.go
+++ b/staging/src/k8s.io/client-go/rest/request_test.go
@@ -4105,7 +4105,7 @@ func TestRequestLogging(t *testing.T) {
 			klog.LogToStderr(false)
 			var fs flag.FlagSet
 			klog.InitFlags(&fs)
-			require.NoError(t, fs.Set("v", fmt.Sprintf("%d", tc.v)), "set verbosity")
+			require.NoErrorf(t, fs.Set("v", fmt.Sprintf("%d", tc.v)), "set verbosity")
 
 			client := clientForFunc(func(req *http.Request) (*http.Response, error) {
 				return &http.Response{
@@ -4123,7 +4123,7 @@ func TestRequestLogging(t *testing.T) {
 
 			_, file, line, _ := goruntime.Caller(0)
 			result := req.Do(ctx)
-			require.NoError(t, result.Error(), "request.Do")
+			require.NoErrorf(t, result.Error(), "request.Do")
 
 			// Compare log output:
 			// - strip date/time/pid from each line (fixed length header)

--- a/staging/src/k8s.io/client-go/restmapper/discovery_test.go
+++ b/staging/src/k8s.io/client-go/restmapper/discovery_test.go
@@ -247,8 +247,8 @@ func TestDeferredDiscoveryRESTMapper_CacheMiss(t *testing.T) {
 
 	cdc := fakeCachedDiscoveryInterface{fresh: false}
 	m := NewDeferredDiscoveryRESTMapper(&cdc)
-	assert.False(cdc.fresh, "should NOT be fresh after instantiation")
-	assert.Zero(cdc.invalidateCalls, "should not have called Invalidate()")
+	assert.Falsef(cdc.fresh, "should NOT be fresh after instantiation")
+	assert.Zerof(cdc.invalidateCalls, "should not have called Invalidate()")
 
 	gvk, err := m.KindFor(schema.GroupVersionResource{
 		Group:    "a",
@@ -256,8 +256,8 @@ func TestDeferredDiscoveryRESTMapper_CacheMiss(t *testing.T) {
 		Resource: "foo",
 	})
 	assert.NoError(err)
-	assert.True(cdc.fresh, "should be fresh after a cache-miss")
-	assert.Equal(1, cdc.invalidateCalls, "should have called Invalidate() once")
+	assert.Truef(cdc.fresh, "should be fresh after a cache-miss")
+	assert.Equalf(1, cdc.invalidateCalls, "should have called Invalidate() once")
 	assert.Equal("Foo", gvk.Kind)
 
 	gvk, err = m.KindFor(schema.GroupVersionResource{
@@ -266,7 +266,7 @@ func TestDeferredDiscoveryRESTMapper_CacheMiss(t *testing.T) {
 		Resource: "foo",
 	})
 	assert.NoError(err)
-	assert.Equal(1, cdc.invalidateCalls, "should NOT have called Invalidate() again")
+	assert.Equalf(1, cdc.invalidateCalls, "should NOT have called Invalidate() again")
 
 	gvk, err = m.KindFor(schema.GroupVersionResource{
 		Group:    "a",
@@ -274,7 +274,7 @@ func TestDeferredDiscoveryRESTMapper_CacheMiss(t *testing.T) {
 		Resource: "bar",
 	})
 	assert.Error(err)
-	assert.Equal(1, cdc.invalidateCalls, "should NOT have called Invalidate() again after another cache-miss, but with fresh==true")
+	assert.Equalf(1, cdc.invalidateCalls, "should NOT have called Invalidate() again after another cache-miss, but with fresh==true")
 
 	cdc.fresh = false
 	gvk, err = m.KindFor(schema.GroupVersionResource{
@@ -283,7 +283,7 @@ func TestDeferredDiscoveryRESTMapper_CacheMiss(t *testing.T) {
 		Resource: "bar",
 	})
 	assert.Error(err)
-	assert.Equal(2, cdc.invalidateCalls, "should HAVE called Invalidate() again after another cache-miss, but with fresh==false")
+	assert.Equalf(2, cdc.invalidateCalls, "should HAVE called Invalidate() again after another cache-miss, but with fresh==false")
 }
 
 func TestGetAPIGroupResources(t *testing.T) {

--- a/staging/src/k8s.io/client-go/scale/client_test.go
+++ b/staging/src/k8s.io/client-go/scale/client_test.go
@@ -274,12 +274,12 @@ func TestGetScale(t *testing.T) {
 
 	for _, groupResource := range groupResources {
 		scale, err := scaleClient.Scales("default").Get(context.TODO(), groupResource, "foo", metav1.GetOptions{})
-		if !assert.NoError(t, err, "should have been able to fetch a scale for %s", groupResource.String()) {
+		if !assert.NoErrorf(t, err, "should have been able to fetch a scale for %s", groupResource.String()) {
 			continue
 		}
-		assert.NotNil(t, scale, "should have returned a non-nil scale for %s", groupResource.String())
+		assert.NotNilf(t, scale, "should have returned a non-nil scale for %s", groupResource.String())
 
-		assert.Equal(t, expectedScale, scale, "should have returned the expected scale for %s", groupResource.String())
+		assert.Equalf(t, expectedScale, scale, "should have returned the expected scale for %s", groupResource.String())
 	}
 }
 
@@ -302,12 +302,12 @@ func TestUpdateScale(t *testing.T) {
 
 	for _, groupResource := range groupResources {
 		scale, err := scaleClient.Scales("default").Update(context.TODO(), groupResource, expectedScale, metav1.UpdateOptions{})
-		if !assert.NoError(t, err, "should have been able to fetch a scale for %s", groupResource.String()) {
+		if !assert.NoErrorf(t, err, "should have been able to fetch a scale for %s", groupResource.String()) {
 			continue
 		}
-		assert.NotNil(t, scale, "should have returned a non-nil scale for %s", groupResource.String())
+		assert.NotNilf(t, scale, "should have returned a non-nil scale for %s", groupResource.String())
 
-		assert.Equal(t, expectedScale, scale, "should have returned the expected scale for %s", groupResource.String())
+		assert.Equalf(t, expectedScale, scale, "should have returned the expected scale for %s", groupResource.String())
 	}
 }
 
@@ -345,20 +345,20 @@ func TestPatchScale(t *testing.T) {
 	patch := []byte(`{"spec":{"replicas":5}}`)
 	for _, gvr := range gvrs {
 		scale, err := scaleClient.Scales("default").Patch(context.TODO(), gvr, "foo", types.MergePatchType, patch, metav1.PatchOptions{})
-		if !assert.NoError(t, err, "should have been able to fetch a scale for %s", gvr.String()) {
+		if !assert.NoErrorf(t, err, "should have been able to fetch a scale for %s", gvr.String()) {
 			continue
 		}
-		assert.NotNil(t, scale, "should have returned a non-nil scale for %s", gvr.String())
-		assert.Equal(t, expectedScale, scale, "should have returned the expected scale for %s", gvr.String())
+		assert.NotNilf(t, scale, "should have returned a non-nil scale for %s", gvr.String())
+		assert.Equalf(t, expectedScale, scale, "should have returned the expected scale for %s", gvr.String())
 	}
 
 	patch = []byte(`[{"op":"replace","path":"/spec/replicas","value":5}]`)
 	for _, gvr := range gvrs {
 		scale, err := scaleClient.Scales("default").Patch(context.TODO(), gvr, "foo", types.JSONPatchType, patch, metav1.PatchOptions{})
-		if !assert.NoError(t, err, "should have been able to fetch a scale for %s", gvr.String()) {
+		if !assert.NoErrorf(t, err, "should have been able to fetch a scale for %s", gvr.String()) {
 			continue
 		}
-		assert.NotNil(t, scale, "should have returned a non-nil scale for %s", gvr.String())
-		assert.Equal(t, expectedScale, scale, "should have returned the expected scale for %s", gvr.String())
+		assert.NotNilf(t, scale, "should have returned a non-nil scale for %s", gvr.String())
+		assert.Equalf(t, expectedScale, scale, "should have returned the expected scale for %s", gvr.String())
 	}
 }

--- a/staging/src/k8s.io/client-go/testing/fake_test.go
+++ b/staging/src/k8s.io/client-go/testing/fake_test.go
@@ -60,7 +60,7 @@ func TestOriginalObjectCaptured(t *testing.T) {
 
 	// execute the reaction chain
 	ret, err := f.Invokes(action, nil)
-	assert.NoError(t, err, "running Invokes failed")
+	assert.NoErrorf(t, err, "running Invokes failed")
 
 	// obtain a metadata accessor for the returned resource
 	accessor, err := meta.Accessor(ret)
@@ -137,7 +137,7 @@ func TestReactorChangesPersisted(t *testing.T) {
 
 	// execute the reaction chain
 	ret, err := f.Invokes(action, nil)
-	assert.NoError(t, err, "running Invokes failed")
+	assert.NoErrorf(t, err, "running Invokes failed")
 
 	// obtain a metadata accessor for the returned resource
 	accessor, err := meta.Accessor(ret)

--- a/staging/src/k8s.io/client-go/testing/fixture_test.go
+++ b/staging/src/k8s.io/client-go/testing/fixture_test.go
@@ -79,7 +79,7 @@ func TestWatchCallNonNamespace(t *testing.T) {
 		}
 	}()
 	out := <-watch.ResultChan()
-	assert.Equal(t, testObj, out.Object, "watched object mismatch")
+	assert.Equalf(t, testObj, out.Object, "watched object mismatch")
 }
 
 func TestWatchCallAllNamespace(t *testing.T) {
@@ -103,34 +103,34 @@ func TestWatchCallAllNamespace(t *testing.T) {
 	}
 	go func() {
 		err := o.Create(testResource, testObj, ns)
-		assert.NoError(t, err, "test resource creation failed")
+		assert.NoErrorf(t, err, "test resource creation failed")
 	}()
 	out := <-w.ResultChan()
 	outAll := <-wAll.ResultChan()
-	assert.Equal(t, watch.Added, out.Type, "watch event mismatch")
-	assert.Equal(t, watch.Added, outAll.Type, "watch event mismatch")
-	assert.Equal(t, testObj, out.Object, "watched created object mismatch")
-	assert.Equal(t, testObj, outAll.Object, "watched created object mismatch")
+	assert.Equalf(t, watch.Added, out.Type, "watch event mismatch")
+	assert.Equalf(t, watch.Added, outAll.Type, "watch event mismatch")
+	assert.Equalf(t, testObj, out.Object, "watched created object mismatch")
+	assert.Equalf(t, testObj, outAll.Object, "watched created object mismatch")
 	go func() {
 		err := o.Update(testResource, testObj, ns)
-		assert.NoError(t, err, "test resource updating failed")
+		assert.NoErrorf(t, err, "test resource updating failed")
 	}()
 	out = <-w.ResultChan()
 	outAll = <-wAll.ResultChan()
-	assert.Equal(t, watch.Modified, out.Type, "watch event mismatch")
-	assert.Equal(t, watch.Modified, outAll.Type, "watch event mismatch")
-	assert.Equal(t, testObj, out.Object, "watched updated object mismatch")
-	assert.Equal(t, testObj, outAll.Object, "watched updated object mismatch")
+	assert.Equalf(t, watch.Modified, out.Type, "watch event mismatch")
+	assert.Equalf(t, watch.Modified, outAll.Type, "watch event mismatch")
+	assert.Equalf(t, testObj, out.Object, "watched updated object mismatch")
+	assert.Equalf(t, testObj, outAll.Object, "watched updated object mismatch")
 	go func() {
 		err := o.Delete(testResource, "test_namespace", "test_name")
-		assert.NoError(t, err, "test resource deletion failed")
+		assert.NoErrorf(t, err, "test resource deletion failed")
 	}()
 	out = <-w.ResultChan()
 	outAll = <-wAll.ResultChan()
-	assert.Equal(t, watch.Deleted, out.Type, "watch event mismatch")
-	assert.Equal(t, watch.Deleted, outAll.Type, "watch event mismatch")
-	assert.Equal(t, testObj, out.Object, "watched deleted object mismatch")
-	assert.Equal(t, testObj, outAll.Object, "watched deleted object mismatch")
+	assert.Equalf(t, watch.Deleted, out.Type, "watch event mismatch")
+	assert.Equalf(t, watch.Deleted, outAll.Type, "watch event mismatch")
+	assert.Equalf(t, testObj, out.Object, "watched deleted object mismatch")
+	assert.Equalf(t, testObj, outAll.Object, "watched deleted object mismatch")
 }
 
 func TestWatchCallMultipleInvocation(t *testing.T) {
@@ -202,7 +202,7 @@ func TestWatchCallMultipleInvocation(t *testing.T) {
 			t.Fatalf("test resource watch failed in %s: %v", watchNamespace, err)
 		}
 		go func() {
-			assert.NoError(t, err, "watch invocation failed")
+			assert.NoErrorf(t, err, "watch invocation failed")
 			for _, c := range cases {
 				if watchNamespace == "" || c.ns == watchNamespace {
 					fmt.Printf("%#v %#v\n", c, i)
@@ -212,9 +212,9 @@ func TestWatchCallMultipleInvocation(t *testing.T) {
 						t.Errorf("unexpected error: %v", err)
 						break
 					}
-					assert.Equal(t, c.op, event.Type, "watch event mismatched")
-					assert.Equal(t, c.name, accessor.GetName(), "watched object mismatch")
-					assert.Equal(t, c.ns, accessor.GetNamespace(), "watched object mismatch")
+					assert.Equalf(t, c.op, event.Type, "watch event mismatched")
+					assert.Equalf(t, c.name, accessor.GetName(), "watched object mismatch")
+					assert.Equalf(t, c.ns, accessor.GetNamespace(), "watched object mismatch")
 				}
 			}
 			wg.Done()

--- a/staging/src/k8s.io/client-go/tools/cache/reflector_watchlist_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector_watchlist_test.go
@@ -58,7 +58,7 @@ func TestInitialEventsEndBookmarkTicker(t *testing.T) {
 		assertNoEvents(t, target.C())
 		actualWarning := target.produceWarningIfExpired()
 
-		require.Empty(t, actualWarning, "didn't expect any warning")
+		require.Emptyf(t, actualWarning, "didn't expect any warning")
 		// validate if the other methods don't produce panic
 		target.warnIfExpired()
 		target.observeLastEventTimeStamp(clock.Now())
@@ -66,7 +66,7 @@ func TestInitialEventsEndBookmarkTicker(t *testing.T) {
 		// make sure that after calling the other methods
 		// nothing hasn't changed
 		actualWarning = target.produceWarningIfExpired()
-		require.Empty(t, actualWarning, "didn't expect any warning")
+		require.Emptyf(t, actualWarning, "didn't expect any warning")
 		assertNoEvents(t, target.C())
 
 		target.Stop()

--- a/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection_test.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection_test.go
@@ -1112,7 +1112,7 @@ func TestFastPathLeaderElection(t *testing.T) {
 			cancelFunc = cancel
 
 			elector.Run(ctx)
-			assert.Equal(t, test.expectedLockOps, lockOps, "Expected lock ops %q, got %q", test.expectedLockOps, lockOps)
+			assert.Equalf(t, test.expectedLockOps, lockOps, "Expected lock ops %q, got %q", test.expectedLockOps, lockOps)
 		})
 	}
 }

--- a/staging/src/k8s.io/client-go/tools/portforward/fallback_dialer_test.go
+++ b/staging/src/k8s.io/client-go/tools/portforward/fallback_dialer_test.go
@@ -35,19 +35,19 @@ func TestFallbackDialer(t *testing.T) {
 	secondary := &fakeDialer{dialed: false, negotiatedProtocol: secondaryProtocol}
 	fallbackDialer := NewFallbackDialer(primary, secondary, notCalled)
 	_, negotiated, err := fallbackDialer.Dial(protocols...)
-	assert.True(t, primary.dialed, "no fallback; primary should have dialed")
-	assert.False(t, secondary.dialed, "no fallback; secondary should *not* have dialed")
-	assert.Equal(t, primaryProtocol, negotiated, "primary negotiated protocol returned")
-	require.NoError(t, err, "error from primary dialer should be nil")
+	assert.Truef(t, primary.dialed, "no fallback; primary should have dialed")
+	assert.Falsef(t, secondary.dialed, "no fallback; secondary should *not* have dialed")
+	assert.Equalf(t, primaryProtocol, negotiated, "primary negotiated protocol returned")
+	require.NoErrorf(t, err, "error from primary dialer should be nil")
 	// If primary dialer error is upgrade error, then fallback returning secondary dial response.
 	primary = &fakeDialer{dialed: false, negotiatedProtocol: primaryProtocol, err: &httpstream.UpgradeFailureError{}}
 	secondary = &fakeDialer{dialed: false, negotiatedProtocol: secondaryProtocol}
 	fallbackDialer = NewFallbackDialer(primary, secondary, httpstream.IsUpgradeFailure)
 	_, negotiated, err = fallbackDialer.Dial(protocols...)
-	assert.True(t, primary.dialed, "fallback; primary should have dialed")
-	assert.True(t, secondary.dialed, "fallback; secondary should have dialed")
-	assert.Equal(t, secondaryProtocol, negotiated, "negotiated protocol is from secondary dialer")
-	require.NoError(t, err, "error from secondary dialer should be nil")
+	assert.Truef(t, primary.dialed, "fallback; primary should have dialed")
+	assert.Truef(t, secondary.dialed, "fallback; secondary should have dialed")
+	assert.Equalf(t, secondaryProtocol, negotiated, "negotiated protocol is from secondary dialer")
+	require.NoErrorf(t, err, "error from secondary dialer should be nil")
 	// If primary dialer error is https proxy dialing error, then fallback returning secondary dial response.
 	primary = &fakeDialer{negotiatedProtocol: primaryProtocol, err: errors.New("proxy: unknown scheme: https")}
 	secondary = &fakeDialer{negotiatedProtocol: secondaryProtocol}
@@ -55,19 +55,19 @@ func TestFallbackDialer(t *testing.T) {
 		return httpstream.IsUpgradeFailure(err) || httpstream.IsHTTPSProxyError(err)
 	})
 	_, negotiated, err = fallbackDialer.Dial(protocols...)
-	assert.True(t, primary.dialed, "fallback; primary should have dialed")
-	assert.True(t, secondary.dialed, "fallback; secondary should have dialed")
-	assert.Equal(t, secondaryProtocol, negotiated, "negotiated protocol is from secondary dialer")
-	require.NoError(t, err, "error from secondary dialer should be nil")
+	assert.Truef(t, primary.dialed, "fallback; primary should have dialed")
+	assert.Truef(t, secondary.dialed, "fallback; secondary should have dialed")
+	assert.Equalf(t, secondaryProtocol, negotiated, "negotiated protocol is from secondary dialer")
+	require.NoErrorf(t, err, "error from secondary dialer should be nil")
 	// If primary dialer returns non-upgrade error, then primary error is returned.
 	nonUpgradeErr := fmt.Errorf("This is a non-upgrade error")
 	primary = &fakeDialer{dialed: false, err: nonUpgradeErr}
 	secondary = &fakeDialer{dialed: false}
 	fallbackDialer = NewFallbackDialer(primary, secondary, httpstream.IsUpgradeFailure)
 	_, _, err = fallbackDialer.Dial(protocols...)
-	assert.True(t, primary.dialed, "no fallback; primary should have dialed")
-	assert.False(t, secondary.dialed, "no fallback; secondary should *not* have dialed")
-	assert.Equal(t, nonUpgradeErr, err, "error is from primary dialer")
+	assert.Truef(t, primary.dialed, "no fallback; primary should have dialed")
+	assert.Falsef(t, secondary.dialed, "no fallback; secondary should *not* have dialed")
+	assert.Equalf(t, nonUpgradeErr, err, "error is from primary dialer")
 }
 
 func notCalled(err error) bool { return false }

--- a/staging/src/k8s.io/client-go/tools/portforward/portforward_test.go
+++ b/staging/src/k8s.io/client-go/tools/portforward/portforward_test.go
@@ -511,7 +511,7 @@ func TestHandleConnection(t *testing.T) {
 
 	// Test handleConnection
 	pf.handleConnection(localConnection, ForwardedPort{Local: 1111, Remote: 2222})
-	assert.Equal(t, 0, remoteConnection.streamCount, "stream count should be zero")
+	assert.Equalf(t, 0, remoteConnection.streamCount, "stream count should be zero")
 	assert.Equal(t, "test data from local", remoteDataReceived.String())
 	assert.Equal(t, "test data from remote", localConnection.receiveBuffer.String())
 	assert.Equal(t, "Handling connection for 1111\n", out.String())
@@ -545,7 +545,7 @@ func TestHandleConnectionSendsRemoteError(t *testing.T) {
 	// Test handleConnection, using go-routine because it needs to be able to write to unbuffered pf.errorChan
 	pf.handleConnection(localConnection, ForwardedPort{Local: 1111, Remote: 2222})
 
-	assert.Equal(t, 0, remoteConnection.streamCount, "stream count should be zero")
+	assert.Equalf(t, 0, remoteConnection.streamCount, "stream count should be zero")
 	assert.Equal(t, "", remoteDataReceived.String())
 	assert.Equal(t, "", localConnection.receiveBuffer.String())
 	assert.Equal(t, "Handling connection for 1111\n", out.String())

--- a/staging/src/k8s.io/client-go/tools/portforward/tunneling_connection_test.go
+++ b/staging/src/k8s.io/client-go/tools/portforward/tunneling_connection_test.go
@@ -90,7 +90,7 @@ func TestTunnelingConnection_ReadWriteClose(t *testing.T) {
 	case <-time.After(wait.ForeverTestTimeout):
 		t.Fatalf("timeout waiting for spdy stream to arrive on channel.")
 	}
-	assert.Equal(t, expected, string(actual), "error validating tunneled string")
+	assert.Equalf(t, expected, string(actual), "error validating tunneled string")
 }
 
 func TestTunnelingConnection_LocalRemoteAddress(t *testing.T) {
@@ -112,17 +112,17 @@ func TestTunnelingConnection_LocalRemoteAddress(t *testing.T) {
 	url, err := url.Parse(tunnelingServer.URL)
 	require.NoError(t, err)
 	tConn, err := dialForTunnelingConnection(url)
-	require.NoError(t, err, "error creating client tunneling connection")
+	require.NoErrorf(t, err, "error creating client tunneling connection")
 	defer tConn.Close() //nolint:errcheck
 	// Validate "LocalAddr()" and "RemoteAddr()"
 	localAddr := tConn.LocalAddr()
 	remoteAddr := tConn.RemoteAddr()
-	assert.Equal(t, "tcp", localAddr.Network(), "tunneling connection must be TCP")
-	assert.Equal(t, "tcp", remoteAddr.Network(), "tunneling connection must be TCP")
+	assert.Equalf(t, "tcp", localAddr.Network(), "tunneling connection must be TCP")
+	assert.Equalf(t, "tcp", remoteAddr.Network(), "tunneling connection must be TCP")
 	_, err = net.ResolveTCPAddr("tcp", localAddr.String())
-	assert.NoError(t, err, "tunneling connection local addr should parse")
+	assert.NoErrorf(t, err, "tunneling connection local addr should parse")
 	_, err = net.ResolveTCPAddr("tcp", remoteAddr.String())
-	assert.NoError(t, err, "tunneling connection remote addr should parse")
+	assert.NoErrorf(t, err, "tunneling connection remote addr should parse")
 }
 
 func TestTunnelingConnection_ReadWriteDeadlines(t *testing.T) {
@@ -144,21 +144,21 @@ func TestTunnelingConnection_ReadWriteDeadlines(t *testing.T) {
 	url, err := url.Parse(tunnelingServer.URL)
 	require.NoError(t, err)
 	tConn, err := dialForTunnelingConnection(url)
-	require.NoError(t, err, "error creating client tunneling connection")
+	require.NoErrorf(t, err, "error creating client tunneling connection")
 	defer tConn.Close() //nolint:errcheck
 	// Validate the read and write deadlines.
 	err = tConn.SetReadDeadline(time.Time{})
-	assert.NoError(t, err, "setting zero deadline should always succeed; turns off deadline")
+	assert.NoErrorf(t, err, "setting zero deadline should always succeed; turns off deadline")
 	err = tConn.SetWriteDeadline(time.Time{})
-	assert.NoError(t, err, "setting zero deadline should always succeed; turns off deadline")
+	assert.NoErrorf(t, err, "setting zero deadline should always succeed; turns off deadline")
 	err = tConn.SetDeadline(time.Time{})
-	assert.NoError(t, err, "setting zero deadline should always succeed; turns off deadline")
+	assert.NoErrorf(t, err, "setting zero deadline should always succeed; turns off deadline")
 	err = tConn.SetReadDeadline(time.Now().AddDate(10, 0, 0))
-	assert.NoError(t, err, "setting deadline 10 year from now succeeds")
+	assert.NoErrorf(t, err, "setting deadline 10 year from now succeeds")
 	err = tConn.SetWriteDeadline(time.Now().AddDate(10, 0, 0))
-	assert.NoError(t, err, "setting deadline 10 year from now succeeds")
+	assert.NoErrorf(t, err, "setting deadline 10 year from now succeeds")
 	err = tConn.SetDeadline(time.Now().AddDate(10, 0, 0))
-	assert.NoError(t, err, "setting deadline 10 year from now succeeds")
+	assert.NoErrorf(t, err, "setting deadline 10 year from now succeeds")
 }
 
 // dialForTunnelingConnection upgrades a request at the passed "url", creating

--- a/staging/src/k8s.io/client-go/tools/record/event_test.go
+++ b/staging/src/k8s.io/client-go/tools/record/event_test.go
@@ -450,7 +450,7 @@ func TestEventf(t *testing.T) {
 		// We don't get notified by the structured test logger directly.
 		// Instead, we periodically check what new output it has produced.
 		assert.EventuallyWithT(t, func(t *assert.CollectT) {
-			assert.Equal(t, item.expectStructuredLog, logSink.GetBuffer().String()[oldEnd:], "new structured log output")
+			assert.Equalf(t, item.expectStructuredLog, logSink.GetBuffer().String()[oldEnd:], "new structured log output")
 		}, time.Minute, time.Millisecond)
 
 		// validate event

--- a/staging/src/k8s.io/client-go/tools/remotecommand/fallback_test.go
+++ b/staging/src/k8s.io/client-go/tools/remotecommand/fallback_test.go
@@ -198,9 +198,9 @@ func TestFallbackClient_PrimaryAndSecondaryFail(t *testing.T) {
 	require.NoError(t, err)
 	// Update the websocket executor to request remote command v4, which is unsupported.
 	fallbackExec, ok := exec.(*FallbackExecutor)
-	assert.True(t, ok, "error casting executor as FallbackExecutor")
+	assert.Truef(t, ok, "error casting executor as FallbackExecutor")
 	websocketExec, ok := fallbackExec.primary.(*wsStreamExecutor)
-	assert.True(t, ok, "error casting executor as websocket executor")
+	assert.Truef(t, ok, "error casting executor as websocket executor")
 	// Set the attempted subprotocol version to V4; websocket server only accepts V5.
 	websocketExec.protocols = []string{remotecommand.StreamProtocolV4Name}
 

--- a/staging/src/k8s.io/cloud-provider/controllers/node/node_controller_test.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/node/node_controller_test.go
@@ -2114,7 +2114,7 @@ func TestNodeAddressesChangeDetected(t *testing.T) {
 		},
 	}
 
-	assert.False(t, nodeAddressesChangeDetected(addressSet1, addressSet2),
+	assert.Falsef(t, nodeAddressesChangeDetected(addressSet1, addressSet2),
 		"Node address changes are not detected correctly")
 
 	addressSet1 = []v1.NodeAddress{
@@ -2138,7 +2138,7 @@ func TestNodeAddressesChangeDetected(t *testing.T) {
 		},
 	}
 
-	assert.True(t, nodeAddressesChangeDetected(addressSet1, addressSet2),
+	assert.Truef(t, nodeAddressesChangeDetected(addressSet1, addressSet2),
 		"Node address changes are not detected correctly")
 
 	addressSet1 = []v1.NodeAddress{
@@ -2166,7 +2166,7 @@ func TestNodeAddressesChangeDetected(t *testing.T) {
 		},
 	}
 
-	assert.True(t, nodeAddressesChangeDetected(addressSet1, addressSet2),
+	assert.Truef(t, nodeAddressesChangeDetected(addressSet1, addressSet2),
 		"Node address changes are not detected correctly")
 
 	addressSet1 = []v1.NodeAddress{
@@ -2194,7 +2194,7 @@ func TestNodeAddressesChangeDetected(t *testing.T) {
 		},
 	}
 
-	assert.True(t, nodeAddressesChangeDetected(addressSet1, addressSet2),
+	assert.Truef(t, nodeAddressesChangeDetected(addressSet1, addressSet2),
 		"Node address changes are not detected correctly")
 
 	addressSet1 = []v1.NodeAddress{
@@ -2218,7 +2218,7 @@ func TestNodeAddressesChangeDetected(t *testing.T) {
 		},
 	}
 
-	assert.True(t, nodeAddressesChangeDetected(addressSet1, addressSet2),
+	assert.Truef(t, nodeAddressesChangeDetected(addressSet1, addressSet2),
 		"Node address changes are not detected correctly")
 }
 

--- a/staging/src/k8s.io/cloud-provider/controllers/route/route_controller_test.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/route/route_controller_test.go
@@ -428,7 +428,7 @@ func TestReconcile(t *testing.T) {
 				cloud.RouteMap[route.Name] = fakeRoute
 			}
 			routes, ok := cloud.Routes()
-			assert.True(t, ok, "fakecloud failed to run Routes()")
+			assert.Truef(t, ok, "fakecloud failed to run Routes()")
 			cidrs := make([]*net.IPNet, 0)
 			_, cidr, _ := netutils.ParseCIDRSloppy("10.120.0.0/16")
 			cidrs = append(cidrs, cidr)
@@ -440,12 +440,12 @@ func TestReconcile(t *testing.T) {
 			informerFactory := informers.NewSharedInformerFactory(testCase.clientset, 0)
 			rc := New(routes, testCase.clientset, informerFactory.Core().V1().Nodes(), cluster, cidrs)
 			rc.nodeListerSynced = alwaysReady
-			require.NoError(t, rc.reconcile(ctx, testCase.nodes, testCase.initialRoutes), "failed to reconcile")
+			require.NoErrorf(t, rc.reconcile(ctx, testCase.nodes, testCase.initialRoutes), "failed to reconcile")
 			for _, action := range testCase.clientset.Actions() {
 				if action.GetVerb() == "update" && action.GetResource().Resource == "nodes" {
 					node := action.(core.UpdateAction).GetObject().(*v1.Node)
 					_, condition := nodeutil.GetNodeCondition(&node.Status, v1.NodeNetworkUnavailable)
-					assert.NotEmpty(t, condition, "Missing NodeNetworkUnavailable condition for Node %q", node.Name)
+					assert.NotEmptyf(t, condition, "Missing NodeNetworkUnavailable condition for Node %q", node.Name)
 					check := func(index int) bool {
 						return (condition.Status == v1.ConditionFalse) == testCase.expectedNetworkUnavailable[index]
 					}
@@ -459,7 +459,7 @@ func TestReconcile(t *testing.T) {
 						// Something's wrong
 						continue
 					}
-					assert.True(t, check(index), "Invalid NodeNetworkUnavailable condition for Node %q, expected %v, got %v",
+					assert.Truef(t, check(index), "Invalid NodeNetworkUnavailable condition for Node %q, expected %v, got %v",
 						node.Name, testCase.expectedNetworkUnavailable[index], (condition.Status == v1.ConditionFalse))
 				}
 			}

--- a/staging/src/k8s.io/cloud-provider/options/options_test.go
+++ b/staging/src/k8s.io/cloud-provider/options/options_test.go
@@ -371,14 +371,14 @@ func TestCreateConfig(t *testing.T) {
 		"--webhook-secure-port=10300",
 	}
 	err = fs.Parse(args)
-	require.NoError(t, err, "unexpected error: %s", err)
+	require.NoErrorf(t, err, "unexpected error: %s", err)
 
 	fs.VisitAll(func(f *pflag.Flag) {
 		fmt.Printf("%s: %s\n", f.Name, f.Value)
 	})
 
 	c, err := s.Config([]string{"foo", "bar"}, []string{}, nil, []string{"foo", "bar", "baz"}, []string{})
-	require.NoError(t, err, "unexpected error: %s", err)
+	require.NoErrorf(t, err, "unexpected error: %s", err)
 
 	expected := &appconfig.Config{
 		ComponentConfig: cpconfig.CloudControllerManagerConfiguration{
@@ -437,7 +437,7 @@ func TestCreateConfig(t *testing.T) {
 
 	// Don't check
 	c.SecureServing = nil
-	assert.NotNil(t, c.WebhookSecureServing, "webhook secureserving shouldn't be nil")
+	assert.NotNilf(t, c.WebhookSecureServing, "webhook secureserving shouldn't be nil")
 	c.WebhookSecureServing = nil
 	c.Authentication = apiserver.AuthenticationInfo{}
 	c.Authorization = apiserver.AuthorizationInfo{}

--- a/staging/src/k8s.io/cluster-bootstrap/token/jws/jws_test.go
+++ b/staging/src/k8s.io/cluster-bootstrap/token/jws/jws_test.go
@@ -30,8 +30,8 @@ const (
 
 func TestComputeDetachedSignature(t *testing.T) {
 	sig, err := ComputeDetachedSignature(content, id, secret)
-	assert.NoError(t, err, "Error when computing signature: %v", err)
-	assert.Equal(
+	assert.NoErrorf(t, err, "Error when computing signature: %v", err)
+	assert.Equalf(
 		t,
 		"eyJhbGciOiJIUzI1NiIsImtpZCI6Impvc2h1YSJ9..VShe2taLd-YTrmWuRkcL_8QTNDHYxQIEBsAYYiIj1_8",
 		sig,
@@ -39,8 +39,8 @@ func TestComputeDetachedSignature(t *testing.T) {
 
 	// Try with null content
 	sig, err = ComputeDetachedSignature("", id, secret)
-	assert.NoError(t, err, "Error when computing signature: %v", err)
-	assert.Equal(
+	assert.NoErrorf(t, err, "Error when computing signature: %v", err)
+	assert.Equalf(
 		t,
 		"eyJhbGciOiJIUzI1NiIsImtpZCI6Impvc2h1YSJ9..7Ui1ALizW4jXphVUB7xUqC9vLYLL9RZeOFfVLoB7Tgk",
 		sig,
@@ -48,8 +48,8 @@ func TestComputeDetachedSignature(t *testing.T) {
 
 	// Try with no secret
 	sig, err = ComputeDetachedSignature(content, id, "")
-	assert.NoError(t, err, "Error when computing signature: %v", err)
-	assert.Equal(
+	assert.NoErrorf(t, err, "Error when computing signature: %v", err)
+	assert.Equalf(
 		t,
 		"eyJhbGciOiJIUzI1NiIsImtpZCI6Impvc2h1YSJ9..UfkqvDGiIFxrMnFseDj9LYJOLNrvjW8aHhF71mvvAs8",
 		sig,
@@ -59,11 +59,11 @@ func TestComputeDetachedSignature(t *testing.T) {
 func TestDetachedTokenIsValid(t *testing.T) {
 	// Valid detached JWS token and valid inputs should succeed
 	sig := "eyJhbGciOiJIUzI1NiIsImtpZCI6Impvc2h1YSJ9..VShe2taLd-YTrmWuRkcL_8QTNDHYxQIEBsAYYiIj1_8"
-	assert.True(t, DetachedTokenIsValid(sig, content, id, secret),
+	assert.Truef(t, DetachedTokenIsValid(sig, content, id, secret),
 		"Content %q and token \"%s:%s\" should equal signature: %q", content, id, secret, sig)
 
 	// Invalid detached JWS token and valid inputs should fail
 	sig2 := sig + "foo"
-	assert.False(t, DetachedTokenIsValid(sig2, content, id, secret),
+	assert.Falsef(t, DetachedTokenIsValid(sig2, content, id, secret),
 		"Content %q and token \"%s:%s\" should not equal signature: %q", content, id, secret, sig)
 }

--- a/staging/src/k8s.io/component-base/logs/api/v1/options_test.go
+++ b/staging/src/k8s.io/component-base/logs/api/v1/options_test.go
@@ -251,14 +251,14 @@ func testContextualLogging(t *testing.T, enabled bool) {
 	// nolint:logcheck // This intentionally creates a new context independently of the feature gate.
 	ctx = logr.NewContext(ctx, logger)
 	if enabled {
-		assert.Equal(t, logger, klog.FromContext(ctx), "FromContext")
-		assert.NotEqual(t, ctx, klog.NewContext(ctx, logger), "NewContext")
-		assert.NotEqual(t, logger, klog.LoggerWithName(logger, "foo"), "LoggerWithName")
-		assert.NotEqual(t, logger, klog.LoggerWithValues(logger, "x", "y"), "LoggerWithValues")
+		assert.Equalf(t, logger, klog.FromContext(ctx), "FromContext")
+		assert.NotEqualf(t, ctx, klog.NewContext(ctx, logger), "NewContext")
+		assert.NotEqualf(t, logger, klog.LoggerWithName(logger, "foo"), "LoggerWithName")
+		assert.NotEqualf(t, logger, klog.LoggerWithValues(logger, "x", "y"), "LoggerWithValues")
 	} else {
-		assert.NotEqual(t, logger, klog.FromContext(ctx), "FromContext")
-		assert.Equal(t, ctx, klog.NewContext(ctx, logger), "NewContext")
-		assert.Equal(t, logger, klog.LoggerWithName(logger, "foo"), "LoggerWithName")
-		assert.Equal(t, logger, klog.LoggerWithValues(logger, "x", "y"), "LoggerWithValues")
+		assert.NotEqualf(t, logger, klog.FromContext(ctx), "FromContext")
+		assert.Equalf(t, ctx, klog.NewContext(ctx, logger), "NewContext")
+		assert.Equalf(t, logger, klog.LoggerWithName(logger, "foo"), "LoggerWithName")
+		assert.Equalf(t, logger, klog.LoggerWithValues(logger, "x", "y"), "LoggerWithValues")
 	}
 }

--- a/staging/src/k8s.io/component-base/logs/api/v1/types_test.go
+++ b/staging/src/k8s.io/component-base/logs/api/v1/types_test.go
@@ -110,7 +110,7 @@ func TestVModule(t *testing.T) {
 				if err == nil {
 					t.Fatal("parsing should have failed")
 				}
-				assert.Equal(t, test.expectError, err.Error(), "parse error")
+				assert.Equalf(t, test.expectError, err.Error(), "parse error")
 			} else {
 				if err != nil {
 					t.Fatalf("unexpected error: %v", err)
@@ -120,7 +120,7 @@ func TestVModule(t *testing.T) {
 				if expectParam == "" {
 					expectParam = test.arg
 				}
-				assert.Equal(t, expectParam, param, "encoded parameter value not identical")
+				assert.Equalf(t, expectParam, param, "encoded parameter value not identical")
 			}
 		})
 	}

--- a/staging/src/k8s.io/component-base/metrics/collector_test.go
+++ b/staging/src/k8s.io/component-base/metrics/collector_test.go
@@ -134,7 +134,7 @@ func TestInvalidCustomCollector(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			registry := newKubeRegistry(currentVersion)
 			customCollector := newTestCustomCollector(tc.descriptors...)
-			assert.Panics(t, func() {
+			assert.Panicsf(t, func() {
 				registry.CustomMustRegister(customCollector)
 			}, tc.panicStr)
 		})

--- a/staging/src/k8s.io/component-base/metrics/counter_test.go
+++ b/staging/src/k8s.io/component-base/metrics/counter_test.go
@@ -89,10 +89,10 @@ func TestCounter(t *testing.T) {
 			var buf bytes.Buffer
 			enc := expfmt.NewEncoder(&buf, "text/plain; version=0.0.4; charset=utf-8")
 			assert.Lenf(t, mfs, test.expectedMetricCount, "Got %v metrics, Want: %v metrics", len(mfs), test.expectedMetricCount)
-			require.NoError(t, err, "Gather failed %v", err)
+			require.NoErrorf(t, err, "Gather failed %v", err)
 			for _, metric := range mfs {
 				err := enc.Encode(metric)
-				require.NoError(t, err, "Unexpected err %v in encoding the metric", err)
+				require.NoErrorf(t, err, "Unexpected err %v in encoding the metric", err)
 				assert.Equalf(t, test.expectedHelp, metric.GetHelp(), "Got %s as help message, want %s", metric.GetHelp(), test.expectedHelp)
 			}
 
@@ -102,7 +102,7 @@ func TestCounter(t *testing.T) {
 				c.Inc()
 			}
 			mfs, err = registry.Gather()
-			require.NoError(t, err, "Gather failed %v", err)
+			require.NoErrorf(t, err, "Gather failed %v", err)
 
 			for _, mf := range mfs {
 				mfMetric := mf.GetMetric()
@@ -188,7 +188,7 @@ func TestCounterVec(t *testing.T) {
 			c.WithLabelValues("1", "2").Inc()
 			mfs, err := registry.Gather()
 			assert.Lenf(t, mfs, test.expectedMetricFamilyCount, "Got %v metric families, Want: %v metric families", len(mfs), test.expectedMetricFamilyCount)
-			require.NoError(t, err, "Gather failed %v", err)
+			require.NoErrorf(t, err, "Gather failed %v", err)
 
 			// this no-opts here when there are no metric families (i.e. when the metric is hidden)
 			for _, mf := range mfs {
@@ -200,7 +200,7 @@ func TestCounterVec(t *testing.T) {
 			c.WithLabelValues("1", "3").Inc()
 			c.WithLabelValues("2", "3").Inc()
 			mfs, err = registry.Gather()
-			require.NoError(t, err, "Gather failed %v", err)
+			require.NoErrorf(t, err, "Gather failed %v", err)
 
 			// this no-opts here when there are no metric families (i.e. when the metric is hidden)
 			for _, mf := range mfs {
@@ -258,7 +258,7 @@ func TestCounterWithLabelValueAllowList(t *testing.T) {
 				c.WithLabelValues(lv...).Inc()
 			}
 			mfs, err := registry.Gather()
-			require.NoError(t, err, "Gather failed %v", err)
+			require.NoErrorf(t, err, "Gather failed %v", err)
 
 			for _, mf := range mfs {
 				if *mf.Name != BuildFQName(opts.Namespace, opts.Subsystem, opts.Name) {
@@ -278,7 +278,7 @@ func TestCounterWithLabelValueAllowList(t *testing.T) {
 					}
 					labelValuePair := aValue + " " + bValue
 					expectedValue, ok := test.expectMetricValues[labelValuePair]
-					assert.True(t, ok, "Got unexpected label values, lable_a is %v, label_b is %v", aValue, bValue)
+					assert.Truef(t, ok, "Got unexpected label values, lable_a is %v, label_b is %v", aValue, bValue)
 					actualValue := int(m.GetCounter().GetValue())
 					assert.Equalf(t, expectedValue, actualValue, "Got %v, wanted %v as the count while setting label_a to %v and label b to %v", actualValue, expectedValue, aValue, bValue)
 				}

--- a/staging/src/k8s.io/component-base/metrics/gauge_test.go
+++ b/staging/src/k8s.io/component-base/metrics/gauge_test.go
@@ -89,7 +89,7 @@ func TestGauge(t *testing.T) {
 
 			ms, err := registry.Gather()
 			assert.Lenf(t, ms, test.expectedMetricCount, "Got %v metrics, Want: %v metrics", len(ms), test.expectedMetricCount)
-			require.NoError(t, err, "Gather failed %v", err)
+			require.NoErrorf(t, err, "Gather failed %v", err)
 
 			for _, metric := range ms {
 				assert.Equalf(t, test.expectedHelp, metric.GetHelp(), "Got %s as help message, want %s", metric.GetHelp(), test.expectedHelp)
@@ -100,7 +100,7 @@ func TestGauge(t *testing.T) {
 			c.Set(101)
 			expected := 101
 			ms, err = registry.Gather()
-			require.NoError(t, err, "Gather failed %v", err)
+			require.NoErrorf(t, err, "Gather failed %v", err)
 
 			for _, mf := range ms {
 				for _, m := range mf.GetMetric() {
@@ -177,7 +177,7 @@ func TestGaugeVec(t *testing.T) {
 			c.WithLabelValues("1", "2").Set(1.0)
 			ms, err := registry.Gather()
 			assert.Lenf(t, ms, test.expectedMetricCount, "Got %v metrics, Want: %v metrics", len(ms), test.expectedMetricCount)
-			require.NoError(t, err, "Gather failed %v", err)
+			require.NoErrorf(t, err, "Gather failed %v", err)
 			for _, metric := range ms {
 				assert.Equalf(t, test.expectedHelp, metric.GetHelp(), "Got %s as help message, want %s", metric.GetHelp(), test.expectedHelp)
 			}
@@ -186,7 +186,7 @@ func TestGaugeVec(t *testing.T) {
 			c.WithLabelValues("1", "3").Set(1.0)
 			c.WithLabelValues("2", "3").Set(1.0)
 			ms, err = registry.Gather()
-			require.NoError(t, err, "Gather failed %v", err)
+			require.NoErrorf(t, err, "Gather failed %v", err)
 
 			for _, mf := range ms {
 				assert.Lenf(t, mf.GetMetric(), 3, "Got %v metrics, wanted 3 as the count", len(mf.GetMetric()))
@@ -318,7 +318,7 @@ func TestGaugeWithLabelValueAllowList(t *testing.T) {
 				g.WithLabelValues(lv...).Set(100.0)
 			}
 			mfs, err := registry.Gather()
-			require.NoError(t, err, "Gather failed %v", err)
+			require.NoErrorf(t, err, "Gather failed %v", err)
 
 			for _, mf := range mfs {
 				if *mf.Name != BuildFQName(opts.Namespace, opts.Subsystem, opts.Name) {
@@ -338,7 +338,7 @@ func TestGaugeWithLabelValueAllowList(t *testing.T) {
 					}
 					labelValuePair := aValue + " " + bValue
 					expectedValue, ok := test.expectMetricValues[labelValuePair]
-					assert.True(t, ok, "Got unexpected label values, lable_a is %v, label_b is %v", aValue, bValue)
+					assert.Truef(t, ok, "Got unexpected label values, lable_a is %v, label_b is %v", aValue, bValue)
 					actualValue := m.GetGauge().GetValue()
 					assert.InDeltaf(t, expectedValue, actualValue, 0.01, "Got %v, wanted %v as the gauge while setting label_a to %v and label b to %v", actualValue, expectedValue, aValue, bValue)
 				}

--- a/staging/src/k8s.io/component-base/metrics/histogram_test.go
+++ b/staging/src/k8s.io/component-base/metrics/histogram_test.go
@@ -104,7 +104,7 @@ func TestHistogram(t *testing.T) {
 
 			ms, err := registry.Gather()
 			assert.Lenf(t, ms, test.expectedMetricCount, "Got %v metrics, Want: %v metrics", len(ms), test.expectedMetricCount)
-			require.NoError(t, err, "Gather failed %v", err)
+			require.NoErrorf(t, err, "Gather failed %v", err)
 
 			for _, metric := range ms {
 				assert.Equalf(t, test.expectedHelp, metric.GetHelp(), "Got %s as help message, want %s", metric.GetHelp(), test.expectedHelp)
@@ -117,7 +117,7 @@ func TestHistogram(t *testing.T) {
 			c.Observe(1.5)
 			expected := 4
 			ms, err = registry.Gather()
-			require.NoError(t, err, "Gather failed %v", err)
+			require.NoErrorf(t, err, "Gather failed %v", err)
 
 			for _, mf := range ms {
 				for _, m := range mf.GetMetric() {
@@ -213,7 +213,7 @@ func TestHistogramVec(t *testing.T) {
 
 			ms, err := registry.Gather()
 			assert.Lenf(t, ms, test.expectedMetricCount, "Got %v metrics, Want: %v metrics", len(ms), test.expectedMetricCount)
-			require.NoError(t, err, "Gather failed %v", err)
+			require.NoErrorf(t, err, "Gather failed %v", err)
 			for _, metric := range ms {
 				if metric.GetHelp() != test.expectedHelp {
 					assert.Equalf(t, test.expectedHelp, metric.GetHelp(), "Got %s as help message, want %s", metric.GetHelp(), test.expectedHelp)
@@ -224,7 +224,7 @@ func TestHistogramVec(t *testing.T) {
 			c.WithLabelValues("1", "3").Observe(1.0)
 			c.WithLabelValues("2", "3").Observe(1.0)
 			ms, err = registry.Gather()
-			require.NoError(t, err, "Gather failed %v", err)
+			require.NoErrorf(t, err, "Gather failed %v", err)
 
 			for _, mf := range ms {
 				assert.Lenf(t, mf.GetMetric(), 3, "Got %v metrics, wanted 3 as the count", len(mf.GetMetric()))
@@ -284,7 +284,7 @@ func TestHistogramWithLabelValueAllowList(t *testing.T) {
 				c.WithLabelValues(lv...).Observe(1.0)
 			}
 			mfs, err := registry.Gather()
-			require.NoError(t, err, "Gather failed %v", err)
+			require.NoErrorf(t, err, "Gather failed %v", err)
 
 			for _, mf := range mfs {
 				if *mf.Name != BuildFQName(opts.Namespace, opts.Subsystem, opts.Name) {
@@ -304,7 +304,7 @@ func TestHistogramWithLabelValueAllowList(t *testing.T) {
 					}
 					labelValuePair := aValue + " " + bValue
 					expectedValue, ok := test.expectMetricValues[labelValuePair]
-					assert.True(t, ok, "Got unexpected label values, lable_a is %v, label_b is %v", aValue, bValue)
+					assert.Truef(t, ok, "Got unexpected label values, lable_a is %v, label_b is %v", aValue, bValue)
 					actualValue := m.GetHistogram().GetSampleCount()
 					assert.Equalf(t, expectedValue, actualValue, "Got %v, wanted %v as the count while setting label_a to %v and label b to %v", actualValue, expectedValue, aValue, bValue)
 				}

--- a/staging/src/k8s.io/component-base/metrics/registry_test.go
+++ b/staging/src/k8s.io/component-base/metrics/registry_test.go
@@ -213,7 +213,7 @@ func TestMustRegister(t *testing.T) {
 			})
 			for i, m := range test.metrics {
 				if test.expectedPanics[i] {
-					assert.Panics(t,
+					assert.Panicsf(t,
 						func() { registry.MustRegister(m) },
 						"Did not panic even though we expected it.")
 				} else {
@@ -235,7 +235,7 @@ func TestShowHiddenMetric(t *testing.T) {
 	registry.MustRegister(alphaHiddenCounter)
 
 	ms, err := registry.Gather()
-	require.NoError(t, err, "Gather failed %v", err)
+	require.NoErrorf(t, err, "Gather failed %v", err)
 	assert.Lenf(t, ms, expectedMetricCount, "Got %v metrics, Want: %v metrics", len(ms), expectedMetricCount)
 
 	showHidden.Store(true)
@@ -253,7 +253,7 @@ func TestShowHiddenMetric(t *testing.T) {
 	expectedMetricCount = 1
 
 	ms, err = registry.Gather()
-	require.NoError(t, err, "Gather failed %v", err)
+	require.NoErrorf(t, err, "Gather failed %v", err)
 	assert.Lenf(t, ms, expectedMetricCount, "Got %v metrics, Want: %v metrics", len(ms), expectedMetricCount)
 }
 

--- a/staging/src/k8s.io/component-base/metrics/summary_test.go
+++ b/staging/src/k8s.io/component-base/metrics/summary_test.go
@@ -89,7 +89,7 @@ func TestSummary(t *testing.T) {
 
 			ms, err := registry.Gather()
 			assert.Lenf(t, ms, test.expectedMetricCount, "Got %v metrics, Want: %v metrics", len(ms), test.expectedMetricCount)
-			require.NoError(t, err, "Gather failed %v", err)
+			require.NoErrorf(t, err, "Gather failed %v", err)
 
 			for _, metric := range ms {
 				assert.Equalf(t, test.expectedHelp, metric.GetHelp(), "Got %s as help message, want %s", metric.GetHelp(), test.expectedHelp)
@@ -102,7 +102,7 @@ func TestSummary(t *testing.T) {
 			c.Observe(1.5)
 			expected := 4
 			ms, err = registry.Gather()
-			require.NoError(t, err, "Gather failed %v", err)
+			require.NoErrorf(t, err, "Gather failed %v", err)
 
 			for _, mf := range ms {
 				for _, m := range mf.GetMetric() {
@@ -178,7 +178,7 @@ func TestSummaryVec(t *testing.T) {
 			c.WithLabelValues("1", "2").Observe(1.0)
 			ms, err := registry.Gather()
 			assert.Lenf(t, ms, test.expectedMetricCount, "Got %v metrics, Want: %v metrics", len(ms), test.expectedMetricCount)
-			require.NoError(t, err, "Gather failed %v", err)
+			require.NoErrorf(t, err, "Gather failed %v", err)
 
 			for _, metric := range ms {
 				assert.Equalf(t, test.expectedHelp, metric.GetHelp(), "Got %s as help message, want %s", metric.GetHelp(), test.expectedHelp)
@@ -188,7 +188,7 @@ func TestSummaryVec(t *testing.T) {
 			c.WithLabelValues("1", "3").Observe(1.0)
 			c.WithLabelValues("2", "3").Observe(1.0)
 			ms, err = registry.Gather()
-			require.NoError(t, err, "Gather failed %v", err)
+			require.NoErrorf(t, err, "Gather failed %v", err)
 
 			for _, mf := range ms {
 				assert.Lenf(t, mf.GetMetric(), 3, "Got %v metrics, wanted 2 as the count", len(mf.GetMetric()))
@@ -248,7 +248,7 @@ func TestSummaryWithLabelValueAllowList(t *testing.T) {
 				c.WithLabelValues(lv...).Observe(1.0)
 			}
 			mfs, err := registry.Gather()
-			require.NoError(t, err, "Gather failed %v", err)
+			require.NoErrorf(t, err, "Gather failed %v", err)
 
 			for _, mf := range mfs {
 				if *mf.Name != BuildFQName(opts.Namespace, opts.Subsystem, opts.Name) {
@@ -268,7 +268,7 @@ func TestSummaryWithLabelValueAllowList(t *testing.T) {
 					}
 					labelValuePair := aValue + " " + bValue
 					expectedValue, ok := test.expectMetricValues[labelValuePair]
-					assert.True(t, ok, "Got unexpected label values, lable_a is %v, label_b is %v", aValue, bValue)
+					assert.Truef(t, ok, "Got unexpected label values, lable_a is %v, label_b is %v", aValue, bValue)
 					actualValue := int(m.GetSummary().GetSampleCount())
 					assert.Equalf(t, expectedValue, actualValue, "Got %v, wanted %v as the count while setting label_a to %v and label b to %v", actualValue, expectedValue, aValue, bValue)
 				}

--- a/staging/src/k8s.io/component-base/metrics/timing_histogram_test.go
+++ b/staging/src/k8s.io/component-base/metrics/timing_histogram_test.go
@@ -113,7 +113,7 @@ func TestTimingHistogram(t *testing.T) {
 
 			ms, err := registry.Gather()
 			assert.Lenf(t, ms, test.expectedMetricCount, "Got %v metrics, Want: %v metrics", len(ms), test.expectedMetricCount)
-			require.NoError(t, err, "Gather failed %v", err)
+			require.NoErrorf(t, err, "Gather failed %v", err)
 
 			for _, metric := range ms {
 				assert.Equalf(t, test.expectedHelp, metric.GetHelp(), "Got %s as help message, want %s", metric.GetHelp(), test.expectedHelp)
@@ -138,7 +138,7 @@ func TestTimingHistogram(t *testing.T) {
 			expectedCount := uint64(dt1 + dt2 + dt3)
 			expectedSum := float64(dt1)*v0 + float64(dt2)*v1 + float64(dt3)*v2
 			ms, err = registry.Gather()
-			require.NoError(t, err, "Gather failed %v", err)
+			require.NoErrorf(t, err, "Gather failed %v", err)
 
 			for _, mf := range ms {
 				t.Logf("Considering metric family %s", mf.GetName())
@@ -244,7 +244,7 @@ func TestTimingHistogramVec(t *testing.T) {
 
 			ms, err := registry.Gather()
 			assert.Lenf(t, ms, test.expectedMetricCount, "Got %v metrics, Want: %v metrics", len(ms), test.expectedMetricCount)
-			require.NoError(t, err, "Gather failed %v", err)
+			require.NoErrorf(t, err, "Gather failed %v", err)
 			for _, metric := range ms {
 				if metric.GetHelp() != test.expectedHelp {
 					assert.Equalf(t, test.expectedHelp, metric.GetHelp(), "Got %s as help message, want %s", metric.GetHelp(), test.expectedHelp)
@@ -261,7 +261,7 @@ func TestTimingHistogramVec(t *testing.T) {
 			c.WithLabelValues("1", "3").Add(5.0)
 			c.WithLabelValues("2", "3").Add(5.0)
 			ms, err = registry.Gather()
-			require.NoError(t, err, "Gather failed %v", err)
+			require.NoErrorf(t, err, "Gather failed %v", err)
 
 			for _, mf := range ms {
 				t.Logf("Considering metric family %s", mf.String())
@@ -336,7 +336,7 @@ func TestTimingHistogramWithLabelValueAllowList(t *testing.T) {
 				c.WithLabelValues(lv...).Add(1.0)
 			}
 			mfs, err := registry.Gather()
-			require.NoError(t, err, "Gather failed %v", err)
+			require.NoErrorf(t, err, "Gather failed %v", err)
 
 			for _, mf := range mfs {
 				if *mf.Name != BuildFQName(opts.Namespace, opts.Subsystem, opts.Name) {
@@ -357,7 +357,7 @@ func TestTimingHistogramWithLabelValueAllowList(t *testing.T) {
 					}
 					labelValuePair := aValue + " " + bValue
 					expectedCount, ok := test.expectMetricValues[labelValuePair]
-					assert.True(t, ok, "Got unexpected label values, lable_a is %v, label_b is %v", aValue, bValue)
+					assert.Truef(t, ok, "Got unexpected label values, lable_a is %v, label_b is %v", aValue, bValue)
 					expectedSum := float64(dt1) * v0 * float64(expectedCount)
 					expectedCount *= uint64(dt1)
 					actualCount := m.GetHistogram().GetSampleCount()

--- a/staging/src/k8s.io/controller-manager/app/helper_test.go
+++ b/staging/src/k8s.io/controller-manager/app/helper_test.go
@@ -85,7 +85,7 @@ func TestIsControllerEnabled(t *testing.T) {
 
 	for _, tc := range tcs {
 		actual := IsControllerEnabled(tc.controllerName, sets.NewString(tc.disabledByDefaultControllers...), tc.controllers)
-		assert.Equal(t, tc.expected, actual, "%v: expected %v, got %v", tc.name, tc.expected, actual)
+		assert.Equalf(t, tc.expected, actual, "%v: expected %v, got %v", tc.name, tc.expected, actual)
 	}
 
 }

--- a/staging/src/k8s.io/cri-api/pkg/apis/testing/fake_image_service.go
+++ b/staging/src/k8s.io/cri-api/pkg/apis/testing/fake_image_service.go
@@ -247,7 +247,7 @@ func (r *FakeImageService) AssertImagePulledWithAuth(t *testing.T, image *runtim
 	r.Lock()
 	defer r.Unlock()
 	expected := &pulledImage{imageSpec: image, authConfig: auth}
-	assert.Contains(t, r.pulledImages, expected, failMsg)
+	assert.Containsf(t, r.pulledImages, expected, failMsg)
 }
 
 type pulledImage struct {

--- a/staging/src/k8s.io/cri-client/pkg/logs/logs_test.go
+++ b/staging/src/k8s.io/cri-client/pkg/logs/logs_test.go
@@ -276,7 +276,7 @@ func TestReadRotatedLog(t *testing.T) {
 
 			newF := filepath.Join(dir, baseName)
 			if file, err = os.Create(newF); err != nil {
-				assert.NoError(t, err, "unable to create new log file")
+				assert.NoErrorf(t, err, "unable to create new log file")
 				return
 			}
 			time.Sleep(20 * time.Millisecond)
@@ -534,9 +534,9 @@ func TestReadLogsLimitsWithTimestamps(t *testing.T) {
 		//   1. The timestamp should exist
 		//   2. The last item in the log should be 9999
 		_, err = time.Parse(time.RFC3339, string(ts))
-		assert.NoError(t, err, "timestamp not found")
-		assert.True(t, bytes.HasSuffix(logline, []byte("9999")), "is the complete log found")
+		assert.NoErrorf(t, err, "timestamp not found")
+		assert.Truef(t, bytes.HasSuffix(logline, []byte("9999")), "is the complete log found")
 	}
 
-	assert.Equal(t, 2, lineCount, "should have two lines")
+	assert.Equalf(t, 2, lineCount, "should have two lines")
 }

--- a/staging/src/k8s.io/cri-client/pkg/util/util_unix_test.go
+++ b/staging/src/k8s.io/cri-client/pkg/util/util_unix_test.go
@@ -62,10 +62,10 @@ func TestParseEndpoint(t *testing.T) {
 		protocol, addr, err := parseEndpoint(test.endpoint)
 		assert.Equal(t, test.expectedProtocol, protocol)
 		if test.expectError {
-			assert.Error(t, err, "Expect error during parsing %q", test.endpoint)
+			assert.Errorf(t, err, "Expect error during parsing %q", test.endpoint)
 			continue
 		}
-		assert.NoError(t, err, "Expect no error during parsing %q", test.endpoint)
+		assert.NoErrorf(t, err, "Expect no error during parsing %q", test.endpoint)
 		assert.Equal(t, test.expectedAddr, addr)
 	}
 
@@ -109,10 +109,10 @@ func TestGetAddressAndDialer(t *testing.T) {
 		// just test addr and err
 		addr, _, err := GetAddressAndDialer(test.endpoint)
 		if test.expectError {
-			assert.Error(t, err, "expected error during parsing %s", test.endpoint)
+			assert.Errorf(t, err, "expected error during parsing %s", test.endpoint)
 			continue
 		}
-		assert.NoError(t, err, "expected no error during parsing %s", test.endpoint)
+		assert.NoErrorf(t, err, "expected no error during parsing %s", test.endpoint)
 		assert.Equal(t, test.expectedAddr, addr)
 	}
 }

--- a/staging/src/k8s.io/csi-translation-lib/plugins/azure_file_test.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/azure_file_test.go
@@ -644,7 +644,7 @@ func TestGetStorageAccount(t *testing.T) {
 
 	for i, test := range tests {
 		accountName, err := getStorageAccountName(test.secretName)
-		assert.Equal(t, test.expectedError, err != nil, "TestCase[%d]", i)
-		assert.Equal(t, test.expectedResult, accountName, "TestCase[%d]", i)
+		assert.Equalf(t, test.expectedError, err != nil, "TestCase[%d]", i)
+		assert.Equalf(t, test.expectedResult, accountName, "TestCase[%d]", i)
 	}
 }

--- a/staging/src/k8s.io/dynamic-resource-allocation/controller/controller_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/controller/controller_test.go
@@ -319,11 +319,11 @@ func TestController(t *testing.T) {
 			for _, obj := range initialObjects {
 				switch obj.(type) {
 				case *resourceapi.ResourceClaim:
-					require.NoError(t, claimInformer.Informer().GetStore().Add(obj), "add resource claim")
+					require.NoErrorf(t, claimInformer.Informer().GetStore().Add(obj), "add resource claim")
 				case *corev1.Pod:
-					require.NoError(t, podInformer.Informer().GetStore().Add(obj), "add pod")
+					require.NoErrorf(t, podInformer.Informer().GetStore().Add(obj), "add pod")
 				case *resourceapi.PodSchedulingContext:
-					require.NoError(t, podSchedulingInformer.Informer().GetStore().Add(obj), "add pod scheduling")
+					require.NoErrorf(t, podSchedulingInformer.Informer().GetStore().Add(obj), "add pod scheduling")
 				default:
 					t.Fatalf("unknown initialObject type: %+v", obj)
 				}
@@ -351,7 +351,7 @@ func TestController(t *testing.T) {
 				t.Fatalf("expected error %q, got %q", test.expectedError, err.Error())
 			}
 			claims, err := kubeClient.ResourceV1alpha3().ResourceClaims("").List(ctx, metav1.ListOptions{})
-			require.NoError(t, err, "list claims")
+			require.NoErrorf(t, err, "list claims")
 			var expectedClaims []resourceapi.ResourceClaim
 			if test.expectedClaim != nil {
 				expectedClaims = append(expectedClaims, *test.expectedClaim)
@@ -359,7 +359,7 @@ func TestController(t *testing.T) {
 			assert.Equal(t, expectedClaims, claims.Items)
 
 			podSchedulings, err := kubeClient.ResourceV1alpha3().PodSchedulingContexts("").List(ctx, metav1.ListOptions{})
-			require.NoError(t, err, "list pod schedulings")
+			require.NoErrorf(t, err, "list pod schedulings")
 			var expectedPodSchedulings []resourceapi.PodSchedulingContext
 			if test.expectedSchedulingCtx != nil {
 				expectedPodSchedulings = append(expectedPodSchedulings, *test.expectedSchedulingCtx)
@@ -426,7 +426,7 @@ func (m mockDriver) Allocate(ctx context.Context, claims []*ClaimAllocation, sel
 		if !ok {
 			m.t.Fatalf("unexpected Allocate call for claim %s", claimAllocation.Claim.Name)
 		}
-		assert.Equal(m.t, allocate.selectedNode, selectedNode, "selected node")
+		assert.Equalf(m.t, allocate.selectedNode, selectedNode, "selected node")
 		claimAllocation.Error = allocate.allocErr
 		claimAllocation.Allocation = allocate.allocResult
 	}

--- a/staging/src/k8s.io/dynamic-resource-allocation/resourceclaim/pod_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/resourceclaim/pod_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package resourceclaim
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -69,9 +68,9 @@ func TestPodStatusEqual(t *testing.T) {
 
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
-			assert.True(t, PodStatusEqual(tc.sliceA, tc.sliceA), fmt.Sprintf("%v", tc.sliceA))
-			assert.True(t, PodStatusEqual(tc.sliceB, tc.sliceB), fmt.Sprintf("%v", tc.sliceB))
-			assert.Equal(t, tc.expectEqual, PodStatusEqual(tc.sliceA, tc.sliceB), fmt.Sprintf("%v and %v", tc.sliceA, tc.sliceB))
+			assert.Truef(t, PodStatusEqual(tc.sliceA, tc.sliceA), "%v", tc.sliceA)
+			assert.Truef(t, PodStatusEqual(tc.sliceB, tc.sliceB), "%v", tc.sliceB)
+			assert.Equalf(t, tc.expectEqual, PodStatusEqual(tc.sliceA, tc.sliceB), "%v and %v", tc.sliceA, tc.sliceB)
 		})
 
 	}

--- a/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/resourceslicecontroller_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/resourceslicecontroller_test.go
@@ -196,14 +196,14 @@ func TestControllerSyncPool(t *testing.T) {
 			}
 			ctrl, err := newController(ctx, kubeClient, driveName, owner, test.inputDriverResources)
 			defer ctrl.Stop()
-			require.NoError(t, err, "unexpected controller creation error")
+			require.NoErrorf(t, err, "unexpected controller creation error")
 			err = ctrl.syncPool(ctx, test.poolName)
-			require.NoError(t, err, "unexpected syncPool error")
+			require.NoErrorf(t, err, "unexpected syncPool error")
 
 			// Check ResourceSlices
 			resourceSlices, err := kubeClient.ResourceV1alpha3().ResourceSlices().List(ctx, metav1.ListOptions{})
-			require.NoError(t, err, "list resource slices")
-			assert.Equal(t, test.expectedResourceSlices, resourceSlices.Items, "unexpected ResourceSlices")
+			require.NoErrorf(t, err, "list resource slices")
+			assert.Equalf(t, test.expectedResourceSlices, resourceSlices.Items, "unexpected ResourceSlices")
 		})
 	}
 }

--- a/staging/src/k8s.io/endpointslice/reconciler_test.go
+++ b/staging/src/k8s.io/endpointslice/reconciler_test.go
@@ -123,7 +123,7 @@ func TestReconcileEmpty(t *testing.T) {
 	expectActions(t, client.Actions(), 1, "create", "endpointslices")
 
 	slices := fetchEndpointSlices(t, client, namespace)
-	assert.Len(t, slices, 1, "Expected 1 endpoint slices")
+	assert.Lenf(t, slices, 1, "Expected 1 endpoint slices")
 
 	assert.Regexp(t, "^"+svc.Name, slices[0].Name)
 	assert.Equal(t, svc.Name, slices[0].Labels[discovery.LabelServiceName])
@@ -580,7 +580,7 @@ func TestReconcile1EndpointSlice(t *testing.T) {
 			if tc.existing != nil {
 				existingSlices = append(existingSlices, tc.existing)
 				_, createErr := client.DiscoveryV1().EndpointSlices(namespace).Create(context.TODO(), tc.existing, metav1.CreateOptions{})
-				assert.NoError(t, createErr, "Expected no error creating endpoint slice")
+				assert.NoErrorf(t, createErr, "Expected no error creating endpoint slice")
 			}
 
 			numActionsBefore := len(client.Actions())
@@ -592,10 +592,10 @@ func TestReconcile1EndpointSlice(t *testing.T) {
 				numUpdates = 1
 			}
 			wantActions := numActionsBefore + numUpdates
-			assert.Len(t, client.Actions(), wantActions, "Expected %d additional clientset actions", numUpdates)
+			assert.Lenf(t, client.Actions(), wantActions, "Expected %d additional clientset actions", numUpdates)
 
 			slices := fetchEndpointSlices(t, client, namespace)
-			assert.Len(t, slices, 1, "Expected 1 endpoint slices")
+			assert.Lenf(t, slices, 1, "Expected 1 endpoint slices")
 
 			if !tc.wantUpdate {
 				assert.Regexp(t, "^"+svc.Name, slices[0].Name)
@@ -708,7 +708,7 @@ func TestReconcile1EndpointSlicePublishNotReadyAddresses(t *testing.T) {
 	reconcileHelper(t, r, &svc, pods, []*discovery.EndpointSlice{}, time.Now())
 
 	// Only 1 action, an EndpointSlice create
-	assert.Len(t, client.Actions(), 1, "Expected 1 additional clientset action")
+	assert.Lenf(t, client.Actions(), 1, "Expected 1 additional clientset action")
 	expectActions(t, client.Actions(), 1, "create", "endpointslices")
 
 	// Two endpoint slices should be completely full, the remainder should be in another one
@@ -742,7 +742,7 @@ func TestReconcileManyPods(t *testing.T) {
 	reconcileHelper(t, r, &svc, pods, []*discovery.EndpointSlice{}, time.Now())
 
 	// This is an ideal scenario where only 3 actions are required, and they're all creates
-	assert.Len(t, client.Actions(), 3, "Expected 3 additional clientset actions")
+	assert.Lenf(t, client.Actions(), 3, "Expected 3 additional clientset actions")
 	expectActions(t, client.Actions(), 3, "create", "endpointslices")
 
 	// Two endpoint slices should be completely full, the remainder should be in another one
@@ -792,9 +792,9 @@ func TestReconcileEndpointSlicesSomePreexisting(t *testing.T) {
 	reconcileHelper(t, r, &svc, pods, existingSlices, time.Now())
 
 	actions := client.Actions()
-	assert.Len(t, actions, numActionsBefore+2, "Expected 2 additional client actions as part of reconcile")
-	assert.True(t, actions[numActionsBefore].Matches("create", "endpointslices"), "First action should be create endpoint slice")
-	assert.True(t, actions[numActionsBefore+1].Matches("update", "endpointslices"), "Second action should be update endpoint slice")
+	assert.Lenf(t, actions, numActionsBefore+2, "Expected 2 additional client actions as part of reconcile")
+	assert.Truef(t, actions[numActionsBefore].Matches("create", "endpointslices"), "First action should be create endpoint slice")
+	assert.Truef(t, actions[numActionsBefore+1].Matches("update", "endpointslices"), "Second action should be update endpoint slice")
 
 	// 1 new slice (0->100) + 1 updated slice (62->89)
 	expectUnorderedSlicesWithLengths(t, fetchEndpointSlices(t, client, namespace), []int{89, 61, 100})
@@ -848,7 +848,7 @@ func TestReconcileEndpointSlicesSomePreexistingWorseAllocation(t *testing.T) {
 	reconcileHelper(t, r, &svc, pods, existingSlices, time.Now())
 
 	actions := client.Actions()
-	assert.Len(t, actions, numActionsBefore+2, "Expected 2 additional client actions as part of reconcile")
+	assert.Lenf(t, actions, numActionsBefore+2, "Expected 2 additional client actions as part of reconcile")
 	expectActions(t, client.Actions(), 2, "create", "endpointslices")
 
 	// 2 new slices (100, 52) in addition to existing slices (74, 74)
@@ -876,7 +876,7 @@ func TestReconcileEndpointSlicesUpdating(t *testing.T) {
 	r := newReconciler(client, []*corev1.Node{{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}}}, defaultMaxEndpointsPerSlice)
 	reconcileHelper(t, r, &svc, pods, []*discovery.EndpointSlice{}, time.Now())
 	numActionsExpected := 3
-	assert.Len(t, client.Actions(), numActionsExpected, "Expected 3 additional clientset actions")
+	assert.Lenf(t, client.Actions(), numActionsExpected, "Expected 3 additional clientset actions")
 
 	slices := fetchEndpointSlices(t, client, namespace)
 	numActionsExpected++
@@ -886,7 +886,7 @@ func TestReconcileEndpointSlicesUpdating(t *testing.T) {
 	reconcileHelper(t, r, &svc, pods, []*discovery.EndpointSlice{&slices[0], &slices[1], &slices[2]}, time.Now())
 
 	numActionsExpected += 3
-	assert.Len(t, client.Actions(), numActionsExpected, "Expected 3 additional clientset actions")
+	assert.Lenf(t, client.Actions(), numActionsExpected, "Expected 3 additional clientset actions")
 	expectActions(t, client.Actions(), 3, "update", "endpointslices")
 
 	expectUnorderedSlicesWithLengths(t, fetchEndpointSlices(t, client, namespace), []int{100, 100, 50})
@@ -909,7 +909,7 @@ func TestReconcileEndpointSlicesServicesLabelsUpdating(t *testing.T) {
 	r := newReconciler(client, []*corev1.Node{{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}}}, defaultMaxEndpointsPerSlice)
 	reconcileHelper(t, r, &svc, pods, []*discovery.EndpointSlice{}, time.Now())
 	numActionsExpected := 3
-	assert.Len(t, client.Actions(), numActionsExpected, "Expected 3 additional clientset actions")
+	assert.Lenf(t, client.Actions(), numActionsExpected, "Expected 3 additional clientset actions")
 
 	slices := fetchEndpointSlices(t, client, namespace)
 	numActionsExpected++
@@ -920,7 +920,7 @@ func TestReconcileEndpointSlicesServicesLabelsUpdating(t *testing.T) {
 	reconcileHelper(t, r, &svc, pods, []*discovery.EndpointSlice{&slices[0], &slices[1], &slices[2]}, time.Now())
 
 	numActionsExpected += 3
-	assert.Len(t, client.Actions(), numActionsExpected, "Expected 3 additional clientset actions")
+	assert.Lenf(t, client.Actions(), numActionsExpected, "Expected 3 additional clientset actions")
 	expectActions(t, client.Actions(), 3, "update", "endpointslices")
 
 	newSlices := fetchEndpointSlices(t, client, namespace)
@@ -953,7 +953,7 @@ func TestReconcileEndpointSlicesServicesReservedLabels(t *testing.T) {
 	r := newReconciler(client, []*corev1.Node{{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}}}, defaultMaxEndpointsPerSlice)
 	reconcileHelper(t, r, &svc, pods, []*discovery.EndpointSlice{}, time.Now())
 	numActionsExpected := 3
-	assert.Len(t, client.Actions(), numActionsExpected, "Expected 3 additional clientset actions")
+	assert.Lenf(t, client.Actions(), numActionsExpected, "Expected 3 additional clientset actions")
 	slices := fetchEndpointSlices(t, client, namespace)
 	numActionsExpected++
 	expectUnorderedSlicesWithLengths(t, slices, []int{100, 100, 50})
@@ -961,7 +961,7 @@ func TestReconcileEndpointSlicesServicesReservedLabels(t *testing.T) {
 	// update service with new labels
 	svc.Labels = map[string]string{discovery.LabelServiceName: "bad", discovery.LabelManagedBy: "actor", corev1.IsHeadlessService: "invalid"}
 	reconcileHelper(t, r, &svc, pods, []*discovery.EndpointSlice{&slices[0], &slices[1], &slices[2]}, time.Now())
-	assert.Len(t, client.Actions(), numActionsExpected, "Expected no additional clientset actions")
+	assert.Lenf(t, client.Actions(), numActionsExpected, "Expected no additional clientset actions")
 
 	newSlices := fetchEndpointSlices(t, client, namespace)
 	expectUnorderedSlicesWithLengths(t, newSlices, []int{100, 100, 50})
@@ -1001,14 +1001,14 @@ func TestReconcileEndpointSlicesRecycling(t *testing.T) {
 	r := newReconciler(client, []*corev1.Node{{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}}}, defaultMaxEndpointsPerSlice)
 	reconcileHelper(t, r, &svc, pods, existingSlices, time.Now())
 	// initial reconcile should be a no op, all pods are accounted for in slices, no repacking should be done
-	assert.Len(t, client.Actions(), numActionsBefore+0, "Expected 0 additional client actions as part of reconcile")
+	assert.Lenf(t, client.Actions(), numActionsBefore+0, "Expected 0 additional client actions as part of reconcile")
 
 	// changing a service port should require all slices to be updated, time for a repack
 	svc.Spec.Ports[0].TargetPort.IntVal = 81
 	reconcileHelper(t, r, &svc, pods, existingSlices, time.Now())
 
 	// this should reflect 3 updates + 7 deletes
-	assert.Len(t, client.Actions(), numActionsBefore+10, "Expected 10 additional client actions as part of reconcile")
+	assert.Lenf(t, client.Actions(), numActionsBefore+10, "Expected 10 additional client actions as part of reconcile")
 
 	// thanks to recycling, we get a free repack of endpoints, resulting in 3 full slices instead of 10 mostly empty slices
 	expectUnorderedSlicesWithLengths(t, fetchEndpointSlices(t, client, namespace), []int{100, 100, 100})
@@ -1242,7 +1242,7 @@ func TestReconcileEndpointSlicesNamedPorts(t *testing.T) {
 	reconcileHelper(t, r, &svc, pods, []*discovery.EndpointSlice{}, time.Now())
 
 	// reconcile should create 5 endpoint slices
-	assert.Len(t, client.Actions(), 5, "Expected 5 client actions as part of reconcile")
+	assert.Lenf(t, client.Actions(), 5, "Expected 5 client actions as part of reconcile")
 	expectActions(t, client.Actions(), 5, "create", "endpointslices")
 	expectMetrics(t, expectedMetrics{desiredSlices: 5, actualSlices: 5, desiredEndpoints: 300, addedPerSync: 300, removedPerSync: 0, numCreated: 5, numUpdated: 0, numDeleted: 0, slicesChangedPerSync: 5})
 
@@ -1338,8 +1338,8 @@ func TestReconcileEndpointSlicesMetrics(t *testing.T) {
 	reconcileHelper(t, r, &svc, pods, []*discovery.EndpointSlice{}, time.Now())
 
 	actions := client.Actions()
-	assert.Len(t, actions, 1, "Expected 1 additional client actions as part of reconcile")
-	assert.True(t, actions[0].Matches("create", "endpointslices"), "First action should be create endpoint slice")
+	assert.Lenf(t, actions, 1, "Expected 1 additional client actions as part of reconcile")
+	assert.Truef(t, actions[0].Matches("create", "endpointslices"), "First action should be create endpoint slice")
 
 	expectMetrics(t, expectedMetrics{desiredSlices: 1, actualSlices: 1, desiredEndpoints: 20, addedPerSync: 20, removedPerSync: 0, numCreated: 1, numUpdated: 0, numDeleted: 0, slicesChangedPerSync: 1})
 
@@ -2206,7 +2206,7 @@ func newReconciler(client *fake.Clientset, nodes []*corev1.Node, maxEndpointsPer
 
 // ensures endpoint slices exist with the desired set of lengths
 func expectUnorderedSlicesWithLengths(t *testing.T, endpointSlices []discovery.EndpointSlice, expectedLengths []int) {
-	assert.Len(t, endpointSlices, len(expectedLengths), "Expected %d endpoint slices", len(expectedLengths))
+	assert.Lenf(t, endpointSlices, len(expectedLengths), "Expected %d endpoint slices", len(expectedLengths))
 
 	lengthsWithNoMatch := []int{}
 	desiredLengths := expectedLengths
@@ -2236,7 +2236,7 @@ func expectUnorderedSlicesWithLengths(t *testing.T, endpointSlices []discovery.E
 // ensures endpoint slices exist with the desired set of ports and address types
 func expectUnorderedSlicesWithTopLevelAttrs(t *testing.T, endpointSlices []discovery.EndpointSlice, expectedSlices []discovery.EndpointSlice) {
 	t.Helper()
-	assert.Len(t, endpointSlices, len(expectedSlices), "Expected %d endpoint slices", len(expectedSlices))
+	assert.Lenf(t, endpointSlices, len(expectedSlices), "Expected %d endpoint slices", len(expectedSlices))
 
 	slicesWithNoMatch := []discovery.EndpointSlice{}
 	for _, endpointSlice := range endpointSlices {
@@ -2254,8 +2254,8 @@ func expectUnorderedSlicesWithTopLevelAttrs(t *testing.T, endpointSlices []disco
 		}
 	}
 
-	assert.Empty(t, slicesWithNoMatch, "EndpointSlice(s) found without matching attributes")
-	assert.Empty(t, expectedSlices, "Expected slices(s) not found in EndpointSlices")
+	assert.Emptyf(t, slicesWithNoMatch, "EndpointSlice(s) found without matching attributes")
+	assert.Emptyf(t, expectedSlices, "Expected slices(s) not found in EndpointSlices")
 }
 
 func expectActions(t *testing.T, actions []k8stesting.Action, num int, verb, resource string) {
@@ -2267,8 +2267,8 @@ func expectActions(t *testing.T, actions []k8stesting.Action, num int, verb, res
 
 	for i := 0; i < num; i++ {
 		relativePos := len(actions) - i - 1
-		assert.Equal(t, verb, actions[relativePos].GetVerb(), "Expected action -%d verb to be %s", i, verb)
-		assert.Equal(t, resource, actions[relativePos].GetResource().Resource, "Expected action -%d resource to be %s", i, resource)
+		assert.Equalf(t, verb, actions[relativePos].GetVerb(), "Expected action -%d verb to be %s", i, verb)
+		assert.Equalf(t, resource, actions[relativePos].GetResource().Resource, "Expected action -%d resource to be %s", i, resource)
 	}
 }
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_test.go
@@ -147,13 +147,13 @@ func TestAlphaEnablement(t *testing.T) {
 		cmd := &cobra.Command{}
 		flags := NewApplyFlags(genericiooptions.NewTestIOStreamsDiscard())
 		flags.AddFlags(cmd)
-		require.Nil(t, cmd.Flags().Lookup(flag), "flag %q should not be registered without the %q feature enabled", flag, feature)
+		require.Nilf(t, cmd.Flags().Lookup(flag), "flag %q should not be registered without the %q feature enabled", flag, feature)
 
 		cmdtesting.WithAlphaEnvs([]cmdutil.FeatureGate{feature}, t, func(t *testing.T) {
 			cmd := &cobra.Command{}
 			flags := NewApplyFlags(genericiooptions.NewTestIOStreamsDiscard())
 			flags.AddFlags(cmd)
-			require.NotNil(t, cmd.Flags().Lookup(flag), "flag %q should be registered with the %q feature enabled", flag, feature)
+			require.NotNilf(t, cmd.Flags().Lookup(flag), "flag %q should be registered with the %q feature enabled", flag, feature)
 		})
 	}
 }
@@ -1361,8 +1361,8 @@ func TestApplyCSAMigration(t *testing.T) {
 			cmd.Run(cmd, []string{})
 
 			// JSONPatch should have been attempted exactly the given number of times
-			require.Equal(t, targetPatches, patches, "should retry as many times as a conflict was returned")
-			require.Equal(t, 3, applies, "should perform specified # of apply calls upon migration")
+			require.Equalf(t, targetPatches, patches, "should retry as many times as a conflict was returned")
+			require.Equalf(t, 3, applies, "should perform specified # of apply calls upon migration")
 			require.Empty(t, errBuf.String())
 
 			// ensure that in the future there will be no migrations necessary
@@ -1377,7 +1377,7 @@ func TestApplyCSAMigration(t *testing.T) {
 			err = csaupgrade.UpgradeManagedFields(upgradedRC, sets.New("kubectl-client-side-apply"), "kubectl")
 			require.NoError(t, err)
 			require.NotEmpty(t, rc.ManagedFields)
-			require.Equal(t, rc, upgradedRC, "upgrading should be no-op in future")
+			require.Equalf(t, rc, upgradedRC, "upgrading should be no-op in future")
 
 			// Apply the upgraded object.
 			// Expect only a single PATCH call to apiserver
@@ -1390,8 +1390,8 @@ func TestApplyCSAMigration(t *testing.T) {
 			cmd.Run(cmd, []string{})
 
 			require.Empty(t, errBuf)
-			require.Equal(t, 4, applies, "only a single call to server-side apply should have been performed")
-			require.Equal(t, targetPatches, patches, "no more json patches should have been needed")
+			require.Equalf(t, 4, applies, "only a single call to server-side apply should have been performed")
+			require.Equalf(t, targetPatches, patches, "no more json patches should have been needed")
 		})
 	}
 }
@@ -2389,7 +2389,7 @@ func TestApplySetParentValidation(t *testing.T) {
 
 				o, err := flags.ToOptions(f, cmd, "kubectl", []string{})
 				if test.expectErr == "" {
-					require.NoError(t, err, "ToOptions error")
+					require.NoErrorf(t, err, "ToOptions error")
 				} else if err != nil {
 					require.EqualError(t, err, test.expectErr)
 					return
@@ -2402,7 +2402,7 @@ func TestApplySetParentValidation(t *testing.T) {
 				if test.expectErr != "" {
 					require.EqualError(t, err, test.expectErr)
 				} else {
-					require.NoError(t, err, "Validate error")
+					require.NoErrorf(t, err, "Validate error")
 				}
 			})
 		})
@@ -2450,7 +2450,7 @@ func setUpClientsForApplySetWithSSA(t *testing.T, tf *cmdtesting.TestFactory, ob
 					t.Fatalf("error getting object: %v", err)
 				}
 			case "PATCH":
-				require.Equal(t, string(types.ApplyPatchType), req.Header.Get("Content-Type"), "received patch request with unexpected patch type")
+				require.Equalf(t, string(types.ApplyPatchType), req.Header.Get("Content-Type"), "received patch request with unexpected patch type")
 
 				var existing *unstructured.Unstructured
 				existingObj, err := fakeDynamicClient.Tracker().Get(gvr, namespace, name)
@@ -2473,20 +2473,20 @@ func setUpClientsForApplySetWithSSA(t *testing.T, tf *cmdtesting.TestFactory, ob
 				if existing == nil {
 					patch.SetUID("a-static-fake-uid")
 					err := fakeDynamicClient.Tracker().Create(gvr, patch, namespace)
-					require.NoError(t, err, "error creating object")
+					require.NoErrorf(t, err, "error creating object")
 
 					returnData, err = json.Marshal(patch)
-					require.NoError(t, err, "error marshalling response: %v", err)
+					require.NoErrorf(t, err, "error marshalling response: %v", err)
 				} else {
 					uid := existing.GetUID()
 					patch.DeepCopyInto(existing)
 					existing.SetUID(uid)
 
 					err = fakeDynamicClient.Tracker().Update(gvr, existing, namespace)
-					require.NoError(t, err, "error updating object")
+					require.NoErrorf(t, err, "error updating object")
 
 					returnData, err = json.Marshal(existing)
-					require.NoError(t, err, "error marshalling response")
+					require.NoErrorf(t, err, "error marshalling response")
 				}
 				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: io.NopCloser(bytes.NewReader(returnData))}, nil
 
@@ -2784,7 +2784,7 @@ func TestApplySetInvalidLiveParent(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			require.NotEmpty(t, test.expectErr, "invalid test case")
+			require.NotEmptyf(t, test.expectErr, "invalid test case")
 			cmdutil.BehaviorOnFatal(func(s string, i int) {
 				assert.Equal(t, test.expectErr, s)
 			})
@@ -3432,8 +3432,8 @@ func TestApplySetDryRun(t *testing.T) {
 			cmd.Run(cmd, []string{})
 		})
 		assert.Equal(t, "replicationcontroller/test-rc serverside-applied (server dry run)\n", outbuff.String())
-		assert.Len(t, serverSideData, 1, "unexpected creation")
-		require.Nil(t, serverSideData[pathSecret], "secret was created")
+		assert.Lenf(t, serverSideData, 1, "unexpected creation")
+		require.Nilf(t, serverSideData[pathSecret], "secret was created")
 	})
 
 	t.Run("client side dry run", func(t *testing.T) {
@@ -3449,7 +3449,7 @@ func TestApplySetDryRun(t *testing.T) {
 			cmd.Run(cmd, []string{})
 		})
 		assert.Equal(t, "replicationcontroller/test-rc configured (dry run)\n", outbuff.String())
-		assert.Len(t, serverSideData, 1, "unexpected creation")
-		require.Nil(t, serverSideData[pathSecret], "secret was created")
+		assert.Lenf(t, serverSideData, 1, "unexpected creation")
+		require.Nilf(t, serverSideData[pathSecret], "secret was created")
 	})
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/cp/cp_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cp/cp_test.go
@@ -889,10 +889,10 @@ func TestUntar(t *testing.T) {
 				Mode: 0666,
 				Size: int64(len(f.path)),
 			}
-			require.NoError(t, tw.WriteHeader(hdr), f.path)
+			require.NoErrorf(t, tw.WriteHeader(hdr), f.path)
 			if !strings.HasSuffix(f.path, "/") {
 				_, err := tw.Write([]byte(f.path))
-				require.NoError(t, err, f.path)
+				require.NoErrorf(t, err, f.path)
 			}
 		} else {
 			hdr := &tar.Header{
@@ -901,7 +901,7 @@ func TestUntar(t *testing.T) {
 				Typeflag: tar.TypeSymlink,
 				Linkname: f.linkTarget,
 			}
-			require.NoError(t, tw.WriteHeader(hdr), f.path)
+			require.NoErrorf(t, tw.WriteHeader(hdr), f.path)
 		}
 	}
 	tw.Close()

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_deployment_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_deployment_test.go
@@ -159,5 +159,5 @@ func TestCreateDeploymentNoImage(t *testing.T) {
 	}
 
 	err = options.Run()
-	assert.Error(t, err, "at least one image must be specified")
+	assert.Errorf(t, err, "at least one image must be specified")
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_selector_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_selector_test.go
@@ -161,7 +161,7 @@ func TestUpdateNewSelectorValuesForObject(t *testing.T) {
 			t.Errorf("%q. updateSelectorForObject() error = %v, wantErr %v", tt.name, err, tt.wantErr)
 		}
 
-		assert.EqualValues(t, tt.args.selector.MatchLabels, ser.Spec.Selector, tt.name)
+		assert.EqualValuesf(t, tt.args.selector.MatchLabels, ser.Spec.Selector, tt.name)
 
 	}
 }
@@ -235,7 +235,7 @@ func TestUpdateOldSelectorValuesForObject(t *testing.T) {
 		if (err != nil) != tt.wantErr {
 			t.Errorf("%q. updateSelectorForObject() error = %v, wantErr %v", tt.name, err, tt.wantErr)
 		} else if !tt.wantErr {
-			assert.EqualValues(t, tt.args.selector.MatchLabels, ser.Spec.Selector, tt.name)
+			assert.EqualValuesf(t, tt.args.selector.MatchLabels, ser.Spec.Selector, tt.name)
 		}
 	}
 }

--- a/staging/src/k8s.io/kubectl/pkg/util/prune/prune_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/prune/prune_test.go
@@ -93,8 +93,8 @@ func TestGetRESTMappings(t *testing.T) {
 		if tc.expectederr != nil {
 			assert.NotEmptyf(t, actualerr, "getRESTMappings error expected but not fired")
 		}
-		assert.Equal(t, len(actualns), tc.expectedns, "getRESTMappings failed expected number namespaced %d actual %d", tc.expectedns, len(actualns))
-		assert.Equal(t, len(actualnns), tc.expectednns, "getRESTMappings failed expected number nonnamespaced %d actual %d", tc.expectednns, len(actualnns))
+		assert.Equalf(t, len(actualns), tc.expectedns, "getRESTMappings failed expected number namespaced %d actual %d", tc.expectedns, len(actualns))
+		assert.Equalf(t, len(actualnns), tc.expectednns, "getRESTMappings failed expected number nonnamespaced %d actual %d", tc.expectednns, len(actualnns))
 	}
 }
 

--- a/staging/src/k8s.io/kubelet/pkg/cri/streaming/request_cache_test.go
+++ b/staging/src/k8s.io/kubelet/pkg/cri/streaming/request_cache_test.go
@@ -51,13 +51,13 @@ func TestInsert(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, newestTok, tokenLen)
 	assertCacheSize(t, c, maxInFlight)
-	require.Contains(t, c.tokens, oldestTok, "oldest request should still be cached")
+	require.Containsf(t, c.tokens, oldestTok, "oldest request should still be cached")
 
 	// Consume newest token.
 	req, ok := c.Consume(newestTok)
-	assert.True(t, ok, "newest request should still be cached")
+	assert.Truef(t, ok, "newest request should still be cached")
 	assert.Equal(t, newestReq, req)
-	require.Contains(t, c.tokens, oldestTok, "oldest request should still be cached")
+	require.Containsf(t, c.tokens, oldestTok, "oldest request should still be cached")
 
 	// Insert again (still full)
 	tok, err := c.Insert(nextRequest())
@@ -67,7 +67,7 @@ func TestInsert(t *testing.T) {
 
 	// Insert again (should evict)
 	_, err = c.Insert(nextRequest())
-	assert.Error(t, err, "should reject further requests")
+	assert.Errorf(t, err, "should reject further requests")
 	recorder := httptest.NewRecorder()
 	require.NoError(t, WriteError(err, recorder))
 	errResponse := recorder.Result()
@@ -76,7 +76,7 @@ func TestInsert(t *testing.T) {
 
 	assertCacheSize(t, c, maxInFlight)
 	_, ok = c.Consume(oldestTok)
-	assert.True(t, ok, "oldest request should be valid")
+	assert.Truef(t, ok, "oldest request should be valid")
 }
 
 func TestConsume(t *testing.T) {
@@ -210,8 +210,8 @@ func newTestCache() (*requestCache, *testingclock.FakeClock) {
 func assertCacheSize(t *testing.T, cache *requestCache, expectedSize int) {
 	tokenLen := len(cache.tokens)
 	llLen := cache.ll.Len()
-	assert.Equal(t, tokenLen, llLen, "inconsistent cache size! len(tokens)=%d; len(ll)=%d", tokenLen, llLen)
-	assert.Equal(t, expectedSize, tokenLen, "unexpected cache size!")
+	assert.Equalf(t, tokenLen, llLen, "inconsistent cache size! len(tokens)=%d; len(ll)=%d", tokenLen, llLen)
+	assert.Equalf(t, expectedSize, tokenLen, "unexpected cache size!")
 }
 
 var requestUID = 0

--- a/staging/src/k8s.io/kubelet/pkg/cri/streaming/server_test.go
+++ b/staging/src/k8s.io/kubelet/pkg/cri/streaming/server_test.go
@@ -70,7 +70,7 @@ func TestGetExec(t *testing.T) {
 
 	assertRequestToken := func(expectedReq *runtimeapi.ExecRequest, cache *requestCache, token string) {
 		req, ok := cache.Consume(token)
-		require.True(t, ok, "token %s not found!", token)
+		require.Truef(t, ok, "token %s not found!", token)
 		assert.Equal(t, expectedReq, req)
 	}
 	request := &runtimeapi.ExecRequest{
@@ -165,7 +165,7 @@ func TestValidateExecAttachRequest(t *testing.T) {
 					Stderr:      c.stderr,
 				}
 				err := validateExecRequest(execReq)
-				assert.Equal(t, tc.expectErr, err != nil, "config: %v,  err: %v", c, err)
+				assert.Equalf(t, tc.expectErr, err != nil, "config: %v,  err: %v", c, err)
 
 				// validate the attach request.
 				attachReq := &runtimeapi.AttachRequest{
@@ -176,7 +176,7 @@ func TestValidateExecAttachRequest(t *testing.T) {
 					Stderr:      c.stderr,
 				}
 				err = validateAttachRequest(attachReq)
-				assert.Equal(t, tc.expectErr, err != nil, "config: %v, err: %v", c, err)
+				assert.Equalf(t, tc.expectErr, err != nil, "config: %v, err: %v", c, err)
 			}
 		})
 	}
@@ -196,7 +196,7 @@ func TestGetAttach(t *testing.T) {
 
 	assertRequestToken := func(expectedReq *runtimeapi.AttachRequest, cache *requestCache, token string) {
 		req, ok := cache.Consume(token)
-		require.True(t, ok, "token %s not found!", token)
+		require.Truef(t, ok, "token %s not found!", token)
 		assert.Equal(t, expectedReq, req)
 	}
 
@@ -242,7 +242,7 @@ func TestGetPortForward(t *testing.T) {
 		assert.True(t, strings.HasPrefix(resp.Url, expectedURL))
 		token := strings.TrimPrefix(resp.Url, expectedURL)
 		req, ok := serv.(*server).cache.Consume(token)
-		require.True(t, ok, "token %s not found!", token)
+		require.Truef(t, ok, "token %s not found!", token)
 		assert.Equal(t, testPodSandboxID, req.(*runtimeapi.PortForwardRequest).PodSandboxId)
 	}
 
@@ -258,7 +258,7 @@ func TestGetPortForward(t *testing.T) {
 		assert.True(t, strings.HasPrefix(resp.Url, expectedURL))
 		token := strings.TrimPrefix(resp.Url, expectedURL)
 		req, ok := tlsServer.(*server).cache.Consume(token)
-		require.True(t, ok, "token %s not found!", token)
+		require.Truef(t, ok, "token %s not found!", token)
 		assert.Equal(t, testPodSandboxID, req.(*runtimeapi.PortForwardRequest).PodSandboxId)
 	}
 }
@@ -457,13 +457,13 @@ func doClientStreams(t *testing.T, prefix string, stdin io.Writer, stdout, stder
 func readExpected(t *testing.T, streamName string, r io.Reader, expected string) {
 	result := make([]byte, len(expected))
 	_, err := io.ReadAtLeast(r, result, len(expected))
-	assert.NoError(t, err, "stream %s", streamName)
-	assert.Equal(t, expected, string(result), "stream %s", streamName)
+	assert.NoErrorf(t, err, "stream %s", streamName)
+	assert.Equalf(t, expected, string(result), "stream %s", streamName)
 }
 
 // Write and verify success of the data over the stream.
 func writeExpected(t *testing.T, streamName string, w io.Writer, data string) {
 	n, err := io.WriteString(w, data)
-	assert.NoError(t, err, "stream %s", streamName)
-	assert.Equal(t, len(data), n, "stream %s", streamName)
+	assert.NoErrorf(t, err, "stream %s", streamName)
+	assert.Equalf(t, len(data), n, "stream %s", streamName)
 }

--- a/staging/src/k8s.io/pod-security-admission/admission/admission_test.go
+++ b/staging/src/k8s.io/pod-security-admission/admission/admission_test.go
@@ -141,9 +141,9 @@ func TestDefaultExtractPodSpec(t *testing.T) {
 	for _, obj := range objects {
 		name := obj.(metav1.Object).GetName()
 		actualMetadata, actualSpec, err := extractor.ExtractPodSpec(obj)
-		assert.NoError(t, err, name)
-		assert.Equal(t, &metadata, actualMetadata, "%s: Metadata mismatch", name)
-		assert.Equal(t, &spec, actualSpec, "%s: PodSpec mismatch", name)
+		assert.NoErrorf(t, err, name)
+		assert.Equalf(t, &metadata, actualMetadata, "%s: Metadata mismatch", name)
+		assert.Equalf(t, &spec, actualSpec, "%s: PodSpec mismatch", name)
 	}
 
 	service := &corev1.Service{
@@ -152,7 +152,7 @@ func TestDefaultExtractPodSpec(t *testing.T) {
 		},
 	}
 	_, _, err := extractor.ExtractPodSpec(service)
-	assert.Error(t, err, "service should not have an extractable pod spec")
+	assert.Errorf(t, err, "service should not have an extractable pod spec")
 }
 
 func TestDefaultHasPodSpec(t *testing.T) {
@@ -169,7 +169,7 @@ func TestDefaultHasPodSpec(t *testing.T) {
 	}
 	extractor := &DefaultPodSpecExtractor{}
 	for _, gr := range podLikeResources {
-		assert.True(t, extractor.HasPodSpec(gr), gr.String())
+		assert.Truef(t, extractor.HasPodSpec(gr), gr.String())
 	}
 
 	nonPodResources := []schema.GroupResource{
@@ -178,7 +178,7 @@ func TestDefaultHasPodSpec(t *testing.T) {
 		appsv1.Resource("foobars"),
 	}
 	for _, gr := range nonPodResources {
-		assert.False(t, extractor.HasPodSpec(gr), gr.String())
+		assert.Falsef(t, extractor.HasPodSpec(gr), gr.String())
 	}
 }
 
@@ -697,7 +697,7 @@ func TestValidatePodAndController(t *testing.T) {
 	}
 
 	config, err := load.LoadFromData(nil) // Start with the default config.
-	require.NoError(t, err, "loading default config")
+	require.NoErrorf(t, err, "loading default config")
 	config.Exemptions.Namespaces = []string{exemptNs}
 	config.Exemptions.RuntimeClasses = []string{exemptRuntimeClass}
 	config.Exemptions.Usernames = []string{exemptUser}
@@ -999,27 +999,27 @@ func TestValidatePodAndController(t *testing.T) {
 				Metrics:         recorder,
 				NamespaceGetter: nsGetter,
 			}
-			require.NoError(t, a.CompleteConfiguration(), "CompleteConfiguration()")
-			require.NoError(t, a.ValidateConfiguration(), "ValidateConfiguration()")
+			require.NoErrorf(t, a.CompleteConfiguration(), "CompleteConfiguration()")
+			require.NoErrorf(t, a.ValidateConfiguration(), "ValidateConfiguration()")
 
 			response := a.Validate(ctx, attrs)
 
 			var expectedEvaluations []MetricsRecord
 			var expectedAuditAnnotationKeys []string
 			if tc.expectAllowed {
-				assert.True(t, response.Allowed, "Allowed")
+				assert.Truef(t, response.Allowed, "Allowed")
 				assert.Nil(t, response.Result)
 			} else {
 				assert.False(t, response.Allowed)
-				if assert.NotNil(t, response.Result, "Result") {
-					assert.Equal(t, tc.expectReason, response.Result.Reason, "Reason")
+				if assert.NotNilf(t, response.Result, "Result") {
+					assert.Equalf(t, tc.expectReason, response.Result.Reason, "Reason")
 				}
 			}
 
 			if tc.expectWarning != "" {
-				assert.NotEmpty(t, response.Warnings, "Warnings")
+				assert.NotEmptyf(t, response.Warnings, "Warnings")
 			} else {
-				assert.Empty(t, response.Warnings, "Warnings")
+				assert.Emptyf(t, response.Warnings, "Warnings")
 			}
 
 			if tc.expectEnforce != "" {
@@ -1039,23 +1039,23 @@ func TestValidatePodAndController(t *testing.T) {
 			}
 			if tc.expectError {
 				expectedAuditAnnotationKeys = append(expectedAuditAnnotationKeys, "error")
-				assert.ElementsMatch(t, []MetricsRecord{{ObjectName: podName}}, recorder.errors, "expected RecordError() calls")
+				assert.ElementsMatchf(t, []MetricsRecord{{ObjectName: podName}}, recorder.errors, "expected RecordError() calls")
 			} else {
-				assert.Empty(t, recorder.errors, "expected RecordError() calls")
+				assert.Emptyf(t, recorder.errors, "expected RecordError() calls")
 			}
 			if tc.expectExempt {
 				expectedAuditAnnotationKeys = append(expectedAuditAnnotationKeys, "exempt")
-				assert.ElementsMatch(t, []MetricsRecord{{ObjectName: podName}}, recorder.exemptions, "expected RecordExemption() calls")
+				assert.ElementsMatchf(t, []MetricsRecord{{ObjectName: podName}}, recorder.exemptions, "expected RecordExemption() calls")
 			} else {
-				assert.Empty(t, recorder.exemptions, "expected RecordExemption() calls")
+				assert.Emptyf(t, recorder.exemptions, "expected RecordExemption() calls")
 			}
 
-			assert.Len(t, response.AuditAnnotations, len(expectedAuditAnnotationKeys), "AuditAnnotations")
+			assert.Lenf(t, response.AuditAnnotations, len(expectedAuditAnnotationKeys), "AuditAnnotations")
 			for _, key := range expectedAuditAnnotationKeys {
-				assert.Contains(t, response.AuditAnnotations, key, "AuditAnnotations")
+				assert.Containsf(t, response.AuditAnnotations, key, "AuditAnnotations")
 			}
 
-			assert.ElementsMatch(t, expectedEvaluations, recorder.evaluations, "expected RecordEvaluation() calls")
+			assert.ElementsMatchf(t, expectedEvaluations, recorder.evaluations, "expected RecordEvaluation() calls")
 		})
 	}
 }
@@ -1238,8 +1238,8 @@ func TestExemptNamespaceWarning(t *testing.T) {
 			}
 			require.NotEmpty(t, warning)
 
-			assert.NotContains(t, warning, sentinelLabelKey, "non-podsecurity label key included")
-			assert.NotContains(t, warning, sentinelLabelValue, "non-podsecurity label value included")
+			assert.NotContainsf(t, warning, sentinelLabelKey, "non-podsecurity label key included")
+			assert.NotContainsf(t, warning, sentinelLabelValue, "non-podsecurity label value included")
 
 			assert.Contains(t, warning, test.expectWarningContains)
 		})

--- a/staging/src/k8s.io/pod-security-admission/api/helpers_test.go
+++ b/staging/src/k8s.io/pod-security-admission/api/helpers_test.go
@@ -60,7 +60,7 @@ func TestLevelVersionEquals(t *testing.T) {
 			for _, v := range []Version{LatestVersion(), MajorMinorVersion(1, 18), MajorMinorVersion(1, 30)} {
 				lv := LevelVersion{l, v}
 				other := lv
-				assert.True(t, lv.Equivalent(&other), lv.String())
+				assert.Truef(t, lv.Equivalent(&other), lv.String())
 			}
 		}
 	})
@@ -70,7 +70,7 @@ func TestLevelVersionEquals(t *testing.T) {
 				if l1 != l2 {
 					lv1 := LevelVersion{l1, LatestVersion()}
 					lv2 := LevelVersion{l2, LatestVersion()}
-					assert.False(t, lv1.Equivalent(&lv2), "%#v != %#v", lv1, lv2)
+					assert.Falsef(t, lv1.Equivalent(&lv2), "%#v != %#v", lv1, lv2)
 				}
 			}
 		}
@@ -81,7 +81,7 @@ func TestLevelVersionEquals(t *testing.T) {
 				for _, v2 := range []Version{MajorMinorVersion(1, 16), MajorMinorVersion(1, 13)} {
 					lv1 := LevelVersion{l, v1}
 					lv2 := LevelVersion{l, v2}
-					assert.False(t, lv1.Equivalent(&lv2), "%#v != %#v", lv1, lv2)
+					assert.Falsef(t, lv1.Equivalent(&lv2), "%#v != %#v", lv1, lv2)
 				}
 			}
 		}
@@ -91,7 +91,7 @@ func TestLevelVersionEquals(t *testing.T) {
 			for _, v2 := range []Version{MajorMinorVersion(1, 16), MajorMinorVersion(1, 13)} {
 				lv1 := LevelVersion{LevelPrivileged, v1}
 				lv2 := LevelVersion{LevelPrivileged, v2}
-				assert.True(t, lv1.Equivalent(&lv2), "%#v == %#v", lv1, lv2)
+				assert.Truef(t, lv1.Equivalent(&lv2), "%#v == %#v", lv1, lv2)
 			}
 		}
 	})
@@ -113,9 +113,9 @@ func TestPolicyEquals(t *testing.T) {
 	baseline.Audit.Level = LevelBaseline
 	require.False(t, baseline.FullyPrivileged())
 
-	assert.True(t, privileged.Equivalent(&privileged2), "ignore privileged versions")
-	assert.True(t, baseline.Equivalent(&baseline), "baseline policy equals itself")
-	assert.False(t, privileged.Equivalent(&baseline), "privileged != baseline")
+	assert.Truef(t, privileged.Equivalent(&privileged2), "ignore privileged versions")
+	assert.Truef(t, baseline.Equivalent(&baseline), "baseline policy equals itself")
+	assert.Falsef(t, privileged.Equivalent(&baseline), "privileged != baseline")
 }
 
 func TestPolicyToEvaluate(t *testing.T) {

--- a/staging/src/k8s.io/pod-security-admission/policy/checks_test.go
+++ b/staging/src/k8s.io/pod-security-admission/policy/checks_test.go
@@ -36,7 +36,7 @@ func TestValidChecks(t *testing.T) {
 	for _, check := range allChecks {
 		for _, c := range check.Versions {
 			for _, override := range c.OverrideCheckIDs {
-				assert.Contains(t, allIDs, override, "check %s overrides non-existent check %s", check.ID, override)
+				assert.Containsf(t, allIDs, override, "check %s overrides non-existent check %s", check.ID, override)
 			}
 		}
 	}

--- a/test/e2e/framework/config/config_test.go
+++ b/test/e2e/framework/config/config_test.go
@@ -200,11 +200,11 @@ func testTypes(t *testing.T, testcase TypesTestCase) {
 		copy := bytes.Buffer{}
 		flags.SetOutput(&copy)
 		flags.PrintDefaults()
-		assert.Equal(t, original.String(), copy.String(), testcase.name+": help messages equal")
-		assert.Contains(t, copy.String(), "some number", testcase.name+": copied help message contains defaults")
+		assert.Equalf(t, original.String(), copy.String(), testcase.name+": help messages equal")
+		assert.Containsf(t, copy.String(), "some number", testcase.name+": copied help message contains defaults")
 	}
 
-	require.Equal(t, []simpleFlag{
+	require.Equalf(t, []simpleFlag{
 		{
 			name:     "bool",
 			defValue: "true",
@@ -241,13 +241,13 @@ func testTypes(t *testing.T, testcase TypesTestCase) {
 		},
 	},
 		allFlags(flags), testcase.name)
-	assert.Equal(t,
+	assert.Equalf(t,
 		Context{true, time.Millisecond, 1.23456789, "hello world",
 			-1, -1234567890123456789, 1, 1234567890123456789,
 		},
 		context,
 		"default values must match")
-	require.NoError(t, flags.Parse([]string{
+	require.NoErrorf(t, flags.Parse([]string{
 		"-int", "-2",
 		"-int64", "-9123456789012345678",
 		"-uint", "2",
@@ -257,7 +257,7 @@ func testTypes(t *testing.T, testcase TypesTestCase) {
 		"-bool=false",
 		"-duration=1s",
 	}), testcase.name)
-	assert.Equal(t,
+	assert.Equalf(t,
 		Context{false, time.Second, -1.23456789, "pong",
 			-2, -9123456789012345678, 2, 9123456789012345678,
 		},

--- a/test/e2e/framework/log_test.go
+++ b/test/e2e/framework/log_test.go
@@ -263,16 +263,16 @@ In [AfterEach] at: log_test.go:53 <time>
 	tmp := t.TempDir()
 	filename := path.Join(tmp, "stderr.log")
 	f, err := os.Create(filename)
-	require.NoError(t, err, "create temporary file")
+	require.NoErrorf(t, err, "create temporary file")
 	os.Stderr = f
 	defer func() {
 		os.Stderr = oldStderr
 
 		err := f.Close()
-		require.NoError(t, err, "close temporary file")
+		require.NoErrorf(t, err, "close temporary file")
 		actual, err := os.ReadFile(filename)
-		require.NoError(t, err, "read temporary file")
-		assert.Empty(t, string(actual), "no output on stderr")
+		require.NoErrorf(t, err, "read temporary file")
+		assert.Emptyf(t, string(actual), "no output on stderr")
 	}()
 
 	output.TestGinkgoOutput(t, expected)

--- a/test/e2e/framework/pod/utils_test.go
+++ b/test/e2e/framework/pod/utils_test.go
@@ -67,9 +67,9 @@ func TestMixinRestrictedPodSecurity(t *testing.T) {
 		t.Run(pod.Name, func(t *testing.T) {
 			p := pod // closure
 			require.NoError(t, MixinRestrictedPodSecurity(&p))
-			assert.Equal(t, GetRestrictedPodSecurityContext(), p.Spec.SecurityContext,
+			assert.Equalf(t, GetRestrictedPodSecurityContext(), p.Spec.SecurityContext,
 				"Mixed in PodSecurityContext should equal the from-scratch PodSecurityContext")
-			assert.Equal(t, GetRestrictedContainerSecurityContext(), p.Spec.Containers[0].SecurityContext,
+			assert.Equalf(t, GetRestrictedContainerSecurityContext(), p.Spec.Containers[0].SecurityContext,
 				"Mixed in SecurityContext should equal the from-scratch SecurityContext")
 		})
 	}

--- a/test/e2e/storage/external/external_test.go
+++ b/test/e2e/storage/external/external_test.go
@@ -69,9 +69,9 @@ func TestDriverParameter(t *testing.T) {
 	for _, testcase := range testcases {
 		actual, err := loadDriverDefinition(testcase.filename)
 		if testcase.err == "" {
-			require.NoError(t, err, testcase.name)
+			require.NoErrorf(t, err, testcase.name)
 		} else {
-			if assert.Error(t, err, testcase.name) {
+			if assert.Errorf(t, err, testcase.name) {
 				assert.Equal(t, testcase.err, err.Error())
 			}
 		}

--- a/test/integration/apiserver/oidc/oidc_test.go
+++ b/test/integration/apiserver/oidc/oidc_test.go
@@ -207,7 +207,7 @@ jwt:
 			},
 			configureClient: configureClientFetchingOIDCCredentials,
 			assertErrFn: func(t *testing.T, errorToCheck error) {
-				assert.True(t, apierrors.IsUnauthorized(errorToCheck), errorToCheck)
+				assert.Truef(t, apierrors.IsUnauthorized(errorToCheck), "%v is expected to be Unauthorized but is not", errorToCheck)
 			},
 		},
 		{
@@ -329,7 +329,7 @@ jwt:
 			},
 			configureClient: configureClientFetchingOIDCCredentials,
 			assertErrFn: func(t *testing.T, errorToCheck error) {
-				assert.True(t, apierrors.IsUnauthorized(errorToCheck), errorToCheck)
+				assert.Truef(t, apierrors.IsUnauthorized(errorToCheck), "%v is expected to be Unauthorized but is not", errorToCheck)
 			},
 		},
 		{
@@ -391,10 +391,10 @@ jwt:
 			configureClient: configureClientFetchingOIDCCredentials,
 			assertErrFn: func(t *testing.T, errorToCheck error) {
 				if useAuthenticationConfig { // since the config uses a CEL expression
-					assert.True(t, apierrors.IsUnauthorized(errorToCheck), errorToCheck)
+					assert.Truef(t, apierrors.IsUnauthorized(errorToCheck), "%v is expected to be Unauthorized but is not", errorToCheck)
 				} else {
 					// the claim based approach is still allowed to use empty usernames
-					_ = assert.True(t, apierrors.IsForbidden(errorToCheck), errorToCheck) &&
+					_ = assert.True(t, apierrors.IsForbidden(errorToCheck)) &&
 						assert.Equal(
 							t,
 							`pods is forbidden: User "" cannot list resource "pods" in API group "" in the namespace "default"`,
@@ -739,7 +739,7 @@ jwt:
 			},
 			configureClient: configureClientFetchingOIDCCredentials,
 			assertErrFn: func(t *testing.T, errorToCheck error) {
-				assert.True(t, apierrors.IsUnauthorized(errorToCheck), errorToCheck)
+				assert.Truef(t, apierrors.IsUnauthorized(errorToCheck), "%v is expected to be Unauthorized but is not", errorToCheck)
 			},
 		},
 		{
@@ -897,7 +897,7 @@ jwt:
 			},
 			configureClient: configureClientFetchingOIDCCredentials,
 			assertErrFn: func(t *testing.T, errorToCheck error) {
-				assert.True(t, apierrors.IsUnauthorized(errorToCheck), errorToCheck)
+				assert.Truef(t, apierrors.IsUnauthorized(errorToCheck), "%v is expected to be Unauthorized but is not", errorToCheck)
 			},
 			wantUser: nil,
 		},
@@ -1136,7 +1136,7 @@ jwt:
 `, issuerURL, defaultOIDCClientID, indentCertificateAuthority(caCert))
 			},
 			assertErrFn: func(t *testing.T, errorToCheck error) {
-				assert.True(t, apierrors.IsUnauthorized(errorToCheck))
+				assert.Truef(t, apierrors.IsUnauthorized(errorToCheck), "%v is expected to be Unauthorized but is not", errorToCheck)
 			},
 			wantUser:              nil,
 			ignoreTransitionErrFn: apierrors.IsUnauthorized,
@@ -1196,7 +1196,7 @@ jwt:
 `, issuerURL, defaultOIDCClientID, indentCertificateAuthority(caCert))
 			},
 			assertErrFn: func(t *testing.T, errorToCheck error) {
-				assert.True(t, apierrors.IsUnauthorized(errorToCheck))
+				assert.Truef(t, apierrors.IsUnauthorized(errorToCheck), "%v is expected to be Unauthorized but is not", errorToCheck)
 			},
 			wantUser:              nil,
 			ignoreTransitionErrFn: apierrors.IsUnauthorized,
@@ -1304,7 +1304,7 @@ kind: AuthenticationConfiguration
 				Groups:   []string{"system:authenticated"},
 			},
 			newAssertErrFn: func(t *testing.T, errorToCheck error) {
-				assert.True(t, apierrors.IsUnauthorized(errorToCheck))
+				assert.Truef(t, apierrors.IsUnauthorized(errorToCheck), "%v is expected to be Unauthorized but is not", errorToCheck)
 			},
 			newWantUser:         nil,
 			waitAfterConfigSwap: true,
@@ -1433,7 +1433,7 @@ jwt:
 
 					return len(diff) == 0, nil
 				})
-				require.NoError(t, err, "new authentication config not loaded")
+				require.NoErrorf(t, err, "new authentication config not loaded")
 			}
 
 			_, err = client.CoreV1().Pods(defaultNamespace).List(ctx, metav1.ListOptions{})

--- a/test/utils/image/csi_manifests_test.go
+++ b/test/utils/image/csi_manifests_test.go
@@ -56,10 +56,10 @@ func TestCSIImageConfigs(t *testing.T) {
 	}
 	actualImages := sets.NewString()
 	for _, config := range configs {
-		assert.NotEmpty(t, config.registry, "registry")
-		assert.NotEmpty(t, config.name, "name")
-		assert.NotEmpty(t, config.version, "version")
+		assert.NotEmptyf(t, config.registry, "registry")
+		assert.NotEmptyf(t, config.name, "name")
+		assert.NotEmptyf(t, config.version, "version")
 		actualImages.Insert(config.name)
 	}
-	assert.ElementsMatch(t, expectedImages, actualImages.UnsortedList(), "found these images: %+v", configs)
+	assert.ElementsMatchf(t, expectedImages, actualImages.UnsortedList(), "found these images: %+v", configs)
 }

--- a/test/utils/ktesting/contexthelper_test.go
+++ b/test/utils/ktesting/contexthelper_test.go
@@ -113,7 +113,7 @@ func TestCause(t *testing.T) {
 			}
 			if tt.expectDeadline != 0 {
 				actualDeadline, ok := ctx.Deadline()
-				if assert.True(t, ok, "should have had a deadline") {
+				if assert.Truef(t, ok, "should have had a deadline") {
 					// Testing timing behavior is unreliable in Prow because
 					// the test runs in parallel with several others.
 					// Therefore this check is skipped if a CI environment is
@@ -123,7 +123,7 @@ func TestCause(t *testing.T) {
 					case "yes", "true", "1":
 						// Skip.
 					default:
-						assert.InDelta(t, time.Until(actualDeadline), tt.expectDeadline, float64(time.Second), "remaining time till Deadline()")
+						assert.InDeltaf(t, time.Until(actualDeadline), tt.expectDeadline, float64(time.Second), "remaining time till Deadline()")
 					}
 				}
 			}
@@ -135,8 +135,8 @@ func TestCause(t *testing.T) {
 			case "yes", "true", "1":
 				// Skip.
 			default:
-				assert.Equal(t, tt.expectErr, actualErr, "ctx.Err()")
-				assert.Equal(t, tt.expectCause, actualCause, "context.Cause()")
+				assert.Equalf(t, tt.expectErr, actualErr, "ctx.Err()")
+				assert.Equalf(t, tt.expectCause, actualCause, "context.Cause()")
 			}
 		})
 	}

--- a/test/utils/ktesting/errorcontext_test.go
+++ b/test/utils/ktesting/errorcontext_test.go
@@ -105,7 +105,7 @@ second error`,
 				tc.cb(tCtx)
 			}()
 
-			assert.Equal(t, !tc.expectNoFail, tCtx.Failed(), "Failed()")
+			assert.Equalf(t, !tc.expectNoFail, tCtx.Failed(), "Failed()")
 			if tc.expectError == "" {
 				assert.NoError(t, err)
 			} else if assert.Error(t, err) {

--- a/test/utils/ktesting/helper_test.go
+++ b/test/utils/ktesting/helper_test.go
@@ -56,8 +56,8 @@ func (tc testcase) run(t *testing.T) {
 	}
 
 	duration := time.Since(start)
-	assert.InDelta(t, tc.expectDuration.Seconds(), duration.Seconds(), 0.1, "callback invocation duration %s", duration)
-	assert.Equal(t, !tc.expectNoFail, tCtx.Failed(), "Failed()")
+	assert.InDeltaf(t, tc.expectDuration.Seconds(), duration.Seconds(), 0.1, "callback invocation duration %s", duration)
+	assert.Equalf(t, !tc.expectNoFail, tCtx.Failed(), "Failed()")
 	if tc.expectError == "" {
 		assert.NoError(t, err)
 	} else if assert.Error(t, err) {

--- a/test/utils/ktesting/stepcontext_test.go
+++ b/test/utils/ktesting/stepcontext_test.go
@@ -74,7 +74,7 @@ step: Errorf a b 42`,
 				tCtx.Log(buffer.String())
 
 				noSuchValue := tCtx.Value("some other key")
-				assert.Nil(tCtx, noSuchValue, "value for unknown context value key")
+				assert.Nilf(tCtx, noSuchValue, "value for unknown context value key")
 			},
 			expectLog: `<klog header>: step: You requested a progress report.
 

--- a/test/utils/ktesting/tcontext_test.go
+++ b/test/utils/ktesting/tcontext_test.go
@@ -74,12 +74,12 @@ func TestCancelCtx(t *testing.T) {
 		if tCtx.Err() != nil {
 			t.Errorf("context should not be canceled but is: %v", tCtx.Err())
 		}
-		assert.Equal(t, baseCtx.Logger(), tCtx.Logger(), "Logger()")
-		assert.Equal(t, baseCtx.RESTConfig(), tCtx.RESTConfig(), "RESTConfig()")
-		assert.Equal(t, baseCtx.RESTMapper(), tCtx.RESTMapper(), "RESTMapper()")
-		assert.Equal(t, baseCtx.Client(), tCtx.Client(), "Client()")
-		assert.Equal(t, baseCtx.Dynamic(), tCtx.Dynamic(), "Dynamic()")
-		assert.Equal(t, baseCtx.APIExtensions(), tCtx.APIExtensions(), "APIExtensions()")
+		assert.Equalf(t, baseCtx.Logger(), tCtx.Logger(), "Logger()")
+		assert.Equalf(t, baseCtx.RESTConfig(), tCtx.RESTConfig(), "RESTConfig()")
+		assert.Equalf(t, baseCtx.RESTMapper(), tCtx.RESTMapper(), "RESTMapper()")
+		assert.Equalf(t, baseCtx.Client(), tCtx.Client(), "Client()")
+		assert.Equalf(t, baseCtx.Dynamic(), tCtx.Dynamic(), "Dynamic()")
+		assert.Equalf(t, baseCtx.APIExtensions(), tCtx.APIExtensions(), "APIExtensions()")
 	})
 
 	// Cancel, then let testing.T invoke test cleanup.
@@ -99,11 +99,11 @@ func TestWithTB(t *testing.T) {
 	t.Run("sub", func(t *testing.T) {
 		tCtx := ktesting.WithTB(tCtx, t)
 
-		assert.Equal(t, cfg, tCtx.RESTConfig(), "RESTConfig")
-		assert.Equal(t, mapper, tCtx.RESTMapper(), "RESTMapper")
-		assert.Equal(t, client, tCtx.Client(), "Client")
-		assert.Equal(t, dynamic, tCtx.Dynamic(), "Dynamic")
-		assert.Equal(t, apiextensions, tCtx.APIExtensions(), "APIExtensions")
+		assert.Equalf(t, cfg, tCtx.RESTConfig(), "RESTConfig")
+		assert.Equalf(t, mapper, tCtx.RESTMapper(), "RESTMapper")
+		assert.Equalf(t, client, tCtx.Client(), "Client")
+		assert.Equalf(t, dynamic, tCtx.Dynamic(), "Dynamic")
+		assert.Equalf(t, apiextensions, tCtx.APIExtensions(), "APIExtensions")
 
 		tCtx.Cancel("test is complete")
 	})


### PR DESCRIPTION
#### What type of PR is this?

/area test
/kind cleanup
/priority backlog
/sig testing

#### What this PR does / why we need it:

This fixes [formatter](https://github.com/Antonboom/testifylint?tab=readme-ov-file#formatter) rule from [testifylint](https://github.com/Antonboom/testifylint) with `formatter.require-f-funcs`

I missed it the first time, there is an [historical note](https://github.com/Antonboom/testifylint?tab=readme-ov-file#historical-reference) that is interesting to read to have a clear idea of with the `f` suffix is there
