### PR TITLE
Fix pre-provisioned snapshots e2e test

### DIFF
--- a/test/e2e/storage/framework/snapshot_resource.go
+++ b/test/e2e/storage/framework/snapshot_resource.go
@@ -111,6 +111,7 @@ func CreateSnapshotResource(ctx context.Context, sDriver SnapshottableTestDriver
 		framework.Logf("Recording snapshot content annotations: %v", snapshotContentAnnotations)
 		csiDriverName := r.Vsclass.Object["driver"].(string)
 		framework.Logf("Recording snapshot driver: %s", csiDriverName)
+		snapshotClassName := r.Vsclass.GetName()
 
 		// If the deletion policy is retain on vscontent:
 		// when vs is deleted vscontent will not be deleted
@@ -143,7 +144,7 @@ func CreateSnapshotResource(ctx context.Context, sDriver SnapshottableTestDriver
 		snapName := getPreProvisionedSnapshotName(uuid)
 		snapcontentName := getPreProvisionedSnapshotContentName(uuid)
 
-		r.Vscontent = getPreProvisionedSnapshotContent(snapcontentName, snapshotContentAnnotations, snapName, pvcNamespace, snapshotHandle, pattern.SnapshotDeletionPolicy.String(), csiDriverName)
+		r.Vscontent = getPreProvisionedSnapshotContent(snapcontentName, snapshotClassName, snapshotContentAnnotations, snapName, pvcNamespace, snapshotHandle, pattern.SnapshotDeletionPolicy.String(), csiDriverName)
 		r.Vscontent, err = dc.Resource(utils.SnapshotContentGVR).Create(ctx, r.Vscontent, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
 
@@ -302,7 +303,7 @@ func getPreProvisionedSnapshot(snapName, ns, snapshotContentName string) *unstru
 
 	return snapshot
 }
-func getPreProvisionedSnapshotContent(snapcontentName string, snapshotContentAnnotations map[string]string, snapshotName, snapshotNamespace, snapshotHandle, deletionPolicy, csiDriverName string) *unstructured.Unstructured {
+func getPreProvisionedSnapshotContent(snapcontentName, snapshotClassName string, snapshotContentAnnotations map[string]string, snapshotName, snapshotNamespace, snapshotHandle, deletionPolicy, csiDriverName string) *unstructured.Unstructured {
 	snapshotContent := &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"kind":       "VolumeSnapshotContent",
@@ -315,6 +316,7 @@ func getPreProvisionedSnapshotContent(snapcontentName string, snapshotContentAnn
 				"source": map[string]interface{}{
 					"snapshotHandle": snapshotHandle,
 				},
+				"volumeSnapshotClassName": snapshotClassName,
 				"volumeSnapshotRef": map[string]interface{}{
 					"name":      snapshotName,
 					"namespace": snapshotNamespace,


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind failing-test

#### What this PR does / why we need it:
Adds missing VolumeSnapshotClass to VolumeSnapshotContent. This fixes failing tests with external CSI driver.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
VolumeSnapshotContents object created for the pre-provisioned snapshots does not include VolumeSnapshotClass. Therefore secrets required by backing CSI driver cannot be provided via external snapshot controller. The missing secrets causes failure in the backing CSI driver.

https://github.com/kubernetes/kubernetes/issues/127804

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

