### PR TITLE
Automated cherry pick of #127780: Fix deleted UDP endpoint detection

### DIFF
--- a/pkg/proxy/endpointschangetracker.go
+++ b/pkg/proxy/endpointschangetracker.go
@@ -308,7 +308,8 @@ func detectStaleConntrackEntries(oldEndpointsMap, newEndpointsMap EndpointsMap, 
 			// serving to not serving. If it did change stale entries for the old
 			// endpoint have to be cleared.
 			for i := range newEndpointsMap[svcPortName] {
-				if newEndpointsMap[svcPortName][i].String() == ep.String() {
+				if newEndpointsMap[svcPortName][i].String() == ep.String() &&
+					newEndpointsMap[svcPortName][i].IsServing() == ep.IsServing() {
 					deleted = false
 					break
 				}


### PR DESCRIPTION
Cherry pick of #127780 on release-1.30.

#127780: Fix deleted UDP endpoint detection

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixes a regression introduced in 1.29 where conntrack entries for UDP connections
to deleted pods did not get cleaned up correctly, which could (among other things)
cause DNS problems when DNS pods were restarted.
```