### PR TITLE
Increase test coverage for kubelet - pod container manager

### DIFF
--- a/pkg/kubelet/cm/fake_cgroup_manager_linux.go
+++ b/pkg/kubelet/cm/fake_cgroup_manager_linux.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cm
+
+import (
+	"sync"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+type FakeCgroupManager struct {
+	sync.Mutex
+	CalledFunctions []string
+
+	// Return values
+	create error
+	exists bool
+}
+
+func (cgm *FakeCgroupManager) Create(_ *CgroupConfig) error {
+	cgm.Lock()
+	defer cgm.Unlock()
+	cgm.CalledFunctions = append(cgm.CalledFunctions, "Create")
+	return cgm.create
+}
+
+// Destroy the cgroup.
+func (cgm *FakeCgroupManager) Destroy(_ *CgroupConfig) error {
+	cgm.Lock()
+	defer cgm.Unlock()
+	cgm.CalledFunctions = append(cgm.CalledFunctions, "Destroy")
+	return nil
+}
+
+// Update cgroup configuration.
+func (cgm *FakeCgroupManager) Update(_ *CgroupConfig) error {
+	cgm.Lock()
+	defer cgm.Unlock()
+	cgm.CalledFunctions = append(cgm.CalledFunctions, "Update")
+	return nil
+}
+
+// Validate checks if the cgroup is valid
+func (cgm *FakeCgroupManager) Validate(name CgroupName) error {
+	cgm.Lock()
+	defer cgm.Unlock()
+	cgm.CalledFunctions = append(cgm.CalledFunctions, "Validate")
+	return nil
+}
+
+// Exists checks if the cgroup already exists
+func (cgm *FakeCgroupManager) Exists(name CgroupName) bool {
+	cgm.Lock()
+	defer cgm.Unlock()
+	cgm.CalledFunctions = append(cgm.CalledFunctions, "Exists")
+	return cgm.exists
+}
+
+// Name returns the literal cgroupfs name on the host after any driver specific conversions.
+// We would expect systemd implementation to make appropriate name conversion.
+// For example, if we pass {"foo", "bar"}
+// then systemd should convert the name to something like
+// foo.slice/foo-bar.slice
+func (cgm *FakeCgroupManager) Name(name CgroupName) string {
+	cgm.Lock()
+	defer cgm.Unlock()
+	cgm.CalledFunctions = append(cgm.CalledFunctions, "Name")
+	return ""
+}
+
+// CgroupName converts the literal cgroupfs name on the host to an internal identifier.
+func (cgm *FakeCgroupManager) CgroupName(name string) CgroupName {
+	cgm.Lock()
+	defer cgm.Unlock()
+	cgm.CalledFunctions = append(cgm.CalledFunctions, "CgroupName")
+	return nil
+}
+
+// Pids scans through all subsystems to find pids associated with specified cgroup.
+func (cgm *FakeCgroupManager) Pids(name CgroupName) []int {
+	cgm.Lock()
+	defer cgm.Unlock()
+	cgm.CalledFunctions = append(cgm.CalledFunctions, "Pids")
+	return nil
+}
+
+// ReduceCPULimits reduces the CPU CFS values to the minimum amount of shares.
+func (cgm *FakeCgroupManager) ReduceCPULimits(cgroupName CgroupName) error {
+	cgm.Lock()
+	defer cgm.Unlock()
+	cgm.CalledFunctions = append(cgm.CalledFunctions, "ReduceCPULimits")
+	return nil
+}
+
+// MemoryUsage returns current memory usage of the specified cgroup, as read from the cgroupfs.
+func (cgm *FakeCgroupManager) MemoryUsage(name CgroupName) (int64, error) {
+	cgm.Lock()
+	defer cgm.Unlock()
+	cgm.CalledFunctions = append(cgm.CalledFunctions, "MemoryUsage")
+	return 0, nil
+}
+
+// Get the resource config values applied to the cgroup for specified resource type
+func (cgm *FakeCgroupManager) GetCgroupConfig(name CgroupName, resource v1.ResourceName) (*ResourceConfig, error) {
+	cgm.Lock()
+	defer cgm.Unlock()
+	cgm.CalledFunctions = append(cgm.CalledFunctions, "GetCgroupConfig")
+	return nil, nil
+}
+
+// Set resource config for the specified resource type on the cgroup
+func (cgm *FakeCgroupManager) SetCgroupConfig(name CgroupName, resourceConfig *ResourceConfig) error {
+	cgm.Lock()
+	defer cgm.Unlock()
+	cgm.CalledFunctions = append(cgm.CalledFunctions, "SetCgroupConfig")
+	return nil
+}
+
+// Version of the cgroup implementation on the host
+func (cgm *FakeCgroupManager) Version() int {
+	cgm.Lock()
+	defer cgm.Unlock()
+	cgm.CalledFunctions = append(cgm.CalledFunctions, "Version")
+	return 0
+}

--- a/pkg/kubelet/cm/pod_container_manager_linux_test.go
+++ b/pkg/kubelet/cm/pod_container_manager_linux_test.go
@@ -20,14 +20,15 @@ limitations under the License.
 package cm
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -290,6 +291,93 @@ func TestGetPodContainerName(t *testing.T) {
 			actualCgroupName, actualLiteralCgroupfs := pcm.GetPodContainerName(tt.args.pod)
 			require.Equalf(t, tt.wantCgroupName, actualCgroupName, "Unexpected cgroup name for pod with UID %s, container resources: %v", tt.args.pod.UID, tt.args.pod.Spec.Containers[0].Resources)
 			require.Equalf(t, tt.wantLiteralCgroupfs, actualLiteralCgroupfs, "Unexpected literal cgroupfs for pod with UID %s, container resources: %v", tt.args.pod.UID, tt.args.pod.Spec.Containers[0].Resources)
+		})
+	}
+}
+
+func Test_podContainerManagerImpl_EnsureExists(t *testing.T) {
+	newGuaranteedPodWithUID := func(uid types.UID) *v1.Pod {
+		return &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				UID: uid,
+			},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Name: "container",
+						Resources: v1.ResourceRequirements{
+							Requests: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("1000m"),
+								v1.ResourceMemory: resource.MustParse("1G"),
+							},
+							Limits: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("1000m"),
+								v1.ResourceMemory: resource.MustParse("1G"),
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	type fields struct {
+		cgroupManager CgroupManager
+	}
+	type args struct {
+		pod *v1.Pod
+	}
+	tests := []struct {
+		name               string
+		fields             fields
+		args               args
+		wantErr            bool
+		wantCgroupCalls    []string
+		excludeCgroupCalls []string
+	}{
+		{
+			name: "cgroup exists",
+			fields: fields{
+				cgroupManager: &FakeCgroupManager{exists: true},
+			},
+			args:               args{pod: newGuaranteedPodWithUID("fake-uid-1")},
+			wantErr:            false,
+			wantCgroupCalls:    []string{"Exists"},
+			excludeCgroupCalls: []string{"Create"},
+		},
+		{
+			name: "cgroup created",
+			fields: fields{
+				cgroupManager: &FakeCgroupManager{exists: false},
+			},
+			args:            args{pod: newGuaranteedPodWithUID("fake-uid-1")},
+			wantErr:         false,
+			wantCgroupCalls: []string{"Exists", "Create"},
+		},
+		{
+			name: "failed to create cgroup",
+			fields: fields{
+				cgroupManager: &FakeCgroupManager{exists: false, create: errors.New("test - failed to create cgroup")},
+			},
+			args:            args{pod: newGuaranteedPodWithUID("fake-uid-1")},
+			wantErr:         true,
+			wantCgroupCalls: []string{"Exists", "Create"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &podContainerManagerImpl{
+				cgroupManager: tt.fields.cgroupManager,
+			}
+			err := m.EnsureExists(tt.args.pod)
+			assert.Equalf(t, tt.wantErr, err != nil, "podContainerManagerImpl.EnsureExists() error = %v, wantErr %v", err, tt.wantErr)
+
+			for _, call := range tt.wantCgroupCalls {
+				require.Contains(t, tt.fields.cgroupManager.(*FakeCgroupManager).CalledFunctions, call)
+			}
+			for _, call := range tt.excludeCgroupCalls {
+				require.NotContains(t, tt.fields.cgroupManager.(*FakeCgroupManager).CalledFunctions, call)
+			}
 		})
 	}
 }


### PR DESCRIPTION
A fake cgroup manager was made to facilitate the tests.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This increases the test coverage of the pod container manager within the kubelet.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # None
Part of #109717

#### Special notes for your reviewer:

This adds a FakeCgroupManager as most of the functionality tested relies on the behavior of this manager. 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
