### PR TITLE
Added --depth  flag  to get fields recursively upto certain depth

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/explain/explain.go
+++ b/staging/src/k8s.io/kubectl/pkg/explain/explain.go
@@ -151,7 +151,7 @@ func SplitAndParseResourceRequestWithMatchingPrefix(inResource string, mapper me
 // PrintModelDescription prints the description of a specific model or dot path.
 // If recursive, all components nested within the fields of the schema will be
 // printed.
-func PrintModelDescription(fieldsPath []string, w io.Writer, schema proto.Schema, gvk schema.GroupVersionKind, recursive bool) error {
+func PrintModelDescription(fieldsPath []string, w io.Writer, schema proto.Schema, gvk schema.GroupVersionKind, recursive bool, depth int) error {
 	fieldName := ""
 	if len(fieldsPath) != 0 {
 		fieldName = fieldsPath[len(fieldsPath)-1]
@@ -162,7 +162,7 @@ func PrintModelDescription(fieldsPath []string, w io.Writer, schema proto.Schema
 	if err != nil {
 		return err
 	}
-	b := fieldsPrinterBuilder{Recursive: recursive}
+	b := fieldsPrinterBuilder{Recursive: recursive, Depth: depth}
 	f := &Formatter{Writer: w, Wrap: 80}
-	return PrintModel(fieldName, f, b, schema, gvk)
+	return PrintModel(fieldName, f, b, schema, gvk, depth)
 }

--- a/staging/src/k8s.io/kubectl/pkg/explain/fields_printer_builder.go
+++ b/staging/src/k8s.io/kubectl/pkg/explain/fields_printer_builder.go
@@ -20,6 +20,7 @@ package explain
 // recursiveFieldsPrinter based on the argument.
 type fieldsPrinterBuilder struct {
 	Recursive bool
+	Depth     int
 }
 
 // BuildFieldsPrinter builds the appropriate fieldsPrinter.
@@ -27,6 +28,7 @@ func (f fieldsPrinterBuilder) BuildFieldsPrinter(writer *Formatter) fieldsPrinte
 	if f.Recursive {
 		return &recursiveFieldsPrinter{
 			Writer: writer,
+			Depth:  f.Depth,
 		}
 	}
 

--- a/staging/src/k8s.io/kubectl/pkg/explain/model_printer.go
+++ b/staging/src/k8s.io/kubectl/pkg/explain/model_printer.go
@@ -38,6 +38,7 @@ type modelPrinter struct {
 	Writer       *Formatter
 	Builder      fieldsPrinterBuilder
 	GVK          schema.GroupVersionKind
+	Depth        int
 	Error        error
 }
 
@@ -156,8 +157,8 @@ func (m *modelPrinter) VisitReference(r proto.Reference) {
 }
 
 // PrintModel prints the description of a schema in writer.
-func PrintModel(name string, writer *Formatter, builder fieldsPrinterBuilder, schema proto.Schema, gvk schema.GroupVersionKind) error {
-	m := &modelPrinter{Name: name, Writer: writer, Builder: builder, GVK: gvk}
+func PrintModel(name string, writer *Formatter, builder fieldsPrinterBuilder, schema proto.Schema, gvk schema.GroupVersionKind, depth int) error {
+	m := &modelPrinter{Name: name, Writer: writer, Builder: builder, GVK: gvk, Depth: depth}
 	schema.Accept(m)
 	return m.Error
 }

--- a/staging/src/k8s.io/kubectl/pkg/explain/model_printer_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/explain/model_printer_test.go
@@ -150,7 +150,7 @@ FIELDS:
 			t.Fatalf("Couldn't find schema %v", test.gvk)
 		}
 		buf := bytes.Buffer{}
-		if err := PrintModelDescription(test.path, &buf, schema, test.gvk, false); err != nil {
+		if err := PrintModelDescription(test.path, &buf, schema, test.gvk, false, 0); err != nil {
 			t.Fatalf("Failed to PrintModelDescription for path %v: %v", test.path, err)
 		}
 		got := buf.String()
@@ -187,7 +187,7 @@ DESCRIPTION:
 
 	for _, test := range tests {
 		buf := bytes.Buffer{}
-		if err := PrintModelDescription(test.path, &buf, schema, gvk, false); err != nil {
+		if err := PrintModelDescription(test.path, &buf, schema, gvk, false, 0); err != nil {
 			t.Fatalf("Failed to PrintModelDescription for path %v: %v", test.path, err)
 		}
 		got := buf.String()

--- a/staging/src/k8s.io/kubectl/pkg/explain/recursive_fields_printer_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/explain/recursive_fields_printer_test.go
@@ -52,7 +52,7 @@ field2	<[]map[string]string>
 	if err != nil {
 		t.Fatalf("Invalid path %v: %v", []string{}, err)
 	}
-	if err := (fieldsPrinterBuilder{Recursive: true}).BuildFieldsPrinter(&f).PrintFields(s); err != nil {
+	if err := (fieldsPrinterBuilder{Recursive: true, Depth: 0}).BuildFieldsPrinter(&f).PrintFields(s); err != nil {
 		t.Fatalf("Failed to print fields: %v", err)
 	}
 	got := buf.String()
@@ -91,7 +91,44 @@ field2	<Object>
 	if err != nil {
 		t.Fatalf("Invalid path %v: %v", []string{}, err)
 	}
-	if err := (fieldsPrinterBuilder{Recursive: true}).BuildFieldsPrinter(&f).PrintFields(s); err != nil {
+	if err := (fieldsPrinterBuilder{Recursive: true, Depth: 0}).BuildFieldsPrinter(&f).PrintFields(s); err != nil {
+		t.Fatalf("Failed to print fields: %v", err)
+	}
+	got := buf.String()
+	if got != want {
+		t.Errorf("Got:\n%v\nWant:\n%v\n", buf.String(), want)
+	}
+}
+
+func TestRecursiveFieldsWithDepthTwo(t *testing.T) {
+	var resources = tst.NewFakeResources("test-recursive-swagger.json")
+	schema := resources.LookupResource(schema.GroupVersionKind{
+		Group:   "",
+		Version: "v2",
+		Kind:    "OneKind",
+	})
+	if schema == nil {
+		t.Fatal("Couldn't find schema v2.OneKind")
+	}
+
+	want := `field1	<Object>
+   referencefield	<Object>
+   referencesarray	<[]Object>
+field2	<Object>
+   reference	<Object>
+   string	<string>
+`
+
+	buf := bytes.Buffer{}
+	f := Formatter{
+		Writer: &buf,
+		Wrap:   80,
+	}
+	s, err := LookupSchemaForField(schema, []string{})
+	if err != nil {
+		t.Fatalf("Invalid path %v: %v", []string{}, err)
+	}
+	if err := (fieldsPrinterBuilder{Recursive: true, Depth: 2}).BuildFieldsPrinter(&f).PrintFields(s); err != nil {
 		t.Fatalf("Failed to print fields: %v", err)
 	}
 	got := buf.String()

--- a/staging/src/k8s.io/kubectl/pkg/explain/v2/explain.go
+++ b/staging/src/k8s.io/kubectl/pkg/explain/v2/explain.go
@@ -37,6 +37,7 @@ func PrintModelDescription(
 	gvr schema.GroupVersionResource,
 	recursive bool,
 	outputFormat string,
+	depth int,
 ) error {
 	generator := NewGenerator()
 	if err := registerBuiltinTemplates(generator); err != nil {
@@ -44,7 +45,7 @@ func PrintModelDescription(
 	}
 
 	return printModelDescriptionWithGenerator(
-		generator, fieldsPath, w, client, gvr, recursive, outputFormat)
+		generator, fieldsPath, w, client, gvr, recursive, outputFormat, depth)
 }
 
 // Factored out for testability
@@ -56,6 +57,7 @@ func printModelDescriptionWithGenerator(
 	gvr schema.GroupVersionResource,
 	recursive bool,
 	outputFormat string,
+	depth int,
 ) error {
 	paths, err := client.Paths()
 
@@ -86,7 +88,7 @@ func printModelDescriptionWithGenerator(
 		return fmt.Errorf("failed to parse openapi schema for %s: %w", resourcePath, err)
 	}
 
-	err = generator.Render(outputFormat, parsedV3Schema, gvr, fieldsPath, recursive, w)
+	err = generator.Render(outputFormat, parsedV3Schema, gvr, fieldsPath, recursive, w, depth)
 
 	explainErr := explainError("")
 	if errors.As(err, &explainErr) {

--- a/staging/src/k8s.io/kubectl/pkg/explain/v2/explain_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/explain/v2/explain_test.go
@@ -44,12 +44,12 @@ func TestExplainErrors(t *testing.T) {
 		Group:    "test0.example.com",
 		Version:  "v1",
 		Resource: "doesntmatter",
-	}, false, "unknown-format")
+	}, false, "unknown-format", 0)
 	require.ErrorContains(t, err, "couldn't find resource for \"test0.example.com/v1, Resource=doesntmatter\"")
 
 	// Validate error when openapi client returns error.
 	fakeClient.ForcedErr = fmt.Errorf("Always fails")
-	err = PrintModelDescription(nil, &buf, fakeClient, apiGroupsGVR, false, "unknown-format")
+	err = PrintModelDescription(nil, &buf, fakeClient, apiGroupsGVR, false, "unknown-format", 0)
 	require.ErrorContains(t, err, "failed to fetch list of groupVersions")
 
 	// Validate error when GroupVersion "Schema()" call returns error.
@@ -60,7 +60,7 @@ func TestExplainErrors(t *testing.T) {
 		Group:    "test1.example.com",
 		Version:  "v1",
 		Resource: "doesntmatter",
-	}, false, "unknown-format")
+	}, false, "unknown-format", 0)
 	require.ErrorContains(t, err, "failed to fetch openapi schema ")
 
 	// Validate error when returned bytes from GroupVersion "Schema" are invalid.
@@ -70,18 +70,17 @@ func TestExplainErrors(t *testing.T) {
 		Group:    "test2.example.com",
 		Version:  "v1",
 		Resource: "doesntmatter",
-	}, false, "unknown-format")
+	}, false, "unknown-format", 0)
 	require.ErrorContains(t, err, "failed to parse openapi schema")
 
 	// Validate error when render template is not recognized.
 	client := openapitest.NewEmbeddedFileClient()
-	err = PrintModelDescription(nil, &buf, client, apiGroupsGVR, false, "unknown-format")
+	err = PrintModelDescription(nil, &buf, client, apiGroupsGVR, false, "unknown-format", 0)
 	require.ErrorContains(t, err, "unrecognized format: unknown-format")
 }
 
-// Shows that the correct GVR is fetched from the open api client when
-// given to explain
-func TestExplainOpenAPIClient(t *testing.T) {
+// Shows that the correct GVR is fetched from the openapi client and that depth is passed
+func TestExplainOpenAPIClientWithDepth(t *testing.T) {
 	var buf bytes.Buffer
 
 	fileClient := openapitest.NewEmbeddedFileClient()
@@ -105,9 +104,10 @@ func TestExplainOpenAPIClient(t *testing.T) {
 		GVR:       apiGroupsGVR,
 		Recursive: false,
 		FieldPath: nil,
+		Depth:     2,
 	}
 
-	err = printModelDescriptionWithGenerator(gen, nil, &buf, fileClient, apiGroupsGVR, false, "Context")
+	err = printModelDescriptionWithGenerator(gen, nil, &buf, fileClient, apiGroupsGVR, false, "Context", 2)
 	require.NoError(t, err)
 
 	var actualContext TemplateContext

--- a/staging/src/k8s.io/kubectl/pkg/explain/v2/generator.go
+++ b/staging/src/k8s.io/kubectl/pkg/explain/v2/generator.go
@@ -41,6 +41,7 @@ type Generator interface {
 		recursive bool,
 		// Output writer
 		writer io.Writer,
+		depth int,
 	) error
 }
 
@@ -49,6 +50,7 @@ type TemplateContext struct {
 	Document  map[string]interface{}
 	Recursive bool
 	FieldPath []string
+	Depth     int
 }
 
 type generator struct {
@@ -86,6 +88,7 @@ func (g *generator) Render(
 	recursive bool,
 	// Output writer
 	writer io.Writer,
+	depth int,
 ) error {
 	compiledTemplate, ok := g.templates[templateName]
 	if !ok {
@@ -97,6 +100,7 @@ func (g *generator) Render(
 		Recursive: recursive,
 		FieldPath: fieldSelector,
 		GVR:       gvr,
+		Depth:     depth,
 	})
 	return err
 }

--- a/staging/src/k8s.io/kubectl/pkg/explain/v2/generator_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/explain/v2/generator_test.go
@@ -46,7 +46,7 @@ func TestGeneratorMissingOutput(t *testing.T) {
 
 	gen := NewGenerator()
 	badTemplateName := "bad-template"
-	err = gen.Render(badTemplateName, doc, appsDeploymentGVR, nil, false, &buf)
+	err = gen.Render(badTemplateName, doc, appsDeploymentGVR, nil, false, &buf, 0)
 
 	require.ErrorContains(t, err, "unrecognized format: "+badTemplateName)
 	require.Zero(t, buf.Len())
@@ -54,7 +54,7 @@ func TestGeneratorMissingOutput(t *testing.T) {
 	err = gen.AddTemplate(badTemplateName, "ok")
 	require.NoError(t, err)
 
-	err = gen.Render(badTemplateName, doc, appsDeploymentGVR, nil, false, &buf)
+	err = gen.Render(badTemplateName, doc, appsDeploymentGVR, nil, false, &buf, 0)
 	require.NoError(t, err)
 	require.Equal(t, "ok", buf.String())
 }
@@ -77,6 +77,7 @@ func TestGeneratorContext(t *testing.T) {
 		GVR:       appsDeploymentGVR,
 		Recursive: false,
 		FieldPath: nil,
+		Depth:     1,
 	}
 
 	err = gen.Render("Context",
@@ -84,7 +85,8 @@ func TestGeneratorContext(t *testing.T) {
 		expectedContext.GVR,
 		expectedContext.FieldPath,
 		expectedContext.Recursive,
-		&buf)
+		&buf,
+		expectedContext.Depth)
 	require.NoError(t, err)
 
 	var actualContext TemplateContext

--- a/staging/src/k8s.io/kubectl/pkg/explain/v2/templates/plaintext.tmpl
+++ b/staging/src/k8s.io/kubectl/pkg/explain/v2/templates/plaintext.tmpl
@@ -36,7 +36,7 @@
     VERSION:    {{ $gvk.version }}{{"\n" -}}
     {{- "\n" -}}
 
-    {{- with include "schema" (dict "gvk" $gvk "Document" $.Document "FieldPath" $.FieldPath "Recursive" $.Recursive) -}}
+    {{- with include "schema" (dict "gvk" $gvk "Document" $.Document "FieldPath" $.FieldPath "Recursive" $.Recursive "Depth" $.Depth) -}}
         {{- . -}}
     {{- else -}}
         {{- throw "error: GVK %v not found in OpenAPI schema" $gvk -}}
@@ -98,7 +98,7 @@ Takes dictionary as argument with keys:
     {{- if not $.FieldPath -}}
         DESCRIPTION:{{- "\n" -}}
         {{- or (include "description" (dict "schema" $resolved "Document" $.Document)) "<empty>" | wrap 76 | indent 4 -}}{{- "\n" -}}
-        {{- with include "fieldList" (dict "schema" $resolved "level" 1 "Document" $.Document "Recursive" $.Recursive) -}}
+        {{- with include "fieldList" (dict "schema" $resolved "level" 1 "Document" $.Document "Recursive" $.Recursive "Depth" $.Depth) -}}
             FIELDS:{{- "\n" -}}
             {{- . -}}
         {{- end -}}
@@ -171,20 +171,26 @@ Takes dictionary as argument with keys:
     {{- else -}}
         {{- $nextContext := set $ "history" (set $.history $refString 1) -}}
         {{- $resolved := or (resolveRef $refString $.Document) $.schema -}}
-        {{- range $k, $v := $resolved.properties -}}
-            {{- template "fieldDetail" (dict "name" $k "schema" $resolved "short" $.Recursive "level" $.level "Document" $.Document) -}}
-            {{- if $.Recursive -}}
-                {{- /* Check if we already know about this element */}}
-                {{- template "fieldList" (set $nextContext "schema" $v "level" (add $.level 1)) -}}
+        
+        {{- if or (le $.level $.Depth) (le $.Depth 0) -}}  {{/* Check if current level is less than max level */}}
+            {{- range $k, $v := $resolved.properties -}}
+                {{- /* Print field name with indentation */ -}} 
+                {{- template "fieldDetail" (dict "name" $k "schema" $resolved "short" $.Recursive "level" $.level "Document" $.Document) -}}
+                {{- if $.Recursive -}}
+                    {{- /* Check if we already know about this element */}}
+                    {{- template "fieldList" (set $nextContext "schema" $v "level" (add $.level 1) "Depth" $.Depth) -}}
+                {{- end -}}
             {{- end -}}
-        {{- end -}}
-        {{- range $resolved.allOf -}}
-            {{- template "fieldList" (set $nextContext "schema" .)}}
-        {{- end -}}
-        {{- if $resolved.items}}{{- template "fieldList" (set $nextContext "schema" $resolved.items)}}{{end}}
-        {{- if and $resolved.additionalProperties (not (eq "bool" (printf "%T" $resolved.additionalProperties))) -}}
-            {{- template "fieldList" (set $nextContext "schema" $resolved.additionalProperties)}}
-        {{- end -}}
+            {{- range $resolved.allOf -}}
+                {{- template "fieldList" (set $nextContext "schema" . "Depth" $.Depth) -}}
+            {{- end -}}
+            {{- if $resolved.items -}}
+                {{- template "fieldList" (set $nextContext "schema" $resolved.items "Depth" $.Depth) -}}
+            {{- end -}}
+            {{- if and $resolved.additionalProperties (not (eq "bool" (printf "%T" $resolved.additionalProperties))) -}}
+                {{- template "fieldList" (set $nextContext "schema" $resolved.additionalProperties "Depth" $.Depth) -}}
+            {{- end -}}
+        {{- end -}} 
     {{- end -}}
 {{- end -}}
 

--- a/test/cmd/legacy-script.sh
+++ b/test/cmd/legacy-script.sh
@@ -535,6 +535,14 @@ runTests() {
     record_command run_explain_crd_with_additional_properties_tests
   fi
 
+  #################
+  # Explain depth #
+  #################
+
+  if kube::test::if_supports_resource "${customresourcedefinitions}" ; then
+    record_command run_explain_crd_with_depth_tests
+  fi
+
   #########################
   # Assert categories     #
   #########################


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR adds new flag `--depth` to `kubectl explain <resource> --recursive`  command to limit the level up to which fields are recursively explained. Users can now limit the depth of field explanations when using the recursive option, providing more control over the output. It enhances the UX by giving more flexibility.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes  https://github.com/kubernetes/kubectl/issues/1659
#### Special notes for your reviewer:

1. `--depth` support added in `kubectl/pkg/cmd/explain/explain.go`
2.  Depth support added for two and only types of outputs -> `plaintext` and `plaintext-openapiv2`
3.  Updated command usage information
4.  Added relevant unit tests
5.  Error handling for invalid `--depth` inputs 

#### Does this PR introduce a user-facing change?

```release-note
Added a new `--depth` flag to the `kubectl explain <resource> --recursive` command. This flag allows users to limit the depth of recursive field explanations, providing more control over the output.
```

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
Example: 

When the `--depth` flag is not used, the entire structure of the resource fields will be recursively explained. For ex: 

```bash
$ kubectl explain pods.spec.affinity.podAffinity --recursive --output plaintext-openapiv2

KIND:     Pod
VERSION:  v1

RESOURCE: podAffinity <Object>

DESCRIPTION:
     Describes pod affinity scheduling rules (e.g. co-locate this pod in the
     same node, zone, etc. as some other pod(s)).

     Pod affinity is a group of inter pod affinity scheduling rules.

FIELDS:
   preferredDuringSchedulingIgnoredDuringExecution	<[]Object>
      podAffinityTerm	<Object>
         labelSelector	<Object>
            matchExpressions	<[]Object>
               key	<string>
               operator	<string>
               values	<[]string>
            matchLabels	<map[string]string>
         matchLabelKeys	<[]string>
         mismatchLabelKeys	<[]string>
         namespaceSelector	<Object>
            matchExpressions	<[]Object>
               key	<string>
               operator	<string>
               values	<[]string>
            matchLabels	<map[string]string>
         namespaces	<[]string>
         topologyKey	<string>
      weight	<integer>
   requiredDuringSchedulingIgnoredDuringExecution	<[]Object>
      labelSelector	<Object>
         matchExpressions	<[]Object>
            key	<string>
            operator	<string>
            values	<[]string>
         matchLabels	<map[string]string>
      matchLabelKeys	<[]string>
      mismatchLabelKeys	<[]string>
      namespaceSelector	<Object>
         matchExpressions	<[]Object>
            key	<string>
            operator	<string>
            values	<[]string>
         matchLabels	<map[string]string>
      namespaces	<[]string>
      topologyKey	<string>
```

By using the --depth flag, user can now limit how deep the recursive explanation goes. For ex, setting --depth=2 will limit the output to only two levels of fields

```bash
$ kubectl explain pods.spec.affinity.podAffinity --recursive --depth 2 --output plaintext-openapiv2

KIND:     Pod
VERSION:  v1

RESOURCE: podAffinity <Object>

DESCRIPTION:
     Describes pod affinity scheduling rules (e.g. co-locate this pod in the
     same node, zone, etc. as some other pod(s)).

     Pod affinity is a group of inter pod affinity scheduling rules.

FIELDS:
   preferredDuringSchedulingIgnoredDuringExecution	<[]Object>
      podAffinityTerm	<Object>
      weight	<integer>
   requiredDuringSchedulingIgnoredDuringExecution	<[]Object>
      labelSelector	<Object>
      matchLabelKeys	<[]string>
      mismatchLabelKeys	<[]string>
      namespaceSelector	<Object>
      namespaces	<[]string>
      topologyKey	<string>
```
