### PR TITLE
Test concrete type changes in unstructured float64 JSON roundtrips.

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/json_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/json_test.go
@@ -1042,3 +1042,50 @@ func TestEncode(t *testing.T) {
 		})
 	}
 }
+
+// TestRoundtripUnstructuredFloat64 demonstrates that encoding a fractionless float64 value to JSON
+// then decoding into interface{} can produce a value with concrete type int64. This is a
+// consequence of two specific behaviors. First, there is nothing in the JSON encoding of a
+// fractionless float64 value to distinguish it from the JSON encoding of an integer value. Second,
+// if, when unmarshaling into interface{}, the decoder encounters a JSON number with no decimal
+// point in the input, it produces a value with concrete type int64 as long as the number can be
+// precisely represented by an int64.
+func TestRoundtripUnstructuredFractionlessFloat64(t *testing.T) {
+	s := json.NewSerializerWithOptions(json.DefaultMetaFactory, runtime.NewScheme(), runtime.NewScheme(), json.SerializerOptions{})
+
+	initial := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion":                    "v1",
+		"kind":                          "Test",
+		"with-fraction":                 float64(1.5),
+		"without-fraction":              float64(1),
+		"without-fraction-big-positive": float64(9223372036854776000),
+		"without-fraction-big-negative": float64(-9223372036854776000),
+	}}
+
+	var buf bytes.Buffer
+	if err := s.Encode(initial, &buf); err != nil {
+		t.Fatal(err)
+	}
+
+	final := &unstructured.Unstructured{}
+	got, _, err := s.Decode(buf.Bytes(), nil, final)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != final {
+		t.Fatalf("expected Decode to return target Unstructured object but got: %v", got)
+	}
+
+	expected := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion":                    "v1",
+		"kind":                          "Test",
+		"with-fraction":                 float64(1.5),
+		"without-fraction":              int64(1), // note the change in concrete type
+		"without-fraction-big-positive": float64(9223372036854776000),
+		"without-fraction-big-negative": float64(-9223372036854776000),
+	}}
+
+	if diff := cmp.Diff(expected, final); diff != "" {
+		t.Fatalf("unexpected diff:\n%s", diff)
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:

During JSON roundtrips of unstructured objects, float64 values with no fractional component will in certain cases roundtrip to int64. This is potentially surprising existing behavior. Adding dedicated test coverage for this will help codify the behavior and mitigate future regression risk.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
