### PR TITLE
aggregator: add NewLegacyDiscoveryManager to support registering APIService objects with a legacy discovery endpoint

### DIFF
--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
@@ -372,10 +372,15 @@ func (c completedConfig) NewWithDelegate(delegationTarget genericapiserver.Deleg
 	})
 
 	if utilfeature.DefaultFeatureGate.Enabled(genericfeatures.AggregatedDiscoveryEndpoint) {
-		s.discoveryAggregationController = NewDiscoveryManager(
+		var legacyDiscoveryManager aggregated.ResourceManager
+		if s.GenericAPIServer.AggregatedLegacyDiscoveryGroupManager != nil {
+			legacyDiscoveryManager = s.GenericAPIServer.AggregatedLegacyDiscoveryGroupManager.WithSource(aggregated.AggregatorSource)
+		}
+		s.discoveryAggregationController = NewLegacyDiscoveryManager(
 			// Use aggregator as the source name to avoid overwriting native/CRD
 			// groups
 			s.GenericAPIServer.AggregatedDiscoveryGroupManager.WithSource(aggregated.AggregatorSource),
+			legacyDiscoveryManager,
 		)
 
 		// Setup discovery endpoint

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_discovery.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_discovery.go
@@ -108,6 +108,9 @@ type discoveryManager struct {
 	// Merged handler which stores all known groupversions
 	mergedDiscoveryHandler discoveryendpoint.ResourceManager
 
+	// Used to register the core API group into discovery
+	legacyDiscoveryHandler discoveryendpoint.ResourceManager
+
 	// Codecs is the serializer used for decoding aggregated apiserver responses
 	codecs serializer.CodecFactory
 }
@@ -186,6 +189,15 @@ var _ DiscoveryAggregationController = &discoveryManager{}
 func NewDiscoveryManager(
 	target discoveryendpoint.ResourceManager,
 ) DiscoveryAggregationController {
+	return NewLegacyDiscoveryManager(target, nil)
+}
+
+// NewLegacyDiscoveryManager creates a new DiscoveryAggregationController that
+// supports registering the core API group into a separate legacy ResourceManager.
+func NewLegacyDiscoveryManager(
+	target discoveryendpoint.ResourceManager,
+	legacy discoveryendpoint.ResourceManager,
+) DiscoveryAggregationController {
 	discoveryScheme := runtime.NewScheme()
 	utilruntime.Must(apidiscoveryv2.AddToScheme(discoveryScheme))
 	utilruntime.Must(apidiscoveryv2beta1.AddToScheme(discoveryScheme))
@@ -195,6 +207,7 @@ func NewDiscoveryManager(
 
 	return &discoveryManager{
 		mergedDiscoveryHandler: target,
+		legacyDiscoveryHandler: legacy,
 		apiServices:            make(map[string]groupVersionInfo),
 		cachedResults:          make(map[serviceKey]cachedResult),
 		dirtyAPIServiceQueue: workqueue.NewTypedRateLimitingQueueWithConfig(
@@ -383,10 +396,13 @@ func (dm *discoveryManager) syncAPIService(apiServiceName string) error {
 
 	gv := helper.APIServiceNameToGroupVersion(apiServiceName)
 	mgv := metav1.GroupVersion{Group: gv.Group, Version: gv.Version}
-
+	discoveryHandler := dm.mergedDiscoveryHandler
+	if dm.legacyDiscoveryHandler != nil && gv.Group == "" {
+		discoveryHandler = dm.legacyDiscoveryHandler
+	}
 	if !exists {
-		// apiservice was removed. remove it from merged discovery
-		dm.mergedDiscoveryHandler.RemoveGroupVersion(mgv)
+		// apiservice was removed. remove it from discovery
+		discoveryHandler.RemoveGroupVersion(mgv)
 		return nil
 	}
 
@@ -429,8 +445,9 @@ func (dm *discoveryManager) syncAPIService(apiServiceName string) error {
 		entry.Freshness = apidiscoveryv2.DiscoveryFreshnessStale
 	}
 
-	dm.mergedDiscoveryHandler.AddGroupVersion(gv.Group, entry)
-	dm.mergedDiscoveryHandler.SetGroupVersionPriority(metav1.GroupVersion(gv), info.groupPriority, info.versionPriority)
+	discoveryHandler.AddGroupVersion(gv.Group, entry)
+	discoveryHandler.SetGroupVersionPriority(metav1.GroupVersion(gv), info.groupPriority, info.versionPriority)
+
 	return nil
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig api-machinery

#### What this PR does / why we need it:

Wire the legacy API discovery ResourceManager through to the aggregator DiscoveryManager to allow the `v1.` APIService to be registered with an externally referenced server.

I am utilising kube-aggregator as a proxying layer, and currently when configuring my APIService for `v1.` I get the core API group registered in the `/apis` discovery manager, leading to improper discovery information (an empty entry for the core API group is inserted into the `/apis` endpoint output).

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

I *think* this PR technically makes it possible for the core API group to be served by an external service referenced by an APIService, which _may_ be an administrative concern/consideration.

However, this bug does not affect anything outside of the core API group, namely any other `*.k8s.io` resource (including authorization/authentication related groups). I don't think core is particularly special in this regard.

#### Does this PR introduce a user-facing change?
```release-note
TODO pending confirmation this is desirable
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
```

/cc @sttts @liggitt 