### PR TITLE
Add scheduler_perf test case for pod update events handling

### DIFF
--- a/test/integration/scheduler_perf/config/event_handling/podupdate-node-unschedulable.yaml
+++ b/test/integration/scheduler_perf/config/event_handling/podupdate-node-unschedulable.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Node
+metadata:
+  name: unschedulable-node
+spec:
+  unschedulable: true
+status:
+  capacity:
+    pods: "90000"
+    cpu: "4"
+    memory: 32Gi
+  conditions:
+    - status: "True"
+      type: Ready
+  phase: Running

--- a/test/integration/scheduler_perf/config/event_handling/podupdate-node-with-taint.yaml
+++ b/test/integration/scheduler_perf/config/event_handling/podupdate-node-with-taint.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Node
+metadata:
+  name: node-with-taint
+spec:
+  taints:
+    - key: toleration
+      effect: NoSchedule
+status:
+  capacity:
+    pods: "90000"
+    cpu: "4"
+    memory: 32Gi
+  conditions:
+    - status: "True"
+      type: Ready
+  phase: Running

--- a/test/integration/scheduler_perf/config/event_handling/podupdate-pod-blocker-update.yaml
+++ b/test/integration/scheduler_perf/config/event_handling/podupdate-pod-blocker-update.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-blocker-{{ .Index }}
+spec:
+  containers:
+  - image: registry.k8s.io/pause:3.10
+    name: pause
+    resources:
+      requests:
+        cpu: 0.0001
+        memory: 1Mi
+  nodeName: scheduler-perf-node

--- a/test/integration/scheduler_perf/config/event_handling/podupdate-pod-blocker.yaml
+++ b/test/integration/scheduler_perf/config/event_handling/podupdate-pod-blocker.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-blocker-{{ .Index }}
+  labels:
+    color: green-{{ .Index }}
+    topology: blue
+spec:
+  containers:
+  - image: registry.k8s.io/pause:3.10
+    name: pause
+    resources:
+      requests:
+        cpu: 0.0001
+        memory: {{ div 30000 .Count }}Mi

--- a/test/integration/scheduler_perf/config/event_handling/podupdate-pod-interpodaffinity.yaml
+++ b/test/integration/scheduler_perf/config/event_handling/podupdate-pod-interpodaffinity.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  generateName: pod-interpodaffinity-
+  labels:
+    color: green-{{ .Index }}
+    type: unsched
+spec:
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchLabels:
+            color: green-{{ .Index }}
+        topologyKey: kubernetes.io/hostname
+        namespaces: [blocker]
+  containers:
+  - image: registry.k8s.io/pause:3.10
+    name: pause

--- a/test/integration/scheduler_perf/config/event_handling/podupdate-pod-noderesources.yaml
+++ b/test/integration/scheduler_perf/config/event_handling/podupdate-pod-noderesources.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-noderesources-{{ .Index }}
+  labels:
+    type: unsched
+spec:
+  containers:
+  - image: registry.k8s.io/pause:3.10
+    name: pause
+    resources:
+      requests:
+        cpu: 0.0001
+        memory: {{ div 30000 .Count }}Mi

--- a/test/integration/scheduler_perf/config/event_handling/podupdate-pod-nodeunschedulable-update.yaml
+++ b/test/integration/scheduler_perf/config/event_handling/podupdate-pod-nodeunschedulable-update.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-nodeunschedulable-{{ .Index }}
+  labels:
+    type: unsched
+spec:
+  tolerations:
+  - key: node.kubernetes.io/unschedulable
+    operator: Exists
+    effect: NoSchedule
+  containers:
+  - image: registry.k8s.io/pause:3.10
+    name: pause

--- a/test/integration/scheduler_perf/config/event_handling/podupdate-pod-nodeunschedulable.yaml
+++ b/test/integration/scheduler_perf/config/event_handling/podupdate-pod-nodeunschedulable.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-nodeunschedulable-{{ .Index }}
+  labels:
+    type: unsched
+spec:
+  containers:
+  - image: registry.k8s.io/pause:3.10
+    name: pause

--- a/test/integration/scheduler_perf/config/event_handling/podupdate-pod-podtopologyspread.yaml
+++ b/test/integration/scheduler_perf/config/event_handling/podupdate-pod-podtopologyspread.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  generateName: pod-podtopologyspread-
+  labels:
+    type: unsched
+    topology: blue
+spec:
+  topologySpreadConstraints:
+    - maxSkew: {{ .Count }}
+      minDomains: 100
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: DoNotSchedule
+      labelSelector:
+        matchLabels:
+          topology: blue
+  containers:
+  - image: registry.k8s.io/pause:3.10
+    name: pause

--- a/test/integration/scheduler_perf/config/event_handling/podupdate-pod-schedulinggates-update.yaml
+++ b/test/integration/scheduler_perf/config/event_handling/podupdate-pod-schedulinggates-update.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-schedulinggates-{{ .Index }}
+  labels:
+    type: unsched
+spec:
+  containers:
+  - image: registry.k8s.io/pause:3.10
+    name: pause

--- a/test/integration/scheduler_perf/config/event_handling/podupdate-pod-schedulinggates.yaml
+++ b/test/integration/scheduler_perf/config/event_handling/podupdate-pod-schedulinggates.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-schedulinggates-{{ .Index }}
+  labels:
+    type: unsched
+spec:
+  schedulingGates:
+  - name: test.k8s.io/hold
+  containers:
+  - image: registry.k8s.io/pause:3.10
+    name: pause

--- a/test/integration/scheduler_perf/config/event_handling/podupdate-pod-tainttoleration-update.yaml
+++ b/test/integration/scheduler_perf/config/event_handling/podupdate-pod-tainttoleration-update.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-tainttoleration-{{ .Index }}
+  labels:
+    type: unsched
+spec:
+  tolerations:
+  - key: toleration
+    operator: Exists
+    effect: NoSchedule
+  containers:
+  - image: registry.k8s.io/pause:3.10
+    name: pause

--- a/test/integration/scheduler_perf/config/event_handling/podupdate-pod-tainttoleration.yaml
+++ b/test/integration/scheduler_perf/config/event_handling/podupdate-pod-tainttoleration.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-tainttoleration-{{ .Index }}
+  labels:
+    type: unsched
+spec:
+  containers:
+  - image: registry.k8s.io/pause:3.10
+    name: pause

--- a/test/integration/scheduler_perf/config/performance-config.yaml
+++ b/test/integration/scheduler_perf/config/performance-config.yaml
@@ -1663,3 +1663,124 @@
       initNodes: 50
       blockerPods: 480 # Must be slightly below initNodes * 10 to be stable
       measurePods: 500 # Must be initNodes * 10
+
+# This test case is used to measure the performance of queuing hints when handling the pod update events: 
+# UpdatePodLabel, UpdatePodScaleDown, UpdatePodTolerations and UpdatePodSchedulingGatesEliminated.
+# It has a few stages, but general idea is to make a node and block some pods on it
+# or to create additional blocker pods that will prevent the other ones from being scheduled.
+# Then, updating the blocker pods or the unschedulable pods themselves generate cluster events,
+# that through QHints make the pods schedulable. 
+# Plugins covered: InterPodAffinity, NodeResources, NodeUnschedulable, PodTopologySpread, SchedulingGates and TaintToleration.
+- name: EventHandlingPodUpdate
+  featureGates:
+    SchedulerQueueingHints: true
+    InPlacePodVerticalScaling: true
+  workloadTemplate:
+  # Collect metrics from all createPods ops that initially create unschedulable pods (type: unsched).
+  - opcode: startCollectingMetrics
+    namespaces: [nodeunschedulable, tainttoleration, blocker, interpodaffinity, noderesources, schedulinggates]
+    labelSelector:
+      type: unsched
+  # Create one unschedulable node.
+  - opcode: createNodes
+    count: 1
+    nodeTemplatePath: config/event_handling/podupdate-node-unschedulable.yaml
+  # Created pods blocked using NodeUnschedulable plugin.
+  - opcode: createPods
+    countParam: $measurePods
+    podTemplatePath: config/event_handling/podupdate-pod-nodeunschedulable.yaml
+    skipWaitToCompletion: true
+    namespace: nodeunschedulable
+  # Create one node with NoSchedule taint.
+  - opcode: createNodes
+    count: 1
+    nodeTemplatePath: config/event_handling/podupdate-node-with-taint.yaml
+  # Created pods blocked using TaintToleration plugin.
+  - opcode: createPods
+    countParam: $measurePods
+    podTemplatePath: config/event_handling/podupdate-pod-tainttoleration.yaml
+    skipWaitToCompletion: true
+    namespace: tainttoleration
+  # Wait for unschedulable pods to be processed by the scheduler.
+  - opcode: barrier
+    stageRequirement: Attempted
+  # Update pods blocked using NodeUnschedulable plugin to make them schedulable.
+  - opcode: updateAny
+    countParam: $measurePods
+    templatePath: config/event_handling/podupdate-pod-nodeunschedulable-update.yaml
+    updatePerSecond: 100
+    namespace: nodeunschedulable
+  # Update pods blocked using TaintToleration plugin to make them schedulable.
+  - opcode: updateAny
+    countParam: $measurePods
+    templatePath: config/event_handling/podupdate-pod-tainttoleration-update.yaml
+    updatePerSecond: 100
+    namespace: tainttoleration
+  # Wait for NodeUnschedulable and TaintToleration pods to be scheduled.
+  - opcode: barrier
+  # Create schedulable nodes.
+  - opcode: createNodes
+    count: 1
+    nodeTemplatePath: config/templates/node-with-name.yaml
+  # Create pods that will block other pods from being scheduled.
+  # They'll block using InterPodAffinity, NodeResources and PodTopologySpread plugins.
+  # All blocker pods are scheduled before proceeding.
+  - opcode: createPods
+    countParam: $blockerPods
+    podTemplatePath: config/event_handling/podupdate-pod-blocker.yaml
+    namespace: blocker
+  # Created pods blocked using InterPodAffinity plugin.
+  - opcode: createPods
+    countParam: $measurePods
+    podTemplatePath: config/event_handling/podupdate-pod-interpodaffinity.yaml
+    skipWaitToCompletion: true
+    namespace: interpodaffinity
+  # Created pods blocked using NodeResources plugin.
+  - opcode: createPods
+    countParam: $measurePods
+    podTemplatePath: config/event_handling/podupdate-pod-noderesources.yaml
+    skipWaitToCompletion: true
+    namespace: noderesources
+  # Created pods blocked using PodTopologySpread plugin.
+  # Count has to match $blockerPods as pod uses it as a maxSkew value, 
+  # that must be equal to number of blocker pods.
+  - opcode: createPods
+    countParam: $blockerPods
+    podTemplatePath: config/event_handling/podupdate-pod-podtopologyspread.yaml
+    skipWaitToCompletion: true
+    namespace: blocker
+  # Created pods blocked using SchedulingGates plugin.
+  - opcode: createPods
+    countParam: $measurePods
+    podTemplatePath: config/event_handling/podupdate-pod-schedulinggates.yaml
+    skipWaitToCompletion: true
+    namespace: schedulinggates
+  # Wait for unschedulable pods to be processed by the scheduler.
+  - opcode: barrier
+    stageRequirement: Attempted
+    labelSelector:
+      type: unsched
+  # Update blocker pods' labels and scale down their resource requests 
+  # to make the unschedulable pods schedulable.
+  - opcode: updateAny
+    countParam: $blockerPods
+    templatePath: config/event_handling/podupdate-pod-blocker-update.yaml
+    updatePerSecond: 100
+    namespace: blocker
+  # Update pods blocked by SchedulingGates by removing the gate from themselves.
+  - opcode: updateAny
+    countParam: $measurePods
+    templatePath: config/event_handling/podupdate-pod-schedulinggates-update.yaml
+    updatePerSecond: 100
+    namespace: schedulinggates
+  # Wait for previously unschedulable pods to be scheduled.
+  - opcode: barrier
+    labelSelector:
+      type: unsched
+  - opcode: stopCollectingMetrics
+  workloads:
+  - name: 1Node_1000Pods
+    labels: [performance, short]
+    params:
+      blockerPods: 1000
+      measurePods: 1000


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

It adds a scheduler_perf test case focused on utilizing `scheduler_queueing_hint_execution_duration_seconds` metric for plugins with hints for pod update events: `UpdatePodLabel`, `UpdatePodScaleDown`, `UpdatePodTolerations` and `UpdatePodSchedulingGatesEliminated`. It runs corresponding QueueingHintFn for in-tree plugins: InterPodAffinity, NodeResources, NodeUnschedulable, PodTopologySpread, SchedulingGates and TaintToleration.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
