### PR TITLE
client-go: remove obsolete auth plugins from examples

### DIFF
--- a/staging/src/k8s.io/client-go/examples/in-cluster-client-configuration/main.go
+++ b/staging/src/k8s.io/client-go/examples/in-cluster-client-configuration/main.go
@@ -31,8 +31,6 @@ import (
 	// _ "k8s.io/client-go/plugin/pkg/client/auth"
 	//
 	// Or uncomment to load specific auth plugins
-	// _ "k8s.io/client-go/plugin/pkg/client/auth/azure"
-	// _ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	// _ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 )
 

--- a/staging/src/k8s.io/client-go/examples/out-of-cluster-client-configuration/main.go
+++ b/staging/src/k8s.io/client-go/examples/out-of-cluster-client-configuration/main.go
@@ -34,8 +34,6 @@ import (
 	// _ "k8s.io/client-go/plugin/pkg/client/auth"
 	//
 	// Or uncomment to load specific auth plugins
-	// _ "k8s.io/client-go/plugin/pkg/client/auth/azure"
-	// _ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	// _ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 )
 


### PR DESCRIPTION
/kind cleanup

#### What this PR does / why we need it:

The azure and gcp plugins no longer do anything other than point to the corresponding external credential plugins. Client code should no longer try to load them, so they should be removed from the examples.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
