### PR TITLE
Add template parameters to createNodesOp in scheduler_perf

### DIFF
--- a/test/integration/framework/perf_utils.go
+++ b/test/integration/framework/perf_utils.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
 	clientset "k8s.io/client-go/kubernetes"
@@ -33,29 +32,44 @@ const (
 	retries = 5
 )
 
+// NodeTemplate is responsible for creating a v1.Node instance that is ready
+// to be sent to the API server.
+type NodeTemplate interface {
+	// GetNodeTemplate returns a node template for one out of many different nodes.
+	// Nodes with numbers in the range [index, index+count-1] will be created
+	// based on what GetNodeTemplate returns. It gets called multiple times
+	// with a fixed index and increasing count parameters. This number can,
+	// but doesn't have to be, used to modify parts of the node spec like
+	// for example a named reference to some other object.
+	GetNodeTemplate(index, count int) (*v1.Node, error)
+}
+
+// StaticNodeTemplate returns an implementation of NodeTemplate for a fixed node that is the same regardless of the index.
+func StaticNodeTemplate(node *v1.Node) NodeTemplate {
+	return (*staticNodeTemplate)(node)
+}
+
+type staticNodeTemplate v1.Node
+
+// GetNodeTemplate implements [NodeTemplate.GetNodeTemplate] by returning the same node
+// for each call.
+func (s *staticNodeTemplate) GetNodeTemplate(index, count int) (*v1.Node, error) {
+	return (*v1.Node)(s), nil
+}
+
 // IntegrationTestNodePreparer holds configuration information for the test node preparer.
 type IntegrationTestNodePreparer struct {
 	client          clientset.Interface
 	countToStrategy []testutils.CountToStrategy
-	nodeNamePrefix  string
-	nodeSpec        *v1.Node
+	nodeTemplate    NodeTemplate
 }
 
-// NewIntegrationTestNodePreparer creates an IntegrationTestNodePreparer configured with defaults.
-func NewIntegrationTestNodePreparer(client clientset.Interface, countToStrategy []testutils.CountToStrategy, nodeNamePrefix string) testutils.TestNodePreparer {
+// NewIntegrationTestNodePreparer creates an IntegrationTestNodePreparer with a given nodeTemplate.
+func NewIntegrationTestNodePreparer(client clientset.Interface, countToStrategy []testutils.CountToStrategy, nodeTemplate NodeTemplate) testutils.TestNodePreparer {
 	return &IntegrationTestNodePreparer{
 		client:          client,
 		countToStrategy: countToStrategy,
-		nodeNamePrefix:  nodeNamePrefix,
-	}
-}
-
-// NewIntegrationTestNodePreparerWithNodeSpec creates an IntegrationTestNodePreparer configured with nodespec.
-func NewIntegrationTestNodePreparerWithNodeSpec(client clientset.Interface, countToStrategy []testutils.CountToStrategy, nodeSpec *v1.Node) testutils.TestNodePreparer {
-	return &IntegrationTestNodePreparer{
-		client:          client,
-		countToStrategy: countToStrategy,
-		nodeSpec:        nodeSpec,
+		nodeTemplate:    nodeTemplate,
 	}
 }
 
@@ -67,29 +81,12 @@ func (p *IntegrationTestNodePreparer) PrepareNodes(ctx context.Context, nextNode
 	}
 
 	klog.Infof("Making %d nodes", numNodes)
-	baseNode := &v1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: p.nodeNamePrefix,
-		},
-		Status: v1.NodeStatus{
-			Capacity: v1.ResourceList{
-				v1.ResourcePods:   *resource.NewQuantity(110, resource.DecimalSI),
-				v1.ResourceCPU:    resource.MustParse("4"),
-				v1.ResourceMemory: resource.MustParse("32Gi"),
-			},
-			Phase: v1.NodeRunning,
-			Conditions: []v1.NodeCondition{
-				{Type: v1.NodeReady, Status: v1.ConditionTrue},
-			},
-		},
-	}
-
-	if p.nodeSpec != nil {
-		baseNode = p.nodeSpec
-	}
 
 	for i := 0; i < numNodes; i++ {
-		var err error
+		baseNode, err := p.nodeTemplate.GetNodeTemplate(i, numNodes)
+		if err != nil {
+			return fmt.Errorf("failed to get node template: %w", err)
+		}
 		for retry := 0; retry < retries; retry++ {
 			// Create nodes with the usual kubernetes.io/hostname label.
 			// For that we need to know the name in advance, if we want to

--- a/test/integration/framework/util.go
+++ b/test/integration/framework/util.go
@@ -22,23 +22,12 @@ import (
 	"context"
 	"fmt"
 	"testing"
-	"time"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 	nodectlr "k8s.io/kubernetes/pkg/controller/nodelifecycle"
-)
-
-const (
-	// poll is how often to Poll pods, nodes and claims.
-	poll = 2 * time.Second
-
-	// singleCallTimeout is how long to try single API calls (like 'get' or 'list'). Used to prevent
-	// transient failures from failing tests.
-	singleCallTimeout = 5 * time.Minute
 )
 
 // CreateNamespaceOrDie creates a namespace.
@@ -57,22 +46,6 @@ func DeleteNamespaceOrDie(c clientset.Interface, ns *v1.Namespace, t testing.TB)
 	if err != nil {
 		t.Fatalf("Failed to delete namespace: %v", err)
 	}
-}
-
-// waitListAllNodes is a wrapper around listing nodes supporting retries.
-func waitListAllNodes(c clientset.Interface) (*v1.NodeList, error) {
-	var nodes *v1.NodeList
-	var err error
-	if wait.PollImmediate(poll, singleCallTimeout, func() (bool, error) {
-		nodes, err = c.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
-		if err != nil {
-			return false, err
-		}
-		return true, nil
-	}) != nil {
-		return nodes, err
-	}
-	return nodes, nil
 }
 
 // Filter filters nodes in NodeList in place, removing nodes that do not

--- a/test/integration/scheduler_perf/scheduler_perf.go
+++ b/test/integration/scheduler_perf/scheduler_perf.go
@@ -1688,12 +1688,12 @@ func getNodePreparer(prefix string, cno *createNodesOp, clientset clientset.Inte
 		nodeStrategy = cno.UniqueNodeLabelStrategy
 	}
 
-	nodeTemplate := framework.StaticNodeTemplate(makeBaseNode(prefix))
+	nodeTemplate := StaticNodeTemplate(makeBaseNode(prefix))
 	if cno.NodeTemplatePath != nil {
 		nodeTemplate = nodeTemplateFromFile(*cno.NodeTemplatePath)
 	}
 
-	return framework.NewIntegrationTestNodePreparer(
+	return NewIntegrationTestNodePreparer(
 		clientset,
 		[]testutils.CountToStrategy{{Count: cno.Count, Strategy: nodeStrategy}},
 		nodeTemplate,

--- a/test/integration/scheduler_perf/util.go
+++ b/test/integration/scheduler_perf/util.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -225,6 +226,27 @@ func makeBasePod() *v1.Pod {
 		Spec: testutils.MakePodSpec(),
 	}
 	return basePod
+}
+
+// makeBaseNode creates a Node object with given nodeNamePrefix to be used as a template.
+func makeBaseNode(nodeNamePrefix string) *v1.Node {
+	return &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: nodeNamePrefix,
+		},
+		Status: v1.NodeStatus{
+			Capacity: v1.ResourceList{
+				v1.ResourcePods:   *resource.NewQuantity(110, resource.DecimalSI),
+				v1.ResourceCPU:    resource.MustParse("4"),
+				v1.ResourceMemory: resource.MustParse("32Gi"),
+			},
+			Phase: v1.NodeRunning,
+			Conditions: []v1.NodeCondition{
+				{Type: v1.NodeReady, Status: v1.ConditionTrue},
+			},
+		},
+	}
+
 }
 
 func dataItems2JSONFile(dataItems DataItems, namePrefix string) error {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

Add index and count template parameters to `createNodesOp`. This implementation is similar to `createPodsOp`. Added parameters will be mostly beneficial when using `updateAnyOp` to update previously created nodes.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
