### PR TITLE
Add PreemptionBlocking test in scheduler_perf to monitor how long the preemption process (which blocks scheduling of regular nodes) takes.

### DIFF
--- a/test/integration/scheduler_perf/config/performance-config.yaml
+++ b/test/integration/scheduler_perf/config/performance-config.yaml
@@ -688,6 +688,49 @@
 #      initPods: 20000
 #      measurePods: 5000
 
+# Measure throughput of regular schedulable pods that are interleaved by high priority preemption pods scheduled at 20/s rate.
+# Implementation of asynchrounous preemption feature https://github.com/kubernetes/kubernetes/issues/126858 is supposed to increase the trhoughput of the measured pods as all heavy operations (apiserver communication) will be performed asyncronously, wihtout blocking the scheduler loop.
+# How is it achieved:
+# 1. There are X initial nodes with 4 low priority pods each, consuming 3.6 CPU out of the total 4 available.
+# 2. High priority preemption which need to preempt 3 of 4 low priority pods to fit (require 3 CPU).
+# 3. Measured pods are always schedulable, as they require 0.1 CPU only.
+- name: PreemptionAsync
+  workloadTemplate:
+  - opcode: createNodes
+    countParam: $initNodes
+  - opcode: createPods
+    countParam: $initPods
+    podTemplatePath: config/templates/pod-low-priority.yaml
+  - opcode: churn
+    mode: create
+    templatePaths:
+    - config/templates/pod-high-priority-large-cpu.yaml
+    intervalMilliseconds: 50
+  - opcode: createPods
+    countParam: $measurePods
+    podTemplatePath: config/templates/pod-default.yaml
+    collectMetrics: true
+  workloads:
+  - name: 5Nodes
+    labels: [integration-test, performance, short]
+    params:
+      initNodes: 5
+      initPods: 20
+      measurePods: 5
+  - name: 500Nodes
+    labels: [performance, short]
+    params:
+      initNodes: 500
+      initPods: 2000
+      measurePods: 500
+  - name: 5000Nodes
+    labels: [performance]
+    threshold: 200
+    params:
+      initNodes: 5000
+      initPods: 20000
+      measurePods: 5000
+
 - name: Unschedulable
   workloadTemplate:
   - opcode: createNodes


### PR DESCRIPTION

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
Extend scheduler performance test to measure effects of async PostFilters implementation once it's done (https://github.com/kubernetes/kubernetes/issues/126858)

#### Which issue(s) this PR fixes:

part of #126858

#### Special notes for your reviewer:

#### Does this PR introduce a user-
```release-note
NONE
```

#### Additional documentation e.g., 
```docs

```
