### PR TITLE
Add NestedNumberAsFloat64 unstructured field accessor.

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/helpers.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/helpers.go
@@ -125,6 +125,28 @@ func NestedInt64(obj map[string]interface{}, fields ...string) (int64, bool, err
 	return i, true, nil
 }
 
+// NestedNumberAsFloat64 returns the float64 value of a nested field. If the field's value is a
+// float64, it is returned. If the field's value is an int64 that can be losslessly converted to
+// float64, it will be converted and returned.  Returns false if value is not found and an error if
+// not a float64 or an int64 that can be accurately represented as a float64.
+func NestedNumberAsFloat64(obj map[string]interface{}, fields ...string) (float64, bool, error) {
+	val, found, err := NestedFieldNoCopy(obj, fields...)
+	if !found || err != nil {
+		return 0, found, err
+	}
+	switch x := val.(type) {
+	case int64:
+		if x != int64(float64(x)) {
+			return 0, false, fmt.Errorf("%v accessor error: int64 value %v cannot be losslessly converted to float64", jsonPath(fields), x)
+		}
+		return float64(x), true, nil
+	case float64:
+		return x, true, nil
+	default:
+		return 0, false, fmt.Errorf("%v accessor error: %v is of the type %T, expected float64 or int64", jsonPath(fields), val, val)
+	}
+}
+
 // NestedStringSlice returns a copy of []string value of a nested field.
 // Returns false if value is not found and an error if not a []interface{} or contains non-string items in the slice.
 func NestedStringSlice(obj map[string]interface{}, fields ...string) ([]string, bool, error) {

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/helpers_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/helpers_test.go
@@ -18,6 +18,7 @@ package unstructured
 
 import (
 	"io/ioutil"
+	"math"
 	"sync"
 	"testing"
 
@@ -224,4 +225,75 @@ func TestSetNestedMap(t *testing.T) {
 	assert.Len(t, obj["x"], 3)
 	assert.Len(t, obj["x"].(map[string]interface{})["z"], 1)
 	assert.Equal(t, "bar", obj["x"].(map[string]interface{})["z"].(map[string]interface{})["b"])
+}
+
+func TestNestedNumberAsFloat64(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		obj            map[string]interface{}
+		path           []string
+		wantFloat64    float64
+		wantBool       bool
+		wantErrMessage string
+	}{
+		{
+			name:           "not found",
+			obj:            nil,
+			path:           []string{"missing"},
+			wantFloat64:    0,
+			wantBool:       false,
+			wantErrMessage: "",
+		},
+		{
+			name:           "found float64",
+			obj:            map[string]interface{}{"value": float64(42)},
+			path:           []string{"value"},
+			wantFloat64:    42,
+			wantBool:       true,
+			wantErrMessage: "",
+		},
+		{
+			name:           "found unexpected type bool",
+			obj:            map[string]interface{}{"value": true},
+			path:           []string{"value"},
+			wantFloat64:    0,
+			wantBool:       false,
+			wantErrMessage: ".value accessor error: true is of the type bool, expected float64 or int64",
+		},
+		{
+			name:           "found int64",
+			obj:            map[string]interface{}{"value": int64(42)},
+			path:           []string{"value"},
+			wantFloat64:    42,
+			wantBool:       true,
+			wantErrMessage: "",
+		},
+		{
+			name:           "found int64 not representable as float64",
+			obj:            map[string]interface{}{"value": int64(math.MaxInt64)},
+			path:           []string{"value"},
+			wantFloat64:    0,
+			wantBool:       false,
+			wantErrMessage: ".value accessor error: int64 value 9223372036854775807 cannot be losslessly converted to float64",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			gotFloat64, gotBool, gotErr := NestedNumberAsFloat64(tc.obj, tc.path...)
+			if gotFloat64 != tc.wantFloat64 {
+				t.Errorf("got %v, wanted %v", gotFloat64, tc.wantFloat64)
+			}
+			if gotBool != tc.wantBool {
+				t.Errorf("got %t, wanted %t", gotBool, tc.wantBool)
+			}
+			if tc.wantErrMessage != "" {
+				if gotErr == nil {
+					t.Errorf("got nil error, wanted %s", tc.wantErrMessage)
+				} else if gotErrMessage := gotErr.Error(); gotErrMessage != tc.wantErrMessage {
+					t.Errorf("wanted error %q, got: %v", gotErrMessage, tc.wantErrMessage)
+				}
+			} else if gotErr != nil {
+				t.Errorf("wanted nil error, got %v", gotErr)
+			}
+		})
+	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:

Go float64 values that have no fractional component and can be accurately represented as an int64, when present in an unstructured object and roundtripped through JSON, appear in the resulting object with the concrete type int64. For code that processes unstructured objects and expects to find float64 values, this is a surprising edge case. NestedNumberAsFloat64 behaves the same as NestedFloat64 when accessing a float64 value, but will additionally convert to float64 and return an int64 value at the requested path. Errors are returned on encountering an int64 that cannot be precisely represented as a float64.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

This API was proposed during the sig-api-machinery biweekly meeting on March 6, 2024.

/sig api-machinery

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
