### PR TITLE
fix: apply makezero linter with golangci strict and hints

### DIFF
--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -87,6 +87,7 @@ linters:
     - errorlint
     - ineffassign
     - logcheck
+    - makezero
     - revive
     - staticcheck
     - stylecheck

--- a/hack/golangci-strict.yaml
+++ b/hack/golangci-strict.yaml
@@ -130,6 +130,7 @@ linters:
     - govet
     - ineffassign
     - logcheck
+    - makezero
     - revive
     - staticcheck
     - stylecheck

--- a/hack/golangci.yaml.in
+++ b/hack/golangci.yaml.in
@@ -145,6 +145,9 @@ linters:
     {{- end}}
     - ineffassign
     - logcheck
+    {{- if not .Base}}
+    - makezero
+    {{- end}}
     - revive
     - staticcheck
     - stylecheck


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/priority backlog
/sig testing

#### What this PR does / why we need it:

[makezero](https://github.com/ashanbrown/makezero) is a Go static analysis tool to find slice declarations that are not initialized with zero length and are later used with append.

This covers the following pull request and ensure it's associated best practice with a linter.

Related to #127785

<!--
Signed-off-by: Matthieu MOREL <matthieu.morel35@gmail.com>
-->