### PR TITLE
fix node start time inconsistency in kubelet

### DIFF
--- a/pkg/kubelet/util/boottime_util_linux_test.go
+++ b/pkg/kubelet/util/boottime_util_linux_test.go
@@ -35,3 +35,19 @@ func TestGetBootTime(t *testing.T) {
 		t.Errorf("Invalid system uptime")
 	}
 }
+
+func TestGetBootTimeConsistency(t *testing.T) {
+	boottime, err := GetBootTime()
+
+        if err != nil {
+                t.Errorf("Unable to get system uptime")
+        }
+
+	for i:=0;i<50;i++ {
+		time.Sleep(100 * time.Millisecond)
+		if bt, _ := GetBootTime(); bt != boottime {
+			t.Errorf("inconsistent boot time")
+			break
+		}
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Make kubelet report consistent start time at every restart.

See the linked issue for why we need it.

#### Which issue(s) this PR fixes:

Fixes #127841

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

