### PR TITLE
e2e node: Test probes during pod termination

### DIFF
--- a/test/e2e_node/container_lifecycle_test.go
+++ b/test/e2e_node/container_lifecycle_test.go
@@ -910,6 +910,172 @@ var _ = SIGDescribe(framework.WithNodeConformance(), "Containers Lifecycle", fun
 			gomega.Expect(err).To(gomega.HaveOccurred())
 		})
 	})
+
+	ginkgo.When("a pod is terminating because of deletion request", func() {
+		regular1 := "regular-1"
+
+		testPod := func() *v1.Pod {
+			return &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pod",
+				},
+				Spec: v1.PodSpec{
+					RestartPolicy:                 v1.RestartPolicyNever,
+					TerminationGracePeriodSeconds: ptr.To(int64(100)),
+					Containers: []v1.Container{
+						{
+							Name:  regular1,
+							Image: imageutils.GetE2EImage(imageutils.BusyBox),
+							Command: ExecCommand(regular1, execCommand{
+								Delay:              100,
+								TerminationSeconds: 15,
+								ExitCode:           0,
+							}),
+							LivenessProbe: &v1.Probe{
+								ProbeHandler: v1.ProbeHandler{
+									Exec: &v1.ExecAction{
+										Command: ExecCommand(prefixedName(LivenessPrefix, regular1), execCommand{
+											ExitCode:      0,
+											ContainerName: regular1,
+										}),
+									},
+								},
+								InitialDelaySeconds: 1,
+								PeriodSeconds:       1,
+								FailureThreshold:    1,
+							},
+							Lifecycle: &v1.Lifecycle{
+								PreStop: &v1.LifecycleHandler{
+									Exec: &v1.ExecAction{
+										Command: ExecCommand(prefixedName(PreStopPrefix, regular1), execCommand{
+											Delay:         15,
+											ExitCode:      0,
+											ContainerName: regular1,
+										}),
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+		}
+
+		f.It("should execute readiness probe while in preStop, but not liveness", f.WithNodeConformance(), func(ctx context.Context) {
+			client := e2epod.NewPodClient(f)
+			podSpec := testPod()
+
+			ginkgo.By("creating a pod with a readiness probe and a preStop hook")
+			podSpec.Spec.Containers[0].ReadinessProbe = &v1.Probe{
+				ProbeHandler: v1.ProbeHandler{
+					Exec: &v1.ExecAction{
+						Command: ExecCommand(prefixedName(ReadinessPrefix, regular1), execCommand{
+							ExitCode:      0,
+							ContainerName: regular1,
+						}),
+					},
+				},
+				InitialDelaySeconds: 1,
+				PeriodSeconds:       1,
+			}
+
+			preparePod(podSpec)
+
+			podSpec = client.Create(ctx, podSpec)
+
+			ginkgo.By("Waiting for the pod to be initialized and run")
+			err := e2epod.WaitForPodRunningInNamespace(ctx, f.ClientSet, podSpec)
+			framework.ExpectNoError(err)
+
+			ginkgo.By("deleting the pod")
+			err = client.Delete(ctx, podSpec.Name, metav1.DeleteOptions{})
+			framework.ExpectNoError(err)
+
+			// Sleep expecting thet the preStop wiil complete and the container will get into TerminationSeconds window.
+			time.Sleep(25 * time.Second)
+
+			// Obtain logs before the pod has been deleted.
+			ginkgo.By("Parsing results")
+			podSpec, err = client.Get(ctx, podSpec.Name, metav1.GetOptions{})
+			framework.ExpectNoError(err)
+			results := parseOutput(ctx, f, podSpec)
+
+			ginkgo.By("waiting for the pod to disappear")
+			err = e2epod.WaitForPodNotFoundInNamespace(ctx, f.ClientSet, podSpec.Name, podSpec.Namespace, 120*time.Second)
+			framework.ExpectNoError(err)
+
+			ginkgo.By("Analyzing results")
+			// readiness probes are called during pod termination
+			framework.ExpectNoError(results.RunTogetherLhsFirst(prefixedName(PreStopPrefix, regular1), prefixedName(ReadinessPrefix, regular1)))
+			// liveness probes are not called during pod termination
+			err = results.RunTogetherLhsFirst(prefixedName(PreStopPrefix, regular1), prefixedName(LivenessPrefix, regular1))
+			gomega.Expect(err).To(gomega.HaveOccurred())
+		})
+
+		f.It("should continue running liveness probes for restartable init containers and restart them while in preStop", f.WithNodeConformance(), func(ctx context.Context) {
+			client := e2epod.NewPodClient(f)
+			podSpec := testPod()
+			restartableInit1 := "restartable-init-1"
+
+			ginkgo.By("creating a pod with a restartable init container and a preStop hook")
+			podSpec.Spec.InitContainers = []v1.Container{{
+				RestartPolicy: &containerRestartPolicyAlways,
+				Name:          restartableInit1,
+				Image:         imageutils.GetE2EImage(imageutils.BusyBox),
+				Command: ExecCommand(restartableInit1, execCommand{
+					Delay:              100,
+					TerminationSeconds: 1,
+					ExitCode:           0,
+				}),
+				LivenessProbe: &v1.Probe{
+					ProbeHandler: v1.ProbeHandler{
+						Exec: &v1.ExecAction{
+							Command: ExecCommand(prefixedName(LivenessPrefix, restartableInit1), execCommand{
+								ExitCode:      1,
+								ContainerName: restartableInit1,
+							}),
+						},
+					},
+					InitialDelaySeconds: 8, // Start probing after preStop starts
+					PeriodSeconds:       1,
+					FailureThreshold:    1,
+				},
+			}}
+
+			preparePod(podSpec)
+
+			podSpec = client.Create(ctx, podSpec)
+
+			ginkgo.By("Waiting for the pod to be initialized and run")
+			err := e2epod.WaitForPodRunningInNamespace(ctx, f.ClientSet, podSpec)
+			framework.ExpectNoError(err)
+
+			ginkgo.By("deleting the pod")
+			err = client.Delete(ctx, podSpec.Name, metav1.DeleteOptions{})
+			framework.ExpectNoError(err)
+
+			// Sleep expecting thet the preStop wiil complete and the container will get into TerminationSeconds window.
+			time.Sleep(25 * time.Second)
+
+			// Obtain logs before the pod has been deleted.
+			ginkgo.By("Parsing results")
+			podSpec, err = client.Get(ctx, podSpec.Name, metav1.GetOptions{})
+			framework.ExpectNoError(err)
+			results := parseOutput(ctx, f, podSpec)
+
+			ginkgo.By("waiting for the pod to disappear")
+			err = e2epod.WaitForPodNotFoundInNamespace(ctx, f.ClientSet, podSpec.Name, podSpec.Namespace, 120*time.Second)
+			framework.ExpectNoError(err)
+
+			ginkgo.By("Analyzing results")
+			// liveness probes are called for restartable init containers during pod termination
+			framework.ExpectNoError(results.RunTogetherLhsFirst(prefixedName(PreStopPrefix, regular1), prefixedName(LivenessPrefix, restartableInit1)))
+			// FIXME ExpectNoError: this will be implemented in KEP 4438
+			// restartable init containers are restarted during pod termination
+			err = results.RunTogetherLhsFirst(prefixedName(PreStopPrefix, regular1), restartableInit1)
+			gomega.Expect(err).To(gomega.HaveOccurred())
+		})
+	})
 })
 
 var _ = SIGDescribe(framework.WithSerial(), "Containers Lifecycle", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:
These test cases look to intend to verify probe behaviors while a pod is being terminated:
https://github.com/kubernetes/kubernetes/blob/7ab8a2b92f675bb81715bfca7085b0c4d0a284c9/test/e2e_node/container_lifecycle_test.go#L756

In `SyncTerminatingPod()`, liveness probes are stopped before killing a pod while readiness probes are stopped after killing the pod:
https://github.com/kubernetes/kubernetes/blob/c9a61afdb7266b93b08da0d4ca4f334f62c3e7e2/pkg/kubelet/kubelet.go#L2024-L2038

The test cases are trying to test this code path with a failing liveness probe. However, when a liveness probe fails, the container is stopped at `SyncPod()` before the pod gets into termination phase even if `RestartPolicy` is `Never`:
https://github.com/kubernetes/kubernetes/blob/c9a61afdb7266b93b08da0d4ca4f334f62c3e7e2/pkg/kubelet/kubelet.go#L1963
https://github.com/kubernetes/kubernetes/blob/c9a61afdb7266b93b08da0d4ca4f334f62c3e7e2/pkg/kubelet/kuberuntime/kuberuntime_manager.go#L996-L999
So, both liveness probes and readiness probes can run while the preStop hook is running. The test case to see if the liveness probe is stopped passes just because the init container gets into `CrashLoopBackoff`. If the init container doesn’t get into `CrashLoopBackoff`, this test fails (#127312).

In order to run the preStop hook in `SyncTerminatingPod()`, this PR adds test cases to terminate a pod with  `ActiveDeadlineSeconds`.

After this is fixed, there remains a problem. Due to #124648, all probes are stopped before killing a pod if pod termination is triggered by kubelet such as active deadline and eviction. We need to fix this issue.

Alternatively, we can test this code path with deleting a pod. This PR also adds test cases to delete a pod with probes.

By the way, liveness probes for init containers are not stopped before killing the pod when the pod is terminated by deletion because `StopLivenessAndStartup()` stops only probes of regular containers:
https://github.com/kubernetes/kubernetes/blob/5ecd83f1e688e148a4ba7369392d7a58e212e1f6/pkg/kubelet/prober/prober_manager.go#L232

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
