### PR TITLE
Cleanup unused images or containers first when eviction manager detects ContainerFsInodesFree signal

### DIFF
--- a/pkg/kubelet/eviction/helpers.go
+++ b/pkg/kubelet/eviction/helpers.go
@@ -1205,6 +1205,8 @@ func buildSignalToNodeReclaimFuncs(imageGC ImageGC, containerGC ContainerGC, wit
 		// with an imagefs, imagefs pressure should delete unused images
 		signalToReclaimFunc[evictionapi.SignalImageFsAvailable] = nodeReclaimFuncs{containerGC.DeleteAllUnusedContainers, imageGC.DeleteUnusedImages}
 		signalToReclaimFunc[evictionapi.SignalImageFsInodesFree] = nodeReclaimFuncs{containerGC.DeleteAllUnusedContainers, imageGC.DeleteUnusedImages}
+		signalToReclaimFunc[evictionapi.SignalContainerFsAvailable] = signalToReclaimFunc[evictionapi.SignalImageFsAvailable]
+		signalToReclaimFunc[evictionapi.SignalContainerFsInodesFree] = signalToReclaimFunc[evictionapi.SignalImageFsInodesFree]
 		// usage of imagefs and container fs on separate disks
 		// containers gc on containerfs pressure
 		// image gc on imagefs pressure
@@ -1215,6 +1217,8 @@ func buildSignalToNodeReclaimFuncs(imageGC ImageGC, containerGC ContainerGC, wit
 		// with an split fs and imagefs, containerfs pressure should delete unused containers
 		signalToReclaimFunc[evictionapi.SignalNodeFsAvailable] = nodeReclaimFuncs{containerGC.DeleteAllUnusedContainers}
 		signalToReclaimFunc[evictionapi.SignalNodeFsInodesFree] = nodeReclaimFuncs{containerGC.DeleteAllUnusedContainers}
+		signalToReclaimFunc[evictionapi.SignalContainerFsAvailable] = signalToReclaimFunc[evictionapi.SignalNodeFsAvailable]
+		signalToReclaimFunc[evictionapi.SignalContainerFsInodesFree] = signalToReclaimFunc[evictionapi.SignalNodeFsInodesFree]
 	} else {
 		// without an imagefs, nodefs pressure should delete logs, and unused images
 		// since imagefs, containerfs and nodefs share a common device, they share common reclaim functions
@@ -1222,6 +1226,8 @@ func buildSignalToNodeReclaimFuncs(imageGC ImageGC, containerGC ContainerGC, wit
 		signalToReclaimFunc[evictionapi.SignalNodeFsInodesFree] = nodeReclaimFuncs{containerGC.DeleteAllUnusedContainers, imageGC.DeleteUnusedImages}
 		signalToReclaimFunc[evictionapi.SignalImageFsAvailable] = nodeReclaimFuncs{containerGC.DeleteAllUnusedContainers, imageGC.DeleteUnusedImages}
 		signalToReclaimFunc[evictionapi.SignalImageFsInodesFree] = nodeReclaimFuncs{containerGC.DeleteAllUnusedContainers, imageGC.DeleteUnusedImages}
+		signalToReclaimFunc[evictionapi.SignalContainerFsAvailable] = signalToReclaimFunc[evictionapi.SignalNodeFsAvailable]
+		signalToReclaimFunc[evictionapi.SignalContainerFsInodesFree] = signalToReclaimFunc[evictionapi.SignalNodeFsInodesFree]
 	}
 	return signalToReclaimFunc
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind flake

#### What this PR does / why we need it:

The [`ImageGCNoEviction` test](https://github.com/kubernetes/kubernetes/blob/3a620a3f5e2b89d0d59a01ca422bbc3e750e71cd/test/e2e_node/eviction_test.go#L111) has been flaky lately. It's designed to verify that when the node is under `DiskPressure` (specifically inodes), kubelet eviction manager prioritizes removing unused containers and images and not resorting to evicting active pods. However, I've observed that in many failed test runs, the eviction manager is prematurely evicting a pod without attempting to free up space by cleaning up unnecessary containers and images. This is happening because the code doesn't include any logic to trigger cleanup based on the `ContainerFsInodesFree` signal.

Flaky test failure:

![image](https://github.com/user-attachments/assets/1620943f-49fd-497a-8c80-6d08d9338c31)

Test success:

![image](https://github.com/user-attachments/assets/04c08a00-32ca-49ca-82e1-87e97517821c)


With this change, I got [~10 green runs of `ImageGCNoEviction` test](https://prow.k8s.io/pr-history/?org=kubernetes&repo=kubernetes&pr=127874) across CRI-O and containerd runtime.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?


```release-note
Fix an issue where eviction manager was not deleting unused images or containers when it detected containerfs signal.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:


```docs

```
