### PR TITLE
remove unnecessary dependency on k8s.io/api

### DIFF
--- a/staging/src/k8s.io/api/go.mod
+++ b/staging/src/k8s.io/api/go.mod
@@ -8,7 +8,6 @@ godebug default=go1.23
 
 require (
 	github.com/gogo/protobuf v1.3.2
-	github.com/stretchr/testify v1.9.0
 	k8s.io/apimachinery v0.0.0
 )
 
@@ -23,7 +22,6 @@ require (
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
-	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rogpeppe/go-internal v1.12.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
@@ -33,7 +31,6 @@ require (
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect

--- a/staging/src/k8s.io/api/go.sum
+++ b/staging/src/k8s.io/api/go.sum
@@ -57,7 +57,6 @@ github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=

--- a/staging/src/k8s.io/api/roundtrip_test.go
+++ b/staging/src/k8s.io/api/roundtrip_test.go
@@ -78,7 +78,6 @@ import (
 	storagev1beta1 "k8s.io/api/storage/v1beta1"
 	svmv1alpha1 "k8s.io/api/storagemigration/v1alpha1"
 
-	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/apitesting/fuzzer"
 	"k8s.io/apimachinery/pkg/api/apitesting/roundtrip"
 	genericfuzzer "k8s.io/apimachinery/pkg/apis/meta/fuzzer"
@@ -150,7 +149,9 @@ func TestRoundTripExternalTypes(t *testing.T) {
 	scheme := runtime.NewScheme()
 	codecs := serializer.NewCodecFactory(scheme)
 	for _, builder := range groups {
-		require.NoError(t, builder.AddToScheme(scheme))
+		if err := builder.AddToScheme(scheme); err != nil {
+			t.Fatalf("unexpected error adding to scheme: %v", err)
+		}
 	}
 	seed := rand.Int63()
 	// I'm only using the generic fuzzer funcs, but at some point in time we might need to
@@ -163,7 +164,9 @@ func TestRoundTripExternalTypes(t *testing.T) {
 func TestCompatibility(t *testing.T) {
 	scheme := runtime.NewScheme()
 	for _, builder := range groups {
-		require.NoError(t, builder.AddToScheme(scheme))
+		if err := builder.AddToScheme(scheme); err != nil {
+			t.Fatalf("unexpected error adding to scheme: %v", err)
+		}
 	}
 	roundtrip.NewCompatibilityTestOptions(scheme).Complete(t).Run(t)
 }


### PR DESCRIPTION
/kind cleanup
```release-note
NONE
```

/area code-organization

If I understand correctly https://go.dev/ref/mod#graph-pruning this will not cause any problem to build binaries since the test in code does not impact, but helps to have a cleaner go module for having just a cosmetic assertion on the test code that can be easily done with the standard library go code