### PR TITLE
fix: Allow go k8s client to accept KUBECONFIG env readily

### DIFF
--- a/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
@@ -660,13 +660,13 @@ func (config *inClusterClientConfig) Possible() bool {
 // BuildConfigFromFlags is a helper function that builds configs from a master
 // url or a kubeconfig filepath. These are passed in as command line flags for cluster
 // components. Warnings should reflect this usage. If neither masterUrl or kubeconfigPath
-// are passed in we fallback to inClusterConfig. If inClusterConfig fails, we fallback
-// to the default config.
+// we look for the KUBECONFIG environment variable to find a config files. If nothing is proviced, we fallback to inClusterConfig.
+// If inClusterConfig fails, we fallback to the default config.
 func BuildConfigFromFlags(masterUrl, kubeconfigPath string) (*restclient.Config, error) {
 	if kubeconfigPath == "" && masterUrl == "" {
 		klog.Warning("Neither --kubeconfig nor --master was specified. Using the KUBECONFIG environment variable to find a kubeconfig files.")
 		kubeconfigPaths := NewDefaultPathOptions().GetEnvVarFiles()
-		if len(kubeconfigPaths) < 0 {
+		if len(kubeconfigPaths) == 0 {
 			klog.Warning("KUBECONFIG environment variable was specified.  Using the inClusterConfig.  This might not work.")
 			kubeconfig, err := restclient.InClusterConfig()
 			if err == nil {

--- a/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
@@ -671,6 +671,13 @@ func BuildConfigFromFlags(masterUrl, kubeconfigPath string) (*restclient.Config,
 		}
 		klog.Warning("error creating inClusterConfig, falling back to default config: ", err)
 	}
+
+	if strings.Contains(kubeconfigPath, ":") {
+		configPaths := strings.Split(kubeconfigPath, ":")
+		return NewNonInteractiveDeferredLoadingClientConfig(
+			&ClientConfigLoadingRules{Precedence: configPaths},
+			&ConfigOverrides{ClusterInfo: clientcmdapi.Cluster{Server: masterUrl}}).ClientConfig()
+	}
 	return NewNonInteractiveDeferredLoadingClientConfig(
 		&ClientConfigLoadingRules{ExplicitPath: kubeconfigPath},
 		&ConfigOverrides{ClusterInfo: clientcmdapi.Cluster{Server: masterUrl}}).ClientConfig()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

/sig api-machinery


#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Fixes ([127891](https://github.com/kubernetes/kubernetes/issues/127891)).

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

Currently, users have to do extra work to get the config-path value from KUBECONFIG env. The Go client library expects a single value, but the system environment variables for KUBECONFIG are separated by colons. Let's make the Go client accept the KUBECONFIG env value readily. This would make it consistent with how the system handles these variables and make things easier for developers

<!--

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
var kubeconfig string
	if envVar := os.Getenv("KUBECONFIG"); envVar != "" {
		kubeconfig = envVar
	}

	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
	if err != nil {
		panic(err)
	}
	clientset, err := kubernetes.NewForConfig(config)
	if err != nil {
		panic(err)
	}
```
