### PR TITLE
Set User.UID from x509 cert

### DIFF
--- a/pkg/features/versioned_kube_features.go
+++ b/pkg/features/versioned_kube_features.go
@@ -220,6 +220,10 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 		{Version: version.MustParse("1.30"), Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	},
 
+	genericfeatures.AllowParsingUserUIDFromCertAuth: {
+		{Version: version.MustParse("1.33"), Default: true, PreRelease: featuregate.Beta},
+	},
+
 	genericfeatures.AllowUnsafeMalformedObjectDeletion: {
 		{Version: version.MustParse("1.32"), Default: false, PreRelease: featuregate.Alpha},
 	},

--- a/staging/src/k8s.io/apimachinery/pkg/apis/asn1/oid.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/asn1/oid.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package asn1
+
+import "encoding/asn1"
+
+// These constants store suffixes for use with the CNCF Private Enterprise Number allocated to Kubernetes:
+// https://www.iana.org/assignments/enterprise-numbers.txt
+//
+// Root: 1.3.6.1.4.1.57683
+//
+// Cloud Native Computing Foundation
+const (
+	// single-value, string value
+	x509UIDSuffix = 2
+)
+
+func makeOID(suffix int) asn1.ObjectIdentifier {
+	return asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 57683, suffix}
+}
+
+// X509UID returns an OID (1.3.6.1.4.1.57683.2) for an element of an x509 distinguished name representing a user UID.
+// The UID is a unique value for a particular user that will change if the user is removed from the system
+// and another user is added with the same username.
+//
+// This element must not appear more than once in a distinguished name, and the value must be a string
+func X509UID() asn1.ObjectIdentifier {
+	return makeOID(x509UIDSuffix)
+}

--- a/staging/src/k8s.io/apiserver/pkg/authentication/request/x509/x509.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/request/x509/x509.go
@@ -21,15 +21,19 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
 	"time"
 
+	asn1util "k8s.io/apimachinery/pkg/apis/asn1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/authentication/authenticator"
 	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/features"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/component-base/metrics"
 	"k8s.io/component-base/metrics/legacyregistry"
 )
@@ -281,9 +285,14 @@ var CommonNameUserConversion = UserConversionFunc(func(chain []*x509.Certificate
 	fp := sha256.Sum256(chain[0].Raw)
 	id := "X509SHA256=" + hex.EncodeToString(fp[:])
 
+	uid, err := parseUIDFromCert(chain[0])
+	if err != nil {
+		return nil, false, err
+	}
 	return &authenticator.Response{
 		User: &user.DefaultInfo{
 			Name:   chain[0].Subject.CommonName,
+			UID:    uid,
 			Groups: chain[0].Subject.Organization,
 			Extra: map[string][]string{
 				user.CredentialIDKey: {id},
@@ -291,3 +300,33 @@ var CommonNameUserConversion = UserConversionFunc(func(chain []*x509.Certificate
 		},
 	}, true, nil
 })
+
+var uidOID = asn1util.X509UID()
+
+func parseUIDFromCert(cert *x509.Certificate) (string, error) {
+	if !utilfeature.DefaultFeatureGate.Enabled(features.AllowParsingUserUIDFromCertAuth) {
+		return "", nil
+	}
+
+	uids := []string{}
+	for _, name := range cert.Subject.Names {
+		if !name.Type.Equal(uidOID) {
+			continue
+		}
+		uid, ok := name.Value.(string)
+		if !ok {
+			return "", fmt.Errorf("unable to parse UID into a string")
+		}
+		uids = append(uids, uid)
+	}
+	if len(uids) == 0 {
+		return "", nil
+	}
+	if len(uids) != 1 {
+		return "", fmt.Errorf("expected 1 UID, but found multiple: %v", uids)
+	}
+	if uids[0] == "" {
+		return "", errors.New("UID cannot be an empty string")
+	}
+	return uids[0], nil
+}

--- a/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
@@ -48,6 +48,11 @@ const (
 	// caching with ETags containing all APIResources known to the apiserver.
 	AggregatedDiscoveryEndpoint featuregate.Feature = "AggregatedDiscoveryEndpoint"
 
+	// owner: @modulitos
+	//
+	// Allow user.DefaultInfo.UID to be set from x509 cert during cert auth.
+	AllowParsingUserUIDFromCertAuth featuregate.Feature = "AllowParsingUserUIDFromCertAuth"
+
 	// owner: @vinayakankugoyal
 	// kep: https://kep.k8s.io/4633
 	//
@@ -271,6 +276,10 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 		{Version: version.MustParse("1.26"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("1.27"), Default: true, PreRelease: featuregate.Beta},
 		{Version: version.MustParse("1.30"), Default: true, PreRelease: featuregate.GA, LockToDefault: true},
+	},
+
+	AllowParsingUserUIDFromCertAuth: {
+		{Version: version.MustParse("1.33"), Default: true, PreRelease: featuregate.Beta},
 	},
 
 	AllowUnsafeMalformedObjectDeletion: {

--- a/test/featuregates_linter/test_data/versioned_feature_list.yaml
+++ b/test/featuregates_linter/test_data/versioned_feature_list.yaml
@@ -44,6 +44,12 @@
     lockToDefault: false
     preRelease: Deprecated
     version: "1.32"
+- name: AllowParsingUserUIDFromCertAuth
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.33"
 - name: AllowServiceLBStatusOnNonLB
   versionedSpecs:
   - default: false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

I will followup this PR with 2 more changes:
 - update kubeadm to include UID in the cert
 - update the docs, [per this comment](https://github.com/kubernetes/kubernetes/pull/127897#discussion_r1797458976)

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:
This PR allows users to optionally set the `User.UID` from an x509 client cert, instead of always having it empty.  This is part of an implementation to resolve https://github.com/kubernetes/kubernetes/issues/127860

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Addresses https://github.com/kubernetes/kubernetes/issues/127860

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Kubernetes components that accept x509 client certificate authentication now read the user UID from a certificate subject name RDN with object id 1.3.6.1.4.1.57683.2. An RDN with this object id must contain a string value, and appear no more than once in the certificate subject. Reading the user UID from this RDN can be disabled by setting the beta feature gate `AllowParsingUserUIDFromCertAuth` to false (until the feature gate graduates to GA).
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
N/A

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
