### PR TITLE
Use sigs.k8s.io/yaml instead of gopkg.in/yaml

### DIFF
--- a/cmd/genyaml/gen_kubectl_yaml.go
+++ b/cmd/genyaml/gen_kubectl_yaml.go
@@ -25,10 +25,11 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"gopkg.in/yaml.v2"
+
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/kubectl/pkg/cmd"
 	"k8s.io/kubernetes/cmd/genutils"
+	yaml "sigs.k8s.io/yaml/goyaml.v2"
 )
 
 type cmdOption struct {

--- a/cmd/importverifier/importverifier.go
+++ b/cmd/importverifier/importverifier.go
@@ -27,7 +27,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"gopkg.in/yaml.v2"
+	yaml "sigs.k8s.io/yaml/goyaml.v2"
 )
 
 // Package is a subset of cmd/go.Package

--- a/cmd/kubelet/app/server_test.go
+++ b/cmd/kubelet/app/server_test.go
@@ -24,11 +24,11 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/cmd/kubelet/app/options"
 	kubeletconfiginternal "k8s.io/kubernetes/pkg/kubelet/apis/config"
+	yaml "sigs.k8s.io/yaml/goyaml.v2"
 )
 
 func TestValueOfAllocatableResources(t *testing.T) {

--- a/cmd/yamlfmt/yamlfmt.go
+++ b/cmd/yamlfmt/yamlfmt.go
@@ -22,7 +22,7 @@ import (
 	"io"
 	"os"
 
-	"gopkg.in/yaml.v3"
+	yaml "sigs.k8s.io/yaml/goyaml.v3"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -86,8 +86,6 @@ require (
 	google.golang.org/protobuf v1.34.2
 	gopkg.in/evanphx/json-patch.v4 v4.12.0
 	gopkg.in/square/go-jose.v2 v2.6.0
-	gopkg.in/yaml.v2 v2.4.0
-	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.0.0
 	k8s.io/apiextensions-apiserver v0.0.0
 	k8s.io/apimachinery v0.0.0
@@ -221,6 +219,8 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20240528184218-531527333157 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/gengo/v2 v2.0.0-20240911193312-2b36238f13e9 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.30.3 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect

--- a/staging/src/k8s.io/apiextensions-apiserver/go.mod
+++ b/staging/src/k8s.io/apiextensions-apiserver/go.mod
@@ -24,7 +24,6 @@ require (
 	google.golang.org/grpc v1.65.0
 	google.golang.org/protobuf v1.34.2
 	gopkg.in/evanphx/json-patch.v4 v4.12.0
-	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.0.0
 	k8s.io/apimachinery v0.0.0
 	k8s.io/apiserver v0.0.0
@@ -121,6 +120,7 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240701130421-f6361c86f094 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/gengo/v2 v2.0.0-20240911193312-2b36238f13e9 // indirect
 	k8s.io/kms v0.0.0 // indirect

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/v2/conversion_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/v2/conversion_test.go
@@ -28,7 +28,6 @@ import (
 	openapi_v2 "github.com/google/gnostic-models/openapiv2"
 	"github.com/google/go-cmp/cmp"
 	fuzz "github.com/google/gofuzz"
-	"gopkg.in/yaml.v2"
 
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
@@ -36,6 +35,7 @@ import (
 	"k8s.io/kube-openapi/pkg/util/proto"
 	"k8s.io/kube-openapi/pkg/validation/spec"
 	"k8s.io/utils/pointer"
+	yaml "sigs.k8s.io/yaml/goyaml.v2"
 )
 
 func Test_ConvertJSONSchemaPropsToOpenAPIv2Schema(t *testing.T) {

--- a/staging/src/k8s.io/cli-runtime/go.mod
+++ b/staging/src/k8s.io/cli-runtime/go.mod
@@ -18,7 +18,6 @@ require (
 	golang.org/x/sync v0.8.0
 	golang.org/x/text v0.17.0
 	gopkg.in/evanphx/json-patch.v4 v4.12.0
-	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.0.0
 	k8s.io/apimachinery v0.0.0
 	k8s.io/client-go v0.0.0
@@ -68,6 +67,7 @@ require (
 	golang.org/x/time v0.3.0 // indirect
 	google.golang.org/protobuf v1.34.2 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/query_param_verifier.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/query_param_verifier.go
@@ -21,11 +21,11 @@ import (
 	"fmt"
 
 	openapi_v2 "github.com/google/gnostic-models/openapiv2"
-	yaml "gopkg.in/yaml.v2"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
+	yaml "sigs.k8s.io/yaml/goyaml.v2"
 )
 
 func NewQueryParamVerifier(dynamicClient dynamic.Interface, openAPIGetter discovery.OpenAPISchemaInterface, queryParam VerifiableQueryParam) *QueryParamVerifier {

--- a/staging/src/k8s.io/code-generator/cmd/applyconfiguration-gen/generators/internal.go
+++ b/staging/src/k8s.io/code-generator/cmd/applyconfiguration-gen/generators/internal.go
@@ -19,13 +19,11 @@ package generators
 import (
 	"io"
 
-	"gopkg.in/yaml.v2"
-
-	"k8s.io/kube-openapi/pkg/schemaconv"
-
 	"k8s.io/gengo/v2/generator"
 	"k8s.io/gengo/v2/namer"
 	"k8s.io/gengo/v2/types"
+	"k8s.io/kube-openapi/pkg/schemaconv"
+	yaml "sigs.k8s.io/yaml/goyaml.v2"
 )
 
 // utilGenerator generates the ForKind() utility function.

--- a/staging/src/k8s.io/code-generator/cmd/applyconfiguration-gen/generators/internal.go
+++ b/staging/src/k8s.io/code-generator/cmd/applyconfiguration-gen/generators/internal.go
@@ -71,13 +71,12 @@ func (g *internalGenerator) GenerateType(c *generator.Context, _ *types.Type, w 
 		return err
 	}
 	sw.Do(schemaBlock, map[string]interface{}{
-		"schemaYAML":    string(schemaYAML),
-		"smdParser":     smdParser,
-		"smdNewParser":  smdNewParser,
-		"fmtSprintf":    fmtSprintf,
-		"syncOnce":      syncOnce,
-		"yamlObject":    yamlObject,
-		"yamlUnmarshal": yamlUnmarshal,
+		"schemaYAML":   string(schemaYAML),
+		"smdParser":    smdParser,
+		"smdNewParser": smdNewParser,
+		"fmtSprintf":   fmtSprintf,
+		"syncOnce":     syncOnce,
+		"yamlObject":   yamlObject,
 	})
 
 	return sw.Error()

--- a/staging/src/k8s.io/code-generator/cmd/applyconfiguration-gen/generators/types.go
+++ b/staging/src/k8s.io/code-generator/cmd/applyconfiguration-gen/generators/types.go
@@ -33,5 +33,4 @@ var (
 	smdParser            = types.Ref("sigs.k8s.io/structured-merge-diff/v4/typed", "Parser")
 	testingTypeConverter = types.Ref("k8s.io/client-go/testing", "TypeConverter")
 	yamlObject           = types.Ref("sigs.k8s.io/structured-merge-diff/v4/typed", "YAMLObject")
-	yamlUnmarshal        = types.Ref("gopkg.in/yaml.v2", "Unmarshal")
 )

--- a/staging/src/k8s.io/code-generator/go.mod
+++ b/staging/src/k8s.io/code-generator/go.mod
@@ -14,11 +14,11 @@ require (
 	github.com/google/gofuzz v1.2.0
 	github.com/spf13/pflag v1.0.5
 	golang.org/x/text v0.17.0
-	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/apimachinery v0.0.0
 	k8s.io/gengo/v2 v2.0.0-20240911193312-2b36238f13e9
 	k8s.io/klog/v2 v2.130.1
 	k8s.io/kube-openapi v0.0.0-20240827152857-f7e401e7b4c2
+	sigs.k8s.io/yaml v1.4.0
 )
 
 require (
@@ -39,6 +39,7 @@ require (
 	golang.org/x/sync v0.8.0 // indirect
 	golang.org/x/tools v0.24.0 // indirect
 	google.golang.org/protobuf v1.34.2 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect

--- a/staging/src/k8s.io/component-base/go.mod
+++ b/staging/src/k8s.io/component-base/go.mod
@@ -26,12 +26,12 @@ require (
 	go.opentelemetry.io/otel/trace v1.28.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/sys v0.23.0
-	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/apimachinery v0.0.0
 	k8s.io/client-go v0.0.0
 	k8s.io/klog/v2 v2.130.1
 	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd
+	sigs.k8s.io/yaml v1.4.0
 )
 
 require (
@@ -76,11 +76,11 @@ require (
 	google.golang.org/grpc v1.65.0 // indirect
 	google.golang.org/protobuf v1.34.2 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/api v0.0.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20240827152857-f7e401e7b4c2 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
-	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
 replace (

--- a/staging/src/k8s.io/component-base/metrics/opts.go
+++ b/staging/src/k8s.io/component-base/metrics/opts.go
@@ -25,11 +25,11 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"gopkg.in/yaml.v2"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	promext "k8s.io/component-base/metrics/prometheusextension"
 	"k8s.io/klog/v2"
+	yaml "sigs.k8s.io/yaml/goyaml.v2"
 )
 
 var (

--- a/staging/src/k8s.io/cri-client/go.mod
+++ b/staging/src/k8s.io/cri-client/go.mod
@@ -76,6 +76,7 @@ require (
 	k8s.io/kube-openapi v0.0.0-20240827152857-f7e401e7b4c2 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
+	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
 replace (

--- a/staging/src/k8s.io/kubectl/go.mod
+++ b/staging/src/k8s.io/kubectl/go.mod
@@ -30,7 +30,6 @@ require (
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/sys v0.23.0
 	gopkg.in/evanphx/json-patch.v4 v4.12.0
-	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.0.0
 	k8s.io/apimachinery v0.0.0
 	k8s.io/cli-runtime v0.0.0
@@ -93,6 +92,7 @@ require (
 	golang.org/x/tools v0.24.0 // indirect
 	google.golang.org/protobuf v1.34.2 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	sigs.k8s.io/kustomize/api v0.17.2 // indirect
 )

--- a/staging/src/k8s.io/kubectl/pkg/cmd/edit/edit_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/edit/edit_test.go
@@ -30,8 +30,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/spf13/cobra"
 
-	yaml "gopkg.in/yaml.v2"
-
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
@@ -41,6 +39,7 @@ import (
 	"k8s.io/kubectl/pkg/cmd/create"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	yaml "sigs.k8s.io/yaml/goyaml.v2"
 )
 
 type EditTestCase struct {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/edit/testdata/record.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/edit/testdata/record.go
@@ -25,7 +25,7 @@ import (
 	"os"
 	"strings"
 
-	yaml "gopkg.in/yaml.v2"
+	yaml "sigs.k8s.io/yaml/goyaml.v2"
 )
 
 type EditTestCase struct {

--- a/test/conformance/walk.go
+++ b/test/conformance/walk.go
@@ -31,9 +31,9 @@ import (
 	"strings"
 	"text/template"
 
-	"gopkg.in/yaml.v2"
-
 	"github.com/onsi/ginkgo/v2/types"
+
+	yaml "sigs.k8s.io/yaml/goyaml.v2"
 )
 
 // ConformanceData describes the structure of the conformance.yaml file

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"gopkg.in/yaml.v2"
+	yaml "sigs.k8s.io/yaml/goyaml.v2"
 
 	// Never, ever remove the line with "/ginkgo". Without it,
 	// the ginkgo test runner will not detect that this

--- a/test/e2e/framework/.import-restrictions
+++ b/test/e2e/framework/.import-restrictions
@@ -35,7 +35,6 @@ rules:
   - selectorRegexp: ^github.com/|^gopkg.in
     allowedPrefixes: [
       "gopkg.in/inf.v0",
-      "gopkg.in/yaml.v2",
       "gopkg.in/evanphx/json-patch.v4",
       "github.com/blang/semver/",
       "github.com/davecgh/go-spew/spew",

--- a/test/e2e_kubeadm/kubeadm_config_test.go
+++ b/test/e2e_kubeadm/kubeadm_config_test.go
@@ -19,12 +19,12 @@ package kubeadm
 import (
 	"context"
 
-	"gopkg.in/yaml.v2"
 	authv1 "k8s.io/api/authorization/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
 	admissionapi "k8s.io/pod-security-admission/api"
+	yaml "sigs.k8s.io/yaml/goyaml.v2"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"

--- a/test/featuregates_linter/cmd/feature_gates.go
+++ b/test/featuregates_linter/cmd/feature_gates.go
@@ -29,9 +29,9 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
 
 	"k8s.io/apimachinery/pkg/util/version"
+	yaml "sigs.k8s.io/yaml/goyaml.v2"
 )
 
 var (

--- a/test/fuzz/yaml/yaml.go
+++ b/test/fuzz/yaml/yaml.go
@@ -23,9 +23,9 @@ import (
 	"fmt"
 	"strings"
 
-	"gopkg.in/yaml.v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	sigyaml "sigs.k8s.io/yaml"
+	yaml "sigs.k8s.io/yaml/goyaml.v2"
 )
 
 // FuzzDurationStrict is a fuzz target for strict-unmarshaling Duration defined
@@ -126,7 +126,7 @@ func FuzzTimeStrict(b []byte) int {
 	return 1
 }
 
-// FuzzYamlV2 is a fuzz target for "gopkg.in/yaml.v2" unmarshaling.
+// FuzzYamlV2 is a fuzz target for "sigs.k8s.io/yaml/goyaml.v2" unmarshaling.
 func FuzzYamlV2(b []byte) int {
 	t := struct{}{}
 	m := map[string]interface{}{}

--- a/test/instrumentation/documentation/main.go
+++ b/test/instrumentation/documentation/main.go
@@ -26,9 +26,9 @@ import (
 	"time"
 
 	flag "github.com/spf13/pflag"
-	"gopkg.in/yaml.v2"
 
 	"k8s.io/component-base/metrics"
+	yaml "sigs.k8s.io/yaml/goyaml.v2"
 )
 
 var (

--- a/test/instrumentation/main.go
+++ b/test/instrumentation/main.go
@@ -31,7 +31,7 @@ import (
 	"strconv"
 	"strings"
 
-	"gopkg.in/yaml.v2"
+	yaml "sigs.k8s.io/yaml/goyaml.v2"
 )
 
 const (

--- a/test/instrumentation/sort/main.go
+++ b/test/instrumentation/sort/main.go
@@ -22,8 +22,8 @@ import (
 	"sort"
 
 	flag "github.com/spf13/pflag"
-	"gopkg.in/yaml.v2"
 	"k8s.io/component-base/metrics"
+	yaml "sigs.k8s.io/yaml/goyaml.v2"
 )
 
 func main() {

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -28,7 +28,7 @@ import (
 	"regexp"
 	"strings"
 
-	"gopkg.in/yaml.v2"
+	yaml "sigs.k8s.io/yaml/goyaml.v2"
 )
 
 // RegistryList holds public and private image registries


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Since we have a Kubernetes-specific fork of go-yaml, use that consistently throughout the project. This doesn't eliminate the dependencies on gopkg.in/yaml, which are still used indirectly; but it ensures that the whole project benefits from fixes or changes to sigs.k8s.io/yaml.

Instead of updating the reference in applyconfiguration-gen (`yamlMarshal`), drop it since it’s unused.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
