### PR TITLE
DRA: allow Cluster Autoscaler to integrate with DRA scheduler plugin

### DIFF
--- a/pkg/scheduler/framework/autoscaler_contract/framework_contract_test.go
+++ b/pkg/scheduler/framework/autoscaler_contract/framework_contract_test.go
@@ -36,6 +36,7 @@ import (
 type frameworkContract interface {
 	RunPreFilterPlugins(ctx context.Context, state *framework.CycleState, pod *v1.Pod) (*framework.PreFilterResult, *framework.Status, sets.Set[string])
 	RunFilterPlugins(context.Context, *framework.CycleState, *v1.Pod, *framework.NodeInfo) *framework.Status
+	RunReservePluginsReserve(ctx context.Context, state *framework.CycleState, pod *v1.Pod, nodeName string) *framework.Status
 }
 
 func TestFrameworkContract(t *testing.T) {

--- a/pkg/scheduler/framework/autoscaler_contract/lister_contract_test.go
+++ b/pkg/scheduler/framework/autoscaler_contract/lister_contract_test.go
@@ -21,12 +21,20 @@ limitations under the License.
 package contract
 
 import (
+	resourceapi "k8s.io/api/resource/v1alpha3"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/dynamic-resource-allocation/structured"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 )
 
 var _ framework.NodeInfoLister = &nodeInfoListerContract{}
 var _ framework.StorageInfoLister = &storageInfoListerContract{}
 var _ framework.SharedLister = &shareListerContract{}
+var _ framework.ResourceSliceLister = &resourceSliceListerContract{}
+var _ framework.DeviceClassLister = &deviceClassListerContract{}
+var _ framework.ResourceClaimTracker = &resourceClaimTrackerContract{}
+var _ framework.SharedDRAManager = &sharedDRAManagerContract{}
 
 type nodeInfoListerContract struct{}
 
@@ -59,5 +67,68 @@ func (c *shareListerContract) NodeInfos() framework.NodeInfoLister {
 }
 
 func (c *shareListerContract) StorageInfos() framework.StorageInfoLister {
+	return nil
+}
+
+type resourceSliceListerContract struct{}
+
+func (c *resourceSliceListerContract) List() ([]*resourceapi.ResourceSlice, error) {
+	return nil, nil
+}
+
+type deviceClassListerContract struct{}
+
+func (c *deviceClassListerContract) List() ([]*resourceapi.DeviceClass, error) {
+	return nil, nil
+}
+
+func (c *deviceClassListerContract) Get(_ string) (*resourceapi.DeviceClass, error) {
+	return nil, nil
+}
+
+type resourceClaimTrackerContract struct{}
+
+func (r *resourceClaimTrackerContract) List() ([]*resourceapi.ResourceClaim, error) {
+	return nil, nil
+}
+
+func (r *resourceClaimTrackerContract) Get(_, _ string) (*resourceapi.ResourceClaim, error) {
+	return nil, nil
+}
+
+func (r *resourceClaimTrackerContract) ListAllAllocatedDevices() (sets.Set[structured.DeviceID], error) {
+	return nil, nil
+}
+
+func (r *resourceClaimTrackerContract) SignalClaimPendingAllocation(_ types.UID, _ *resourceapi.ResourceClaim) error {
+	return nil
+}
+
+func (r *resourceClaimTrackerContract) ClaimHasPendingAllocation(_ types.UID) bool {
+	return false
+}
+
+func (r *resourceClaimTrackerContract) RemoveClaimPendingAllocation(_ types.UID) (deleted bool) {
+	return false
+}
+
+func (r *resourceClaimTrackerContract) AssumeClaimAfterAPICall(_ *resourceapi.ResourceClaim) error {
+	return nil
+}
+
+func (r *resourceClaimTrackerContract) AssumedClaimRestore(_, _ string) {
+}
+
+type sharedDRAManagerContract struct{}
+
+func (s *sharedDRAManagerContract) ResourceClaims() framework.ResourceClaimTracker {
+	return nil
+}
+
+func (s *sharedDRAManagerContract) ResourceSlices() framework.ResourceSliceLister {
+	return nil
+}
+
+func (s *sharedDRAManagerContract) DeviceClasses() framework.DeviceClassLister {
 	return nil
 }

--- a/pkg/scheduler/framework/interface.go
+++ b/pkg/scheduler/framework/interface.go
@@ -39,7 +39,6 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 	"k8s.io/kubernetes/pkg/scheduler/framework/parallelize"
-	"k8s.io/kubernetes/pkg/scheduler/util/assumecache"
 )
 
 // NodeScoreList declares a list of nodes and their scores.
@@ -820,10 +819,9 @@ type Handle interface {
 
 	SharedInformerFactory() informers.SharedInformerFactory
 
-	// ResourceClaimCache returns an assume cache of ResourceClaim objects
-	// which gets populated by the shared informer factory and the dynamic resources
-	// plugin.
-	ResourceClaimCache() *assumecache.AssumeCache
+	// SharedDRAManager can be used to obtain DRA objects, and track modifications to them in-memory - mainly by the DRA plugin.
+	// A non-default implementation can be plugged into the framework to simulate the state of DRA objects.
+	SharedDRAManager() SharedDRAManager
 
 	// RunFilterPluginsWithNominatedPods runs the set of configured filter plugins for nominated pod on the given node.
 	RunFilterPluginsWithNominatedPods(ctx context.Context, state *CycleState, pod *v1.Pod, info *NodeInfo) *Status

--- a/pkg/scheduler/framework/listers.go
+++ b/pkg/scheduler/framework/listers.go
@@ -16,6 +16,13 @@ limitations under the License.
 
 package framework
 
+import (
+	resourceapi "k8s.io/api/resource/v1alpha3"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/dynamic-resource-allocation/structured"
+)
+
 // NodeInfoLister interface represents anything that can list/get NodeInfo objects from node name.
 type NodeInfoLister interface {
 	// List returns the list of NodeInfos.
@@ -39,4 +46,66 @@ type StorageInfoLister interface {
 type SharedLister interface {
 	NodeInfos() NodeInfoLister
 	StorageInfos() StorageInfoLister
+}
+
+// ResourceSliceLister can be used to obtain ResourceSlices.
+type ResourceSliceLister interface {
+	// List returns a list of all ResourceSlices.
+	List() ([]*resourceapi.ResourceSlice, error)
+}
+
+// DeviceClassLister can be used to obtain DeviceClasses.
+type DeviceClassLister interface {
+	// List returns a list of all DeviceClasses.
+	List() ([]*resourceapi.DeviceClass, error)
+	// Get returns the DeviceClass with the given className.
+	Get(className string) (*resourceapi.DeviceClass, error)
+}
+
+// ResourceClaimTracker can be used to obtain ResourceClaims, and track changes to ResourceClaims in-memory.
+//
+// If the claims are meant to be allocated in the API during the binding phase (when used by scheduler), the tracker helps avoid
+// race conditions between scheduling and binding phases (as well as between the binding phase and the informer cache update).
+//
+// If the binding phase is not run (e.g. when used by Cluster Autoscaler which only runs the scheduling phase, and simulates binding in-memory),
+// the tracker allows the framework user to obtain the claim allocations produced by the DRA plugin, and persist them outside of the API (e.g. in-memory).
+type ResourceClaimTracker interface {
+	// List lists ResourceClaims. The result is guaranteed to immediately include any changes made via AssumeClaimAfterAPICall(),
+	// and SignalClaimPendingAllocation().
+	List() ([]*resourceapi.ResourceClaim, error)
+	// Get works like List(), but for a single claim.
+	Get(namespace, claimName string) (*resourceapi.ResourceClaim, error)
+	// ListAllAllocatedDevices lists all allocated Devices from allocated ResourceClaims. The result is guaranteed to immediately include
+	// any changes made via AssumeClaimAfterAPICall(), and SignalClaimPendingAllocation().
+	ListAllAllocatedDevices() (sets.Set[structured.DeviceID], error)
+
+	// SignalClaimPendingAllocation signals to the tracker that the given ResourceClaim will be allocated via an API call in the
+	// binding phase. This change is immediately reflected in the result of List() and the other accessors.
+	SignalClaimPendingAllocation(claimUID types.UID, allocatedClaim *resourceapi.ResourceClaim) error
+	// ClaimHasPendingAllocation answers whether a given claim has a pending allocation during the binding phase. It can be used to avoid
+	// race conditions in subsequent scheduling phases.
+	ClaimHasPendingAllocation(claimUID types.UID) bool
+	// RemoveClaimPendingAllocation removes the pending allocation for the given ResourceClaim from the tracker if any was signaled via
+	// SignalClaimPendingAllocation(). Returns whether there was a pending allocation to remove. List() and the other accessors immediately
+	// stop reflecting the pending allocation in the results.
+	RemoveClaimPendingAllocation(claimUID types.UID) (deleted bool)
+
+	// AssumeClaimAfterAPICall signals to the tracker that an API call modifying the given ResourceClaim was made in the binding phase, and the
+	// changes should be reflected in informers very soon. This change is immediately reflected in the result of List() and the other accessors.
+	// This mechanism can be used to avoid race conditions between the informer update and subsequent scheduling phases.
+	AssumeClaimAfterAPICall(claim *resourceapi.ResourceClaim) error
+	// AssumedClaimRestore signals to the tracker that something went wrong with the API call modifying the given ResourceClaim, and
+	// the changes won't be reflected in informers after all. List() and the other accessors immediately stop reflecting the assumed change,
+	// and go back to the informer version.
+	AssumedClaimRestore(namespace, claimName string)
+}
+
+// SharedDRAManager can be used to obtain DRA objects, and track modifications to them in-memory - mainly by the DRA plugin.
+// The plugin's default implementation obtains the objects from the API. A different implementation can be
+// plugged into the framework in order to simulate the state of DRA objects. For example, Cluster Autoscaler
+// can use this to provide the correct DRA object state to the DRA plugin when simulating scheduling changes in-memory.
+type SharedDRAManager interface {
+	ResourceClaims() ResourceClaimTracker
+	ResourceSlices() ResourceSliceLister
+	DeviceClasses() DeviceClassLister
 }

--- a/pkg/scheduler/framework/plugins/dynamicresources/dra_manager.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dra_manager.go
@@ -1,0 +1,226 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamicresources
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	resourceapi "k8s.io/api/resource/v1alpha3"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/informers"
+	resourcelisters "k8s.io/client-go/listers/resource/v1alpha3"
+	"k8s.io/dynamic-resource-allocation/structured"
+	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+	"k8s.io/kubernetes/pkg/scheduler/util/assumecache"
+)
+
+var _ framework.SharedDRAManager = &DefaultDRAManager{}
+
+// DefaultDRAManager is the default implementation of SharedDRAManager. It obtains the DRA objects
+// from API informers, and uses an AssumeCache and a map of in-flight allocations in order
+// to avoid race conditions when modifying ResourceClaims.
+type DefaultDRAManager struct {
+	resourceClaimTracker *claimTracker
+	resourceSliceLister  *resourceSliceLister
+	deviceClassLister    *deviceClassLister
+}
+
+func NewDRAManager(ctx context.Context, claimsCache *assumecache.AssumeCache, informerFactory informers.SharedInformerFactory) *DefaultDRAManager {
+	logger := klog.FromContext(ctx)
+	manager := &DefaultDRAManager{
+		resourceClaimTracker: &claimTracker{
+			cache:               claimsCache,
+			inFlightAllocations: &sync.Map{},
+			allocatedDevices:    newAllocatedDevices(logger),
+			logger:              logger,
+		},
+		resourceSliceLister: &resourceSliceLister{sliceLister: informerFactory.Resource().V1alpha3().ResourceSlices().Lister()},
+		deviceClassLister:   &deviceClassLister{classLister: informerFactory.Resource().V1alpha3().DeviceClasses().Lister()},
+	}
+
+	// Reacting to events is more efficient than iterating over the list
+	// repeatedly in PreFilter.
+	manager.resourceClaimTracker.cache.AddEventHandler(manager.resourceClaimTracker.allocatedDevices.handlers())
+
+	return manager
+}
+
+func (s *DefaultDRAManager) ResourceClaims() framework.ResourceClaimTracker {
+	return s.resourceClaimTracker
+}
+
+func (s *DefaultDRAManager) ResourceSlices() framework.ResourceSliceLister {
+	return s.resourceSliceLister
+}
+
+func (s *DefaultDRAManager) DeviceClasses() framework.DeviceClassLister {
+	return s.deviceClassLister
+}
+
+var _ framework.ResourceSliceLister = &resourceSliceLister{}
+
+type resourceSliceLister struct {
+	sliceLister resourcelisters.ResourceSliceLister
+}
+
+func (l *resourceSliceLister) List() ([]*resourceapi.ResourceSlice, error) {
+	return l.sliceLister.List(labels.Everything())
+}
+
+var _ framework.DeviceClassLister = &deviceClassLister{}
+
+type deviceClassLister struct {
+	classLister resourcelisters.DeviceClassLister
+}
+
+func (l *deviceClassLister) Get(className string) (*resourceapi.DeviceClass, error) {
+	return l.classLister.Get(className)
+}
+
+func (l *deviceClassLister) List() ([]*resourceapi.DeviceClass, error) {
+	return l.classLister.List(labels.Everything())
+}
+
+var _ framework.ResourceClaimTracker = &claimTracker{}
+
+type claimTracker struct {
+	// cache enables temporarily storing a newer claim object
+	// while the scheduler has allocated it and the corresponding object
+	// update from the apiserver has not been processed by the claim
+	// informer callbacks. ResourceClaimTracker get added here in PreBind and removed by
+	// the informer callback (based on the "newer than" comparison in the
+	// assume cache).
+	//
+	// It uses cache.MetaNamespaceKeyFunc to generate object names, which
+	// therefore are "<namespace>/<name>".
+	//
+	// This is necessary to ensure that reconstructing the resource usage
+	// at the start of a pod scheduling cycle doesn't reuse the resources
+	// assigned to such a claim. Alternatively, claim allocation state
+	// could also get tracked across pod scheduling cycles, but that
+	// - adds complexity (need to carefully sync state with informer events
+	//   for claims and ResourceSlices)
+	// - would make integration with cluster autoscaler harder because it would need
+	//   to trigger informer callbacks.
+	cache *assumecache.AssumeCache
+	// inFlightAllocations is a map from claim UUIDs to claim objects for those claims
+	// for which allocation was triggered during a scheduling cycle and the
+	// corresponding claim status update call in PreBind has not been done
+	// yet. If another pod needs the claim, the pod is treated as "not
+	// schedulable yet". The cluster event for the claim status update will
+	// make it schedulable.
+	//
+	// This mechanism avoids the following problem:
+	// - Pod A triggers allocation for claim X.
+	// - Pod B shares access to that claim and gets scheduled because
+	//   the claim is assumed to be allocated.
+	// - PreBind for pod B is called first, tries to update reservedFor and
+	//   fails because the claim is not really allocated yet.
+	//
+	// We could avoid the ordering problem by allowing either pod A or pod B
+	// to set the allocation. But that is more complicated and leads to another
+	// problem:
+	// - Pod A and B get scheduled as above.
+	// - PreBind for pod A gets called first, then fails with a temporary API error.
+	//   It removes the updated claim from the assume cache because of that.
+	// - PreBind for pod B gets called next and succeeds with adding the
+	//   allocation and its own reservedFor entry.
+	// - The assume cache is now not reflecting that the claim is allocated,
+	//   which could lead to reusing the same resource for some other claim.
+	//
+	// A sync.Map is used because in practice sharing of a claim between
+	// pods is expected to be rare compared to per-pod claim, so we end up
+	// hitting the "multiple goroutines read, write, and overwrite entries
+	// for disjoint sets of keys" case that sync.Map is optimized for.
+	inFlightAllocations *sync.Map
+	allocatedDevices    *allocatedDevices
+	logger              klog.Logger
+}
+
+func (c *claimTracker) ClaimHasPendingAllocation(claimUID types.UID) bool {
+	_, found := c.inFlightAllocations.Load(claimUID)
+	return found
+}
+
+func (c *claimTracker) SignalClaimPendingAllocation(claimUID types.UID, allocatedClaim *resourceapi.ResourceClaim) error {
+	c.inFlightAllocations.Store(claimUID, allocatedClaim)
+	// There's no reason to return an error in this implementation, but the error is helpful for other implementations.
+	// For example, implementations that have to deal with fake claims might want to return an error if the allocation
+	// is for an invalid claim.
+	return nil
+}
+
+func (c *claimTracker) RemoveClaimPendingAllocation(claimUID types.UID) (deleted bool) {
+	_, found := c.inFlightAllocations.LoadAndDelete(claimUID)
+	return found
+}
+
+func (c *claimTracker) Get(namespace, claimName string) (*resourceapi.ResourceClaim, error) {
+	obj, err := c.cache.Get(namespace + "/" + claimName)
+	if err != nil {
+		return nil, err
+	}
+	claim, ok := obj.(*resourceapi.ResourceClaim)
+	if !ok {
+		return nil, fmt.Errorf("unexpected object type %T for assumed object %s/%s", obj, namespace, claimName)
+	}
+	return claim, nil
+}
+
+func (c *claimTracker) List() ([]*resourceapi.ResourceClaim, error) {
+	var result []*resourceapi.ResourceClaim
+	// Probably not worth adding an index for?
+	objs := c.cache.List(nil)
+	for _, obj := range objs {
+		claim, ok := obj.(*resourceapi.ResourceClaim)
+		if ok {
+			result = append(result, claim)
+		}
+	}
+	return result, nil
+}
+
+func (c *claimTracker) ListAllAllocatedDevices() (sets.Set[structured.DeviceID], error) {
+	// Start with a fresh set that matches the current known state of the
+	// world according to the informers.
+	allocated := c.allocatedDevices.Get()
+
+	// Whatever is in flight also has to be checked.
+	c.inFlightAllocations.Range(func(key, value any) bool {
+		claim := value.(*resourceapi.ResourceClaim)
+		foreachAllocatedDevice(claim, func(deviceID structured.DeviceID) {
+			c.logger.V(6).Info("Device is in flight for allocation", "device", deviceID, "claim", klog.KObj(claim))
+			allocated.Insert(deviceID)
+		})
+		return true
+	})
+	// There's no reason to return an error in this implementation, but the error might be helpful for other implementations.
+	return allocated, nil
+}
+
+func (c *claimTracker) AssumeClaimAfterAPICall(claim *resourceapi.ResourceClaim) error {
+	return c.cache.Assume(claim)
+}
+
+func (c *claimTracker) AssumedClaimRestore(namespace, claimName string) {
+	c.cache.Restore(namespace + "/" + claimName)
+}

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/allocator.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/allocator.go
@@ -26,12 +26,18 @@ import (
 	v1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1alpha3"
 	"k8s.io/apimachinery/pkg/util/sets"
-	resourcelisters "k8s.io/client-go/listers/resource/v1alpha3"
 	draapi "k8s.io/dynamic-resource-allocation/api"
 	"k8s.io/dynamic-resource-allocation/cel"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 )
+
+type deviceClassLister interface {
+	// List returns a list of all DeviceClasses.
+	List() ([]*resourceapi.DeviceClass, error)
+	// Get returns the DeviceClass with the given className.
+	Get(className string) (*resourceapi.DeviceClass, error)
+}
 
 // Allocator calculates how to allocate a set of unallocated claims which use
 // structured parameters.
@@ -43,7 +49,7 @@ type Allocator struct {
 	adminAccessEnabled bool
 	claimsToAllocate   []*resourceapi.ResourceClaim
 	allocatedDevices   sets.Set[DeviceID]
-	classLister        resourcelisters.DeviceClassLister
+	classLister        deviceClassLister
 	slices             []*resourceapi.ResourceSlice
 	celCache           *cel.Cache
 }
@@ -56,7 +62,7 @@ func NewAllocator(ctx context.Context,
 	adminAccessEnabled bool,
 	claimsToAllocate []*resourceapi.ResourceClaim,
 	allocatedDevices sets.Set[DeviceID],
-	classLister resourcelisters.DeviceClassLister,
+	classLister deviceClassLister,
 	slices []*resourceapi.ResourceSlice,
 	celCache *cel.Cache,
 ) (*Allocator, error) {

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/allocator_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/allocator_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package structured
 
 import (
-	"errors"
 	"flag"
 	"fmt"
 	"slices"
@@ -33,7 +32,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -1402,10 +1400,7 @@ type informerLister[T any] struct {
 	err  error
 }
 
-func (l informerLister[T]) List(selector labels.Selector) (ret []*T, err error) {
-	if selector.String() != labels.Everything().String() {
-		return nil, errors.New("labels selector not implemented")
-	}
+func (l informerLister[T]) List() (ret []*T, err error) {
 	return l.objs, l.err
 }
 

--- a/test/integration/scheduler_perf/dra.go
+++ b/test/integration/scheduler_perf/dra.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/dynamic-resource-allocation/cel"
 	"k8s.io/dynamic-resource-allocation/structured"
 	"k8s.io/kubernetes/pkg/features"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/dynamicresources"
 	"k8s.io/kubernetes/pkg/scheduler/util/assumecache"
 	"k8s.io/kubernetes/test/utils/ktesting"
 	"k8s.io/utils/ptr"
@@ -275,10 +276,8 @@ func (op *allocResourceClaimsOp) run(tCtx ktesting.TContext) {
 	// Track cluster state.
 	informerFactory := informers.NewSharedInformerFactory(tCtx.Client(), 0)
 	claimInformer := informerFactory.Resource().V1alpha3().ResourceClaims().Informer()
-	classLister := informerFactory.Resource().V1alpha3().DeviceClasses().Lister()
-	sliceLister := informerFactory.Resource().V1alpha3().ResourceSlices().Lister()
 	nodeLister := informerFactory.Core().V1().Nodes().Lister()
-	claimCache := assumecache.NewAssumeCache(tCtx.Logger(), claimInformer, "ResourceClaim", "", nil)
+	draManager := dynamicresources.NewDRAManager(tCtx, assumecache.NewAssumeCache(tCtx.Logger(), claimInformer, "ResourceClaim", "", nil), informerFactory)
 	informerFactory.Start(tCtx.Done())
 	defer func() {
 		tCtx.Cancel("allocResourceClaimsOp.run is shutting down")
@@ -297,7 +296,7 @@ func (op *allocResourceClaimsOp) run(tCtx ktesting.TContext) {
 	// The set of nodes is assumed to be fixed at this point.
 	nodes, err := nodeLister.List(labels.Everything())
 	tCtx.ExpectNoError(err, "list nodes")
-	slices, err := sliceLister.List(labels.Everything())
+	slices, err := draManager.ResourceSlices().List()
 	tCtx.ExpectNoError(err, "list slices")
 
 	// Allocate one claim at a time, picking nodes randomly. Each
@@ -310,10 +309,10 @@ claims:
 			continue
 		}
 
-		objs := claimCache.List(nil)
+		claims, err := draManager.ResourceClaims().List()
+		tCtx.ExpectNoError(err, "list claims")
 		allocatedDevices := sets.New[structured.DeviceID]()
-		for _, obj := range objs {
-			claim := obj.(*resourceapi.ResourceClaim)
+		for _, claim := range claims {
 			if claim.Status.Allocation == nil {
 				continue
 			}
@@ -322,7 +321,7 @@ claims:
 			}
 		}
 
-		allocator, err := structured.NewAllocator(tCtx, utilfeature.DefaultFeatureGate.Enabled(features.DRAAdminAccess), []*resourceapi.ResourceClaim{claim}, allocatedDevices, classLister, slices, celCache)
+		allocator, err := structured.NewAllocator(tCtx, utilfeature.DefaultFeatureGate.Enabled(features.DRAAdminAccess), []*resourceapi.ResourceClaim{claim}, allocatedDevices, draManager.DeviceClasses(), slices, celCache)
 		tCtx.ExpectNoError(err, "create allocator")
 
 		rand.Shuffle(len(nodes), func(i, j int) {
@@ -336,10 +335,10 @@ claims:
 				claim.Status.Allocation = &result[0]
 				claim, err := tCtx.Client().ResourceV1alpha3().ResourceClaims(claim.Namespace).UpdateStatus(tCtx, claim, metav1.UpdateOptions{})
 				tCtx.ExpectNoError(err, "update claim status with allocation")
-				tCtx.ExpectNoError(claimCache.Assume(claim), "assume claim")
+				tCtx.ExpectNoError(draManager.ResourceClaims().AssumeClaimAfterAPICall(claim), "assume claim")
 				continue claims
 			}
 		}
-		tCtx.Fatalf("Could not allocate claim %d out of %d", i, len(claims.Items))
+		tCtx.Fatalf("Could not allocate claim %d out of %d", i, len(claims))
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR refactors the DRA scheduler plugin so that all accesses to DRA objects, and all in-memory tracking for ResourceClaim modifications, go through a `SharedDRAManager` interface that can be plugged into the scheduler framework. 

This is needed for Cluster Autoscaler to integrate with DRA. Cluster Autoscaler will plug a different `SharedDRAManager` implementation.

Plugging `SharedDRAManager` allows CA to make modifications to the DRA objects provided to the DRA plugin:
* Injecting fake node-local `ResourceSlices`  - when a Node exposing `ResourceSlices` is duplicated in-memory (e.g. during a scale-up simulation).
* Removing node-local `ResourceSlices` - when a Node exposing `ResourceSlices` is deleted in-memory (e.g. during a scale-down simulation).
* Injecting fake pod-owned `ResourceClaims` - when a Pod owning `ResourceClaims` is duplicated in-memory (e.g. a DS pod during a scale-up simulation).
* Removing pod-owned `ResourceClaims` - when a Pod owning `ResourceClaims` is deleted in-memory (e.g. for the concept of "expendable pods").
* Modifying `ResourceClaims` - e.g. clearing the allocation, or modifying `ReservedFor`, when simulating where else a given scheduled pod can be "rescheduled" .

Plugging `SharedDRAManager` also allows CA to obtain ResourceClaim allocations computed during `Filter` back from the DRA plugin.

#### Which issue(s) this PR fixes:

The CA/DRA integration is tracked in #118612. The integration requires changes in CA and kube-scheduler - this is the scheduler part. The corresponding CA changes are in https://github.com/kubernetes/autoscaler/pull/7350.

#### Special notes for your reviewer:

1. Some parts of `SharedDRAManager` aren't strictly necessary for CA integration - e.g. CA will never modify `DeviceClasses`, so that could technically stay as just a lister. Having all DRA objects in the interface simplifies testing on the CA side. Instead of having to fiddle with faking informers separately for `DeviceClasses`, they can just be injected easily through `SharedDRAManager`, like claims and slices. IMO it also makes for cleaner code overall.
2. Some of `ResourceClaimTracker` methods (`RemoveClaimPendingAllocation`, `AssumeClaimAfterApiCall`, `AssumedClaimRestore`) are only applicable to the binding cycle, so they'll never be run by Cluster Autoscaler (which only runs the scheduling cycle phases). It'd be nice to separate them into 2 interfaces or do something similar, instead of just not implementing a subset of the methods in CA. But that's not great from readability perspective, as we'd have tightly coupled methods in separate interfaces. I'd appreciate any ideas on how to separate the methods for scheduling/binding phases while maintaining readability.
3. The added layer of abstraction in the DRA plugin decreases readability a bit (`ResourceClaimTracker` coupling unrelated mechanisms together is not ideal..), but it was the cleanest solution I found while prototyping. CA definitely needs to be able to plug into the listers, and to have some way of getting an allocation result back. I didn't find a good solution that satisfies the 2 properties without extracting the cache + the in-flight map + the listers behind a single interface.
4. I know this conflicts with #127277. From a quick read, it should be fairly straightforward to rebase one on top of the other. I can rebase after #127277 is submitted, just wanted to get this PR out together with the CA PR. Also note that I'm OOO from Oct 11th to Oct 27th, so I won't have a lot of time to iterate on it before the 1.32 code freeze date.

#### Does this PR introduce a user-facing change?

Not on its own, the PR just makes Cluster Autoscaler integration possible.

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/9de7f62e16fc5c1ea3bd40689487c9edc7fa5057/keps/sig-node/4381-dra-structured-parameters/README.md
```
