### PR TITLE
bump kube-network-policies to 0.6.0

### DIFF
--- a/cluster/addons/kube-network-policies/kube-network-policies.yaml
+++ b/cluster/addons/kube-network-policies/kube-network-policies.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: kube-network-policies
       containers:
       - name: kube-network-policies
-        image: registry.k8s.io/networking/kube-network-policies:v0.5.0
+        image: registry.k8s.io/networking/kube-network-policies:v0.6.0
         command:
         - /bin/sh
         - -c


### PR DESCRIPTION

/kind cleanup
/kind flake
```release-note
NONE
```

New version with workaround for kernel bugs on netfilter conntrack races with DNS