### PR TITLE
Promote CSINode e2e test to Conformance

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -2791,6 +2791,18 @@
     patch, and delete operations.
   release: v1.26
   file: test/e2e/storage/csi_inline.go
+- testname: CSINode, lifecycle
+  codename: '[sig-storage] CSINodes CSI Conformance should run through the lifecycle
+    of a csinode [Conformance]'
+  description: Creating an initial CSINode MUST succeed. Reading a CSINode MUST succeed
+    with required name retrieved. Patching a CSINode MUST succeed with its new label
+    found. Listing CSINode with a labelSelector MUST succeed. Deleting a CSINode MUST
+    succeed and it MUST be confirmed. Creating a replacement CSINode MUST succeed.
+    Reading a CSINode MUST succeed with required name retrieved. Updating a CSINode
+    MUST succeed with its new label found. Deleting the CSINode via deleteCollection
+    MUST succeed and it MUST be confirmed.
+  release: v1.32
+  file: test/e2e/storage/csi_node.go
 - testname: CSIStorageCapacity API
   codename: '[sig-storage] CSIStorageCapacity should support CSIStorageCapacities
     API operations [Conformance]'

--- a/test/e2e/storage/csi_node.go
+++ b/test/e2e/storage/csi_node.go
@@ -40,7 +40,18 @@ var _ = utils.SIGDescribe("CSINodes", func() {
 
 	ginkgo.Describe("CSI Conformance", func() {
 
-		ginkgo.It("should run through the lifecycle of a csinode", func(ctx context.Context) {
+		/*
+			Release: v1.32
+			Testname: CSINode, lifecycle
+			Description: Creating an initial CSINode MUST succeed. Reading a CSINode MUST
+			succeed with required name retrieved. Patching a CSINode MUST succeed with its
+			new label found. Listing CSINode with a labelSelector MUST succeed. Deleting a
+			CSINode MUST succeed and it MUST be confirmed. Creating a replacement CSINode
+			MUST succeed. Reading a CSINode MUST succeed with required name retrieved. Updating
+			a CSINode MUST succeed with its new label found. Deleting the CSINode via deleteCollection
+			MUST succeed and it MUST be confirmed.
+		*/
+		framework.ConformanceIt("should run through the lifecycle of a csinode", func(ctx context.Context) {
 
 			csiNodeClient := f.ClientSet.StorageV1().CSINodes()
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR promotes to Conformance the following endpoints in a recently added [e2e test](https://pr.k8s.io/127309):

-  createStorageV1CSINode
-  deleteStorageV1CollectionCSINode
-  deleteStorageV1CSINode
-  listStorageV1CSINode
-  patchStorageV1CSINode
-  readStorageV1CSINode
-  replaceStorageV1CSINode

#### Which issue(s) this PR fixes:

Fixes #127308

#### Special notes for your reviewer:

- Adds +7 endpoint test coverage (good for conformance)
- Links for e2e test progress on [Testgrid](https://testgrid.k8s.io/sig-release-master-blocking#gce-cos-master-default&width=5&graph-metrics=test-duration-minutes&include-filter-by-regex=should.run.through.the.lifecycle.of.a.csinode) and [K8s Triage](https://storage.googleapis.com/k8s-triage/index.html?test=should.run.through.the.lifecycle.of.a.csinode)

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
/sig testing
/sig architecture
/area conformance
