### PR TITLE
fix node start time inconsistency in kubelet

### DIFF
--- a/pkg/kubelet/util/boottime_util_linux_test.go
+++ b/pkg/kubelet/util/boottime_util_linux_test.go
@@ -35,3 +35,18 @@ func TestGetBootTime(t *testing.T) {
 		t.Errorf("Invalid system uptime")
 	}
 }
+
+func TestVariationBetweenGetBootTimeMethods(t *testing.T) {
+	boottime1, err := getBootTimeWithProcStat()
+	if err != nil {
+		t.Errorf("Unable to get boot time from /proc/uptime")
+	}
+	boottime2, err := getBootTimeWithSysinfo()
+	if err != nil {
+		t.Errorf("Unable to get boot time from unix.Sysinfo")
+	}
+	diff := boottime1.Sub(boottime2)
+	if diff > time.Second || diff < -time.Second {
+		t.Errorf("boot time produced by 2 methods should not vary more than a second")
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Make kubelet report consistent start time at every restart.

See the linked issue for why we need it.

#### Which issue(s) this PR fixes:

Fixes #127841

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
