### PR TITLE
Fix data race in kubelet/volumemanager

### DIFF
--- a/pkg/controller/volume/attachdetach/cache/actual_state_of_world.go
+++ b/pkg/controller/volume/attachdetach/cache/actual_state_of_world.go
@@ -584,13 +584,13 @@ func (asw *actualStateOfWorld) GetAttachState(
 }
 
 // SetVolumeClaimSize sets size of the volume. But this function should not be used from attach_detach controller.
-func (asw *actualStateOfWorld) InitializeClaimSize(logger klog.Logger, volumeName v1.UniqueVolumeName, claimSize *resource.Quantity) {
+func (asw *actualStateOfWorld) InitializeClaimSize(logger klog.Logger, volumeName v1.UniqueVolumeName, claimSize resource.Quantity) {
 	logger.V(5).Info("no-op InitializeClaimSize call in attach-detach controller")
 }
 
-func (asw *actualStateOfWorld) GetClaimSize(volumeName v1.UniqueVolumeName) *resource.Quantity {
+func (asw *actualStateOfWorld) GetClaimSize(volumeName v1.UniqueVolumeName) resource.Quantity {
 	// not needed in attach-detach controller
-	return nil
+	return resource.Quantity{}
 }
 
 func (asw *actualStateOfWorld) GetAttachedVolumes() []AttachedVolume {

--- a/pkg/kubelet/volumemanager/cache/desired_state_of_world.go
+++ b/pkg/kubelet/volumemanager/cache/desired_state_of_world.go
@@ -134,7 +134,7 @@ type DesiredStateOfWorld interface {
 	// UpdatePersistentVolumeSize updates persistentVolumeSize in desired state of the world
 	// so as it can be compared against actual size and volume expansion performed
 	// if necessary
-	UpdatePersistentVolumeSize(volumeName v1.UniqueVolumeName, size *resource.Quantity)
+	UpdatePersistentVolumeSize(volumeName v1.UniqueVolumeName, size resource.Quantity)
 }
 
 // VolumeToMount represents a volume that is attached to this node and needs to
@@ -206,7 +206,7 @@ type volumeToMount struct {
 
 	// persistentVolumeSize records desired size of a persistent volume.
 	// Usually this value reflects size recorded in pv.Spec.Capacity
-	persistentVolumeSize *resource.Quantity
+	persistentVolumeSize resource.Quantity
 
 	// effectiveSELinuxMountFileLabel is the SELinux label that will be applied to the volume using mount options.
 	// If empty, then:
@@ -347,7 +347,7 @@ func (dsw *desiredStateOfWorld) AddPodToVolume(
 			pvCap := volumeSpec.PersistentVolume.Spec.Capacity.Storage()
 			if pvCap != nil {
 				pvCapCopy := pvCap.DeepCopy()
-				vmt.persistentVolumeSize = &pvCapCopy
+				vmt.persistentVolumeSize = pvCapCopy
 			}
 		}
 		dsw.volumesToMount[volumeName] = vmt
@@ -499,7 +499,7 @@ func (dsw *desiredStateOfWorld) DeletePodFromVolume(
 
 // UpdatePersistentVolumeSize updates last known PV size. This is used for volume expansion and
 // should be only used for persistent volumes.
-func (dsw *desiredStateOfWorld) UpdatePersistentVolumeSize(volumeName v1.UniqueVolumeName, size *resource.Quantity) {
+func (dsw *desiredStateOfWorld) UpdatePersistentVolumeSize(volumeName v1.UniqueVolumeName, size resource.Quantity) {
 	dsw.Lock()
 	defer dsw.Unlock()
 
@@ -610,7 +610,7 @@ func (dsw *desiredStateOfWorld) GetVolumesToMount() []VolumeToMount {
 					SELinuxLabel:            volumeObj.effectiveSELinuxMountFileLabel,
 				},
 			}
-			if volumeObj.persistentVolumeSize != nil {
+			if !volumeObj.persistentVolumeSize.IsZero() {
 				vmt.DesiredPersistentVolumeSize = volumeObj.persistentVolumeSize.DeepCopy()
 			}
 			volumesToMount = append(volumesToMount, vmt)

--- a/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator.go
+++ b/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator.go
@@ -384,8 +384,8 @@ func (dswp *desiredStateOfWorldPopulator) checkVolumeFSResize(
 		return
 	}
 
-	pvCap := volumeSpec.PersistentVolume.Spec.Capacity.Storage()
-	pvcStatusCap := pvc.Status.Capacity.Storage()
+	pvCap := volumeSpec.PersistentVolume.Spec.Capacity.Storage().DeepCopy()
+	pvcStatusCap := pvc.Status.Capacity.Storage().DeepCopy()
 	dswp.desiredStateOfWorld.UpdatePersistentVolumeSize(uniqueVolumeName, pvCap)
 	klog.V(5).InfoS("NodeExpandVolume updating size", "actualSize", pvcStatusCap.String(), "desiredSize", pvCap.String(), "volumeName", uniqueVolumeName)
 	// in case the actualStateOfWorld was rebuild after kubelet restart ensure that claimSize is set to accurate value

--- a/pkg/kubelet/volumemanager/reconciler/reconciler_test.go
+++ b/pkg/kubelet/volumemanager/reconciler/reconciler_test.go
@@ -1374,7 +1374,7 @@ func Test_Run_Positive_VolumeFSResizeControllerAttachEnabled(t *testing.T) {
 
 			t.Logf("Changing size of the volume to %s", tc.newPVSize.String())
 			newSize := tc.newPVSize.DeepCopy()
-			dsw.UpdatePersistentVolumeSize(volumeName, &newSize)
+			dsw.UpdatePersistentVolumeSize(volumeName, newSize)
 
 			_, _, podExistErr := asw.PodExistsInVolume(podName, volumeName, newSize, "" /* SELinuxLabel */)
 			if tc.expansionFailed {

--- a/pkg/volume/util/operationexecutor/node_expander_test.go
+++ b/pkg/volume/util/operationexecutor/node_expander_test.go
@@ -266,7 +266,7 @@ func (f *fakeActualStateOfWorld) MarkVolumeAsMounted(markVolumeOpts MarkVolumeOp
 }
 
 // MarkVolumeAsResized implements ActualStateOfWorldMounterUpdater.
-func (f *fakeActualStateOfWorld) MarkVolumeAsResized(volumeName v1.UniqueVolumeName, claimSize *resource.Quantity) bool {
+func (f *fakeActualStateOfWorld) MarkVolumeAsResized(volumeName v1.UniqueVolumeName, claimSize resource.Quantity) bool {
 	panic("unimplemented")
 }
 

--- a/pkg/volume/util/operationexecutor/operation_executor.go
+++ b/pkg/volume/util/operationexecutor/operation_executor.go
@@ -198,7 +198,7 @@ type ActualStateOfWorldMounterUpdater interface {
 	MarkDeviceAsUnmounted(volumeName v1.UniqueVolumeName) error
 
 	// Marks the specified volume's file system resize request is finished.
-	MarkVolumeAsResized(volumeName v1.UniqueVolumeName, claimSize *resource.Quantity) bool
+	MarkVolumeAsResized(volumeName v1.UniqueVolumeName, claimSize resource.Quantity) bool
 
 	// GetDeviceMountState returns mount state of the device in global path
 	GetDeviceMountState(volumeName v1.UniqueVolumeName) DeviceMountState
@@ -277,9 +277,9 @@ type ActualStateOfWorldAttacherUpdater interface {
 	AddVolumeToReportAsAttached(logger klog.Logger, volumeName v1.UniqueVolumeName, nodeName types.NodeName)
 
 	// InitializeClaimSize sets pvc claim size by reading pvc.Status.Capacity
-	InitializeClaimSize(logger klog.Logger, volumeName v1.UniqueVolumeName, claimSize *resource.Quantity)
+	InitializeClaimSize(logger klog.Logger, volumeName v1.UniqueVolumeName, claimSize resource.Quantity)
 
-	GetClaimSize(volumeName v1.UniqueVolumeName) *resource.Quantity
+	GetClaimSize(volumeName v1.UniqueVolumeName) resource.Quantity
 }
 
 // VolumeLogger defines a set of operations for generating volume-related logging and error msgs


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

```
...
==================
WARNING: DATA RACE
Read at 0x00c000794418 by goroutine 125:
  k8s.io/kubernetes/pkg/kubelet/volumemanager/cache.(*desiredStateOfWorld).GetVolumesToMount()
      /Users/kiki/workspace/golang/src/k8s.io/kubernetes/pkg/kubelet/volumemanager/cache/desired_state_of_world.go:614 +0x430
  k8s.io/kubernetes/pkg/kubelet/volumemanager/reconciler.(*reconciler).mountOrAttachVolumes()
      /Users/kiki/workspace/golang/src/k8s.io/kubernetes/pkg/kubelet/volumemanager/reconciler/reconciler_common.go:167 +0x50
  k8s.io/kubernetes/pkg/kubelet/volumemanager/reconciler.(*reconciler).reconcile()
...
Previous write at 0x00c000794418 by goroutine 123:
  k8s.io/apimachinery/pkg/api/resource.(*Quantity).String()
      /Users/kiki/workspace/golang/src/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go:687 +0xfc
  k8s.io/kubernetes/pkg/kubelet/volumemanager/populator.(*desiredStateOfWorldPopulator).checkVolumeFSResize()
      /Users/kiki/workspace/golang/src/k8s.io/kubernetes/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator.go:391 +0x80c
```

`DeepCopy` and `String` funcs on the `resource.(*Quantity)` are not thread-safe. It was used by https://github.com/kubernetes/kubernetes/pull/108693 and detected by the new test https://github.com/kubernetes/kubernetes/commit/b4a21a3e43ced6c573d8b16086bd5bbe1c70123d

With this patch:

```
(base) ➜  kubernetes git:(fix-127852) stress ./volumemanager.test -test.run TestWaitForAllPodsUnmount

5s: 8 runs so far, 0 failures
10s: 32 runs so far, 0 failures
15s: 48 runs so far, 0 failures
20s: 64 runs so far, 0 failures
25s: 80 runs so far, 0 failures
30s: 104 runs so far, 0 failures
35s: 120 runs so far, 0 failures
40s: 136 runs so far, 0 failures
45s: 152 runs so far, 0 failures
50s: 176 runs so far, 0 failures
55s: 192 runs so far, 0 failures
1m0s: 208 runs so far, 0 failures
1m5s: 224 runs so far, 0 failures
1m10s: 248 runs so far, 0 failures
1m15s: 264 runs so far, 0 failures
1m20s: 280 runs so far, 0 failures
1m25s: 304 runs so far, 0 failures
1m30s: 320 runs so far, 0 failures
1m35s: 336 runs so far, 0 failures
^C
```


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #127852

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix data race in kubelet/volumemanager
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
