### PR TITLE
CRI: clarify `Mount.host_path` docs

### DIFF
--- a/staging/src/k8s.io/cri-api/pkg/apis/runtime/v1/api.pb.go
+++ b/staging/src/k8s.io/cri-api/pkg/apis/runtime/v1/api.pb.go
@@ -627,8 +627,10 @@ func (m *PortMapping) GetHostIp() string {
 type Mount struct {
 	// Path of the mount within the container.
 	ContainerPath string `protobuf:"bytes,1,opt,name=container_path,json=containerPath,proto3" json:"container_path,omitempty"`
-	// Path of the mount on the host. If the hostPath doesn't exist, then runtimes
-	// should report error. If the hostpath is a symbolic link, runtimes should
+	// Path of the mount on the host. Has to be empty if the image field below
+	// is provided, because those fields are mutually exclusive. If the image
+	// field below is nil and the host path doesn't exist, then runtimes should
+	// report an error. If the hostpath is a symbolic link, runtimes should
 	// follow the symlink and mount the real destination to container.
 	HostPath string `protobuf:"bytes,2,opt,name=host_path,json=hostPath,proto3" json:"host_path,omitempty"`
 	// If set, the mount is read-only.

--- a/staging/src/k8s.io/cri-api/pkg/apis/runtime/v1/api.proto
+++ b/staging/src/k8s.io/cri-api/pkg/apis/runtime/v1/api.proto
@@ -221,8 +221,10 @@ enum MountPropagation {
 message Mount {
     // Path of the mount within the container.
     string container_path = 1;
-    // Path of the mount on the host. If the hostPath doesn't exist, then runtimes
-    // should report error. If the hostpath is a symbolic link, runtimes should
+    // Path of the mount on the host. Has to be empty if the image field below
+    // is provided, because those fields are mutually exclusive. If the image
+    // field below is nil and the host path doesn't exist, then runtimes should
+    // report an error. If the hostpath is a symbolic link, runtimes should
     // follow the symlink and mount the real destination to container.
     string host_path = 2;
     // If set, the mount is read-only.


### PR DESCRIPTION


#### What type of PR is this?


/kind documentation


#### What this PR does / why we need it:
Mention that the `host_path` can be empty if image volumes are being used.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
PTAL @kubernetes/sig-node-pr-reviews 
cc @carlory 
#### Does this PR introduce a user-facing change?

```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
None
```
