### PR TITLE
Configure topology manager policy in local-up-cluster

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -95,6 +95,7 @@ CLOUD_CONFIG=${CLOUD_CONFIG:-""}
 KUBELET_PROVIDER_ID=${KUBELET_PROVIDER_ID:-"$(hostname)"}
 FEATURE_GATES=${FEATURE_GATES:-"AllAlpha=false"}
 EMULATED_VERSION=${EMULATED_VERSION:+kube=$EMULATED_VERSION}
+TOPOLOGY_MANAGER_POLICY=${TOPOLOGY_MANAGER_POLICY:-""}
 CPUMANAGER_POLICY=${CPUMANAGER_POLICY:-""}
 CPUMANAGER_RECONCILE_PERIOD=${CPUMANAGER_RECONCILE_PERIOD:-""}
 CPUMANAGER_POLICY_OPTIONS=${CPUMANAGER_POLICY_OPTIONS:-""}
@@ -168,6 +169,7 @@ function usage {
             echo "Example 2: hack/local-up-cluster.sh -O (auto-guess the bin path for your platform)"
             echo "Example 3: hack/local-up-cluster.sh (build a local copy of the source)"
             echo "Example 4: FEATURE_GATES=CPUManagerPolicyOptions=true \\"
+            echo "           TOPOLOGY_MANAGER_POLICY=\"single-numa-node\" \\"
             echo "           CPUMANAGER_POLICY=\"static\" \\"
             echo "           CPUMANAGER_POLICY_OPTIONS=full-pcpus-only=\"true\" \\"
             echo "           CPUMANAGER_RECONCILE_PERIOD=\"5s\" \\"
@@ -944,6 +946,11 @@ EOF
       # feature gate
       if [[ -n ${FEATURE_GATES} ]]; then
         parse_feature_gates "${FEATURE_GATES}"
+      fi
+
+      # topology maanager policy
+      if [[ -n ${TOPOLOGY_MANAGER_POLICY} ]]; then
+        echo "topologyManagerPolicy: \"${TOPOLOGY_MANAGER_POLICY}\""
       fi
 
       # cpumanager policy


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig testing

#### What this PR does / why we need it:
    
This commit allows the configuration of topology manager
policy option with the use of one environment variable, following
same approach as done for configuring cpumanager policy
options.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```