### PR TITLE
watchlist supports encoding as Table

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/table/table.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/table/table.go
@@ -17,11 +17,16 @@ limitations under the License.
 package table
 
 import (
+	"errors"
+	"fmt"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	metav1beta1 "k8s.io/apimachinery/pkg/apis/meta/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/duration"
 )
 
@@ -67,4 +72,169 @@ func ConvertToHumanReadableDateType(timestamp metav1.Time) string {
 		return "<unknown>"
 	}
 	return duration.HumanDuration(time.Since(timestamp.Time))
+}
+
+// IsTable returns if the provided Object is a Table
+func IsTable(obj runtime.Object) bool {
+	visitUnstructured := func(gvk schema.GroupVersionKind) bool {
+		if gvk.Kind != "Table" {
+			return false
+		}
+
+		return gvk.GroupVersion() == metav1.SchemeGroupVersion || gvk.GroupVersion() == metav1beta1.SchemeGroupVersion
+	}
+
+	switch t := obj.(type) {
+	case *metav1.Table: // metav1beta1.Table is an alias of metav1.Table
+		return true
+	case *unstructured.UnstructuredList:
+		return visitUnstructured(t.GroupVersionKind())
+	case *unstructured.Unstructured:
+		return visitUnstructured(t.GroupVersionKind())
+	default:
+		return false
+	}
+}
+
+// SetTableRows set the provided rows in to given Table object.
+func SetTableRows(obj runtime.Object, rows []any) error {
+	switch t := obj.(type) {
+	case *metav1.Table:
+		var err error
+		t.Rows, err = convertToSlice[metav1.TableRow](rows)
+		if err != nil {
+			return err
+		}
+	case *unstructured.UnstructuredList:
+		t.Object["rows"] = rows
+	case *unstructured.Unstructured:
+		t.Object["rows"] = rows
+	default:
+		return fmt.Errorf("unsupported type %T", obj)
+	}
+
+	return nil
+}
+
+// EachTableRow invokes fn on each row in the Table. Any error immediately terminates the loop.
+func EachTableRow(obj runtime.Object, fn func(any) error) error {
+	visitUnstructured := func(object map[string]any) error {
+		items, ok := object["rows"]
+		if !ok {
+			return nil
+		}
+
+		rows, ok := items.([]any)
+		if !ok {
+			return errors.New("content is not a table")
+		}
+		for i := range rows {
+			if err := fn(rows[i]); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
+
+	switch t := obj.(type) {
+	case *metav1.Table:
+		for i := range t.Rows {
+			if err := fn(t.Rows[i]); err != nil {
+				return err
+			}
+		}
+	case *unstructured.UnstructuredList:
+		return visitUnstructured(t.Object)
+	case *unstructured.Unstructured:
+		return visitUnstructured(t.Object)
+	default:
+		return fmt.Errorf("unsupported type %T", obj)
+	}
+
+	return nil
+}
+
+// EachTableRowObject invokes fn on runtime.Object embed in each row of the Table.
+// Any error immediately terminates the loop.
+func EachTableRowObject(obj runtime.Object, fn func(object runtime.Object) error) error {
+	return EachTableRow(obj, func(row any) error {
+		switch t := row.(type) {
+		case metav1.TableRow:
+			if t.Object.Object != nil {
+				return fn(t.Object.Object)
+			}
+
+			return fn(&runtime.Unknown{Raw: t.Object.Raw})
+		case map[string]any:
+			var innerObject = &unstructured.Unstructured{}
+
+			if obj, ok := t["object"]; ok {
+				var found bool
+				innerObject.Object, found = obj.(map[string]any)
+				if !found {
+					return fmt.Errorf("unexpected object type %T", obj)
+				}
+			}
+
+			return fn(innerObject)
+		default:
+			return fmt.Errorf("unsupported type %T", row)
+		}
+	})
+}
+
+// GetColumnDefinitions returns columnDefinitions of the given Table.
+func GetColumnDefinitions(obj runtime.Object) (any, error) {
+	switch t := obj.(type) {
+	case *metav1.Table:
+		return t.ColumnDefinitions, nil
+	case *unstructured.UnstructuredList:
+		return t.Object["columnDefinitions"], nil
+	case *unstructured.Unstructured:
+		return t.Object["columnDefinitions"], nil
+	default:
+		return nil, fmt.Errorf("unsupported type %T", obj)
+	}
+}
+
+// SetColumnDefinitions set the passed columnDefinitions to the given Object.
+func SetColumnDefinitions(obj runtime.Object, columnDefinitions any) error {
+	switch t := obj.(type) {
+	case *metav1.Table:
+		var err error
+		t.ColumnDefinitions, err = convertToSlice[metav1.TableColumnDefinition](columnDefinitions)
+		if err != nil {
+			return fmt.Errorf("unexpected table column definitions type %T", columnDefinitions)
+		}
+	case *unstructured.Unstructured:
+		t.Object["columnDefinitions"] = columnDefinitions
+	case *unstructured.UnstructuredList:
+		t.Object["columnDefinitions"] = columnDefinitions
+	default:
+		return fmt.Errorf("unsupported type %T", obj)
+	}
+
+	return nil
+}
+
+func convertToSlice[T any](in any) ([]T, error) {
+	switch v := in.(type) {
+	case nil:
+		return nil, nil
+	case []T:
+		return v, nil
+	case []any:
+		out := make([]T, len(v))
+		for i := range v {
+			var ok bool
+			out[i], ok = v[i].(T)
+			if !ok {
+				return nil, fmt.Errorf("unexpected convert %T to %T", v[i], new(T))
+			}
+		}
+		return out, nil
+	default:
+		return nil, fmt.Errorf("unsupported type %T", in)
+	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/get.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/get.go
@@ -204,12 +204,7 @@ func ListResource(r rest.Lister, rw rest.Watcher, scope *RequestScope, forceWatc
 			return
 		}
 
-		var restrictions negotiation.EndpointRestrictions
-		restrictions = scope
-		if isListWatchRequest(opts) {
-			restrictions = &watchListEndpointRestrictions{scope}
-		}
-		outputMediaType, _, err := negotiation.NegotiateOutputMediaType(req, scope.Serializer, restrictions)
+		outputMediaType, _, err := negotiation.NegotiateOutputMediaType(req, scope.Serializer, scope)
 		if err != nil {
 			scope.err(err, w, req)
 			return
@@ -323,17 +318,6 @@ func ListResource(r rest.Lister, rw rest.Watcher, scope *RequestScope, forceWatc
 		defer span.AddEvent("Writing http response done", attribute.Int("count", meta.LenList(result)))
 		transformResponseObject(ctx, scope, req, w, http.StatusOK, outputMediaType, result)
 	}
-}
-
-type watchListEndpointRestrictions struct {
-	negotiation.EndpointRestrictions
-}
-
-func (e *watchListEndpointRestrictions) AllowsMediaTypeTransform(mimeType, mimeSubType string, target *schema.GroupVersionKind) bool {
-	if target != nil && target.Kind == "Table" {
-		return false
-	}
-	return e.EndpointRestrictions.AllowsMediaTypeTransform(mimeType, mimeSubType, target)
 }
 
 func isListWatchRequest(opts metainternalversion.ListOptions) bool {


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
As https://github.com/kubernetes/kubernetes/issues/126206#issuecomment-2374037106 mentioned, encoding as Table is not supported and restricted in https://github.com/kubernetes/kubernetes/pull/126996

This PR provides table supporting for watchlist and remove restriction.



#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?
```release-note
WatchList supports `application/json;as=Table` content type in both apiserver and client-go side
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
