### PR TITLE
Automated cherry pick of #127902: server/config: assing system:apiserver user to system:authenticated group

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -1170,7 +1170,7 @@ func AuthorizeClientBearerToken(loopback *restclient.Config, authn *Authenticati
 	tokens[privilegedLoopbackToken] = &user.DefaultInfo{
 		Name:   user.APIServerUser,
 		UID:    uid,
-		Groups: []string{user.SystemPrivilegedGroup},
+		Groups: []string{user.AllAuthenticated, user.SystemPrivilegedGroup},
 	}
 
 	tokenAuthenticator := authenticatorfactory.NewFromTokens(tokens, authn.APIAudiences)

--- a/staging/src/k8s.io/apiserver/pkg/server/config_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config_test.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/apiserver/pkg/audit/policy"
 	"k8s.io/apiserver/pkg/authentication/authenticator"
 	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
 	"k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/server/healthz"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -80,6 +81,34 @@ func TestAuthorizeClientBearerTokenNoops(t *testing.T) {
 				}
 			}
 		}
+	}
+}
+
+func TestAuthorizeClientBearerTokenRequiredGroups(t *testing.T) {
+	fakeAuthenticator := authenticator.RequestFunc(func(req *http.Request) (*authenticator.Response, bool, error) {
+		return &authenticator.Response{User: &user.DefaultInfo{}}, false, nil
+	})
+	fakeAuthorizer := authorizer.AuthorizerFunc(func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
+		return authorizer.DecisionAllow, "", nil
+	})
+	target := &rest.Config{BearerToken: "secretToken"}
+	authN := &AuthenticationInfo{Authenticator: fakeAuthenticator}
+	authC := &AuthorizationInfo{Authorizer: fakeAuthorizer}
+
+	AuthorizeClientBearerToken(target, authN, authC)
+
+	fakeRequest, err := http.NewRequest("", "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fakeRequest.Header.Set("Authorization", "bearer secretToken")
+	rsp, _, err := authN.Authenticator.AuthenticateRequest(fakeRequest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedGroups := []string{user.AllAuthenticated, user.SystemPrivilegedGroup}
+	if !reflect.DeepEqual(expectedGroups, rsp.User.GetGroups()) {
+		t.Fatalf("unexpected groups = %v returned, expected = %v", rsp.User.GetGroups(), expectedGroups)
 	}
 }
 


### PR DESCRIPTION
Cherry pick of #127902 on release-1.31.

#127902: server/config: assing system:apiserver user to system:authenticated group

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```