### PR TITLE
Added missing 'time' for a field manager that server-side-applied same configuration

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/managedfields/internal/manager.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/managedfields/internal/manager.go
@@ -45,7 +45,7 @@ type Manager interface {
 	// Apply is used when server-side apply is called, as it merges the
 	// object and updates the managed fields.
 	//  * `liveObj` is not mutated by this function
-	//  * `newObj` may be mutated by this function
+	//  * `appliedObj` may be mutated by this function
 	// Returns the new object with managedFields removed, and the object's new
 	// proposed managedFields separately.
 	Apply(liveObj, appliedObj runtime.Object, managed Managed, fieldManager string, force bool) (runtime.Object, Managed, error)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
The 'time' stanza in `metadata.managedFields` is missing under some circumstances after a server-side apply. This PR tries to get the missing 'time' stanza back. More details are documented in #127938.

#### Which issue(s) this PR fixes:
Fixes #127938

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Fixed an issue in `metadata.managedFields`. Before this fix, the `time` stanza for a 2nd field manager was not set if that 2nd field manager server-side applies the same configuration as the 1st manager.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
