### PR TITLE
Promote ServiceAccount e2e test to Conformance

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -1314,6 +1314,14 @@
     and 3c the ServiceTokenVolume MUST not be auto mounted.
   release: v1.9
   file: test/e2e/auth/service_accounts.go
+- testname: ServiceAccount, create and review token
+  codename: '[sig-auth] ServiceAccounts should create a serviceAccountToken and ensure
+    a successful TokenReview [Conformance]'
+  description: Creating a ServiceAccount MUST succeed. Creating a ServiceAccountToken
+    MUST succeed. The token MUST not be empty. Creating a TokenReview MUST succeed.
+    The TokenReview MUST be authenticated without any errors.
+  release: v1.32
+  file: test/e2e/auth/service_accounts.go
 - testname: RootCA ConfigMap test
   codename: '[sig-auth] ServiceAccounts should guarantee kube-root-ca.crt exist in
     any namespace [Conformance]'

--- a/test/e2e/auth/service_accounts.go
+++ b/test/e2e/auth/service_accounts.go
@@ -839,7 +839,14 @@ var _ = SIGDescribe("ServiceAccounts", func() {
 		framework.Logf("AutomountServiceAccountToken: %v", *updatedServiceAccount.AutomountServiceAccountToken)
 	})
 
-	ginkgo.It("should create a serviceAccountToken and ensure a successful TokenReview", func(ctx context.Context) {
+	/*
+		Release: v1.32
+		Testname: ServiceAccount, create and review token
+		Description: Creating a ServiceAccount MUST succeed. Creating a ServiceAccountToken
+		MUST succeed. The token MUST not be empty. Creating a TokenReview MUST succeed.
+		The TokenReview MUST be authenticated without any errors.
+	*/
+	framework.ConformanceIt("should create a serviceAccountToken and ensure a successful TokenReview", func(ctx context.Context) {
 		ns := f.Namespace.Name
 		saClient := f.ClientSet.CoreV1().ServiceAccounts(ns)
 		saName := "e2e-sa-" + utilrand.String(5)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR promotes to Conformance the following endpoints in a recently added [e2e test](https://pr.k8s.io//127768):
- createCoreV1NamespacedServiceAccountToken

#### Which issue(s) this PR fixes:

Fixes #127767

#### Special notes for your reviewer:
- Adds +1 endpoint test coverage (good for conformance)
- Links for e2e test progress on [Testgrid](https://testgrid.k8s.io/sig-release-master-blocking#gce-cos-master-default&width=5&graph-metrics=test-duration-minutes&include-filter-by-regex=should.create.a.serviceAccountToken.and.ensure.a.successful.TokenReview) and [K8s Triage](https://storage.googleapis.com/k8s-triage/index.html?test=should.create.a.serviceAccountToken.and.ensure.a.successful.TokenReview)

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
/sig testing
/sig architecture
/area conformance