### PR TITLE
node-lifecycle-controller: improve processPod test-coverage

### DIFF
--- a/pkg/controller/nodelifecycle/node_lifecycle_controller_test.go
+++ b/pkg/controller/nodelifecycle/node_lifecycle_controller_test.go
@@ -40,7 +40,6 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	testcore "k8s.io/client-go/testing"
-	"k8s.io/klog/v2/ktesting"
 	kubeletapis "k8s.io/kubelet/pkg/apis"
 	"k8s.io/kubernetes/pkg/controller"
 	"k8s.io/kubernetes/pkg/controller/nodelifecycle/scheduler"
@@ -48,6 +47,7 @@ import (
 	controllerutil "k8s.io/kubernetes/pkg/controller/util/node"
 	"k8s.io/kubernetes/pkg/util/node"
 	taintutils "k8s.io/kubernetes/pkg/util/taints"
+	"k8s.io/kubernetes/test/utils/ktesting"
 	"k8s.io/utils/pointer"
 )
 
@@ -796,13 +796,13 @@ func TestMonitorNodeHealth(t *testing.T) {
 
 	for testName, tt := range tests {
 		t.Run(testName, func(t *testing.T) {
-			_, ctx := ktesting.NewTestContext(t)
+			tCtx := ktesting.Init(t)
 			fakeNodeHandler := &testutil.FakeNodeHandler{
 				Existing:  tt.nodeList,
 				Clientset: fake.NewSimpleClientset(),
 			}
 			nodeController, _ := newNodeLifecycleControllerFromClient(
-				ctx,
+				tCtx,
 				fakeNodeHandler,
 				testRateLimiterQPS,
 				testRateLimiterQPS,
@@ -823,7 +823,7 @@ func TestMonitorNodeHealth(t *testing.T) {
 				if err := nodeController.syncNodeStore(fakeNodeHandler); err != nil {
 					t.Errorf("unexpected error: %v", err)
 				}
-				if err := nodeController.monitorNodeHealth(ctx); err != nil {
+				if err := nodeController.monitorNodeHealth(tCtx); err != nil {
 					t.Errorf("unexpected error: %v", err)
 				}
 				if diff := cmp.Diff(wanted, nodeController.zoneStates); diff != "" {
@@ -941,10 +941,10 @@ func TestPodStatusChange(t *testing.T) {
 		},
 	}
 
-	_, ctx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
 	for _, item := range table {
 		nodeController, _ := newNodeLifecycleControllerFromClient(
-			ctx,
+			tCtx,
 			item.fakeNodeHandler,
 			testRateLimiterQPS,
 			testRateLimiterQPS,
@@ -960,7 +960,7 @@ func TestPodStatusChange(t *testing.T) {
 		if err := nodeController.syncNodeStore(item.fakeNodeHandler); err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
-		if err := nodeController.monitorNodeHealth(ctx); err != nil {
+		if err := nodeController.monitorNodeHealth(tCtx); err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
 		if item.timeToPass > 0 {
@@ -971,19 +971,21 @@ func TestPodStatusChange(t *testing.T) {
 		if err := nodeController.syncNodeStore(item.fakeNodeHandler); err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
-		if err := nodeController.monitorNodeHealth(ctx); err != nil {
+		if err := nodeController.monitorNodeHealth(tCtx); err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
 		zones := testutil.GetZones(item.fakeNodeHandler)
-		logger, _ := ktesting.NewTestContext(t)
 		for _, zone := range zones {
-			nodeController.zoneNoExecuteTainter[zone].Try(logger, func(value scheduler.TimedValue) (bool, time.Duration) {
+			nodeController.zoneNoExecuteTainter[zone].Try(tCtx.Logger(), func(value scheduler.TimedValue) (bool, time.Duration) {
 				nodeUID, _ := value.UID.(string)
 				pods, err := nodeController.getPodsAssignedToNode(value.Value)
 				if err != nil {
 					t.Errorf("unexpected error: %v", err)
 				}
-				controllerutil.DeletePods(ctx, item.fakeNodeHandler, pods, nodeController.recorder, value.Value, nodeUID, nodeController.daemonSetStore)
+				_, err = controllerutil.DeletePods(tCtx, item.fakeNodeHandler, pods, nodeController.recorder, value.Value, nodeUID, nodeController.daemonSetStore)
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
 				return true, 0
 			})
 		}
@@ -1224,10 +1226,10 @@ func TestMonitorNodeHealthUpdateStatus(t *testing.T) {
 			expectedPodStatusUpdate: false,
 		},
 	}
-	_, ctx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
 	for i, item := range table {
 		nodeController, _ := newNodeLifecycleControllerFromClient(
-			ctx,
+			tCtx,
 			item.fakeNodeHandler,
 			testRateLimiterQPS,
 			testRateLimiterQPS,
@@ -1243,7 +1245,7 @@ func TestMonitorNodeHealthUpdateStatus(t *testing.T) {
 		if err := nodeController.syncNodeStore(item.fakeNodeHandler); err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
-		if err := nodeController.monitorNodeHealth(ctx); err != nil {
+		if err := nodeController.monitorNodeHealth(tCtx); err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
 		if item.timeToPass > 0 {
@@ -1252,7 +1254,7 @@ func TestMonitorNodeHealthUpdateStatus(t *testing.T) {
 			if err := nodeController.syncNodeStore(item.fakeNodeHandler); err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
-			if err := nodeController.monitorNodeHealth(ctx); err != nil {
+			if err := nodeController.monitorNodeHealth(tCtx); err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
 		}
@@ -1769,9 +1771,9 @@ func TestMonitorNodeHealthUpdateNodeAndPodStatusWithLease(t *testing.T) {
 
 	for _, item := range testcases {
 		t.Run(item.description, func(t *testing.T) {
-			_, ctx := ktesting.NewTestContext(t)
+			tCtx := ktesting.Init(t)
 			nodeController, _ := newNodeLifecycleControllerFromClient(
-				ctx,
+				tCtx,
 				item.fakeNodeHandler,
 				testRateLimiterQPS,
 				testRateLimiterQPS,
@@ -1790,7 +1792,7 @@ func TestMonitorNodeHealthUpdateNodeAndPodStatusWithLease(t *testing.T) {
 			if err := nodeController.syncLeaseStore(item.lease); err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if err := nodeController.monitorNodeHealth(ctx); err != nil {
+			if err := nodeController.monitorNodeHealth(tCtx); err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			if item.timeToPass > 0 {
@@ -1802,7 +1804,7 @@ func TestMonitorNodeHealthUpdateNodeAndPodStatusWithLease(t *testing.T) {
 				if err := nodeController.syncLeaseStore(item.newLease); err != nil {
 					t.Fatalf("unexpected error: %v", err)
 				}
-				if err := nodeController.monitorNodeHealth(ctx); err != nil {
+				if err := nodeController.monitorNodeHealth(tCtx); err != nil {
 					t.Fatalf("unexpected error: %v", err)
 				}
 			}
@@ -1933,10 +1935,10 @@ func TestMonitorNodeHealthMarkPodsNotReady(t *testing.T) {
 		},
 	}
 
-	_, ctx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
 	for i, item := range table {
 		nodeController, _ := newNodeLifecycleControllerFromClient(
-			ctx,
+			tCtx,
 			item.fakeNodeHandler,
 			testRateLimiterQPS,
 			testRateLimiterQPS,
@@ -1952,7 +1954,7 @@ func TestMonitorNodeHealthMarkPodsNotReady(t *testing.T) {
 		if err := nodeController.syncNodeStore(item.fakeNodeHandler); err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
-		if err := nodeController.monitorNodeHealth(ctx); err != nil {
+		if err := nodeController.monitorNodeHealth(tCtx); err != nil {
 			t.Errorf("Case[%d] unexpected error: %v", i, err)
 		}
 		if item.timeToPass > 0 {
@@ -1961,7 +1963,7 @@ func TestMonitorNodeHealthMarkPodsNotReady(t *testing.T) {
 			if err := nodeController.syncNodeStore(item.fakeNodeHandler); err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
-			if err := nodeController.monitorNodeHealth(ctx); err != nil {
+			if err := nodeController.monitorNodeHealth(tCtx); err != nil {
 				t.Errorf("Case[%d] unexpected error: %v", i, err)
 			}
 		}
@@ -2028,7 +2030,7 @@ func TestMonitorNodeHealthMarkPodsNotReadyWithWorkerSize(t *testing.T) {
 		{workers: 1},
 	}
 
-	_, ctx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
 	for i, item := range table {
 		fakeNow := metav1.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC)
 
@@ -2038,7 +2040,7 @@ func TestMonitorNodeHealthMarkPodsNotReadyWithWorkerSize(t *testing.T) {
 		}
 
 		nodeController, _ := newNodeLifecycleControllerFromClient(
-			ctx,
+			tCtx,
 			fakeNodeHandler,
 			testRateLimiterQPS,
 			testRateLimiterQPS,
@@ -2056,7 +2058,7 @@ func TestMonitorNodeHealthMarkPodsNotReadyWithWorkerSize(t *testing.T) {
 		if err := nodeController.syncNodeStore(fakeNodeHandler); err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
-		if err := nodeController.monitorNodeHealth(ctx); err != nil {
+		if err := nodeController.monitorNodeHealth(tCtx); err != nil {
 			t.Errorf("Case[%d] unexpected error: %v", i, err)
 		}
 
@@ -2082,7 +2084,7 @@ func TestMonitorNodeHealthMarkPodsNotReadyWithWorkerSize(t *testing.T) {
 		if err := nodeController.syncNodeStore(fakeNodeHandler); err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
-		if err := nodeController.monitorNodeHealth(ctx); err != nil {
+		if err := nodeController.monitorNodeHealth(tCtx); err != nil {
 			t.Errorf("Case[%d] unexpected error: %v", i, err)
 		}
 
@@ -2239,9 +2241,9 @@ func TestMonitorNodeHealthMarkPodsNotReadyRetry(t *testing.T) {
 
 	for _, item := range table {
 		t.Run(item.desc, func(t *testing.T) {
-			_, ctx := ktesting.NewTestContext(t)
+			tCtx := ktesting.Init(t)
 			nodeController, _ := newNodeLifecycleControllerFromClient(
-				ctx,
+				tCtx,
 				item.fakeNodeHandler,
 				testRateLimiterQPS,
 				testRateLimiterQPS,
@@ -2263,7 +2265,7 @@ func TestMonitorNodeHealthMarkPodsNotReadyRetry(t *testing.T) {
 				if err := nodeController.syncNodeStore(item.fakeNodeHandler); err != nil {
 					t.Errorf("unexpected error: %v", err)
 				}
-				if err := nodeController.monitorNodeHealth(ctx); err != nil {
+				if err := nodeController.monitorNodeHealth(tCtx); err != nil {
 					t.Errorf("unexpected error: %v", err)
 				}
 			}
@@ -2418,9 +2420,9 @@ func TestApplyNoExecuteTaints(t *testing.T) {
 		},
 	}
 	originalTaint := UnreachableTaintTemplate
-	_, ctx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
 	nodeController, _ := newNodeLifecycleControllerFromClient(
-		ctx,
+		tCtx,
 		fakeNodeHandler,
 		testRateLimiterQPS,
 		testRateLimiterQPS,
@@ -2436,11 +2438,11 @@ func TestApplyNoExecuteTaints(t *testing.T) {
 	if err := nodeController.syncNodeStore(fakeNodeHandler); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	if err := nodeController.monitorNodeHealth(ctx); err != nil {
+	if err := nodeController.monitorNodeHealth(tCtx); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	nodeController.doNoExecuteTaintingPass(ctx)
-	node0, err := fakeNodeHandler.Get(ctx, "node0", metav1.GetOptions{})
+	nodeController.doNoExecuteTaintingPass(tCtx)
+	node0, err := fakeNodeHandler.Get(tCtx, "node0", metav1.GetOptions{})
 	if err != nil {
 		t.Errorf("Can't get current node0...")
 		return
@@ -2448,7 +2450,7 @@ func TestApplyNoExecuteTaints(t *testing.T) {
 	if !taintutils.TaintExists(node0.Spec.Taints, UnreachableTaintTemplate) {
 		t.Errorf("Can't find taint %v in %v", originalTaint, node0.Spec.Taints)
 	}
-	node2, err := fakeNodeHandler.Get(ctx, "node2", metav1.GetOptions{})
+	node2, err := fakeNodeHandler.Get(tCtx, "node2", metav1.GetOptions{})
 	if err != nil {
 		t.Errorf("Can't get current node2...")
 		return
@@ -2459,7 +2461,7 @@ func TestApplyNoExecuteTaints(t *testing.T) {
 
 	// Make node3 healthy again.
 	node2.Status = healthyNodeNewStatus
-	_, err = fakeNodeHandler.UpdateStatus(ctx, node2, metav1.UpdateOptions{})
+	_, err = fakeNodeHandler.UpdateStatus(tCtx, node2, metav1.UpdateOptions{})
 	if err != nil {
 		t.Error(err.Error())
 		return
@@ -2467,12 +2469,12 @@ func TestApplyNoExecuteTaints(t *testing.T) {
 	if err := nodeController.syncNodeStore(fakeNodeHandler); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	if err := nodeController.monitorNodeHealth(ctx); err != nil {
+	if err := nodeController.monitorNodeHealth(tCtx); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	nodeController.doNoExecuteTaintingPass(ctx)
+	nodeController.doNoExecuteTaintingPass(tCtx)
 
-	node2, err = fakeNodeHandler.Get(ctx, "node2", metav1.GetOptions{})
+	node2, err = fakeNodeHandler.Get(tCtx, "node2", metav1.GetOptions{})
 	if err != nil {
 		t.Errorf("Can't get current node2...")
 		return
@@ -2482,13 +2484,13 @@ func TestApplyNoExecuteTaints(t *testing.T) {
 		t.Errorf("Found taint %v in %v, which should not be present", NotReadyTaintTemplate, node2.Spec.Taints)
 	}
 
-	node3, err := fakeNodeHandler.Get(ctx, "node3", metav1.GetOptions{})
+	node3, err := fakeNodeHandler.Get(tCtx, "node3", metav1.GetOptions{})
 	if err != nil {
 		t.Errorf("Can't get current node3...")
 		return
 	}
 	node3.Status = unhealthyNodeNewStatus
-	_, err = fakeNodeHandler.UpdateStatus(ctx, node3, metav1.UpdateOptions{})
+	_, err = fakeNodeHandler.UpdateStatus(tCtx, node3, metav1.UpdateOptions{})
 	if err != nil {
 		t.Error(err.Error())
 		return
@@ -2496,12 +2498,12 @@ func TestApplyNoExecuteTaints(t *testing.T) {
 	if err := nodeController.syncNodeStore(fakeNodeHandler); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	if err := nodeController.monitorNodeHealth(ctx); err != nil {
+	if err := nodeController.monitorNodeHealth(tCtx); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 	// Before taint manager work, the status has been replaced(maybe merge-patch replace).
 	node3.Status.Conditions = overrideNodeNewStatusConditions
-	_, err = fakeNodeHandler.UpdateStatus(ctx, node3, metav1.UpdateOptions{})
+	_, err = fakeNodeHandler.UpdateStatus(tCtx, node3, metav1.UpdateOptions{})
 	if err != nil {
 		t.Error(err.Error())
 		return
@@ -2509,8 +2511,8 @@ func TestApplyNoExecuteTaints(t *testing.T) {
 	if err := nodeController.syncNodeStore(fakeNodeHandler); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	nodeController.doNoExecuteTaintingPass(ctx)
-	node3, err = fakeNodeHandler.Get(ctx, "node3", metav1.GetOptions{})
+	nodeController.doNoExecuteTaintingPass(tCtx)
+	node3, err = fakeNodeHandler.Get(tCtx, "node3", metav1.GetOptions{})
 	if err != nil {
 		t.Errorf("Can't get current node3...")
 		return
@@ -2614,9 +2616,9 @@ func TestApplyNoExecuteTaintsToNodesEnqueueTwice(t *testing.T) {
 			},
 		},
 	}
-	_, ctx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
 	nodeController, _ := newNodeLifecycleControllerFromClient(
-		ctx,
+		tCtx,
 		fakeNodeHandler,
 		testRateLimiterQPS,
 		testRateLimiterQPS,
@@ -2633,21 +2635,21 @@ func TestApplyNoExecuteTaintsToNodesEnqueueTwice(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 	// 1. monitor node health twice, add untainted node once
-	if err := nodeController.monitorNodeHealth(ctx); err != nil {
+	if err := nodeController.monitorNodeHealth(tCtx); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	if err := nodeController.monitorNodeHealth(ctx); err != nil {
+	if err := nodeController.monitorNodeHealth(tCtx); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 
 	// 2. mark node0 healthy
-	node0, err := fakeNodeHandler.Get(ctx, "node0", metav1.GetOptions{})
+	node0, err := fakeNodeHandler.Get(tCtx, "node0", metav1.GetOptions{})
 	if err != nil {
 		t.Errorf("Can't get current node0...")
 		return
 	}
 	node0.Status = healthyNodeNewStatus
-	_, err = fakeNodeHandler.UpdateStatus(ctx, node0, metav1.UpdateOptions{})
+	_, err = fakeNodeHandler.UpdateStatus(tCtx, node0, metav1.UpdateOptions{})
 	if err != nil {
 		t.Error(err.Error())
 		return
@@ -2730,17 +2732,17 @@ func TestApplyNoExecuteTaintsToNodesEnqueueTwice(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 	// 3. start monitor node health again, add untainted node twice, construct UniqueQueue with duplicated node cache
-	if err := nodeController.monitorNodeHealth(ctx); err != nil {
+	if err := nodeController.monitorNodeHealth(tCtx); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 
 	// 4. do NoExecute taint pass
 	// when processing with node0, condition.Status is NodeReady, and return true with default case
 	// then remove the set value and queue value both, the taint job never stuck
-	nodeController.doNoExecuteTaintingPass(ctx)
+	nodeController.doNoExecuteTaintingPass(tCtx)
 
 	// 5. get node3 and node5, see if it has ready got NoExecute taint
-	node3, err := fakeNodeHandler.Get(ctx, "node3", metav1.GetOptions{})
+	node3, err := fakeNodeHandler.Get(tCtx, "node3", metav1.GetOptions{})
 	if err != nil {
 		t.Errorf("Can't get current node3...")
 		return
@@ -2748,7 +2750,7 @@ func TestApplyNoExecuteTaintsToNodesEnqueueTwice(t *testing.T) {
 	if !taintutils.TaintExists(node3.Spec.Taints, UnreachableTaintTemplate) || len(node3.Spec.Taints) == 0 {
 		t.Errorf("Not found taint %v in %v, which should be present in %s", UnreachableTaintTemplate, node3.Spec.Taints, node3.Name)
 	}
-	node5, err := fakeNodeHandler.Get(ctx, "node5", metav1.GetOptions{})
+	node5, err := fakeNodeHandler.Get(tCtx, "node5", metav1.GetOptions{})
 	if err != nil {
 		t.Errorf("Can't get current node5...")
 		return
@@ -2837,9 +2839,9 @@ func TestSwapUnreachableNotReadyTaints(t *testing.T) {
 	originalTaint := UnreachableTaintTemplate
 	updatedTaint := NotReadyTaintTemplate
 
-	_, ctx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
 	nodeController, _ := newNodeLifecycleControllerFromClient(
-		ctx,
+		tCtx,
 		fakeNodeHandler,
 		testRateLimiterQPS,
 		testRateLimiterQPS,
@@ -2855,17 +2857,17 @@ func TestSwapUnreachableNotReadyTaints(t *testing.T) {
 	if err := nodeController.syncNodeStore(fakeNodeHandler); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	if err := nodeController.monitorNodeHealth(ctx); err != nil {
+	if err := nodeController.monitorNodeHealth(tCtx); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	nodeController.doNoExecuteTaintingPass(ctx)
+	nodeController.doNoExecuteTaintingPass(tCtx)
 
-	node0, err := fakeNodeHandler.Get(ctx, "node0", metav1.GetOptions{})
+	node0, err := fakeNodeHandler.Get(tCtx, "node0", metav1.GetOptions{})
 	if err != nil {
 		t.Errorf("Can't get current node0...")
 		return
 	}
-	node1, err := fakeNodeHandler.Get(ctx, "node1", metav1.GetOptions{})
+	node1, err := fakeNodeHandler.Get(tCtx, "node1", metav1.GetOptions{})
 	if err != nil {
 		t.Errorf("Can't get current node1...")
 		return
@@ -2879,12 +2881,12 @@ func TestSwapUnreachableNotReadyTaints(t *testing.T) {
 
 	node0.Status = newNodeStatus
 	node1.Status = healthyNodeNewStatus
-	_, err = fakeNodeHandler.UpdateStatus(ctx, node0, metav1.UpdateOptions{})
+	_, err = fakeNodeHandler.UpdateStatus(tCtx, node0, metav1.UpdateOptions{})
 	if err != nil {
 		t.Error(err.Error())
 		return
 	}
-	_, err = fakeNodeHandler.UpdateStatus(ctx, node1, metav1.UpdateOptions{})
+	_, err = fakeNodeHandler.UpdateStatus(tCtx, node1, metav1.UpdateOptions{})
 	if err != nil {
 		t.Error(err.Error())
 		return
@@ -2893,12 +2895,12 @@ func TestSwapUnreachableNotReadyTaints(t *testing.T) {
 	if err := nodeController.syncNodeStore(fakeNodeHandler); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	if err := nodeController.monitorNodeHealth(ctx); err != nil {
+	if err := nodeController.monitorNodeHealth(tCtx); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	nodeController.doNoExecuteTaintingPass(ctx)
+	nodeController.doNoExecuteTaintingPass(tCtx)
 
-	node0, err = fakeNodeHandler.Get(ctx, "node0", metav1.GetOptions{})
+	node0, err = fakeNodeHandler.Get(tCtx, "node0", metav1.GetOptions{})
 	if err != nil {
 		t.Errorf("Can't get current node0...")
 		return
@@ -2941,9 +2943,9 @@ func TestTaintsNodeByCondition(t *testing.T) {
 		Clientset: fake.NewSimpleClientset(&v1.PodList{Items: []v1.Pod{*testutil.NewPod("pod0", "node0")}}),
 	}
 
-	_, ctx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
 	nodeController, _ := newNodeLifecycleControllerFromClient(
-		ctx,
+		tCtx,
 		fakeNodeHandler,
 		testRateLimiterQPS,
 		testRateLimiterQPS,
@@ -3094,11 +3096,15 @@ func TestTaintsNodeByCondition(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		fakeNodeHandler.Update(ctx, test.Node, metav1.UpdateOptions{})
+		if _, err := fakeNodeHandler.Update(tCtx, test.Node, metav1.UpdateOptions{}); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
 		if err := nodeController.syncNodeStore(fakeNodeHandler); err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
-		nodeController.doNoScheduleTaintingPass(ctx, test.Node.Name)
+		if err := nodeController.doNoScheduleTaintingPass(tCtx, test.Node.Name); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
 		if err := nodeController.syncNodeStore(fakeNodeHandler); err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
@@ -3144,9 +3150,9 @@ func TestNodeEventGeneration(t *testing.T) {
 		Clientset: fake.NewSimpleClientset(&v1.PodList{Items: []v1.Pod{*testutil.NewPod("pod0", "node0")}}),
 	}
 
-	_, ctx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
 	nodeController, _ := newNodeLifecycleControllerFromClient(
-		ctx,
+		tCtx,
 		fakeNodeHandler,
 		testRateLimiterQPS,
 		testRateLimiterQPS,
@@ -3164,7 +3170,7 @@ func TestNodeEventGeneration(t *testing.T) {
 	if err := nodeController.syncNodeStore(fakeNodeHandler); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	if err := nodeController.monitorNodeHealth(ctx); err != nil {
+	if err := nodeController.monitorNodeHealth(tCtx); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 	if len(fakeRecorder.Events) != 1 {
@@ -3217,9 +3223,9 @@ func TestReconcileNodeLabels(t *testing.T) {
 		Clientset: fake.NewSimpleClientset(&v1.PodList{Items: []v1.Pod{*testutil.NewPod("pod0", "node0")}}),
 	}
 
-	_, ctx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
 	nodeController, _ := newNodeLifecycleControllerFromClient(
-		ctx,
+		tCtx,
 		fakeNodeHandler,
 		testRateLimiterQPS,
 		testRateLimiterQPS,
@@ -3306,11 +3312,15 @@ func TestReconcileNodeLabels(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		fakeNodeHandler.Update(ctx, test.Node, metav1.UpdateOptions{})
+		if _, err := fakeNodeHandler.Update(tCtx, test.Node, metav1.UpdateOptions{}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 		if err := nodeController.syncNodeStore(fakeNodeHandler); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		nodeController.reconcileNodeLabels(ctx, test.Node.Name)
+		if err := nodeController.reconcileNodeLabels(tCtx, test.Node.Name); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 		if err := nodeController.syncNodeStore(fakeNodeHandler); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -3360,9 +3370,9 @@ func TestTryUpdateNodeHealth(t *testing.T) {
 		Clientset: fake.NewSimpleClientset(&v1.PodList{Items: []v1.Pod{*testutil.NewPod("pod0", "node0")}}),
 	}
 
-	_, ctx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
 	nodeController, _ := newNodeLifecycleControllerFromClient(
-		ctx,
+		tCtx,
 		fakeNodeHandler,
 		testRateLimiterQPS,
 		testRateLimiterQPS,
@@ -3534,7 +3544,7 @@ func TestTryUpdateNodeHealth(t *testing.T) {
 				probeTimestamp:           test.node.CreationTimestamp,
 				readyTransitionTimestamp: test.node.CreationTimestamp,
 			})
-			_, _, currentReadyCondition, err := nodeController.tryUpdateNodeHealth(ctx, test.node)
+			_, _, currentReadyCondition, err := nodeController.tryUpdateNodeHealth(tCtx, test.node)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -3662,11 +3672,11 @@ func TestProcessPodMarkPodNotReady(t *testing.T) {
 		},
 	}
 
-	_, ctx := ktesting.NewTestContext(t)
 	for _, item := range table {
 		t.Run(item.desc, func(t *testing.T) {
+			tCtx := ktesting.Init(t)
 			nodeController, _ := newNodeLifecycleControllerFromClient(
-				ctx,
+				tCtx,
 				item.fakeNodeHandler,
 				testRateLimiterQPS,
 				testRateLimiterQPS,
@@ -3683,7 +3693,7 @@ func TestProcessPodMarkPodNotReady(t *testing.T) {
 				t.Errorf("unexpected error: %v", err)
 			}
 			if item.monitorNodeHealth {
-				if err := nodeController.monitorNodeHealth(ctx); err != nil {
+				if err := nodeController.monitorNodeHealth(tCtx); err != nil {
 					t.Errorf("unexpected error: %v", err)
 				}
 			}
@@ -3692,7 +3702,7 @@ func TestProcessPodMarkPodNotReady(t *testing.T) {
 				t.Errorf("unexpected error: %v", err)
 			}
 			nodeController.podUpdated(nil, item.pod)
-			nodeController.processPod(ctx, podUpdateItem{name: item.pod.Name, namespace: item.pod.Namespace})
+			nodeController.processPod(tCtx, podUpdateItem{name: item.pod.Name, namespace: item.pod.Namespace})
 
 			podStatusUpdated := false
 			for _, action := range item.fakeNodeHandler.Actions() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

`processPod` is not covered by tests. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

**nodelifecycle**  The coverage has now been increased to cover 69.3% of the statements vs the current  64.9% of statements coverage

```
(base) ➜  kubernetes git:(KEP-3902-test) make test WHAT=./pkg/controller/nodelifecycle KUBE_COVER=y
...
+++ [1009 18:35:59] Saving coverage output in '/tmp/k8s_coverage/20241009-183559'
+++ [1009 18:35:59] Running tests with code coverage and with -race
ok  	k8s.io/kubernetes/pkg/controller/nodelifecycle	20.639s	coverage: 64.9% of statements

DONE 46 tests in 81.961s
+++ [1009 18:37:23] Combined coverage report: /tmp/k8s_coverage/20241009-183559/combined-coverage.html
(base) ➜  kubernetes git:(master) git checkout -
Switched to branch 'KEP-3902-test'
Your branch is up to date with 'origin/KEP-3902-test'.
(base) ➜  kubernetes git:(KEP-3902-test) make test WHAT=./pkg/controller/nodelifecycle KUBE_COVER=y
...
+++ [1009 18:38:57] Saving coverage output in '/tmp/k8s_coverage/20241009-183857'
+++ [1009 18:38:57] Running tests with code coverage and with -race
ok  	k8s.io/kubernetes/pkg/controller/nodelifecycle	12.254s	coverage: 69.3% of statements

DONE 47 tests in 19.573s
+++ [1009 18:39:17] Combined coverage report: /tmp/k8s_coverage/20241009-183857/combined-coverage.html
```

```diff
(base) ➜  kubernetes git:(KEP-3902-test)  diff <(go tool cover -func=/tmp/k8s_coverage/20241009-183559/combined-coverage.out) <(go tool cover -func=/tmp/k8s_coverage/20241009-183857/combined-coverage.out)
7c7
< k8s.io/kubernetes/pkg/controller/nodelifecycle/node_lifecycle_controller.go:307:	NewNodeLifecycleController		42.0%
---
> k8s.io/kubernetes/pkg/controller/nodelifecycle/node_lifecycle_controller.go:307:	NewNodeLifecycleController		47.8%
17c17
< k8s.io/kubernetes/pkg/controller/nodelifecycle/node_lifecycle_controller.go:1087:	podUpdated				0.0%
---
> k8s.io/kubernetes/pkg/controller/nodelifecycle/node_lifecycle_controller.go:1087:	podUpdated				80.0%
19c19
< k8s.io/kubernetes/pkg/controller/nodelifecycle/node_lifecycle_controller.go:1115:	processPod				0.0%
---
> k8s.io/kubernetes/pkg/controller/nodelifecycle/node_lifecycle_controller.go:1115:	processPod				57.7%
29c29
< total:											(statements)				64.9%
---
> total:											(statements)				69.3%
```

**nodelifecycle/scheduler** The coverage has now been increased to cover 92.6% of the statements vs the current  85.3%  of statements coverage

```
(base) ➜  kubernetes git:(master) make test WHAT=./pkg/controller/nodelifecycle/scheduler KUBE_COVER=y
Makefile:195: warning: undefined variable `''
+++ [1009 18:45:56] Set GOMAXPROCS automatically to 8
+++ [1009 18:45:56] Normalizing Go targets
WARNING: ulimit -n (files) should be at least 1000, is 256, may cause test failure
+++ [1009 18:45:56] Saving coverage output in '/tmp/k8s_coverage/20241009-184556'
+++ [1009 18:45:56] Running tests with code coverage and with -race
ok  	k8s.io/kubernetes/pkg/controller/nodelifecycle/scheduler	1.358s	coverage: 85.3% of statements

DONE 8 tests in 2.056s
+++ [1009 18:45:58] Combined coverage report: /tmp/k8s_coverage/20241009-184556/combined-coverage.html
(base) ➜  kubernetes git:(master) git checkout -
Switched to branch 'KEP-3902-test'
Your branch is up to date with 'origin/KEP-3902-test'.
(base) ➜  kubernetes git:(KEP-3902-test) make test WHAT=./pkg/controller/nodelifecycle/scheduler KUBE_COVER=y
Makefile:195: warning: undefined variable `''
+++ [1009 18:46:07] Set GOMAXPROCS automatically to 8
+++ [1009 18:46:07] Normalizing Go targets
WARNING: ulimit -n (files) should be at least 1000, is 256, may cause test failure
+++ [1009 18:46:07] Saving coverage output in '/tmp/k8s_coverage/20241009-184607'
+++ [1009 18:46:07] Running tests with code coverage and with -race
ok  	k8s.io/kubernetes/pkg/controller/nodelifecycle/scheduler	1.269s	coverage: 92.6% of statements

DONE 9 tests in 1.615s
+++ [1009 18:46:08] Combined coverage report: /tmp/k8s_coverage/20241009-184607/combined-coverage.html
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
