### PR TITLE
Automated cherry pick of #127650: kubeadm: fix a bug where the RemoveMember function did not

### DIFF
--- a/cmd/kubeadm/app/util/etcd/etcd.go
+++ b/cmd/kubeadm/app/util/etcd/etcd.go
@@ -331,17 +331,18 @@ func (c *Client) ListMembers() ([]Member, error) {
 
 // RemoveMember notifies an etcd cluster to remove an existing member
 func (c *Client) RemoveMember(id uint64) ([]Member, error) {
-	// Remove an existing member from the cluster
-	var lastError error
-	var resp *clientv3.MemberRemoveResponse
-	err := wait.ExponentialBackoff(etcdBackoff, func() (bool, error) {
-		cli, err := c.newEtcdClient(c.Endpoints)
-		if err != nil {
-			lastError = err
-			return false, nil
-		}
-		defer cli.Close()
+	cli, err := c.newEtcdClient(c.Endpoints)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = cli.Close() }()
 
+	// Remove an existing member from the cluster
+	var (
+		lastError   error
+		respMembers []*etcdserverpb.Member
+	)
+	err = wait.ExponentialBackoff(etcdBackoff, func() (bool, error) {
 		ctx, cancel := context.WithTimeout(context.Background(), etcdTimeout)
 		defer cancel()
 
@@ -361,16 +362,22 @@ func (c *Client) RemoveMember(id uint64) ([]Member, error) {
 		}
 		if !found {
 			klog.V(5).Infof("Member %s was not found; assuming it was already removed", strconv.FormatUint(id, 16))
+			respMembers = listResp.Members
 			return true, nil
 		}
 
-		resp, err = cli.MemberRemove(ctx, id)
+		resp, err := cli.MemberRemove(ctx, id)
 		if err == nil {
+			respMembers = resp.Members
 			return true, nil
 		}
 		if errors.Is(rpctypes.ErrMemberNotFound, err) {
 			klog.V(5).Infof("Member was already removed, because member %s was not found", strconv.FormatUint(id, 16))
-			return true, nil
+			listResp, err = cli.MemberList(ctx)
+			if err == nil {
+				respMembers = listResp.Members
+				return true, nil
+			}
 		}
 		klog.V(5).Infof("Failed to remove etcd member: %v", err)
 		lastError = err
@@ -382,11 +389,8 @@ func (c *Client) RemoveMember(id uint64) ([]Member, error) {
 
 	// Returns the updated list of etcd members
 	ret := []Member{}
-	if resp != nil {
-		for _, m := range resp.Members {
-			ret = append(ret, Member{Name: m.Name, PeerURL: m.PeerURLs[0]})
-		}
-
+	for _, m := range respMembers {
+		ret = append(ret, Member{Name: m.Name, PeerURL: m.PeerURLs[0]})
 	}
 
 	return ret, nil
@@ -466,7 +470,6 @@ func (c *Client) addMember(name string, peerAddrs string, isLearner bool) ([]Mem
 		// call out to MemberList to fetch all the members before returning.
 		if errors.Is(err, rpctypes.ErrPeerURLExist) {
 			klog.V(5).Info("The peer URL for the added etcd member already exists. Fetching the existing etcd members")
-			var listResp *clientv3.MemberListResponse
 			listResp, err = cli.MemberList(ctx)
 			if err == nil {
 				respMembers = listResp.Members


### PR DESCRIPTION
Cherry pick of #127650 on release-1.28.

#127650: kubeadm: fix a bug where the RemoveMember function did not

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
kubeadm: fix wrong member list reported when removing an etcd member
```