### PR TITLE
test: enable featureGate AddMetrics on kube-apiserver testserver

### DIFF
--- a/cmd/kube-apiserver/app/testing/testserver.go
+++ b/cmd/kube-apiserver/app/testing/testserver.go
@@ -194,6 +194,7 @@ func StartTestServer(t ktesting.TB, instanceOptions *TestServerInstanceOptions, 
 	fs := pflag.NewFlagSet("test", pflag.PanicOnError)
 
 	featureGate := utilfeature.DefaultMutableFeatureGate
+	featureGate.AddMetrics()
 	effectiveVersion := utilversion.DefaultKubeEffectiveVersion()
 	if instanceOptions.BinaryVersion != "" {
 		effectiveVersion = utilversion.NewEffectiveVersion(instanceOptions.BinaryVersion)


### PR DESCRIPTION
### What type of PR is this?
/kind test

### Which issue(s) this PR fixes:
fixes #127969

### What this PR does / why we need it:

While writing an integration test for K8s feature - Compatibility Versions around feature gate compatibility I encountered an issue when using cmd/kube-apiserver/app/testing/testserver.go where hitting the test kube-apiserver /metrics endpoint did not have any feature_gate_enabled* entries. This is because for cmd/kube-apiserver/app/testing/testserver.go it seems AddMetrics (https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/component-base/featuregate/feature_gate.go#L141) is currently not called. In discussing with @Jefftree and @jpbetz offline it seems that this should likely be enabled always for cmd/kube-apiserver/app/testing/testserver.go


This PR makes the suggested change and hopes to validate:
- this does not break any current tests
- this does not cause any notable test performance regressions

EDIT:
Very small performance time analysis:
This PR's test run time for `pull-kubernetes-integration` (prow run #1844065226018787328) -  passed after 58m52s.

Other PRs' that are green tests run time for for `pull-kubernetes-integration`:
https://github.com/kubernetes/kubernetes/pull/127965 - (prow run #1844071293977104384) - passed after 58m20s
https://github.com/kubernetes/kubernetes/pull/127952 - (prow run #1843942827881402368) - passed after 1h1m10s

From the above very small analysis I don't believe this has a meaning impact on integration test performance

### Does this PR introduce a user-facing change?
No

