### PR TITLE
e2e_node: skip critical pod test case on cgroup v1

### DIFF
--- a/test/e2e_node/swap_test.go
+++ b/test/e2e_node/swap_test.go
@@ -92,6 +92,11 @@ var _ = SIGDescribe("Swap", "[LinuxOnly]", nodefeature.Swap, framework.WithSeria
 			pod.Spec.PriorityClassName = "system-node-critical"
 
 			pod = runPodAndWaitUntilScheduled(f, pod)
+
+			if !isPodCgroupV2(f, pod) {
+				e2eskipper.Skipf("swap tests require cgroup v2")
+			}
+
 			gomega.Expect(types.IsCriticalPod(pod)).To(gomega.BeTrueBecause("pod should be critical"))
 
 			ginkgo.By("expecting pod to not have swap access")


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:

It fixes test case failing on cgroup v1 systems with `Exec stderr: "cat: can't open '/sys/fs/cgroup/memory.swap.max': No such file or directory"`

Here is an example of failing job's build log: https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/120459/pull-kubernetes-node-kubelet-serial-crio-cgroupv1/1844384687703724032/build-log.txt

#### Special notes for your reviewer:

Here is how the test case fails:
```
[sig-node] Swap [LinuxOnly] [NodeFeature:NodeSwap] [Serial] [NodeConformance] with a critical pod - should avoid swap [sig-node, NodeFeature:NodeSwap, Serial, NodeConformance]
k8s.io/kubernetes/test/e2e_node/swap_test.go:88
  STEP: Creating a kubernetes client @ 10/10/24 15:15:11.265
  STEP: Building a namespace api object, basename swap-qos @ 10/10/24 15:15:11.265
  I1010 15:15:11.269193 3179 framework.go:275] Skipping waiting for service account
  STEP: figuring if NodeSwap feature gate is turned on @ 10/10/24 15:15:11.269
  STEP: Creating a critical pod @ 10/10/24 15:15:11.269
  STEP: running swap test pod @ 10/10/24 15:15:11.269
  STEP: expecting pod to not have swap access @ 10/10/24 15:15:13.281
  STEP: expecting no swap @ 10/10/24 15:15:13.281
  I1010 15:15:13.281835 3179 exec_util.go:59] ExecWithOptions {Command:[sh -c cat /sys/fs/cgroup/memory.swap.max] Namespace:swap-qos-2096 PodName:sleeping-test-pod-swap-tnm4d ContainerName:busybox-container Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false Quiet:false}
  I1010 15:15:13.281858 3179 exec_util.go:66] ExecWithOptions: Clientset creation
  I1010 15:15:13.281899 3179 exec_util.go:82] ExecWithOptions: execute(POST https://127.0.0.1:6443/api/v1/namespaces/swap-qos-2096/pods/sleeping-test-pod-swap-tnm4d/exec?command=sh&command=-c&command=cat+%2Fsys%2Ffs%2Fcgroup%2Fmemory.swap.max&container=busybox-container&stderr=true&stdout=true)
  I1010 15:15:13.334779 3179 exec_util.go:110] Exec stderr: "cat: can't open '/sys/fs/cgroup/memory.swap.max': No such file or directory"
  I1010 15:15:13.334868 3179 exec_util.go:111] Unexpected error: failed to execute command in pod sleeping-test-pod-swap-tnm4d, container busybox-container: command terminated with exit code 1: 
      <exec.CodeExitError>: 
      command terminated with exit code 1
      {
          Err: <*errors.errorString | 0xc000e55800>{
              s: "command terminated with exit code 1",
          },
          Code: 1,
      }
  [FAILED] in [It] - k8s.io/kubernetes/test/e2e/framework/pod/exec_util.go:111 @ 10/10/24 15:15:13.335
```


#### Does this PR introduce a user-facing change?

```release-note
NONE
```