### PR TITLE
lock the GA feature-gate ExecProbeTimeout to true

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -263,7 +263,7 @@ const (
 	//
 	// Ensure kubelet respects exec probe timeouts. Feature gate exists in-case existing workloads
 	// may depend on old behavior where exec probe timeouts were ignored.
-	// Lock to default and remove after v1.22 based on user feedback that should be reflected in KEP #1972 update
+	// Locked to default, will remove after v1.34
 	ExecProbeTimeout featuregate.Feature = "ExecProbeTimeout"
 
 	// owner: @bobbypage

--- a/pkg/features/versioned_kube_features.go
+++ b/pkg/features/versioned_kube_features.go
@@ -183,7 +183,8 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 	},
 
 	ExecProbeTimeout: {
-		{Version: version.MustParse("1.20"), Default: true, PreRelease: featuregate.GA}, // lock to default and remove after v1.22 based on KEP #1972 update
+		{Version: version.MustParse("1.20"), Default: true, PreRelease: featuregate.GA},
+		{Version: version.MustParse("1.32"), Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.34
 	},
 
 	genericfeatures.AdmissionWebhookMatchConditions: {

--- a/pkg/probe/exec/exec.go
+++ b/pkg/probe/exec/exec.go
@@ -20,9 +20,7 @@ import (
 	"bytes"
 	"errors"
 
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	remote "k8s.io/cri-client/pkg"
-	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/util/ioutils"
 	"k8s.io/kubernetes/pkg/probe"
 
@@ -72,11 +70,7 @@ func (pr execProber) Probe(e exec.Cmd) (probe.Result, string, error) {
 		}
 
 		if errors.Is(err, remote.ErrCommandTimedOut) {
-			if utilfeature.DefaultFeatureGate.Enabled(features.ExecProbeTimeout) {
-				return probe.Failure, err.Error(), nil
-			}
-
-			klog.Warningf("Exec probe timed out but ExecProbeTimeout feature gate was disabled")
+			return probe.Failure, err.Error(), nil
 		}
 
 		return probe.Unknown, "", err

--- a/pkg/probe/exec/exec_test.go
+++ b/pkg/probe/exec/exec_test.go
@@ -22,10 +22,7 @@ import (
 	"strings"
 	"testing"
 
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	remote "k8s.io/cri-client/pkg"
-	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/probe"
 )
 
@@ -110,31 +107,27 @@ func TestExec(t *testing.T) {
 	elevenKilobyte := strings.Repeat("logs-123", 8*128*11) // 8*128*11=11264 = 11KB of text.
 
 	tests := []struct {
-		expectedStatus   probe.Result
-		expectError      bool
-		execProbeTimeout bool
-		input            string
-		output           string
-		err              error
+		expectedStatus probe.Result
+		expectError    bool
+		input          string
+		output         string
+		err            error
 	}{
 		// Ok
-		{probe.Success, false, true, "OK", "OK", nil},
+		{probe.Success, false, "OK", "OK", nil},
 		// Ok
-		{probe.Success, false, true, "OK", "OK", &fakeExitError{true, 0}},
+		{probe.Success, false, "OK", "OK", &fakeExitError{true, 0}},
 		// Ok - truncated output
-		{probe.Success, false, true, elevenKilobyte, tenKilobyte, nil},
+		{probe.Success, false, elevenKilobyte, tenKilobyte, nil},
 		// Run returns error
-		{probe.Unknown, true, true, "", "", fmt.Errorf("test error")},
+		{probe.Unknown, true, "", "", fmt.Errorf("test error")},
 		// Unhealthy
-		{probe.Failure, false, true, "Fail", "", &fakeExitError{true, 1}},
+		{probe.Failure, false, "Fail", "", &fakeExitError{true, 1}},
 		// Timeout
-		{probe.Failure, false, true, "", remote.ErrCommandTimedOut.Error() + ": command testcmd timed out", fmt.Errorf("%w: command testcmd timed out", remote.ErrCommandTimedOut)},
-		// ExecProbeTimeout
-		{probe.Unknown, true, false, "", "", fmt.Errorf("%w: command testcmd timed out", remote.ErrCommandTimedOut)},
+		{probe.Failure, false, "", remote.ErrCommandTimedOut.Error() + ": command testcmd timed out", fmt.Errorf("%w: command testcmd timed out", remote.ErrCommandTimedOut)},
 	}
 
 	for i, test := range tests {
-		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ExecProbeTimeout, test.execProbeTimeout)
 		fake := FakeCmd{
 			out: []byte(test.output),
 			err: test.err,

--- a/test/e2e/common/node/container_probe.go
+++ b/test/e2e/common/node/container_probe.go
@@ -260,7 +260,7 @@ var _ = SIGDescribe("Probing container", func() {
 	/*
 		Release: v1.21
 		Testname: Pod liveness probe, container exec timeout, restart
-		Description: A Pod is created with liveness probe with a Exec action on the Pod. If the liveness probe call does not return within the timeout specified, liveness probe MUST restart the Pod. When ExecProbeTimeout feature gate is disabled and cluster is using dockershim, the timeout is ignored BUT a failing liveness probe MUST restart the Pod.
+		Description: A Pod is created with liveness probe with a Exec action on the Pod. If the liveness probe call does not return within the timeout specified, liveness probe MUST restart the Pod.
 	*/
 	ginkgo.It("should be restarted with a failing exec liveness probe that took longer than the timeout", func(ctx context.Context) {
 		cmd := []string{"/bin/sh", "-c", "sleep 600"}
@@ -968,9 +968,7 @@ var _ = SIGDescribe(nodefeature.SidecarContainers, feature.SidecarContainers, "P
 		Testname: Pod restartalbe init container liveness probe, container exec timeout, restart
 		Description: A Pod is created with liveness probe with a Exec action on the
 		Pod. If the liveness probe call does not return within the timeout
-		specified, liveness probe MUST restart the Pod. When ExecProbeTimeout
-		feature gate is disabled and cluster is using dockershim, the timeout is
-		ignored BUT a failing liveness probe MUST restart the Pod.
+		specified, liveness probe MUST restart the Pod.
 	*/
 	ginkgo.It("should be restarted with a failing exec liveness probe that took longer than the timeout", func(ctx context.Context) {
 		cmd := []string{"/bin/sh", "-c", "sleep 600"}

--- a/test/featuregates_linter/test_data/versioned_feature_list.yaml
+++ b/test/featuregates_linter/test_data/versioned_feature_list.yaml
@@ -400,6 +400,10 @@
     lockToDefault: false
     preRelease: GA
     version: "1.20"
+  - default: true
+    lockToDefault: true
+    preRelease: GA
+    version: "1.32"
 - name: GracefulNodeShutdown
   versionedSpecs:
   - default: false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

KEP Graduation Criteria:

```
This is a bug fix so the feature gate will be GA and on by default from the start.

Documentation on the migration steps must be provided at kubernetes documentation site offering tips on detecting and updating affected workloads.

The feature flag should be kept available till we get a sufficient evidence of people not being affected by this bug fix - either directly (adjusting the timeouts in pod definition), or indirectly, when the timeout is not specified in some third party templates and products that cannot be easily fixed by end user.

Tentative timeline is to lock the feature flag to true in 1.25.
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->


#### Special notes for your reviewer:

Dockershim was removed from Kubernetes with the release of v1.24 and release 1.28 is the oldest supported version.

KEP (closed by bot):
- https://github.com/kubernetes/enhancements/issues/1972 GA is 1.20
- https://github.com/kubernetes/enhancements/pull/2294 in 1.22
- https://github.com/kubernetes/enhancements/pull/3201 in 1.24

Website:
- https://github.com/kubernetes/website/pull/24692

Some Closed PRs or Issues:
- https://github.com/kubernetes/kubernetes/pull/107480 
- https://github.com/kubernetes/kubernetes/pull/115227
- https://github.com/kubernetes/kubernetes/issues/99854

Some feature/bugfix PRs:
- https://github.com/kubernetes/kubernetes/pull/94115 in 1.20
- https://github.com/kubernetes/kubernetes/pull/104484 in 1.25

e2e test:
- https://github.com/kubernetes/kubernetes/pull/109649 for ExecProbeTimeout

The metrics PR had been merged but @SergeyKanzhelev left a comment on the KEP that it still needed more work last year.

I'm not sure what the current status is. Dockershim was removed from Kubernetes with the release of v1.24 and release 1.28 is the oldest supported version. 

Is it ready to lock this feature-gate to true or remove it immediately? Does the PR need to update the KEP?

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Locked the (generally available) feature gate `ExecProbeTimeout` to true. Although the bug fix feature gate is for a generally available feature, cluster administrators were able to disable it in previous minor releases.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/1972
```
