### PR TITLE
DRA: Update resourceslice controller filtering logic

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/resourceslicecontroller.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/resourceslicecontroller.go
@@ -198,7 +198,10 @@ func (c *Controller) initInformer(ctx context.Context) error {
 	logger := klog.FromContext(ctx)
 
 	// We always filter by driver name, by node name only for node-local resources.
-	selector := fields.Set{resourceapi.ResourceSliceSelectorDriver: c.driver}
+	selector := fields.Set{
+		resourceapi.ResourceSliceSelectorDriver:   c.driver,
+		resourceapi.ResourceSliceSelectorNodeName: "",
+	}
 	if c.owner.APIVersion == "v1" && c.owner.Kind == "Node" {
 		selector[resourceapi.ResourceSliceSelectorNodeName] = c.owner.Name
 	}


### PR DESCRIPTION
The logic has been updated to ensure that a controller started for non-node-local resources filters out all resourceslices created for node-local resources. Without this change, a single driver with both node-local and non-node-local resources would end up in a constant battle of creating and deleting node-local resource slices in the controller it setup for its non-node-local resources. This change fixes that.

/kind bug
/wg device-management

#### Does this PR introduce a user-facing change?
```release-note
NONE
```