### PR TITLE
feature(kubectl): add renewTime field when using kubectl get lease -owide

### DIFF
--- a/pkg/printers/internalversion/printers.go
+++ b/pkg/printers/internalversion/printers.go
@@ -428,6 +428,7 @@ func AddHandlers(h printers.PrintHandler) {
 		{Name: "Name", Type: "string", Format: "name", Description: metav1.ObjectMeta{}.SwaggerDoc()["name"]},
 		{Name: "Holder", Type: "string", Description: coordinationv1.LeaseSpec{}.SwaggerDoc()["holderIdentity"]},
 		{Name: "Age", Type: "string", Description: metav1.ObjectMeta{}.SwaggerDoc()["creationTimestamp"]},
+		{Name: "RenewTime", Type: "string", Description: coordinationv1.LeaseSpec{}.SwaggerDoc()["renewTime"]},
 	}
 	_ = h.TableHandler(leaseColumnDefinitions, printLease)
 	_ = h.TableHandler(leaseColumnDefinitions, printLeaseList)
@@ -2565,6 +2566,11 @@ func printLease(obj *coordination.Lease, options printers.GenerateOptions) ([]me
 		holderIdentity = *obj.Spec.HolderIdentity
 	}
 	row.Cells = append(row.Cells, obj.Name, holderIdentity, translateTimestampSince(obj.CreationTimestamp))
+	if options.Wide {
+		if obj.Spec.RenewTime != nil {
+			row.Cells = append(row.Cells, obj.Spec.RenewTime.Time.Format(time.DateTime))
+		}
+	}
 	return []metav1.TableRow{row}, nil
 }
 

--- a/pkg/printers/internalversion/printers_test.go
+++ b/pkg/printers/internalversion/printers_test.go
@@ -5714,7 +5714,10 @@ func TestPrintVolumeAttributesClass(t *testing.T) {
 func TestPrintLease(t *testing.T) {
 	holder1 := "holder1"
 	holder2 := "holder2"
+	fixedTimeStrAndLayout := "2006-01-02 15:04:05"
+	fixedTime, _ := time.Parse(fixedTimeStrAndLayout, fixedTimeStrAndLayout)
 	tests := []struct {
+		options  printers.GenerateOptions
 		lease    coordination.Lease
 		expected []metav1.TableRow
 	}{
@@ -5742,10 +5745,24 @@ func TestPrintLease(t *testing.T) {
 			},
 			expected: []metav1.TableRow{{Cells: []interface{}{"lease2", "holder2", "5m"}}},
 		},
+		{
+			options: printers.GenerateOptions{Wide: true},
+			lease: coordination.Lease{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "lease3",
+					CreationTimestamp: metav1.Time{Time: time.Now().Add(-3e11)},
+				},
+				Spec: coordination.LeaseSpec{
+					HolderIdentity: &holder2,
+					RenewTime:      &metav1.MicroTime{Time: fixedTime},
+				},
+			},
+			expected: []metav1.TableRow{{Cells: []interface{}{"lease3", "holder2", "5m", "2006-01-02 15:04:05"}}},
+		},
 	}
 
 	for i, test := range tests {
-		rows, err := printLease(&test.lease, printers.GenerateOptions{})
+		rows, err := printLease(&test.lease, test.options)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
- add renew field when using `kubectl get lease -owide`

We use the Lease resource object in the cluster. When SREs troubleshoot issues, they need to quickly check if the leases have been updated. Using -owide would make it easier to view multiple lease objects for updates.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/128005

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added renewTime field when using `kubectl get lease -owide`
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
