### PR TITLE
LeaderMigrationConfig now uses strict validation kube-controller-manager

### DIFF
--- a/staging/src/k8s.io/controller-manager/pkg/leadermigration/config/config.go
+++ b/staging/src/k8s.io/controller-manager/pkg/leadermigration/config/config.go
@@ -25,7 +25,7 @@ import (
 	util "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	internal "k8s.io/controller-manager/config"
-	"k8s.io/controller-manager/config/v1"
+	v1 "k8s.io/controller-manager/config/v1"
 	"k8s.io/controller-manager/config/v1alpha1"
 	"k8s.io/controller-manager/config/v1beta1"
 )
@@ -63,7 +63,7 @@ func ReadLeaderMigrationConfiguration(configFilePath string) (*internal.LeaderMi
 	if err != nil {
 		return nil, fmt.Errorf("unable to read leader migration configuration from %q: %w", configFilePath, err)
 	}
-	config, gvk, err := serializer.NewCodecFactory(cfgScheme).UniversalDecoder().Decode(data, nil, nil)
+	config, gvk, err := serializer.NewCodecFactory(cfgScheme, serializer.EnableStrict).UniversalDecoder().Decode(data, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/controller-manager/pkg/leadermigration/config/config_test.go
+++ b/staging/src/k8s.io/controller-manager/pkg/leadermigration/config/config_test.go
@@ -83,6 +83,30 @@ controllerLeaders: []
 			},
 		},
 		{
+			name: "unknown field causes error with strict validation",
+			content: `
+apiVersion: controllermanager.config.k8s.io/v1alpha1
+kind: LeaderMigrationConfiguration
+leaderName: migration-120-to-121
+resourceLock: endpoints
+foo: bar
+controllerLeaders: []
+`,
+			expectErr: true,
+		},
+		{
+			name: "duplicate field causes error with strict validation",
+			content: `
+apiVersion: controllermanager.config.k8s.io/v1alpha1
+kind: LeaderMigrationConfiguration
+leaderName: migration-120-to-121
+resourceLock: endpoints
+resourceLock: endpoints1
+controllerLeaders: []
+`,
+			expectErr: true,
+		},
+		{
 			name: "withLeaders",
 			content: `
 apiVersion: controllermanager.config.k8s.io/v1alpha1


### PR DESCRIPTION
* `LeaderMigrationConfiguration` files are now decoded using `EnableStrict`
  * Duplicate fields in the configuration will now cause an error during decoding.
  * Unknown fields in the configuration will now cause an error during decoding.

/kind cleanup

```release-note
kube-controller-manager `--leader-migration-config` files are now validated strictly (EnableStrict). Duplicate and unknown fields in the configuration will now cause an error.
```

One of several PR's to address: https://github.com/kubernetes/kubernetes/issues/127940