### PR TITLE
EgressSelectorConfiguration now uses strict validation

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/egressselector/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/egressselector/config.go
@@ -22,13 +22,12 @@ import (
 	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/apis/apiserver"
 	"k8s.io/apiserver/pkg/apis/apiserver/install"
-	"k8s.io/apiserver/pkg/apis/apiserver/v1beta1"
 	"k8s.io/utils/path"
-	"sigs.k8s.io/yaml"
 )
 
 var cfgScheme = runtime.NewScheme()
@@ -55,19 +54,13 @@ func ReadEgressSelectorConfiguration(configFilePath string) (*apiserver.EgressSe
 	if err != nil {
 		return nil, fmt.Errorf("unable to read egress selector configuration from %q [%v]", configFilePath, err)
 	}
-	var decodedConfig v1beta1.EgressSelectorConfiguration
-	err = yaml.Unmarshal(data, &decodedConfig)
+	config, gvk, err := serializer.NewCodecFactory(cfgScheme, serializer.EnableStrict).UniversalDecoder().Decode(data, nil, nil)
 	if err != nil {
-		// we got an error where the decode wasn't related to a missing type
 		return nil, err
 	}
-	if decodedConfig.Kind != "EgressSelectorConfiguration" {
-		return nil, fmt.Errorf("invalid service configuration object %q", decodedConfig.Kind)
-	}
-	internalConfig := &apiserver.EgressSelectorConfiguration{}
-	if err := cfgScheme.Convert(&decodedConfig, internalConfig, nil); err != nil {
-		// we got an error where the decode wasn't related to a missing type
-		return nil, err
+	internalConfig, ok := config.(*apiserver.EgressSelectorConfiguration)
+	if !ok {
+		return nil, fmt.Errorf("unexpected config type: %v", gvk)
 	}
 	return internalConfig, nil
 }

--- a/test/integration/apiserver/tracing/tracing_test.go
+++ b/test/integration/apiserver/tracing/tracing_test.go
@@ -208,7 +208,7 @@ func TestAPIServerTracingWithEgressSelector(t *testing.T) {
 	defer os.Remove(egressSelectorConfigFile.Name())
 
 	if err := os.WriteFile(egressSelectorConfigFile.Name(), []byte(`
-apiVersion: apiserver.config.k8s.io/v1beta1
+apiVersion: apiserver.k8s.io/v1beta1
 kind: EgressSelectorConfiguration
 egressSelections:
 - name: cluster


### PR DESCRIPTION
* `EgressSelectorConfiguration` files are now decoded using a codec with the `EnableStrict` option (previously the decoding happened in a simple `yaml.Unmarshal`).
  * Duplicate fields in the configuration will now cause an error during decoding.
  * Unknown fields in the configuration will now cause an error during decoding.

/kind cleanup

```release-note
kube-apiserver `--egress-selector-config-file` files are now validated strictly (EnableStrict). Duplicate and unknown fields in the configuration will now cause an error.
```

One of several PR's to address: https://github.com/kubernetes/kubernetes/issues/127940