### PR TITLE
fix: Remove unnecessary lock in metrics parsing allow-list manifest

### DIFF
--- a/staging/src/k8s.io/component-base/metrics/opts.go
+++ b/staging/src/k8s.io/component-base/metrics/opts.go
@@ -315,7 +315,7 @@ func (o *SummaryOpts) toPromSummaryOpts() prometheus.SummaryOpts {
 }
 
 type MetricLabelAllowList struct {
-	labelToAllowList map[string]sets.String
+	labelToAllowList map[string]sets.Set[string]
 }
 
 func (allowList *MetricLabelAllowList) ConstrainToAllowedList(labelNameList, labelValueList []string) {
@@ -347,13 +347,13 @@ func SetLabelAllowListFromCLI(allowListMapping map[string]string) {
 	for metricLabelName, labelValues := range allowListMapping {
 		metricName := strings.Split(metricLabelName, ",")[0]
 		labelName := strings.Split(metricLabelName, ",")[1]
-		valueSet := sets.NewString(strings.Split(labelValues, ",")...)
+		valueSet := sets.New[string](strings.Split(labelValues, ",")...)
 
 		allowList, ok := labelValueAllowLists[metricName]
 		if ok {
 			allowList.labelToAllowList[labelName] = valueSet
 		} else {
-			labelToAllowList := make(map[string]sets.String)
+			labelToAllowList := make(map[string]sets.Set[string])
 			labelToAllowList[labelName] = valueSet
 			labelValueAllowLists[metricName] = &MetricLabelAllowList{
 				labelToAllowList,

--- a/staging/src/k8s.io/component-base/metrics/opts.go
+++ b/staging/src/k8s.io/component-base/metrics/opts.go
@@ -363,8 +363,6 @@ func SetLabelAllowListFromCLI(allowListMapping map[string]string) {
 }
 
 func SetLabelAllowListFromManifest(manifest string) {
-	allowListLock.Lock()
-	defer allowListLock.Unlock()
 	allowListMapping := make(map[string]string)
 	data, err := os.ReadFile(filepath.Clean(manifest))
 	if err != nil {

--- a/staging/src/k8s.io/component-base/metrics/opts_test.go
+++ b/staging/src/k8s.io/component-base/metrics/opts_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package metrics
 
 import (
+	"os"
 	"reflect"
 	"testing"
 
@@ -134,6 +135,75 @@ func TestConstrainLabelMap(t *testing.T) {
 			allowList.ConstrainLabelMap(test.inputLabelMap)
 			if !reflect.DeepEqual(test.inputLabelMap, test.outputLabelMap) {
 				t.Errorf("Got %v, expected %v", test.inputLabelMap, test.outputLabelMap)
+			}
+		})
+	}
+}
+
+func TestSetLabelAllowListFromManifest(t *testing.T) {
+	tests := []struct {
+		name                       string
+		manifest                   string
+		manifestExist              bool
+		expectlabelValueAllowLists map[string]*MetricLabelAllowList
+	}{
+		{
+			name:          "successfully parse manifest",
+			manifestExist: true,
+			manifest: `metric1,label1: v1,v2
+metric2,label2: v3`,
+			expectlabelValueAllowLists: map[string]*MetricLabelAllowList{
+				"metric1": {
+					labelToAllowList: map[string]sets.String{
+						"label1": sets.NewString("v1", "v2"),
+					},
+				},
+				"metric2": {
+					labelToAllowList: map[string]sets.String{
+						"label2": sets.NewString("v3"),
+					},
+				},
+			},
+		},
+		{
+			name:                       "failed to read manifest file",
+			manifestExist:              false,
+			expectlabelValueAllowLists: map[string]*MetricLabelAllowList{},
+		},
+		{
+			name:          "failed to parse manifest",
+			manifestExist: true,
+			manifest: `allow-list:
+- metric1,label1:v1
+- metric2,label2:v2,v3`,
+			expectlabelValueAllowLists: map[string]*MetricLabelAllowList{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			labelValueAllowLists = map[string]*MetricLabelAllowList{}
+			manifestFilePath := "/non-existent-file.yaml"
+			if tc.manifestExist {
+				tempFile, err := os.CreateTemp("", "allow-list-test")
+				if err != nil {
+					t.Fatalf("failed to create temp file: %v", err)
+				}
+				defer func() {
+					if err := os.Remove(tempFile.Name()); err != nil {
+						t.Errorf("failed to remove temp file: %v", err)
+					}
+				}()
+
+				if _, err := tempFile.WriteString(tc.manifest); err != nil {
+					t.Fatalf("failed to write to temp file: %v", err)
+				}
+				manifestFilePath = tempFile.Name()
+			}
+
+			SetLabelAllowListFromManifest(manifestFilePath)
+			if !reflect.DeepEqual(labelValueAllowLists, tc.expectlabelValueAllowLists) {
+				t.Errorf("labelValueAllowLists = %+v, want %+v", labelValueAllowLists, tc.expectlabelValueAllowLists)
 			}
 		})
 	}

--- a/staging/src/k8s.io/component-base/metrics/opts_test.go
+++ b/staging/src/k8s.io/component-base/metrics/opts_test.go
@@ -65,8 +65,8 @@ func TestDefaultStabilityLevel(t *testing.T) {
 
 func TestConstrainToAllowedList(t *testing.T) {
 	allowList := &MetricLabelAllowList{
-		labelToAllowList: map[string]sets.String{
-			"label_a": sets.NewString("allow_value1", "allow_value2"),
+		labelToAllowList: map[string]sets.Set[string]{
+			"label_a": sets.New[string]("allow_value1", "allow_value2"),
 		},
 	}
 	labelNameList := []string{"label_a", "label_b"}
@@ -98,8 +98,8 @@ func TestConstrainToAllowedList(t *testing.T) {
 
 func TestConstrainLabelMap(t *testing.T) {
 	allowList := &MetricLabelAllowList{
-		labelToAllowList: map[string]sets.String{
-			"label_a": sets.NewString("allow_value1", "allow_value2"),
+		labelToAllowList: map[string]sets.Set[string]{
+			"label_a": sets.New[string]("allow_value1", "allow_value2"),
 		},
 	}
 	var tests = []struct {
@@ -154,13 +154,13 @@ func TestSetLabelAllowListFromManifest(t *testing.T) {
 metric2,label2: v3`,
 			expectlabelValueAllowLists: map[string]*MetricLabelAllowList{
 				"metric1": {
-					labelToAllowList: map[string]sets.String{
-						"label1": sets.NewString("v1", "v2"),
+					labelToAllowList: map[string]sets.Set[string]{
+						"label1": sets.New[string]("v1", "v2"),
 					},
 				},
 				"metric2": {
-					labelToAllowList: map[string]sets.String{
-						"label2": sets.NewString("v3"),
+					labelToAllowList: map[string]sets.Set[string]{
+						"label2": sets.New[string]("v3"),
 					},
 				},
 			},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:
It removes unnecessary lock when parsing metrics allow list manifest.
It also adds a unit test to cover the related function.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #127992 
[KEP]: https://github.com/kubernetes/enhancements/issues/2305

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs
[KEP]https://github.com/kubernetes/enhancements/issues/2305
```

