### PR TITLE
AdmissionConfiguration now uses strict validation

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/config.go
@@ -63,7 +63,7 @@ func ReadAdmissionConfiguration(pluginNames []string, configFilePath string, con
 	if err != nil {
 		return nil, fmt.Errorf("unable to read admission control configuration from %q [%v]", configFilePath, err)
 	}
-	codecs := serializer.NewCodecFactory(configScheme)
+	codecs := serializer.NewCodecFactory(configScheme, serializer.EnableStrict)
 	decoder := codecs.UniversalDecoder()
 	decodedObj, err := runtime.Decode(decoder, data)
 	// we were able to decode the file successfully


### PR DESCRIPTION
* `AdmissionConfiguration` files are now decoded using `EnableStrict`
  * Duplicate fields in the configuration will now cause an error during decoding.
  * Unknown fields in the configuration will now cause an error during decoding.

/kind cleanup

```release-note
kube-apiserver `--admission-control-config-file` files are now validated strictly (EnableStrict). Duplicate and unknown fields in the configuration will now cause an error.
```

One of several PR's to address: https://github.com/kubernetes/kubernetes/issues/127940