### PR TITLE
add warnings for duplicate port names in pod's container ports

### DIFF
--- a/pkg/api/pod/warnings.go
+++ b/pkg/api/pod/warnings.go
@@ -293,6 +293,14 @@ func warningsForPodSpecAndMeta(fieldPath *field.Path, podSpec *api.PodSpec, meta
 					fldPath.Child("ports").Index(i), port))
 			}
 			k := fmt.Sprintf("%d/%s", port.ContainerPort, port.Protocol)
+			// Check for duplicate port names
+			for _, others := range allPorts {
+				for _, otherPort := range others {
+					if len(port.Name) > 0 && port.Name == otherPort.port.Name {
+						warnings = append(warnings, fmt.Sprintf("%s: duplicate port name with %s", fldPath.Child("ports").Index(i), otherPort.field))
+					}
+				}
+			}
 			if others, found := allPorts[k]; found {
 				// Someone else has this protcol+port, but it still might not be a conflict.
 				for _, other := range others {

--- a/pkg/api/pod/warnings_test.go
+++ b/pkg/api/pod/warnings_test.go
@@ -984,13 +984,52 @@ func TestWarnings(t *testing.T) {
 			},
 		},
 		{
+			name: "duplicate container port names",
+			template: &api.PodTemplateSpec{Spec: api.PodSpec{
+				Containers: []api.Container{{
+					Name: "foo",
+					Ports: []api.ContainerPort{
+						{Name: "a", ContainerPort: 80, Protocol: api.ProtocolTCP},
+					},
+				}, {
+					Name: "foo",
+					Ports: []api.ContainerPort{
+						{Name: "a", ContainerPort: 81, Protocol: api.ProtocolTCP},
+					},
+				}},
+			}},
+			expected: []string{
+				`spec.containers[1].ports[0]: duplicate port name with spec.containers[0].ports[0]`,
+			},
+		},
+		{
+			name: "duplicate container port names between init containers and containers",
+			template: &api.PodTemplateSpec{Spec: api.PodSpec{
+				InitContainers: []api.Container{{
+					Name: "foo",
+					Ports: []api.ContainerPort{
+						{Name: "a", ContainerPort: 80, Protocol: api.ProtocolTCP},
+					},
+				}},
+				Containers: []api.Container{{
+					Name: "foo",
+					Ports: []api.ContainerPort{
+						{Name: "a", ContainerPort: 81, Protocol: api.ProtocolTCP},
+					},
+				}},
+			}},
+			expected: []string{
+				`spec.containers[0].ports[0]: duplicate port name with spec.initContainers[0].ports[0]`,
+			},
+		},
+		{
 			name: "create duplicate container ports in two containers",
 			template: &api.PodTemplateSpec{Spec: api.PodSpec{
 				Containers: []api.Container{
 					{
 						Name: "foo1",
 						Ports: []api.ContainerPort{
-							{ContainerPort: 80, HostPort: 80, Protocol: api.ProtocolUDP},
+							{Name: "a", ContainerPort: 80, HostPort: 80, Protocol: api.ProtocolUDP},
 							{ContainerPort: 180, HostPort: 80, Protocol: api.ProtocolUDP},
 							{ContainerPort: 80, HostPort: 80, Protocol: api.ProtocolUDP},
 						},
@@ -999,7 +1038,7 @@ func TestWarnings(t *testing.T) {
 						Name: "foo",
 						Ports: []api.ContainerPort{
 							{ContainerPort: 80, HostPort: 80, Protocol: api.ProtocolUDP},
-							{ContainerPort: 80, HostPort: 80, Protocol: api.ProtocolUDP},
+							{Name: "a", ContainerPort: 80, HostPort: 80, Protocol: api.ProtocolUDP},
 						},
 					}},
 			}},
@@ -1010,6 +1049,7 @@ func TestWarnings(t *testing.T) {
 				`spec.containers[1].ports[1]: duplicate port definition with spec.containers[0].ports[0]`,
 				`spec.containers[1].ports[1]: duplicate port definition with spec.containers[0].ports[2]`,
 				`spec.containers[1].ports[1]: duplicate port definition with spec.containers[1].ports[0]`,
+				`spec.containers[1].ports[1]: duplicate port name with spec.containers[0].ports[0]`,
 			},
 		},
 		{


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
The same port name should not appear in the pod, but we cannot make breaking changes at the moment, so add warnings

Related pr #127993 
Related comments https://github.com/kubernetes/kubernetes/pull/127976#discussion_r1797164793

#### Special notes for your reviewer: @thockin @SergeyKanzhelev @aojea 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add warning for dup port names in pod's container ports
```
