### PR TITLE
[Sidecar Containers] Check for restarts without being affected by container startup order

### DIFF
--- a/test/e2e_node/container_lifecycle_pod_construction.go
+++ b/test/e2e_node/container_lifecycle_pod_construction.go
@@ -179,24 +179,6 @@ func (o containerOutputList) StartsBefore(lhs, rhs string) error {
 	return nil
 }
 
-// DoesntStartAfter returns an error if lhs started after rhs
-func (o containerOutputList) DoesntStartAfter(lhs, rhs string) error {
-	rhsStart := o.findIndex(rhs, "Starting", 0)
-
-	if rhsStart == -1 {
-		return fmt.Errorf("couldn't find that %s ever started, got\n%v", rhs, o)
-	}
-
-	// this works even for the same names (restart case)
-	lhsStart := o.findIndex(lhs, "Started", rhsStart+1)
-
-	if lhsStart != -1 {
-		return fmt.Errorf("expected %s to not start after %s, got\n%v", lhs, rhs, o)
-	}
-
-	return nil
-}
-
 // ExitsBefore returns an error if lhs did not end before rhs
 func (o containerOutputList) ExitsBefore(lhs, rhs string) error {
 	lhsExit := o.findIndex(lhs, "Exiting", 0)

--- a/test/e2e_node/container_lifecycle_test.go
+++ b/test/e2e_node/container_lifecycle_test.go
@@ -1631,7 +1631,7 @@ var _ = SIGDescribe(nodefeature.SidecarContainers, "Containers Lifecycle", func(
 				results = parseOutput(context.TODO(), f, podSpec)
 			})
 			ginkgo.It("should not restart a restartable init container", func() {
-				framework.ExpectNoError(results.DoesntStartAfter(restartableInit1, regular1))
+				framework.ExpectNoError(results.HasNotRestarted(restartableInit1))
 			})
 			ginkgo.It("should run a regular container to completion", func() {
 				framework.ExpectNoError(results.Exits(regular1))
@@ -2033,7 +2033,7 @@ var _ = SIGDescribe(nodefeature.SidecarContainers, "Containers Lifecycle", func(
 				results = parseOutput(context.TODO(), f, podSpec)
 			})
 			ginkgo.It("should not restart a restartable init container", func() {
-				framework.ExpectNoError(results.DoesntStartAfter(restartableInit1, regular1))
+				framework.ExpectNoError(results.HasNotRestarted(restartableInit1))
 			})
 			ginkgo.It("should run a regular container to completion", func() {
 				framework.ExpectNoError(results.Exits(regular1))
@@ -2454,7 +2454,7 @@ var _ = SIGDescribe(nodefeature.SidecarContainers, "Containers Lifecycle", func(
 			})
 
 			ginkgo.It("should not restart a restartable init container", func() {
-				framework.ExpectNoError(results.DoesntStartAfter(restartableInit1, regular1))
+				framework.ExpectNoError(results.HasNotRestarted(restartableInit1))
 			})
 			// this test case is different from restartPolicy=Never
 			ginkgo.It("should start a regular container", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind flake

#### What this PR does / why we need it:

The test for checking container restarts in a Pod with `restartable-init-1` and `regular-1` is flaky. Right now, when we check if `restartable-init-1` has restarted, we see if it hasn’t written the "Started" log message after `regular-1` has written its "Started" log message. But even though the startup sequence starts with `restartable-init-1` and then `regular-1`, there’s no guarantee they’ll finish starting up in that order.

Sometimes `regular-1` finishes first and writes its "Started" log message before `restartable-init-1`.
1. `restartable-init-1` Starting
2. `regular-1` Starting
3. `regular-1` Started
4. `restartable-init-1` Started

In this test, the startup order doesn’t really matter; all we need to check is if `restartable-init-1` restarted. So I changed the test to simply look for more than one "Starting" log in `restartable-init-1`'s logs.

There are other places that used the same helper function `DoesntStartAfter()`, so replaced those as well and deleted the helper function.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #128015

#### Special notes for your reviewer:

Modifying the `DoesntStartAfter()` helper function this way might reduce the number of flaky tests. However, in cases like this one, where `regular-1` starts right after `restartable-init-1`, I can't say for sure that the log order won't get swapped. So, I've removed the `DoesntStartAfter()` helper function and replaced it with the `HasNotRestarted()` helper function instead.

```diff
diff --git a/test/e2e_node/container_lifecycle_pod_construction.go b/test/e2e_node/container_lifecycle_pod_construction.go
index b8220919c49..535e1e324f6 100644
--- a/test/e2e_node/container_lifecycle_pod_construction.go
+++ b/test/e2e_node/container_lifecycle_pod_construction.go
@@ -188,7 +188,7 @@ func (o containerOutputList) DoesntStartAfter(lhs, rhs string) error {
        }

        // this works even for the same names (restart case)
-       lhsStart := o.findIndex(lhs, "Started", rhsStart+1)
+       lhsStart := o.findIndex(lhs, "Starting", rhsStart+1)

        if lhsStart != -1 {
                return fmt.Errorf("expected %s to not start after %s, got\n%v", lhs, rhs, o)
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
[KEP]: https://github.com/kubernetes/enhancements/issues/753
```
