### PR TITLE
Implement new metrics `goroutines_duration_seconds` and `goroutines_execution_total` for async preemption

### DIFF
--- a/pkg/scheduler/framework/parallelize/error_channel.go
+++ b/pkg/scheduler/framework/parallelize/error_channel.go
@@ -18,31 +18,31 @@ package parallelize
 
 import "context"
 
-// ErrorChannel supports non-blocking send and receive operation to capture error.
+// errorChannel supports non-blocking send and receive operation to capture error.
 // A maximum of one error is kept in the channel and the rest of the errors sent
 // are ignored, unless the existing error is received and the channel becomes empty
 // again.
-type ErrorChannel struct {
+type errorChannel struct {
 	errCh chan error
 }
 
-// SendError sends an error without blocking the sender.
-func (e *ErrorChannel) SendError(err error) {
+// sendError sends an error without blocking the sender.
+func (e *errorChannel) sendError(err error) {
 	select {
 	case e.errCh <- err:
 	default:
 	}
 }
 
-// SendErrorWithCancel sends an error without blocking the sender and calls
+// sendErrorWithCancel sends an error without blocking the sender and calls
 // cancel function.
-func (e *ErrorChannel) SendErrorWithCancel(err error, cancel context.CancelFunc) {
-	e.SendError(err)
+func (e *errorChannel) sendErrorWithCancel(err error, cancel context.CancelFunc) {
+	e.sendError(err)
 	cancel()
 }
 
-// ReceiveError receives an error from channel without blocking on the receiver.
-func (e *ErrorChannel) ReceiveError() error {
+// receiveError receives an error from channel without blocking on the receiver.
+func (e *errorChannel) receiveError() error {
 	select {
 	case err := <-e.errCh:
 		return err
@@ -51,9 +51,9 @@ func (e *ErrorChannel) ReceiveError() error {
 	}
 }
 
-// NewErrorChannel returns a new ErrorChannel.
-func NewErrorChannel() *ErrorChannel {
-	return &ErrorChannel{
+// newErrorChannel returns a new errorChannel.
+func newErrorChannel() *errorChannel {
+	return &errorChannel{
 		errCh: make(chan error, 1),
 	}
 }

--- a/pkg/scheduler/framework/parallelize/error_channel_test.go
+++ b/pkg/scheduler/framework/parallelize/error_channel_test.go
@@ -33,14 +33,14 @@ func TestErrorChannel(t *testing.T) {
 
 	err := errors.New("unknown error")
 	errCh.sendError(err)
-	if actualErr := errCh.receiveError(); actualErr != err {
+	if actualErr := errCh.receiveError(); !errors.Is(actualErr, err) {
 		t.Errorf("expect %v from err channel, but got %v", err, actualErr)
 	}
 
 	_, ctx := ktesting.NewTestContext(t)
 	ctx, cancel := context.WithCancel(ctx)
 	errCh.sendErrorWithCancel(err, cancel)
-	if actualErr := errCh.receiveError(); actualErr != err {
+	if actualErr := errCh.receiveError(); !errors.Is(actualErr, err) {
 		t.Errorf("expect %v from err channel, but got %v", err, actualErr)
 	}
 

--- a/pkg/scheduler/framework/parallelize/error_channel_test.go
+++ b/pkg/scheduler/framework/parallelize/error_channel_test.go
@@ -25,22 +25,22 @@ import (
 )
 
 func TestErrorChannel(t *testing.T) {
-	errCh := NewErrorChannel()
+	errCh := newErrorChannel()
 
-	if actualErr := errCh.ReceiveError(); actualErr != nil {
+	if actualErr := errCh.receiveError(); actualErr != nil {
 		t.Errorf("expect nil from err channel, but got %v", actualErr)
 	}
 
 	err := errors.New("unknown error")
-	errCh.SendError(err)
-	if actualErr := errCh.ReceiveError(); actualErr != err {
+	errCh.sendError(err)
+	if actualErr := errCh.receiveError(); actualErr != err {
 		t.Errorf("expect %v from err channel, but got %v", err, actualErr)
 	}
 
 	_, ctx := ktesting.NewTestContext(t)
 	ctx, cancel := context.WithCancel(ctx)
-	errCh.SendErrorWithCancel(err, cancel)
-	if actualErr := errCh.ReceiveError(); actualErr != err {
+	errCh.sendErrorWithCancel(err, cancel)
+	if actualErr := errCh.receiveError(); actualErr != err {
 		t.Errorf("expect %v from err channel, but got %v", err, actualErr)
 	}
 

--- a/pkg/scheduler/framework/plugins/interpodaffinity/filtering.go
+++ b/pkg/scheduler/framework/plugins/interpodaffinity/filtering.go
@@ -170,7 +170,7 @@ func (pl *InterPodAffinity) getExistingAntiAffinityCounts(ctx context.Context, p
 		return nil
 	}
 	if err := pl.parallelizer.Until(ctx, len(nodes), processNode, pl.Name()); err != nil {
-		logger.Error(err, "get an error during getExistingAntiAffinityCounts")
+		logger.Error(err, "Failed to processing nodes in getExistingAntiAffinityCounts")
 	}
 
 	result := make(topologyToMatchedTermCount)
@@ -217,7 +217,7 @@ func (pl *InterPodAffinity) getIncomingAffinityAntiAffinityCounts(ctx context.Co
 		return nil
 	}
 	if err := pl.parallelizer.Until(ctx, len(allNodes), processNode, pl.Name()); err != nil {
-		logger.Error(err, "get an error during getIncomingAffinityAntiAffinityCounts")
+		logger.Error(err, "Failed to processing nodes in getIncomingAffinityAntiAffinityCounts")
 	}
 
 	for i := 0; i <= int(index); i++ {

--- a/pkg/scheduler/framework/plugins/interpodaffinity/filtering.go
+++ b/pkg/scheduler/framework/plugins/interpodaffinity/filtering.go
@@ -155,7 +155,7 @@ func podMatchesAllAffinityTerms(terms []framework.AffinityTerm, pod *v1.Pod) boo
 func (pl *InterPodAffinity) getExistingAntiAffinityCounts(ctx context.Context, pod *v1.Pod, nsLabels labels.Set, nodes []*framework.NodeInfo) topologyToMatchedTermCount {
 	topoMaps := make([]topologyToMatchedTermCount, len(nodes))
 	index := int32(-1)
-	processNode := func(i int) {
+	processNode := func(i int) error {
 		nodeInfo := nodes[i]
 		node := nodeInfo.Node()
 
@@ -166,6 +166,7 @@ func (pl *InterPodAffinity) getExistingAntiAffinityCounts(ctx context.Context, p
 		if len(topoMap) != 0 {
 			topoMaps[atomic.AddInt32(&index, 1)] = topoMap
 		}
+		return nil
 	}
 	pl.parallelizer.Until(ctx, len(nodes), processNode, pl.Name())
 
@@ -191,7 +192,7 @@ func (pl *InterPodAffinity) getIncomingAffinityAntiAffinityCounts(ctx context.Co
 	affinityCountsList := make([]topologyToMatchedTermCount, len(allNodes))
 	antiAffinityCountsList := make([]topologyToMatchedTermCount, len(allNodes))
 	index := int32(-1)
-	processNode := func(i int) {
+	processNode := func(i int) error {
 		nodeInfo := allNodes[i]
 		node := nodeInfo.Node()
 
@@ -209,6 +210,7 @@ func (pl *InterPodAffinity) getIncomingAffinityAntiAffinityCounts(ctx context.Co
 			affinityCountsList[k] = affinity
 			antiAffinityCountsList[k] = antiAffinity
 		}
+		return nil
 	}
 	pl.parallelizer.Until(ctx, len(allNodes), processNode, pl.Name())
 

--- a/pkg/scheduler/framework/plugins/interpodaffinity/scoring.go
+++ b/pkg/scheduler/framework/plugins/interpodaffinity/scoring.go
@@ -190,7 +190,7 @@ func (pl *InterPodAffinity) PreScore(
 
 	topoScores := make([]scoreMap, len(allNodes))
 	index := int32(-1)
-	processNode := func(i int) {
+	processNode := func(i int) error {
 		nodeInfo := allNodes[i]
 
 		// Unless the pod being scheduled has preferred affinity terms, we only
@@ -208,6 +208,7 @@ func (pl *InterPodAffinity) PreScore(
 		if len(topoScore) > 0 {
 			topoScores[atomic.AddInt32(&index, 1)] = topoScore
 		}
+		return nil
 	}
 	pl.parallelizer.Until(pCtx, len(allNodes), processNode, pl.Name())
 

--- a/pkg/scheduler/framework/plugins/interpodaffinity/scoring.go
+++ b/pkg/scheduler/framework/plugins/interpodaffinity/scoring.go
@@ -210,7 +210,9 @@ func (pl *InterPodAffinity) PreScore(
 		}
 		return nil
 	}
-	pl.parallelizer.Until(pCtx, len(allNodes), processNode, pl.Name())
+	if err := pl.parallelizer.Until(pCtx, len(allNodes), processNode, pl.Name()); err != nil {
+		return framework.NewStatus(framework.Error, err.Error())
+	}
 
 	if index == -1 {
 		return framework.NewStatus(framework.Skip)

--- a/pkg/scheduler/framework/plugins/podtopologyspread/filtering.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/filtering.go
@@ -286,7 +286,9 @@ func (pl *PodTopologySpread) calPreFilterState(ctx context.Context, pod *v1.Pod)
 		tpCountsByNode[i] = tpCounts
 		return nil
 	}
-	pl.parallelizer.Until(ctx, len(allNodes), processNode, pl.Name())
+	if err := pl.parallelizer.Until(ctx, len(allNodes), processNode, pl.Name()); err != nil {
+		return nil, err
+	}
 
 	for _, tpCounts := range tpCountsByNode {
 		for tp, count := range tpCounts {

--- a/pkg/scheduler/framework/plugins/podtopologyspread/filtering_test.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/filtering_test.go
@@ -2446,7 +2446,9 @@ func BenchmarkFilter(b *testing.B) {
 					p.Filter(ctx, state, tt.pod, n)
 					return nil
 				}
-				p.parallelizer.Until(ctx, len(allNodes), filterNode, "")
+				if err := p.parallelizer.Until(ctx, len(allNodes), filterNode, ""); err != nil {
+					panic(err)
+				}
 			}
 		})
 		b.Run(tt.name+"/Clone", func(b *testing.B) {

--- a/pkg/scheduler/framework/plugins/podtopologyspread/filtering_test.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/filtering_test.go
@@ -2441,9 +2441,10 @@ func BenchmarkFilter(b *testing.B) {
 				if _, s := p.PreFilter(ctx, state, tt.pod); !s.IsSuccess() {
 					b.Fatal(s.AsError())
 				}
-				filterNode := func(i int) {
+				filterNode := func(i int) error {
 					n, _ := p.sharedLister.NodeInfos().Get(allNodes[i].Name)
 					p.Filter(ctx, state, tt.pod, n)
+					return nil
 				}
 				p.parallelizer.Until(ctx, len(allNodes), filterNode, "")
 			}

--- a/pkg/scheduler/framework/plugins/podtopologyspread/scoring.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/scoring.go
@@ -180,7 +180,9 @@ func (pl *PodTopologySpread) PreScore(
 		}
 		return nil
 	}
-	pl.parallelizer.Until(ctx, len(allNodes), processAllNode, pl.Name())
+	if err := pl.parallelizer.Until(ctx, len(allNodes), processAllNode, pl.Name()); err != nil {
+		return framework.NewStatus(framework.Error, err.Error())
+	}
 
 	cycleState.Write(preScoreStateKey, state)
 	return nil

--- a/pkg/scheduler/framework/preemption/preemption.go
+++ b/pkg/scheduler/framework/preemption/preemption.go
@@ -586,6 +586,8 @@ func (ev *Evaluator) DryRunPreemption(ctx context.Context, pod *v1.Pod, potentia
 		statusesLock.Unlock()
 		return nil
 	}
-	fh.Parallelizer().Until(ctx, len(potentialNodes), checkNode, ev.PluginName)
+	if err := fh.Parallelizer().Until(ctx, len(potentialNodes), checkNode, ev.PluginName); err != nil {
+		errs = append(errs, err)
+	}
 	return append(nonViolatingCandidates.get(), violatingCandidates.get()...), nodeStatuses, utilerrors.NewAggregate(errs)
 }

--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -96,6 +96,8 @@ var (
 	pendingPods                *metrics.GaugeVec
 	InFlightEvents             *metrics.GaugeVec
 	Goroutines                 *metrics.GaugeVec
+	GoroutinesDuration         *metrics.HistogramVec
+	GoroutinesExecutionTotal   *metrics.CounterVec
 
 	// PodSchedulingDuration is deprecated as of Kubernetes v1.28, and will be removed
 	// in v1.31. Please use PodSchedulingSLIDuration instead.
@@ -204,6 +206,23 @@ func InitMetrics() {
 			Help:           "Number of running goroutines split by the work they do such as binding.",
 			StabilityLevel: metrics.ALPHA,
 		}, []string{"operation"})
+	GoroutinesDuration = metrics.NewHistogramVec(
+		&metrics.HistogramOpts{
+			Subsystem:      SchedulerSubsystem,
+			Name:           "goroutines_duration_seconds",
+			Help:           "how long each preemption goroutine takes to complete",
+			Buckets:        metrics.ExponentialBuckets(0.01, 2, 20),
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"operation"})
+	GoroutinesExecutionTotal = metrics.NewCounterVec(
+		&metrics.CounterOpts{
+			Subsystem:      SchedulerSubsystem,
+			Name:           "goroutines_execution_total",
+			Help:           "how many preemption goroutines have executed",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"operation", "result"})
 
 	// PodSchedulingDuration is deprecated as of Kubernetes v1.28, and will be removed
 	// in v1.31. Please use PodSchedulingSLIDuration instead.

--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -210,7 +210,7 @@ func InitMetrics() {
 		&metrics.HistogramOpts{
 			Subsystem:      SchedulerSubsystem,
 			Name:           "goroutines_duration_seconds",
-			Help:           "how long each preemption goroutine takes to complete",
+			Help:           "Duration in seconds for running goroutines split by the work they do such as binding.",
 			Buckets:        metrics.ExponentialBuckets(0.01, 2, 20),
 			StabilityLevel: metrics.ALPHA,
 		},
@@ -219,7 +219,7 @@ func InitMetrics() {
 		&metrics.CounterOpts{
 			Subsystem:      SchedulerSubsystem,
 			Name:           "goroutines_execution_total",
-			Help:           "how many preemption goroutines have executed",
+			Help:           "Number of goroutines executed split by the work they do such as binding and the result of the work.",
 			StabilityLevel: metrics.ALPHA,
 		},
 		[]string{"operation", "result"})

--- a/pkg/scheduler/schedule_one.go
+++ b/pkg/scheduler/schedule_one.go
@@ -654,8 +654,7 @@ func (sched *Scheduler) findNodesThatPassFilters(
 	// Stops searching for more nodes once the configured number of feasible nodes
 	// are found.
 	if err := fwk.Parallelizer().Until(ctx, numAllNodes, checkNode, metrics.Filter); err != nil {
-		statusCode = framework.Error
-		return feasibleNodes, err
+		return nil, err
 	}
 	feasibleNodes = feasibleNodes[:feasibleNodesLen]
 	for _, item := range result {

--- a/pkg/scheduler/schedule_one.go
+++ b/pkg/scheduler/schedule_one.go
@@ -622,14 +622,14 @@ func (sched *Scheduler) findNodesThatPassFilters(
 		status *framework.Status
 	}
 	result := make([]*nodeStatus, numAllNodes)
-	checkNode := func(i int) {
+	checkNode := func(i int) error {
 		// We check the nodes starting from where we left off in the previous scheduling cycle,
 		// this is to make sure all nodes have the same chance of being examined across pods.
 		nodeInfo := nodes[(sched.nextStartNodeIndex+i)%numAllNodes]
 		status := fwk.RunFilterPluginsWithNominatedPods(ctx, state, pod, nodeInfo)
 		if status.Code() == framework.Error {
 			errCh.SendErrorWithCancel(status.AsError(), cancel)
-			return
+			return nil
 		}
 		if status.IsSuccess() {
 			length := atomic.AddInt32(&feasibleNodesLen, 1)
@@ -642,6 +642,7 @@ func (sched *Scheduler) findNodesThatPassFilters(
 		} else {
 			result[i] = &nodeStatus{node: nodeInfo.Node().Name, status: status}
 		}
+		return nil
 	}
 
 	beginCheckNode := time.Now()


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Implement new metrics `goroutines_duration_seconds` and `goroutines_execution_total` for async preemption.

#### Which issue(s) this PR fixes:
Fixes #128019 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Implement new metrics `goroutines_duration_seconds` and `goroutines_execution_total` for a better observability of goroutines running in the scheduler.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
