### PR TITLE
Makefile: escape $ to prevent confusing output

### DIFF
--- a/build/root/Makefile
+++ b/build/root/Makefile
@@ -203,7 +203,7 @@ define TEST_IT_HELP_INFO
 # Example:
 #   make test-integration
 #   make test-integration WHAT=./test/integration/kubelet GOFLAGS="-v -coverpkg=./pkg/kubelet/..." KUBE_COVER="y"
-#   make test-integration WHAT=./test/integration/pods GOFLAGS="-v" KUBE_TEST_ARGS='-run ^TestPodUpdateActiveDeadlineSeconds$'
+#   make test-integration WHAT=./test/integration/pods GOFLAGS="-v" KUBE_TEST_ARGS='-run ^TestPodUpdateActiveDeadlineSeconds$$'
 endef
 .PHONY: test-integration
 ifeq ($(PRINT_HELP),y)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Fix confusing warning:
```
$ make
Makefile:195: warning: undefined variable '''
```

and incorrect help output (no `$'` at the end of the last string) in the help output:
```
$ PRINT_HELP=y make test-integration
Makefile:195: warning: undefined variable '''
# Build and run integration tests.
#
# Args:
#   WHAT: Directory names to test.  All *_test.go files under these
#     directories will be run.  If not specified, "everything" will be tested.
#   KUBE_TEST_ARGS: Arguments to pass to the resulting go test invocation.
#
# Example:
#   make test-integration
#   make test-integration WHAT=./test/integration/kubelet GOFLAGS="-v -coverpkg=./pkg/kubelet/..." KUBE_COVER="y"
#   make test-integration WHAT=./test/integration/pods GOFLAGS="-v" KUBE_TEST_ARGS='-run ^TestPodUpdateActiveDeadlineSeconds
```

by reverting https://github.com/kubernetes/kubernetes/pull/127799

#### Does this PR introduce a user-facing change?

```release-note
NONE
```