### PR TITLE
[Kubeadm] KEP-4656: Add kubelet instance configuration to configure CRI socket for each node

### DIFF
--- a/cmd/kubeadm/app/componentconfigs/kubelet.go
+++ b/cmd/kubeadm/app/componentconfigs/kubelet.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 
 	"github.com/pkg/errors"
+
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 	kubeletconfig "k8s.io/kubelet/config/v1beta1"

--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -306,6 +306,10 @@ const (
 	// This file should exist under KubeletRunDirectory
 	KubeletConfigurationFileName = "config.yaml"
 
+	// KubeletInstanceConfigurationFileName is the name of the kubelet instance configuration file written
+	// to all nodes. This file should exist under KubeletRunDirectory.
+	KubeletInstanceConfigurationFileName = "instance-config.yaml"
+
 	// KubeletEnvFileName is a file "kubeadm init" writes at runtime. Using that interface, kubeadm can customize certain
 	// kubelet flags conditionally based on the environment at runtime. Also, parameters given to the configuration file
 	// might be passed through this file. "kubeadm init" writes one variable, with the name ${KubeletEnvFileVariableName}.

--- a/cmd/kubeadm/app/features/features.go
+++ b/cmd/kubeadm/app/features/features.go
@@ -40,6 +40,8 @@ const (
 	WaitForAllControlPlaneComponents = "WaitForAllControlPlaneComponents"
 	// ControlPlaneKubeletLocalMode is expected to be in alpha in v1.31, beta in v1.32
 	ControlPlaneKubeletLocalMode = "ControlPlaneKubeletLocalMode"
+	// NodeLocalCRISocket is expected to be in alpha in v1.32, beta in v1.33, ga in v1.35
+	NodeLocalCRISocket = "NodeLocalCRISocket"
 )
 
 // InitFeatureGates are the default feature gates for the init command
@@ -56,6 +58,7 @@ var InitFeatureGates = FeatureList{
 	EtcdLearnerMode:                  {FeatureSpec: featuregate.FeatureSpec{Default: true, PreRelease: featuregate.GA, LockToDefault: true}},
 	WaitForAllControlPlaneComponents: {FeatureSpec: featuregate.FeatureSpec{Default: false, PreRelease: featuregate.Alpha}},
 	ControlPlaneKubeletLocalMode:     {FeatureSpec: featuregate.FeatureSpec{Default: false, PreRelease: featuregate.Alpha}},
+	NodeLocalCRISocket:               {FeatureSpec: featuregate.FeatureSpec{Default: false, PreRelease: featuregate.Alpha}},
 }
 
 // Feature represents a feature being gated

--- a/cmd/kubeadm/app/phases/kubelet/flags_test.go
+++ b/cmd/kubeadm/app/phases/kubelet/flags_test.go
@@ -37,11 +37,11 @@ func TestBuildKubeletArgs(t *testing.T) {
 			name: "hostname override",
 			opts: kubeletFlagsOpts{
 				nodeRegOpts: &kubeadmapi.NodeRegistrationOptions{
-					CRISocket: "unix:///var/run/containerd/containerd.sock",
 					KubeletExtraArgs: []kubeadmapi.Arg{
 						{Name: "hostname-override", Value: "override-name"},
 					},
 				},
+				criSocket: "unix:///var/run/containerd/containerd.sock",
 			},
 			expected: []kubeadmapi.Arg{
 				{Name: "container-runtime-endpoint", Value: "unix:///var/run/containerd/containerd.sock"},
@@ -52,7 +52,6 @@ func TestBuildKubeletArgs(t *testing.T) {
 			name: "register with taints",
 			opts: kubeletFlagsOpts{
 				nodeRegOpts: &kubeadmapi.NodeRegistrationOptions{
-					CRISocket: "unix:///var/run/containerd/containerd.sock",
 					Taints: []v1.Taint{
 						{
 							Key:    "foo",
@@ -66,6 +65,7 @@ func TestBuildKubeletArgs(t *testing.T) {
 						},
 					},
 				},
+				criSocket:                "unix:///var/run/containerd/containerd.sock",
 				registerTaintsUsingFlags: true,
 			},
 			expected: []kubeadmapi.Arg{
@@ -76,10 +76,9 @@ func TestBuildKubeletArgs(t *testing.T) {
 		{
 			name: "pause image is set",
 			opts: kubeletFlagsOpts{
-				nodeRegOpts: &kubeadmapi.NodeRegistrationOptions{
-					CRISocket: "unix:///var/run/containerd/containerd.sock",
-				},
-				pauseImage: "registry.k8s.io/pause:ver",
+				nodeRegOpts: &kubeadmapi.NodeRegistrationOptions{},
+				criSocket:   "unix:///var/run/containerd/containerd.sock",
+				pauseImage:  "registry.k8s.io/pause:ver",
 			},
 			expected: []kubeadmapi.Arg{
 				{Name: "container-runtime-endpoint", Value: "unix:///var/run/containerd/containerd.sock"},

--- a/cmd/kubeadm/app/phases/upgrade/postupgrade.go
+++ b/cmd/kubeadm/app/phases/upgrade/postupgrade.go
@@ -27,14 +27,15 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	errorsutil "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
+	kubeletconfig "k8s.io/kubelet/config/v1beta1"
 
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
+	"k8s.io/kubernetes/cmd/kubeadm/app/features"
 	kubeletphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/kubelet"
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
 	dryrunutil "k8s.io/kubernetes/cmd/kubeadm/app/util/dryrun"
@@ -124,19 +125,57 @@ func WriteKubeletConfigFiles(cfg *kubeadmapi.InitConfiguration, patchesDir strin
 		fmt.Printf("[dryrun] Would back up kubelet config file to %s\n", dest)
 	}
 
-	errs := []error{}
+	if features.Enabled(cfg.FeatureGates, features.NodeLocalCRISocket) {
+		// If instance-config.yaml exist on disk, we don't need to create it.
+		_, err := os.Stat(filepath.Join(kubeletDir, kubeadmconstants.KubeletInstanceConfigurationFileName))
+		if os.IsNotExist(err) {
+			var containerRuntimeEndpoint string
+			dynamicFlags, err := kubeletphase.ReadKubeletDynamicEnvFile(filepath.Join(kubeletDir, kubeadmconstants.KubeletEnvFileName))
+			if err == nil {
+				args := kubeadmutil.ArgumentsFromCommand(dynamicFlags)
+				for _, arg := range args {
+					if arg.Name == "container-runtime-endpoint" {
+						containerRuntimeEndpoint = arg.Value
+						break
+					}
+				}
+			} else if dryRun {
+				fmt.Fprintf(os.Stdout, "[dryrun] would read the flag --container-runtime-endpoint value from %q, which is missing. "+
+					"Using default socket %q instead", kubeadmconstants.KubeletEnvFileName, kubeadmconstants.DefaultCRISocket)
+				containerRuntimeEndpoint = kubeadmconstants.DefaultCRISocket
+			} else {
+				return errors.Wrap(err, "error reading kubeadm flags file")
+			}
+
+			kubeletConfig := &kubeletconfig.KubeletConfiguration{
+				ContainerRuntimeEndpoint: containerRuntimeEndpoint,
+			}
+
+			if err := kubeletphase.WriteInstanceConfigToDisk(kubeletConfig, kubeletDir); err != nil {
+				return errors.Wrap(err, "error writing kubelet instance configuration")
+			}
+
+			if dryRun { // Print what contents would be written
+				err = dryrunutil.PrintDryRunFile(kubeadmconstants.KubeletInstanceConfigurationFileName, kubeletDir, kubeadmconstants.KubeletRunDirectory, os.Stdout)
+				if err != nil {
+					return errors.Wrap(err, "error printing kubelet instance configuration file on dryrun")
+				}
+			}
+		}
+	}
+
 	// Write the configuration for the kubelet down to disk so the upgraded kubelet can start with fresh config
 	if err := kubeletphase.WriteConfigToDisk(&cfg.ClusterConfiguration, kubeletDir, patchesDir, out); err != nil {
-		errs = append(errs, errors.Wrap(err, "error writing kubelet configuration to file"))
+		return errors.Wrap(err, "error writing kubelet configuration to file")
 	}
 
 	if dryRun { // Print what contents would be written
 		err := dryrunutil.PrintDryRunFile(kubeadmconstants.KubeletConfigurationFileName, kubeletDir, kubeadmconstants.KubeletRunDirectory, os.Stdout)
 		if err != nil {
-			errs = append(errs, errors.Wrap(err, "error printing files on dryrun"))
+			return errors.Wrap(err, "error printing kubelet configuration file on dryrun")
 		}
 	}
-	return errorsutil.NewAggregate(errs)
+	return nil
 }
 
 // GetKubeletDir gets the kubelet directory based on whether the user is dry-running this command or not.

--- a/cmd/kubeadm/app/util/config/cluster_test.go
+++ b/cmd/kubeadm/app/util/config/cluster_test.go
@@ -335,7 +335,7 @@ func TestGetNodeRegistration(t *testing.T) {
 			}
 
 			cfg := &kubeadmapi.InitConfiguration{}
-			err = GetNodeRegistration(cfgPath, client, &cfg.NodeRegistration)
+			err = GetNodeRegistration(cfgPath, client, &cfg.NodeRegistration, &cfg.ClusterConfiguration)
 			if rt.expectedError != (err != nil) {
 				t.Errorf("unexpected return err from getNodeRegistration: %v", err)
 				return

--- a/cmd/kubeadm/app/util/patches/patches.go
+++ b/cmd/kubeadm/app/util/patches/patches.go
@@ -53,20 +53,20 @@ type PatchTarget struct {
 
 // PatchManager defines an object that can apply patches.
 type PatchManager struct {
-	patchSets    []*patchSet
+	patchSets    []*PatchSet
 	knownTargets []string
 	output       io.Writer
 }
 
-// patchSet defines a set of patches of a certain type that can patch a PatchTarget.
-type patchSet struct {
+// PatchSet defines a set of patches of a certain type that can patch a PatchTarget.
+type PatchSet struct {
 	targetName string
 	patchType  types.PatchType
 	patches    []string
 }
 
 // String() is used for unit-testing.
-func (ps *patchSet) String() string {
+func (ps *PatchSet) String() string {
 	return fmt.Sprintf(
 		"{%q, %q, %#v}",
 		ps.targetName,
@@ -111,6 +111,15 @@ var (
 // KnownTargets returns the locally defined knownTargets.
 func KnownTargets() []string {
 	return knownTargets
+}
+
+// NewPatchManager creates a patch manager that can be used to apply patches to "knownTargets".
+func NewPatchManager(patchSets []*PatchSet, knownTargets []string, output io.Writer) *PatchManager {
+	return &PatchManager{
+		patchSets:    patchSets,
+		knownTargets: knownTargets,
+		output:       output,
+	}
 }
 
 // GetPatchManagerForPath creates a patch manager that can be used to apply patches to "knownTargets".
@@ -257,8 +266,8 @@ func parseFilename(fileName string, knownTargets []string) (string, types.PatchT
 	return targetName, patchType, nil, nil
 }
 
-// createPatchSet creates a patchSet object, by splitting the given "data" by "\n---".
-func createPatchSet(targetName string, patchType types.PatchType, data string) (*patchSet, error) {
+// CreatePatchSet creates a patchSet object, by splitting the given "data" by "\n---".
+func CreatePatchSet(targetName string, patchType types.PatchType, data string) (*PatchSet, error) {
 	var patches []string
 
 	// Split the patches and convert them to JSON.
@@ -285,7 +294,7 @@ func createPatchSet(targetName string, patchType types.PatchType, data string) (
 		patches = append(patches, string(patchJSON))
 	}
 
-	return &patchSet{
+	return &PatchSet{
 		targetName: targetName,
 		patchType:  patchType,
 		patches:    patches,
@@ -294,10 +303,10 @@ func createPatchSet(targetName string, patchType types.PatchType, data string) (
 
 // getPatchSetsFromPath walks a path, ignores sub-directories and non-patch files, and
 // returns a list of patchFile objects.
-func getPatchSetsFromPath(targetPath string, knownTargets []string, output io.Writer) ([]*patchSet, []string, []string, error) {
+func getPatchSetsFromPath(targetPath string, knownTargets []string, output io.Writer) ([]*PatchSet, []string, []string, error) {
 	patchFiles := []string{}
 	ignoredFiles := []string{}
-	patchSets := []*patchSet{}
+	patchSets := []*PatchSet{}
 
 	// Check if targetPath is a directory.
 	info, err := os.Lstat(targetPath)
@@ -349,7 +358,7 @@ func getPatchSetsFromPath(targetPath string, knownTargets []string, output io.Wr
 		}
 
 		// Create a patchSet object.
-		patchSet, err := createPatchSet(targetName, patchType, string(data))
+		patchSet, err := CreatePatchSet(targetName, patchType, string(data))
 		if err != nil {
 			return err
 		}

--- a/cmd/kubeadm/app/util/patches/patches_test.go
+++ b/cmd/kubeadm/app/util/patches/patches_test.go
@@ -120,7 +120,7 @@ func TestCreatePatchSet(t *testing.T) {
 		name             string
 		targetName       string
 		patchType        types.PatchType
-		expectedPatchSet *patchSet
+		expectedPatchSet *PatchSet
 		data             string
 	}{
 		{
@@ -129,7 +129,7 @@ func TestCreatePatchSet(t *testing.T) {
 			targetName: "etcd",
 			patchType:  types.StrategicMergePatchType,
 			data:       "foo: bar\n---\nfoo: baz\n",
-			expectedPatchSet: &patchSet{
+			expectedPatchSet: &PatchSet{
 				targetName: "etcd",
 				patchType:  types.StrategicMergePatchType,
 				patches:    []string{`{"foo":"bar"}`, `{"foo":"baz"}`},
@@ -140,7 +140,7 @@ func TestCreatePatchSet(t *testing.T) {
 			targetName: "etcd",
 			patchType:  types.StrategicMergePatchType,
 			data:       `{"foo":"bar"}` + "\n---\n" + `{"foo":"baz"}`,
-			expectedPatchSet: &patchSet{
+			expectedPatchSet: &PatchSet{
 				targetName: "etcd",
 				patchType:  types.StrategicMergePatchType,
 				patches:    []string{`{"foo":"bar"}`, `{"foo":"baz"}`},
@@ -151,7 +151,7 @@ func TestCreatePatchSet(t *testing.T) {
 			targetName: "etcd",
 			patchType:  types.StrategicMergePatchType,
 			data:       `{"foo":"bar"}` + "\n---\n     ---\n" + `{"foo":"baz"}`,
-			expectedPatchSet: &patchSet{
+			expectedPatchSet: &PatchSet{
 				targetName: "etcd",
 				patchType:  types.StrategicMergePatchType,
 				patches:    []string{`{"foo":"bar"}`, `{"foo":"baz"}`},
@@ -161,7 +161,7 @@ func TestCreatePatchSet(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			ps, _ := createPatchSet(tc.targetName, tc.patchType, tc.data)
+			ps, _ := CreatePatchSet(tc.targetName, tc.patchType, tc.data)
 			if !reflect.DeepEqual(ps, tc.expectedPatchSet) {
 				t.Fatalf("expected patch set:\n%+v\ngot:\n%+v\n", tc.expectedPatchSet, ps)
 			}
@@ -189,7 +189,7 @@ func TestGetPatchSetsForPath(t *testing.T) {
 	tests := []struct {
 		name                 string
 		filesToWrite         []string
-		expectedPatchSets    []*patchSet
+		expectedPatchSets    []*PatchSet
 		expectedPatchFiles   []string
 		expectedIgnoredFiles []string
 		expectedError        bool
@@ -199,7 +199,7 @@ func TestGetPatchSetsForPath(t *testing.T) {
 			name:         "valid: patch files are sorted and non-patch files are ignored",
 			filesToWrite: []string{"kube-scheduler+merge.json", "kube-apiserver+json.yaml", "etcd.yaml", "foo", "bar.json"},
 			patchData:    patchData,
-			expectedPatchSets: []*patchSet{
+			expectedPatchSets: []*PatchSet{
 				{
 					targetName: "etcd",
 					patchType:  types.StrategicMergePatchType,
@@ -225,7 +225,7 @@ func TestGetPatchSetsForPath(t *testing.T) {
 			filesToWrite:         []string{"kube-scheduler.json"},
 			expectedPatchFiles:   []string{},
 			expectedIgnoredFiles: []string{"kube-scheduler.json"},
-			expectedPatchSets:    []*patchSet{},
+			expectedPatchSets:    []*PatchSet{},
 		},
 		{
 			name:          "invalid: bad patch type in filename returns and error",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR implements KEP-4656:

It will create an instance config per node and overriding the `ContainerRuntimeEndpoint` in the kubelet config when calling kubeadm commands. This will eliminate the need for kubeadm to store CRI socket configuration on each Node object.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
This PR modifies the content of kubeadm:

**kubeadm init:**
  If the CRI socket provided in the kubeadm configuration is set, it is used first and the `/var/lib/kubelet/instance-config.yaml` configuration file is generated based on it. If the CRI socket is not set, the container runtime endpoint is automatically detected uploaded to the global configuration, and `/var/lib/kubelet/instance-config.yaml` will be generated.

**kubeadm join:**
  If the CRI socket provided in the kubeadm configuration is set, it is used first and the `/var/lib/kubelet/instance-config.yaml` configuration file is generated based on it, overwriting the kubelet configuration downloaded from the global configuration; If no CRI socket is specified, the socket is automatically detected on the node and `/var/lib/kubelet/instance-config.yaml` is generated based on it.

**kubeadm upgrade:**
  kubeadm upgrade node/apply will check the `--container-runtime-endpoint` args in the `/var/lib/kubelet/kubeadm-flags.env` file and generate `/var/lib/kubelet/instance-config.yaml` based on them, and override the ContainerRuntimeEndpoint field to `/var/lib/kubelet/config.yaml`.


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: added the feature gate `NodeLocalCRISocket`. When the feature gate is enabled, kubeadm will generate the `/var/lib/kubelet/instance-config.yaml` file to customize the `containerRuntimeEndpoint` field in the kubelet configuration for each node and will not write the same CRI socket on the Node object as an annotation.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
https://github.com/kubernetes/enhancements/tree/master/keps/sig-cluster-lifecycle/kubeadm/4656-add-kubelet-instance-configuration
```
