### PR TITLE
make more explict superuser validation on ValidatingAdmissionPolicy

### DIFF
--- a/pkg/registry/admissionregistration/validatingadmissionpolicy/authz.go
+++ b/pkg/registry/admissionregistration/validatingadmissionpolicy/authz.go
@@ -22,10 +22,11 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
+	userpkg "k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/kubernetes/pkg/apis/admissionregistration"
-	rbacregistry "k8s.io/kubernetes/pkg/registry/rbac"
 )
 
 func (v *validatingAdmissionPolicyStrategy) authorizeCreate(ctx context.Context, obj runtime.Object) error {
@@ -59,14 +60,15 @@ func (v *validatingAdmissionPolicyStrategy) authorize(ctx context.Context, polic
 		return nil
 	}
 
-	// for superuser, skip all checks
-	if rbacregistry.EscalationAllowed(ctx) {
-		return nil
-	}
-
 	user, ok := genericapirequest.UserFrom(ctx)
 	if !ok {
 		return fmt.Errorf("cannot identify user to authorize read access to paramKind resources")
+	}
+
+	// for superuser, skip all checks
+	isSystemAdmin := sets.New(user.GetGroups()...).Has(userpkg.SystemPrivilegedGroup)
+	if isSystemAdmin {
+		return nil
 	}
 
 	paramKind := policy.Spec.ParamKind

--- a/pkg/registry/admissionregistration/validatingadmissionpolicybinding/authz.go
+++ b/pkg/registry/admissionregistration/validatingadmissionpolicybinding/authz.go
@@ -22,10 +22,11 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
+	userpkg "k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/kubernetes/pkg/apis/admissionregistration"
-	rbacregistry "k8s.io/kubernetes/pkg/registry/rbac"
 )
 
 func (v *validatingAdmissionPolicyBindingStrategy) authorizeCreate(ctx context.Context, obj runtime.Object) error {
@@ -59,14 +60,15 @@ func (v *validatingAdmissionPolicyBindingStrategy) authorize(ctx context.Context
 		return nil
 	}
 
-	// for superuser, skip all checks
-	if rbacregistry.EscalationAllowed(ctx) {
-		return nil
-	}
-
 	user, ok := genericapirequest.UserFrom(ctx)
 	if !ok {
 		return fmt.Errorf("cannot identify user to authorize read access to paramRef object")
+	}
+
+	// for superuser, skip all checks
+	isSystemAdmin := sets.New(user.GetGroups()...).Has(userpkg.SystemPrivilegedGroup)
+	if isSystemAdmin {
+		return nil
 	}
 
 	// default to requiring permissions on all group/version/resources


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Related issue #127935 

For ValidatingAdmissionPolicy we misuse ExcalationAllowed slightly to perform what is logically a isSystemAdmin check. We should make it more explicit.

#### Which issue(s) this PR fixes:

Fixes #127935 

#### Special notes for your reviewer:

Any predictions on the merge of 
[PR12713](https://github.com/kubernetes/kubernetes/pull/127134) ? to adjust in MutatingAdmissionPolicy too.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
