### PR TITLE
Enable strict validation for ResourceQuotaConfiguration

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/resourcequota/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/resourcequota/config.go
@@ -29,7 +29,7 @@ import (
 
 var (
 	scheme = runtime.NewScheme()
-	codecs = serializer.NewCodecFactory(scheme)
+	codecs = serializer.NewCodecFactory(scheme, serializer.EnableStrict)
 )
 
 func init() {

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/resourcequota/config_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/resourcequota/config_test.go
@@ -44,6 +44,34 @@ func TestLoadConfiguration(t *testing.T) {
 			expectErr: `no kind "Unknown" is registered`,
 		},
 		{
+			name: "duplicate field error; strict validation",
+			input: `
+kind: ResourceQuotaConfiguration
+apiVersion: apiserver.config.k8s.io/v1
+limitedResources:
+- apiGroup: ""
+  resource: persistentvolumeclaims
+  resource: persistentvolumeclaims
+  matchContains:
+  - .storageclass.storage.k8s.io/requests.storage
+`,
+			expectErr: `strict decoding error`,
+		},
+		{
+			name: "unknown field error; strict validation",
+			input: `
+kind: ResourceQuotaConfiguration
+apiVersion: apiserver.config.k8s.io/v1
+limitedResources:
+- apiGroup: ""
+  foo:      bar
+  resource: persistentvolumeclaims
+  matchContains:
+  - .storageclass.storage.k8s.io/requests.storage
+`,
+			expectErr: `strict decoding error`,
+		},
+		{
 			name: "valid v1alpha1 config",
 			input: `
 kind: Configuration


### PR DESCRIPTION
* `ResourceQuotaConfiguration` within the admission control configuration file are now decoded using `EnableStrict`
  * Duplicate fields in the configuration will now cause an error during decoding.
  * Unknown fields in the configuration will now cause an error during decoding.

/kind cleanup

```release-note
kube-apiserver ResourceQuotaConfiguration admission plugin subsection within `--admission-control-config-file` files are now validated strictly (EnableStrict). Duplicate and unknown fields in the configuration will now cause an error.
```
One of several PR's to address: https://github.com/kubernetes/kubernetes/issues/127940
