### PR TITLE
Don't assign a storage class to claim when the user asked for a specific volume.

### DIFF
--- a/plugin/pkg/admission/storage/storageclass/setdefault/admission.go
+++ b/plugin/pkg/admission/storage/storageclass/setdefault/admission.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+
 	"k8s.io/kubernetes/pkg/volume/util"
 
 	"k8s.io/klog/v2"
@@ -100,6 +101,11 @@ func (a *claimDefaulterPlugin) Admit(ctx context.Context, attr admission.Attribu
 
 	if helper.PersistentVolumeClaimHasClass(pvc) {
 		// The user asked for a class.
+		return nil
+	}
+
+	if pvc.Spec.VolumeName != "" {
+		// The user asked for a specific volume.
 		return nil
 	}
 

--- a/plugin/pkg/admission/storage/storageclass/setdefault/admission_test.go
+++ b/plugin/pkg/admission/storage/storageclass/setdefault/admission_test.go
@@ -155,6 +155,18 @@ func TestAdmission(t *testing.T) {
 			Namespace: "ns",
 		},
 	}
+	claimWithVolume := &api.PersistentVolumeClaim{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "PersistentVolumeClaim",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "claimWithVolumeName",
+			Namespace: "ns",
+		},
+		Spec: api.PersistentVolumeClaimSpec{
+			VolumeName: "volume",
+		},
+	}
 
 	tests := []struct {
 		name              string
@@ -176,6 +188,13 @@ func TestAdmission(t *testing.T) {
 			claimWithNoClass,
 			false,
 			"default1",
+		},
+		{
+			"one default, no modification of PVC with volume!=''",
+			[]*storagev1.StorageClass{defaultClass1, classWithFalseDefault, classWithNoDefault, classWithEmptyDefault},
+			claimWithVolume,
+			false,
+			"",
 		},
 		{
 			"one default, no modification of PVC with class=''",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

There are 2 approaches to assigning a default storage class to a persistent volume claim (PVC) in Kubernetes when the storage class is not specified in the PVC object. The first approach is to use `DefaultStorageClass` admission plugin which assigns a default storage class to a PVC if the storage class field of the PVC is unset when it is created. The limitation of this approach is that it only works for PVCs created after the admission plugin is enabled and the default storage class existed in the cluster before the PVC was created. The second approach unlocks the limitation of the first approach by leveraging the `PV controller` to retroactively assign a default storage class to PVCs when it reconciles the unbound PVC objects if the PVC object does not have a storage class and no user-specified volume name is set. 

There is a gap between the two approaches on how to handle the PVC when the PVC has a user-specified volume name.

- https://github.com/carlory/kubernetes/blob/master/plugin/pkg/admission/storage/storageclass/setdefault/admission.go#L108
- https://github.com/carlory/kubernetes/blob/master/pkg/controller/volume/persistentvolume/pv_controller.go#L335

It may make users confused. See https://github.com/kubernetes/website/issues/42288 and https://github.com/kubernetes/website/pull/48200#discussion_r1788537037

StorageClass describes the parameters for a class of storage for which PersistentVolumes can be dynamically provisioned. When a user creates a PVC with a given storage class, if the PVC does not contain a user-specified volume name, the `PV controller` or `external provisioner` will dynamically provision a PV for the PVC. 

If a user asks for a given volume, the user must create the PV object manually because the volume won't be dynamically provisioned.

- https://github.com/carlory/kubernetes/blob/master/pkg/controller/volume/persistentvolume/pv_controller.go#L414
- https://github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/blob/master/controller/controller.go#L1213

There is a side effect for the user-specified volume case, see https://github.com/kubernetes/website/pull/48200#discussion_r1798634882. 

Even if we have clarified the breaking change on the `storage class` field of claim in the KEP, user should assign an empty storage class to the PVC object explicitly when the PVC has an user-specified volume name (static provision).

- https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage/3333-retroactive-default-storage-class#behavior-change
- https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage/3333-retroactive-default-storage-class#risks-and-mitigations

And the website is updated to reflect the change. But some users may still get confused. Why need to assign an empty storage class to the PVC object explicitly when the PVC has an user-specified volume name? 

I have a proposal to improve the user experience. It will clear the confusion and make the behavior more consistent and predictable.

1. `DefaultStorageClass` admission plugin does not again assign a default storage class to the PVC object when the PVC has a user-specified volume name.
2. kube-apiserver will reject the PVC object updation if a user/controller tries to update the storage class field of the PVC object from nil to non-nil when the PVC has a user-specified volume name. (I'm not sure whether it should be applied)
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
DefaultStorageClass admission plugins would not assign a default storage class to a claim when the user asked for a specific volume.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
