### PR TITLE
Add scheduler_perf test case for AssignedPodAdd event handling

### DIFF
--- a/test/integration/scheduler_perf/config/event_handling/podadd-node.yaml
+++ b/test/integration/scheduler_perf/config/event_handling/podadd-node.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Node
+metadata:
+  generateName: scheduler-perf-
+spec: {}
+status:
+  capacity:
+    pods: "3000"
+    cpu: "4"
+    memory: 32Gi
+  conditions:
+    - status: "True"
+      type: Ready
+  phase: Running

--- a/test/integration/scheduler_perf/config/event_handling/podadd-pod-interpodaffinity.yaml
+++ b/test/integration/scheduler_perf/config/event_handling/podadd-pod-interpodaffinity.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  generateName: pod-interpodaffinity-
+  labels:
+    type: unsched
+spec:
+  affinity:
+    podAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchLabels:
+            color: yellow-{{ .Index }}
+        topologyKey: kubernetes.io/hostname
+        namespaces: ["interpodaffinity"]
+  containers:
+  - image: registry.k8s.io/pause:3.10
+    name: pause

--- a/test/integration/scheduler_perf/config/event_handling/podadd-pod-podtopologyspread.yaml
+++ b/test/integration/scheduler_perf/config/event_handling/podadd-pod-podtopologyspread.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  generateName: pod-podtopologyspread-
+  labels:
+    type: unsched
+    topology: blue
+spec:
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchLabels:
+            color: green
+        topologyKey: kubernetes.io/hostname
+        namespaces: ["podtopologyspread"]
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: DoNotSchedule
+      labelSelector:
+        matchLabels:
+          topology: blue
+  containers:
+  - image: registry.k8s.io/pause:3.10
+    name: pause

--- a/test/integration/scheduler_perf/config/event_handling/podadd-pod-unblocker-affinity.yaml
+++ b/test/integration/scheduler_perf/config/event_handling/podadd-pod-unblocker-affinity.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  generateName: pod-unblocker-affinity-
+  labels:
+    color: yellow-{{ .Index }}
+spec:
+  containers:
+  - image: registry.k8s.io/pause:3.10
+    name: pause

--- a/test/integration/scheduler_perf/config/event_handling/podadd-pod-unblocker-topology.yaml
+++ b/test/integration/scheduler_perf/config/event_handling/podadd-pod-unblocker-topology.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  generateName: pod-unblocker-topology-
+  labels:
+    topology: blue
+    color: green
+spec:
+  affinity:
+    podAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchLabels:
+            color: green
+        topologyKey: kubernetes.io/hostname
+        namespaces: ["podtopologyspread"]
+  containers:
+  - image: registry.k8s.io/pause:3.10
+    name: pause

--- a/test/integration/scheduler_perf/config/event_handling/podadd-pod-with-label.yaml
+++ b/test/integration/scheduler_perf/config/event_handling/podadd-pod-with-label.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  generateName: pod-with-label-
+  labels:
+    color: green
+spec:
+  containers:
+  - image: registry.k8s.io/pause:3.10
+    name: pause

--- a/test/integration/scheduler_perf/config/performance-config.yaml
+++ b/test/integration/scheduler_perf/config/performance-config.yaml
@@ -1881,3 +1881,75 @@
     params:
       nodes: 100
       measurePods: 1000 # Must be initNodes * 10
+
+# This test case is used to measure the performance of queuing hints when handling the AssignedPodAdd events.
+# First, two nodes are created. Then, one pod is created and scheduled on one of the nodes.
+# Next, group of topology spreading pods tries to be scheduled, but they can only fill one node,
+# because of the anti affinity to the pod on the second node.
+# Then, group of interpodaffinity pods is created and wait for pods with matching labels to be scheduled first.
+# Next, new pods are scheduled that unblock the previously unschedulable pods, by balancing the topology
+# and scheduling pods with matching labels to the intepodaffinity pods.
+# Plugins covered: InterPodAffinity and PodTopologySpread.
+- name: EventHandlingPodAdd
+  featureGates:
+    SchedulerQueueingHints: true
+  workloadTemplate:
+  # Create two nodes with enough capacity.
+  - opcode: createNodes
+    count: 2
+    nodeTemplatePath: config/event_handling/podadd-node.yaml
+  # Create one pod with label that will block topology spreading pods 
+  # from being scheduled on one node using pod anti affinity.
+  - opcode: createPods
+    count: 1
+    podTemplatePath: config/event_handling/podadd-pod-with-label.yaml
+    namespace: podtopologyspread
+  # Collect metrics for unsched pods created below.
+  - opcode: startCollectingMetrics
+    name: unschedPods
+    namespaces: [podtopologyspread, interpodaffinity]
+    labelSelector:
+      type: unsched
+  # Create pods blocked using PodTopologySpread plugin.
+  # Max skew is configured to 1, so more pods need to be created on the first node 
+  # (with the pod created above), to fill up the second node with these pods.
+  - opcode: createPods
+    countParam: $measurePods
+    podTemplatePath: config/event_handling/podadd-pod-podtopologyspread.yaml
+    skipWaitToCompletion: true
+    namespace: podtopologyspread
+  # Create pods blocked using InterPodAffinity plugin.
+  # They don't have the affinity to themselves, 
+  # so have to wait for another pods with matching labels to be created at first.
+  - opcode: createPods
+    countParam: $measurePods
+    podTemplatePath: config/event_handling/podadd-pod-interpodaffinity.yaml
+    skipWaitToCompletion: true
+    namespace: interpodaffinity
+  # Wait for unschedulable pods to be processed by the scheduler.
+  - opcode: barrier
+    stageRequirement: Attempted
+    labelSelector:
+      type: unsched
+  # Create pods that will get scheduled on the node with the first pod created with matching label.
+  # Their creation will gradually unblock topology spreading pods and make them schedulable on the second node.
+  - opcode: createPods
+    countParam: $measurePods
+    podTemplatePath: config/event_handling/podadd-pod-unblocker-topology.yaml
+    namespace: podtopologyspread
+  # Create pods with matching labels to the affinity of previously created interpodaffinity pods.
+  # Each of them will unblock one pod and make it schedulable.
+  - opcode: createPods
+    countParam: $measurePods
+    podTemplatePath: config/event_handling/podadd-pod-unblocker-affinity.yaml
+    namespace: interpodaffinity
+  # Wait for previously unschedulable pods to be scheduled.
+  - opcode: barrier
+    labelSelector:
+      type: unsched
+  - opcode: stopCollectingMetrics
+  workloads:
+  - name: 1000Pods
+    labels: [performance, short]
+    params:
+      measurePods: 1000


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

It adds a scheduler_perf test case focused on utilizing `scheduler_queueing_hint_execution_duration_seconds` metric for plugins with hints for `AssignedPodAdd` event. It runs all `AssignedPodAdd` QueueingHintFn for in-tree plugins: InterPodAffinity and PodTopologySpread.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
