### PR TITLE
CRI client: use default timeout for ImageFsInfo RPC

### DIFF
--- a/staging/src/k8s.io/cri-client/pkg/remote_image.go
+++ b/staging/src/k8s.io/cri-client/pkg/remote_image.go
@@ -232,9 +232,7 @@ func (r *remoteImageService) RemoveImage(ctx context.Context, image *runtimeapi.
 
 // ImageFsInfo returns information of the filesystem that is used to store images.
 func (r *remoteImageService) ImageFsInfo(ctx context.Context) (*runtimeapi.ImageFsInfoResponse, error) {
-	// Do not set timeout, because `ImageFsInfo` takes time.
-	// TODO(random-liu): Should we assume runtime should cache the result, and set timeout here?
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel := context.WithTimeout(ctx, r.timeout)
 	defer cancel()
 
 	return r.imageFsInfoV1(ctx)


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
The RPC call usually does not take much time for containerd or CRI-O. We now assume the default timeout is fine and therefore resolve the `TODO`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
None

#### Special notes for your reviewer:
cc @kubernetes/sig-node-pr-reviews 
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
CRI client: use default timeout for `ImageFsInfo` RPC
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
