### PR TITLE
KEP-3926: add a new type to represent a corrupt object in storage error

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/errors.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/errors.go
@@ -37,6 +37,7 @@ const (
 	ErrCodeInvalidObj
 	ErrCodeUnreachable
 	ErrCodeTimeout
+	ErrCodeCorruptObj
 )
 
 var errCodeToMessage = map[int]string{
@@ -46,6 +47,7 @@ var errCodeToMessage = map[int]string{
 	ErrCodeInvalidObj:               "invalid object",
 	ErrCodeUnreachable:              "server unreachable",
 	ErrCodeTimeout:                  "request timeout",
+	ErrCodeCorruptObj:               "corrupt object",
 }
 
 func NewKeyNotFoundError(key string, rv int64) *StorageError {
@@ -82,30 +84,45 @@ func NewUnreachableError(key string, rv int64) *StorageError {
 
 func NewTimeoutError(key, msg string) *StorageError {
 	return &StorageError{
-		Code:               ErrCodeTimeout,
-		Key:                key,
-		AdditionalErrorMsg: msg,
+		Code: ErrCodeTimeout,
+		Key:  key,
+		err:  errors.New(msg),
 	}
 }
 
 func NewInvalidObjError(key, msg string) *StorageError {
 	return &StorageError{
-		Code:               ErrCodeInvalidObj,
-		Key:                key,
-		AdditionalErrorMsg: msg,
+		Code: ErrCodeInvalidObj,
+		Key:  key,
+		err:  errors.New(msg),
+	}
+}
+
+// NewCorruptObjError returns a new StorageError, it represents a corrupt object:
+// a) object data retrieved from the storage failed to transform with the given err.
+// b) the given object failed to decode with the given err
+func NewCorruptObjError(key string, err error) *StorageError {
+	return &StorageError{
+		Code: ErrCodeCorruptObj,
+		Key:  key,
+		err:  err,
 	}
 }
 
 type StorageError struct {
-	Code               int
-	Key                string
-	ResourceVersion    int64
-	AdditionalErrorMsg string
+	Code            int
+	Key             string
+	ResourceVersion int64
+
+	// inner error
+	err error
 }
 
+func (e *StorageError) Unwrap() error { return e.err }
+
 func (e *StorageError) Error() string {
-	return fmt.Sprintf("StorageError: %s, Code: %d, Key: %s, ResourceVersion: %d, AdditionalErrorMsg: %s",
-		errCodeToMessage[e.Code], e.Code, e.Key, e.ResourceVersion, e.AdditionalErrorMsg)
+	return fmt.Sprintf("StorageError: %s, Code: %d, Key: %s, ResourceVersion: %d, AdditionalErrorMsg: %v",
+		errCodeToMessage[e.Code], e.Code, e.Key, e.ResourceVersion, e.err)
 }
 
 // IsNotFound returns true if and only if err is "key" not found error.
@@ -136,6 +153,21 @@ func IsRequestTimeout(err error) bool {
 // IsInvalidObj returns true if and only if err is invalid error
 func IsInvalidObj(err error) bool {
 	return isErrCode(err, ErrCodeInvalidObj)
+}
+
+// IsCorruptObject returns true if and only if:
+// a) the given object data retrieved from the storage is not transformable, or
+// b) the given object failed to decode properly
+func IsCorruptObject(err error) bool {
+	if err == nil {
+		return false
+	}
+	var storageErr *StorageError
+	if !errors.As(err, &storageErr) {
+		return false
+	}
+
+	return storageErr.Code == ErrCodeCorruptObj
 }
 
 func isErrCode(err error, code int) bool {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind feature

#### What this PR does / why we need it:

- add a new type `ErrCodeCorruptObj` to represent a corrupt object in storage error
- add a new private member `err error` to `storage.StorageError` to hold the inner error so we can do proper error checking. 
- remove the `AdditionalErrorMsg` field since both `err` and `AdditionalErrorMsg` together are confusing to the user. 


#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

https://github.com/kubernetes/kubernetes/pull/127513 uses this error type

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

KEP: https://github.com/kubernetes/enhancements/pull/3927

```docs

```
