### PR TITLE
credential provider config: detect typos

### DIFF
--- a/pkg/credentialprovider/plugin/config_test.go
+++ b/pkg/credentialprovider/plugin/config_test.go
@@ -33,7 +33,7 @@ func Test_readCredentialProviderConfigFile(t *testing.T) {
 		name       string
 		configData string
 		config     *kubeletconfig.CredentialProviderConfig
-		expectErr  bool
+		expectErr  string
 	}{
 		{
 			name: "config with 1 plugin and 1 image matcher",
@@ -293,7 +293,7 @@ providers:
     - name: FOO
       value: BAR`,
 			config:    nil,
-			expectErr: true,
+			expectErr: `no kind "WrongKind" is registered for version "kubelet.config.k8s.io/v1alpha1"`,
 		},
 		{
 			name: "config with wrong apiversion",
@@ -312,7 +312,27 @@ providers:
     - name: FOO
       value: BAR`,
 			config:    nil,
-			expectErr: true,
+			expectErr: `no kind "CredentialProviderConfig" is registered for version "foobar/v1alpha1`,
+		},
+		{
+			name: "config with invalid typo",
+			configData: `---
+kind: CredentialProviderConfig
+apiVersion: kubelet.config.k8s.io/v1
+providers:
+  - name: test
+    matchImages:
+    - "registry.io/foobar"
+    defaultCacheDuration: 10m
+    unknownField: should not be here # this field should not be here
+    apiVersion: credentialprovider.kubelet.k8s.io/v1alpha1
+    args:
+    - --v=5
+    env:
+    - name: FOO
+      value: BAR`,
+			config:    nil,
+			expectErr: `strict decoding error: unknown field "providers[0].unknownField"`,
 		},
 	}
 
@@ -330,12 +350,12 @@ providers:
 			}
 
 			authConfig, err := readCredentialProviderConfigFile(file.Name())
-			if err != nil && !testcase.expectErr {
+			if err != nil && len(testcase.expectErr) == 0 {
 				t.Fatal(err)
 			}
 
-			if err == nil && testcase.expectErr {
-				t.Error("expected error but got none")
+			if err == nil && len(testcase.expectErr) > 0 {
+				t.Fatalf("expected error %q but got none", testcase.expectErr)
 			}
 
 			if !reflect.DeepEqual(authConfig, testcase.config) {
@@ -521,7 +541,6 @@ func Test_validateCredentialProviderConfig(t *testing.T) {
 				t.Errorf("expected error but got none")
 			} else if !testcase.shouldErr && len(errs) > 0 {
 				t.Errorf("expected no error but received errors: %v", errs.ToAggregate())
-
 			}
 		})
 	}

--- a/pkg/credentialprovider/plugin/plugin.go
+++ b/pkg/credentialprovider/plugin/plugin.go
@@ -56,7 +56,7 @@ const (
 
 var (
 	scheme = runtime.NewScheme()
-	codecs = serializer.NewCodecFactory(scheme)
+	codecs = serializer.NewCodecFactory(scheme, serializer.EnableStrict)
 
 	apiVersions = map[string]schema.GroupVersion{
 		credentialproviderv1alpha1.SchemeGroupVersion.String(): credentialproviderv1alpha1.SchemeGroupVersion,


### PR DESCRIPTION
/kind bug
/kind api-change
/triage accepted
/sig auth node
/assign enj liggitt

```release-note
kubelet: the `--image-credential-provider-config` file is now loaded with strict deserialization, which fails if the config file contains duplicate or unknown fields. This protects against accidentally running with config files that are malformed, mis-indented, or have typos in field names, and getting unexpected behavior.
```