### PR TITLE
e2e_node: fix mirror pod test

### DIFF
--- a/test/e2e_node/mirror_pod_test.go
+++ b/test/e2e_node/mirror_pod_test.go
@@ -233,9 +233,6 @@ var _ = SIGDescribe("MirrorPod", func() {
 			ginkgo.By("Stopping the NFS server")
 			stopNfsServer(f, nfsServerPod)
 
-			ginkgo.By("Waiting for NFS server to stop...")
-			time.Sleep(30 * time.Second)
-
 			ginkgo.By(fmt.Sprintf("Deleting the static nfs test pod: %s", staticPodName))
 			err = deleteStaticPod(podPath, staticPodName, ns)
 			framework.ExpectNoError(err)
@@ -303,7 +300,7 @@ func restartNfsServer(f *framework.Framework, serverPod *v1.Pod) {
 // pod's (only) container. This command changes the number of nfs server threads to 0,
 // thus closing all open nfs connections.
 func stopNfsServer(f *framework.Framework, serverPod *v1.Pod) {
-	const stopcmd = "/usr/sbin/rpc.nfsd 0"
+	const stopcmd = "rpc.nfsd 0 && for i in $(seq 200); do rpcinfo -p | grep -q nfs || break; sleep 1; done"
 	_, _, err := e2evolume.PodExec(f, serverPod, stopcmd)
 	framework.ExpectNoError(err)
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test
/kind flake

#### What this PR does / why we need it:

Modified stopNfsServer function to wait until nfs rpc is unregistered.
This should fix failing pull-kubernetes-node-arm64-ubuntu-serial-gce job.

#### Special notes for your reviewer:

The job fails with this error:
```
STEP: delete the static pod @ 10/14/24 09:24:47.974
  I1014 09:24:47.974357 2365 mirror_pod_test.go:268] Unexpected error: 
      <*fs.PathError | 0x4001af2210>: 
      remove /tmp/node-e2e-20241014T085411/static-pods166444039/mirror-pod-9439-static-pod-nfs-test-podd355306e-dd2b-4129-9ee3-9037f5c7e17f.yaml: no such file or directory
      {
          Op: "remove",
          Path: "/tmp/node-e2e-20241014T085411/static-pods166444039/mirror-pod-9439-static-pod-nfs-test-podd355306e-dd2b-4129-9ee3-9037f5c7e17f.yaml",
          Err: <syscall.Errno>0x2,
      }
  [FAILED] in [AfterEach] - k8s.io/kubernetes/test/e2e_node/mirror_pod_test.go:268 @ 10/14/24 09:24:47.974
```
because it removed mirror-pod-*.yaml during the test as nfs server was still running after 30 min of unconditional sleep.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```