### PR TITLE
TracingConfiguration is now validated strictly

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/options/tracing.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/tracing.go
@@ -27,7 +27,7 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	"go.opentelemetry.io/otel/metric/noop"
 	"go.opentelemetry.io/otel/sdk/resource"
-	"go.opentelemetry.io/otel/semconv/v1.12.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.12.0"
 	"google.golang.org/grpc"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -47,7 +47,7 @@ const apiserverService = "apiserver"
 
 var (
 	cfgScheme = runtime.NewScheme()
-	codecs    = serializer.NewCodecFactory(cfgScheme)
+	codecs    = serializer.NewCodecFactory(cfgScheme, serializer.EnableStrict)
 )
 
 func init() {

--- a/staging/src/k8s.io/apiserver/pkg/server/options/tracing_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/tracing_test.go
@@ -99,6 +99,32 @@ func TestReadTracingConfiguration(t *testing.T) {
 			expectedError:  strptr("unable to read tracing configuration from \"test-tracing-config-absent\": open test-tracing-config-absent: no such file or directory"),
 		},
 		{
+			name:       "duplicate field error; strict validation",
+			createFile: true,
+			contents: `
+apiVersion: apiserver.config.k8s.io/v1alpha1
+kind: TracingConfiguration
+endpoint: localhost:4317
+endpoint: localhost:4318
+samplingRatePerMillion: 12345
+`,
+			expectedResult: nil,
+			expectedError:  strptr("unable to decode tracing configuration data: strict decoding error"),
+		},
+		{
+			name:       "unknown field error; strict validation",
+			createFile: true,
+			contents: `
+apiVersion: apiserver.config.k8s.io/v1alpha1
+kind: TracingConfiguration
+foo: bar
+endpoint: localhost:4318
+samplingRatePerMillion: 12345
+`,
+			expectedResult: nil,
+			expectedError:  strptr("unable to decode tracing configuration data: strict decoding error"),
+		},
+		{
 			name:       "v1alpha1",
 			createFile: true,
 			contents: `


### PR DESCRIPTION
* `TracingConfiguration` configuration file is now decoded using `EnableStrict`
  * `kube-apiserver --tracing-config-file` parameter specifies the file path to configuration. 
  * Duplicate fields in the configuration will now cause an error during decoding.
  * Unknown fields in the configuration will now cause an error during decoding.

/kind cleanup

```release-note
kube-apiserver `--tracing-config-file` file is now validated strictly (EnableStrict). Duplicate and unknown fields in the configuration will now cause an error.
```

One of several PR's to address: https://github.com/kubernetes/kubernetes/issues/127940