### PR TITLE
Fix spacing in --validate flag description

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
@@ -451,10 +451,7 @@ func AddValidateFlags(cmd *cobra.Command) {
 	cmd.Flags().String(
 		"validate",
 		"strict",
-		`Must be one of: strict (or true), warn, ignore (or false).
-		"true" or "strict" will use a schema to validate the input and fail the request if invalid. It will perform server side validation if ServerSideFieldValidation is enabled on the api-server, but will fall back to less reliable client-side validation if not.
-		"warn" will warn about unknown or duplicate fields without blocking the request if server-side field validation is enabled on the API server, and behave as "ignore" otherwise.
-		"false" or "ignore" will not perform any schema validation, silently dropping any unknown or duplicate fields.`,
+		`Must be one of: strict (or true), warn, ignore (or false). "true" or "strict" will use a schema to validate the input and fail the request if invalid. It will perform server side validation if ServerSideFieldValidation is enabled on the api-server, but will fall back to less reliable client-side validation if not. "warn" will warn about unknown or duplicate fields without blocking the request if server-side field validation is enabled on the API server, and behave as "ignore" otherwise. "false" or "ignore" will not perform any schema validation, silently dropping any unknown or duplicate fields.`,
 	)
 
 	cmd.Flags().Lookup("validate").NoOptDefVal = "strict"


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/sig cli

#### What this PR does / why we need it:
Before our help looked like this:
```
    --validate='strict':
	Must be one of: strict (or true), warn, ignore (or false). 		"true" or "strict" will use a schema to validate
	the input and fail the request if invalid. It will perform server side validation if ServerSideFieldValidation
	is enabled on the api-server, but will fall back to less reliable client-side validation if not. 		"warn" will
	warn about unknown or duplicate fields without blocking the request if server-side field validation is enabled
	on the API server, and behave as "ignore" otherwise. 		"false" or "ignore" will not perform any schema
	validation, silently dropping any unknown or duplicate fields.
```
with this change we have:
```
    --validate='strict':
	Must be one of: strict (or true), warn, ignore (or false). "true" or "strict" will use a schema to validate
	the input and fail the request if invalid. It will perform server side validation if ServerSideFieldValidation
	is enabled on the api-server, but will fall back to less reliable client-side validation if not. "warn" will
	warn about unknown or duplicate fields without blocking the request if server-side field validation is enabled
	on the API server, and behave as "ignore" otherwise. "false" or "ignore" will not perform any schema
	validation, silently dropping any unknown or duplicate fields.
```

#### Which issue(s) this PR fixes:
NONE

#### Special notes for your reviewer:
/assign @ardaguclu 

#### Does this PR introduce a user-facing change?
```release-note
Fix spacing in --validate flag description in kubectl. 
```
