### PR TITLE
kubelet: fix a bug where kubelet wrongly drops the QOSClass field of the Pod's s status when it rejects a Pod

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -42,6 +42,7 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/mount-utils"
 
+	v1qos "k8s.io/kubernetes/pkg/apis/core/v1/helper/qos"
 	utilfs "k8s.io/kubernetes/pkg/util/filesystem"
 	netutils "k8s.io/utils/net"
 
@@ -2276,9 +2277,10 @@ func (kl *Kubelet) deletePod(pod *v1.Pod) error {
 func (kl *Kubelet) rejectPod(pod *v1.Pod, reason, message string) {
 	kl.recorder.Eventf(pod, v1.EventTypeWarning, reason, message)
 	kl.statusManager.SetPodStatus(pod, v1.PodStatus{
-		Phase:   v1.PodFailed,
-		Reason:  reason,
-		Message: "Pod was rejected: " + message})
+		QOSClass: v1qos.GetPodQOS(pod), // keep it as is
+		Phase:    v1.PodFailed,
+		Reason:   reason,
+		Message:  "Pod was rejected: " + message})
 }
 
 // canAdmitPod determines if a pod can be admitted, and gives a reason if it

--- a/test/e2e/common/node/pod_admission.go
+++ b/test/e2e/common/node/pod_admission.go
@@ -20,8 +20,10 @@ import (
 	"context"
 
 	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -36,7 +38,7 @@ var _ = SIGDescribe("PodOSRejection", framework.WithNodeConformance(), func() {
 	f := framework.NewDefaultFramework("pod-os-rejection")
 	f.NamespacePodSecurityLevel = admissionapi.LevelBaseline
 	ginkgo.Context("Kubelet", func() {
-		ginkgo.It("should reject pod when the node OS doesn't match pod's OS", func(ctx context.Context) {
+		ginkgo.It("[LinuxOnly] should reject pod when the node OS doesn't match pod's OS", func(ctx context.Context) {
 			linuxNode, err := findLinuxNode(ctx, f)
 			framework.ExpectNoError(err)
 			pod := &v1.Pod{
@@ -61,6 +63,83 @@ var _ = SIGDescribe("PodOSRejection", framework.WithNodeConformance(), func() {
 			// Check the pod is still not running
 			err = e2epod.WaitForPodFailedReason(ctx, f.ClientSet, pod, "PodOSNotSupported", f.Timeouts.PodStartShort)
 			framework.ExpectNoError(err)
+		})
+	})
+})
+
+var _ = SIGDescribe("PodRejectionStatus", func() {
+	f := framework.NewDefaultFramework("pod-rejection-status")
+	f.NamespacePodSecurityLevel = admissionapi.LevelBaseline
+	ginkgo.Context("Kubelet", func() {
+		ginkgo.It("should reject pod when the node didn't have enough resource", func(ctx context.Context) {
+			node, err := e2enode.GetRandomReadySchedulableNode(ctx, f.ClientSet)
+			framework.ExpectNoError(err, "Failed to get a ready schedulable node")
+
+			// Create a pod that requests more CPU than the node has
+			pod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod-out-of-cpu",
+					Namespace: f.Namespace.Name,
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name:  "pod-out-of-cpu",
+							Image: imageutils.GetPauseImageName(),
+							Resources: v1.ResourceRequirements{
+								Requests: v1.ResourceList{
+									v1.ResourceCPU: resource.MustParse("1000000000000"), // requests more CPU than any node has
+								},
+							},
+						},
+					},
+				},
+			}
+
+			pod = e2epod.NewPodClient(f).Create(ctx, pod)
+
+			// Wait for the scheduler to update the pod status
+			err = e2epod.WaitForPodNameUnschedulableInNamespace(ctx, f.ClientSet, pod.Name, pod.Namespace)
+			framework.ExpectNoError(err)
+
+			// Fetch the pod to get the latest status which should be last one observed by the scheduler
+			// before it rejected the pod
+			pod, err = f.ClientSet.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
+			framework.ExpectNoError(err)
+
+			// force assign the Pod to a node in order to get rejection status later
+			binding := &v1.Binding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      pod.Name,
+					Namespace: pod.Namespace,
+					UID:       pod.UID,
+				},
+				Target: v1.ObjectReference{
+					Kind: "Node",
+					Name: node.Name,
+				},
+			}
+			err = f.ClientSet.CoreV1().Pods(pod.Namespace).Bind(ctx, binding, metav1.CreateOptions{})
+			framework.ExpectNoError(err)
+
+			// kubelet has rejected the pod
+			err = e2epod.WaitForPodFailedReason(ctx, f.ClientSet, pod, "OutOfcpu", f.Timeouts.PodStartShort)
+			framework.ExpectNoError(err)
+
+			// fetch the reject Pod and compare the status
+			gotPod, err := f.ClientSet.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
+			framework.ExpectNoError(err)
+
+			// This detects if there are any new fields in Status that were dropped by the pod rejection.
+			// These new fields either should be kept by kubelet's admission or added explicitly in the list of fields that are having a different value or must be cleared.
+			expectedStatus := pod.Status.DeepCopy()
+			expectedStatus.Phase = gotPod.Status.Phase
+			expectedStatus.Conditions = nil
+			expectedStatus.Message = gotPod.Status.Message
+			expectedStatus.Reason = gotPod.Status.Reason
+			expectedStatus.StartTime = gotPod.Status.StartTime
+			// expectedStatus.QOSClass keep it as is
+			gomega.Expect(gotPod.Status).To(gomega.Equal(*expectedStatus))
 		})
 	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

https://github.com/kubernetes/kubernetes/pull/127744 tries tightening validation on the qosClass field of pod status. It will be forbidden to update the QoS class field via the status subsource. If a Node can not admit a pod, the kubelet will update the pod status with the reason and message and mark the pod as failed but it forgets to keep the qosClass field unchanged. This will cause the pod to be updated with an empty qosClass field. the Pod will stay pending forever because the update is forbidden by a kube-apiserver once https://github.com/kubernetes/kubernetes/pull/127744 is merged. 

Considering the upgrade/downgrade scenario, I submit this PR to fix the issue. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

- https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/127744/pull-kubernetes-e2e-kind/1846094694094737408
- https://storage.googleapis.com/kubernetes-ci-logs/pr-logs/pull/127744/pull-kubernetes-e2e-kind/1846094694094737408/artifacts/kind-control-plane/kubelet.log

```
Oct 15 08:06:42 kind-control-plane kubelet[748]: I1015 08:06:42.562211     748 config.go:292] "Setting pods for source" source="api"
Oct 15 08:06:42 kind-control-plane kubelet[748]: I1015 08:06:42.563598     748 config.go:397] "Receiving a new pod" pod="pod-os-rejection-9071/wrong-pod-os"
Oct 15 08:06:42 kind-control-plane kubelet[748]: I1015 08:06:42.563690     748 kubelet.go:2410] "SyncLoop ADD" source="api" pods=["pod-os-rejection-9071/wrong-pod-os"]
Oct 15 08:06:42 kind-control-plane kubelet[748]: I1015 08:06:42.563844     748 kubelet.go:2309] "Pod admission denied" podUID="d3affda3-8d17-4cc8-b730-56bacfe136fe" pod="pod-os-rejection-9071/wrong-pod-os" reason="PodOSNotSupported" message="Failed to admit pod as the OS field doesn't match node OS"
Oct 15 08:06:42 kind-control-plane kubelet[748]: I1015 08:06:42.563934     748 status_manager.go:227] "Syncing updated statuses"
Oct 15 08:06:42 kind-control-plane kubelet[748]: I1015 08:06:42.564160     748 event.go:389] "Event occurred" object="pod-os-rejection-9071/wrong-pod-os" fieldPath="" kind="Pod" apiVersion="v1" type="Warning" reason="PodOSNotSupported" message="Failed to admit pod as the OS field doesn't match node OS"
Oct 15 08:06:42 kind-control-plane kubelet[748]: I1015 08:06:42.573671     748 status_manager.go:872] "Patch status for pod" pod="pod-os-rejection-9071/wrong-pod-os" podUID="d3affda3-8d17-4cc8-b730-56bacfe136fe" patch=""
Oct 15 08:06:42 kind-control-plane kubelet[748]: I1015 08:06:42.573723     748 status_manager.go:875] "Failed to update status for pod" pod="pod-os-rejection-9071/wrong-pod-os" err="failed to patch status \"{\\\"metadata\\\":{\\\"uid\\\":\\\"d3affda3-8d17-4cc8-b730-56bacfe136fe\\\"},\\\"status\\\":{\\\"message\\\":\\\"Pod was rejected: Failed to admit pod as the OS field doesn't match node OS\\\",\\\"phase\\\":\\\"Failed\\\",\\\"qosClass\\\":null,\\\"reason\\\":\\\"PodOSNotSupported\\\",\\\"startTime\\\":\\\"2024-10-15T08:06:42Z\\\"}}\" for pod \"pod-os-rejection-9071\"/\"wrong-pod-os\": Pod \"wrong-pod-os\" is invalid: status.qosClass: Invalid value: \"\": field is immutable"
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubelet: fix a bug where kubelet wrongly drops the QOSClass field of the Pod's s status when it rejects a Pod
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
