### PR TITLE
Revert "credential provider config: detect typos"

### DIFF
--- a/pkg/credentialprovider/plugin/plugin.go
+++ b/pkg/credentialprovider/plugin/plugin.go
@@ -56,7 +56,7 @@ const (
 
 var (
 	scheme = runtime.NewScheme()
-	codecs = serializer.NewCodecFactory(scheme, serializer.EnableStrict)
+	codecs = serializer.NewCodecFactory(scheme)
 
 	apiVersions = map[string]schema.GroupVersion{
 		credentialproviderv1alpha1.SchemeGroupVersion.String(): credentialproviderv1alpha1.SchemeGroupVersion,


### PR DESCRIPTION
Reverts kubernetes/kubernetes#128062 to fix the master blocking CI. Probably we can fix it in other ways. 

https://testgrid.k8s.io/sig-release-master-blocking#gce-cos-master-reboot
This testgrid started to fail after this PR is merged(according to the date).

```

Oct 15 08:41:30.289037 err-e2e-minion-group-htl3 kubelet[1825]: I1015 08:41:30.289014    1825 kuberuntime_manager.go:262] "Container runtime initialized" containerRuntime="containerd" version="1.7.22" apiVersion="v1"
Oct 15 08:41:30.289748 err-e2e-minion-group-htl3 kubelet[1825]: E1015 08:41:30.289717    1825 kuberuntime_manager.go:269] "Failed to register CRI auth plugins" err=<
Oct 15 08:41:30.289748 err-e2e-minion-group-htl3 kubelet[1825]:         error decoding config /home/kubernetes/cri-auth-config.yaml: strict decoding error: yaml: unmarshal errors:
Oct 15 08:41:30.289748 err-e2e-minion-group-htl3 kubelet[1825]:           line 15: key "kind" already set in map
Oct 15 08:41:30.289748 err-e2e-minion-group-htl3 kubelet[1825]:           line 16: key "apiVersion" already set in map
Oct 15 08:41:30.289748 err-e2e-minion-group-htl3 kubelet[1825]:           line 18: key "providers" already set in map
Oct 15 08:41:30.289748 err-e2e-minion-group-htl3 kubelet[1825]:  >
Oct 15 08:41:30.296966 err-e2e-minion-group-htl3 systemd[1]: kubelet.service: Main process exited, code=exited, status=1/FAILURE
Oct 15 08:41:30.297223 err-e2e-minion-group-htl3 systemd[1]: kubelet.service: Failed with result 'exit-code'.
```

The failure seems to be related. But I am still not sure the root cause.

https://storage.googleapis.com/kubernetes-ci-logs/logs/ci-kubernetes-e2e-gci-gce-reboot/1846106076810842112/artifacts/err-e2e-minion-group-htl3/kubelet.log

https://github.com/kubernetes/kubernetes/blame/d32e9b0b6996a439674a998d63ccebb5b1b4cbde/cluster/gce/gci/configure.sh#L605-L621

See more in https://github.com/kubernetes/kubernetes/pull/128062#issuecomment-2413535879.

```release-note
None
```