### PR TITLE
WIP: Use highest attempt value when determining if pod sandbox has changed

### DIFF
--- a/pkg/kubelet/kuberuntime/util/util_test.go
+++ b/pkg/kubelet/kuberuntime/util/util_test.go
@@ -155,6 +155,26 @@ func TestPodSandboxChanged(t *testing.T) {
 			expectedAttempt:   0,
 			expectedSandboxID: "sandboxID1",
 		},
+		"Pod with multiple sandboxes but ready one is not latest": {
+			pod: &v1.Pod{},
+			status: &kubecontainer.PodStatus{
+				SandboxStatuses: []*runtimeapi.PodSandboxStatus{
+					{
+						Id:       "sandboxID1",
+						Metadata: &runtimeapi.PodSandboxMetadata{Attempt: uint32(0)},
+						State:    runtimeapi.PodSandboxState_SANDBOX_READY,
+					},
+					{
+						Id:       "sandboxID2",
+						Metadata: &runtimeapi.PodSandboxMetadata{Attempt: uint32(1)},
+						State:    runtimeapi.PodSandboxState_SANDBOX_NOTREADY,
+					},
+				},
+			},
+			expectedChanged:   false,
+			expectedAttempt:   1,
+			expectedSandboxID: "sandboxID1",
+		},
 	} {
 		t.Run(desc, func(t *testing.T) {
 			changed, attempt, id := PodSandboxChanged(test.pod, test.status)


### PR DESCRIPTION


#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:
This allows to fix the pod creation when the ready pod is not the latest one. The final attempt value should be the successor of all pod creation attempts, independently of the sate of the ready pod.

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubernetes/issues/127948

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed bug where pod creation fails because the ready pod sandbox is not the latest one (for example on system time sync issues).
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
