### PR TITLE
Promote CRD field selector e2e test to conformance

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -341,7 +341,7 @@
     resources matching the field selector. Delete and update some of the resources
     with field selectors; the lists, watches and informers MUST return only the custom
     resources matching custom resources.
-  release: v1.31, v1.32
+  release: v1.32
   file: test/e2e/apimachinery/crd_selectable_fields.go
 - testname: Custom Resource OpenAPI Publish, stop serving version
   codename: '[sig-api-machinery] CustomResourcePublishOpenAPI [Privileged:ClusterAdmin]

--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -330,6 +330,19 @@
     resources are available.
   release: v1.16
   file: test/e2e/apimachinery/custom_resource_definition.go
+- testname: custom-resource-definition-field-selectors-list-watch-register-informers
+  codename: '[sig-api-machinery] CustomResourceFieldSelectors [Privileged:ClusterAdmin]
+    [FeatureGate:CustomResourceFieldSelectors] [Beta] CustomResourceFieldSelectors
+    MUST list and watch custom resources matching the field selector [Conformance]'
+  description: Create a Custom Resource Definition with SelectableFields. Create a
+    custom resource with two versions and a conversion webhook that converts between
+    the versions. Attempt to list, watch and register informers for the custom resources
+    with field selectors; the lists, watches and informers MUST return only custom
+    resources matching the field selector. Delete and update some of the resources
+    with field selectors; the lists, watches and informers MUST return only the custom
+    resources matching custom resources.
+  release: v1.31, v1.32
+  file: test/e2e/apimachinery/crd_selectable_fields.go
 - testname: Custom Resource OpenAPI Publish, stop serving version
   codename: '[sig-api-machinery] CustomResourcePublishOpenAPI [Privileged:ClusterAdmin]
     removes definition from spec when one version gets changed to not be served [Conformance]'

--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -332,8 +332,8 @@
   file: test/e2e/apimachinery/custom_resource_definition.go
 - testname: custom-resource-definition-field-selectors-list-watch-register-informers
   codename: '[sig-api-machinery] CustomResourceFieldSelectors [Privileged:ClusterAdmin]
-    [FeatureGate:CustomResourceFieldSelectors] [Beta] CustomResourceFieldSelectors
-    MUST list and watch custom resources matching the field selector [Conformance]'
+    CustomResourceFieldSelectors MUST list and watch custom resources matching the
+    field selector [Conformance]'
   description: Create a Custom Resource Definition with SelectableFields. Create a
     custom resource with two versions and a conversion webhook that converts between
     the versions. Attempt to list, watch and register informers for the custom resources

--- a/test/e2e/apimachinery/crd_selectable_fields.go
+++ b/test/e2e/apimachinery/crd_selectable_fields.go
@@ -113,15 +113,15 @@ var _ = SIGDescribe("CustomResourceFieldSelectors [Privileged:ClusterAdmin]", fu
 		})
 
 		/*
-			Release: v1.31
-			Testname: Custom Resource Definition, list and watch with selectable fields
-			Description: Create a Custom Resource Definition with SelectableFields. Create custom resources. Attempt to
-			list and watch custom resources with object selectors; the list and watch MUST return only custom resources
-			matching the field selector. Delete and update some of the custom resources. Attempt to list and watch the
-			custom resources with object selectors; the list and watch MUST return only the custom resources matching
-			the object selectors.
+			Release: v1.31, v1.32
+			Testname: custom-resource-definition-field-selectors-list-watch-register-informers
+			Description: Create a Custom Resource Definition with SelectableFields. Create a custom resource with
+			two versions and a conversion webhook that converts between the versions. Attempt to list, watch and register
+			informers for the custom resources with field selectors; the lists, watches and informers MUST return only
+			custom resources matching the field selector. Delete and update some of the resources with field selectors;
+			the lists, watches and informers MUST return only the custom resources matching custom resources.
 		*/
-		framework.It("MUST list and watch custom resources matching the field selector", func(ctx context.Context) {
+		framework.ConformanceIt("MUST list and watch custom resources matching the field selector", func(ctx context.Context) {
 			ginkgo.By("Creating a custom resource definition with selectable fields")
 			testcrd, err := crd.CreateMultiVersionTestCRD(f, "stable.example.com", func(crd *apiextensionsv1.CustomResourceDefinition) {
 				crd.Spec.Versions = apiVersions

--- a/test/e2e/apimachinery/crd_selectable_fields.go
+++ b/test/e2e/apimachinery/crd_selectable_fields.go
@@ -113,7 +113,7 @@ var _ = SIGDescribe("CustomResourceFieldSelectors [Privileged:ClusterAdmin]", fu
 		})
 
 		/*
-			Release: v1.31, v1.32
+			Release: v1.32
 			Testname: custom-resource-definition-field-selectors-list-watch-register-informers
 			Description: Create a Custom Resource Definition with SelectableFields. Create a custom resource with
 			two versions and a conversion webhook that converts between the versions. Attempt to list, watch and register


### PR DESCRIPTION
#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

KEP-4358 is promoting to stable in 1.32

Test history: https://storage.googleapis.com/k8s-triage/index.html?test=CustomResourceFieldSelectors

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

/area conformance
@kubernetes/sig-architecture-pr-reviews @kubernetes/sig-api-machinery-pr-reviews @kubernetes/cncf-conformance-wg