### PR TITLE
feature(kubelet InPlacePodVerticalScaling): add kubelet_resize_requests_total metric

### DIFF
--- a/pkg/kubelet/metrics/metrics.go
+++ b/pkg/kubelet/metrics/metrics.go
@@ -152,6 +152,8 @@ const (
 
 	// Metrics to track kubelet admission rejections.
 	AdmissionRejectionsTotalKey = "admission_rejections_total"
+	// Metrics to track container resizing
+	ResizeRequestsTotalKey = "resize_requests_total"
 )
 
 type imageSizeBucket struct {
@@ -1008,6 +1010,16 @@ var (
 		},
 		[]string{"reason"},
 	)
+	// ResizeRequestsTotal is a CounterVec that tracks the total number of resize requests observed by the Kubelet.
+	ResizeRequestsTotal = metrics.NewCounterVec(
+		&metrics.CounterOpts{
+			Subsystem:      KubeletSubsystem,
+			Name:           ResizeRequestsTotalKey,
+			Help:           "Total number of resize requests observed by the Kubelet.",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"resize_state"},
+	)
 )
 
 var registerMetrics sync.Once
@@ -1107,6 +1119,9 @@ func Register(collectors ...metrics.StableCollector) {
 		}
 
 		legacyregistry.MustRegister(AdmissionRejectionsTotal)
+		if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {
+			legacyregistry.MustRegister(ResizeRequestsTotal)
+		}
 	})
 }
 

--- a/pkg/kubelet/status/state/state_mem.go
+++ b/pkg/kubelet/status/state/state_mem.go
@@ -21,6 +21,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/pkg/kubelet/metrics"
 )
 
 type stateMemory struct {
@@ -88,6 +89,11 @@ func (s *stateMemory) SetPodResizeStatus(podUID string, resizeStatus v1.PodResiz
 	defer s.Unlock()
 
 	if resizeStatus != "" {
+		oldResizeStatus, exist := s.podResizeStatus[podUID]
+		// If the resize status is changed or the resize status is not exist, record the metrics
+		if (exist && oldResizeStatus != resizeStatus) || !exist {
+			metrics.ResizeRequestsTotal.WithLabelValues(string(resizeStatus)).Inc()
+		}
 		s.podResizeStatus[podUID] = resizeStatus
 	} else {
 		delete(s.podResizeStatus, podUID)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
- add kubelet_resize_requests_total metric for kubelet
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/128071

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
add kubelet_resize_requests_total metric for kubelet
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
add kubelet_resize_requests_total metric for kubelet
```
