### PR TITLE
ktesting: improve context message

### DIFF
--- a/test/utils/ktesting/contexthelper.go
+++ b/test/utils/ktesting/contexthelper.go
@@ -66,7 +66,7 @@ func withTimeout(ctx context.Context, tb TB, timeout time.Duration, timeoutCause
 			//
 			// Would be nice to log this with the source code location
 			// of our caller, but testing.Logf does not support that.
-			tb.Logf("\nWARNING: %s\n", timeoutCause)
+			tb.Logf("\nINFO: canceling context: %s\n", timeoutCause)
 			cancel(canceledError(timeoutCause))
 		}
 	}()


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/priority backlog

#### What this PR does / why we need it:

Canceling a context is not necessarily a problem, some code might use a timeout and expect it to trigger. Therefore this should only be an info message, not a warning. Long-term it might be useful to have an API where the caller decides whether this gets logged.

The caller should use short messages and leave it to the user of those to provide more context (no pun intended...). When logging, "canceling context" is that context.

#### Special notes for your reviewer:

https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/directory/pull-kubernetes-integration/1846427252674269184

Before:

    scheduler_perf.go:1431: FATAL ERROR: op 7: delete scheduled pods: client rate limiter Wait returned an error: rate: Wait(n=1) would exceed context deadline
    contexthelper.go:69:
        WARNING: the operation ran for the configured 2s

After:

    scheduler_perf.go:1431: FATAL ERROR: op 7: delete scheduled pods: client rate limiter Wait returned an error: rate: Wait(n=1) would exceed context deadline
    contexthelper.go:69:
        INFO: canceling context: the operation ran for the configured 2s


#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @towca 