### PR TITLE
Fix misleading kubeadm output

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/init/showjoincommand.go
+++ b/cmd/kubeadm/app/cmd/phases/init/showjoincommand.go
@@ -47,7 +47,7 @@ var (
 
 		{{if .ControlPlaneEndpoint -}}
 		{{if .UploadCerts -}}
-		You can now join any number of the control-plane node running the following command on each as root:
+		You can now join any number of control-plane nodes running the following command on each as root:
 
 		  {{.joinControlPlaneCommand}}
 


### PR DESCRIPTION
The control-plane should be referred to in plural otherwise it can be misleading to join the the cp to other nodes.

#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

When running `kubeadm init` the produced output is confusing:

> "You can now join any number of the control-plane node running the following command on each as root:"

I suggests that you can join the initializied control-plane node to somewhere. It is the other way round. You can create another control plane node and let it join. So the change would be:

> "You can now join any number of control-plane nodes running the following command on each as root:"

This must have been forgotten. As the exact phrase is seen in file `cmd/kubeadm/app/cmd/phases/init/showjoincommand.go` in line `59`. See PR.

#### Which issue(s) this PR fixes:
Fixes #128117 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
kubeadm: fixed a misleading output (typo) when executing the "kubeadm init" command.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
