### PR TITLE
use same name as the folder for the package

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/metrics/errors.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/metrics/errors.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cel
+package metrics
 
 import (
 	"errors"

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/metrics/metrics.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cel
+package metrics
 
 import (
 	"context"

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/metrics/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/metrics/metrics_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cel
+package metrics
 
 import (
 	"context"


### PR DESCRIPTION

/kind cleanup


```release-note
NONE
```

It works, but it has some interesting side effects , so better to follow conventions