### PR TITLE
test: add feature gate consistency test for kubernetes feature - compatibililty versions

### DIFF
--- a/hack/tools/parse-feature-gates/parse-feature-gates.go
+++ b/hack/tools/parse-feature-gates/parse-feature-gates.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"regexp"
+	"sort"
+	"strconv"
+)
+
+type featureGateInfo struct {
+	stage         string
+	lockToDefault bool
+	enabled       int
+}
+
+func main() {
+	if len(os.Args) != 3 {
+		fmt.Fprintf(os.Stderr, "Usage: %s <metrics_file> <source_file>\n", os.Args[0])
+		os.Exit(1)
+	}
+
+	// Initialize feature gates map
+	featureGates := make(map[string]featureGateInfo)
+
+	// Parse metrics file
+	if err := parseMetrics(os.Args[1], featureGates); err != nil {
+		fmt.Fprintf(os.Stderr, "Error parsing metrics file: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Parse source file
+	if err := parseSources(os.Args[2], featureGates); err != nil {
+		fmt.Fprintf(os.Stderr, "Error parsing source file: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Print test case for test/integration/apiserver/compatibility_versions_test.go - TestFeatureGateCompatibilityEmulationVersion
+	printFeatureGates(featureGates)
+}
+
+func parseMetrics(filename string, featureGates map[string]featureGateInfo) error {
+	content, err := os.ReadFile(filename)
+	if err != nil {
+		return fmt.Errorf("failed to read metrics file: %v", err)
+	}
+
+	metricsRe := regexp.MustCompile(`kubernetes_feature_enabled{name="([^"]+)",stage="([^"]*)"} (\d+)`)
+	matches := metricsRe.FindAllStringSubmatch(string(content), -1)
+
+	for _, match := range matches {
+		featureName := match[1]
+		stage := match[2]
+		enabledStr := match[3]
+
+		enabled, err := strconv.Atoi(enabledStr)
+		if err != nil {
+			return fmt.Errorf("unable to convert value %s to integer for feature gate %s", enabled, featureName)
+		}
+
+		featureGates[featureName] = featureGateInfo{
+			stage:         stage,
+			lockToDefault: false,
+			enabled:       enabled,
+		}
+	}
+	return nil
+}
+
+func parseSources(filename string, featureGates map[string]featureGateInfo) error {
+	file, err := os.Open(filename)
+	if err != nil {
+		return fmt.Errorf("failed to open source file: %v", err)
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	featureGateRegex := regexp.MustCompile(`^\s*(\w+):\s*{`)
+	lockToDefaultTrueRegex := regexp.MustCompile(`LockToDefault:\s*true`)
+	var currentFeature string
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if matches := featureGateRegex.FindStringSubmatch(line); len(matches) > 1 {
+			currentFeature = matches[1]
+		}
+		if lockToDefaultTrueRegex.MatchString(line) && currentFeature != "" {
+			// Update existing feature gate info or create new one
+			if info, exists := featureGates[currentFeature]; exists {
+				info.lockToDefault = true
+				featureGates[currentFeature] = info
+			} else {
+				featureGates[currentFeature] = featureGateInfo{
+					stage:         "",
+					lockToDefault: true,
+					enabled:       0,
+				}
+			}
+			currentFeature = ""
+		}
+	}
+	return scanner.Err()
+}
+
+func printFeatureGates(featureGates map[string]featureGateInfo) {
+	// Extract and sort keys
+	keys := make([]string, 0, len(featureGates))
+	for key := range featureGates {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	// Print combined output
+	fmt.Println("expectedFeatureGatesForVersion: map[string]featureGateInfo{")
+	for _, key := range keys {
+		info := featureGates[key]
+		fmt.Printf("\t%q: {\"%s\", %v, %d},\n",
+			key,
+			info.stage,
+			info.lockToDefault,
+			info.enabled)
+	}
+	fmt.Println("}")
+}

--- a/test/integration/apiserver/compatibility_versions_test.go
+++ b/test/integration/apiserver/compatibility_versions_test.go
@@ -1,0 +1,290 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiserver
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strconv"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/version"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	restclient "k8s.io/client-go/rest"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	kubeapiservertesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
+	"k8s.io/kubernetes/test/integration/framework"
+)
+
+func TestFeatureGateCompatibilityEmulationVersion(t *testing.T) {
+	type featureGateInfo struct {
+		stage             string
+		lockToDefaultTrue bool
+		enabled           int
+	}
+	tcs := []struct {
+		emulatedVersion                string
+		expectedFeatureGatesForVersion map[string]featureGateInfo
+	}{
+		// TODO(#128193): Update this test cases with each new k8s version so that n-1..3 are the correct versions (add or remove them as the k8s version evolves)
+		{
+			emulatedVersion: "1.31",
+			expectedFeatureGatesForVersion: map[string]featureGateInfo{
+				"APIListChunking":                 {"", true, 1},
+				"APIResponseCompression":          {"BETA", false, 1},
+				"APIServerIdentity":               {"BETA", false, 1},
+				"APIServerTracing":                {"BETA", false, 1},
+				"APIServingWithRoutine":           {"ALPHA", false, 0},
+				"AdmissionWebhookMatchConditions": {"", true, 1},
+				"AggregatedDiscoveryEndpoint":     {"", true, 1},
+				"AllAlpha":                        {"ALPHA", false, 0},
+				"AllBeta":                         {"BETA", false, 0},
+				"AllowDNSOnlyNodeCSR":             {"DEPRECATED", false, 0},
+				"AllowInsecureKubeletCertificateSigningRequests": {"DEPRECATED", false, 0},
+				"AllowServiceLBStatusOnNonLB":                    {"DEPRECATED", false, 0},
+				"AnonymousAuthConfigurableEndpoints":             {"ALPHA", false, 0},
+				"AnyVolumeDataSource":                            {"BETA", false, 1},
+				"AppArmor":                                       {"", true, 1},
+				"AppArmorFields":                                 {"", true, 1},
+				"AuthorizeNodeWithSelectors":                     {"ALPHA", false, 0},
+				"AuthorizeWithSelectors":                         {"ALPHA", false, 0},
+				"CPUManager":                                     {"", true, 1},
+				"CPUManagerPolicyAlphaOptions":                   {"ALPHA", false, 0},
+				"CPUManagerPolicyBetaOptions":                    {"BETA", false, 1},
+				"CPUManagerPolicyOptions":                        {"BETA", false, 1},
+				"CRDValidationRatcheting":                        {"BETA", false, 1},
+				"CSIMigrationPortworx":                           {"BETA", false, 1},
+				"CSIVolumeHealth":                                {"ALPHA", false, 0},
+				"CloudControllerManagerWebhook":                  {"ALPHA", false, 0},
+				"CloudDualStackNodeIPs":                          {"", true, 1},
+				"ClusterTrustBundle":                             {"ALPHA", false, 0},
+				"ClusterTrustBundleProjection":                   {"ALPHA", false, 0},
+				"ComponentSLIs":                                  {"BETA", false, 1},
+				"ConcurrentWatchObjectDecode":                    {"BETA", false, 0},
+				"ConsistentListFromCache":                        {"BETA", false, 1},
+				"ContainerCheckpoint":                            {"BETA", false, 1},
+				"ContextualLogging":                              {"BETA", false, 1},
+				"CoordinatedLeaderElection":                      {"ALPHA", false, 0},
+				"CronJobsScheduledAnnotation":                    {"BETA", false, 1},
+				"CrossNamespaceVolumeDataSource":                 {"ALPHA", false, 0},
+				"CustomCPUCFSQuotaPeriod":                        {"ALPHA", false, 0},
+				"CustomResourceFieldSelectors":                   {"BETA", false, 1},
+				"DRAControlPlaneController":                      {"ALPHA", false, 0},
+				"DevicePluginCDIDevices":                         {"", true, 1},
+				"DisableAllocatorDualWrite":                      {"ALPHA", false, 0},
+				"DisableCloudProviders":                          {"", true, 1},
+				"DisableKubeletCloudCredentialProviders":         {"", true, 1},
+				"DisableNodeKubeProxyVersion":                    {"DEPRECATED", false, 0},
+				"DynamicResourceAllocation":                      {"ALPHA", false, 0},
+				"EfficientWatchResumption":                       {"", true, 1},
+				"ElasticIndexedJob":                              {"", true, 1},
+				"EventedPLEG":                                    {"ALPHA", false, 0},
+				"ExecProbeTimeout":                               {"", false, 1},
+				"GracefulNodeShutdown":                           {"BETA", false, 1},
+				"GracefulNodeShutdownBasedOnPodPriority":         {"BETA", false, 1},
+				"HPAContainerMetrics":                            {"", true, 1},
+				"HPAScaleToZero":                                 {"ALPHA", false, 0},
+				"HonorPVReclaimPolicy":                           {"BETA", false, 1},
+				"ImageMaximumGCAge":                              {"BETA", false, 1},
+				"ImageVolume":                                    {"ALPHA", false, 0},
+				"InPlacePodVerticalScaling":                      {"ALPHA", false, 0},
+				"InTreePluginPortworxUnregister":                 {"ALPHA", false, 0},
+				"InformerResourceVersion":                        {"ALPHA", false, 0},
+				"JobBackoffLimitPerIndex":                        {"BETA", false, 1},
+				"JobManagedBy":                                   {"ALPHA", false, 0},
+				"JobPodFailurePolicy":                            {"", true, 1},
+				"JobPodReplacementPolicy":                        {"BETA", false, 1},
+				"JobSuccessPolicy":                               {"BETA", false, 1},
+				"KMSv1":                                          {"DEPRECATED", false, 0},
+				"KMSv2":                                          {"", true, 1},
+				"KMSv2KDF":                                       {"", true, 1},
+				"KubeProxyDrainingTerminatingNodes":              {"", true, 1},
+				"KubeletCgroupDriverFromCRI":                     {"BETA", false, 1},
+				"KubeletInUserNamespace":                         {"ALPHA", false, 0},
+				"KubeletPodResourcesDynamicResources":            {"ALPHA", false, 0},
+				"KubeletPodResourcesGet":                         {"ALPHA", false, 0},
+				"KubeletSeparateDiskGC":                          {"BETA", false, 1},
+				"KubeletTracing":                                 {"BETA", false, 1},
+				"LegacyServiceAccountTokenCleanUp":               {"", true, 1},
+				"LoadBalancerIPMode":                             {"BETA", false, 1},
+				"LocalStorageCapacityIsolationFSQuotaMonitoring": {"BETA", false, 0},
+				"LogarithmicScaleDown":                           {"", true, 1},
+				"LoggingAlphaOptions":                            {"ALPHA", false, 0},
+				"LoggingBetaOptions":                             {"BETA", false, 1},
+				"MatchLabelKeysInPodAffinity":                    {"BETA", false, 1},
+				"MatchLabelKeysInPodTopologySpread":              {"BETA", false, 1},
+				"MaxUnavailableStatefulSet":                      {"ALPHA", false, 0},
+				"MemoryManager":                                  {"BETA", false, 1},
+				"MemoryQoS":                                      {"ALPHA", false, 0},
+				"MinDomainsInPodTopologySpread":                  {"", true, 1},
+				"MultiCIDRServiceAllocator":                      {"BETA", false, 0},
+				"MutatingAdmissionPolicy":                        {"ALPHA", false, 0},
+				"NFTablesProxyMode":                              {"BETA", false, 1},
+				"NewVolumeManagerReconstruction":                 {"", true, 1},
+				"NodeInclusionPolicyInPodTopologySpread":         {"BETA", false, 1},
+				"NodeLogQuery":                                   {"BETA", false, 0},
+				"NodeOutOfServiceVolumeDetach":                   {"", true, 1},
+				"NodeSwap":                                       {"BETA", false, 1},
+				"OpenAPIEnums":                                   {"BETA", false, 1},
+				"PDBUnhealthyPodEvictionPolicy":                  {"", true, 1},
+				"PersistentVolumeLastPhaseTransitionTime":        {"", true, 1},
+				"PodAndContainerStatsFromCRI":                    {"ALPHA", false, 0},
+				"PodDeletionCost":                                {"BETA", false, 1},
+				"PodDisruptionConditions":                        {"", true, 1},
+				"PodHostIPs":                                     {"", true, 1},
+				"PodIndexLabel":                                  {"BETA", false, 1},
+				"PodLifecycleSleepAction":                        {"BETA", false, 1},
+				"PodReadyToStartContainersCondition":             {"BETA", false, 1},
+				"PodSchedulingReadiness":                         {"", true, 1},
+				"PortForwardWebsockets":                          {"BETA", false, 1},
+				"ProcMountType":                                  {"BETA", false, 0},
+				"QOSReserved":                                    {"ALPHA", false, 0},
+				"RecoverVolumeExpansionFailure":                  {"ALPHA", false, 0},
+				"RecursiveReadOnlyMounts":                        {"BETA", false, 1},
+				"RelaxedEnvironmentVariableValidation":           {"ALPHA", false, 0},
+				"ReloadKubeletServerCertificateFile":             {"BETA", false, 1},
+				"RemainingItemCount":                             {"", true, 1},
+				"ResilientWatchCacheInitialization":              {"BETA", false, 1},
+				"ResourceHealthStatus":                           {"ALPHA", false, 0},
+				"RetryGenerateName":                              {"BETA", false, 1},
+				"RotateKubeletServerCertificate":                 {"BETA", false, 1},
+				"RuntimeClassInImageCriApi":                      {"ALPHA", false, 0},
+				"SELinuxMount":                                   {"ALPHA", false, 0},
+				"SELinuxMountReadWriteOncePod":                   {"BETA", false, 1},
+				"SchedulerQueueingHints":                         {"BETA", false, 0},
+				"SeparateCacheWatchRPC":                          {"BETA", false, 1},
+				"SeparateTaintEvictionController":                {"BETA", false, 1},
+				"ServerSideApply":                                {"", true, 1},
+				"ServerSideFieldValidation":                      {"", true, 1},
+				"ServiceAccountTokenJTI":                         {"BETA", false, 1},
+				"ServiceAccountTokenNodeBinding":                 {"BETA", false, 1},
+				"ServiceAccountTokenNodeBindingValidation":       {"BETA", false, 1},
+				"ServiceAccountTokenPodNodeInfo":                 {"BETA", false, 1},
+				"ServiceTrafficDistribution":                     {"BETA", false, 1},
+				"SidecarContainers":                              {"BETA", false, 1},
+				"SizeMemoryBackedVolumes":                        {"BETA", false, 1},
+				"StableLoadBalancerNodeSet":                      {"", true, 1},
+				"StatefulSetAutoDeletePVC":                       {"BETA", false, 1},
+				"StatefulSetStartOrdinal":                        {"", true, 1},
+				"StorageNamespaceIndex":                          {"BETA", false, 1},
+				"StorageVersionAPI":                              {"ALPHA", false, 0},
+				"StorageVersionHash":                             {"BETA", false, 1},
+				"StorageVersionMigrator":                         {"ALPHA", false, 0},
+				"StrictCostEnforcementForVAP":                    {"BETA", false, 0},
+				"StrictCostEnforcementForWebhooks":               {"BETA", false, 0},
+				"StructuredAuthenticationConfiguration":          {"BETA", false, 1},
+				"StructuredAuthorizationConfiguration":           {"BETA", false, 1},
+				"SupplementalGroupsPolicy":                       {"ALPHA", false, 0},
+				"TopologyAwareHints":                             {"BETA", false, 1},
+				"TopologyManagerPolicyAlphaOptions":              {"ALPHA", false, 0},
+				"TopologyManagerPolicyBetaOptions":               {"BETA", false, 1},
+				"TopologyManagerPolicyOptions":                   {"BETA", false, 1},
+				"TranslateStreamCloseWebsocketRequests":          {"BETA", false, 1},
+				"UnauthenticatedHTTP2DOSMitigation":              {"BETA", false, 1},
+				"UnknownVersionInteroperabilityProxy":            {"ALPHA", false, 0},
+				"UserNamespacesPodSecurityStandards":             {"ALPHA", false, 0},
+				"UserNamespacesSupport":                          {"BETA", false, 0},
+				"ValidatingAdmissionPolicy":                      {"", true, 1},
+				"VolumeAttributesClass":                          {"BETA", false, 0},
+				"VolumeCapacityPriority":                         {"ALPHA", false, 0},
+				"WatchBookmark":                                  {"", true, 1},
+				"WatchCacheInitializationPostStartHook":          {"BETA", false, 0},
+				"WatchFromStorageWithoutResourceVersion":         {"BETA", false, 0},
+				"WatchList":                                      {"ALPHA", false, 0},
+				"WatchListClient":                                {"BETA", false, 0},
+				"WinDSR":                                         {"ALPHA", false, 0},
+				"WinOverlay":                                     {"BETA", false, 1},
+				"WindowsHostNetwork":                             {"ALPHA", false, 0},
+				"ZeroLimitedNominalConcurrencyShares":            {"", true, 1},
+			},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.emulatedVersion, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateEmulationVersionDuringTest(t, utilfeature.DefaultFeatureGate, version.MustParse(tc.emulatedVersion))
+			server := kubeapiservertesting.StartTestServerOrDie(t, nil, framework.DefaultTestServerFlags(), framework.SharedEtcd())
+			defer server.TearDownFn()
+
+			rt, err := restclient.TransportFor(server.ClientConfig)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			req, err := http.NewRequest(http.MethodGet, server.ClientConfig.Host+"/metrics", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			resp, err := rt.RoundTrip(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() {
+				_ = resp.Body.Close()
+			}()
+
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+			actualFeatureGates, err := parseFeatureGates(string(body))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			for expectedFeatureName, expectedFeatureInfo := range tc.expectedFeatureGatesForVersion {
+				actualValue, exists := actualFeatureGates[expectedFeatureName]
+				if !exists && !expectedFeatureInfo.lockToDefaultTrue && expectedFeatureInfo.stage != "ALPHA" {
+					t.Errorf("expected feature gate %s not found in /metrics output", expectedFeatureName)
+					continue
+				}
+				if exists && expectedFeatureInfo.stage != "ALPHA" && actualValue != expectedFeatureInfo.enabled {
+					t.Errorf("feature %s expected value %d, got %d", expectedFeatureName, expectedFeatureInfo.enabled, actualValue)
+				}
+			}
+
+			for featureName := range actualFeatureGates {
+				prevFeatureGateInfo, exists := tc.expectedFeatureGatesForVersion[featureName]
+				if !exists && prevFeatureGateInfo.enabled == 1 {
+					// new feature gates can exist in emulated version n+1..3 but must be zero/off by default
+					t.Errorf("unexpected feature %s found in /metrics output", featureName)
+					continue
+				}
+			}
+		})
+	}
+}
+
+func parseFeatureGates(metricsBody string) (map[string]int, error) {
+	featureGates := make(map[string]int)
+	re := regexp.MustCompile(`(?m)^kubernetes_feature_enabled{name="([^"]+)",stage="[^"]*"} (\d+)`)
+	matches := re.FindAllStringSubmatch(metricsBody, -1) // Find all matches
+
+	for _, match := range matches {
+		if len(match) != 3 { // Each match should have the full match and two capture groups
+			return nil, fmt.Errorf("parsing feature gates where match did not have expected length of 3: %s", match)
+		}
+		value, err := strconv.Atoi(match[2])
+		if err != nil {
+			return nil, fmt.Errorf("unable to convert value %s to integer for feature gate %s", match[2], match[1])
+		}
+		featureGates[match[1]] = value
+	}
+	return featureGates, nil
+}

--- a/test/integration/apiserver/generate-compatibility-versions-test.sh
+++ b/test/integration/apiserver/generate-compatibility-versions-test.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+# Copyright 2024 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Script generates test case for test/integration/apiserver/compatibility_versions_test.go - TestFeatureGateCompatibilityEmulationVersion.
+# Usage: `test/integration/apiserver/generate-compatibility-versions-test.sh` 1.31.1 kindest/node:v1.31.1
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Ensure the previous version and kind image are passed as arguments
+if [ "$#" -ne 2 ]; then
+  echo "Usage: $0 <PREV_VERSION> <KIND_IMAGE_FOR_PREV_VERSION> (eg: v1.31.1 kindest/node:v1.31.1)"
+  exit 1
+fi
+
+PREV_VERSION="$1"
+
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+source "${KUBE_ROOT}/hack/lib/init.sh"
+
+kube::golang::setup_env
+
+# Check if cluster with name $PREV_VERSION already exists
+if kind get clusters | grep -q "^${PREV_VERSION}$"; then
+  echo "Cluster ${PREV_VERSION} already exists, skipping creation."
+else
+  # Create a kind cluster for the previous versions if a cluster doesn't already exist
+  echo "Creating kind cluster ${PREV_VERSION}..."
+  kind create cluster --name "${PREV_VERSION}" --image "${2}"
+fi
+
+echo "==========Test Case for ${PREV_VERSION}=============="
+echo "emulationVersion: ${PREV_VERSION},"
+
+# Create temporary files
+metrics_file=$(mktemp)
+sources_file=$(mktemp)
+
+# Get metrics data
+kubectl get --raw /metrics | grep kubernetes_feature_enabled > "$metrics_file"
+
+# Get source code
+git show "${PREV_VERSION}":staging/src/k8s.io/apiserver/pkg/features/kube_features.go \
+  "${PREV_VERSION}":pkg/features/versioned_kube_features.go \
+  "${PREV_VERSION}":staging/src/k8s.io/apiextensions-apiserver/pkg/features/kube_features.go > "$sources_file"
+
+# Process both files through the combined parser
+go run hack/tools/parse-feature-gates/parse-feature-gates.go "$metrics_file" "$sources_file"
+
+# Clean up
+rm "$metrics_file" "$sources_file"
+
+echo "====================================================="
+kind delete cluster --name "${PREV_VERSION}"


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR adds an integration test for testing feature gate compatibility for the Kubernetes Compatibility Versions [KEP-4330](https://github.com/kubernetes/enhancements/blob/master/keps/sig-architecture/4330-compatibility-versions/README.md) feature.  This test parses the feature gate information from a test kube-apiserver w/ --emulation-version=\<prior-version\> and hits the /metrics endpoint.  It compares the values it gets from this to the known correct values for that version.  This test is needed as Compatibility Versions guarantees that APIs and feature gate values are correctly emulated properly when using --emulated-version=n-1..3.  This test tests that core functionality of the feature.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #127947 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-architecture/4330-compatibility-versions/README.md
```
