### PR TITLE
Replace PollImmediate with PollUntilContextTimeout

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/patcher.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/patcher.go
@@ -388,13 +388,12 @@ func (p *Patcher) deleteAndCreate(original runtime.Object, modified []byte, name
 		return modified, nil, err
 	}
 	// TODO: use wait
-	err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, p.Timeout, true, func(ctx context.Context) (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, p.Timeout, true, func(ctx context.Context) (bool, error) {
 		if _, err := p.Helper.Get(namespace, name); !apierrors.IsNotFound(err) {
 			return false, err
 		}
 		return true, nil
-	})
-	if err != nil {
+	}); err != nil {
 		return modified, nil, err
 	}
 	versionedObject, _, err := unstructured.UnstructuredJSONScheme.Decode(modified, nil, nil)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/replace/replace.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/replace/replace.go
@@ -17,6 +17,7 @@ limitations under the License.
 package replace
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"os"
@@ -365,8 +366,7 @@ func (o *ReplaceOptions) forceReplace() error {
 		if err != nil {
 			return err
 		}
-
-		return wait.PollImmediate(1*time.Second, timeout, func() (bool, error) {
+		return wait.PollUntilContextTimeout(context.Background(), 1*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
 			if err := info.Get(); !errors.IsNotFound(err) {
 				return false, err
 			}

--- a/staging/src/k8s.io/kubectl/pkg/scale/scale.go
+++ b/staging/src/k8s.io/kubectl/pkg/scale/scale.go
@@ -80,8 +80,8 @@ func NewRetryParams(interval, timeout time.Duration) *RetryParams {
 }
 
 // ScaleCondition is a closure around Scale that facilitates retries via util.wait
-func ScaleCondition(r Scaler, precondition *ScalePrecondition, namespace, name string, count uint, updatedResourceVersion *string, gvr schema.GroupVersionResource, dryRun bool) wait.ConditionFunc {
-	return func() (bool, error) {
+func ScaleCondition(r Scaler, precondition *ScalePrecondition, namespace, name string, count uint, updatedResourceVersion *string, gvr schema.GroupVersionResource, dryRun bool) wait.ConditionWithContextFunc {
+	return func(context.Context) (bool, error) {
 		rv, err := r.ScaleSimple(namespace, name, precondition, count, gvr, dryRun)
 		if updatedResourceVersion != nil {
 			*updatedResourceVersion = rv
@@ -171,7 +171,7 @@ func (s *genericScaler) Scale(namespace, resourceName string, newSize uint, prec
 		retry = &RetryParams{Interval: time.Millisecond, Timeout: time.Millisecond}
 	}
 	cond := ScaleCondition(s, preconditions, namespace, resourceName, newSize, nil, gvr, dryRun)
-	if err := wait.PollImmediate(retry.Interval, retry.Timeout, cond); err != nil {
+	if err := wait.PollUntilContextTimeout(context.Background(), retry.Interval, retry.Timeout, true, cond); err != nil {
 		return err
 	}
 	if waitForReplicas != nil {
@@ -182,9 +182,9 @@ func (s *genericScaler) Scale(namespace, resourceName string, newSize uint, prec
 
 // scaleHasDesiredReplicas returns a condition that will be true if and only if the desired replica
 // count for a scale (Spec) equals its updated replicas count (Status)
-func scaleHasDesiredReplicas(sClient scaleclient.ScalesGetter, gr schema.GroupResource, resourceName string, namespace string, desiredReplicas int32) wait.ConditionFunc {
-	return func() (bool, error) {
-		actualScale, err := sClient.Scales(namespace).Get(context.TODO(), gr, resourceName, metav1.GetOptions{})
+func scaleHasDesiredReplicas(sClient scaleclient.ScalesGetter, gr schema.GroupResource, resourceName string, namespace string, desiredReplicas int32) wait.ConditionWithContextFunc {
+	return func(ctx context.Context) (bool, error) {
+		actualScale, err := sClient.Scales(namespace).Get(ctx, gr, resourceName, metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}
@@ -203,11 +203,8 @@ func WaitForScaleHasDesiredReplicas(sClient scaleclient.ScalesGetter, gr schema.
 	if waitForReplicas == nil {
 		return fmt.Errorf("waitForReplicas parameter cannot be nil")
 	}
-	err := wait.PollImmediate(
-		waitForReplicas.Interval,
-		waitForReplicas.Timeout,
-		scaleHasDesiredReplicas(sClient, gr, resourceName, namespace, int32(newSize)))
-	if err == wait.ErrWaitTimeout {
+	err := wait.PollUntilContextTimeout(context.Background(), waitForReplicas.Interval, waitForReplicas.Timeout, true, scaleHasDesiredReplicas(sClient, gr, resourceName, namespace, int32(newSize)))
+	if err == context.DeadlineExceeded {
 		return fmt.Errorf("timed out waiting for %q to be synced", resourceName)
 	}
 	return err

--- a/staging/src/k8s.io/kubectl/pkg/scale/scale_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/scale/scale_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package scale
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -69,7 +70,7 @@ func TestReplicationControllerScaleRetry(t *testing.T) {
 	namespace := metav1.NamespaceDefault
 
 	scaleFunc := ScaleCondition(scaler, nil, namespace, name, count, nil, rcgvr, false)
-	pass, err := scaleFunc()
+	pass, err := scaleFunc(context.Background())
 	if pass {
 		t.Errorf("Expected an update failure to return pass = false, got pass = %v", pass)
 	}
@@ -78,7 +79,7 @@ func TestReplicationControllerScaleRetry(t *testing.T) {
 	}
 	preconditions := ScalePrecondition{3, ""}
 	scaleFunc = ScaleCondition(scaler, &preconditions, namespace, name, count, nil, rcgvr, false)
-	_, err = scaleFunc()
+	_, err = scaleFunc(context.Background())
 	if err == nil {
 		t.Errorf("Expected error on precondition failure")
 	}
@@ -105,7 +106,7 @@ func TestReplicationControllerScaleInvalid(t *testing.T) {
 	namespace := "default"
 
 	scaleFunc := ScaleCondition(scaler, nil, namespace, name, count, nil, rcgvr, false)
-	pass, err := scaleFunc()
+	pass, err := scaleFunc(context.Background())
 	if pass {
 		t.Errorf("Expected an update failure to return pass = false, got pass = %v", pass)
 	}
@@ -179,7 +180,7 @@ func TestDeploymentScaleRetry(t *testing.T) {
 	namespace := "default"
 
 	scaleFunc := ScaleCondition(scaler, nil, namespace, name, count, nil, deploygvr, false)
-	pass, err := scaleFunc()
+	pass, err := scaleFunc(context.Background())
 	if pass != false {
 		t.Errorf("Expected an update failure to return pass = false, got pass = %v", pass)
 	}
@@ -188,7 +189,7 @@ func TestDeploymentScaleRetry(t *testing.T) {
 	}
 	preconditions := &ScalePrecondition{3, ""}
 	scaleFunc = ScaleCondition(scaler, preconditions, namespace, name, count, nil, deploygvr, false)
-	_, err = scaleFunc()
+	_, err = scaleFunc(context.Background())
 	if err == nil {
 		t.Error("Expected error on precondition failure")
 	}
@@ -236,7 +237,7 @@ func TestDeploymentScaleInvalid(t *testing.T) {
 	namespace := "default"
 
 	scaleFunc := ScaleCondition(scaler, nil, namespace, name, count, nil, deploygvr, false)
-	pass, err := scaleFunc()
+	pass, err := scaleFunc(context.Background())
 	if pass {
 		t.Errorf("Expected an update failure to return pass = false, got pass = %v", pass)
 	}
@@ -309,7 +310,7 @@ func TestStatefulSetScaleRetry(t *testing.T) {
 	namespace := "default"
 
 	scaleFunc := ScaleCondition(scaler, nil, namespace, name, count, nil, stsgvr, false)
-	pass, err := scaleFunc()
+	pass, err := scaleFunc(context.Background())
 	if pass != false {
 		t.Errorf("Expected an update failure to return pass = false, got pass = %v", pass)
 	}
@@ -318,7 +319,7 @@ func TestStatefulSetScaleRetry(t *testing.T) {
 	}
 	preconditions := &ScalePrecondition{3, ""}
 	scaleFunc = ScaleCondition(scaler, preconditions, namespace, name, count, nil, stsgvr, false)
-	_, err = scaleFunc()
+	_, err = scaleFunc(context.Background())
 	if err == nil {
 		t.Error("Expected error on precondition failure")
 	}
@@ -345,7 +346,7 @@ func TestStatefulSetScaleInvalid(t *testing.T) {
 	namespace := "default"
 
 	scaleFunc := ScaleCondition(scaler, nil, namespace, name, count, nil, stsgvr, false)
-	pass, err := scaleFunc()
+	pass, err := scaleFunc(context.Background())
 	if pass {
 		t.Errorf("Expected an update failure to return pass = false, got pass = %v", pass)
 	}
@@ -418,7 +419,7 @@ func TestReplicaSetScaleRetry(t *testing.T) {
 	namespace := "default"
 
 	scaleFunc := ScaleCondition(scaler, nil, namespace, name, count, nil, rsgvr, false)
-	pass, err := scaleFunc()
+	pass, err := scaleFunc(context.Background())
 	if pass != false {
 		t.Errorf("Expected an update failure to return pass = false, got pass = %v", pass)
 	}
@@ -427,7 +428,7 @@ func TestReplicaSetScaleRetry(t *testing.T) {
 	}
 	preconditions := &ScalePrecondition{3, ""}
 	scaleFunc = ScaleCondition(scaler, preconditions, namespace, name, count, nil, rsgvr, false)
-	_, err = scaleFunc()
+	_, err = scaleFunc(context.Background())
 	if err == nil {
 		t.Error("Expected error on precondition failure")
 	}
@@ -454,7 +455,7 @@ func TestReplicaSetScaleInvalid(t *testing.T) {
 	namespace := "default"
 
 	scaleFunc := ScaleCondition(scaler, nil, namespace, name, count, nil, rsgvr, false)
-	pass, err := scaleFunc()
+	pass, err := scaleFunc(context.Background())
 	if pass {
 		t.Errorf("Expected an update failure to return pass = false, got pass = %v", pass)
 	}

--- a/test/utils/update_resources.go
+++ b/test/utils/update_resources.go
@@ -37,8 +37,8 @@ const (
 )
 
 func RetryErrorCondition(condition wait.ConditionWithContextFunc) wait.ConditionWithContextFunc {
-	return func(context.Context) (bool, error) {
-		done, err := condition(context.Background())
+	return func(ctx context.Context) (bool, error) {
+		done, err := condition(ctx)
 		return done, err
 	}
 }

--- a/test/utils/update_resources.go
+++ b/test/utils/update_resources.go
@@ -17,6 +17,7 @@ limitations under the License.
 package utils
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -35,9 +36,9 @@ const (
 	waitRetryTimeout    = 5 * time.Minute
 )
 
-func RetryErrorCondition(condition wait.ConditionFunc) wait.ConditionFunc {
-	return func() (bool, error) {
-		done, err := condition()
+func RetryErrorCondition(condition wait.ConditionWithContextFunc) wait.ConditionWithContextFunc {
+	return func(context.Context) (bool, error) {
+		done, err := condition(context.Background())
 		return done, err
 	}
 }
@@ -50,7 +51,7 @@ func ScaleResourceWithRetries(scalesGetter scaleclient.ScalesGetter, namespace, 
 	}
 	waitForReplicas := scale.NewRetryParams(waitRetryInterval, waitRetryTimeout)
 	cond := RetryErrorCondition(scale.ScaleCondition(scaler, preconditions, namespace, name, size, nil, gvr, false))
-	err := wait.PollImmediate(updateRetryInterval, updateRetryTimeout, cond)
+	err := wait.PollUntilContextTimeout(context.Background(), updateRetryInterval, updateRetryTimeout, true, cond)
 	if err == nil {
 		err = scale.WaitForScaleHasDesiredReplicas(scalesGetter, gvr.GroupResource(), name, namespace, size, waitForReplicas)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Updates the polling functions in the patcher, replace, and scale packages to use wait.PollUntilContextTimeout instead of the deprecated wait.PollImmediate.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
Can I remove this [line](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/kubectl/pkg/cmd/apply/patcher.go#L389) also? not sure why it's there.
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
