### PR TITLE
Add UnschedulableAsync test in scheduler_perf to monitor impact of unschedulable pods on scheduler performance

### DIFF
--- a/test/integration/scheduler_perf/config/performance-config.yaml
+++ b/test/integration/scheduler_perf/config/performance-config.yaml
@@ -731,52 +731,8 @@
       initPods: 20000
       measurePods: 5000
 
-- name: Unschedulable
-  workloadTemplate:
-  - opcode: createNodes
-    countParam: $initNodes
-  - opcode: createPods
-    countParam: $initPods
-    podTemplatePath: config/templates/pod-large-cpu.yaml
-    skipWaitToCompletion: true
-  - opcode: createPods
-    countParam: $measurePods
-    podTemplatePath: config/templates/pod-default.yaml
-    collectMetrics: true
-  workloads:
-  - name: 5Nodes/2InitPods
-    labels: [integration-test, performance, short]
-    params:
-      initNodes: 5
-      initPods: 2
-      measurePods: 10
-  - name: 500Nodes/200InitPods
-    labels: [performance, short]
-    params:
-      initNodes: 500
-      initPods: 200
-      measurePods: 1000
-  - name: 5000Nodes/200InitPods
-    labels: [performance, short]
-    params:
-      initNodes: 5000
-      initPods: 200
-      measurePods: 5000
-  - name: 5000Nodes/200InitPods/10000Pods
-    labels: [performance]
-    threshold: 300
-    params:
-      initNodes: 5000
-      initPods: 200
-      measurePods: 10000
-  - name: 5000Nodes/2000InitPods
-    params:
-      initNodes: 5000
-      initPods: 2000
-      measurePods: 5000
-
 # Measure throughput of regular schedulable pods that are interleaved by unschedulable pods injected at 100/s rate.
-- name: UnschedulableAsync
+- name: Unschedulable
   workloadTemplate:
   - opcode: createNodes
     countParam: $initNodes

--- a/test/integration/scheduler_perf/config/performance-config.yaml
+++ b/test/integration/scheduler_perf/config/performance-config.yaml
@@ -746,8 +746,13 @@
     podTemplatePath: config/templates/pod-default.yaml
     collectMetrics: true
   workloads:
-  - name: 500Nodes/1kPods
+  - name: 5Nodes/10Pods
     labels: [integration-test, performance, short]
+    params:
+      initNodes: 5
+      measurePods: 10
+  - name: 500Nodes/1kPods
+    labels: [performance, short]
     params:
       initNodes: 500
       measurePods: 1000

--- a/test/integration/scheduler_perf/config/performance-config.yaml
+++ b/test/integration/scheduler_perf/config/performance-config.yaml
@@ -775,6 +775,38 @@
       initPods: 2000
       measurePods: 5000
 
+# Measure throughput of regular schedulable pods that are interleaved by unschedulable pods injected at 100/s rate.
+- name: UnschedulableAsync
+  workloadTemplate:
+  - opcode: createNodes
+    countParam: $initNodes
+  - opcode: churn
+    mode: create
+    templatePaths:
+    - config/templates/pod-large-cpu.yaml
+    intervalMilliseconds: 10
+  - opcode: createPods
+    countParam: $measurePods
+    podTemplatePath: config/templates/pod-default.yaml
+    collectMetrics: true
+  workloads:
+  - name: 500Nodes/1kPods
+    labels: [integration-test, performance, short]
+    params:
+      initNodes: 500
+      measurePods: 1000
+  - name: 5kNodes/1kPods
+    labels: [performance, short]
+    params:
+      initNodes: 5000
+      measurePods: 1000
+  - name: 5kNodes/10kPods
+    labels: [performance]
+    threshold: 400
+    params:
+      initNodes: 5000
+      measurePods: 10000
+
 - name: SchedulingWithMixedChurn
   workloadTemplate:
   - opcode: createNodes


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Extend scheduler performance tests to masure the impact of unschedulable pods traffic on scheduler performance.

#### Which issue(s) this PR fixes:

part of #126858

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```