### PR TITLE
feat(kubectl): print the logs from given log sream

### DIFF
--- a/test/e2e/kubectl/logs.go
+++ b/test/e2e/kubectl/logs.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+	"k8s.io/utils/ptr"
 
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -34,6 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/uuid"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubectl/pkg/cmd/util/podcmd"
+	"k8s.io/kubernetes/test/e2e/feature"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2edeployment "k8s.io/kubernetes/test/e2e/framework/deployment"
 	e2ekubectl "k8s.io/kubernetes/test/e2e/framework/kubectl"
@@ -41,7 +43,6 @@ import (
 	e2eoutput "k8s.io/kubernetes/test/e2e/framework/pod/output"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 	admissionapi "k8s.io/pod-security-admission/api"
-	"k8s.io/utils/ptr"
 )
 
 func testingDeployment(name, ns string, numberOfPods int32) appsv1.Deployment {
@@ -356,5 +357,50 @@ var _ = SIGDescribe("Kubectl logs", func() {
 
 		})
 	})
+})
 
+var _ = SIGDescribe("kubectl logs with specific stream", feature.PodLogsQuerySplitStreams, func() {
+	f := framework.NewDefaultFramework("kubectl-logs-stream")
+	f.NamespacePodSecurityLevel = admissionapi.LevelBaseline
+	defer ginkgo.GinkgoRecover()
+
+	var c clientset.Interface
+	var ns string
+	ginkgo.BeforeEach(func() {
+		c = f.ClientSet
+		ns = f.Namespace.Name
+	})
+
+	ginkgo.Describe("specific log stream", func() {
+		podName := "log-stream"
+		ginkgo.BeforeEach(func() {
+			ginkgo.By("creating a pod")
+			e2ekubectl.RunKubectlOrDie(ns, "run", podName, "--image="+imageutils.GetE2EImage(imageutils.BusyBox), "--restart=Never", podRunningTimeoutArg, "--", "/bin/sh", "-c", "echo out1; echo err1 >&2; tail -f /dev/null")
+		})
+		ginkgo.AfterEach(func() {
+			e2ekubectl.RunKubectlOrDie(ns, "delete", "pod", podName)
+		})
+		ginkgo.It("should get logs from specific log stream", func(ctx context.Context) {
+			ginkgo.By("Waiting for pod to start.")
+			// we need to wait for pod completion, to check the generated number of lines
+			if err := e2epod.WaitForPodSuccessInNamespaceTimeout(ctx, c, podName, ns, framework.PodStartTimeout); err != nil {
+				framework.Failf("Pod %s did not finish: %v", podName, err)
+			}
+
+			ginkgo.By("get logs from stdout")
+			out := e2ekubectl.RunKubectlOrDie(ns, "logs", podName, "--stream=stdout")
+			framework.Logf("got output %q", out)
+			gomega.Expect(out).To(gomega.ContainSubstring("out1"))
+			gomega.Expect(out).NotTo(gomega.ContainSubstring("err1"))
+
+			ginkgo.By("get logs from stderr")
+			out = e2ekubectl.RunKubectlOrDie(ns, "logs", podName, "--stream=stderr")
+			framework.Logf("got output %q", out)
+			gomega.Expect(out).To(gomega.ContainSubstring("err1"))
+			gomega.Expect(out).NotTo(gomega.ContainSubstring("out1"))
+
+			out = e2ekubectl.RunKubectlOrDie(ns, "logs", podName, "--stream=stdout", "--limit-bytes=6")
+			gomega.Expect(out).To(gomega.Equal("out1\ne"))
+		})
+	})
 })

--- a/test/e2e/kubectl/logs.go
+++ b/test/e2e/kubectl/logs.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/uuid"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubectl/pkg/cmd/util/podcmd"
+	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/test/e2e/feature"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2edeployment "k8s.io/kubernetes/test/e2e/framework/deployment"
@@ -359,7 +360,7 @@ var _ = SIGDescribe("Kubectl logs", func() {
 	})
 })
 
-var _ = SIGDescribe("kubectl logs with specific stream", feature.PodLogsQuerySplitStreams, func() {
+var _ = SIGDescribe("kubectl logs with specific stream", feature.PodLogsQuerySplitStreams, framework.WithFeatureGate(features.PodLogsQuerySplitStreams), func() {
 	f := framework.NewDefaultFramework("kubectl-logs-stream")
 	f.NamespacePodSecurityLevel = admissionapi.LevelBaseline
 	defer ginkgo.GinkgoRecover()

--- a/test/e2e/node/kubelet.go
+++ b/test/e2e/node/kubelet.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/pkg/features"
 	admissionapi "k8s.io/pod-security-admission/api"
 
 	"k8s.io/kubernetes/test/e2e/feature"
@@ -642,7 +643,7 @@ var _ = SIGDescribe("kubelet", func() {
 	})
 })
 
-var _ = SIGDescribe("specific log stream", feature.PodLogsQuerySplitStreams, func() {
+var _ = SIGDescribe("specific log stream", feature.PodLogsQuerySplitStreams, framework.WithFeatureGate(features.PodLogsQuerySplitStreams), func() {
 	var (
 		c  clientset.Interface
 		ns string


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:

Depends on #127360.

Complete the changes on the kubectl side to support the new functionality.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added kubectl support for fetching a specific log stream (stdout or stderr). Example: `kubectl logs pods/<pod> --stream=stdout`.
You need to connect to a cluster where the `PodLogsQuerySplitStreams` feature gate is enabled in order to use this kubectl feature.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/3288-separate-stdout-from-stderr
```
