### PR TITLE
e2e_node: print system validation warnings

### DIFF
--- a/test/e2e_node/e2e_node_suite_test.go
+++ b/test/e2e_node/e2e_node_suite_test.go
@@ -193,8 +193,12 @@ func TestE2eNode(t *testing.T) {
 				klog.Exitf("chroot %q failed: %v", rootfs, err)
 			}
 		}
-		if _, err := system.ValidateSpec(*spec, "remote"); len(err) != 0 {
-			klog.Exitf("system validation failed: %v", err)
+		warns, errs := system.ValidateSpec(*spec, "remote")
+		if len(warns) != 0 {
+			klog.Warningf("system validation warns: %v", warns)
+		}
+		if len(errs) != 0 {
+			klog.Exitf("system validation failed: %v", errs)
 		}
 		return
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
- during investigating the issue https://github.com/kubernetes/kubernetes/issues/128171, I found that the warning is not printed in the CI

#### Which issue(s) this PR fixes:
Fixes None

#### Special notes for your reviewer:
/priority backlog

#### Does this PR introduce a user-facing change?

```release-note
None
```

