### PR TITLE
kubeadm: using options.Force constant instead of 'force' string

### DIFF
--- a/cmd/kubeadm/app/cmd/options/constant.go
+++ b/cmd/kubeadm/app/cmd/options/constant.go
@@ -125,8 +125,8 @@ const (
 	// SkipCertificateKeyPrint flag instructs kubeadm to skip printing certificate key used to encrypt certs by 'kubeadm init'.
 	SkipCertificateKeyPrint = "skip-certificate-key-print"
 
-	// ForceReset flag instructs kubeadm to reset the node without prompting for confirmation
-	ForceReset = "force"
+	// Force flag instructs kubeadm to do something (such as reset, upgrade, etc.) without prompting for confirmation.
+	Force = "force"
 
 	// CertificateRenewal flag instructs kubeadm to execute certificate renewal during upgrades
 	CertificateRenewal = "certificate-renewal"

--- a/cmd/kubeadm/app/cmd/phases/reset/preflight.go
+++ b/cmd/kubeadm/app/cmd/phases/reset/preflight.go
@@ -39,7 +39,7 @@ func NewPreflightPhase() workflow.Phase {
 		Run:     runPreflight,
 		InheritFlags: []string{
 			options.IgnorePreflightErrors,
-			options.ForceReset,
+			options.Force,
 			options.DryRun,
 		},
 	}

--- a/cmd/kubeadm/app/cmd/phases/upgrade/apply/preflight.go
+++ b/cmd/kubeadm/app/cmd/phases/upgrade/apply/preflight.go
@@ -47,11 +47,11 @@ func NewPreflightPhase() workflow.Phase {
 		InheritFlags: []string{
 			options.CfgPath,
 			options.KubeconfigPath,
+			options.Force,
 			options.DryRun,
 			options.IgnorePreflightErrors,
 			"allow-experimental-upgrades",
 			"allow-release-candidate-upgrades",
-			"force",
 			"yes",
 		},
 	}

--- a/cmd/kubeadm/app/cmd/reset.go
+++ b/cmd/kubeadm/app/cmd/reset.go
@@ -183,7 +183,7 @@ func newResetData(cmd *cobra.Command, opts *resetOptions, in io.Reader, out io.W
 		cfg:                   initCfg,
 		resetCfg:              resetCfg,
 		dryRun:                dryRunFlag,
-		forceReset:            cmdutil.ValueFromFlagsOrConfig(cmd.Flags(), options.ForceReset, resetCfg.Force, opts.externalcfg.Force).(bool),
+		forceReset:            cmdutil.ValueFromFlagsOrConfig(cmd.Flags(), options.Force, resetCfg.Force, opts.externalcfg.Force).(bool),
 		cleanupTmpDir:         cmdutil.ValueFromFlagsOrConfig(cmd.Flags(), options.CleanupTmpDir, resetCfg.CleanupTmpDir, opts.externalcfg.CleanupTmpDir).(bool),
 	}, nil
 }
@@ -195,7 +195,7 @@ func AddResetFlags(flagSet *flag.FlagSet, resetOptions *resetOptions) {
 		`The path to the directory where the certificates are stored. If specified, clean this directory.`,
 	)
 	flagSet.BoolVarP(
-		&resetOptions.externalcfg.Force, options.ForceReset, "f", resetOptions.externalcfg.Force,
+		&resetOptions.externalcfg.Force, options.Force, "f", resetOptions.externalcfg.Force,
 		"Reset the node without prompting for confirmation.",
 	)
 	flagSet.BoolVar(

--- a/cmd/kubeadm/app/cmd/reset_test.go
+++ b/cmd/kubeadm/app/cmd/reset_test.go
@@ -80,7 +80,7 @@ func TestNewResetData(t *testing.T) {
 				options.CertificatesDir:       "/tmp",
 				options.NodeCRISocket:         constants.CRISocketCRIO,
 				options.IgnorePreflightErrors: "all",
-				options.ForceReset:            "true",
+				options.Force:                 "true",
 				options.DryRun:                "true",
 				options.CleanupTmpDir:         "true",
 			},
@@ -184,8 +184,8 @@ func TestNewResetData(t *testing.T) {
 		{
 			name: "--force flag is not allowed to mix with config",
 			flags: map[string]string{
-				options.CfgPath:    configFilePath,
-				options.ForceReset: "false",
+				options.CfgPath: configFilePath,
+				options.Force:   "false",
 			},
 			expectError: "can not mix '--config' with arguments",
 		},

--- a/cmd/kubeadm/app/cmd/upgrade/apply.go
+++ b/cmd/kubeadm/app/cmd/upgrade/apply.go
@@ -124,7 +124,7 @@ func newCmdApply(apf *applyPlanFlags) *cobra.Command {
 	addApplyPlanFlags(cmd.Flags(), flags.applyPlanFlags)
 	// Specify the valid flags specific for apply
 	cmd.Flags().BoolVarP(&flags.nonInteractiveMode, "yes", "y", flags.nonInteractiveMode, "Perform the upgrade and do not prompt for confirmation (non-interactive mode).")
-	cmd.Flags().BoolVarP(&flags.force, "force", "f", flags.force, "Force upgrading although some requirements might not be met. This also implies non-interactive mode.")
+	cmd.Flags().BoolVarP(&flags.force, options.Force, "f", flags.force, "Force upgrading although some requirements might not be met. This also implies non-interactive mode.")
 	cmd.Flags().BoolVar(&flags.dryRun, options.DryRun, flags.dryRun, "Do not change any state, just output what actions would be performed.")
 	cmd.Flags().BoolVar(&flags.etcdUpgrade, options.EtcdUpgrade, flags.etcdUpgrade, "Perform the upgrade of etcd.")
 	cmd.Flags().BoolVar(&flags.renewCerts, options.CertificateRenewal, flags.renewCerts, "Perform the renewal of certificates used by component changed during upgrades.")
@@ -188,7 +188,7 @@ func newApplyData(cmd *cobra.Command, args []string, applyFlags *applyFlags) (*a
 		return nil, err
 	}
 
-	force, ok := cmdutil.ValueFromFlagsOrConfig(cmd.Flags(), "force", upgradeCfg.Apply.ForceUpgrade, &applyFlags.force).(*bool)
+	force, ok := cmdutil.ValueFromFlagsOrConfig(cmd.Flags(), options.Force, upgradeCfg.Apply.ForceUpgrade, &applyFlags.force).(*bool)
 	if !ok {
 		return nil, cmdutil.TypeMismatchErr("forceUpgrade", "bool")
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug

/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
kubeadm: using `options.Force` constant instead of 'force' string

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
