### PR TITLE
Fix crash on kube manager's service-lb-controller after v1.31.0.

### DIFF
--- a/cmd/kube-controller-manager/app/controllermanager_test.go
+++ b/cmd/kube-controller-manager/app/controllermanager_test.go
@@ -219,3 +219,29 @@ func TestTaintEvictionControllerGating(t *testing.T) {
 		})
 	}
 }
+
+func TestNoCloudProviderControllerStarted(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	controllerCtx := ControllerContext{
+		Cloud:    nil,
+		LoopMode: IncludeCloudLoops,
+	}
+
+	for _, controller := range NewControllerDescriptors() {
+		if !controller.IsCloudProviderController() {
+			continue
+		}
+
+		controllerName := controller.Name()
+		checker, err := StartController(ctx, controllerCtx, controller, nil)
+		if err != nil {
+			t.Errorf("Error starting controller %q: %v", controllerName, err)
+		}
+		if checker != nil {
+			t.Errorf("Controller %q should not be started", controllerName)
+		}
+	}
+}

--- a/cmd/kube-controller-manager/app/controllermanager_test.go
+++ b/cmd/kube-controller-manager/app/controllermanager_test.go
@@ -229,7 +229,7 @@ func TestNoCloudProviderControllerStarted(t *testing.T) {
 		Cloud:    nil,
 		LoopMode: IncludeCloudLoops,
 	}
-
+	controllerCtx.ComponentConfig.Generic.Controllers = []string{"*"}
 	for _, controller := range NewControllerDescriptors() {
 		if !controller.IsCloudProviderController() {
 			continue

--- a/staging/src/k8s.io/cloud-provider/controllers/service/controller.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/service/controller.go
@@ -108,6 +108,7 @@ func New(
 	featureGate featuregate.FeatureGate,
 ) (*Controller, error) {
 	registerMetrics()
+
 	s := &Controller{
 		cloud:            cloud,
 		kubeClient:       kubeClient,
@@ -124,6 +125,10 @@ func New(
 			workqueue.TypedRateLimitingQueueConfig[string]{Name: "node"},
 		),
 		lastSyncedNodes: make(map[string][]*v1.Node),
+	}
+
+	if err := s.init(); err != nil {
+		return nil, err
 	}
 
 	serviceInformer.Informer().AddEventHandlerWithResyncPeriod(
@@ -179,10 +184,6 @@ func New(
 		},
 		nodeSyncPeriod,
 	)
-
-	if err := s.init(); err != nil {
-		return nil, err
-	}
 
 	return s, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
/kind regression


#### What this PR does / why we need it:


If the init fails, we shouldn't register event handlers. It will cause a crash since https://github.com/kubernetes/kubernetes/pull/122145 is merged. 

There's a memory leak in the code. the queue has no worker to consume the event.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/128121

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixes 1.31 regression that can crash kube-controller-manager's service-lb-controller loop
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
