### PR TITLE
[Fix] SharedIndexInformer not calling event handlers during the first…

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/controller.go
+++ b/staging/src/k8s.io/client-go/tools/cache/controller.go
@@ -536,11 +536,35 @@ func NewTransformingIndexerInformer(
 	return clientState, newInformer(clientState, options)
 }
 
+// DeltaHandler can handle deltas emitted by processDeltas
+type DeltaHandler interface {
+	OnAdd(obj interface{}, isInInitialList bool)
+	OnUpdate(oldObj, newObj interface{}, isSync bool)
+	OnDelete(obj interface{})
+}
+
+// DeltaHandlerAdapter adapts a DeltaHandler to a ResourceEventHandler
+type DeltaHandlerToResourceEventHandlerAdapter struct {
+	handler ResourceEventHandler
+}
+
+func (a *DeltaHandlerToResourceEventHandlerAdapter) OnAdd(obj interface{}, isInInitialList bool) {
+	a.handler.OnAdd(obj, isInInitialList)
+}
+
+func (a *DeltaHandlerToResourceEventHandlerAdapter) OnUpdate(oldObj, newObj interface{}, isSync bool) {
+	a.handler.OnUpdate(oldObj, newObj)
+}
+
+func (a *DeltaHandlerToResourceEventHandlerAdapter) OnDelete(obj interface{}) {
+	a.handler.OnDelete(obj)
+}
+
 // Multiplexes updates in the form of a list of Deltas into a Store, and informs
 // a given handler of events OnUpdate, OnAdd, OnDelete
 func processDeltas(
 	// Object which receives event notifications from the given deltas
-	handler ResourceEventHandler,
+	handler DeltaHandler,
 	clientState Store,
 	deltas Deltas,
 	isInInitialList bool,
@@ -555,7 +579,7 @@ func processDeltas(
 				if err := clientState.Update(obj); err != nil {
 					return err
 				}
-				handler.OnUpdate(old, obj)
+				handler.OnUpdate(old, obj, d.Type == Sync)
 			} else {
 				if err := clientState.Add(obj); err != nil {
 					return err
@@ -598,7 +622,10 @@ func newInformer(clientState Store, options InformerOptions) Controller {
 
 		Process: func(obj interface{}, isInInitialList bool) error {
 			if deltas, ok := obj.(Deltas); ok {
-				return processDeltas(options.Handler, clientState, deltas, isInInitialList)
+				handlerAdapter := &DeltaHandlerToResourceEventHandlerAdapter{
+					handler: options.Handler,
+				}
+				return processDeltas(handlerAdapter, clientState, deltas, isInInitialList)
 			}
 			return errors.New("object given as Process argument is not Deltas")
 		},

--- a/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
+++ b/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
@@ -654,18 +654,18 @@ func (s *sharedIndexInformer) OnAdd(obj interface{}, isInInitialList bool) {
 }
 
 // Conforms to ResourceEventHandler
-func (s *sharedIndexInformer) OnUpdate(old, new interface{}) {
-	isSync := false
-
+func (s *sharedIndexInformer) OnUpdate(old, new interface{}, isSync bool) {
 	// If is a Sync event, isSync should be true
 	// If is a Replaced event, isSync is true if resource version is unchanged.
 	// If RV is unchanged: this is a Sync/Replaced event, so isSync is true
 
-	if accessor, err := meta.Accessor(new); err == nil {
-		if oldAccessor, err := meta.Accessor(old); err == nil {
-			// Events that didn't change resourceVersion are treated as resync events
-			// and only propagated to listeners that requested resync
-			isSync = accessor.GetResourceVersion() == oldAccessor.GetResourceVersion()
+	if !isSync {
+		if accessor, err := meta.Accessor(new); err == nil {
+			if oldAccessor, err := meta.Accessor(old); err == nil {
+				// Events that didn't change resourceVersion are treated as resync events
+				// and only propagated to listeners that requested resync
+				isSync = accessor.GetResourceVersion() == oldAccessor.GetResourceVersion()
+			}
 		}
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind regression

#### What this PR does / why we need it:

There is a small behavioral change introduced in https://github.com/kubernetes/client-go/commit/54928eef9f824667b23a938188498992d437156a#diff-dbac68d65bbc9814c2336df6ee91f22e807d84a9127a4d34a8b39c5657d0e447L551 causing the shared informer to not be called during the first resync.

More details described in the linked issue.

#### Which issue(s) this PR fixes:
Fixes #127964

#### Special notes for your reviewer:
I don't know how to build and run tests. Relying on build pipeline.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
