### PR TITLE
KEP-4049: Add storage capacity scoring to VolumeBinding plugin

### DIFF
--- a/cmd/kube-scheduler/app/server_test.go
+++ b/cmd/kube-scheduler/app/server_test.go
@@ -39,10 +39,8 @@ import (
 	basecompatibility "k8s.io/component-base/compatibility"
 	componentbaseconfig "k8s.io/component-base/config"
 	"k8s.io/component-base/featuregate"
-	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	configv1 "k8s.io/kube-scheduler/config/v1"
 	"k8s.io/kubernetes/cmd/kube-scheduler/app/options"
-	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config/testing/defaults"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
@@ -222,19 +220,6 @@ leaderElection:
 		wantErr              bool
 		wantFeaturesGates    map[string]bool
 	}{
-		{
-			name: "default config with an alpha feature enabled",
-			flags: []string{
-				"--kubeconfig", configKubeconfig,
-				"--feature-gates=StorageCapacityScoring=true",
-			},
-			wantPlugins: map[string]*config.Plugins{
-				"default-scheduler": defaults.ExpandedPluginsV1,
-			},
-			restoreFeatures: map[featuregate.Feature]bool{
-				features.StorageCapacityScoring: false,
-			},
-		},
 		{
 			name: "component configuration v1 with only scheduler name configured",
 			flags: []string{
@@ -435,9 +420,6 @@ leaderElection:
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			for k, v := range tc.restoreFeatures {
-				featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, k, v)
-			}
 			componentGlobalsRegistry := basecompatibility.NewComponentGlobalsRegistry()
 			verKube := basecompatibility.NewEffectiveVersionFromString("1.32", "1.31", "1.31")
 			fg := feature.DefaultFeatureGate.DeepCopy()

--- a/cmd/kube-scheduler/app/server_test.go
+++ b/cmd/kube-scheduler/app/server_test.go
@@ -226,13 +226,13 @@ leaderElection:
 			name: "default config with an alpha feature enabled",
 			flags: []string{
 				"--kubeconfig", configKubeconfig,
-				"--feature-gates=VolumeCapacityPriority=true",
+				"--feature-gates=StorageCapacityScoring=true",
 			},
 			wantPlugins: map[string]*config.Plugins{
 				"default-scheduler": defaults.ExpandedPluginsV1,
 			},
 			restoreFeatures: map[featuregate.Feature]bool{
-				features.VolumeCapacityPriority: false,
+				features.StorageCapacityScoring: false,
 			},
 		},
 		{

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -681,7 +681,7 @@ const (
 	// kep: https://kep.k8s.io/4049
 	//
 	// Enables scoring nodes by available storage capacity with
-	// StorageCapacityScoring feature gate (dynamic provisioning only).
+	// StorageCapacityScoring feature gate.
 	StorageCapacityScoring featuregate.Feature = "StorageCapacityScoring"
 
 	// owner: @gjkim42 @SergeyKanzhelev @matthyx @tzneal

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -790,9 +790,6 @@ const (
 	// Enables user specified volume attributes for persistent volumes, like iops and throughput.
 	VolumeAttributesClass featuregate.Feature = "VolumeAttributesClass"
 
-	// owner: @cofyc
-	VolumeCapacityPriority featuregate.Feature = "VolumeCapacityPriority"
-
 	// owner: @ksubrmnn
 	//
 	// Allows kube-proxy to create DSR loadbalancers for Windows

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -677,6 +677,13 @@ const (
 	// Enables trafficDistribution field on Services.
 	ServiceTrafficDistribution featuregate.Feature = "ServiceTrafficDistribution"
 
+	// owner: @cupnes
+	// kep: https://kep.k8s.io/4049
+	//
+	// Enables scoring nodes by available storage capacity with
+	// StorageCapacityScoring feature gate (dynamic provisioning only).
+	StorageCapacityScoring featuregate.Feature = "StorageCapacityScoring"
+
 	// owner: @gjkim42 @SergeyKanzhelev @matthyx @tzneal
 	// kep: http://kep.k8s.io/753
 	//

--- a/pkg/features/versioned_kube_features.go
+++ b/pkg/features/versioned_kube_features.go
@@ -826,10 +826,6 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 		{Version: version.MustParse("1.31"), Default: false, PreRelease: featuregate.Beta},
 	},
 
-	VolumeCapacityPriority: {
-		{Version: version.MustParse("1.21"), Default: false, PreRelease: featuregate.Alpha},
-	},
-
 	WinDSR: {
 		{Version: version.MustParse("1.14"), Default: false, PreRelease: featuregate.Alpha},
 	},

--- a/pkg/features/versioned_kube_features.go
+++ b/pkg/features/versioned_kube_features.go
@@ -753,6 +753,10 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 		{Version: version.MustParse("1.31"), Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // GA in 1.31, remove in 1.33
 	},
 
+	StorageCapacityScoring: {
+		{Version: version.MustParse("1.33"), Default: false, PreRelease: featuregate.Alpha},
+	},
+
 	StorageVersionMigrator: {
 		{Version: version.MustParse("1.30"), Default: false, PreRelease: featuregate.Alpha},
 	},

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -64030,7 +64030,7 @@ func schema_k8sio_kube_scheduler_config_v1_VolumeBindingArgs(ref common.Referenc
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "Shape specifies the points defining the score function shape, which is used to score nodes based on the utilization of statically provisioned PVs. The utilization is calculated by dividing the total requested storage of the pod by the total capacity of feasible PVs on each node. Each point contains utilization (ranges from 0 to 100) and its associated score (ranges from 0 to 10). You can turn the priority by specifying different scores for different utilization numbers. The default shape points are: 1) 0 for 0 utilization 2) 10 for 100 utilization All points must be sorted in increasing order by utilization.",
+							Description: "Shape specifies the points defining the score function shape, which is used to score nodes based on the utilization of provisioned PVs. The utilization is calculated by dividing the total requested storage of the pod by the total capacity of feasible PVs on each node. Each point contains utilization (ranges from 0 to 100) and its associated score (ranges from 0 to 10). You can turn the priority by specifying different scores for different utilization numbers. The default shape points are: 1) 10 for 0 utilization 2) 0 for 100 utilization All points must be sorted in increasing order by utilization.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{

--- a/pkg/scheduler/apis/config/types_pluginargs.go
+++ b/pkg/scheduler/apis/config/types_pluginargs.go
@@ -163,7 +163,7 @@ type VolumeBindingArgs struct {
 	// 1) 0 for 0 utilization
 	// 2) 10 for 100 utilization
 	// All points must be sorted in increasing order by utilization.
-	// +featureGate=VolumeCapacityPriority
+	// +featureGate=StorageCapacityScoring
 	// +optional
 	Shape []UtilizationShapePoint
 }

--- a/pkg/scheduler/apis/config/v1/defaults.go
+++ b/pkg/scheduler/apis/config/v1/defaults.go
@@ -192,29 +192,16 @@ func SetDefaults_VolumeBindingArgs(obj *configv1.VolumeBindingArgs) {
 	if obj.BindTimeoutSeconds == nil {
 		obj.BindTimeoutSeconds = ptr.To[int64](600)
 	}
-	if len(obj.Shape) == 0 && feature.DefaultFeatureGate.Enabled(features.VolumeCapacityPriority) {
-		if feature.DefaultFeatureGate.Enabled(features.StorageCapacityScoring) {
-			obj.Shape = []configv1.UtilizationShapePoint{
-				{
-					Utilization: 0,
-					Score:       int32(config.MaxCustomPriorityScore),
-				},
-				{
-					Utilization: 100,
-					Score:       0,
-				},
-			}
-		} else {
-			obj.Shape = []configv1.UtilizationShapePoint{
-				{
-					Utilization: 0,
-					Score:       0,
-				},
-				{
-					Utilization: 100,
-					Score:       int32(config.MaxCustomPriorityScore),
-				},
-			}
+	if len(obj.Shape) == 0 && feature.DefaultFeatureGate.Enabled(features.StorageCapacityScoring) {
+		obj.Shape = []configv1.UtilizationShapePoint{
+			{
+				Utilization: 0,
+				Score:       int32(config.MaxCustomPriorityScore),
+			},
+			{
+				Utilization: 100,
+				Score:       0,
+			},
 		}
 	}
 }

--- a/pkg/scheduler/apis/config/v1/defaults.go
+++ b/pkg/scheduler/apis/config/v1/defaults.go
@@ -193,15 +193,28 @@ func SetDefaults_VolumeBindingArgs(obj *configv1.VolumeBindingArgs) {
 		obj.BindTimeoutSeconds = ptr.To[int64](600)
 	}
 	if len(obj.Shape) == 0 && feature.DefaultFeatureGate.Enabled(features.VolumeCapacityPriority) {
-		obj.Shape = []configv1.UtilizationShapePoint{
-			{
-				Utilization: 0,
-				Score:       0,
-			},
-			{
-				Utilization: 100,
-				Score:       int32(config.MaxCustomPriorityScore),
-			},
+		if feature.DefaultFeatureGate.Enabled(features.StorageCapacityScoring) {
+			obj.Shape = []configv1.UtilizationShapePoint{
+				{
+					Utilization: 0,
+					Score:       int32(config.MaxCustomPriorityScore),
+				},
+				{
+					Utilization: 100,
+					Score:       0,
+				},
+			}
+		} else {
+			obj.Shape = []configv1.UtilizationShapePoint{
+				{
+					Utilization: 0,
+					Score:       0,
+				},
+				{
+					Utilization: 100,
+					Score:       int32(config.MaxCustomPriorityScore),
+				},
+			}
 		}
 	}
 }

--- a/pkg/scheduler/apis/config/v1/defaults_test.go
+++ b/pkg/scheduler/apis/config/v1/defaults_test.go
@@ -810,9 +810,9 @@ func TestPluginArgsDefaults(t *testing.T) {
 			},
 		},
 		{
-			name: "VolumeBindingArgs empty, VolumeCapacityPriority disabled",
+			name: "VolumeBindingArgs empty, StorageCapacityScoring disabled",
 			features: map[featuregate.Feature]bool{
-				features.VolumeCapacityPriority: false,
+				features.StorageCapacityScoring: false,
 			},
 			in: &configv1.VolumeBindingArgs{},
 			want: &configv1.VolumeBindingArgs{
@@ -820,16 +820,16 @@ func TestPluginArgsDefaults(t *testing.T) {
 			},
 		},
 		{
-			name: "VolumeBindingArgs empty, VolumeCapacityPriority enabled",
+			name: "VolumeBindingArgs empty, StorageCapacityScoring enabled",
 			features: map[featuregate.Feature]bool{
-				features.VolumeCapacityPriority: true,
+				features.StorageCapacityScoring: true,
 			},
 			in: &configv1.VolumeBindingArgs{},
 			want: &configv1.VolumeBindingArgs{
 				BindTimeoutSeconds: ptr.To[int64](600),
 				Shape: []configv1.UtilizationShapePoint{
-					{Utilization: 0, Score: 0},
-					{Utilization: 100, Score: 10},
+					{Utilization: 0, Score: 10},
+					{Utilization: 100, Score: 0},
 				},
 			},
 		},

--- a/pkg/scheduler/apis/config/validation/validation_pluginargs.go
+++ b/pkg/scheduler/apis/config/validation/validation_pluginargs.go
@@ -261,13 +261,13 @@ func ValidateNodeAffinityArgs(path *field.Path, args *config.NodeAffinityArgs) e
 
 // VolumeBindingArgsValidationOptions contains the different settings for validation.
 type VolumeBindingArgsValidationOptions struct {
-	AllowVolumeCapacityPriority bool
+	AllowStorageCapacityScoring bool
 }
 
 // ValidateVolumeBindingArgs validates that VolumeBindingArgs are set correctly.
 func ValidateVolumeBindingArgs(path *field.Path, args *config.VolumeBindingArgs) error {
 	return ValidateVolumeBindingArgsWithOptions(path, args, VolumeBindingArgsValidationOptions{
-		AllowVolumeCapacityPriority: utilfeature.DefaultFeatureGate.Enabled(features.VolumeCapacityPriority),
+		AllowStorageCapacityScoring: utilfeature.DefaultFeatureGate.Enabled(features.StorageCapacityScoring),
 	})
 }
 
@@ -279,13 +279,13 @@ func ValidateVolumeBindingArgsWithOptions(path *field.Path, args *config.VolumeB
 		allErrs = append(allErrs, field.Invalid(path.Child("bindTimeoutSeconds"), args.BindTimeoutSeconds, "invalid BindTimeoutSeconds, should not be a negative value"))
 	}
 
-	if opts.AllowVolumeCapacityPriority {
+	if opts.AllowStorageCapacityScoring {
 		allErrs = append(allErrs, validateFunctionShape(args.Shape, path.Child("shape"))...)
 	} else if args.Shape != nil {
 		// When the feature is off, return an error if the config is not nil.
 		// This prevents unexpected configuration from taking effect when the
 		// feature turns on in the future.
-		allErrs = append(allErrs, field.Invalid(path.Child("shape"), args.Shape, "unexpected field `shape`, remove it or turn on the feature gate VolumeCapacityPriority"))
+		allErrs = append(allErrs, field.Invalid(path.Child("shape"), args.Shape, "unexpected field `shape`, remove it or turn on the feature gate StorageCapacityScoring"))
 	}
 	return allErrs.ToAggregate()
 }

--- a/pkg/scheduler/apis/config/validation/validation_pluginargs_test.go
+++ b/pkg/scheduler/apis/config/validation/validation_pluginargs_test.go
@@ -559,9 +559,9 @@ func TestValidateVolumeBindingArgs(t *testing.T) {
 			}}),
 		},
 		{
-			name: "[VolumeCapacityPriority=off] shape should be nil when the feature is off",
+			name: "[StorageCapacityScoring=off] shape should be nil when the feature is off",
 			features: map[featuregate.Feature]bool{
-				features.VolumeCapacityPriority: false,
+				features.StorageCapacityScoring: false,
 			},
 			args: config.VolumeBindingArgs{
 				BindTimeoutSeconds: 10,
@@ -569,9 +569,9 @@ func TestValidateVolumeBindingArgs(t *testing.T) {
 			},
 		},
 		{
-			name: "[VolumeCapacityPriority=off] error if the shape is not nil when the feature is off",
+			name: "[StorageCapacityScoring=off] error if the shape is not nil when the feature is off",
 			features: map[featuregate.Feature]bool{
-				features.VolumeCapacityPriority: false,
+				features.StorageCapacityScoring: false,
 			},
 			args: config.VolumeBindingArgs{
 				BindTimeoutSeconds: 10,
@@ -586,9 +586,9 @@ func TestValidateVolumeBindingArgs(t *testing.T) {
 			}}),
 		},
 		{
-			name: "[VolumeCapacityPriority=on] shape should not be empty",
+			name: "[StorageCapacityScoring=on] shape should not be empty",
 			features: map[featuregate.Feature]bool{
-				features.VolumeCapacityPriority: true,
+				features.StorageCapacityScoring: true,
 			},
 			args: config.VolumeBindingArgs{
 				BindTimeoutSeconds: 10,
@@ -600,9 +600,9 @@ func TestValidateVolumeBindingArgs(t *testing.T) {
 			}}),
 		},
 		{
-			name: "[VolumeCapacityPriority=on] shape points must be sorted in increasing order",
+			name: "[StorageCapacityScoring=on] shape points must be sorted in increasing order",
 			features: map[featuregate.Feature]bool{
-				features.VolumeCapacityPriority: true,
+				features.StorageCapacityScoring: true,
 			},
 			args: config.VolumeBindingArgs{
 				BindTimeoutSeconds: 10,
@@ -618,9 +618,9 @@ func TestValidateVolumeBindingArgs(t *testing.T) {
 			}}),
 		},
 		{
-			name: "[VolumeCapacityPriority=on] shape point: invalid utilization and score",
+			name: "[StorageCapacityScoring=on] shape point: invalid utilization and score",
 			features: map[featuregate.Feature]bool{
-				features.VolumeCapacityPriority: true,
+				features.StorageCapacityScoring: true,
 			},
 			args: config.VolumeBindingArgs{
 				BindTimeoutSeconds: 10,

--- a/pkg/scheduler/framework/plugins/feature/feature.go
+++ b/pkg/scheduler/framework/plugins/feature/feature.go
@@ -33,4 +33,5 @@ type Features struct {
 	EnableSchedulingQueueHint                    bool
 	EnableAsyncPreemption                        bool
 	EnablePodLevelResources                      bool
+	EnableStorageCapacityScoring                 bool
 }

--- a/pkg/scheduler/framework/plugins/feature/feature.go
+++ b/pkg/scheduler/framework/plugins/feature/feature.go
@@ -23,7 +23,6 @@ type Features struct {
 	EnableDRAPrioritizedList                     bool
 	EnableDRAAdminAccess                         bool
 	EnableDynamicResourceAllocation              bool
-	EnableVolumeCapacityPriority                 bool
 	EnableVolumeAttributesClass                  bool
 	EnableCSIMigrationPortworx                   bool
 	EnableNodeInclusionPolicyInPodTopologySpread bool

--- a/pkg/scheduler/framework/plugins/registry.go
+++ b/pkg/scheduler/framework/plugins/registry.go
@@ -59,6 +59,7 @@ func NewInTreeRegistry() runtime.Registry {
 		EnableSchedulingQueueHint:                    feature.DefaultFeatureGate.Enabled(features.SchedulerQueueingHints),
 		EnableAsyncPreemption:                        feature.DefaultFeatureGate.Enabled(features.SchedulerAsyncPreemption),
 		EnablePodLevelResources:                      feature.DefaultFeatureGate.Enabled(features.PodLevelResources),
+		EnableStorageCapacityScoring:                 feature.DefaultFeatureGate.Enabled(features.StorageCapacityScoring),
 	}
 
 	registry := runtime.Registry{

--- a/pkg/scheduler/framework/plugins/registry.go
+++ b/pkg/scheduler/framework/plugins/registry.go
@@ -49,7 +49,6 @@ func NewInTreeRegistry() runtime.Registry {
 		EnableDRAPrioritizedList:                     feature.DefaultFeatureGate.Enabled(features.DRAPrioritizedList),
 		EnableDRAAdminAccess:                         feature.DefaultFeatureGate.Enabled(features.DRAAdminAccess),
 		EnableDynamicResourceAllocation:              feature.DefaultFeatureGate.Enabled(features.DynamicResourceAllocation),
-		EnableVolumeCapacityPriority:                 feature.DefaultFeatureGate.Enabled(features.VolumeCapacityPriority),
 		EnableVolumeAttributesClass:                  feature.DefaultFeatureGate.Enabled(features.VolumeAttributesClass),
 		EnableCSIMigrationPortworx:                   feature.DefaultFeatureGate.Enabled(features.CSIMigrationPortworx),
 		EnableNodeInclusionPolicyInPodTopologySpread: feature.DefaultFeatureGate.Enabled(features.NodeInclusionPolicyInPodTopologySpread),

--- a/pkg/scheduler/framework/plugins/volumebinding/volume_binding.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/volume_binding.go
@@ -29,6 +29,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	corelisters "k8s.io/client-go/listers/core/v1"
+	storagelisters "k8s.io/client-go/listers/storage/v1"
 	"k8s.io/component-helpers/storage/ephemeral"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
@@ -70,10 +71,11 @@ func (d *stateData) Clone() framework.StateData {
 // In the Filter phase, pod binding cache is created for the pod and used in
 // Reserve and PreBind phases.
 type VolumeBinding struct {
-	Binder    SchedulerVolumeBinder
-	PVCLister corelisters.PersistentVolumeClaimLister
-	scorer    volumeCapacityScorer
-	fts       feature.Features
+	Binder      SchedulerVolumeBinder
+	PVCLister   corelisters.PersistentVolumeClaimLister
+	classLister storagelisters.StorageClassLister
+	scorer      volumeCapacityScorer
+	fts         feature.Features
 }
 
 var _ framework.PreFilterPlugin = &VolumeBinding{}
@@ -451,7 +453,7 @@ func (pl *VolumeBinding) PreScore(ctx context.Context, cs *framework.CycleState,
 	if err != nil {
 		return framework.AsStatus(err)
 	}
-	if state.hasStaticBindings {
+	if state.hasStaticBindings || pl.fts.EnableStorageCapacityScoring {
 		return nil
 	}
 	return framework.NewStatus(framework.Skip)
@@ -471,20 +473,44 @@ func (pl *VolumeBinding) Score(ctx context.Context, cs *framework.CycleState, po
 	if !ok {
 		return 0, nil
 	}
-	// group by storage class
+
 	classResources := make(classResourceMap)
-	for _, staticBinding := range podVolumes.StaticBindings {
-		class := staticBinding.StorageClassName()
-		storageResource := staticBinding.StorageResource()
-		if _, ok := classResources[class]; !ok {
-			classResources[class] = &StorageResource{
-				Requested: 0,
-				Capacity:  0,
+	if len(podVolumes.StaticBindings) != 0 || !pl.fts.EnableStorageCapacityScoring {
+		// group static binding volumes by storage class
+		for _, staticBinding := range podVolumes.StaticBindings {
+			class := staticBinding.StorageClassName()
+			storageResource := staticBinding.StorageResource()
+			if _, ok := classResources[class]; !ok {
+				classResources[class] = &StorageResource{
+					Requested: 0,
+					Capacity:  0,
+				}
 			}
+			classResources[class].Requested += storageResource.Requested
+			classResources[class].Capacity += storageResource.Capacity
 		}
-		classResources[class].Requested += storageResource.Requested
-		classResources[class].Capacity += storageResource.Capacity
+	} else {
+		// group dynamic binding volumes by storage class
+		for _, provision := range podVolumes.DynamicProvisions {
+			if provision.NodeCapacity == nil {
+				continue
+			}
+			class := *provision.PVC.Spec.StorageClassName
+			if _, ok := classResources[class]; !ok {
+				classResources[class] = &StorageResource{
+					Requested: 0,
+					Capacity:  0,
+				}
+			}
+			// The following line cannot be +=. For example, if a Pod requests two 50GB volumes from
+			// a StorageClass with 100GB of capacity on a node, this part of the code will be executed twice.
+			// In that case, using += would incorrectly set classResources[class].Capacity to 200GB.
+			classResources[class].Capacity = provision.NodeCapacity.Capacity.Value()
+			requestedQty := provision.PVC.Spec.Resources.Requests[v1.ResourceName(v1.ResourceStorage)]
+			classResources[class].Requested += requestedQty.Value()
+		}
 	}
+
 	return pl.scorer(classResources), nil
 }
 
@@ -595,9 +621,10 @@ func New(ctx context.Context, plArgs runtime.Object, fh framework.Handle, fts fe
 		scorer = buildScorerFunction(shape)
 	}
 	return &VolumeBinding{
-		Binder:    binder,
-		PVCLister: pvcInformer.Lister(),
-		scorer:    scorer,
-		fts:       fts,
+		Binder:      binder,
+		PVCLister:   pvcInformer.Lister(),
+		classLister: storageClassInformer.Lister(),
+		scorer:      scorer,
+		fts:         fts,
 	}, nil
 }

--- a/pkg/scheduler/framework/plugins/volumebinding/volume_binding.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/volume_binding.go
@@ -592,7 +592,7 @@ func New(ctx context.Context, plArgs runtime.Object, fh framework.Handle, fts fe
 		return nil, fmt.Errorf("want args to be of type VolumeBindingArgs, got %T", plArgs)
 	}
 	if err := validation.ValidateVolumeBindingArgsWithOptions(nil, args, validation.VolumeBindingArgsValidationOptions{
-		AllowVolumeCapacityPriority: fts.EnableVolumeCapacityPriority,
+		AllowStorageCapacityScoring: fts.EnableStorageCapacityScoring,
 	}); err != nil {
 		return nil, err
 	}
@@ -610,7 +610,7 @@ func New(ctx context.Context, plArgs runtime.Object, fh framework.Handle, fts fe
 
 	// build score function
 	var scorer volumeCapacityScorer
-	if fts.EnableVolumeCapacityPriority {
+	if fts.EnableStorageCapacityScoring {
 		shape := make(helper.FunctionShape, 0, len(args.Shape))
 		for _, point := range args.Shape {
 			shape = append(shape, helper.FunctionShapePoint{

--- a/pkg/scheduler/framework/plugins/volumebinding/volume_binding_test.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/volume_binding_test.go
@@ -327,7 +327,7 @@ func TestVolumeBinding(t *testing.T) {
 					withNodeAffinity(map[string][]string{v1.LabelHostname: {"node-b"}}).PersistentVolume,
 			},
 			fts: feature.Features{
-				EnableVolumeCapacityPriority: true,
+				EnableStorageCapacityScoring: true,
 			},
 			wantPreFilterStatus: nil,
 			wantStateAfterPreFilter: &stateData{
@@ -417,7 +417,7 @@ func TestVolumeBinding(t *testing.T) {
 					withNodeAffinity(map[string][]string{v1.LabelHostname: {"node-b"}}).PersistentVolume,
 			},
 			fts: feature.Features{
-				EnableVolumeCapacityPriority: true,
+				EnableStorageCapacityScoring: true,
 			},
 			wantPreFilterStatus: nil,
 			wantStateAfterPreFilter: &stateData{
@@ -536,7 +536,7 @@ func TestVolumeBinding(t *testing.T) {
 					}).PersistentVolume,
 			},
 			fts: feature.Features{
-				EnableVolumeCapacityPriority: true,
+				EnableStorageCapacityScoring: true,
 			},
 			wantPreFilterStatus: nil,
 			wantStateAfterPreFilter: &stateData{
@@ -654,7 +654,7 @@ func TestVolumeBinding(t *testing.T) {
 					}).PersistentVolume,
 			},
 			fts: feature.Features{
-				EnableVolumeCapacityPriority: true,
+				EnableStorageCapacityScoring: true,
 			},
 			args: &config.VolumeBindingArgs{
 				BindTimeoutSeconds: 300,
@@ -750,7 +750,6 @@ func TestVolumeBinding(t *testing.T) {
 				makeCapacity("node-c", waitSCWithStorageCapacity.Name, makeNode("node-c").withLabel(nodeLabelKey, "node-c").Node, "10Gi", ""),
 			},
 			fts: feature.Features{
-				EnableVolumeCapacityPriority: true,
 				EnableStorageCapacityScoring: true,
 			},
 			wantPreFilterStatus: nil,
@@ -807,7 +806,6 @@ func TestVolumeBinding(t *testing.T) {
 				makeCapacity("node-c", waitSCWithStorageCapacity.Name, makeNode("node-c").withLabel(nodeLabelKey, "node-c").Node, "10Gi", ""),
 			},
 			fts: feature.Features{
-				EnableVolumeCapacityPriority: true,
 				EnableStorageCapacityScoring: true,
 			},
 			wantPreFilterStatus: nil,
@@ -863,7 +861,6 @@ func TestVolumeBinding(t *testing.T) {
 				makeCapacity("node-a", waitSCWithStorageCapacity.Name, makeNode("node-a").withLabel(nodeLabelKey, "node-a").Node, "100Gi", ""),
 			},
 			fts: feature.Features{
-				EnableVolumeCapacityPriority: true,
 				EnableStorageCapacityScoring: true,
 			},
 			wantPreFilterStatus: nil,
@@ -902,7 +899,6 @@ func TestVolumeBinding(t *testing.T) {
 				makeCapacity("node-c", waitSCWithStorageCapacity.Name, makeNode("node-c").withLabel(nodeLabelKey, "node-c").Node, "10Gi", ""),
 			},
 			fts: feature.Features{
-				EnableVolumeCapacityPriority: true,
 				EnableStorageCapacityScoring: true,
 			},
 			wantPreFilterStatus: nil,
@@ -944,7 +940,6 @@ func TestVolumeBinding(t *testing.T) {
 				makeCapacity("node-c", waitSCWithStorageCapacity.Name, makeNode("node-c").withLabel(nodeLabelKey, "node-c").Node, "10Gi", ""),
 			},
 			fts: feature.Features{
-				EnableVolumeCapacityPriority: true,
 				EnableStorageCapacityScoring: true,
 			},
 			args: &config.VolumeBindingArgs{
@@ -1006,7 +1001,7 @@ func TestVolumeBinding(t *testing.T) {
 				args = &config.VolumeBindingArgs{
 					BindTimeoutSeconds: 300,
 				}
-				if item.fts.EnableVolumeCapacityPriority {
+				if item.fts.EnableStorageCapacityScoring {
 					args.Shape = defaultShapePoint
 				}
 			}

--- a/staging/src/k8s.io/kube-scheduler/config/v1/types_pluginargs.go
+++ b/staging/src/k8s.io/kube-scheduler/config/v1/types_pluginargs.go
@@ -159,17 +159,17 @@ type VolumeBindingArgs struct {
 	BindTimeoutSeconds *int64 `json:"bindTimeoutSeconds,omitempty"`
 
 	// Shape specifies the points defining the score function shape, which is
-	// used to score nodes based on the utilization of statically provisioned
-	// PVs. The utilization is calculated by dividing the total requested
+	// used to score nodes based on the utilization of provisioned PVs.
+	// The utilization is calculated by dividing the total requested
 	// storage of the pod by the total capacity of feasible PVs on each node.
 	// Each point contains utilization (ranges from 0 to 100) and its
 	// associated score (ranges from 0 to 10). You can turn the priority by
 	// specifying different scores for different utilization numbers.
 	// The default shape points are:
-	// 1) 0 for 0 utilization
-	// 2) 10 for 100 utilization
+	// 1) 10 for 0 utilization
+	// 2) 0 for 100 utilization
 	// All points must be sorted in increasing order by utilization.
-	// +featureGate=VolumeCapacityPriority
+	// +featureGate=StorageCapacityScoring
 	// +optional
 	// +listType=atomic
 	Shape []UtilizationShapePoint `json:"shape,omitempty"`

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -1557,12 +1557,6 @@
     lockToDefault: false
     preRelease: Beta
     version: "1.31"
-- name: VolumeCapacityPriority
-  versionedSpecs:
-  - default: false
-    lockToDefault: false
-    preRelease: Alpha
-    version: "1.21"
 - name: WatchCacheInitializationPostStartHook
   versionedSpecs:
   - default: false

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -1345,6 +1345,12 @@
     lockToDefault: true
     preRelease: GA
     version: "1.31"
+- name: StorageCapacityScoring
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.33"
 - name: StorageNamespaceIndex
   versionedSpecs:
   - default: true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR is the alpha version of [KEP-4049](https://github.com/kubernetes/enhancements/blob/master/keps/sig-storage/4049-storage-capacity-scoring-of-nodes-for-dynamic-provisioning/README.md), incorporating its detailed design and adding basic tests.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of https://github.com/kubernetes/enhancements/issues/4049

#### Special notes for your reviewer:

None.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The `StorageCapacityScoring` feature gate was added to score nodes by available storage capacity. It's in alpha and disabled by default. The `VolumeCapacityPriority` alpha feature was replaced with this, and the default behavior was changed. The `VolumeCapacityPriority` preferred a node with the least allocatable, but the `StorageCapacityScoring` preferred a node with the maximum allocatable. See [KEP-4049](https://github.com/kubernetes/enhancements/blob/master/keps/sig-storage/4049-storage-capacity-scoring-of-nodes-for-dynamic-provisioning/README.md) for details.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage/4049-storage-capacity-scoring-of-nodes-for-dynamic-provisioning
```
