### PR TITLE
Fix issue template link in staging README

### DIFF
--- a/staging/README.md
+++ b/staging/README.md
@@ -92,7 +92,7 @@ import (
 
 ### Creating the published repository
 
-1. Create an [issue](https://github.com/kubernetes/org/issues/new?template=repo-create.md)
+1. Create an [issue](https://github.com/kubernetes/org/issues/new?assignees=&labels=area%2Fgithub-repo&projects=&template=repo-create.yml&title=REQUEST%3A+%3CCreate+or+Migrate%3E+%3Cgithub+repo%3E)
 in the `kubernetes/org` repo to request creation of the respective published
 repository in the Kubernetes org. The published repository **must** have an
 initial empty commit. It also needs specific access rules and branch settings.


### PR DESCRIPTION
update hyper-link for 'create issue' to point to the right template.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

updated hyperlink to point to the right template for filing a repo publish request.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
