### PR TITLE
[WIP] feat: enable concurrent mode for kubectl delete

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete_flags.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete_flags.go
@@ -49,6 +49,7 @@ type DeleteFlags struct {
 	Output            *string
 	Raw               *string
 	Interactive       *bool
+	Concurrent        *bool
 }
 
 func (f *DeleteFlags) ToOptions(dynamicClient dynamic.Interface, streams genericiooptions.IOStreams) (*DeleteOptions, error) {
@@ -110,6 +111,9 @@ func (f *DeleteFlags) ToOptions(dynamicClient dynamic.Interface, streams generic
 	if f.Interactive != nil {
 		options.Interactive = *f.Interactive
 	}
+	if f.Concurrent != nil {
+		options.Concurrent = *f.Concurrent
+	}
 
 	return options, nil
 }
@@ -163,6 +167,9 @@ func (f *DeleteFlags) AddFlags(cmd *cobra.Command) {
 	if f.Interactive != nil {
 		cmd.Flags().BoolVarP(f.Interactive, "interactive", "i", *f.Interactive, "If true, delete resource only when user confirms.")
 	}
+	if f.Concurrent != nil {
+		cmd.Flags().BoolVar(f.Concurrent, "concurrent", *f.Concurrent, "If true, delete resources in parallel.")
+	}
 }
 
 // NewDeleteCommandFlags provides default flags and values for use with the "delete" command
@@ -187,6 +194,7 @@ func NewDeleteCommandFlags(usage string) *DeleteFlags {
 	filenames := []string{}
 	recursive := false
 	kustomize := ""
+	concurrent := false
 
 	return &DeleteFlags{
 		// Not using helpers.go since it provides function to add '-k' for FileNameOptions, but not FileNameFlags
@@ -207,6 +215,7 @@ func NewDeleteCommandFlags(usage string) *DeleteFlags {
 		Output:         &output,
 		Raw:            &raw,
 		Interactive:    &interactive,
+		Concurrent:     &concurrent,
 	}
 }
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete_test.go
@@ -65,6 +65,14 @@ func TestDeleteFlagValidation(t *testing.T) {
 			},
 			expectedErr: "--interactive can not be used with --raw",
 		},
+		{
+			flags: DeleteFlags{
+				All:         ptr.To(true),
+				Concurrent:  ptr.To(true),
+				Interactive: ptr.To(true),
+			},
+			expectedErr: "cannot set --concurrent and --interactive at the same time",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Introduces an option to enable concurrent mode in the kubectl delete command, improving performance by allowing resources to be deleted in parallel.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #125407

#### Special notes for your reviewer:
This is a work in progress—please confirm if the implementation is on the right track.
I have conducted initial tests using my EKS cluster:

Test with 10 deployments:
Concurrent: 3.713 seconds
Non-concurrent: 5.509 seconds

Test with 20 deployments:
Concurrent: 5.878 seconds
Non-concurrent: 9.192 seconds

Test with 35 deployments:
Concurrent: 8.802 seconds
Non-concurrent: 14.727 seconds


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Adds --concurrent option to kubectl delete for parallel deletion of resources.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
