### PR TITLE
chore: remove sig/api-machinery from OWNERS files that sig/etcd owns

### DIFF
--- a/cluster/images/etcd-version-monitor/OWNERS
+++ b/cluster/images/etcd-version-monitor/OWNERS
@@ -1,5 +1,4 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 labels:
-  - sig/api-machinery
   - sig/etcd

--- a/cluster/images/etcd/OWNERS
+++ b/cluster/images/etcd/OWNERS
@@ -7,5 +7,4 @@ approvers:
   - jpbetz
   - serathius
 labels:
-  - sig/api-machinery
   - sig/etcd


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR removes sig/api-machinery from OWNERS files that likely sig/etcd should solely own.  This is related to the issue https://github.com/kubernetes/kubernetes/issues/127336 that was filed during the sig/api-machinery bi-weekly bugscrub. The gist of this issue is that sig/api-machinery is flagged on PRs that should likely solely belong to sig/etcd. Fully "fixing" this issue would also likely include using OWNERS `filters:` for top level directories and setting specific files to be delegated to sig/etcd (for example - `hack/lib/etcd.sh`, etc.)  As such this PR is only part of the solution to https://github.com/kubernetes/kubernetes/issues/127336.  For additional context on the sig/etcd label and OWNERS, see the original PR that added the sig/etcd label to OWNERS here: https://github.com/kubernetes/kubernetes/pull/125679

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #127336 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
/sig api-machinery
/sig etcd

/triage approved