### PR TITLE
Update publishing-bot rules to Go 1.22.8

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -7,25 +7,25 @@ rules:
       dirs:
       - staging/src/k8s.io/apimachinery
   - name: release-1.28
-    go: 1.22.6
+    go: 1.22.8
     source:
       branch: release-1.28
       dirs:
       - staging/src/k8s.io/apimachinery
   - name: release-1.29
-    go: 1.22.6
+    go: 1.22.8
     source:
       branch: release-1.29
       dirs:
       - staging/src/k8s.io/apimachinery
   - name: release-1.30
-    go: 1.22.6
+    go: 1.22.8
     source:
       branch: release-1.30
       dirs:
       - staging/src/k8s.io/apimachinery
   - name: release-1.31
-    go: 1.22.6
+    go: 1.22.8
     source:
       branch: release-1.31
       dirs:
@@ -42,7 +42,7 @@ rules:
       dirs:
       - staging/src/k8s.io/api
   - name: release-1.28
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -51,7 +51,7 @@ rules:
       dirs:
       - staging/src/k8s.io/api
   - name: release-1.29
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -60,7 +60,7 @@ rules:
       dirs:
       - staging/src/k8s.io/api
   - name: release-1.30
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -69,7 +69,7 @@ rules:
       dirs:
       - staging/src/k8s.io/api
   - name: release-1.31
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -95,7 +95,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.28
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -110,7 +110,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.29
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -125,7 +125,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.30
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -140,7 +140,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.31
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -166,19 +166,19 @@ rules:
       dirs:
       - staging/src/k8s.io/code-generator
   - name: release-1.28
-    go: 1.22.6
+    go: 1.22.8
     source:
       branch: release-1.28
       dirs:
       - staging/src/k8s.io/code-generator
   - name: release-1.29
-    go: 1.22.6
+    go: 1.22.8
     source:
       branch: release-1.29
       dirs:
       - staging/src/k8s.io/code-generator
   - name: release-1.30
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -187,7 +187,7 @@ rules:
       dirs:
       - staging/src/k8s.io/code-generator
   - name: release-1.31
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -210,7 +210,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-base
   - name: release-1.28
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -223,7 +223,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-base
   - name: release-1.29
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -236,7 +236,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-base
   - name: release-1.30
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -249,7 +249,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-base
   - name: release-1.31
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -277,7 +277,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-helpers
   - name: release-1.28
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -290,7 +290,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-helpers
   - name: release-1.29
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -303,7 +303,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-helpers
   - name: release-1.30
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -316,7 +316,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-helpers
   - name: release-1.31
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -340,7 +340,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kms
   - name: release-1.28
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -353,7 +353,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kms
   - name: release-1.29
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -362,7 +362,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kms
   - name: release-1.30
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -371,7 +371,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kms
   - name: release-1.31
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -399,7 +399,7 @@ rules:
       dirs:
       - staging/src/k8s.io/apiserver
   - name: release-1.28
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -416,7 +416,7 @@ rules:
       dirs:
       - staging/src/k8s.io/apiserver
   - name: release-1.29
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -433,7 +433,7 @@ rules:
       dirs:
       - staging/src/k8s.io/apiserver
   - name: release-1.30
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -450,7 +450,7 @@ rules:
       dirs:
       - staging/src/k8s.io/apiserver
   - name: release-1.31
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -490,7 +490,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-aggregator
   - name: release-1.28
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -511,7 +511,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-aggregator
   - name: release-1.29
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -532,7 +532,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-aggregator
   - name: release-1.30
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -553,7 +553,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-aggregator
   - name: release-1.31
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -601,7 +601,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.28
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -627,7 +627,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.29
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -653,7 +653,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.30
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -679,7 +679,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.31
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -726,7 +726,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.28
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -746,7 +746,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.29
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -766,7 +766,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.30
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -786,7 +786,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.31
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -830,7 +830,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.28
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -853,7 +853,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.29
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -876,7 +876,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.30
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -899,7 +899,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.31
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -938,7 +938,7 @@ rules:
       dirs:
       - staging/src/k8s.io/metrics
   - name: release-1.28
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -953,7 +953,7 @@ rules:
       dirs:
       - staging/src/k8s.io/metrics
   - name: release-1.29
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -968,7 +968,7 @@ rules:
       dirs:
       - staging/src/k8s.io/metrics
   - name: release-1.30
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -983,7 +983,7 @@ rules:
       dirs:
       - staging/src/k8s.io/metrics
   - name: release-1.31
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -1013,7 +1013,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cli-runtime
   - name: release-1.28
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: api
       branch: release-1.28
@@ -1026,7 +1026,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cli-runtime
   - name: release-1.29
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: api
       branch: release-1.29
@@ -1039,7 +1039,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cli-runtime
   - name: release-1.30
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: api
       branch: release-1.30
@@ -1052,7 +1052,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cli-runtime
   - name: release-1.31
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: api
       branch: release-1.31
@@ -1082,7 +1082,7 @@ rules:
       dirs:
       - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.28
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: api
       branch: release-1.28
@@ -1097,7 +1097,7 @@ rules:
       dirs:
       - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.29
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: api
       branch: release-1.29
@@ -1112,7 +1112,7 @@ rules:
       dirs:
       - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.30
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: api
       branch: release-1.30
@@ -1127,7 +1127,7 @@ rules:
       dirs:
       - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.31
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: api
       branch: release-1.31
@@ -1158,7 +1158,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-proxy
   - name: release-1.28
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -1173,7 +1173,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-proxy
   - name: release-1.29
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -1188,7 +1188,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-proxy
   - name: release-1.30
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -1203,7 +1203,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-proxy
   - name: release-1.31
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -1226,25 +1226,25 @@ rules:
       dirs:
       - staging/src/k8s.io/cri-api
   - name: release-1.28
-    go: 1.22.6
+    go: 1.22.8
     source:
       branch: release-1.28
       dirs:
       - staging/src/k8s.io/cri-api
   - name: release-1.29
-    go: 1.22.6
+    go: 1.22.8
     source:
       branch: release-1.29
       dirs:
       - staging/src/k8s.io/cri-api
   - name: release-1.30
-    go: 1.22.6
+    go: 1.22.8
     source:
       branch: release-1.30
       dirs:
       - staging/src/k8s.io/cri-api
   - name: release-1.31
-    go: 1.22.6
+    go: 1.22.8
     source:
       branch: release-1.31
       dirs:
@@ -1269,7 +1269,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cri-client
   - name: release-1.31
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: api
       branch: release-1.31
@@ -1309,7 +1309,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubelet
   - name: release-1.28
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -1330,7 +1330,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubelet
   - name: release-1.29
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -1351,7 +1351,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubelet
   - name: release-1.30
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -1372,7 +1372,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubelet
   - name: release-1.31
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -1410,7 +1410,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-scheduler
   - name: release-1.28
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -1425,7 +1425,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-scheduler
   - name: release-1.29
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -1440,7 +1440,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-scheduler
   - name: release-1.30
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -1455,7 +1455,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-scheduler
   - name: release-1.31
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -1491,7 +1491,7 @@ rules:
       dirs:
       - staging/src/k8s.io/controller-manager
   - name: release-1.28
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: api
       branch: release-1.28
@@ -1510,7 +1510,7 @@ rules:
       dirs:
       - staging/src/k8s.io/controller-manager
   - name: release-1.29
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: api
       branch: release-1.29
@@ -1529,7 +1529,7 @@ rules:
       dirs:
       - staging/src/k8s.io/controller-manager
   - name: release-1.30
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: api
       branch: release-1.30
@@ -1548,7 +1548,7 @@ rules:
       dirs:
       - staging/src/k8s.io/controller-manager
   - name: release-1.31
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: api
       branch: release-1.31
@@ -1592,7 +1592,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cloud-provider
   - name: release-1.28
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: api
       branch: release-1.28
@@ -1615,7 +1615,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cloud-provider
   - name: release-1.29
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: api
       branch: release-1.29
@@ -1638,7 +1638,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cloud-provider
   - name: release-1.30
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: api
       branch: release-1.30
@@ -1661,7 +1661,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cloud-provider
   - name: release-1.31
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: api
       branch: release-1.31
@@ -1711,7 +1711,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-controller-manager
   - name: release-1.28
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -1736,7 +1736,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-controller-manager
   - name: release-1.29
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -1761,7 +1761,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-controller-manager
   - name: release-1.30
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -1786,7 +1786,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-controller-manager
   - name: release-1.31
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -1824,7 +1824,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.28
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -1835,7 +1835,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.29
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -1846,7 +1846,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.30
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -1857,7 +1857,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.31
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -1881,7 +1881,7 @@ rules:
       dirs:
       - staging/src/k8s.io/csi-translation-lib
   - name: release-1.28
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: api
       branch: release-1.28
@@ -1892,7 +1892,7 @@ rules:
       dirs:
       - staging/src/k8s.io/csi-translation-lib
   - name: release-1.29
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: api
       branch: release-1.29
@@ -1903,7 +1903,7 @@ rules:
       dirs:
       - staging/src/k8s.io/csi-translation-lib
   - name: release-1.30
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: api
       branch: release-1.30
@@ -1914,7 +1914,7 @@ rules:
       dirs:
       - staging/src/k8s.io/csi-translation-lib
   - name: release-1.31
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: api
       branch: release-1.31
@@ -1933,25 +1933,25 @@ rules:
       dirs:
       - staging/src/k8s.io/mount-utils
   - name: release-1.28
-    go: 1.22.6
+    go: 1.22.8
     source:
       branch: release-1.28
       dirs:
       - staging/src/k8s.io/mount-utils
   - name: release-1.29
-    go: 1.22.6
+    go: 1.22.8
     source:
       branch: release-1.29
       dirs:
       - staging/src/k8s.io/mount-utils
   - name: release-1.30
-    go: 1.22.6
+    go: 1.22.8
     source:
       branch: release-1.30
       dirs:
       - staging/src/k8s.io/mount-utils
   - name: release-1.31
-    go: 1.22.6
+    go: 1.22.8
     source:
       branch: release-1.31
       dirs:
@@ -1960,7 +1960,7 @@ rules:
 - destination: legacy-cloud-providers
   branches:
   - name: release-1.28
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: api
       branch: release-1.28
@@ -1985,7 +1985,7 @@ rules:
       dirs:
       - staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.29
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: api
       branch: release-1.29
@@ -2010,7 +2010,7 @@ rules:
       dirs:
       - staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.30
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: api
       branch: release-1.30
@@ -2060,7 +2060,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubectl
   - name: release-1.28
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: api
       branch: release-1.28
@@ -2083,7 +2083,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubectl
   - name: release-1.29
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: api
       branch: release-1.29
@@ -2106,7 +2106,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubectl
   - name: release-1.30
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: api
       branch: release-1.30
@@ -2129,7 +2129,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubectl
   - name: release-1.31
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: api
       branch: release-1.31
@@ -2173,7 +2173,7 @@ rules:
       dirs:
       - staging/src/k8s.io/pod-security-admission
   - name: release-1.28
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: api
       branch: release-1.28
@@ -2192,7 +2192,7 @@ rules:
       dirs:
       - staging/src/k8s.io/pod-security-admission
   - name: release-1.29
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: api
       branch: release-1.29
@@ -2211,7 +2211,7 @@ rules:
       dirs:
       - staging/src/k8s.io/pod-security-admission
   - name: release-1.30
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: api
       branch: release-1.30
@@ -2230,7 +2230,7 @@ rules:
       dirs:
       - staging/src/k8s.io/pod-security-admission
   - name: release-1.31
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: api
       branch: release-1.31
@@ -2276,7 +2276,7 @@ rules:
       dirs:
       - staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.28
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -2297,7 +2297,7 @@ rules:
       dirs:
       - staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.29
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -2318,7 +2318,7 @@ rules:
       dirs:
       - staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.30
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -2341,7 +2341,7 @@ rules:
       dirs:
       - staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.31
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -2382,7 +2382,7 @@ rules:
       dirs:
       - staging/src/k8s.io/endpointslice
   - name: release-1.28
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: api
       branch: release-1.28
@@ -2397,7 +2397,7 @@ rules:
       dirs:
       - staging/src/k8s.io/endpointslice
   - name: release-1.29
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: api
       branch: release-1.29
@@ -2412,7 +2412,7 @@ rules:
       dirs:
       - staging/src/k8s.io/endpointslice
   - name: release-1.30
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: api
       branch: release-1.30
@@ -2427,7 +2427,7 @@ rules:
       dirs:
       - staging/src/k8s.io/endpointslice
   - name: release-1.31
-    go: 1.22.6
+    go: 1.22.8
     dependencies:
     - repository: api
       branch: release-1.31


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Update publishing-bot rules to Go 1.22.6

#### Which issue(s) this PR fixes:

xref: https://github.com/kubernetes/release/issues/3778

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
