### PR TITLE
kubelet: Fix the volume manager didn't check the device mount state in the actual state of the world before marking the volume as detached

### DIFF
--- a/pkg/kubelet/volumemanager/cache/actual_state_of_world.go
+++ b/pkg/kubelet/volumemanager/cache/actual_state_of_world.go
@@ -176,6 +176,11 @@ type ActualStateOfWorld interface {
 	// or have a mount/unmount operation pending.
 	GetAttachedVolumes() []AttachedVolume
 
+	// GetAttachedVolume returns the volume that is known to be attached to the node
+	// with the given volume name. If the volume is not found, the second return value
+	// is false.
+	GetAttachedVolume(volumeName v1.UniqueVolumeName) (AttachedVolume, bool)
+
 	// Add the specified volume to ASW as uncertainly attached.
 	AddAttachUncertainReconstructedVolume(volumeName v1.UniqueVolumeName, volumeSpec *volume.Spec, nodeName types.NodeName, devicePath string) error
 
@@ -1158,6 +1163,18 @@ func (asw *actualStateOfWorld) GetAttachedVolumes() []AttachedVolume {
 	}
 
 	return allAttachedVolumes
+}
+
+func (asw *actualStateOfWorld) GetAttachedVolume(volumeName v1.UniqueVolumeName) (AttachedVolume, bool) {
+	asw.RLock()
+	defer asw.RUnlock()
+
+	volumeObj, ok := asw.attachedVolumes[volumeName]
+	if !ok {
+		return AttachedVolume{}, false
+	}
+
+	return asw.newAttachedVolume(&volumeObj), true
 }
 
 func (asw *actualStateOfWorld) GetUnmountedVolumes() []AttachedVolume {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

See https://github.com/kubernetes/kubernetes/issues/127520#issuecomment-2419280422

```
(base) ➜  ~ cat /var/folders/n6/33y75ytn36g38k2wnkb6lp8r0000gn/T/go-stress-20241021T135714-609664758
E1021 13:58:06.267415   43361 reconstruct.go:54] "Cannot get volumes from disk, skip sync states for volume reconstruction" err="open fake-dir-6ec1e204152d0da11b247a1c9de569d6: no such file or directory"
I1021 13:58:06.267546   43361 reconciler.go:26] "Reconciler: start to sync state"
I1021 13:58:06.267724   43361 reconciler_common.go:251] "operationExecutor.VerifyControllerAttachedVolume started for volume \"timeout-mount-device-volume\" (UniqueName: \"fake-plugin/timeout-mount-device-volume\") pod \"pod1\" (UID: \"pod1uid\") " pod="pod1"
I1021 13:58:06.315859   43361 operation_generator.go:1491] "Controller attach succeeded for volume \"timeout-mount-device-volume\" (UniqueName: \"fake-plugin/timeout-mount-device-volume\") pod \"pod1\" (UID: \"pod1uid\") device path: \"fake/path\"" pod="pod1"
I1021 13:58:06.448432   43361 operation_generator.go:1014] "MapVolume.WaitForAttach entering for volume \"timeout-mount-device-volume\" (UniqueName: \"fake-plugin/timeout-mount-device-volume\") pod \"pod1\" (UID: \"pod1uid\") DevicePath \"fake/path\"" pod="pod1"
I1021 13:58:06.466757   43361 operation_generator.go:1024] "MapVolume.WaitForAttach succeeded for volume \"timeout-mount-device-volume\" (UniqueName: \"fake-plugin/timeout-mount-device-volume\") pod \"pod1\" (UID: \"pod1uid\") DevicePath \"/dev/sdb\"" pod="pod1"
E1021 13:58:06.501953   43361 nestedpendingoperations.go:348] Operation for "{volumeName:fake-plugin/timeout-mount-device-volume podName: nodeName:}" failed. No retries permitted until 2024-10-21 13:58:07.001894 +0800 CST m=+48.058283126 (durationBeforeRetry 500ms). Error: MapVolume.SetUpDevice failed for volume "timeout-mount-device-volume" (UniqueName: "fake-plugin/timeout-mount-device-volume") pod "pod1" (UID: "pod1uid") : mount failed
I1021 13:58:07.074835   43361 reconciler_common.go:290] "compare volume" attachedVolume={"VolumeName":"fake-plugin/timeout-mount-device-volume","VolumeSpec":{"Volume":null,"PersistentVolume":{"metadata":{"name":"timeout-mount-device-volume","uid":"pvuid","creationTimestamp":null},"spec":{"claimRef":{"name":"pvc"},"volumeMode":"Block"},"status":{}},"ReadOnly":false,"InlineVolumeSpecForCSIMigration":false,"Migrated":false},"NodeName":"mynodename","PluginIsAttachable":true,"DevicePath":"fake/path","DeviceMountPath":"","PluginName":"fake-plugin","DeviceMountState":"DeviceNotMounted","SELinuxMountContext":""} asw=[{"VolumeName":"fake-plugin/timeout-mount-device-volume","VolumeSpec":{"Volume":null,"PersistentVolume":{"metadata":{"name":"timeout-mount-device-volume","uid":"pvuid","creationTimestamp":null},"spec":{"claimRef":{"name":"pvc"},"volumeMode":"Block"},"status":{}},"ReadOnly":false,"InlineVolumeSpecForCSIMigration":false,"Migrated":false},"NodeName":"mynodename","PluginIsAttachable":true,"DevicePath":"/dev/sdb","DeviceMountPath":"plugins/fake-plugin/volumeDevices/pluginDependentPath","PluginName":"fake-plugin","DeviceMountState":"DeviceMountUncertain","SELinuxMountContext":""}]
I1021 13:58:07.074943   43361 reconciler_common.go:295] "Volume detached for volume \"timeout-mount-device-volume\" (UniqueName: \"fake-plugin/timeout-mount-device-volume\") on node \"mynodename\" DevicePath \"fake/path\""
--- FAIL: Test_UncertainDeviceGlobalMounts (0.00s)
    --- FAIL: Test_UncertainDeviceGlobalMounts/timed_out_operations_should_result_in_device_marked_as_uncertain_[Block][ (1.64s)
        reconciler_test.go:1655: Error verifying UnMountDeviceCallCount: No Unmapper have expected TearDownDeviceCallCount. Expected: <1>.
```
I added a log for debugging purposes, see `I1021 13:58:07.074835   43361 reconciler_common.go:290` from the above test. the  DeviceMountState is `DeviceNotMounted` but the actual state is `DeviceMountUncertain`. if the state has been changed, we can not do detach action.

With this patch: no flaky within 15m

```
(base) ➜  kubernetes git:(master) ✗ stress -p 300 ./reconciler.test -test.run "^Test_UncertainDeviceGlobalMounts/timed_out_operations_should_result_in_device_marked_as_uncertain_\[Block\]\[$"
5s: 0 runs so far, 0 failures
10s: 0 runs so far, 0 failures
15s: 0 runs so far, 0 failures
20s: 0 runs so far, 0 failures
...
14m40s: 3634 runs so far, 0 failures
14m45s: 3653 runs so far, 0 failures
14m50s: 3672 runs so far, 0 failures
14m55s: 3690 runs so far, 0 failures
15m0s: 3702 runs so far, 0 failures
^C
```


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #127520
Fixes #128126

#### Special notes for your reviewer:

We need to backport it.

Ref #125541 #123960 https://github.com/kubernetes/kubernetes/issues/113289

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubelet: Fix the volume manager didn't check the device mount state in the actual state of the world before marking the volume as detached. It may cause a pod to be stuck in the Terminating state due to the above issue when it was deleted.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
