### PR TITLE
Add a resourceVersion compare before ssc.enqueueStatefulSet in setInformer's UpdateFunc in statefulset controller.

### DIFF
--- a/pkg/controller/statefulset/stateful_set.go
+++ b/pkg/controller/statefulset/stateful_set.go
@@ -139,6 +139,11 @@ func NewStatefulSetController(
 				if oldPS.Status.Replicas != curPS.Status.Replicas {
 					logger.V(4).Info("Observed updated replica count for StatefulSet", "statefulSet", klog.KObj(curPS), "oldReplicas", oldPS.Status.Replicas, "newReplicas", curPS.Status.Replicas)
 				}
+				if curPS.ResourceVersion == oldPS.ResourceVersion {
+					// In the event of a resync we may receive update events for all known statefulsets.
+					// Two different versions of the same statefulset will always have different RVs.
+					return
+				}
 				ssc.enqueueStatefulSet(cur)
 			},
 			DeleteFunc: ssc.enqueueStatefulSet,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup
#### What this PR does / why we need it:
The statefulset controller will resync all statefulsets every 12~24 hours.As discussed in the linked issue, it can cause several minutes delays processing actual updates when large amounts of statefulsets exist,and this delays may confuse users a lot.We want optimize this by add a resourceVersion compare before enqueueStatefulSet,just as podInformer's UpdateFunc do.

![image](https://github.com/user-attachments/assets/3d380d4c-1b63-4dad-968f-b531feaf295c)


![image](https://github.com/user-attachments/assets/0907be5c-b257-449b-aa38-801e8b04335f)


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
https://github.com/kubernetes/kubernetes/issues/75495#issuecomment-475954346
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
StatefulSet controller no longer enqueue statefulset when resync event from setInformer has nothing changed(namely the same resourceVersion statefulset).
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
