### PR TITLE
Introducing l4proxy annotation.

### DIFF
--- a/pkg/proxy/winkernel/hns.go
+++ b/pkg/proxy/winkernel/hns.go
@@ -53,6 +53,8 @@ var (
 	LoadBalancerFlagsIPv6 hcn.LoadBalancerFlags = 2
 	// LoadBalancerPortMappingFlagsVipExternalIP enables VipExternalIP.
 	LoadBalancerPortMappingFlagsVipExternalIP hcn.LoadBalancerPortMappingFlags = 16
+	// LoadBalancerFlagsL4Proxy enables L4Proxy.
+	LoadBalancerFlagsL4Proxy hcn.LoadBalancerFlags = 4
 )
 
 func getLoadBalancerPolicyFlags(flags loadBalancerFlags) (lbPortMappingFlags hcn.LoadBalancerPortMappingFlags, lbFlags hcn.LoadBalancerFlags) {
@@ -78,6 +80,9 @@ func getLoadBalancerPolicyFlags(flags loadBalancerFlags) (lbPortMappingFlags hcn
 	}
 	if flags.isIPv6 {
 		lbFlags |= LoadBalancerFlagsIPv6
+	}
+	if flags.l4ProxyEnabled {
+		lbFlags |= LoadBalancerFlagsL4Proxy
 	}
 	return
 }
@@ -388,6 +393,9 @@ func (hns hns) getLoadBalancer(endpoints []endpointInfo, flags loadBalancerFlags
 
 	if flags.isIPv6 {
 		lbFlags |= LoadBalancerFlagsIPv6
+	}
+	if flags.l4ProxyEnabled {
+		lbFlags |= LoadBalancerFlagsL4Proxy
 	}
 
 	lbDistributionType := hcn.LoadBalancerDistributionNone

--- a/pkg/proxy/winkernel/proxier.go
+++ b/pkg/proxy/winkernel/proxier.go
@@ -112,6 +112,7 @@ type loadBalancerFlags struct {
 	preserveDIP     bool
 	sessionAffinity bool
 	isIPv6          bool
+	l4ProxyEnabled  bool
 }
 
 // internal struct for string service information
@@ -129,6 +130,7 @@ type serviceInfo struct {
 	localTrafficDSR        bool
 	internalTrafficLocal   bool
 	winProxyOptimization   bool
+	l4ProxyEnabled         bool
 }
 
 type hnsNetworkInfo struct {
@@ -531,6 +533,7 @@ func (proxier *Proxier) newServiceInfo(port *v1.ServicePort, service *v1.Service
 	preserveDIP := service.Annotations["preserve-destination"] == "true"
 	// Annotation introduced to enable optimized loadbalancing
 	winProxyOptimization := !(strings.ToUpper(service.Annotations["winProxyOptimization"]) == "DISABLED")
+	l4ProxyEnabled := (service.Spec.Type == v1.ServiceTypeClusterIP) && (strings.ToUpper(service.Annotations["l4Proxy"]) == "ENABLED")
 	localTrafficDSR := service.Spec.ExternalTrafficPolicy == v1.ServiceExternalTrafficPolicyLocal
 	var internalTrafficLocal bool
 	if service.Spec.InternalTrafficPolicy != nil {
@@ -555,7 +558,8 @@ func (proxier *Proxier) newServiceInfo(port *v1.ServicePort, service *v1.Service
 	info.localTrafficDSR = localTrafficDSR
 	info.internalTrafficLocal = internalTrafficLocal
 	info.winProxyOptimization = winProxyOptimization
-	klog.V(3).InfoS("Flags enabled for service", "service", service.Name, "localTrafficDSR", localTrafficDSR, "internalTrafficLocal", internalTrafficLocal, "preserveDIP", preserveDIP, "winProxyOptimization", winProxyOptimization)
+	info.l4ProxyEnabled = l4ProxyEnabled
+	klog.V(3).InfoS("Flags enabled for service", "service", service.Name, "localTrafficDSR", localTrafficDSR, "internalTrafficLocal", internalTrafficLocal, "preserveDIP", preserveDIP, "winProxyOptimization", winProxyOptimization, "l4ProxyEnabled", l4ProxyEnabled)
 
 	for _, eip := range service.Spec.ExternalIPs {
 		info.externalIPs = append(info.externalIPs, &externalIPInfo{ip: eip})
@@ -1444,7 +1448,7 @@ func (proxier *Proxier) syncProxyRules() {
 				sourceVip,
 				svcInfo.ClusterIP().String(),
 				clusterIPEndpoints,
-				loadBalancerFlags{isDSR: proxier.isDSR, isIPv6: proxier.ipFamily == v1.IPv6Protocol, sessionAffinity: sessionAffinityClientIP},
+				loadBalancerFlags{isDSR: proxier.isDSR, isIPv6: proxier.ipFamily == v1.IPv6Protocol, sessionAffinity: sessionAffinityClientIP, l4ProxyEnabled: svcInfo.l4ProxyEnabled},
 				Enum(svcInfo.Protocol()),
 				uint16(svcInfo.targetPort),
 				uint16(svcInfo.Port()),
@@ -1463,7 +1467,7 @@ func (proxier *Proxier) syncProxyRules() {
 				// Cluster IP LoadBalancer creation
 				hnsLoadBalancer, err := hns.getLoadBalancer(
 					clusterIPEndpoints,
-					loadBalancerFlags{isDSR: proxier.isDSR, isIPv6: proxier.ipFamily == v1.IPv6Protocol, sessionAffinity: sessionAffinityClientIP},
+					loadBalancerFlags{isDSR: proxier.isDSR, isIPv6: proxier.ipFamily == v1.IPv6Protocol, sessionAffinity: sessionAffinityClientIP, l4ProxyEnabled: svcInfo.l4ProxyEnabled},
 					sourceVip,
 					svcInfo.ClusterIP().String(),
 					Enum(svcInfo.Protocol()),


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
These changes are introduced to support L4Proxy feature for a ClusterIP service in Windows container networking stack.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
Introduction of "l4Proxy: Enabled" annotation in service yaml which will enable L4Proxy feature for the ClusterIP service in Windows container networking stack.

For enabling L4proxy feature in a service, the new service yaml will look like below.

apiVersion: v1
kind: Service
metadata:
  labels:
    app: tcp-server
  name: tcp-server-ipv4-local
  namespace: demo
  annotations:
    l4Proxy: Enabled
spec:
  ipFamilies:
  - IPv4
  ipFamilyPolicy: SingleStack
  selector:
    app: tcp-server
  sessionAffinity: None
  type: ClusterIP
  ports:
  - name: tcp
    port: 4444
    protocol: TCP
    targetPort: 4444

```
