### PR TITLE
Automated cherry pick of #128182: Fix crash on kube manager's service-lb-controller after v1.31.0.

### DIFF
--- a/staging/src/k8s.io/cloud-provider/controllers/service/controller.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/service/controller.go
@@ -110,6 +110,7 @@ func New(
 	featureGate featuregate.FeatureGate,
 ) (*Controller, error) {
 	registerMetrics()
+
 	s := &Controller{
 		cloud:            cloud,
 		kubeClient:       kubeClient,
@@ -126,6 +127,10 @@ func New(
 			workqueue.TypedRateLimitingQueueConfig[string]{Name: "node"},
 		),
 		lastSyncedNodes: make(map[string][]*v1.Node),
+	}
+
+	if err := s.init(); err != nil {
+		return nil, err
 	}
 
 	serviceInformer.Informer().AddEventHandlerWithResyncPeriod(
@@ -181,10 +186,6 @@ func New(
 		},
 		nodeSyncPeriod,
 	)
-
-	if err := s.init(); err != nil {
-		return nil, err
-	}
 
 	return s, nil
 }


### PR DESCRIPTION
Cherry pick of #128182 on release-1.31.

#128182: Fix crash on kube manager's service-lb-controller after v1.31.0.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixes 1.31 regression that can crash kube-controller-manager's service-lb-controller loop
```