### PR TITLE
 Fix container lifecycle flaking e2e tests

### DIFF
--- a/test/e2e_node/container_lifecycle_pod_construction.go
+++ b/test/e2e_node/container_lifecycle_pod_construction.go
@@ -48,6 +48,8 @@ type execCommand struct {
 	// ContainerName is the name of the container to append the log. If empty,
 	// the name specified in ExecCommand will be used.
 	ContainerName string
+	// LoopPeriod is the time interval for executing the loop.
+	LoopPeriod float32
 }
 
 // ExecCommand returns the command to execute in the container that implements
@@ -88,8 +90,13 @@ func ExecCommand(name string, c execCommand) []string {
 	if c.Delay != 0 {
 		fmt.Fprint(&cmd, sleepCommand(c.Delay))
 	}
+
+	loopPeriod := float32(1)
+	if c.LoopPeriod != 0 {
+		loopPeriod = c.LoopPeriod
+	}
 	if c.LoopForever {
-		fmt.Fprintf(&cmd, "while true; do echo %s '%s Looping' | tee -a %s >> /proc/1/fd/1 ; sleep 1 ; done; ", timeCmd, name, containerLog)
+		fmt.Fprintf(&cmd, "while true; do echo %s '%s Looping' | tee -a %s >> /proc/1/fd/1 ; sleep %f ; done; ", timeCmd, name, containerLog, loopPeriod)
 	}
 	fmt.Fprintf(&cmd, "echo %s '%s Exiting'  | tee -a %s >> /proc/1/fd/1; ", timeCmd, name, containerLog)
 	fmt.Fprintf(&cmd, "exit %d", c.ExitCode)

--- a/test/e2e_node/container_lifecycle_test.go
+++ b/test/e2e_node/container_lifecycle_test.go
@@ -3178,6 +3178,7 @@ var _ = SIGDescribe(nodefeature.SidecarContainers, "Containers Lifecycle", func(
 									ExitCode:      0,
 									ContainerName: containerName,
 									LoopForever:   true,
+									LoopPeriod:    0.2,
 								}),
 							},
 						},
@@ -3280,7 +3281,7 @@ var _ = SIGDescribe(nodefeature.SidecarContainers, "Containers Lifecycle", func(
 				ps3Last, err := results.TimeOfLastLoop(prefixedName(PreStopPrefix, restartableInit3))
 				framework.ExpectNoError(err)
 
-				const simulToleration = 500 // milliseconds
+				const simulToleration = 1000 // milliseconds
 				// should all end together since they loop infinitely and exceed their grace period
 				gomega.Expect(ps1Last-ps2Last).To(gomega.BeNumerically("~", 0, simulToleration),
 					fmt.Sprintf("expected PostStart 1 & PostStart 2 to be killed at the same time, got %s", results))
@@ -3290,7 +3291,7 @@ var _ = SIGDescribe(nodefeature.SidecarContainers, "Containers Lifecycle", func(
 					fmt.Sprintf("expected PostStart 2 & PostStart 3 to be killed at the same time, got %s", results))
 
 				// 30 seconds + 2 second minimum grace for the SIGKILL
-				const lifetimeToleration = 1000 // milliseconds
+				const lifetimeToleration = 1500 // milliseconds
 				gomega.Expect(ps1Last-ps1).To(gomega.BeNumerically("~", 32000, lifetimeToleration),
 					fmt.Sprintf("expected PostStart 1 to live for ~32 seconds, got %s", results))
 				gomega.Expect(ps2Last-ps2).To(gomega.BeNumerically("~", 32000, lifetimeToleration),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind failing-test
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes part of #128113 #129036

#### Special notes for your reviewer:
In the PreStop hook of a pod, we continuously output "Looping" in a loop and sleep for 1 second. The script declared in PreStop is as follows:
```
sh -c '
touch /persistent/my-container.log;
echo $(date -u +%FT$(nmeter -d0 '%3t' | head -n1)Z) '\''prestop-my-container Starting 0'\'' | tee -a /persistent/my-container.log >> /proc/1/fd/1;
_term() { sleep 0; echo $(date -u +%FT$(nmeter -d0 '%3t' | head -n1)Z) '\''prestop-my-container Exiting'\'' | tee -a /persistent/my-container.log >> /proc/1/fd/1; exit 0; };
trap _term TERM;
touch started;
echo $(date -u +%FT$(nmeter -d0 '%3t' | head -n1)Z) '\''prestop-my-container Started'\'' | tee -a /persistent/my-container.log >> /proc/1/fd/1;
echo $(date -u +%FT$(nmeter -d0 '%3t' | head -n1)Z) '\''prestop-my-container Delaying 0'\'' | tee -a /persistent/my-container.log >> /proc/1/fd/1;
while true; do
  echo $(date -u +%FT$(nmeter -d0 '%3t' | head -n1)Z) '\''prestop-my-container Looping'\'' | tee -a /persistent/my-container.log >> /proc/1/fd/1;
  sleep 1;
done;
echo $(date -u +%FT$(nmeter -d0 '%3t' | head -n1)Z) '\''prestop-my-container Exiting'\'' | tee -a /persistent/my-container.log >> /proc/1/fd/1;
exit 0'
```
It exhibits the following issues:

1. The while loop execution time isn't consistently 1 second - it often takes slightly longer by tens of milliseconds

2. The start/end times of the while loop vary across containers (not just loop execution variance, but also hundreds of milliseconds difference in when kubelet initiates preStop execution)

3. When kubelet forcibly terminates containers, due to the inconsistent loop timings across containers, some loops might execute N times while others execute N+1 times

To mitigate these, I modified the loop timing to be configurable externally through ExecCommand parameters, which should help alleviate these issues.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
