### PR TITLE
KEP-4222: Add CBOR variant of admission webhook integration test.

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/cbor_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/cbor_test.go
@@ -1,0 +1,236 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	"k8s.io/apiextensions-apiserver/test/integration/fixtures"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	cbor "k8s.io/apimachinery/pkg/runtime/serializer/cbor/direct"
+	"k8s.io/apiserver/pkg/features"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/util/retry"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+)
+
+func TestCBORServingEnablement(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		enabled bool
+	}{
+		{name: "enabled", enabled: true},
+		{name: "disabled", enabled: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.TestOnlyFeatureGate, features.TestOnlyCBORServingAndStorage, tc.enabled)
+
+			tearDown, config, _, err := fixtures.StartDefaultServer(t)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer tearDown()
+
+			apiExtensionsClientset, err := apiextensionsclientset.NewForConfig(config)
+			if err != nil {
+				t.Fatal(err)
+			}
+			dynamicClient, err := dynamic.NewForConfig(config)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			crd := &apiextensionsv1.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{Name: "foos.mygroup.example.com"},
+				Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+					Group: "mygroup.example.com",
+					Versions: []apiextensionsv1.CustomResourceDefinitionVersion{{
+						Name:    "v1beta1",
+						Served:  true,
+						Storage: true,
+						Schema:  fixtures.AllowAllSchema(),
+						Subresources: &apiextensionsv1.CustomResourceSubresources{
+							Status: &apiextensionsv1.CustomResourceSubresourceStatus{},
+							Scale: &apiextensionsv1.CustomResourceSubresourceScale{
+								SpecReplicasPath:   ".spec.replicas",
+								StatusReplicasPath: ".status.replicas",
+							},
+						},
+					}},
+					Names: apiextensionsv1.CustomResourceDefinitionNames{
+						Plural:   "foos",
+						Singular: "foo",
+						Kind:     "Foo",
+						ListKind: "FooList",
+					},
+					Scope: apiextensionsv1.ClusterScoped,
+				},
+			}
+			if _, err = fixtures.CreateNewV1CustomResourceDefinition(crd, apiExtensionsClientset, dynamicClient); err != nil {
+				t.Fatal(err)
+			}
+			cr, err := dynamicClient.Resource(schema.GroupVersionResource{Group: "mygroup.example.com", Version: "v1beta1", Resource: "foos"}).Create(
+				context.TODO(),
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "mygroup.example.com/v1beta1",
+						"kind":       "Foo",
+						"metadata": map[string]interface{}{
+							"name": fmt.Sprintf("test-cbor-%s", tc.name),
+						},
+						"spec": map[string]interface{}{
+							"replicas": int64(0),
+						},
+						"status": map[string]interface{}{
+							"replicas": int64(0),
+						},
+					}},
+				metav1.CreateOptions{},
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			config = rest.CopyConfig(config)
+			config.NegotiatedSerializer = serializer.NewCodecFactory(runtime.NewScheme()).WithoutConversion()
+			config.APIPath = "/apis"
+			config.GroupVersion = &schema.GroupVersion{Group: "mygroup.example.com", Version: "v1beta1"}
+			restClient, err := rest.RESTClientFor(config)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			for _, subresource := range []string{"", "status", "scale"} {
+				err = restClient.Get().
+					Resource(crd.Spec.Names.Plural).
+					SubResource(subresource).
+					Name(cr.GetName()).
+					SetHeader("Accept", "application/cbor").
+					Do(context.TODO()).Error()
+				switch {
+				case tc.enabled && err == nil:
+					// ok
+				case !tc.enabled && errors.IsNotAcceptable(err):
+					// ok
+				default:
+					t.Errorf("unexpected error on read (subresource %q): %v", subresource, err)
+				}
+			}
+
+			createBody, err := cbor.Marshal(map[string]interface{}{
+				"apiVersion": "mygroup.example.com/v1beta1",
+				"kind":       "Foo",
+				"metadata": map[string]interface{}{
+					"name": fmt.Sprintf("test-cbor-%s-2", tc.name),
+				},
+				"spec": map[string]interface{}{
+					"replicas": int64(0),
+				},
+				"status": map[string]interface{}{
+					"replicas": int64(0),
+				},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = restClient.Post().
+				Resource(crd.Spec.Names.Plural).
+				SetHeader("Content-Type", "application/cbor").
+				Body(createBody).
+				Do(context.TODO()).Error()
+			switch {
+			case tc.enabled && err == nil:
+				// ok
+			case !tc.enabled && errors.IsUnsupportedMediaType(err):
+				// ok
+			default:
+				t.Errorf("unexpected error on write: %v", err)
+			}
+
+			scaleBody, err := cbor.Marshal(map[string]interface{}{
+				"apiVersion": "autoscaling/v1",
+				"kind":       "Scale",
+				"metadata": map[string]interface{}{
+					"name": cr.GetName(),
+				},
+				"spec": map[string]interface{}{
+					"replicas": int64(0),
+				},
+				"status": map[string]interface{}{
+					"replicas": int64(0),
+				},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = restClient.Put().
+				Resource(crd.Spec.Names.Plural).
+				SubResource("scale").
+				Name(cr.GetName()).
+				SetHeader("Content-Type", "application/cbor").
+				Body(scaleBody).
+				Do(context.TODO()).Error()
+			switch {
+			case tc.enabled && err == nil:
+				// ok
+			case !tc.enabled && errors.IsUnsupportedMediaType(err):
+				// ok
+			default:
+				t.Errorf("unexpected error on scale write: %v", err)
+			}
+
+			err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+				latest, err := dynamicClient.Resource(schema.GroupVersionResource{Group: "mygroup.example.com", Version: "v1beta1", Resource: "foos"}).Get(context.TODO(), cr.GetName(), metav1.GetOptions{})
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				statusBody, err := cbor.Marshal(latest.Object)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				return restClient.Put().
+					Resource(crd.Spec.Names.Plural).
+					SubResource("status").
+					Name(cr.GetName()).
+					SetHeader("Content-Type", "application/cbor").
+					Body(statusBody).
+					Do(context.TODO()).Error()
+			})
+			switch {
+			case tc.enabled && err == nil:
+				// ok
+			case !tc.enabled && errors.IsUnsupportedMediaType(err):
+				// ok
+			default:
+				t.Fatalf("unexpected error on status write: %v", err)
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/internalversion/scheme/register.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/internalversion/scheme/register.go
@@ -24,16 +24,16 @@ import (
 )
 
 // Scheme is the registry for any type that adheres to the meta API spec.
-var scheme = runtime.NewScheme()
+var Scheme = runtime.NewScheme()
 
 // Codecs provides access to encoding and decoding for the scheme.
-var Codecs = serializer.NewCodecFactory(scheme)
+var Codecs = serializer.NewCodecFactory(Scheme)
 
 // ParameterCodec handles versioning of objects that are converted to query parameters.
-var ParameterCodec = runtime.NewParameterCodec(scheme)
+var ParameterCodec = runtime.NewParameterCodec(Scheme)
 
 // Unlike other API groups, meta internal knows about all meta external versions, but keeps
 // the logic for conversion private.
 func init() {
-	utilruntime.Must(internalversion.AddToScheme(scheme))
+	utilruntime.Must(internalversion.AddToScheme(Scheme))
 }

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/internalversion/scheme/register_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/internalversion/scheme/register_test.go
@@ -37,11 +37,11 @@ func TestListOptions(t *testing.T) {
 		Watch:           true,
 	}
 	out := &metainternalversion.ListOptions{}
-	if err := scheme.Convert(in, out, nil); err != nil {
+	if err := Scheme.Convert(in, out, nil); err != nil {
 		t.Fatal(err)
 	}
 	actual := &metav1.ListOptions{}
-	if err := scheme.Convert(out, actual, nil); err != nil {
+	if err := Scheme.Convert(out, actual, nil); err != nil {
 		t.Fatal(err)
 	}
 	if !reflect.DeepEqual(in, actual) {
@@ -54,16 +54,16 @@ func TestListOptions(t *testing.T) {
 		{FieldSelector: "a!!!"},
 	} {
 		out = &metainternalversion.ListOptions{}
-		if err := scheme.Convert(failingObject, out, nil); err == nil {
+		if err := Scheme.Convert(failingObject, out, nil); err == nil {
 			t.Errorf("%d: unexpected conversion: %#v", i, out)
 		}
 	}
 
 	// verify kind registration
-	if gvks, unversioned, err := scheme.ObjectKinds(in); err != nil || unversioned || gvks[0] != metav1.SchemeGroupVersion.WithKind("ListOptions") {
+	if gvks, unversioned, err := Scheme.ObjectKinds(in); err != nil || unversioned || gvks[0] != metav1.SchemeGroupVersion.WithKind("ListOptions") {
 		t.Errorf("unexpected: %v %v %v", gvks[0], unversioned, err)
 	}
-	if gvks, unversioned, err := scheme.ObjectKinds(out); err != nil || unversioned || gvks[0] != metainternalversion.SchemeGroupVersion.WithKind("ListOptions") {
+	if gvks, unversioned, err := Scheme.ObjectKinds(out); err != nil || unversioned || gvks[0] != metainternalversion.SchemeGroupVersion.WithKind("ListOptions") {
 		t.Errorf("unexpected: %v %v %v", gvks[0], unversioned, err)
 	}
 

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/internalversion/scheme/roundtrip_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/internalversion/scheme/roundtrip_test.go
@@ -24,5 +24,5 @@ import (
 )
 
 func TestRoundTrip(t *testing.T) {
-	roundtrip.RoundTripTestForScheme(t, scheme, fuzzer.Funcs)
+	roundtrip.RoundTripTestForScheme(t, Scheme, fuzzer.Funcs)
 }

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/codec_factory.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/codec_factory.go
@@ -89,6 +89,10 @@ func newSerializersForScheme(scheme *runtime.Scheme, mf json.MetaFactory, option
 		},
 	}
 
+	for _, f := range options.serializers {
+		serializers = append(serializers, f(scheme, scheme))
+	}
+
 	return serializers
 }
 
@@ -108,6 +112,8 @@ type CodecFactoryOptions struct {
 	Strict bool
 	// Pretty includes a pretty serializer along with the non-pretty one
 	Pretty bool
+
+	serializers []func(runtime.ObjectCreater, runtime.ObjectTyper) runtime.SerializerInfo
 }
 
 // CodecFactoryOptionsMutator takes a pointer to an options struct and then modifies it.
@@ -132,6 +138,13 @@ func EnableStrict(options *CodecFactoryOptions) {
 // DisableStrict disables configuring all serializers in strict mode
 func DisableStrict(options *CodecFactoryOptions) {
 	options.Strict = false
+}
+
+// WithSerializer configures a serializer to be supported in addition to the default serializers.
+func WithSerializer(f func(runtime.ObjectCreater, runtime.ObjectTyper) runtime.SerializerInfo) CodecFactoryOptionsMutator {
+	return func(options *CodecFactoryOptions) {
+		options.serializers = append(options.serializers, f)
+	}
 }
 
 // NewCodecFactory provides methods for retrieving serializers for the supported wire formats

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/codec_factory.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/codec_factory.go
@@ -17,9 +17,6 @@ limitations under the License.
 package serializer
 
 import (
-	"mime"
-	"strings"
-
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
@@ -28,41 +25,26 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer/versioning"
 )
 
-// serializerExtensions are for serializers that are conditionally compiled in
-var serializerExtensions = []func(*runtime.Scheme) (serializerType, bool){}
-
-type serializerType struct {
-	AcceptContentTypes []string
-	ContentType        string
-	FileExtensions     []string
-	// EncodesAsText should be true if this content type can be represented safely in UTF-8
-	EncodesAsText bool
-
-	Serializer       runtime.Serializer
-	PrettySerializer runtime.Serializer
-	StrictSerializer runtime.Serializer
-
-	AcceptStreamContentTypes []string
-	StreamContentType        string
-
-	Framer           runtime.Framer
-	StreamSerializer runtime.Serializer
-}
-
-func newSerializersForScheme(scheme *runtime.Scheme, mf json.MetaFactory, options CodecFactoryOptions) []serializerType {
+func newSerializersForScheme(scheme *runtime.Scheme, mf json.MetaFactory, options CodecFactoryOptions) []runtime.SerializerInfo {
 	jsonSerializer := json.NewSerializerWithOptions(
 		mf, scheme, scheme,
 		json.SerializerOptions{Yaml: false, Pretty: false, Strict: options.Strict},
 	)
-	jsonSerializerType := serializerType{
-		AcceptContentTypes: []string{runtime.ContentTypeJSON},
-		ContentType:        runtime.ContentTypeJSON,
-		FileExtensions:     []string{"json"},
-		EncodesAsText:      true,
-		Serializer:         jsonSerializer,
-
-		Framer:           json.Framer,
-		StreamSerializer: jsonSerializer,
+	jsonSerializerType := runtime.SerializerInfo{
+		MediaType:        runtime.ContentTypeJSON,
+		MediaTypeType:    "application",
+		MediaTypeSubType: "json",
+		EncodesAsText:    true,
+		Serializer:       jsonSerializer,
+		StrictSerializer: json.NewSerializerWithOptions(
+			mf, scheme, scheme,
+			json.SerializerOptions{Yaml: false, Pretty: false, Strict: true},
+		),
+		StreamSerializer: &runtime.StreamSerializerInfo{
+			EncodesAsText: true,
+			Serializer:    jsonSerializer,
+			Framer:        json.Framer,
+		},
 	}
 	if options.Pretty {
 		jsonSerializerType.PrettySerializer = json.NewSerializerWithOptions(
@@ -70,12 +52,6 @@ func newSerializersForScheme(scheme *runtime.Scheme, mf json.MetaFactory, option
 			json.SerializerOptions{Yaml: false, Pretty: true, Strict: options.Strict},
 		)
 	}
-
-	strictJSONSerializer := json.NewSerializerWithOptions(
-		mf, scheme, scheme,
-		json.SerializerOptions{Yaml: false, Pretty: false, Strict: true},
-	)
-	jsonSerializerType.StrictSerializer = strictJSONSerializer
 
 	yamlSerializer := json.NewSerializerWithOptions(
 		mf, scheme, scheme,
@@ -88,35 +64,31 @@ func newSerializersForScheme(scheme *runtime.Scheme, mf json.MetaFactory, option
 	protoSerializer := protobuf.NewSerializer(scheme, scheme)
 	protoRawSerializer := protobuf.NewRawSerializer(scheme, scheme)
 
-	serializers := []serializerType{
+	serializers := []runtime.SerializerInfo{
 		jsonSerializerType,
 		{
-			AcceptContentTypes: []string{runtime.ContentTypeYAML},
-			ContentType:        runtime.ContentTypeYAML,
-			FileExtensions:     []string{"yaml"},
-			EncodesAsText:      true,
-			Serializer:         yamlSerializer,
-			StrictSerializer:   strictYAMLSerializer,
+			MediaType:        runtime.ContentTypeYAML,
+			MediaTypeType:    "application",
+			MediaTypeSubType: "yaml",
+			EncodesAsText:    true,
+			Serializer:       yamlSerializer,
+			StrictSerializer: strictYAMLSerializer,
 		},
 		{
-			AcceptContentTypes: []string{runtime.ContentTypeProtobuf},
-			ContentType:        runtime.ContentTypeProtobuf,
-			FileExtensions:     []string{"pb"},
-			Serializer:         protoSerializer,
+			MediaType:        runtime.ContentTypeProtobuf,
+			MediaTypeType:    "application",
+			MediaTypeSubType: "vnd.kubernetes.protobuf",
+			Serializer:       protoSerializer,
 			// note, strict decoding is unsupported for protobuf,
 			// fall back to regular serializing
 			StrictSerializer: protoSerializer,
-
-			Framer:           protobuf.LengthDelimitedFramer,
-			StreamSerializer: protoRawSerializer,
+			StreamSerializer: &runtime.StreamSerializerInfo{
+				Serializer: protoRawSerializer,
+				Framer:     protobuf.LengthDelimitedFramer,
+			},
 		},
 	}
 
-	for _, fn := range serializerExtensions {
-		if serializer, ok := fn(scheme); ok {
-			serializers = append(serializers, serializer)
-		}
-	}
 	return serializers
 }
 
@@ -184,7 +156,7 @@ func NewCodecFactory(scheme *runtime.Scheme, mutators ...CodecFactoryOptionsMuta
 }
 
 // newCodecFactory is a helper for testing that allows a different metafactory to be specified.
-func newCodecFactory(scheme *runtime.Scheme, serializers []serializerType) CodecFactory {
+func newCodecFactory(scheme *runtime.Scheme, serializers []runtime.SerializerInfo) CodecFactory {
 	decoders := make([]runtime.Decoder, 0, len(serializers))
 	var accepts []runtime.SerializerInfo
 	alreadyAccepted := make(map[string]struct{})
@@ -192,38 +164,20 @@ func newCodecFactory(scheme *runtime.Scheme, serializers []serializerType) Codec
 	var legacySerializer runtime.Serializer
 	for _, d := range serializers {
 		decoders = append(decoders, d.Serializer)
-		for _, mediaType := range d.AcceptContentTypes {
-			if _, ok := alreadyAccepted[mediaType]; ok {
-				continue
-			}
-			alreadyAccepted[mediaType] = struct{}{}
-			info := runtime.SerializerInfo{
-				MediaType:        d.ContentType,
-				EncodesAsText:    d.EncodesAsText,
-				Serializer:       d.Serializer,
-				PrettySerializer: d.PrettySerializer,
-				StrictSerializer: d.StrictSerializer,
-			}
+		if _, ok := alreadyAccepted[d.MediaType]; ok {
+			continue
+		}
+		alreadyAccepted[d.MediaType] = struct{}{}
 
-			mediaType, _, err := mime.ParseMediaType(info.MediaType)
-			if err != nil {
-				panic(err)
-			}
-			parts := strings.SplitN(mediaType, "/", 2)
-			info.MediaTypeType = parts[0]
-			info.MediaTypeSubType = parts[1]
+		acceptedSerializerShallowCopy := d
+		if d.StreamSerializer != nil {
+			cloned := *d.StreamSerializer
+			acceptedSerializerShallowCopy.StreamSerializer = &cloned
+		}
+		accepts = append(accepts, acceptedSerializerShallowCopy)
 
-			if d.StreamSerializer != nil {
-				info.StreamSerializer = &runtime.StreamSerializerInfo{
-					Serializer:    d.StreamSerializer,
-					EncodesAsText: d.EncodesAsText,
-					Framer:        d.Framer,
-				}
-			}
-			accepts = append(accepts, info)
-			if mediaType == runtime.ContentTypeJSON {
-				legacySerializer = d.Serializer
-			}
+		if d.MediaType == runtime.ContentTypeJSON {
+			legacySerializer = d.Serializer
 		}
 	}
 	if legacySerializer == nil {

--- a/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
@@ -87,6 +87,15 @@ const (
 	// Allows authorization to use field and label selectors.
 	AuthorizeWithSelectors featuregate.Feature = "AuthorizeWithSelectors"
 
+	// owner: @benluddy
+	// kep: https://kep.k8s.io/4222
+	//
+	// Enables CBOR as a supported encoding for requests and responses, and as the
+	// preferred storage encoding for custom resources.
+	//
+	// This feature is currently PRE-ALPHA and MUST NOT be enabled outside of integration tests.
+	TestOnlyCBORServingAndStorage featuregate.Feature = "TestOnlyCBORServingAndStorage"
+
 	// owner: @serathius
 	// Enables concurrent watch object decoding to avoid starving watch cache when conversion webhook is installed.
 	ConcurrentWatchObjectDecode featuregate.Feature = "ConcurrentWatchObjectDecode"
@@ -238,6 +247,7 @@ const (
 func init() {
 	runtime.Must(utilfeature.DefaultMutableFeatureGate.Add(defaultKubernetesFeatureGates))
 	runtime.Must(utilfeature.DefaultMutableFeatureGate.AddVersioned(defaultVersionedKubernetesFeatureGates))
+	runtime.Must(utilfeature.TestOnlyMutableFeatureGate.AddVersioned(testOnlyVersionedKubernetesFeatureGates))
 }
 
 // defaultVersionedKubernetesFeatureGates consists of all known Kubernetes-specific feature keys with VersionedSpecs.
@@ -410,3 +420,12 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 // defaultKubernetesFeatureGates consists of legacy unversioned Kubernetes-specific feature keys.
 // Please do not add to this struct and use defaultVersionedKubernetesFeatureGates instead.
 var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{}
+
+// testOnlyVersionedKubernetesFeatureGates consists of features that require programmatic enablement
+// for integration testing, but have not yet graduated to alpha in a release and must not be enabled
+// by a runtime option.
+var testOnlyVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate.VersionedSpecs{
+	TestOnlyCBORServingAndStorage: {
+		{Version: version.MustParse("1.32"), Default: false, PreRelease: featuregate.Alpha},
+	},
+}

--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -742,7 +742,7 @@ func (c *RecommendedConfig) Complete() CompletedConfig {
 	return c.Config.Complete(c.SharedInformerFactory)
 }
 
-var allowedMediaTypes = []string{
+var defaultAllowedMediaTypes = []string{
 	runtime.ContentTypeJSON,
 	runtime.ContentTypeYAML,
 	runtime.ContentTypeProtobuf,
@@ -754,6 +754,10 @@ var allowedMediaTypes = []string{
 func (c completedConfig) New(name string, delegationTarget DelegationTarget) (*GenericAPIServer, error) {
 	if c.Serializer == nil {
 		return nil, fmt.Errorf("Genericapiserver.New() called with config.Serializer == nil")
+	}
+	allowedMediaTypes := defaultAllowedMediaTypes
+	if utilfeature.TestOnlyFeatureGate.Enabled(genericfeatures.TestOnlyCBORServingAndStorage) {
+		allowedMediaTypes = append(allowedMediaTypes, runtime.ContentTypeCBOR)
 	}
 	for _, info := range c.Serializer.SupportedMediaTypes() {
 		var ok bool

--- a/staging/src/k8s.io/apiserver/pkg/server/config_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config_test.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -40,12 +41,14 @@ import (
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	"k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/features"
 	"k8s.io/apiserver/pkg/server/healthz"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	utilversion "k8s.io/apiserver/pkg/util/version"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/component-base/tracing"
 	"k8s.io/klog/v2/ktesting"
 	netutils "k8s.io/utils/net"
@@ -416,6 +419,25 @@ func TestNewErrorForbiddenSerializer(t *testing.T) {
 	if err == nil {
 		t.Error("successfully created a new server configured with cbor support")
 	} else if err.Error() != `refusing to create new apiserver "test" with support for media type "application/cbor" (allowed media types are: application/json, application/yaml, application/vnd.kubernetes.protobuf)` {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestNewFeatureGatedSerializer(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.TestOnlyFeatureGate, features.TestOnlyCBORServingAndStorage, true)
+
+	config := NewConfig(serializer.NewCodecFactory(scheme, serializer.WithSerializer(func(creater runtime.ObjectCreater, typer runtime.ObjectTyper) runtime.SerializerInfo {
+		return runtime.SerializerInfo{
+			MediaType:        "application/cbor",
+			MediaTypeType:    "application",
+			MediaTypeSubType: "cbor",
+		}
+	})))
+	config.ExternalAddress = "192.168.10.4:443"
+	config.EffectiveVersion = utilversion.NewEffectiveVersion("")
+	config.LoopbackClientConfig = &rest.Config{}
+
+	if _, err := config.Complete(nil).New("test", NewEmptyDelegate()); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/util/feature/feature_gate.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/feature/feature_gate.go
@@ -31,3 +31,15 @@ var (
 	// Top-level commands/options setup that needs to modify this feature gate should use DefaultMutableFeatureGate.
 	DefaultFeatureGate featuregate.FeatureGate = DefaultMutableFeatureGate
 )
+
+var (
+	// TestOnlyMutableFeatureGate is a mutable version of TestOnlyFeatureGate. Only top-level
+	// commands/options setup and the k8s.io/component-base/featuregate/testing package should
+	// make use of this.
+	TestOnlyMutableFeatureGate featuregate.MutableVersionedFeatureGate = featuregate.NewFeatureGate()
+
+	// TestOnlyFeatureGate is a shared global FeatureGate for features that have not yet
+	// graduated to alpha and require programmatic feature enablement for pre-alpha integration
+	// testing without exposing the feature as a runtime option.
+	TestOnlyFeatureGate featuregate.FeatureGate = TestOnlyMutableFeatureGate
+)

--- a/staging/src/k8s.io/client-go/features/known_features.go
+++ b/staging/src/k8s.io/client-go/features/known_features.go
@@ -41,6 +41,27 @@ const (
 	// owner: @nilekhc
 	// alpha: v1.30
 	InformerResourceVersion Feature = "InformerResourceVersion"
+
+	// owner: @benluddy
+	// kep: https://kep.k8s.io/4222
+	//
+	// If disabled, clients configured to accept "application/cbor" will instead accept
+	// "application/json" with the same relative preference, and clients configured to write
+	// "application/cbor" or "application/apply-patch+cbor" will instead write
+	// "application/json" or "application/apply-patch+yaml", respectively.
+	//
+	// This feature is currently PRE-ALPHA and MUST NOT be enabled outside of integration tests.
+	TestOnlyClientAllowsCBOR Feature = "TestOnlyClientAllowsCBOR"
+
+	// owner: @benluddy
+	// kep: https://kep.k8s.io/4222
+	//
+	// If enabled AND TestOnlyClientAllowsCBOR is also enabled, the default request content type
+	// (if not explicitly configured) and the dynamic client's request content type both become
+	// "application/cbor".
+	//
+	// This feature is currently PRE-ALPHA and MUST NOT be enabled outside of integration tests.
+	TestOnlyClientPrefersCBOR Feature = "TestOnlyClientPrefersCBOR"
 )
 
 // defaultKubernetesFeatureGates consists of all known Kubernetes-specific feature keys.

--- a/test/featuregates_linter/test_data/versioned_feature_list.yaml
+++ b/test/featuregates_linter/test_data/versioned_feature_list.yaml
@@ -1228,6 +1228,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "1.32"
+- name: TestOnlyCBORServingAndStorage
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.32"
 - name: TopologyAwareHints
   versionedSpecs:
   - default: false

--- a/test/integration/framework/cbor.go
+++ b/test/integration/framework/cbor.go
@@ -17,6 +17,9 @@ limitations under the License.
 package framework
 
 import (
+	"bytes"
+	"io"
+	"net/http"
 	"testing"
 
 	apiextensionsapiserver "k8s.io/apiextensions-apiserver/pkg/apiserver"
@@ -24,9 +27,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/runtime/serializer/cbor"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/features"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	clientfeatures "k8s.io/client-go/features"
+	"k8s.io/client-go/transport"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	aggregatorscheme "k8s.io/kube-aggregator/pkg/apiserver/scheme"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
@@ -101,4 +106,68 @@ func EnableCBORServingAndStorageForTest(tb testing.TB) {
 		tb.Cleanup(func() { *codecs[scheme] = original })
 		*codecs[scheme] = serializer.NewCodecFactory(scheme, serializer.WithSerializer(newCBORSerializerInfo))
 	}
+}
+
+// AssertRequestResponseAsCBOR returns a transport.WrapperFunc that will report a test error if a
+// non-empty request or response body contains data that does not appear to be CBOR-encoded.
+func AssertRequestResponseAsCBOR(t testing.TB) transport.WrapperFunc {
+	recognizer := cbor.NewSerializer(runtime.NewScheme(), runtime.NewScheme())
+
+	unsupportedPatchContentTypes := sets.New(
+		"application/json-patch+json",
+		"application/merge-patch+json",
+		"application/strategic-merge-patch+json",
+	)
+
+	return func(rt http.RoundTripper) http.RoundTripper {
+		return roundTripperFunc(func(request *http.Request) (*http.Response, error) {
+			if request.Body != nil && !unsupportedPatchContentTypes.Has(request.Header.Get("Content-Type")) {
+				requestbody, err := io.ReadAll(request.Body)
+				if err != nil {
+					t.Error(err)
+				}
+				recognized, _, err := recognizer.RecognizesData(requestbody)
+				if err != nil {
+					t.Error(err)
+				}
+				if len(requestbody) > 0 && !recognized {
+					t.Errorf("non-cbor request: 0x%x", requestbody)
+				}
+				request.Body = io.NopCloser(bytes.NewReader(requestbody))
+			}
+
+			response, rterr := rt.RoundTrip(request)
+			if rterr != nil {
+				return response, rterr
+			}
+
+			// We can't synchronously inspect streaming responses, so tee to a buffer
+			// and inspect it at the end of the test.
+			var buf bytes.Buffer
+			response.Body = struct {
+				io.Reader
+				io.Closer
+			}{
+				Reader: io.TeeReader(response.Body, &buf),
+				Closer: response.Body,
+			}
+			t.Cleanup(func() {
+				recognized, _, err := recognizer.RecognizesData(buf.Bytes())
+				if err != nil {
+					t.Error(err)
+				}
+				if buf.Len() > 0 && !recognized {
+					t.Errorf("non-cbor response: 0x%x", buf.Bytes())
+				}
+			})
+
+			return response, rterr
+		})
+	}
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
 }

--- a/test/integration/framework/cbor.go
+++ b/test/integration/framework/cbor.go
@@ -26,10 +26,44 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer/cbor"
 	"k8s.io/apiserver/pkg/features"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	clientfeatures "k8s.io/client-go/features"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	aggregatorscheme "k8s.io/kube-aggregator/pkg/apiserver/scheme"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 )
+
+// SetTestOnlyCBORClientFeatureGatesForTest overrides the CBOR client feature gates in the test-only
+// client feature gate instance for the duration of a test. The CBOR client feature gates are
+// temporarily registered in their own feature gate instance that does not include runtime wiring to
+// command-line flags or environment variables in order to mitigate the risk of enabling a new
+// encoding before all integration tests have been demonstrated to pass.
+//
+// This will be removed as an alpha requirement. The client feature gates will be registered with
+// the existing feature gate instance and tests will use
+// k8s.io/client-go/features/testing.SetFeatureDuringTest (which unlike
+// k8s.io/component-base/featuregate/testing.SetFeatureGateDuringTest does not accept a feature gate
+// instance as a parameter).
+func SetTestOnlyCBORClientFeatureGatesForTest(tb testing.TB, allowed, preferred bool) {
+	originalAllowed := clientfeatures.TestOnlyFeatureGates.Enabled(clientfeatures.TestOnlyClientAllowsCBOR)
+	tb.Cleanup(func() {
+		if err := clientfeatures.TestOnlyFeatureGates.Set(clientfeatures.TestOnlyClientAllowsCBOR, originalAllowed); err != nil {
+			tb.Fatal(err)
+		}
+	})
+	if err := clientfeatures.TestOnlyFeatureGates.Set(clientfeatures.TestOnlyClientAllowsCBOR, allowed); err != nil {
+		tb.Fatal(err)
+	}
+
+	originalPreferred := clientfeatures.TestOnlyFeatureGates.Enabled(clientfeatures.TestOnlyClientPrefersCBOR)
+	tb.Cleanup(func() {
+		if err := clientfeatures.TestOnlyFeatureGates.Set(clientfeatures.TestOnlyClientPrefersCBOR, originalPreferred); err != nil {
+			tb.Fatal(err)
+		}
+	})
+	if err := clientfeatures.TestOnlyFeatureGates.Set(clientfeatures.TestOnlyClientPrefersCBOR, preferred); err != nil {
+		tb.Fatal(err)
+	}
+}
 
 // EnableCBORForTest patches global state to enable the CBOR serializer and reverses those changes
 // at the end of the test. As a risk mitigation, integration tests are initially written this way so

--- a/test/integration/framework/cbor.go
+++ b/test/integration/framework/cbor.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"testing"
+
+	apiextensionsapiserver "k8s.io/apiextensions-apiserver/pkg/apiserver"
+	metainternalscheme "k8s.io/apimachinery/pkg/apis/meta/internalversion/scheme"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/runtime/serializer/cbor"
+	"k8s.io/apiserver/pkg/features"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	aggregatorscheme "k8s.io/kube-aggregator/pkg/apiserver/scheme"
+	"k8s.io/kubernetes/pkg/api/legacyscheme"
+)
+
+// EnableCBORForTest patches global state to enable the CBOR serializer and reverses those changes
+// at the end of the test. As a risk mitigation, integration tests are initially written this way so
+// that integration tests can be implemented fully and incrementally before exposing options
+// (including feature gates) that can enable CBOR at runtime. After integration test coverage is
+// complete, feature gates will be introduced to completely supersede this mechanism.
+func EnableCBORServingAndStorageForTest(tb testing.TB) {
+	featuregatetesting.SetFeatureGateDuringTest(tb, utilfeature.TestOnlyFeatureGate, features.TestOnlyCBORServingAndStorage, true)
+
+	newCBORSerializerInfo := func(creater runtime.ObjectCreater, typer runtime.ObjectTyper) runtime.SerializerInfo {
+		return runtime.SerializerInfo{
+			MediaType:        "application/cbor",
+			MediaTypeType:    "application",
+			MediaTypeSubType: "cbor",
+			Serializer:       cbor.NewSerializer(creater, typer),
+			StrictSerializer: cbor.NewSerializer(creater, typer, cbor.Strict(true)),
+			StreamSerializer: &runtime.StreamSerializerInfo{
+				Framer:     cbor.NewFramer(),
+				Serializer: cbor.NewSerializer(creater, typer, cbor.Transcode(false)),
+			},
+		}
+	}
+
+	// Codecs for built-in types are constructed at package initialization time and read by
+	// value from REST storage providers.
+	codecs := map[*runtime.Scheme]*serializer.CodecFactory{
+		legacyscheme.Scheme:           &legacyscheme.Codecs,
+		metainternalscheme.Scheme:     &metainternalscheme.Codecs,
+		aggregatorscheme.Scheme:       &aggregatorscheme.Codecs,
+		apiextensionsapiserver.Scheme: &apiextensionsapiserver.Codecs,
+	}
+
+	for scheme, factory := range codecs {
+		original := *factory // shallow copy of original value
+		tb.Cleanup(func() { *codecs[scheme] = original })
+		*codecs[scheme] = serializer.NewCodecFactory(scheme, serializer.WithSerializer(newCBORSerializerInfo))
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup
/sig api-machinery

#### What this PR does / why we need it:

The existing admission webhook integration test provides good coverage of serving built-in resources
and custom resources, including subresources. Serialization concerns, including roundtrippability,
of built-in types have existing test coverage; the CBOR variant of the admission webhook integration
test additionally exercises client and server codec wiring.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

As outlined in https://github.com/kubernetes/enhancements/tree/e1d4725d07a07c40da7ded6e1dd44c0f9aaeaeb9/keps/sig-api-machinery/4222-cbor-serializer#phased-implementation, the programmatic wiring to enable integration testing CBOR functionality is being added first, with runtime feature gating to follow only after all required tests are merged.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://kep.k8s.io/4222
```
