### PR TITLE
Apply fsGroup when accessMode is ReadWriteOncePod

### DIFF
--- a/pkg/apis/storage/types.go
+++ b/pkg/apis/storage/types.go
@@ -423,7 +423,7 @@ const (
 	// ReadWriteOnceWithFSTypeFSGroupPolicy indicates that each volume will be examined
 	// to determine if the volume ownership and permissions
 	// should be modified. If a fstype is defined and the volume's access mode
-	// contains ReadWriteOnce, then the defined fsGroup will be applied.
+	// contains ReadWriteOnce or ReadWriteOncePod, then the defined fsGroup will be applied.
 	// This mode should be defined if it's expected that the
 	// fsGroup may need to be modified depending on the pod's SecurityPolicy.
 	// This is the default behavior if no other FSGroupPolicy is defined.

--- a/pkg/volume/csi/csi_mounter_test.go
+++ b/pkg/volume/csi/csi_mounter_test.go
@@ -861,6 +861,15 @@ func TestMounterSetUpWithFSGroup(t *testing.T) {
 			fsGroup:    3000,
 		},
 		{
+			name: "fstype, fsgroup, RWOP provided (should apply fsgroup)",
+			accessModes: []corev1.PersistentVolumeAccessMode{
+				corev1.ReadWriteOncePod,
+			},
+			fsType:     "ext4",
+			setFsGroup: true,
+			fsGroup:    3000,
+		},
+		{
 			name: "fstype, fsgroup, RWO provided, FSGroupPolicy ReadWriteOnceWithFSType (should apply fsgroup)",
 			accessModes: []corev1.PersistentVolumeAccessMode{
 				corev1.ReadWriteOnce,

--- a/pkg/volume/csi/csi_util.go
+++ b/pkg/volume/csi/csi_util.go
@@ -134,7 +134,8 @@ func hasReadWriteOnce(modes []api.PersistentVolumeAccessMode) bool {
 		return false
 	}
 	for _, mode := range modes {
-		if mode == api.ReadWriteOnce {
+		if mode == api.ReadWriteOnce ||
+			mode == api.ReadWriteOncePod {
 			return true
 		}
 	}

--- a/staging/src/k8s.io/api/storage/v1/types.go
+++ b/staging/src/k8s.io/api/storage/v1/types.go
@@ -433,7 +433,7 @@ const (
 	// ReadWriteOnceWithFSTypeFSGroupPolicy indicates that each volume will be examined
 	// to determine if the volume ownership and permissions
 	// should be modified. If a fstype is defined and the volume's access mode
-	// contains ReadWriteOnce, then the defined fsGroup will be applied.
+	// contains ReadWriteOnce or ReadWriteOncePod, then the defined fsGroup will be applied.
 	// This mode should be defined if it's expected that the
 	// fsGroup may need to be modified depending on the pod's SecurityPolicy.
 	// This is the default behavior if no other FSGroupPolicy is defined.


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/127170

```release-note
Apply fsGroup policy for ReadWriteOncePod volumes
```