### PR TITLE
Update context in cleanup func for e2e test

### DIFF
--- a/test/e2e/storage/pvc_storageclass.go
+++ b/test/e2e/storage/pvc_storageclass.go
@@ -73,7 +73,7 @@ var _ = utils.SIGDescribe("Retroactive StorageClass Assignment", func() {
 
 		// Create a PVC with nil StorageClass
 		pvc := createPVC(ctx, client, namespace)
-		ginkgo.DeferCleanup(func(cleanupContext context.Context) {
+		ginkgo.DeferCleanup(func(ctx context.Context) {
 			err := client.CoreV1().PersistentVolumeClaims(namespace).Delete(ctx, pvc.Name, *metav1.NewDeleteOptions(0))
 			framework.ExpectNoError(err, "Error deleting PVC")
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind failing-test
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

The following can be observed in the logs from
[e2e-ci-kubernetes-e2e-cos-gce-serial-canary #1848492383512039424](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-ci-kubernetes-e2e-cos-gce-serial-canary/1848492383512039424):

```
  I1021 23:09:59.452691 15595 pvc_storageclass.go:78] Unexpected error: Error deleting PVC: 
      <*fmt.wrapError | 0xc000392f60>: 
      client rate limiter Wait returned an error: context canceled
      {
          msg: "client rate limiter Wait returned an error: context canceled",
          err: <*errors.errorString | 0x70442e0>{
              s: "context canceled",
          },
      }
  [FAILED] in [DeferCleanup (Each)] - k8s.io/kubernetes/test/e2e/storage/pvc_storageclass.go:78 @ 10/21/24 23:09:59.452
```

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Special notes for your reviewer:

We are striving to get https://prow.k8s.io/job-history/gs/kubernetes-ci-logs/logs/e2e-ci-kubernetes-e2e-cos-gce-serial-canary back reliably in the green.


