### PR TITLE
Automated cherry pick of #128220: update zeitgeist to v0.5.4

### DIFF
--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -11,7 +11,7 @@ dependencies:
   #
   # ref: https://github.com/kubernetes/kubernetes/pull/98845
   - name: "zeitgeist"
-    version: "v0.2.0"
+    version: "v0.5.4"
     refPaths:
     - path: hack/verify-external-dependencies-version.sh
       match: sigs.k8s.io/zeitgeist@v.*

--- a/hack/verify-external-dependencies-version.sh
+++ b/hack/verify-external-dependencies-version.sh
@@ -31,14 +31,14 @@ export GOBIN="${KUBE_OUTPUT_BIN}"
 PATH="${GOBIN}:${PATH}"
 
 # Install zeitgeist
-go install sigs.k8s.io/zeitgeist@v0.2.0
+go install sigs.k8s.io/zeitgeist@v0.5.4
 
 # Prefer full path for running zeitgeist
 ZEITGEIST_BIN="$(which zeitgeist)"
 
 # TODO: revert sed hack when zetigeist respects CLICOLOR/ttys
 CLICOLOR=0 "${ZEITGEIST_BIN}" validate \
-  --local \
+  --local-only \
   --base-path "${KUBE_ROOT}" \
   --config "${KUBE_ROOT}"/build/dependencies.yaml \
   2> >(sed -e $'s/\x1b\[[0-9;]*m//g' >&2)


### PR DESCRIPTION
Cherry pick of #128220 on release-1.30.

#128220: update zeitgeist to v0.5.4

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```