### PR TITLE
Promote the Job pod failure policy to Conformance

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -1055,6 +1055,29 @@
     pod. Modify the labels of one of the Job's Pods. The Job MUST release the Pod.
   release: v1.16
   file: test/e2e/apps/job.go
+- testname: Ensure pod failure policy allows to ignore failure matching on the DisruptionTarget
+    condition
+  codename: '[sig-apps] Job should allow to use a pod failure policy to ignore failure
+    matching on DisruptionTarget condition [Conformance]'
+  description: This test is using an indexed job. The pod corresponding to each index
+    creates a marker file on the host and runs 'forever' until evicted. Once the marker
+    file is created the pod succeeds seeing it on restart. Thus, we trigger one failure
+    per index due to eviction (DisruptionTarget condition is added in the process).
+    The Job would be marked as failed, if not for the ignore rule matching on exit
+    codes.
+  release: v1.32
+  file: test/e2e/apps/job.go
+- testname: Ensure pod failure policy allows to ignore failure matching on the exit
+    code
+  codename: '[sig-apps] Job should allow to use a pod failure policy to ignore failure
+    matching on exit code [Conformance]'
+  description: This test is using an indexed job. The pod corresponding to each index
+    creates a marker file on the host and runs 'forever' until evicted. Once the marker
+    file is created the pod succeeds seeing it on restart. Thus, we trigger one failure
+    per index due to eviction, so the Job would be marked as failed, if not for the
+    ignore rule matching on exit codes.
+  release: v1.32
+  file: test/e2e/apps/job.go
 - testname: Verify Pod Failure policy allows to fail job early on exit code.
   codename: '[sig-apps] Job should allow to use the pod failure policy on exit code
     to fail the job early [Conformance]'

--- a/test/e2e/apps/job.go
+++ b/test/e2e/apps/job.go
@@ -143,6 +143,7 @@ var _ = SIGDescribe("Job", func() {
 	})
 
 	/*
+		Release: v1.32
 		Testname: Ensure pod failure policy allows to ignore failure matching on the exit code
 		Description: This test is using an indexed job. The pod corresponding to each index
 		creates a marker file on the host and runs 'forever' until evicted. Once
@@ -150,7 +151,7 @@ var _ = SIGDescribe("Job", func() {
 		we trigger one failure per index due to eviction, so the Job would be
 		marked as failed, if not for the ignore rule matching on exit codes.
 	*/
-	ginkgo.It("should allow to use a pod failure policy to ignore failure matching on exit code", func(ctx context.Context) {
+	framework.ConformanceIt("should allow to use a pod failure policy to ignore failure matching on exit code", func(ctx context.Context) {
 		// We set the backoffLimit = numPods-1  so that we can tolerate random
 		// failures (like OutOfPods from kubelet). Yet, the Job would fail if the
 		// pod failures were not be ignored.
@@ -217,6 +218,7 @@ var _ = SIGDescribe("Job", func() {
 	})
 
 	/*
+		Release: v1.32
 		Testname: Ensure pod failure policy allows to ignore failure matching on the DisruptionTarget condition
 		Description: This test is using an indexed job. The pod corresponding to each index
 		creates a marker file on the host and runs 'forever' until evicted. Once
@@ -225,7 +227,7 @@ var _ = SIGDescribe("Job", func() {
 		condition is added in the process). The Job would be marked as failed,
 		if not for the ignore rule matching on exit codes.
 	*/
-	ginkgo.It("should allow to use a pod failure policy to ignore failure matching on DisruptionTarget condition", func(ctx context.Context) {
+	framework.ConformanceIt("should allow to use a pod failure policy to ignore failure matching on DisruptionTarget condition", func(ctx context.Context) {
 		// We set the backoffLimit = numPods-1 so that we can tolerate random
 		// failures (like OutOfPods from kubelet). Yet, the Job would fail if the
 		// pod failures were not be ignored.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig apps
/area conformance
@kubernetes/sig-architecture-pr-reviews @kubernetes/sig-apps-pr-reviews @kubernetes/cncf-conformance-wg

#### What this PR does / why we need it:

Follow up to https://github.com/kubernetes/kubernetes/pull/126169

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

The promotion of these tests was delayed as it required pre-work in https://github.com/kubernetes/kubernetes/pull/126169. 

In the meanwhile the feature https://github.com/kubernetes/enhancements/issues/3329 was already GA-ed as we had other e2e tests already promoted.

These tests are stable now:
![image](https://github.com/user-attachments/assets/61f75470-4ba3-4a0e-936c-9df5458d8d98)


from
https://storage.googleapis.com/k8s-triage/index.html?test=should%20allow%20to%20use%20a%20pod%20failure%20policy%20to%20ignore%20failure%20matching%20on%20exit%20code%7Cshould%20allow%20to%20use%20a%20pod%20failure%20policy%20to%20ignore%20failure%20matching%20on%20DisruptionTarget%20condition

in the last two weeks there was only one failure, https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-e2e-ubuntu-ec2-arm64-containerd/1844854820297510912, but in this case 409/6604 tests failed. Looking at the test log, the test failed in BeforeEach without reaching the actual test body.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
https://github.com/kubernetes/enhancements/tree/master/keps/sig-apps/3329-retriable-and-non-retriable-failures
```
