### PR TITLE
client-go: add example for verify audience scoped tokens with TokenReview

### DIFF
--- a/staging/src/k8s.io/client-go/examples/verify-audience-scoped-tokens-with-tokenreview/README.md
+++ b/staging/src/k8s.io/client-go/examples/verify-audience-scoped-tokens-with-tokenreview/README.md
@@ -1,0 +1,45 @@
+# Verify audience scoped tokens with TokenReview
+
+This example program demonstrates how to validate a token presented to a service
+external to the kube-apiserver using the TokenReview API.
+
+You can adopt the source code from this example to write programs that validate
+audience-scoped service account tokens.
+
+## Running this example
+
+Make sure you have a Kubernetes cluster and `kubectl` is configured:
+
+    kubectl get nodes
+
+Compile this example on your workstation:
+
+```
+cd verify-audience-scoped-tokens-with-tokenreview
+go build -o ./app
+```
+
+Now, run this application on your workstation with your local kubeconfig file:
+
+```
+# override required audiences with -target-audience flag
+# or specify a kubeconfig file with flag
+kubectl create token default --namespace default | ./app -kubeconfig=$HOME/.kube/config
+```
+
+Running this command will execute the following operations on your cluster:
+
+1. **Create a new ServiceAccount token:** This will create a new JWT for the `default`
+   ServiceAccount in the `default` namespace.
+2. **Create a TokenReview request:** The TokenReview will be submitted to the apiserver
+   which will validate the token against the requested `-target-audience` (more information
+   on JWT audience claims can be found in [RFC 7519]().
+3. **Inspect the TokenReview status in response:** Checking the `status.authenticated` and
+   `status.error` fields allow you to understand whether your token is considered valid,
+   and if not, what part of the validation failed.
+
+[RFC 7519]: https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3
+
+## Cleanup
+
+Because tokens are ephemeral by nature and not persisted anywhere, there is no clean-up required.

--- a/staging/src/k8s.io/client-go/examples/verify-audience-scoped-tokens-with-tokenreview/main.go
+++ b/staging/src/k8s.io/client-go/examples/verify-audience-scoped-tokens-with-tokenreview/main.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"flag"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+
+	authenticationv1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/util/homedir"
+	//
+	// Uncomment to load all auth plugins
+	//_ "k8s.io/client-go/plugin/pkg/client/auth"
+	//
+	// Or uncomment to load specific auth plugins
+	// _ "k8s.io/client-go/plugin/pkg/client/auth/azure"
+	// _ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	// _ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
+)
+
+func main() {
+	token := flag.String("token", "-", "the JWT token to verify (defaults to stdin)")
+	audience := flag.String("target-audience", "https://kubernetes.default.svc.cluster.local", "the audience to verify tokens against (passed in the TokenReview)")
+	var kubeconfig *string
+	if home := homedir.HomeDir(); home != "" {
+		kubeconfig = flag.String("kubeconfig", filepath.Join(home, ".kube", "config"), "(optional) absolute path to the kubeconfig file")
+	} else {
+		kubeconfig = flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
+	}
+	flag.Parse()
+	if *token == "-" {
+		tokenBytes, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			panic(err)
+		}
+		tokenStr := string(tokenBytes)
+		token = &tokenStr
+	}
+
+	config, err := clientcmd.BuildConfigFromFlags("", *kubeconfig)
+	if err != nil {
+		panic(err)
+	}
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		panic(err)
+	}
+
+	review, err := clientset.AuthenticationV1().TokenReviews().Create(context.TODO(), &authenticationv1.TokenReview{
+		Spec: authenticationv1.TokenReviewSpec{
+			Token:     *token,
+			Audiences: []string{*audience},
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		panic(err)
+	}
+
+	if !review.Status.Authenticated {
+		log.Printf("Token was NOT authenticated by the apiserver due to: %v", review.Status.Error)
+	} else {
+		log.Printf("Token was successfully authenticated with user=%#v, audiences from token=%#v, ", review.Status.User, review.Status.Audiences)
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Adds an example on how to verify audience scoped JWTs with client-go. This is to supplement/be linked to from: https://github.com/kubernetes/website/pull/48495#discussion_r1810805738.

#### Which issue(s) this PR fixes:

Related to [KEP-4193](https://github.com/kubernetes/enhancements/issues/4193).

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/4193
- [Doc update]: https://github.com/kubernetes/website/pull/48495
```

/sig auth
/cc @liggitt