### PR TITLE
[WIP for testing] Fix oom_score_adj failing test

### DIFF
--- a/test/e2e_node/container_manager_test.go
+++ b/test/e2e_node/container_manager_test.go
@@ -156,6 +156,7 @@ var _ = SIGDescribe("Container Manager Misc", framework.WithSerial(), func() {
 							Containers: []v1.Container{
 								{
 									Image: imageutils.GetE2EImage(imageutils.Agnhost),
+									Args:  []string{"test-webserver"},
 									Name:  podName,
 								},
 							},


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:

An agnhost container without args start pause command. This sets an oom_score_adj
equal to -998 even if the pod is BestEffort. This commit tries to test the theory by specifiying test-webserver as args, to see if the failing test will pass.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```