### PR TITLE
[FG:InPlacePodVerticalScaling] Implement resize for sidecar containers

### DIFF
--- a/pkg/api/pod/util.go
+++ b/pkg/api/pod/util.go
@@ -1268,14 +1268,10 @@ func MarkPodProposedForResize(oldPod, newPod *api.Pod) {
 	newPodSpecContainers := newPod.Spec.Containers
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.SidecarContainers) {
-		for _, c := range oldPod.Spec.InitContainers {
+		for i, c := range oldPod.Spec.InitContainers {
 			if isRestartableInitContainer(&c) {
 				oldPodSpecContainers = append(oldPodSpecContainers, c)
-			}
-		}
-		for _, c := range newPod.Spec.InitContainers {
-			if isRestartableInitContainer(&c) {
-				newPodSpecContainers = append(newPodSpecContainers, c)
+				newPodSpecContainers = append(newPodSpecContainers, newPod.Spec.InitContainers[i])
 			}
 		}
 	}

--- a/pkg/api/pod/util_test.go
+++ b/pkg/api/pod/util_test.go
@@ -2874,14 +2874,6 @@ func TestMarkPodProposedForResize(t *testing.T) {
 						},
 					},
 				},
-				Status: api.PodStatus{
-					ContainerStatuses: []api.ContainerStatus{
-						{
-							Name:  "c1",
-							Image: "image",
-						},
-					},
-				},
 			},
 			oldPod: &api.Pod{
 				Spec: api.PodSpec{
@@ -2896,14 +2888,6 @@ func TestMarkPodProposedForResize(t *testing.T) {
 						},
 					},
 				},
-				Status: api.PodStatus{
-					ContainerStatuses: []api.ContainerStatus{
-						{
-							Name:  "c1",
-							Image: "image",
-						},
-					},
-				},
 			},
 			expectedPod: &api.Pod{
 				Spec: api.PodSpec{
@@ -2915,14 +2899,6 @@ func TestMarkPodProposedForResize(t *testing.T) {
 								Requests: api.ResourceList{api.ResourceCPU: resource.MustParse("100m")},
 								Limits:   api.ResourceList{api.ResourceCPU: resource.MustParse("200m")},
 							},
-						},
-					},
-				},
-				Status: api.PodStatus{
-					ContainerStatuses: []api.ContainerStatus{
-						{
-							Name:  "c1",
-							Image: "image",
 						},
 					},
 				},
@@ -2955,20 +2931,6 @@ func TestMarkPodProposedForResize(t *testing.T) {
 						},
 					},
 				},
-				Status: api.PodStatus{
-					ContainerStatuses: []api.ContainerStatus{
-						{
-							Name:  "c1",
-							Image: "image",
-						},
-					},
-					InitContainerStatuses: []api.ContainerStatus{
-						{
-							Name:  "i1",
-							Image: "image",
-						},
-					},
-				},
 			},
 			oldPod: &api.Pod{
 				Spec: api.PodSpec{
@@ -2994,20 +2956,6 @@ func TestMarkPodProposedForResize(t *testing.T) {
 						},
 					},
 				},
-				Status: api.PodStatus{
-					ContainerStatuses: []api.ContainerStatus{
-						{
-							Name:  "c1",
-							Image: "image",
-						},
-					},
-					InitContainerStatuses: []api.ContainerStatus{
-						{
-							Name:  "i1",
-							Image: "image",
-						},
-					},
-				},
 			},
 			expectedPod: &api.Pod{
 				Spec: api.PodSpec{
@@ -3030,20 +2978,6 @@ func TestMarkPodProposedForResize(t *testing.T) {
 								Limits:   api.ResourceList{api.ResourceCPU: resource.MustParse("300m")},
 							},
 							RestartPolicy: &containerRestartPolicyAlways,
-						},
-					},
-				},
-				Status: api.PodStatus{
-					ContainerStatuses: []api.ContainerStatus{
-						{
-							Name:  "c1",
-							Image: "image",
-						},
-					},
-					InitContainerStatuses: []api.ContainerStatus{
-						{
-							Name:  "i1",
-							Image: "image",
 						},
 					},
 				},
@@ -3073,20 +3007,6 @@ func TestMarkPodProposedForResize(t *testing.T) {
 						},
 					},
 				},
-				Status: api.PodStatus{
-					ContainerStatuses: []api.ContainerStatus{
-						{
-							Name:               "c1",
-							Image:              "image",
-							AllocatedResources: api.ResourceList{api.ResourceCPU: resource.MustParse("100m")},
-						},
-						{
-							Name:               "c2",
-							Image:              "image",
-							AllocatedResources: api.ResourceList{api.ResourceCPU: resource.MustParse("200m")},
-						},
-					},
-				},
 			},
 			oldPod: &api.Pod{
 				Spec: api.PodSpec{
@@ -3106,20 +3026,6 @@ func TestMarkPodProposedForResize(t *testing.T) {
 								Requests: api.ResourceList{api.ResourceCPU: resource.MustParse("200m")},
 								Limits:   api.ResourceList{api.ResourceCPU: resource.MustParse("300m")},
 							},
-						},
-					},
-				},
-				Status: api.PodStatus{
-					ContainerStatuses: []api.ContainerStatus{
-						{
-							Name:               "c1",
-							Image:              "image",
-							AllocatedResources: api.ResourceList{api.ResourceCPU: resource.MustParse("100m")},
-						},
-						{
-							Name:               "c2",
-							Image:              "image",
-							AllocatedResources: api.ResourceList{api.ResourceCPU: resource.MustParse("200m")},
 						},
 					},
 				},
@@ -3147,18 +3053,6 @@ func TestMarkPodProposedForResize(t *testing.T) {
 				},
 				Status: api.PodStatus{
 					Resize: api.PodResizeStatusProposed,
-					ContainerStatuses: []api.ContainerStatus{
-						{
-							Name:               "c1",
-							Image:              "image",
-							AllocatedResources: api.ResourceList{api.ResourceCPU: resource.MustParse("100m")},
-						},
-						{
-							Name:               "c2",
-							Image:              "image",
-							AllocatedResources: api.ResourceList{api.ResourceCPU: resource.MustParse("200m")},
-						},
-					},
 				},
 			},
 		},
@@ -3189,22 +3083,6 @@ func TestMarkPodProposedForResize(t *testing.T) {
 						},
 					},
 				},
-				Status: api.PodStatus{
-					ContainerStatuses: []api.ContainerStatus{
-						{
-							Name:               "c1",
-							Image:              "image",
-							AllocatedResources: api.ResourceList{api.ResourceCPU: resource.MustParse("100m")},
-						},
-					},
-					InitContainerStatuses: []api.ContainerStatus{
-						{
-							Name:               "i1",
-							Image:              "image",
-							AllocatedResources: api.ResourceList{api.ResourceCPU: resource.MustParse("200m")},
-						},
-					},
-				},
 			},
 			oldPod: &api.Pod{
 				Spec: api.PodSpec{
@@ -3227,22 +3105,6 @@ func TestMarkPodProposedForResize(t *testing.T) {
 								Limits:   api.ResourceList{api.ResourceCPU: resource.MustParse("300m")},
 							},
 							RestartPolicy: &containerRestartPolicyAlways,
-						},
-					},
-				},
-				Status: api.PodStatus{
-					ContainerStatuses: []api.ContainerStatus{
-						{
-							Name:               "c1",
-							Image:              "image",
-							AllocatedResources: api.ResourceList{api.ResourceCPU: resource.MustParse("100m")},
-						},
-					},
-					InitContainerStatuses: []api.ContainerStatus{
-						{
-							Name:               "i1",
-							Image:              "image",
-							AllocatedResources: api.ResourceList{api.ResourceCPU: resource.MustParse("200m")},
 						},
 					},
 				},
@@ -3273,20 +3135,6 @@ func TestMarkPodProposedForResize(t *testing.T) {
 				},
 				Status: api.PodStatus{
 					Resize: api.PodResizeStatusProposed,
-					ContainerStatuses: []api.ContainerStatus{
-						{
-							Name:               "c1",
-							Image:              "image",
-							AllocatedResources: api.ResourceList{api.ResourceCPU: resource.MustParse("100m")},
-						},
-					},
-					InitContainerStatuses: []api.ContainerStatus{
-						{
-							Name:               "i1",
-							Image:              "image",
-							AllocatedResources: api.ResourceList{api.ResourceCPU: resource.MustParse("200m")},
-						},
-					},
 				},
 			},
 		},

--- a/pkg/api/v1/resource/helpers.go
+++ b/pkg/api/v1/resource/helpers.go
@@ -25,9 +25,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
-	"k8s.io/kubernetes/pkg/features"
 	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
 )
 
@@ -45,6 +43,8 @@ type PodResourcesOptions struct {
 	// NonMissingContainerRequests if provided will replace any missing container level requests for the specified resources
 	// with the given values.  If the requests for those resources are explicitly set, even if zero, they will not be modified.
 	NonMissingContainerRequests v1.ResourceList
+	// IsSidecarContainers indicates that the sidecar containers feature gate is enabled.
+	IsSidecarContainersEnabled bool
 }
 
 // PodRequests computes the pod requests per the PodResourcesOptions supplied. If PodResourcesOptions is nil, then
@@ -60,7 +60,7 @@ func PodRequests(pod *v1.Pod, opts PodResourcesOptions) v1.ResourceList {
 		for i := range pod.Status.ContainerStatuses {
 			containerStatuses[pod.Status.ContainerStatuses[i].Name] = &pod.Status.ContainerStatuses[i]
 		}
-		if utilfeature.DefaultFeatureGate.Enabled(features.SidecarContainers) {
+		if opts.IsSidecarContainersEnabled {
 			for i := range pod.Status.InitContainerStatuses {
 				containerStatuses[pod.Status.InitContainerStatuses[i].Name] = &pod.Status.InitContainerStatuses[i]
 			}
@@ -98,7 +98,7 @@ func PodRequests(pod *v1.Pod, opts PodResourcesOptions) v1.ResourceList {
 	// See https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/753-sidecar-containers#exposing-pod-resource-requirements for the detail.
 	for _, container := range pod.Spec.InitContainers {
 		containerReqs := container.Resources.Requests
-		if opts.InPlacePodVerticalScalingEnabled && utilfeature.DefaultFeatureGate.Enabled(features.SidecarContainers) && kubetypes.IsRestartableInitContainer(&container) {
+		if opts.InPlacePodVerticalScalingEnabled && opts.IsSidecarContainersEnabled && kubetypes.IsRestartableInitContainer(&container) {
 			cs, found := containerStatuses[container.Name]
 			if found {
 				containerReqs = setContainerReqs(pod, container, cs)
@@ -142,6 +142,9 @@ func PodRequests(pod *v1.Pod, opts PodResourcesOptions) v1.ResourceList {
 // setContainerReqs will return a copy of the container requests based on if resizing is feasible or not.
 func setContainerReqs(pod *v1.Pod, container v1.Container, cs *v1.ContainerStatus) v1.ResourceList {
 	cp := v1.ResourceList{}
+	if cs.AllocatedResources == nil {
+		return cp
+	}
 	if pod.Status.Resize == v1.PodResizeStatusInfeasible {
 		cp = cs.AllocatedResources.DeepCopy()
 	} else {

--- a/pkg/api/v1/resource/helpers_test.go
+++ b/pkg/api/v1/resource/helpers_test.go
@@ -757,7 +757,7 @@ func TestPodResourceRequests(t *testing.T) {
 				v1.ResourceCPU: resource.MustParse("7"),
 			},
 			podResizeStatus: v1.PodResizeStatusInfeasible,
-			options:         PodResourcesOptions{InPlacePodVerticalScalingEnabled: true},
+			options:         PodResourcesOptions{InPlacePodVerticalScalingEnabled: true, IsSidecarContainersEnabled: true},
 			containers: []v1.Container{
 				{
 					Name: "container-1",
@@ -835,7 +835,7 @@ func TestPodResourceRequests(t *testing.T) {
 			expectedRequests: v1.ResourceList{
 				v1.ResourceCPU: resource.MustParse("7"),
 			},
-			options: PodResourcesOptions{InPlacePodVerticalScalingEnabled: true},
+			options: PodResourcesOptions{InPlacePodVerticalScalingEnabled: true, IsSidecarContainersEnabled: true},
 			containers: []v1.Container{
 				{
 					Name: "container-1",
@@ -881,7 +881,7 @@ func TestPodResourceRequests(t *testing.T) {
 				v1.ResourceCPU: resource.MustParse("7"),
 			},
 			podResizeStatus: v1.PodResizeStatusInfeasible,
-			options:         PodResourcesOptions{InPlacePodVerticalScalingEnabled: false},
+			options:         PodResourcesOptions{InPlacePodVerticalScalingEnabled: false, IsSidecarContainersEnabled: true},
 			containers: []v1.Container{
 				{
 					Name: "container-1",

--- a/pkg/apis/core/v1/defaults.go
+++ b/pkg/apis/core/v1/defaults.go
@@ -182,7 +182,7 @@ func SetDefaults_Pod(obj *v1.Pod) {
 			}
 		}
 		if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) &&
-			obj.Spec.Containers[i].Resources.Requests != nil {
+			(obj.Spec.Containers[i].Resources.Requests != nil || obj.Spec.Containers[i].Resources.Limits != nil) {
 			// For normal containers, set resize restart policy to default value (NotRequired), if not specified..
 			setDefaultResizePolicy(&obj.Spec.Containers[i])
 		}
@@ -198,7 +198,8 @@ func SetDefaults_Pod(obj *v1.Pod) {
 				}
 			}
 		}
-		if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) && utilfeature.DefaultFeatureGate.Enabled(features.SidecarContainers) && kubetypes.IsRestartableInitContainer(&obj.Spec.InitContainers[i]) && obj.Spec.InitContainers[i].Resources.Requests != nil {
+		if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) && utilfeature.DefaultFeatureGate.Enabled(features.SidecarContainers) &&
+			kubetypes.IsRestartableInitContainer(&obj.Spec.InitContainers[i]) && (obj.Spec.InitContainers[i].Resources.Requests != nil || obj.Spec.InitContainers[i].Resources.Limits != nil) {
 			// For restartable init containers, set resize restart policy to default value (NotRequired), if not specified.
 			setDefaultResizePolicy(&obj.Spec.InitContainers[i])
 		}

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -47,6 +47,7 @@ import (
 	utilsysctl "k8s.io/component-helpers/node/util/sysctl"
 	schedulinghelper "k8s.io/component-helpers/scheduling/corev1"
 	kubeletapis "k8s.io/kubelet/pkg/apis"
+	podutil "k8s.io/kubernetes/pkg/api/pod"
 	apiservice "k8s.io/kubernetes/pkg/api/service"
 	"k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/core/helper"
@@ -5193,7 +5194,7 @@ func ValidatePodUpdate(newPod, oldPod *core.Pod, opts PodValidationOptions) fiel
 	for ix, container := range mungedPodSpec.InitContainers {
 		container.Image = oldPod.Spec.InitContainers[ix].Image // +k8s:verify-mutation:reason=clone
 		if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) && utilfeature.DefaultFeatureGate.Enabled(features.SidecarContainers) {
-			if isRestartableInitContainer(&container) {
+			if podutil.IsRestartableInitContainer(&container) {
 				lim := mungeCpuMemResources(container.Resources.Limits, oldPod.Spec.InitContainers[ix].Resources.Limits)
 				req := mungeCpuMemResources(container.Resources.Requests, oldPod.Spec.InitContainers[ix].Resources.Requests)
 				container.Resources = core.ResourceRequirements{Limits: lim, Requests: req}
@@ -5296,13 +5297,6 @@ func mungeCpuMemResources(resourceList, oldResourceList core.ResourceList) core.
 		mungedResourceList[core.ResourceMemory] = mem
 	}
 	return mungedResourceList
-}
-
-func isRestartableInitContainer(initContainer *core.Container) bool {
-	if initContainer.RestartPolicy == nil {
-		return false
-	}
-	return *initContainer.RestartPolicy == core.ContainerRestartPolicyAlways
 }
 
 // ValidateContainerStateTransition test to if any illegal container state transitions are being attempted

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -5277,7 +5277,7 @@ func ValidatePodUpdate(newPod, oldPod *core.Pod, opts PodValidationOptions) fiel
 	return allErrs
 }
 
-func mungeCpuMemResources(resourceList, oldResourceList core.ResourceList) core.ResourceList {
+func mungeResizableResources(resourceList, oldResourceList core.ResourceList) core.ResourceList {
 	if oldResourceList == nil {
 		return nil
 	}

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -24818,7 +24818,7 @@ func TestValidateContainerStatusAllocatedResourcesStatus(t *testing.T) {
 	}
 }
 
-func TestMungeCpuMemResources(t *testing.T) {
+func TestMungeResizableResources(t *testing.T) {
 	tests := []struct {
 		name            string
 		resourceList    core.ResourceList

--- a/pkg/kubelet/cm/cpumanager/policy_static.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static.go
@@ -443,11 +443,13 @@ func (p *staticPolicy) guaranteedCPUs(pod *v1.Pod, container *v1.Container) int 
 	// and the value configured with runtime.
 	if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {
 		containerStatuses := pod.Status.ContainerStatuses
-		//if utilfeature.DefaultFeatureGate.Enabled(features.SidecarContainers) && types.IsRestartableInitContainer(container) {
-		//if len(pod.Status.InitContainerStatuses) != 0 {
-		containerStatuses = append(containerStatuses, pod.Status.InitContainerStatuses...)
-		//}
-		//}
+		// TODO: Uncomment below code when in-place pod resize is enabled for nodes with static topology policy. See https://github.com/kubernetes/kubernetes/issues/128068
+		// for the detail.
+		/* 		if utilfeature.DefaultFeatureGate.Enabled(features.SidecarContainers) && types.IsRestartableInitContainer(container) {
+			if len(pod.Status.InitContainerStatuses) != 0 {
+				containerStatuses = append(containerStatuses, pod.Status.InitContainerStatuses...)
+			}
+		} */
 		if cs, ok := podutil.GetContainerStatus(containerStatuses, container.Name); ok {
 			cpuQuantity = cs.AllocatedResources[v1.ResourceCPU]
 		}

--- a/pkg/kubelet/cm/helpers_linux.go
+++ b/pkg/kubelet/cm/helpers_linux.go
@@ -120,9 +120,11 @@ func HugePageLimits(resourceList v1.ResourceList) map[int64]int64 {
 // ResourceConfigForPod takes the input pod and outputs the cgroup resource config.
 func ResourceConfigForPod(pod *v1.Pod, enforceCPULimits bool, cpuPeriod uint64, enforceMemoryQoS bool) *ResourceConfig {
 	inPlacePodVerticalScalingEnabled := utilfeature.DefaultFeatureGate.Enabled(kubefeatures.InPlacePodVerticalScaling)
+	sidecarContainers := utilfeature.DefaultFeatureGate.Enabled(kubefeatures.SidecarContainers)
 	// sum requests and limits.
 	reqs := resource.PodRequests(pod, resource.PodResourcesOptions{
 		InPlacePodVerticalScalingEnabled: inPlacePodVerticalScalingEnabled,
+		IsSidecarContainersEnabled:       sidecarContainers,
 	})
 	// track if limits were applied for each resource.
 	memoryLimitsDeclared := true

--- a/pkg/kubelet/cm/memorymanager/policy_static.go
+++ b/pkg/kubelet/cm/memorymanager/policy_static.go
@@ -450,11 +450,13 @@ func getRequestedResources(pod *v1.Pod, container *v1.Container) (map[v1.Resourc
 	// and the value configured with runtime.
 	if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {
 		containerStatuses := pod.Status.ContainerStatuses
-		//if utilfeature.DefaultFeatureGate.Enabled(features.SidecarContainers) && types.IsRestartableInitContainer(container) {
-		//if len(pod.Status.InitContainerStatuses) != 0 {
-		containerStatuses = append(containerStatuses, pod.Status.InitContainerStatuses...)
-		//}
-		//}
+		// TODO: Uncomment below code when in-place pod resize is enabled for nodes with static topology policy. See https://github.com/kubernetes/kubernetes/issues/128068
+		// for the detail.
+		/* 		if utilfeature.DefaultFeatureGate.Enabled(features.SidecarContainers) && types.IsRestartableInitContainer(container) {
+			if len(pod.Status.InitContainerStatuses) != 0 {
+				containerStatuses = append(containerStatuses, pod.Status.InitContainerStatuses...)
+			}
+		} */
 		if cs, ok := podutil.GetContainerStatus(containerStatuses, container.Name); ok {
 			resources = cs.AllocatedResources
 		}

--- a/pkg/kubelet/cm/qos_container_manager_linux.go
+++ b/pkg/kubelet/cm/qos_container_manager_linux.go
@@ -171,7 +171,7 @@ func (m *qosContainerManagerImpl) setHugePagesConfig(configs map[v1.PodQOSClass]
 func (m *qosContainerManagerImpl) setCPUCgroupConfig(configs map[v1.PodQOSClass]*CgroupConfig) error {
 	pods := m.activePods()
 	burstablePodCPURequest := int64(0)
-	reuseReqs := make(v1.ResourceList, 4)
+	reuseReqs := make(v1.ResourceList, 5)
 	for i := range pods {
 		pod := pods[i]
 		qosClass := v1qos.GetPodQOS(pod)
@@ -205,7 +205,7 @@ func (m *qosContainerManagerImpl) getQoSMemoryRequests() map[v1.PodQOSClass]int6
 
 	// Sum the pod limits for pods in each QOS class
 	pods := m.activePods()
-	reuseReqs := make(v1.ResourceList, 4)
+	reuseReqs := make(v1.ResourceList, 5)
 	for _, pod := range pods {
 		podMemoryRequest := int64(0)
 		qosClass := v1qos.GetPodQOS(pod)

--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -3737,6 +3737,7 @@ func Test_generateAPIPodStatusForInPlaceVPAEnabled(t *testing.T) {
 	CPU1AndMem1GAndStorage2G[v1.ResourceEphemeralStorage] = resource.MustParse("2Gi")
 	CPU1AndMem1GAndStorage2GAndCustomResource := CPU1AndMem1GAndStorage2G.DeepCopy()
 	CPU1AndMem1GAndStorage2GAndCustomResource["unknown-resource"] = resource.MustParse("1")
+	containerRestartPolicyAlways := v1.ContainerRestartPolicyAlways
 
 	testKubecontainerPodStatus := kubecontainer.PodStatus{
 		ContainerStatuses: []*kubecontainer.Status{
@@ -3754,9 +3755,10 @@ func Test_generateAPIPodStatusForInPlaceVPAEnabled(t *testing.T) {
 	}
 
 	tests := []struct {
-		name      string
-		pod       *v1.Pod
-		oldStatus *v1.PodStatus
+		name                string
+		pod                 *v1.Pod
+		hasSidecarContainer bool
+		oldStatus           *v1.PodStatus
 	}{
 		{
 			name: "custom resource in ResourcesAllocated, resize should be null",
@@ -3820,9 +3822,76 @@ func Test_generateAPIPodStatusForInPlaceVPAEnabled(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:                "custom resource in ResourcesAllocated in case of restartable init containers, resize should be null",
+			hasSidecarContainer: true,
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					UID:       "1234560",
+					Name:      "foo0",
+					Namespace: "bar0",
+				},
+				Spec: v1.PodSpec{
+					NodeName: "machine",
+					InitContainers: []v1.Container{
+						{
+							Name:          testContainerName,
+							Image:         "img",
+							Resources:     v1.ResourceRequirements{Limits: CPU1AndMem1GAndStorage2GAndCustomResource, Requests: CPU1AndMem1GAndStorage2GAndCustomResource},
+							RestartPolicy: &containerRestartPolicyAlways,
+						},
+					},
+					RestartPolicy: v1.RestartPolicyAlways,
+				},
+				Status: v1.PodStatus{
+					InitContainerStatuses: []v1.ContainerStatus{
+						{
+							Name:               testContainerName,
+							Resources:          &v1.ResourceRequirements{Limits: CPU1AndMem1GAndStorage2G, Requests: CPU1AndMem1GAndStorage2G},
+							AllocatedResources: CPU1AndMem1GAndStorage2GAndCustomResource,
+						},
+					},
+					Resize: "InProgress",
+				},
+			},
+		},
+		{
+			name:                "cpu/memory resource in ResourcesAllocated in case of restartable init containers, resize should be null",
+			hasSidecarContainer: true,
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					UID:       "1234560",
+					Name:      "foo0",
+					Namespace: "bar0",
+				},
+				Spec: v1.PodSpec{
+					NodeName: "machine",
+					InitContainers: []v1.Container{
+						{
+							Name:          testContainerName,
+							Image:         "img",
+							Resources:     v1.ResourceRequirements{Limits: CPU1AndMem1GAndStorage2G, Requests: CPU1AndMem1GAndStorage2G},
+							RestartPolicy: &containerRestartPolicyAlways,
+						},
+					},
+					RestartPolicy: v1.RestartPolicyAlways,
+				},
+				Status: v1.PodStatus{
+					InitContainerStatuses: []v1.ContainerStatus{
+						{
+							Name:               testContainerName,
+							Resources:          &v1.ResourceRequirements{Limits: CPU1AndMem1GAndStorage2G, Requests: CPU1AndMem1GAndStorage2G},
+							AllocatedResources: CPU1AndMem1GAndStorage2G,
+						},
+					},
+					Resize: "InProgress",
+				},
+			},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.SidecarContainers, test.hasSidecarContainer)
 			testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 			defer testKubelet.Cleanup()
 			kl := testKubelet.kubelet

--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -1147,6 +1147,10 @@ func (m *kubeGenericRuntimeManager) computeInitContainerActions(pod *v1.Pod, pod
 						changes.InitContainersToStart = append(changes.InitContainersToStart, i)
 					}
 				}
+				if isInPlacePodVerticalScalingAllowed(pod) && m.computePodResizeAction(pod, i, true, status, changes) {
+					// computePodResizeAction updates 'changes' if resize policy requires restarting this container
+					changes.InitContainersToStart = append(changes.InitContainersToStart, i)
+				}
 			} else { // init container
 				// nothing do to but wait for it to finish
 				break

--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -1147,9 +1147,9 @@ func (m *kubeGenericRuntimeManager) computeInitContainerActions(pod *v1.Pod, pod
 						changes.InitContainersToStart = append(changes.InitContainersToStart, i)
 					}
 				}
-				if isInPlacePodVerticalScalingAllowed(pod) && m.computePodResizeAction(pod, i, true, status, changes) {
+				if isInPlacePodVerticalScalingAllowed(pod) && !m.computePodResizeAction(pod, i, true, status, changes) {
 					// computePodResizeAction updates 'changes' if resize policy requires restarting this container
-					changes.InitContainersToStart = append(changes.InitContainersToStart, i)
+					continue
 				}
 			} else { // init container
 				// nothing do to but wait for it to finish

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -660,7 +660,7 @@ func (m *kubeGenericRuntimeManager) computePodResizeAction(pod *v1.Pod, containe
 			message:   fmt.Sprintf("Container %s resize requires restart", container.Name),
 		}
 		if isRestartableInitContainer {
-			changes.InitContainersToStart = append(changes.ContainersToStart, containerIdx)
+			changes.InitContainersToStart = append(changes.InitContainersToStart, containerIdx)
 		} else {
 			changes.ContainersToStart = append(changes.ContainersToStart, containerIdx)
 		}
@@ -735,7 +735,6 @@ func (m *kubeGenericRuntimeManager) doPodResizeAction(pod *v1.Pod, podStatus *ku
 				return err
 			}
 		}
-
 		if newPodCgLimValue < currPodCgLimValue {
 			err = setPodCgroupConfig(rName, true)
 		}
@@ -1346,10 +1345,10 @@ func (m *kubeGenericRuntimeManager) SyncPod(ctx context.Context, pod *v1.Pod, po
 		}
 	}
 
-	// Step 7: For containers in podContainerChanges.ContainersToUpdate[CPU,Memory] list, invoke UpdateContainerResources
+	// Step 7: For containers in podContainerChanges.ContainersToUpdate[CPU,Memory] or podContainerChanges.InitContainersToUpdate[CPU,Memory] lists, invoke UpdateContainerResources
 	if isInPlacePodVerticalScalingAllowed(pod) {
 		updateInitContainers := utilfeature.DefaultFeatureGate.Enabled(features.SidecarContainers) && len(podContainerChanges.InitContainersToUpdate) > 0
-		if len(podContainerChanges.ContainersToUpdate) > 0 || podContainerChanges.UpdatePodResources || updateInitContainers {
+		if len(podContainerChanges.ContainersToUpdate) > 0 || updateInitContainers || podContainerChanges.UpdatePodResources {
 			m.doPodResizeAction(pod, podStatus, podContainerChanges, result)
 		}
 	}

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -2619,7 +2619,7 @@ func TestUpdatePodContainerResources(t *testing.T) {
 			containersToUpdate = append(containersToUpdate, cInfo)
 		}
 		fakeRuntime.Called = []string{}
-		err := m.updatePodContainerResources(pod, tc.resourceName, containersToUpdate)
+		err := m.updatePodContainerResources(pod, tc.resourceName, containersToUpdate, false)
 		assert.NoError(t, err, dsc)
 
 		if tc.invokeUpdateResources {

--- a/pkg/quota/v1/evaluator/core/pods.go
+++ b/pkg/quota/v1/evaluator/core/pods.go
@@ -366,6 +366,7 @@ func PodUsageFunc(obj runtime.Object, clock clock.Clock) (corev1.ResourceList, e
 
 	opts := resourcehelper.PodResourcesOptions{
 		InPlacePodVerticalScalingEnabled: feature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling),
+		IsSidecarContainersEnabled:       feature.DefaultFeatureGate.Enabled(features.SidecarContainers),
 	}
 	requests := resourcehelper.PodRequests(pod, opts)
 	limits := resourcehelper.PodLimits(pod, opts)

--- a/pkg/scheduler/framework/events.go
+++ b/pkg/scheduler/framework/events.go
@@ -92,6 +92,7 @@ type podChangeExtractor func(newPod *v1.Pod, oldPod *v1.Pod) ActionType
 func extractPodScaleDown(newPod, oldPod *v1.Pod) ActionType {
 	opt := resource.PodResourcesOptions{
 		InPlacePodVerticalScalingEnabled: utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling),
+		IsSidecarContainersEnabled:       utilfeature.DefaultFeatureGate.Enabled(features.SidecarContainers),
 	}
 	newPodRequests := resource.PodRequests(newPod, opt)
 	oldPodRequests := resource.PodRequests(oldPod, opt)

--- a/pkg/scheduler/framework/plugins/noderesources/fit.go
+++ b/pkg/scheduler/framework/plugins/noderesources/fit.go
@@ -330,11 +330,11 @@ func (f *Fit) isSchedulableAfterPodScaleDown(targetPod, originalPod, modifiedPod
 
 	// the other pod was scheduled, so modification or deletion may free up some resources.
 	originalMaxResourceReq, modifiedMaxResourceReq := &framework.Resource{}, &framework.Resource{}
-	originalMaxResourceReq.SetMaxResource(resource.PodRequests(originalPod, resource.PodResourcesOptions{InPlacePodVerticalScalingEnabled: f.enableInPlacePodVerticalScaling}))
-	modifiedMaxResourceReq.SetMaxResource(resource.PodRequests(modifiedPod, resource.PodResourcesOptions{InPlacePodVerticalScalingEnabled: f.enableInPlacePodVerticalScaling}))
+	originalMaxResourceReq.SetMaxResource(resource.PodRequests(originalPod, resource.PodResourcesOptions{InPlacePodVerticalScalingEnabled: f.enableInPlacePodVerticalScaling, IsSidecarContainersEnabled: f.enableSidecarContainers}))
+	modifiedMaxResourceReq.SetMaxResource(resource.PodRequests(modifiedPod, resource.PodResourcesOptions{InPlacePodVerticalScalingEnabled: f.enableInPlacePodVerticalScaling, IsSidecarContainersEnabled: f.enableSidecarContainers}))
 
 	// check whether the resource request of the modified pod is less than the original pod.
-	podRequests := resource.PodRequests(targetPod, resource.PodResourcesOptions{InPlacePodVerticalScalingEnabled: f.enableInPlacePodVerticalScaling})
+	podRequests := resource.PodRequests(targetPod, resource.PodResourcesOptions{InPlacePodVerticalScalingEnabled: f.enableInPlacePodVerticalScaling, IsSidecarContainersEnabled: f.enableSidecarContainers})
 	for rName, rValue := range podRequests {
 		if rValue.IsZero() {
 			// We only care about the resources requested by the pod we are trying to schedule.

--- a/pkg/scheduler/framework/plugins/noderesources/resource_allocation.go
+++ b/pkg/scheduler/framework/plugins/noderesources/resource_allocation.go
@@ -119,6 +119,7 @@ func (r *resourceAllocationScorer) calculatePodResourceRequest(pod *v1.Pod, reso
 
 	opts := resourcehelper.PodResourcesOptions{
 		InPlacePodVerticalScalingEnabled: utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling),
+		IsSidecarContainersEnabled:       utilfeature.DefaultFeatureGate.Enabled(features.SidecarContainers),
 	}
 	if !r.useRequested {
 		opts.NonMissingContainerRequests = v1.ResourceList{

--- a/pkg/scheduler/framework/types.go
+++ b/pkg/scheduler/framework/types.go
@@ -1050,6 +1050,7 @@ func (n *NodeInfo) update(pod *v1.Pod, sign int64) {
 func calculateResource(pod *v1.Pod) (Resource, int64, int64) {
 	requests := resourcehelper.PodRequests(pod, resourcehelper.PodResourcesOptions{
 		InPlacePodVerticalScalingEnabled: utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling),
+		IsSidecarContainersEnabled:       utilfeature.DefaultFeatureGate.Enabled(features.SidecarContainers),
 	})
 
 	non0Requests := resourcehelper.PodRequests(pod, resourcehelper.PodResourcesOptions{

--- a/pkg/scheduler/metrics/resources/resources.go
+++ b/pkg/scheduler/metrics/resources/resources.go
@@ -110,7 +110,7 @@ func (c *podResourceCollector) CollectWithStability(ch chan<- metrics.Metric) {
 	if err != nil {
 		return
 	}
-	reuseReqs, reuseLimits := make(v1.ResourceList, 4), make(v1.ResourceList, 4)
+	reuseReqs, reuseLimits := make(v1.ResourceList, 5), make(v1.ResourceList, 5)
 	for _, p := range pods {
 		reqs, limits, terminal := podRequestsAndLimitsByLifecycle(p, reuseReqs, reuseLimits)
 		if terminal {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Resize of sidecar containers should work the same as resize of regular containers. This PR adds the capability to resize the sidecar containers (restartable init containers) when in-place pod resizing is enabled. Resize of non-restartable init containers is still not allowed. 

#### Which issue(s) this PR fixes:
Addressed https://github.com/kubernetes/kubernetes/issues/128070

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
/sig node
/priority important-soon
/milestone v1.32
