### PR TITLE
fix: cel type provider should return a type type

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/cel/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/types.go
@@ -429,7 +429,7 @@ func (rt *DeclTypeProvider) FindStructType(typeName string) (*types.Type, bool) 
 	declType, found := rt.findDeclType(typeName)
 	if found {
 		expT := declType.CelType()
-		return expT, found
+		return types.NewTypeTypeWithParam(expT), found
 	}
 	return rt.typeProvider.FindStructType(typeName)
 }

--- a/staging/src/k8s.io/apiserver/pkg/cel/types_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/types_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	"github.com/google/cel-go/common/types"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTypes_ListType(t *testing.T) {
@@ -88,8 +88,8 @@ func TestDeclTypeProvider_FindStructType(t *testing.T) {
 	base := types.NewEmptyRegistry()
 	provider := NewDeclTypeProvider(obj)
 	provider, err := provider.WithTypeProvider(base)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	wrappedType, found := provider.FindStructType("foo")
-	assert.True(t, found)
-	assert.Equal(t, types.TypeKind, wrappedType.Kind())
+	require.True(t, found)
+	require.Equal(t, types.TypeKind, wrappedType.Kind())
 }

--- a/staging/src/k8s.io/apiserver/pkg/cel/types_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/types_test.go
@@ -18,6 +18,9 @@ package cel
 
 import (
 	"testing"
+
+	"github.com/google/cel-go/common/types"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestTypes_ListType(t *testing.T) {
@@ -76,4 +79,17 @@ func testValue(t *testing.T, id int64, val interface{}) *DynValue {
 		t.Fatalf("NewDynValue(%d, %v) failed: %v", id, val, err)
 	}
 	return dv
+}
+
+func TestDeclTypeProvider_FindStructType(t *testing.T) {
+	obj := NewObjectType("foo", map[string]*DeclField{
+		"bar": NewDeclField("bar", StringType, true, nil, nil),
+	})
+	base := types.NewEmptyRegistry()
+	provider := NewDeclTypeProvider(obj)
+	provider, err := provider.WithTypeProvider(base)
+	assert.NoError(t, err)
+	wrappedType, found := provider.FindStructType("foo")
+	assert.True(t, found)
+	assert.Equal(t, types.TypeKind, wrappedType.Kind())
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR fixes cel type provider `FindStructType` by returning a type type.
From cel comment on the interface:
```
    // FindStructType returns the Type give a qualified type name.
    //
    // For historical reasons, only struct types are expected to be returned through this
    // method, and the type values are expected to be wrapped in a TypeType instance using
    // TypeTypeWithParam(<structType>).
    //
    // Returns false if not found.
    FindStructType(structType string) (*Type, bool)
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
