### PR TITLE
Bump DefaultKubeBinaryVersion to 1.33

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/options/server_run_options_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/server_run_options_test.go
@@ -34,8 +34,8 @@ import (
 func TestServerRunOptionsValidate(t *testing.T) {
 	testRegistry := featuregate.NewComponentGlobalsRegistry()
 	featureGate := utilfeature.DefaultFeatureGate.DeepCopy()
-	effectiveVersion := utilversion.NewEffectiveVersion("1.30")
-	effectiveVersion.SetEmulationVersion(version.MajorMinor(1, 32))
+	effectiveVersion := utilversion.NewEffectiveVersion("1.35")
+	effectiveVersion.SetEmulationVersion(version.MajorMinor(1, 31))
 	testComponent := "test"
 	utilruntime.Must(testRegistry.Register(testComponent, effectiveVersion, featureGate))
 
@@ -197,7 +197,7 @@ func TestServerRunOptionsValidate(t *testing.T) {
 				ComponentName:               testComponent,
 				ComponentGlobalsRegistry:    testRegistry,
 			},
-			expectErr: "emulation version 1.32 is not between [1.29, 1.30.0]",
+			expectErr: "emulation version 1.31 is not between [1.32, 1.35.0]",
 		},
 		{
 			name: "Test when ServerRunOptions is valid",

--- a/staging/src/k8s.io/component-base/featuregate/registry_test.go
+++ b/staging/src/k8s.io/component-base/featuregate/registry_test.go
@@ -118,7 +118,7 @@ func TestVersionFlagOptions(t *testing.T) {
 func TestVersionFlagOptionsWithMapping(t *testing.T) {
 	r := testRegistry(t)
 	utilruntime.Must(r.SetEmulationVersionMapping(testComponent, DefaultKubeComponent,
-		func(from *version.Version) *version.Version { return from.OffsetMinor(3) }))
+		func(from *version.Version) *version.Version { return version.MajorMinor(1, from.Minor()+23) }))
 	emuVers := strings.Join(r.unsafeVersionFlagOptions(true), "\n")
 	expectedEmuVers := "test=2.8..2.8 (default=2.8)"
 	if emuVers != expectedEmuVers {

--- a/staging/src/k8s.io/component-base/version/base.go
+++ b/staging/src/k8s.io/component-base/version/base.go
@@ -66,5 +66,5 @@ const (
 	// DefaultKubeBinaryVersion is the hard coded k8 binary version based on the latest K8s release.
 	// It is supposed to be consistent with gitMajor and gitMinor, except for local tests, where gitMajor and gitMinor are "".
 	// Should update for each minor release!
-	DefaultKubeBinaryVersion = "1.32"
+	DefaultKubeBinaryVersion = "1.33"
 )

--- a/staging/src/k8s.io/component-base/version/version_test.go
+++ b/staging/src/k8s.io/component-base/version/version_test.go
@@ -43,9 +43,22 @@ func TestValidate(t *testing.T) {
 			minCompatibilityVersion: "v1.31.0",
 		},
 		{
-			name:                    "emulation version two minor lower than binary not ok",
+			name:                    "emulation version two minor lower than binary ok",
 			binaryVersion:           "v1.33.2",
 			emulationVersion:        "v1.31.0",
+			minCompatibilityVersion: "v1.31.0",
+			expectErrors:            false,
+		},
+		{
+			name:                    "emulation version three minor lower than binary ok",
+			binaryVersion:           "v1.35.0",
+			emulationVersion:        "v1.32.0",
+			minCompatibilityVersion: "v1.32.0",
+		},
+		{
+			name:                    "emulation version four minor lower than binary not ok",
+			binaryVersion:           "v1.36.0",
+			emulationVersion:        "v1.32.0",
 			minCompatibilityVersion: "v1.32.0",
 			expectErrors:            true,
 		},
@@ -64,22 +77,36 @@ func TestValidate(t *testing.T) {
 			expectErrors:            true,
 		},
 		{
-			name:                    "compatibility version same as binary not ok",
+			name:                    "compatibility version same as binary ok",
 			binaryVersion:           "v1.32.2",
 			emulationVersion:        "v1.32.0",
 			minCompatibilityVersion: "v1.32.0",
-			expectErrors:            true,
+			expectErrors:            false,
 		},
 		{
-			name:                    "compatibility version two minor lower than binary not ok",
+			name:                    "compatibility version two minor lower than binary ok",
 			binaryVersion:           "v1.32.2",
 			emulationVersion:        "v1.32.0",
 			minCompatibilityVersion: "v1.30.0",
-			expectErrors:            true,
+			expectErrors:            false,
+		},
+		{
+			name:                    "compatibility version three minor lower than binary ok",
+			binaryVersion:           "v1.34.2",
+			emulationVersion:        "v1.33.0",
+			minCompatibilityVersion: "v1.31.0",
+			expectErrors:            false,
 		},
 		{
 			name:                    "compatibility version one minor higher than binary not ok",
 			binaryVersion:           "v1.32.2",
+			emulationVersion:        "v1.32.0",
+			minCompatibilityVersion: "v1.33.0",
+			expectErrors:            true,
+		},
+		{
+			name:                    "emulation version lower than compatibility version not ok",
+			binaryVersion:           "v1.34.2",
 			emulationVersion:        "v1.32.0",
 			minCompatibilityVersion: "v1.33.0",
 			expectErrors:            true,
@@ -101,6 +128,57 @@ func TestValidate(t *testing.T) {
 
 			if len(errs) == 0 && test.expectErrors {
 				t.Errorf("expected errors, no errors found")
+			}
+		})
+	}
+}
+
+func TestValidateKubeEffectiveVersion(t *testing.T) {
+	tests := []struct {
+		name                    string
+		emulationVersion        string
+		minCompatibilityVersion string
+		expectErr               bool
+	}{
+		{
+			name:                    "valid versions",
+			emulationVersion:        "v1.31.0",
+			minCompatibilityVersion: "v1.31.0",
+			expectErr:               false,
+		},
+		{
+			name:                    "emulationVersion too low",
+			emulationVersion:        "v1.30.0",
+			minCompatibilityVersion: "v1.31.0",
+			expectErr:               true,
+		},
+		{
+			name:                    "minCompatibilityVersion too low",
+			emulationVersion:        "v1.31.0",
+			minCompatibilityVersion: "v1.29.0",
+			expectErr:               true,
+		},
+		{
+			name:                    "both versions too low",
+			emulationVersion:        "v1.30.0",
+			minCompatibilityVersion: "v1.30.0",
+			expectErr:               true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+
+			effective := NewEffectiveVersion("1.32")
+			effective.SetEmulationVersion(version.MustParseGeneric(test.emulationVersion))
+			effective.SetMinCompatibilityVersion(version.MustParseGeneric(test.minCompatibilityVersion))
+
+			err := ValidateKubeEffectiveVersion(effective)
+			if test.expectErr && err == nil {
+				t.Error("expected error, but got nil")
+			}
+			if !test.expectErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
 			}
 		})
 	}

--- a/test/integration/apiserver/apiserver_test.go
+++ b/test/integration/apiserver/apiserver_test.go
@@ -2976,20 +2976,6 @@ func TestEmulatedStorageVersion(t *testing.T) {
 	}
 	cases := []testCase{
 		{
-			name:            "vap first ga release",
-			emulatedVersion: "1.30",
-			gvr: schema.GroupVersionResource{
-				Group:    "admissionregistration.k8s.io",
-				Version:  "v1",
-				Resource: "validatingadmissionpolicies",
-			},
-			object: validVap,
-			expectedStorageVersion: schema.GroupVersion{
-				Group:   "admissionregistration.k8s.io",
-				Version: "v1beta1",
-			},
-		},
-		{
 			name:            "vap after ga release",
 			emulatedVersion: "1.31",
 			gvr: schema.GroupVersionResource{

--- a/test/integration/controlplane/transformation/kms_transformation_test.go
+++ b/test/integration/controlplane/transformation/kms_transformation_test.go
@@ -618,9 +618,6 @@ resources:
         endpoint: unix:///@encrypt-all-kms-provider.sock
 `
 
-	// KUBE_APISERVER_SERVE_REMOVED_APIS_FOR_ONE_RELEASE allows for APIs pending removal to not block tests
-	t.Setenv("KUBE_APISERVER_SERVE_REMOVED_APIS_FOR_ONE_RELEASE", "true")
-
 	t.Run("encrypt all resources", func(t *testing.T) {
 		_ = mock.NewBase64Plugin(t, "@encrypt-all-kms-provider.sock")
 		// To ensure we are checking all REST resources

--- a/test/integration/metrics/metrics_test.go
+++ b/test/integration/metrics/metrics_test.go
@@ -119,7 +119,7 @@ func TestAPIServerMetrics(t *testing.T) {
 	}
 
 	// Make a request to a deprecated API to ensure there's at least one data point
-	if _, err := client.FlowcontrolV1beta3().FlowSchemas().List(context.TODO(), metav1.ListOptions{}); err != nil {
+	if _, err := client.AdmissionregistrationV1beta1().ValidatingAdmissionPolicies().List(context.TODO(), metav1.ListOptions{}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Bump DefaultKubeBinaryVersion to 1.33

- Fixed the etcd tests to account for previous emulated versions
- Removed a emulated version test that tests for 1.30. Unfortunately we don't have a GA API in the 1.31-1.32 range to test the storage version, it might be worthwhile to (similar to the metrics test) create a fake API that we inject into tests for this purpose.
- Changed the version validation to support n-3 with clamp at 1.31 min for emulatedVersion and 1.30 min for minCompatibilityVersion

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/triage accepted
