### PR TITLE
Automated cherry pick of #123082: Fix test flake: remove unnecessary skip healthz check from test

### DIFF
--- a/test/integration/apiserver/cel/validatingadmissionpolicy_test.go
+++ b/test/integration/apiserver/cel/validatingadmissionpolicy_test.go
@@ -2533,9 +2533,7 @@ func TestCRDsOnStartup(t *testing.T) {
 	// Start the server.
 	server = apiservertesting.StartTestServerOrDie(
 		t,
-		&apiservertesting.TestServerInstanceOptions{
-			SkipHealthzCheck: true,
-		},
+		&apiservertesting.TestServerInstanceOptions{},
 		[]string{
 			"--enable-admission-plugins", "ValidatingAdmissionPolicy",
 			"--authorization-mode=RBAC",


### PR DESCRIPTION
Cherry pick of #123082 on release-1.28.

#123082: Fix test flake: remove unnecessary skip healthz check from test

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
None
```