### PR TITLE
fix: apply whitespace linters with golangci strict and hints

### DIFF
--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -104,6 +104,7 @@ linters:
     - testifylint
     - unused
     - usestdlibvars
+    - whitespace
 
 linters-settings: # please keep this alphabetized
   custom:

--- a/hack/golangci-strict.yaml
+++ b/hack/golangci-strict.yaml
@@ -147,6 +147,7 @@ linters:
     - testifylint
     - unused
     - usestdlibvars
+    - whitespace
   disable:
     # https://github.com/kubernetes/kubernetes/issues/117288#issuecomment-1507008359
     - errcheck

--- a/hack/golangci.yaml.in
+++ b/hack/golangci.yaml.in
@@ -163,6 +163,7 @@ linters:
     - unused
   {{- if not .Base }}
     - usestdlibvars
+    - whitespace
   {{- end}}
   {{- if .Strict}}
   disable:


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/priority backlog
/sig testing

#### What this PR does / why we need it:

`whitespace` is a linter that checks for unnecessary newlines at the start and end of functions, if, for, etc.

This applies whitespace linter with golangci strict and hints.

<!--
Signed-off-by: Matthieu MOREL <matthieu.morel35@gmail.com>
-->