### PR TITLE
Remove alculquicondor from job approvers

### DIFF
--- a/pkg/controller/job/OWNERS
+++ b/pkg/controller/job/OWNERS
@@ -2,7 +2,6 @@
 
 approvers:
   - sig-apps-approvers
-  - alculquicondor
   - mimowo
 reviewers:
   - sig-apps-reviewers
@@ -10,3 +9,5 @@ reviewers:
   - kannon92
 labels:
   - sig/apps
+emeritus_approvers:
+  - alculquicondor

--- a/test/integration/job/OWNERS
+++ b/test/integration/job/OWNERS
@@ -2,7 +2,6 @@
 
 approvers:
   - sig-apps-approvers
-  - alculquicondor
   - mimowo
 reviewers:
   - sig-apps-reviewers


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

I will be reducing my involvement in the kubernetes project.

Thank you @soltysh for the opportunity to contribute to the job controller.

And thanks @atiratree and @mimowo for stepping up in contributions.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
