### PR TITLE
apimachinery: remove some log spam on watch

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning/versioning.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning/versioning.go
@@ -221,8 +221,6 @@ func (c *codec) doEncode(obj runtime.Object, w io.Writer, memAlloc runtime.Memor
 			encodeFn = func(obj runtime.Object, w io.Writer) error {
 				return encoder.EncodeWithAllocator(obj, w, memAlloc)
 			}
-		} else {
-			klog.V(6).Infof("a memory allocator was provided but the encoder %s doesn't implement the runtime.EncoderWithAllocator, using regular encoder.Encode method", c.encoder.Identifier())
 		}
 	}
 	switch obj := obj.(type) {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Removes a log line from EncodeWithAllocator

Callers of EncoderWithAllocator have no way to tell if the underlying encoder supports allocators or not.

Currently, the watch endpoints ALWAYS pass an allocator if the interface is implemented:
https://github.com/kubernetes/kubernetes/blob/753b6fe40b8caeafa6d521dd29b9c85890f92d6d/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/watch.go#L124

so there doesn't really seem like a good reason to log here.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
