### PR TITLE
Rollback promotion of Job e2e test for pod failure policy using exit code

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -1067,17 +1067,6 @@
     codes.
   release: v1.32
   file: test/e2e/apps/job.go
-- testname: Ensure pod failure policy allows to ignore failure matching on the exit
-    code
-  codename: '[sig-apps] Job should allow to use a pod failure policy to ignore failure
-    matching on exit code [Conformance]'
-  description: This test is using an indexed job. The pod corresponding to each index
-    creates a marker file on the host and runs 'forever' until evicted. Once the marker
-    file is created the pod succeeds seeing it on restart. Thus, we trigger one failure
-    per index due to eviction, so the Job would be marked as failed, if not for the
-    ignore rule matching on exit codes.
-  release: v1.32
-  file: test/e2e/apps/job.go
 - testname: Verify Pod Failure policy allows to fail job early on exit code.
   codename: '[sig-apps] Job should allow to use the pod failure policy on exit code
     to fail the job early [Conformance]'

--- a/test/e2e/apps/job.go
+++ b/test/e2e/apps/job.go
@@ -143,7 +143,6 @@ var _ = SIGDescribe("Job", func() {
 	})
 
 	/*
-		Release: v1.32
 		Testname: Ensure pod failure policy allows to ignore failure matching on the exit code
 		Description: This test is using an indexed job. The pod corresponding to each index
 		creates a marker file on the host and runs 'forever' until evicted. Once
@@ -151,7 +150,7 @@ var _ = SIGDescribe("Job", func() {
 		we trigger one failure per index due to eviction, so the Job would be
 		marked as failed, if not for the ignore rule matching on exit codes.
 	*/
-	framework.ConformanceIt("should allow to use a pod failure policy to ignore failure matching on exit code", func(ctx context.Context) {
+	ginkgo.It("should allow to use a pod failure policy to ignore failure matching on exit code", func(ctx context.Context) {
 		// We set the backoffLimit = numPods-1  so that we can tolerate random
 		// failures (like OutOfPods from kubelet). Yet, the Job would fail if the
 		// pod failures were not be ignored.


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test
/kind regression

#### What this PR does / why we need it:

Because it fails on the Windows release -informing build. 

#### Which issue(s) this PR fixes:

Fixes #128302

#### Special notes for your reviewer:

The test was promoted only recently and not released yet: https://github.com/kubernetes/kubernetes/pull/128264


The exit code for the evicted pods on Windows is not 137 as expected by the test.
See more investigation on the issue.


#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
https://github.com/kubernetes/enhancements/tree/master/keps/sig-apps/3329-retriable-and-non-retriable-failures
```
