### PR TITLE
Allow `/run` timeout using the kubelet HTTP debug API

### DIFF
--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -32,6 +32,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -2443,7 +2444,7 @@ func (kl *Kubelet) findContainer(ctx context.Context, podFullName string, podUID
 }
 
 // RunInContainer runs a command in a container, returns the combined stdout, stderr as an array of bytes
-func (kl *Kubelet) RunInContainer(ctx context.Context, podFullName string, podUID types.UID, containerName string, cmd []string) ([]byte, error) {
+func (kl *Kubelet) RunInContainer(ctx context.Context, podFullName string, podUID types.UID, containerName string, cmd []string, timeout time.Duration) ([]byte, error) {
 	container, err := kl.findContainer(ctx, podFullName, podUID, containerName)
 	if err != nil {
 		return nil, err
@@ -2451,8 +2452,7 @@ func (kl *Kubelet) RunInContainer(ctx context.Context, podFullName string, podUI
 	if container == nil {
 		return nil, fmt.Errorf("container not found (%q)", containerName)
 	}
-	// TODO(tallclair): Pass a proper timeout value.
-	return kl.runner.RunInContainer(ctx, container.ID, cmd, 0)
+	return kl.runner.RunInContainer(ctx, container.ID, cmd, timeout)
 }
 
 // GetExec gets the URL the exec will be served from, or nil if the Kubelet will serve it.

--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -318,7 +318,9 @@ func TestRunInContainerNoSuchPod(t *testing.T) {
 		kubecontainer.GetPodFullName(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: podName, Namespace: podNamespace}}),
 		"",
 		containerName,
-		[]string{"ls"})
+		[]string{"ls"},
+		0,
+	)
 	assert.Error(t, err)
 	assert.Nil(t, output, "output should be nil")
 }
@@ -350,7 +352,7 @@ func TestRunInContainer(t *testing.T) {
 			}},
 		}
 		cmd := []string{"ls"}
-		actualOutput, err := kubelet.RunInContainer(ctx, "podFoo_nsFoo", "", "containerFoo", cmd)
+		actualOutput, err := kubelet.RunInContainer(ctx, "podFoo_nsFoo", "", "containerFoo", cmd, 0)
 		assert.Equal(t, containerID, fakeCommandRunner.ContainerID, "(testError=%v) ID", testError)
 		assert.Equal(t, cmd, fakeCommandRunner.Cmd, "(testError=%v) command", testError)
 		// this isn't 100% foolproof as a bug in a real CommandRunner where it fails to copy to stdout/stderr wouldn't be caught by this test

--- a/pkg/kubelet/server/server.go
+++ b/pkg/kubelet/server/server.go
@@ -265,7 +265,7 @@ type HostInterface interface {
 	GetVersionInfo() (*cadvisorapi.VersionInfo, error)
 	GetCachedMachineInfo() (*cadvisorapi.MachineInfo, error)
 	GetRunningPods(ctx context.Context) ([]*v1.Pod, error)
-	RunInContainer(ctx context.Context, name string, uid types.UID, container string, cmd []string) ([]byte, error)
+	RunInContainer(ctx context.Context, name string, uid types.UID, container string, cmd []string, timeout time.Duration) ([]byte, error)
 	CheckpointContainer(ctx context.Context, podUID types.UID, podFullName, containerName string, options *runtimeapi.CheckpointContainerRequest) error
 	GetKubeletContainerLogs(ctx context.Context, podFullName, containerName string, logOptions *v1.PodLogOptions, stdout, stderr io.Writer) error
 	ServeLogs(w http.ResponseWriter, req *http.Request)
@@ -945,7 +945,22 @@ func (s *Server) getRun(request *restful.Request, response *restful.Response) {
 
 	// For legacy reasons, run uses different query param than exec.
 	params.cmd = strings.Split(request.QueryParameter("cmd"), " ")
-	data, err := s.host.RunInContainer(request.Request.Context(), kubecontainer.GetPodFullName(pod), params.podUID, params.containerName, params.cmd)
+
+	var (
+		timeout time.Duration
+		err     error
+	)
+	queryTimeout := request.QueryParameter("timeout")
+	if queryTimeout != "" {
+		timeout, err = time.ParseDuration(queryTimeout)
+		if err != nil {
+			//nolint:errcheck // Checking the error will not lead into a valuable action
+			response.WriteError(http.StatusInternalServerError, err)
+			return
+		}
+	}
+
+	data, err := s.host.RunInContainer(request.Request.Context(), kubecontainer.GetPodFullName(pod), params.podUID, params.containerName, params.cmd, timeout)
 	if err != nil {
 		response.WriteError(http.StatusInternalServerError, err)
 		return

--- a/pkg/kubelet/server/server_test.go
+++ b/pkg/kubelet/server/server_test.go
@@ -80,7 +80,7 @@ type fakeKubelet struct {
 	podsFunc            func() []*v1.Pod
 	runningPodsFunc     func(ctx context.Context) ([]*v1.Pod, error)
 	logFunc             func(w http.ResponseWriter, req *http.Request)
-	runFunc             func(podFullName string, uid types.UID, containerName string, cmd []string) ([]byte, error)
+	runFunc             func(podFullName string, uid types.UID, containerName string, cmd []string, timeout time.Duration) ([]byte, error)
 	getExecCheck        func(string, types.UID, string, []string, remotecommandserver.Options)
 	getAttachCheck      func(string, types.UID, string, remotecommandserver.Options)
 	getPortForwardCheck func(string, string, types.UID, portforward.V4Options)
@@ -133,8 +133,8 @@ func (fk *fakeKubelet) GetHostname() string {
 	return fk.hostnameFunc()
 }
 
-func (fk *fakeKubelet) RunInContainer(_ context.Context, podFullName string, uid types.UID, containerName string, cmd []string) ([]byte, error) {
-	return fk.runFunc(podFullName, uid, containerName, cmd)
+func (fk *fakeKubelet) RunInContainer(_ context.Context, podFullName string, uid types.UID, containerName string, cmd []string, timeout time.Duration) ([]byte, error) {
+	return fk.runFunc(podFullName, uid, containerName, cmd, timeout)
 }
 
 func (fk *fakeKubelet) CheckpointContainer(_ context.Context, podUID types.UID, podFullName, containerName string, options *runtimeapi.CheckpointContainerRequest) error {
@@ -425,7 +425,7 @@ func TestServeRunInContainer(t *testing.T) {
 	expectedPodName := getPodName(podName, podNamespace)
 	expectedContainerName := "baz"
 	expectedCommand := "ls -a"
-	fw.fakeKubelet.runFunc = func(podFullName string, uid types.UID, containerName string, cmd []string) ([]byte, error) {
+	fw.fakeKubelet.runFunc = func(podFullName string, uid types.UID, containerName string, cmd []string, timeout time.Duration) ([]byte, error) {
 		if podFullName != expectedPodName {
 			t.Errorf("expected %s, got %s", expectedPodName, podFullName)
 		}
@@ -466,7 +466,7 @@ func TestServeRunInContainerWithUID(t *testing.T) {
 	expectedPodName := getPodName(podName, podNamespace)
 	expectedContainerName := "baz"
 	expectedCommand := "ls -a"
-	fw.fakeKubelet.runFunc = func(podFullName string, uid types.UID, containerName string, cmd []string) ([]byte, error) {
+	fw.fakeKubelet.runFunc = func(podFullName string, uid types.UID, containerName string, cmd []string, timeout time.Duration) ([]byte, error) {
 		if podFullName != expectedPodName {
 			t.Errorf("expected %s, got %s", expectedPodName, podFullName)
 		}
@@ -497,6 +497,56 @@ func TestServeRunInContainerWithUID(t *testing.T) {
 	result := string(body)
 	if result != output {
 		t.Errorf("expected %s, got %s", output, result)
+	}
+}
+
+func TestServeRunInContainerWithTimeout(t *testing.T) {
+	const (
+		podNamespace  = "namespace"
+		podName       = "pod"
+		containerName = "container"
+		successOutput = "succeed"
+		deadline      = time.Second
+	)
+	for name, tc := range map[string]struct {
+		timeoutValue   string
+		expectedOutput string
+	}{
+		"should succeed with valid timeout": {
+			timeoutValue:   "10s",
+			expectedOutput: successOutput,
+		},
+		"should timeout with valid timeout": {
+			timeoutValue:   fmt.Sprintf("%v", deadline),
+			expectedOutput: context.DeadlineExceeded.Error(),
+		},
+		"should fail with invalid timeout value": {
+			timeoutValue:   "wrong",
+			expectedOutput: "invalid duration",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			fw := newServerTest()
+			defer fw.testHTTPServer.Close()
+
+			fw.fakeKubelet.runFunc = func(podFullName string, uid types.UID, containerName string, cmd []string, timeout time.Duration) ([]byte, error) {
+				if timeout == time.Second {
+					return nil, context.DeadlineExceeded
+				}
+				return []byte(successOutput), nil
+			}
+
+			resp, err := http.Post(fw.testHTTPServer.URL+"/run/"+podNamespace+"/"+podName+"/"+testUID+"/"+containerName+"?cmd=ls&timeout="+tc.timeoutValue, "", nil)
+			require.NoError(t, err)
+			defer func() { require.NoError(t, resp.Body.Close()) }()
+
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+
+			assert.Contains(t, string(body), tc.expectedOutput)
+		})
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
Allow specifying a timeout using the kubelet's `/run/[NAMESPACE]/[POD]/[CONTAINER]?cmd=…?timeout=…` API for running commands within containers. This enables end users to set a timeout accordingly while the kubelet can pass the correct value down to the CRI if set.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes a long-term TODO in the codebase.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Allow to set a `timeout` value via the kubelet's `/run` pod debug API, for example:
`https://localhost:10250/run/[NAMESPACE]/[POD]/[CONTAINER]?cmd=…?timeout=2s`
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
