### PR TITLE
Set ComponentSLIs feature as GA

### DIFF
--- a/staging/src/k8s.io/component-base/metrics/features/kube_features.go
+++ b/staging/src/k8s.io/component-base/metrics/features/kube_features.go
@@ -17,23 +17,30 @@ limitations under the License.
 package features
 
 import (
+	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/component-base/featuregate"
 )
 
 const (
 	// owner: @logicalhan
 	// kep: https://kep.k8s.io/3466
-	// alpha: v1.26
 	ComponentSLIs featuregate.Feature = "ComponentSLIs"
 )
 
-func featureGates() map[featuregate.Feature]featuregate.FeatureSpec {
-	return map[featuregate.Feature]featuregate.FeatureSpec{
-		ComponentSLIs: {Default: true, PreRelease: featuregate.Beta},
+
+func featureGates() map[featuregate.Feature]featuregate.VersionedSpecs {
+	return map[featuregate.Feature]featuregate.VersionedSpecs{
+		ComponentSLIs: {
+			{Version: version.MustParse("1.26"), Default: false, PreRelease: featuregate.Alpha},
+			{Version: version.MustParse("1.27"), Default: true, PreRelease: featuregate.Beta},
+			// ComponentSLIs officially graduated to GA in v1.29 but the gate was not updated until v1.32.
+			// To support emulated versions, keep the gate until v1.35.
+			{Version: version.MustParse("1.32"), Default: true, PreRelease: featuregate.GA, LockToDefault: true},
+		},
 	}
 }
 
 // AddFeatureGates adds all feature gates used by this package.
-func AddFeatureGates(mutableFeatureGate featuregate.MutableFeatureGate) error {
-	return mutableFeatureGate.Add(featureGates())
+func AddFeatureGates(mutableFeatureGate featuregate.MutableVersionedFeatureGate) error {
+	return mutableFeatureGate.AddVersioned(featureGates())
 }

--- a/staging/src/k8s.io/component-base/metrics/features/kube_features.go
+++ b/staging/src/k8s.io/component-base/metrics/features/kube_features.go
@@ -20,8 +20,17 @@ import (
 	"k8s.io/component-base/featuregate"
 )
 
+const (
+	// owner: @logicalhan
+	// kep: https://kep.k8s.io/3466
+	// alpha: v1.26
+	ComponentSLIs featuregate.Feature = "ComponentSLIs"
+)
+
 func featureGates() map[featuregate.Feature]featuregate.FeatureSpec {
-	return map[featuregate.Feature]featuregate.FeatureSpec{}
+	return map[featuregate.Feature]featuregate.FeatureSpec{
+		ComponentSLIs: {Default: true, PreRelease: featuregate.Beta},
+	}
 }
 
 // AddFeatureGates adds all feature gates used by this package.

--- a/staging/src/k8s.io/component-base/metrics/features/kube_features.go
+++ b/staging/src/k8s.io/component-base/metrics/features/kube_features.go
@@ -27,7 +27,6 @@ const (
 	ComponentSLIs featuregate.Feature = "ComponentSLIs"
 )
 
-
 func featureGates() map[featuregate.Feature]featuregate.VersionedSpecs {
 	return map[featuregate.Feature]featuregate.VersionedSpecs{
 		ComponentSLIs: {

--- a/test/featuregates_linter/test_data/unversioned_feature_list.yaml
+++ b/test/featuregates_linter/test_data/unversioned_feature_list.yaml
@@ -1,9 +1,3 @@
-- name: ComponentSLIs
-  versionedSpecs:
-  - default: true
-    lockToDefault: false
-    preRelease: Beta
-    version: ""
 - name: ContextualLogging
   versionedSpecs:
   - default: true

--- a/test/featuregates_linter/test_data/unversioned_feature_list.yaml
+++ b/test/featuregates_linter/test_data/unversioned_feature_list.yaml
@@ -1,3 +1,9 @@
+- name: ComponentSLIs
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: ""
 - name: ContextualLogging
   versionedSpecs:
   - default: true

--- a/test/featuregates_linter/test_data/versioned_feature_list.yaml
+++ b/test/featuregates_linter/test_data/versioned_feature_list.yaml
@@ -172,6 +172,20 @@
     lockToDefault: false
     preRelease: Alpha
     version: "1.29"
+- name: ComponentSLIs
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.26"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.27"
+  - default: true
+    lockToDefault: true
+    preRelease: GA
+    version: "1.32"
 - name: ConcurrentWatchObjectDecode
   versionedSpecs:
   - default: false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

ComponentSLIs has been GA since 1.29 https://kubernetes.io/docs/reference/instrumentation/slis/, however the feature was not listed as GA in the feature gates. I originally removed this feature https://github.com/kubernetes/kubernetes/pull/127787, but that creates an inconsistency in feature gate emulation for 1.31 (ref: https://github.com/kubernetes/kubernetes/issues/128036#issuecomment-2415364482). 

The safest option is to mark this feature as GA and remove in 3 releases. The caveat being that the "GA" version described in this file is inaccurate compared to the actual feature graduation date. This also unblocks https://github.com/kubernetes/kubernetes/pull/128138

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
`ComponentSLIs` feature is marked as GA and locked
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/triage accepted
/assign @logicalhan @jpbetz @aaron-prindle 
