### PR TITLE
Reset streams when an error happens during port-forward (part 1/2) 

### DIFF
--- a/staging/src/k8s.io/kubelet/pkg/cri/streaming/portforward/httpstream.go
+++ b/staging/src/k8s.io/kubelet/pkg/cri/streaming/portforward/httpstream.go
@@ -256,6 +256,12 @@ func (h *httpStreamHandler) portForward(p *httpStreamPair) {
 		msg := fmt.Errorf("error forwarding port %d to pod %s, uid %v: %v", port, h.pod, h.uid, err)
 		utilruntime.HandleError(msg)
 		fmt.Fprint(p.errorStream, msg.Error())
+		// receiving an error from a port-forward operation indicates a problem
+		// with data stream most probably, thus we want to reset the streams
+		// indicating there was a problem and allow a new set of streams be
+		// created to mitigate the problem
+		p.dataStream.Reset()  // nolint:errcheck
+		p.errorStream.Reset() // nolint:errcheck
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
This PR is the kubelet part of port-forward fix, see (https://github.com/kubernetes/kubernetes/pull/128319) for the client-side fixes and tests. The reason for the split is to simplify the backport process, so that we can update the vendored bits in both crio and containerd.

This PR is a replacement for https://github.com/kubernetes/kubernetes/pull/117493 and https://github.com/kubernetes/kubernetes/pull/126718

#### Which issue(s) this PR fixes:
Related to https://github.com/kubernetes/kubernetes/issues/74551 https://github.com/kubernetes/kubernetes/issues/107203

#### Special notes for your reviewer:
/assign @liggitt @aojea 
/cc @brianpursley @sxllwx @nic-6443 @eddiezane 

#### Does this PR introduce a user-facing change?
```release-note
Reset streams when an error happens during port-forward allowing kubectl to maintain port-forward connection open
```
