### PR TITLE
Reset streams when an error happens during port-forward (part 2/2)

### DIFF
--- a/staging/src/k8s.io/client-go/tools/portforward/portforward.go
+++ b/staging/src/k8s.io/client-go/tools/portforward/portforward.go
@@ -406,6 +406,11 @@ func (pf *PortForwarder) handleConnection(conn net.Conn, port ForwardedPort) {
 	case <-remoteDone:
 	case <-localError:
 	}
+	/*
+		reset dataStream to discard any unsent data, preventing port forwarding from being blocked.
+		we must reset dataStream before waiting on errorChan, otherwise, the blocking data will affect errorStream and cause <-errorChan to block indefinitely.
+	*/
+	_ = dataStream.Reset()
 
 	// always expect something on errorChan (it may be nil)
 	err = <-errorChan

--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -2265,6 +2265,27 @@ func curl(url string) (string, error) {
 	return curlTransport(url, utilnet.SetTransportDefaults(&http.Transport{}))
 }
 
+func post(url string, reader io.Reader, transport *http.Transport) (string, error) {
+	if transport == nil {
+		transport = utilnet.SetTransportDefaults(&http.Transport{})
+	}
+	client := &http.Client{Transport: transport}
+	req, err := http.NewRequest(http.MethodPost, url, reader)
+	if err != nil {
+		return "", err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close() //nolint: errcheck
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	return string(body), nil
+}
+
 func validateGuestbookApp(ctx context.Context, c clientset.Interface, ns string) {
 	framework.Logf("Waiting for all frontend pods to be Running.")
 	label := labels.SelectorFromSet(labels.Set(map[string]string{"tier": "frontend", "app": "guestbook"}))

--- a/test/e2e/kubectl/portforward.go
+++ b/test/e2e/kubectl/portforward.go
@@ -296,6 +296,8 @@ func runPortForward(ns, podName string, port int) *portForwardCommand {
 }
 
 // Reproduces issue #74551 (https://github.com/kubernetes/kubernetes/issues/74551)
+//
+//nolint:unused
 func doTestConnectionNeverReadRequestBody(ctx context.Context, f *framework.Framework) {
 	ginkgo.By("Creating the target pod")
 	pod := pfNeverReadRequestBodyPod()
@@ -690,11 +692,14 @@ var _ = SIGDescribe("Kubectl Port forwarding", func() {
 		})
 	})
 
-	ginkgo.Describe("with a server that never read request body", func() {
-		ginkgo.It("port-forward service should be provided continuously", func(ctx context.Context) {
-			doTestConnectionNeverReadRequestBody(ctx, f)
-		})
-	})
+	// due to required CRI fixes from https://github.com/kubernetes/kubernetes/pull/128318
+	// we can only enable this test once we have that dependency updated in CRIO and containerd,
+	// at minimum
+	// ginkgo.Describe("with a server that never read request body", func() {
+	// 	ginkgo.It("port-forward service should be provided continuously", func(ctx context.Context) {
+	// 		doTestConnectionNeverReadRequestBody(ctx, f)
+	// 	})
+	// })
 
 	ginkgo.Describe("with a server that sends RST upon accepting a connection", func() {
 		ginkgo.It("should connect, send data, and then connect again", func(ctx context.Context) {

--- a/test/e2e/kubectl/portforward.go
+++ b/test/e2e/kubectl/portforward.go
@@ -299,12 +299,11 @@ func runPortForward(ns, podName string, port int) *portForwardCommand {
 func doTestConnectionNeverReadRequestBody(ctx context.Context, f *framework.Framework) {
 	ginkgo.By("Creating the target pod")
 	pod := pfNeverReadRequestBodyPod()
-	if _, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{}); err != nil {
-		framework.Failf("Couldn't create pod: %v", err)
-	}
-	if err := e2epod.WaitTimeoutForPodReadyInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name, framework.PodStartTimeout); err != nil {
-		framework.Failf("Pod did not start running: %v", err)
-	}
+	_, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
+	framework.ExpectNoError(err, "couldn't create pod")
+
+	err = e2epod.WaitTimeoutForPodReadyInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name, framework.PodStartTimeout)
+	framework.ExpectNoError(err, "pod did not start running")
 
 	ginkgo.By("Running 'kubectl port-forward'")
 	cmd := runPortForward(f.Namespace.Name, pod.Name, 80)
@@ -335,9 +334,8 @@ func doTestConnectionNeverReadRequestBody(ctx context.Context, f *framework.Fram
 	))
 
 	ginkgo.By("Waiting for the target pod to stop running")
-	if err := WaitForTerminatedContainer(ctx, f, pod, "server"); err != nil {
-		framework.Failf("Container did not terminate: %v", err)
-	}
+	err = WaitForTerminatedContainer(ctx, f, pod, "server")
+	framework.ExpectNoError(err, "container did not terminate")
 }
 
 func doTestConnectSendDisconnect(ctx context.Context, bindAddress string, f *framework.Framework) {
@@ -392,12 +390,11 @@ func doTestConnectSendDisconnect(ctx context.Context, bindAddress string, f *fra
 func doTestConnectionReset(ctx context.Context, f *framework.Framework) {
 	ginkgo.By("Creating the target pod")
 	pod := pfResetPod()
-	if _, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{}); err != nil {
-		framework.Failf("Couldn't create pod: %v", err)
-	}
-	if err := e2epod.WaitTimeoutForPodReadyInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name, framework.PodStartTimeout); err != nil {
-		framework.Failf("Pod did not start running: %v", err)
-	}
+	_, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
+	framework.ExpectNoError(err, "couldn't create pod")
+
+	err = e2epod.WaitTimeoutForPodReadyInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name, framework.PodStartTimeout)
+	framework.ExpectNoError(err, "pod did not start running")
 
 	ginkgo.By("Running 'kubectl port-forward'")
 	func() {
@@ -437,10 +434,8 @@ func doTestConnectionReset(ctx context.Context, f *framework.Framework) {
 		ginkgo.By("Attempting connection #2")
 		func() {
 			conn, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", cmd.port))
-			if err != nil {
-				ginkgo.By("Connection couldn't connect to port")
-				framework.Failf("Connection couldn't connect to port %d: %v", cmd.port, err)
-			}
+			framework.ExpectNoError(err, "connection couldn't connect to port %d", cmd.port)
+
 			defer func() {
 				ginkgo.By("Closing the connection to the local port")
 				conn.Close() //nolint: errcheck
@@ -449,12 +444,11 @@ func doTestConnectionReset(ctx context.Context, f *framework.Framework) {
 	}()
 
 	ginkgo.By("Deleting the port forward pod")
-	if err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(ctx, pod.Name, metav1.DeleteOptions{}); err != nil {
-		framework.Failf("Couldn't delete pod: %v", err)
-	}
-	if err := e2epod.WaitForPodNotFoundInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name, framework.PodStartTimeout); err != nil {
-		framework.Failf("Pod did not terminate: %v", err)
-	}
+	err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(ctx, pod.Name, metav1.DeleteOptions{})
+	framework.ExpectNoError(err, "Couldn't delete pod")
+
+	err = e2epod.WaitForPodNotFoundInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name, framework.PodStartTimeout)
+	framework.ExpectNoError(err, "Pod did not terminate")
 }
 
 func doTestMustConnectSendNothing(ctx context.Context, bindAddress string, f *framework.Framework) {
@@ -696,7 +690,7 @@ var _ = SIGDescribe("Kubectl Port forwarding", func() {
 		})
 	})
 
-	ginkgo.Describe("With a server that never read request body", func() {
+	ginkgo.Describe("with a server that never read request body", func() {
 		ginkgo.It("port-forward service should be provided continuously", func(ctx context.Context) {
 			doTestConnectionNeverReadRequestBody(ctx, f)
 		})
@@ -708,16 +702,70 @@ var _ = SIGDescribe("Kubectl Port forwarding", func() {
 		})
 	})
 
+	ginkgo.Describe("with a pod being removed", func() {
+		ginkgo.It("should stop port-forwarding", func(ctx context.Context) {
+			ginkgo.By("Creating the target pod")
+			pod := pfNeverReadRequestBodyPod()
+			_, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
+			framework.ExpectNoError(err, "couldn't create pod")
+
+			err = e2epod.WaitTimeoutForPodReadyInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name, framework.PodStartTimeout)
+			framework.ExpectNoError(err, "pod did not start running")
+
+			ginkgo.By("Running 'kubectl port-forward'")
+			cmd := runPortForward(f.Namespace.Name, pod.Name, 80)
+			defer cmd.Stop()
+
+			ginkgo.By("Running port-forward client")
+			reqChan := make(chan bool)
+			errorChan := make(chan error)
+			go func() {
+				defer ginkgo.GinkgoRecover()
+
+				// try to mock a big request, which should take some time
+				for sentBodySize := 0; sentBodySize < 1024*1024*1024; {
+					size := rand.Intn(4 * 1024 * 1024)
+					url := fmt.Sprintf("http://localhost:%d/header", cmd.port)
+					_, err := post(url, strings.NewReader(strings.Repeat("x", size)), nil)
+					if err != nil {
+						errorChan <- err
+					}
+					ginkgo.By(fmt.Sprintf("Sent %d chunk of data", sentBodySize))
+					if sentBodySize == 0 {
+						close(reqChan)
+					}
+					sentBodySize += size
+				}
+			}()
+
+			ginkgo.By("Remove the forwarded pod after the first client request")
+			<-reqChan
+			e2epod.DeletePodOrFail(ctx, f.ClientSet, f.Namespace.Name, pod.Name)
+
+			ginkgo.By("Wait for client being interrupted")
+			select {
+			case err = <-errorChan:
+			case <-time.After(e2epod.DefaultPodDeletionTimeout):
+			}
+
+			ginkgo.By("Check the client error")
+			gomega.Expect(err).To(gomega.HaveOccurred())
+			gomega.Expect(err.Error()).To(gomega.Or(gomega.ContainSubstring("connection reset by peer"), gomega.ContainSubstring("EOF")))
+
+			ginkgo.By("Check kubectl port-forward exit code")
+			gomega.Expect(cmd.cmd.ProcessState.ExitCode()).To(gomega.BeNumerically("<", 0), "kubectl port-forward should finish with non-zero exit code")
+		})
+	})
+
 	ginkgo.Describe("Shutdown client connection while the remote stream is writing data to the port-forward connection", func() {
 		ginkgo.It("port-forward should keep working after detect broken connection", func(ctx context.Context) {
 			ginkgo.By("Creating the target pod")
 			pod := testWebServerPod()
-			if _, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{}); err != nil {
-				framework.Failf("Couldn't create pod: %v", err)
-			}
-			if err := e2epod.WaitTimeoutForPodReadyInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name, framework.PodStartTimeout); err != nil {
-				framework.Failf("Pod did not start running: %v", err)
-			}
+			_, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
+			framework.ExpectNoError(err, "couldn't create pod")
+
+			err = e2epod.WaitTimeoutForPodReadyInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name, framework.PodStartTimeout)
+			framework.ExpectNoError(err, "pod did not start running")
 
 			ginkgo.By("Running 'kubectl port-forward'")
 			cmd := runPortForward(f.Namespace.Name, pod.Name, 80)
@@ -725,49 +773,36 @@ var _ = SIGDescribe("Kubectl Port forwarding", func() {
 
 			ginkgo.By("Send a http request to verify port-forward working")
 			client := http.Client{
-				Timeout: 5 * time.Second,
+				Timeout: 10 * time.Second,
 			}
 			resp, err := client.Get(fmt.Sprintf("http://127.0.0.1:%d/", cmd.port))
-			if err != nil {
-				framework.Failf("Couldn't get http response from port-forward: %v", err)
-			}
-			if resp.StatusCode != http.StatusOK {
-				framework.Failf("Expected status code %d, got %d", http.StatusOK, resp.StatusCode)
-			}
+			framework.ExpectNoError(err, "couldn't get http response from port-forward")
+			gomega.Expect(resp.StatusCode).To(gomega.Equal(http.StatusOK), "unexpected status code")
 
 			ginkgo.By("Dialing the local port")
 			conn, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", cmd.port))
-			if err != nil {
-				framework.Failf("Couldn't connect to port %d: %v", cmd.port, err)
-			}
+			framework.ExpectNoError(err, "couldn't connect to port %d", cmd.port)
 
 			// use raw tcp connection to emulate client close connection without reading response
-			ginkgo.By("Request agohost binary file (40MB+)")
+			ginkgo.By("Request agnhost binary file (40MB+)")
 			requestLines := []string{"GET /agnhost HTTP/1.1", "Host: localhost", ""}
 			for _, line := range requestLines {
-				if _, err := conn.Write(append([]byte(line), []byte("\r\n")...)); err != nil {
-					framework.Failf("Couldn't write http request to local connection: %v", err)
-				}
+				_, err := conn.Write(append([]byte(line), []byte("\r\n")...))
+				framework.ExpectNoError(err, "couldn't write http request to local connection")
 			}
 
 			ginkgo.By("Read only one byte from the connection")
-			if _, err := conn.Read(make([]byte, 1)); err != nil {
-				framework.Logf("Couldn't reading from the local connection: %v", err)
-			}
+			_, err = conn.Read(make([]byte, 1))
+			framework.ExpectNoError(err, "couldn't read from the local connection")
 
 			ginkgo.By("Close client connection without reading remain data")
-			if err := conn.Close(); err != nil {
-				framework.Failf("Couldn't close local connection: %v", err)
-			}
+			err = conn.Close()
+			framework.ExpectNoError(err, "couldn't close local connection")
 
 			ginkgo.By("Send another http request through port-forward again")
 			resp, err = client.Get(fmt.Sprintf("http://127.0.0.1:%d/", cmd.port))
-			if err != nil {
-				framework.Failf("Couldn't get http response from port-forward: %v", err)
-			}
-			if resp.StatusCode != http.StatusOK {
-				framework.Failf("Expected status code %d, got %d", http.StatusOK, resp.StatusCode)
-			}
+			framework.ExpectNoError(err, "couldn't get http response from port-forward")
+			gomega.Expect(resp.StatusCode).To(gomega.Equal(http.StatusOK), "unexpected status code")
 		})
 	})
 })

--- a/test/e2e/kubectl/portforward.go
+++ b/test/e2e/kubectl/portforward.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"net/http"
 	"os/exec"
 	"regexp"
 	"strconv"
@@ -170,6 +171,36 @@ func pfResetPod() *v1.Pod {
 				},
 			},
 			RestartPolicy: v1.RestartPolicyNever,
+		},
+	}
+}
+
+func testWebServerPod() *v1.Pod {
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   podName,
+			Labels: map[string]string{"name": podName},
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:  "testwebserver",
+					Image: imageutils.GetE2EImage(imageutils.Agnhost),
+					Args:  []string{"test-webserver"},
+					Ports: []v1.ContainerPort{{ContainerPort: int32(80)}},
+					ReadinessProbe: &v1.Probe{
+						ProbeHandler: v1.ProbeHandler{
+							HTTPGet: &v1.HTTPGetAction{
+								Path: "/",
+								Port: intstr.FromInt32(int32(80)),
+							},
+						},
+						InitialDelaySeconds: 5,
+						TimeoutSeconds:      3,
+						FailureThreshold:    10,
+					},
+				},
+			},
 		},
 	}
 }
@@ -674,6 +705,69 @@ var _ = SIGDescribe("Kubectl Port forwarding", func() {
 	ginkgo.Describe("with a server that sends RST upon accepting a connection", func() {
 		ginkgo.It("should connect, send data, and then connect again", func(ctx context.Context) {
 			doTestConnectionReset(ctx, f)
+		})
+	})
+
+	ginkgo.Describe("Shutdown client connection while the remote stream is writing data to the port-forward connection", func() {
+		ginkgo.It("port-forward should keep working after detect broken connection", func(ctx context.Context) {
+			ginkgo.By("Creating the target pod")
+			pod := testWebServerPod()
+			if _, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{}); err != nil {
+				framework.Failf("Couldn't create pod: %v", err)
+			}
+			if err := e2epod.WaitTimeoutForPodReadyInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name, framework.PodStartTimeout); err != nil {
+				framework.Failf("Pod did not start running: %v", err)
+			}
+
+			ginkgo.By("Running 'kubectl port-forward'")
+			cmd := runPortForward(f.Namespace.Name, pod.Name, 80)
+			defer cmd.Stop()
+
+			ginkgo.By("Send a http request to verify port-forward working")
+			client := http.Client{
+				Timeout: 5 * time.Second,
+			}
+			resp, err := client.Get(fmt.Sprintf("http://127.0.0.1:%d/", cmd.port))
+			if err != nil {
+				framework.Failf("Couldn't get http response from port-forward: %v", err)
+			}
+			if resp.StatusCode != http.StatusOK {
+				framework.Failf("Expected status code %d, got %d", http.StatusOK, resp.StatusCode)
+			}
+
+			ginkgo.By("Dialing the local port")
+			conn, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", cmd.port))
+			if err != nil {
+				framework.Failf("Couldn't connect to port %d: %v", cmd.port, err)
+			}
+
+			// use raw tcp connection to emulate client close connection without reading response
+			ginkgo.By("Request agohost binary file (40MB+)")
+			requestLines := []string{"GET /agnhost HTTP/1.1", "Host: localhost", ""}
+			for _, line := range requestLines {
+				if _, err := conn.Write(append([]byte(line), []byte("\r\n")...)); err != nil {
+					framework.Failf("Couldn't write http request to local connection: %v", err)
+				}
+			}
+
+			ginkgo.By("Read only one byte from the connection")
+			if _, err := conn.Read(make([]byte, 1)); err != nil {
+				framework.Logf("Couldn't reading from the local connection: %v", err)
+			}
+
+			ginkgo.By("Close client connection without reading remain data")
+			if err := conn.Close(); err != nil {
+				framework.Failf("Couldn't close local connection: %v", err)
+			}
+
+			ginkgo.By("Send another http request through port-forward again")
+			resp, err = client.Get(fmt.Sprintf("http://127.0.0.1:%d/", cmd.port))
+			if err != nil {
+				framework.Failf("Couldn't get http response from port-forward: %v", err)
+			}
+			if resp.StatusCode != http.StatusOK {
+				framework.Failf("Expected status code %d, got %d", http.StatusOK, resp.StatusCode)
+			}
 		})
 	})
 })


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
This PR contains both the kubelet fix (https://github.com/kubernetes/kubernetes/pull/128318) and client-go changes and tests covering all the cases from replaced PRs (https://github.com/kubernetes/kubernetes/pull/117493 and https://github.com/kubernetes/kubernetes/pull/126718). 

The first commit was split into separate PR to simplify backport process, so that we can update the vendored bits in both crio and containerd.

This PR has been extensively tested on both containerd and crio (I've run more than 50+ successful tests with new and old backends), with the changes from kubelet updated. There were these scenarios identified (with the help from @liggitt and @aojea) to ensure we can safely implement this change:

1. Backend is gone; client should tear down the connection (covered in test added in the last commit):
Before: `kubectl port-forward` will hang until next request from client (app using forwarded port), removing pod doesn't affect port-forward itself, only the error establishing connection.
After: we can achieve a similar behavior through error introspection, iow. we invoke `pr.streamConn.Close` only if error matches `network namespace for sandbox "\w+" is closed` (containerd) or `sandbox \w+ is not running` (crio) which is what we're getting from the backend.

2. Individual request failed, backend doesn't contain the kubelet fix (first commit) and won't reset so will clog spdy stream (every test with old CRI will run into this case when invoking e2e).
Before: port-forward will terminate immediately. 
After: similarly to the first approach, we look for error `creating forwarding stream for port \d+ -> \d+: Timeout occurred` and close it.

3. Individual request failed, backend is new/fixed (ie. with the first commit included) and will reset; client doesn't need to tear down connection, and leaving the connection up is nice so other requests work.
This is working, but only with new kubectl, with the fixes mentioned above, old kubectl will still terminate on every error.

This PR is a replacement for https://github.com/kubernetes/kubernetes/pull/117493 and https://github.com/kubernetes/kubernetes/pull/126718

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubernetes/issues/74551 https://github.com/kubernetes/kubernetes/issues/107203

#### Special notes for your reviewer:
/assign @liggitt @aojea 
/cc @brianpursley @sxllwx @nic-6443 @eddiezane 

#### Does this PR introduce a user-facing change?
```release-note
Revised error handling for port forwards to Pods. On detecting an lost backend, `kubectl port-forward` now resets streams and attempts to tear down the forwarded connection. The kubelet also handles failure differently to support the improved behavior.
```
