### PR TITLE
feat(metrics): Add method to reset label allow lists

### DIFF
--- a/staging/src/k8s.io/component-base/metrics/counter.go
+++ b/staging/src/k8s.io/component-base/metrics/counter.go
@@ -18,6 +18,7 @@ package metrics
 
 import (
 	"context"
+	"sync"
 
 	"github.com/blang/semver/v4"
 	"github.com/prometheus/client_golang/prometheus"
@@ -247,6 +248,13 @@ func (v *CounterVec) Reset() {
 	}
 
 	v.CounterVec.Reset()
+}
+
+// ResetLabelAllowLists resets the label allow list for the CounterVec.
+// NOTE: This should only be used in test.
+func (v *CounterVec) ResetLabelAllowLists() {
+	v.initializeLabelAllowListsOnce = sync.Once{}
+	v.LabelValueAllowLists = nil
 }
 
 // WithContext returns wrapped CounterVec with context

--- a/staging/src/k8s.io/component-base/metrics/gauge.go
+++ b/staging/src/k8s.io/component-base/metrics/gauge.go
@@ -18,6 +18,7 @@ package metrics
 
 import (
 	"context"
+	"sync"
 
 	"github.com/blang/semver/v4"
 	"github.com/prometheus/client_golang/prometheus"
@@ -237,6 +238,13 @@ func (v *GaugeVec) Reset() {
 	}
 
 	v.GaugeVec.Reset()
+}
+
+// ResetLabelAllowLists resets the label allow list for the GaugeVec.
+// NOTE: This should only be used in test.
+func (v *GaugeVec) ResetLabelAllowLists() {
+	v.initializeLabelAllowListsOnce = sync.Once{}
+	v.LabelValueAllowLists = nil
 }
 
 func newGaugeFunc(opts *GaugeOpts, function func() float64, v semver.Version) GaugeFunc {

--- a/staging/src/k8s.io/component-base/metrics/histogram.go
+++ b/staging/src/k8s.io/component-base/metrics/histogram.go
@@ -18,6 +18,7 @@ package metrics
 
 import (
 	"context"
+	"sync"
 
 	"github.com/blang/semver/v4"
 	"github.com/prometheus/client_golang/prometheus"
@@ -200,6 +201,13 @@ func (v *HistogramVec) Reset() {
 	}
 
 	v.HistogramVec.Reset()
+}
+
+// ResetLabelAllowLists resets the label allow list for the HistogramVec.
+// NOTE: This should only be used in test.
+func (v *HistogramVec) ResetLabelAllowLists() {
+	v.initializeLabelAllowListsOnce = sync.Once{}
+	v.LabelValueAllowLists = nil
 }
 
 // WithContext returns wrapped HistogramVec with context

--- a/staging/src/k8s.io/component-base/metrics/summary.go
+++ b/staging/src/k8s.io/component-base/metrics/summary.go
@@ -18,6 +18,7 @@ package metrics
 
 import (
 	"context"
+	"sync"
 
 	"github.com/blang/semver/v4"
 	"github.com/prometheus/client_golang/prometheus"
@@ -212,6 +213,13 @@ func (v *SummaryVec) Reset() {
 	}
 
 	v.SummaryVec.Reset()
+}
+
+// ResetLabelAllowLists resets the label allow list for the SummaryVec.
+// NOTE: This should only be used in test.
+func (v *SummaryVec) ResetLabelAllowLists() {
+	v.initializeLabelAllowListsOnce = sync.Once{}
+	v.LabelValueAllowLists = nil
 }
 
 // WithContext returns wrapped SummaryVec with context

--- a/staging/src/k8s.io/component-base/metrics/timing_histogram.go
+++ b/staging/src/k8s.io/component-base/metrics/timing_histogram.go
@@ -18,6 +18,7 @@ package metrics
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/blang/semver/v4"
@@ -265,6 +266,13 @@ func (v *TimingHistogramVec) Reset() {
 	}
 
 	v.TimingHistogramVec.Reset()
+}
+
+// ResetLabelAllowLists resets the label allow list for the TimingHistogramVec.
+// NOTE: This should only be used in test.
+func (v *TimingHistogramVec) ResetLabelAllowLists() {
+	v.initializeLabelAllowListsOnce = sync.Once{}
+	v.LabelValueAllowLists = nil
 }
 
 // WithContext returns wrapped TimingHistogramVec with context


### PR DESCRIPTION
Adds a new method `ResetLabelAllowLists` to various metric types, allowing for the reset of label allow lists. This is intended specifically for use in testing scenarios.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:
Add method to reset metrics' label allow lists
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes 
- #128246

#### Special notes for your reviewer:
PR relies on it: 
- #128166

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
