### PR TITLE
Job Pod Failure policy refactor e2e test using exit codes

### DIFF
--- a/test/e2e/framework/job/fixtures.go
+++ b/test/e2e/framework/job/fixtures.go
@@ -136,6 +136,21 @@ func NewTestJobOnNode(behavior, name string, rPol v1.RestartPolicy, parallelism,
 				exit 1
 			fi
 		`}
+	case "failOncePerIndex":
+		// Use marker files per index. If the given marker file already exists
+		// then terminate successfully. Otherwise create the marker file and
+		// fail with exit code 42.
+		setupHostPathDirectory(job)
+		job.Spec.Template.Spec.Containers[0].Command = []string{"/bin/sh", "-c"}
+		job.Spec.Template.Spec.Containers[0].Args = []string{`
+			if [[ -r /data/foo-$JOB_COMPLETION_INDEX ]]
+			then
+				exit 0
+			else
+				touch /data/foo-$JOB_COMPLETION_INDEX
+				exit 42
+			fi
+		`}
 	case "notTerminateOncePerIndex":
 		// Use marker files per index. If the given marker file already exists
 		// then terminate successfully. Otherwise create the marker file and


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind failing-test

#### What this PR does / why we need it:

To make sure the negative exit codes are supported.

#### Which issue(s) this PR fixes:

Fixes #128302

#### Special notes for your reviewer:

I verified that including the negative exit code makes the e2e test pass on Windows.

 However, in the process I figured out we can simplify the test and make the returned exit code platform independent.

So I propose to refactor this test to make the returned exit code platform independent and I opened another PR to show that negative exit codes are supported.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
https://github.com/kubernetes/enhancements/tree/master/keps/sig-apps/3329-retriable-and-non-retriable-failures
```
