### PR TITLE
Automated cherry pick of #127834: fix(leaderelection): nil check in OnStoppedLeading func

### DIFF
--- a/pkg/controlplane/controller/leaderelection/run_with_leaderelection.go
+++ b/pkg/controlplane/controller/leaderelection/run_with_leaderelection.go
@@ -50,7 +50,9 @@ func RunWithLeaderElection(ctx context.Context, config *rest.Config, newRunnerFn
 			run(ctx, 1)
 		},
 		OnStoppedLeading: func() {
-			cancel()
+			if cancel != nil {
+				cancel()
+			}
 		},
 	}
 


### PR DESCRIPTION
Cherry pick of #127834 on release-1.31.

#127834: fix(leaderelection): nil check in OnStoppedLeading func

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
None
```