### PR TITLE
Move RecoverVolumeExpansionFailure feature to beta

### DIFF
--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -3066,19 +3066,21 @@ func TestValidationOptionsForPersistentVolumeClaim(t *testing.T) {
 		"nil pv": {
 			oldPvc: nil,
 			expectValidationOpts: PersistentVolumeClaimSpecValidationOptions{
-				EnableRecoverFromExpansionFailure: false,
+				EnableRecoverFromExpansionFailure: true,
 				EnableVolumeAttributesClass:       false,
 			},
 		},
 		"invaild apiGroup in dataSource allowed because the old pvc is used": {
 			oldPvc: pvcWithDataSource(&core.TypedLocalObjectReference{APIGroup: &invaildAPIGroup}),
 			expectValidationOpts: PersistentVolumeClaimSpecValidationOptions{
+				EnableRecoverFromExpansionFailure:     true,
 				AllowInvalidAPIGroupInDataSourceOrRef: true,
 			},
 		},
 		"invaild apiGroup in dataSourceRef allowed because the old pvc is used": {
 			oldPvc: pvcWithDataSourceRef(&core.TypedObjectReference{APIGroup: &invaildAPIGroup}),
 			expectValidationOpts: PersistentVolumeClaimSpecValidationOptions{
+				EnableRecoverFromExpansionFailure:     true,
 				AllowInvalidAPIGroupInDataSourceOrRef: true,
 			},
 		},
@@ -3086,7 +3088,7 @@ func TestValidationOptionsForPersistentVolumeClaim(t *testing.T) {
 			oldPvc:                      pvcWithVolumeAttributesClassName(utilpointer.String("foo")),
 			enableVolumeAttributesClass: true,
 			expectValidationOpts: PersistentVolumeClaimSpecValidationOptions{
-				EnableRecoverFromExpansionFailure: false,
+				EnableRecoverFromExpansionFailure: true,
 				EnableVolumeAttributesClass:       true,
 			},
 		},
@@ -3094,7 +3096,7 @@ func TestValidationOptionsForPersistentVolumeClaim(t *testing.T) {
 			oldPvc:                      pvcWithVolumeAttributesClassName(utilpointer.String("foo")),
 			enableVolumeAttributesClass: false,
 			expectValidationOpts: PersistentVolumeClaimSpecValidationOptions{
-				EnableRecoverFromExpansionFailure: false,
+				EnableRecoverFromExpansionFailure: true,
 				EnableVolumeAttributesClass:       true,
 			},
 		},

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -488,6 +488,7 @@ const (
 
 	// owner: @gnufied
 	// kep: https://kep.k8s.io/1790
+	// beta - v1.32
 	//
 	// Allow users to recover from volume expansion failure
 	RecoverVolumeExpansionFailure featuregate.Feature = "RecoverVolumeExpansionFailure"

--- a/pkg/features/versioned_kube_features.go
+++ b/pkg/features/versioned_kube_features.go
@@ -592,6 +592,7 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 
 	RecoverVolumeExpansionFailure: {
 		{Version: version.MustParse("1.23"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.32"), Default: true, PreRelease: featuregate.Beta},
 	},
 	RecursiveReadOnlyMounts: {
 		{Version: version.MustParse("1.30"), Default: false, PreRelease: featuregate.Alpha},

--- a/pkg/volume/util/operationexecutor/node_expander_test.go
+++ b/pkg/volume/util/operationexecutor/node_expander_test.go
@@ -121,7 +121,7 @@ func TestNodeExpander(t *testing.T) {
 			expectedStatusSize:       resource.MustParse("2G"),
 		},
 		{
-			name: "RWOP volumes, pv.spec.cap = pvc.status.cap, resizeStatus='', desiredSize > actualSize",
+			name: "RWX volumes, pv.spec.cap = pvc.status.cap, resizeStatus='', desiredSize > actualSize",
 			pvc:  addAccessMode(getTestPVC("test-vol0", "2G", "2G", "2G", nil), v1.ReadWriteMany),
 			pv:   getTestPV("test-vol0", "2G"),
 

--- a/pkg/volume/util/operationexecutor/node_expander_test.go
+++ b/pkg/volume/util/operationexecutor/node_expander_test.go
@@ -110,8 +110,19 @@ func TestNodeExpander(t *testing.T) {
 			expectedStatusSize:       resource.MustParse("1G"),
 		},
 		{
-			name: "pv.spec.cap = pvc.status.cap, resizeStatus='', desiredSize > actualSize",
+			name: "RWO volumes, pv.spec.cap = pvc.status.cap, resizeStatus='', desiredSize > actualSize",
 			pvc:  getTestPVC("test-vol0", "2G", "2G", "2G", nil),
+			pv:   getTestPV("test-vol0", "2G"),
+
+			expectedResizeStatus:     "",
+			expectResizeCall:         false,
+			assumeResizeOpAsFinished: true,
+			expectFinalErrors:        false,
+			expectedStatusSize:       resource.MustParse("2G"),
+		},
+		{
+			name: "RWOP volumes, pv.spec.cap = pvc.status.cap, resizeStatus='', desiredSize > actualSize",
+			pvc:  addAccessMode(getTestPVC("test-vol0", "2G", "2G", "2G", nil), v1.ReadWriteMany),
 			pv:   getTestPV("test-vol0", "2G"),
 
 			expectedResizeStatus:     "",

--- a/pkg/volume/util/operationexecutor/operation_generator_test.go
+++ b/pkg/volume/util/operationexecutor/operation_generator_test.go
@@ -455,6 +455,11 @@ func getTestPVC(volumeName string, specSize, statusSize, allocatedSize string, r
 	return pvc
 }
 
+func addAccessMode(pvc *v1.PersistentVolumeClaim, mode v1.PersistentVolumeAccessMode) *v1.PersistentVolumeClaim {
+	pvc.Spec.AccessModes = append(pvc.Spec.AccessModes, mode)
+	return pvc
+}
+
 func getTestPV(volumeName string, specSize string) *v1.PersistentVolume {
 	return &v1.PersistentVolume{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/volume/util/operationexecutor/operation_generator_test.go
+++ b/pkg/volume/util/operationexecutor/operation_generator_test.go
@@ -255,7 +255,7 @@ func TestOperationGenerator_nodeExpandVolume(t *testing.T) {
 			actualSize:  getSizeFunc("1G"),
 
 			expectedResizeStatus: "",
-			resizeCallCount:      1,
+			resizeCallCount:      0,
 			expectedStatusSize:   resource.MustParse("2G"),
 		},
 		{

--- a/test/featuregates_linter/test_data/versioned_feature_list.yaml
+++ b/test/featuregates_linter/test_data/versioned_feature_list.yaml
@@ -922,6 +922,10 @@
     lockToDefault: false
     preRelease: Alpha
     version: "1.23"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.32"
 - name: RecursiveReadOnlyMounts
   versionedSpecs:
   - default: false


### PR DESCRIPTION
Also fixes https://github.com/kubernetes/kubernetes/issues/115294

xref https://github.com/kubernetes/enhancements/issues/1790

```release-note
Promoted `RecoverVolumeExpansionFailure` feature gate to beta.
```




