### PR TITLE
Add tests for InMemoryResponseWriter

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/responsewriter/inmemoryresponsewriter_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/responsewriter/inmemoryresponsewriter_test.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package responsewriter
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestInMemoryResponseWriter(t *testing.T) {
+	w := NewInMemoryResponseWriter()
+
+	h := w.Header()
+	h.Set("Content-Type", "application/json")
+
+	w.WriteHeader(http.StatusCreated)
+
+	_, err := w.Write([]byte(`{"message": "hello"}`))
+	if err != nil {
+		t.Errorf("Write() returned an error: %v", err)
+	}
+
+	if w.RespCode() != http.StatusCreated {
+		t.Errorf("RespCode() returned unexpected code: %d, want %d", w.RespCode(), http.StatusCreated)
+	}
+
+	if string(w.Data()) != `{"message": "hello"}` {
+		t.Errorf("Data() returned unexpected body: %s, want %s", string(w.Data()), `{"message": "hello"}`)
+	}
+
+	expectedString := "ResponseCode: 201, Body: {\"message\": \"hello\"}, Header: map[Content-Type:[application/json]]"
+	if w.String() != expectedString {
+		t.Errorf("String() returned unexpected output: %s, want %s", w.String(), expectedString)
+	}
+}
+
+func TestInMemoryResponseWriter_DefaultHeader(t *testing.T) {
+	w := NewInMemoryResponseWriter()
+
+	_, err := w.Write([]byte(`{"message": "hello"}`))
+	if err != nil {
+		t.Errorf("Write() returned an error: %v", err)
+	}
+
+	// should be StatusOK (200) by default
+	if w.RespCode() != http.StatusOK {
+		t.Errorf("RespCode() returned unexpected code: %d, want %d", w.RespCode(), http.StatusOK)
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup 

#### What this PR does / why we need it:

Noticed this package was missing tests and add a basic one.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/triage accepted
/assign @jpbetz
