### PR TITLE
Fix: use pod-high-priority.yaml to trigger preemption in PreemptionAsync test case

### DIFF
--- a/test/integration/scheduler_perf/config/performance-config.yaml
+++ b/test/integration/scheduler_perf/config/performance-config.yaml
@@ -704,7 +704,7 @@
   - opcode: churn
     mode: create
     templatePaths:
-    - config/templates/pod-high-priority-large-cpu.yaml
+    - config/templates/pod-high-priority.yaml
     intervalMilliseconds: 200
   - opcode: createPods
     countParam: $measurePods


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug


<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

We're using `pod-high-priority-large-cpu.yaml` which require 9 CPUs. 
Given the nodes only have 4 CPUs, these Pods cannot trigger preemption.

Actually, I only see the following logs, and never see any preemption successful logs. which proves we haven't triggered the preemption at all currently.

```
I1026 11:25:33.658425   31249 schedule_one.go:1056] "Unable to schedule pod; no fit; waiting" pod="namespace-2/pod-h-glg8x" err="0/5000 nodes are available: 5000 Insufficient cpu. preemption: 0/5000 nodes are available: 5000 Insufficient cpu."
I10
```

This PR changes the test case to use `pod-high-priority.yaml`, which requires 3 CPUs.


> High priority preemption which need to preempt 3 of 4 low priority pods to fit (require 3 CPU).

Given the test case has the above comment, I guess this pod is actually what @dom4ha meant to use.

Confirmed that, after this change, the test case triggers preemption.

```
I1026 14:15:19.797294   59778 preemption.go:408] "Preemptor Pod preempted victim Pod" pod="namespace-2/pod-5j2r4" preemptor="namespace-2/pod-5j2r4" victim="namespace-1/pod-sjlrh" node="node-0-p6fmp"
I1026 14:15:19.802383   59778 preemption.go:408] "Preemptor Pod preempted victim Pod" pod="namespace-2/pod-5j2r4" preemptor="namespace-2/pod-5j2r4" victim="namespace-1/pod-m78tj" node="node-0-p6fmp"
I1026 14:15:19.802793   59778 preemption.go:408] "Preemptor Pod preempted victim Pod" pod="namespace-2/pod-5j2r4" preemptor="namespace-2/pod-5j2r4" victim="namespace-1/pod-mztc8" node="node-0-p6fmp"
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Found at https://github.com/kubernetes/kubernetes/issues/128221#issuecomment-2439247775

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
