### PR TITLE
fix: replace http verbs by their "net/http" constant value

### DIFF
--- a/cluster/images/etcd-version-monitor/etcd-version-monitor.go
+++ b/cluster/images/etcd-version-monitor/etcd-version-monitor.go
@@ -202,7 +202,7 @@ type EtcdVersion struct {
 // Function for fetching etcd version info and feeding it to the prometheus metric.
 func getVersion(lastSeenBinaryVersion *string) error {
 	// Create the get request for the etcd version endpoint.
-	req, err := http.NewRequest("GET", etcdVersionScrapeURI, nil)
+	req, err := http.NewRequest(http.MethodGet, etcdVersionScrapeURI, nil)
 	if err != nil {
 		return fmt.Errorf("failed to create GET request for etcd version: %v", err)
 	}
@@ -259,7 +259,7 @@ func getVersionPeriodically(stopCh <-chan struct{}) {
 
 // scrapeMetrics scrapes the prometheus metrics from the etcd metrics URI.
 func scrapeMetrics() (map[string]*dto.MetricFamily, error) {
-	req, err := http.NewRequest("GET", etcdMetricsScrapeURI, nil)
+	req, err := http.NewRequest(http.MethodGet, etcdMetricsScrapeURI, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create GET request for etcd metrics: %v", err)
 	}

--- a/cmd/kubeadm/app/preflight/checks.go
+++ b/cmd/kubeadm/app/preflight/checks.go
@@ -431,7 +431,7 @@ func (hst HTTPProxyCheck) Check() (warnings, errorList []error) {
 		u.Host = net.JoinHostPort(hst.Host, "1234")
 	}
 
-	req, err := http.NewRequest("GET", u.String(), nil)
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
 	if err != nil {
 		return nil, []error{err}
 	}
@@ -485,7 +485,7 @@ func (subnet HTTPProxyCIDRCheck) Check() (warnings, errorList []error) {
 	}
 	url := fmt.Sprintf("%s://%s/", subnet.Proto, testIPstring)
 
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return nil, []error{err}
 	}

--- a/cmd/kubeadm/app/preflight/checks_test.go
+++ b/cmd/kubeadm/app/preflight/checks_test.go
@@ -756,7 +756,7 @@ func resetProxyEnv(t *testing.T) {
 	// ProxyFromEnvironment caches the *_proxy environment variables and
 	// if ProxyFromEnvironment already executed before our test with empty
 	// HTTP_PROXY it will make these tests return false positive failures
-	req, err := http.NewRequest("GET", "http://host.fake.tld/", nil)
+	req, err := http.NewRequest(http.MethodGet, "http://host.fake.tld/", nil)
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}

--- a/pkg/controlplane/instance_test.go
+++ b/pkg/controlplane/instance_test.go
@@ -228,7 +228,7 @@ func TestVersion(t *testing.T) {
 	s, etcdserver, _, _ := newInstance(t)
 	defer etcdserver.Terminate(t)
 
-	req, _ := http.NewRequest("GET", "/version", nil)
+	req, _ := http.NewRequest(http.MethodGet, "/version", nil)
 	resp := httptest.NewRecorder()
 	s.ControlPlane.GenericAPIServer.Handler.ServeHTTP(resp, req)
 	if resp.Code != 200 {

--- a/pkg/credentialprovider/config.go
+++ b/pkg/credentialprovider/config.go
@@ -188,7 +188,7 @@ func (he *HTTPError) Error() string {
 
 // ReadURL read contents from given url
 func ReadURL(url string, client *http.Client, header *http.Header) (body []byte, err error) {
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kubelet/config/http.go
+++ b/pkg/kubelet/config/http.go
@@ -83,7 +83,7 @@ func (s *sourceURL) applyDefaults(pod *api.Pod) error {
 }
 
 func (s *sourceURL) extractFromURL() error {
-	req, err := http.NewRequest("GET", s.url, nil)
+	req, err := http.NewRequest(http.MethodGet, s.url, nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/kubelet/lifecycle/handlers_test.go
+++ b/pkg/kubelet/lifecycle/handlers_test.go
@@ -810,7 +810,7 @@ kubelet_lifecycle_handler_http_fallbacks_total 1
 func TestIsHTTPResponseError(t *testing.T) {
 	s := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
 	defer s.Close()
-	req, err := http.NewRequest("GET", s.URL, nil)
+	req, err := http.NewRequest(http.MethodGet, s.URL, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/kubelet/server/server_test.go
+++ b/pkg/kubelet/server/server_test.go
@@ -1627,7 +1627,7 @@ func TestFineGrainedAuthz(t *testing.T) {
 				return tc.authorizer(a)
 			}
 
-			req, err := http.NewRequest("GET", fw.testHTTPServer.URL+tc.path, nil)
+			req, err := http.NewRequest(http.MethodGet, fw.testHTTPServer.URL+tc.path, nil)
 			require.NoError(t, err)
 
 			resp, err := http.DefaultClient.Do(req)

--- a/pkg/probe/http/request.go
+++ b/pkg/probe/http/request.go
@@ -61,7 +61,7 @@ func NewRequestForHTTPGetAction(httpGet *v1.HTTPGetAction, container *v1.Contain
 }
 
 func newProbeRequest(url *url.URL, headers http.Header, userAgentFragment string) (*http.Request, error) {
-	req, err := http.NewRequest("GET", url.String(), nil)
+	req, err := http.NewRequest(http.MethodGet, url.String(), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/proxy/healthcheck/healthcheck_test.go
+++ b/pkg/proxy/healthcheck/healthcheck_test.go
@@ -396,7 +396,7 @@ func tHandler(hcs *server, nsn types.NamespacedName, status int, endpoints int, 
 	for _, h := range instance.httpServers {
 		handler := h.(*fakeHTTPServer).handler
 
-		req, err := http.NewRequest("GET", "/healthz", nil)
+		req, err := http.NewRequest(http.MethodGet, "/healthz", nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -613,7 +613,7 @@ func testProxierHealthUpdater(hs *ProxierHealthServer, hsTest *serverTest, fakeC
 
 func testHTTPHandler(hsTest *serverTest, status int, t *testing.T) {
 	handler := hsTest.server.(*fakeHTTPServer).handler
-	req, err := http.NewRequest("GET", string(hsTest.url), nil)
+	req, err := http.NewRequest(http.MethodGet, string(hsTest.url), nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/scheduler/extender.go
+++ b/pkg/scheduler/extender.go
@@ -403,7 +403,7 @@ func (h *HTTPExtender) send(action string, args interface{}, result interface{})
 
 	url := strings.TrimRight(h.extenderURL, "/") + "/" + action
 
-	req, err := http.NewRequest("POST", url, bytes.NewReader(out))
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(out))
 	if err != nil {
 		return err
 	}

--- a/pkg/scheduler/metrics/resources/resources_test.go
+++ b/pkg/scheduler/metrics/resources/resources_test.go
@@ -87,7 +87,7 @@ func Test_podResourceCollector_Handler(t *testing.T) {
 	}})
 
 	r := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "/metrics/resources", nil)
+	req, err := http.NewRequest(http.MethodGet, "/metrics/resources", nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/controller_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/controller_test.go
@@ -394,7 +394,7 @@ func (t *testEnv) fetchOpenAPIOrDie() *spec.Swagger {
 	defer server.Close()
 	client := server.Client()
 
-	req, err := http.NewRequest("GET", server.URL+"/openapi/v2", nil)
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/openapi/v2", nil)
 	if err != nil {
 		t.t.Error(err)
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/util/httpstream/httpstream_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/httpstream/httpstream_test.go
@@ -79,7 +79,7 @@ func TestHandshake(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		req, err := http.NewRequest("GET", "http://www.example.com/", nil)
+		req, err := http.NewRequest(http.MethodGet, "http://www.example.com/", nil)
 		if err != nil {
 			t.Fatalf("%s: error creating request: %v", name, err)
 		}

--- a/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/roundtripper_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/roundtripper_test.go
@@ -321,7 +321,7 @@ func TestRoundTripAndNewConnection(t *testing.T) {
 			if err != nil {
 				t.Fatalf("error creating request: %s", err)
 			}
-			req, err := http.NewRequest("GET", server.URL, nil)
+			req, err := http.NewRequest(http.MethodGet, server.URL, nil)
 			if err != nil {
 				t.Fatalf("error creating request: %s", err)
 			}
@@ -612,7 +612,7 @@ func TestRoundTripSocks5AndNewConnection(t *testing.T) {
 			))
 			defer server.Close()
 
-			req, err := http.NewRequest("GET", server.URL, nil)
+			req, err := http.NewRequest(http.MethodGet, server.URL, nil)
 			if err != nil {
 				t.Fatalf("error creating request: %s", err)
 			}

--- a/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/upgrade_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/upgrade_test.go
@@ -68,7 +68,7 @@ func TestUpgradeResponse(t *testing.T) {
 		}))
 		defer server.Close()
 
-		req, err := http.NewRequest("GET", server.URL, nil)
+		req, err := http.NewRequest(http.MethodGet, server.URL, nil)
 		if err != nil {
 			t.Fatalf("%d: error creating request: %s", i, err)
 		}

--- a/staging/src/k8s.io/apimachinery/pkg/util/httpstream/wsstream/conn_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/httpstream/wsstream/conn_test.go
@@ -369,7 +369,7 @@ func TestIsWebSocketRequestWithStreamCloseProtocol(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		req, err := http.NewRequest("GET", "http://www.example.com/", nil)
+		req, err := http.NewRequest(http.MethodGet, "http://www.example.com/", nil)
 		require.NoError(t, err)
 		for key, value := range test.headers {
 			req.Header.Add(key, value)

--- a/staging/src/k8s.io/apimachinery/pkg/util/net/http_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/net/http_test.go
@@ -211,7 +211,7 @@ func TestProxierWithNoProxyCIDR(t *testing.T) {
 			return nil, nil
 		})
 
-		req, err := http.NewRequest("GET", test.url, nil)
+		req, err := http.NewRequest(http.MethodGet, test.url, nil)
 		if err != nil {
 			t.Errorf("%s: unexpected err: %v", test.name, err)
 			continue
@@ -444,7 +444,7 @@ func TestSourceIPs(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			req, _ := http.NewRequest("GET", "https://cluster.k8s.io/apis/foobars/v1/foo/bar", nil)
+			req, _ := http.NewRequest(http.MethodGet, "https://cluster.k8s.io/apis/foobars/v1/foo/bar", nil)
 			req.RemoteAddr = test.remoteAddr
 			if test.forwardedFor != "" {
 				req.Header.Set("X-Forwarded-For", test.forwardedFor)

--- a/staging/src/k8s.io/apimachinery/pkg/util/proxy/transport_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/proxy/transport_test.go
@@ -280,7 +280,7 @@ func TestProxyTransport(t *testing.T) {
 		item.redirect = strings.Replace(item.redirect, sourceURL.Host, serverURL.Host, -1)
 		sourceURL.Host = serverURL.Host
 
-		req, err := http.NewRequest("GET", sourceURL.String(), nil)
+		req, err := http.NewRequest(http.MethodGet, sourceURL.String(), nil)
 		if err != nil {
 			t.Errorf("%v: Unexpected error: %v", name, err)
 			return
@@ -375,7 +375,7 @@ func TestRewriteResponse(t *testing.T) {
 		t.Errorf("%s failed to read and write: %v", encode, err)
 	}
 	for _, v := range test {
-		request, _ := http.NewRequest("GET", "http://mynode.com/", nil)
+		request, _ := http.NewRequest(http.MethodGet, "http://mynode.com/", nil)
 		request.Header.Set("Content-Encoding", v.encodeType)
 		request.Header.Add("Accept-Encoding", v.encodeType)
 

--- a/staging/src/k8s.io/apimachinery/pkg/util/proxy/upgradeaware_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/proxy/upgradeaware_test.go
@@ -590,7 +590,7 @@ func TestProxyUpgradeConnectionErrorResponse(t *testing.T) {
 	defer proxy.Close()
 
 	// Send request to proxy server.
-	req, err := http.NewRequest("POST", "http://"+proxy.Listener.Addr().String()+"/some/path", nil)
+	req, err := http.NewRequest(http.MethodPost, "http://"+proxy.Listener.Addr().String()+"/some/path", nil)
 	require.NoError(t, err)
 	req.Header.Set(httpstream.HeaderConnection, httpstream.HeaderUpgrade)
 	resp, err := http.DefaultClient.Do(req)
@@ -633,7 +633,7 @@ func TestProxyUpgradeErrorResponseTerminates(t *testing.T) {
 			bufferedReader := bufio.NewReader(conn)
 
 			// Send upgrade request resulting in a non-101 response from the backend
-			req, _ := http.NewRequest("GET", "/", nil)
+			req, _ := http.NewRequest(http.MethodGet, "/", nil)
 			req.Header.Set(httpstream.HeaderConnection, httpstream.HeaderUpgrade)
 			require.NoError(t, req.Write(conn))
 			// Verify we get the correct response and full message body content
@@ -653,7 +653,7 @@ func TestProxyUpgradeErrorResponseTerminates(t *testing.T) {
 			}
 
 			// Send another request to another endpoint to verify it is not received
-			req, _ = http.NewRequest("GET", "/there", nil)
+			req, _ = http.NewRequest(http.MethodGet, "/there", nil)
 			req.Write(conn)
 			// wait to ensure the handler does not receive the request
 			time.Sleep(time.Second)
@@ -688,7 +688,7 @@ func TestProxyUpgradeErrorResponse(t *testing.T) {
 			bufferedReader := bufio.NewReader(conn)
 
 			// Send upgrade request resulting in a non-101 response from the backend
-			req, _ := http.NewRequest("GET", "/", nil)
+			req, _ := http.NewRequest(http.MethodGet, "/", nil)
 			req.Header.Set(httpstream.HeaderConnection, httpstream.HeaderUpgrade)
 			require.NoError(t, req.Write(conn))
 			// Verify we get the correct response and full message body content
@@ -783,7 +783,7 @@ func TestRejectForwardingRedirectsOption(t *testing.T) {
 			require.NoError(t, err)
 			bufferedReader := bufio.NewReader(conn)
 
-			req, _ := http.NewRequest("GET", proxyURL.String(), nil)
+			req, _ := http.NewRequest(http.MethodGet, proxyURL.String(), nil)
 			require.NoError(t, req.Write(conn))
 			// Verify we get the correct response and message body content
 			resp, err := http.ReadResponse(bufferedReader, nil)
@@ -1073,7 +1073,7 @@ func TestFlushIntervalHeaders(t *testing.T) {
 	frontend := httptest.NewServer(proxyHandler)
 	defer frontend.Close()
 
-	req, _ := http.NewRequest("GET", frontend.URL, nil)
+	req, _ := http.NewRequest(http.MethodGet, frontend.URL, nil)
 	req.Close = true
 
 	ctx, cancel := context.WithTimeout(req.Context(), 10*time.Second)
@@ -1118,7 +1118,7 @@ func TestErrorPropagation(t *testing.T) {
 	frontend := httptest.NewServer(proxyHandler)
 	defer frontend.Close()
 
-	req, _ := http.NewRequest("GET", frontend.URL, nil)
+	req, _ := http.NewRequest(http.MethodGet, frontend.URL, nil)
 	req.Close = true
 
 	ctx, cancel := context.WithTimeout(req.Context(), 10*time.Second)

--- a/staging/src/k8s.io/apiserver/pkg/authentication/request/union/unionauth_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/request/union/unionauth_test.go
@@ -46,7 +46,7 @@ func TestAuthenticateRequestSecondPasses(t *testing.T) {
 	handler1 := &mockAuthRequestHandler{returnUser: user1}
 	handler2 := &mockAuthRequestHandler{returnUser: user2, isAuthenticated: true}
 	authRequestHandler := New(handler1, handler2)
-	req, _ := http.NewRequest("GET", "http://example.org", nil)
+	req, _ := http.NewRequest(http.MethodGet, "http://example.org", nil)
 
 	resp, isAuthenticated, err := authRequestHandler.AuthenticateRequest(req)
 	if err != nil {
@@ -64,7 +64,7 @@ func TestAuthenticateRequestFirstPasses(t *testing.T) {
 	handler1 := &mockAuthRequestHandler{returnUser: user1, isAuthenticated: true}
 	handler2 := &mockAuthRequestHandler{returnUser: user2}
 	authRequestHandler := New(handler1, handler2)
-	req, _ := http.NewRequest("GET", "http://example.org", nil)
+	req, _ := http.NewRequest(http.MethodGet, "http://example.org", nil)
 
 	resp, isAuthenticated, err := authRequestHandler.AuthenticateRequest(req)
 	if err != nil {
@@ -82,7 +82,7 @@ func TestAuthenticateRequestSuppressUnnecessaryErrors(t *testing.T) {
 	handler1 := &mockAuthRequestHandler{err: errors.New("first")}
 	handler2 := &mockAuthRequestHandler{isAuthenticated: true}
 	authRequestHandler := New(handler1, handler2)
-	req, _ := http.NewRequest("GET", "http://example.org", nil)
+	req, _ := http.NewRequest(http.MethodGet, "http://example.org", nil)
 
 	_, isAuthenticated, err := authRequestHandler.AuthenticateRequest(req)
 	if err != nil {
@@ -95,7 +95,7 @@ func TestAuthenticateRequestSuppressUnnecessaryErrors(t *testing.T) {
 
 func TestAuthenticateRequestNoAuthenticators(t *testing.T) {
 	authRequestHandler := New()
-	req, _ := http.NewRequest("GET", "http://example.org", nil)
+	req, _ := http.NewRequest(http.MethodGet, "http://example.org", nil)
 
 	resp, isAuthenticated, err := authRequestHandler.AuthenticateRequest(req)
 	if err != nil {
@@ -113,7 +113,7 @@ func TestAuthenticateRequestNonePass(t *testing.T) {
 	handler1 := &mockAuthRequestHandler{}
 	handler2 := &mockAuthRequestHandler{}
 	authRequestHandler := New(handler1, handler2)
-	req, _ := http.NewRequest("GET", "http://example.org", nil)
+	req, _ := http.NewRequest(http.MethodGet, "http://example.org", nil)
 
 	_, isAuthenticated, err := authRequestHandler.AuthenticateRequest(req)
 	if err != nil {
@@ -128,7 +128,7 @@ func TestAuthenticateRequestAdditiveErrors(t *testing.T) {
 	handler1 := &mockAuthRequestHandler{err: errors.New("first")}
 	handler2 := &mockAuthRequestHandler{err: errors.New("second")}
 	authRequestHandler := New(handler1, handler2)
-	req, _ := http.NewRequest("GET", "http://example.org", nil)
+	req, _ := http.NewRequest(http.MethodGet, "http://example.org", nil)
 
 	_, isAuthenticated, err := authRequestHandler.AuthenticateRequest(req)
 	if err == nil {
@@ -149,7 +149,7 @@ func TestAuthenticateRequestFailEarly(t *testing.T) {
 	handler1 := &mockAuthRequestHandler{err: errors.New("first")}
 	handler2 := &mockAuthRequestHandler{err: errors.New("second")}
 	authRequestHandler := NewFailOnError(handler1, handler2)
-	req, _ := http.NewRequest("GET", "http://example.org", nil)
+	req, _ := http.NewRequest(http.MethodGet, "http://example.org", nil)
 
 	_, isAuthenticated, err := authRequestHandler.AuthenticateRequest(req)
 	if err == nil {

--- a/staging/src/k8s.io/apiserver/pkg/authentication/request/websocket/protocol_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/request/websocket/protocol_test.go
@@ -217,7 +217,7 @@ func TestBearerToken(t *testing.T) {
 	}
 
 	for k, tc := range tests {
-		req, _ := http.NewRequest("GET", "/", nil)
+		req, _ := http.NewRequest(http.MethodGet, "/", nil)
 		req.Header.Set("Connection", "upgrade")
 		req.Header.Set("Upgrade", "websocket")
 		for _, h := range tc.ProtocolHeaders {

--- a/staging/src/k8s.io/apiserver/pkg/authentication/request/x509/x509_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/request/x509/x509_test.go
@@ -744,7 +744,7 @@ func TestX509(t *testing.T) {
 
 	for k, testCase := range testCases {
 		t.Run(k, func(t *testing.T) {
-			req, _ := http.NewRequest("GET", "/", nil)
+			req, _ := http.NewRequest(http.MethodGet, "/", nil)
 			if !testCase.Insecure {
 				req.TLS = &tls.ConnectionState{PeerCertificates: testCase.Certs}
 			}
@@ -887,7 +887,7 @@ func TestX509Verifier(t *testing.T) {
 	}
 
 	for k, testCase := range testCases {
-		req, _ := http.NewRequest("GET", "/", nil)
+		req, _ := http.NewRequest(http.MethodGet, "/", nil)
 		if !testCase.Insecure {
 			req.TLS = &tls.ConnectionState{PeerCertificates: testCase.Certs}
 		}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/apiserver_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/apiserver_test.go
@@ -1228,7 +1228,7 @@ func TestListCompression(t *testing.T) {
 
 		defer server.Close()
 
-		req, err := http.NewRequest("GET", server.URL+testCase.url, nil)
+		req, err := http.NewRequest(http.MethodGet, server.URL+testCase.url, nil)
 		if err != nil {
 			t.Errorf("%d: unexpected error: %v", i, err)
 			continue
@@ -1289,7 +1289,7 @@ func TestLogs(t *testing.T) {
 	defer server.Close()
 	client := http.Client{}
 
-	request, err := http.NewRequest("GET", server.URL+"/logs", nil)
+	request, err := http.NewRequest(http.MethodGet, server.URL+"/logs", nil)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -1526,7 +1526,7 @@ func TestGetCompression(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		req, err := http.NewRequest("GET", server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/id", nil)
+		req, err := http.NewRequest(http.MethodGet, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/id", nil)
 		if err != nil {
 			t.Fatalf("unexpected error creating request: %v", err)
 		}
@@ -2271,7 +2271,7 @@ func TestGetBinary(t *testing.T) {
 	server := httptest.NewServer(handle(map[string]rest.Storage{"simple": &simpleStorage}))
 	defer server.Close()
 
-	req, err := http.NewRequest("GET", server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/binary", nil)
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/binary", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -2768,7 +2768,7 @@ func TestDelete(t *testing.T) {
 	defer server.Close()
 
 	client := http.Client{}
-	request, err := http.NewRequest("DELETE", server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/"+ID, nil)
+	request, err := http.NewRequest(http.MethodDelete, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/"+ID, nil)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -2803,7 +2803,7 @@ func TestDeleteWithOptions(t *testing.T) {
 	}
 
 	client := http.Client{}
-	request, err := http.NewRequest("DELETE", server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/"+ID, bytes.NewReader(body))
+	request, err := http.NewRequest(http.MethodDelete, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/"+ID, bytes.NewReader(body))
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -2843,7 +2843,7 @@ func TestDeleteWithOptionsQuery(t *testing.T) {
 	}
 
 	client := http.Client{}
-	request, err := http.NewRequest("DELETE", server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/"+ID+"?gracePeriodSeconds="+strconv.FormatInt(grace, 10), nil)
+	request, err := http.NewRequest(http.MethodDelete, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/"+ID+"?gracePeriodSeconds="+strconv.FormatInt(grace, 10), nil)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -2886,7 +2886,7 @@ func TestDeleteWithOptionsQueryAndBody(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	client := http.Client{}
-	request, err := http.NewRequest("DELETE", server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/"+ID+"?gracePeriodSeconds="+strconv.FormatInt(grace+10, 10), bytes.NewReader(body))
+	request, err := http.NewRequest(http.MethodDelete, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/"+ID+"?gracePeriodSeconds="+strconv.FormatInt(grace+10, 10), bytes.NewReader(body))
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -2925,7 +2925,7 @@ func TestDeleteInvokesAdmissionControl(t *testing.T) {
 		defer server.Close()
 
 		client := http.Client{}
-		request, err := http.NewRequest("DELETE", server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/"+ID, nil)
+		request, err := http.NewRequest(http.MethodDelete, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/"+ID, nil)
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
@@ -2951,7 +2951,7 @@ func TestDeleteMissing(t *testing.T) {
 	defer server.Close()
 
 	client := http.Client{}
-	request, err := http.NewRequest("DELETE", server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/"+ID, nil)
+	request, err := http.NewRequest(http.MethodDelete, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/"+ID, nil)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -2988,7 +2988,7 @@ func TestUpdate(t *testing.T) {
 	}
 
 	client := http.Client{}
-	request, err := http.NewRequest("PUT", server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/"+ID, bytes.NewReader(body))
+	request, err := http.NewRequest(http.MethodPut, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/"+ID, bytes.NewReader(body))
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -3030,7 +3030,7 @@ func TestUpdateInvokesAdmissionControl(t *testing.T) {
 		}
 
 		client := http.Client{}
-		request, err := http.NewRequest("PUT", server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/"+ID, bytes.NewReader(body))
+		request, err := http.NewRequest(http.MethodPut, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/"+ID, bytes.NewReader(body))
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
@@ -3066,7 +3066,7 @@ func TestUpdateRequiresMatchingName(t *testing.T) {
 	}
 
 	client := http.Client{}
-	request, err := http.NewRequest("PUT", server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/"+ID, bytes.NewReader(body))
+	request, err := http.NewRequest(http.MethodPut, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/"+ID, bytes.NewReader(body))
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -3103,7 +3103,7 @@ func TestUpdateAllowsMissingNamespace(t *testing.T) {
 	}
 
 	client := http.Client{}
-	request, err := http.NewRequest("PUT", server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/"+ID, bytes.NewReader(body))
+	request, err := http.NewRequest(http.MethodPut, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/"+ID, bytes.NewReader(body))
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -3143,7 +3143,7 @@ func TestUpdateDisallowsMismatchedNamespaceOnError(t *testing.T) {
 	}
 
 	client := http.Client{}
-	request, err := http.NewRequest("PUT", server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/"+ID, bytes.NewReader(body))
+	request, err := http.NewRequest(http.MethodPut, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/"+ID, bytes.NewReader(body))
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -3182,7 +3182,7 @@ func TestUpdatePreventsMismatchedNamespace(t *testing.T) {
 	}
 
 	client := http.Client{}
-	request, err := http.NewRequest("PUT", server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/"+ID, bytes.NewReader(body))
+	request, err := http.NewRequest(http.MethodPut, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/"+ID, bytes.NewReader(body))
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -3219,7 +3219,7 @@ func TestUpdateMissing(t *testing.T) {
 	}
 
 	client := http.Client{}
-	request, err := http.NewRequest("PUT", server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/"+ID, bytes.NewReader(body))
+	request, err := http.NewRequest(http.MethodPut, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/"+ID, bytes.NewReader(body))
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -3249,7 +3249,7 @@ func TestCreateNotFound(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	request, err := http.NewRequest("POST", server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple", bytes.NewBuffer(data))
+	request, err := http.NewRequest(http.MethodPost, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple", bytes.NewBuffer(data))
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -3275,7 +3275,7 @@ func TestCreateChecksDecode(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	request, err := http.NewRequest("POST", server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple", bytes.NewBuffer(data))
+	request, err := http.NewRequest(http.MethodPost, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple", bytes.NewBuffer(data))
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -3395,7 +3395,7 @@ func TestNamedCreaterWithName(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	request, err := http.NewRequest("POST", server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/"+pathName+"/sub", bytes.NewBuffer(data))
+	request, err := http.NewRequest(http.MethodPost, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/"+pathName+"/sub", bytes.NewBuffer(data))
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -3433,7 +3433,7 @@ func TestNamedCreaterWithoutName(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	request, err := http.NewRequest("POST", server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/foo", bytes.NewBuffer(data))
+	request, err := http.NewRequest(http.MethodPost, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/foo", bytes.NewBuffer(data))
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -3507,7 +3507,7 @@ func TestNamedCreaterWithGenerateName(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	request, err := http.NewRequest("POST", server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/foo", bytes.NewBuffer(data))
+	request, err := http.NewRequest(http.MethodPost, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/foo", bytes.NewBuffer(data))
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -3554,7 +3554,7 @@ func TestUpdateChecksDecode(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	request, err := http.NewRequest("PUT", server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/bar", bytes.NewBuffer(data))
+	request, err := http.NewRequest(http.MethodPut, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/bar", bytes.NewBuffer(data))
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -3592,7 +3592,7 @@ func TestCreate(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	request, err := http.NewRequest("POST", server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/foo", bytes.NewBuffer(data))
+	request, err := http.NewRequest(http.MethodPost, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/foo", bytes.NewBuffer(data))
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -3654,7 +3654,7 @@ func TestCreateYAML(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	request, err := http.NewRequest("POST", server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/foo", bytes.NewBuffer(data))
+	request, err := http.NewRequest(http.MethodPost, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/foo", bytes.NewBuffer(data))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -3710,7 +3710,7 @@ func TestCreateInNamespace(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	request, err := http.NewRequest("POST", server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/other/foo", bytes.NewBuffer(data))
+	request, err := http.NewRequest(http.MethodPost, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/other/foo", bytes.NewBuffer(data))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -3767,7 +3767,7 @@ func TestCreateInvokeAdmissionControl(t *testing.T) {
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
-		request, err := http.NewRequest("POST", server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/other/foo", bytes.NewBuffer(data))
+		request, err := http.NewRequest(http.MethodPost, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/other/foo", bytes.NewBuffer(data))
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
@@ -3921,7 +3921,7 @@ func TestCreateChecksAPIVersion(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	request, err := http.NewRequest("POST", server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple", bytes.NewBuffer(data))
+	request, err := http.NewRequest(http.MethodPost, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple", bytes.NewBuffer(data))
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -3962,7 +3962,7 @@ func TestCreateDefaultsAPIVersion(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	request, err := http.NewRequest("POST", server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple", bytes.NewBuffer(data))
+	request, err := http.NewRequest(http.MethodPost, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple", bytes.NewBuffer(data))
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -3986,7 +3986,7 @@ func TestUpdateChecksAPIVersion(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	request, err := http.NewRequest("PUT", server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/bar", bytes.NewBuffer(data))
+	request, err := http.NewRequest(http.MethodPut, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/bar", bytes.NewBuffer(data))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -4425,7 +4425,7 @@ func BenchmarkUpdateProtobuf(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		request, err := http.NewRequest("PUT", dest.String(), bytes.NewReader(data))
+		request, err := http.NewRequest(http.MethodPut, dest.String(), bytes.NewReader(data))
 		if err != nil {
 			b.Fatalf("unexpected error: %v", err)
 		}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/audit_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/audit_test.go
@@ -156,7 +156,7 @@ func TestAudit(t *testing.T) {
 		{
 			"get",
 			func(server string) (*http.Request, error) {
-				return http.NewRequest("GET", server+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/other/simple/c", bytes.NewBuffer(simpleFooJSON))
+				return http.NewRequest(http.MethodGet, server+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/other/simple/c", bytes.NewBuffer(simpleFooJSON))
 			},
 			200,
 			2,
@@ -169,7 +169,7 @@ func TestAudit(t *testing.T) {
 		{
 			"list",
 			func(server string) (*http.Request, error) {
-				return http.NewRequest("GET", server+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/other/simple?labelSelector=a%3Dfoobar", nil)
+				return http.NewRequest(http.MethodGet, server+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/other/simple?labelSelector=a%3Dfoobar", nil)
 			},
 			200,
 			2,
@@ -182,7 +182,7 @@ func TestAudit(t *testing.T) {
 		{
 			"create",
 			func(server string) (*http.Request, error) {
-				return http.NewRequest("POST", server+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple", bytes.NewBuffer(simpleFooJSON))
+				return http.NewRequest(http.MethodPost, server+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple", bytes.NewBuffer(simpleFooJSON))
 			},
 			201,
 			2,
@@ -195,7 +195,7 @@ func TestAudit(t *testing.T) {
 		{
 			"not-allowed-named-create",
 			func(server string) (*http.Request, error) {
-				return http.NewRequest("POST", server+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/named", bytes.NewBuffer(simpleFooJSON))
+				return http.NewRequest(http.MethodPost, server+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/named", bytes.NewBuffer(simpleFooJSON))
 			},
 			405,
 			2,
@@ -208,7 +208,7 @@ func TestAudit(t *testing.T) {
 		{
 			"delete",
 			func(server string) (*http.Request, error) {
-				return http.NewRequest("DELETE", server+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/a", nil)
+				return http.NewRequest(http.MethodDelete, server+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/a", nil)
 			},
 			200,
 			2,
@@ -221,7 +221,7 @@ func TestAudit(t *testing.T) {
 		{
 			"delete-with-options-in-body",
 			func(server string) (*http.Request, error) {
-				return http.NewRequest("DELETE", server+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/a", bytes.NewBuffer([]byte(`{"kind":"DeleteOptions"}`)))
+				return http.NewRequest(http.MethodDelete, server+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/a", bytes.NewBuffer([]byte(`{"kind":"DeleteOptions"}`)))
 			},
 			200,
 			2,
@@ -234,7 +234,7 @@ func TestAudit(t *testing.T) {
 		{
 			"update",
 			func(server string) (*http.Request, error) {
-				return http.NewRequest("PUT", server+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/other/simple/c", bytes.NewBuffer(simpleCPrimeJSON))
+				return http.NewRequest(http.MethodPut, server+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/other/simple/c", bytes.NewBuffer(simpleCPrimeJSON))
 			},
 			200,
 			2,
@@ -247,7 +247,7 @@ func TestAudit(t *testing.T) {
 		{
 			"update-wrong-namespace",
 			func(server string) (*http.Request, error) {
-				return http.NewRequest("PUT", server+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/c", bytes.NewBuffer(simpleCPrimeJSON))
+				return http.NewRequest(http.MethodPut, server+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/c", bytes.NewBuffer(simpleCPrimeJSON))
 			},
 			400,
 			2,
@@ -260,7 +260,7 @@ func TestAudit(t *testing.T) {
 		{
 			"patch",
 			func(server string) (*http.Request, error) {
-				req, _ := http.NewRequest("PATCH", server+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/other/simple/c", bytes.NewReader([]byte(`{"labels":{"foo":"bar"}}`)))
+				req, _ := http.NewRequest(http.MethodPatch, server+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/other/simple/c", bytes.NewReader([]byte(`{"labels":{"foo":"bar"}}`)))
 				req.Header.Set("Content-Type", "application/merge-patch+json; charset=UTF-8")
 				return req, nil
 			},
@@ -275,7 +275,7 @@ func TestAudit(t *testing.T) {
 		{
 			"watch",
 			func(server string) (*http.Request, error) {
-				return http.NewRequest("GET", server+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/other/simple?watch=true", nil)
+				return http.NewRequest(http.MethodGet, server+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/other/simple?watch=true", nil)
 			},
 			200,
 			3,

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit_test.go
@@ -743,7 +743,7 @@ func TestAudit(t *testing.T) {
 func TestAuditNoPanicOnNilUser(t *testing.T) {
 	fakeRuleEvaluator := policy.NewFakePolicyRuleEvaluator(auditinternal.LevelRequestResponse, nil)
 	handler := WithAudit(&fakeHTTPHandler{}, &fakeAuditSink{}, fakeRuleEvaluator, nil)
-	req, _ := http.NewRequest("GET", "/api/v1/namespaces/default/pods", nil)
+	req, _ := http.NewRequest(http.MethodGet, "/api/v1/namespaces/default/pods", nil)
 	req = withTestContext(req, nil, nil)
 	req.RemoteAddr = "127.0.0.1"
 	handler.ServeHTTP(httptest.NewRecorder(), req)
@@ -758,7 +758,7 @@ func TestAuditLevelNone(t *testing.T) {
 	fakeRuleEvaluator := policy.NewFakePolicyRuleEvaluator(auditinternal.LevelNone, nil)
 	handler = WithAudit(handler, sink, fakeRuleEvaluator, nil)
 
-	req, _ := http.NewRequest("GET", "/api/v1/namespaces/default/pods", nil)
+	req, _ := http.NewRequest(http.MethodGet, "/api/v1/namespaces/default/pods", nil)
 	req.RemoteAddr = "127.0.0.1"
 	req = withTestContext(req, &user.DefaultInfo{Name: "admin"}, nil)
 
@@ -814,7 +814,7 @@ func TestAuditIDHttpHeader(t *testing.T) {
 			handler = WithAudit(handler, sink, fakeRuleEvaluator, nil)
 			handler = WithAuditInit(handler)
 
-			req, _ := http.NewRequest("GET", "/api/v1/namespaces/default/pods", nil)
+			req, _ := http.NewRequest(http.MethodGet, "/api/v1/namespaces/default/pods", nil)
 			req.RemoteAddr = "127.0.0.1"
 			req = withTestContext(req, &user.DefaultInfo{Name: "admin"}, nil)
 			if test.requestHeader != "" {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authn_audit_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authn_audit_test.go
@@ -36,7 +36,7 @@ func TestFailedAuthnAudit(t *testing.T) {
 			http.Error(w, "", http.StatusUnauthorized)
 		}),
 		sink, fakeRuleEvaluator)
-	req, _ := http.NewRequest("GET", "/api/v1/namespaces/default/pods", nil)
+	req, _ := http.NewRequest(http.MethodGet, "/api/v1/namespaces/default/pods", nil)
 	req.RemoteAddr = "127.0.0.1"
 	req = withTestContext(req, nil, nil)
 	req.SetBasicAuth("username", "password")
@@ -68,7 +68,7 @@ func TestFailedMultipleAuthnAudit(t *testing.T) {
 			http.Error(w, "", http.StatusUnauthorized)
 		}),
 		sink, fakeRuleEvaluator)
-	req, _ := http.NewRequest("GET", "/api/v1/namespaces/default/pods", nil)
+	req, _ := http.NewRequest(http.MethodGet, "/api/v1/namespaces/default/pods", nil)
 	req.RemoteAddr = "127.0.0.1"
 	req = withTestContext(req, nil, nil)
 	req.SetBasicAuth("username", "password")
@@ -101,7 +101,7 @@ func TestFailedAuthnAuditWithoutAuthorization(t *testing.T) {
 			http.Error(w, "", http.StatusUnauthorized)
 		}),
 		sink, fakeRuleEvaluator)
-	req, _ := http.NewRequest("GET", "/api/v1/namespaces/default/pods", nil)
+	req, _ := http.NewRequest(http.MethodGet, "/api/v1/namespaces/default/pods", nil)
 	req.RemoteAddr = "127.0.0.1"
 	req = withTestContext(req, nil, nil)
 	handler.ServeHTTP(httptest.NewRecorder(), req)
@@ -132,7 +132,7 @@ func TestFailedAuthnAuditOmitted(t *testing.T) {
 			http.Error(w, "", http.StatusUnauthorized)
 		}),
 		sink, fakeRuleEvaluator)
-	req, _ := http.NewRequest("GET", "/api/v1/namespaces/default/pods", nil)
+	req, _ := http.NewRequest(http.MethodGet, "/api/v1/namespaces/default/pods", nil)
 	req.RemoteAddr = "127.0.0.1"
 	req = withTestContext(req, nil, nil)
 	handler.ServeHTTP(httptest.NewRecorder(), req)

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authorization_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authorization_test.go
@@ -19,16 +19,17 @@ package filters
 import (
 	"context"
 	"errors"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 	genericfeatures "k8s.io/apiserver/pkg/features"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
-	"net/http"
-	"net/http/httptest"
-	"reflect"
-	"testing"
 
 	"github.com/stretchr/testify/assert"
 	batch "k8s.io/api/batch/v1"
@@ -284,7 +285,7 @@ func TestAuditAnnotation(t *testing.T) {
 		handler := WithAuthorization(&fakeHTTPHandler{}, tc.authorizer, negotiatedSerializer)
 		// TODO: fake audit injector
 
-		req, _ := http.NewRequest("GET", "/api/v1/namespaces/default/pods", nil)
+		req, _ := http.NewRequest(http.MethodGet, "/api/v1/namespaces/default/pods", nil)
 		req = withTestContext(req, nil, &auditinternal.Event{Level: auditinternal.LevelMetadata})
 		ae := audit.AuditEventFrom(req.Context())
 		req.RemoteAddr = "127.0.0.1"

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/impersonation_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/impersonation_test.go
@@ -532,7 +532,7 @@ func TestImpersonationFilter(t *testing.T) {
 				ctx = request.WithUser(request.NewContext(), tc.user)
 			}()
 
-			req, err := http.NewRequest("GET", server.URL, nil)
+			req, err := http.NewRequest(http.MethodGet, server.URL, nil)
 			if err != nil {
 				t.Errorf("%s: unexpected error: %v", tc.name, err)
 				return

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/metrics_test.go
@@ -258,7 +258,7 @@ func TestRecordAuthorizationMetricsMetrics(t *testing.T) {
 			handler := WithAuthorization(&fakeHTTPHandler{}, tt.authorizer, negotiatedSerializer)
 			// TODO: fake audit injector
 
-			req, _ := http.NewRequest("GET", "/api/v1/namespaces/default/pods", nil)
+			req, _ := http.NewRequest(http.MethodGet, "/api/v1/namespaces/default/pods", nil)
 			req = withTestContext(req, nil, audit)
 			req.RemoteAddr = "127.0.0.1"
 			handler.ServeHTTP(httptest.NewRecorder(), req)

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/read_write_deadline_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/read_write_deadline_test.go
@@ -1313,7 +1313,7 @@ func TestPerRequestWithSlowReader(t *testing.T) {
 
 func sendWithTrace(t *testing.T, client *http.Client, url string, f func(*testing.T, httptrace.GotConnInfo)) (*http.Response, error) {
 	t.Helper()
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		t.Fatalf("failed to create new request: %v", err)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/delete_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/delete_test.go
@@ -229,7 +229,7 @@ func TestDeleteCollectionWithNoContextDeadlineEnforced(t *testing.T) {
 	}
 	handler := DeleteCollection(fakeCollectionDeleterFunc(fakeDeleterFn), false, scope, nil)
 
-	request, err := http.NewRequest("GET", "/test", nil)
+	request, err := http.NewRequest(http.MethodGet, "/test", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest_test.go
@@ -181,7 +181,7 @@ func TestLimitedReadBody(t *testing.T) {
 			defer metrics.RequestBodySizes.Reset()
 			defer legacyregistry.Reset()
 
-			req, err := http.NewRequest("POST", "/", tc.requestBody)
+			req, err := http.NewRequest(http.MethodPost, "/", tc.requestBody)
 			if err != nil {
 				t.Errorf("err not expected: got %v", err)
 			}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/patchhandler_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/patchhandler_test.go
@@ -46,7 +46,7 @@ func TestPatch(t *testing.T) {
 	defer server.Close()
 
 	client := http.Client{}
-	request, err := http.NewRequest("PATCH", server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/"+ID, bytes.NewReader([]byte(`{"labels":{"foo":"bar"}}`)))
+	request, err := http.NewRequest(http.MethodPatch, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/"+ID, bytes.NewReader([]byte(`{"labels":{"foo":"bar"}}`)))
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -81,7 +81,7 @@ func TestForbiddenForceOnNonApply(t *testing.T) {
 	defer server.Close()
 
 	client := http.Client{}
-	request, err := http.NewRequest("PATCH", server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/"+ID, bytes.NewReader([]byte(`{"labels":{"foo":"bar"}}`)))
+	request, err := http.NewRequest(http.MethodPatch, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/"+ID, bytes.NewReader([]byte(`{"labels":{"foo":"bar"}}`)))
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -91,7 +91,7 @@ func TestForbiddenForceOnNonApply(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	request, err = http.NewRequest("PATCH", server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/"+ID+"?force=true", bytes.NewReader([]byte(`{"labels":{"foo":"bar"}}`)))
+	request, err = http.NewRequest(http.MethodPatch, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/"+ID+"?force=true", bytes.NewReader([]byte(`{"labels":{"foo":"bar"}}`)))
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -104,7 +104,7 @@ func TestForbiddenForceOnNonApply(t *testing.T) {
 		t.Errorf("Unexpected response %#v", response)
 	}
 
-	request, err = http.NewRequest("PATCH", server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/"+ID+"?force=false", bytes.NewReader([]byte(`{"labels":{"foo":"bar"}}`)))
+	request, err = http.NewRequest(http.MethodPatch, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/"+ID+"?force=false", bytes.NewReader([]byte(`{"labels":{"foo":"bar"}}`)))
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -136,7 +136,7 @@ func TestPatchRequiresMatchingName(t *testing.T) {
 	defer server.Close()
 
 	client := http.Client{}
-	request, err := http.NewRequest("PATCH", server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/"+ID, bytes.NewReader([]byte(`{"metadata":{"name":"idbar"}}`)))
+	request, err := http.NewRequest(http.MethodPatch, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/"+ID, bytes.NewReader([]byte(`{"metadata":{"name":"idbar"}}`)))
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/request/requestinfo_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/request/requestinfo_test.go
@@ -136,7 +136,7 @@ func TestGetAPIRequestInfo(t *testing.T) {
 		"missing api group":           "/apis/version/resource",
 	}
 	for k, v := range errorCases {
-		req, err := http.NewRequest("GET", v, nil)
+		req, err := http.NewRequest(http.MethodGet, v, nil)
 		if err != nil {
 			t.Errorf("Unexpected error %v", err)
 		}
@@ -174,7 +174,7 @@ func TestGetNonAPIRequestInfo(t *testing.T) {
 	resolver := newTestRequestInfoResolver()
 
 	for testName, tc := range tests {
-		req, _ := http.NewRequest("GET", tc.url, nil)
+		req, _ := http.NewRequest(http.MethodGet, tc.url, nil)
 
 		apiRequestInfo, err := resolver.NewRequestInfo(req)
 		if err != nil {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/responsewriter/wrapper_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/responsewriter/wrapper_test.go
@@ -222,7 +222,7 @@ func newServer(t *testing.T, h http.Handler, http2 bool) *httptest.Server {
 }
 
 func sendRequest(t *testing.T, server *httptest.Server) {
-	req, err := http.NewRequest("GET", server.URL, nil)
+	req, err := http.NewRequest(http.MethodGet, server.URL, nil)
 	if err != nil {
 		t.Fatalf("error creating request: %v", err)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/watch_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/watch_test.go
@@ -227,7 +227,7 @@ func TestWatchClientClose(t *testing.T) {
 	dest.Path = "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/simples"
 	dest.RawQuery = "watch=1"
 
-	request, err := http.NewRequest("GET", dest.String(), nil)
+	request, err := http.NewRequest(http.MethodGet, dest.String(), nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -271,7 +271,7 @@ func TestWatchRead(t *testing.T) {
 
 	connectHTTP := func(accept string) (io.ReadCloser, string) {
 		client := http.Client{}
-		request, err := http.NewRequest("GET", dest.String(), nil)
+		request, err := http.NewRequest(http.MethodGet, dest.String(), nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -423,7 +423,7 @@ func TestWatchHTTPAccept(t *testing.T) {
 	dest.Path = "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/watch/simples"
 	dest.RawQuery = ""
 
-	request, err := http.NewRequest("GET", dest.String(), nil)
+	request, err := http.NewRequest(http.MethodGet, dest.String(), nil)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -573,7 +573,7 @@ func TestWatchProtocolSelection(t *testing.T) {
 	}
 
 	for _, item := range table {
-		request, err := http.NewRequest("GET", dest.String(), nil)
+		request, err := http.NewRequest(http.MethodGet, dest.String(), nil)
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
@@ -658,7 +658,7 @@ func TestWatchHTTPErrors(t *testing.T) {
 	dest.Path = "/" + prefix + "/" + newGroupVersion.Group + "/" + newGroupVersion.Version + "/simple"
 	dest.RawQuery = "watch=true"
 
-	req, _ := http.NewRequest("GET", dest.String(), nil)
+	req, _ := http.NewRequest(http.MethodGet, dest.String(), nil)
 	client := http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
@@ -724,7 +724,7 @@ func TestWatchHTTPErrorsBeforeServe(t *testing.T) {
 	dest.Path = "/" + prefix + "/" + newGroupVersion.Group + "/" + newGroupVersion.Version + "/simple"
 	dest.RawQuery = "watch=true"
 
-	req, _ := http.NewRequest("GET", dest.String(), nil)
+	req, _ := http.NewRequest(http.MethodGet, dest.String(), nil)
 	client := http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
@@ -822,7 +822,7 @@ func TestWatchHTTPTimeout(t *testing.T) {
 	dest.Path = "/" + prefix + "/" + newGroupVersion.Group + "/" + newGroupVersion.Version + "/simple"
 	dest.RawQuery = "watch=true"
 
-	req, _ := http.NewRequest("GET", dest.String(), nil)
+	req, _ := http.NewRequest(http.MethodGet, dest.String(), nil)
 	client := http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
@@ -911,7 +911,7 @@ func runWatchHTTPBenchmark(b *testing.B, items []runtime.Object, contentType str
 	dest.Path = "/" + prefix + "/" + newGroupVersion.Group + "/" + newGroupVersion.Version + "/watch/simples"
 	dest.RawQuery = ""
 
-	request, err := http.NewRequest("GET", dest.String(), nil)
+	request, err := http.NewRequest(http.MethodGet, dest.String(), nil)
 	if err != nil {
 		b.Fatalf("unexpected error: %v", err)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/rest/streamer.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/rest/streamer.go
@@ -78,7 +78,7 @@ func (s *LocationStreamer) InputStream(ctx context.Context, apiVersion, acceptHe
 		Transport:     transport,
 		CheckRedirect: s.RedirectChecker,
 	}
-	req, err := http.NewRequest("GET", s.Location.String(), nil)
+	req, err := http.NewRequest(http.MethodGet, s.Location.String(), nil)
 	if err != nil {
 		return nil, false, "", fmt.Errorf("failed to construct request for %s, got %v", s.Location.String(), err)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/content_type_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/content_type_test.go
@@ -43,7 +43,7 @@ func TestWithContentType(t *testing.T) {
 	for _, test := range tests {
 		path := "http://example.com" + test.path
 		t.Run(path, func(t *testing.T) {
-			req, err := http.NewRequest("GET", path, nil)
+			req, err := http.NewRequest(http.MethodGet, path, nil)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/cors_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/cors_test.go
@@ -105,7 +105,7 @@ func TestCORSAllowedOrigins(t *testing.T) {
 					server := httptest.NewServer(handler)
 					defer server.Close()
 
-					request, err := http.NewRequest("GET", server.URL+"/version", nil)
+					request, err := http.NewRequest(http.MethodGet, server.URL+"/version", nil)
 					if err != nil {
 						t.Errorf("unexpected error: %v", err)
 					}

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/timeout_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/timeout_test.go
@@ -468,7 +468,7 @@ func TestErrConnKilledHTTP2(t *testing.T) {
 	defer ts.Close()
 
 	newServerRequest := func(tr *panicOnNonReuseTransport) *http.Request {
-		req, _ := http.NewRequest("GET", fmt.Sprintf("https://127.0.0.1:%d", ts.Listener.Addr().(*net.TCPAddr).Port), nil)
+		req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("https://127.0.0.1:%d", ts.Listener.Addr().(*net.TCPAddr).Port), nil)
 		trace := &httptrace.ClientTrace{
 			GotConn: tr.GotConn,
 		}

--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver_graceful_termination_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver_graceful_termination_test.go
@@ -966,7 +966,7 @@ func setupDoer(t *testing.T, info *SecureServingInfo) doer {
 		url := fmt.Sprintf("https://%s:%d%s", "127.0.0.1", port, path)
 		t.Logf("Sending request - timeout: %s, url: %s", timeout, url)
 
-		req, err := http.NewRequest("GET", url, nil)
+		req, err := http.NewRequest(http.MethodGet, url, nil)
 		if err != nil {
 			return result{response: nil, err: err}
 		}

--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver_test.go
@@ -430,7 +430,7 @@ func TestCustomHandlerChain(t *testing.T) {
 		protected, called = false, false
 
 		var w io.Reader
-		req, err := http.NewRequest("GET", test.path, w)
+		req, err := http.NewRequest(http.MethodGet, test.path, w)
 		if err != nil {
 			t.Errorf("%d: Unexpected http error: %v", i, err)
 			continue
@@ -478,7 +478,7 @@ func TestNotRestRoutesHaveAuth(t *testing.T) {
 		{"/version"},
 	} {
 		resp := httptest.NewRecorder()
-		req, _ := http.NewRequest("GET", test.route, nil)
+		req, _ := http.NewRequest(http.MethodGet, test.route, nil)
 		s.Handler.ServeHTTP(resp, req)
 		if resp.Code != 200 {
 			t.Errorf("route %q expected to work: code %d", test.route, resp.Code)
@@ -739,7 +739,7 @@ func TestWarningWithRequestTimeout(t *testing.T) {
 	server.StartTLS()
 	defer server.Close()
 
-	request, err := http.NewRequest("GET", server.URL+"/test?timeout=100ms", nil)
+	request, err := http.NewRequest(http.MethodGet, server.URL+"/test?timeout=100ms", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/server/healthz/healthz_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/healthz/healthz_test.go
@@ -37,7 +37,7 @@ import (
 func TestInstallHandler(t *testing.T) {
 	mux := http.NewServeMux()
 	InstallHandler(mux)
-	req, err := http.NewRequest("GET", "http://example.com/healthz", nil)
+	req, err := http.NewRequest(http.MethodGet, "http://example.com/healthz", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -59,7 +59,7 @@ func TestInstallPathHandler(t *testing.T) {
 	mux := http.NewServeMux()
 	InstallPathHandler(mux, "/healthz/test")
 	InstallPathHandler(mux, "/healthz/ready")
-	req, err := http.NewRequest("GET", "http://example.com/healthz/test", nil)
+	req, err := http.NewRequest(http.MethodGet, "http://example.com/healthz/test", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -76,7 +76,7 @@ func TestInstallPathHandler(t *testing.T) {
 		t.Errorf("expected %v, got %v", "ok", w.Body.String())
 	}
 
-	req, err = http.NewRequest("GET", "http://example.com/healthz/ready", nil)
+	req, err = http.NewRequest(http.MethodGet, "http://example.com/healthz/ready", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -129,7 +129,7 @@ func testMultipleChecks(path, name string, t *testing.T) {
 		} else {
 			InstallPathHandler(mux, path, checks...)
 		}
-		req, err := http.NewRequest("GET", fmt.Sprintf("http://example.com%s%v", path, test.path), nil)
+		req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://example.com%s%v", path, test.path), nil)
 		if err != nil {
 			t.Fatalf("case[%d] Unexpected error: %v", i, err)
 		}
@@ -245,7 +245,7 @@ func TestMetrics(t *testing.T) {
 
 	paths := []string{"/healthz", "/livez", "/readyz"}
 	for _, path := range paths {
-		req, err := http.NewRequest("GET", fmt.Sprintf("http://example.com%s", path), nil)
+		req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://example.com%s", path), nil)
 		if err != nil {
 			t.Errorf("%v", err)
 		}
@@ -324,7 +324,7 @@ func TestInstallPathHandlerWithHealthyFunc(t *testing.T) {
 	InstallPathHandlerWithHealthyFunc(mux, "/readyz", hasBeenReadyFn, readyOnChanClose{readyzCh})
 
 	// scenario 1: expect the check to fail since the channel hasn't been closed
-	req, err := http.NewRequest("GET", fmt.Sprintf("http://example.com%s", "/readyz"), nil)
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://example.com%s", "/readyz"), nil)
 	if err != nil {
 		t.Errorf("%v", err)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/server/httplog/httplog_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/httplog/httplog_test.go
@@ -59,7 +59,7 @@ func TestStatusIsNot(t *testing.T) {
 }
 
 func TestWithLogging(t *testing.T) {
-	req, err := http.NewRequest("GET", "http://example.com", nil)
+	req, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -100,7 +100,7 @@ func TestLogOf(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			req, err := http.NewRequest("GET", "http://example.com", nil)
+			req, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
 			if err != nil {
 				t.Errorf("Unexpected error: %v", err)
 			}
@@ -121,7 +121,7 @@ func TestLogOf(t *testing.T) {
 func TestUnlogged(t *testing.T) {
 	unloggedTests := []bool{true, false}
 	for _, makeLogger := range unloggedTests {
-		req, err := http.NewRequest("GET", "http://example.com", nil)
+		req, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
 		if err != nil {
 			t.Errorf("Unexpected error: %v", err)
 		}
@@ -143,7 +143,7 @@ func TestUnlogged(t *testing.T) {
 }
 
 func TestLoggedStatus(t *testing.T) {
-	req, err := http.NewRequest("GET", "http://example.com", nil)
+	req, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -190,7 +190,7 @@ func TestRespLoggerWithDecoratedResponseWriter(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			req, err := http.NewRequest("GET", "http://example.com", nil)
+			req, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
 			if err != nil {
 				t.Errorf("Unexpected error: %v", err)
 			}

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/width_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/width_test.go
@@ -559,7 +559,7 @@ func TestWorkEstimator(t *testing.T) {
 
 			estimator := NewWorkEstimator(countsFn, watchCountsFn, defaultCfg, maxSeatsFn)
 
-			req, err := http.NewRequest("GET", test.requestURI, nil)
+			req, err := http.NewRequest(http.MethodGet, test.requestURI, nil)
 			if err != nil {
 				t.Fatalf("Failed to create new HTTP request - %v", err)
 			}

--- a/staging/src/k8s.io/apiserver/pkg/util/proxy/translatinghandler_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/proxy/translatinghandler_test.go
@@ -92,7 +92,7 @@ func TestTranslatingHandler(t *testing.T) {
 		},
 	}
 	for name, test := range tests {
-		req, err := http.NewRequest("GET", "http://www.example.com/", nil)
+		req, err := http.NewRequest(http.MethodGet, "http://www.example.com/", nil)
 		require.NoError(t, err)
 		if test.upgrade != "" {
 			req.Header.Add("Connection", "Upgrade")

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/oidc/oidc.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/oidc/oidc.go
@@ -976,7 +976,7 @@ func getCredentialID(c claims) string {
 // TODO: Allow passing in JSON hints to the IDP.
 func getClaimJWT(ctx context.Context, client *http.Client, url, accessToken string) (string, error) {
 	// TODO: Allow passing request body with configurable information.
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return "", fmt.Errorf("while calling %v: %v", url, err)
 	}

--- a/staging/src/k8s.io/client-go/tools/portforward/tunneling_connection_test.go
+++ b/staging/src/k8s.io/client-go/tools/portforward/tunneling_connection_test.go
@@ -165,7 +165,7 @@ func TestTunnelingConnection_ReadWriteDeadlines(t *testing.T) {
 // a websocket connection. Returns the TunnelingConnection injected with the
 // websocket connection or an error if one occurs.
 func dialForTunnelingConnection(url *url.URL) (*TunnelingConnection, error) {
-	req, err := http.NewRequest("GET", url.String(), nil)
+	req, err := http.NewRequest(http.MethodGet, url.String(), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/tools/portforward/tunneling_dialer.go
+++ b/staging/src/k8s.io/client-go/tools/portforward/tunneling_dialer.go
@@ -61,7 +61,7 @@ func NewSPDYOverWebsocketDialer(url *url.URL, config *restclient.Config) (httpst
 func (d *tunnelingDialer) Dial(protocols ...string) (httpstream.Connection, string, error) {
 	// There is no passed context, so skip the context when creating request for now.
 	// Websockets requires "GET" method: RFC 6455 Sec. 4.1 (page 17).
-	req, err := http.NewRequest("GET", d.url.String(), nil)
+	req, err := http.NewRequest(http.MethodGet, d.url.String(), nil)
 	if err != nil {
 		return nil, "", err
 	}

--- a/staging/src/k8s.io/client-go/util/testing/fake_handler_test.go
+++ b/staging/src/k8s.io/client-go/util/testing/fake_handler_test.go
@@ -109,7 +109,7 @@ func TestFakeHandlerWrongMethod(t *testing.T) {
 	path := "/foo/bar"
 	fakeT := fakeError{}
 
-	req, err := http.NewRequest("PUT", server.URL+path, nil)
+	req, err := http.NewRequest(http.MethodPut, server.URL+path, nil)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}

--- a/staging/src/k8s.io/component-base/metrics/legacyregistry/registry_test.go
+++ b/staging/src/k8s.io/component-base/metrics/legacyregistry/registry_test.go
@@ -32,7 +32,7 @@ func TestProcessStartTimeHeader(t *testing.T) {
 	now := time.Now()
 	handler := Handler()
 
-	request, _ := http.NewRequest("GET", "/", nil)
+	request, _ := http.NewRequest(http.MethodGet, "/", nil)
 	writer := httptest.NewRecorder()
 	handler.ServeHTTP(writer, request)
 	got := writer.Header().Get(processStartTimeHeader)

--- a/staging/src/k8s.io/controller-manager/pkg/healthz/handler_test.go
+++ b/staging/src/k8s.io/controller-manager/pkg/healthz/handler_test.go
@@ -109,7 +109,7 @@ func TestMutableHealthzHandler(t *testing.T) {
 			for _, batch := range tc.checkBatches {
 				h.AddHealthChecker(batch...)
 			}
-			req, err := http.NewRequest("GET", fmt.Sprintf("https://example.com%v", tc.path), nil)
+			req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("https://example.com%v", tc.path), nil)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_discovery.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_discovery.go
@@ -225,7 +225,7 @@ func (dm *discoveryManager) fetchFreshDiscoveryForService(gv metav1.GroupVersion
 	// If we have a handler to contact the server for this APIService, and
 	// the cache entry is too old to use, refresh the cache entry now.
 	handler := http.TimeoutHandler(info.handler, 5*time.Second, "request timed out")
-	req, err := http.NewRequest("GET", "/apis", nil)
+	req, err := http.NewRequest(http.MethodGet, "/apis", nil)
 	if err != nil {
 		// NewRequest should not fail, but if it does for some reason,
 		// log it and continue
@@ -320,7 +320,7 @@ func (dm *discoveryManager) fetchFreshDiscoveryForService(gv metav1.GroupVersion
 			path = "/apis/" + gv.Group + "/" + gv.Version
 		}
 
-		req, err := http.NewRequest("GET", path, nil)
+		req, err := http.NewRequest(http.MethodGet, path, nil)
 		if err != nil {
 			// NewRequest should not fail, but if it does for some reason,
 			// log it and continue

--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator/aggregator_test.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator/aggregator_test.go
@@ -598,7 +598,7 @@ func fetchOpenAPI(mux *http.ServeMux) (*spec.Swagger, error) {
 	defer server.Close()
 	client := server.Client()
 
-	req, err := http.NewRequest("GET", server.URL+"/openapi/v2", nil)
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/openapi/v2", nil)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator/downloader.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator/downloader.go
@@ -116,7 +116,7 @@ func (s *Downloader) Download(handler http.Handler, etag string) (returnSpec *sp
 	handler = s.handlerWithUser(handler, &user.DefaultInfo{Name: aggregatorUser})
 	handler = http.TimeoutHandler(handler, specDownloadTimeout, "request timed out")
 
-	req, err := http.NewRequest("GET", "/openapi/v2", nil)
+	req, err := http.NewRequest(http.MethodGet, "/openapi/v2", nil)
 	if err != nil {
 		return nil, "", 0, err
 	}

--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapiv3/aggregator/aggregator_test.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapiv3/aggregator/aggregator_test.go
@@ -298,7 +298,7 @@ apiserver_request_total{code="200",component="",dry_run="",group="",resource="",
 }
 
 func sendReq(t *testing.T, handler http.Handler, path string) []byte {
-	req, err := http.NewRequest("GET", path, nil)
+	req, err := http.NewRequest(http.MethodGet, path, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapiv3/aggregator/downloader.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapiv3/aggregator/downloader.go
@@ -55,7 +55,7 @@ func (s *Downloader) OpenAPIV3Root(handler http.Handler) (*handler3.OpenAPIV3Dis
 	handler = s.handlerWithUser(handler, &user.DefaultInfo{Name: aggregatorUser})
 	handler = http.TimeoutHandler(handler, specDownloadTimeout, "request timed out")
 
-	req, err := http.NewRequest("GET", "/openapi/v3", nil)
+	req, err := http.NewRequest(http.MethodGet, "/openapi/v3", nil)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/remote/remote_available_controller.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/remote/remote_available_controller.go
@@ -298,7 +298,7 @@ func (c *AvailableConditionController) sync(key string) error {
 				errCh := make(chan error, 1)
 				go func() {
 					// be sure to check a URL that the aggregated API server is required to serve
-					newReq, err := http.NewRequest("GET", discoveryURL.String(), nil)
+					newReq, err := http.NewRequest(http.MethodGet, discoveryURL.String(), nil)
 					if err != nil {
 						errCh <- err
 						return

--- a/test/e2e/apimachinery/crd_publish_openapi.go
+++ b/test/e2e/apimachinery/crd_publish_openapi.go
@@ -652,7 +652,7 @@ func waitForOpenAPISchema(c k8sclientset.Interface, pred func(*spec.Swagger) (bo
 	if err := wait.Poll(500*time.Millisecond, 60*time.Second, mustSucceedMultipleTimes(waitSuccessThreshold, func() (bool, error) {
 		// download spec with etag support
 		spec := &spec.Swagger{}
-		req, err := http.NewRequest("GET", url.String(), nil)
+		req, err := http.NewRequest(http.MethodGet, url.String(), nil)
 		if err != nil {
 			return false, err
 		}

--- a/test/e2e/framework/websocket/websocket_util.go
+++ b/test/e2e/framework/websocket/websocket_util.go
@@ -69,7 +69,7 @@ func headersForConfig(c *restclient.Config, url *url.URL) (http.Header, error) {
 	if err != nil {
 		return nil, err
 	}
-	request, err := http.NewRequest("GET", url.String(), nil)
+	request, err := http.NewRequest(http.MethodGet, url.String(), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e_node/kubeletconfig/kubeletconfig.go
+++ b/test/e2e_node/kubeletconfig/kubeletconfig.go
@@ -154,7 +154,7 @@ func pollConfigz(ctx context.Context, timeout time.Duration, pollInterval time.D
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	}
 	client := &http.Client{Transport: tr}
-	req, err := http.NewRequest("GET", endpoint, nil)
+	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
 	framework.ExpectNoError(err)
 	if !useProxy {
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", framework.TestContext.BearerToken))

--- a/test/e2e_node/plugins/gcp-credential-provider/provider.go
+++ b/test/e2e_node/plugins/gcp-credential-provider/provider.go
@@ -84,7 +84,7 @@ func (p *provider) Provide(image string) (map[string]credentialproviderv1.AuthCo
 }
 
 func readURL(url string, client *http.Client) (body []byte, err error) {
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e_node/services/util.go
+++ b/test/e2e_node/services/util.go
@@ -94,7 +94,7 @@ func readinessCheck(name string, urls []string, errCh <-chan error) error {
 // Perform a health check. Anything other than a 200-response is treated as a failure.
 // Only returns non-recoverable errors.
 func healthCheck(client *http.Client, url string) bool {
-	req, err := http.NewRequest("HEAD", url, nil)
+	req, err := http.NewRequest(http.MethodHead, url, nil)
 	if err != nil {
 		return false
 	}

--- a/test/e2e_node/standalone_test.go
+++ b/test/e2e_node/standalone_test.go
@@ -155,7 +155,7 @@ func getPodFromStandaloneKubelet(ctx context.Context, podNamespace string, podNa
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	}
 	client := &http.Client{Transport: tr}
-	req, err := http.NewRequest("GET", endpoint, nil)
+	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
 	framework.ExpectNoError(err)
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", framework.TestContext.BearerToken))
 	req.Header.Add("Accept", "application/json")

--- a/test/e2e_node/util.go
+++ b/test/e2e_node/util.go
@@ -468,7 +468,7 @@ func kubeletHealthCheck(url string) bool {
 		Transport: insecureTransport,
 	}
 
-	req, err := http.NewRequest("HEAD", url, nil)
+	req, err := http.NewRequest(http.MethodHead, url, nil)
 	if err != nil {
 		return false
 	}

--- a/test/images/agnhost/crd-conversion-webhook/converter/converter_test.go
+++ b/test/images/agnhost/crd-conversion-webhook/converter/converter_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
@@ -76,7 +76,7 @@ request:
 			sampleObj := fmt.Sprintf(sampleObjTemplate, tc.apiVersion)
 			// First try json, it should fail as the data is taml
 			response := httptest.NewRecorder()
-			request, err := http.NewRequest("POST", "/convert", strings.NewReader(sampleObj))
+			request, err := http.NewRequest(http.MethodPost, "/convert", strings.NewReader(sampleObj))
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/test/integration/apimachinery/watch_timeout_test.go
+++ b/test/integration/apimachinery/watch_timeout_test.go
@@ -60,7 +60,7 @@ func headersForConfig(c *restclient.Config, url *url.URL) (http.Header, error) {
 	if err != nil {
 		return nil, err
 	}
-	request, err := http.NewRequest("GET", url.String(), nil)
+	request, err := http.NewRequest(http.MethodGet, url.String(), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/test/integration/apiserver/apiserver_test.go
+++ b/test/integration/apiserver/apiserver_test.go
@@ -251,7 +251,7 @@ func TestCacheControl(t *testing.T) {
 	}
 	for _, path := range paths {
 		t.Run(path, func(t *testing.T) {
-			req, err := http.NewRequest("GET", server.ClientConfig.Host+path, nil)
+			req, err := http.NewRequest(http.MethodGet, server.ClientConfig.Host+path, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -297,7 +297,7 @@ func TestHSTS(t *testing.T) {
 	}
 	for _, path := range paths {
 		t.Run(path, func(t *testing.T) {
-			req, err := http.NewRequest("GET", server.ClientConfig.Host+path, nil)
+			req, err := http.NewRequest(http.MethodGet, server.ClientConfig.Host+path, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -3127,7 +3127,7 @@ func TestAllowedEmulationVersions(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			req, err := http.NewRequest("GET", server.ClientConfig.Host+"/", nil)
+			req, err := http.NewRequest(http.MethodGet, server.ClientConfig.Host+"/", nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -3189,7 +3189,7 @@ func TestEnableEmulationVersion(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.path, func(t *testing.T) {
-			req, err := http.NewRequest("GET", server.ClientConfig.Host+tc.path, nil)
+			req, err := http.NewRequest(http.MethodGet, server.ClientConfig.Host+tc.path, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -3250,7 +3250,7 @@ func TestDisableEmulationVersion(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.path, func(t *testing.T) {
-			req, err := http.NewRequest("GET", server.ClientConfig.Host+tc.path, nil)
+			req, err := http.NewRequest(http.MethodGet, server.ClientConfig.Host+tc.path, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/test/integration/apiserver/openapi/openapi_enum_test.go
+++ b/test/integration/apiserver/openapi/openapi_enum_test.go
@@ -88,7 +88,7 @@ func TestEnablingOpenAPIEnumTypes(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			req, err := http.NewRequest("GET", kubeConfig.Host+"/openapi/v2", nil)
+			req, err := http.NewRequest(http.MethodGet, kubeConfig.Host+"/openapi/v2", nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/test/integration/apiserver/openapi/openapiv3_test.go
+++ b/test/integration/apiserver/openapi/openapiv3_test.go
@@ -62,7 +62,7 @@ func TestOpenAPIV3SpecRoundTrip(t *testing.T) {
 			}
 			// attempt to fetch and unmarshal
 			url := kubeConfig.Host + "/openapi/v3" + path
-			req, err := http.NewRequest("GET", url, nil)
+			req, err := http.NewRequest(http.MethodGet, url, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -195,7 +195,7 @@ func TestOpenAPIV3ProtoRoundtrip(t *testing.T) {
 		t.Fatal(err)
 	}
 	// attempt to fetch and unmarshal
-	req, err := http.NewRequest("GET", kubeConfig.Host+"/openapi/v3/apis/apps/v1", nil)
+	req, err := http.NewRequest(http.MethodGet, kubeConfig.Host+"/openapi/v3/apis/apps/v1", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -214,7 +214,7 @@ func TestOpenAPIV3ProtoRoundtrip(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	protoReq, err := http.NewRequest("GET", kubeConfig.Host+"/openapi/v3/apis/apps/v1", nil)
+	protoReq, err := http.NewRequest(http.MethodGet, kubeConfig.Host+"/openapi/v3/apis/apps/v1", nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/apiserver/portforward/portforward_test.go
+++ b/test/integration/apiserver/portforward/portforward_test.go
@@ -164,7 +164,7 @@ func TestPortforward(t *testing.T) {
 
 	timeoutContext, cleanupTimeoutContext := context.WithDeadline(context.Background(), time.Now().Add(5*time.Second))
 	defer cleanupTimeoutContext()
-	testReq, _ := http.NewRequest("GET", fmt.Sprintf("http://127.0.0.1:%s/test", localPort), nil)
+	testReq, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("http://127.0.0.1:%s/test", localPort), nil)
 	testReq = testReq.WithContext(timeoutContext)
 	testResp, err := http.DefaultClient.Do(testReq)
 	if err != nil {

--- a/test/integration/controlplane/synthetic_controlplane_test.go
+++ b/test/integration/controlplane/synthetic_controlplane_test.go
@@ -63,7 +63,7 @@ func testPrefix(t *testing.T, prefix string) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	req, err := http.NewRequest("GET", server.ClientConfig.Host+prefix, nil)
+	req, err := http.NewRequest(http.MethodGet, server.ClientConfig.Host+prefix, nil)
 	if err != nil {
 		t.Fatalf("couldn't create a request: %v", err)
 	}
@@ -118,7 +118,7 @@ func TestEmptyList(t *testing.T) {
 	}
 
 	u := server.ClientConfig.Host + "/api/v1/namespaces/default/pods"
-	req, err := http.NewRequest("GET", u, nil)
+	req, err := http.NewRequest(http.MethodGet, u, nil)
 	if err != nil {
 		t.Fatalf("couldn't create a request: %v", err)
 	}
@@ -210,7 +210,7 @@ func TestStatus(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			req, err := http.NewRequest("GET", kubeConfig.Host+tc.reqPath, nil)
+			req, err := http.NewRequest(http.MethodGet, kubeConfig.Host+tc.reqPath, nil)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -388,7 +388,7 @@ func TestWatchSucceedsWithoutArgs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	req, err := http.NewRequest("GET", server.ClientConfig.Host+"/api/v1/namespaces?watch=1", nil)
+	req, err := http.NewRequest(http.MethodGet, server.ClientConfig.Host+"/api/v1/namespaces?watch=1", nil)
 	if err != nil {
 		t.Fatalf("couldn't create a request: %v", err)
 	}
@@ -580,7 +580,7 @@ func TestAccept(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	req, err := http.NewRequest("GET", server.ClientConfig.Host+"/api/", nil)
+	req, err := http.NewRequest(http.MethodGet, server.ClientConfig.Host+"/api/", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -600,7 +600,7 @@ func TestAccept(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	req, err = http.NewRequest("GET", server.ClientConfig.Host+"/api/", nil)
+	req, err = http.NewRequest(http.MethodGet, server.ClientConfig.Host+"/api/", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -619,7 +619,7 @@ func TestAccept(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	req, err = http.NewRequest("GET", server.ClientConfig.Host+"/api/", nil)
+	req, err = http.NewRequest(http.MethodGet, server.ClientConfig.Host+"/api/", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -638,7 +638,7 @@ func TestAccept(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	req, err = http.NewRequest("GET", server.ClientConfig.Host+"/api/", nil)
+	req, err = http.NewRequest(http.MethodGet, server.ClientConfig.Host+"/api/", nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/scheduler/serving/healthcheck_test.go
+++ b/test/integration/scheduler/serving/healthcheck_test.go
@@ -137,7 +137,7 @@ func TestHealthEndpoints(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to get client from test server: %v", err)
 			}
-			req, err := http.NewRequest("GET", base+tt.path, nil)
+			req, err := http.NewRequest(http.MethodGet, base+tt.path, nil)
 			if err != nil {
 				t.Fatalf("failed to request: %v", err)
 			}

--- a/test/integration/serving/serving_test.go
+++ b/test/integration/serving/serving_test.go
@@ -255,7 +255,7 @@ func testComponentWithSecureServing(t *testing.T, tester componentTester, kubeco
 				}
 
 				client := &http.Client{Transport: tr}
-				req, err := http.NewRequest("GET", url, nil)
+				req, err := http.NewRequest(http.MethodGet, url, nil)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/test/integration/tls/ciphers_test.go
+++ b/test/integration/tls/ciphers_test.go
@@ -70,7 +70,7 @@ func runTestAPICiphers(t *testing.T, testID int, kubePort int, clientCiphers []u
 		},
 	}
 	client := &http.Client{Transport: tr}
-	req, err := http.NewRequest("GET", fmt.Sprintf("https://127.0.0.1:%d", kubePort), nil)
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("https://127.0.0.1:%d", kubePort), nil)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
#### What type of PR is this?

/area test
/kind cleanup
/priority backlog
/sig testing

#### What this PR does / why we need it:

This replaces "GET" and "POST" by http.MethodGet and http.MethodPost in `http.NewRequest()` calls it's part of [usestdlibvars](https://golangci-lint.run/usage/linters/#usestdlibvars)

<!-- Signed-off-by: Matthieu MOREL <matthieu.morel35@gmail.com> -->

