### PR TITLE
disable caching for authoritative zone to comply with rfc-1035 section 6.1.2

### DIFF
--- a/cmd/kubeadm/app/phases/addons/dns/dns_test.go
+++ b/cmd/kubeadm/app/phases/addons/dns/dns_test.go
@@ -184,7 +184,10 @@ func TestCreateCoreDNSAddon(t *testing.T) {
     forward . /etc/resolv.conf {
        max_concurrent 1000
     }
-    cache 30
+    cache 30 {
+       disable success cluster.local
+       disable denial cluster.local
+    }
     loop
     reload
     loadbalance
@@ -228,7 +231,10 @@ func TestCreateCoreDNSAddon(t *testing.T) {
     forward . /etc/resolv.conf {
        max_concurrent 1000
     }
-    cache 30
+    cache 30 {
+       disable success cluster.local
+       disable denial cluster.local
+    }
     loop
     reload
     loadbalance
@@ -314,7 +320,10 @@ func TestCreateCoreDNSAddon(t *testing.T) {
     forward . /etc/resolv.conf {
        max_concurrent 1000
     }
-    cache 30
+    cache 30 {
+       disable success cluster.local
+       disable denial cluster.local
+    }
     loop
     reload
     loadbalance

--- a/cmd/kubeadm/app/phases/addons/dns/manifests.go
+++ b/cmd/kubeadm/app/phases/addons/dns/manifests.go
@@ -178,6 +178,11 @@ data:
            max_concurrent 1000
         }
         cache 30
+        {{- if .DNSDomain }} {
+           disable success {{ .DNSDomain }}
+           disable denial {{ .DNSDomain }}
+        }
+        {{- end }}
         loop
         reload
         loadbalance


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
It changes the kubernetes plugin configuration in the coredns Corefile to disable caching for the domain which the plugin is authoritative for.

Coredns delegates responsibility to plugins which it chains together. Currently a `cache` plugin is earlier in the chain than the `kubernetes` plugin. This combined with the current Corefile has undesirable consequences such as being slow to reflect changes in the environment and the possibility of providing conflicting responses around the time of a cache update.

Without this change coredns will be misconfigured according to RFC 1035 (6.1.2 name server implementation, database):
> With the proper search procedures, authoritative data in zones
     will always "hide", and hence take precedence over, cached
     data.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #128325
Fixes #92559

See also:
https://github.com/kubernetes/kubernetes/issues/92559#issuecomment-1203320093
https://github.com/coredns/coredns/issues/6937#issuecomment-2439731989
https://github.com/coredns/coredns/pull/6939#issuecomment-2439756769
https://github.com/coredns/coredns/pull/5540

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: added "disable success" and "disable denial" as parameters of the "cache" plugin in the Corefile managed by kubeadm. This is to prevent conflicting responses during CoreDNS cache updates.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
