### PR TITLE
KEP-4603: Refactor various hardcoded backoffs into separate constants

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -196,10 +196,10 @@ const (
 	// error.
 	backOffPeriod = time.Second * 10
 
-	// base period for the exponential backoff for container restarts.
+	// Initial period for the exponential backoff for container restarts.
 	containerBackOffPeriod = time.Second * 10
 
-	// base period for the exponential backoff for image pulls.
+	// Initial period for the exponential backoff for image pulls.
 	imageBackOffPeriod = time.Second * 10
 
 	// ContainerGCPeriod is the period for performing container garbage collection.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/kind feature


#### What this PR does / why we need it:
Refactors the various backoff parameters used to initialize different backoff objects by kubelet into separate constants. This is to prepare for future PRs (https://github.com/kubernetes/kubernetes/pull/128374, and second one forthcoming) where only the parameters for the backoff object initialized for container restarts is changed as part of KEP-4603.

#### Which issue(s) this PR fixes:
Partial for https://github.com/kubernetes/enhancements/issues/4603, specifically [this section](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/4603-tune-crashloopbackoff/README.md#relationship-with-imagepullbackoff).

#### Special notes for your reviewer:
👋  **NOTE**: This commit is also in the derivative PR https://github.com/kubernetes/kubernetes/pull/128369, but I separated them so this can be seen clearly/tested clearly separately and approved separately given it has no behavior change.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
**N/A**
```docs

```
