### PR TITLE
DRA: add wg/device-management label automatically

### DIFF
--- a/pkg/apis/resource/OWNERS
+++ b/pkg/apis/resource/OWNERS
@@ -4,3 +4,5 @@ reviewers:
   - bart0sh
   - klueska
   - pohly
+labels:
+  - wg/device-management

--- a/pkg/controller/resourceclaim/OWNERS
+++ b/pkg/controller/resourceclaim/OWNERS
@@ -10,3 +10,4 @@ reviewers:
   - bart0sh
 labels:
   - sig/node
+  - wg/device-management

--- a/pkg/kubelet/cm/dra/OWNERS
+++ b/pkg/kubelet/cm/dra/OWNERS
@@ -1,0 +1,2 @@
+labels:
+  - wg/device-management

--- a/pkg/registry/resource/OWNERS
+++ b/pkg/registry/resource/OWNERS
@@ -4,3 +4,5 @@ reviewers:
   - bart0sh
   - klueska
   - pohly
+labels:
+  - wg/device-management

--- a/pkg/scheduler/framework/plugins/dynamicresources/OWNERS
+++ b/pkg/scheduler/framework/plugins/dynamicresources/OWNERS
@@ -6,3 +6,4 @@ reviewers:
   - bart0sh
 labels:
   - sig/node
+  - wg/device-management

--- a/staging/src/k8s.io/dynamic-resource-allocation/OWNERS
+++ b/staging/src/k8s.io/dynamic-resource-allocation/OWNERS
@@ -9,3 +9,4 @@ reviewers:
   - bart0sh
 labels:
   - sig/node
+  - wg/device-management

--- a/staging/src/k8s.io/kubelet/pkg/apis/dra/OWNERS
+++ b/staging/src/k8s.io/kubelet/pkg/apis/dra/OWNERS
@@ -9,3 +9,4 @@ reviewers:
   - bart0sh
 labels:
   - sig/node
+  - wg/device-management

--- a/test/e2e/dra/OWNERS
+++ b/test/e2e/dra/OWNERS
@@ -9,3 +9,4 @@ reviewers:
   - bart0sh
 labels:
   - sig/node
+  - wg/device-management


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This makes PRs show up automatically in the WG's project board (https://github.com/orgs/kubernetes/projects/95/views/1).

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
