### PR TITLE
[WIP] KEP-4963: Kube-proxy Services Acceleration

### DIFF
--- a/cmd/kube-proxy/app/options.go
+++ b/cmd/kube-proxy/app/options.go
@@ -171,6 +171,8 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.Int32Var(&o.metricsPort, "metrics-port", o.metricsPort, "The port to bind the metrics server. Use 0 to disable.")
 	_ = fs.MarkDeprecated("metrics-port", "This flag is deprecated and will be removed in a future release. Please use --metrics-bind-address instead.")
 
+	fs.Int32Var(o.config.NFTables.FastpathPacketThreshold, "fastpath-packet-threshold", ptr.Deref(o.config.NFTables.FastpathPacketThreshold, 20),
+		"Number of packets required for the proxy to offload the connection to the fastpath. Use 0 to disable.")
 	logsapi.AddFlags(&o.config.Logging, fs)
 }
 

--- a/cmd/kube-proxy/app/server_linux.go
+++ b/cmd/kube-proxy/app/server_linux.go
@@ -305,6 +305,7 @@ func (s *ProxyServer) createProxier(ctx context.Context, config *proxyconfigapi.
 				s.Recorder,
 				s.HealthzServer,
 				config.NodePortAddresses,
+				int(*config.NFTables.FastpathPacketThreshold),
 				initOnly,
 			)
 		} else {
@@ -323,6 +324,7 @@ func (s *ProxyServer) createProxier(ctx context.Context, config *proxyconfigapi.
 				s.Recorder,
 				s.HealthzServer,
 				config.NodePortAddresses,
+				int(*config.NFTables.FastpathPacketThreshold),
 				initOnly,
 			)
 		}

--- a/go.mod
+++ b/go.mod
@@ -121,7 +121,7 @@ require (
 	k8s.io/sample-apiserver v0.0.0
 	k8s.io/system-validators v1.9.1
 	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738
-	sigs.k8s.io/knftables v0.0.17
+	sigs.k8s.io/knftables v0.0.18
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.2
 	sigs.k8s.io/yaml v1.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -669,8 +669,8 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.0 h1:CPT0ExVicCzcp
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.0/go.mod h1:Ve9uj1L+deCXFrPOk1LpFXqTg7LCFzFso6PA48q/XZw=
 sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 h1:/Rv+M11QRah1itp8VhT6HoVx1Ray9eB4DBr+K+/sCJ8=
 sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3/go.mod h1:18nIHnGi6636UCz6m8i4DhaJ65T6EruyzmoQqI2BVDo=
-sigs.k8s.io/knftables v0.0.17 h1:wGchTyRF/iGTIjd+vRaR1m676HM7jB8soFtyr/148ic=
-sigs.k8s.io/knftables v0.0.17/go.mod h1:f/5ZLKYEUPUhVjUCg6l80ACdL7CIIyeL0DxfgojGRTk=
+sigs.k8s.io/knftables v0.0.18 h1:6Duvmu0s/HwGifKrtl6G3AyAPYlWiZqTgS8bkVMiyaE=
+sigs.k8s.io/knftables v0.0.18/go.mod h1:f/5ZLKYEUPUhVjUCg6l80ACdL7CIIyeL0DxfgojGRTk=
 sigs.k8s.io/kustomize/api v0.18.0 h1:hTzp67k+3NEVInwz5BHyzc9rGxIauoXferXyjv5lWPo=
 sigs.k8s.io/kustomize/api v0.18.0/go.mod h1:f8isXnX+8b+SGLHQ6yO4JG1rdkZlvhaCf/uZbLVMb0U=
 sigs.k8s.io/kustomize/cmd/config v0.15.0/go.mod h1:Jq57b0nPaoYUlOqg//0JtAh6iibboqMcfbtCYoWPM00=

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -61964,8 +61964,15 @@ func schema_k8sio_kube_proxy_config_v1alpha1_KubeProxyNFTablesConfiguration(ref 
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Duration"),
 						},
 					},
+					"fastpathPacketThreshold": {
+						SchemaProps: spec.SchemaProps{
+							Description: "FastpathPacketThreshold is the number of packets untile the proxy starts offloading the connection to the fast path and skipping the kernel stack. Set to 0 to disable it.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
 				},
-				Required: []string{"masqueradeBit", "masqueradeAll", "syncPeriod", "minSyncPeriod"},
+				Required: []string{"masqueradeBit", "masqueradeAll", "syncPeriod", "minSyncPeriod", "fastpathPacketThreshold"},
 			},
 		},
 		Dependencies: []string{

--- a/pkg/proxy/apis/config/scheme/testdata/KubeProxyConfiguration/after/v1alpha1.yaml
+++ b/pkg/proxy/apis/config/scheme/testdata/KubeProxyConfiguration/after/v1alpha1.yaml
@@ -52,6 +52,7 @@ logging:
 metricsBindAddress: 127.0.0.1:10249
 mode: ""
 nftables:
+  fastpathPacketThreshold: 20
   masqueradeAll: false
   masqueradeBit: 14
   minSyncPeriod: 0s

--- a/pkg/proxy/apis/config/scheme/testdata/KubeProxyConfiguration/roundtrip/default/v1alpha1.yaml
+++ b/pkg/proxy/apis/config/scheme/testdata/KubeProxyConfiguration/roundtrip/default/v1alpha1.yaml
@@ -52,6 +52,7 @@ logging:
 metricsBindAddress: 127.0.0.1:10249
 mode: ""
 nftables:
+  fastpathPacketThreshold: 20
   masqueradeAll: false
   masqueradeBit: 14
   minSyncPeriod: 0s

--- a/pkg/proxy/apis/config/types.go
+++ b/pkg/proxy/apis/config/types.go
@@ -83,6 +83,11 @@ type KubeProxyNFTablesConfiguration struct {
 	// masqueradeBit is the bit of the iptables fwmark space to use for SNAT if using
 	// the nftables proxy mode. Values must be within the range [0, 31].
 	MasqueradeBit *int32
+
+	// FastpathPacketThreshold is the number of packets untile the proxy starts offloading
+	// the connection to the fast path and skipping the kernel stack.
+	// Set to 0 to disable it.
+	FastpathPacketThreshold *int32
 }
 
 // KubeProxyConntrackConfiguration contains conntrack settings for

--- a/pkg/proxy/apis/config/v1alpha1/defaults.go
+++ b/pkg/proxy/apis/config/v1alpha1/defaults.go
@@ -132,6 +132,14 @@ func SetDefaults_KubeProxyConfiguration(obj *kubeproxyconfigv1alpha1.KubeProxyCo
 	if obj.ClientConnection.Burst == 0 {
 		obj.ClientConnection.Burst = 10
 	}
+	if obj.NFTables.FastpathPacketThreshold == nil {
+		// Number of packets required to offload the connection to the fastpath.
+		// Short connections will not benefit much from the switch to fastpath,
+		// so we consider that a connection that has exchanged more than 20 packets
+		// in each direction should be offloaded by default.
+		temp := int32(20)
+		obj.NFTables.FastpathPacketThreshold = &temp
+	}
 	if obj.FeatureGates == nil {
 		obj.FeatureGates = make(map[string]bool)
 	}

--- a/pkg/proxy/apis/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/proxy/apis/config/v1alpha1/zz_generated.conversion.go
@@ -293,11 +293,13 @@ func autoConvert_v1alpha1_KubeProxyNFTablesConfiguration_To_config_KubeProxyNFTa
 	// WARNING: in.MasqueradeAll requires manual conversion: does not exist in peer-type
 	// WARNING: in.SyncPeriod requires manual conversion: does not exist in peer-type
 	// WARNING: in.MinSyncPeriod requires manual conversion: does not exist in peer-type
+	out.FastpathPacketThreshold = (*int32)(unsafe.Pointer(in.FastpathPacketThreshold))
 	return nil
 }
 
 func autoConvert_config_KubeProxyNFTablesConfiguration_To_v1alpha1_KubeProxyNFTablesConfiguration(in *config.KubeProxyNFTablesConfiguration, out *configv1alpha1.KubeProxyNFTablesConfiguration, s conversion.Scope) error {
 	out.MasqueradeBit = (*int32)(unsafe.Pointer(in.MasqueradeBit))
+	out.FastpathPacketThreshold = (*int32)(unsafe.Pointer(in.FastpathPacketThreshold))
 	return nil
 }
 

--- a/pkg/proxy/apis/config/zz_generated.deepcopy.go
+++ b/pkg/proxy/apis/config/zz_generated.deepcopy.go
@@ -214,6 +214,11 @@ func (in *KubeProxyNFTablesConfiguration) DeepCopyInto(out *KubeProxyNFTablesCon
 		*out = new(int32)
 		**out = **in
 	}
+	if in.FastpathPacketThreshold != nil {
+		in, out := &in.FastpathPacketThreshold, &out.FastpathPacketThreshold
+		*out = new(int32)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/proxy/nftables/helpers_test.go
+++ b/pkg/proxy/nftables/helpers_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/lithammer/dedent"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	netutils "k8s.io/utils/net"
 	"sigs.k8s.io/knftables"
@@ -286,6 +286,9 @@ var ignoredRegexp = regexp.MustCompile(strings.Join(
 		// The trace tests only check new connections, so for our purposes, this
 		// check always succeeds (and thus can be ignored).
 		`^ct state new`,
+
+		// The trace tests does not check flowtables offloading
+		`^.*flow offload.*$`,
 	},
 	"|",
 ))

--- a/staging/src/k8s.io/kube-proxy/config/v1alpha1/types.go
+++ b/staging/src/k8s.io/kube-proxy/config/v1alpha1/types.go
@@ -94,6 +94,10 @@ type KubeProxyNFTablesConfiguration struct {
 	// '1m', '2h22m'). A value of 0 means every Service or EndpointSlice change will
 	// result in an immediate iptables resync.
 	MinSyncPeriod metav1.Duration `json:"minSyncPeriod"`
+	// FastpathPacketThreshold is the number of packets untile the proxy starts offloading
+	// the connection to the fast path and skipping the kernel stack.
+	// Set to 0 to disable it.
+	FastpathPacketThreshold *int32 `json:"fastpathPacketThreshold"`
 }
 
 // KubeProxyConntrackConfiguration contains conntrack settings for

--- a/staging/src/k8s.io/kube-proxy/config/v1alpha1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/kube-proxy/config/v1alpha1/zz_generated.deepcopy.go
@@ -195,6 +195,11 @@ func (in *KubeProxyNFTablesConfiguration) DeepCopyInto(out *KubeProxyNFTablesCon
 	}
 	out.SyncPeriod = in.SyncPeriod
 	out.MinSyncPeriod = in.MinSyncPeriod
+	if in.FastpathPacketThreshold != nil {
+		in, out := &in.FastpathPacketThreshold, &out.FastpathPacketThreshold
+		*out = new(int32)
+		**out = **in
+	}
 	return
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1154,7 +1154,7 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client/proto/client
 ## explicit; go 1.21
 sigs.k8s.io/json
 sigs.k8s.io/json/internal/golang/encoding/json
-# sigs.k8s.io/knftables v0.0.17
+# sigs.k8s.io/knftables v0.0.18
 ## explicit; go 1.20
 sigs.k8s.io/knftables
 # sigs.k8s.io/kustomize/api v0.18.0

--- a/vendor/sigs.k8s.io/knftables/CHANGELOG.md
+++ b/vendor/sigs.k8s.io/knftables/CHANGELOG.md
@@ -1,5 +1,16 @@
 # ChangeLog
 
+## v0.0.18
+
+- Added locking to `Fake` to allow it to be safely used concurrently.
+  (`@npinaeva`)
+
+- Added a `Flowtable` object, and `Fake` support for correctly parsing
+  flowtable references. (`@aojea`)
+
+- Fixed a bug in `Fake.ParseDump`, which accidentally required the
+  table to have a comment. (`@danwinship`)
+
 ## v0.0.17
 
 - `ListRules()` now accepts `""` for the chain name, meaning to list

--- a/vendor/sigs.k8s.io/knftables/README.md
+++ b/vendor/sigs.k8s.io/knftables/README.md
@@ -134,6 +134,7 @@ The `Transaction` methods take arguments of type `knftables.Object`.
 The currently-supported objects are:
 
 - `Table`
+- `Flowtable`
 - `Chain`
 - `Rule`
 - `Set`

--- a/vendor/sigs.k8s.io/knftables/fake.go
+++ b/vendor/sigs.k8s.io/knftables/fake.go
@@ -23,26 +23,36 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"sync"
 )
 
 // Fake is a fake implementation of Interface
 type Fake struct {
 	nftContext
+	// mutex is used to protect Table and LastTransaction.
+	// When Table and LastTransaction are accessed directly, the caller must acquire Fake.RLock
+	// and release when finished.
+	sync.RWMutex
 
 	nextHandle int
 
 	// Table contains the Interface's table. This will be `nil` until you `tx.Add()`
 	// the table.
+	// Make sure to acquire Fake.RLock before accessing Table in a concurrent environment.
 	Table *FakeTable
 
 	// LastTransaction is the last transaction passed to Run(). It will remain set until the
 	// next time Run() is called. (It is not affected by Check().)
+	// Make sure to acquire Fake.RLock before accessing LastTransaction in a concurrent environment.
 	LastTransaction *Transaction
 }
 
 // FakeTable wraps Table for the Fake implementation
 type FakeTable struct {
 	Table
+
+	// Flowtables contains the table's flowtables, keyed by name
+	Flowtables map[string]*FakeFlowtable
 
 	// Chains contains the table's chains, keyed by name
 	Chains map[string]*FakeChain
@@ -52,6 +62,11 @@ type FakeTable struct {
 
 	// Maps contains the table's maps, keyed by name
 	Maps map[string]*FakeMap
+}
+
+// FakeFlowtable wraps Flowtable for the Fake implementation
+type FakeFlowtable struct {
+	Flowtable
 }
 
 // FakeChain wraps Chain for the Fake implementation
@@ -94,6 +109,8 @@ var _ Interface = &Fake{}
 
 // List is part of Interface.
 func (fake *Fake) List(_ context.Context, objectType string) ([]string, error) {
+	fake.RLock()
+	defer fake.RUnlock()
 	if fake.Table == nil {
 		return nil, notFoundError("no such table %q", fake.table)
 	}
@@ -101,6 +118,10 @@ func (fake *Fake) List(_ context.Context, objectType string) ([]string, error) {
 	var result []string
 
 	switch objectType {
+	case "flowtable", "flowtables":
+		for name := range fake.Table.Flowtables {
+			result = append(result, name)
+		}
 	case "chain", "chains":
 		for name := range fake.Table.Chains {
 			result = append(result, name)
@@ -123,6 +144,8 @@ func (fake *Fake) List(_ context.Context, objectType string) ([]string, error) {
 
 // ListRules is part of Interface
 func (fake *Fake) ListRules(_ context.Context, chain string) ([]*Rule, error) {
+	fake.RLock()
+	defer fake.RUnlock()
 	if fake.Table == nil {
 		return nil, notFoundError("no such table %q", fake.table)
 	}
@@ -145,6 +168,8 @@ func (fake *Fake) ListRules(_ context.Context, chain string) ([]*Rule, error) {
 
 // ListElements is part of Interface
 func (fake *Fake) ListElements(_ context.Context, objectType, name string) ([]*Element, error) {
+	fake.RLock()
+	defer fake.RUnlock()
 	if fake.Table == nil {
 		return nil, notFoundError("no such %s %q", objectType, name)
 	}
@@ -169,6 +194,8 @@ func (fake *Fake) NewTransaction() *Transaction {
 
 // Run is part of Interface
 func (fake *Fake) Run(_ context.Context, tx *Transaction) error {
+	fake.Lock()
+	defer fake.Unlock()
 	fake.LastTransaction = tx
 	updatedTable, err := fake.run(tx)
 	if err == nil {
@@ -179,10 +206,13 @@ func (fake *Fake) Run(_ context.Context, tx *Transaction) error {
 
 // Check is part of Interface
 func (fake *Fake) Check(_ context.Context, tx *Transaction) error {
+	fake.RLock()
+	defer fake.RUnlock()
 	_, err := fake.run(tx)
 	return err
 }
 
+// must be called with fake.lock held
 func (fake *Fake) run(tx *Transaction) (*FakeTable, error) {
 	if tx.err != nil {
 		return nil, tx.err
@@ -218,13 +248,37 @@ func (fake *Fake) run(tx *Transaction) (*FakeTable, error) {
 				table := *obj
 				table.Handle = PtrTo(fake.nextHandle)
 				updatedTable = &FakeTable{
-					Table:  table,
-					Chains: make(map[string]*FakeChain),
-					Sets:   make(map[string]*FakeSet),
-					Maps:   make(map[string]*FakeMap),
+					Table:      table,
+					Flowtables: make(map[string]*FakeFlowtable),
+					Chains:     make(map[string]*FakeChain),
+					Sets:       make(map[string]*FakeSet),
+					Maps:       make(map[string]*FakeMap),
 				}
 			case deleteVerb:
 				updatedTable = nil
+			default:
+				return nil, fmt.Errorf("unhandled operation %q", op.verb)
+			}
+
+		case *Flowtable:
+			existingFlowtable := updatedTable.Flowtables[obj.Name]
+			err := checkExists(op.verb, "flowtable", obj.Name, existingFlowtable != nil)
+			if err != nil {
+				return nil, err
+			}
+			switch op.verb {
+			case addVerb, createVerb:
+				if existingFlowtable != nil {
+					continue
+				}
+				flowtable := *obj
+				flowtable.Handle = PtrTo(fake.nextHandle)
+				updatedTable.Flowtables[obj.Name] = &FakeFlowtable{
+					Flowtable: flowtable,
+				}
+			case deleteVerb:
+				// FIXME delete-by-handle
+				delete(updatedTable.Flowtables, obj.Name)
 			default:
 				return nil, fmt.Errorf("unhandled operation %q", op.verb)
 			}
@@ -443,9 +497,13 @@ func checkRuleRefs(rule *Rule, table *FakeTable) error {
 	for i, word := range words {
 		if strings.HasPrefix(word, "@") {
 			name := word[1:]
-			if i > 0 && (words[i] == "map" || words[i] == "vmap") {
+			if i > 0 && (words[i-1] == "map" || words[i-1] == "vmap") {
 				if table.Maps[name] == nil {
 					return notFoundError("no such map %q", name)
+				}
+			} else if i > 0 && words[i-1] == "offload" {
+				if table.Flowtables[name] == nil {
+					return notFoundError("no such flowtable %q", name)
 				}
 			} else {
 				// recent nft lets you use a map in a set lookup
@@ -480,6 +538,8 @@ func checkElementRefs(element *Element, table *FakeTable) error {
 
 // Dump dumps the current contents of fake, in a way that looks like an nft transaction.
 func (fake *Fake) Dump() string {
+	fake.RLock()
+	defer fake.RUnlock()
 	if fake.Table == nil {
 		return ""
 	}
@@ -487,6 +547,7 @@ func (fake *Fake) Dump() string {
 	buf := &strings.Builder{}
 
 	table := fake.Table
+	flowtables := sortKeys(table.Flowtables)
 	chains := sortKeys(table.Chains)
 	sets := sortKeys(table.Sets)
 	maps := sortKeys(table.Maps)
@@ -494,6 +555,10 @@ func (fake *Fake) Dump() string {
 	// Write out all of the object adds first.
 
 	table.writeOperation(addVerb, &fake.nftContext, buf)
+	for _, fname := range flowtables {
+		ft := table.Flowtables[fname]
+		ft.writeOperation(addVerb, &fake.nftContext, buf)
+	}
 	for _, cname := range chains {
 		ch := table.Chains[cname]
 		ch.writeOperation(addVerb, &fake.nftContext, buf)
@@ -550,7 +615,7 @@ func (fake *Fake) ParseDump(data string) (err error) {
 		}
 	}()
 	tx := fake.NewTransaction()
-	commonRegexp := regexp.MustCompile(fmt.Sprintf(`add %s %s %s (.*)`, noSpaceGroup, fake.family, fake.table))
+	commonRegexp := regexp.MustCompile(fmt.Sprintf(`add ([^ ]*) %s %s( (.*))?`, fake.family, fake.table))
 
 	for i, line = range lines {
 		line = strings.TrimSpace(line)
@@ -565,6 +630,8 @@ func (fake *Fake) ParseDump(data string) (err error) {
 		switch match[1] {
 		case "table":
 			obj = &Table{}
+		case "flowtable":
+			obj = &Flowtable{}
 		case "chain":
 			obj = &Chain{}
 		case "rule":
@@ -578,7 +645,7 @@ func (fake *Fake) ParseDump(data string) (err error) {
 		default:
 			return fmt.Errorf("unknown object %s", match[1])
 		}
-		err = obj.parse(match[2])
+		err = obj.parse(match[3])
 		if err != nil {
 			return err
 		}
@@ -623,10 +690,16 @@ func (table *FakeTable) copy() *FakeTable {
 	}
 
 	tcopy := &FakeTable{
-		Table:  table.Table,
-		Chains: make(map[string]*FakeChain),
-		Sets:   make(map[string]*FakeSet),
-		Maps:   make(map[string]*FakeMap),
+		Table:      table.Table,
+		Flowtables: make(map[string]*FakeFlowtable),
+		Chains:     make(map[string]*FakeChain),
+		Sets:       make(map[string]*FakeSet),
+		Maps:       make(map[string]*FakeMap),
+	}
+	for name, flowtable := range table.Flowtables {
+		tcopy.Flowtables[name] = &FakeFlowtable{
+			Flowtable: flowtable.Flowtable,
+		}
 	}
 	for name, chain := range table.Chains {
 		tcopy.Chains[name] = &FakeChain{

--- a/vendor/sigs.k8s.io/knftables/types.go
+++ b/vendor/sigs.k8s.io/knftables/types.go
@@ -382,3 +382,30 @@ type Element struct {
 	// Comment is an optional comment for the element
 	Comment *string
 }
+
+type FlowtableIngressPriority string
+
+const (
+	// FilterIngressPriority is the priority for the filter value in the Ingress hook
+	// that stands for 0.
+	FilterIngressPriority FlowtableIngressPriority = "filter"
+)
+
+// Flowtable represents an nftables flowtable.
+// https://wiki.nftables.org/wiki-nftables/index.php/Flowtables
+type Flowtable struct {
+	// Name is the name of the flowtable.
+	Name string
+
+	// The Priority can be a signed integer or FlowtableIngressPriority which stands for 0.
+	// Addition and subtraction can be used to set relative priority, e.g. filter + 5 equals to 5.
+	Priority *FlowtableIngressPriority
+
+	// The Devices are specified as iifname(s) of the input interface(s) of the traffic
+	// that should be offloaded.
+	Devices []string
+
+	// Handle is an identifier that can be used to uniquely identify an object when
+	// deleting it. When adding a new object, this must be nil
+	Handle *int
+}


### PR DESCRIPTION
/kind feature


```release-note
kube-proxy, on nftables mode, allows to offload the Service traffic to the fastpath defined by the Kernel flowtables infrastructure. Users can define a threshold based on the number packets per connection since the connection will be offloaded by the datapath. Because small connections may not benefit or it can also regress in performance, the default threshold is 20 packets. The feature can be disabled by setting the threshold to 0.
```


Use the netfilter flowtable architecture to offload all the Services
traffic that has been established.

This present some real interesting wins, in a kind cluster using
kube-proxy nftables:

- no offloading
```
[  1] local 10.244.0.8 port 52080 connected with 10.96.117.116 port 5001
[ ID] Interval       Transfer     Bandwidth
[  1] 0.00-1.00 sec  4.64 GBytes  39.9 Gbits/sec
[  1] 1.00-2.00 sec  4.88 GBytes  41.9 Gbits/sec
[  1] 2.00-3.00 sec  4.81 GBytes  41.3 Gbits/sec
[  1] 3.00-4.00 sec  4.75 GBytes  40.8 Gbits/sec
[  1] 4.00-5.00 sec  4.86 GBytes  41.7 Gbits/sec
[  1] 5.00-6.00 sec  4.85 GBytes  41.7 Gbits/sec
[  1] 6.00-7.00 sec  4.91 GBytes  42.2 Gbits/sec
[  1] 7.00-8.00 sec  4.84 GBytes  41.6 Gbits/sec
[  1] 8.00-9.00 sec  4.80 GBytes  41.2 Gbits/sec
[  1] 9.00-10.00 sec  4.75 GBytes  40.8 Gbits/sec
[  1] 0.00-10.01 sec  48.1 GBytes  41.3 Gbits/sec
```
- offloading
```
[  1] local 10.244.0.8 port 53332 connected with 10.96.117.116 port 5001
[ ID] Interval       Transfer     Bandwidth
[  1] 0.00-1.00 sec  5.57 GBytes  47.8 Gbits/sec
[  1] 1.00-2.00 sec  5.52 GBytes  47.4 Gbits/sec
[  1] 2.00-3.00 sec  5.63 GBytes  48.4 Gbits/sec
[  1] 3.00-4.00 sec  5.50 GBytes  47.3 Gbits/sec
[  1] 4.00-5.00 sec  5.53 GBytes  47.5 Gbits/sec
[  1] 5.00-6.00 sec  5.61 GBytes  48.2 Gbits/sec
[  1] 6.00-7.00 sec  5.57 GBytes  47.9 Gbits/sec
[  1] 7.00-8.00 sec  5.65 GBytes  48.5 Gbits/sec
[  1] 8.00-9.00 sec  5.61 GBytes  48.2 Gbits/sec
[  1] 9.00-10.00 sec  5.57 GBytes  47.9 Gbits/sec
[  1] 0.00-10.01 sec  55.8 GBytes  47.9 Gbits/sec
```
https://docs.kernel.org/networking/nf_flowtable.html


## How to test it

1. build a kind node image 
```
kind build node-image
```
2. create a cluster with the new image using nftables proxy

```yaml
kind: Cluster
apiVersion: kind.x-k8s.io/v1alpha4
networking:
  kubeProxyMode: "nftables"
nodes:
- role: control-plane
```
```
kind create cluster --image kindest/node:latest  --config src/yamls/kind-nftables.yaml
```

Edit the kube-proxy config to use flowtables in all interfaces

```
 kubectl edit cm kube-proxy -n kube-system
```

```
    kind: KubeProxyConfiguration
    mode: nftables
    nftables:
      acceleratedInterfaceExpression: "interface.name != \"\""
```

Apply the changes
```
kubectl rollout restart ds kube-proxy -n kube-system
```



3. Deploy two pods, a client and a server
```
 kubectl run client --image=registry.k8s.io/e2e-test-images/agnhost:2.53
 kubectl run server --image=registry.k8s.io/e2e-test-images/agnhost:2.53
```

4. Expose the port 5001 through a Service in pod server
```
 kubectl expose pod server --port=5001
```
5. in one window, set up an iperf server in the server pod
```
 kubectl exec -it server -- iperf -s
```
6. In other window, run an iperf client against the pod IP (IMPORTANT), Pod IP here, this path is not accelerated

```
 kubectl exec -it client -- iperf -c 10.244.0.5
------------------------------------------------------------
Client connecting to 10.244.0.5, TCP port 5001
TCP window size: 16.0 KByte (default)
------------------------------------------------------------
[  1] local 10.244.0.6 port 41054 connected with 10.244.0.5 port 5001
[ ID] Interval       Transfer     Bandwidth
[  1] 0.00-10.00 sec  49.5 GBytes  42.5 Gbits/sec
```

7. Now run the same test against the ClusterIP
```
kubectl exec -it test -- iperf -c 10.96.157.37
------------------------------------------------------------
Client connecting to 10.96.157.37, TCP port 5001
TCP window size: 16.0 KByte (default)
------------------------------------------------------------
[  1] local 10.244.0.6 port 44274 connected with 10.96.157.37 port 5001
[ ID] Interval       Transfer     Bandwidth
[  1] 0.00-10.01 sec  56.1 GBytes  48.2 Gbits/sec

```



### Development workflow

For those using kind or kube-proxy images, you don't need to rebuild the kind cluster internally, just from the kubernetes repo do

```
make quick-release-images
```

You'll have the tarball with the kube-proxy image that you can load directly into kind 
```
$ kind load image-archive _output/release-images/amd64/kube-proxy.tar 
$ kubectl rollout restart ds kube-proxy -n kube-system
```
or locally to retag it and replace the existing image
```sh
$ docker load < _output/release-images/amd64/kube-proxy.tar
Loaded image: registry.k8s.io/kube-proxy-amd64:v1.32.0-alpha.2.328_c4102eb7359925
$ docker tag registry.k8s.io/kube-proxy-amd64:v1.32.0-alpha.2.328_c4102eb7359925 registry.k8s.io/kube-proxy-amd64:test
$ kubectl -n kube-system set image ds kube-proxy kube-proxy=registry.k8s.io/kube-proxy-amd64:test
```




