### PR TITLE
Job: Remove JobTrackingFinalizer annotation specific testings

### DIFF
--- a/pkg/registry/batch/job/strategy_test.go
+++ b/pkg/registry/batch/job/strategy_test.go
@@ -988,49 +988,6 @@ func TestJobStrategy_ValidateUpdate(t *testing.T) {
 				{Type: field.ErrorTypeInvalid, Field: "spec.completions"},
 			},
 		},
-		"preserving tracking annotation": {
-			job: &batch.Job{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:            "myjob",
-					Namespace:       metav1.NamespaceDefault,
-					ResourceVersion: "0",
-					Annotations: map[string]string{
-						batch.JobTrackingFinalizer: "",
-					},
-				},
-				Spec: batch.JobSpec{
-					Selector:       validSelector,
-					Template:       validPodTemplateSpec,
-					ManualSelector: ptr.To(true),
-					Parallelism:    ptr.To[int32](1),
-				},
-			},
-			update: func(job *batch.Job) {
-				job.Annotations["foo"] = "bar"
-			},
-		},
-		"deleting user annotation": {
-			job: &batch.Job{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:            "myjob",
-					Namespace:       metav1.NamespaceDefault,
-					ResourceVersion: "0",
-					Annotations: map[string]string{
-						batch.JobTrackingFinalizer: "",
-						"foo":                      "bar",
-					},
-				},
-				Spec: batch.JobSpec{
-					Selector:       validSelector,
-					Template:       validPodTemplateSpec,
-					ManualSelector: ptr.To(true),
-					Parallelism:    ptr.To[int32](1),
-				},
-			},
-			update: func(job *batch.Job) {
-				delete(job.Annotations, "foo")
-			},
-		},
 		"updating node selector for unsuspended job disallowed": {
 			job: &batch.Job{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
The [JobTrackingFinalizer](https://github.com/kubernetes/enhancements/issues/2307) has already been graduated to GA, and the annotation mechanism are completely removed from controller codes. So, I think we should remove related testing.

Before:

```shell
go test -cover ./pkg/registry/batch/job/...
ok      k8s.io/kubernetes/pkg/registry/batch/job        0.512s  coverage: 93.5% of statements
ok      k8s.io/kubernetes/pkg/registry/batch/job/storage        18.496s coverage: 73.1% of statements
```

After:

```shell
go test -cover ./pkg/registry/batch/job/...
ok      k8s.io/kubernetes/pkg/registry/batch/job        0.534s  coverage: 93.5% of statements
ok      k8s.io/kubernetes/pkg/registry/batch/job/storage        (cached)        coverage: 73.1% of statements
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
