### PR TITLE
Job: Refactor uncountedTerminatedPods to avoid casting everywhere

### DIFF
--- a/pkg/controller/job/indexed_job_utils_test.go
+++ b/pkg/controller/job/indexed_job_utils_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	batch "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
@@ -405,7 +406,7 @@ func TestGetPodsWithDelayedDeletionPerIndex(t *testing.T) {
 	cases := map[string]struct {
 		job                                 batch.Job
 		pods                                []*v1.Pod
-		expectedRmFinalizers                sets.Set[string]
+		expectedRmFinalizers                sets.Set[types.UID]
 		wantPodsWithDelayedDeletionPerIndex []string
 	}{
 		"failed pods are kept corresponding to non-failed indexes are kept": {
@@ -444,7 +445,7 @@ func TestGetPodsWithDelayedDeletionPerIndex(t *testing.T) {
 			pods: []*v1.Pod{
 				buildPod().uid("a").indexFailureCount("0").phase(v1.PodFailed).index("0").trackingFinalizer().Pod,
 			},
-			expectedRmFinalizers:                sets.New("a"),
+			expectedRmFinalizers:                sets.New[types.UID]("a"),
 			wantPodsWithDelayedDeletionPerIndex: []string{},
 		},
 		"failed pod with index outside of completions; the pod's deletion is not delayed": {

--- a/pkg/controller/job/tracking_utils_test.go
+++ b/pkg/controller/job/tracking_utils_test.go
@@ -25,6 +25,7 @@ import (
 	batch "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/component-base/metrics/testutil"
 	"k8s.io/klog/v2/ktesting"
@@ -35,23 +36,23 @@ func TestUIDTrackingExpectations(t *testing.T) {
 	logger, _ := ktesting.NewTestContext(t)
 	tracks := []struct {
 		job         string
-		firstRound  []string
-		secondRound []string
+		firstRound  []types.UID
+		secondRound []types.UID
 	}{
 		{
 			job:         "foo",
-			firstRound:  []string{"a", "b", "c", "d"},
-			secondRound: []string{"e", "f"},
+			firstRound:  []types.UID{"a", "b", "c", "d"},
+			secondRound: []types.UID{"e", "f"},
 		},
 		{
 			job:         "bar",
-			firstRound:  []string{"x", "y", "z"},
-			secondRound: []string{"u", "v", "w"},
+			firstRound:  []types.UID{"x", "y", "z"},
+			secondRound: []types.UID{"u", "v", "w"},
 		},
 		{
 			job:         "baz",
-			firstRound:  []string{"w"},
-			secondRound: []string{"a"},
+			firstRound:  []types.UID{"w"},
+			secondRound: []types.UID{"a"},
 		},
 	}
 	expectations := newUIDTrackingExpectations()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
I refactored the `uncountedTerminalPods` in the following 2 points:

1. Use `sets.New` function in the `newUncountedTerminalPods` since the `sets.New` performs the same initialization: https://github.com/kubernetes/kubernetes/blob/ce47f7b416ff0e5a5c73d70e8dd3175ced5afaa9/staging/src/k8s.io/apimachinery/pkg/util/sets/set.go#L32-L36
2. Replace the `succeeded` and `failed` fields typed with `sets.Set[typed.UID]`

Especially the type change allows us to avoid the typed casting (string <-> types.UID) everywhere.

The previous `uncountedTerminatedPods`:

```go
type uncountedTerminatedPods struct {
	succeeded sets.Set[string]
	failed    sets.Set[string]
}
```

Since this PR:

```go
type uncountedTerminatedPods struct {
	succeeded sets.Set[types.UID]
	failed    sets.Set[types.UID]
}
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
