### PR TITLE
apiserver: expose all resources in response_sizes for watch requests

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
@@ -578,7 +578,7 @@ func MonitorRequest(req *http.Request, verb, group, version, resource, subresour
 		requestSliLatencies.WithContext(req.Context()).WithLabelValues(reportedVerb, group, version, resource, subresource, scope, component).Observe(sliLatency)
 	}
 	// We are only interested in response sizes of read requests.
-	if verb == "GET" || verb == "LIST" {
+	if verb == "GET" || verb == "LIST" || verb == "WATCH" {
 		responseSizes.WithContext(req.Context()).WithLabelValues(reportedVerb, group, version, resource, subresource, scope, component).Observe(float64(respSize))
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

Today only watch requests for built in resources show up in this metric. This is mainly because the actual "verb" for built in resources for watch requests show up as "LIST" while it for resources from custom resource definitions show up as "WATCH". The "reportedVerb" is "WATCH" in both cases, so the metric will work as expected.

Given we already show this metric for "WATCH" requests for built in resources, and its a pretty useful metric to estimate the throughput of watch events per resource, adding resources from custom resource definitions is also going to be useful. This metric is also marked STABLE, so removing the WATCH events seems sub-optimal.

```bash
# before this PR looking at _only_ pods and ciliumnetworkpolicies metrics on cluster scope
$ kubectl get --raw /metrics | egrep 'apiserver_response_sizes_sum\{component="apiserver",group="(cilium.io)?",resource="(pods|ciliumnetworkpolicies)",scope="cluster"'
apiserver_response_sizes_sum{component="apiserver",group="",resource="pods",scope="cluster",subresource="",verb="LIST",version="v1"} 1.00624648e+08
apiserver_response_sizes_sum{component="apiserver",group="",resource="pods",scope="cluster",subresource="",verb="WATCH",version="v1"} 2.6141637319e+10
apiserver_response_sizes_sum{component="apiserver",group="cilium.io",resource="ciliumnetworkpolicies",scope="cluster",subresource="",verb="LIST",version="v2"} 1.723691e+06
# with this PR looking at _only_ pods and ciliumnetworkpolicies metrics on cluster scope
$ kubectl get --raw /metrics | egrep 'apiserver_response_sizes_sum\{component="apiserver",group="(cilium.io)?",resource="(pods|ciliumnetworkpolicies)",scope="cluster"'
apiserver_response_sizes_sum{component="apiserver",group="",resource="pods",scope="cluster",subresource="",verb="LIST",version="v1"} 1.00624648e+08
apiserver_response_sizes_sum{component="apiserver",group="",resource="pods",scope="cluster",subresource="",verb="WATCH",version="v1"} 2.6141637319e+10
apiserver_response_sizes_sum{component="apiserver",group="cilium.io",resource="ciliumnetworkpolicies",scope="cluster",subresource="",verb="LIST",version="v2"} 1.723691e+06
apiserver_response_sizes_sum{component="apiserver",group="cilium.io",resource="ciliumnetworkpolicies",scope="cluster",subresource="",verb="WATCH",version="v2"} 1.090217513e+09
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/128413

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed the metric `apiserver_response_sizes` to include resources and groups from custom resources for watch requests
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
