### PR TITLE
Provide link with e2e guidelines when verity-test-code.sh fails

### DIFF
--- a/hack/verify-test-code.sh
+++ b/hack/verify-test-code.sh
@@ -62,6 +62,7 @@ if [ ${#errors_expect_no_error[@]} -ne 0 ]; then
     echo 'The above files need to use framework.ExpectNoError(err) instead of '
     echo 'Expect(err).NotTo(HaveOccurred()) or gomega.Expect(err).NotTo(gomega.HaveOccurred())'
     echo
+    echo 'See https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/writing-good-e2e-tests.md for more guidance'
   } >&2
   exit 1
 fi


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/sig testing

#### What this PR does / why we need it:
The link https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/writing-good-e2e-tests.md has lots of valuable information what a test looks like and when a failure from `hack/verify-test-code.sh` appears it will be handy for folks who not necessarily know what to do with the failure. 

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
/assign @pohly 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
