### PR TITLE
Pre stop hook test suite

### DIFF
--- a/test/e2e/framework/testdoc/build-log.txt
+++ b/test/e2e/framework/testdoc/build-log.txt
@@ -1,0 +1,198 @@
+go version go1.23.0 linux/amd64
++++ [1024 15:32:13] Building go targets for linux/amd64
+    github.com/onsi/ginkgo/v2/ginkgo (non-static)
+Makefile:195: warning: undefined variable '''
+go version go1.23.0 linux/amd64
++++ [1024 15:32:15] Set GOMAXPROCS automatically to 4
+Creating artifacts directory at /tmp/_artifacts/241024T153215
+Test artifacts will be written to /tmp/_artifacts/241024T153215
+No need to refresh sudo credentials
+I1024 15:32:21.052675  950231 build.go:60] Building k8s binaries...
+Makefile:195: warning: undefined variable '''
++++ [1024 15:32:21] Building go targets for linux/amd64
+    k8s.io/kubernetes/cmd/kubelet (non-static)
+I1024 15:32:26.940064  950231 build.go:60] Building k8s binaries...
+Makefile:195: warning: undefined variable '''
++++ [1024 15:32:27] Building go targets for linux/amd64
+    github.com/onsi/ginkgo/v2/ginkgo (non-static)
+    k8s.io/kubernetes/cluster/gce/gci/mounter (static)
+    k8s.io/kubernetes/test/e2e_node/e2e_node.test (test)
+    k8s.io/kubernetes/test/e2e_node/plugins/gcp-credential-provider (non-static)
+I1024 15:32:36.229308  950231 run_local.go:60] Got build output dir: /home/ubuntu/kubernetes/_output/local/go/bin
+I1024 15:32:36.229347  950231 run_local.go:121] Running command: /home/ubuntu/kubernetes/_output/local/go/bin/ginkgo -timeout=24h -nodes=8  -focus="PreStop Hook TestSuite"  -skip="\[Flaky\]|\[Slow\]|\[Serial\]"  /home/ubuntu/kubernetes/_output/local/go/bin/e2e_node.test -- --v 4 --report-dir=/tmp/_artifacts/241024T153215 --node-name srv579909 --kubelet-flags="--cluster-domain=cluster.local" --dns-domain="cluster.local" --prepull-images=false  --container-runtime-endpoint=unix:///run/containerd/containerd.sock  --runtime-config= --kubelet-config-file="test/e2e_node/jenkins/default-kubelet-config.yaml"
+Running Suite: E2eNode Suite - /home/ubuntu/kubernetes/_output/local/go/bin
+===========================================================================
+Random Seed: 1729783956 - will randomize all specs
+
+Will run 1 of 668 specs
+Running in parallel across 8 processes
+I1024 15:32:36.623820  951785 factory.go:193] Registered Plugin "containerd"
+  I1024 15:32:36.646544  951785 mount_linux.go:334] Detected umount with safe 'not mounted' behavior
+  I1024 15:32:36.648275  951785 mount_linux.go:334] Detected umount with safe 'not mounted' behavior
+  I1024 15:32:36.649755  951785 mount_linux.go:334] Detected umount with safe 'not mounted' behavior
+  W1024 15:32:36.672323  951785 test_context.go:538] Unable to find in-cluster config, using default host : https://127.0.0.1:6443
+  I1024 15:32:36.672373  951785 test_context.go:553] Tolerating taints "node-role.kubernetes.io/control-plane" when considering if nodes are ready
+  I1024 15:32:36.672379 951785 test_context.go:561] The --provider flag is not set. Continuing as if --provider=skeleton had been used.
+  I1024 15:32:36.672511  951785 feature_gate.go:387] feature gates: {map[]}
+  I1024 15:32:36.672555  951785 feature_gate.go:387] feature gates: {map[]}
+Validating os...
+OS: Linux
+Validating kernel...
+KERNEL_VERSION: 6.8.0-47-generic
+CONFIG_NAMESPACES: enabled
+CONFIG_NET_NS: enabled
+CONFIG_PID_NS: enabled
+CONFIG_IPC_NS: enabled
+CONFIG_UTS_NS: enabled
+CONFIG_CGROUPS: enabled
+CONFIG_CGROUP_CPUACCT: enabled
+CONFIG_CGROUP_DEVICE: enabled
+CONFIG_CGROUP_FREEZER: enabled
+CONFIG_CGROUP_PIDS: enabled
+CONFIG_CGROUP_SCHED: enabled
+CONFIG_CPUSETS: enabled
+CONFIG_MEMCG: enabled
+CONFIG_INET: enabled
+CONFIG_EXT4_FS: enabled
+CONFIG_PROC_FS: enabled
+CONFIG_NETFILTER_XT_TARGET_REDIRECT: enabled (as module)
+CONFIG_NETFILTER_XT_MATCH_COMMENT: enabled (as module)
+CONFIG_FAIR_GROUP_SCHED: enabled
+CONFIG_OVERLAY_FS: enabled (as module)
+CONFIG_AUFS_FS: not set - Required for aufs.
+CONFIG_BLK_DEV_DM: enabled
+CONFIG_CFS_BANDWIDTH: enabled
+CONFIG_CGROUP_HUGETLB: enabled
+CONFIG_SECCOMP: enabled
+CONFIG_SECCOMP_FILTER: enabled
+Validating cgroups...
+CGROUPS_CPU: enabled
+CGROUPS_CPUSET: enabled
+CGROUPS_DEVICES: enabled
+CGROUPS_FREEZER: enabled
+CGROUPS_MEMORY: enabled
+CGROUPS_PIDS: enabled
+CGROUPS_HUGETLB: enabled
+CGROUPS_IO: enabled
+Validating package...
+PASS
+------------------------------
+[SynchronizedBeforeSuite] PASSED [4.265 seconds]
+[SynchronizedBeforeSuite] 
+k8s.io/kubernetes/test/e2e_node/e2e_node_suite_test.go:228
+
+  Captured StdOut/StdErr Output >>
+  I1024 15:32:36.623820  951785 factory.go:193] Registered Plugin "containerd"
+    I1024 15:32:36.646544  951785 mount_linux.go:334] Detected umount with safe 'not mounted' behavior
+    I1024 15:32:36.648275  951785 mount_linux.go:334] Detected umount with safe 'not mounted' behavior
+    I1024 15:32:36.649755  951785 mount_linux.go:334] Detected umount with safe 'not mounted' behavior
+    W1024 15:32:36.672323  951785 test_context.go:538] Unable to find in-cluster config, using default host : https://127.0.0.1:6443
+    I1024 15:32:36.672373  951785 test_context.go:553] Tolerating taints "node-role.kubernetes.io/control-plane" when considering if nodes are ready
+    I1024 15:32:36.672379 951785 test_context.go:561] The --provider flag is not set. Continuing as if --provider=skeleton had been used.
+    I1024 15:32:36.672511  951785 feature_gate.go:387] feature gates: {map[]}
+    I1024 15:32:36.672555  951785 feature_gate.go:387] feature gates: {map[]}
+  Validating os...
+  OS: Linux
+  Validating kernel...
+  KERNEL_VERSION: 6.8.0-47-generic
+  CONFIG_NAMESPACES: enabled
+  CONFIG_NET_NS: enabled
+  CONFIG_PID_NS: enabled
+  CONFIG_IPC_NS: enabled
+  CONFIG_UTS_NS: enabled
+  CONFIG_CGROUPS: enabled
+  CONFIG_CGROUP_CPUACCT: enabled
+  CONFIG_CGROUP_DEVICE: enabled
+  CONFIG_CGROUP_FREEZER: enabled
+  CONFIG_CGROUP_PIDS: enabled
+  CONFIG_CGROUP_SCHED: enabled
+  CONFIG_CPUSETS: enabled
+  CONFIG_MEMCG: enabled
+  CONFIG_INET: enabled
+  CONFIG_EXT4_FS: enabled
+  CONFIG_PROC_FS: enabled
+  CONFIG_NETFILTER_XT_TARGET_REDIRECT: enabled (as module)
+  CONFIG_NETFILTER_XT_MATCH_COMMENT: enabled (as module)
+  CONFIG_FAIR_GROUP_SCHED: enabled
+  CONFIG_OVERLAY_FS: enabled (as module)
+  CONFIG_AUFS_FS: not set - Required for aufs.
+  CONFIG_BLK_DEV_DM: enabled
+  CONFIG_CFS_BANDWIDTH: enabled
+  CONFIG_CGROUP_HUGETLB: enabled
+  CONFIG_SECCOMP: enabled
+  CONFIG_SECCOMP_FILTER: enabled
+  Validating cgroups...
+  CGROUPS_CPU: enabled
+  CGROUPS_CPUSET: enabled
+  CGROUPS_DEVICES: enabled
+  CGROUPS_FREEZER: enabled
+  CGROUPS_MEMORY: enabled
+  CGROUPS_PIDS: enabled
+  CGROUPS_HUGETLB: enabled
+  CGROUPS_IO: enabled
+  Validating package...
+  PASS
+  << Captured StdOut/StdErr Output
+------------------------------
+SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+------------------------------
+• [14.141 seconds]
+PreStop Hook TestSuite should run PreStop hook basic test case and verify execution
+k8s.io/kubernetes/test/e2e_node/prestop_hook_test.go:37
+
+  Captured StdOut/StdErr Output >>
+  <testdoc:name>hooks:prestop:Basic</testdoc:name>
+  <testdoc:step>When you have a PreStop hook defined on your container, it will execute before the container is terminated.</testdoc:step>
+  <testdoc:log>Creating a Pod with PreStop hook that writes to a shared volume</testdoc:log>
+  <testdoc:step>Imagine You Have a Pod with the Following Specification</testdoc:step>
+  <testdoc:podspec>metadata:
+    creationTimestamp: null
+    name: prestop-pod
+  spec:
+    containers:
+    - args:
+      - pause
+      image: registry.k8s.io/e2e-test-images/agnhost:2.53
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - sh
+            - -c
+            - echo 'PreStop Hook Executed' > /data/prestop_hook_executed; sleep 10
+      name: prestop-container
+      resources: {}
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      volumeMounts:
+      - mountPath: /data
+        name: shared-data
+    terminationGracePeriodSeconds: 60
+    volumes:
+    - emptyDir: {}
+      name: shared-data
+  status: {}
+  </testdoc:podspec>
+  <testdoc:step>This Pod should start successfully and run for some time</testdoc:step>
+  <testdoc:log>Pod is created successfully</testdoc:log>
+  <testdoc:log>The Pod is running successfully</testdoc:log>
+  <testdoc:step>When the container is terminated, the PreStop hook will be triggered within the grace period</testdoc:step>
+  <testdoc:log>Pod was deleted successfully</testdoc:log>
+  <testdoc:step>Waiting briefly before checking for the file</testdoc:step>
+  <testdoc:step>Once the PreStop hook is successfully executed, the container terminates successfully</testdoc:step>
+  <testdoc:log>Pod Events and debug</testdoc:log>
+  <testdoc:step>PreStop hook logs will be created</testdoc:step>
+  <testdoc:log>PreStop Hook Executed</testdoc:log>
+  <testdoc:log>PreStop hook executed successfully</testdoc:log>
+  <testdoc:log>Waiting for the Pod to be deleted</testdoc:log>
+  << Captured StdOut/StdErr Output
+------------------------------
+SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

--- a/test/e2e/framework/testdoc/helper.go
+++ b/test/e2e/framework/testdoc/helper.go
@@ -1,0 +1,43 @@
+package testdoc
+import (
+	"fmt"
+	v1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/yaml"
+
+)
+
+// Helper methods
+
+// Logs the name of the test
+func TestName(s string) {
+    fmt.Print("<testdoc:name>",s,"</testdoc:name>\n")
+}
+
+// Logs individual steps of the test
+func TestStep(step string) {
+    fmt.Print("<testdoc:step>",step,"</testdoc:step>\n")
+}
+
+// Logs the Pod specification in YAML format
+func PodSpec(p *v1.Pod) {
+    fmt.Print("<testdoc:podspec>",getYaml(p),"</testdoc:podspec>\n")
+}
+
+// Logs general log output for the test case
+func TestLog(log string) {
+    fmt.Print("<testdoc:log>",log,"</testdoc:log>\n")
+}
+
+// Logs the status of the Pod
+func PodStatus(status string) {
+    fmt.Print("<testdoc:status>",status,"</testdoc:status>\n")
+}
+
+// Converts Pod object to YAML for logging purposes
+func getYaml(pod *v1.Pod) string {
+    data, err := yaml.Marshal(pod)
+    if err != nil {
+        return ""
+    }
+    return string(data)
+}

--- a/test/e2e/framework/testdoc/script.py
+++ b/test/e2e/framework/testdoc/script.py
@@ -92,10 +92,9 @@ if __name__ == "__main__":
     try:
         with open("build-log.txt", "r") as file:
             log_content = file.read()
-
         # Extract name and steps from the log content
         name = find_strings_between(log_content, "<testdoc:name>", "</testdoc:name>")
-        namePath = ["documentation/lifecycle_hooks/" + s.rsplit(':', 1)[0].replace(':','/') + ".md" for s in name]
+        namePath = ["content/en/docs/pod-lifecycle-events" + s.rsplit(':', 1)[0].replace(':','/') + ".md" for s in name]
         steps = find_strings_between(log_content, ("<testdoc:podspec>","<testdoc:step>"),("</testdoc:podspec>","</testdoc:step>"))
         logs = find_strings_between(log_content, "<testdoc:log>", "</testdoc:log>")
   

--- a/test/e2e/framework/testdoc/script.py
+++ b/test/e2e/framework/testdoc/script.py
@@ -1,0 +1,111 @@
+import os
+import re
+import datetime
+import json
+
+
+def extract_substrings(text, start_indices, end_indices):
+    """
+    Extract substrings from text based on start and end indices.
+    Removes specific tags before returning the substrings.
+    """
+    if len(start_indices) != len(end_indices):
+        raise ValueError("Start and end index lists must have the same length.")
+    
+    substrings = [
+        text[start:end]
+        .replace("<testdoc:step>", "")
+        .replace("<testdoc:podspec>", "")
+        .replace("<testdoc:name>", "")
+        .replace("<testdoc:log>", "")
+        for start, end in zip(start_indices, end_indices)
+    ]
+    
+    return substrings
+
+
+def find_strings_between(text, start, end):
+    """
+    Find all substrings between start and end patterns in the given text.
+    """
+    start_indices = [i for i in range(len(text)) if text.startswith(start, i)]
+    end_indices = [i for i in range(len(text)) if text.startswith(end, i)]
+
+    if not start_indices or not end_indices:
+        return None
+
+    return extract_substrings(text, start_indices, end_indices)
+
+
+def find_test_key(mapper_value):
+    """
+    Find a key in 'mapper.json' corresponding to a given value.
+    """
+    try:
+        with open('mapper.json', 'r') as file:
+            mapper = json.load(file)
+
+        return next((key for key, value in mapper.items() if value == mapper_value), None)
+    except Exception as e:
+        print(f"Error loading or parsing mapper.json: {e}")
+        return None
+
+
+def read_and_replace_content(file_path, name, steps,logs):
+    """
+    Read markdown file, find specific tags, replace them with given values, and save the updated content.
+    """
+    try:
+        with open(file_path[0], 'r') as file:
+            content = file.read()
+
+        test_name = find_test_key(name[0].rsplit(":",1)[1])
+
+        if not test_name:
+            raise ValueError(f"Test name '{name[0]}' not found in mapper.")
+
+        tag = f"<!-- {test_name} -->"
+
+        # Replace the tag with steps
+        updated_content = content.replace(tag, tag + "\n" + "\n".join(str(step) for step in steps)+"\n\n###Logs for the test\n" +"\n".join(str(log) for log in logs))
+
+        print(f"Updated content:\n{updated_content}")
+
+        # Save the modified content to a new file with a timestamped filename
+        # output_file_name = f"file_{datetime.datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}.txt"
+        output_file_name = file_path[0]
+        with open(output_file_name, 'w') as output_file:
+            output_file.write(updated_content)
+
+        print(f"File '{output_file_name}' has been successfully created.")
+
+    except FileNotFoundError:
+        print(f"File '{file_path}' not found.")
+    except ValueError as e:
+        print(e)
+    except Exception as e:
+        print(f"An error occurred: {e}")
+
+
+# Example usage
+if __name__ == "__main__":
+    try:
+        with open("build-log.txt", "r") as file:
+            log_content = file.read()
+
+        # Extract name and steps from the log content
+        name = find_strings_between(log_content, "<testdoc:name>", "</testdoc:name>")
+        namePath = ["documentation/lifecycle_hooks/" + s.rsplit(':', 1)[0].replace(':','/') + ".md" for s in name]
+        steps = find_strings_between(log_content, ("<testdoc:podspec>","<testdoc:step>"),("</testdoc:podspec>","</testdoc:step>"))
+        logs = find_strings_between(log_content, "<testdoc:log>", "</testdoc:log>")
+  
+        if not name or not steps:
+            print("Could not find the required tags in the log file.")
+        else:
+            # Process markdown file and replace content
+            read_and_replace_content(namePath, name, steps,logs)
+
+    except FileNotFoundError:
+        print("Log file 'build-log.txt' not found.")
+    except Exception as e:
+        print(f"An error occurred: {e}")

--- a/test/e2e_node/lifecycle_hook/prestop_hook.go
+++ b/test/e2e_node/lifecycle_hook/prestop_hook.go
@@ -1,0 +1,142 @@
+package lifecycle_hooks
+ 
+import (
+    "context"
+    "fmt"
+    "time"
+ 
+    "k8s.io/kubernetes/test/e2e/framework/ssh"
+    v1 "k8s.io/api/core/v1"
+    metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+    "k8s.io/kubernetes/test/e2e/framework"
+    e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+    imageutils "k8s.io/kubernetes/test/utils/image"
+ 
+    "github.com/onsi/ginkgo/v2"
+    "github.com/onsi/gomega"
+)
+ 
+ 
+var _ = ginkgo.Describe("PreStop Hook TestSuite", func() {
+ 
+    f := framework.NewDefaultFramework("prestop-hook-testsuite")
+    
+    var podClient *e2epod.PodClient
+    ginkgo.BeforeEach(func() {
+        podClient = e2epod.NewPodClient(f)
+    })
+ 
+    ginkgo.It("should run PreStop hook basic test case and verify execution ", func(ctx context.Context) {
+ 
+        TestName("PreStop Hook")
+        TestStep("When you have a PreStop hook defined on your container, it will execute before the container is terminated within grace period.")
+ 
+        volumeName := "shared-data"
+        mountPath := "/tmp/prestop-test-logs"
+ 
+        // Define the lifecycle with the PreStop hook
+        lifecycle := &v1.Lifecycle{
+            PreStop: &v1.LifecycleHandler{
+                Exec: &v1.ExecAction{
+                    Command: []string{
+                        "sh",
+                        "-c",
+                        fmt.Sprintf("echo 'PreStop Hook Executed' > %s/prestop_hook_executed; sleep 10", mountPath),
+                        //"echo 'PreStop Hook Executed' > /tmp/prestop-test-logs/prestop_hook_executed",
+                    },
+                },
+            },
+        }
+ 
+        TestStep("Imagine You Have a Pod with the Following Specification")
+ 
+        // Define the pod with the emptyDir volume and appropriate security context
+        podWithHook := &v1.Pod{
+            ObjectMeta: metav1.ObjectMeta{
+                Name: "prestop-pod",
+            },
+            Spec: v1.PodSpec{
+                Containers: []v1.Container{
+                    {
+                        Name:    "prestop-container",
+                        Image:   imageutils.GetE2EImage(imageutils.Agnhost),
+                        Args:    []string{"pause"},
+                        Lifecycle: lifecycle,
+                        VolumeMounts: []v1.VolumeMount{
+                            {
+                                Name:      volumeName,
+                                MountPath: mountPath,
+                            },
+                        },
+                        SecurityContext: &v1.SecurityContext{
+                            RunAsNonRoot:             boolPtr(true),
+                            RunAsUser:                int64Ptr(1000),
+                            RunAsGroup:               int64Ptr(1000),
+                            AllowPrivilegeEscalation: boolPtr(false),
+                            Capabilities: &v1.Capabilities{
+                                Drop: []v1.Capability{"ALL"},
+                            },
+                            SeccompProfile: &v1.SeccompProfile{
+                                Type: v1.SeccompProfileTypeRuntimeDefault,
+                            },
+                        },
+                    },
+                },
+                Volumes: []v1.Volume{
+                    {
+                        Name: volumeName,
+                        VolumeSource: v1.VolumeSource{
+                            EmptyDir: &v1.EmptyDirVolumeSource{
+                                Medium: v1.StorageMediumDefault,
+                            },
+                        },
+                    },
+                },
+                TerminationGracePeriodSeconds: int64Ptr(30),
+            },
+        }
+ 
+        PodSpec(podWithHook)
+ 
+        // Create and run the pod
+        TestStep("This Pod should start successfully and run for some time")
+ 
+        createdPod := podClient.CreateSync(ctx, podWithHook)
+    
+        ginkgo.By("Pod is created successfully")
+        TestLog("Pod is created successfully")
+ 
+        // Wait for the pod to be running
+        err := e2epod.WaitForPodRunningInNamespace(ctx, f.ClientSet, createdPod)
+        framework.ExpectNoError(err)
+ 
+        TestLog("The Pod is running successfully")
+ 
+        TestStep("When the container is terminated, the PreStop hook will be triggered within the grace period")
+ 
+        // Delete the pod to trigger the PreStop hook
+        err = podClient.Delete(ctx, createdPod.Name, metav1.DeleteOptions{})
+        framework.ExpectNoError(err)
+ 
+        TestLog("Pod was deleted successfully")
+ 
+        ginkgo.By("ensuring the pod is terminated within the grace period seconds")
+        err = e2epod.WaitForPodNotFoundInNamespace(ctx, f.ClientSet, podWithHook.Name, podWithHook.Namespace, 30*time.Second)
+        framework.ExpectNoError(err)
+ 
+        // Verify the file on the host using SSH helper
+        ginkgo.By("verifying the PreStop hook output on the host")
+        node, err := f.ClientSet.CoreV1().Nodes().Get(ctx, podWithHook.Spec.NodeName, metav1.GetOptions{})
+        cmd := fmt.Sprintf("cat %s/prestop_hook_executed", mountPath)
+        result, err := ssh.IssueSSHCommandWithResult(ctx, cmd, "local", node)
+ 
+        // Print Stdout and validate it contains the expected message
+        TestLog(result.Stdout)
+        gomega.Expect(result.Stdout).To(gomega.ContainSubstring("PreStop Hook Executed"))
+ 
+        TestStep("Once the PreStop hook is successfully executed, the container terminates successfully.")
+ 
+    })
+ 
+})
+ 


### PR DESCRIPTION
What this PR does / why we need it:
This PR introduces a basic PreStop hook test and restructures the PreStop test suite by integrating helper/marker blocks intended for automated documentation generation. This restructuring allows the test suite to be utilized more effectively for documentation purposes, streamlining the auto-generation process via these markers, ultimately enhancing the maintainability and usability of test documentation.