### PR TITLE
Reuse cached client config for exec requests in e2e

### DIFF
--- a/test/e2e/framework/pod/exec_util.go
+++ b/test/e2e/framework/pod/exec_util.go
@@ -58,8 +58,6 @@ func ExecWithOptionsContext(ctx context.Context, f *framework.Framework, options
 	if !options.Quiet {
 		framework.Logf("ExecWithOptions %+v", options)
 	}
-	config, err := framework.LoadConfig()
-	framework.ExpectNoError(err, "failed to load restclient config")
 
 	const tty = false
 
@@ -80,7 +78,7 @@ func ExecWithOptionsContext(ctx context.Context, f *framework.Framework, options
 
 	var stdout, stderr bytes.Buffer
 	framework.Logf("ExecWithOptions: execute(POST %s)", req.URL())
-	err = execute(ctx, "POST", req.URL(), config, options.Stdin, &stdout, &stderr, tty)
+	err := execute(ctx, "POST", req.URL(), f.ClientConfig(), options.Stdin, &stdout, &stderr, tty)
 
 	if options.PreserveWhitespace {
 		return stdout.String(), stderr.String(), err


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Reuse the ClientConfig that is already loaded by the framework, rather than reloading it for ever exec requests. Also suppresses noisy logs:
```
  I1028 18:08:16.519826 64596 util.go:502] >>> kubeConfig: /workspace/.kube/config
  I1028 18:08:16.520707 64596 exec_util.go:66] ExecWithOptions: Clientset creation
```

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/sig testing