### PR TITLE
Fix Unschedulable test by using high priority churn pods to get processed right after they were injected

### DIFF
--- a/test/integration/scheduler_perf/config/performance-config.yaml
+++ b/test/integration/scheduler_perf/config/performance-config.yaml
@@ -725,13 +725,13 @@
       measurePods: 500
   - name: 5000Nodes
     labels: [performance]
-    threshold: 120
+    threshold: 200
     params:
       initNodes: 5000
       initPods: 20000
       measurePods: 5000
 
-# Measure throughput of regular schedulable pods that are interleaved by unschedulable pods injected at 100/s rate.
+# Measure throughput of regular schedulable pods that are interleaved by unschedulable pods injected at 5/s rate.
 - name: Unschedulable
   workloadTemplate:
   - opcode: createNodes
@@ -739,8 +739,8 @@
   - opcode: churn
     mode: create
     templatePaths:
-    - config/templates/pod-large-cpu.yaml
-    intervalMilliseconds: 10
+    - config/templates/pod-high-priority-large-cpu.yaml
+    intervalMilliseconds: 200
   - opcode: createPods
     countParam: $measurePods
     podTemplatePath: config/templates/pod-default.yaml
@@ -763,7 +763,7 @@
       measurePods: 1000
   - name: 5kNodes/10kPods
     labels: [performance]
-    threshold: 250
+    threshold: 200
     params:
       initNodes: 5000
       measurePods: 10000


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The churn used in the `Unschedulable` performance test was injecting pods with equal priority to the test pods, therefore they were ending up at the end of the scheduling queue and processed when their time comes.

The intention of the test was to generate load at the defined rate, therefore the pods need to be of higher pririty than the test pods.

#### Which issue(s) this PR fixes:

Part of #128221

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
