### PR TITLE
do not install handler for '/metrics/slis' endpoint using sync.Once

### DIFF
--- a/pkg/kubelet/server/auth_test.go
+++ b/pkg/kubelet/server/auth_test.go
@@ -137,6 +137,7 @@ func AuthzTestCases(fineGrained bool) []AuthzTestCase {
 		"/logs/":                              {"log"},
 		"/logs/{logpath:*}":                   {"log"},
 		"/metrics":                            {"metrics"},
+		"/metrics/slis":                       {"metrics"},
 		"/metrics/cadvisor":                   {"metrics"},
 		"/metrics/probes":                     {"metrics"},
 		"/metrics/resource":                   {"metrics"},

--- a/pkg/kubelet/server/server_test.go
+++ b/pkg/kubelet/server/server_test.go
@@ -1641,3 +1641,19 @@ func TestFineGrainedAuthz(t *testing.T) {
 		})
 	}
 }
+
+func TestNewServerRegistersMetricsSLIsEndpointTwice(t *testing.T) {
+	host := &fakeKubelet{
+		hostnameFunc: func() string {
+			return "127.0.0.1"
+		},
+	}
+	resourceAnalyzer := stats.NewResourceAnalyzer(nil, time.Minute, &record.FakeRecorder{})
+
+	server1 := NewServer(host, resourceAnalyzer, nil, nil)
+	server2 := NewServer(host, resourceAnalyzer, nil, nil)
+
+	// Check if both servers registered the /metrics/slis endpoint
+	assert.Contains(t, server1.restfulCont.RegisteredHandlePaths(), "/metrics/slis", "First server should register /metrics/slis")
+	assert.Contains(t, server2.restfulCont.RegisteredHandlePaths(), "/metrics/slis", "Second server should register /metrics/slis")
+}

--- a/staging/src/k8s.io/component-base/metrics/prometheus/slis/routes.go
+++ b/staging/src/k8s.io/component-base/metrics/prometheus/slis/routes.go
@@ -38,8 +38,8 @@ type SLIMetrics struct{}
 func (s SLIMetrics) Install(m mux) {
 	installOnce.Do(func() {
 		Register(Registry)
-		m.Handle("/metrics/slis", metrics.HandlerFor(Registry, metrics.HandlerOpts{}))
 	})
+	m.Handle("/metrics/slis", metrics.HandlerFor(Registry, metrics.HandlerOpts{}))
 }
 
 type SLIMetricsWithReset struct{}
@@ -48,6 +48,6 @@ type SLIMetricsWithReset struct{}
 func (s SLIMetricsWithReset) Install(m mux) {
 	installWithResetOnce.Do(func() {
 		Register(Registry)
-		m.Handle("/metrics/slis", metrics.HandlerWithReset(Registry, metrics.HandlerOpts{}))
 	})
+	m.Handle("/metrics/slis", metrics.HandlerWithReset(Registry, metrics.HandlerOpts{}))
 }

--- a/staging/src/k8s.io/component-base/metrics/prometheus/slis/routes_test.go
+++ b/staging/src/k8s.io/component-base/metrics/prometheus/slis/routes_test.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package slis
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type mockMux struct {
+	handledPaths []string
+}
+
+func (m *mockMux) Handle(path string, handler http.Handler) {
+	m.handledPaths = append(m.handledPaths, path)
+}
+
+func TestSLIMetrics_Install(t *testing.T) {
+	m := &mockMux{}
+	s := SLIMetrics{}
+
+	s.Install(m)
+	assert.Equal(t, []string{"/metrics/slis"}, m.handledPaths)
+
+	s.Install(m)
+	// Assert that the path is registered twice for the 2 calls made to Install().
+	assert.Equal(t, []string{"/metrics/slis", "/metrics/slis"}, m.handledPaths, "Should handle the path twice.")
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:
This PR moves the installation of handler for `/metrics/slis` endpoint outside of the [sync.Once.Do()](https://github.com/kubernetes/kubernetes/blob/release-1.31/staging/src/k8s.io/component-base/metrics/prometheus/slis/routes.go#L49). This was causing the endpoint to be unavailable on one of the 2 kubelet ports (10250, 10255) intermittently.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/kubernetes/kubernetes/issues/128545

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Makes kubelet's /metrics/slis endpoint always available
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
