### PR TITLE
DRA API: check "AdminAccess in use" only once

### DIFF
--- a/pkg/registry/resource/resourceclaimtemplate/strategy.go
+++ b/pkg/registry/resource/resourceclaimtemplate/strategy.go
@@ -108,11 +108,14 @@ func dropDisabledDRAAdminAccessFields(newClaimTemplate, oldClaimTemplate *resour
 		// No need to drop anything.
 		return
 	}
+	if draAdminAccessFeatureInUse(oldClaimTemplate) {
+		// If anything was set in the past, then fields must not get
+		// dropped on potentially unrelated updates.
+		return
+	}
 
 	for i := range newClaimTemplate.Spec.Spec.Devices.Requests {
-		if newClaimTemplate.Spec.Spec.Devices.Requests[i].AdminAccess != nil && !draAdminAccessFeatureInUse(oldClaimTemplate) {
-			newClaimTemplate.Spec.Spec.Devices.Requests[i].AdminAccess = nil
-		}
+		newClaimTemplate.Spec.Spec.Devices.Requests[i].AdminAccess = nil
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This is simpler and an opportunity to explain the concept.

#### Special notes for your reviewer:

Follow-up for https://github.com/kubernetes/kubernetes/pull/127266#discussion_r1821678195

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @thockin 