### PR TITLE
Add configuration flag for readonly-monitor plugin

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -1680,6 +1680,7 @@ function start-node-problem-detector {
   local flags="${NODE_PROBLEM_DETECTOR_CUSTOM_FLAGS:-}"
   if [[ -z "${flags}" ]]; then
     local -r km_config="${KUBE_HOME}/node-problem-detector/config/kernel-monitor.json"
+    local -r rom_config="${KUBE_HOME}/node-problem-detector/config/readonly-monitor.json"
     # TODO(random-liu): Handle this for alternative container runtime.
     local -r dm_config="${KUBE_HOME}/node-problem-detector/config/docker-monitor.json"
     local -r sm_config="${KUBE_HOME}/node-problem-detector/config/systemd-monitor.json"
@@ -1690,7 +1691,7 @@ function start-node-problem-detector {
 
     flags="${NPD_TEST_LOG_LEVEL:-"--v=2"} ${NPD_TEST_ARGS:-}"
     flags+=" --logtostderr"
-    flags+=" --config.system-log-monitor=${km_config},${dm_config},${sm_config}"
+    flags+=" --config.system-log-monitor=${km_config},${dm_config},${sm_config},${rom_config}"
     flags+=" --config.system-stats-monitor=${ssm_config}"
     flags+=" --config.custom-plugin-monitor=${custom_km_config},${custom_sm_config}"
     local -r npd_port=${NODE_PROBLEM_DETECTOR_PORT:-20256}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This PR enables the readonly-monitor plugin in NPD to maintain backward compatibility. The ReadOnlyFileSystem node condition has been moved to a different plugin, so this PR updates the configuration to include the new plugin, ensuring no loss of functionality.


#### Special notes for your reviewer:
This change is a follow up of https://github.com/kubernetes/node-problem-detector/pull/955.

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

