### PR TITLE
Add --concurrent-daemonset-syncs argument to kube-controller-manager

### DIFF
--- a/cmd/kube-controller-manager/app/options/daemonsetcontroller.go
+++ b/cmd/kube-controller-manager/app/options/daemonsetcontroller.go
@@ -17,6 +17,8 @@ limitations under the License.
 package options
 
 import (
+	"fmt"
+
 	"github.com/spf13/pflag"
 
 	daemonconfig "k8s.io/kubernetes/pkg/controller/daemon/config"
@@ -32,6 +34,8 @@ func (o *DaemonSetControllerOptions) AddFlags(fs *pflag.FlagSet) {
 	if o == nil {
 		return
 	}
+
+	fs.Int32Var(&o.ConcurrentDaemonSetSyncs, "concurrent-daemonset-syncs", o.ConcurrentDaemonSetSyncs, "The number of daemonset objects that are allowed to sync concurrently. Larger number = more responsive daemonsets, but more CPU (and network) load")
 }
 
 // ApplyTo fills up DaemonSetController config with options.
@@ -52,5 +56,8 @@ func (o *DaemonSetControllerOptions) Validate() []error {
 	}
 
 	errs := []error{}
+	if o.ConcurrentDaemonSetSyncs < 1 {
+		errs = append(errs, fmt.Errorf("concurrent-daemonset-syncs must be greater than 0, but got %d", o.ConcurrentDaemonSetSyncs))
+	}
 	return errs
 }

--- a/cmd/kube-controller-manager/app/options/options_test.go
+++ b/cmd/kube-controller-manager/app/options/options_test.go
@@ -98,6 +98,7 @@ var args = []string{
 	"--cluster-signing-legacy-unknown-cert-file=/cluster-signing-legacy-unknown/cert-file",
 	"--cluster-signing-legacy-unknown-key-file=/cluster-signing-legacy-unknown/key-file",
 	"--concurrent-deployment-syncs=10",
+	"--concurrent-daemonset-syncs=10",
 	"--concurrent-horizontal-pod-autoscaler-syncs=10",
 	"--concurrent-statefulset-syncs=15",
 	"--concurrent-endpoint-syncs=10",
@@ -264,7 +265,7 @@ func TestAddFlags(t *testing.T) {
 		},
 		DaemonSetController: &DaemonSetControllerOptions{
 			&daemonconfig.DaemonSetControllerConfiguration{
-				ConcurrentDaemonSetSyncs: 2,
+				ConcurrentDaemonSetSyncs: 10,
 			},
 		},
 		DeploymentController: &DeploymentControllerOptions{
@@ -514,6 +515,13 @@ func TestValidateFlags(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "concurrent daemonset syncs set to 0",
+			flags: []string{
+				"--concurrent-daemonset-syncs=0",
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tc := range testcases {
@@ -609,7 +617,7 @@ func TestApplyTo(t *testing.T) {
 				},
 			},
 			DaemonSetController: daemonconfig.DaemonSetControllerConfiguration{
-				ConcurrentDaemonSetSyncs: 2,
+				ConcurrentDaemonSetSyncs: 10,
 			},
 			DeploymentController: deploymentconfig.DeploymentControllerConfiguration{
 				ConcurrentDeploymentSyncs: 10,


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Number of daemonset controller workers now [defaults to 2](https://github.com/kubernetes/kubernetes/blob/daef8c2419a638d3925e146d0f5a6b217ea69b74/pkg/controller/daemon/config/v1alpha1/defaults.go#L23-L36) but cannot be overridden through CLI flags like one can already do for many other controllers in KCM.

As pointed out in the issue below, this limits the controller's throughput which is detrimental to the speed of provisioning new Nodes, especially in large clusters with large number of DaemonSets.

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubernetes/issues/128442.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Add `--concurrent-daemonset-syncs` command line flag to kube-controller-manager. The value sets the number of workers for the daemonset controller.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
