### PR TITLE
kubelet: Migrate CAdvisor to contextual logging

### DIFF
--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -167,6 +167,7 @@ linters-settings: # please keep this alphabetized
           contextual k8s.io/kubernetes/pkg/kubelet/pleg/.*
           contextual k8s.io/kubernetes/pkg/kubelet/clustertrustbundle/.*
           contextual k8s.io/kubernetes/pkg/kubelet/token/.*
+          contextual k8s.io/kubernetes/pkg/kubelet/cadvisor/.*
           
           # As long as contextual logging is alpha or beta, all WithName, WithValues,
           # NewContext calls have to go through klog. Once it is GA, we can lift

--- a/hack/golangci-strict.yaml
+++ b/hack/golangci-strict.yaml
@@ -213,6 +213,7 @@ linters-settings: # please keep this alphabetized
           contextual k8s.io/kubernetes/pkg/kubelet/pleg/.*
           contextual k8s.io/kubernetes/pkg/kubelet/clustertrustbundle/.*
           contextual k8s.io/kubernetes/pkg/kubelet/token/.*
+          contextual k8s.io/kubernetes/pkg/kubelet/cadvisor/.*
           
           # As long as contextual logging is alpha or beta, all WithName, WithValues,
           # NewContext calls have to go through klog. Once it is GA, we can lift

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -215,6 +215,7 @@ linters-settings: # please keep this alphabetized
           contextual k8s.io/kubernetes/pkg/kubelet/pleg/.*
           contextual k8s.io/kubernetes/pkg/kubelet/clustertrustbundle/.*
           contextual k8s.io/kubernetes/pkg/kubelet/token/.*
+          contextual k8s.io/kubernetes/pkg/kubelet/cadvisor/.*
           
           # As long as contextual logging is alpha or beta, all WithName, WithValues,
           # NewContext calls have to go through klog. Once it is GA, we can lift

--- a/hack/logcheck.conf
+++ b/hack/logcheck.conf
@@ -51,6 +51,7 @@ contextual k8s.io/kubernetes/pkg/kubelet/cm/dra/.*
 contextual k8s.io/kubernetes/pkg/kubelet/pleg/.*
 contextual k8s.io/kubernetes/pkg/kubelet/clustertrustbundle/.*
 contextual k8s.io/kubernetes/pkg/kubelet/token/.*
+contextual k8s.io/kubernetes/pkg/kubelet/cadvisor/.*
 
 # As long as contextual logging is alpha or beta, all WithName, WithValues,
 # NewContext calls have to go through klog. Once it is GA, we can lift

--- a/pkg/kubelet/cadvisor/cadvisor_unsupported.go
+++ b/pkg/kubelet/cadvisor/cadvisor_unsupported.go
@@ -20,6 +20,7 @@ limitations under the License.
 package cadvisor
 
 import (
+	"context"
 	"errors"
 
 	cadvisorapi "github.com/google/cadvisor/info/v1"
@@ -58,7 +59,7 @@ func (cu *cadvisorUnsupported) VersionInfo() (*cadvisorapi.VersionInfo, error) {
 	return nil, errUnsupported
 }
 
-func (cu *cadvisorUnsupported) ImagesFsInfo() (cadvisorapiv2.FsInfo, error) {
+func (cu *cadvisorUnsupported) ImagesFsInfo(context.Context) (cadvisorapiv2.FsInfo, error) {
 	return cadvisorapiv2.FsInfo{}, errUnsupported
 }
 
@@ -66,7 +67,7 @@ func (cu *cadvisorUnsupported) RootFsInfo() (cadvisorapiv2.FsInfo, error) {
 	return cadvisorapiv2.FsInfo{}, errUnsupported
 }
 
-func (cu *cadvisorUnsupported) ContainerFsInfo() (cadvisorapiv2.FsInfo, error) {
+func (cu *cadvisorUnsupported) ContainerFsInfo(context.Context) (cadvisorapiv2.FsInfo, error) {
 	return cadvisorapiv2.FsInfo{}, errUnsupported
 }
 

--- a/pkg/kubelet/cadvisor/cadvisor_windows.go
+++ b/pkg/kubelet/cadvisor/cadvisor_windows.go
@@ -20,6 +20,8 @@ limitations under the License.
 package cadvisor
 
 import (
+	"context"
+
 	cadvisorapi "github.com/google/cadvisor/info/v1"
 	cadvisorapiv2 "github.com/google/cadvisor/info/v2"
 	"k8s.io/kubernetes/pkg/kubelet/winstats"
@@ -62,11 +64,11 @@ func (cu *cadvisorClient) VersionInfo() (*cadvisorapi.VersionInfo, error) {
 	return cu.winStatsClient.WinVersionInfo()
 }
 
-func (cu *cadvisorClient) ImagesFsInfo() (cadvisorapiv2.FsInfo, error) {
+func (cu *cadvisorClient) ImagesFsInfo(context.Context) (cadvisorapiv2.FsInfo, error) {
 	return cadvisorapiv2.FsInfo{}, nil
 }
 
-func (cu *cadvisorClient) ContainerFsInfo() (cadvisorapiv2.FsInfo, error) {
+func (cu *cadvisorClient) ContainerFsInfo(context.Context) (cadvisorapiv2.FsInfo, error) {
 	return cadvisorapiv2.FsInfo{}, nil
 }
 

--- a/pkg/kubelet/cadvisor/testing/cadvisor_fake.go
+++ b/pkg/kubelet/cadvisor/testing/cadvisor_fake.go
@@ -17,6 +17,8 @@ limitations under the License.
 package testing
 
 import (
+	"context"
+
 	cadvisorapi "github.com/google/cadvisor/info/v1"
 	cadvisorapiv2 "github.com/google/cadvisor/info/v2"
 	"k8s.io/kubernetes/pkg/kubelet/cadvisor"
@@ -76,7 +78,7 @@ func (c *Fake) VersionInfo() (*cadvisorapi.VersionInfo, error) {
 }
 
 // ImagesFsInfo is a fake implementation of Interface.ImagesFsInfo.
-func (c *Fake) ImagesFsInfo() (cadvisorapiv2.FsInfo, error) {
+func (c *Fake) ImagesFsInfo(context.Context) (cadvisorapiv2.FsInfo, error) {
 	return cadvisorapiv2.FsInfo{}, nil
 }
 
@@ -86,7 +88,7 @@ func (c *Fake) RootFsInfo() (cadvisorapiv2.FsInfo, error) {
 }
 
 // ContainerFsInfo is a fake implementation of Interface.ContainerFsInfo.
-func (c *Fake) ContainerFsInfo() (cadvisorapiv2.FsInfo, error) {
+func (c *Fake) ContainerFsInfo(context.Context) (cadvisorapiv2.FsInfo, error) {
 	return cadvisorapiv2.FsInfo{}, nil
 }
 

--- a/pkg/kubelet/cadvisor/testing/cadvisor_mock.go
+++ b/pkg/kubelet/cadvisor/testing/cadvisor_mock.go
@@ -19,6 +19,8 @@ limitations under the License.
 package testing
 
 import (
+	context "context"
+
 	v1 "github.com/google/cadvisor/info/v1"
 	mock "github.com/stretchr/testify/mock"
 
@@ -38,9 +40,9 @@ func (_m *MockInterface) EXPECT() *MockInterface_Expecter {
 	return &MockInterface_Expecter{mock: &_m.Mock}
 }
 
-// ContainerFsInfo provides a mock function with given fields:
-func (_m *MockInterface) ContainerFsInfo() (v2.FsInfo, error) {
-	ret := _m.Called()
+// ContainerFsInfo provides a mock function with given fields: _a0
+func (_m *MockInterface) ContainerFsInfo(_a0 context.Context) (v2.FsInfo, error) {
+	ret := _m.Called(_a0)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ContainerFsInfo")
@@ -48,17 +50,17 @@ func (_m *MockInterface) ContainerFsInfo() (v2.FsInfo, error) {
 
 	var r0 v2.FsInfo
 	var r1 error
-	if rf, ok := ret.Get(0).(func() (v2.FsInfo, error)); ok {
-		return rf()
+	if rf, ok := ret.Get(0).(func(context.Context) (v2.FsInfo, error)); ok {
+		return rf(_a0)
 	}
-	if rf, ok := ret.Get(0).(func() v2.FsInfo); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(context.Context) v2.FsInfo); ok {
+		r0 = rf(_a0)
 	} else {
 		r0 = ret.Get(0).(v2.FsInfo)
 	}
 
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(_a0)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -72,13 +74,14 @@ type MockInterface_ContainerFsInfo_Call struct {
 }
 
 // ContainerFsInfo is a helper method to define mock.On call
-func (_e *MockInterface_Expecter) ContainerFsInfo() *MockInterface_ContainerFsInfo_Call {
-	return &MockInterface_ContainerFsInfo_Call{Call: _e.mock.On("ContainerFsInfo")}
+//   - _a0 context.Context
+func (_e *MockInterface_Expecter) ContainerFsInfo(_a0 interface{}) *MockInterface_ContainerFsInfo_Call {
+	return &MockInterface_ContainerFsInfo_Call{Call: _e.mock.On("ContainerFsInfo", _a0)}
 }
 
-func (_c *MockInterface_ContainerFsInfo_Call) Run(run func()) *MockInterface_ContainerFsInfo_Call {
+func (_c *MockInterface_ContainerFsInfo_Call) Run(run func(_a0 context.Context)) *MockInterface_ContainerFsInfo_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		run(args[0].(context.Context))
 	})
 	return _c
 }
@@ -88,7 +91,7 @@ func (_c *MockInterface_ContainerFsInfo_Call) Return(_a0 v2.FsInfo, _a1 error) *
 	return _c
 }
 
-func (_c *MockInterface_ContainerFsInfo_Call) RunAndReturn(run func() (v2.FsInfo, error)) *MockInterface_ContainerFsInfo_Call {
+func (_c *MockInterface_ContainerFsInfo_Call) RunAndReturn(run func(context.Context) (v2.FsInfo, error)) *MockInterface_ContainerFsInfo_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -267,9 +270,9 @@ func (_c *MockInterface_GetRequestedContainersInfo_Call) RunAndReturn(run func(s
 	return _c
 }
 
-// ImagesFsInfo provides a mock function with given fields:
-func (_m *MockInterface) ImagesFsInfo() (v2.FsInfo, error) {
-	ret := _m.Called()
+// ImagesFsInfo provides a mock function with given fields: _a0
+func (_m *MockInterface) ImagesFsInfo(_a0 context.Context) (v2.FsInfo, error) {
+	ret := _m.Called(_a0)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ImagesFsInfo")
@@ -277,17 +280,17 @@ func (_m *MockInterface) ImagesFsInfo() (v2.FsInfo, error) {
 
 	var r0 v2.FsInfo
 	var r1 error
-	if rf, ok := ret.Get(0).(func() (v2.FsInfo, error)); ok {
-		return rf()
+	if rf, ok := ret.Get(0).(func(context.Context) (v2.FsInfo, error)); ok {
+		return rf(_a0)
 	}
-	if rf, ok := ret.Get(0).(func() v2.FsInfo); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(context.Context) v2.FsInfo); ok {
+		r0 = rf(_a0)
 	} else {
 		r0 = ret.Get(0).(v2.FsInfo)
 	}
 
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(_a0)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -301,13 +304,14 @@ type MockInterface_ImagesFsInfo_Call struct {
 }
 
 // ImagesFsInfo is a helper method to define mock.On call
-func (_e *MockInterface_Expecter) ImagesFsInfo() *MockInterface_ImagesFsInfo_Call {
-	return &MockInterface_ImagesFsInfo_Call{Call: _e.mock.On("ImagesFsInfo")}
+//   - _a0 context.Context
+func (_e *MockInterface_Expecter) ImagesFsInfo(_a0 interface{}) *MockInterface_ImagesFsInfo_Call {
+	return &MockInterface_ImagesFsInfo_Call{Call: _e.mock.On("ImagesFsInfo", _a0)}
 }
 
-func (_c *MockInterface_ImagesFsInfo_Call) Run(run func()) *MockInterface_ImagesFsInfo_Call {
+func (_c *MockInterface_ImagesFsInfo_Call) Run(run func(_a0 context.Context)) *MockInterface_ImagesFsInfo_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		run(args[0].(context.Context))
 	})
 	return _c
 }
@@ -317,7 +321,7 @@ func (_c *MockInterface_ImagesFsInfo_Call) Return(_a0 v2.FsInfo, _a1 error) *Moc
 	return _c
 }
 
-func (_c *MockInterface_ImagesFsInfo_Call) RunAndReturn(run func() (v2.FsInfo, error)) *MockInterface_ImagesFsInfo_Call {
+func (_c *MockInterface_ImagesFsInfo_Call) RunAndReturn(run func(context.Context) (v2.FsInfo, error)) *MockInterface_ImagesFsInfo_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/kubelet/cadvisor/types.go
+++ b/pkg/kubelet/cadvisor/types.go
@@ -18,6 +18,8 @@ limitations under the License.
 package cadvisor
 
 import (
+	"context"
+
 	cadvisorapi "github.com/google/cadvisor/info/v1"
 	cadvisorapiv2 "github.com/google/cadvisor/info/v2"
 )
@@ -32,14 +34,14 @@ type Interface interface {
 	VersionInfo() (*cadvisorapi.VersionInfo, error)
 
 	// Returns usage information about the filesystem holding container images.
-	ImagesFsInfo() (cadvisorapiv2.FsInfo, error)
+	ImagesFsInfo(context.Context) (cadvisorapiv2.FsInfo, error)
 
 	// Returns usage information about the root filesystem.
 	RootFsInfo() (cadvisorapiv2.FsInfo, error)
 
 	// Returns usage information about the writeable layer.
 	// KEP 4191 can separate the image filesystem
-	ContainerFsInfo() (cadvisorapiv2.FsInfo, error)
+	ContainerFsInfo(context.Context) (cadvisorapiv2.FsInfo, error)
 
 	// Get filesystem information for the filesystem that contains the given file.
 	GetDirFsInfo(path string) (cadvisorapiv2.FsInfo, error)

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -60,7 +60,6 @@ import (
 	remote "k8s.io/cri-client/pkg"
 	fakeremote "k8s.io/cri-client/pkg/fake"
 	"k8s.io/klog/v2"
-	"k8s.io/klog/v2/ktesting"
 	"k8s.io/kubernetes/pkg/features"
 	kubeletconfiginternal "k8s.io/kubernetes/pkg/kubelet/apis/config"
 	cadvisortest "k8s.io/kubernetes/pkg/kubelet/cadvisor/testing"
@@ -104,6 +103,7 @@ import (
 	"k8s.io/kubernetes/pkg/volume/util"
 	"k8s.io/kubernetes/pkg/volume/util/hostutil"
 	"k8s.io/kubernetes/pkg/volume/util/subpath"
+	"k8s.io/kubernetes/test/utils/ktesting"
 	"k8s.io/utils/clock"
 	testingclock "k8s.io/utils/clock/testing"
 	"k8s.io/utils/ptr"
@@ -3052,6 +3052,7 @@ func createRemoteRuntimeService(endpoint string, t *testing.T, tp oteltrace.Trac
 }
 
 func TestNewMainKubeletStandAlone(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	tempDir, err := os.MkdirTemp("", "logs")
 	ContainerLogsDir = tempDir
 	assert.NoError(t, err)
@@ -3067,7 +3068,7 @@ func TestNewMainKubeletStandAlone(t *testing.T) {
 	tp := noopoteltrace.NewTracerProvider()
 	cadvisor := cadvisortest.NewMockInterface(t)
 	cadvisor.EXPECT().MachineInfo().Return(&cadvisorapi.MachineInfo{}, nil).Maybe()
-	cadvisor.EXPECT().ImagesFsInfo().Return(cadvisorapiv2.FsInfo{
+	cadvisor.EXPECT().ImagesFsInfo(tCtx).Return(cadvisorapiv2.FsInfo{
 		Usage:     400,
 		Capacity:  1000,
 		Available: 600,

--- a/pkg/kubelet/runonce_test.go
+++ b/pkg/kubelet/runonce_test.go
@@ -59,7 +59,7 @@ func TestRunOnce(t *testing.T) {
 
 	cadvisor := cadvisortest.NewMockInterface(t)
 	cadvisor.EXPECT().MachineInfo().Return(&cadvisorapi.MachineInfo{}, nil).Maybe()
-	cadvisor.EXPECT().ImagesFsInfo().Return(cadvisorapiv2.FsInfo{
+	cadvisor.EXPECT().ImagesFsInfo(ctx).Return(cadvisorapiv2.FsInfo{
 		Usage:     400,
 		Capacity:  1000,
 		Available: 600,

--- a/pkg/kubelet/stats/cadvisor_stats_provider.go
+++ b/pkg/kubelet/stats/cadvisor_stats_provider.go
@@ -77,7 +77,7 @@ func newCadvisorStatsProvider(
 }
 
 // ListPodStats returns the stats of all the pod-managed containers.
-func (p *cadvisorStatsProvider) ListPodStats(_ context.Context) ([]statsapi.PodStats, error) {
+func (p *cadvisorStatsProvider) ListPodStats(ctx context.Context) ([]statsapi.PodStats, error) {
 	// Gets node root filesystem information and image filesystem stats, which
 	// will be used to populate the available and capacity bytes/inodes in
 	// container stats.
@@ -85,7 +85,7 @@ func (p *cadvisorStatsProvider) ListPodStats(_ context.Context) ([]statsapi.PodS
 	if err != nil {
 		return nil, fmt.Errorf("failed to get rootFs info: %v", err)
 	}
-	imageFsInfo, err := p.cadvisor.ImagesFsInfo()
+	imageFsInfo, err := p.cadvisor.ImagesFsInfo(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get imageFs info: %v", err)
 	}
@@ -241,7 +241,7 @@ func (p *cadvisorStatsProvider) ListPodCPUAndMemoryStats(_ context.Context) ([]s
 
 // ImageFsStats returns the stats of the filesystem for storing images.
 func (p *cadvisorStatsProvider) ImageFsStats(ctx context.Context) (imageFsRet *statsapi.FsStats, containerFsRet *statsapi.FsStats, errCall error) {
-	imageFsInfo, err := p.cadvisor.ImagesFsInfo()
+	imageFsInfo, err := p.cadvisor.ImagesFsInfo(ctx)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get imageFs info: %v", err)
 	}
@@ -308,7 +308,7 @@ func (p *cadvisorStatsProvider) ImageFsStats(ctx context.Context) (imageFsRet *s
 		return fsStats, fsStats, nil
 	}
 
-	containerFsInfo, err := p.cadvisor.ContainerFsInfo()
+	containerFsInfo, err := p.cadvisor.ContainerFsInfo(ctx)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get container fs info: %w", err)
 	}
@@ -344,8 +344,8 @@ func (p *cadvisorStatsProvider) ImageFsStats(ctx context.Context) (imageFsRet *s
 
 // ImageFsDevice returns name of the device where the image filesystem locates,
 // e.g. /dev/sda1.
-func (p *cadvisorStatsProvider) ImageFsDevice(_ context.Context) (string, error) {
-	imageFsInfo, err := p.cadvisor.ImagesFsInfo()
+func (p *cadvisorStatsProvider) ImageFsDevice(ctx context.Context) (string, error) {
+	imageFsInfo, err := p.cadvisor.ImagesFsInfo(ctx)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/kubelet/stats/cadvisor_stats_provider_test.go
+++ b/pkg/kubelet/stats/cadvisor_stats_provider_test.go
@@ -248,7 +248,7 @@ func TestCadvisorListPodStats(t *testing.T) {
 	mockCadvisor := cadvisortest.NewMockInterface(t)
 	mockCadvisor.EXPECT().ContainerInfoV2("/", options).Return(infos, nil)
 	mockCadvisor.EXPECT().RootFsInfo().Return(rootfs, nil)
-	mockCadvisor.EXPECT().ImagesFsInfo().Return(imagefs, nil)
+	mockCadvisor.EXPECT().ImagesFsInfo(ctx).Return(imagefs, nil)
 
 	mockRuntime := containertest.NewMockRuntime(t)
 
@@ -531,7 +531,7 @@ func TestCadvisorImagesFsStatsKubeletSeparateDiskOff(t *testing.T) {
 
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.KubeletSeparateDiskGC, false)
 
-	mockCadvisor.EXPECT().ImagesFsInfo().Return(imageFsInfo, nil)
+	mockCadvisor.EXPECT().ImagesFsInfo(ctx).Return(imageFsInfo, nil)
 	mockRuntime.EXPECT().ImageStats(ctx).Return(imageStats, nil)
 
 	provider := newCadvisorStatsProvider(mockCadvisor, &fakeResourceAnalyzer{}, mockRuntime, nil, NewFakeHostStatsProvider())
@@ -609,10 +609,10 @@ func TestImageFsStatsCustomResponse(t *testing.T) {
 		mockRuntime := containertest.NewMockRuntime(t)
 
 		res := getTestFsInfo(1000)
-		mockCadvisor.EXPECT().ImagesFsInfo().Return(res, nil)
+		mockCadvisor.EXPECT().ImagesFsInfo(ctx).Return(res, nil)
 		mockRuntime.EXPECT().ImageFsInfo(ctx).Return(tc.response, nil)
 		if tc.callContainerFsInfo {
-			mockCadvisor.EXPECT().ContainerFsInfo().Return(res, nil)
+			mockCadvisor.EXPECT().ContainerFsInfo(ctx).Return(res, nil)
 		}
 
 		provider := newCadvisorStatsProvider(mockCadvisor, &fakeResourceAnalyzer{}, mockRuntime, nil, NewFakeHostStatsProvider())
@@ -649,7 +649,7 @@ func TestCadvisorImagesFsStats(t *testing.T) {
 	}
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.KubeletSeparateDiskGC, true)
 
-	mockCadvisor.EXPECT().ImagesFsInfo().Return(imageFsInfo, nil)
+	mockCadvisor.EXPECT().ImagesFsInfo(ctx).Return(imageFsInfo, nil)
 	mockRuntime.EXPECT().ImageFsInfo(ctx).Return(imageFsInfoResponse, nil)
 
 	provider := newCadvisorStatsProvider(mockCadvisor, &fakeResourceAnalyzer{}, mockRuntime, nil, NewFakeHostStatsProvider())
@@ -701,8 +701,8 @@ func TestCadvisorSplitImagesFsStats(t *testing.T) {
 		ContainerFilesystems: []*runtimeapi.FilesystemUsage{containerFsInfoCRI},
 	}
 
-	mockCadvisor.EXPECT().ImagesFsInfo().Return(imageFsInfo, nil)
-	mockCadvisor.EXPECT().ContainerFsInfo().Return(containerFsInfo, nil)
+	mockCadvisor.EXPECT().ImagesFsInfo(ctx).Return(imageFsInfo, nil)
+	mockCadvisor.EXPECT().ContainerFsInfo(ctx).Return(containerFsInfo, nil)
 	mockRuntime.EXPECT().ImageFsInfo(ctx).Return(imageFsInfoResponse, nil)
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.KubeletSeparateDiskGC, true)
 
@@ -754,8 +754,8 @@ func TestCadvisorSameDiskDifferentLocations(t *testing.T) {
 		ContainerFilesystems: []*runtimeapi.FilesystemUsage{containerFsInfoCRI},
 	}
 
-	mockCadvisor.EXPECT().ImagesFsInfo().Return(imageFsInfo, nil)
-	mockCadvisor.EXPECT().ContainerFsInfo().Return(containerFsInfo, nil)
+	mockCadvisor.EXPECT().ImagesFsInfo(ctx).Return(imageFsInfo, nil)
+	mockCadvisor.EXPECT().ContainerFsInfo(ctx).Return(containerFsInfo, nil)
 	mockRuntime.EXPECT().ImageFsInfo(ctx).Return(imageFsInfoResponse, nil)
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.KubeletSeparateDiskGC, true)
 
@@ -858,7 +858,7 @@ func TestCadvisorListPodStatsWhenContainerLogFound(t *testing.T) {
 	mockCadvisor := cadvisortest.NewMockInterface(t)
 	mockCadvisor.EXPECT().ContainerInfoV2("/", options).Return(infos, nil)
 	mockCadvisor.EXPECT().RootFsInfo().Return(rootfs, nil)
-	mockCadvisor.EXPECT().ImagesFsInfo().Return(imagefs, nil)
+	mockCadvisor.EXPECT().ImagesFsInfo(ctx).Return(imagefs, nil)
 
 	mockRuntime := containertest.NewMockRuntime(t)
 	mockRuntime.EXPECT().ImageStats(ctx).Return(&kubecontainer.ImageStats{TotalStorageBytes: 123}, nil).Maybe()

--- a/pkg/kubelet/stats/provider.go
+++ b/pkg/kubelet/stats/provider.go
@@ -200,11 +200,11 @@ func (p *Provider) HasDedicatedImageFs(ctx context.Context) (bool, error) {
 // HasDedicatedImageFs returns true if a dedicated image filesystem exists for storing images.
 // KEP Issue Number 4191: Enhanced this to allow for the containers to be separate from images.
 func (p *Provider) HasDedicatedContainerFs(ctx context.Context) (bool, error) {
-	imageFs, err := p.cadvisor.ImagesFsInfo()
+	imageFs, err := p.cadvisor.ImagesFsInfo(ctx)
 	if err != nil {
 		return false, err
 	}
-	containerFs, err := p.cadvisor.ContainerFsInfo()
+	containerFs, err := p.cadvisor.ContainerFsInfo(ctx)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

migrate pkg/kubelet/cadvisor to contextual logging

#### Does this PR introduce a user-facing change?

```release-note
NONE
```