### PR TITLE
Revert "Merge pull request #127669 from olyazavr/fix-probe-race"

### DIFF
--- a/pkg/volume/plugins.go
+++ b/pkg/volume/plugins.go
@@ -627,7 +627,6 @@ func (pm *VolumePluginMgr) initProbedPlugin(probedPlugin VolumePlugin) error {
 // specification.  If no plugins can support or more than one plugin can
 // support it, return error.
 func (pm *VolumePluginMgr) FindPluginBySpec(spec *Spec) (VolumePlugin, error) {
-	pm.refreshProbedPlugins()
 	pm.mutex.RLock()
 	defer pm.mutex.RUnlock()
 
@@ -644,6 +643,7 @@ func (pm *VolumePluginMgr) FindPluginBySpec(spec *Spec) (VolumePlugin, error) {
 		}
 	}
 
+	pm.refreshProbedPlugins()
 	for _, plugin := range pm.probedPlugins {
 		if plugin.CanSupport(spec) {
 			match = plugin
@@ -663,7 +663,6 @@ func (pm *VolumePluginMgr) FindPluginBySpec(spec *Spec) (VolumePlugin, error) {
 
 // FindPluginByName fetches a plugin by name. If no plugin is found, returns error.
 func (pm *VolumePluginMgr) FindPluginByName(name string) (VolumePlugin, error) {
-	pm.refreshProbedPlugins()
 	pm.mutex.RLock()
 	defer pm.mutex.RUnlock()
 
@@ -672,6 +671,7 @@ func (pm *VolumePluginMgr) FindPluginByName(name string) (VolumePlugin, error) {
 		match = v
 	}
 
+	pm.refreshProbedPlugins()
 	if plugin, found := pm.probedPlugins[name]; found {
 		if match != nil {
 			return nil, fmt.Errorf("multiple volume plugins matched: %s and %s", match.GetPluginName(), plugin.GetPluginName())
@@ -694,12 +694,6 @@ func (pm *VolumePluginMgr) refreshProbedPlugins() {
 		klog.ErrorS(err, "Error dynamically probing plugins")
 	}
 
-	if len(events) == 0 {
-		return
-	}
-
-	pm.mutex.Lock()
-	defer pm.mutex.Unlock()
 	// because the probe function can return a list of valid plugins
 	// even when an error is present we still must add the plugins
 	// or they will be skipped because each event only fires once


### PR DESCRIPTION
This reverts commit 3d00d6e42113db6fca88ec6a0d03970bc63d7bea, reversing changes made to a7fcc89ac0e7124158eee58820bbf517e0a15377.

Revert of https://github.com/kubernetes/kubernetes/pull/127669 because panics / negative waitgroup counts are seen in the added unit test: https://github.com/kubernetes/kubernetes/pull/127669/files#r1822848065

/kind bug
/sig storage
/assign @jsafrane 

before reintroducing, please ensure the added tests pass in race mode and under stress (https://gist.github.com/liggitt/6a3a2217fa5f846b52519acfc0ffece0#running-unit-tests-to-reproduce-flakes)

```release-note
NONE
```