### PR TITLE
deflake probe race tests

### DIFF
--- a/pkg/volume/flexvolume/probe_test.go
+++ b/pkg/volume/flexvolume/probe_test.go
@@ -345,14 +345,14 @@ func TestProberMultiThreaded(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
+			pluginNameMutex.Lock()
 			events, err := prober.Probe()
 			for _, event := range events {
 				if event.Op == volume.ProbeAddOrUpdate {
-					pluginNameMutex.Lock()
 					pluginName = event.Plugin.GetPluginName()
-					pluginNameMutex.Unlock()
 				}
 			}
+			pluginNameMutex.Unlock()
 			// this fails if ProbeAll is not complete before the next call comes in but we have assumed that it has
 			pluginNameMutex.RLock()
 			assert.Equal(t, "fake-driver", pluginName)

--- a/pkg/volume/flexvolume/probe_test.go
+++ b/pkg/volume/flexvolume/probe_test.go
@@ -342,6 +342,7 @@ func TestProberMultiThreaded(t *testing.T) {
 
 	// Act
 	for i := 0; i < 100; i++ {
+		wg.Add(1)
 		go func() {
 			defer wg.Done()
 			events, err := prober.Probe()
@@ -361,7 +362,6 @@ func TestProberMultiThreaded(t *testing.T) {
 				totalErrors.Add(1)
 			}
 		}()
-		wg.Add(1)
 	}
 	wg.Wait()
 

--- a/pkg/volume/plugins.go
+++ b/pkg/volume/plugins.go
@@ -688,6 +688,8 @@ func (pm *VolumePluginMgr) FindPluginByName(name string) (VolumePlugin, error) {
 // Check if probedPlugin cache update is required.
 // If it is, initialize all probed plugins and replace the cache with them.
 func (pm *VolumePluginMgr) refreshProbedPlugins() {
+	pm.mutex.Lock()
+	defer pm.mutex.Unlock()
 	events, err := pm.prober.Probe()
 
 	if err != nil {
@@ -698,8 +700,6 @@ func (pm *VolumePluginMgr) refreshProbedPlugins() {
 		return
 	}
 
-	pm.mutex.Lock()
-	defer pm.mutex.Unlock()
 	// because the probe function can return a list of valid plugins
 	// even when an error is present we still must add the plugins
 	// or they will be skipped because each event only fires once

--- a/pkg/volume/plugins_test.go
+++ b/pkg/volume/plugins_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package volume
 
 import (
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"sync"
 	"sync/atomic"
@@ -180,7 +179,6 @@ func TestVolumePluginMultiThreaded(t *testing.T) {
 	require.NoError(t, err)
 
 	volumeSpec := &Spec{}
-	totalErrors := atomic.Int32{}
 	var wg sync.WaitGroup
 
 	for i := 0; i < 100; i++ {
@@ -189,13 +187,11 @@ func TestVolumePluginMultiThreaded(t *testing.T) {
 			defer wg.Done()
 			_, err := vpm.FindPluginByName(testPluginName)
 			if err != nil {
-				totalErrors.Add(1)
+				require.NoError(t, err)
 			}
 		}()
 	}
 	wg.Wait()
-
-	assert.Equal(t, int32(0), totalErrors.Load())
 
 	for i := 0; i < 100; i++ {
 		wg.Add(1)
@@ -203,13 +199,11 @@ func TestVolumePluginMultiThreaded(t *testing.T) {
 			defer wg.Done()
 			_, err := vpm.FindPluginBySpec(volumeSpec)
 			if err != nil {
-				totalErrors.Add(1)
+				require.NoError(t, err)
 			}
 		}()
 	}
 	wg.Wait()
-
-	assert.Equal(t, int32(0), totalErrors.Load())
 }
 
 type fakeProber struct {

--- a/pkg/volume/plugins_test.go
+++ b/pkg/volume/plugins_test.go
@@ -184,6 +184,7 @@ func TestVolumePluginMultiThreaded(t *testing.T) {
 	var wg sync.WaitGroup
 
 	for i := 0; i < 100; i++ {
+		wg.Add(1)
 		go func() {
 			defer wg.Done()
 			_, err := vpm.FindPluginByName(testPluginName)
@@ -191,7 +192,6 @@ func TestVolumePluginMultiThreaded(t *testing.T) {
 				totalErrors.Add(1)
 			}
 		}()
-		wg.Add(1)
 	}
 	wg.Wait()
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind flake
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

In https://github.com/kubernetes/kubernetes/pull/127669/files#r1822848065 we see that the test introduced in https://github.com/kubernetes/kubernetes/pull/127669 is flakey because the waitgroup is incorrectly done- `wg.Add` should be called before the goroutine, in the event that the goroutine finishes quickly and calls `wg.Done`

After running [stress as per the docs](https://gist.github.com/liggitt/6a3a2217fa5f846b52519acfc0ffece0#running-unit-tests-to-reproduce-flakes), I also found one place that needed locking earlier

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
