### PR TITLE
kubeadm: support dryrunning upgrade without a real cluster

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/upgrade/apply/preflight.go
+++ b/cmd/kubeadm/app/cmd/phases/upgrade/apply/preflight.go
@@ -80,7 +80,7 @@ func runPreflight(c workflow.RunData) error {
 
 	// Run healthchecks against the cluster.
 	klog.V(1).Infoln("[upgrade/preflight] Verifying the cluster health")
-	if err := upgrade.CheckClusterHealth(client, &initCfg.ClusterConfiguration, ignorePreflightErrors, printer); err != nil {
+	if err := upgrade.CheckClusterHealth(client, &initCfg.ClusterConfiguration, ignorePreflightErrors, data.DryRun(), printer); err != nil {
 		return err
 	}
 

--- a/cmd/kubeadm/app/cmd/upgrade/apply.go
+++ b/cmd/kubeadm/app/cmd/upgrade/apply.go
@@ -223,12 +223,12 @@ func newApplyData(cmd *cobra.Command, args []string, applyFlags *applyFlags) (*a
 		return nil, cmdutil.TypeMismatchErr("printConfig", "bool")
 	}
 
-	client, err := getClient(applyFlags.kubeConfigPath, *dryRun)
+	printer := &output.TextPrinter{}
+
+	client, err := getClient(applyFlags.kubeConfigPath, *dryRun, printer)
 	if err != nil {
 		return nil, errors.Wrapf(err, "couldn't create a Kubernetes client from file %q", applyFlags.kubeConfigPath)
 	}
-
-	printer := &output.TextPrinter{}
 
 	// Fetches the cluster configuration.
 	klog.V(1).Infoln("[upgrade] retrieving configuration from cluster")

--- a/cmd/kubeadm/app/phases/upgrade/staticpods_test.go
+++ b/cmd/kubeadm/app/phases/upgrade/staticpods_test.go
@@ -113,11 +113,6 @@ func (w *fakeWaiter) WaitForPodsWithLabel(kvLabel string) error {
 	return w.errsToReturn[waitForPodsWithLabel]
 }
 
-// WaitForPodToDisappear just returns a dummy nil, to indicate that the program should just proceed
-func (w *fakeWaiter) WaitForPodToDisappear(podName string) error {
-	return nil
-}
-
 // SetTimeout is a no-op; we don't use it in this implementation
 func (w *fakeWaiter) SetTimeout(_ time.Duration) {}
 

--- a/cmd/kubeadm/app/util/apiclient/dryrun_test.go
+++ b/cmd/kubeadm/app/util/apiclient/dryrun_test.go
@@ -316,6 +316,35 @@ func TestReactors(t *testing.T) {
 			},
 		},
 		{
+			name: "GetCoreDNSConfigReactor",
+			setup: func(d *DryRun) {
+				d.PrependReactor((d.GetCoreDNSConfigReactor()))
+			},
+			apiCall: func(d *DryRun, namespace, name string) error {
+				obj, err := d.FakeClient().CoreV1().ConfigMaps(namespace).Get(ctx, name, metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+				expectedObj := getCoreDNSConfigMap()
+				if diff := cmp.Diff(expectedObj, obj); diff != "" {
+					return errors.Errorf("object differs (-want,+got):\n%s", diff)
+				}
+				return nil
+			},
+			apiCallCases: []apiCallCase{
+				{
+					name:          "foo",
+					namespace:     "bar",
+					expectedError: true,
+				},
+				{
+					name:          "coredns",
+					namespace:     metav1.NamespaceSystem,
+					expectedError: false,
+				},
+			},
+		},
+		{
 			name: "DeleteBootstrapTokenReactor",
 			setup: func(d *DryRun) {
 				d.PrependReactor((d.DeleteBootstrapTokenReactor()))
@@ -335,6 +364,89 @@ func TestReactors(t *testing.T) {
 				},
 				{
 					name:          "bootstrap-token-foo",
+					namespace:     metav1.NamespaceSystem,
+					expectedError: false,
+				},
+			},
+		},
+		{
+			name: "GetKubeadmCertsReactor",
+			setup: func(d *DryRun) {
+				d.PrependReactor((d.GetKubeadmCertsReactor()))
+			},
+			apiCall: func(d *DryRun, namespace, name string) error {
+				obj, err := d.FakeClient().CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+				expectedObj := getKubeadmCertsSecret()
+				if diff := cmp.Diff(expectedObj, obj); diff != "" {
+					return errors.Errorf("object differs (-want,+got):\n%s", diff)
+				}
+				return nil
+			},
+			apiCallCases: []apiCallCase{
+				{
+					name:          "foo",
+					namespace:     "bar",
+					expectedError: true,
+				},
+				{
+					name:          "kubeadm-certs",
+					namespace:     metav1.NamespaceSystem,
+					expectedError: false,
+				},
+			},
+		},
+		{
+			name: "ListPodsReactor",
+			setup: func(d *DryRun) {
+				d.PrependReactor((d.ListPodsReactor("foo")))
+			},
+			apiCall: func(d *DryRun, namespace, name string) error {
+				obj, err := d.FakeClient().CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{})
+				if err != nil {
+					return err
+				}
+				expectedObj := getPodList("foo")
+				if diff := cmp.Diff(expectedObj, obj); diff != "" {
+					return errors.Errorf("object differs (-want,+got):\n%s", diff)
+				}
+				return nil
+			},
+			apiCallCases: []apiCallCase{
+				{
+					namespace:     "bar",
+					expectedError: true,
+				},
+				{
+					namespace:     metav1.NamespaceSystem,
+					expectedError: false,
+				},
+			},
+		},
+		{
+			name: "ListDeploymentsReactor",
+			setup: func(d *DryRun) {
+				d.PrependReactor((d.ListDeploymentsReactor()))
+			},
+			apiCall: func(d *DryRun, namespace, name string) error {
+				obj, err := d.FakeClient().AppsV1().Deployments(namespace).List(ctx, metav1.ListOptions{})
+				if err != nil {
+					return err
+				}
+				expectedObj := getDeploymentList()
+				if diff := cmp.Diff(expectedObj, obj); diff != "" {
+					return errors.Errorf("object differs (-want,+got):\n%s", diff)
+				}
+				return nil
+			},
+			apiCallCases: []apiCallCase{
+				{
+					namespace:     "bar",
+					expectedError: true,
+				},
+				{
 					namespace:     metav1.NamespaceSystem,
 					expectedError: false,
 				},

--- a/cmd/kubeadm/app/util/dryrun/dryrun.go
+++ b/cmd/kubeadm/app/util/dryrun/dryrun.go
@@ -106,12 +106,6 @@ func (w *Waiter) WaitForPodsWithLabel(kvLabel string) error {
 	return nil
 }
 
-// WaitForPodToDisappear just returns a dummy nil, to indicate that the program should just proceed
-func (w *Waiter) WaitForPodToDisappear(podName string) error {
-	fmt.Printf("[dryrun] Would wait for the %q Pod in the %s namespace to be deleted\n", podName, metav1.NamespaceSystem)
-	return nil
-}
-
 // WaitForKubelet blocks until the kubelet /healthz endpoint returns 'ok'
 func (w *Waiter) WaitForKubelet(healthzAddress string, healthzPort int32) error {
 	fmt.Printf("[dryrun] Would make sure the kubelet returns 'ok' at http://%s:%d/healthz\n", healthzAddress, healthzPort)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup feature

#### What this PR does / why we need it:

Make the following changes:
- When dryrunning if the given kubeconfig does not exist create a DryRun object without a real client. This means only a fake client will be used for all actions.
- Skip the preflight check if manifests exist during dryrun. Print "would ..." instead.
- Add new reactors that handle objects during upgrade.
- Add unit tests for new reactors.
- Print message on "upgrade node" that this is not a CP node if the apiserver manifest is missing.
- Various other minor fixes.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
xref:
- https://github.com/kubernetes/kubeadm/pull/3116
- https://github.com/kubernetes/kubeadm/issues/2653
- 
follow-up on:
- https://github.com/kubernetes/kubernetes/pull/126776

fixes https://github.com/kubernetes/kubeadm/issues/1098

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
