### PR TITLE
KEP-4222: Reject custom marshalers from direct CBOR Marshal and Unmarshal.

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/direct/direct.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/direct/direct.go
@@ -23,14 +23,39 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer/cbor/internal/modes"
 )
 
+// Marshal serializes a value to CBOR. If there is more than one way to encode the value, it will
+// make the same choice as the CBOR implementation of runtime.Serializer.
+//
+// Note: Support for CBOR is at an alpha stage. If the value (or, for composite types, any of its
+// nested values) implement any of the interfaces encoding.TextMarshaler, encoding.TextUnmarshaler,
+// encoding/json.Marshaler, or encoding/json.Unmarshaler, a non-nil error will be returned unless
+// the value also implements the corresponding CBOR interfaces. This limitation will ultimately be
+// removed in favor of automatic transcoding to CBOR.
 func Marshal(src interface{}) ([]byte, error) {
+	if err := modes.RejectCustomMarshalers(src); err != nil {
+		return nil, err
+	}
 	return modes.Encode.Marshal(src)
 }
 
+// Unmarshal deserializes from CBOR into an addressable value. If there is more than one way to
+// unmarshal a value, it will make the same choice as the CBOR implementation of runtime.Serializer.
+//
+// Note: Support for CBOR is at an alpha stage. If the value (or, for composite types, any of its
+// nested values) implement any of the interfaces encoding.TextMarshaler, encoding.TextUnmarshaler,
+// encoding/json.Marshaler, or encoding/json.Unmarshaler, a non-nil error will be returned unless
+// the value also implements the corresponding CBOR interfaces. This limitation will ultimately be
+// removed in favor of automatic transcoding to CBOR.
 func Unmarshal(src []byte, dst interface{}) error {
+	if err := modes.RejectCustomMarshalers(dst); err != nil {
+		return err
+	}
 	return modes.Decode.Unmarshal(src, dst)
 }
 
+// Diagnose accepts well-formed CBOR bytes and returns a string representing the same data item in
+// human-readable diagnostic notation (RFC 8949 Section 8). The diagnostic notation is not meant to
+// be parsed.
 func Diagnose(src []byte) (string, error) {
 	return modes.Diagnostic.Diagnose(src)
 }

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/direct/direct_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/direct/direct_test.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package direct_test
+
+import (
+	"encoding"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime/serializer/cbor/direct"
+)
+
+var _ json.Marshaler = CustomJSONMarshaler{}
+
+type CustomJSONMarshaler struct{}
+
+func (CustomJSONMarshaler) MarshalJSON() ([]byte, error) {
+	panic("unimplemented")
+}
+
+var _ json.Unmarshaler = CustomJSONUnmarshaler{}
+
+type CustomJSONUnmarshaler struct{}
+
+func (CustomJSONUnmarshaler) UnmarshalJSON([]byte) error {
+	panic("unimplemented")
+}
+
+var _ encoding.TextMarshaler = CustomTextMarshaler{}
+
+type CustomTextMarshaler struct{}
+
+func (CustomTextMarshaler) MarshalText() ([]byte, error) {
+	panic("unimplemented")
+}
+
+var _ encoding.TextUnmarshaler = CustomTextUnmarshaler{}
+
+type CustomTextUnmarshaler struct{}
+
+func (CustomTextUnmarshaler) UnmarshalText([]byte) error {
+	panic("unimplemented")
+}
+
+func TestRejectsCustom(t *testing.T) {
+	for _, tc := range []struct {
+		value interface{}
+		iface reflect.Type
+	}{
+		{value: CustomJSONMarshaler{}, iface: reflect.TypeFor[json.Marshaler]()},
+		{value: CustomJSONUnmarshaler{}, iface: reflect.TypeFor[json.Unmarshaler]()},
+		{value: CustomTextMarshaler{}, iface: reflect.TypeFor[encoding.TextMarshaler]()},
+		{value: CustomTextUnmarshaler{}, iface: reflect.TypeFor[encoding.TextUnmarshaler]()},
+	} {
+		t.Run(fmt.Sprintf("%T", tc.value), func(t *testing.T) {
+			want := fmt.Sprintf("unable to serialize %T: %T implements %s without corresponding cbor interface", tc.value, tc.value, tc.iface.String())
+			if _, err := direct.Marshal(tc.value); err == nil || err.Error() != want {
+				t.Errorf("want error: %q, got: %v", want, err)
+			}
+			if err := direct.Unmarshal(nil, tc.value); err == nil || err.Error() != want {
+				t.Errorf("want error: %q, got: %v", want, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup
/sig api-machinery

#### What this PR does / why we need it:

Types that implement any of the stdlib text and JSON marshaler and unmarshaler interfaces without implementing the corresponding CBOR interfaces are currently rejected by the CBOR serializer. This is a temporary measure for the initial alpha; such types will ultimately be handled via automatic transcoding. The "cbor/direct" subpackage exports Marshal and Unmarshal functions to support the implementation of custom CBOR marshalling and unmarshalling behaviors, but did not include the safeguard against handling non-CBOR custom marshalers.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://kep.k8s.io/4222
```
