### PR TITLE
feature: Make Unschedulable scheduler performance test parametrized with the number of initial nodes.

### DIFF
--- a/test/integration/scheduler_perf/misc/performance-config.yaml
+++ b/test/integration/scheduler_perf/misc/performance-config.yaml
@@ -383,10 +383,13 @@
       measurePods: 5000
 
 # Measure throughput of regular schedulable pods that are interleaved by unschedulable pods injected at 5/s rate.
+# Note that the scheduling performance depends on the number of Pods, as preemption plugin needs to loop over all Pods in attempt to preempt them.
 - name: Unschedulable
   workloadTemplate:
   - opcode: createNodes
     countParam: $initNodes
+  - opcode: createPods
+    countParam: $initPods
   - opcode: churn
     mode: create
     templatePaths:
@@ -397,45 +400,67 @@
     podTemplatePath: ../templates/pod-default.yaml
     collectMetrics: true
   workloads:
-  - name: 5Nodes/10Pods
+  - name: 5Nodes/1Init/10Pods
     featureGates:
       SchedulerQueueingHints: false
     labels: [integration-test, short]
     params:
       initNodes: 5
+      initPods: 1
       measurePods: 10
-  - name: 5Nodes/10Pods_QueueingHintsEnabled
+  - name: 5Nodes/1Init/10Pods_QueueingHintsEnabled
     featureGates:
       SchedulerQueueingHints: true
     labels: [integration-test, short]
     params:
       initNodes: 5
+      initPods: 1
       measurePods: 10
-  - name: 500Nodes/1kPods
+  - name: 500Nodes/10Init/1kPods
     labels: [performance, short]
     params:
       initNodes: 500
+      initPods: 10
       measurePods: 1000
-  - name: 5kNodes/1kPods
+  - name: 5kNodes/100Init/1kPods
     labels: [performance, short]
     params:
       initNodes: 5000
+      initPods: 100
       measurePods: 1000
-  - name: 5kNodes/10kPods
+  - name: 5kNodes/100Init/10kPods
     featureGates:
       SchedulerQueueingHints: false
     labels: [performance]
     threshold: 140
     params:
       initNodes: 5000
+      initPods: 100
       measurePods: 10000
-  - name: 5kNodes/10kPods_QueueingHintsEnabled
+  - name: 5kNodes/100Init/10kPods_QueueingHintsEnabled
     featureGates:
       SchedulerQueueingHints: true
     labels: [performance]
     threshold: 170
     params:
       initNodes: 5000
+      initPods: 100
+      measurePods: 10000
+  - name: 5kNodes/20kInit/10kPods
+    featureGates:
+      SchedulerQueueingHints: false
+    labels: [performance]
+    params:
+      initNodes: 5000
+      initPods: 20000
+      measurePods: 10000
+  - name: 5kNodes/20kInit/10kPods_QueueingHintsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
+    labels: [performance]
+    params:
+      initNodes: 5000
+      initPods: 20000
       measurePods: 10000
 
 - name: SchedulingWithMixedChurn


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Performance of processing unschedulable pods depends on the overall number of the scheduled pods, since all of them need to be considered in the postfilter by the preemption plugin.

This change parametrizes Unschedulable test with the number of initial pods, to show the difference in the throughput of regular pods when they are interleaved with these unschedulable ones.

The throughput numbers shown by this test case are not fully representative, as they only indirectly show the time scheduler needs spend processing unschedulable pods. In practices, we are more interested in the time this processing takes, since scheduling large number of high priority unschedulable pods will in fact block scheduler for a certain time.

I made some measures and it turns out that when there is 20k pods running, the scheduling takes 20ms (50/s), which means that scheduling 3k such pods will block scheduling for a minute.

#### Which issue(s) this PR fixes:
Part of #128221

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
