### PR TITLE
volume: fix unit test flake, II

### DIFF
--- a/pkg/volume/plugins_test.go
+++ b/pkg/volume/plugins_test.go
@@ -17,11 +17,12 @@ limitations under the License.
 package volume
 
 import (
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"sync"
 	"sync/atomic"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -184,6 +185,7 @@ func TestVolumePluginMultiThreaded(t *testing.T) {
 	var wg sync.WaitGroup
 
 	for i := 0; i < 100; i++ {
+		wg.Add(1)
 		go func() {
 			defer wg.Done()
 			_, err := vpm.FindPluginByName(testPluginName)
@@ -191,7 +193,6 @@ func TestVolumePluginMultiThreaded(t *testing.T) {
 				totalErrors.Add(1)
 			}
 		}()
-		wg.Add(1)
 	}
 	wg.Wait()
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind failing-test
/kind flake

#### What this PR does / why we need it:

```
=== RUN   TestVolumePluginMultiThreaded
panic: sync: negative WaitGroup counter

goroutine 104 [running]:
sync.(*WaitGroup).Add(0xc000138e20, 0xffffffffffffffff)
	/usr/local/go/src/sync/waitgroup.go:64 +0x1b8
sync.(*WaitGroup).Done(0xc000138e20)
	/usr/local/go/src/sync/waitgroup.go:89 +0x2e
k8s.io/kubernetes/pkg/volume.TestVolumePluginMultiThreaded.func1()
	/home/prow/go/src/k8s.io/kubernetes/pkg/volume/plugins_test.go:193 +0xae
created by k8s.io/kubernetes/pkg/volume.TestVolumePluginMultiThreaded in goroutine 58
	/home/prow/go/src/k8s.io/kubernetes/pkg/volume/plugins_test.go:187 +0x2ba
```

#### Special notes for your reviewer:

33749d0436b3b3590c90dba785a6dee957f561f9 fixed this in one place. Here's the fix for the other place.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/cc @jsafrane @sttts 