### PR TITLE
kubeadm: use actual addresses/ports for WaitForAllControlPlaneComponents

### DIFF
--- a/cmd/kubeadm/app/util/apiclient/wait.go
+++ b/cmd/kubeadm/app/util/apiclient/wait.go
@@ -40,7 +40,7 @@ import (
 
 // Waiter is an interface for waiting for criteria in Kubernetes to happen
 type Waiter interface {
-	// WaitForControlPlaneComponents waits for all control plane components to report "ok" on /healthz
+	// WaitForControlPlaneComponents waits for all control plane components to be ready.
 	WaitForControlPlaneComponents(cfg *kubeadmapi.ClusterConfiguration) error
 	// WaitForAPI waits for the API Server's /healthz endpoint to become "ok"
 	// TODO: remove WaitForAPI once WaitForAllControlPlaneComponents goes GA:
@@ -84,31 +84,58 @@ type controlPlaneComponent struct {
 	url  string
 }
 
+const (
+	// TODO: switch to /livez once all components support it
+	// and delete the endpointHealthz constant.
+	// https://github.com/kubernetes/kubernetes/issues/118158
+	endpointHealthz = "healthz"
+	endpointLivez   = "livez"
+)
+
 // getControlPlaneComponents takes a ClusterConfiguration and returns a slice of
-// control plane components and their secure ports.
+// control plane components and their health check URLs.
 func getControlPlaneComponents(cfg *kubeadmapi.ClusterConfiguration) []controlPlaneComponent {
-	portArg := "secure-port"
+	const (
+		portArg        = "secure-port"
+		addressArg     = "bind-address"
+		defaultAddress = "127.0.0.1"
+	)
+
 	portAPIServer, idx := kubeadmapi.GetArgValue(cfg.APIServer.ExtraArgs, portArg, -1)
 	if idx == -1 {
-		portAPIServer = "6443"
+		portAPIServer = fmt.Sprintf("%d", constants.KubeAPIServerPort)
 	}
 	portKCM, idx := kubeadmapi.GetArgValue(cfg.ControllerManager.ExtraArgs, portArg, -1)
 	if idx == -1 {
-		portKCM = "10257"
+		portKCM = fmt.Sprintf("%d", constants.KubeControllerManagerPort)
 	}
 	portScheduler, idx := kubeadmapi.GetArgValue(cfg.Scheduler.ExtraArgs, portArg, -1)
 	if idx == -1 {
-		portScheduler = "10259"
+		portScheduler = fmt.Sprintf("%d", constants.KubeSchedulerPort)
 	}
-	urlFormat := "https://127.0.0.1:%s/healthz"
+
+	addressAPIServer, idx := kubeadmapi.GetArgValue(cfg.APIServer.ExtraArgs, addressArg, -1)
+	if idx == -1 {
+		addressAPIServer = defaultAddress
+	}
+	addressKCM, idx := kubeadmapi.GetArgValue(cfg.ControllerManager.ExtraArgs, addressArg, -1)
+	if idx == -1 {
+		addressKCM = defaultAddress
+	}
+	addressScheduler, idx := kubeadmapi.GetArgValue(cfg.Scheduler.ExtraArgs, addressArg, -1)
+	if idx == -1 {
+		addressScheduler = defaultAddress
+	}
+
+	urlFormat := "https://%s:%s/%s"
 	return []controlPlaneComponent{
-		{name: "kube-apiserver", url: fmt.Sprintf(urlFormat, portAPIServer)},
-		{name: "kube-controller-manager", url: fmt.Sprintf(urlFormat, portKCM)},
-		{name: "kube-scheduler", url: fmt.Sprintf(urlFormat, portScheduler)},
+		{name: "kube-apiserver", url: fmt.Sprintf(urlFormat, addressAPIServer, portAPIServer, endpointLivez)},
+		{name: "kube-controller-manager", url: fmt.Sprintf(urlFormat, addressKCM, portKCM, endpointHealthz)},
+		{name: "kube-scheduler", url: fmt.Sprintf(urlFormat, addressScheduler, portScheduler, endpointLivez)},
 	}
 }
 
-// WaitForControlPlaneComponents waits for all control plane components to report "ok" on /healthz
+// WaitForControlPlaneComponents waits for all control plane components to report "ok".
 func (w *KubeWaiter) WaitForControlPlaneComponents(cfg *kubeadmapi.ClusterConfiguration) error {
 	fmt.Printf("[control-plane-check] Waiting for healthy control plane components."+
 		" This can take up to %v\n", w.timeout)
@@ -136,7 +163,7 @@ func (w *KubeWaiter) WaitForControlPlaneComponents(cfg *kubeadmapi.ClusterConfig
 				true, func(ctx context.Context) (bool, error) {
 					resp, err := client.Get(comp.url)
 					if err != nil {
-						lastError = errors.WithMessagef(err, "%s /healthz check failed", comp.name)
+						lastError = errors.WithMessagef(err, "%s check failed at %s", comp.name, comp.url)
 						return false, nil
 					}
 
@@ -144,7 +171,8 @@ func (w *KubeWaiter) WaitForControlPlaneComponents(cfg *kubeadmapi.ClusterConfig
 						_ = resp.Body.Close()
 					}()
 					if resp.StatusCode != http.StatusOK {
-						lastError = errors.Errorf("%s /healthz check failed with status: %d", comp.name, resp.StatusCode)
+						lastError = errors.Errorf("%s check failed at %s with status: %d",
+							comp.name, comp.url, resp.StatusCode)
 						return false, nil
 					}
 

--- a/cmd/kubeadm/app/util/apiclient/wait_test.go
+++ b/cmd/kubeadm/app/util/apiclient/wait_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package apiclient
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -30,39 +31,42 @@ func TestGetControlPlaneComponents(t *testing.T) {
 		expected []controlPlaneComponent
 	}{
 		{
-			name: "port values from config",
+			name: "port and addresses from config",
 			cfg: &kubeadmapi.ClusterConfiguration{
 				APIServer: kubeadmapi.APIServer{
 					ControlPlaneComponent: kubeadmapi.ControlPlaneComponent{
 						ExtraArgs: []kubeadmapi.Arg{
 							{Name: "secure-port", Value: "1111"},
+							{Name: "bind-address", Value: "0.0.0.0"},
 						},
 					},
 				},
 				ControllerManager: kubeadmapi.ControlPlaneComponent{
 					ExtraArgs: []kubeadmapi.Arg{
 						{Name: "secure-port", Value: "2222"},
+						{Name: "bind-address", Value: "0.0.0.0"},
 					},
 				},
 				Scheduler: kubeadmapi.ControlPlaneComponent{
 					ExtraArgs: []kubeadmapi.Arg{
 						{Name: "secure-port", Value: "3333"},
+						{Name: "bind-address", Value: "0.0.0.0"},
 					},
 				},
 			},
 			expected: []controlPlaneComponent{
-				{name: "kube-apiserver", url: "https://127.0.0.1:1111/healthz"},
-				{name: "kube-controller-manager", url: "https://127.0.0.1:2222/healthz"},
-				{name: "kube-scheduler", url: "https://127.0.0.1:3333/healthz"},
+				{name: "kube-apiserver", url: fmt.Sprintf("https://0.0.0.0:1111/%s", endpointLivez)},
+				{name: "kube-controller-manager", url: fmt.Sprintf("https://0.0.0.0:2222/%s", endpointHealthz)},
+				{name: "kube-scheduler", url: fmt.Sprintf("https://0.0.0.0:3333/%s", endpointLivez)},
 			},
 		},
 		{
-			name: "default ports",
+			name: "default ports and addresses",
 			cfg:  &kubeadmapi.ClusterConfiguration{},
 			expected: []controlPlaneComponent{
-				{name: "kube-apiserver", url: "https://127.0.0.1:6443/healthz"},
-				{name: "kube-controller-manager", url: "https://127.0.0.1:10257/healthz"},
-				{name: "kube-scheduler", url: "https://127.0.0.1:10259/healthz"},
+				{name: "kube-apiserver", url: fmt.Sprintf("https://127.0.0.1:6443/%s", endpointLivez)},
+				{name: "kube-controller-manager", url: fmt.Sprintf("https://127.0.0.1:10257/%s", endpointHealthz)},
+				{name: "kube-scheduler", url: fmt.Sprintf("https://127.0.0.1:10259/%s", endpointLivez)},
 			},
 		},
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature cleanup

#### What this PR does / why we need it:

By default check the KCM and scheduler on 127.0.0.1:<port> as that is the
defaall --bind-address kubeamd uses for these components.

For kube-apiserver take the value from APIEndpoint.AdvertiseAddress which is
dynamically detected from the host. Unless the user has passed explicitly --advertise-address
as an extra arg.

Read the <port> values for all components from the --secure-port flag
value if needed. Otherwise use defaults.

Use /livez for apiserver and scheduler. Add TODO for KCM to
switch to /livez as well.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
xref 
- https://github.com/kubernetes/kubeadm/issues/2907

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: consider --bind-address or --advertise-address and --secure-port for control plane components when the feature gate WaitForAllControlPlaneComponents is enabled. Use /livez for kube-apiserver and kube-scheduler, but continue using /healthz for kube-controller-manager until it supports /livez. 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
