### PR TITLE
Add metrics for policy and binding counts

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_source_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_source_test.go
@@ -132,7 +132,16 @@ func TestPolicySourceHasSyncedInitialList(t *testing.T) {
 		},
 	))
 	require.Len(t, testContext.Source.Hooks(), 3, "should have 3 policies")
-
+	require.Len(t, testContext.MetricHookTracker.MetricHooks, 3, "should have 3 metric policies")
+	require.Equal(t, testContext.Source.Hooks()[0].Bindings[0].GetName(),
+		testContext.MetricHookTracker.MetricHooks[0].Bindings[0].GetName(),
+		"First binding names should be the same")
+	require.Equal(t, testContext.Source.Hooks()[1].Bindings[0].GetName(),
+		testContext.MetricHookTracker.MetricHooks[1].Bindings[0].GetName(),
+		"Second binding names should be the same")
+	require.Equal(t, testContext.Source.Hooks()[2].Bindings[0].GetName(),
+		testContext.MetricHookTracker.MetricHooks[2].Bindings[0].GetName(),
+		"Third binding names should be the same")
 }
 
 func TestPolicySourceBindsToPolicies(t *testing.T) {
@@ -166,7 +175,11 @@ func TestPolicySourceBindsToPolicies(t *testing.T) {
 
 	require.Len(t, testContext.Source.Hooks(), 1, "should have one policy")
 	require.Len(t, testContext.Source.Hooks()[0].Bindings, 1, "should have one binding")
-	require.Equal(t, "binding1", testContext.Source.Hooks()[0].Bindings[0].GetName(), "should have one binding")
+	require.Equal(t, "binding1", testContext.Source.Hooks()[0].Bindings[0].GetName(), "binding name should be binding1")
+
+	require.Len(t, testContext.MetricHookTracker.MetricHooks, 1, "should have one metric policy")
+	require.Len(t, testContext.MetricHookTracker.MetricHooks[0].Bindings, 1, "should have one metric binding")
+	require.Equal(t, "binding1", testContext.MetricHookTracker.MetricHooks[0].Bindings[0].GetName(), "binding name should be binding1")
 
 	// Change the binding to another policy (policies without bindings should
 	// be ignored, so it should remove the first
@@ -187,6 +200,10 @@ func TestPolicySourceBindsToPolicies(t *testing.T) {
 	require.Len(t, testContext.Source.Hooks()[0].Bindings, 1, "should have one binding")
 	require.Equal(t, "binding1", testContext.Source.Hooks()[0].Bindings[0].GetName(), "binding name should be binding1")
 
+	require.Len(t, testContext.MetricHookTracker.MetricHooks, 1, "should have one metric policy")
+	require.Equal(t, "policy2", testContext.MetricHookTracker.MetricHooks[0].Policy.GetName(), "metric policy name should be policy2")
+	require.Len(t, testContext.MetricHookTracker.MetricHooks[0].Bindings, 1, "should have one metric binding")
+	require.Equal(t, "binding1", testContext.MetricHookTracker.MetricHooks[0].Bindings[0].GetName(), "metric binding name should be binding1")
 }
 
 type FakePolicy struct {

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/mutating/plugin.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/mutating/plugin.go
@@ -104,6 +104,7 @@ func NewPlugin(_ io.Reader) *Plugin {
 				//!TODO: Create a way to share param informers between
 				// mutating/validating plugins
 				f,
+				nil,
 				dynamicClient,
 				restMapper,
 			)

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/metrics/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/metrics/metrics_test.go
@@ -33,6 +33,9 @@ func TestNoUtils(t *testing.T) {
 	metrics := []string{
 		"apiserver_validating_admission_policy_check_total",
 		"apiserver_validating_admission_policy_check_duration_seconds",
+		"apiserver_validating_admission_policy_active_policies",
+		"apiserver_validating_admission_policy_active_bindings",
+		"apiserver_validating_admission_policy_active_bindings_enforcement",
 	}
 
 	testCases := []struct {
@@ -43,19 +46,22 @@ func TestNoUtils(t *testing.T) {
 		{
 			desc: "observe policy admission",
 			want: `
+			# HELP apiserver_validating_admission_policy_active_policies [ALPHA] Validation admission policy active policies
+			# TYPE apiserver_validating_admission_policy_active_policies gauge
+			apiserver_validating_admission_policy_active_policies 0
 			# HELP apiserver_validating_admission_policy_check_duration_seconds [BETA] Validation admission latency for individual validation expressions in seconds, labeled by policy and further including binding and enforcement action taken.
-            # TYPE apiserver_validating_admission_policy_check_duration_seconds histogram
+			# TYPE apiserver_validating_admission_policy_check_duration_seconds histogram
 			apiserver_validating_admission_policy_check_duration_seconds_bucket{enforcement_action="allow",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com",le="0.0000005"} 0
-            apiserver_validating_admission_policy_check_duration_seconds_bucket{enforcement_action="allow",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com",le="0.001"} 0
-            apiserver_validating_admission_policy_check_duration_seconds_bucket{enforcement_action="allow",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com",le="0.01"} 0
-            apiserver_validating_admission_policy_check_duration_seconds_bucket{enforcement_action="allow",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com",le="0.1"} 0
-            apiserver_validating_admission_policy_check_duration_seconds_bucket{enforcement_action="allow",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com",le="1"} 0
-            apiserver_validating_admission_policy_check_duration_seconds_bucket{enforcement_action="allow",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com",le="+Inf"} 1
-            apiserver_validating_admission_policy_check_duration_seconds_sum{enforcement_action="allow",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com"} 10
-            apiserver_validating_admission_policy_check_duration_seconds_count{enforcement_action="allow",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com"} 1
-            # HELP apiserver_validating_admission_policy_check_total [BETA] Validation admission policy check total, labeled by policy and further identified by binding and enforcement action taken.
-            # TYPE apiserver_validating_admission_policy_check_total counter
-            apiserver_validating_admission_policy_check_total{enforcement_action="allow",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com"} 1
+			apiserver_validating_admission_policy_check_duration_seconds_bucket{enforcement_action="allow",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com",le="0.001"} 0
+			apiserver_validating_admission_policy_check_duration_seconds_bucket{enforcement_action="allow",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com",le="0.01"} 0
+			apiserver_validating_admission_policy_check_duration_seconds_bucket{enforcement_action="allow",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com",le="0.1"} 0
+			apiserver_validating_admission_policy_check_duration_seconds_bucket{enforcement_action="allow",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com",le="1"} 0
+			apiserver_validating_admission_policy_check_duration_seconds_bucket{enforcement_action="allow",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com",le="+Inf"} 1
+			apiserver_validating_admission_policy_check_duration_seconds_sum{enforcement_action="allow",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com"} 10
+			apiserver_validating_admission_policy_check_duration_seconds_count{enforcement_action="allow",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com"} 1
+			# HELP apiserver_validating_admission_policy_check_total [BETA] Validation admission policy check total, labeled by policy and further identified by binding and enforcement action taken.
+			# TYPE apiserver_validating_admission_policy_check_total counter
+			apiserver_validating_admission_policy_check_total{enforcement_action="allow",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com"} 1
 			`,
 			observer: func() {
 				Metrics.ObserveAdmission(context.TODO(), time.Duration(10)*time.Second, "policy.example.com", "binding.example.com", ValidatingInvalidError)
@@ -64,26 +70,47 @@ func TestNoUtils(t *testing.T) {
 		{
 			desc: "observe policy rejection",
 			want: `
+			# HELP apiserver_validating_admission_policy_active_policies [ALPHA] Validation admission policy active policies
+			# TYPE apiserver_validating_admission_policy_active_policies gauge
+			apiserver_validating_admission_policy_active_policies 0
 			# HELP apiserver_validating_admission_policy_check_duration_seconds [BETA] Validation admission latency for individual validation expressions in seconds, labeled by policy and further including binding and enforcement action taken.
-            # TYPE apiserver_validating_admission_policy_check_duration_seconds histogram
+			# TYPE apiserver_validating_admission_policy_check_duration_seconds histogram
 			apiserver_validating_admission_policy_check_duration_seconds_bucket{enforcement_action="deny",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com",le="0.0000005"} 0
-            apiserver_validating_admission_policy_check_duration_seconds_bucket{enforcement_action="deny",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com",le="0.001"} 0
-            apiserver_validating_admission_policy_check_duration_seconds_bucket{enforcement_action="deny",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com",le="0.01"} 0
-            apiserver_validating_admission_policy_check_duration_seconds_bucket{enforcement_action="deny",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com",le="0.1"} 0
-            apiserver_validating_admission_policy_check_duration_seconds_bucket{enforcement_action="deny",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com",le="1"} 0
-            apiserver_validating_admission_policy_check_duration_seconds_bucket{enforcement_action="deny",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com",le="+Inf"} 1
-            apiserver_validating_admission_policy_check_duration_seconds_sum{enforcement_action="deny",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com"} 10
-            apiserver_validating_admission_policy_check_duration_seconds_count{enforcement_action="deny",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com"} 1
-            # HELP apiserver_validating_admission_policy_check_total [BETA] Validation admission policy check total, labeled by policy and further identified by binding and enforcement action taken.
-            # TYPE apiserver_validating_admission_policy_check_total counter
-            apiserver_validating_admission_policy_check_total{enforcement_action="deny",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com"} 1
+			apiserver_validating_admission_policy_check_duration_seconds_bucket{enforcement_action="deny",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com",le="0.001"} 0
+			apiserver_validating_admission_policy_check_duration_seconds_bucket{enforcement_action="deny",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com",le="0.01"} 0
+			apiserver_validating_admission_policy_check_duration_seconds_bucket{enforcement_action="deny",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com",le="0.1"} 0
+			apiserver_validating_admission_policy_check_duration_seconds_bucket{enforcement_action="deny",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com",le="1"} 0
+			apiserver_validating_admission_policy_check_duration_seconds_bucket{enforcement_action="deny",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com",le="+Inf"} 1
+			apiserver_validating_admission_policy_check_duration_seconds_sum{enforcement_action="deny",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com"} 10
+			apiserver_validating_admission_policy_check_duration_seconds_count{enforcement_action="deny",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com"} 1
+			# HELP apiserver_validating_admission_policy_check_total [BETA] Validation admission policy check total, labeled by policy and further identified by binding and enforcement action taken.
+			# TYPE apiserver_validating_admission_policy_check_total counter
+			apiserver_validating_admission_policy_check_total{enforcement_action="deny",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com"} 1
 			`,
 			observer: func() {
 				Metrics.ObserveRejection(context.TODO(), time.Duration(10)*time.Second, "policy.example.com", "binding.example.com", ValidatingInvalidError)
 			},
 		},
+		{
+			desc: "observe active bindings",
+			want: `
+            # HELP apiserver_validating_admission_policy_active_bindings_enforcement [ALPHA] Validation admission policy active bindings, labeled by enforcement action.
+            # TYPE apiserver_validating_admission_policy_active_bindings_enforcement gauge
+            apiserver_validating_admission_policy_active_bindings_enforcement{enforcement_action="audit"} 5
+            apiserver_validating_admission_policy_active_bindings_enforcement{enforcement_action="audit_warn"} 6
+            apiserver_validating_admission_policy_active_bindings_enforcement{enforcement_action="deny"} 11
+            apiserver_validating_admission_policy_active_bindings_enforcement{enforcement_action="warn"} 7
+            # HELP apiserver_validating_admission_policy_active_policies [ALPHA] Validation admission policy active policies
+            # TYPE apiserver_validating_admission_policy_active_policies gauge
+            apiserver_validating_admission_policy_active_policies 13
+			`,
+			observer: func() {
+				Metrics.ObserveActiveBindings(13, 5, 6, 7, 11)
+			},
+		},
 	}
 
+	Metrics.Register()
 	Metrics.Reset()
 
 	for _, tt := range testCases {

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/plugin.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/plugin.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apiserver/pkg/admission/plugin/cel"
 	"k8s.io/apiserver/pkg/admission/plugin/policy/generic"
 	"k8s.io/apiserver/pkg/admission/plugin/policy/matching"
+	celmetrics "k8s.io/apiserver/pkg/admission/plugin/policy/validating/metrics"
 	"k8s.io/apiserver/pkg/admission/plugin/webhook/matchconditions"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	"k8s.io/apiserver/pkg/cel/environment"
@@ -36,6 +37,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
 )
 
 const (
@@ -75,6 +77,7 @@ func getCompositionEnvTemplateWithoutStrictCost() *cel.CompositionEnv {
 
 // Register registers a plugin
 func Register(plugins *admission.Plugins) {
+	celmetrics.Metrics.Register()
 	plugins.Register(PluginName, func(configFile io.Reader) (admission.Interface, error) {
 		return NewPlugin(configFile), nil
 	})
@@ -94,6 +97,36 @@ var _ admission.Interface = &Plugin{}
 var _ admission.ValidationInterface = &Plugin{}
 var _ initializer.WantsExcludedAdmissionResources = &Plugin{}
 
+type ValidatingAction int
+
+const (
+	ValidatingActionAudit ValidatingAction = iota
+	ValidatingActionAuditWarn
+	ValidatingActionWarn
+	ValidatingActionDeny
+	ValidatingActionInvalid
+)
+
+func getValidatingAction(validationActions []v1.ValidationAction) ValidatingAction {
+	switch len(validationActions) {
+	case 1:
+		switch validationActions[0] {
+		case v1.Audit:
+			return ValidatingActionAudit
+		case v1.Warn:
+			return ValidatingActionWarn
+		case v1.Deny:
+			return ValidatingActionDeny
+		}
+	case 2:
+		if (validationActions[0] == v1.Warn && validationActions[1] == v1.Audit) ||
+			(validationActions[1] == v1.Warn && validationActions[0] == v1.Audit) {
+			return ValidatingActionAuditWarn
+		}
+	}
+	return ValidatingActionInvalid
+}
+
 func NewPlugin(_ io.Reader) *Plugin {
 	handler := admission.NewHandler(admission.Connect, admission.Create, admission.Delete, admission.Update)
 
@@ -108,6 +141,27 @@ func NewPlugin(_ io.Reader) *Plugin {
 					NewValidatingAdmissionPolicyBindingAccessor,
 					compilePolicy,
 					f,
+					func(hooks []generic.PolicyHook[*Policy, *PolicyBinding, PolicyEvaluator]) {
+						var auditCount, auditWarnCount, warnCount, denyCount int
+						policyCount := len(hooks)
+						for _, hook := range hooks {
+							for _, binding := range hook.Bindings {
+								switch getValidatingAction(binding.Spec.ValidationActions) {
+								case ValidatingActionAudit:
+									auditCount++
+								case ValidatingActionAuditWarn:
+									auditWarnCount++
+								case ValidatingActionWarn:
+									warnCount++
+								case ValidatingActionDeny:
+									denyCount++
+								case ValidatingActionInvalid:
+									klog.V(2).InfoS("Invalid Validating Admission Policy Binding Action", "namespace", binding.Namespace, "name", binding.Name)
+								}
+							}
+						}
+						celmetrics.Metrics.ObserveActiveBindings(policyCount, auditCount, auditWarnCount, warnCount, denyCount)
+					},
 					dynamicClient,
 					restMapper,
 				)


### PR DESCRIPTION

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR introduces additional metrics to track the count of active ValidatingAdmissionPolicy policies (`apiserver_validating_admission_policy_active_policies`), as well as bindings qualified by their action (`allow`, `deny`, `warn` - `apiserver_validating_admission_policy_active_bindings_enforcement`)

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

N/A

#### Does this PR introduce a user-facing change?

```release-note
New metrics to track counts of active ValidatingAdmissionPolicy policies (apiserver_validating_admission_policy_active_policies) and active bindings qualified by their actions (allow, deny or warn - apiserver_validating_admission_policy_active_bindings_enforcement)
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

N/A