### PR TITLE
Fine grained vap metrics

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_source.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_source.go
@@ -55,6 +55,7 @@ type policySource[P runtime.Object, B runtime.Object, E Evaluator] struct {
 	restMapper         meta.RESTMapper
 	newPolicyAccessor  func(P) PolicyAccessor
 	newBindingAccessor func(B) BindingAccessor
+	updateHookMetrics  func([]PolicyHook[P, B, E])
 
 	informerFactory informers.SharedInformerFactory
 	dynamicClient   dynamic.Interface
@@ -111,6 +112,7 @@ func NewPolicySource[P runtime.Object, B runtime.Object, E Evaluator](
 	newBindingAccessor func(B) BindingAccessor,
 	compiler func(P) E,
 	paramInformerFactory informers.SharedInformerFactory,
+	updateHookMetrics func([]PolicyHook[P, B, E]),
 	dynamicClient dynamic.Interface,
 	restMapper meta.RESTMapper,
 ) Source[PolicyHook[P, B, E]] {
@@ -123,6 +125,7 @@ func NewPolicySource[P runtime.Object, B runtime.Object, E Evaluator](
 		newBindingAccessor:   newBindingAccessor,
 		paramsCRDControllers: map[schema.GroupVersionKind]*paramInfo{},
 		informerFactory:      paramInformerFactory,
+		updateHookMetrics:    updateHookMetrics,
 		dynamicClient:        dynamicClient,
 		restMapper:           restMapper,
 	}
@@ -369,6 +372,10 @@ func (s *policySource[P, B, E]) calculatePolicyData() ([]PolicyHook[P, B, E], er
 			info.cancelFunc()
 			delete(s.paramsCRDControllers, paramKind)
 		}
+	}
+
+	if s.updateHookMetrics != nil {
+		s.updateHookMetrics(result)
 	}
 
 	err = nil

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_source_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_source_test.go
@@ -130,7 +130,16 @@ func TestPolicySourceHasSyncedInitialList(t *testing.T) {
 		},
 	))
 	require.Len(t, testContext.Source.Hooks(), 3, "should have 3 policies")
-
+	require.Len(t, testContext.MetricHookTracker.MetricHooks, 3, "should have 3 metric policies")
+	require.Equal(t, testContext.Source.Hooks()[0].Bindings[0].GetName(),
+		testContext.MetricHookTracker.MetricHooks[0].Bindings[0].GetName(),
+		"First binding names should be the same")
+	require.Equal(t, testContext.Source.Hooks()[1].Bindings[0].GetName(),
+		testContext.MetricHookTracker.MetricHooks[1].Bindings[0].GetName(),
+		"Second binding names should be the same")
+	require.Equal(t, testContext.Source.Hooks()[2].Bindings[0].GetName(),
+		testContext.MetricHookTracker.MetricHooks[2].Bindings[0].GetName(),
+		"Third binding names should be the same")
 }
 
 func TestPolicySourceBindsToPolicies(t *testing.T) {
@@ -163,7 +172,11 @@ func TestPolicySourceBindsToPolicies(t *testing.T) {
 
 	require.Len(t, testContext.Source.Hooks(), 1, "should have one policy")
 	require.Len(t, testContext.Source.Hooks()[0].Bindings, 1, "should have one binding")
-	require.Equal(t, "binding1", testContext.Source.Hooks()[0].Bindings[0].GetName(), "should have one binding")
+	require.Equal(t, "binding1", testContext.Source.Hooks()[0].Bindings[0].GetName(), "binding name should be binding1")
+
+	require.Len(t, testContext.MetricHookTracker.MetricHooks, 1, "should have one metric policy")
+	require.Len(t, testContext.MetricHookTracker.MetricHooks[0].Bindings, 1, "should have one metric binding")
+	require.Equal(t, "binding1", testContext.MetricHookTracker.MetricHooks[0].Bindings[0].GetName(), "binding name should be binding1")
 
 	// Change the binding to another policy (policies without bindings should
 	// be ignored, so it should remove the first
@@ -184,6 +197,10 @@ func TestPolicySourceBindsToPolicies(t *testing.T) {
 	require.Len(t, testContext.Source.Hooks()[0].Bindings, 1, "should have one binding")
 	require.Equal(t, "binding1", testContext.Source.Hooks()[0].Bindings[0].GetName(), "binding name should be binding1")
 
+	require.Len(t, testContext.MetricHookTracker.MetricHooks, 1, "should have one metric policy")
+	require.Equal(t, "policy2", testContext.MetricHookTracker.MetricHooks[0].Policy.GetName(), "metric policy name should be policy2")
+	require.Len(t, testContext.MetricHookTracker.MetricHooks[0].Bindings, 1, "should have one metric binding")
+	require.Equal(t, "binding1", testContext.MetricHookTracker.MetricHooks[0].Bindings[0].GetName(), "metric binding name should be binding1")
 }
 
 type FakePolicy struct {

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/mutating/plugin.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/mutating/plugin.go
@@ -104,6 +104,7 @@ func NewPlugin(_ io.Reader) *Plugin {
 				//!TODO: Create a way to share param informers between
 				// mutating/validating plugins
 				f,
+				nil,
 				dynamicClient,
 				restMapper,
 			)

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/metrics/metrics.go
@@ -18,6 +18,7 @@ package metrics
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"k8s.io/component-base/metrics"
@@ -48,12 +49,15 @@ const (
 var (
 	// Metrics provides access to validation admission metrics.
 	Metrics = newValidationAdmissionMetrics()
+	once    sync.Once
 )
 
 // ValidatingAdmissionPolicyMetrics aggregates Prometheus metrics related to validation admission control.
 type ValidatingAdmissionPolicyMetrics struct {
-	policyCheck   *metrics.CounterVec
-	policyLatency *metrics.HistogramVec
+	policyCheck                     *metrics.CounterVec
+	policyLatency                   *metrics.HistogramVec
+	policyActivePolicies            *metrics.Gauge
+	policyActiveBindingsEnforcement *metrics.GaugeVec
 }
 
 func newValidationAdmissionMetrics() *ValidatingAdmissionPolicyMetrics {
@@ -85,16 +89,43 @@ func newValidationAdmissionMetrics() *ValidatingAdmissionPolicyMetrics {
 	},
 		[]string{"policy", "policy_binding", "error_type", "enforcement_action"},
 	)
+	activePolicies := metrics.NewGauge(&metrics.GaugeOpts{
+		Namespace:      metricsNamespace,
+		Subsystem:      metricsSubsystem,
+		Name:           "active_policies",
+		Help:           "Validation admission policy active policies",
+		StabilityLevel: metrics.ALPHA,
+	})
+	activeBindingsEnforcement := metrics.NewGaugeVec(&metrics.GaugeOpts{
+		Namespace:      metricsNamespace,
+		Subsystem:      metricsSubsystem,
+		Name:           "active_bindings_enforcement",
+		Help:           "Validation admission policy active bindings, labeled by enforcement action.",
+		StabilityLevel: metrics.ALPHA,
+	},
+		[]string{"enforcement_action"},
+	)
 
-	legacyregistry.MustRegister(check)
-	legacyregistry.MustRegister(latency)
-	return &ValidatingAdmissionPolicyMetrics{policyCheck: check, policyLatency: latency}
+	return &ValidatingAdmissionPolicyMetrics{
+		policyCheck:                     check,
+		policyLatency:                   latency,
+		policyActivePolicies:            activePolicies,
+		policyActiveBindingsEnforcement: activeBindingsEnforcement,
+	}
+}
+
+func (m *ValidatingAdmissionPolicyMetrics) Register() {
+	once.Do(func() {
+		legacyregistry.MustRegister(m.policyCheck, m.policyLatency, m.policyActivePolicies, m.policyActiveBindingsEnforcement)
+	})
 }
 
 // Reset resets all validation admission-related Prometheus metrics.
 func (m *ValidatingAdmissionPolicyMetrics) Reset() {
 	m.policyCheck.Reset()
 	m.policyLatency.Reset()
+	m.policyActivePolicies.Set(0)
+	m.policyActiveBindingsEnforcement.Reset()
 }
 
 // ObserveAdmission observes a policy validation, with an optional error to indicate the error that may occur but ignored.
@@ -119,4 +150,12 @@ func (m *ValidatingAdmissionPolicyMetrics) ObserveAudit(ctx context.Context, ela
 func (m *ValidatingAdmissionPolicyMetrics) ObserveWarn(ctx context.Context, elapsed time.Duration, policy, binding string, errorType ValidationErrorType) {
 	m.policyCheck.WithContext(ctx).WithLabelValues(policy, binding, string(errorType), "warn").Inc()
 	m.policyLatency.WithContext(ctx).WithLabelValues(policy, binding, string(errorType), "warn").Observe(elapsed.Seconds())
+}
+
+// ObserveActiveBindings observes the count of active validation admission policy bindings.
+func (m *ValidatingAdmissionPolicyMetrics) ObserveActiveBindings(policyCount, allowCount, warnCount, denyCount int) {
+	m.policyActivePolicies.Set(float64(policyCount))
+	m.policyActiveBindingsEnforcement.WithLabelValues("allow").Set(float64(allowCount))
+	m.policyActiveBindingsEnforcement.WithLabelValues("warn").Set(float64(warnCount))
+	m.policyActiveBindingsEnforcement.WithLabelValues("deny").Set(float64(denyCount))
 }

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/metrics/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/metrics/metrics_test.go
@@ -33,6 +33,9 @@ func TestNoUtils(t *testing.T) {
 	metrics := []string{
 		"apiserver_validating_admission_policy_check_total",
 		"apiserver_validating_admission_policy_check_duration_seconds",
+		"apiserver_validating_admission_policy_active_policies",
+		"apiserver_validating_admission_policy_active_bindings",
+		"apiserver_validating_admission_policy_active_bindings_enforcement",
 	}
 
 	testCases := []struct {
@@ -43,19 +46,22 @@ func TestNoUtils(t *testing.T) {
 		{
 			desc: "observe policy admission",
 			want: `
+			# HELP apiserver_validating_admission_policy_active_policies [ALPHA] Validation admission policy active policies
+			# TYPE apiserver_validating_admission_policy_active_policies gauge
+			apiserver_validating_admission_policy_active_policies 0
 			# HELP apiserver_validating_admission_policy_check_duration_seconds [BETA] Validation admission latency for individual validation expressions in seconds, labeled by policy and further including binding and enforcement action taken.
-            # TYPE apiserver_validating_admission_policy_check_duration_seconds histogram
+			# TYPE apiserver_validating_admission_policy_check_duration_seconds histogram
 			apiserver_validating_admission_policy_check_duration_seconds_bucket{enforcement_action="allow",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com",le="0.0000005"} 0
-            apiserver_validating_admission_policy_check_duration_seconds_bucket{enforcement_action="allow",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com",le="0.001"} 0
-            apiserver_validating_admission_policy_check_duration_seconds_bucket{enforcement_action="allow",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com",le="0.01"} 0
-            apiserver_validating_admission_policy_check_duration_seconds_bucket{enforcement_action="allow",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com",le="0.1"} 0
-            apiserver_validating_admission_policy_check_duration_seconds_bucket{enforcement_action="allow",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com",le="1"} 0
-            apiserver_validating_admission_policy_check_duration_seconds_bucket{enforcement_action="allow",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com",le="+Inf"} 1
-            apiserver_validating_admission_policy_check_duration_seconds_sum{enforcement_action="allow",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com"} 10
-            apiserver_validating_admission_policy_check_duration_seconds_count{enforcement_action="allow",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com"} 1
-            # HELP apiserver_validating_admission_policy_check_total [BETA] Validation admission policy check total, labeled by policy and further identified by binding and enforcement action taken.
-            # TYPE apiserver_validating_admission_policy_check_total counter
-            apiserver_validating_admission_policy_check_total{enforcement_action="allow",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com"} 1
+			apiserver_validating_admission_policy_check_duration_seconds_bucket{enforcement_action="allow",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com",le="0.001"} 0
+			apiserver_validating_admission_policy_check_duration_seconds_bucket{enforcement_action="allow",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com",le="0.01"} 0
+			apiserver_validating_admission_policy_check_duration_seconds_bucket{enforcement_action="allow",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com",le="0.1"} 0
+			apiserver_validating_admission_policy_check_duration_seconds_bucket{enforcement_action="allow",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com",le="1"} 0
+			apiserver_validating_admission_policy_check_duration_seconds_bucket{enforcement_action="allow",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com",le="+Inf"} 1
+			apiserver_validating_admission_policy_check_duration_seconds_sum{enforcement_action="allow",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com"} 10
+			apiserver_validating_admission_policy_check_duration_seconds_count{enforcement_action="allow",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com"} 1
+			# HELP apiserver_validating_admission_policy_check_total [BETA] Validation admission policy check total, labeled by policy and further identified by binding and enforcement action taken.
+			# TYPE apiserver_validating_admission_policy_check_total counter
+			apiserver_validating_admission_policy_check_total{enforcement_action="allow",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com"} 1
 			`,
 			observer: func() {
 				Metrics.ObserveAdmission(context.TODO(), time.Duration(10)*time.Second, "policy.example.com", "binding.example.com", ValidatingInvalidError)
@@ -64,26 +70,46 @@ func TestNoUtils(t *testing.T) {
 		{
 			desc: "observe policy rejection",
 			want: `
+			# HELP apiserver_validating_admission_policy_active_policies [ALPHA] Validation admission policy active policies
+			# TYPE apiserver_validating_admission_policy_active_policies gauge
+			apiserver_validating_admission_policy_active_policies 0
 			# HELP apiserver_validating_admission_policy_check_duration_seconds [BETA] Validation admission latency for individual validation expressions in seconds, labeled by policy and further including binding and enforcement action taken.
-            # TYPE apiserver_validating_admission_policy_check_duration_seconds histogram
+			# TYPE apiserver_validating_admission_policy_check_duration_seconds histogram
 			apiserver_validating_admission_policy_check_duration_seconds_bucket{enforcement_action="deny",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com",le="0.0000005"} 0
-            apiserver_validating_admission_policy_check_duration_seconds_bucket{enforcement_action="deny",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com",le="0.001"} 0
-            apiserver_validating_admission_policy_check_duration_seconds_bucket{enforcement_action="deny",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com",le="0.01"} 0
-            apiserver_validating_admission_policy_check_duration_seconds_bucket{enforcement_action="deny",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com",le="0.1"} 0
-            apiserver_validating_admission_policy_check_duration_seconds_bucket{enforcement_action="deny",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com",le="1"} 0
-            apiserver_validating_admission_policy_check_duration_seconds_bucket{enforcement_action="deny",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com",le="+Inf"} 1
-            apiserver_validating_admission_policy_check_duration_seconds_sum{enforcement_action="deny",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com"} 10
-            apiserver_validating_admission_policy_check_duration_seconds_count{enforcement_action="deny",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com"} 1
-            # HELP apiserver_validating_admission_policy_check_total [BETA] Validation admission policy check total, labeled by policy and further identified by binding and enforcement action taken.
-            # TYPE apiserver_validating_admission_policy_check_total counter
-            apiserver_validating_admission_policy_check_total{enforcement_action="deny",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com"} 1
+			apiserver_validating_admission_policy_check_duration_seconds_bucket{enforcement_action="deny",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com",le="0.001"} 0
+			apiserver_validating_admission_policy_check_duration_seconds_bucket{enforcement_action="deny",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com",le="0.01"} 0
+			apiserver_validating_admission_policy_check_duration_seconds_bucket{enforcement_action="deny",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com",le="0.1"} 0
+			apiserver_validating_admission_policy_check_duration_seconds_bucket{enforcement_action="deny",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com",le="1"} 0
+			apiserver_validating_admission_policy_check_duration_seconds_bucket{enforcement_action="deny",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com",le="+Inf"} 1
+			apiserver_validating_admission_policy_check_duration_seconds_sum{enforcement_action="deny",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com"} 10
+			apiserver_validating_admission_policy_check_duration_seconds_count{enforcement_action="deny",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com"} 1
+			# HELP apiserver_validating_admission_policy_check_total [BETA] Validation admission policy check total, labeled by policy and further identified by binding and enforcement action taken.
+			# TYPE apiserver_validating_admission_policy_check_total counter
+			apiserver_validating_admission_policy_check_total{enforcement_action="deny",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com"} 1
 			`,
 			observer: func() {
 				Metrics.ObserveRejection(context.TODO(), time.Duration(10)*time.Second, "policy.example.com", "binding.example.com", ValidatingInvalidError)
 			},
 		},
+		{
+			desc: "observe active bindings",
+			want: `
+            # HELP apiserver_validating_admission_policy_active_bindings_enforcement [ALPHA] Validation admission policy active bindings, labeled by enforcement action.
+            # TYPE apiserver_validating_admission_policy_active_bindings_enforcement gauge
+            apiserver_validating_admission_policy_active_bindings_enforcement{enforcement_action="allow"} 5
+            apiserver_validating_admission_policy_active_bindings_enforcement{enforcement_action="deny"} 11
+            apiserver_validating_admission_policy_active_bindings_enforcement{enforcement_action="warn"} 7
+            # HELP apiserver_validating_admission_policy_active_policies [ALPHA] Validation admission policy active policies
+            # TYPE apiserver_validating_admission_policy_active_policies gauge
+            apiserver_validating_admission_policy_active_policies 13
+			`,
+			observer: func() {
+				Metrics.ObserveActiveBindings(13, 5, 7, 11)
+			},
+		},
 	}
 
+	Metrics.Register()
 	Metrics.Reset()
 
 	for _, tt := range testCases {

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/metrics/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/metrics/metrics_test.go
@@ -49,22 +49,23 @@ func TestNoUtils(t *testing.T) {
 			# HELP apiserver_validating_admission_policy_active_policies [ALPHA] Validation admission policy active policies
 			# TYPE apiserver_validating_admission_policy_active_policies gauge
 			apiserver_validating_admission_policy_active_policies 0
-			# HELP apiserver_validating_admission_policy_check_duration_seconds [BETA] Validation admission latency for individual validation expressions in seconds, labeled by policy and further including binding and enforcement action taken.
+			# HELP apiserver_validating_admission_policy_check_duration_seconds [BETA] Validation admission latency for individual validation expressions in seconds, labeled by policy and further including binding and enforcement action taken, result type, namespace and name of the associated parameter resource, and index of the result.
 			# TYPE apiserver_validating_admission_policy_check_duration_seconds histogram
-			apiserver_validating_admission_policy_check_duration_seconds_bucket{enforcement_action="allow",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com",le="0.0000005"} 0
-			apiserver_validating_admission_policy_check_duration_seconds_bucket{enforcement_action="allow",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com",le="0.001"} 0
-			apiserver_validating_admission_policy_check_duration_seconds_bucket{enforcement_action="allow",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com",le="0.01"} 0
-			apiserver_validating_admission_policy_check_duration_seconds_bucket{enforcement_action="allow",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com",le="0.1"} 0
-			apiserver_validating_admission_policy_check_duration_seconds_bucket{enforcement_action="allow",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com",le="1"} 0
-			apiserver_validating_admission_policy_check_duration_seconds_bucket{enforcement_action="allow",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com",le="+Inf"} 1
-			apiserver_validating_admission_policy_check_duration_seconds_sum{enforcement_action="allow",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com"} 10
-			apiserver_validating_admission_policy_check_duration_seconds_count{enforcement_action="allow",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com"} 1
-			# HELP apiserver_validating_admission_policy_check_total [BETA] Validation admission policy check total, labeled by policy and further identified by binding and enforcement action taken.
+			apiserver_validating_admission_policy_check_duration_seconds_bucket{enforcement_action="allow",error_type="invalid_error",param_name="param_name",param_namespace="param_namespace",policy="policy.example.com",policy_binding="binding.example.com",result_index="0",result_type="validation",le="5e-07"} 0
+			apiserver_validating_admission_policy_check_duration_seconds_bucket{enforcement_action="allow",error_type="invalid_error",param_name="param_name",param_namespace="param_namespace",policy="policy.example.com",policy_binding="binding.example.com",result_index="0",result_type="validation",le="0.001"} 0
+			apiserver_validating_admission_policy_check_duration_seconds_bucket{enforcement_action="allow",error_type="invalid_error",param_name="param_name",param_namespace="param_namespace",policy="policy.example.com",policy_binding="binding.example.com",result_index="0",result_type="validation",le="0.01"} 0
+			apiserver_validating_admission_policy_check_duration_seconds_bucket{enforcement_action="allow",error_type="invalid_error",param_name="param_name",param_namespace="param_namespace",policy="policy.example.com",policy_binding="binding.example.com",result_index="0",result_type="validation",le="0.1"} 0
+			apiserver_validating_admission_policy_check_duration_seconds_bucket{enforcement_action="allow",error_type="invalid_error",param_name="param_name",param_namespace="param_namespace",policy="policy.example.com",policy_binding="binding.example.com",result_index="0",result_type="validation",le="1"} 0
+			apiserver_validating_admission_policy_check_duration_seconds_bucket{enforcement_action="allow",error_type="invalid_error",param_name="param_name",param_namespace="param_namespace",policy="policy.example.com",policy_binding="binding.example.com",result_index="0",result_type="validation",le="+Inf"} 1
+			apiserver_validating_admission_policy_check_duration_seconds_sum{enforcement_action="allow",error_type="invalid_error",param_name="param_name",param_namespace="param_namespace",policy="policy.example.com",policy_binding="binding.example.com",result_index="0",result_type="validation"} 10
+			apiserver_validating_admission_policy_check_duration_seconds_count{enforcement_action="allow",error_type="invalid_error",param_name="param_name",param_namespace="param_namespace",policy="policy.example.com",policy_binding="binding.example.com",result_index="0",result_type="validation"} 1
+			# HELP apiserver_validating_admission_policy_check_total [BETA] Validation admission policy check total, labeled by policy and further identified by binding, enforcement action taken, result type, namespace and name of the associated parameter resource, and index of the result.
 			# TYPE apiserver_validating_admission_policy_check_total counter
-			apiserver_validating_admission_policy_check_total{enforcement_action="allow",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com"} 1
+			apiserver_validating_admission_policy_check_total{enforcement_action="allow",error_type="invalid_error",param_name="param_name",param_namespace="param_namespace",policy="policy.example.com",policy_binding="binding.example.com",result_index="0",result_type="validation"} 1
 			`,
 			observer: func() {
-				Metrics.ObserveAdmission(context.TODO(), time.Duration(10)*time.Second, "policy.example.com", "binding.example.com", ValidatingInvalidError)
+				Metrics.ObserveAdmission(context.TODO(), time.Duration(10)*time.Second, "policy.example.com", "binding.example.com", ValidatingInvalidError,
+					"validation", "param_namespace", "param_name", 0)
 			},
 		},
 		{
@@ -73,22 +74,23 @@ func TestNoUtils(t *testing.T) {
 			# HELP apiserver_validating_admission_policy_active_policies [ALPHA] Validation admission policy active policies
 			# TYPE apiserver_validating_admission_policy_active_policies gauge
 			apiserver_validating_admission_policy_active_policies 0
-			# HELP apiserver_validating_admission_policy_check_duration_seconds [BETA] Validation admission latency for individual validation expressions in seconds, labeled by policy and further including binding and enforcement action taken.
+			# HELP apiserver_validating_admission_policy_check_duration_seconds [BETA] Validation admission latency for individual validation expressions in seconds, labeled by policy and further including binding and enforcement action taken, result type, namespace and name of the associated parameter resource, and index of the result.
 			# TYPE apiserver_validating_admission_policy_check_duration_seconds histogram
-			apiserver_validating_admission_policy_check_duration_seconds_bucket{enforcement_action="deny",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com",le="0.0000005"} 0
-			apiserver_validating_admission_policy_check_duration_seconds_bucket{enforcement_action="deny",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com",le="0.001"} 0
-			apiserver_validating_admission_policy_check_duration_seconds_bucket{enforcement_action="deny",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com",le="0.01"} 0
-			apiserver_validating_admission_policy_check_duration_seconds_bucket{enforcement_action="deny",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com",le="0.1"} 0
-			apiserver_validating_admission_policy_check_duration_seconds_bucket{enforcement_action="deny",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com",le="1"} 0
-			apiserver_validating_admission_policy_check_duration_seconds_bucket{enforcement_action="deny",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com",le="+Inf"} 1
-			apiserver_validating_admission_policy_check_duration_seconds_sum{enforcement_action="deny",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com"} 10
-			apiserver_validating_admission_policy_check_duration_seconds_count{enforcement_action="deny",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com"} 1
-			# HELP apiserver_validating_admission_policy_check_total [BETA] Validation admission policy check total, labeled by policy and further identified by binding and enforcement action taken.
+			apiserver_validating_admission_policy_check_duration_seconds_bucket{enforcement_action="deny",error_type="invalid_error",param_name="param_name",param_namespace="param_namespace",policy="policy.example.com",policy_binding="binding.example.com",result_index="0",result_type="validation",le="5e-07"} 0
+			apiserver_validating_admission_policy_check_duration_seconds_bucket{enforcement_action="deny",error_type="invalid_error",param_name="param_name",param_namespace="param_namespace",policy="policy.example.com",policy_binding="binding.example.com",result_index="0",result_type="validation",le="0.001"} 0
+			apiserver_validating_admission_policy_check_duration_seconds_bucket{enforcement_action="deny",error_type="invalid_error",param_name="param_name",param_namespace="param_namespace",policy="policy.example.com",policy_binding="binding.example.com",result_index="0",result_type="validation",le="0.01"} 0
+			apiserver_validating_admission_policy_check_duration_seconds_bucket{enforcement_action="deny",error_type="invalid_error",param_name="param_name",param_namespace="param_namespace",policy="policy.example.com",policy_binding="binding.example.com",result_index="0",result_type="validation",le="0.1"} 0
+			apiserver_validating_admission_policy_check_duration_seconds_bucket{enforcement_action="deny",error_type="invalid_error",param_name="param_name",param_namespace="param_namespace",policy="policy.example.com",policy_binding="binding.example.com",result_index="0",result_type="validation",le="1"} 0
+			apiserver_validating_admission_policy_check_duration_seconds_bucket{enforcement_action="deny",error_type="invalid_error",param_name="param_name",param_namespace="param_namespace",policy="policy.example.com",policy_binding="binding.example.com",result_index="0",result_type="validation",le="+Inf"} 1
+			apiserver_validating_admission_policy_check_duration_seconds_sum{enforcement_action="deny",error_type="invalid_error",param_name="param_name",param_namespace="param_namespace",policy="policy.example.com",policy_binding="binding.example.com",result_index="0",result_type="validation"} 10
+			apiserver_validating_admission_policy_check_duration_seconds_count{enforcement_action="deny",error_type="invalid_error",param_name="param_name",param_namespace="param_namespace",policy="policy.example.com",policy_binding="binding.example.com",result_index="0",result_type="validation"} 1
+			# HELP apiserver_validating_admission_policy_check_total [BETA] Validation admission policy check total, labeled by policy and further identified by binding, enforcement action taken, result type, namespace and name of the associated parameter resource, and index of the result.
 			# TYPE apiserver_validating_admission_policy_check_total counter
-			apiserver_validating_admission_policy_check_total{enforcement_action="deny",error_type="invalid_error",policy="policy.example.com",policy_binding="binding.example.com"} 1
+			apiserver_validating_admission_policy_check_total{enforcement_action="deny",error_type="invalid_error",param_name="param_name",param_namespace="param_namespace",policy="policy.example.com",policy_binding="binding.example.com",result_index="0",result_type="validation"} 1
 			`,
 			observer: func() {
-				Metrics.ObserveRejection(context.TODO(), time.Duration(10)*time.Second, "policy.example.com", "binding.example.com", ValidatingInvalidError)
+				Metrics.ObserveRejection(context.TODO(), time.Duration(10)*time.Second, "policy.example.com", "binding.example.com", ValidatingInvalidError,
+					"validation", "param_namespace", "param_name", 0)
 			},
 		},
 		{


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

The current `apiserver_validating_admission_policy_check_duration_seconds` metrics only deal with certain circumstances (errors, rejection, warn and audit) but not successful validations.  The metrics are also limited to the policy and binding names, but will be created at the individual validation and/or auditAnnotation level.

This PR extends the labels of these metrics to include information about the param name/namespace, the result type (validation or auditAnnotation) and the index of the result within the specific validation/auditAnnotation list.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

This PR also includes the changes in #128477, and should be merged after that PR.

#### Does this PR introduce a user-facing change?
```release-note
Extend the ValidatingAdmissionPolicy apiserver_validating_admission_policy_check_duration_seconds metric to include labels for the param name/namespace, the result type (validation or auditAnnotation) and the index of the result within the policy's validations or auditAnnotations.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

