### PR TITLE
fix evented pleg panic when use generic pleg relisting

### DIFF
--- a/pkg/kubelet/pleg/evented.go
+++ b/pkg/kubelet/pleg/evented.go
@@ -359,7 +359,11 @@ func getPodSandboxState(podStatus *kubecontainer.PodStatus) kubecontainer.State 
 func (e *EventedPLEG) updateRunningPodMetric(podStatus *kubecontainer.PodStatus) {
 	cachedPodStatus, err := e.cache.Get(podStatus.ID)
 	if err != nil {
-		e.logger.Error(err, "Evented PLEG: Get cache", "podID", podStatus.ID)
+		// The cachedPodStatus may be set to nil when use generic pleg relisting sometimes.
+		// Here just skip for the evented pleg cannot get the real state of the pod.
+		// The pod metric will be updated when everything come back to normal.
+		e.logger.Error(err, "Evented PLEG: Get cache error, skip update pod metric", "podID", podStatus.ID)
+		return
 	}
 	// cache miss condition: The pod status object will have empty state if missed in cache
 	if len(cachedPodStatus.SandboxStatuses) < 1 {
@@ -390,7 +394,11 @@ func getContainerStateCount(podStatus *kubecontainer.PodStatus) map[kubecontaine
 func (e *EventedPLEG) updateRunningContainerMetric(podStatus *kubecontainer.PodStatus) {
 	cachedPodStatus, err := e.cache.Get(podStatus.ID)
 	if err != nil {
-		e.logger.Error(err, "Evented PLEG: Get cache", "podID", podStatus.ID)
+		// The cachedPodStatus may be set to nil when use generic pleg relisting sometimes.
+		// Here just skip for the evented pleg cannot get the real state of the pod.
+		// The container metric will be updated when everything come back to normal.
+		e.logger.Error(err, "Evented PLEG: Get cache error, skip update container metric", "podID", podStatus.ID)
+		return
 	}
 
 	// cache miss condition: The pod status object will have empty state if missed in cache


### PR DESCRIPTION
The generic pleg relisting may set PodStatus to nil when the runtime call timeout. This will cause evented pleg panic when update the pod and container metric. We just skip the update when it occurs.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #128654

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
