### PR TITLE
kubelet : DNS:  inherit options when options exists

### DIFF
--- a/pkg/kubelet/network/dns/dns.go
+++ b/pkg/kubelet/network/dns/dns.go
@@ -409,7 +409,9 @@ func (c *Configurer) GetPodDNS(pod *v1.Pod) (*runtimeapi.DNSConfig, error) {
 				dnsConfig.Servers = append(dnsConfig.Servers, ip.String())
 			}
 			dnsConfig.Searches = c.generateSearchesForDNSClusterFirst(dnsConfig.Searches, pod)
-			dnsConfig.Options = defaultDNSOptions
+			if len(dnsConfig.Options) == 0 {
+				dnsConfig.Options = defaultDNSOptions
+			}
 			break
 		}
 		// clusterDNS is not known. Pod with ClusterDNSFirst Policy cannot be created.


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

The options of resolv.conf have many configuration items not only ndots.

In the current version, if there are many options configuration in resolv.conf, all will be set to
`defaultDNSOptions = []string{"ndots:5"}`.

Only when there is no options configuration in resolv.conf, it needs to be set to the default configuration.

So we can control  options through resolv.conf file.

#### Does this PR introduce a user-facing change?

NONE


```release-note
kubelet : DNS: inherit options when options exists
```
