### PR TITLE
kubelet : DNS: inherit options when options exists

### DIFF
--- a/pkg/kubelet/network/dns/dns.go
+++ b/pkg/kubelet/network/dns/dns.go
@@ -39,8 +39,14 @@ import (
 )
 
 var (
+	defaultNdots = "5"
 	// The default dns opt strings.
-	defaultDNSOptions = []string{"ndots:5"}
+	defaultDNSOptions = []v1.PodDNSConfigOption{
+		{
+			Name:  "ndots",
+			Value: &defaultNdots,
+		},
+	}
 )
 
 type podDNSType int
@@ -409,7 +415,7 @@ func (c *Configurer) GetPodDNS(pod *v1.Pod) (*runtimeapi.DNSConfig, error) {
 				dnsConfig.Servers = append(dnsConfig.Servers, ip.String())
 			}
 			dnsConfig.Searches = c.generateSearchesForDNSClusterFirst(dnsConfig.Searches, pod)
-			dnsConfig.Options = defaultDNSOptions
+			dnsConfig.Options = mergeDNSOptions(dnsConfig.Options, defaultDNSOptions)
 			break
 		}
 		// clusterDNS is not known. Pod with ClusterDNSFirst Policy cannot be created.

--- a/pkg/kubelet/network/dns/dns_test.go
+++ b/pkg/kubelet/network/dns/dns_test.go
@@ -39,9 +39,12 @@ import (
 
 var (
 	// testHostNameserver and testHostDomain are also being used in dns_windows_test.go.
-	testHostNameserver = "8.8.8.8"
-	testHostDomain     = "host.domain"
-	fetchEvent         = func(recorder *record.FakeRecorder) string {
+	testHostNameserver    = "8.8.8.8"
+	testHostDomain        = "host.domain"
+	testHostOptionTimeout = "timeout:2"
+	testHostOptionNdots   = "ndots:4"
+	testHostOptions       = fmt.Sprintf("%s %s", testHostOptionTimeout, testHostOptionNdots)
+	fetchEvent            = func(recorder *record.FakeRecorder) string {
 		select {
 		case event := <-recorder.Events:
 			return event
@@ -565,7 +568,11 @@ func TestGetPodDNSCustom(t *testing.T) {
 		},
 	}
 
-	resolvConfContent := []byte(fmt.Sprintf("nameserver %s\nsearch %s\n", testHostNameserver, testHostDomain))
+	resolvConfContent := []byte(fmt.Sprintf("nameserver %s\nsearch %s\noptions %s\n",
+		testHostNameserver,
+		testHostDomain,
+		testHostOptions,
+	))
 	tmpfile, err := os.CreateTemp("", "tmpResolvConf")
 	if err != nil {
 		t.Fatal(err)
@@ -623,7 +630,7 @@ func TestGetPodDNSCustom(t *testing.T) {
 			expectedDNSConfig: &runtimeapi.DNSConfig{
 				Servers:  []string{testClusterNameserver, "10.0.0.11"},
 				Searches: []string{testNsSvcDomain, testSvcDomain, testClusterDNSDomain, testHostDomain, "my.domain"},
-				Options:  []string{"ndots:3", "debug"},
+				Options:  []string{"ndots:3", "debug", testHostOptionTimeout},
 			},
 		},
 		{
@@ -641,7 +648,7 @@ func TestGetPodDNSCustom(t *testing.T) {
 			expectedDNSConfig: &runtimeapi.DNSConfig{
 				Servers:  []string{testClusterNameserver, "10.0.0.11"},
 				Searches: []string{testNsSvcDomain, testSvcDomain, testClusterDNSDomain, testHostDomain, "my.domain"},
-				Options:  []string{"ndots:3", "debug"},
+				Options:  []string{"ndots:3", "debug", testHostOptionTimeout},
 			},
 		},
 		{
@@ -658,7 +665,7 @@ func TestGetPodDNSCustom(t *testing.T) {
 			expectedDNSConfig: &runtimeapi.DNSConfig{
 				Servers:  []string{testHostNameserver, "10.0.0.11"},
 				Searches: []string{testHostDomain, "my.domain"},
-				Options:  []string{"ndots:3", "debug"},
+				Options:  []string{"ndots:3", "debug", testHostOptionTimeout},
 			},
 		},
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

The options of resolv.conf have many configuration items not only ndots.

In the current version, if there are many options configuration in resolv.conf, all will be set to
`defaultDNSOptions = []string{"ndots:5"}`.

Only when there is no options configuration in resolv.conf, it needs to be set to the default configuration.

So we can control  options through resolv.conf file.

#### Does this PR introduce a user-facing change?

NONE


```release-note
kubelet : DNS: inherit options when options exists
```
