### PR TITLE
refresh probed plugins on init to avoid probe race/erroneous unmounts

### DIFF
--- a/pkg/volume/plugins.go
+++ b/pkg/volume/plugins.go
@@ -605,6 +605,7 @@ func (pm *VolumePluginMgr) InitPlugins(plugins []VolumePlugin, prober DynamicPlu
 		pm.plugins[name] = plugin
 		klog.V(1).InfoS("Loaded volume plugin", "pluginName", name)
 	}
+	pm.refreshProbedPlugins()
 	return utilerrors.NewAggregate(allErrs)
 }
 

--- a/pkg/volume/plugins_test.go
+++ b/pkg/volume/plugins_test.go
@@ -17,11 +17,16 @@ limitations under the License.
 package volume
 
 import (
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const testPluginName = "kubernetes.io/testPlugin"
@@ -164,4 +169,64 @@ func Test_ValidatePodTemplate(t *testing.T) {
 	if got := ValidateRecyclerPodTemplate(pod); got == nil {
 		t.Errorf("isPodTemplateValid(%v) returned (%v), want (%v)", pod.String(), got, "Error: pod specification does not contain any volume(s).")
 	}
+}
+
+// TestVolumePluginMultiThreaded tests FindPluginByName/FindPluginBySpec in a multi-threaded environment.
+// If these are called by different threads at the same time, they should still be able to reconcile the plugins
+// and return the same results (no missing plugin)
+func TestVolumePluginMultiThreaded(t *testing.T) {
+	vpm := VolumePluginMgr{}
+	var prober DynamicPluginProber = &fakeProber{events: []ProbeEvent{{PluginName: testPluginName, Op: ProbeAddOrUpdate, Plugin: &testPlugins{}}}}
+	err := vpm.InitPlugins([]VolumePlugin{}, prober, nil)
+	require.NoError(t, err)
+
+	volumeSpec := &Spec{}
+	totalErrors := atomic.Int32{}
+	var wg sync.WaitGroup
+
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := vpm.FindPluginByName(testPluginName)
+			if err != nil {
+				totalErrors.Add(1)
+			}
+		}()
+	}
+	wg.Wait()
+
+	assert.Equal(t, int32(0), totalErrors.Load())
+	totalErrors.Store(0)
+
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := vpm.FindPluginBySpec(volumeSpec)
+			if err != nil {
+				totalErrors.Add(1)
+			}
+		}()
+	}
+	wg.Wait()
+
+	assert.Equal(t, int32(0), totalErrors.Load())
+}
+
+type fakeProber struct {
+	events         []ProbeEvent
+	firstExecution atomic.Bool
+}
+
+func (prober *fakeProber) Init() error {
+	prober.firstExecution.Store(true)
+	return nil
+}
+
+func (prober *fakeProber) Probe() (events []ProbeEvent, err error) {
+	if prober.firstExecution.CompareAndSwap(true, false) {
+		return prober.events, nil
+	}
+	return []ProbeEvent{}, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This is a followup to https://github.com/kubernetes/kubernetes/pull/127669

After upgrading from 1.27 to 1.28, we noticed that on kubelet restart, some pods would sometimes incorrectly get their volumes unmounted with the error:
`
E0926 13:39:38.676490 3845949 kubelet.go:1949] "Unable to attach or mount volumes for pod; skipping pod" err="unmounted volumes=[artifact kube-api-access-rrq9m], unattached volumes=[], failed to process volumes=[artifact]: failed to get Plugin from volumeSpec for volume \"artifact\" err=no volume plugin matched"
`
along with previous errors:
`
13:29:36.094274 3707146 desired_state_of_world_populator.go:330] "Failed to add volume to desiredStateOfWorld" err="failed to get Plugin from volumeSpec for volume \"artifact\" err=no volume plugin matched" pod="vt-agkogkakis/vtickets-service-translator-5d5bccb84f-w2tpz" volumeName="artifact" volumeSpecName="artifact"
`
And then soon after would follow `operationExecutor.UnmountVolume started for volume` 

When we turned off the feature flag `NewVolumeManagerReconstruction`, these would not occur. 

Taking a closer look here, I found some non-threadsafe behavior around loading plugins. The reason this did not occur before (before the flag was on by default) is because the new volume manager would call [reconstructVolumes](https://github.com/kubernetes/kubernetes/blob/5ebd0da6ccb156bee76783394df120bbac6f0d4d/pkg/kubelet/volumemanager/reconciler/reconciler.go#L25) which calls `reconstructVolume` which calls [FindPluginByName](https://github.com/kubernetes/kubernetes/blob/5ebd0da6ccb156bee76783394df120bbac6f0d4d/pkg/kubelet/volumemanager/reconciler/reconstruct_common.go#L264). The old reconstruction flow did not do this. This new flow would be in a race with DSOW [AddPodToVolume, which calls FindPluginBySpec](https://github.com/kubernetes/kubernetes/blob/5ebd0da6ccb156bee76783394df120bbac6f0d4d/pkg/kubelet/volumemanager/cache/desired_state_of_world.go#L270). 

On kubelet startup, [Probe()](https://github.com/kubernetes/kubernetes/blob/74b9204b6a6bd5cce1c8b7c68bd2f39caf1b7fcb/pkg/volume/flexvolume/probe.go#L73) returns the probe events to the first caller, but then an empty map to the next (this map is populated by events later on). 

So when `FindPluginBySpec`/`FindPluginByName` call `Probe()` and iterate over the events to add the plugins to their map, the first thread would sometimes get the empty map, and assume there are no plugins.

My first PR went down a locking path to fix this, but the simpler way is to just call `refreshProbedPlugins` on init, so we don't have this race to populate plugins on startup.


This is easily reproducible by repeatedly restarting kubelet when there are pods on the node that have flex volumes, and grepping for `no volume plugin matched`. In my test example, my node had 100+ pods and I ran `while sleep 20; do date && systemctl restart kubelet ; done` - only took a few minutes to get a hit

I ran my test with `go test ./pkg/volume -race -count=1  -run TestVolumePluginMultiThreaded` and 
`stress ./volume.test -test.run TestVolumePluginMultiThreaded ` to confirm it was not flakey

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixes a race condition that could result in erroneous volume unmounts for flex volume plugins on kubelet restart

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
