### PR TITLE
Revert "Don't stop the next poll when it fails to grab logs"

### DIFF
--- a/test/e2e/network/dns_common.go
+++ b/test/e2e/network/dns_common.go
@@ -508,7 +508,9 @@ func assertFilesContain(ctx context.Context, fileNames []string, fileDir string,
 		// grab logs from all the containers
 		for _, container := range pod.Spec.Containers {
 			logs, err := e2epod.GetPodLogs(ctx, client, pod.Namespace, pod.Name, container.Name)
-			framework.ExpectNoError(err)
+			if err != nil {
+				return false, fmt.Errorf("unexpected error getting pod client logs for %s: %v", container.Name, err)
+			}
 			framework.Logf("Pod client logs for %s: %s", container.Name, logs)
 		}
 

--- a/test/e2e/network/dns_common.go
+++ b/test/e2e/network/dns_common.go
@@ -508,10 +508,7 @@ func assertFilesContain(ctx context.Context, fileNames []string, fileDir string,
 		// grab logs from all the containers
 		for _, container := range pod.Spec.Containers {
 			logs, err := e2epod.GetPodLogs(ctx, client, pod.Namespace, pod.Name, container.Name)
-			if err != nil {
-				framework.Logf("Unable to get logs for %s: %v", container.Name, err)
-				continue
-			}
+			framework.ExpectNoError(err)
 			framework.Logf("Pod client logs for %s: %s", container.Name, logs)
 		}
 


### PR DESCRIPTION
Reverts kubernetes/kubernetes#128508

We should not mask legit errors, the goal of the tests is not to pass, is to identify problems on the software so we can fix them


The test fails with an unexpected error in the apiserver
```
    {
        ErrStatus: 
            code: 500
            details:
              causes:
              - message: unknown
                reason: UnexpectedServerResponse
              kind: pods
              name: dns-test-3928ca26-e2c4-4c99-9509-2b0a28959732
            message: an error on the server ("unknown") has prevented the request from succeeding
              (get pods dns-test-3928ca26-e2c4-4c99-9509-2b0a28959732)
            metadata: {}
            reason: InternalError
            status: Failure,
    }
```

We need to understand what happen, it may be possible there is some bug in the apiserver, if we just ignore and continue, we'll never know until it reaches production.

```release-note
NONE
```

