### PR TITLE
KubeletClientConfig.ReadOnlyPort is unused.

### DIFF
--- a/cmd/kube-apiserver/app/options/options.go
+++ b/cmd/kube-apiserver/app/options/options.go
@@ -72,8 +72,7 @@ func NewServerRunOptions() *ServerRunOptions {
 		Extra: Extra{
 			EndpointReconcilerType: string(reconcilers.LeaseEndpointReconcilerType),
 			KubeletConfig: kubeletclient.KubeletClientConfig{
-				Port:         ports.KubeletPort,
-				ReadOnlyPort: ports.KubeletReadOnlyPort,
+				Port: ports.KubeletPort,
 				PreferredAddressTypes: []string{
 					// --override-hostname
 					string(api.NodeHostName),
@@ -136,9 +135,9 @@ func (s *ServerRunOptions) Flags() (fss cliflag.NamedFlagSets) {
 		"DEPRECATED: kubelet port.")
 	fs.MarkDeprecated("kubelet-port", "kubelet-port is deprecated and will be removed.")
 
-	fs.UintVar(&s.KubeletConfig.ReadOnlyPort, "kubelet-read-only-port", s.KubeletConfig.ReadOnlyPort,
-		"DEPRECATED: kubelet read only port.")
-	fs.MarkDeprecated("kubelet-read-only-port", "kubelet-read-only-port is deprecated and will be removed.")
+	fs.UintVar(new(uint), "kubelet-read-only-port", 0,
+		"DEPRECATED: kubelet read only port. Value ignored even if set.")
+	fs.MarkDeprecated("kubelet-read-only-port", "kubelet-read-only-port is deprecated, ignored and will be removed.") //nolint:errcheck
 
 	fs.DurationVar(&s.KubeletConfig.HTTPTimeout, "kubelet-timeout", s.KubeletConfig.HTTPTimeout,
 		"Timeout for kubelet operations.")

--- a/cmd/kube-apiserver/app/options/options_test.go
+++ b/cmd/kube-apiserver/app/options/options_test.go
@@ -312,8 +312,7 @@ func TestAddFlags(t *testing.T) {
 			EndpointReconcilerType: string(reconcilers.LeaseEndpointReconcilerType),
 			AllowPrivileged:        false,
 			KubeletConfig: kubeletclient.KubeletClientConfig{
-				Port:         10250,
-				ReadOnlyPort: 10255,
+				Port: 10250,
 				PreferredAddressTypes: []string{
 					string(kapi.NodeHostName),
 					string(kapi.NodeInternalDNS),

--- a/pkg/kubelet/client/kubelet_client.go
+++ b/pkg/kubelet/client/kubelet_client.go
@@ -36,9 +36,6 @@ type KubeletClientConfig struct {
 	// Port specifies the default port - used if no information about Kubelet port can be found in Node.NodeStatus.DaemonEndpoints.
 	Port uint
 
-	// ReadOnlyPort specifies the Port for ReadOnly communications.
-	ReadOnlyPort uint
-
 	// PreferredAddressTypes - used to select an address from Node.NodeStatus.Addresses
 	PreferredAddressTypes []string
 


### PR DESCRIPTION
 KubeletClientConfig.ReadOnlyPort is unused.
    
 The `kube-apiserver` flag `--kubelet-read-only-port` is
 marked deprecated, but not actually used anywhere.
    
 Remove the field, but keep the flag, discarding the parsed value.
    
 Update the help text to reflect reality.


/kind cleanup

```release-note
Document that the deprecated `kube-apiserver` flag `--kubelet-read-only-port` has been ignored by the server since it was first introduced.
```