### PR TITLE
Job: Utilize parallel executions with workqueue.ParallelizeUntil

### DIFF
--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -1070,26 +1070,20 @@ func delayTerminalCondition() bool {
 // which the objects can actually be deleted.
 // Returns number of successfully deleted ready pods and total number of successfully deleted pods.
 func (jm *Controller) deleteActivePods(ctx context.Context, job *batch.Job, pods []*v1.Pod) (int32, int32, error) {
-	errCh := make(chan error, len(pods))
-	successfulDeletes := int32(len(pods))
+	podsCount := len(pods)
+	successfulDeletes := int32(podsCount)
 	var deletedReady int32 = 0
-	wg := sync.WaitGroup{}
-	wg.Add(len(pods))
-	for i := range pods {
-		go func(pod *v1.Pod) {
-			defer wg.Done()
-			if err := jm.podControl.DeletePod(ctx, job.Namespace, pod.Name, job); err != nil && !apierrors.IsNotFound(err) {
-				atomic.AddInt32(&successfulDeletes, -1)
-				errCh <- err
-				utilruntime.HandleError(err)
-			}
-			if podutil.IsPodReady(pod) {
-				atomic.AddInt32(&deletedReady, 1)
-			}
-		}(pods[i])
-	}
-	wg.Wait()
-	return deletedReady, successfulDeletes, errorFromChannel(errCh)
+	err := parallelizeUntil(ctx, podsCount, func(i int) error {
+		err := jm.podControl.DeletePod(ctx, job.Namespace, pods[i].Name, job)
+		if err != nil && !apierrors.IsNotFound(err) {
+			atomic.AddInt32(&successfulDeletes, -1)
+		}
+		if podutil.IsPodReady(pods[i]) {
+			atomic.AddInt32(&deletedReady, 1)
+		}
+		return err
+	})
+	return deletedReady, successfulDeletes, err
 }
 
 func nonIgnoredFailedPodsCount(jobCtx *syncJobCtx, failedPods []*v1.Pod) int {
@@ -1108,43 +1102,37 @@ func nonIgnoredFailedPodsCount(jobCtx *syncJobCtx, failedPods []*v1.Pod) int {
 // deleteJobPods deletes the pods, returns the number of successful removals of ready pods and total number of successful pod removals
 // and any error.
 func (jm *Controller) deleteJobPods(ctx context.Context, job *batch.Job, jobKey string, pods []*v1.Pod) (int32, int32, error) {
-	errCh := make(chan error, len(pods))
-	successfulDeletes := int32(len(pods))
+	podsCount := len(pods)
+	successfulDeletes := int32(podsCount)
 	var deletedReady int32 = 0
 	logger := klog.FromContext(ctx)
 
-	failDelete := func(pod *v1.Pod, err error) {
+	failDelete := func(pod *v1.Pod, err error) error {
 		// Decrement the expected number of deletes because the informer won't observe this deletion
 		jm.expectations.DeletionObserved(logger, jobKey)
 		if !apierrors.IsNotFound(err) {
 			logger.V(2).Info("Failed to delete Pod", "job", klog.KObj(job), "pod", klog.KObj(pod), "err", err)
 			atomic.AddInt32(&successfulDeletes, -1)
-			errCh <- err
-			utilruntime.HandleError(err)
+			return err
 		}
+		return nil
 	}
-
-	wg := sync.WaitGroup{}
-	wg.Add(len(pods))
-	for i := range pods {
-		go func(pod *v1.Pod) {
-			defer wg.Done()
-			if patch := removeTrackingFinalizerPatch(pod); patch != nil {
-				if err := jm.podControl.PatchPod(ctx, pod.Namespace, pod.Name, patch); err != nil {
-					failDelete(pod, fmt.Errorf("removing completion finalizer: %w", err))
-					return
-				}
+	err := parallelizeUntil(ctx, podsCount, func(i int) error {
+		var err error
+		if patch := removeTrackingFinalizerPatch(pods[i]); patch != nil {
+			if err = jm.podControl.PatchPod(ctx, pods[i].Namespace, pods[i].Name, patch); err != nil {
+				return failDelete(pods[i], fmt.Errorf("removing completion fainalizer: %w", err))
 			}
-			if err := jm.podControl.DeletePod(ctx, job.Namespace, pod.Name, job); err != nil {
-				failDelete(pod, err)
-			}
-			if podutil.IsPodReady(pod) {
-				atomic.AddInt32(&deletedReady, 1)
-			}
-		}(pods[i])
-	}
-	wg.Wait()
-	return deletedReady, successfulDeletes, errorFromChannel(errCh)
+		}
+		if err = jm.podControl.DeletePod(ctx, job.Namespace, pods[i].Name, job); err != nil {
+			_ = failDelete(pods[i], err)
+		}
+		if podutil.IsPodReady(pods[i]) {
+			atomic.AddInt32(&deletedReady, 1)
+		}
+		return err
+	})
+	return deletedReady, successfulDeletes, err
 }
 
 // trackJobStatusAndRemoveFinalizers does:
@@ -1411,9 +1399,9 @@ func cleanUncountedPodsWithoutFinalizers(status *batch.JobStatus, uidsWithFinali
 // function was called, it's considered as the finalizer was removed successfully).
 func (jm *Controller) removeTrackingFinalizerFromPods(ctx context.Context, jobKey string, pods []*v1.Pod) ([]bool, error) {
 	logger := klog.FromContext(ctx)
-	errCh := make(chan error, len(pods))
-	succeeded := make([]bool, len(pods))
-	uids := make([]types.UID, len(pods))
+	podsCount := len(pods)
+	succeeded := make([]bool, podsCount)
+	uids := make([]types.UID, podsCount)
 	for i, p := range pods {
 		uids[i] = p.UID
 	}
@@ -1423,32 +1411,23 @@ func (jm *Controller) removeTrackingFinalizerFromPods(ctx context.Context, jobKe
 			return succeeded, fmt.Errorf("setting expected removed finalizers: %w", err)
 		}
 	}
-	wg := sync.WaitGroup{}
-	wg.Add(len(pods))
-	for i := range pods {
-		go func(i int) {
-			pod := pods[i]
-			defer wg.Done()
-			if patch := removeTrackingFinalizerPatch(pod); patch != nil {
-				if err := jm.podControl.PatchPod(ctx, pod.Namespace, pod.Name, patch); err != nil {
-					// In case of any failure, we don't expect a Pod update for the
-					// finalizer removed. Clear expectation now.
-					if jobKey != "" {
-						jm.finalizerExpectations.finalizerRemovalObserved(logger, jobKey, pod.UID)
-					}
-					if !apierrors.IsNotFound(err) {
-						errCh <- err
-						utilruntime.HandleError(fmt.Errorf("removing tracking finalizer: %w", err))
-						return
-					}
+	err := parallelizeUntil(ctx, podsCount, func(i int) error {
+		if patch := removeTrackingFinalizerPatch(pods[i]); patch != nil {
+			if err := jm.podControl.PatchPod(ctx, pods[i].Namespace, pods[i].Name, patch); err != nil {
+				// In case of any failure, we don't expect a Pod update for the
+				// finalizer removed. Clear expectation now.
+				if jobKey != "" {
+					jm.finalizerExpectations.finalizerRemovalObserved(logger, jobKey, pods[i].UID)
 				}
-				succeeded[i] = true
+				if !apierrors.IsNotFound(err) {
+					return fmt.Errorf("removing tracking finalizer: %w", err)
+				}
 			}
-		}(i)
-	}
-	wg.Wait()
-
-	return succeeded, errorFromChannel(errCh)
+		}
+		succeeded[i] = true
+		return nil
+	})
+	return succeeded, err
 }
 
 // enactJobFinished adds the Complete or Failed condition and records events.
@@ -1935,6 +1914,17 @@ func errorFromChannel(errCh <-chan error) error {
 	default:
 	}
 	return nil
+}
+
+func parallelizeUntil(ctx context.Context, pieces int, doWorkPiece func(i int) error) error {
+	errCh := make(chan error, pieces)
+	workqueue.ParallelizeUntil(ctx, pieces, pieces, func(i int) {
+		if err := doWorkPiece(i); err != nil {
+			errCh <- err
+			utilruntime.HandleError(err)
+		}
+	})
+	return errorFromChannel(errCh)
 }
 
 // ensureJobConditionStatus appends or updates an existing job condition of the


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
I simplified and utilized goroutine processes to improve readability.
Potentially, we could apply the same approach to the manageJob: https://github.com/kubernetes/kubernetes/blob/6cb5ea56cb96f6a4ddec677d3d94faf07179368d/pkg/controller/job/job_controller.go#L1730-L1736

But, the manageJob goroutine is slightly different from other ones, like dynamically changing parent batch size based on the number of errors.
So, I would like to work on the maangeJob one in a separate PR to reduce the differences in this PR.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
Job Integration Benchmark result


Master branch:

```shell
# BenchmarkLargeIndexedJob
goos: darwin
goarch: arm64
pkg: k8s.io/kubernetes/test/integration/job
cpu: Apple M3 Max

BenchmarkLargeIndexedJob/job_with_backoffLimitPerIndex_without_failures;_size=10-14         1   3029993084 ns/op
BenchmarkLargeIndexedJob/job_with_backoffLimitPerIndex_without_failures;_size=100-14        1   3040892833 ns/op
BenchmarkLargeIndexedJob/regular_indexed_job_without_failures;_size=10-14                   1   3031930500 ns/op
BenchmarkLargeIndexedJob/regular_indexed_job_without_failures;_size=100-14                  1   3051722833 ns/op
BenchmarkLargeIndexedJob/job_with_backoffLimitPerIndex_without_failures;_size=10-14         1   3029993084 ns/op
BenchmarkLargeIndexedJob/job_with_backoffLimitPerIndex_without_failures;_size=100-14        1   3040892833 ns/op
BenchmarkLargeIndexedJob/regular_indexed_job_without_failures;_size=10-14                   1   3031930500 ns/op
BenchmarkLargeIndexedJob/regular_indexed_job_without_failures;_size=100-14                  1   3051722833 ns/op

# BenchmarkLargeFailureHandling
goos: darwin
goarch: arm64
pkg: k8s.io/kubernetes/test/integration/job
cpu: Apple M3 Max

BenchmarkLargeFailureHandling/job_with_backoffLimitPerIndex_with_failures;_size=10-14       1   3039860125 ns/op
BenchmarkLargeFailureHandling/job_with_backoffLimitPerIndex_with_failures;_size=100-14      1   3032641874 ns/op
BenchmarkLargeFailureHandling/regular_indexed_job_with_failures;_size=10-14                 1   2021753084 ns/op
BenchmarkLargeFailureHandling/regular_indexed_job_with_failures;_size=100-14                1   3031300000 ns/op
BenchmarkLargeFailureHandling/job_with_backoffLimitPerIndex_with_failures;_size=10-14       1   3039860125 ns/op
BenchmarkLargeFailureHandling/job_with_backoffLimitPerIndex_with_failures;_size=100-14      1   3032641874 ns/op
BenchmarkLargeFailureHandling/regular_indexed_job_with_failures;_size=10-14                 1   2021753084 ns/op
BenchmarkLargeFailureHandling/regular_indexed_job_with_failures;_size=100-14                1   3031300000 ns/op
```

This PR:

```shell
# BenchmarkLargeIndexedJob
goos: darwin
goarch: arm64
pkg: k8s.io/kubernetes/test/integration/job
cpu: Apple M3 Max

BenchmarkLargeIndexedJob/job_with_backoffLimitPerIndex_without_failures;_size=10-14           1   3032995666 ns/op
BenchmarkLargeIndexedJob/job_with_backoffLimitPerIndex_without_failures;_size=100-14          1   3037585417 ns/op
BenchmarkLargeIndexedJob/regular_indexed_job_without_failures;_size=10-14                     1   3022537250 ns/op
BenchmarkLargeIndexedJob/regular_indexed_job_without_failures;_size=100-14                    1   3037767625 ns/op
BenchmarkLargeIndexedJob/job_with_backoffLimitPerIndex_without_failures;_size=10-14           1   3032995666 ns/op
BenchmarkLargeIndexedJob/job_with_backoffLimitPerIndex_without_failures;_size=100-14          1   3037585417 ns/op
BenchmarkLargeIndexedJob/regular_indexed_job_without_failures;_size=10-14                     1   3022537250 ns/op
BenchmarkLargeIndexedJob/regular_indexed_job_without_failures;_size=100-14                    1   3037767625 ns/op

# BenchmarkLargeFailureHandling
goos: darwin
goarch: arm64
pkg: k8s.io/kubernetes/test/integration/job
cpu: Apple M3 Max

BenchmarkLargeFailureHandling/job_with_backoffLimitPerIndex_with_failures;_size=10-14         1   3015064042 ns/op
BenchmarkLargeFailureHandling/job_with_backoffLimitPerIndex_with_failures;_size=100-14        1   3030077124 ns/op
BenchmarkLargeFailureHandling/regular_indexed_job_with_failures;_size=10-14                   1   2018357917 ns/op
BenchmarkLargeFailureHandling/regular_indexed_job_with_failures;_size=100-14                  1   3025510750 ns/op
BenchmarkLargeFailureHandling/job_with_backoffLimitPerIndex_with_failures;_size=10-14         1   3015064042 ns/op
BenchmarkLargeFailureHandling/job_with_backoffLimitPerIndex_with_failures;_size=100-14        1   3030077124 ns/op
BenchmarkLargeFailureHandling/regular_indexed_job_with_failures;_size=10-14                   1   2018357917 ns/op
BenchmarkLargeFailureHandling/regular_indexed_job_with_failures;_size=100-14                  1   3025510750 ns/op
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
