### PR TITLE
e2e_node: Pass e2eCriProxy instead of updating global.

### DIFF
--- a/test/e2e_node/criproxy_test.go
+++ b/test/e2e_node/criproxy_test.go
@@ -48,19 +48,19 @@ var _ = SIGDescribe(feature.CriProxy, framework.WithSerial(), func() {
 
 	ginkgo.Context("Inject a pull image error exception into the CriProxy", func() {
 		ginkgo.BeforeEach(func() {
-			if err := resetCRIProxyInjector(); err != nil {
+			if err := resetCRIProxyInjector(e2eCriProxy); err != nil {
 				ginkgo.Skip("Skip the test since the CRI Proxy is undefined.")
 			}
 		})
 
 		ginkgo.AfterEach(func() {
-			err := resetCRIProxyInjector()
+			err := resetCRIProxyInjector(e2eCriProxy)
 			framework.ExpectNoError(err)
 		})
 
 		ginkgo.It("Pod failed to start due to an image pull error.", func(ctx context.Context) {
 			expectedErr := fmt.Errorf("PullImage failed")
-			err := addCRIProxyInjector(func(apiName string) error {
+			err := addCRIProxyInjector(e2eCriProxy, func(apiName string) error {
 				if apiName == criproxy.PullImage {
 					return expectedErr
 				}
@@ -86,19 +86,19 @@ var _ = SIGDescribe(feature.CriProxy, framework.WithSerial(), func() {
 
 	ginkgo.Context("Inject a pull image timeout exception into the CriProxy", func() {
 		ginkgo.BeforeEach(func() {
-			if err := resetCRIProxyInjector(); err != nil {
+			if err := resetCRIProxyInjector(e2eCriProxy); err != nil {
 				ginkgo.Skip("Skip the test since the CRI Proxy is undefined.")
 			}
 		})
 
 		ginkgo.AfterEach(func() {
-			err := resetCRIProxyInjector()
+			err := resetCRIProxyInjector(e2eCriProxy)
 			framework.ExpectNoError(err)
 		})
 
 		ginkgo.It("Image pull time exceeded 10 seconds", func(ctx context.Context) {
 			const delayTime = 10 * time.Second
-			err := addCRIProxyInjector(func(apiName string) error {
+			err := addCRIProxyInjector(e2eCriProxy, func(apiName string) error {
 				if apiName == criproxy.PullImage {
 					time.Sleep(10 * time.Second)
 				}

--- a/test/e2e_node/image_pull_test.go
+++ b/test/e2e_node/image_pull_test.go
@@ -59,7 +59,7 @@ var _ = SIGDescribe("Pull Image", feature.CriProxy, framework.WithSerial(), func
 		})
 
 		ginkgo.BeforeEach(func(ctx context.Context) {
-			if err := resetCRIProxyInjector(); err != nil {
+			if err := resetCRIProxyInjector(e2eCriProxy); err != nil {
 				ginkgo.Skip("Skip the test since the CRI Proxy is undefined.")
 			}
 
@@ -68,7 +68,7 @@ var _ = SIGDescribe("Pull Image", feature.CriProxy, framework.WithSerial(), func
 		})
 
 		ginkgo.AfterEach(func(ctx context.Context) {
-			err := resetCRIProxyInjector()
+			err := resetCRIProxyInjector(e2eCriProxy)
 			framework.ExpectNoError(err)
 
 			ginkgo.By("cleanup pods")
@@ -82,7 +82,7 @@ var _ = SIGDescribe("Pull Image", feature.CriProxy, framework.WithSerial(), func
 			timeout := 20 * time.Second
 			callCh := make(chan struct{})
 			callStatus := make(map[int]chan struct{})
-			err := addCRIProxyInjector(func(apiName string) error {
+			err := addCRIProxyInjector(e2eCriProxy, func(apiName string) error {
 				if apiName == criproxy.PullImage {
 					mu.Lock()
 					callID := len(callStatus)
@@ -142,7 +142,7 @@ var _ = SIGDescribe("Pull Image", feature.CriProxy, framework.WithSerial(), func
 		var testpods []*v1.Pod
 
 		ginkgo.BeforeEach(func(ctx context.Context) {
-			if err := resetCRIProxyInjector(); err != nil {
+			if err := resetCRIProxyInjector(e2eCriProxy); err != nil {
 				ginkgo.Skip("Skip the test since the CRI Proxy is undefined.")
 			}
 
@@ -151,7 +151,7 @@ var _ = SIGDescribe("Pull Image", feature.CriProxy, framework.WithSerial(), func
 		})
 
 		ginkgo.AfterEach(func(ctx context.Context) {
-			err := resetCRIProxyInjector()
+			err := resetCRIProxyInjector(e2eCriProxy)
 			framework.ExpectNoError(err)
 
 			ginkgo.By("cleanup pods")
@@ -166,7 +166,7 @@ var _ = SIGDescribe("Pull Image", feature.CriProxy, framework.WithSerial(), func
 			var mu sync.Mutex
 			callCh := make(chan struct{})
 			callStatus := make(map[int]chan struct{})
-			err := addCRIProxyInjector(func(apiName string) error {
+			err := addCRIProxyInjector(e2eCriProxy, func(apiName string) error {
 				if apiName == criproxy.PullImage {
 					mu.Lock()
 					callID := len(callStatus)

--- a/test/e2e_node/utils_linux.go
+++ b/test/e2e_node/utils_linux.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 
 	libcontainercgroups "github.com/opencontainers/runc/libcontainer/cgroups"
+	"k8s.io/kubernetes/test/e2e_node/criproxy"
 )
 
 // IsCgroup2UnifiedMode returns whether we are running in cgroup v2 unified mode.
@@ -31,19 +32,19 @@ func IsCgroup2UnifiedMode() bool {
 }
 
 // addCRIProxyInjector registers an injector function for the CRIProxy.
-func addCRIProxyInjector(injector func(apiName string) error) error {
-	if e2eCriProxy != nil {
-		e2eCriProxy.AddInjector(injector)
-		return nil
+func addCRIProxyInjector(proxy *criproxy.RemoteRuntime, injector func(apiName string) error) error {
+	if proxy == nil {
+		return fmt.Errorf("failed to add injector because the CRI Proxy is undefined")
 	}
-	return fmt.Errorf("failed to add injector because the CRI Proxy is undefined")
+	proxy.AddInjector(injector)
+	return nil
 }
 
 // resetCRIProxyInjector resets all injector functions for the CRIProxy.
-func resetCRIProxyInjector() error {
-	if e2eCriProxy != nil {
-		e2eCriProxy.ResetInjectors()
-		return nil
+func resetCRIProxyInjector(proxy *criproxy.RemoteRuntime) error {
+	if proxy == nil {
+		return fmt.Errorf("failed to reset injector because the CRI Proxy is undefined")
 	}
-	return fmt.Errorf("failed to reset injector because the CRI Proxy is undefined")
+	proxy.ResetInjectors()
+	return nil
 }


### PR DESCRIPTION
e2eCriProxy is defined in a _test.go and referenced in a non-test file. This confuses gopls.

It's also clearer to future readers.

/kind cleanup
```release-note
NONE
```