### PR TITLE
[FG:InPlacePodVerticalScaling] PLEG watch conditions: rapid polling for expected changes

### DIFF
--- a/pkg/kubelet/container/helpers.go
+++ b/pkg/kubelet/container/helpers.go
@@ -66,6 +66,9 @@ type RuntimeHelper interface {
 
 	// UnprepareDynamicResources unprepares resources for a a pod.
 	UnprepareDynamicResources(ctx context.Context, pod *v1.Pod) error
+
+	// SetPodWatchCondition flags a pod to be inspected until the condition is met.
+	SetPodWatchCondition(types.UID, string, func(*PodStatus) bool)
 }
 
 // ShouldContainerBeRestarted checks whether a container needs to be restarted.

--- a/pkg/kubelet/container/testing/fake_runtime_helper.go
+++ b/pkg/kubelet/container/testing/fake_runtime_helper.go
@@ -114,3 +114,7 @@ func (f *FakeRuntimeHelper) PrepareDynamicResources(ctx context.Context, pod *v1
 func (f *FakeRuntimeHelper) UnprepareDynamicResources(ctx context.Context, pod *v1.Pod) error {
 	return nil
 }
+
+func (f *FakeRuntimeHelper) SetPodWatchCondition(_ kubetypes.UID, _ string, _ func(*kubecontainer.PodStatus) bool) {
+	// Not implemented.
+}

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -799,6 +799,9 @@ func (m *kubeGenericRuntimeManager) updatePodContainerResources(pod *v1.Pod, res
 			return err
 		}
 		resizeKey := fmt.Sprintf("%s:resize:%s", container.Name, resourceName)
+
+		// Watch (poll) the container for the expected resources update. Stop watching once the resources
+		// match the desired values.
 		resizeCondition := pleg.RunningContainerWatchCondition(container.Name, func(status *kubecontainer.Status) bool {
 			if status.Resources == nil {
 				return false
@@ -814,6 +817,7 @@ func (m *kubeGenericRuntimeManager) updatePodContainerResources(pod *v1.Pod, res
 			}
 		})
 		m.runtimeHelper.SetPodWatchCondition(pod.UID, resizeKey, resizeCondition)
+
 		// If UpdateContainerResources is error-free, it means desired values for 'resourceName' was accepted by runtime.
 		// So we update currentContainerResources for 'resourceName', which is our view of most recently configured resources.
 		// Note: We can't rely on GetPodStatus as runtime may lag in actuating the resource values it just accepted.

--- a/pkg/kubelet/pleg/evented.go
+++ b/pkg/kubelet/pleg/evented.go
@@ -427,10 +427,6 @@ func (e *EventedPLEG) updateLatencyMetric(event *runtimeapi.ContainerEventRespon
 	metrics.EventedPLEGConnLatency.Observe(duration.Seconds())
 }
 
-func (e *EventedPLEG) UpdateCache(pod *kubecontainer.Pod, pid types.UID) (error, bool) {
-	return fmt.Errorf("not implemented"), false
-}
-
 func (e *EventedPLEG) SetPodWatchCondition(podUID types.UID, conditionKey string, condition WatchCondition) {
 	e.genericPleg.SetPodWatchCondition(podUID, conditionKey, condition)
 }

--- a/pkg/kubelet/pleg/evented.go
+++ b/pkg/kubelet/pleg/evented.go
@@ -430,3 +430,7 @@ func (e *EventedPLEG) updateLatencyMetric(event *runtimeapi.ContainerEventRespon
 func (e *EventedPLEG) UpdateCache(pod *kubecontainer.Pod, pid types.UID) (error, bool) {
 	return fmt.Errorf("not implemented"), false
 }
+
+func (e *EventedPLEG) SetPodWatchCondition(podUID types.UID, conditionKey string, condition WatchCondition) {
+	e.genericPleg.SetPodWatchCondition(podUID, conditionKey, condition)
+}

--- a/pkg/kubelet/pleg/generic.go
+++ b/pkg/kubelet/pleg/generic.go
@@ -305,11 +305,9 @@ func (g *GenericPLEG) Relist() {
 			needsReinspection[pid] = pod
 
 			continue
-		} else {
-			if utilfeature.DefaultFeatureGate.Enabled(features.EventedPLEG) {
-				if !updated {
-					continue
-				}
+		} else if utilfeature.DefaultFeatureGate.Enabled(features.EventedPLEG) {
+			if !updated {
+				continue
 			}
 		}
 
@@ -481,15 +479,6 @@ func (g *GenericPLEG) updateCache(ctx context.Context, pod *kubecontainer.Pod, p
 	}
 
 	return status, g.cache.Set(pod.ID, status, err, timestamp), err
-}
-
-func (g *GenericPLEG) UpdateCache(pod *kubecontainer.Pod, pid types.UID) (error, bool) {
-	ctx := context.Background()
-	if pod == nil {
-		return fmt.Errorf("pod cannot be nil"), false
-	}
-	_, updated, err := g.updateCache(ctx, pod, pid)
-	return err, updated
 }
 
 func (g *GenericPLEG) SetPodWatchCondition(podUID types.UID, conditionKey string, condition WatchCondition) {

--- a/pkg/kubelet/pleg/generic.go
+++ b/pkg/kubelet/pleg/generic.go
@@ -317,7 +317,10 @@ func (g *GenericPLEG) Relist() {
 				completedConditions = append(completedConditions, condition)
 			}
 		}
-		g.completeWatchConditions(pid, completedConditions)
+		if len(completedConditions) > 0 {
+			g.completeWatchConditions(pid, completedConditions)
+			events = append(events, &PodLifecycleEvent{ID: pid, Type: ConditionMet})
+		}
 
 		// Update the internal storage and send out the events.
 		g.podRecords.update(pid)

--- a/pkg/kubelet/pleg/generic_test.go
+++ b/pkg/kubelet/pleg/generic_test.go
@@ -766,7 +766,8 @@ func TestWatchConditions(t *testing.T) {
 			},
 		},
 	}}
-	initialPods := append(pods, &containertest.FakePod{Pod: &kubecontainer.Pod{
+	initialPods := pods
+	initialPods = append(initialPods, &containertest.FakePod{Pod: &kubecontainer.Pod{
 		Name: "terminated-pod",
 		ID:   "terminated",
 		Sandboxes: []*kubecontainer.Container{
@@ -813,8 +814,8 @@ func TestWatchConditions(t *testing.T) {
 			"updating": {version: 1},
 		},
 	}, {
-		name:   "non-existant pod",
-		podUID: "non-existant",
+		name:   "non-existent pod",
+		podUID: "non-existent",
 		watchConditions: map[string]WatchCondition{
 			"watching": neverComplete,
 		},

--- a/pkg/kubelet/pleg/pleg.go
+++ b/pkg/kubelet/pleg/pleg.go
@@ -67,6 +67,10 @@ type PodLifecycleEventGenerator interface {
 	Watch() chan *PodLifecycleEvent
 	Healthy() (bool, error)
 	UpdateCache(*kubecontainer.Pod, types.UID) (error, bool)
+	// SetPodWatchCondition flags the pod for reinspection on every Relist iteration until the watch
+	// condition is met. The condition is keyed so it can be updated before the condition
+	// is met.
+	SetPodWatchCondition(podUID types.UID, conditionKey string, condition WatchCondition)
 }
 
 // podLifecycleEventGeneratorHandler contains functions that are useful for different PLEGs
@@ -76,4 +80,20 @@ type podLifecycleEventGeneratorHandler interface {
 	Stop()
 	Update(relistDuration *RelistDuration)
 	Relist()
+}
+
+// WatchCondition takes the latest PodStatus, and returns whether the condition is met.
+type WatchCondition func(*kubecontainer.PodStatus) bool
+
+// RunningContainerWatchCondition wraps a condition on the container status to make a pod
+// WatchCondition. If the container is no longer running, the condition is implicitly cleared.
+func RunningContainerWatchCondition(containerName string, condition func(*kubecontainer.Status) bool) WatchCondition {
+	return func(podStatus *kubecontainer.PodStatus) bool {
+		status := podStatus.FindContainerStatusByName(containerName)
+		if status == nil || status.State != kubecontainer.ContainerStateRunning {
+			// Container isn't running. Consider the condition "completed" so it is cleared.
+			return true
+		}
+		return condition(status)
+	}
 }

--- a/pkg/kubelet/pleg/pleg.go
+++ b/pkg/kubelet/pleg/pleg.go
@@ -47,6 +47,8 @@ const (
 	PodSync PodLifeCycleEventType = "PodSync"
 	// ContainerChanged - event type when the new state of container is unknown.
 	ContainerChanged PodLifeCycleEventType = "ContainerChanged"
+	// ConditionMet - event type triggered when any number of watch conditions are met.
+	ConditionMet PodLifeCycleEventType = "ConditionMet"
 )
 
 // PodLifecycleEvent is an event that reflects the change of the pod state.

--- a/pkg/kubelet/pleg/pleg.go
+++ b/pkg/kubelet/pleg/pleg.go
@@ -66,7 +66,6 @@ type PodLifecycleEventGenerator interface {
 	Start()
 	Watch() chan *PodLifecycleEvent
 	Healthy() (bool, error)
-	UpdateCache(*kubecontainer.Pod, types.UID) (error, bool)
 	// SetPodWatchCondition flags the pod for reinspection on every Relist iteration until the watch
 	// condition is met. The condition is keyed so it can be updated before the condition
 	// is met.
@@ -83,7 +82,7 @@ type podLifecycleEventGeneratorHandler interface {
 }
 
 // WatchCondition takes the latest PodStatus, and returns whether the condition is met.
-type WatchCondition func(*kubecontainer.PodStatus) bool
+type WatchCondition = func(*kubecontainer.PodStatus) bool
 
 // RunningContainerWatchCondition wraps a condition on the container status to make a pod
 // WatchCondition. If the container is no longer running, the condition is implicitly cleared.


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

**Motivation & Background:**

The Kubelet's PLEG only triggers events and fetches the latest PodStatus from the runtime when a container changes state. This is a problem for in-place pod resize, since resource updates are not considered a state change. To get around this, `pleg.UpdateCache` was called at the end of SyncPod if a pod was resizing to force a "reinspection" of the pod status. This violates some principles of the PLEG, and also means that resizes need to wait a full resync period (1 minute) to detect that the resize completed.

**What this PR does:**

This PR adds a new concept of "Watch Conditions" to the PLEG. If a pod has a watch condition set, then the pod is reinspected (via `runtime.GetPodStatus`) on every `Relist` loop (every 2 seconds) until the watch condition function returns true, indicating that the condition was reached. The Kubelet sets a watch condition for each resource resize, so it no longer needs to manually do the reinspection via update cache.

Not Yet Implemented: When a watch condition is completed, an event is emitted by the PLEG to trigger SyncPod. This should greatly speed up pod resize completion.

#### Which issue(s) this PR fixes:
Fixes #123940

#### Special notes for your reviewer:
This PR starts with some refactoring. I can pull the refactor into a separate PR if you prefer.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/sig node
/priority important-longterm