### PR TITLE
KEP-4222: Add CBOR feature gates.

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -20905,7 +20905,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified ConfigMap",
         "operationId": "patchCoreV1NamespacedConfigMap",
@@ -21390,7 +21391,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified Endpoints",
         "operationId": "patchCoreV1NamespacedEndpoints",
@@ -21875,7 +21877,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified Event",
         "operationId": "patchCoreV1NamespacedEvent",
@@ -22360,7 +22363,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified LimitRange",
         "operationId": "patchCoreV1NamespacedLimitRange",
@@ -22845,7 +22849,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified PersistentVolumeClaim",
         "operationId": "patchCoreV1NamespacedPersistentVolumeClaim",
@@ -23035,7 +23040,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update status of the specified PersistentVolumeClaim",
         "operationId": "patchCoreV1NamespacedPersistentVolumeClaimStatus",
@@ -23520,7 +23526,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified Pod",
         "operationId": "patchCoreV1NamespacedPod",
@@ -23898,7 +23905,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update ephemeralcontainers of the specified Pod",
         "operationId": "patchCoreV1NamespacedPodEphemeralcontainers",
@@ -24942,7 +24950,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update status of the specified Pod",
         "operationId": "patchCoreV1NamespacedPodStatus",
@@ -25427,7 +25436,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified PodTemplate",
         "operationId": "patchCoreV1NamespacedPodTemplate",
@@ -25912,7 +25922,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified ReplicationController",
         "operationId": "patchCoreV1NamespacedReplicationController",
@@ -26102,7 +26113,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update scale of the specified ReplicationController",
         "operationId": "patchCoreV1NamespacedReplicationControllerScale",
@@ -26292,7 +26304,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update status of the specified ReplicationController",
         "operationId": "patchCoreV1NamespacedReplicationControllerStatus",
@@ -26777,7 +26790,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified ResourceQuota",
         "operationId": "patchCoreV1NamespacedResourceQuota",
@@ -26967,7 +26981,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update status of the specified ResourceQuota",
         "operationId": "patchCoreV1NamespacedResourceQuotaStatus",
@@ -27452,7 +27467,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified Secret",
         "operationId": "patchCoreV1NamespacedSecret",
@@ -27937,7 +27953,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified ServiceAccount",
         "operationId": "patchCoreV1NamespacedServiceAccount",
@@ -28514,7 +28531,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified Service",
         "operationId": "patchCoreV1NamespacedService",
@@ -29205,7 +29223,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update status of the specified Service",
         "operationId": "patchCoreV1NamespacedServiceStatus",
@@ -29454,7 +29473,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified Namespace",
         "operationId": "patchCoreV1Namespace",
@@ -29724,7 +29744,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update status of the specified Namespace",
         "operationId": "patchCoreV1NamespaceStatus",
@@ -30203,7 +30224,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified Node",
         "operationId": "patchCoreV1Node",
@@ -30885,7 +30907,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update status of the specified Node",
         "operationId": "patchCoreV1NodeStatus",
@@ -31438,7 +31461,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified PersistentVolume",
         "operationId": "patchCoreV1PersistentVolume",
@@ -31625,7 +31649,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update status of the specified PersistentVolume",
         "operationId": "patchCoreV1PersistentVolumeStatus",
@@ -36021,7 +36046,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified MutatingWebhookConfiguration",
         "operationId": "patchAdmissionregistrationV1MutatingWebhookConfiguration",
@@ -36500,7 +36526,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified ValidatingAdmissionPolicy",
         "operationId": "patchAdmissionregistrationV1ValidatingAdmissionPolicy",
@@ -36687,7 +36714,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update status of the specified ValidatingAdmissionPolicy",
         "operationId": "patchAdmissionregistrationV1ValidatingAdmissionPolicyStatus",
@@ -37166,7 +37194,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified ValidatingAdmissionPolicyBinding",
         "operationId": "patchAdmissionregistrationV1ValidatingAdmissionPolicyBinding",
@@ -37645,7 +37674,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified ValidatingWebhookConfiguration",
         "operationId": "patchAdmissionregistrationV1ValidatingWebhookConfiguration",
@@ -38781,7 +38811,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified MutatingAdmissionPolicy",
         "operationId": "patchAdmissionregistrationV1alpha1MutatingAdmissionPolicy",
@@ -39260,7 +39291,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified MutatingAdmissionPolicyBinding",
         "operationId": "patchAdmissionregistrationV1alpha1MutatingAdmissionPolicyBinding",
@@ -39739,7 +39771,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified ValidatingAdmissionPolicy",
         "operationId": "patchAdmissionregistrationV1alpha1ValidatingAdmissionPolicy",
@@ -39926,7 +39959,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update status of the specified ValidatingAdmissionPolicy",
         "operationId": "patchAdmissionregistrationV1alpha1ValidatingAdmissionPolicyStatus",
@@ -40405,7 +40439,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified ValidatingAdmissionPolicyBinding",
         "operationId": "patchAdmissionregistrationV1alpha1ValidatingAdmissionPolicyBinding",
@@ -41541,7 +41576,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified ValidatingAdmissionPolicy",
         "operationId": "patchAdmissionregistrationV1beta1ValidatingAdmissionPolicy",
@@ -41728,7 +41764,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update status of the specified ValidatingAdmissionPolicy",
         "operationId": "patchAdmissionregistrationV1beta1ValidatingAdmissionPolicyStatus",
@@ -42207,7 +42244,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified ValidatingAdmissionPolicyBinding",
         "operationId": "patchAdmissionregistrationV1beta1ValidatingAdmissionPolicyBinding",
@@ -43064,7 +43102,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified CustomResourceDefinition",
         "operationId": "patchApiextensionsV1CustomResourceDefinition",
@@ -43251,7 +43290,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update status of the specified CustomResourceDefinition",
         "operationId": "patchApiextensionsV1CustomResourceDefinitionStatus",
@@ -43952,7 +43992,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified APIService",
         "operationId": "patchApiregistrationV1APIService",
@@ -44139,7 +44180,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update status of the specified APIService",
         "operationId": "patchApiregistrationV1APIServiceStatus",
@@ -45068,7 +45110,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified ControllerRevision",
         "operationId": "patchAppsV1NamespacedControllerRevision",
@@ -45553,7 +45596,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified DaemonSet",
         "operationId": "patchAppsV1NamespacedDaemonSet",
@@ -45743,7 +45787,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update status of the specified DaemonSet",
         "operationId": "patchAppsV1NamespacedDaemonSetStatus",
@@ -46228,7 +46273,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified Deployment",
         "operationId": "patchAppsV1NamespacedDeployment",
@@ -46418,7 +46464,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update scale of the specified Deployment",
         "operationId": "patchAppsV1NamespacedDeploymentScale",
@@ -46608,7 +46655,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update status of the specified Deployment",
         "operationId": "patchAppsV1NamespacedDeploymentStatus",
@@ -47093,7 +47141,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified ReplicaSet",
         "operationId": "patchAppsV1NamespacedReplicaSet",
@@ -47283,7 +47332,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update scale of the specified ReplicaSet",
         "operationId": "patchAppsV1NamespacedReplicaSetScale",
@@ -47473,7 +47523,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update status of the specified ReplicaSet",
         "operationId": "patchAppsV1NamespacedReplicaSetStatus",
@@ -47958,7 +48009,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified StatefulSet",
         "operationId": "patchAppsV1NamespacedStatefulSet",
@@ -48148,7 +48200,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update scale of the specified StatefulSet",
         "operationId": "patchAppsV1NamespacedStatefulSetScale",
@@ -48338,7 +48391,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update status of the specified StatefulSet",
         "operationId": "patchAppsV1NamespacedStatefulSetStatus",
@@ -51140,7 +51194,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified HorizontalPodAutoscaler",
         "operationId": "patchAutoscalingV1NamespacedHorizontalPodAutoscaler",
@@ -51330,7 +51385,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update status of the specified HorizontalPodAutoscaler",
         "operationId": "patchAutoscalingV1NamespacedHorizontalPodAutoscalerStatus",
@@ -52158,7 +52214,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified HorizontalPodAutoscaler",
         "operationId": "patchAutoscalingV2NamespacedHorizontalPodAutoscaler",
@@ -52348,7 +52405,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update status of the specified HorizontalPodAutoscaler",
         "operationId": "patchAutoscalingV2NamespacedHorizontalPodAutoscalerStatus",
@@ -53283,7 +53341,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified CronJob",
         "operationId": "patchBatchV1NamespacedCronJob",
@@ -53473,7 +53532,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update status of the specified CronJob",
         "operationId": "patchBatchV1NamespacedCronJobStatus",
@@ -53958,7 +54018,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified Job",
         "operationId": "patchBatchV1NamespacedJob",
@@ -54148,7 +54209,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update status of the specified Job",
         "operationId": "patchBatchV1NamespacedJobStatus",
@@ -55165,7 +55227,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified CertificateSigningRequest",
         "operationId": "patchCertificatesV1CertificateSigningRequest",
@@ -55352,7 +55415,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update approval of the specified CertificateSigningRequest",
         "operationId": "patchCertificatesV1CertificateSigningRequestApproval",
@@ -55539,7 +55603,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update status of the specified CertificateSigningRequest",
         "operationId": "patchCertificatesV1CertificateSigningRequestStatus",
@@ -56207,7 +56272,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified ClusterTrustBundle",
         "operationId": "patchCertificatesV1alpha1ClusterTrustBundle",
@@ -56988,7 +57054,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified Lease",
         "operationId": "patchCoordinationV1NamespacedLease",
@@ -57816,7 +57883,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified LeaseCandidate",
         "operationId": "patchCoordinationV1alpha1NamespacedLeaseCandidate",
@@ -58677,7 +58745,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified EndpointSlice",
         "operationId": "patchDiscoveryV1NamespacedEndpointSlice",
@@ -59538,7 +59607,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified Event",
         "operationId": "patchEventsV1NamespacedEvent",
@@ -60319,7 +60389,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified FlowSchema",
         "operationId": "patchFlowcontrolApiserverV1FlowSchema",
@@ -60506,7 +60577,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update status of the specified FlowSchema",
         "operationId": "patchFlowcontrolApiserverV1FlowSchemaStatus",
@@ -60985,7 +61057,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified PriorityLevelConfiguration",
         "operationId": "patchFlowcontrolApiserverV1PriorityLevelConfiguration",
@@ -61172,7 +61245,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update status of the specified PriorityLevelConfiguration",
         "operationId": "patchFlowcontrolApiserverV1PriorityLevelConfigurationStatus",
@@ -61996,7 +62070,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified FlowSchema",
         "operationId": "patchFlowcontrolApiserverV1beta3FlowSchema",
@@ -62183,7 +62258,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update status of the specified FlowSchema",
         "operationId": "patchFlowcontrolApiserverV1beta3FlowSchemaStatus",
@@ -62662,7 +62738,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified PriorityLevelConfiguration",
         "operationId": "patchFlowcontrolApiserverV1beta3PriorityLevelConfiguration",
@@ -62849,7 +62926,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update status of the specified PriorityLevelConfiguration",
         "operationId": "patchFlowcontrolApiserverV1beta3PriorityLevelConfigurationStatus",
@@ -63706,7 +63784,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified StorageVersion",
         "operationId": "patchInternalApiserverV1alpha1StorageVersion",
@@ -63893,7 +63972,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update status of the specified StorageVersion",
         "operationId": "patchInternalApiserverV1alpha1StorageVersionStatus",
@@ -64594,7 +64674,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified IngressClass",
         "operationId": "patchNetworkingV1IngressClass",
@@ -65153,7 +65234,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified Ingress",
         "operationId": "patchNetworkingV1NamespacedIngress",
@@ -65343,7 +65425,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update status of the specified Ingress",
         "operationId": "patchNetworkingV1NamespacedIngressStatus",
@@ -65828,7 +65911,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified NetworkPolicy",
         "operationId": "patchNetworkingV1NamespacedNetworkPolicy",
@@ -67042,7 +67126,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified IPAddress",
         "operationId": "patchNetworkingV1beta1IPAddress",
@@ -67521,7 +67606,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified ServiceCIDR",
         "operationId": "patchNetworkingV1beta1ServiceCIDR",
@@ -67708,7 +67794,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update status of the specified ServiceCIDR",
         "operationId": "patchNetworkingV1beta1ServiceCIDRStatus",
@@ -68565,7 +68652,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified RuntimeClass",
         "operationId": "patchNodeV1RuntimeClass",
@@ -69272,7 +69360,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified PodDisruptionBudget",
         "operationId": "patchPolicyV1NamespacedPodDisruptionBudget",
@@ -69462,7 +69551,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update status of the specified PodDisruptionBudget",
         "operationId": "patchPolicyV1NamespacedPodDisruptionBudgetStatus",
@@ -70317,7 +70407,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified ClusterRoleBinding",
         "operationId": "patchRbacAuthorizationV1ClusterRoleBinding",
@@ -70796,7 +70887,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified ClusterRole",
         "operationId": "patchRbacAuthorizationV1ClusterRole",
@@ -71281,7 +71373,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified RoleBinding",
         "operationId": "patchRbacAuthorizationV1NamespacedRoleBinding",
@@ -71766,7 +71859,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified Role",
         "operationId": "patchRbacAuthorizationV1NamespacedRole",
@@ -73243,7 +73337,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified DeviceClass",
         "operationId": "patchResourceV1alpha3DeviceClass",
@@ -73728,7 +73823,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified ResourceClaim",
         "operationId": "patchResourceV1alpha3NamespacedResourceClaim",
@@ -73918,7 +74014,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update status of the specified ResourceClaim",
         "operationId": "patchResourceV1alpha3NamespacedResourceClaimStatus",
@@ -74403,7 +74500,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified ResourceClaimTemplate",
         "operationId": "patchResourceV1alpha3NamespacedResourceClaimTemplate",
@@ -75030,7 +75128,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified ResourceSlice",
         "operationId": "patchResourceV1alpha3ResourceSlice",
@@ -76359,7 +76458,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified PriorityClass",
         "operationId": "patchSchedulingV1PriorityClass",
@@ -77060,7 +77160,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified CSIDriver",
         "operationId": "patchStorageV1CSIDriver",
@@ -77539,7 +77640,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified CSINode",
         "operationId": "patchStorageV1CSINode",
@@ -78098,7 +78200,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified CSIStorageCapacity",
         "operationId": "patchStorageV1NamespacedCSIStorageCapacity",
@@ -78577,7 +78680,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified StorageClass",
         "operationId": "patchStorageV1StorageClass",
@@ -79056,7 +79160,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified VolumeAttachment",
         "operationId": "patchStorageV1VolumeAttachment",
@@ -79243,7 +79348,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update status of the specified VolumeAttachment",
         "operationId": "patchStorageV1VolumeAttachmentStatus",
@@ -80615,7 +80721,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified VolumeAttributesClass",
         "operationId": "patchStorageV1alpha1VolumeAttributesClass",
@@ -81283,7 +81390,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified VolumeAttributesClass",
         "operationId": "patchStorageV1beta1VolumeAttributesClass",
@@ -81984,7 +82092,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update the specified StorageVersionMigration",
         "operationId": "patchStoragemigrationV1alpha1StorageVersionMigration",
@@ -82171,7 +82280,8 @@
           "application/json-patch+json",
           "application/merge-patch+json",
           "application/strategic-merge-patch+json",
-          "application/apply-patch+yaml"
+          "application/apply-patch+yaml",
+          "application/apply-patch+cbor"
         ],
         "description": "partially update status of the specified StorageVersionMigration",
         "operationId": "patchStoragemigrationV1alpha1StorageVersionMigrationStatus",

--- a/api/openapi-spec/v3/api__v1_openapi.json
+++ b/api/openapi-spec/v3/api__v1_openapi.json
@@ -11820,6 +11820,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -12651,6 +12656,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -13482,6 +13492,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -14313,6 +14328,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -15144,6 +15164,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -15433,6 +15458,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -16264,6 +16294,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -16826,6 +16861,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -18102,6 +18142,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -18933,6 +18978,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -19764,6 +19814,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -20053,6 +20108,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -20342,6 +20402,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -21173,6 +21238,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -21462,6 +21532,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -22293,6 +22368,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -23124,6 +23204,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -24103,6 +24188,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -24860,6 +24950,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -25244,6 +25339,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -25641,6 +25741,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -26452,6 +26557,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -27179,6 +27289,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -28141,6 +28256,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -28420,6 +28540,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"

--- a/api/openapi-spec/v3/apis__admissionregistration.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__admissionregistration.k8s.io__v1_openapi.json
@@ -3035,6 +3035,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -3846,6 +3851,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -4125,6 +4135,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -4936,6 +4951,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -5747,6 +5767,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"

--- a/api/openapi-spec/v3/apis__admissionregistration.k8s.io__v1alpha1_openapi.json
+++ b/api/openapi-spec/v3/apis__admissionregistration.k8s.io__v1alpha1_openapi.json
@@ -2865,6 +2865,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -3676,6 +3681,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -4487,6 +4497,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -4766,6 +4781,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -5577,6 +5597,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"

--- a/api/openapi-spec/v3/apis__admissionregistration.k8s.io__v1beta1_openapi.json
+++ b/api/openapi-spec/v3/apis__admissionregistration.k8s.io__v1beta1_openapi.json
@@ -2549,6 +2549,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -2828,6 +2833,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -3639,6 +3649,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"

--- a/api/openapi-spec/v3/apis__apiextensions.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__apiextensions.k8s.io__v1_openapi.json
@@ -2701,6 +2701,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -2980,6 +2985,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"

--- a/api/openapi-spec/v3/apis__apiregistration.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__apiregistration.k8s.io__v1_openapi.json
@@ -2054,6 +2054,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -2333,6 +2338,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"

--- a/api/openapi-spec/v3/apis__apps__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__apps__v1_openapi.json
@@ -7744,6 +7744,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -8575,6 +8580,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -8864,6 +8874,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -9695,6 +9710,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -9984,6 +10004,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -10273,6 +10298,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -11104,6 +11134,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -11393,6 +11428,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -11682,6 +11722,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -12513,6 +12558,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -12802,6 +12852,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -13091,6 +13146,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"

--- a/api/openapi-spec/v3/apis__autoscaling__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__autoscaling__v1_openapi.json
@@ -2198,6 +2198,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -2487,6 +2492,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"

--- a/api/openapi-spec/v3/apis__autoscaling__v2_openapi.json
+++ b/api/openapi-spec/v3/apis__autoscaling__v2_openapi.json
@@ -2907,6 +2907,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -3196,6 +3201,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"

--- a/api/openapi-spec/v3/apis__batch__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__batch__v1_openapi.json
@@ -6797,6 +6797,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -7086,6 +7091,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -7917,6 +7927,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -8206,6 +8221,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"

--- a/api/openapi-spec/v3/apis__certificates.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__certificates.k8s.io__v1_openapi.json
@@ -2063,6 +2063,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -2342,6 +2347,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -2621,6 +2631,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"

--- a/api/openapi-spec/v3/apis__certificates.k8s.io__v1alpha1_openapi.json
+++ b/api/openapi-spec/v3/apis__certificates.k8s.io__v1alpha1_openapi.json
@@ -1939,6 +1939,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"

--- a/api/openapi-spec/v3/apis__coordination.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__coordination.k8s.io__v1_openapi.json
@@ -2138,6 +2138,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"

--- a/api/openapi-spec/v3/apis__coordination.k8s.io__v1alpha1_openapi.json
+++ b/api/openapi-spec/v3/apis__coordination.k8s.io__v1alpha1_openapi.json
@@ -2142,6 +2142,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"

--- a/api/openapi-spec/v3/apis__discovery.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__discovery.k8s.io__v1_openapi.json
@@ -2288,6 +2288,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"

--- a/api/openapi-spec/v3/apis__events.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__events.k8s.io__v1_openapi.json
@@ -2248,6 +2248,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"

--- a/api/openapi-spec/v3/apis__flowcontrol.apiserver.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__flowcontrol.apiserver.k8s.io__v1_openapi.json
@@ -2563,6 +2563,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -2842,6 +2847,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -3653,6 +3663,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -3932,6 +3947,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"

--- a/api/openapi-spec/v3/apis__flowcontrol.apiserver.k8s.io__v1beta3_openapi.json
+++ b/api/openapi-spec/v3/apis__flowcontrol.apiserver.k8s.io__v1beta3_openapi.json
@@ -2564,6 +2564,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -2843,6 +2848,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -3654,6 +3664,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -3933,6 +3948,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"

--- a/api/openapi-spec/v3/apis__internal.apiserver.k8s.io__v1alpha1_openapi.json
+++ b/api/openapi-spec/v3/apis__internal.apiserver.k8s.io__v1alpha1_openapi.json
@@ -2053,6 +2053,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -2332,6 +2337,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"

--- a/api/openapi-spec/v3/apis__networking.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__networking.k8s.io__v1_openapi.json
@@ -2704,6 +2704,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -3686,6 +3691,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -3975,6 +3985,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -4806,6 +4821,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"

--- a/api/openapi-spec/v3/apis__networking.k8s.io__v1beta1_openapi.json
+++ b/api/openapi-spec/v3/apis__networking.k8s.io__v1beta1_openapi.json
@@ -2139,6 +2139,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -2950,6 +2955,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -3229,6 +3239,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"

--- a/api/openapi-spec/v3/apis__node.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__node.k8s.io__v1_openapi.json
@@ -2012,6 +2012,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"

--- a/api/openapi-spec/v3/apis__policy__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__policy__v1_openapi.json
@@ -2163,6 +2163,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -2452,6 +2457,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"

--- a/api/openapi-spec/v3/apis__rbac.authorization.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__rbac.authorization.k8s.io__v1_openapi.json
@@ -2404,6 +2404,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -3215,6 +3220,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -4046,6 +4056,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -4877,6 +4892,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"

--- a/api/openapi-spec/v3/apis__resource.k8s.io__v1alpha3_openapi.json
+++ b/api/openapi-spec/v3/apis__resource.k8s.io__v1alpha3_openapi.json
@@ -2894,6 +2894,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -3725,6 +3730,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -4014,6 +4024,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -4845,6 +4860,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -5958,6 +5978,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"

--- a/api/openapi-spec/v3/apis__scheduling.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__scheduling.k8s.io__v1_openapi.json
@@ -1930,6 +1930,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"

--- a/api/openapi-spec/v3/apis__storage.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__storage.k8s.io__v1_openapi.json
@@ -3849,6 +3849,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -4660,6 +4665,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -5642,6 +5652,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -6453,6 +6468,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -7264,6 +7284,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -7543,6 +7568,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"

--- a/api/openapi-spec/v3/apis__storage.k8s.io__v1alpha1_openapi.json
+++ b/api/openapi-spec/v3/apis__storage.k8s.io__v1alpha1_openapi.json
@@ -1925,6 +1925,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"

--- a/api/openapi-spec/v3/apis__storage.k8s.io__v1beta1_openapi.json
+++ b/api/openapi-spec/v3/apis__storage.k8s.io__v1beta1_openapi.json
@@ -1925,6 +1925,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"

--- a/api/openapi-spec/v3/apis__storagemigration.k8s.io__v1alpha1_openapi.json
+++ b/api/openapi-spec/v3/apis__storagemigration.k8s.io__v1alpha1_openapi.json
@@ -2037,6 +2037,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
@@ -2316,6 +2321,11 @@
         ],
         "requestBody": {
           "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
             "application/apply-patch+yaml": {
               "schema": {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"

--- a/pkg/features/client_adapter.go
+++ b/pkg/features/client_adapter.go
@@ -67,3 +67,10 @@ func (a *clientAdapter) Add(in map[clientfeatures.Feature]clientfeatures.Feature
 	}
 	return a.mfg.Add(out)
 }
+
+// Set implements the unexported interface that client-go feature gate testing expects for
+// ek8s.io/client-go/features/testing.SetFeatureDuringTest. This is necessary for integration tests
+// to set test overrides for client-go feature gates.
+func (a *clientAdapter) Set(name clientfeatures.Feature, enabled bool) error {
+	return a.mfg.SetFromMap(map[string]bool{string(name): enabled})
+}

--- a/pkg/features/versioned_kube_features.go
+++ b/pkg/features/versioned_kube_features.go
@@ -245,6 +245,10 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 		{Version: version.MustParse("1.32"), Default: true, PreRelease: featuregate.Beta},
 	},
 
+	genericfeatures.CBORServingAndStorage: {
+		{Version: version.MustParse("1.32"), Default: false, PreRelease: featuregate.Alpha},
+	},
+
 	genericfeatures.ConcurrentWatchObjectDecode: {
 		{Version: version.MustParse("1.31"), Default: false, PreRelease: featuregate.Beta},
 	},

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
@@ -327,7 +327,7 @@ func (r *crdHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		string(types.MergePatchType),
 		string(types.ApplyYAMLPatchType),
 	}
-	if utilfeature.TestOnlyFeatureGate.Enabled(features.TestOnlyCBORServingAndStorage) {
+	if utilfeature.DefaultFeatureGate.Enabled(features.CBORServingAndStorage) {
 		supportedTypes = append(supportedTypes, string(types.ApplyCBORPatchType))
 	}
 
@@ -913,7 +913,7 @@ func (r *crdHandler) getOrCreateServingInfoFor(uid types.UID, name string) (*crd
 			},
 		}
 
-		if utilfeature.TestOnlyFeatureGate.Enabled(features.TestOnlyCBORServingAndStorage) {
+		if utilfeature.DefaultFeatureGate.Enabled(features.CBORServingAndStorage) {
 			negotiatedSerializer.supportedMediaTypes = append(negotiatedSerializer.supportedMediaTypes, newCBORSerializerInfo(creator, typer))
 		}
 
@@ -981,7 +981,7 @@ func (r *crdHandler) getOrCreateServingInfoFor(uid types.UID, name string) (*crd
 		scaleConverter := scale.NewScaleConverter()
 		scaleScope.Subresource = "scale"
 		var opts []serializer.CodecFactoryOptionsMutator
-		if utilfeature.TestOnlyFeatureGate.Enabled(features.TestOnlyCBORServingAndStorage) {
+		if utilfeature.DefaultFeatureGate.Enabled(features.CBORServingAndStorage) {
 			opts = append(opts, serializer.WithSerializer(newCBORSerializerInfo))
 		}
 		scaleScope.Serializer = serializer.NewCodecFactory(scaleConverter.Scheme(), opts...)

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/options/options.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/options/options.go
@@ -139,7 +139,7 @@ func NewCRDRESTOptionsGetter(etcdOptions genericoptions.EtcdOptions, resourceTra
 	ucbor := cbor.NewSerializer(unstructuredscheme.NewUnstructuredCreator(), unstructuredscheme.NewUnstructuredObjectTyper())
 
 	encoder := unstructured.UnstructuredJSONScheme
-	if utilfeature.TestOnlyFeatureGate.Enabled(features.TestOnlyCBORServingAndStorage) {
+	if utilfeature.DefaultFeatureGate.Enabled(features.CBORServingAndStorage) {
 		encoder = ucbor
 	}
 

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/cbor_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/cbor_test.go
@@ -69,7 +69,7 @@ func TestCBORStorageEnablement(t *testing.T) {
 
 	func() {
 		t.Log("starting server with feature gate disabled")
-		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.TestOnlyFeatureGate, features.TestOnlyCBORServingAndStorage, false)
+		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.CBORServingAndStorage, false)
 		tearDown, apiExtensionsClientset, dynamicClient, etcdClient, _, err := fixtures.StartDefaultServerWithClientsAndEtcd(t, "--etcd-prefix", etcdPrefix)
 		if err != nil {
 			t.Fatal(err)
@@ -109,7 +109,7 @@ func TestCBORStorageEnablement(t *testing.T) {
 
 	func() {
 		t.Log("starting server with feature gate enabled")
-		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.TestOnlyFeatureGate, features.TestOnlyCBORServingAndStorage, true)
+		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.CBORServingAndStorage, true)
 		tearDown, _, dynamicClient, etcdClient, _, err := fixtures.StartDefaultServerWithClientsAndEtcd(t, "--etcd-prefix", etcdPrefix)
 		if err != nil {
 			t.Fatal(err)
@@ -159,7 +159,7 @@ func TestCBORStorageEnablement(t *testing.T) {
 
 	func() {
 		t.Log("starting server with feature gate disabled")
-		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.TestOnlyFeatureGate, features.TestOnlyCBORServingAndStorage, false)
+		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.CBORServingAndStorage, false)
 		tearDown, _, dynamicClient, _, _, err := fixtures.StartDefaultServerWithClientsAndEtcd(t, "--etcd-prefix", etcdPrefix)
 		if err != nil {
 			t.Fatal(err)
@@ -185,7 +185,7 @@ func TestCBORServingEnablement(t *testing.T) {
 		{name: "disabled", enabled: false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.TestOnlyFeatureGate, features.TestOnlyCBORServingAndStorage, tc.enabled)
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.CBORServingAndStorage, tc.enabled)
 
 			tearDown, config, _, err := fixtures.StartDefaultServer(t)
 			if err != nil {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
@@ -138,7 +138,7 @@ func PatchResource(r rest.Patcher, scope *RequestScope, admit admission.Interfac
 		case types.ApplyYAMLPatchType:
 			baseContentType = runtime.ContentTypeYAML
 		case types.ApplyCBORPatchType:
-			if !utilfeature.TestOnlyFeatureGate.Enabled(features.TestOnlyCBORServingAndStorage) {
+			if !utilfeature.DefaultFeatureGate.Enabled(features.CBORServingAndStorage) {
 				// This request should have already been rejected by the
 				// Content-Type allowlist check. Return 500 because assumptions are
 				// already broken and the feature is not GA.
@@ -673,7 +673,7 @@ func (p *patcher) patchResource(ctx context.Context, scope *RequestScope) (runti
 		p.mechanism = newApplyPatcher(p, scope.FieldManager, yaml.Unmarshal, yaml.UnmarshalStrict)
 		p.forceAllowCreate = true
 	case types.ApplyCBORPatchType:
-		if !utilfeature.TestOnlyFeatureGate.Enabled(features.TestOnlyCBORServingAndStorage) {
+		if !utilfeature.DefaultFeatureGate.Enabled(features.CBORServingAndStorage) {
 			utilruntime.HandleErrorWithContext(context.TODO(), nil, "CBOR apply requests should be rejected before reaching this point unless the feature gate is enabled.")
 			return nil, false, fmt.Errorf("%v: unimplemented patch type", p.patchType)
 		}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go
@@ -286,7 +286,7 @@ func WriteObjectNegotiated(s runtime.NegotiatedSerializer, restrictions negotiat
 	audit.LogResponseObject(req.Context(), object, gv, s)
 
 	var encoder runtime.Encoder
-	if utilfeature.TestOnlyFeatureGate.Enabled(features.TestOnlyCBORServingAndStorage) {
+	if utilfeature.DefaultFeatureGate.Enabled(features.CBORServingAndStorage) {
 		encoder = s.EncoderForVersion(runtime.UseNondeterministicEncoding(serializer.Serializer), gv)
 	} else {
 		encoder = s.EncoderForVersion(serializer.Serializer, gv)

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/watch.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/watch.go
@@ -77,7 +77,7 @@ func serveWatchHandler(watcher watch.Interface, scope *RequestScope, mediaTypeOp
 	}
 	framer := serializer.StreamSerializer.Framer
 	var encoder runtime.Encoder
-	if utilfeature.TestOnlyFeatureGate.Enabled(features.TestOnlyCBORServingAndStorage) {
+	if utilfeature.DefaultFeatureGate.Enabled(features.CBORServingAndStorage) {
 		encoder = scope.Serializer.EncoderForVersion(runtime.UseNondeterministicEncoding(serializer.StreamSerializer.Serializer), scope.Kind.GroupVersion())
 	} else {
 		encoder = scope.Serializer.EncoderForVersion(serializer.StreamSerializer.Serializer, scope.Kind.GroupVersion())
@@ -102,13 +102,13 @@ func serveWatchHandler(watcher watch.Interface, scope *RequestScope, mediaTypeOp
 		if !ok {
 			return nil, fmt.Errorf("no encoder for %q exists in the requested target %#v", serializer.MediaType, contentSerializer)
 		}
-		if utilfeature.TestOnlyFeatureGate.Enabled(features.TestOnlyCBORServingAndStorage) {
+		if utilfeature.DefaultFeatureGate.Enabled(features.CBORServingAndStorage) {
 			negotiatedEncoder = contentSerializer.EncoderForVersion(runtime.UseNondeterministicEncoding(info.Serializer), contentKind.GroupVersion())
 		} else {
 			negotiatedEncoder = contentSerializer.EncoderForVersion(info.Serializer, contentKind.GroupVersion())
 		}
 	} else {
-		if utilfeature.TestOnlyFeatureGate.Enabled(features.TestOnlyCBORServingAndStorage) {
+		if utilfeature.DefaultFeatureGate.Enabled(features.CBORServingAndStorage) {
 			negotiatedEncoder = scope.Serializer.EncoderForVersion(runtime.UseNondeterministicEncoding(serializer.Serializer), contentKind.GroupVersion())
 		} else {
 			negotiatedEncoder = scope.Serializer.EncoderForVersion(serializer.Serializer, contentKind.GroupVersion())

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
@@ -895,7 +895,7 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 				string(types.StrategicMergePatchType),
 				string(types.ApplyYAMLPatchType),
 			}
-			if utilfeature.TestOnlyFeatureGate.Enabled(features.TestOnlyCBORServingAndStorage) {
+			if utilfeature.DefaultFeatureGate.Enabled(features.CBORServingAndStorage) {
 				supportedTypes = append(supportedTypes, string(types.ApplyCBORPatchType))
 			}
 			handler := metrics.InstrumentRouteFunc(action.Verb, group, version, resource, subresource, requestScope, metrics.APIServerComponent, deprecated, removedRelease, restfulPatchResource(patcher, reqScope, admit, supportedTypes))

--- a/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
@@ -92,9 +92,7 @@ const (
 	//
 	// Enables CBOR as a supported encoding for requests and responses, and as the
 	// preferred storage encoding for custom resources.
-	//
-	// This feature is currently PRE-ALPHA and MUST NOT be enabled outside of integration tests.
-	TestOnlyCBORServingAndStorage featuregate.Feature = "TestOnlyCBORServingAndStorage"
+	CBORServingAndStorage featuregate.Feature = "CBORServingAndStorage"
 
 	// owner: @serathius
 	//
@@ -245,7 +243,6 @@ const (
 func init() {
 	runtime.Must(utilfeature.DefaultMutableFeatureGate.Add(defaultKubernetesFeatureGates))
 	runtime.Must(utilfeature.DefaultMutableFeatureGate.AddVersioned(defaultVersionedKubernetesFeatureGates))
-	runtime.Must(utilfeature.TestOnlyMutableFeatureGate.AddVersioned(testOnlyVersionedKubernetesFeatureGates))
 }
 
 // defaultVersionedKubernetesFeatureGates consists of all known Kubernetes-specific feature keys with VersionedSpecs.
@@ -304,6 +301,10 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 	AuthorizeWithSelectors: {
 		{Version: version.MustParse("1.31"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("1.32"), Default: true, PreRelease: featuregate.Beta},
+	},
+
+	CBORServingAndStorage: {
+		{Version: version.MustParse("1.32"), Default: false, PreRelease: featuregate.Alpha},
 	},
 
 	ConcurrentWatchObjectDecode: {
@@ -417,12 +418,3 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 // defaultKubernetesFeatureGates consists of legacy unversioned Kubernetes-specific feature keys.
 // Please do not add to this struct and use defaultVersionedKubernetesFeatureGates instead.
 var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{}
-
-// testOnlyVersionedKubernetesFeatureGates consists of features that require programmatic enablement
-// for integration testing, but have not yet graduated to alpha in a release and must not be enabled
-// by a runtime option.
-var testOnlyVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate.VersionedSpecs{
-	TestOnlyCBORServingAndStorage: {
-		{Version: version.MustParse("1.32"), Default: false, PreRelease: featuregate.Alpha},
-	},
-}

--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -756,7 +756,7 @@ func (c completedConfig) New(name string, delegationTarget DelegationTarget) (*G
 		return nil, fmt.Errorf("Genericapiserver.New() called with config.Serializer == nil")
 	}
 	allowedMediaTypes := defaultAllowedMediaTypes
-	if utilfeature.TestOnlyFeatureGate.Enabled(genericfeatures.TestOnlyCBORServingAndStorage) {
+	if utilfeature.DefaultFeatureGate.Enabled(genericfeatures.CBORServingAndStorage) {
 		allowedMediaTypes = append(allowedMediaTypes, runtime.ContentTypeCBOR)
 	}
 	for _, info := range c.Serializer.SupportedMediaTypes() {

--- a/staging/src/k8s.io/apiserver/pkg/server/config_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config_test.go
@@ -424,7 +424,7 @@ func TestNewErrorForbiddenSerializer(t *testing.T) {
 }
 
 func TestNewFeatureGatedSerializer(t *testing.T) {
-	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.TestOnlyFeatureGate, features.TestOnlyCBORServingAndStorage, true)
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.CBORServingAndStorage, true)
 
 	config := NewConfig(serializer.NewCodecFactory(scheme, serializer.WithSerializer(func(creater runtime.ObjectCreater, typer runtime.ObjectTyper) runtime.SerializerInfo {
 		return runtime.SerializerInfo{

--- a/staging/src/k8s.io/apiserver/pkg/util/feature/feature_gate.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/feature/feature_gate.go
@@ -31,15 +31,3 @@ var (
 	// Top-level commands/options setup that needs to modify this feature gate should use DefaultMutableFeatureGate.
 	DefaultFeatureGate featuregate.FeatureGate = DefaultMutableFeatureGate
 )
-
-var (
-	// TestOnlyMutableFeatureGate is a mutable version of TestOnlyFeatureGate. Only top-level
-	// commands/options setup and the k8s.io/component-base/featuregate/testing package should
-	// make use of this.
-	TestOnlyMutableFeatureGate featuregate.MutableVersionedFeatureGate = featuregate.NewFeatureGate()
-
-	// TestOnlyFeatureGate is a shared global FeatureGate for features that have not yet
-	// graduated to alpha and require programmatic feature enablement for pre-alpha integration
-	// testing without exposing the feature as a runtime option.
-	TestOnlyFeatureGate featuregate.FeatureGate = TestOnlyMutableFeatureGate
-)

--- a/staging/src/k8s.io/client-go/dynamic/scheme.go
+++ b/staging/src/k8s.io/client-go/dynamic/scheme.go
@@ -53,7 +53,7 @@ func newBasicNegotiatedSerializer() basicNegotiatedSerializer {
 			},
 		},
 	}
-	if features.TestOnlyFeatureGates.Enabled(features.TestOnlyClientAllowsCBOR) {
+	if features.FeatureGates().Enabled(features.ClientsAllowCBOR) {
 		supportedMediaTypes = append(supportedMediaTypes, runtime.SerializerInfo{
 			MediaType:        "application/cbor",
 			MediaTypeType:    "application",

--- a/staging/src/k8s.io/client-go/dynamic/simple.go
+++ b/staging/src/k8s.io/client-go/dynamic/simple.go
@@ -49,9 +49,9 @@ func ConfigFor(inConfig *rest.Config) *rest.Config {
 
 	config.ContentType = "application/json"
 	config.AcceptContentTypes = "application/json"
-	if features.TestOnlyFeatureGates.Enabled(features.TestOnlyClientAllowsCBOR) {
+	if features.FeatureGates().Enabled(features.ClientsAllowCBOR) {
 		config.AcceptContentTypes = "application/json;q=0.9,application/cbor;q=1"
-		if features.TestOnlyFeatureGates.Enabled(features.TestOnlyClientPrefersCBOR) {
+		if features.FeatureGates().Enabled(features.ClientsPreferCBOR) {
 			config.ContentType = "application/cbor"
 		}
 	}

--- a/staging/src/k8s.io/client-go/features/features.go
+++ b/staging/src/k8s.io/client-go/features/features.go
@@ -18,8 +18,6 @@ package features
 
 import (
 	"errors"
-	"fmt"
-	"sync"
 	"sync/atomic"
 
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -143,43 +141,3 @@ var (
 	// should use AddFeaturesToExistingFeatureGates followed by ReplaceFeatureGates.
 	featureGates = &atomic.Value{}
 )
-
-// TestOnlyFeatureGates is a distinct registry of pre-alpha client features that must not be
-// included in runtime wiring to command-line flags or environment variables. It exists as a risk
-// mitigation to allow only programmatic enablement of CBOR serialization for integration testing
-// purposes.
-//
-// TODO: Once all required integration test coverage is complete, this will be deleted and the
-// test-only feature gates will be replaced by normal feature gates.
-var TestOnlyFeatureGates = &testOnlyFeatureGates{
-	features: map[Feature]bool{
-		TestOnlyClientAllowsCBOR:  false,
-		TestOnlyClientPrefersCBOR: false,
-	},
-}
-
-type testOnlyFeatureGates struct {
-	lock     sync.RWMutex
-	features map[Feature]bool
-}
-
-func (t *testOnlyFeatureGates) Enabled(feature Feature) bool {
-	t.lock.RLock()
-	defer t.lock.RUnlock()
-
-	enabled, ok := t.features[feature]
-	if !ok {
-		panic(fmt.Sprintf("test-only feature %q not recognized", feature))
-	}
-	return enabled
-}
-
-func (t *testOnlyFeatureGates) Set(feature Feature, enabled bool) error {
-	t.lock.Lock()
-	defer t.lock.Unlock()
-	if _, ok := t.features[feature]; !ok {
-		return fmt.Errorf("test-only feature %q not recognized", feature)
-	}
-	t.features[feature] = enabled
-	return nil
-}

--- a/staging/src/k8s.io/client-go/features/known_features.go
+++ b/staging/src/k8s.io/client-go/features/known_features.go
@@ -28,6 +28,31 @@ const (
 	// of code conflicts because changes are more likely to be scattered
 	// across the file.
 
+	// owner: @benluddy
+	// kep: https://kep.k8s.io/4222
+	// alpha: 1.32
+	//
+	// If disabled, clients configured to accept "application/cbor" will instead accept
+	// "application/json" with the same relative preference, and clients configured to write
+	// "application/cbor" or "application/apply-patch+cbor" will instead write
+	// "application/json" or "application/apply-patch+yaml", respectively.
+	ClientsAllowCBOR Feature = "ClientsAllowCBOR"
+
+	// owner: @benluddy
+	// kep: https://kep.k8s.io/4222
+	// alpha: 1.32
+	//
+	// If enabled, and only if ClientsAllowCBOR is also enabled, the default request content
+	// type (if not explicitly configured) and the dynamic client's request content type both
+	// become "application/cbor" instead of "application/json". The default content type for
+	// apply patch requests becomes "application/apply-patch+cbor" instead of
+	// "application/apply-patch+yaml".
+	ClientsPreferCBOR Feature = "ClientsPreferCBOR"
+
+	// owner: @nilekhc
+	// alpha: v1.30
+	InformerResourceVersion Feature = "InformerResourceVersion"
+
 	// owner: @p0lyn0mial
 	// beta: v1.30
 	//
@@ -37,31 +62,6 @@ const (
 	//  The feature is disabled in Beta by default because
 	//  it will only be turned on for selected control plane component(s).
 	WatchListClient Feature = "WatchListClient"
-
-	// owner: @nilekhc
-	// alpha: v1.30
-	InformerResourceVersion Feature = "InformerResourceVersion"
-
-	// owner: @benluddy
-	// kep: https://kep.k8s.io/4222
-	//
-	// If disabled, clients configured to accept "application/cbor" will instead accept
-	// "application/json" with the same relative preference, and clients configured to write
-	// "application/cbor" or "application/apply-patch+cbor" will instead write
-	// "application/json" or "application/apply-patch+yaml", respectively.
-	//
-	// This feature is currently PRE-ALPHA and MUST NOT be enabled outside of integration tests.
-	TestOnlyClientAllowsCBOR Feature = "TestOnlyClientAllowsCBOR"
-
-	// owner: @benluddy
-	// kep: https://kep.k8s.io/4222
-	//
-	// If enabled AND TestOnlyClientAllowsCBOR is also enabled, the default request content type
-	// (if not explicitly configured) and the dynamic client's request content type both become
-	// "application/cbor".
-	//
-	// This feature is currently PRE-ALPHA and MUST NOT be enabled outside of integration tests.
-	TestOnlyClientPrefersCBOR Feature = "TestOnlyClientPrefersCBOR"
 )
 
 // defaultKubernetesFeatureGates consists of all known Kubernetes-specific feature keys.
@@ -70,6 +70,8 @@ const (
 // After registering with the binary, the features are, by default, controllable using environment variables.
 // For more details, please see envVarFeatureGates implementation.
 var defaultKubernetesFeatureGates = map[Feature]FeatureSpec{
-	WatchListClient:         {Default: false, PreRelease: Beta},
+	ClientsAllowCBOR:        {Default: false, PreRelease: Alpha},
+	ClientsPreferCBOR:       {Default: false, PreRelease: Alpha},
 	InformerResourceVersion: {Default: false, PreRelease: Alpha},
+	WatchListClient:         {Default: false, PreRelease: Beta},
 }

--- a/staging/src/k8s.io/client-go/rest/client.go
+++ b/staging/src/k8s.io/client-go/rest/client.go
@@ -128,7 +128,7 @@ func NewRESTClient(baseURL *url.URL, versionedAPIPath string, config ClientConte
 }
 
 func scrubCBORContentConfigIfDisabled(content ClientContentConfig) ClientContentConfig {
-	if clientfeatures.TestOnlyFeatureGates.Enabled(clientfeatures.TestOnlyClientAllowsCBOR) {
+	if clientfeatures.FeatureGates().Enabled(clientfeatures.ClientsAllowCBOR) {
 		return content
 	}
 
@@ -258,7 +258,7 @@ type requestClientContentConfigProvider struct {
 // GetClientContentConfig returns the ClientContentConfig that should be used for new requests by
 // this client.
 func (p *requestClientContentConfigProvider) GetClientContentConfig() ClientContentConfig {
-	if !clientfeatures.TestOnlyFeatureGates.Enabled(clientfeatures.TestOnlyClientAllowsCBOR) {
+	if !clientfeatures.FeatureGates().Enabled(clientfeatures.ClientsAllowCBOR) {
 		return p.base
 	}
 
@@ -280,7 +280,7 @@ func (p *requestClientContentConfigProvider) GetClientContentConfig() ClientCont
 // UnsupportedMediaType reports that the server has responded to a request with HTTP 415 Unsupported
 // Media Type.
 func (p *requestClientContentConfigProvider) UnsupportedMediaType(requestContentType string) {
-	if !clientfeatures.TestOnlyFeatureGates.Enabled(clientfeatures.TestOnlyClientAllowsCBOR) {
+	if !clientfeatures.FeatureGates().Enabled(clientfeatures.ClientsAllowCBOR) {
 		return
 	}
 

--- a/staging/src/k8s.io/client-go/rest/config.go
+++ b/staging/src/k8s.io/client-go/rest/config.go
@@ -683,7 +683,7 @@ func CopyConfig(config *Config) *Config {
 // This is supported ONLY for use by clients generated with client-gen. The caller is responsible
 // for ensuring that the CodecFactory argument was constructed using the Scheme argument.
 func CodecFactoryForGeneratedClient(scheme *runtime.Scheme, codecs serializer.CodecFactory) serializer.CodecFactory {
-	if !features.TestOnlyFeatureGates.Enabled(features.TestOnlyClientAllowsCBOR) {
+	if !features.FeatureGates().Enabled(features.ClientsAllowCBOR) {
 		// NOTE: This assumes client-gen will not generate CBOR-enabled Codecs as long as
 		// the feature gate exists.
 		return codecs

--- a/staging/src/k8s.io/client-go/rest/request.go
+++ b/staging/src/k8s.io/client-go/rest/request.go
@@ -160,7 +160,7 @@ func NewRequest(c *RESTClient) *Request {
 	contentTypeNotSet := len(contentConfig.ContentType) == 0
 	if contentTypeNotSet {
 		contentConfig.ContentType = "application/json"
-		if clientfeatures.TestOnlyFeatureGates.Enabled(clientfeatures.TestOnlyClientAllowsCBOR) && clientfeatures.TestOnlyFeatureGates.Enabled(clientfeatures.TestOnlyClientPrefersCBOR) {
+		if clientfeatures.FeatureGates().Enabled(clientfeatures.ClientsAllowCBOR) && clientfeatures.FeatureGates().Enabled(clientfeatures.ClientsPreferCBOR) {
 			contentConfig.ContentType = "application/cbor"
 		}
 	}

--- a/staging/src/k8s.io/client-go/util/apply/apply.go
+++ b/staging/src/k8s.io/client-go/util/apply/apply.go
@@ -35,7 +35,7 @@ func NewRequest(client rest.Interface, applyConfiguration interface{}) (*rest.Re
 	pt := types.ApplyYAMLPatchType
 	marshal := json.Marshal
 
-	if features.TestOnlyFeatureGates.Enabled(features.TestOnlyClientAllowsCBOR) && features.TestOnlyFeatureGates.Enabled(features.TestOnlyClientPrefersCBOR) {
+	if features.FeatureGates().Enabled(features.ClientsAllowCBOR) && features.FeatureGates().Enabled(features.ClientsPreferCBOR) {
 		pt = types.ApplyCBORPatchType
 		marshal = cbor.Marshal
 	}

--- a/test/featuregates_linter/test_data/versioned_feature_list.yaml
+++ b/test/featuregates_linter/test_data/versioned_feature_list.yaml
@@ -170,6 +170,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "1.32"
+- name: CBORServingAndStorage
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.32"
 - name: CloudControllerManagerWebhook
   versionedSpecs:
   - default: false
@@ -1285,12 +1291,6 @@
   - default: true
     lockToDefault: false
     preRelease: Beta
-    version: "1.32"
-- name: TestOnlyCBORServingAndStorage
-  versionedSpecs:
-  - default: false
-    lockToDefault: false
-    preRelease: Alpha
     version: "1.32"
 - name: TopologyAwareHints
   versionedSpecs:

--- a/test/integration/apiserver/admissionwebhook/admission_test.go
+++ b/test/integration/apiserver/admissionwebhook/admission_test.go
@@ -53,6 +53,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/client-go/dynamic"
+	clientfeatures "k8s.io/client-go/features"
+	clientfeaturestesting "k8s.io/client-go/features/testing"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/retry"
@@ -458,7 +460,8 @@ func TestWebhookAdmissionWithoutWatchCache(t *testing.T) {
 
 func TestWebhookAdmissionWithCBOR(t *testing.T) {
 	framework.EnableCBORServingAndStorageForTest(t)
-	framework.SetTestOnlyCBORClientFeatureGatesForTest(t, true, true)
+	clientfeaturestesting.SetFeatureDuringTest(t, clientfeatures.ClientsAllowCBOR, true)
+	clientfeaturestesting.SetFeatureDuringTest(t, clientfeatures.ClientsPreferCBOR, true)
 	testWebhookAdmission(t, false, func(t testing.TB, config *rest.Config) {
 		config.Wrap(framework.AssertRequestResponseAsCBOR(t))
 	})

--- a/test/integration/apiserver/apply/apply_test.go
+++ b/test/integration/apiserver/apply/apply_test.go
@@ -46,6 +46,8 @@ import (
 	appsv1ac "k8s.io/client-go/applyconfigurations/apps/v1"
 	corev1ac "k8s.io/client-go/applyconfigurations/core/v1"
 	metav1ac "k8s.io/client-go/applyconfigurations/meta/v1"
+	clientfeatures "k8s.io/client-go/features"
+	clientfeaturestesting "k8s.io/client-go/features/testing"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	restclient "k8s.io/client-go/rest"
@@ -1057,7 +1059,7 @@ func TestPatchVeryLargeObject(t *testing.T) {
 // syntax suffix for application/apply-patch and with CBOR enabled.
 func TestPatchVeryLargeObjectCBORApply(t *testing.T) {
 	framework.EnableCBORServingAndStorageForTest(t)
-	framework.SetTestOnlyCBORClientFeatureGatesForTest(t, true, false)
+	clientfeaturestesting.SetFeatureDuringTest(t, clientfeatures.ClientsAllowCBOR, true)
 
 	client, closeFn := setup(t)
 	defer closeFn()

--- a/test/integration/apiserver/apply/status_test.go
+++ b/test/integration/apiserver/apply/status_test.go
@@ -29,6 +29,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/client-go/dynamic"
+	clientfeatures "k8s.io/client-go/features"
+	clientfeaturestesting "k8s.io/client-go/features/testing"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	apiservertesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
@@ -99,7 +101,8 @@ func TestApplyStatus(t *testing.T) {
 // TestApplyStatus makes sure that applying the status works for all known types.
 func TestApplyStatusWithCBOR(t *testing.T) {
 	framework.EnableCBORServingAndStorageForTest(t)
-	framework.SetTestOnlyCBORClientFeatureGatesForTest(t, true, true)
+	clientfeaturestesting.SetFeatureDuringTest(t, clientfeatures.ClientsAllowCBOR, true)
+	clientfeaturestesting.SetFeatureDuringTest(t, clientfeatures.ClientsPreferCBOR, true)
 	testApplyStatus(t, func(t testing.TB, config *rest.Config) {
 		config.Wrap(framework.AssertRequestResponseAsCBOR(t))
 	})

--- a/test/integration/apiserver/cbor_test.go
+++ b/test/integration/apiserver/cbor_test.go
@@ -36,6 +36,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer/cbor/direct"
 	"k8s.io/apimachinery/pkg/runtime/serializer/streaming"
 	"k8s.io/apimachinery/pkg/types"
+	clientfeatures "k8s.io/client-go/features"
+	clientfeaturestesting "k8s.io/client-go/features/testing"
 	"k8s.io/client-go/kubernetes/scheme"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
@@ -57,7 +59,8 @@ func TestNondeterministicResponseEncoding(t *testing.T) {
 	const NTrials = 40
 
 	framework.EnableCBORServingAndStorageForTest(t)
-	framework.SetTestOnlyCBORClientFeatureGatesForTest(t, true, true)
+	clientfeaturestesting.SetFeatureDuringTest(t, clientfeatures.ClientsAllowCBOR, true)
+	clientfeaturestesting.SetFeatureDuringTest(t, clientfeatures.ClientsPreferCBOR, true)
 
 	server := kubeapiservertesting.StartTestServerOrDie(t, nil, framework.DefaultTestServerFlags(), framework.SharedEtcd())
 	t.Cleanup(server.TearDownFn)

--- a/test/integration/client/client_test.go
+++ b/test/integration/client/client_test.go
@@ -51,6 +51,8 @@ import (
 	corev1ac "k8s.io/client-go/applyconfigurations/core/v1"
 	metav1ac "k8s.io/client-go/applyconfigurations/meta/v1"
 	"k8s.io/client-go/discovery"
+	clientfeatures "k8s.io/client-go/features"
+	clientfeaturestesting "k8s.io/client-go/features/testing"
 	"k8s.io/client-go/gentype"
 	"k8s.io/client-go/kubernetes"
 	clientscheme "k8s.io/client-go/kubernetes/scheme"
@@ -1754,7 +1756,8 @@ func TestClientCBOREnablement(t *testing.T) {
 				}
 
 				t.Run(tc.name, func(t *testing.T) {
-					framework.SetTestOnlyCBORClientFeatureGatesForTest(t, tc.allowed, tc.preferred)
+					clientfeaturestesting.SetFeatureDuringTest(t, clientfeatures.ClientsAllowCBOR, tc.allowed)
+					clientfeaturestesting.SetFeatureDuringTest(t, clientfeatures.ClientsPreferCBOR, tc.preferred)
 
 					config := rest.CopyConfig(server.ClientConfig)
 					config.ContentType = tc.configuredContentType
@@ -1795,7 +1798,8 @@ func TestClientCBOREnablement(t *testing.T) {
 
 func TestCBORWithTypedClient(t *testing.T) {
 	framework.EnableCBORServingAndStorageForTest(t)
-	framework.SetTestOnlyCBORClientFeatureGatesForTest(t, true, true)
+	clientfeaturestesting.SetFeatureDuringTest(t, clientfeatures.ClientsAllowCBOR, true)
+	clientfeaturestesting.SetFeatureDuringTest(t, clientfeatures.ClientsPreferCBOR, true)
 
 	server := kubeapiservertesting.StartTestServerOrDie(t, nil, framework.DefaultTestServerFlags(), framework.SharedEtcd())
 	t.Cleanup(server.TearDownFn)
@@ -1986,7 +1990,8 @@ func TestCBORWithTypedClient(t *testing.T) {
 }
 
 func TestUnsupportedMediaTypeCircuitBreaker(t *testing.T) {
-	framework.SetTestOnlyCBORClientFeatureGatesForTest(t, true, true)
+	clientfeaturestesting.SetFeatureDuringTest(t, clientfeatures.ClientsAllowCBOR, true)
+	clientfeaturestesting.SetFeatureDuringTest(t, clientfeatures.ClientsPreferCBOR, true)
 
 	server := kubeapiservertesting.StartTestServerOrDie(t, nil, framework.DefaultTestServerFlags(), framework.SharedEtcd())
 	t.Cleanup(server.TearDownFn)

--- a/test/integration/client/dynamic_client_test.go
+++ b/test/integration/client/dynamic_client_test.go
@@ -41,6 +41,8 @@ import (
 	metav1ac "k8s.io/client-go/applyconfigurations/meta/v1"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
+	clientfeatures "k8s.io/client-go/features"
+	clientfeaturestesting "k8s.io/client-go/features/testing"
 	clientset "k8s.io/client-go/kubernetes"
 	clientscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -145,7 +147,8 @@ func TestDynamicClientWatch(t *testing.T) {
 
 func TestDynamicClientWatchWithCBOR(t *testing.T) {
 	framework.EnableCBORServingAndStorageForTest(t)
-	framework.SetTestOnlyCBORClientFeatureGatesForTest(t, true, true)
+	clientfeaturestesting.SetFeatureDuringTest(t, clientfeatures.ClientsAllowCBOR, true)
+	clientfeaturestesting.SetFeatureDuringTest(t, clientfeatures.ClientsPreferCBOR, true)
 
 	result := kubeapiservertesting.StartTestServerOrDie(t, nil, framework.DefaultTestServerFlags(), framework.SharedEtcd())
 	defer result.TearDownFn()
@@ -554,7 +557,8 @@ func TestDynamicClientCBOREnablement(t *testing.T) {
 				}
 
 				t.Run(tc.name, func(t *testing.T) {
-					framework.SetTestOnlyCBORClientFeatureGatesForTest(t, tc.allowed, tc.preferred)
+					clientfeaturestesting.SetFeatureDuringTest(t, clientfeatures.ClientsAllowCBOR, tc.allowed)
+					clientfeaturestesting.SetFeatureDuringTest(t, clientfeatures.ClientsPreferCBOR, tc.preferred)
 
 					config := rest.CopyConfig(server.ClientConfig)
 					config.Wrap(func(rt http.RoundTripper) http.RoundTripper {
@@ -591,7 +595,8 @@ func TestDynamicClientCBOREnablement(t *testing.T) {
 }
 
 func TestUnsupportedMediaTypeCircuitBreakerDynamicClient(t *testing.T) {
-	framework.SetTestOnlyCBORClientFeatureGatesForTest(t, true, true)
+	clientfeaturestesting.SetFeatureDuringTest(t, clientfeatures.ClientsAllowCBOR, true)
+	clientfeaturestesting.SetFeatureDuringTest(t, clientfeatures.ClientsPreferCBOR, true)
 
 	server := kubeapiservertesting.StartTestServerOrDie(t, nil, framework.DefaultTestServerFlags(), framework.SharedEtcd())
 	t.Cleanup(server.TearDownFn)

--- a/test/integration/controlplane/transformation/kms_transformation_test.go
+++ b/test/integration/controlplane/transformation/kms_transformation_test.go
@@ -53,6 +53,8 @@ import (
 	mock "k8s.io/apiserver/pkg/storage/value/encrypt/envelope/testing/v1beta1"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/dynamic"
+	clientfeatures "k8s.io/client-go/features"
+	clientfeaturestesting "k8s.io/client-go/features/testing"
 	"k8s.io/client-go/rest"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	kmsapi "k8s.io/kms/apis/v1beta1"
@@ -628,6 +630,9 @@ resources:
 		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, "AllBeta", true)
 		// Need to enable this explicitly as the feature is deprecated
 		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.KMSv1, true)
+
+		// TODO: Remove this override when the codecs used for serving all built-in APIs are wired to the apiserver feature gate.
+		clientfeaturestesting.SetFeatureDuringTest(t, clientfeatures.ClientsPreferCBOR, false)
 
 		test, err := newTransformTest(t, encryptionConfig, false, "", nil)
 		if err != nil {

--- a/test/integration/etcd/etcd_storage_path_test.go
+++ b/test/integration/etcd/etcd_storage_path_test.go
@@ -18,7 +18,6 @@ package etcd
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"path/filepath"
 	"reflect"
@@ -33,10 +32,17 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer/cbor"
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+	"k8s.io/apimachinery/pkg/runtime/serializer/recognizer"
+	utiljson "k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/dynamic"
+	clientfeatures "k8s.io/client-go/features"
+	clientfeaturestesting "k8s.io/client-go/features/testing"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 )
 
@@ -76,6 +82,9 @@ func TestEtcdStoragePath(t *testing.T) {
 
 	featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, "AllAlpha", true)
 	featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, "AllBeta", true)
+
+	// TODO: Remove this override when the codecs used for serving all built-in APIs are wired to the apiserver feature gate.
+	clientfeaturestesting.SetFeatureDuringTest(t, clientfeatures.ClientsPreferCBOR, false)
 
 	apiServer := StartRealAPIServerOrDie(t)
 	defer apiServer.Cleanup()
@@ -124,7 +133,8 @@ func TestEtcdStoragePath(t *testing.T) {
 				err   error
 			)
 			if shouldCreate {
-				if input, err = jsonToMetaObject([]byte(testData.Stub)); err != nil || input.isEmpty() {
+				input = new(metaObject)
+				if err = utiljson.Unmarshal([]byte(testData.Stub), input); err != nil || input.isEmpty() {
 					t.Fatalf("invalid test data for %s: %v", gvResource, err)
 				}
 				// unset type meta fields - we only set these in the CRD test data and it makes
@@ -152,7 +162,20 @@ func TestEtcdStoragePath(t *testing.T) {
 				}
 			}
 
-			output, err := getFromEtcd(apiServer.KV, testData.ExpectedEtcdPath)
+			// Build a decoder that can decode JSON and CBOR from storage.
+			scheme := runtime.NewScheme()
+			if testData.ExpectedGVK != nil {
+				scheme.AddKnownTypeWithName(*testData.ExpectedGVK, &metaObject{})
+			} else {
+				scheme.AddKnownTypeWithName(gvk, &metaObject{})
+
+			}
+			decoder := recognizer.NewDecoder(
+				cbor.NewSerializer(scheme, scheme),
+				json.NewSerializerWithOptions(json.DefaultMetaFactory, scheme, scheme, json.SerializerOptions{}),
+			)
+
+			output, err := getFromEtcd(decoder, apiServer.KV, testData.ExpectedEtcdPath)
 			if err != nil {
 				t.Fatalf("failed to get from etcd for %s: %#v", gvResource, err)
 			}
@@ -208,7 +231,7 @@ func TestEtcdStoragePath(t *testing.T) {
 				)
 			}
 
-			actualGVK := output.getGVK()
+			actualGVK := output.GroupVersionKind()
 			if actualGVK != expectedGVK {
 				t.Errorf("GVK for %s does not match, expected %s got %s", kind, expectedGVK, actualGVK)
 			}
@@ -289,9 +312,7 @@ func getEtcdBucket(path string) string {
 
 // stable fields to compare as a sanity check
 type metaObject struct {
-	// all of type meta
-	Kind       string `json:"kind,omitempty"`
-	APIVersion string `json:"apiVersion,omitempty"`
+	metav1.TypeMeta `json:",inline"`
 
 	// parts of object meta
 	Metadata struct {
@@ -300,8 +321,10 @@ type metaObject struct {
 	} `json:"metadata,omitempty"`
 }
 
-func (obj *metaObject) getGVK() schema.GroupVersionKind {
-	return schema.FromAPIVersionAndKind(obj.APIVersion, obj.Kind)
+var _ runtime.Object = &metaObject{}
+
+func (*metaObject) DeepCopyObject() runtime.Object {
+	panic("unimplemented")
 }
 
 func (obj *metaObject) isEmpty() bool {
@@ -313,14 +336,6 @@ type empty struct{}
 type cleanupData struct {
 	obj      *unstructured.Unstructured
 	resource schema.GroupVersionResource
-}
-
-func jsonToMetaObject(stub []byte) (*metaObject, error) {
-	obj := &metaObject{}
-	if err := json.Unmarshal(stub, obj); err != nil {
-		return nil, err
-	}
-	return obj, nil
 }
 
 func keyStringer(i interface{}) string {
@@ -386,7 +401,7 @@ func (c *allClient) createPrerequisites(mapper meta.RESTMapper, ns string, prere
 	return nil
 }
 
-func getFromEtcd(keys clientv3.KV, path string) (*metaObject, error) {
+func getFromEtcd(decoder runtime.Decoder, keys clientv3.KV, path string) (*metaObject, error) {
 	response, err := keys.Get(context.Background(), path)
 	if err != nil {
 		return nil, err
@@ -394,7 +409,11 @@ func getFromEtcd(keys clientv3.KV, path string) (*metaObject, error) {
 	if response.More || response.Count != 1 || len(response.Kvs) != 1 {
 		return nil, fmt.Errorf("Invalid etcd response (not found == %v): %#v", response.Count == 0, response)
 	}
-	return jsonToMetaObject(response.Kvs[0].Value)
+	var obj metaObject
+	if err := runtime.DecodeInto(decoder, response.Kvs[0].Value, &obj); err != nil {
+		return nil, err
+	}
+	return &obj, nil
 }
 
 func diffMaps(a, b interface{}) ([]string, []string) {

--- a/test/integration/framework/cbor.go
+++ b/test/integration/framework/cbor.go
@@ -31,45 +31,11 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/features"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	clientfeatures "k8s.io/client-go/features"
 	"k8s.io/client-go/transport"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	aggregatorscheme "k8s.io/kube-aggregator/pkg/apiserver/scheme"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 )
-
-// SetTestOnlyCBORClientFeatureGatesForTest overrides the CBOR client feature gates in the test-only
-// client feature gate instance for the duration of a test. The CBOR client feature gates are
-// temporarily registered in their own feature gate instance that does not include runtime wiring to
-// command-line flags or environment variables in order to mitigate the risk of enabling a new
-// encoding before all integration tests have been demonstrated to pass.
-//
-// This will be removed as an alpha requirement. The client feature gates will be registered with
-// the existing feature gate instance and tests will use
-// k8s.io/client-go/features/testing.SetFeatureDuringTest (which unlike
-// k8s.io/component-base/featuregate/testing.SetFeatureGateDuringTest does not accept a feature gate
-// instance as a parameter).
-func SetTestOnlyCBORClientFeatureGatesForTest(tb testing.TB, allowed, preferred bool) {
-	originalAllowed := clientfeatures.TestOnlyFeatureGates.Enabled(clientfeatures.TestOnlyClientAllowsCBOR)
-	tb.Cleanup(func() {
-		if err := clientfeatures.TestOnlyFeatureGates.Set(clientfeatures.TestOnlyClientAllowsCBOR, originalAllowed); err != nil {
-			tb.Fatal(err)
-		}
-	})
-	if err := clientfeatures.TestOnlyFeatureGates.Set(clientfeatures.TestOnlyClientAllowsCBOR, allowed); err != nil {
-		tb.Fatal(err)
-	}
-
-	originalPreferred := clientfeatures.TestOnlyFeatureGates.Enabled(clientfeatures.TestOnlyClientPrefersCBOR)
-	tb.Cleanup(func() {
-		if err := clientfeatures.TestOnlyFeatureGates.Set(clientfeatures.TestOnlyClientPrefersCBOR, originalPreferred); err != nil {
-			tb.Fatal(err)
-		}
-	})
-	if err := clientfeatures.TestOnlyFeatureGates.Set(clientfeatures.TestOnlyClientPrefersCBOR, preferred); err != nil {
-		tb.Fatal(err)
-	}
-}
 
 // EnableCBORForTest patches global state to enable the CBOR serializer and reverses those changes
 // at the end of the test. As a risk mitigation, integration tests are initially written this way so
@@ -77,7 +43,7 @@ func SetTestOnlyCBORClientFeatureGatesForTest(tb testing.TB, allowed, preferred 
 // (including feature gates) that can enable CBOR at runtime. After integration test coverage is
 // complete, feature gates will be introduced to completely supersede this mechanism.
 func EnableCBORServingAndStorageForTest(tb testing.TB) {
-	featuregatetesting.SetFeatureGateDuringTest(tb, utilfeature.TestOnlyFeatureGate, features.TestOnlyCBORServingAndStorage, true)
+	featuregatetesting.SetFeatureGateDuringTest(tb, utilfeature.DefaultFeatureGate, features.CBORServingAndStorage, true)
 
 	newCBORSerializerInfo := func(creater runtime.ObjectCreater, typer runtime.ObjectTyper) runtime.SerializerInfo {
 		return runtime.SerializerInfo{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature
/sig api-machinery

#### What this PR does / why we need it:

For alpha, there is one apiserver feature gate and two client-go feature gates controlling CBOR. They were initially wired to separate test-only feature gate instances in order to prevent them from being configurable at runtime via command-line flags or environment variables (for client-go feature gates outside of Kubernetes components). All of the integration tests required by the KEP as alpha criteria have been implemented. This adds the feature gates to the usual feature gate instances and removes the temporary code to support separate test-only feature gate instances.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

This PR excludes wiring the codecs used for serving built-in API resources (by request from @deads2k). That will follow before 1.32 code freeze.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added the feature gate CBORServingAndStorage to allow CBOR as the encoding for API request and response bodies, and as the storage encoding for custom resources. Clients must opt in; programs built with client-go can do this using the client-go feature gates ClientsAllowCBOR and ClientsPreferCBOR.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://kep.k8s.io/4222
```
