### PR TITLE
[DO-NOT-MERGE] [FG:InPlacePodVerticalScaling] Test PR for resize subresource with version skew

### DIFF
--- a/api/discovery/api__v1.json
+++ b/api/discovery/api__v1.json
@@ -357,6 +357,17 @@
     },
     {
       "kind": "Pod",
+      "name": "pods/resize",
+      "namespaced": true,
+      "singularName": "",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
+    },
+    {
+      "kind": "Pod",
       "name": "pods/status",
       "namespaced": true,
       "singularName": "",

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -24643,6 +24643,196 @@
         }
       }
     },
+    "/api/v1/namespaces/{namespace}/pods/{name}/resize": {
+      "get": {
+        "consumes": [
+          "*/*"
+        ],
+        "description": "read resize of the specified Pod",
+        "operationId": "readCoreV1NamespacedPodResize",
+        "produces": [
+          "application/json",
+          "application/yaml",
+          "application/vnd.kubernetes.protobuf"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/io.k8s.api.core.v1.Pod"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "schemes": [
+          "https"
+        ],
+        "tags": [
+          "core_v1"
+        ],
+        "x-kubernetes-action": "get",
+        "x-kubernetes-group-version-kind": {
+          "group": "",
+          "kind": "Pod",
+          "version": "v1"
+        }
+      },
+      "parameters": [
+        {
+          "description": "name of the Pod",
+          "in": "path",
+          "name": "name",
+          "required": true,
+          "type": "string",
+          "uniqueItems": true
+        },
+        {
+          "$ref": "#/parameters/namespace-vgWSWtn3"
+        },
+        {
+          "$ref": "#/parameters/pretty-tJGM1-ng"
+        }
+      ],
+      "patch": {
+        "consumes": [
+          "application/json-patch+json",
+          "application/merge-patch+json",
+          "application/strategic-merge-patch+json",
+          "application/apply-patch+yaml"
+        ],
+        "description": "partially update resize of the specified Pod",
+        "operationId": "patchCoreV1NamespacedPodResize",
+        "parameters": [
+          {
+            "$ref": "#/parameters/body-78PwaGsr"
+          },
+          {
+            "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+            "in": "query",
+            "name": "dryRun",
+            "type": "string",
+            "uniqueItems": true
+          },
+          {
+            "$ref": "#/parameters/fieldManager-7c6nTn1T"
+          },
+          {
+            "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+            "in": "query",
+            "name": "fieldValidation",
+            "type": "string",
+            "uniqueItems": true
+          },
+          {
+            "$ref": "#/parameters/force-tOGGb0Yi"
+          }
+        ],
+        "produces": [
+          "application/json",
+          "application/yaml",
+          "application/vnd.kubernetes.protobuf"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/io.k8s.api.core.v1.Pod"
+            }
+          },
+          "201": {
+            "description": "Created",
+            "schema": {
+              "$ref": "#/definitions/io.k8s.api.core.v1.Pod"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "schemes": [
+          "https"
+        ],
+        "tags": [
+          "core_v1"
+        ],
+        "x-kubernetes-action": "patch",
+        "x-kubernetes-group-version-kind": {
+          "group": "",
+          "kind": "Pod",
+          "version": "v1"
+        }
+      },
+      "put": {
+        "consumes": [
+          "*/*"
+        ],
+        "description": "replace resize of the specified Pod",
+        "operationId": "replaceCoreV1NamespacedPodResize",
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/io.k8s.api.core.v1.Pod"
+            }
+          },
+          {
+            "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+            "in": "query",
+            "name": "dryRun",
+            "type": "string",
+            "uniqueItems": true
+          },
+          {
+            "$ref": "#/parameters/fieldManager-Qy4HdaTW"
+          },
+          {
+            "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+            "in": "query",
+            "name": "fieldValidation",
+            "type": "string",
+            "uniqueItems": true
+          }
+        ],
+        "produces": [
+          "application/json",
+          "application/yaml",
+          "application/vnd.kubernetes.protobuf"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/io.k8s.api.core.v1.Pod"
+            }
+          },
+          "201": {
+            "description": "Created",
+            "schema": {
+              "$ref": "#/definitions/io.k8s.api.core.v1.Pod"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "schemes": [
+          "https"
+        ],
+        "tags": [
+          "core_v1"
+        ],
+        "x-kubernetes-action": "put",
+        "x-kubernetes-group-version-kind": {
+          "group": "",
+          "kind": "Pod",
+          "version": "v1"
+        }
+      }
+    },
     "/api/v1/namespaces/{namespace}/pods/{name}/status": {
       "get": {
         "consumes": [

--- a/api/openapi-spec/v3/api__v1_openapi.json
+++ b/api/openapi-spec/v3/api__v1_openapi.json
@@ -17985,6 +17985,295 @@
         }
       }
     },
+    "/api/v1/namespaces/{namespace}/pods/{name}/resize": {
+      "get": {
+        "description": "read resize of the specified Pod",
+        "operationId": "readCoreV1NamespacedPodResize",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.core.v1.Pod"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.core.v1.Pod"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.core.v1.Pod"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "tags": [
+          "core_v1"
+        ],
+        "x-kubernetes-action": "get",
+        "x-kubernetes-group-version-kind": {
+          "group": "",
+          "kind": "Pod",
+          "version": "v1"
+        }
+      },
+      "parameters": [
+        {
+          "description": "name of the Pod",
+          "in": "path",
+          "name": "name",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "object name and auth scope, such as for teams and projects",
+          "in": "path",
+          "name": "namespace",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+          "in": "query",
+          "name": "pretty",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        }
+      ],
+      "patch": {
+        "description": "partially update resize of the specified Pod",
+        "operationId": "patchCoreV1NamespacedPodResize",
+        "parameters": [
+          {
+            "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+            "in": "query",
+            "name": "dryRun",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+            "in": "query",
+            "name": "fieldManager",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+            "in": "query",
+            "name": "fieldValidation",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+            "in": "query",
+            "name": "force",
+            "schema": {
+              "type": "boolean",
+              "uniqueItems": true
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/apply-patch+yaml": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
+            "application/merge-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
+            "application/strategic-merge-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.core.v1.Pod"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.core.v1.Pod"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.core.v1.Pod"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.core.v1.Pod"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.core.v1.Pod"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.core.v1.Pod"
+                }
+              }
+            },
+            "description": "Created"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "tags": [
+          "core_v1"
+        ],
+        "x-kubernetes-action": "patch",
+        "x-kubernetes-group-version-kind": {
+          "group": "",
+          "kind": "Pod",
+          "version": "v1"
+        }
+      },
+      "put": {
+        "description": "replace resize of the specified Pod",
+        "operationId": "replaceCoreV1NamespacedPodResize",
+        "parameters": [
+          {
+            "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+            "in": "query",
+            "name": "dryRun",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+            "in": "query",
+            "name": "fieldManager",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+            "in": "query",
+            "name": "fieldValidation",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "*/*": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.api.core.v1.Pod"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.core.v1.Pod"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.core.v1.Pod"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.core.v1.Pod"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.core.v1.Pod"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.core.v1.Pod"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.core.v1.Pod"
+                }
+              }
+            },
+            "description": "Created"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "tags": [
+          "core_v1"
+        ],
+        "x-kubernetes-action": "put",
+        "x-kubernetes-group-version-kind": {
+          "group": "",
+          "kind": "Pod",
+          "version": "v1"
+        }
+      }
+    },
     "/api/v1/namespaces/{namespace}/pods/{name}/status": {
       "get": {
         "description": "read status of the specified Pod",

--- a/pkg/api/pod/testing/make.go
+++ b/pkg/api/pod/testing/make.go
@@ -27,6 +27,7 @@ import (
 // Tweak is a function that modifies a Pod.
 type Tweak func(*api.Pod)
 type TweakContainer func(*api.Container)
+type TweakPodStatus func(*api.PodStatus)
 
 // MakePod helps construct Pod objects (which pass API validation) more
 // legibly and tersely than a Go struct definition.  By default this produces
@@ -295,5 +296,36 @@ func SetContainerSecurityContext(ctx api.SecurityContext) TweakContainer {
 func SetContainerRestartPolicy(policy api.ContainerRestartPolicy) TweakContainer {
 	return func(cnr *api.Container) {
 		cnr.RestartPolicy = &policy
+	}
+}
+
+func MakePodStatus(tweaks ...TweakPodStatus) api.PodStatus {
+	ps := api.PodStatus{}
+
+	for _, tweak := range tweaks {
+		tweak(&ps)
+	}
+
+	return ps
+}
+
+func SetContainerStatuses(containerStatuses ...api.ContainerStatus) TweakPodStatus {
+	return func(podstatus *api.PodStatus) {
+		podstatus.ContainerStatuses = containerStatuses
+	}
+}
+
+func MakeContainerStatus(name string, allocatedResources api.ResourceList) api.ContainerStatus {
+	cs := api.ContainerStatus{
+		Name:               name,
+		AllocatedResources: allocatedResources,
+	}
+
+	return cs
+}
+
+func SetResizeStatus(resizeStatus api.PodResizeStatus) TweakPodStatus {
+	return func(podstatus *api.PodStatus) {
+		podstatus.Resize = resizeStatus
 	}
 }

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -5451,6 +5451,9 @@ func ValidatePodEphemeralContainersUpdate(newPod, oldPod *core.Pod, opts PodVali
 	return allErrs
 }
 
+// ValidatePodResize tests that a user update to pod container resources is valid.
+// newPod and oldPod must only differ in their Containers[*].Resources and
+// Containers[*].ResizePolicy field.
 func ValidatePodResize(newPod, oldPod *core.Pod, opts PodValidationOptions) field.ErrorList {
 	// Part 1: Validate newPod's spec and updates to metadata
 	fldPath := field.NewPath("metadata")
@@ -5467,7 +5470,7 @@ func ValidatePodResize(newPod, oldPod *core.Pod, opts PodValidationOptions) fiel
 	// newPod.Spec.Containers[].Resources are allowed.
 	specPath := field.NewPath("spec")
 	if qos.GetPodQOS(oldPod) != qos.ComputePodQOS(newPod) {
-		allErrs = append(allErrs, field.Invalid(specPath, newPod.Status.QOSClass, "Pod QoS is immutable"))
+		allErrs = append(allErrs, field.Invalid(specPath, newPod.Status.QOSClass, "Pod QOS Class must not change"))
 	}
 
 	// Ensure that only CPU and memory resources are mutable.

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -5104,16 +5104,6 @@ var updatablePodSpecFields = []string{
 	"`spec.activeDeadlineSeconds`",
 	"`spec.tolerations` (only additions to existing tolerations)",
 	"`spec.terminationGracePeriodSeconds` (allow it to be set to 1 if it was previously negative)",
-	"`spec.containers[*].resources` (for CPU/memory only)",
-}
-
-// TODO(vinaykul,InPlacePodVerticalScaling): Drop this var once InPlacePodVerticalScaling goes GA and featuregate is gone.
-var updatablePodSpecFieldsNoResources = []string{
-	"`spec.containers[*].image`",
-	"`spec.initContainers[*].image`",
-	"`spec.activeDeadlineSeconds`",
-	"`spec.tolerations` (only additions to existing tolerations)",
-	"`spec.terminationGracePeriodSeconds` (allow it to be set to 1 if it was previously negative)",
 }
 
 // ValidatePodUpdate tests to see if the update is legal for an end user to make. newPod is updated with fields
@@ -5175,45 +5165,12 @@ func ValidatePodUpdate(newPod, oldPod *core.Pod, opts PodValidationOptions) fiel
 		return allErrs
 	}
 
-	if qos.GetPodQOS(oldPod) != qos.ComputePodQOS(newPod) {
-		allErrs = append(allErrs, field.Invalid(fldPath, newPod.Status.QOSClass, "Pod QoS is immutable"))
-	}
-
 	// handle updateable fields by munging those fields prior to deep equal comparison.
 	mungedPodSpec := *newPod.Spec.DeepCopy()
 	// munge spec.containers[*].image
 	var newContainers []core.Container
 	for ix, container := range mungedPodSpec.Containers {
 		container.Image = oldPod.Spec.Containers[ix].Image // +k8s:verify-mutation:reason=clone
-		// When the feature-gate is turned off, any new requests attempting to update CPU or memory
-		// resource values will result in validation failure.
-		if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {
-			// Resources are mutable for CPU & memory only
-			//   - user can now modify Resources to express new desired Resources
-			mungeCpuMemResources := func(resourceList, oldResourceList core.ResourceList) core.ResourceList {
-				if oldResourceList == nil {
-					return nil
-				}
-				var mungedResourceList core.ResourceList
-				if resourceList == nil {
-					mungedResourceList = make(core.ResourceList)
-				} else {
-					mungedResourceList = resourceList.DeepCopy()
-				}
-				delete(mungedResourceList, core.ResourceCPU)
-				delete(mungedResourceList, core.ResourceMemory)
-				if cpu, found := oldResourceList[core.ResourceCPU]; found {
-					mungedResourceList[core.ResourceCPU] = cpu
-				}
-				if mem, found := oldResourceList[core.ResourceMemory]; found {
-					mungedResourceList[core.ResourceMemory] = mem
-				}
-				return mungedResourceList
-			}
-			lim := mungeCpuMemResources(container.Resources.Limits, oldPod.Spec.Containers[ix].Resources.Limits)
-			req := mungeCpuMemResources(container.Resources.Requests, oldPod.Spec.Containers[ix].Resources.Requests)
-			container.Resources = core.ResourceRequirements{Limits: lim, Requests: req}
-		}
 		newContainers = append(newContainers, container)
 	}
 	mungedPodSpec.Containers = newContainers
@@ -5290,10 +5247,7 @@ func ValidatePodUpdate(newPod, oldPod *core.Pod, opts PodValidationOptions) fiel
 		// This diff isn't perfect, but it's a helluva lot better an "I'm not going to tell you what the difference is".
 		// TODO: Pinpoint the specific field that causes the invalid error after we have strategic merge diff
 		specDiff := cmp.Diff(oldPod.Spec, mungedPodSpec)
-		errs := field.Forbidden(specPath, fmt.Sprintf("pod updates may not change fields other than %s\n%v", strings.Join(updatablePodSpecFieldsNoResources, ","), specDiff))
-		if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {
-			errs = field.Forbidden(specPath, fmt.Sprintf("pod updates may not change fields other than %s\n%v", strings.Join(updatablePodSpecFields, ","), specDiff))
-		}
+		errs := field.Forbidden(specPath, fmt.Sprintf("pod updates may not change fields other than %s\n%v", strings.Join(updatablePodSpecFields, ","), specDiff))
 		allErrs = append(allErrs, errs)
 	}
 	return allErrs
@@ -5494,6 +5448,65 @@ func ValidatePodEphemeralContainersUpdate(newPod, oldPod *core.Pod, opts PodVali
 		}
 	}
 
+	return allErrs
+}
+
+func ValidatePodResize(newPod, oldPod *core.Pod, opts PodValidationOptions) field.ErrorList {
+	// Part 1: Validate newPod's spec and updates to metadata
+	fldPath := field.NewPath("metadata")
+	allErrs := ValidateObjectMetaUpdate(&newPod.ObjectMeta, &oldPod.ObjectMeta, fldPath)
+	allErrs = append(allErrs, validatePodMetadataAndSpec(newPod, opts)...)
+	allErrs = append(allErrs, ValidatePodSpecificAnnotationUpdates(newPod, oldPod, fldPath.Child("annotations"), opts)...)
+
+	// static pods cannot be resized.
+	if _, ok := oldPod.Annotations[core.MirrorPodAnnotationKey]; ok {
+		return field.ErrorList{field.Forbidden(field.NewPath(""), "static pods cannot be resized")}
+	}
+
+	// Part 2: Validate that the changes between oldPod.Spec.Containers[].Resources and
+	// newPod.Spec.Containers[].Resources are allowed.
+	specPath := field.NewPath("spec")
+	if qos.GetPodQOS(oldPod) != qos.ComputePodQOS(newPod) {
+		allErrs = append(allErrs, field.Invalid(specPath, newPod.Status.QOSClass, "Pod QoS is immutable"))
+	}
+
+	// Ensure that only CPU and memory resources are mutable.
+	mungedPodSpec := *newPod.Spec.DeepCopy()
+	var newContainers []core.Container
+	for ix, container := range mungedPodSpec.Containers {
+		mungeCPUMemResources := func(resourceList, oldResourceList core.ResourceList) core.ResourceList {
+			if oldResourceList == nil {
+				return nil
+			}
+			var mungedResourceList core.ResourceList
+			if resourceList == nil {
+				mungedResourceList = make(core.ResourceList)
+			} else {
+				mungedResourceList = resourceList.DeepCopy()
+			}
+			delete(mungedResourceList, core.ResourceCPU)
+			delete(mungedResourceList, core.ResourceMemory)
+			if cpu, found := oldResourceList[core.ResourceCPU]; found {
+				mungedResourceList[core.ResourceCPU] = cpu
+			}
+			if mem, found := oldResourceList[core.ResourceMemory]; found {
+				mungedResourceList[core.ResourceMemory] = mem
+			}
+			return mungedResourceList
+		}
+		lim := mungeCPUMemResources(container.Resources.Limits, oldPod.Spec.Containers[ix].Resources.Limits)
+		req := mungeCPUMemResources(container.Resources.Requests, oldPod.Spec.Containers[ix].Resources.Requests)
+		container.Resources = core.ResourceRequirements{Limits: lim, Requests: req}
+		container.ResizePolicy = oldPod.Spec.Containers[ix].ResizePolicy // +k8s:verify-mutation:reason=clone
+		newContainers = append(newContainers, container)
+	}
+	mungedPodSpec.Containers = newContainers
+	if !apiequality.Semantic.DeepEqual(mungedPodSpec, oldPod.Spec) {
+		// This likely means that the user has made changes to CPU and Memory resources.
+		specDiff := cmp.Diff(oldPod.Spec, mungedPodSpec)
+		errs := field.Forbidden(specPath, fmt.Sprintf("pod resize may not change fields other than cpu and memory\n%v", specDiff))
+		allErrs = append(allErrs, errs)
+	}
 	return allErrs
 }
 

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -5524,7 +5524,7 @@ func isPodResizeRequestValid(pod core.Pod) bool {
 	// This code handles the version skew as described in the KEP.
 	// For handling version skew we're only allowing to update the Pod's Resources
 	// if the Pod already has Pod.Status.ContainerStatuses[i].Resources. This means
-	// that the apiserver would only allow updates to Pods running on Nodes with 
+	// that the apiserver would only allow updates to Pods running on Nodes with
 	// the InPlacePodVerticalScaling feature gate enabled.
 	if !utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {
 		return false

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -5474,10 +5474,10 @@ func ValidatePodResize(newPod, oldPod *core.Pod, opts PodValidationOptions) fiel
 	}
 
 	// Ensure that only CPU and memory resources are mutable.
-	mungedPodSpec := *newPod.Spec.DeepCopy()
+	originalCPUMemPodSpec := *newPod.Spec.DeepCopy()
 	var newContainers []core.Container
-	for ix, container := range mungedPodSpec.Containers {
-		mungeCPUMemResources := func(resourceList, oldResourceList core.ResourceList) core.ResourceList {
+	for ix, container := range originalCPUMemPodSpec.Containers {
+		dropCPUMemoryUpdates := func(resourceList, oldResourceList core.ResourceList) core.ResourceList {
 			if oldResourceList == nil {
 				return nil
 			}
@@ -5497,17 +5497,17 @@ func ValidatePodResize(newPod, oldPod *core.Pod, opts PodValidationOptions) fiel
 			}
 			return mungedResourceList
 		}
-		lim := mungeCPUMemResources(container.Resources.Limits, oldPod.Spec.Containers[ix].Resources.Limits)
-		req := mungeCPUMemResources(container.Resources.Requests, oldPod.Spec.Containers[ix].Resources.Requests)
+		lim := dropCPUMemoryUpdates(container.Resources.Limits, oldPod.Spec.Containers[ix].Resources.Limits)
+		req := dropCPUMemoryUpdates(container.Resources.Requests, oldPod.Spec.Containers[ix].Resources.Requests)
 		container.Resources = core.ResourceRequirements{Limits: lim, Requests: req}
 		container.ResizePolicy = oldPod.Spec.Containers[ix].ResizePolicy // +k8s:verify-mutation:reason=clone
 		newContainers = append(newContainers, container)
 	}
-	mungedPodSpec.Containers = newContainers
-	if !apiequality.Semantic.DeepEqual(mungedPodSpec, oldPod.Spec) {
+	originalCPUMemPodSpec.Containers = newContainers
+	if !apiequality.Semantic.DeepEqual(originalCPUMemPodSpec, oldPod.Spec) {
 		// This likely means that the user has made changes to resources other than CPU and Memory.
-		specDiff := cmp.Diff(oldPod.Spec, mungedPodSpec)
-		errs := field.Forbidden(specPath, fmt.Sprintf("pod resize may not change fields other than cpu and memory\n%v", specDiff))
+		specDiff := cmp.Diff(oldPod.Spec, originalCPUMemPodSpec)
+		errs := field.Forbidden(specPath, fmt.Sprintf("only cpu and memory resources are mutable\n%v", specDiff))
 		allErrs = append(allErrs, errs)
 	}
 	return allErrs

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -5470,7 +5470,7 @@ func ValidatePodResize(newPod, oldPod *core.Pod, opts PodValidationOptions) fiel
 	// newPod.Spec.Containers[].Resources are allowed.
 	specPath := field.NewPath("spec")
 	if qos.GetPodQOS(oldPod) != qos.ComputePodQOS(newPod) {
-		allErrs = append(allErrs, field.Invalid(specPath, newPod.Status.QOSClass, "Pod QOS Class must not change"))
+		allErrs = append(allErrs, field.Invalid(specPath, newPod.Status.QOSClass, "Pod QOS Class may not change as a result of resizing"))
 	}
 
 	// Ensure that only CPU and memory resources are mutable.
@@ -5505,7 +5505,7 @@ func ValidatePodResize(newPod, oldPod *core.Pod, opts PodValidationOptions) fiel
 	}
 	mungedPodSpec.Containers = newContainers
 	if !apiequality.Semantic.DeepEqual(mungedPodSpec, oldPod.Spec) {
-		// This likely means that the user has made changes to CPU and Memory resources.
+		// This likely means that the user has made changes to resources other than CPU and Memory.
 		specDiff := cmp.Diff(oldPod.Spec, mungedPodSpec)
 		errs := field.Forbidden(specPath, fmt.Sprintf("pod resize may not change fields other than cpu and memory\n%v", specDiff))
 		allErrs = append(allErrs, errs)

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -25009,7 +25009,7 @@ func TestValidatePodResize(t *testing.T) {
 			test: "storage limit change",
 			old:  mkPod(core.ResourceList{}, getResources("100m", "100Mi", "2Gi", "")),
 			new:  mkPod(core.ResourceList{}, getResources("100m", "100Mi", "1Gi", "")),
-			err:  "spec: Forbidden: pod resize may not change fields other than cpu and memory",
+			err:  "spec: Forbidden: only cpu and memory resources are mutable",
 		}, {
 			test: "cpu request change",
 			old:  mkPod(getResources("200m", "0", "", ""), core.ResourceList{}),
@@ -25024,7 +25024,7 @@ func TestValidatePodResize(t *testing.T) {
 			test: "storage request change",
 			old:  mkPod(getResources("100m", "0", "1Gi", ""), core.ResourceList{}),
 			new:  mkPod(getResources("100m", "0", "2Gi", ""), core.ResourceList{}),
-			err:  "spec: Forbidden: pod resize may not change fields other than cpu and memory",
+			err:  "spec: Forbidden: only cpu and memory resources are mutable",
 		}, {
 			test: "Pod QoS unchanged, guaranteed -> guaranteed",
 			old:  mkPod(getResources("100m", "100Mi", "1Gi", ""), getResources("100m", "100Mi", "1Gi", "")),

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -7793,14 +7793,7 @@ func TestValidateResizePolicy(t *testing.T) {
 	}
 }
 
-func getResourceLimits(cpu, memory string) core.ResourceList {
-	res := core.ResourceList{}
-	res[core.ResourceCPU] = resource.MustParse(cpu)
-	res[core.ResourceMemory] = resource.MustParse(memory)
-	return res
-}
-
-func getResources(cpu, memory, storage string) core.ResourceList {
+func getResources(cpu, memory, ephemeralStorage, persistentStorage string) core.ResourceList {
 	res := core.ResourceList{}
 	if cpu != "" {
 		res[core.ResourceCPU] = resource.MustParse(cpu)
@@ -7808,8 +7801,11 @@ func getResources(cpu, memory, storage string) core.ResourceList {
 	if memory != "" {
 		res[core.ResourceMemory] = resource.MustParse(memory)
 	}
-	if storage != "" {
-		res[core.ResourceEphemeralStorage] = resource.MustParse(storage)
+	if ephemeralStorage != "" {
+		res[core.ResourceEphemeralStorage] = resource.MustParse(ephemeralStorage)
+	}
+	if persistentStorage != "" {
+		res[core.ResourceStorage] = resource.MustParse(persistentStorage)
 	}
 	return res
 }
@@ -8943,7 +8939,7 @@ func TestValidateContainers(t *testing.T) {
 			Name:  "abc-123",
 			Image: "image",
 			Resources: core.ResourceRequirements{
-				Limits: getResourceLimits("-10", "0"),
+				Limits: getResources("-10", "0", "", ""),
 			},
 			ImagePullPolicy:          "IfNotPresent",
 			TerminationMessagePolicy: "File",
@@ -8956,7 +8952,7 @@ func TestValidateContainers(t *testing.T) {
 			Name:  "abc-123",
 			Image: "image",
 			Resources: core.ResourceRequirements{
-				Requests: getResourceLimits("-10", "0"),
+				Requests: getResources("-10", "0", "", ""),
 			},
 			ImagePullPolicy:          "IfNotPresent",
 			TerminationMessagePolicy: "File",
@@ -8969,7 +8965,7 @@ func TestValidateContainers(t *testing.T) {
 			Name:  "abc-123",
 			Image: "image",
 			Resources: core.ResourceRequirements{
-				Limits: getResourceLimits("0", "-10"),
+				Limits: getResources("0", "-10", "", ""),
 			},
 			ImagePullPolicy:          "IfNotPresent",
 			TerminationMessagePolicy: "File",
@@ -8982,8 +8978,8 @@ func TestValidateContainers(t *testing.T) {
 			Name:  "abc-123",
 			Image: "image",
 			Resources: core.ResourceRequirements{
-				Limits:   getResourceLimits("5", "3"),
-				Requests: getResourceLimits("6", "3"),
+				Limits:   getResources("5", "3", "", ""),
+				Requests: getResources("6", "3", "", ""),
 			},
 			ImagePullPolicy:          "IfNotPresent",
 			TerminationMessagePolicy: "File",
@@ -9014,8 +9010,8 @@ func TestValidateContainers(t *testing.T) {
 			Name:  "abc-123",
 			Image: "image",
 			Resources: core.ResourceRequirements{
-				Limits:   getResourceLimits("5", "3"),
-				Requests: getResourceLimits("6", "3"),
+				Limits:   getResources("5", "3", "", ""),
+				Requests: getResources("6", "3", "", ""),
 			},
 			ImagePullPolicy:          "IfNotPresent",
 			TerminationMessagePolicy: "File",
@@ -9028,8 +9024,8 @@ func TestValidateContainers(t *testing.T) {
 			Name:  "abc-123",
 			Image: "image",
 			Resources: core.ResourceRequirements{
-				Limits:   getResourceLimits("5", "3"),
-				Requests: getResourceLimits("5", "4"),
+				Limits:   getResources("5", "3", "", ""),
+				Requests: getResources("5", "4", "", ""),
 			},
 			ImagePullPolicy:          "IfNotPresent",
 			TerminationMessagePolicy: "File",
@@ -12315,10 +12311,10 @@ func TestValidatePodUpdate(t *testing.T) {
 	)
 
 	tests := []struct {
-		new  core.Pod
-		old  core.Pod
-		err  string
 		test string
+		old  core.Pod
+		new  core.Pod
+		err  string
 	}{
 		{new: *podtest.MakePod(""), old: *podtest.MakePod(""), err: "", test: "nothing"}, {
 			new:  *podtest.MakePod("foo"),
@@ -12484,13 +12480,13 @@ func TestValidatePodUpdate(t *testing.T) {
 			new: *podtest.MakePod("pod",
 				podtest.SetContainers(podtest.MakeContainer("container",
 					podtest.SetContainerResources(core.ResourceRequirements{
-						Limits: getResources("200m", "0", "1Gi"),
+						Limits: getResources("200m", "0", "1Gi", ""),
 					}))),
 			),
 			old: *podtest.MakePod("pod",
 				podtest.SetContainers(podtest.MakeContainer("container",
 					podtest.SetContainerResources(core.ResourceRequirements{
-						Limits: getResources("100m", "0", "1Gi"),
+						Limits: getResources("100m", "0", "1Gi", ""),
 					}))),
 			),
 			err:  "spec: Forbidden: pod updates may not change fields",
@@ -12499,13 +12495,13 @@ func TestValidatePodUpdate(t *testing.T) {
 			new: *podtest.MakePod("pod",
 				podtest.SetContainers(podtest.MakeContainer("container",
 					podtest.SetContainerResources(core.ResourceRequirements{
-						Limits: getResourceLimits("100m", "100Mi"),
+						Limits: getResources("100m", "100Mi", "", ""),
 					}))),
 			),
 			old: *podtest.MakePod("pod",
 				podtest.SetContainers(podtest.MakeContainer("container",
 					podtest.SetContainerResources(core.ResourceRequirements{
-						Limits: getResourceLimits("100m", "200Mi"),
+						Limits: getResources("100m", "200Mi", "", ""),
 					}))),
 			),
 			err:  "spec: Forbidden: pod updates may not change fields",
@@ -12514,13 +12510,13 @@ func TestValidatePodUpdate(t *testing.T) {
 			new: *podtest.MakePod("pod",
 				podtest.SetContainers(podtest.MakeContainer("container",
 					podtest.SetContainerResources(core.ResourceRequirements{
-						Limits: getResources("100m", "100Mi", "1Gi"),
+						Limits: getResources("100m", "100Mi", "1Gi", ""),
 					}))),
 			),
 			old: *podtest.MakePod("pod",
 				podtest.SetContainers(podtest.MakeContainer("container",
 					podtest.SetContainerResources(core.ResourceRequirements{
-						Limits: getResources("100m", "100Mi", "2Gi"),
+						Limits: getResources("100m", "100Mi", "2Gi", ""),
 					}))),
 			),
 			err:  "Forbidden: pod updates may not change fields other than",
@@ -12529,13 +12525,13 @@ func TestValidatePodUpdate(t *testing.T) {
 			new: *podtest.MakePod("pod",
 				podtest.SetContainers(podtest.MakeContainer("container",
 					podtest.SetContainerResources(core.ResourceRequirements{
-						Requests: getResourceLimits("100m", "0"),
+						Requests: getResources("100m", "0", "", ""),
 					}))),
 			),
 			old: *podtest.MakePod("pod",
 				podtest.SetContainers(podtest.MakeContainer("container",
 					podtest.SetContainerResources(core.ResourceRequirements{
-						Requests: getResourceLimits("200m", "0"),
+						Requests: getResources("200m", "0", "", ""),
 					}))),
 			),
 			err:  "spec: Forbidden: pod updates may not change fields",
@@ -12544,13 +12540,13 @@ func TestValidatePodUpdate(t *testing.T) {
 			new: *podtest.MakePod("pod",
 				podtest.SetContainers(podtest.MakeContainer("container",
 					podtest.SetContainerResources(core.ResourceRequirements{
-						Requests: getResourceLimits("0", "200Mi"),
+						Requests: getResources("0", "200Mi", "", ""),
 					}))),
 			),
 			old: *podtest.MakePod("pod",
 				podtest.SetContainers(podtest.MakeContainer("container",
 					podtest.SetContainerResources(core.ResourceRequirements{
-						Requests: getResourceLimits("0", "100Mi"),
+						Requests: getResources("0", "100Mi", "", ""),
 					}))),
 			),
 			err:  "spec: Forbidden: pod updates may not change fields",
@@ -12559,13 +12555,13 @@ func TestValidatePodUpdate(t *testing.T) {
 			new: *podtest.MakePod("pod",
 				podtest.SetContainers(podtest.MakeContainer("container",
 					podtest.SetContainerResources(core.ResourceRequirements{
-						Requests: getResources("100m", "0", "2Gi"),
+						Requests: getResources("100m", "0", "2Gi", ""),
 					}))),
 			),
 			old: *podtest.MakePod("pod",
 				podtest.SetContainers(podtest.MakeContainer("container",
 					podtest.SetContainerResources(core.ResourceRequirements{
-						Requests: getResources("100m", "0", "1Gi"),
+						Requests: getResources("100m", "0", "1Gi", ""),
 					}))),
 			),
 			err:  "Forbidden: pod updates may not change fields other than",
@@ -12574,15 +12570,15 @@ func TestValidatePodUpdate(t *testing.T) {
 			new: *podtest.MakePod("pod",
 				podtest.SetContainers(podtest.MakeContainer("container",
 					podtest.SetContainerResources(core.ResourceRequirements{
-						Limits:   getResources("200m", "400Mi", "1Gi"),
-						Requests: getResources("200m", "400Mi", "1Gi"),
+						Limits:   getResources("200m", "400Mi", "1Gi", ""),
+						Requests: getResources("200m", "400Mi", "1Gi", ""),
 					}))),
 			),
 			old: *podtest.MakePod("pod",
 				podtest.SetContainers(podtest.MakeContainer("container",
 					podtest.SetContainerResources(core.ResourceRequirements{
-						Limits:   getResources("100m", "100Mi", "1Gi"),
-						Requests: getResources("100m", "100Mi", "1Gi"),
+						Limits:   getResources("100m", "100Mi", "1Gi", ""),
+						Requests: getResources("100m", "100Mi", "1Gi", ""),
 					}))),
 			),
 			err:  "spec: Forbidden: pod updates may not change fields",
@@ -12591,15 +12587,15 @@ func TestValidatePodUpdate(t *testing.T) {
 			new: *podtest.MakePod("pod",
 				podtest.SetContainers(podtest.MakeContainer("container",
 					podtest.SetContainerResources(core.ResourceRequirements{
-						Limits:   getResources("200m", "200Mi", "2Gi"),
-						Requests: getResources("100m", "100Mi", "1Gi"),
+						Limits:   getResources("200m", "200Mi", "2Gi", ""),
+						Requests: getResources("100m", "100Mi", "1Gi", ""),
 					}))),
 			),
 			old: *podtest.MakePod("pod",
 				podtest.SetContainers(podtest.MakeContainer("container",
 					podtest.SetContainerResources(core.ResourceRequirements{
-						Limits:   getResources("400m", "400Mi", "2Gi"),
-						Requests: getResources("200m", "200Mi", "1Gi"),
+						Limits:   getResources("400m", "400Mi", "2Gi", ""),
+						Requests: getResources("200m", "200Mi", "1Gi", ""),
 					}))),
 			),
 			err:  "spec: Forbidden: pod updates may not change fields",
@@ -12608,14 +12604,14 @@ func TestValidatePodUpdate(t *testing.T) {
 			new: *podtest.MakePod("pod",
 				podtest.SetContainers(podtest.MakeContainer("container",
 					podtest.SetContainerResources(core.ResourceRequirements{
-						Limits:   getResourceLimits("200m", "200Mi"),
-						Requests: getResourceLimits("100m", "100Mi"),
+						Limits:   getResources("200m", "200Mi", "", ""),
+						Requests: getResources("100m", "100Mi", "", ""),
 					}))),
 			),
 			old: *podtest.MakePod("pod",
 				podtest.SetContainers(podtest.MakeContainer("container",
 					podtest.SetContainerResources(core.ResourceRequirements{
-						Requests: getResourceLimits("100m", "100Mi"),
+						Requests: getResources("100m", "100Mi", "", ""),
 					}))),
 			),
 			err:  "spec: Forbidden: pod updates may not change fields",
@@ -12624,14 +12620,14 @@ func TestValidatePodUpdate(t *testing.T) {
 			new: *podtest.MakePod("pod",
 				podtest.SetContainers(podtest.MakeContainer("container",
 					podtest.SetContainerResources(core.ResourceRequirements{
-						Requests: getResourceLimits("100m", "100Mi"),
+						Requests: getResources("100m", "100Mi", "", ""),
 					}))),
 			),
 			old: *podtest.MakePod("pod",
 				podtest.SetContainers(podtest.MakeContainer("container",
 					podtest.SetContainerResources(core.ResourceRequirements{
-						Limits:   getResourceLimits("200m", "200Mi"),
-						Requests: getResourceLimits("100m", "100Mi"),
+						Limits:   getResources("200m", "200Mi", "", ""),
+						Requests: getResources("100m", "100Mi", "", ""),
 					}))),
 			),
 			err:  "spec: Forbidden: pod updates may not change fields",
@@ -12640,14 +12636,14 @@ func TestValidatePodUpdate(t *testing.T) {
 			new: *podtest.MakePod("pod",
 				podtest.SetContainers(podtest.MakeContainer("container",
 					podtest.SetContainerResources(core.ResourceRequirements{
-						Limits:   getResources("400m", "", "1Gi"),
-						Requests: getResources("300m", "", "1Gi"),
+						Limits:   getResources("400m", "", "1Gi", ""),
+						Requests: getResources("300m", "", "1Gi", ""),
 					}))),
 			),
 			old: *podtest.MakePod("pod",
 				podtest.SetContainers(podtest.MakeContainer("container",
 					podtest.SetContainerResources(core.ResourceRequirements{
-						Limits: getResources("200m", "500Mi", "1Gi"),
+						Limits: getResources("200m", "500Mi", "1Gi", ""),
 					}))),
 			),
 			err:  "spec: Forbidden: pod updates may not change fields",
@@ -12656,14 +12652,14 @@ func TestValidatePodUpdate(t *testing.T) {
 			new: *podtest.MakePod("pod",
 				podtest.SetContainers(podtest.MakeContainer("container",
 					podtest.SetContainerResources(core.ResourceRequirements{
-						Limits: getResources("400m", "500Mi", "2Gi"),
+						Limits: getResources("400m", "500Mi", "2Gi", ""),
 					}))),
 			),
 			old: *podtest.MakePod("pod",
 				podtest.SetContainers(podtest.MakeContainer("container",
 					podtest.SetContainerResources(core.ResourceRequirements{
-						Limits:   getResources("200m", "300Mi", "2Gi"),
-						Requests: getResourceLimits("100m", "200Mi"),
+						Limits:   getResources("200m", "300Mi", "2Gi", ""),
+						Requests: getResources("100m", "200Mi", "", ""),
 					}))),
 			),
 			err:  "spec: Forbidden: pod updates may not change fields",
@@ -12672,15 +12668,15 @@ func TestValidatePodUpdate(t *testing.T) {
 			new: *podtest.MakePod("pod",
 				podtest.SetContainers(podtest.MakeContainer("container",
 					podtest.SetContainerResources(core.ResourceRequirements{
-						Limits:   getResourceLimits("200m", "200Mi"),
-						Requests: getResourceLimits("100m", "100Mi"),
+						Limits:   getResources("200m", "200Mi", "", ""),
+						Requests: getResources("100m", "100Mi", "", ""),
 					}))),
 			),
 			old: *podtest.MakePod("pod",
 				podtest.SetContainers(podtest.MakeContainer("container",
 					podtest.SetContainerResources(core.ResourceRequirements{
-						Limits:   getResourceLimits("100m", "100Mi"),
-						Requests: getResourceLimits("100m", "100Mi"),
+						Limits:   getResources("100m", "100Mi", "", ""),
+						Requests: getResources("100m", "100Mi", "", ""),
 					}))),
 			),
 			err:  "spec: Forbidden: pod updates may not change fields",
@@ -12689,14 +12685,14 @@ func TestValidatePodUpdate(t *testing.T) {
 			new: *podtest.MakePod("pod",
 				podtest.SetContainers(podtest.MakeContainer("container",
 					podtest.SetContainerResources(core.ResourceRequirements{
-						Limits:   getResourceLimits("100m", "100Mi"),
-						Requests: getResourceLimits("100m", "100Mi"),
+						Limits:   getResources("100m", "100Mi", "", ""),
+						Requests: getResources("100m", "100Mi", "", ""),
 					}))),
 			),
 			old: *podtest.MakePod("pod",
 				podtest.SetContainers(podtest.MakeContainer("container",
 					podtest.SetContainerResources(core.ResourceRequirements{
-						Requests: getResourceLimits("100m", "100Mi"),
+						Requests: getResources("100m", "100Mi", "", ""),
 					}))),
 			),
 			err:  "spec: Forbidden: pod updates may not change fields",
@@ -12705,8 +12701,8 @@ func TestValidatePodUpdate(t *testing.T) {
 			new: *podtest.MakePod("pod",
 				podtest.SetContainers(podtest.MakeContainer("container",
 					podtest.SetContainerResources(core.ResourceRequirements{
-						Limits:   getResourceLimits("200m", "200Mi"),
-						Requests: getResourceLimits("100m", "100Mi"),
+						Limits:   getResources("200m", "200Mi", "", ""),
+						Requests: getResources("100m", "100Mi", "", ""),
 					}))),
 			),
 			old:  *podtest.MakePod("pod"),
@@ -12717,8 +12713,8 @@ func TestValidatePodUpdate(t *testing.T) {
 			old: *podtest.MakePod("pod",
 				podtest.SetContainers(podtest.MakeContainer("container",
 					podtest.SetContainerResources(core.ResourceRequirements{
-						Limits:   getResourceLimits("200m", "200Mi"),
-						Requests: getResourceLimits("100m", "100Mi"),
+						Limits:   getResources("200m", "200Mi", "", ""),
+						Requests: getResources("100m", "100Mi", "", ""),
 					}))),
 			),
 			err:  "spec: Forbidden: pod updates may not change fields",
@@ -18664,33 +18660,6 @@ func TestValidateResourceNames(t *testing.T) {
 	}
 }
 
-func getResourceList(cpu, memory string) core.ResourceList {
-	res := core.ResourceList{}
-	if cpu != "" {
-		res[core.ResourceCPU] = resource.MustParse(cpu)
-	}
-	if memory != "" {
-		res[core.ResourceMemory] = resource.MustParse(memory)
-	}
-	return res
-}
-
-func getStorageResourceList(storage string) core.ResourceList {
-	res := core.ResourceList{}
-	if storage != "" {
-		res[core.ResourceStorage] = resource.MustParse(storage)
-	}
-	return res
-}
-
-func getLocalStorageResourceList(ephemeralStorage string) core.ResourceList {
-	res := core.ResourceList{}
-	if ephemeralStorage != "" {
-		res[core.ResourceEphemeralStorage] = resource.MustParse(ephemeralStorage)
-	}
-	return res
-}
-
 func TestValidateLimitRangeForLocalStorage(t *testing.T) {
 	testCases := []struct {
 		name string
@@ -18700,16 +18669,16 @@ func TestValidateLimitRangeForLocalStorage(t *testing.T) {
 		spec: core.LimitRangeSpec{
 			Limits: []core.LimitRangeItem{{
 				Type:                 core.LimitTypePod,
-				Max:                  getLocalStorageResourceList("10000Mi"),
-				Min:                  getLocalStorageResourceList("100Mi"),
-				MaxLimitRequestRatio: getLocalStorageResourceList(""),
+				Max:                  getResources("", "", "10000Mi", ""),
+				Min:                  getResources("", "", "100Mi", ""),
+				MaxLimitRequestRatio: getResources("", "", "", ""),
 			}, {
 				Type:                 core.LimitTypeContainer,
-				Max:                  getLocalStorageResourceList("10000Mi"),
-				Min:                  getLocalStorageResourceList("100Mi"),
-				Default:              getLocalStorageResourceList("500Mi"),
-				DefaultRequest:       getLocalStorageResourceList("200Mi"),
-				MaxLimitRequestRatio: getLocalStorageResourceList(""),
+				Max:                  getResources("", "", "10000Mi", ""),
+				Min:                  getResources("", "", "100Mi", ""),
+				Default:              getResources("", "", "500Mi", ""),
+				DefaultRequest:       getResources("", "", "200Mi", ""),
+				MaxLimitRequestRatio: getResources("", "", "", ""),
 			}},
 		},
 	},
@@ -18732,20 +18701,20 @@ func TestValidateLimitRange(t *testing.T) {
 		spec: core.LimitRangeSpec{
 			Limits: []core.LimitRangeItem{{
 				Type:                 core.LimitTypePod,
-				Max:                  getResourceList("100m", "10000Mi"),
-				Min:                  getResourceList("5m", "100Mi"),
-				MaxLimitRequestRatio: getResourceList("10", ""),
+				Max:                  getResources("100m", "10000Mi", "", ""),
+				Min:                  getResources("5m", "100Mi", "", ""),
+				MaxLimitRequestRatio: getResources("10", "", "", ""),
 			}, {
 				Type:                 core.LimitTypeContainer,
-				Max:                  getResourceList("100m", "10000Mi"),
-				Min:                  getResourceList("5m", "100Mi"),
-				Default:              getResourceList("50m", "500Mi"),
-				DefaultRequest:       getResourceList("10m", "200Mi"),
-				MaxLimitRequestRatio: getResourceList("10", ""),
+				Max:                  getResources("100m", "10000Mi", "", ""),
+				Min:                  getResources("5m", "100Mi", "", ""),
+				Default:              getResources("50m", "500Mi", "", ""),
+				DefaultRequest:       getResources("10m", "200Mi", "", ""),
+				MaxLimitRequestRatio: getResources("10", "", "", ""),
 			}, {
 				Type: core.LimitTypePersistentVolumeClaim,
-				Max:  getStorageResourceList("10Gi"),
-				Min:  getStorageResourceList("5Gi"),
+				Max:  getResources("", "", "", "10Gi"),
+				Min:  getResources("", "", "", "5Gi"),
 			}},
 		},
 	}, {
@@ -18753,7 +18722,7 @@ func TestValidateLimitRange(t *testing.T) {
 		spec: core.LimitRangeSpec{
 			Limits: []core.LimitRangeItem{{
 				Type: core.LimitTypePersistentVolumeClaim,
-				Min:  getStorageResourceList("5Gi"),
+				Min:  getResources("", "", "", "5Gi"),
 			}},
 		},
 	}, {
@@ -18761,7 +18730,7 @@ func TestValidateLimitRange(t *testing.T) {
 		spec: core.LimitRangeSpec{
 			Limits: []core.LimitRangeItem{{
 				Type: core.LimitTypePersistentVolumeClaim,
-				Max:  getStorageResourceList("10Gi"),
+				Max:  getResources("", "", "", "10Gi"),
 			}},
 		},
 	}, {
@@ -18769,11 +18738,11 @@ func TestValidateLimitRange(t *testing.T) {
 		spec: core.LimitRangeSpec{
 			Limits: []core.LimitRangeItem{{
 				Type:                 core.LimitTypeContainer,
-				Max:                  getResourceList("100m", "10000T"),
-				Min:                  getResourceList("5m", "100Mi"),
-				Default:              getResourceList("50m", "500Mi"),
-				DefaultRequest:       getResourceList("10m", "200Mi"),
-				MaxLimitRequestRatio: getResourceList("10", ""),
+				Max:                  getResources("100m", "10000T", "", ""),
+				Min:                  getResources("5m", "100Mi", "", ""),
+				Default:              getResources("50m", "500Mi", "", ""),
+				DefaultRequest:       getResources("10m", "200Mi", "", ""),
+				MaxLimitRequestRatio: getResources("10", "", "", ""),
 			}},
 		},
 	}, {
@@ -18781,11 +18750,11 @@ func TestValidateLimitRange(t *testing.T) {
 		spec: core.LimitRangeSpec{
 			Limits: []core.LimitRangeItem{{
 				Type:                 "thirdparty.com/foo",
-				Max:                  getResourceList("100m", "10000T"),
-				Min:                  getResourceList("5m", "100Mi"),
-				Default:              getResourceList("50m", "500Mi"),
-				DefaultRequest:       getResourceList("10m", "200Mi"),
-				MaxLimitRequestRatio: getResourceList("10", ""),
+				Max:                  getResources("100m", "10000T", "", ""),
+				Min:                  getResources("5m", "100Mi", "", ""),
+				Default:              getResources("50m", "500Mi", "", ""),
+				DefaultRequest:       getResources("10m", "200Mi", "", ""),
+				MaxLimitRequestRatio: getResources("10", "", "", ""),
 			}},
 		},
 	}, {
@@ -18793,11 +18762,11 @@ func TestValidateLimitRange(t *testing.T) {
 		spec: core.LimitRangeSpec{
 			Limits: []core.LimitRangeItem{{
 				Type:                 "thirdparty.com/foo",
-				Max:                  getStorageResourceList("10000T"),
-				Min:                  getStorageResourceList("100Mi"),
-				Default:              getStorageResourceList("500Mi"),
-				DefaultRequest:       getStorageResourceList("200Mi"),
-				MaxLimitRequestRatio: getStorageResourceList(""),
+				Max:                  getResources("", "", "", "10000T"),
+				Min:                  getResources("", "", "", "100Mi"),
+				Default:              getResources("", "", "", "500Mi"),
+				DefaultRequest:       getResources("", "", "", "200Mi"),
+				MaxLimitRequestRatio: getResources("", "", "", ""),
 			}},
 		},
 	},
@@ -18834,11 +18803,11 @@ func TestValidateLimitRange(t *testing.T) {
 			core.LimitRange{ObjectMeta: metav1.ObjectMeta{Name: "abc", Namespace: "foo"}, Spec: core.LimitRangeSpec{
 				Limits: []core.LimitRangeItem{{
 					Type: core.LimitTypePod,
-					Max:  getResourceList("100m", "10000m"),
-					Min:  getResourceList("0m", "100m"),
+					Max:  getResources("100m", "10000m", "", ""),
+					Min:  getResources("0m", "100m", "", ""),
 				}, {
 					Type: core.LimitTypePod,
-					Min:  getResourceList("0m", "100m"),
+					Min:  getResources("0m", "100m", "", ""),
 				}},
 			}},
 			"",
@@ -18847,9 +18816,9 @@ func TestValidateLimitRange(t *testing.T) {
 			core.LimitRange{ObjectMeta: metav1.ObjectMeta{Name: "abc", Namespace: "foo"}, Spec: core.LimitRangeSpec{
 				Limits: []core.LimitRangeItem{{
 					Type:    core.LimitTypePod,
-					Max:     getResourceList("100m", "10000m"),
-					Min:     getResourceList("0m", "100m"),
-					Default: getResourceList("10m", "100m"),
+					Max:     getResources("100m", "10000m", "", ""),
+					Min:     getResources("0m", "100m", "", ""),
+					Default: getResources("10m", "100m", "", ""),
 				}},
 			}},
 			"may not be specified when `type` is 'Pod'",
@@ -18858,9 +18827,9 @@ func TestValidateLimitRange(t *testing.T) {
 			core.LimitRange{ObjectMeta: metav1.ObjectMeta{Name: "abc", Namespace: "foo"}, Spec: core.LimitRangeSpec{
 				Limits: []core.LimitRangeItem{{
 					Type:           core.LimitTypePod,
-					Max:            getResourceList("100m", "10000m"),
-					Min:            getResourceList("0m", "100m"),
-					DefaultRequest: getResourceList("10m", "100m"),
+					Max:            getResources("100m", "10000m", "", ""),
+					Min:            getResources("0m", "100m", "", ""),
+					DefaultRequest: getResources("10m", "100m", "", ""),
 				}},
 			}},
 			"may not be specified when `type` is 'Pod'",
@@ -18869,8 +18838,8 @@ func TestValidateLimitRange(t *testing.T) {
 			core.LimitRange{ObjectMeta: metav1.ObjectMeta{Name: "abc", Namespace: "foo"}, Spec: core.LimitRangeSpec{
 				Limits: []core.LimitRangeItem{{
 					Type: core.LimitTypePod,
-					Max:  getResourceList("10m", ""),
-					Min:  getResourceList("100m", ""),
+					Max:  getResources("10m", "", "", ""),
+					Min:  getResources("100m", "", "", ""),
 				}},
 			}},
 			"min value 100m is greater than max value 10m",
@@ -18879,9 +18848,9 @@ func TestValidateLimitRange(t *testing.T) {
 			core.LimitRange{ObjectMeta: metav1.ObjectMeta{Name: "abc", Namespace: "foo"}, Spec: core.LimitRangeSpec{
 				Limits: []core.LimitRangeItem{{
 					Type:    core.LimitTypeContainer,
-					Max:     getResourceList("1", ""),
-					Min:     getResourceList("100m", ""),
-					Default: getResourceList("2000m", ""),
+					Max:     getResources("1", "", "", ""),
+					Min:     getResources("100m", "", "", ""),
+					Default: getResources("2000m", "", "", ""),
 				}},
 			}},
 			"default value 2 is greater than max value 1",
@@ -18890,9 +18859,9 @@ func TestValidateLimitRange(t *testing.T) {
 			core.LimitRange{ObjectMeta: metav1.ObjectMeta{Name: "abc", Namespace: "foo"}, Spec: core.LimitRangeSpec{
 				Limits: []core.LimitRangeItem{{
 					Type:           core.LimitTypeContainer,
-					Max:            getResourceList("1", ""),
-					Min:            getResourceList("100m", ""),
-					DefaultRequest: getResourceList("2000m", ""),
+					Max:            getResources("1", "", "", ""),
+					Min:            getResources("100m", "", "", ""),
+					DefaultRequest: getResources("2000m", "", "", ""),
 				}},
 			}},
 			"default request value 2 is greater than max value 1",
@@ -18901,10 +18870,10 @@ func TestValidateLimitRange(t *testing.T) {
 			core.LimitRange{ObjectMeta: metav1.ObjectMeta{Name: "abc", Namespace: "foo"}, Spec: core.LimitRangeSpec{
 				Limits: []core.LimitRangeItem{{
 					Type:           core.LimitTypeContainer,
-					Max:            getResourceList("2", ""),
-					Min:            getResourceList("100m", ""),
-					Default:        getResourceList("500m", ""),
-					DefaultRequest: getResourceList("800m", ""),
+					Max:            getResources("2", "", "", ""),
+					Min:            getResources("100m", "", "", ""),
+					Default:        getResources("500m", "", "", ""),
+					DefaultRequest: getResources("800m", "", "", ""),
 				}},
 			}},
 			"default request value 800m is greater than default limit value 500m",
@@ -18913,7 +18882,7 @@ func TestValidateLimitRange(t *testing.T) {
 			core.LimitRange{ObjectMeta: metav1.ObjectMeta{Name: "abc", Namespace: "foo"}, Spec: core.LimitRangeSpec{
 				Limits: []core.LimitRangeItem{{
 					Type:                 core.LimitTypePod,
-					MaxLimitRequestRatio: getResourceList("800m", ""),
+					MaxLimitRequestRatio: getResources("800m", "", "", ""),
 				}},
 			}},
 			"ratio 800m is less than 1",
@@ -18922,9 +18891,9 @@ func TestValidateLimitRange(t *testing.T) {
 			core.LimitRange{ObjectMeta: metav1.ObjectMeta{Name: "abc", Namespace: "foo"}, Spec: core.LimitRangeSpec{
 				Limits: []core.LimitRangeItem{{
 					Type:                 core.LimitTypeContainer,
-					Max:                  getResourceList("", "2Gi"),
-					Min:                  getResourceList("", "512Mi"),
-					MaxLimitRequestRatio: getResourceList("", "10"),
+					Max:                  getResources("", "2Gi", "", ""),
+					Min:                  getResources("", "512Mi", "", ""),
+					MaxLimitRequestRatio: getResources("", "10", "", ""),
 				}},
 			}},
 			"ratio 10 is greater than max/min = 4.000000",
@@ -18933,11 +18902,11 @@ func TestValidateLimitRange(t *testing.T) {
 			core.LimitRange{ObjectMeta: metav1.ObjectMeta{Name: "abc", Namespace: "foo"}, Spec: core.LimitRangeSpec{
 				Limits: []core.LimitRangeItem{{
 					Type:                 "foo",
-					Max:                  getStorageResourceList("10000T"),
-					Min:                  getStorageResourceList("100Mi"),
-					Default:              getStorageResourceList("500Mi"),
-					DefaultRequest:       getStorageResourceList("200Mi"),
-					MaxLimitRequestRatio: getStorageResourceList(""),
+					Max:                  getResources("", "", "", "10000T"),
+					Min:                  getResources("", "", "", "100Mi"),
+					Default:              getResources("", "", "", "500Mi"),
+					DefaultRequest:       getResources("", "", "", "200Mi"),
+					MaxLimitRequestRatio: getResources("", "", "", ""),
 				}},
 			}},
 			"must be a standard limit type or fully qualified",
@@ -18954,8 +18923,8 @@ func TestValidateLimitRange(t *testing.T) {
 			core.LimitRange{ObjectMeta: metav1.ObjectMeta{Name: "abc", Namespace: "foo"}, Spec: core.LimitRangeSpec{
 				Limits: []core.LimitRangeItem{{
 					Type: core.LimitTypePersistentVolumeClaim,
-					Min:  getStorageResourceList("10Gi"),
-					Max:  getStorageResourceList("1Gi"),
+					Min:  getResources("", "", "", "10Gi"),
+					Max:  getResources("", "", "", "1Gi"),
 				}},
 			}},
 			"min value 10Gi is greater than max value 1Gi",
@@ -25002,255 +24971,110 @@ func TestValidateContainerStatusAllocatedResourcesStatus(t *testing.T) {
 }
 
 func TestValidatePodResize(t *testing.T) {
+	mkPod := func(req, lim core.ResourceList, tweaks ...podtest.TweakContainer) *core.Pod {
+		return podtest.MakePod("pod",
+			podtest.SetContainers(
+				podtest.MakeContainer(
+					"container",
+					append(tweaks,
+						podtest.SetContainerResources(
+							core.ResourceRequirements{
+								Requests: req,
+								Limits:   lim,
+							},
+						),
+					)...,
+				),
+			),
+		)
+	}
+
 	tests := []struct {
-		new  core.Pod
-		old  core.Pod
-		err  string
 		test string
+		old  *core.Pod
+		new  *core.Pod
+		err  string
 	}{
 		{
-			new: *podtest.MakePod("pod",
-				podtest.SetContainers(podtest.MakeContainer("container",
-					podtest.SetContainerResources(core.ResourceRequirements{
-						Limits: getResources("200m", "0", "1Gi"),
-					}))),
-			),
-			old: *podtest.MakePod("pod",
-				podtest.SetContainers(podtest.MakeContainer("container",
-					podtest.SetContainerResources(core.ResourceRequirements{
-						Limits: getResources("100m", "0", "1Gi"),
-					}))),
-			),
-			err:  "",
 			test: "cpu limit change",
-		}, {
-			new: *podtest.MakePod("pod",
-				podtest.SetContainers(podtest.MakeContainer("container",
-					podtest.SetContainerResources(core.ResourceRequirements{
-						Limits: getResourceLimits("100m", "100Mi"),
-					}))),
-			),
-			old: *podtest.MakePod("pod",
-				podtest.SetContainers(podtest.MakeContainer("container",
-					podtest.SetContainerResources(core.ResourceRequirements{
-						Limits: getResourceLimits("100m", "200Mi"),
-					}))),
-			),
+			old:  mkPod(core.ResourceList{}, getResources("100m", "0", "1Gi", "")),
+			new:  mkPod(core.ResourceList{}, getResources("200m", "0", "1Gi", "")),
 			err:  "",
+		}, {
 			test: "memory limit change",
+			old:  mkPod(core.ResourceList{}, getResources("100m", "200Mi", "", "")),
+			new:  mkPod(core.ResourceList{}, getResources("100m", "100Mi", "", "")),
+			err:  "",
 		}, {
-			new: *podtest.MakePod("pod",
-				podtest.SetContainers(podtest.MakeContainer("container",
-					podtest.SetContainerResources(core.ResourceRequirements{
-						Limits: getResources("100m", "100Mi", "1Gi"),
-					}))),
-			),
-			old: *podtest.MakePod("pod",
-				podtest.SetContainers(podtest.MakeContainer("container",
-					podtest.SetContainerResources(core.ResourceRequirements{
-						Limits: getResources("100m", "100Mi", "2Gi"),
-					}))),
-			),
-			err:  "spec: Forbidden: pod resize may not change fields other than cpu and memory",
 			test: "storage limit change",
-		}, {
-			new: *podtest.MakePod("pod",
-				podtest.SetContainers(podtest.MakeContainer("container",
-					podtest.SetContainerResources(core.ResourceRequirements{
-						Requests: getResourceLimits("100m", "0"),
-					}))),
-			),
-			old: *podtest.MakePod("pod",
-				podtest.SetContainers(podtest.MakeContainer("container",
-					podtest.SetContainerResources(core.ResourceRequirements{
-						Requests: getResourceLimits("200m", "0"),
-					}))),
-			),
-			err:  "",
-			test: "cpu request change",
-		}, {
-			new: *podtest.MakePod("pod",
-				podtest.SetContainers(podtest.MakeContainer("container",
-					podtest.SetContainerResources(core.ResourceRequirements{
-						Requests: getResourceLimits("0", "200Mi"),
-					}))),
-			),
-			old: *podtest.MakePod("pod",
-				podtest.SetContainers(podtest.MakeContainer("container",
-					podtest.SetContainerResources(core.ResourceRequirements{
-						Requests: getResourceLimits("0", "100Mi"),
-					}))),
-			),
-			err:  "",
-			test: "memory request change",
-		}, {
-			new: *podtest.MakePod("pod",
-				podtest.SetContainers(podtest.MakeContainer("container",
-					podtest.SetContainerResources(core.ResourceRequirements{
-						Requests: getResources("100m", "0", "2Gi"),
-					}))),
-			),
-			old: *podtest.MakePod("pod",
-				podtest.SetContainers(podtest.MakeContainer("container",
-					podtest.SetContainerResources(core.ResourceRequirements{
-						Requests: getResources("100m", "0", "1Gi"),
-					}))),
-			),
+			old:  mkPod(core.ResourceList{}, getResources("100m", "100Mi", "2Gi", "")),
+			new:  mkPod(core.ResourceList{}, getResources("100m", "100Mi", "1Gi", "")),
 			err:  "spec: Forbidden: pod resize may not change fields other than cpu and memory",
+		}, {
+			test: "cpu request change",
+			old:  mkPod(getResources("200m", "0", "", ""), core.ResourceList{}),
+			new:  mkPod(getResources("100m", "0", "", ""), core.ResourceList{}),
+			err:  "",
+		}, {
+			test: "memory request change",
+			old:  mkPod(getResources("0", "100Mi", "", ""), core.ResourceList{}),
+			new:  mkPod(getResources("0", "200Mi", "", ""), core.ResourceList{}),
+			err:  "",
+		}, {
 			test: "storage request change",
+			old:  mkPod(getResources("100m", "0", "1Gi", ""), core.ResourceList{}),
+			new:  mkPod(getResources("100m", "0", "2Gi", ""), core.ResourceList{}),
+			err:  "spec: Forbidden: pod resize may not change fields other than cpu and memory",
 		}, {
-			new: *podtest.MakePod("pod",
-				podtest.SetContainers(podtest.MakeContainer("container",
-					podtest.SetContainerResources(core.ResourceRequirements{
-						Limits:   getResources("200m", "400Mi", "1Gi"),
-						Requests: getResources("200m", "400Mi", "1Gi"),
-					}))),
-			),
-			old: *podtest.MakePod("pod",
-				podtest.SetContainers(podtest.MakeContainer("container",
-					podtest.SetContainerResources(core.ResourceRequirements{
-						Limits:   getResources("100m", "100Mi", "1Gi"),
-						Requests: getResources("100m", "100Mi", "1Gi"),
-					}))),
-			),
-			err:  "",
 			test: "Pod QoS unchanged, guaranteed -> guaranteed",
-		}, {
-			new: *podtest.MakePod("pod",
-				podtest.SetContainers(podtest.MakeContainer("container",
-					podtest.SetContainerResources(core.ResourceRequirements{
-						Limits:   getResources("200m", "200Mi", "2Gi"),
-						Requests: getResources("100m", "100Mi", "1Gi"),
-					}))),
-			),
-			old: *podtest.MakePod("pod",
-				podtest.SetContainers(podtest.MakeContainer("container",
-					podtest.SetContainerResources(core.ResourceRequirements{
-						Limits:   getResources("400m", "400Mi", "2Gi"),
-						Requests: getResources("200m", "200Mi", "1Gi"),
-					}))),
-			),
+			old:  mkPod(getResources("100m", "100Mi", "1Gi", ""), getResources("100m", "100Mi", "1Gi", "")),
+			new:  mkPod(getResources("200m", "400Mi", "1Gi", ""), getResources("200m", "400Mi", "1Gi", "")),
 			err:  "",
+		}, {
 			test: "Pod QoS unchanged, burstable -> burstable",
-		}, {
-			new: *podtest.MakePod("pod",
-				podtest.SetContainers(podtest.MakeContainer("container",
-					podtest.SetContainerResources(core.ResourceRequirements{
-						Limits:   getResourceLimits("200m", "200Mi"),
-						Requests: getResourceLimits("100m", "100Mi"),
-					}))),
-			),
-			old: *podtest.MakePod("pod",
-				podtest.SetContainers(podtest.MakeContainer("container",
-					podtest.SetContainerResources(core.ResourceRequirements{
-						Requests: getResourceLimits("100m", "100Mi"),
-					}))),
-			),
+			old:  mkPod(getResources("200m", "200Mi", "1Gi", ""), getResources("400m", "400Mi", "2Gi", "")),
+			new:  mkPod(getResources("100m", "100Mi", "1Gi", ""), getResources("200m", "200Mi", "2Gi", "")),
 			err:  "",
+		}, {
 			test: "Pod QoS unchanged, burstable -> burstable, add limits",
-		}, {
-			new: *podtest.MakePod("pod",
-				podtest.SetContainers(podtest.MakeContainer("container",
-					podtest.SetContainerResources(core.ResourceRequirements{
-						Requests: getResourceLimits("100m", "100Mi"),
-					}))),
-			),
-			old: *podtest.MakePod("pod",
-				podtest.SetContainers(podtest.MakeContainer("container",
-					podtest.SetContainerResources(core.ResourceRequirements{
-						Limits:   getResourceLimits("200m", "200Mi"),
-						Requests: getResourceLimits("100m", "100Mi"),
-					}))),
-			),
+			old:  mkPod(getResources("100m", "100Mi", "", ""), core.ResourceList{}),
+			new:  mkPod(getResources("100m", "100Mi", "", ""), getResources("200m", "200Mi", "", "")),
 			err:  "",
+		}, {
 			test: "Pod QoS unchanged, burstable -> burstable, remove limits",
-		}, {
-			new: *podtest.MakePod("pod",
-				podtest.SetContainers(podtest.MakeContainer("container",
-					podtest.SetContainerResources(core.ResourceRequirements{
-						Limits:   getResources("400m", "", "1Gi"),
-						Requests: getResources("300m", "", "1Gi"),
-					}))),
-			),
-			old: *podtest.MakePod("pod",
-				podtest.SetContainers(podtest.MakeContainer("container",
-					podtest.SetContainerResources(core.ResourceRequirements{
-						Limits: getResources("200m", "500Mi", "1Gi"),
-					}))),
-			),
+			old:  mkPod(getResources("100m", "100Mi", "", ""), getResources("200m", "200Mi", "", "")),
+			new:  mkPod(getResources("100m", "100Mi", "", ""), core.ResourceList{}),
 			err:  "",
+		}, {
 			test: "Pod QoS unchanged, burstable -> burstable, add requests",
-		}, {
-			new: *podtest.MakePod("pod",
-				podtest.SetContainers(podtest.MakeContainer("container",
-					podtest.SetContainerResources(core.ResourceRequirements{
-						Limits: getResources("400m", "500Mi", "2Gi"),
-					}))),
-			),
-			old: *podtest.MakePod("pod",
-				podtest.SetContainers(podtest.MakeContainer("container",
-					podtest.SetContainerResources(core.ResourceRequirements{
-						Limits:   getResources("200m", "300Mi", "2Gi"),
-						Requests: getResourceLimits("100m", "200Mi"),
-					}))),
-			),
+			old:  mkPod(core.ResourceList{}, getResources("200m", "500Mi", "1Gi", "")),
+			new:  mkPod(getResources("300m", "", "", ""), getResources("400m", "", "1Gi", "")),
 			err:  "",
+		}, {
 			test: "Pod QoS unchanged, burstable -> burstable, remove requests",
+			old:  mkPod(getResources("100m", "200Mi", "", ""), getResources("200m", "300Mi", "2Gi", "")),
+			new:  mkPod(core.ResourceList{}, getResources("400m", "500Mi", "2Gi", "")),
+			err:  "",
 		}, {
-			new: *podtest.MakePod("pod",
-				podtest.SetContainers(podtest.MakeContainer("container",
-					podtest.SetContainerResources(core.ResourceRequirements{
-						Limits:   getResourceLimits("200m", "200Mi"),
-						Requests: getResourceLimits("100m", "100Mi"),
-					}))),
-			),
-			old: *podtest.MakePod("pod",
-				podtest.SetContainers(podtest.MakeContainer("container",
-					podtest.SetContainerResources(core.ResourceRequirements{
-						Limits:   getResourceLimits("100m", "100Mi"),
-						Requests: getResourceLimits("100m", "100Mi"),
-					}))),
-			),
-			err:  "Pod QOS Class must not change",
 			test: "Pod QoS change, guaranteed -> burstable",
+			old:  mkPod(getResources("100m", "100Mi", "", ""), getResources("100m", "100Mi", "", "")),
+			new:  mkPod(getResources("100m", "100Mi", "", ""), getResources("200m", "200Mi", "", "")),
+			err:  "Pod QOS Class may not change as a result of resizing",
 		}, {
-			new: *podtest.MakePod("pod",
-				podtest.SetContainers(podtest.MakeContainer("container",
-					podtest.SetContainerResources(core.ResourceRequirements{
-						Limits:   getResourceLimits("100m", "100Mi"),
-						Requests: getResourceLimits("100m", "100Mi"),
-					}))),
-			),
-			old: *podtest.MakePod("pod",
-				podtest.SetContainers(podtest.MakeContainer("container",
-					podtest.SetContainerResources(core.ResourceRequirements{
-						Requests: getResourceLimits("100m", "100Mi"),
-					}))),
-			),
-			err:  "Pod QOS Class must not change",
 			test: "Pod QoS change, burstable -> guaranteed",
+			old:  mkPod(getResources("100m", "100Mi", "", ""), core.ResourceList{}),
+			new:  mkPod(getResources("100m", "100Mi", "", ""), getResources("100m", "100Mi", "", "")),
+			err:  "Pod QOS Class may not change as a result of resizing",
 		}, {
-			new: *podtest.MakePod("pod",
-				podtest.SetContainers(podtest.MakeContainer("container",
-					podtest.SetContainerResources(core.ResourceRequirements{
-						Limits:   getResourceLimits("200m", "200Mi"),
-						Requests: getResourceLimits("100m", "100Mi"),
-					}))),
-			),
-			old:  *podtest.MakePod("pod"),
-			err:  "Pod QOS Class must not change",
 			test: "Pod QoS change, besteffort -> burstable",
+			old:  mkPod(core.ResourceList{}, core.ResourceList{}),
+			new:  mkPod(getResources("100m", "100Mi", "", ""), getResources("200m", "200Mi", "", "")),
+			err:  "Pod QOS Class may not change as a result of resizing",
 		}, {
-			new: *podtest.MakePod("pod"),
-			old: *podtest.MakePod("pod",
-				podtest.SetContainers(podtest.MakeContainer("container",
-					podtest.SetContainerResources(core.ResourceRequirements{
-						Limits:   getResourceLimits("200m", "200Mi"),
-						Requests: getResourceLimits("100m", "100Mi"),
-					}))),
-			),
-			err:  "Pod QOS Class must not change",
 			test: "Pod QoS change, burstable -> besteffort",
+			old:  mkPod(getResources("100m", "100Mi", "", ""), getResources("200m", "200Mi", "", "")),
+			new:  mkPod(core.ResourceList{}, core.ResourceList{}),
+			err:  "Pod QOS Class may not change as a result of resizing",
 		},
 	}
 
@@ -25280,7 +25104,7 @@ func TestValidatePodResize(t *testing.T) {
 			test.old.Spec.RestartPolicy = "Always"
 		}
 
-		errs := ValidatePodResize(&test.new, &test.old, PodValidationOptions{})
+		errs := ValidatePodResize(test.new, test.old, PodValidationOptions{})
 		if test.err == "" {
 			if len(errs) != 0 {
 				t.Errorf("unexpected invalid: %s (%+v)\nA: %+v\nB: %+v", test.test, errs, test.new, test.old)

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -24990,95 +24990,120 @@ func TestValidatePodResize(t *testing.T) {
 	}
 
 	tests := []struct {
-		test string
-		old  *core.Pod
-		new  *core.Pod
-		err  string
+		test                            string
+		old                             *core.Pod
+		new                             *core.Pod
+		enableInPlacePodVerticalScaling bool
+		err                             string
 	}{
 		{
-			test: "cpu limit change",
-			old:  mkPod(core.ResourceList{}, getResources("100m", "0", "1Gi", "")),
-			new:  mkPod(core.ResourceList{}, getResources("200m", "0", "1Gi", "")),
-			err:  "",
+			test:                            "cpu limit change",
+			old:                             mkPod(core.ResourceList{}, getResources("100m", "0", "1Gi", "")),
+			new:                             mkPod(core.ResourceList{}, getResources("200m", "0", "1Gi", "")),
+			enableInPlacePodVerticalScaling: true,
+			err:                             "",
 		}, {
-			test: "memory limit change",
-			old:  mkPod(core.ResourceList{}, getResources("100m", "200Mi", "", "")),
-			new:  mkPod(core.ResourceList{}, getResources("100m", "100Mi", "", "")),
-			err:  "",
+			test:                            "memory limit change",
+			old:                             mkPod(core.ResourceList{}, getResources("100m", "200Mi", "", "")),
+			new:                             mkPod(core.ResourceList{}, getResources("100m", "100Mi", "", "")),
+			enableInPlacePodVerticalScaling: true,
+			err:                             "",
 		}, {
-			test: "storage limit change",
-			old:  mkPod(core.ResourceList{}, getResources("100m", "100Mi", "2Gi", "")),
-			new:  mkPod(core.ResourceList{}, getResources("100m", "100Mi", "1Gi", "")),
-			err:  "spec: Forbidden: only cpu and memory resources are mutable",
+			test:                            "memory limit change without feature gate enabled",
+			old:                             mkPod(core.ResourceList{}, getResources("100m", "200Mi", "", "")),
+			new:                             mkPod(core.ResourceList{}, getResources("100m", "100Mi", "", "")),
+			enableInPlacePodVerticalScaling: false,
+			err:                             "spec: Forbidden: Pod running on node without IPPVS enabled may not be updated",
 		}, {
-			test: "cpu request change",
-			old:  mkPod(getResources("200m", "0", "", ""), core.ResourceList{}),
-			new:  mkPod(getResources("100m", "0", "", ""), core.ResourceList{}),
-			err:  "",
+			test:                            "storage limit change",
+			old:                             mkPod(core.ResourceList{}, getResources("100m", "100Mi", "2Gi", "")),
+			new:                             mkPod(core.ResourceList{}, getResources("100m", "100Mi", "1Gi", "")),
+			enableInPlacePodVerticalScaling: true,
+			err:                             "spec: Forbidden: only cpu and memory resources are mutable",
 		}, {
-			test: "memory request change",
-			old:  mkPod(getResources("0", "100Mi", "", ""), core.ResourceList{}),
-			new:  mkPod(getResources("0", "200Mi", "", ""), core.ResourceList{}),
-			err:  "",
+			test:                            "cpu request change",
+			old:                             mkPod(getResources("200m", "0", "", ""), core.ResourceList{}),
+			new:                             mkPod(getResources("100m", "0", "", ""), core.ResourceList{}),
+			enableInPlacePodVerticalScaling: true,
+			err:                             "",
 		}, {
-			test: "storage request change",
-			old:  mkPod(getResources("100m", "0", "1Gi", ""), core.ResourceList{}),
-			new:  mkPod(getResources("100m", "0", "2Gi", ""), core.ResourceList{}),
-			err:  "spec: Forbidden: only cpu and memory resources are mutable",
+			test:                            "memory request change",
+			old:                             mkPod(getResources("0", "100Mi", "", ""), core.ResourceList{}),
+			new:                             mkPod(getResources("0", "200Mi", "", ""), core.ResourceList{}),
+			enableInPlacePodVerticalScaling: true,
+			err:                             "",
 		}, {
-			test: "Pod QoS unchanged, guaranteed -> guaranteed",
-			old:  mkPod(getResources("100m", "100Mi", "1Gi", ""), getResources("100m", "100Mi", "1Gi", "")),
-			new:  mkPod(getResources("200m", "400Mi", "1Gi", ""), getResources("200m", "400Mi", "1Gi", "")),
-			err:  "",
+			test:                            "storage request change",
+			old:                             mkPod(getResources("100m", "0", "1Gi", ""), core.ResourceList{}),
+			new:                             mkPod(getResources("100m", "0", "2Gi", ""), core.ResourceList{}),
+			enableInPlacePodVerticalScaling: true,
+			err:                             "spec: Forbidden: only cpu and memory resources are mutable",
 		}, {
-			test: "Pod QoS unchanged, burstable -> burstable",
-			old:  mkPod(getResources("200m", "200Mi", "1Gi", ""), getResources("400m", "400Mi", "2Gi", "")),
-			new:  mkPod(getResources("100m", "100Mi", "1Gi", ""), getResources("200m", "200Mi", "2Gi", "")),
-			err:  "",
+			test:                            "Pod QoS unchanged, guaranteed -> guaranteed",
+			old:                             mkPod(getResources("100m", "100Mi", "1Gi", ""), getResources("100m", "100Mi", "1Gi", "")),
+			new:                             mkPod(getResources("200m", "400Mi", "1Gi", ""), getResources("200m", "400Mi", "1Gi", "")),
+			enableInPlacePodVerticalScaling: true,
+			err:                             "",
 		}, {
-			test: "Pod QoS unchanged, burstable -> burstable, add limits",
-			old:  mkPod(getResources("100m", "100Mi", "", ""), core.ResourceList{}),
-			new:  mkPod(getResources("100m", "100Mi", "", ""), getResources("200m", "200Mi", "", "")),
-			err:  "",
+			test:                            "Pod QoS unchanged, burstable -> burstable",
+			old:                             mkPod(getResources("200m", "200Mi", "1Gi", ""), getResources("400m", "400Mi", "2Gi", "")),
+			new:                             mkPod(getResources("100m", "100Mi", "1Gi", ""), getResources("200m", "200Mi", "2Gi", "")),
+			enableInPlacePodVerticalScaling: true,
+			err:                             "",
 		}, {
-			test: "Pod QoS unchanged, burstable -> burstable, remove limits",
-			old:  mkPod(getResources("100m", "100Mi", "", ""), getResources("200m", "200Mi", "", "")),
-			new:  mkPod(getResources("100m", "100Mi", "", ""), core.ResourceList{}),
-			err:  "",
+			test:                            "Pod QoS unchanged, burstable -> burstable, add limits",
+			old:                             mkPod(getResources("100m", "100Mi", "", ""), core.ResourceList{}),
+			new:                             mkPod(getResources("100m", "100Mi", "", ""), getResources("200m", "200Mi", "", "")),
+			enableInPlacePodVerticalScaling: true,
+			err:                             "",
 		}, {
-			test: "Pod QoS unchanged, burstable -> burstable, add requests",
-			old:  mkPod(core.ResourceList{}, getResources("200m", "500Mi", "1Gi", "")),
-			new:  mkPod(getResources("300m", "", "", ""), getResources("400m", "", "1Gi", "")),
-			err:  "",
+			test:                            "Pod QoS unchanged, burstable -> burstable, remove limits",
+			old:                             mkPod(getResources("100m", "100Mi", "", ""), getResources("200m", "200Mi", "", "")),
+			new:                             mkPod(getResources("100m", "100Mi", "", ""), core.ResourceList{}),
+			enableInPlacePodVerticalScaling: true,
+			err:                             "",
 		}, {
-			test: "Pod QoS unchanged, burstable -> burstable, remove requests",
-			old:  mkPod(getResources("100m", "200Mi", "", ""), getResources("200m", "300Mi", "2Gi", "")),
-			new:  mkPod(core.ResourceList{}, getResources("400m", "500Mi", "2Gi", "")),
-			err:  "",
+			test:                            "Pod QoS unchanged, burstable -> burstable, add requests",
+			old:                             mkPod(core.ResourceList{}, getResources("200m", "500Mi", "1Gi", "")),
+			new:                             mkPod(getResources("300m", "", "", ""), getResources("400m", "", "1Gi", "")),
+			enableInPlacePodVerticalScaling: true,
+			err:                             "",
 		}, {
-			test: "Pod QoS change, guaranteed -> burstable",
-			old:  mkPod(getResources("100m", "100Mi", "", ""), getResources("100m", "100Mi", "", "")),
-			new:  mkPod(getResources("100m", "100Mi", "", ""), getResources("200m", "200Mi", "", "")),
-			err:  "Pod QOS Class may not change as a result of resizing",
+			test:                            "Pod QoS unchanged, burstable -> burstable, remove requests",
+			old:                             mkPod(getResources("100m", "200Mi", "", ""), getResources("200m", "300Mi", "2Gi", "")),
+			new:                             mkPod(core.ResourceList{}, getResources("400m", "500Mi", "2Gi", "")),
+			enableInPlacePodVerticalScaling: true,
+			err:                             "",
 		}, {
-			test: "Pod QoS change, burstable -> guaranteed",
-			old:  mkPod(getResources("100m", "100Mi", "", ""), core.ResourceList{}),
-			new:  mkPod(getResources("100m", "100Mi", "", ""), getResources("100m", "100Mi", "", "")),
-			err:  "Pod QOS Class may not change as a result of resizing",
+			test:                            "Pod QoS change, guaranteed -> burstable",
+			old:                             mkPod(getResources("100m", "100Mi", "", ""), getResources("100m", "100Mi", "", "")),
+			new:                             mkPod(getResources("100m", "100Mi", "", ""), getResources("200m", "200Mi", "", "")),
+			enableInPlacePodVerticalScaling: true,
+			err:                             "Pod QOS Class may not change as a result of resizing",
 		}, {
-			test: "Pod QoS change, besteffort -> burstable",
-			old:  mkPod(core.ResourceList{}, core.ResourceList{}),
-			new:  mkPod(getResources("100m", "100Mi", "", ""), getResources("200m", "200Mi", "", "")),
-			err:  "Pod QOS Class may not change as a result of resizing",
+			test:                            "Pod QoS change, burstable -> guaranteed",
+			old:                             mkPod(getResources("100m", "100Mi", "", ""), core.ResourceList{}),
+			new:                             mkPod(getResources("100m", "100Mi", "", ""), getResources("100m", "100Mi", "", "")),
+			enableInPlacePodVerticalScaling: true,
+			err:                             "Pod QOS Class may not change as a result of resizing",
 		}, {
-			test: "Pod QoS change, burstable -> besteffort",
-			old:  mkPod(getResources("100m", "100Mi", "", ""), getResources("200m", "200Mi", "", "")),
-			new:  mkPod(core.ResourceList{}, core.ResourceList{}),
-			err:  "Pod QOS Class may not change as a result of resizing",
+			test:                            "Pod QoS change, besteffort -> burstable",
+			old:                             mkPod(core.ResourceList{}, core.ResourceList{}),
+			new:                             mkPod(getResources("100m", "100Mi", "", ""), getResources("200m", "200Mi", "", "")),
+			enableInPlacePodVerticalScaling: true,
+			err:                             "Pod QOS Class may not change as a result of resizing",
+		}, {
+			test:                            "Pod QoS change, burstable -> besteffort",
+			old:                             mkPod(getResources("100m", "100Mi", "", ""), getResources("200m", "200Mi", "", "")),
+			new:                             mkPod(core.ResourceList{}, core.ResourceList{}),
+			enableInPlacePodVerticalScaling: true,
+			err:                             "Pod QOS Class may not change as a result of resizing",
 		},
 	}
 
 	for _, test := range tests {
+		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScaling, test.enableInPlacePodVerticalScaling)
+
 		test.new.ObjectMeta.ResourceVersion = "1"
 		test.old.ObjectMeta.ResourceVersion = "1"
 

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -25211,7 +25211,7 @@ func TestValidatePodResize(t *testing.T) {
 						Requests: getResourceLimits("100m", "100Mi"),
 					}))),
 			),
-			err:  "Pod QoS is immutable",
+			err:  "Pod QOS Class must not change",
 			test: "Pod QoS change, guaranteed -> burstable",
 		}, {
 			new: *podtest.MakePod("pod",
@@ -25227,7 +25227,7 @@ func TestValidatePodResize(t *testing.T) {
 						Requests: getResourceLimits("100m", "100Mi"),
 					}))),
 			),
-			err:  "Pod QoS is immutable",
+			err:  "Pod QOS Class must not change",
 			test: "Pod QoS change, burstable -> guaranteed",
 		}, {
 			new: *podtest.MakePod("pod",
@@ -25238,7 +25238,7 @@ func TestValidatePodResize(t *testing.T) {
 					}))),
 			),
 			old:  *podtest.MakePod("pod"),
-			err:  "Pod QoS is immutable",
+			err:  "Pod QOS Class must not change",
 			test: "Pod QoS change, besteffort -> burstable",
 		}, {
 			new: *podtest.MakePod("pod"),
@@ -25249,7 +25249,7 @@ func TestValidatePodResize(t *testing.T) {
 						Requests: getResourceLimits("100m", "100Mi"),
 					}))),
 			),
-			err:  "Pod QoS is immutable",
+			err:  "Pod QOS Class must not change",
 			test: "Pod QoS change, burstable -> besteffort",
 		},
 	}

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -12493,7 +12493,7 @@ func TestValidatePodUpdate(t *testing.T) {
 						Limits: getResources("100m", "0", "1Gi"),
 					}))),
 			),
-			err:  "",
+			err:  "spec: Forbidden: pod updates may not change fields",
 			test: "cpu limit change",
 		}, {
 			new: *podtest.MakePod("pod",
@@ -12508,7 +12508,7 @@ func TestValidatePodUpdate(t *testing.T) {
 						Limits: getResourceLimits("100m", "200Mi"),
 					}))),
 			),
-			err:  "",
+			err:  "spec: Forbidden: pod updates may not change fields",
 			test: "memory limit change",
 		}, {
 			new: *podtest.MakePod("pod",
@@ -12538,7 +12538,7 @@ func TestValidatePodUpdate(t *testing.T) {
 						Requests: getResourceLimits("200m", "0"),
 					}))),
 			),
-			err:  "",
+			err:  "spec: Forbidden: pod updates may not change fields",
 			test: "cpu request change",
 		}, {
 			new: *podtest.MakePod("pod",
@@ -12553,7 +12553,7 @@ func TestValidatePodUpdate(t *testing.T) {
 						Requests: getResourceLimits("0", "100Mi"),
 					}))),
 			),
-			err:  "",
+			err:  "spec: Forbidden: pod updates may not change fields",
 			test: "memory request change",
 		}, {
 			new: *podtest.MakePod("pod",
@@ -12585,7 +12585,7 @@ func TestValidatePodUpdate(t *testing.T) {
 						Requests: getResources("100m", "100Mi", "1Gi"),
 					}))),
 			),
-			err:  "",
+			err:  "spec: Forbidden: pod updates may not change fields",
 			test: "Pod QoS unchanged, guaranteed -> guaranteed",
 		}, {
 			new: *podtest.MakePod("pod",
@@ -12602,7 +12602,7 @@ func TestValidatePodUpdate(t *testing.T) {
 						Requests: getResources("200m", "200Mi", "1Gi"),
 					}))),
 			),
-			err:  "",
+			err:  "spec: Forbidden: pod updates may not change fields",
 			test: "Pod QoS unchanged, burstable -> burstable",
 		}, {
 			new: *podtest.MakePod("pod",
@@ -12618,7 +12618,7 @@ func TestValidatePodUpdate(t *testing.T) {
 						Requests: getResourceLimits("100m", "100Mi"),
 					}))),
 			),
-			err:  "",
+			err:  "spec: Forbidden: pod updates may not change fields",
 			test: "Pod QoS unchanged, burstable -> burstable, add limits",
 		}, {
 			new: *podtest.MakePod("pod",
@@ -12634,7 +12634,7 @@ func TestValidatePodUpdate(t *testing.T) {
 						Requests: getResourceLimits("100m", "100Mi"),
 					}))),
 			),
-			err:  "",
+			err:  "spec: Forbidden: pod updates may not change fields",
 			test: "Pod QoS unchanged, burstable -> burstable, remove limits",
 		}, {
 			new: *podtest.MakePod("pod",
@@ -12650,7 +12650,7 @@ func TestValidatePodUpdate(t *testing.T) {
 						Limits: getResources("200m", "500Mi", "1Gi"),
 					}))),
 			),
-			err:  "",
+			err:  "spec: Forbidden: pod updates may not change fields",
 			test: "Pod QoS unchanged, burstable -> burstable, add requests",
 		}, {
 			new: *podtest.MakePod("pod",
@@ -12666,7 +12666,7 @@ func TestValidatePodUpdate(t *testing.T) {
 						Requests: getResourceLimits("100m", "200Mi"),
 					}))),
 			),
-			err:  "",
+			err:  "spec: Forbidden: pod updates may not change fields",
 			test: "Pod QoS unchanged, burstable -> burstable, remove requests",
 		}, {
 			new: *podtest.MakePod("pod",
@@ -12683,7 +12683,7 @@ func TestValidatePodUpdate(t *testing.T) {
 						Requests: getResourceLimits("100m", "100Mi"),
 					}))),
 			),
-			err:  "Pod QoS is immutable",
+			err:  "spec: Forbidden: pod updates may not change fields",
 			test: "Pod QoS change, guaranteed -> burstable",
 		}, {
 			new: *podtest.MakePod("pod",
@@ -12699,7 +12699,7 @@ func TestValidatePodUpdate(t *testing.T) {
 						Requests: getResourceLimits("100m", "100Mi"),
 					}))),
 			),
-			err:  "Pod QoS is immutable",
+			err:  "spec: Forbidden: pod updates may not change fields",
 			test: "Pod QoS change, burstable -> guaranteed",
 		}, {
 			new: *podtest.MakePod("pod",
@@ -12710,7 +12710,7 @@ func TestValidatePodUpdate(t *testing.T) {
 					}))),
 			),
 			old:  *podtest.MakePod("pod"),
-			err:  "Pod QoS is immutable",
+			err:  "spec: Forbidden: pod updates may not change fields",
 			test: "Pod QoS change, besteffort -> burstable",
 		}, {
 			new: *podtest.MakePod("pod"),
@@ -12721,7 +12721,7 @@ func TestValidatePodUpdate(t *testing.T) {
 						Requests: getResourceLimits("100m", "100Mi"),
 					}))),
 			),
-			err:  "Pod QoS is immutable",
+			err:  "spec: Forbidden: pod updates may not change fields",
 			test: "Pod QoS change, burstable -> besteffort",
 		}, {
 			new: *podtest.MakePod("pod",
@@ -24998,5 +24998,299 @@ func TestValidateContainerStatusAllocatedResourcesStatus(t *testing.T) {
 				t.Errorf("unexpected field errors (-want, +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestValidatePodResize(t *testing.T) {
+	tests := []struct {
+		new  core.Pod
+		old  core.Pod
+		err  string
+		test string
+	}{
+		{
+			new: *podtest.MakePod("pod",
+				podtest.SetContainers(podtest.MakeContainer("container",
+					podtest.SetContainerResources(core.ResourceRequirements{
+						Limits: getResources("200m", "0", "1Gi"),
+					}))),
+			),
+			old: *podtest.MakePod("pod",
+				podtest.SetContainers(podtest.MakeContainer("container",
+					podtest.SetContainerResources(core.ResourceRequirements{
+						Limits: getResources("100m", "0", "1Gi"),
+					}))),
+			),
+			err:  "",
+			test: "cpu limit change",
+		}, {
+			new: *podtest.MakePod("pod",
+				podtest.SetContainers(podtest.MakeContainer("container",
+					podtest.SetContainerResources(core.ResourceRequirements{
+						Limits: getResourceLimits("100m", "100Mi"),
+					}))),
+			),
+			old: *podtest.MakePod("pod",
+				podtest.SetContainers(podtest.MakeContainer("container",
+					podtest.SetContainerResources(core.ResourceRequirements{
+						Limits: getResourceLimits("100m", "200Mi"),
+					}))),
+			),
+			err:  "",
+			test: "memory limit change",
+		}, {
+			new: *podtest.MakePod("pod",
+				podtest.SetContainers(podtest.MakeContainer("container",
+					podtest.SetContainerResources(core.ResourceRequirements{
+						Limits: getResources("100m", "100Mi", "1Gi"),
+					}))),
+			),
+			old: *podtest.MakePod("pod",
+				podtest.SetContainers(podtest.MakeContainer("container",
+					podtest.SetContainerResources(core.ResourceRequirements{
+						Limits: getResources("100m", "100Mi", "2Gi"),
+					}))),
+			),
+			err:  "spec: Forbidden: pod resize may not change fields other than cpu and memory",
+			test: "storage limit change",
+		}, {
+			new: *podtest.MakePod("pod",
+				podtest.SetContainers(podtest.MakeContainer("container",
+					podtest.SetContainerResources(core.ResourceRequirements{
+						Requests: getResourceLimits("100m", "0"),
+					}))),
+			),
+			old: *podtest.MakePod("pod",
+				podtest.SetContainers(podtest.MakeContainer("container",
+					podtest.SetContainerResources(core.ResourceRequirements{
+						Requests: getResourceLimits("200m", "0"),
+					}))),
+			),
+			err:  "",
+			test: "cpu request change",
+		}, {
+			new: *podtest.MakePod("pod",
+				podtest.SetContainers(podtest.MakeContainer("container",
+					podtest.SetContainerResources(core.ResourceRequirements{
+						Requests: getResourceLimits("0", "200Mi"),
+					}))),
+			),
+			old: *podtest.MakePod("pod",
+				podtest.SetContainers(podtest.MakeContainer("container",
+					podtest.SetContainerResources(core.ResourceRequirements{
+						Requests: getResourceLimits("0", "100Mi"),
+					}))),
+			),
+			err:  "",
+			test: "memory request change",
+		}, {
+			new: *podtest.MakePod("pod",
+				podtest.SetContainers(podtest.MakeContainer("container",
+					podtest.SetContainerResources(core.ResourceRequirements{
+						Requests: getResources("100m", "0", "2Gi"),
+					}))),
+			),
+			old: *podtest.MakePod("pod",
+				podtest.SetContainers(podtest.MakeContainer("container",
+					podtest.SetContainerResources(core.ResourceRequirements{
+						Requests: getResources("100m", "0", "1Gi"),
+					}))),
+			),
+			err:  "spec: Forbidden: pod resize may not change fields other than cpu and memory",
+			test: "storage request change",
+		}, {
+			new: *podtest.MakePod("pod",
+				podtest.SetContainers(podtest.MakeContainer("container",
+					podtest.SetContainerResources(core.ResourceRequirements{
+						Limits:   getResources("200m", "400Mi", "1Gi"),
+						Requests: getResources("200m", "400Mi", "1Gi"),
+					}))),
+			),
+			old: *podtest.MakePod("pod",
+				podtest.SetContainers(podtest.MakeContainer("container",
+					podtest.SetContainerResources(core.ResourceRequirements{
+						Limits:   getResources("100m", "100Mi", "1Gi"),
+						Requests: getResources("100m", "100Mi", "1Gi"),
+					}))),
+			),
+			err:  "",
+			test: "Pod QoS unchanged, guaranteed -> guaranteed",
+		}, {
+			new: *podtest.MakePod("pod",
+				podtest.SetContainers(podtest.MakeContainer("container",
+					podtest.SetContainerResources(core.ResourceRequirements{
+						Limits:   getResources("200m", "200Mi", "2Gi"),
+						Requests: getResources("100m", "100Mi", "1Gi"),
+					}))),
+			),
+			old: *podtest.MakePod("pod",
+				podtest.SetContainers(podtest.MakeContainer("container",
+					podtest.SetContainerResources(core.ResourceRequirements{
+						Limits:   getResources("400m", "400Mi", "2Gi"),
+						Requests: getResources("200m", "200Mi", "1Gi"),
+					}))),
+			),
+			err:  "",
+			test: "Pod QoS unchanged, burstable -> burstable",
+		}, {
+			new: *podtest.MakePod("pod",
+				podtest.SetContainers(podtest.MakeContainer("container",
+					podtest.SetContainerResources(core.ResourceRequirements{
+						Limits:   getResourceLimits("200m", "200Mi"),
+						Requests: getResourceLimits("100m", "100Mi"),
+					}))),
+			),
+			old: *podtest.MakePod("pod",
+				podtest.SetContainers(podtest.MakeContainer("container",
+					podtest.SetContainerResources(core.ResourceRequirements{
+						Requests: getResourceLimits("100m", "100Mi"),
+					}))),
+			),
+			err:  "",
+			test: "Pod QoS unchanged, burstable -> burstable, add limits",
+		}, {
+			new: *podtest.MakePod("pod",
+				podtest.SetContainers(podtest.MakeContainer("container",
+					podtest.SetContainerResources(core.ResourceRequirements{
+						Requests: getResourceLimits("100m", "100Mi"),
+					}))),
+			),
+			old: *podtest.MakePod("pod",
+				podtest.SetContainers(podtest.MakeContainer("container",
+					podtest.SetContainerResources(core.ResourceRequirements{
+						Limits:   getResourceLimits("200m", "200Mi"),
+						Requests: getResourceLimits("100m", "100Mi"),
+					}))),
+			),
+			err:  "",
+			test: "Pod QoS unchanged, burstable -> burstable, remove limits",
+		}, {
+			new: *podtest.MakePod("pod",
+				podtest.SetContainers(podtest.MakeContainer("container",
+					podtest.SetContainerResources(core.ResourceRequirements{
+						Limits:   getResources("400m", "", "1Gi"),
+						Requests: getResources("300m", "", "1Gi"),
+					}))),
+			),
+			old: *podtest.MakePod("pod",
+				podtest.SetContainers(podtest.MakeContainer("container",
+					podtest.SetContainerResources(core.ResourceRequirements{
+						Limits: getResources("200m", "500Mi", "1Gi"),
+					}))),
+			),
+			err:  "",
+			test: "Pod QoS unchanged, burstable -> burstable, add requests",
+		}, {
+			new: *podtest.MakePod("pod",
+				podtest.SetContainers(podtest.MakeContainer("container",
+					podtest.SetContainerResources(core.ResourceRequirements{
+						Limits: getResources("400m", "500Mi", "2Gi"),
+					}))),
+			),
+			old: *podtest.MakePod("pod",
+				podtest.SetContainers(podtest.MakeContainer("container",
+					podtest.SetContainerResources(core.ResourceRequirements{
+						Limits:   getResources("200m", "300Mi", "2Gi"),
+						Requests: getResourceLimits("100m", "200Mi"),
+					}))),
+			),
+			err:  "",
+			test: "Pod QoS unchanged, burstable -> burstable, remove requests",
+		}, {
+			new: *podtest.MakePod("pod",
+				podtest.SetContainers(podtest.MakeContainer("container",
+					podtest.SetContainerResources(core.ResourceRequirements{
+						Limits:   getResourceLimits("200m", "200Mi"),
+						Requests: getResourceLimits("100m", "100Mi"),
+					}))),
+			),
+			old: *podtest.MakePod("pod",
+				podtest.SetContainers(podtest.MakeContainer("container",
+					podtest.SetContainerResources(core.ResourceRequirements{
+						Limits:   getResourceLimits("100m", "100Mi"),
+						Requests: getResourceLimits("100m", "100Mi"),
+					}))),
+			),
+			err:  "Pod QoS is immutable",
+			test: "Pod QoS change, guaranteed -> burstable",
+		}, {
+			new: *podtest.MakePod("pod",
+				podtest.SetContainers(podtest.MakeContainer("container",
+					podtest.SetContainerResources(core.ResourceRequirements{
+						Limits:   getResourceLimits("100m", "100Mi"),
+						Requests: getResourceLimits("100m", "100Mi"),
+					}))),
+			),
+			old: *podtest.MakePod("pod",
+				podtest.SetContainers(podtest.MakeContainer("container",
+					podtest.SetContainerResources(core.ResourceRequirements{
+						Requests: getResourceLimits("100m", "100Mi"),
+					}))),
+			),
+			err:  "Pod QoS is immutable",
+			test: "Pod QoS change, burstable -> guaranteed",
+		}, {
+			new: *podtest.MakePod("pod",
+				podtest.SetContainers(podtest.MakeContainer("container",
+					podtest.SetContainerResources(core.ResourceRequirements{
+						Limits:   getResourceLimits("200m", "200Mi"),
+						Requests: getResourceLimits("100m", "100Mi"),
+					}))),
+			),
+			old:  *podtest.MakePod("pod"),
+			err:  "Pod QoS is immutable",
+			test: "Pod QoS change, besteffort -> burstable",
+		}, {
+			new: *podtest.MakePod("pod"),
+			old: *podtest.MakePod("pod",
+				podtest.SetContainers(podtest.MakeContainer("container",
+					podtest.SetContainerResources(core.ResourceRequirements{
+						Limits:   getResourceLimits("200m", "200Mi"),
+						Requests: getResourceLimits("100m", "100Mi"),
+					}))),
+			),
+			err:  "Pod QoS is immutable",
+			test: "Pod QoS change, burstable -> besteffort",
+		},
+	}
+
+	for _, test := range tests {
+		test.new.ObjectMeta.ResourceVersion = "1"
+		test.old.ObjectMeta.ResourceVersion = "1"
+
+		// set required fields if old and new match and have no opinion on the value
+		if test.new.Name == "" && test.old.Name == "" {
+			test.new.Name = "name"
+			test.old.Name = "name"
+		}
+		if test.new.Namespace == "" && test.old.Namespace == "" {
+			test.new.Namespace = "namespace"
+			test.old.Namespace = "namespace"
+		}
+		if test.new.Spec.Containers == nil && test.old.Spec.Containers == nil {
+			test.new.Spec.Containers = []core.Container{{Name: "autoadded", Image: "image", TerminationMessagePolicy: "File", ImagePullPolicy: "Always"}}
+			test.old.Spec.Containers = []core.Container{{Name: "autoadded", Image: "image", TerminationMessagePolicy: "File", ImagePullPolicy: "Always"}}
+		}
+		if len(test.new.Spec.DNSPolicy) == 0 && len(test.old.Spec.DNSPolicy) == 0 {
+			test.new.Spec.DNSPolicy = core.DNSClusterFirst
+			test.old.Spec.DNSPolicy = core.DNSClusterFirst
+		}
+		if len(test.new.Spec.RestartPolicy) == 0 && len(test.old.Spec.RestartPolicy) == 0 {
+			test.new.Spec.RestartPolicy = "Always"
+			test.old.Spec.RestartPolicy = "Always"
+		}
+
+		errs := ValidatePodResize(&test.new, &test.old, PodValidationOptions{})
+		if test.err == "" {
+			if len(errs) != 0 {
+				t.Errorf("unexpected invalid: %s (%+v)\nA: %+v\nB: %+v", test.test, errs, test.new, test.old)
+			}
+		} else {
+			if len(errs) == 0 {
+				t.Errorf("unexpected valid: %s\nA: %+v\nB: %+v", test.test, test.new, test.old)
+			} else if actualErr := errs.ToAggregate().Error(); !strings.Contains(actualErr, test.err) {
+				t.Errorf("unexpected error message: %s\nExpected error: %s\nActual error: %s", test.test, test.err, actualErr)
+			}
+		}
 	}
 }

--- a/pkg/quota/v1/evaluator/core/persistent_volume_claims.go
+++ b/pkg/quota/v1/evaluator/core/persistent_volume_claims.go
@@ -90,14 +90,11 @@ func (p *pvcEvaluator) GroupResource() schema.GroupResource {
 
 // Handles returns true if the evaluator should handle the specified operation.
 func (p *pvcEvaluator) Handles(a admission.Attributes) bool {
+	if a.GetSubresource() != "" {
+		return false
+	}
 	op := a.GetOperation()
-	if op == admission.Create {
-		return true
-	}
-	if op == admission.Update {
-		return true
-	}
-	return false
+	return admission.Create == op || admission.Update == op
 }
 
 // Matches returns true if the evaluator matches the specified quota with the provided input item

--- a/pkg/quota/v1/evaluator/core/pods.go
+++ b/pkg/quota/v1/evaluator/core/pods.go
@@ -155,14 +155,11 @@ func (p *podEvaluator) GroupResource() schema.GroupResource {
 
 // Handles returns true if the evaluator should handle the specified attributes.
 func (p *podEvaluator) Handles(a admission.Attributes) bool {
+	if a.GetSubresource() != "" && a.GetSubresource() != "resize" {
+		return false
+	}
 	op := a.GetOperation()
-	if op == admission.Create {
-		return true
-	}
-	if feature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) && op == admission.Update {
-		return true
-	}
-	return false
+	return op == admission.Create || (a.GetSubresource() == "resize" && op == admission.Update)
 }
 
 // Matches returns true if the evaluator matches the specified quota with the provided input item

--- a/pkg/quota/v1/evaluator/core/pods_test.go
+++ b/pkg/quota/v1/evaluator/core/pods_test.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/admission"
 	quota "k8s.io/apiserver/pkg/quota/v1"
 	"k8s.io/apiserver/pkg/quota/v1/generic"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -1187,5 +1188,60 @@ func makePod(name, pcName string, resList api.ResourceList, phase api.PodPhase) 
 		Status: api.PodStatus{
 			Phase: phase,
 		},
+	}
+}
+
+func TestPodEvaluatorHandles(t *testing.T) {
+	fakeClock := testingclock.NewFakeClock(time.Now())
+	evaluator := NewPodEvaluator(nil, fakeClock)
+	testCases := []struct {
+		name  string
+		attrs admission.Attributes
+		want  bool
+	}{
+		{
+			name:  "create",
+			attrs: admission.NewAttributesRecord(nil, nil, schema.GroupVersionKind{Group: "core", Version: "v1", Kind: "Pod"}, "", "", schema.GroupVersionResource{Group: "core", Version: "v1", Resource: "pods"}, "", admission.Create, nil, false, nil),
+			want:  true,
+		},
+		{
+			name:  "update",
+			attrs: admission.NewAttributesRecord(nil, nil, schema.GroupVersionKind{Group: "core", Version: "v1", Kind: "Pod"}, "", "", schema.GroupVersionResource{Group: "core", Version: "v1", Resource: "pods"}, "", admission.Update, nil, false, nil),
+			want:  false,
+		},
+		{
+			name:  "delete",
+			attrs: admission.NewAttributesRecord(nil, nil, schema.GroupVersionKind{Group: "core", Version: "v1", Kind: "Pod"}, "", "", schema.GroupVersionResource{Group: "core", Version: "v1", Resource: "pods"}, "", admission.Delete, nil, false, nil),
+			want:  false,
+		},
+		{
+			name:  "connect",
+			attrs: admission.NewAttributesRecord(nil, nil, schema.GroupVersionKind{Group: "core", Version: "v1", Kind: "Pod"}, "", "", schema.GroupVersionResource{Group: "core", Version: "v1", Resource: "pods"}, "", admission.Connect, nil, false, nil),
+			want:  false,
+		},
+		{
+			name:  "create-subresource",
+			attrs: admission.NewAttributesRecord(nil, nil, schema.GroupVersionKind{Group: "core", Version: "v1", Kind: "Pod"}, "", "", schema.GroupVersionResource{Group: "core", Version: "v1", Resource: "pods"}, "subresource", admission.Create, nil, false, nil),
+			want:  false,
+		},
+		{
+			name:  "update-subresource",
+			attrs: admission.NewAttributesRecord(nil, nil, schema.GroupVersionKind{Group: "core", Version: "v1", Kind: "Pod"}, "", "", schema.GroupVersionResource{Group: "core", Version: "v1", Resource: "pods"}, "subresource", admission.Update, nil, false, nil),
+			want:  false,
+		},
+		{
+			name:  "update-resize",
+			attrs: admission.NewAttributesRecord(nil, nil, schema.GroupVersionKind{Group: "core", Version: "v1", Kind: "Pod"}, "", "", schema.GroupVersionResource{Group: "core", Version: "v1", Resource: "pods"}, "resize", admission.Update, nil, false, nil),
+			want:  true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := evaluator.Handles(tc.attrs)
+
+			if tc.want != actual {
+				t.Errorf("%s expected:\n%v\n, actual:\n%v", tc.name, tc.want, actual)
+			}
+		})
 	}
 }

--- a/pkg/quota/v1/evaluator/core/resource_claims.go
+++ b/pkg/quota/v1/evaluator/core/resource_claims.go
@@ -68,14 +68,11 @@ func (p *claimEvaluator) GroupResource() schema.GroupResource {
 
 // Handles returns true if the evaluator should handle the specified operation.
 func (p *claimEvaluator) Handles(a admission.Attributes) bool {
+	if a.GetSubresource() != "" {
+		return false
+	}
 	op := a.GetOperation()
-	if op == admission.Create {
-		return true
-	}
-	if op == admission.Update {
-		return true
-	}
-	return false
+	return admission.Create == op || admission.Update == op
 }
 
 // Matches returns true if the evaluator matches the specified quota with the provided input item

--- a/pkg/quota/v1/evaluator/core/services.go
+++ b/pkg/quota/v1/evaluator/core/services.go
@@ -67,6 +67,9 @@ func (p *serviceEvaluator) GroupResource() schema.GroupResource {
 
 // Handles returns true of the evaluator should handle the specified operation.
 func (p *serviceEvaluator) Handles(a admission.Attributes) bool {
+	if a.GetSubresource() != "" {
+		return false
+	}
 	operation := a.GetOperation()
 	// We handle create and update because a service type can change.
 	return admission.Create == operation || admission.Update == operation

--- a/pkg/quota/v1/evaluator/core/services_test.go
+++ b/pkg/quota/v1/evaluator/core/services_test.go
@@ -22,6 +22,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/admission"
 	quota "k8s.io/apiserver/pkg/quota/v1"
 	"k8s.io/apiserver/pkg/quota/v1/generic"
 	api "k8s.io/kubernetes/pkg/apis/core"
@@ -328,5 +329,54 @@ func TestServiceConstraintsFunc(t *testing.T) {
 			err != nil && test.err != err.Error():
 			t.Errorf("%s unexpected error: %v", testName, err)
 		}
+	}
+}
+
+func TestServiceEvaluatorHandles(t *testing.T) {
+	evaluator := NewServiceEvaluator(nil)
+	testCases := []struct {
+		name  string
+		attrs admission.Attributes
+		want  bool
+	}{
+		{
+			name:  "create",
+			attrs: admission.NewAttributesRecord(nil, nil, schema.GroupVersionKind{Group: "core", Version: "v1", Kind: "Pod"}, "", "", schema.GroupVersionResource{Group: "core", Version: "v1", Resource: "pods"}, "", admission.Create, nil, false, nil),
+			want:  true,
+		},
+		{
+			name:  "update",
+			attrs: admission.NewAttributesRecord(nil, nil, schema.GroupVersionKind{Group: "core", Version: "v1", Kind: "Pod"}, "", "", schema.GroupVersionResource{Group: "core", Version: "v1", Resource: "pods"}, "", admission.Update, nil, false, nil),
+			want:  true,
+		},
+		{
+			name:  "delete",
+			attrs: admission.NewAttributesRecord(nil, nil, schema.GroupVersionKind{Group: "core", Version: "v1", Kind: "Pod"}, "", "", schema.GroupVersionResource{Group: "core", Version: "v1", Resource: "pods"}, "", admission.Delete, nil, false, nil),
+			want:  false,
+		},
+		{
+			name:  "connect",
+			attrs: admission.NewAttributesRecord(nil, nil, schema.GroupVersionKind{Group: "core", Version: "v1", Kind: "Pod"}, "", "", schema.GroupVersionResource{Group: "core", Version: "v1", Resource: "pods"}, "", admission.Connect, nil, false, nil),
+			want:  false,
+		},
+		{
+			name:  "create-subresource",
+			attrs: admission.NewAttributesRecord(nil, nil, schema.GroupVersionKind{Group: "core", Version: "v1", Kind: "Pod"}, "", "", schema.GroupVersionResource{Group: "core", Version: "v1", Resource: "pods"}, "subresource", admission.Create, nil, false, nil),
+			want:  false,
+		},
+		{
+			name:  "update-subresource",
+			attrs: admission.NewAttributesRecord(nil, nil, schema.GroupVersionKind{Group: "core", Version: "v1", Kind: "Pod"}, "", "", schema.GroupVersionResource{Group: "core", Version: "v1", Resource: "pods"}, "subresource", admission.Update, nil, false, nil),
+			want:  false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := evaluator.Handles(tc.attrs)
+
+			if tc.want != actual {
+				t.Errorf("%s expected:\n%v\n, actual:\n%v", tc.name, tc.want, actual)
+			}
+		})
 	}
 }

--- a/pkg/registry/core/pod/strategy.go
+++ b/pkg/registry/core/pod/strategy.go
@@ -101,15 +101,6 @@ func (podStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object
 	newPod := obj.(*api.Pod)
 	oldPod := old.(*api.Pod)
 	newPod.Status = oldPod.Status
-
-	if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {
-		// With support for in-place pod resizing, container resources are now mutable.
-		// If container resources are updated with new resource requests values, a pod resize is
-		// desired. The status of this request is reflected by setting Resize field to "Proposed"
-		// as a signal to the caller that the request is being considered.
-		podutil.MarkPodProposedForResize(oldPod, newPod)
-	}
-
 	podutil.DropDisabledPodFields(newPod, oldPod)
 }
 
@@ -278,6 +269,34 @@ func (podEphemeralContainersStrategy) ValidateUpdate(ctx context.Context, obj, o
 
 // WarningsOnUpdate returns warnings for the given update.
 func (podEphemeralContainersStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object) []string {
+	return nil
+}
+
+type podResizeStrategy struct {
+	podStrategy
+}
+
+// ResizeStrategy wraps and exports the used podStrategy for the storage package.
+var ResizeStrategy = podResizeStrategy{Strategy}
+
+func (podResizeStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
+	newPod := obj.(*api.Pod)
+	oldPod := old.(*api.Pod)
+
+	podutil.MarkPodProposedForResize(oldPod, newPod)
+	podutil.DropDisabledPodFields(newPod, oldPod)
+}
+
+func (podResizeStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
+	newPod := obj.(*api.Pod)
+	oldPod := old.(*api.Pod)
+	opts := podutil.GetValidationOptionsFromPodSpecAndMeta(&newPod.Spec, &oldPod.Spec, &newPod.ObjectMeta, &oldPod.ObjectMeta)
+	opts.ResourceIsPod = true
+	return nil 
+}
+
+// WarningsOnUpdate returns warnings for the given update.
+func (podResizeStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object) []string {
 	return nil
 }
 

--- a/pkg/registry/core/pod/strategy.go
+++ b/pkg/registry/core/pod/strategy.go
@@ -316,6 +316,17 @@ func (podResizeStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.
 	return nil
 }
 
+// GetResetFieldsFilter returns a set of fields filter reset by the strategy
+// and should not be modified by the user.
+func (podResizeStrategy) GetResetFieldsFilter() map[fieldpath.APIVersion]fieldpath.Filter {
+	return map[fieldpath.APIVersion]fieldpath.Filter{
+		"v1": fieldpath.NewIncludeMatcherFilter(
+			fieldpath.MakePrefixMatcherOrDie("spec", "containers", fieldpath.MatchAnyPathElement(), "resources"),
+			fieldpath.MakePrefixMatcherOrDie("spec", "containers", fieldpath.MatchAnyPathElement(), "resizePolicy"),
+		),
+	}
+}
+
 // dropPodUpdates drops any changes in the pod.
 func dropPodUpdates(newPod, oldPod *api.Pod) *api.Pod {
 	pod := oldPod.DeepCopy()

--- a/pkg/registry/core/pod/strategy.go
+++ b/pkg/registry/core/pod/strategy.go
@@ -242,7 +242,7 @@ var EphemeralContainersStrategy = podEphemeralContainersStrategy{Strategy}
 
 // dropNonEphemeralContainerUpdates discards all changes except for pod.Spec.EphemeralContainers and certain metadata
 func dropNonEphemeralContainerUpdates(newPod, oldPod *api.Pod) *api.Pod {
-	pod := mungePod(newPod, oldPod)
+	pod := dropPodUpdates(newPod, oldPod)
 	pod.Spec.EphemeralContainers = newPod.Spec.EphemeralContainers
 	return pod
 }
@@ -277,7 +277,7 @@ var ResizeStrategy = podResizeStrategy{Strategy}
 
 // dropNonPodResizeUpdates discards all changes except for pod.Spec.Containers[*].Resources,ResizePolicy and certain metadata
 func dropNonPodResizeUpdates(newPod, oldPod *api.Pod) *api.Pod {
-	pod := mungePod(newPod, oldPod)
+	pod := dropPodUpdates(newPod, oldPod)
 
 	oldCtrToIndex := make(map[string]int)
 	for idx, ctr := range pod.Spec.Containers {
@@ -316,8 +316,8 @@ func (podResizeStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.
 	return nil
 }
 
-// mungePod mutates metadata information of old pod with the new pod.
-func mungePod(newPod, oldPod *api.Pod) *api.Pod {
+// dropPodUpdates drops any changes in the pod.
+func dropPodUpdates(newPod, oldPod *api.Pod) *api.Pod {
 	pod := oldPod.DeepCopy()
 	pod.Name = newPod.Name
 	pod.Namespace = newPod.Namespace

--- a/pkg/registry/core/pod/strategy.go
+++ b/pkg/registry/core/pod/strategy.go
@@ -242,11 +242,7 @@ var EphemeralContainersStrategy = podEphemeralContainersStrategy{Strategy}
 
 // dropNonEphemeralContainerUpdates discards all changes except for pod.Spec.EphemeralContainers and certain metadata
 func dropNonEphemeralContainerUpdates(newPod, oldPod *api.Pod) *api.Pod {
-	pod := oldPod.DeepCopy()
-	pod.Name = newPod.Name
-	pod.Namespace = newPod.Namespace
-	pod.ResourceVersion = newPod.ResourceVersion
-	pod.UID = newPod.UID
+	pod := mungePod(newPod, oldPod)
 	pod.Spec.EphemeralContainers = newPod.Spec.EphemeralContainers
 	return pod
 }
@@ -281,11 +277,7 @@ var ResizeStrategy = podResizeStrategy{Strategy}
 
 // dropNonPodResizeUpdates discards all changes except for pod.Spec.Containers[*].Resources,ResizePolicy and certain metadata
 func dropNonPodResizeUpdates(newPod, oldPod *api.Pod) *api.Pod {
-	pod := oldPod.DeepCopy()
-	pod.Name = newPod.Name
-	pod.Namespace = newPod.Namespace
-	pod.ResourceVersion = newPod.ResourceVersion
-	pod.UID = newPod.UID
+	pod := mungePod(newPod, oldPod)
 
 	oldCtrToIndex := make(map[string]int)
 	for idx, ctr := range pod.Spec.Containers {
@@ -322,6 +314,17 @@ func (podResizeStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Ob
 // WarningsOnUpdate returns warnings for the given update.
 func (podResizeStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object) []string {
 	return nil
+}
+
+// mungePod mutates metadata information of old pod with the new pod.
+func mungePod(newPod, oldPod *api.Pod) *api.Pod {
+	pod := oldPod.DeepCopy()
+	pod.Name = newPod.Name
+	pod.Namespace = newPod.Namespace
+	pod.ResourceVersion = newPod.ResourceVersion
+	pod.UID = newPod.UID
+
+	return pod
 }
 
 // GetAttrs returns labels and fields of a given object for filtering purposes.

--- a/pkg/registry/core/pod/strategy.go
+++ b/pkg/registry/core/pod/strategy.go
@@ -316,7 +316,7 @@ func (podResizeStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Ob
 	oldPod := old.(*api.Pod)
 	opts := podutil.GetValidationOptionsFromPodSpecAndMeta(&newPod.Spec, &oldPod.Spec, &newPod.ObjectMeta, &oldPod.ObjectMeta)
 	opts.ResourceIsPod = true
-	return nil 
+	return corevalidation.ValidatePodResize(newPod, oldPod, opts)
 }
 
 // WarningsOnUpdate returns warnings for the given update.

--- a/pkg/registry/core/pod/strategy_test.go
+++ b/pkg/registry/core/pod/strategy_test.go
@@ -2459,498 +2459,450 @@ func TestPodResizePrepareForUpdate(t *testing.T) {
 	}{
 		{
 			name: "no resize",
-			oldPod: &api.Pod{
-				Spec: api.PodSpec{
-					Containers: []api.Container{
-						{
-							Name: "container1",
-							Resources: api.ResourceRequirements{
-								Requests: api.ResourceList{
-									api.ResourceCPU:    resource.MustParse("100m"),
-									api.ResourceMemory: resource.MustParse("1Gi"),
-								},
-							},
+			oldPod: podtest.MakePod("test-pod",
+				podtest.SetResourceVersion("1"),
+				podtest.SetContainers(podtest.MakeContainer("container1",
+					podtest.SetContainerResources(api.ResourceRequirements{
+						Requests: api.ResourceList{
+							api.ResourceCPU:    resource.MustParse("100m"),
+							api.ResourceMemory: resource.MustParse("1Gi"),
 						},
-					},
-				},
-				Status: api.PodStatus{
-					ContainerStatuses: []api.ContainerStatus{
-						{
-							Name: "container1",
-							AllocatedResources: api.ResourceList{
-								api.ResourceCPU:    resource.MustParse("100m"),
-								api.ResourceMemory: resource.MustParse("1Gi"),
-							},
+					}),
+				)),
+				podtest.SetStatus(podtest.MakePodStatus(
+					podtest.SetContainerStatuses(podtest.MakeContainerStatus("container1",
+						api.ResourceList{
+							api.ResourceCPU:    resource.MustParse("100m"),
+							api.ResourceMemory: resource.MustParse("1Gi"),
+						}),
+					),
+				)),
+			),
+			newPod: podtest.MakePod("test-pod",
+				podtest.SetResourceVersion("1"),
+				podtest.SetContainers(podtest.MakeContainer("container1",
+					podtest.SetContainerResources(api.ResourceRequirements{
+						Requests: api.ResourceList{
+							api.ResourceCPU:    resource.MustParse("100m"),
+							api.ResourceMemory: resource.MustParse("1Gi"),
 						},
-					},
-				},
-			},
-			newPod: &api.Pod{
-				Spec: api.PodSpec{
-					Containers: []api.Container{
-						{
-							Name: "container1",
-							Resources: api.ResourceRequirements{
-								Requests: api.ResourceList{
-									api.ResourceCPU:    resource.MustParse("100m"),
-									api.ResourceMemory: resource.MustParse("1Gi"),
-								},
-							},
+					}),
+				)),
+				podtest.SetStatus(podtest.MakePodStatus(
+					podtest.SetContainerStatuses(podtest.MakeContainerStatus("container1",
+						api.ResourceList{
+							api.ResourceCPU:    resource.MustParse("100m"),
+							api.ResourceMemory: resource.MustParse("1Gi"),
+						}),
+					),
+				)),
+			),
+			expected: podtest.MakePod("test-pod",
+				podtest.SetResourceVersion("1"),
+				podtest.SetContainers(podtest.MakeContainer("container1",
+					podtest.SetContainerResources(api.ResourceRequirements{
+						Requests: api.ResourceList{
+							api.ResourceCPU:    resource.MustParse("100m"),
+							api.ResourceMemory: resource.MustParse("1Gi"),
 						},
-					},
-				},
-				Status: api.PodStatus{
-					ContainerStatuses: []api.ContainerStatus{
-						{
-							Name: "container1",
-							AllocatedResources: api.ResourceList{
-								api.ResourceCPU:    resource.MustParse("100m"),
-								api.ResourceMemory: resource.MustParse("1Gi"),
-							},
-						},
-					},
-				},
-			},
-			expected: &api.Pod{
-				Spec: api.PodSpec{
-					Containers: []api.Container{
-						{
-							Name: "container1",
-							Resources: api.ResourceRequirements{
-								Requests: api.ResourceList{
-									api.ResourceCPU:    resource.MustParse("100m"),
-									api.ResourceMemory: resource.MustParse("1Gi"),
-								},
-							},
-						},
-					},
-				},
-				Status: api.PodStatus{
-					ContainerStatuses: []api.ContainerStatus{
-						{
-							Name: "container1",
-							AllocatedResources: api.ResourceList{
-								api.ResourceCPU:    resource.MustParse("100m"),
-								api.ResourceMemory: resource.MustParse("1Gi"),
-							},
-						},
-					},
-				},
-			},
+					}),
+				)),
+				podtest.SetStatus(podtest.MakePodStatus(
+					podtest.SetContainerStatuses(podtest.MakeContainerStatus("container1",
+						api.ResourceList{
+							api.ResourceCPU:    resource.MustParse("100m"),
+							api.ResourceMemory: resource.MustParse("1Gi"),
+						}),
+					),
+				)),
+			),
 		},
 		{
 			name: "update resizepolicy",
-			oldPod: &api.Pod{
-				Spec: api.PodSpec{
-					Containers: []api.Container{
-						{
-							Name: "container1",
-							Resources: api.ResourceRequirements{
-								Requests: api.ResourceList{
-									api.ResourceCPU:    resource.MustParse("100m"),
-									api.ResourceMemory: resource.MustParse("1Gi"),
-								},
-							},
+			oldPod: podtest.MakePod("test-pod",
+				podtest.SetResourceVersion("1"),
+				podtest.SetContainers(podtest.MakeContainer("container1",
+					podtest.SetContainerResources(api.ResourceRequirements{
+						Requests: api.ResourceList{
+							api.ResourceCPU:    resource.MustParse("100m"),
+							api.ResourceMemory: resource.MustParse("1Gi"),
 						},
-					},
-				},
-				Status: api.PodStatus{
-					ContainerStatuses: []api.ContainerStatus{
-						{
-							Name: "container1",
-							AllocatedResources: api.ResourceList{
-								api.ResourceCPU:    resource.MustParse("100m"),
-								api.ResourceMemory: resource.MustParse("1Gi"),
-							},
+					}),
+				)),
+				podtest.SetStatus(podtest.MakePodStatus(
+					podtest.SetContainerStatuses(podtest.MakeContainerStatus("container1",
+						api.ResourceList{
+							api.ResourceCPU:    resource.MustParse("100m"),
+							api.ResourceMemory: resource.MustParse("1Gi"),
+						})),
+				)),
+			),
+			newPod: podtest.MakePod("test-pod",
+				podtest.SetResourceVersion("2"),
+				podtest.SetContainers(podtest.MakeContainer("container1",
+					podtest.SetContainerResources(api.ResourceRequirements{
+						Requests: api.ResourceList{
+							api.ResourceCPU:    resource.MustParse("100m"),
+							api.ResourceMemory: resource.MustParse("1Gi"),
 						},
-					},
-				},
-			},
-			newPod: &api.Pod{
-				Spec: api.PodSpec{
-					Containers: []api.Container{
-						{
-							Name: "container1",
-							Resources: api.ResourceRequirements{
-								Requests: api.ResourceList{
-									api.ResourceCPU:    resource.MustParse("100m"),
-									api.ResourceMemory: resource.MustParse("1Gi"),
-								},
-							},
-							ResizePolicy: []api.ContainerResizePolicy{
-								{ResourceName: "cpu", RestartPolicy: "NotRequired"},
-								{ResourceName: "memory", RestartPolicy: "RestartContainer"},
-							},
+					}),
+					podtest.SetContainerResizePolicy(
+						api.ContainerResizePolicy{ResourceName: "cpu", RestartPolicy: "NotRequired"},
+						api.ContainerResizePolicy{ResourceName: "memory", RestartPolicy: "RestartContainer"},
+					),
+				)),
+				podtest.SetStatus(podtest.MakePodStatus(
+					podtest.SetContainerStatuses(podtest.MakeContainerStatus("container1",
+						api.ResourceList{
+							api.ResourceCPU:    resource.MustParse("100m"),
+							api.ResourceMemory: resource.MustParse("1Gi"),
+						})),
+				)),
+			),
+			expected: podtest.MakePod("test-pod",
+				podtest.SetResourceVersion("2"),
+				podtest.SetContainers(podtest.MakeContainer("container1",
+					podtest.SetContainerResources(api.ResourceRequirements{
+						Requests: api.ResourceList{
+							api.ResourceCPU:    resource.MustParse("100m"),
+							api.ResourceMemory: resource.MustParse("1Gi"),
 						},
-					},
-				},
-				Status: api.PodStatus{
-					ContainerStatuses: []api.ContainerStatus{
-						{
-							Name: "container1",
-							AllocatedResources: api.ResourceList{
-								api.ResourceCPU:    resource.MustParse("100m"),
-								api.ResourceMemory: resource.MustParse("1Gi"),
-							},
-						},
-					},
-				},
-			},
-			expected: &api.Pod{
-				Spec: api.PodSpec{
-					Containers: []api.Container{
-						{
-							Name: "container1",
-							Resources: api.ResourceRequirements{
-								Requests: api.ResourceList{
-									api.ResourceCPU:    resource.MustParse("100m"),
-									api.ResourceMemory: resource.MustParse("1Gi"),
-								},
-							},
-							ResizePolicy: []api.ContainerResizePolicy{
-								{ResourceName: "cpu", RestartPolicy: "NotRequired"},
-								{ResourceName: "memory", RestartPolicy: "RestartContainer"},
-							},
-						},
-					},
-				},
-				Status: api.PodStatus{
-					ContainerStatuses: []api.ContainerStatus{
-						{
-							Name: "container1",
-							AllocatedResources: api.ResourceList{
-								api.ResourceCPU:    resource.MustParse("100m"),
-								api.ResourceMemory: resource.MustParse("1Gi"),
-							},
-						},
-					},
-				},
-			},
+					}),
+					podtest.SetContainerResizePolicy(
+						api.ContainerResizePolicy{ResourceName: "cpu", RestartPolicy: "NotRequired"},
+						api.ContainerResizePolicy{ResourceName: "memory", RestartPolicy: "RestartContainer"},
+					),
+				)),
+				podtest.SetStatus(podtest.MakePodStatus(
+					podtest.SetContainerStatuses(podtest.MakeContainerStatus("container1",
+						api.ResourceList{
+							api.ResourceCPU:    resource.MustParse("100m"),
+							api.ResourceMemory: resource.MustParse("1Gi"),
+						})),
+				)),
+			),
 		},
 		{
 			name: "add new container",
-			oldPod: &api.Pod{
-				Spec: api.PodSpec{
-					Containers: []api.Container{
-						{
-							Name: "container1",
-							Resources: api.ResourceRequirements{
-								Requests: api.ResourceList{
-									api.ResourceCPU:    resource.MustParse("100m"),
-									api.ResourceMemory: resource.MustParse("1Gi"),
-								},
-							},
+			oldPod: podtest.MakePod("test-pod",
+				podtest.SetResourceVersion("1"),
+				podtest.SetContainers(podtest.MakeContainer("container1",
+					podtest.SetContainerResources(api.ResourceRequirements{
+						Requests: api.ResourceList{
+							api.ResourceCPU:    resource.MustParse("100m"),
+							api.ResourceMemory: resource.MustParse("1Gi"),
 						},
-					},
-				},
-				Status: api.PodStatus{
-					ContainerStatuses: []api.ContainerStatus{
-						{
-							Name: "container1",
-							AllocatedResources: api.ResourceList{
+					}),
+				)),
+				podtest.SetStatus(podtest.MakePodStatus(
+					podtest.SetContainerStatuses(podtest.MakeContainerStatus("container1",
+						api.ResourceList{
+							api.ResourceCPU:    resource.MustParse("100m"),
+							api.ResourceMemory: resource.MustParse("1Gi"),
+						})),
+				)),
+			),
+			newPod: podtest.MakePod("test-pod",
+				podtest.SetResourceVersion("2"),
+				podtest.SetContainers(
+					podtest.MakeContainer("container1",
+						podtest.SetContainerResources(api.ResourceRequirements{
+							Requests: api.ResourceList{
 								api.ResourceCPU:    resource.MustParse("100m"),
 								api.ResourceMemory: resource.MustParse("1Gi"),
 							},
-						},
-					},
-				},
-			},
-			newPod: &api.Pod{
-				Spec: api.PodSpec{
-					Containers: []api.Container{
-						{
-							Name: "container1",
-							Resources: api.ResourceRequirements{
-								Requests: api.ResourceList{
-									api.ResourceCPU:    resource.MustParse("100m"),
-									api.ResourceMemory: resource.MustParse("1Gi"),
-								},
-							},
-						},
-						{
-							Name: "container2",
-							Resources: api.ResourceRequirements{
-								Requests: api.ResourceList{
-									api.ResourceCPU:    resource.MustParse("100m"),
-									api.ResourceMemory: resource.MustParse("1Gi"),
-								},
-							},
-						},
-					},
-				},
-				Status: api.PodStatus{
-					ContainerStatuses: []api.ContainerStatus{
-						{
-							Name: "container1",
-							AllocatedResources: api.ResourceList{
+						}),
+					),
+					podtest.MakeContainer("container2",
+						podtest.SetContainerResources(api.ResourceRequirements{
+							Requests: api.ResourceList{
 								api.ResourceCPU:    resource.MustParse("100m"),
 								api.ResourceMemory: resource.MustParse("1Gi"),
 							},
+						}),
+					),
+				),
+				podtest.SetStatus(podtest.MakePodStatus(
+					podtest.SetContainerStatuses(podtest.MakeContainerStatus("container1",
+						api.ResourceList{
+							api.ResourceCPU:    resource.MustParse("100m"),
+							api.ResourceMemory: resource.MustParse("1Gi"),
+						})),
+				)),
+			),
+			expected: podtest.MakePod("test-pod",
+				podtest.SetResourceVersion("2"),
+				podtest.SetContainers(podtest.MakeContainer("container1",
+					podtest.SetContainerResources(api.ResourceRequirements{
+						Requests: api.ResourceList{
+							api.ResourceCPU:    resource.MustParse("100m"),
+							api.ResourceMemory: resource.MustParse("1Gi"),
 						},
-					},
-				},
-			},
-			expected: &api.Pod{
-				Spec: api.PodSpec{
-					Containers: []api.Container{
-						{
-							Name: "container1",
-							Resources: api.ResourceRequirements{
-								Requests: api.ResourceList{
-									api.ResourceCPU:    resource.MustParse("100m"),
-									api.ResourceMemory: resource.MustParse("1Gi"),
-								},
-							},
-						},
-					},
-				},
-				Status: api.PodStatus{
-					ContainerStatuses: []api.ContainerStatus{
-						{
-							Name: "container1",
-							AllocatedResources: api.ResourceList{
-								api.ResourceCPU:    resource.MustParse("100m"),
-								api.ResourceMemory: resource.MustParse("1Gi"),
-							},
-						},
-					},
-				},
-			},
+					}),
+				)),
+				podtest.SetStatus(podtest.MakePodStatus(
+					podtest.SetContainerStatuses(podtest.MakeContainerStatus("container1",
+						api.ResourceList{
+							api.ResourceCPU:    resource.MustParse("100m"),
+							api.ResourceMemory: resource.MustParse("1Gi"),
+						})),
+				)),
+			),
 		},
 		{
 			name: "add new container and update resources of existing container",
-			oldPod: &api.Pod{
-				Spec: api.PodSpec{
-					Containers: []api.Container{
-						{
-							Name: "container1",
-							Resources: api.ResourceRequirements{
-								Requests: api.ResourceList{
-									api.ResourceCPU:    resource.MustParse("100m"),
-									api.ResourceMemory: resource.MustParse("1Gi"),
-								},
-							},
+			oldPod: podtest.MakePod("test-pod",
+				podtest.SetResourceVersion("1"),
+				podtest.SetContainers(podtest.MakeContainer("container1",
+					podtest.SetContainerResources(api.ResourceRequirements{
+						Requests: api.ResourceList{
+							api.ResourceCPU:    resource.MustParse("100m"),
+							api.ResourceMemory: resource.MustParse("1Gi"),
 						},
-					},
-				},
-				Status: api.PodStatus{
-					ContainerStatuses: []api.ContainerStatus{
-						{
-							Name: "container1",
-							AllocatedResources: api.ResourceList{
+					}),
+				)),
+				podtest.SetStatus(podtest.MakePodStatus(
+					podtest.SetContainerStatuses(podtest.MakeContainerStatus("container1",
+						api.ResourceList{
+							api.ResourceCPU:    resource.MustParse("100m"),
+							api.ResourceMemory: resource.MustParse("1Gi"),
+						})),
+				)),
+			),
+			newPod: podtest.MakePod("test-pod",
+				podtest.SetResourceVersion("2"),
+				podtest.SetContainers(
+					podtest.MakeContainer("container1",
+						podtest.SetContainerResources(api.ResourceRequirements{
+							Requests: api.ResourceList{
+								api.ResourceCPU:    resource.MustParse("100m"),
+								api.ResourceMemory: resource.MustParse("2Gi"), // Updated resource
+							},
+						}),
+					),
+					podtest.MakeContainer("container2",
+						podtest.SetContainerResources(api.ResourceRequirements{
+							Requests: api.ResourceList{
 								api.ResourceCPU:    resource.MustParse("100m"),
 								api.ResourceMemory: resource.MustParse("1Gi"),
 							},
+						}),
+					),
+				),
+				podtest.SetStatus(podtest.MakePodStatus(
+					podtest.SetContainerStatuses(podtest.MakeContainerStatus("container1",
+						api.ResourceList{
+							api.ResourceCPU:    resource.MustParse("100m"),
+							api.ResourceMemory: resource.MustParse("1Gi"),
+						})),
+				)),
+			),
+			expected: podtest.MakePod("test-pod",
+				podtest.SetResourceVersion("2"),
+				podtest.SetContainers(podtest.MakeContainer("container1",
+					podtest.SetContainerResources(api.ResourceRequirements{
+						Requests: api.ResourceList{
+							api.ResourceCPU:    resource.MustParse("100m"),
+							api.ResourceMemory: resource.MustParse("2Gi"), // Updated resource
 						},
-					},
-				},
-			},
-			newPod: &api.Pod{
-				Spec: api.PodSpec{
-					Containers: []api.Container{
-						{
-							Name: "container1",
-							Resources: api.ResourceRequirements{
-								Requests: api.ResourceList{
-									api.ResourceCPU:    resource.MustParse("100m"),
-									api.ResourceMemory: resource.MustParse("2Gi"),
-								},
-							},
-						},
-						{
-							Name: "container2",
-							Resources: api.ResourceRequirements{
-								Requests: api.ResourceList{
-									api.ResourceCPU:    resource.MustParse("100m"),
-									api.ResourceMemory: resource.MustParse("1Gi"),
-								},
-							},
-						},
-					},
-				},
-				Status: api.PodStatus{
-					ContainerStatuses: []api.ContainerStatus{
-						{
-							Name: "container1",
-							AllocatedResources: api.ResourceList{
-								api.ResourceCPU:    resource.MustParse("100m"),
-								api.ResourceMemory: resource.MustParse("1Gi"),
-							},
-						},
-					},
-				},
-			},
-			expected: &api.Pod{
-				Spec: api.PodSpec{
-					Containers: []api.Container{
-						{
-							Name: "container1",
-							Resources: api.ResourceRequirements{
-								Requests: api.ResourceList{
-									api.ResourceCPU:    resource.MustParse("100m"),
-									api.ResourceMemory: resource.MustParse("2Gi"),
-								},
-							},
-						},
-					},
-				},
-				Status: api.PodStatus{
-					Resize: api.PodResizeStatusProposed,
-					ContainerStatuses: []api.ContainerStatus{
-						{
-							Name: "container1",
-							AllocatedResources: api.ResourceList{
-								api.ResourceCPU:    resource.MustParse("100m"),
-								api.ResourceMemory: resource.MustParse("1Gi"),
-							},
-						},
-					},
-				},
-			},
+					}),
+				)),
+				podtest.SetStatus(podtest.MakePodStatus(
+					podtest.SetResizeStatus(api.PodResizeStatusProposed), // Resize status set
+					podtest.SetContainerStatuses(podtest.MakeContainerStatus("container1",
+						api.ResourceList{
+							api.ResourceCPU:    resource.MustParse("100m"),
+							api.ResourceMemory: resource.MustParse("1Gi"),
+						})),
+				)),
+			),
 		},
 		{
 			name: "change container order and update resources",
-			oldPod: &api.Pod{
-				Spec: api.PodSpec{
-					Containers: []api.Container{
-						{
-							Name: "container1",
-							Resources: api.ResourceRequirements{
-								Requests: api.ResourceList{
-									api.ResourceCPU:    resource.MustParse("100m"),
-									api.ResourceMemory: resource.MustParse("1Gi"),
-								},
-							},
-						},
-						{
-							Name: "container2",
-							Resources: api.ResourceRequirements{
-								Requests: api.ResourceList{
-									api.ResourceCPU:    resource.MustParse("100m"),
-									api.ResourceMemory: resource.MustParse("1Gi"),
-								},
-							},
-						},
-					},
-				},
-				Status: api.PodStatus{
-					ContainerStatuses: []api.ContainerStatus{
-						{
-							Name: "container1",
-							AllocatedResources: api.ResourceList{
+			oldPod: podtest.MakePod("test-pod",
+				podtest.SetResourceVersion("1"),
+				podtest.SetContainers(
+					podtest.MakeContainer("container1",
+						podtest.SetContainerResources(api.ResourceRequirements{
+							Requests: api.ResourceList{
 								api.ResourceCPU:    resource.MustParse("100m"),
 								api.ResourceMemory: resource.MustParse("1Gi"),
 							},
-						},
-						{
-							Name: "container2",
-							AllocatedResources: api.ResourceList{
+						}),
+					),
+					podtest.MakeContainer("container2",
+						podtest.SetContainerResources(api.ResourceRequirements{
+							Requests: api.ResourceList{
 								api.ResourceCPU:    resource.MustParse("100m"),
 								api.ResourceMemory: resource.MustParse("1Gi"),
 							},
-						},
-					},
-				},
-			},
-			newPod: &api.Pod{
-				Spec: api.PodSpec{
-					Containers: []api.Container{
-						{
-							Name: "container2",
-							Resources: api.ResourceRequirements{
-								Requests: api.ResourceList{
-									api.ResourceCPU:    resource.MustParse("200m"),
-									api.ResourceMemory: resource.MustParse("2Gi"),
-								},
+						}),
+					),
+				),
+				podtest.SetStatus(podtest.MakePodStatus(
+					podtest.SetContainerStatuses(
+						podtest.MakeContainerStatus("container1",
+							api.ResourceList{
+								api.ResourceCPU:    resource.MustParse("100m"),
+								api.ResourceMemory: resource.MustParse("1Gi"),
+							}),
+						podtest.MakeContainerStatus("container2",
+							api.ResourceList{
+								api.ResourceCPU:    resource.MustParse("100m"),
+								api.ResourceMemory: resource.MustParse("1Gi"),
+							}),
+					),
+				)),
+			),
+			newPod: podtest.MakePod("test-pod",
+				podtest.SetResourceVersion("2"),
+				podtest.SetContainers(
+					podtest.MakeContainer("container2", // Order changed
+						podtest.SetContainerResources(api.ResourceRequirements{
+							Requests: api.ResourceList{
+								api.ResourceCPU:    resource.MustParse("200m"), // Updated resource
+								api.ResourceMemory: resource.MustParse("2Gi"),  // Updated resource
 							},
-						},
-						{
-							Name: "container1",
-							Resources: api.ResourceRequirements{
-								Requests: api.ResourceList{
-									api.ResourceCPU:    resource.MustParse("200m"),
-									api.ResourceMemory: resource.MustParse("4Gi"),
-								},
+						}),
+					),
+					podtest.MakeContainer("container1", // Order changed
+						podtest.SetContainerResources(api.ResourceRequirements{
+							Requests: api.ResourceList{
+								api.ResourceCPU:    resource.MustParse("200m"), // Updated resource
+								api.ResourceMemory: resource.MustParse("4Gi"),  // Updated resource
 							},
-						},
-					},
-				},
-				Status: api.PodStatus{
-					ContainerStatuses: []api.ContainerStatus{
-						{
-							Name: "container1",
-							AllocatedResources: api.ResourceList{
+						}),
+					),
+				),
+				podtest.SetStatus(podtest.MakePodStatus(
+					podtest.SetContainerStatuses(
+						podtest.MakeContainerStatus("container1",
+							api.ResourceList{
+								api.ResourceCPU:    resource.MustParse("100m"),
+								api.ResourceMemory: resource.MustParse("1Gi"),
+							}),
+						podtest.MakeContainerStatus("container2",
+							api.ResourceList{
+								api.ResourceCPU:    resource.MustParse("100m"),
+								api.ResourceMemory: resource.MustParse("1Gi"),
+							}),
+					),
+				)),
+			),
+			expected: podtest.MakePod("test-pod",
+				podtest.SetResourceVersion("2"),
+				podtest.SetContainers(
+					podtest.MakeContainer("container1",
+						podtest.SetContainerResources(api.ResourceRequirements{
+							Requests: api.ResourceList{
+								api.ResourceCPU:    resource.MustParse("200m"), // Updated resource
+								api.ResourceMemory: resource.MustParse("4Gi"),  // Updated resource
+							},
+						}),
+					),
+					podtest.MakeContainer("container2",
+						podtest.SetContainerResources(api.ResourceRequirements{
+							Requests: api.ResourceList{
+								api.ResourceCPU:    resource.MustParse("200m"), // Updated resource
+								api.ResourceMemory: resource.MustParse("2Gi"),  // Updated resource
+							},
+						}),
+					),
+				),
+				podtest.SetStatus(podtest.MakePodStatus(
+					podtest.SetResizeStatus(api.PodResizeStatusProposed), // Resize status set
+					podtest.SetContainerStatuses(
+						podtest.MakeContainerStatus("container1",
+							api.ResourceList{
+								api.ResourceCPU:    resource.MustParse("100m"),
+								api.ResourceMemory: resource.MustParse("1Gi"),
+							}),
+						podtest.MakeContainerStatus("container2",
+							api.ResourceList{
+								api.ResourceCPU:    resource.MustParse("100m"),
+								api.ResourceMemory: resource.MustParse("1Gi"),
+							}),
+					),
+				)),
+			),
+		},
+		{
+			name: "change pod labels",
+			oldPod: podtest.MakePod("test-pod",
+				podtest.SetResourceVersion("1"),
+				podtest.SetLabels(map[string]string{"foo": "bar"}),
+				podtest.SetContainers(
+					podtest.MakeContainer("container1",
+						podtest.SetContainerResources(api.ResourceRequirements{
+							Requests: api.ResourceList{
 								api.ResourceCPU:    resource.MustParse("100m"),
 								api.ResourceMemory: resource.MustParse("1Gi"),
 							},
-						},
-						{
-							Name: "container2",
-							AllocatedResources: api.ResourceList{
+						}),
+					),
+				),
+				podtest.SetStatus(podtest.MakePodStatus(
+					podtest.SetContainerStatuses(
+						podtest.MakeContainerStatus("container1",
+							api.ResourceList{
+								api.ResourceCPU:    resource.MustParse("100m"),
+								api.ResourceMemory: resource.MustParse("1Gi"),
+							}),
+					),
+				)),
+			),
+			newPod: podtest.MakePod("test-pod",
+				podtest.SetResourceVersion("2"),
+				podtest.SetLabels(map[string]string{"foo": "bar", "baz": "qux"}),
+				podtest.SetContainers(
+					podtest.MakeContainer("container1",
+						podtest.SetContainerResources(api.ResourceRequirements{
+							Requests: api.ResourceList{
 								api.ResourceCPU:    resource.MustParse("100m"),
 								api.ResourceMemory: resource.MustParse("1Gi"),
 							},
-						},
-					},
-				},
-			},
-			expected: &api.Pod{
-				Spec: api.PodSpec{
-					Containers: []api.Container{
-						{
-							Name: "container1",
-							Resources: api.ResourceRequirements{
-								Requests: api.ResourceList{
-									api.ResourceCPU:    resource.MustParse("200m"),
-									api.ResourceMemory: resource.MustParse("4Gi"),
-								},
-							},
-						},
-						{
-							Name: "container2",
-							Resources: api.ResourceRequirements{
-								Requests: api.ResourceList{
-									api.ResourceCPU:    resource.MustParse("200m"),
-									api.ResourceMemory: resource.MustParse("2Gi"),
-								},
-							},
-						},
-					},
-				},
-				Status: api.PodStatus{
-					Resize: api.PodResizeStatusProposed,
-					ContainerStatuses: []api.ContainerStatus{
-						{
-							Name: "container1",
-							AllocatedResources: api.ResourceList{
+						}),
+					),
+				),
+				podtest.SetStatus(podtest.MakePodStatus(
+					podtest.SetContainerStatuses(
+						podtest.MakeContainerStatus("container1",
+							api.ResourceList{
+								api.ResourceCPU:    resource.MustParse("100m"),
+								api.ResourceMemory: resource.MustParse("1Gi"),
+							}),
+					),
+				)),
+			),
+			expected: podtest.MakePod("test-pod",
+				podtest.SetResourceVersion("2"),
+				podtest.SetLabels(map[string]string{"foo": "bar"}),
+				podtest.SetContainers(
+					podtest.MakeContainer("container1",
+						podtest.SetContainerResources(api.ResourceRequirements{
+							Requests: api.ResourceList{
 								api.ResourceCPU:    resource.MustParse("100m"),
 								api.ResourceMemory: resource.MustParse("1Gi"),
 							},
-						},
-						{
-							Name: "container2",
-							AllocatedResources: api.ResourceList{
+						}),
+					),
+				),
+				podtest.SetStatus(podtest.MakePodStatus(
+					podtest.SetContainerStatuses(
+						podtest.MakeContainerStatus("container1",
+							api.ResourceList{
 								api.ResourceCPU:    resource.MustParse("100m"),
 								api.ResourceMemory: resource.MustParse("1Gi"),
-							},
-						},
-					},
-				},
-			},
+							}),
+					),
+				)),
+			),
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScaling, true)
-			tc.newPod.Name = "test-pod"
-			tc.newPod.Namespace = "test-ns"
-			tc.newPod.ResourceVersion = "123"
-			tc.newPod.UID = "abc"
-			tc.expected.Name = "test-pod"
-			tc.expected.Namespace = "test-ns"
-			tc.expected.ResourceVersion = "123"
-			tc.expected.UID = "abc"
 			ctx := context.Background()
 			ResizeStrategy.PrepareForUpdate(ctx, tc.newPod, tc.oldPod)
 			if !cmp.Equal(tc.expected, tc.newPod) {

--- a/pkg/registry/core/pod/strategy_test.go
+++ b/pkg/registry/core/pod/strategy_test.go
@@ -2450,7 +2450,7 @@ func (w *warningRecorder) AddWarning(_, text string) {
 	w.warnings = append(w.warnings, text)
 }
 
-func TestDropNonPodResizeUpdates(t *testing.T) {
+func TestPodResizePrepareForUpdate(t *testing.T) {
 	tests := []struct {
 		name     string
 		oldPod   *api.Pod
@@ -2466,9 +2466,20 @@ func TestDropNonPodResizeUpdates(t *testing.T) {
 							Name: "container1",
 							Resources: api.ResourceRequirements{
 								Requests: api.ResourceList{
-									api.ResourceCPU:    resource.MustParse("1"),
+									api.ResourceCPU:    resource.MustParse("100m"),
 									api.ResourceMemory: resource.MustParse("1Gi"),
 								},
+							},
+						},
+					},
+				},
+				Status: api.PodStatus{
+					ContainerStatuses: []api.ContainerStatus{
+						{
+							Name: "container1",
+							AllocatedResources: api.ResourceList{
+								api.ResourceCPU:    resource.MustParse("100m"),
+								api.ResourceMemory: resource.MustParse("1Gi"),
 							},
 						},
 					},
@@ -2481,9 +2492,20 @@ func TestDropNonPodResizeUpdates(t *testing.T) {
 							Name: "container1",
 							Resources: api.ResourceRequirements{
 								Requests: api.ResourceList{
-									api.ResourceCPU:    resource.MustParse("1"),
+									api.ResourceCPU:    resource.MustParse("100m"),
 									api.ResourceMemory: resource.MustParse("1Gi"),
 								},
+							},
+						},
+					},
+				},
+				Status: api.PodStatus{
+					ContainerStatuses: []api.ContainerStatus{
+						{
+							Name: "container1",
+							AllocatedResources: api.ResourceList{
+								api.ResourceCPU:    resource.MustParse("100m"),
+								api.ResourceMemory: resource.MustParse("1Gi"),
 							},
 						},
 					},
@@ -2496,9 +2518,20 @@ func TestDropNonPodResizeUpdates(t *testing.T) {
 							Name: "container1",
 							Resources: api.ResourceRequirements{
 								Requests: api.ResourceList{
-									api.ResourceCPU:    resource.MustParse("1"),
+									api.ResourceCPU:    resource.MustParse("100m"),
 									api.ResourceMemory: resource.MustParse("1Gi"),
 								},
+							},
+						},
+					},
+				},
+				Status: api.PodStatus{
+					ContainerStatuses: []api.ContainerStatus{
+						{
+							Name: "container1",
+							AllocatedResources: api.ResourceList{
+								api.ResourceCPU:    resource.MustParse("100m"),
+								api.ResourceMemory: resource.MustParse("1Gi"),
 							},
 						},
 					},
@@ -2514,9 +2547,20 @@ func TestDropNonPodResizeUpdates(t *testing.T) {
 							Name: "container1",
 							Resources: api.ResourceRequirements{
 								Requests: api.ResourceList{
-									api.ResourceCPU:    resource.MustParse("1"),
+									api.ResourceCPU:    resource.MustParse("100m"),
 									api.ResourceMemory: resource.MustParse("1Gi"),
 								},
+							},
+						},
+					},
+				},
+				Status: api.PodStatus{
+					ContainerStatuses: []api.ContainerStatus{
+						{
+							Name: "container1",
+							AllocatedResources: api.ResourceList{
+								api.ResourceCPU:    resource.MustParse("100m"),
+								api.ResourceMemory: resource.MustParse("1Gi"),
 							},
 						},
 					},
@@ -2529,17 +2573,24 @@ func TestDropNonPodResizeUpdates(t *testing.T) {
 							Name: "container1",
 							Resources: api.ResourceRequirements{
 								Requests: api.ResourceList{
-									api.ResourceCPU:    resource.MustParse("2"),
-									api.ResourceMemory: resource.MustParse("2Gi"),
-								},
-								Limits: api.ResourceList{
-									api.ResourceCPU:    resource.MustParse("4"),
-									api.ResourceMemory: resource.MustParse("4Gi"),
+									api.ResourceCPU:    resource.MustParse("100m"),
+									api.ResourceMemory: resource.MustParse("1Gi"),
 								},
 							},
 							ResizePolicy: []api.ContainerResizePolicy{
 								{ResourceName: "cpu", RestartPolicy: "NotRequired"},
 								{ResourceName: "memory", RestartPolicy: "RestartContainer"},
+							},
+						},
+					},
+				},
+				Status: api.PodStatus{
+					ContainerStatuses: []api.ContainerStatus{
+						{
+							Name: "container1",
+							AllocatedResources: api.ResourceList{
+								api.ResourceCPU:    resource.MustParse("100m"),
+								api.ResourceMemory: resource.MustParse("1Gi"),
 							},
 						},
 					},
@@ -2552,17 +2603,24 @@ func TestDropNonPodResizeUpdates(t *testing.T) {
 							Name: "container1",
 							Resources: api.ResourceRequirements{
 								Requests: api.ResourceList{
-									api.ResourceCPU:    resource.MustParse("2"),
-									api.ResourceMemory: resource.MustParse("2Gi"),
-								},
-								Limits: api.ResourceList{
-									api.ResourceCPU:    resource.MustParse("4"),
-									api.ResourceMemory: resource.MustParse("4Gi"),
+									api.ResourceCPU:    resource.MustParse("100m"),
+									api.ResourceMemory: resource.MustParse("1Gi"),
 								},
 							},
 							ResizePolicy: []api.ContainerResizePolicy{
 								{ResourceName: "cpu", RestartPolicy: "NotRequired"},
 								{ResourceName: "memory", RestartPolicy: "RestartContainer"},
+							},
+						},
+					},
+				},
+				Status: api.PodStatus{
+					ContainerStatuses: []api.ContainerStatus{
+						{
+							Name: "container1",
+							AllocatedResources: api.ResourceList{
+								api.ResourceCPU:    resource.MustParse("100m"),
+								api.ResourceMemory: resource.MustParse("1Gi"),
 							},
 						},
 					},
@@ -2578,9 +2636,20 @@ func TestDropNonPodResizeUpdates(t *testing.T) {
 							Name: "container1",
 							Resources: api.ResourceRequirements{
 								Requests: api.ResourceList{
-									api.ResourceCPU:    resource.MustParse("1"),
+									api.ResourceCPU:    resource.MustParse("100m"),
 									api.ResourceMemory: resource.MustParse("1Gi"),
 								},
+							},
+						},
+					},
+				},
+				Status: api.PodStatus{
+					ContainerStatuses: []api.ContainerStatus{
+						{
+							Name: "container1",
+							AllocatedResources: api.ResourceList{
+								api.ResourceCPU:    resource.MustParse("100m"),
+								api.ResourceMemory: resource.MustParse("1Gi"),
 							},
 						},
 					},
@@ -2593,7 +2662,7 @@ func TestDropNonPodResizeUpdates(t *testing.T) {
 							Name: "container1",
 							Resources: api.ResourceRequirements{
 								Requests: api.ResourceList{
-									api.ResourceCPU:    resource.MustParse("1"),
+									api.ResourceCPU:    resource.MustParse("100m"),
 									api.ResourceMemory: resource.MustParse("1Gi"),
 								},
 							},
@@ -2602,9 +2671,20 @@ func TestDropNonPodResizeUpdates(t *testing.T) {
 							Name: "container2",
 							Resources: api.ResourceRequirements{
 								Requests: api.ResourceList{
-									api.ResourceCPU:    resource.MustParse("1"),
+									api.ResourceCPU:    resource.MustParse("100m"),
 									api.ResourceMemory: resource.MustParse("1Gi"),
 								},
+							},
+						},
+					},
+				},
+				Status: api.PodStatus{
+					ContainerStatuses: []api.ContainerStatus{
+						{
+							Name: "container1",
+							AllocatedResources: api.ResourceList{
+								api.ResourceCPU:    resource.MustParse("100m"),
+								api.ResourceMemory: resource.MustParse("1Gi"),
 							},
 						},
 					},
@@ -2617,9 +2697,20 @@ func TestDropNonPodResizeUpdates(t *testing.T) {
 							Name: "container1",
 							Resources: api.ResourceRequirements{
 								Requests: api.ResourceList{
-									api.ResourceCPU:    resource.MustParse("1"),
+									api.ResourceCPU:    resource.MustParse("100m"),
 									api.ResourceMemory: resource.MustParse("1Gi"),
 								},
+							},
+						},
+					},
+				},
+				Status: api.PodStatus{
+					ContainerStatuses: []api.ContainerStatus{
+						{
+							Name: "container1",
+							AllocatedResources: api.ResourceList{
+								api.ResourceCPU:    resource.MustParse("100m"),
+								api.ResourceMemory: resource.MustParse("1Gi"),
 							},
 						},
 					},
@@ -2635,9 +2726,20 @@ func TestDropNonPodResizeUpdates(t *testing.T) {
 							Name: "container1",
 							Resources: api.ResourceRequirements{
 								Requests: api.ResourceList{
-									api.ResourceCPU:    resource.MustParse("1"),
+									api.ResourceCPU:    resource.MustParse("100m"),
 									api.ResourceMemory: resource.MustParse("1Gi"),
 								},
+							},
+						},
+					},
+				},
+				Status: api.PodStatus{
+					ContainerStatuses: []api.ContainerStatus{
+						{
+							Name: "container1",
+							AllocatedResources: api.ResourceList{
+								api.ResourceCPU:    resource.MustParse("100m"),
+								api.ResourceMemory: resource.MustParse("1Gi"),
 							},
 						},
 					},
@@ -2650,7 +2752,7 @@ func TestDropNonPodResizeUpdates(t *testing.T) {
 							Name: "container1",
 							Resources: api.ResourceRequirements{
 								Requests: api.ResourceList{
-									api.ResourceCPU:    resource.MustParse("1"),
+									api.ResourceCPU:    resource.MustParse("100m"),
 									api.ResourceMemory: resource.MustParse("2Gi"),
 								},
 							},
@@ -2659,9 +2761,20 @@ func TestDropNonPodResizeUpdates(t *testing.T) {
 							Name: "container2",
 							Resources: api.ResourceRequirements{
 								Requests: api.ResourceList{
-									api.ResourceCPU:    resource.MustParse("1"),
+									api.ResourceCPU:    resource.MustParse("100m"),
 									api.ResourceMemory: resource.MustParse("1Gi"),
 								},
+							},
+						},
+					},
+				},
+				Status: api.PodStatus{
+					ContainerStatuses: []api.ContainerStatus{
+						{
+							Name: "container1",
+							AllocatedResources: api.ResourceList{
+								api.ResourceCPU:    resource.MustParse("100m"),
+								api.ResourceMemory: resource.MustParse("1Gi"),
 							},
 						},
 					},
@@ -2674,9 +2787,21 @@ func TestDropNonPodResizeUpdates(t *testing.T) {
 							Name: "container1",
 							Resources: api.ResourceRequirements{
 								Requests: api.ResourceList{
-									api.ResourceCPU:    resource.MustParse("1"),
+									api.ResourceCPU:    resource.MustParse("100m"),
 									api.ResourceMemory: resource.MustParse("2Gi"),
 								},
+							},
+						},
+					},
+				},
+				Status: api.PodStatus{
+					Resize: api.PodResizeStatusProposed,
+					ContainerStatuses: []api.ContainerStatus{
+						{
+							Name: "container1",
+							AllocatedResources: api.ResourceList{
+								api.ResourceCPU:    resource.MustParse("100m"),
+								api.ResourceMemory: resource.MustParse("1Gi"),
 							},
 						},
 					},
@@ -2692,7 +2817,7 @@ func TestDropNonPodResizeUpdates(t *testing.T) {
 							Name: "container1",
 							Resources: api.ResourceRequirements{
 								Requests: api.ResourceList{
-									api.ResourceCPU:    resource.MustParse("1"),
+									api.ResourceCPU:    resource.MustParse("100m"),
 									api.ResourceMemory: resource.MustParse("1Gi"),
 								},
 							},
@@ -2701,9 +2826,27 @@ func TestDropNonPodResizeUpdates(t *testing.T) {
 							Name: "container2",
 							Resources: api.ResourceRequirements{
 								Requests: api.ResourceList{
-									api.ResourceCPU:    resource.MustParse("1"),
+									api.ResourceCPU:    resource.MustParse("100m"),
 									api.ResourceMemory: resource.MustParse("1Gi"),
 								},
+							},
+						},
+					},
+				},
+				Status: api.PodStatus{
+					ContainerStatuses: []api.ContainerStatus{
+						{
+							Name: "container1",
+							AllocatedResources: api.ResourceList{
+								api.ResourceCPU:    resource.MustParse("100m"),
+								api.ResourceMemory: resource.MustParse("1Gi"),
+							},
+						},
+						{
+							Name: "container2",
+							AllocatedResources: api.ResourceList{
+								api.ResourceCPU:    resource.MustParse("100m"),
+								api.ResourceMemory: resource.MustParse("1Gi"),
 							},
 						},
 					},
@@ -2716,7 +2859,7 @@ func TestDropNonPodResizeUpdates(t *testing.T) {
 							Name: "container2",
 							Resources: api.ResourceRequirements{
 								Requests: api.ResourceList{
-									api.ResourceCPU:    resource.MustParse("2"),
+									api.ResourceCPU:    resource.MustParse("200m"),
 									api.ResourceMemory: resource.MustParse("2Gi"),
 								},
 							},
@@ -2725,9 +2868,27 @@ func TestDropNonPodResizeUpdates(t *testing.T) {
 							Name: "container1",
 							Resources: api.ResourceRequirements{
 								Requests: api.ResourceList{
-									api.ResourceCPU:    resource.MustParse("2"),
+									api.ResourceCPU:    resource.MustParse("200m"),
 									api.ResourceMemory: resource.MustParse("4Gi"),
 								},
+							},
+						},
+					},
+				},
+				Status: api.PodStatus{
+					ContainerStatuses: []api.ContainerStatus{
+						{
+							Name: "container1",
+							AllocatedResources: api.ResourceList{
+								api.ResourceCPU:    resource.MustParse("100m"),
+								api.ResourceMemory: resource.MustParse("1Gi"),
+							},
+						},
+						{
+							Name: "container2",
+							AllocatedResources: api.ResourceList{
+								api.ResourceCPU:    resource.MustParse("100m"),
+								api.ResourceMemory: resource.MustParse("1Gi"),
 							},
 						},
 					},
@@ -2740,7 +2901,7 @@ func TestDropNonPodResizeUpdates(t *testing.T) {
 							Name: "container1",
 							Resources: api.ResourceRequirements{
 								Requests: api.ResourceList{
-									api.ResourceCPU:    resource.MustParse("2"),
+									api.ResourceCPU:    resource.MustParse("200m"),
 									api.ResourceMemory: resource.MustParse("4Gi"),
 								},
 							},
@@ -2749,9 +2910,28 @@ func TestDropNonPodResizeUpdates(t *testing.T) {
 							Name: "container2",
 							Resources: api.ResourceRequirements{
 								Requests: api.ResourceList{
-									api.ResourceCPU:    resource.MustParse("2"),
+									api.ResourceCPU:    resource.MustParse("200m"),
 									api.ResourceMemory: resource.MustParse("2Gi"),
 								},
+							},
+						},
+					},
+				},
+				Status: api.PodStatus{
+					Resize: api.PodResizeStatusProposed,
+					ContainerStatuses: []api.ContainerStatus{
+						{
+							Name: "container1",
+							AllocatedResources: api.ResourceList{
+								api.ResourceCPU:    resource.MustParse("100m"),
+								api.ResourceMemory: resource.MustParse("1Gi"),
+							},
+						},
+						{
+							Name: "container2",
+							AllocatedResources: api.ResourceList{
+								api.ResourceCPU:    resource.MustParse("100m"),
+								api.ResourceMemory: resource.MustParse("1Gi"),
 							},
 						},
 					},
@@ -2762,6 +2942,7 @@ func TestDropNonPodResizeUpdates(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScaling, true)
 			tc.newPod.Name = "test-pod"
 			tc.newPod.Namespace = "test-ns"
 			tc.newPod.ResourceVersion = "123"
@@ -2770,9 +2951,10 @@ func TestDropNonPodResizeUpdates(t *testing.T) {
 			tc.expected.Namespace = "test-ns"
 			tc.expected.ResourceVersion = "123"
 			tc.expected.UID = "abc"
-			got := dropNonPodResizeUpdates(tc.newPod, tc.oldPod)
-			if !cmp.Equal(tc.expected, got) {
-				t.Errorf("dropNonPodResizeUpdates() diff = %v", cmp.Diff(tc.expected, got))
+			ctx := context.Background()
+			ResizeStrategy.PrepareForUpdate(ctx, tc.newPod, tc.oldPod)
+			if !cmp.Equal(tc.expected, tc.newPod) {
+				t.Errorf("ResizeStrategy.PrepareForUpdate() diff = %v", cmp.Diff(tc.expected, tc.newPod))
 			}
 		})
 	}

--- a/pkg/registry/core/rest/storage_core.go
+++ b/pkg/registry/core/rest/storage_core.go
@@ -242,6 +242,9 @@ func (p *legacyProvider) NewRESTStorage(apiResourceConfigSource serverstorage.AP
 			storage[resource+"/eviction"] = podStorage.Eviction
 		}
 		storage[resource+"/ephemeralcontainers"] = podStorage.EphemeralContainers
+		if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {
+			storage[resource+"/resize"] = podStorage.Resize
+		}
 	}
 	if resource := "bindings"; apiResourceConfigSource.ResourceEnabled(corev1.SchemeGroupVersion.WithResource(resource)) {
 		storage[resource] = podStorage.LegacyBinding

--- a/plugin/pkg/admission/limitranger/admission.go
+++ b/plugin/pkg/admission/limitranger/admission.go
@@ -417,6 +417,12 @@ func (d *DefaultLimitRangerActions) ValidateLimit(limitRange *corev1.LimitRange,
 // SupportsAttributes ignores all calls that do not deal with pod resources or storage requests (PVCs).
 // Also ignores any call that has a subresource defined.
 func (d *DefaultLimitRangerActions) SupportsAttributes(a admission.Attributes) bool {
+	// Handle the special case for in-place pod vertical scaling
+	if a.GetSubresource() == "resize" && a.GetKind().GroupKind() == api.Kind("Pod") && a.GetOperation() == admission.Update {
+		return true
+	}
+
+	// No other subresources are supported
 	if a.GetSubresource() != "" {
 		return false
 	}

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -4869,6 +4869,7 @@ type PodStatusResult struct {
 
 // +genclient
 // +genclient:method=UpdateEphemeralContainers,verb=update,subresource=ephemeralcontainers
+// +genclient:method=Resize,verb=update,subresource=resize
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +k8s:prerelease-lifecycle-gen:introduced=1.0
 

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -4869,7 +4869,7 @@ type PodStatusResult struct {
 
 // +genclient
 // +genclient:method=UpdateEphemeralContainers,verb=update,subresource=ephemeralcontainers
-// +genclient:method=Resize,verb=update,subresource=resize
+// +genclient:method=UpdateResize,verb=update,subresource=resize
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +k8s:prerelease-lifecycle-gen:introduced=1.0
 

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/resourcequota/admission.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/resourcequota/admission.go
@@ -155,10 +155,6 @@ func (a *QuotaAdmission) ValidateInitialization() error {
 
 // Validate makes admission decisions while enforcing quota
 func (a *QuotaAdmission) Validate(ctx context.Context, attr admission.Attributes, o admission.ObjectInterfaces) (err error) {
-	// ignore all operations that correspond to sub-resource actions
-	if attr.GetSubresource() != "" {
-		return nil
-	}
 	// ignore all operations that are not namespaced or creation of namespaces
 	if attr.GetNamespace() == "" || isNamespaceCreation(attr) {
 		return nil

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/resourcequota/admission_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/resourcequota/admission_test.go
@@ -144,10 +144,6 @@ func TestExcludedOperations(t *testing.T) {
 		attr admission.Attributes
 	}{
 		{
-			"subresource",
-			admission.NewAttributesRecord(nil, nil, schema.GroupVersionKind{}, "namespace", "name", schema.GroupVersionResource{}, "subresource", admission.Create, nil, false, nil),
-		},
-		{
 			"non-namespaced resource",
 			admission.NewAttributesRecord(nil, nil, schema.GroupVersionKind{}, "", "namespace", schema.GroupVersionResource{}, "", admission.Create, nil, false, nil),
 		},

--- a/staging/src/k8s.io/apiserver/pkg/quota/v1/generic/evaluator.go
+++ b/staging/src/k8s.io/apiserver/pkg/quota/v1/generic/evaluator.go
@@ -250,6 +250,9 @@ func (o *objectCountEvaluator) Constraints(required []corev1.ResourceName, item 
 
 // Handles returns true if the object count evaluator needs to track this attributes.
 func (o *objectCountEvaluator) Handles(a admission.Attributes) bool {
+	if a.GetSubresource() != "" {
+		return false
+	}
 	operation := a.GetOperation()
 	return operation == admission.Create
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_pod.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_pod.go
@@ -207,3 +207,15 @@ func (c *FakePods) UpdateEphemeralContainers(ctx context.Context, podName string
 	}
 	return obj.(*v1.Pod), err
 }
+
+// Resize takes the representation of a pod and updates it. Returns the server's representation of the pod, and an error, if there is any.
+func (c *FakePods) Resize(ctx context.Context, podName string, pod *v1.Pod, opts metav1.UpdateOptions) (result *v1.Pod, err error) {
+	emptyResult := &v1.Pod{}
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceActionWithOptions(podsResource, "resize", c.ns, pod, opts), &v1.Pod{})
+
+	if obj == nil {
+		return emptyResult, err
+	}
+	return obj.(*v1.Pod), err
+}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_pod.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_pod.go
@@ -208,8 +208,8 @@ func (c *FakePods) UpdateEphemeralContainers(ctx context.Context, podName string
 	return obj.(*v1.Pod), err
 }
 
-// Resize takes the representation of a pod and updates it. Returns the server's representation of the pod, and an error, if there is any.
-func (c *FakePods) Resize(ctx context.Context, podName string, pod *v1.Pod, opts metav1.UpdateOptions) (result *v1.Pod, err error) {
+// UpdateResize takes the representation of a pod and updates it. Returns the server's representation of the pod, and an error, if there is any.
+func (c *FakePods) UpdateResize(ctx context.Context, podName string, pod *v1.Pod, opts metav1.UpdateOptions) (result *v1.Pod, err error) {
 	emptyResult := &v1.Pod{}
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateSubresourceActionWithOptions(podsResource, "resize", c.ns, pod, opts), &v1.Pod{})

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/pod.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/pod.go
@@ -52,6 +52,7 @@ type PodInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating ApplyStatus().
 	ApplyStatus(ctx context.Context, pod *applyconfigurationscorev1.PodApplyConfiguration, opts metav1.ApplyOptions) (result *corev1.Pod, err error)
 	UpdateEphemeralContainers(ctx context.Context, podName string, pod *corev1.Pod, opts metav1.UpdateOptions) (*corev1.Pod, error)
+	Resize(ctx context.Context, podName string, pod *corev1.Pod, opts metav1.UpdateOptions) (*corev1.Pod, error)
 
 	PodExpansion
 }
@@ -85,6 +86,21 @@ func (c *pods) UpdateEphemeralContainers(ctx context.Context, podName string, po
 		Resource("pods").
 		Name(podName).
 		SubResource("ephemeralcontainers").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Body(pod).
+		Do(ctx).
+		Into(result)
+	return
+}
+
+// Resize takes the top resource name and the representation of a pod and updates it. Returns the server's representation of the pod, and an error, if there is any.
+func (c *pods) Resize(ctx context.Context, podName string, pod *corev1.Pod, opts metav1.UpdateOptions) (result *corev1.Pod, err error) {
+	result = &corev1.Pod{}
+	err = c.GetClient().Put().
+		Namespace(c.GetNamespace()).
+		Resource("pods").
+		Name(podName).
+		SubResource("resize").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(pod).
 		Do(ctx).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/pod.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/pod.go
@@ -97,6 +97,7 @@ func (c *pods) UpdateEphemeralContainers(ctx context.Context, podName string, po
 func (c *pods) Resize(ctx context.Context, podName string, pod *corev1.Pod, opts metav1.UpdateOptions) (result *corev1.Pod, err error) {
 	result = &corev1.Pod{}
 	err = c.GetClient().Put().
+		UseProtobufAsDefault().
 		Namespace(c.GetNamespace()).
 		Resource("pods").
 		Name(podName).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/pod.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/pod.go
@@ -52,7 +52,7 @@ type PodInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating ApplyStatus().
 	ApplyStatus(ctx context.Context, pod *applyconfigurationscorev1.PodApplyConfiguration, opts metav1.ApplyOptions) (result *corev1.Pod, err error)
 	UpdateEphemeralContainers(ctx context.Context, podName string, pod *corev1.Pod, opts metav1.UpdateOptions) (*corev1.Pod, error)
-	Resize(ctx context.Context, podName string, pod *corev1.Pod, opts metav1.UpdateOptions) (*corev1.Pod, error)
+	UpdateResize(ctx context.Context, podName string, pod *corev1.Pod, opts metav1.UpdateOptions) (*corev1.Pod, error)
 
 	PodExpansion
 }
@@ -93,8 +93,8 @@ func (c *pods) UpdateEphemeralContainers(ctx context.Context, podName string, po
 	return
 }
 
-// Resize takes the top resource name and the representation of a pod and updates it. Returns the server's representation of the pod, and an error, if there is any.
-func (c *pods) Resize(ctx context.Context, podName string, pod *corev1.Pod, opts metav1.UpdateOptions) (result *corev1.Pod, err error) {
+// UpdateResize takes the top resource name and the representation of a pod and updates it. Returns the server's representation of the pod, and an error, if there is any.
+func (c *pods) UpdateResize(ctx context.Context, podName string, pod *corev1.Pod, opts metav1.UpdateOptions) (result *corev1.Pod, err error) {
 	result = &corev1.Pod{}
 	err = c.GetClient().Put().
 		UseProtobufAsDefault().

--- a/test/e2e/common/node/pod_resize.go
+++ b/test/e2e/common/node/pod_resize.go
@@ -894,8 +894,8 @@ func doPodResizeTests(f *framework.Framework) {
 
 			patchAndVerify := func(patchString string, expectedContainers []e2epod.ResizableContainerInfo, initialContainers []e2epod.ResizableContainerInfo, opStr string, isRollback bool) {
 				ginkgo.By(fmt.Sprintf("patching pod for %s", opStr))
-				patchedPod, pErr = f.ClientSet.CoreV1().Pods(newPod.Namespace).Patch(context.TODO(), newPod.Name,
-					types.StrategicMergePatchType, []byte(patchString), metav1.PatchOptions{})
+				patchedPod, pErr = f.ClientSet.CoreV1().Pods(newPod.Namespace).Patch(ctx, newPod.Name,
+					types.StrategicMergePatchType, []byte(patchString), metav1.PatchOptions{}, "resize")
 				framework.ExpectNoError(pErr, fmt.Sprintf("failed to patch pod for %s", opStr))
 
 				ginkgo.By(fmt.Sprintf("verifying pod patched for %s", opStr))
@@ -990,7 +990,7 @@ func doPodResizeErrorTests(f *framework.Framework) {
 
 			ginkgo.By("patching pod for resize")
 			patchedPod, pErr = f.ClientSet.CoreV1().Pods(newPod.Namespace).Patch(ctx, newPod.Name,
-				types.StrategicMergePatchType, []byte(tc.patchString), metav1.PatchOptions{})
+				types.StrategicMergePatchType, []byte(tc.patchString), metav1.PatchOptions{}, "resize")
 			if tc.patchError == "" {
 				framework.ExpectNoError(pErr, "failed to patch pod for resize")
 			} else {

--- a/test/e2e/node/pod_resize.go
+++ b/test/e2e/node/pod_resize.go
@@ -135,7 +135,7 @@ func doPodResizeResourceQuotaTests(f *framework.Framework) {
 
 		ginkgo.By(fmt.Sprintf("patching pod %s for resize with CPU exceeding resource quota", resizedPod.Name))
 		_, pErrExceedCPU := f.ClientSet.CoreV1().Pods(resizedPod.Namespace).Patch(ctx,
-			resizedPod.Name, types.StrategicMergePatchType, []byte(patchStringExceedCPU), metav1.PatchOptions{})
+			resizedPod.Name, types.StrategicMergePatchType, []byte(patchStringExceedCPU), metav1.PatchOptions{}, "resize")
 		gomega.Expect(pErrExceedCPU).To(gomega.HaveOccurred(), "exceeded quota: %s, requested: cpu=200m, used: cpu=700m, limited: cpu=800m",
 			resourceQuota.Name)
 

--- a/test/e2e/node/pod_resize.go
+++ b/test/e2e/node/pod_resize.go
@@ -97,7 +97,7 @@ func doPodResizeResourceQuotaTests(f *framework.Framework) {
 
 		ginkgo.By("patching pod for resize within resource quota")
 		patchedPod, pErr := f.ClientSet.CoreV1().Pods(newPod1.Namespace).Patch(ctx, newPod1.Name,
-			types.StrategicMergePatchType, []byte(patchString), metav1.PatchOptions{})
+			types.StrategicMergePatchType, []byte(patchString), metav1.PatchOptions{}, "resize")
 		framework.ExpectNoError(pErr, "failed to patch pod for resize")
 
 		ginkgo.By("verifying pod patched for resize within resource quota")
@@ -121,7 +121,7 @@ func doPodResizeResourceQuotaTests(f *framework.Framework) {
 
 		ginkgo.By("patching pod for resize with memory exceeding resource quota")
 		_, pErrExceedMemory := f.ClientSet.CoreV1().Pods(resizedPod.Namespace).Patch(ctx,
-			resizedPod.Name, types.StrategicMergePatchType, []byte(patchStringExceedMemory), metav1.PatchOptions{})
+			resizedPod.Name, types.StrategicMergePatchType, []byte(patchStringExceedMemory), metav1.PatchOptions{}, "resize")
 		gomega.Expect(pErrExceedMemory).To(gomega.HaveOccurred(), "exceeded quota: %s, requested: memory=350Mi, used: memory=700Mi, limited: memory=800Mi",
 			resourceQuota.Name)
 
@@ -250,7 +250,7 @@ func doPodResizeSchedulerTests(f *framework.Framework) {
 
 		ginkgo.By(fmt.Sprintf("TEST1: Resize pod '%s' to fit in node '%s'", testPod2.Name, node.Name))
 		testPod2, pErr := f.ClientSet.CoreV1().Pods(testPod2.Namespace).Patch(ctx,
-			testPod2.Name, types.StrategicMergePatchType, []byte(patchTestpod2ToFitNode), metav1.PatchOptions{})
+			testPod2.Name, types.StrategicMergePatchType, []byte(patchTestpod2ToFitNode), metav1.PatchOptions{}, "resize")
 		framework.ExpectNoError(pErr, "failed to patch pod for resize")
 
 		ginkgo.By(fmt.Sprintf("TEST1: Verify that pod '%s' is running after resize", testPod2.Name))
@@ -299,7 +299,7 @@ func doPodResizeSchedulerTests(f *framework.Framework) {
 
 		ginkgo.By(fmt.Sprintf("TEST2: Resize pod '%s' to make enough space for pod '%s'", testPod1.Name, testPod3.Name))
 		testPod1, p1Err := f.ClientSet.CoreV1().Pods(testPod1.Namespace).Patch(ctx,
-			testPod1.Name, types.StrategicMergePatchType, []byte(patchTestpod1ToMakeSpaceForPod3), metav1.PatchOptions{})
+			testPod1.Name, types.StrategicMergePatchType, []byte(patchTestpod1ToMakeSpaceForPod3), metav1.PatchOptions{}, "resize")
 		framework.ExpectNoError(p1Err, "failed to patch pod for resize")
 
 		ginkgo.By(fmt.Sprintf("TEST2: Verify pod '%s' is running after successfully resizing pod '%s'", testPod3.Name, testPod1.Name))

--- a/test/e2e/node/pod_resize.go
+++ b/test/e2e/node/pod_resize.go
@@ -37,122 +37,180 @@ import (
 	"github.com/onsi/gomega"
 )
 
-func doPodResizeResourceQuotaTests(f *framework.Framework) {
+func doPodResizeAdmissionPluginsTests(f *framework.Framework) {
 	timeouts := framework.NewTimeoutContext()
 
-	ginkgo.It("pod-resize-resource-quota-test", func(ctx context.Context) {
-		podClient := e2epod.NewPodClient(f)
-		resourceQuota := v1.ResourceQuota{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "resize-resource-quota",
-				Namespace: f.Namespace.Name,
+	testcases := []struct {
+		name                  string
+		enableAdmissionPlugin func(ctx context.Context, f *framework.Framework)
+		wantMemoryError       string
+		wantCPUError          string
+	}{
+		{
+			name: "pod-resize-resource-quota-test",
+			enableAdmissionPlugin: func(ctx context.Context, f *framework.Framework) {
+				resourceQuota := v1.ResourceQuota{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "resize-resource-quota",
+						Namespace: f.Namespace.Name,
+					},
+					Spec: v1.ResourceQuotaSpec{
+						Hard: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("800m"),
+							v1.ResourceMemory: resource.MustParse("800Mi"),
+						},
+					},
+				}
+
+				ginkgo.By("Creating a ResourceQuota")
+				_, rqErr := f.ClientSet.CoreV1().ResourceQuotas(f.Namespace.Name).Create(ctx, &resourceQuota, metav1.CreateOptions{})
+				framework.ExpectNoError(rqErr, "failed to create resource quota")
 			},
-			Spec: v1.ResourceQuotaSpec{
-				Hard: v1.ResourceList{
-					v1.ResourceCPU:    resource.MustParse("800m"),
-					v1.ResourceMemory: resource.MustParse("800Mi"),
+			wantMemoryError: "exceeded quota: resize-resource-quota, requested: memory=350Mi, used: memory=700Mi, limited: memory=800Mi",
+			wantCPUError:    "exceeded quota: resize-resource-quota, requested: cpu=200m, used: cpu=700m, limited: cpu=800m",
+		},
+		{
+			name: "pod-resize-limit-ranger-test",
+			enableAdmissionPlugin: func(ctx context.Context, f *framework.Framework) {
+				lr := v1.LimitRange{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "resize-limit-ranger",
+						Namespace: f.Namespace.Name,
+					},
+					Spec: v1.LimitRangeSpec{
+						Limits: []v1.LimitRangeItem{
+							{
+								Type: v1.LimitTypeContainer,
+								Max: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("500m"),
+									v1.ResourceMemory: resource.MustParse("500Mi"),
+								},
+								Min: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("50m"),
+									v1.ResourceMemory: resource.MustParse("50Mi"),
+								},
+								Default: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("100m"),
+									v1.ResourceMemory: resource.MustParse("100Mi"),
+								},
+								DefaultRequest: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("50m"),
+									v1.ResourceMemory: resource.MustParse("50Mi"),
+								},
+							},
+						},
+					},
+				}
+
+				ginkgo.By("Creating a LimitRanger")
+				_, lrErr := f.ClientSet.CoreV1().LimitRanges(f.Namespace.Name).Create(ctx, &lr, metav1.CreateOptions{})
+				framework.ExpectNoError(lrErr, "failed to create limit ranger")
+			},
+			wantMemoryError: "forbidden: maximum memory usage per Container is 500Mi, but limit is 750Mi",
+			wantCPUError:    "forbidden: maximum cpu usage per Container is 500m, but limit is 600m",
+		},
+	}
+
+	for _, tc := range testcases {
+		ginkgo.It(tc.name, func(ctx context.Context) {
+			containers := []e2epod.ResizableContainerInfo{
+				{
+					Name:      "c1",
+					Resources: &e2epod.ContainerResources{CPUReq: "300m", CPULim: "300m", MemReq: "300Mi", MemLim: "300Mi"},
 				},
-			},
-		}
-		containers := []e2epod.ResizableContainerInfo{
-			{
-				Name:      "c1",
-				Resources: &e2epod.ContainerResources{CPUReq: "300m", CPULim: "300m", MemReq: "300Mi", MemLim: "300Mi"},
-			},
-		}
-		patchString := `{"spec":{"containers":[
-			{"name":"c1", "resources":{"requests":{"cpu":"400m","memory":"400Mi"},"limits":{"cpu":"400m","memory":"400Mi"}}}
-		]}}`
-		expected := []e2epod.ResizableContainerInfo{
-			{
-				Name:      "c1",
-				Resources: &e2epod.ContainerResources{CPUReq: "400m", CPULim: "400m", MemReq: "400Mi", MemLim: "400Mi"},
-			},
-		}
-		patchStringExceedCPU := `{"spec":{"containers":[
-			{"name":"c1", "resources":{"requests":{"cpu":"600m","memory":"200Mi"},"limits":{"cpu":"600m","memory":"200Mi"}}}
-		]}}`
-		patchStringExceedMemory := `{"spec":{"containers":[
-			{"name":"c1", "resources":{"requests":{"cpu":"250m","memory":"750Mi"},"limits":{"cpu":"250m","memory":"750Mi"}}}
-		]}}`
+			}
+			patchString := `{"spec":{"containers":[
+				{"name":"c1", "resources":{"requests":{"cpu":"400m","memory":"400Mi"},"limits":{"cpu":"400m","memory":"400Mi"}}}
+			]}}`
+			expected := []e2epod.ResizableContainerInfo{
+				{
+					Name:      "c1",
+					Resources: &e2epod.ContainerResources{CPUReq: "400m", CPULim: "400m", MemReq: "400Mi", MemLim: "400Mi"},
+				},
+			}
+			patchStringExceedCPU := `{"spec":{"containers":[
+				{"name":"c1", "resources":{"requests":{"cpu":"600m","memory":"200Mi"},"limits":{"cpu":"600m","memory":"200Mi"}}}
+			]}}`
+			patchStringExceedMemory := `{"spec":{"containers":[
+				{"name":"c1", "resources":{"requests":{"cpu":"250m","memory":"750Mi"},"limits":{"cpu":"250m","memory":"750Mi"}}}
+			]}}`
 
-		ginkgo.By("Creating a ResourceQuota")
-		_, rqErr := f.ClientSet.CoreV1().ResourceQuotas(f.Namespace.Name).Create(ctx, &resourceQuota, metav1.CreateOptions{})
-		framework.ExpectNoError(rqErr, "failed to create resource quota")
+			tc.enableAdmissionPlugin(ctx, f)
 
-		tStamp := strconv.Itoa(time.Now().Nanosecond())
-		e2epod.InitDefaultResizePolicy(containers)
-		e2epod.InitDefaultResizePolicy(expected)
-		testPod1 := e2epod.MakePodWithResizableContainers(f.Namespace.Name, "testpod1", tStamp, containers)
-		testPod1 = e2epod.MustMixinRestrictedPodSecurity(testPod1)
-		testPod2 := e2epod.MakePodWithResizableContainers(f.Namespace.Name, "testpod2", tStamp, containers)
-		testPod2 = e2epod.MustMixinRestrictedPodSecurity(testPod2)
+			tStamp := strconv.Itoa(time.Now().Nanosecond())
+			e2epod.InitDefaultResizePolicy(containers)
+			e2epod.InitDefaultResizePolicy(expected)
+			testPod1 := e2epod.MakePodWithResizableContainers(f.Namespace.Name, "testpod1", tStamp, containers)
+			testPod1 = e2epod.MustMixinRestrictedPodSecurity(testPod1)
+			testPod2 := e2epod.MakePodWithResizableContainers(f.Namespace.Name, "testpod2", tStamp, containers)
+			testPod2 = e2epod.MustMixinRestrictedPodSecurity(testPod2)
 
-		ginkgo.By("creating pods")
-		newPod1 := podClient.CreateSync(ctx, testPod1)
-		newPod2 := podClient.CreateSync(ctx, testPod2)
+			ginkgo.By("creating pods")
+			podClient := e2epod.NewPodClient(f)
+			newPod1 := podClient.CreateSync(ctx, testPod1)
+			newPod2 := podClient.CreateSync(ctx, testPod2)
 
-		ginkgo.By("verifying initial pod resources, allocations, and policy are as expected")
-		e2epod.VerifyPodResources(newPod1, containers)
+			ginkgo.By("verifying initial pod resources, allocations, and policy are as expected")
+			e2epod.VerifyPodResources(newPod1, containers)
 
-		ginkgo.By("patching pod for resize within resource quota")
-		patchedPod, pErr := f.ClientSet.CoreV1().Pods(newPod1.Namespace).Patch(ctx, newPod1.Name,
-			types.StrategicMergePatchType, []byte(patchString), metav1.PatchOptions{}, "resize")
-		framework.ExpectNoError(pErr, "failed to patch pod for resize")
+			ginkgo.By("patching pod for resize within resource quota")
+			patchedPod, pErr := f.ClientSet.CoreV1().Pods(newPod1.Namespace).Patch(ctx, newPod1.Name,
+				types.StrategicMergePatchType, []byte(patchString), metav1.PatchOptions{}, "resize")
+			framework.ExpectNoError(pErr, "failed to patch pod for resize")
 
-		ginkgo.By("verifying pod patched for resize within resource quota")
-		e2epod.VerifyPodResources(patchedPod, expected)
-		gomega.Eventually(ctx, e2epod.VerifyPodAllocations, timeouts.PodStartShort, timeouts.Poll).
-			WithArguments(patchedPod, containers).
-			Should(gomega.BeNil(), "failed to verify Pod allocations for patchedPod")
+			ginkgo.By("verifying pod patched for resize within resource quota")
+			e2epod.VerifyPodResources(patchedPod, expected)
+			gomega.Eventually(ctx, e2epod.VerifyPodAllocations, timeouts.PodStartShort, timeouts.Poll).
+				WithArguments(patchedPod, containers).
+				Should(gomega.BeNil(), "failed to verify Pod allocations for patchedPod")
 
-		ginkgo.By("waiting for resize to be actuated")
-		resizedPod := e2epod.WaitForPodResizeActuation(ctx, f, podClient, newPod1, patchedPod, expected, containers, false)
-		ginkgo.By("verifying pod container's cgroup values after resize")
-		framework.ExpectNoError(e2epod.VerifyPodContainersCgroupValues(ctx, f, resizedPod, expected))
+			ginkgo.By("waiting for resize to be actuated")
+			resizedPod := e2epod.WaitForPodResizeActuation(ctx, f, podClient, newPod1, patchedPod, expected, containers, false)
+			ginkgo.By("verifying pod container's cgroup values after resize")
+			framework.ExpectNoError(e2epod.VerifyPodContainersCgroupValues(ctx, f, resizedPod, expected))
 
-		ginkgo.By("verifying pod resources after resize")
-		e2epod.VerifyPodResources(resizedPod, expected)
+			ginkgo.By("verifying pod resources after resize")
+			e2epod.VerifyPodResources(resizedPod, expected)
 
-		ginkgo.By("verifying pod allocations after resize")
-		gomega.Eventually(ctx, e2epod.VerifyPodAllocations, timeouts.PodStartShort, timeouts.Poll).
-			WithArguments(resizedPod, expected).
-			Should(gomega.BeNil(), "failed to verify Pod allocations for patchedPod")
+			ginkgo.By("verifying pod allocations after resize")
+			gomega.Eventually(ctx, e2epod.VerifyPodAllocations, timeouts.PodStartShort, timeouts.Poll).
+				WithArguments(resizedPod, expected).
+				Should(gomega.BeNil(), "failed to verify Pod allocations for patchedPod")
 
-		ginkgo.By("patching pod for resize with memory exceeding resource quota")
-		_, pErrExceedMemory := f.ClientSet.CoreV1().Pods(resizedPod.Namespace).Patch(ctx,
-			resizedPod.Name, types.StrategicMergePatchType, []byte(patchStringExceedMemory), metav1.PatchOptions{}, "resize")
-		gomega.Expect(pErrExceedMemory).To(gomega.HaveOccurred(), "exceeded quota: %s, requested: memory=350Mi, used: memory=700Mi, limited: memory=800Mi",
-			resourceQuota.Name)
+			ginkgo.By("patching pod for resize with memory exceeding resource quota")
+			_, pErrExceedMemory := f.ClientSet.CoreV1().Pods(resizedPod.Namespace).Patch(ctx,
+				resizedPod.Name, types.StrategicMergePatchType, []byte(patchStringExceedMemory), metav1.PatchOptions{}, "resize")
+			gomega.Expect(pErrExceedMemory).To(gomega.HaveOccurred(), tc.wantMemoryError)
 
-		ginkgo.By("verifying pod patched for resize exceeding memory resource quota remains unchanged")
-		patchedPodExceedMemory, pErrEx2 := podClient.Get(ctx, resizedPod.Name, metav1.GetOptions{})
-		framework.ExpectNoError(pErrEx2, "failed to get pod post exceed memory resize")
-		e2epod.VerifyPodResources(patchedPodExceedMemory, expected)
-		gomega.Eventually(ctx, e2epod.VerifyPodAllocations, timeouts.PodStartShort, timeouts.Poll).
-			WithArguments(patchedPodExceedMemory, expected).
-			Should(gomega.BeNil(), "failed to verify Pod allocations for patchedPod")
+			ginkgo.By("verifying pod patched for resize exceeding memory resource quota remains unchanged")
+			patchedPodExceedMemory, pErrEx2 := podClient.Get(ctx, resizedPod.Name, metav1.GetOptions{})
+			framework.ExpectNoError(pErrEx2, "failed to get pod post exceed memory resize")
+			e2epod.VerifyPodResources(patchedPodExceedMemory, expected)
+			gomega.Eventually(ctx, e2epod.VerifyPodAllocations, timeouts.PodStartShort, timeouts.Poll).
+				WithArguments(patchedPodExceedMemory, expected).
+				Should(gomega.BeNil(), "failed to verify Pod allocations for patchedPod")
 
-		ginkgo.By(fmt.Sprintf("patching pod %s for resize with CPU exceeding resource quota", resizedPod.Name))
-		_, pErrExceedCPU := f.ClientSet.CoreV1().Pods(resizedPod.Namespace).Patch(ctx,
-			resizedPod.Name, types.StrategicMergePatchType, []byte(patchStringExceedCPU), metav1.PatchOptions{}, "resize")
-		gomega.Expect(pErrExceedCPU).To(gomega.HaveOccurred(), "exceeded quota: %s, requested: cpu=200m, used: cpu=700m, limited: cpu=800m",
-			resourceQuota.Name)
+			ginkgo.By(fmt.Sprintf("patching pod %s for resize with CPU exceeding resource quota", resizedPod.Name))
+			_, pErrExceedCPU := f.ClientSet.CoreV1().Pods(resizedPod.Namespace).Patch(ctx,
+				resizedPod.Name, types.StrategicMergePatchType, []byte(patchStringExceedCPU), metav1.PatchOptions{}, "resize")
+			gomega.Expect(pErrExceedCPU).To(gomega.HaveOccurred(), tc.wantCPUError)
 
-		ginkgo.By("verifying pod patched for resize exceeding CPU resource quota remains unchanged")
-		patchedPodExceedCPU, pErrEx1 := podClient.Get(ctx, resizedPod.Name, metav1.GetOptions{})
-		framework.ExpectNoError(pErrEx1, "failed to get pod post exceed CPU resize")
-		e2epod.VerifyPodResources(patchedPodExceedCPU, expected)
-		gomega.Eventually(ctx, e2epod.VerifyPodAllocations, timeouts.PodStartShort, timeouts.Poll).
-			WithArguments(patchedPodExceedCPU, expected).
-			Should(gomega.BeNil(), "failed to verify Pod allocations for patchedPod")
+			ginkgo.By("verifying pod patched for resize exceeding CPU resource quota remains unchanged")
+			patchedPodExceedCPU, pErrEx1 := podClient.Get(ctx, resizedPod.Name, metav1.GetOptions{})
+			framework.ExpectNoError(pErrEx1, "failed to get pod post exceed CPU resize")
+			e2epod.VerifyPodResources(patchedPodExceedCPU, expected)
+			gomega.Eventually(ctx, e2epod.VerifyPodAllocations, timeouts.PodStartShort, timeouts.Poll).
+				WithArguments(patchedPodExceedCPU, expected).
+				Should(gomega.BeNil(), "failed to verify Pod allocations for patchedPod")
 
-		ginkgo.By("deleting pods")
-		delErr1 := e2epod.DeletePodWithWait(ctx, f.ClientSet, newPod1)
-		framework.ExpectNoError(delErr1, "failed to delete pod %s", newPod1.Name)
-		delErr2 := e2epod.DeletePodWithWait(ctx, f.ClientSet, newPod2)
-		framework.ExpectNoError(delErr2, "failed to delete pod %s", newPod2.Name)
-	})
+			ginkgo.By("deleting pods")
+			delErr1 := e2epod.DeletePodWithWait(ctx, f.ClientSet, newPod1)
+			framework.ExpectNoError(delErr1, "failed to delete pod %s", newPod1.Name)
+			delErr2 := e2epod.DeletePodWithWait(ctx, f.ClientSet, newPod2)
+			framework.ExpectNoError(delErr2, "failed to delete pod %s", newPod2.Name)
+		})
+	}
+
 }
 
 func doPodResizeSchedulerTests(f *framework.Framework) {
@@ -339,5 +397,5 @@ var _ = SIGDescribe("Pod InPlace Resize Container", feature.InPlacePodVerticalSc
 			e2eskipper.Skipf("runtime does not support InPlacePodVerticalScaling -- skipping")
 		}
 	})
-	doPodResizeResourceQuotaTests(f)
+	doPodResizeAdmissionPluginsTests(f)
 })

--- a/test/integration/pods/pods_test.go
+++ b/test/integration/pods/pods_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -674,6 +675,253 @@ func TestPodUpdateEphemeralContainers(t *testing.T) {
 			t.Errorf("%v: unexpected allowed update to ephemeral containers", tc.name)
 		}
 
+		integration.DeletePodOrErrorf(t, client, ns.Name, pod.Name)
+	}
+}
+
+func TestPodResize(t *testing.T) {
+	// Disable ServiceAccount admission plugin as we don't have serviceaccount controller running.
+	server := kubeapiservertesting.StartTestServerOrDie(t, nil,
+		append(framework.DefaultTestServerFlags(), "--feature-gates=InPlacePodVerticalScaling=true"),
+		framework.SharedEtcd())
+	defer server.TearDownFn()
+
+	client := clientset.NewForConfigOrDie(server.ClientConfig)
+
+	ns := framework.CreateNamespaceOrDie(client, "pod-create-ephemeral-containers", t)
+	defer framework.DeleteNamespaceOrDie(client, ns, t)
+
+	testPod := func(name string) *v1.Pod {
+		return &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+			},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Name:  "fake-name",
+						Image: "fakeimage",
+					},
+				},
+			},
+		}
+	}
+
+	resizeCases := []struct {
+		name        string
+		originalRes v1.ResourceRequirements
+		resize      v1.ResourceRequirements
+		valid       bool
+	}{
+		{
+			name: "cpu request change",
+			originalRes: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceCPU: resource.MustParse("10m"),
+				},
+			},
+			resize: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceCPU: resource.MustParse("20m"),
+				},
+			},
+			valid: true,
+		},
+		{
+			name: "memory request change",
+			originalRes: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+			},
+			resize: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceMemory: resource.MustParse("2Gi"),
+				},
+			},
+			valid: true,
+		},
+		{
+			name: "storage request change",
+			originalRes: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
+				},
+			},
+			resize: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
+				},
+			},
+			valid: false,
+		},
+	}
+
+	for _, tc := range resizeCases {
+		pod := testPod("resize")
+		pod.Spec.Containers[0].Resources = tc.originalRes
+		resp, err := client.CoreV1().Pods(ns.Name).Create(context.TODO(), pod, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatalf("Unexpected error when creating pod: %v", err)
+			integration.DeletePodOrErrorf(t, client, ns.Name, pod.Name)
+		}
+
+		// Part 1. Resize
+		resp.Spec.Containers[0].Resources = tc.resize
+		if _, err := client.CoreV1().Pods(ns.Name).Update(context.TODO(), resp, metav1.UpdateOptions{}); err == nil {
+			t.Fatalf("Unexpected allowed pod update")
+			integration.DeletePodOrErrorf(t, client, ns.Name, pod.Name)
+		} else if !strings.Contains(err.Error(), "spec: Forbidden: pod updates may not change fields other than") {
+			t.Fatalf("Unexpected error when updating pod container resources: %v", err)
+		}
+
+		resp, err = client.CoreV1().Pods(ns.Name).Resize(context.TODO(), resp.Name, resp, metav1.UpdateOptions{})
+		if tc.valid && err != nil {
+			t.Fatalf("Unexpected pod resize failure: %v", err)
+			integration.DeletePodOrErrorf(t, client, ns.Name, pod.Name)
+		}
+		if !tc.valid && err == nil {
+			t.Fatalf("Unexpected pod resize success")
+			integration.DeletePodOrErrorf(t, client, ns.Name, pod.Name)
+		}
+
+		// Part 2. Rollback
+		if !tc.valid {
+			integration.DeletePodOrErrorf(t, client, ns.Name, pod.Name)
+			continue
+		}
+		resp.Spec.Containers[0].Resources = tc.originalRes
+		_, err = client.CoreV1().Pods(ns.Name).Resize(context.TODO(), resp.Name, resp, metav1.UpdateOptions{})
+		if tc.valid && err != nil {
+			t.Fatalf("Unexpected pod resize failure: %v", err)
+			integration.DeletePodOrErrorf(t, client, ns.Name, pod.Name)
+		}
+		if !tc.valid && err == nil {
+			t.Fatalf("Unexpected pod resize success")
+			integration.DeletePodOrErrorf(t, client, ns.Name, pod.Name)
+		}
+
+		integration.DeletePodOrErrorf(t, client, ns.Name, pod.Name)
+	}
+
+	patchCases := []struct {
+		name        string
+		originalRes v1.ResourceRequirements
+		patchBody   string
+		patchType   types.PatchType
+		valid       bool
+	}{
+		{
+			name: "cpu request change (strategic)",
+			originalRes: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceCPU: resource.MustParse("10m"),
+				},
+			},
+			patchType: types.StrategicMergePatchType,
+			patchBody: `{
+				"spec":{
+					"containers":[
+						{
+							"name":"fake-name",
+							"resources": {
+								"requests": {
+									"cpu":"20m"
+								}
+							}
+						}
+					]
+				}
+			}`,
+			valid: true,
+		},
+		{
+			name: "cpu request change (merge)",
+			originalRes: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceCPU: resource.MustParse("10m"),
+				},
+			},
+			patchType: types.MergePatchType,
+			patchBody: `{
+				"spec":{
+					"containers":[
+						{
+							"name":"fake-name",
+							"resources": {
+								"requests": {
+									"cpu":"20m"
+								}
+							}
+						}
+					]
+				}
+			}`,
+			valid: true,
+		},
+		{
+			name: "cpu request change (JSON)",
+			originalRes: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceCPU: resource.MustParse("10m"),
+				},
+			},
+			patchType: types.JSONPatchType,
+			patchBody: `[{
+				"op":"add",
+				"path":"/spec/containers",
+				"value":[{
+					"name":"fake-name",
+					"resources": {
+						"requests": {
+							"cpu":"20m"
+						}
+					}
+				}]
+			}]`,
+			valid: true,
+		},
+		{
+			name: "storage request change (merge)",
+			originalRes: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceCPU: resource.MustParse("10m"),
+				},
+			},
+			patchType: types.MergePatchType,
+			patchBody: `{
+				"spec":{
+					"containers":[
+						{
+							"name":"fake-name",
+							"resources": {
+								"requests": {
+									"ephemeral-storage":"20m"
+								}
+							}
+						}
+					]
+				}
+			}`,
+			valid: false,
+		},
+	}
+
+	for _, tc := range patchCases {
+		pod := testPod("resize")
+		pod.Spec.Containers[0].Resources = tc.originalRes
+		if _, err := client.CoreV1().Pods(ns.Name).Create(context.TODO(), pod, metav1.CreateOptions{}); err != nil {
+			t.Fatalf("Unexpected error when creating pod: %v", err)
+			integration.DeletePodOrErrorf(t, client, ns.Name, pod.Name)
+		}
+
+		if _, err := client.CoreV1().Pods(ns.Name).Patch(context.TODO(), pod.Name, tc.patchType, []byte(tc.patchBody), metav1.PatchOptions{}, "resize"); tc.valid && err != nil {
+			t.Fatalf("Unexpected pod resize failure: %v", err)
+			integration.DeletePodOrErrorf(t, client, ns.Name, pod.Name)
+		} else if !tc.valid && err == nil {
+			t.Fatalf("Unexpected pod resize success")
+			integration.DeletePodOrErrorf(t, client, ns.Name, pod.Name)
+		}
 		integration.DeletePodOrErrorf(t, client, ns.Name, pod.Name)
 	}
 }

--- a/test/integration/pods/pods_test.go
+++ b/test/integration/pods/pods_test.go
@@ -766,7 +766,7 @@ func TestPodResizeRBAC(t *testing.T) {
 					v1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
 				},
 			}
-			_, err = saClient.CoreV1().Pods(ns.Name).Resize(context.TODO(), resp.Name, resp, metav1.UpdateOptions{})
+			_, err = saClient.CoreV1().Pods(ns.Name).UpdateResize(context.TODO(), resp.Name, resp, metav1.UpdateOptions{})
 			if tc.allowResize && err != nil {
 				t.Fatalf("Unexpected pod resize failure: %v", err)
 				integration.DeletePodOrErrorf(t, adminClient, ns.Name, pod.Name)
@@ -878,7 +878,7 @@ func TestPodResize(t *testing.T) {
 			integration.DeletePodOrErrorf(t, client, ns.Name, pod.Name)
 		}
 
-		resp, err = client.CoreV1().Pods(ns.Name).Resize(context.TODO(), resp.Name, resp, metav1.UpdateOptions{})
+		resp, err = client.CoreV1().Pods(ns.Name).UpdateResize(context.TODO(), resp.Name, resp, metav1.UpdateOptions{})
 		if tc.valid && err != nil {
 			t.Fatalf("Unexpected pod resize failure: %v", err)
 			integration.DeletePodOrErrorf(t, client, ns.Name, pod.Name)
@@ -894,7 +894,7 @@ func TestPodResize(t *testing.T) {
 			continue
 		}
 		resp.Spec.Containers[0].Resources = tc.originalRes
-		_, err = client.CoreV1().Pods(ns.Name).Resize(context.TODO(), resp.Name, resp, metav1.UpdateOptions{})
+		_, err = client.CoreV1().Pods(ns.Name).UpdateResize(context.TODO(), resp.Name, resp, metav1.UpdateOptions{})
 		if tc.valid && err != nil {
 			t.Fatalf("Unexpected pod resize failure: %v", err)
 			integration.DeletePodOrErrorf(t, client, ns.Name, pod.Name)

--- a/test/integration/scheduler/queue_test.go
+++ b/test/integration/scheduler/queue_test.go
@@ -406,8 +406,8 @@ func TestCoreResourceEnqueue(t *testing.T) {
 			triggerFn: func(testCtx *testutils.TestContext) (map[framework.ClusterEvent]uint64, error) {
 				// Trigger a PodUpdate event by reducing cpu requested by pod1.
 				// It makes Pod1 schedulable.
-				if _, err := testCtx.ClientSet.CoreV1().Pods(testCtx.NS.Name).Update(testCtx.Ctx, st.MakePod().Name("pod1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Container("image").Obj(), metav1.UpdateOptions{}); err != nil {
-					return nil, fmt.Errorf("failed to update the pod: %w", err)
+				if _, err := testCtx.ClientSet.CoreV1().Pods(testCtx.NS.Name).Resize(testCtx.Ctx, "pod1", st.MakePod().Name("pod1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Container("image").Obj(), metav1.UpdateOptions{}); err != nil {
+					return nil, fmt.Errorf("failed to resize the pod: %w", err)
 				}
 				return map[framework.ClusterEvent]uint64{{Resource: unschedulablePod, ActionType: framework.UpdatePodScaleDown}: 1}, nil
 			},

--- a/test/integration/scheduler/queue_test.go
+++ b/test/integration/scheduler/queue_test.go
@@ -406,7 +406,7 @@ func TestCoreResourceEnqueue(t *testing.T) {
 			triggerFn: func(testCtx *testutils.TestContext) (map[framework.ClusterEvent]uint64, error) {
 				// Trigger a PodUpdate event by reducing cpu requested by pod1.
 				// It makes Pod1 schedulable.
-				if _, err := testCtx.ClientSet.CoreV1().Pods(testCtx.NS.Name).Resize(testCtx.Ctx, "pod1", st.MakePod().Name("pod1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Container("image").Obj(), metav1.UpdateOptions{}); err != nil {
+				if _, err := testCtx.ClientSet.CoreV1().Pods(testCtx.NS.Name).UpdateResize(testCtx.Ctx, "pod1", st.MakePod().Name("pod1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Container("image").Obj(), metav1.UpdateOptions{}); err != nil {
 					return nil, fmt.Errorf("failed to resize the pod: %w", err)
 				}
 				return map[framework.ClusterEvent]uint64{{Resource: unschedulablePod, ActionType: framework.UpdatePodScaleDown}: 1}, nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

This is a dummy PR to test my changes from https://github.com/kubernetes/kubernetes/pull/128186 on top of https://github.com/kubernetes/kubernetes/issues/109553. The first PR had a bunch of breaking tests. Adding the resize subresource takes care of https://github.com/kubernetes/kubernetes/pull/128186#discussion_r1809279116 automatically. I wanted to test this and have a POC ready before code freeze so that I can update it in https://github.com/kubernetes/kubernetes/pull/128186 once the other PR gets merged. For testing this change I rebased with Anish's branch with the resize subresource work from his fork. Because of this, this PR might be outdated as soon as it gets merged. This PR is just for me to test things out.

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Version skew strategy update for InPlacePodVerticalScaling for beta graduation.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/1287
```
