### PR TITLE
Automated cherry pick of #128318: Reset streams when an error happens during port-forward (part 1/2) 

### DIFF
--- a/staging/src/k8s.io/kubelet/pkg/cri/streaming/portforward/httpstream.go
+++ b/staging/src/k8s.io/kubelet/pkg/cri/streaming/portforward/httpstream.go
@@ -256,6 +256,12 @@ func (h *httpStreamHandler) portForward(p *httpStreamPair) {
 		msg := fmt.Errorf("error forwarding port %d to pod %s, uid %v: %v", port, h.pod, h.uid, err)
 		utilruntime.HandleError(msg)
 		fmt.Fprint(p.errorStream, msg.Error())
+		// receiving an error from a port-forward operation indicates a problem
+		// with data stream most probably, thus we want to reset the streams
+		// indicating there was a problem and allow a new set of streams be
+		// created to mitigate the problem
+		p.dataStream.Reset()  // nolint:errcheck
+		p.errorStream.Reset() // nolint:errcheck
 	}
 }
 


### PR DESCRIPTION
Cherry pick of #128318 on release-1.30.

#128318: Reset streams when an error happens during port-forward (part 1/2) 

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Reset streams when an error happens during port-forward allowing kubectl to maintain port-forward connection open
```