### PR TITLE
rest client watch: use same name for package as folder

### DIFF
--- a/staging/src/k8s.io/client-go/rest/watch/decoder.go
+++ b/staging/src/k8s.io/client-go/rest/watch/decoder.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package versioned
+package watch
 
 import (
 	"fmt"

--- a/staging/src/k8s.io/client-go/rest/watch/decoder_test.go
+++ b/staging/src/k8s.io/client-go/rest/watch/decoder_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package versioned_test
+package watch
 
 import (
 	"encoding/json"
@@ -23,7 +23,7 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -32,7 +32,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes/scheme"
-	restclientwatch "k8s.io/client-go/rest/watch"
 )
 
 // getDecoder mimics how k8s.io/client-go/rest.createSerializers creates a decoder
@@ -48,7 +47,7 @@ func TestDecoder(t *testing.T) {
 	for _, eventType := range table {
 		out, in := io.Pipe()
 
-		decoder := restclientwatch.NewDecoder(streaming.NewDecoder(out, getDecoder()), getDecoder())
+		decoder := NewDecoder(streaming.NewDecoder(out, getDecoder()), getDecoder())
 		expect := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}
 		encoder := json.NewEncoder(in)
 		eType := eventType
@@ -108,7 +107,7 @@ func TestDecoder(t *testing.T) {
 
 func TestDecoder_SourceClose(t *testing.T) {
 	out, in := io.Pipe()
-	decoder := restclientwatch.NewDecoder(streaming.NewDecoder(out, getDecoder()), getDecoder())
+	decoder := NewDecoder(streaming.NewDecoder(out, getDecoder()), getDecoder())
 
 	done := make(chan struct{})
 

--- a/staging/src/k8s.io/client-go/rest/watch/encoder.go
+++ b/staging/src/k8s.io/client-go/rest/watch/encoder.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package versioned
+package watch
 
 import (
 	"encoding/json"

--- a/staging/src/k8s.io/client-go/rest/watch/encoder_test.go
+++ b/staging/src/k8s.io/client-go/rest/watch/encoder_test.go
@@ -14,14 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package versioned_test
+package watch
 
 import (
 	"bytes"
 	"io"
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -29,7 +29,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer/streaming"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes/scheme"
-	restclientwatch "k8s.io/client-go/rest/watch"
 )
 
 // getEncoder mimics how k8s.io/client-go/rest.createSerializers creates a encoder
@@ -64,14 +63,14 @@ func TestEncodeDecodeRoundTrip(t *testing.T) {
 	for i, testCase := range testCases {
 		buf := &bytes.Buffer{}
 
-		encoder := restclientwatch.NewEncoder(streaming.NewEncoder(buf, getEncoder()), getEncoder())
+		encoder := NewEncoder(streaming.NewEncoder(buf, getEncoder()), getEncoder())
 		if err := encoder.Encode(&watch.Event{Type: testCase.Type, Object: testCase.Object}); err != nil {
 			t.Errorf("%d: unexpected error: %v", i, err)
 			continue
 		}
 
 		rc := io.NopCloser(buf)
-		decoder := restclientwatch.NewDecoder(streaming.NewDecoder(rc, getDecoder()), getDecoder())
+		decoder := NewDecoder(streaming.NewDecoder(rc, getDecoder()), getDecoder())
 		event, obj, err := decoder.Decode()
 		if err != nil {
 			t.Errorf("%d: unexpected error: %v", i, err)


### PR DESCRIPTION

/kind cleanup
```release-note
NONE
```

Golang by convention uses the same name of the folder for the package, the code still compiles, but it has some side effects  on tooling