### PR TITLE
[FG:InPlacePodVerticalScaling] Don't checkpoint ResizeStatus

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1828,7 +1828,7 @@ func (kl *Kubelet) SyncPod(ctx context.Context, updateType kubetypes.SyncPodType
 		// this conveniently retries any Deferred resize requests
 		// TODO(vinaykul,InPlacePodVerticalScaling): Investigate doing this in HandlePodUpdates + periodic SyncLoop scan
 		//     See: https://github.com/kubernetes/kubernetes/pull/102884#discussion_r663160060
-		pod, err = kl.handlePodResourcesResize(pod)
+		pod, err = kl.handlePodResourcesResize(pod, podStatus)
 		if err != nil {
 			return false, err
 		}
@@ -2793,12 +2793,20 @@ func (kl *Kubelet) canResizePod(pod *v1.Pod) (bool, v1.PodResizeStatus) {
 	return true, v1.PodResizeStatusInProgress
 }
 
-func (kl *Kubelet) handlePodResourcesResize(pod *v1.Pod) (*v1.Pod, error) {
+// handlePodResourcesResize returns the "allocated pod", which should be used for all resource
+// calculations after this function is called. It also updates the cached ResizeStatus according to
+// the allocation decision and pod status.
+func (kl *Kubelet) handlePodResourcesResize(pod *v1.Pod, podStatus *kubecontainer.PodStatus) (*v1.Pod, error) {
 	allocatedPod, updated := kl.statusManager.UpdatePodFromAllocation(pod)
 	if !updated {
-		// Unless a resize is in-progress, clear the resize status.
-		resizeStatus, _ := kl.statusManager.GetPodResizeStatus(string(pod.UID))
-		if resizeStatus != v1.PodResizeStatusInProgress {
+		resizeInProgress := !allocatedResourcesMatchStatus(allocatedPod, podStatus)
+		if resizeInProgress {
+			// If a resize in progress, make sure the cache has the correct state in case the Kubelet restarted.
+			if err := kl.statusManager.SetPodResizeStatus(pod.UID, v1.PodResizeStatusInProgress); err != nil {
+				klog.ErrorS(err, "Failed to set resize status to InProgress", "pod", format.Pod(pod))
+			}
+		} else {
+			// (Desired == Allocated == Actual) => clear the resize status.
 			if err := kl.statusManager.SetPodResizeStatus(pod.UID, ""); err != nil {
 				klog.ErrorS(err, "Failed to clear resize status", "pod", format.Pod(pod))
 			}
@@ -2819,10 +2827,8 @@ func (kl *Kubelet) handlePodResourcesResize(pod *v1.Pod) (*v1.Pod, error) {
 		allocatedPod = pod
 	}
 	if resizeStatus != "" {
-		// Save resize decision to checkpoint
-		if err := kl.statusManager.SetPodResizeStatus(allocatedPod.UID, resizeStatus); err != nil {
-			//TODO(vinaykul,InPlacePodVerticalScaling): Can we recover from this in some way? Investigate
-			klog.ErrorS(err, "SetPodResizeStatus failed", "pod", klog.KObj(allocatedPod))
+		if err := kl.statusManager.SetPodResizeStatus(pod.UID, resizeStatus); err != nil {
+			klog.ErrorS(err, "Failed to set resize status", "pod", format.Pod(pod), "resizeStatus", resizeStatus)
 		}
 	}
 	return allocatedPod, nil

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -1750,13 +1750,11 @@ func (kl *Kubelet) determinePodResizeStatus(allocatedPod *v1.Pod, podStatus *kub
 
 	// If pod is terminal, clear the resize status.
 	if podIsTerminal {
-		if err := kl.statusManager.SetPodResizeStatus(allocatedPod.UID, ""); err != nil {
-			klog.ErrorS(err, "SetPodResizeStatus failed for terminal pod", "pod", format.Pod(allocatedPod))
-		}
+		kl.statusManager.SetPodResizeStatus(allocatedPod.UID, "")
 		return ""
 	}
 
-	resizeStatus, _ := kl.statusManager.GetPodResizeStatus(string(allocatedPod.UID))
+	resizeStatus := kl.statusManager.GetPodResizeStatus(allocatedPod.UID)
 	return resizeStatus
 }
 

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -1757,15 +1757,6 @@ func (kl *Kubelet) determinePodResizeStatus(allocatedPod *v1.Pod, podStatus *kub
 	}
 
 	resizeStatus, _ := kl.statusManager.GetPodResizeStatus(string(allocatedPod.UID))
-	// If the resize was in-progress and the actual resources match the allocated resources, mark
-	// the resize as complete by clearing the resize status.
-	if resizeStatus == v1.PodResizeStatusInProgress &&
-		allocatedResourcesMatchStatus(allocatedPod, podStatus) {
-		if err := kl.statusManager.SetPodResizeStatus(allocatedPod.UID, ""); err != nil {
-			klog.ErrorS(err, "SetPodResizeStatus failed", "pod", format.Pod(allocatedPod))
-		}
-		return ""
-	}
 	return resizeStatus
 }
 

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -2777,7 +2777,7 @@ func TestHandlePodResourcesResize(t *testing.T) {
 			require.True(t, found, "container allocation")
 			assert.Equal(t, tt.expectedAllocations, alloc.Requests, "stored container allocation")
 
-			resizeStatus, _ := kubelet.statusManager.GetPodResizeStatus(string(newPod.UID))
+			resizeStatus := kubelet.statusManager.GetPodResizeStatus(newPod.UID)
 			assert.Equal(t, tt.expectedResize, resizeStatus)
 		})
 	}

--- a/pkg/kubelet/status/fake_status_manager.go
+++ b/pkg/kubelet/status/fake_status_manager.go
@@ -68,8 +68,8 @@ func (m *fakeManager) GetContainerResourceAllocation(podUID string, containerNam
 	return m.state.GetContainerResourceAllocation(podUID, containerName)
 }
 
-func (m *fakeManager) GetPodResizeStatus(podUID string) (v1.PodResizeStatus, bool) {
-	return m.state.GetPodResizeStatus(podUID)
+func (m *fakeManager) GetPodResizeStatus(podUID types.UID) v1.PodResizeStatus {
+	return m.state.GetPodResizeStatus(string(podUID))
 }
 
 func (m *fakeManager) UpdatePodFromAllocation(pod *v1.Pod) (*v1.Pod, bool) {
@@ -86,8 +86,8 @@ func (m *fakeManager) SetPodAllocation(pod *v1.Pod) error {
 	return nil
 }
 
-func (m *fakeManager) SetPodResizeStatus(podUID types.UID, resizeStatus v1.PodResizeStatus) error {
-	return m.state.SetPodResizeStatus(string(podUID), resizeStatus)
+func (m *fakeManager) SetPodResizeStatus(podUID types.UID, resizeStatus v1.PodResizeStatus) {
+	m.state.SetPodResizeStatus(string(podUID), resizeStatus)
 }
 
 // NewFakeManager creates empty/fake memory manager

--- a/pkg/kubelet/status/state/checkpoint.go
+++ b/pkg/kubelet/status/state/checkpoint.go
@@ -28,8 +28,7 @@ import (
 var _ checkpointmanager.Checkpoint = &Checkpoint{}
 
 type PodResourceAllocationInfo struct {
-	AllocationEntries   map[string]map[string]v1.ResourceRequirements `json:"allocationEntries,omitempty"`
-	ResizeStatusEntries map[string]v1.PodResizeStatus                 `json:"resizeStatusEntries,omitempty"`
+	AllocationEntries map[string]map[string]v1.ResourceRequirements `json:"allocationEntries,omitempty"`
 }
 
 // Checkpoint represents a structure to store pod resource allocation checkpoint data

--- a/pkg/kubelet/status/state/state.go
+++ b/pkg/kubelet/status/state/state.go
@@ -42,15 +42,13 @@ func (pr PodResourceAllocation) Clone() PodResourceAllocation {
 type Reader interface {
 	GetContainerResourceAllocation(podUID string, containerName string) (v1.ResourceRequirements, bool)
 	GetPodResourceAllocation() PodResourceAllocation
-	GetPodResizeStatus(podUID string) (v1.PodResizeStatus, bool)
-	GetResizeStatus() PodResizeStatus
+	GetPodResizeStatus(podUID string) v1.PodResizeStatus
 }
 
 type writer interface {
 	SetContainerResourceAllocation(podUID string, containerName string, alloc v1.ResourceRequirements) error
 	SetPodResourceAllocation(PodResourceAllocation) error
-	SetPodResizeStatus(podUID string, resizeStatus v1.PodResizeStatus) error
-	SetResizeStatus(PodResizeStatus) error
+	SetPodResizeStatus(podUID string, resizeStatus v1.PodResizeStatus)
 	Delete(podUID string, containerName string) error
 	ClearState() error
 }

--- a/pkg/kubelet/status/state/state_checkpoint_test.go
+++ b/pkg/kubelet/status/state/state_checkpoint_test.go
@@ -146,7 +146,6 @@ func Test_stateCheckpoint_formatUpgraded(t *testing.T) {
 				},
 			},
 		},
-		ResizeStatusEntries: map[string]v1.PodResizeStatus{},
 	}
 	checkpoint := &Checkpoint{}
 	err := checkpoint.UnmarshalCheckpoint([]byte(checkpointContent))
@@ -160,7 +159,6 @@ func Test_stateCheckpoint_formatUpgraded(t *testing.T) {
 
 	actualPodResourceAllocationInfo := &PodResourceAllocationInfo{}
 	actualPodResourceAllocationInfo.AllocationEntries = sc.cache.GetPodResourceAllocation()
-	actualPodResourceAllocationInfo.ResizeStatusEntries = sc.cache.GetResizeStatus()
 	require.NoError(t, err, "failed to get pod resource allocation info")
 	require.Equal(t, expectedPodResourceAllocationInfo, actualPodResourceAllocationInfo, "pod resource allocation info is not equal")
 }

--- a/pkg/kubelet/status/state/state_mem.go
+++ b/pkg/kubelet/status/state/state_mem.go
@@ -54,22 +54,11 @@ func (s *stateMemory) GetPodResourceAllocation() PodResourceAllocation {
 	return s.podAllocation.Clone()
 }
 
-func (s *stateMemory) GetPodResizeStatus(podUID string) (v1.PodResizeStatus, bool) {
+func (s *stateMemory) GetPodResizeStatus(podUID string) v1.PodResizeStatus {
 	s.RLock()
 	defer s.RUnlock()
 
-	resizeStatus, ok := s.podResizeStatus[podUID]
-	return resizeStatus, ok
-}
-
-func (s *stateMemory) GetResizeStatus() PodResizeStatus {
-	s.RLock()
-	defer s.RUnlock()
-	prs := make(map[string]v1.PodResizeStatus)
-	for k, v := range s.podResizeStatus {
-		prs[k] = v
-	}
-	return prs
+	return s.podResizeStatus[podUID]
 }
 
 func (s *stateMemory) SetContainerResourceAllocation(podUID string, containerName string, alloc v1.ResourceRequirements) error {
@@ -94,7 +83,7 @@ func (s *stateMemory) SetPodResourceAllocation(a PodResourceAllocation) error {
 	return nil
 }
 
-func (s *stateMemory) SetPodResizeStatus(podUID string, resizeStatus v1.PodResizeStatus) error {
+func (s *stateMemory) SetPodResizeStatus(podUID string, resizeStatus v1.PodResizeStatus) {
 	s.Lock()
 	defer s.Unlock()
 
@@ -104,19 +93,6 @@ func (s *stateMemory) SetPodResizeStatus(podUID string, resizeStatus v1.PodResiz
 		delete(s.podResizeStatus, podUID)
 	}
 	klog.V(3).InfoS("Updated pod resize state", "podUID", podUID, "resizeStatus", resizeStatus)
-	return nil
-}
-
-func (s *stateMemory) SetResizeStatus(rs PodResizeStatus) error {
-	s.Lock()
-	defer s.Unlock()
-	prs := make(map[string]v1.PodResizeStatus)
-	for k, v := range rs {
-		prs[k] = v
-	}
-	s.podResizeStatus = prs
-	klog.V(3).InfoS("Updated pod resize state", "resizes", rs)
-	return nil
 }
 
 func (s *stateMemory) deleteContainer(podUID string, containerName string) {

--- a/pkg/kubelet/status/status_manager.go
+++ b/pkg/kubelet/status/status_manager.go
@@ -143,11 +143,11 @@ type Manager interface {
 	// the provided podUIDs.
 	RemoveOrphanedStatuses(podUIDs map[types.UID]bool)
 
-	// GetPodResizeStatus returns checkpointed PodStatus.Resize value
-	GetPodResizeStatus(podUID string) (v1.PodResizeStatus, bool)
+	// GetPodResizeStatus returns cached PodStatus.Resize value
+	GetPodResizeStatus(podUID types.UID) v1.PodResizeStatus
 
-	// SetPodResizeStatus checkpoints the last resizing decision for the pod.
-	SetPodResizeStatus(podUID types.UID, resize v1.PodResizeStatus) error
+	// SetPodResizeStatus caches the last resizing decision for the pod.
+	SetPodResizeStatus(podUID types.UID, resize v1.PodResizeStatus)
 
 	allocationManager
 }
@@ -285,12 +285,11 @@ func updatePodFromAllocation(pod *v1.Pod, allocs state.PodResourceAllocation) (*
 	return pod, updated
 }
 
-// GetPodResizeStatus returns the last checkpointed ResizeStaus value
-// If checkpoint manager has not been initialized, it returns nil, false
-func (m *manager) GetPodResizeStatus(podUID string) (v1.PodResizeStatus, bool) {
+// GetPodResizeStatus returns the last cached ResizeStatus value.
+func (m *manager) GetPodResizeStatus(podUID types.UID) v1.PodResizeStatus {
 	m.podStatusesLock.RLock()
 	defer m.podStatusesLock.RUnlock()
-	return m.state.GetPodResizeStatus(podUID)
+	return m.state.GetPodResizeStatus(string(podUID))
 }
 
 // SetPodAllocation checkpoints the resources allocated to a pod's containers
@@ -307,10 +306,10 @@ func (m *manager) SetPodAllocation(pod *v1.Pod) error {
 }
 
 // SetPodResizeStatus checkpoints the last resizing decision for the pod.
-func (m *manager) SetPodResizeStatus(podUID types.UID, resizeStatus v1.PodResizeStatus) error {
+func (m *manager) SetPodResizeStatus(podUID types.UID, resizeStatus v1.PodResizeStatus) {
 	m.podStatusesLock.RLock()
 	defer m.podStatusesLock.RUnlock()
-	return m.state.SetPodResizeStatus(string(podUID), resizeStatus)
+	m.state.SetPodResizeStatus(string(podUID), resizeStatus)
 }
 
 func (m *manager) GetPodStatus(uid types.UID) (v1.PodStatus, bool) {


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

Resize status can be recomputed from known info and state, so there is no need to checkpoint it.

This PR consolidates the ResizeStatus calculations to `handlePodResourcesResize`, and removes it from the checkpoint.

#### Special notes for your reviewer:

~~Currently based on https://github.com/kubernetes/kubernetes/pull/128377.~~ (merged)

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/sig node
/priority important-soon