### PR TITLE
fix package name

### DIFF
--- a/staging/src/k8s.io/client-go/kubernetes_test/fake_client_test.go
+++ b/staging/src/k8s.io/client-go/kubernetes_test/fake_client_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kubernetes
+package kubernetes_test
 
 import (
 	"context"


### PR DESCRIPTION

/kind cleanup
```release-note
NONE
```

There are 3 files in this folder, two has `package kubernetes_test` and this one only `kubernetes`