### PR TITLE
Add comments to TestGetControlPlaneComponents for clarity

### DIFF
--- a/cmd/kubeadm/app/util/apiclient/wait_test.go
+++ b/cmd/kubeadm/app/util/apiclient/wait_test.go
@@ -24,13 +24,16 @@ import (
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 )
 
+// TestGetControlPlaneComponents tests the getControlPlaneComponents function
 func TestGetControlPlaneComponents(t *testing.T) {
+	// Define test cases with different ClusterConfiguration inputs and expected outputs
 	testcases := []struct {
 		name     string
 		cfg      *kubeadmapi.ClusterConfiguration
 		expected []controlPlaneComponent
 	}{
 		{
+			// Test case: Custom port and address settings from config
 			name: "port and addresses from config",
 			cfg: &kubeadmapi.ClusterConfiguration{
 				APIServer: kubeadmapi.APIServer{
@@ -61,6 +64,7 @@ func TestGetControlPlaneComponents(t *testing.T) {
 			},
 		},
 		{
+			// Test case: Default port and address values
 			name: "default ports and addresses",
 			cfg:  &kubeadmapi.ClusterConfiguration{},
 			expected: []controlPlaneComponent{
@@ -71,9 +75,12 @@ func TestGetControlPlaneComponents(t *testing.T) {
 		},
 	}
 
+	// Iterate over each test case and run the test
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
+			// Call the function being tested
 			actual := getControlPlaneComponents(tc.cfg)
+			// Compare the actual result with the expected result
 			if !reflect.DeepEqual(tc.expected, actual) {
 				t.Fatalf("expected result: %+v, got: %+v", tc.expected, actual)
 			}


### PR DESCRIPTION
This commit adds detailed inline comments to the TestGetControlPlaneComponents function, improving readability and clarity for future maintainers. The comments describe the purpose of each test case and explain key steps in the test logic, including:

A brief overview of the test function.
Descriptions for each test case, highlighting different configurations tested (e.g., custom ports and addresses vs. defaults). Explanations of test assertions to ensure the function output matches expected results. These comments provide context for developers reviewing or modifying the test, facilitating better understanding and easier maintenanc

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
