### PR TITLE
Run scheduler_perf with QueueingHints both enabled and disabled

### DIFF
--- a/test/integration/scheduler_perf/affinity/performance-config.yaml
+++ b/test/integration/scheduler_perf/affinity/performance-config.yaml
@@ -34,6 +34,16 @@
     namespace: sched-1
   workloads:
   - name: 5Nodes
+    featureGates:
+      SchedulerQueueingHints: false
+    labels: [integration-test, short]
+    params:
+      initNodes: 5
+      initPods: 1
+      measurePods: 4
+  - name: 5Nodes_QueueingHintsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
     labels: [integration-test, short]
     params:
       initNodes: 5
@@ -52,6 +62,17 @@
       initPods: 1000
       measurePods: 1000
   - name: 5000Nodes_2000Pods
+    featureGates:
+      SchedulerQueueingHints: false
+    labels: [performance]
+    threshold: 70
+    params:
+      initNodes: 5000
+      initPods: 1000
+      measurePods: 2000
+  - name: 5000Nodes_2000Pods_QueueingHintsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
     labels: [performance]
     threshold: 70
     params:
@@ -80,6 +101,16 @@
     collectMetrics: true
   workloads:
   - name: 5Nodes
+    featureGates:
+      SchedulerQueueingHints: false
+    labels: [integration-test, short]
+    params:
+      initNodes: 5
+      initPods: 5
+      measurePods: 10
+  - name: 5Nodes_QueueingHintsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
     labels: [integration-test, short]
     params:
       initNodes: 5
@@ -98,6 +129,17 @@
       initPods: 5000
       measurePods: 1000
   - name: 5000Nodes_5000Pods
+    featureGates:
+      SchedulerQueueingHints: false
+    labels: [performance]
+    threshold: 35
+    params:
+      initNodes: 5000
+      initPods: 5000
+      measurePods: 5000
+  - name: 5000Nodes_5000Pods_QueueingHintsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
     labels: [performance]
     threshold: 35
     params:
@@ -122,6 +164,16 @@
     collectMetrics: true
   workloads:
   - name: 5Nodes
+    featureGates:
+      SchedulerQueueingHints: false
+    labels: [integration-test, short]
+    params:
+      initNodes: 5
+      initPods: 5
+      measurePods: 10
+  - name: 5Nodes_QueueingHintsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
     labels: [integration-test, short]
     params:
       initNodes: 5
@@ -140,6 +192,17 @@
       initPods: 5000
       measurePods: 1000
   - name: 5000Nodes_5000Pods
+    featureGates:
+      SchedulerQueueingHints: false
+    labels: [performance]
+    threshold: 90
+    params:
+      initNodes: 5000
+      initPods: 5000
+      measurePods: 5000
+  - name: 5000Nodes_5000Pods_QueueingHintsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
     labels: [performance]
     threshold: 90
     params:
@@ -164,6 +227,16 @@
     collectMetrics: true
   workloads:
   - name: 5Nodes
+    featureGates:
+      SchedulerQueueingHints: false
+    labels: [integration-test, short]
+    params:
+      initNodes: 5
+      initPods: 5
+      measurePods: 10
+  - name: 5Nodes_QueueingHintsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
     labels: [integration-test, short]
     params:
       initNodes: 5
@@ -182,6 +255,17 @@
       initPods: 5000
       measurePods: 1000
   - name: 5000Nodes_5000Pods
+    featureGates:
+      SchedulerQueueingHints: false
+    labels: [performance]
+    threshold: 90
+    params:
+      initNodes: 5000
+      initPods: 5000
+      measurePods: 5000
+  - name: 5000Nodes_5000Pods_QueueingHintsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
     labels: [performance]
     threshold: 90
     params:
@@ -205,6 +289,16 @@
     collectMetrics: true
   workloads:
   - name: 5Nodes
+    featureGates:
+      SchedulerQueueingHints: false
+    labels: [integration-test, short]
+    params:
+      initNodes: 5
+      initPods: 5
+      measurePods: 10
+  - name: 5Nodes_QueueingHintsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
     labels: [integration-test, short]
     params:
       initNodes: 5
@@ -223,6 +317,17 @@
       initPods: 5000
       measurePods: 1000
   - name: 5000Nodes_10000Pods
+    featureGates:
+      SchedulerQueueingHints: false
+    labels: [performance]
+    threshold: 220
+    params:
+      initNodes: 5000
+      initPods: 5000
+      measurePods: 10000
+  - name: 5000Nodes_10000Pods_QueueingHintsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
     labels: [performance]
     threshold: 220
     params:
@@ -266,7 +371,17 @@
     collectMetrics: true
   workloads:
   - name: 5Nodes
-    labels: [performance, short]
+    featureGates:
+      SchedulerQueueingHints: false
+    labels: [integration-test, short]
+    params:
+      initNodes: 5
+      initPods: 2
+      measurePods: 10
+  - name: 5Nodes_QueueingHintsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
+    labels: [integration-test, short]
     params:
       initNodes: 5
       initPods: 2
@@ -284,6 +399,17 @@
       initPods: 2000
       measurePods: 1000
   - name: 5000Nodes_5000Pods
+    featureGates:
+      SchedulerQueueingHints: false
+    labels: [performance]
+    threshold: 140
+    params:
+      initNodes: 5000
+      initPods: 2000
+      measurePods: 5000
+  - name: 5000Nodes_5000Pods_QueueingHintsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
     labels: [performance]
     threshold: 140
     params:
@@ -316,7 +442,18 @@
     namespace: measure-ns-0
   workloads:
   - name: 10Nodes
-    labels: [performance, short]
+    featureGates:
+      SchedulerQueueingHints: false
+    labels: [integration-test, short]
+    params:
+      initNodes: 10
+      initPodsPerNamespace: 2
+      initNamespaces: 2
+      measurePods: 6
+  - name: 10Nodes_QueueingHintsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
+    labels: [integration-test, short]
     params:
       initNodes: 10
       initPodsPerNamespace: 2
@@ -337,6 +474,18 @@
       initNamespaces: 100
       measurePods: 1000
   - name: 5000Nodes_2000Pods
+    featureGates:
+      SchedulerQueueingHints: false
+    labels: [performance]
+    threshold: 24
+    params:
+      initNodes: 6000
+      initPodsPerNamespace: 40
+      initNamespaces: 100
+      measurePods: 2000
+  - name: 5000Nodes_2000Pods_QueueingHintsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
     labels: [performance]
     threshold: 24
     params:
@@ -370,7 +519,18 @@
     namespace: measure-ns-0
   workloads:
   - name: 10Nodes
-    labels: [performance, short]
+    featureGates:
+      SchedulerQueueingHints: false
+    labels: [integration-test, short]
+    params:
+      initNodes: 10
+      initPodsPerNamespace: 2
+      initNamespaces: 2
+      measurePods: 10
+  - name: 10Nodes_QueueingHintsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
+    labels: [integration-test, short]
     params:
       initNodes: 10
       initPodsPerNamespace: 2
@@ -391,6 +551,18 @@
       initNamespaces: 100
       measurePods: 1000
   - name: 5000Nodes_2000Pods
+    featureGates:
+      SchedulerQueueingHints: false
+    labels: [performance]
+    threshold: 55
+    params:
+      initNodes: 5000
+      initPodsPerNamespace: 40
+      initNamespaces: 100
+      measurePods: 2000
+  - name: 5000Nodes_2000Pods_QueueingHintsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
     labels: [performance]
     threshold: 55
     params:
@@ -427,7 +599,18 @@
     namespace: measure-ns-0
   workloads:
   - name: 10Nodes
-    labels: [performance, short]
+    featureGates:
+      SchedulerQueueingHints: false
+    labels: [integration-test, short]
+    params:
+      initNodes: 10
+      initPodsPerNamespace: 2
+      initNamespaces: 2
+      measurePods: 10
+  - name: 10Nodes_QueueingHintsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
+    labels: [integration-test, short]
     params:
       initNodes: 10
       initPodsPerNamespace: 2
@@ -448,6 +631,18 @@
       initNamespaces: 100
       measurePods: 1000
   - name: 5000Nodes_2000Pods
+    featureGates:
+      SchedulerQueueingHints: false
+    labels: [performance]
+    threshold: 35
+    params:
+      initNodes: 5000
+      initPodsPerNamespace: 50
+      initNamespaces: 100
+      measurePods: 2000
+  - name: 5000Nodes_2000Pods_QueueingHintsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
     labels: [performance]
     threshold: 35
     params:
@@ -481,7 +676,18 @@
     namespace: measure-ns-0
   workloads:
   - name: 10Nodes
-    labels: [performance, short]
+    featureGates:
+      SchedulerQueueingHints: false
+    labels: [integration-test, short]
+    params:
+      initNodes: 10
+      initPodsPerNamespace: 2
+      initNamespaces: 2
+      measurePods: 10
+  - name: 10Nodes_QueueingHintsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
+    labels: [integration-test, short]
     params:
       initNodes: 10
       initPodsPerNamespace: 2
@@ -502,6 +708,18 @@
       initNamespaces: 100
       measurePods: 1000
   - name: 5000Nodes_5000Pods
+    featureGates:
+      SchedulerQueueingHints: false
+    labels: [performance]
+    threshold: 90
+    params:
+      initNodes: 5000
+      initPodsPerNamespace: 50
+      initNamespaces: 100
+      measurePods: 5000
+  - name: 5000Nodes_5000Pods_QueueingHintsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
     labels: [performance]
     threshold: 90
     params:
@@ -530,12 +748,31 @@
     collectMetrics: true
   workloads:
   - name: 1Node_10GatedPods
-    labels: [performance, short]
+    featureGates:
+      SchedulerQueueingHints: false
+    labels: [integration-test, short]
+    params:
+      gatedPods: 10
+      measurePods: 10
+  - name: 1Node_10GatedPods_QueueingHintsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
+    labels: [integration-test, short]
     params:
       gatedPods: 10
       measurePods: 10
   - name: 1Node_10000GatedPods
-    labels: [performance, short]
+    featureGates:
+      SchedulerQueueingHints: false
+    labels: [performance]
+    threshold: 110
+    params:
+      gatedPods: 10000
+      measurePods: 20000
+  - name: 1Node_10000GatedPods_QueueingHintsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
+    labels: [performance]
     threshold: 110
     params:
       gatedPods: 10000

--- a/test/integration/scheduler_perf/dra/performance-config.yaml
+++ b/test/integration/scheduler_perf/dra/performance-config.yaml
@@ -53,6 +53,20 @@
     collectMetrics: true
   workloads:
   - name: fast
+    featureGates:
+      SchedulerQueueingHints: false
+    labels: [integration-test, short]
+    params:
+      # This testcase runs through all code paths without
+      # taking too long overall.
+      nodesWithDRA: 1
+      nodesWithoutDRA: 1
+      initPods: 0
+      measurePods: 10
+      maxClaimsPerNode: 10
+  - name: fast_QueueingHintsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
     labels: [integration-test, short]
     params:
       # This testcase runs through all code paths without
@@ -125,6 +139,20 @@
     collectMetrics: true
   workloads:
   - name: fast
+    featureGates:
+      SchedulerQueueingHints: false
+    labels: [integration-test, short]
+    params:
+      # This testcase runs through all code paths without
+      # taking too long overall.
+      nodesWithDRA: 1
+      nodesWithoutDRA: 1
+      initClaims: 0
+      maxClaimsPerNode: 10
+      duration: 2s
+  - name: fast_QueueingHintsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
     labels: [integration-test, short]
     params:
       # This testcase runs through all code paths without
@@ -238,6 +266,22 @@
     collectMetrics: true
   workloads:
   - name: fast
+    featureGates:
+      SchedulerQueueingHints: false
+    labels: [integration-test, short]
+    params:
+      # This testcase runs through all code paths without
+      # taking too long overall.
+      nodesWithDRA: 1
+      nodesWithoutDRA: 1
+      initPods: 0
+      initClaims: 0
+      measurePods: 10
+      measureClaims: 2 # must be measurePods / 5
+      maxClaimsPerNode: 2
+  - name: fast_QueueingHintsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
     labels: [integration-test, short]
     params:
       # This testcase runs through all code paths without

--- a/test/integration/scheduler_perf/misc/performance-config.yaml
+++ b/test/integration/scheduler_perf/misc/performance-config.yaml
@@ -29,6 +29,16 @@
     collectMetrics: true
   workloads:
   - name: 5Nodes
+    featureGates:
+      SchedulerQueueingHints: false
+    labels: [integration-test, short]
+    params:
+      initNodes: 5
+      initPods: 5
+      measurePods: 10
+  - name: 5Nodes_QueueingHintsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
     labels: [integration-test, short]
     params:
       initNodes: 5
@@ -47,6 +57,17 @@
       initPods: 1000
       measurePods: 1000
   - name: 5000Nodes_10000Pods
+    featureGates:
+      SchedulerQueueingHints: false
+    labels: [performance]
+    threshold: 270
+    params:
+      initNodes: 5000
+      initPods: 1000
+      measurePods: 10000
+  - name: 5000Nodes_10000Pods_QueueingHintsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
     labels: [performance]
     threshold: 270
     params:
@@ -76,12 +97,31 @@
     collectMetrics: true
   workloads:
   - name: 5Nodes
+    featureGates:
+      SchedulerQueueingHints: false
+    labels: [integration-test, short]
+    params:
+      initNodes: 5
+      measurePods: 10
+  - name: 5Nodes_QueueingHintsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
     labels: [integration-test, short]
     params:
       initNodes: 5
       measurePods: 10
   - name: 15000Nodes
-    labels: [performance, short]
+    featureGates:
+      SchedulerQueueingHints: false
+    labels: [performance]
+    threshold: 390
+    params:
+      initNodes: 15000
+      measurePods: 30000
+  - name: 15000Nodes_QueueingHintsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
+    labels: [performance]
     threshold: 390
     params:
       initNodes: 15000
@@ -104,6 +144,16 @@
     collectMetrics: true
   workloads:
   - name: 5Nodes
+    featureGates:
+      SchedulerQueueingHints: false
+    labels: [integration-test, short]
+    params:
+      initNodes: 5
+      initPods: 10
+      measurePods: 10
+  - name: 5Nodes_QueueingHintsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
     labels: [integration-test, short]
     params:
       initNodes: 5
@@ -122,6 +172,17 @@
       initPods: 5000
       measurePods: 2000
   - name: 5000Nodes_5000Pods
+    featureGates:
+      SchedulerQueueingHints: false
+    labels: [performance]
+    threshold: 85
+    params:
+      initNodes: 5000
+      initPods: 5000
+      measurePods: 5000
+  - name: 5000Nodes_5000Pods_QueueingHintsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
     labels: [performance]
     threshold: 85
     params:
@@ -146,6 +207,16 @@
     collectMetrics: true
   workloads:
   - name: 5Nodes
+    featureGates:
+      SchedulerQueueingHints: false
+    labels: [integration-test, short]
+    params:
+      initNodes: 5
+      initPods: 10
+      measurePods: 10
+  - name: 5Nodes_QueueingHintsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
     labels: [integration-test, short]
     params:
       initNodes: 5
@@ -164,6 +235,17 @@
       initPods: 5000
       measurePods: 2000
   - name: 5000Nodes_5000Pods
+    featureGates:
+      SchedulerQueueingHints: false
+    labels: [performance]
+    threshold: 125
+    params:
+      initNodes: 5000
+      initPods: 5000
+      measurePods: 5000
+  - name: 5000Nodes_5000Pods_QueueingHintsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
     labels: [performance]
     threshold: 125
     params:
@@ -184,12 +266,33 @@
     collectMetrics: true
   workloads:
   - name: 5Nodes
+    featureGates:
+      SchedulerQueueingHints: false
+    labels: [integration-test, short]
+    params:
+      initNodes: 5
+      initPods: 20
+      measurePods: 5
+  - name: 5Nodes_QueueingHintsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
     labels: [integration-test, short]
     params:
       initNodes: 5
       initPods: 20
       measurePods: 5
   - name: 500Nodes
+    featureGates:
+      SchedulerQueueingHints: false
+    labels: [performance, short]
+    threshold: 18
+    params:
+      initNodes: 500
+      initPods: 2000
+      measurePods: 500
+  - name: 500Nodes_QueueingHintsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
     labels: [performance, short]
     threshold: 18
     params:
@@ -229,6 +332,16 @@
     collectMetrics: true
   workloads:
   - name: 5Nodes
+    featureGates:
+      SchedulerQueueingHints: false
+    labels: [integration-test, short]
+    params:
+      initNodes: 5
+      initPods: 20
+      measurePods: 5
+  - name: 5Nodes_QueueingHintsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
     labels: [integration-test, short]
     params:
       initNodes: 5
@@ -241,8 +354,19 @@
       initPods: 2000
       measurePods: 500
   - name: 5000Nodes
+    featureGates:
+      SchedulerQueueingHints: false
     labels: [performance]
     threshold: 200
+    params:
+      initNodes: 5000
+      initPods: 20000
+      measurePods: 5000
+  - name: 5000Nodes_QueueingHintsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
+    labels: [performance]
+    threshold: 120
     params:
       initNodes: 5000
       initPods: 20000
@@ -264,6 +388,15 @@
     collectMetrics: true
   workloads:
   - name: 5Nodes/10Pods
+    featureGates:
+      SchedulerQueueingHints: false
+    labels: [integration-test, short]
+    params:
+      initNodes: 5
+      measurePods: 10
+  - name: 5Nodes/10Pods_QueueingHintsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
     labels: [integration-test, short]
     params:
       initNodes: 5
@@ -279,8 +412,18 @@
       initNodes: 5000
       measurePods: 1000
   - name: 5kNodes/10kPods
+    featureGates:
+      SchedulerQueueingHints: false
     labels: [performance]
     threshold: 200
+    params:
+      initNodes: 5000
+      measurePods: 10000
+  - name: 5kNodes/10kPods_QueueingHintsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
+    labels: [performance]
+    threshold: 250
     params:
       initNodes: 5000
       measurePods: 10000
@@ -303,6 +446,15 @@
     collectMetrics: true
   workloads:
   - name: 10Nodes
+    featureGates:
+      SchedulerQueueingHints: false
+    labels: [integration-test, short]
+    params:
+      initNodes: 10
+      measurePods: 100
+  - name: 10Nodes_QueueingHintsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
     labels: [integration-test, short]
     params:
       initNodes: 10
@@ -318,6 +470,16 @@
       initNodes: 5000
       measurePods: 2000
   - name: 5000Nodes_10000Pods
+    featureGates:
+      SchedulerQueueingHints: false
+    labels: [performance]
+    threshold: 265
+    params:
+      initNodes: 5000
+      measurePods: 10000
+  - name: 5000Nodes_10000Pods_QueueingHintsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
     labels: [performance]
     threshold: 265
     params:
@@ -339,6 +501,16 @@
     collectMetrics: true
   workloads:
   - name: 5Nodes
+    featureGates:
+      SchedulerQueueingHints: false
+    labels: [integration-test, short]
+    params:
+      taintNodes: 1
+      normalNodes: 4
+      measurePods: 4
+  - name: 5Nodes_QueueingHintsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
     labels: [integration-test, short]
     params:
       taintNodes: 1
@@ -351,6 +523,17 @@
       normalNodes: 400
       measurePods: 400
   - name: 5000Nodes
+    featureGates:
+      SchedulerQueueingHints: false
+    labels: [performance, short]
+    threshold: 68
+    params:
+      taintNodes: 1000
+      normalNodes: 4000
+      measurePods: 4000
+  - name: 5000Nodes_QueueingHintsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
     labels: [performance, short]
     threshold: 68
     params:
@@ -389,13 +572,34 @@
     collectMetrics: true
   workloads:
   - name: 1Node_10GatedPods
+    featureGates:
+      SchedulerQueueingHints: false
+    labels: [integration-test, short]
+    params:
+      gatedPods: 10
+      deletingPods: 10
+      measurePods: 10
+  - name: 1Node_10GatedPods_QueueingHintsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
     labels: [integration-test, short]
     params:
       gatedPods: 10
       deletingPods: 10
       measurePods: 10
   - name: 1Node_10000GatedPods
-    labels: [performance, short]
+    featureGates:
+      SchedulerQueueingHints: false
+    labels: [performance]
+    threshold: 130
+    params:
+      gatedPods: 10000
+      deletingPods: 20000
+      measurePods: 20000
+  - name: 1Node_10000GatedPods_QueueingHintsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
+    labels: [performance]
     threshold: 130
     params:
       gatedPods: 10000
@@ -429,12 +633,32 @@
     collectMetrics: true
   workloads:
   - name: 10Node_100DeletingPods
+    featureGates:
+      SchedulerQueueingHints: false
+    labels: [integration-test, short]
+    params:
+      initNodes: 10
+      deletingPods: 10
+      measurePods: 10
+  - name: 10Node_100DeletingPods_QueueingHintsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
     labels: [integration-test, short]
     params:
       initNodes: 10
       deletingPods: 10
       measurePods: 10
   - name: 1000Node_1000DeletingPods
+    featureGates:
+      SchedulerQueueingHints: false
+    labels: [performance, short]
+    params:
+      initNodes: 1000
+      deletingPods: 1000
+      measurePods: 1000
+  - name: 1000Node_1000DeletingPods_QueueingHintsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
     labels: [performance, short]
     params:
       initNodes: 1000

--- a/test/integration/scheduler_perf/volumes/performance-config.yaml
+++ b/test/integration/scheduler_perf/volumes/performance-config.yaml
@@ -29,6 +29,16 @@
     collectMetrics: true
   workloads:
   - name: 5Nodes
+    featureGates:
+      SchedulerQueueingHints: false
+    labels: [integration-test, short]
+    params:
+      initNodes: 5
+      initPods: 5
+      measurePods: 10
+  - name: 5Nodes_QueueingHintsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
     labels: [integration-test, short]
     params:
       initNodes: 5
@@ -47,6 +57,17 @@
       initPods: 5000
       measurePods: 1000
   - name: 5000Nodes_10000Pods
+    featureGates:
+      SchedulerQueueingHints: false
+    labels: [performance]
+    threshold: 260
+    params:
+      initNodes: 5000
+      initPods: 1000
+      measurePods: 10000
+  - name: 5000Nodes_10000Pods_QueueingHintsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
     labels: [performance]
     threshold: 260
     params:
@@ -69,6 +90,16 @@
     collectMetrics: true
   workloads:
   - name: 5Nodes
+    featureGates:
+      SchedulerQueueingHints: false
+    labels: [integration-test, short]
+    params:
+      initNodes: 5
+      initPods: 5
+      measurePods: 10
+  - name: 5Nodes_QueueingHintsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
     labels: [integration-test, short]
     params:
       initNodes: 5
@@ -87,6 +118,17 @@
       initPods: 5000
       measurePods: 1000
   - name: 5000Nodes_2000Pods
+    featureGates:
+      SchedulerQueueingHints: false
+    labels: [performance]
+    threshold: 90
+    params:
+      initNodes: 5000
+      initPods: 1000
+      measurePods: 2000
+  - name: 5000Nodes_2000Pods_QueueingHintsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
     labels: [performance]
     threshold: 90
     params:
@@ -118,6 +160,16 @@
     collectMetrics: true
   workloads:
   - name: 5Nodes
+    featureGates:
+      SchedulerQueueingHints: false
+    labels: [integration-test, short]
+    params:
+      initNodes: 5
+      initPods: 5
+      measurePods: 10
+  - name: 5Nodes_QueueingHintsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
     labels: [integration-test, short]
     params:
       initNodes: 5
@@ -136,6 +188,17 @@
       initPods: 5000
       measurePods: 1000
   - name: 5000Nodes_5000Pods
+    featureGates:
+      SchedulerQueueingHints: false
+    labels: [performance]
+    threshold: 35
+    params:
+      initNodes: 5000
+      initPods: 5000
+      measurePods: 5000
+  - name: 5000Nodes_5000Pods_QueueingHintsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
     labels: [performance]
     threshold: 35
     params:
@@ -165,6 +228,16 @@
     collectMetrics: true
   workloads:
   - name: 5Nodes
+    featureGates:
+      SchedulerQueueingHints: false
+    labels: [integration-test, short]
+    params:
+      initNodes: 5
+      initPods: 5
+      measurePods: 10
+  - name: 5Nodes_QueueingHintsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
     labels: [integration-test, short]
     params:
       initNodes: 5
@@ -183,6 +256,17 @@
       initPods: 5000
       measurePods: 1000
   - name: 5000Nodes_5000Pods
+    featureGates:
+      SchedulerQueueingHints: false
+    labels: [performance]
+    threshold: 48
+    params:
+      initNodes: 5000
+      initPods: 5000
+      measurePods: 5000
+  - name: 5000Nodes_5000Pods_QueueingHintsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
     labels: [performance]
     threshold: 48
     params:
@@ -205,12 +289,33 @@
     collectMetrics: true
   workloads:
   - name: 5Nodes
+    featureGates:
+      SchedulerQueueingHints: false
+    labels: [integration-test, short]
+    params:
+      initNodes: 5
+      initPods: 20
+      measurePods: 5
+  - name: 5Nodes_QueueingHintsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
     labels: [integration-test, short]
     params:
       initNodes: 5
       initPods: 20
       measurePods: 5
   - name: 500Nodes
+    featureGates:
+      SchedulerQueueingHints: false
+    labels: [performance, short]
+    threshold: 18
+    params:
+      initNodes: 500
+      initPods: 2000
+      measurePods: 500
+  - name: 500Nodes_QueueingHintsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
     labels: [performance, short]
     threshold: 18
     params:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

Add new workloads for each test case that have queueing hints enabled - for integration tests and largest performance cases. Also, explicitly disable it in other workloads to work correctly after enabling the feature by default. I left the mid-sized workloads without explicit feature gate, as I think we don't need to run them twice.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #127750

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
