### PR TITLE
e2e_node: refactor Kubelet stopping and restarting

### DIFF
--- a/test/e2e_node/device_manager_test.go
+++ b/test/e2e_node/device_manager_test.go
@@ -194,7 +194,7 @@ var _ = SIGDescribe("Device Manager", framework.WithSerial(), nodefeature.Device
 			framework.Logf("pod %s/%s running", testPod.Namespace, testPod.Name)
 
 			ginkgo.By("stopping the kubelet")
-			startKubelet := stopKubelet()
+			restartKubelet := mustStopKubelet(ctx, f)
 
 			ginkgo.By("stopping all the local containers - using CRI")
 			rs, _, err := getCRIClient()
@@ -210,7 +210,7 @@ var _ = SIGDescribe("Device Manager", framework.WithSerial(), nodefeature.Device
 			}
 
 			ginkgo.By("restarting the kubelet")
-			startKubelet()
+			restartKubelet(ctx)
 
 			ginkgo.By("waiting for the kubelet to be ready again")
 			// Wait for the Kubelet to be ready.

--- a/test/e2e_node/device_plugin_test.go
+++ b/test/e2e_node/device_plugin_test.go
@@ -211,7 +211,7 @@ func testDevicePlugin(f *framework.Framework, pluginSockDir string) {
 				e2epod.NewPodClient(f).DeleteSync(ctx, p.Name, metav1.DeleteOptions{}, 2*time.Minute)
 			}
 
-			restartKubelet(true)
+			restartKubelet(ctx, true)
 
 			ginkgo.By("Waiting for devices to become unavailable on the local node")
 			gomega.Eventually(ctx, func(ctx context.Context) bool {
@@ -365,7 +365,7 @@ func testDevicePlugin(f *framework.Framework, pluginSockDir string) {
 			framework.Logf("testing pod: pre-restart  UID=%s namespace=%s name=%s ready=%v", pod1.UID, pod1.Namespace, pod1.Name, podutils.IsPodReady(pod1))
 
 			ginkgo.By("Restarting Kubelet")
-			restartKubelet(true)
+			restartKubelet(ctx, true)
 
 			ginkgo.By("Wait for node to be ready again")
 			e2enode.WaitForAllNodesSchedulable(ctx, f.ClientSet, 5*time.Minute)
@@ -430,7 +430,7 @@ func testDevicePlugin(f *framework.Framework, pluginSockDir string) {
 			gomega.Expect(devIDRestart1).To(gomega.Equal(devID1))
 
 			ginkgo.By("Restarting Kubelet")
-			restartKubelet(true)
+			restartKubelet(ctx, true)
 
 			ginkgo.By("Wait for node to be ready again")
 			e2enode.WaitForAllNodesSchedulable(ctx, f.ClientSet, 5*time.Minute)
@@ -499,7 +499,7 @@ func testDevicePlugin(f *framework.Framework, pluginSockDir string) {
 			gomega.Eventually(getNodeResourceValues, devicePluginGracefulTimeout, f.Timeouts.Poll).WithContext(ctx).WithArguments(SampleDeviceResourceName).Should(gomega.Equal(ResourceValue{Allocatable: 0, Capacity: int(expectedSampleDevsAmount)}))
 
 			ginkgo.By("Restarting Kubelet")
-			restartKubelet(true)
+			restartKubelet(ctx, true)
 
 			ginkgo.By("Wait for node to be ready again")
 			gomega.Expect(e2enode.WaitForAllNodesSchedulable(ctx, f.ClientSet, 5*time.Minute)).To(gomega.Succeed())
@@ -587,7 +587,7 @@ func testDevicePlugin(f *framework.Framework, pluginSockDir string) {
 			framework.ExpectNoError(err)
 
 			ginkgo.By("Restarting Kubelet")
-			restartKubelet(true)
+			restartKubelet(ctx, true)
 
 			ginkgo.By("Wait for node to be ready again")
 			e2enode.WaitForAllNodesSchedulable(ctx, f.ClientSet, 5*time.Minute)
@@ -652,7 +652,7 @@ func testDevicePlugin(f *framework.Framework, pluginSockDir string) {
 			framework.ExpectNoError(err)
 
 			ginkgo.By("stopping the kubelet")
-			startKubelet := stopKubelet()
+			restartKubelet := mustStopKubelet(ctx, f)
 
 			// wait until the kubelet health check will fail
 			gomega.Eventually(ctx, func() bool {
@@ -666,7 +666,7 @@ func testDevicePlugin(f *framework.Framework, pluginSockDir string) {
 			deletePodSyncByName(ctx, f, pod.Name)
 
 			framework.Logf("Starting the kubelet")
-			startKubelet()
+			restartKubelet(ctx)
 
 			// wait until the kubelet health check will succeed
 			gomega.Eventually(ctx, func() bool {
@@ -947,7 +947,7 @@ func testDevicePluginNodeReboot(f *framework.Framework, pluginSockDir string) {
 			framework.ExpectNoError(err)
 
 			ginkgo.By("stopping the kubelet")
-			startKubelet := stopKubelet()
+			restartKubelet := mustStopKubelet(ctx, f)
 
 			ginkgo.By("stopping all the local containers - using CRI")
 			rs, _, err := getCRIClient()
@@ -963,7 +963,7 @@ func testDevicePluginNodeReboot(f *framework.Framework, pluginSockDir string) {
 			}
 
 			ginkgo.By("restarting the kubelet")
-			startKubelet()
+			restartKubelet(ctx)
 
 			ginkgo.By("Wait for node to be ready again")
 			e2enode.WaitForAllNodesSchedulable(ctx, f.ClientSet, 5*time.Minute)

--- a/test/e2e_node/hugepages_test.go
+++ b/test/e2e_node/hugepages_test.go
@@ -222,7 +222,7 @@ var _ = SIGDescribe("HugePages", framework.WithSerial(), feature.HugePages, "[No
 		gomega.Expect(value.String()).To(gomega.Equal("9Mi"), "huge pages with size 3Mi should be supported")
 
 		ginkgo.By("restarting the node and verifying that huge pages with size 3Mi are not supported")
-		restartKubelet(true)
+		restartKubelet(ctx, true)
 
 		ginkgo.By("verifying that the hugepages-3Mi resource no longer is present")
 		gomega.Eventually(ctx, func() bool {
@@ -235,14 +235,14 @@ var _ = SIGDescribe("HugePages", framework.WithSerial(), feature.HugePages, "[No
 
 	ginkgo.It("should add resources for new huge page sizes on kubelet restart", func(ctx context.Context) {
 		ginkgo.By("Stopping kubelet")
-		startKubelet := stopKubelet()
+		restartKubelet := mustStopKubelet(ctx, f)
 		ginkgo.By(`Patching away support for hugepage resource "hugepages-2Mi"`)
 		patch := []byte(`[{"op": "remove", "path": "/status/capacity/hugepages-2Mi"}, {"op": "remove", "path": "/status/allocatable/hugepages-2Mi"}]`)
 		result := f.ClientSet.CoreV1().RESTClient().Patch(types.JSONPatchType).Resource("nodes").Name(framework.TestContext.NodeName).SubResource("status").Body(patch).Do(ctx)
 		framework.ExpectNoError(result.Error(), "while patching")
 
-		ginkgo.By("Starting kubelet again")
-		startKubelet()
+		ginkgo.By("Restarting kubelet again")
+		restartKubelet(ctx)
 
 		ginkgo.By("verifying that the hugepages-2Mi resource is present")
 		gomega.Eventually(ctx, func() bool {
@@ -352,7 +352,7 @@ var _ = SIGDescribe("HugePages", framework.WithSerial(), feature.HugePages, "[No
 			setHugepages(ctx)
 
 			ginkgo.By("restarting kubelet to pick up pre-allocated hugepages")
-			restartKubelet(true)
+			restartKubelet(ctx, true)
 
 			waitForHugepages(ctx)
 
@@ -370,7 +370,7 @@ var _ = SIGDescribe("HugePages", framework.WithSerial(), feature.HugePages, "[No
 			releaseHugepages(ctx)
 
 			ginkgo.By("restarting kubelet to pick up pre-allocated hugepages")
-			restartKubelet(true)
+			restartKubelet(ctx, true)
 
 			waitForHugepages(ctx)
 		})

--- a/test/e2e_node/image_gc_test.go
+++ b/test/e2e_node/image_gc_test.go
@@ -94,8 +94,7 @@ var _ = SIGDescribe("ImageGarbageCollect", framework.WithSerial(), framework.Wit
 
 			e2epod.NewPodClient(f).DeleteSync(ctx, pod.ObjectMeta.Name, metav1.DeleteOptions{}, e2epod.DefaultPodDeletionTimeout)
 
-			restartKubelet(true)
-			waitForKubeletToStart(ctx, f)
+			restartKubelet(ctx, true)
 
 			// Wait until the maxAge of the image after the kubelet is restarted to ensure it doesn't
 			// GC too early.

--- a/test/e2e_node/kubelet_config_dir_test.go
+++ b/test/e2e_node/kubelet_config_dir_test.go
@@ -54,12 +54,7 @@ var _ = SIGDescribe("Kubelet Config", framework.WithSlow(), framework.WithSerial
 			framework.ExpectNoError(err)
 
 			ginkgo.By("Stopping the kubelet")
-			restartKubelet := stopKubelet()
-
-			// wait until the kubelet health check will fail
-			gomega.Eventually(ctx, func() bool {
-				return kubeletHealthCheck(kubeletHealthCheckURL)
-			}, f.Timeouts.PodStart, f.Timeouts.Poll).Should(gomega.BeFalseBecause("expected kubelet health check to be failed"))
+			restartKubelet := mustStopKubelet(ctx, f)
 
 			configDir := framework.TestContext.KubeletConfigDropinDir
 
@@ -128,7 +123,7 @@ featureGates:
   DynamicResourceAllocation: true`)
 			framework.ExpectNoError(os.WriteFile(filepath.Join(configDir, "20-kubelet.conf"), contents, 0755))
 			ginkgo.By("Restarting the kubelet")
-			restartKubelet()
+			restartKubelet(ctx)
 			// wait until the kubelet health check will succeed
 			gomega.Eventually(ctx, func() bool {
 				return kubeletHealthCheck(kubeletHealthCheckURL)

--- a/test/e2e_node/node_perf_test.go
+++ b/test/e2e_node/node_perf_test.go
@@ -52,22 +52,12 @@ func setKubeletConfig(ctx context.Context, f *framework.Framework, cfg *kubeletc
 	if cfg != nil {
 		// Update the Kubelet configuration.
 		ginkgo.By("Stopping the kubelet")
-		startKubelet := stopKubelet()
-
-		// wait until the kubelet health check will fail
-		gomega.Eventually(ctx, func() bool {
-			return kubeletHealthCheck(kubeletHealthCheckURL)
-		}, time.Minute, time.Second).Should(gomega.BeFalseBecause("expected kubelet health check to be failed"))
+		restartKubelet := mustStopKubelet(ctx, f)
 
 		framework.ExpectNoError(e2enodekubelet.WriteKubeletConfigFile(cfg))
 
-		ginkgo.By("Starting the kubelet")
-		startKubelet()
-
-		// wait until the kubelet health check will succeed
-		gomega.Eventually(ctx, func() bool {
-			return kubeletHealthCheck(kubeletHealthCheckURL)
-		}, 2*time.Minute, 5*time.Second).Should(gomega.BeTrueBecause("expected kubelet to be in healthy state"))
+		ginkgo.By("Restarting the kubelet")
+		restartKubelet(ctx)
 	}
 
 	// Wait for the Kubelet to be ready.

--- a/test/e2e_node/os_label_rename_test.go
+++ b/test/e2e_node/os_label_rename_test.go
@@ -49,7 +49,7 @@ var _ = SIGDescribe("OSArchLabelReconciliation", framework.WithSerial(), framewo
 
 			ginkgo.By("killing and restarting kubelet")
 			// Let's kill the kubelet
-			startKubelet := stopKubelet()
+			restartKubelet := mustStopKubelet(ctx, f)
 			// Update labels
 			newNode := node.DeepCopy()
 			newNode.Labels[v1.LabelOSStable] = "dummyOS"
@@ -57,7 +57,7 @@ var _ = SIGDescribe("OSArchLabelReconciliation", framework.WithSerial(), framewo
 			_, _, err := nodeutil.PatchNodeStatus(f.ClientSet.CoreV1(), types.NodeName(node.Name), node, newNode)
 			framework.ExpectNoError(err)
 			// Restart kubelet
-			startKubelet()
+			restartKubelet(ctx)
 			framework.ExpectNoError(e2enode.WaitForAllNodesSchedulable(ctx, f.ClientSet, framework.RestartNodeReadyAgainTimeout))
 			// If this happens right, node should have all the labels reset properly
 			err = waitForNodeLabels(ctx, f.ClientSet.CoreV1(), node.Name, 5*time.Minute)

--- a/test/e2e_node/podresources_test.go
+++ b/test/e2e_node/podresources_test.go
@@ -1146,7 +1146,7 @@ var _ = SIGDescribe("POD Resources", framework.WithSerial(), feature.PodResource
 					expectPodResources(ctx, 1, cli, []podDesc{desc})
 
 					ginkgo.By("Restarting Kubelet")
-					restartKubelet(true)
+					restartKubelet(ctx, true)
 
 					// we need to wait for the node to be reported ready before we can safely query
 					// the podresources endpoint again. Otherwise we will have false negatives.

--- a/test/e2e_node/restart_test.go
+++ b/test/e2e_node/restart_test.go
@@ -200,8 +200,8 @@ var _ = SIGDescribe("Restart", framework.WithSerial(), framework.WithSlow(), fra
 
 			ginkgo.By("killing and restarting kubelet")
 			// We want to kill the kubelet rather than a graceful restart
-			startKubelet := stopKubelet()
-			startKubelet()
+			restartKubelet := mustStopKubelet(ctx, f)
+			restartKubelet(ctx)
 
 			// If this test works correctly, each of these pods will exit
 			// with no issue. But if accounting breaks, pods scheduled after
@@ -309,19 +309,10 @@ var _ = SIGDescribe("Restart", framework.WithSerial(), framework.WithSlow(), fra
 			// As soon as the pod enters succeeded phase (detected by the watch above); kill the kubelet.
 			// This is a bit racy, but the goal is to stop the kubelet before the kubelet is able to delete the pod from the API-sever in order to repro https://issues.k8s.io/116925
 			ginkgo.By("Stopping the kubelet")
-			startKubelet := stopKubelet()
-			// wait until the kubelet health check will fail
-			gomega.Eventually(ctx, func() bool {
-				return kubeletHealthCheck(kubeletHealthCheckURL)
-			}, f.Timeouts.PodStart, f.Timeouts.Poll).Should(gomega.BeFalseBecause("expected kubelet health check to be failed"))
+			restartKubelet := mustStopKubelet(ctx, f)
 
-			ginkgo.By("Starting the kubelet")
-			startKubelet()
-
-			// wait until the kubelet health check will succeed
-			gomega.Eventually(ctx, func() bool {
-				return kubeletHealthCheck(kubeletHealthCheckURL)
-			}, f.Timeouts.PodStart, f.Timeouts.Poll).Should(gomega.BeTrueBecause("expected kubelet to be in healthy state"))
+			ginkgo.By("Restarting the kubelet")
+			restartKubelet(ctx)
 
 			// Wait for the Kubelet to be ready.
 			gomega.Eventually(ctx, func(ctx context.Context) bool {
@@ -361,12 +352,7 @@ var _ = SIGDescribe("Restart", framework.WithSerial(), framework.WithSlow(), fra
 				},
 			})
 			ginkgo.By("Stopping the kubelet")
-			startKubelet := stopKubelet()
-
-			// wait until the kubelet health check will fail
-			gomega.Eventually(ctx, func() bool {
-				return kubeletHealthCheck(kubeletHealthCheckURL)
-			}, f.Timeouts.PodStart, f.Timeouts.Poll).Should(gomega.BeFalseBecause("expected kubelet health check to be failed"))
+			restartKubelet := mustStopKubelet(ctx, f)
 
 			// Create the pod bound to the node. It will remain in the Pending
 			// phase as Kubelet is down.
@@ -379,19 +365,7 @@ var _ = SIGDescribe("Restart", framework.WithSerial(), framework.WithSlow(), fra
 
 			// Restart Kubelet so that it proceeds with deletion
 			ginkgo.By("Starting the kubelet")
-			startKubelet()
-
-			// wait until the kubelet health check will succeed
-			gomega.Eventually(ctx, func() bool {
-				return kubeletHealthCheck(kubeletHealthCheckURL)
-			}, f.Timeouts.PodStart, f.Timeouts.Poll).Should(gomega.BeTrueBecause("expected kubelet to be in healthy state"))
-
-			// Wait for the Kubelet to be ready.
-			gomega.Eventually(ctx, func(ctx context.Context) bool {
-				nodes, err := e2enode.TotalReady(ctx, f.ClientSet)
-				framework.ExpectNoError(err)
-				return nodes == 1
-			}, time.Minute, f.Timeouts.Poll).Should(gomega.BeTrueBecause("expected kubelet to be in ready state"))
+			restartKubelet(ctx)
 
 			ginkgo.By(fmt.Sprintf("After the kubelet is restarted, verify the pod (%v/%v) is deleted by kubelet", pod.Namespace, pod.Name))
 			gomega.Eventually(ctx, func(ctx context.Context) error {
@@ -439,12 +413,7 @@ var _ = SIGDescribe("Restart", framework.WithSerial(), framework.WithSlow(), fra
 			framework.ExpectNoError(err, "Failed to await for the pod to be running: (%v/%v)", f.Namespace.Name, pod.Name)
 
 			ginkgo.By("Stopping the kubelet")
-			startKubelet := stopKubelet()
-
-			// wait until the kubelet health check will fail
-			gomega.Eventually(ctx, func() bool {
-				return kubeletHealthCheck(kubeletHealthCheckURL)
-			}, f.Timeouts.PodStart, f.Timeouts.Poll).Should(gomega.BeFalseBecause("expected kubelet health check to be failed"))
+			restartKubelet := mustStopKubelet(ctx, f)
 
 			ginkgo.By(fmt.Sprintf("Deleting the pod (%v/%v) to set a deletion timestamp", pod.Namespace, pod.Name))
 			err = e2epod.NewPodClient(f).Delete(ctx, pod.Name, metav1.DeleteOptions{GracePeriodSeconds: &gracePeriod})
@@ -454,13 +423,8 @@ var _ = SIGDescribe("Restart", framework.WithSerial(), framework.WithSlow(), fra
 			e2enode.RemoveLabelOffNode(f.ClientSet, nodeName, nodeLabelKey)
 
 			// Restart Kubelet so that it proceeds with deletion
-			ginkgo.By("Starting the kubelet")
-			startKubelet()
-
-			// wait until the kubelet health check will succeed
-			gomega.Eventually(ctx, func() bool {
-				return kubeletHealthCheck(kubeletHealthCheckURL)
-			}, f.Timeouts.PodStart, f.Timeouts.Poll).Should(gomega.BeTrueBecause("expected kubelet to be in healthy state"))
+			ginkgo.By("Restarting the kubelet")
+			restartKubelet(ctx)
 
 			// Wait for the Kubelet to be ready.
 			gomega.Eventually(ctx, func(ctx context.Context) bool {


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Moved Kubelet health checks from test cases to the stopKubelet API. This should make the API cleaner and easier to use.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```