### PR TITLE
e2e_node: Refactor the helper functions for CriProxy to remove global variables

### DIFF
--- a/test/e2e_node/criproxy_test.go
+++ b/test/e2e_node/criproxy_test.go
@@ -48,19 +48,19 @@ var _ = SIGDescribe(feature.CriProxy, framework.WithSerial(), func() {
 
 	ginkgo.Context("Inject a pull image error exception into the CriProxy", func() {
 		ginkgo.BeforeEach(func() {
-			if err := resetCRIProxyInjector(e2eCriProxy); err != nil {
+			if err := resetCRIProxyInjector(); err != nil {
 				ginkgo.Skip("Skip the test since the CRI Proxy is undefined.")
 			}
 		})
 
 		ginkgo.AfterEach(func() {
-			err := resetCRIProxyInjector(e2eCriProxy)
+			err := resetCRIProxyInjector()
 			framework.ExpectNoError(err)
 		})
 
 		ginkgo.It("Pod failed to start due to an image pull error.", func(ctx context.Context) {
 			expectedErr := fmt.Errorf("PullImage failed")
-			err := addCRIProxyInjector(e2eCriProxy, func(apiName string) error {
+			err := addCRIProxyInjector(func(apiName string) error {
 				if apiName == criproxy.PullImage {
 					return expectedErr
 				}
@@ -86,19 +86,19 @@ var _ = SIGDescribe(feature.CriProxy, framework.WithSerial(), func() {
 
 	ginkgo.Context("Inject a pull image timeout exception into the CriProxy", func() {
 		ginkgo.BeforeEach(func() {
-			if err := resetCRIProxyInjector(e2eCriProxy); err != nil {
+			if err := resetCRIProxyInjector(); err != nil {
 				ginkgo.Skip("Skip the test since the CRI Proxy is undefined.")
 			}
 		})
 
 		ginkgo.AfterEach(func() {
-			err := resetCRIProxyInjector(e2eCriProxy)
+			err := resetCRIProxyInjector()
 			framework.ExpectNoError(err)
 		})
 
 		ginkgo.It("Image pull time exceeded 10 seconds", func(ctx context.Context) {
 			const delayTime = 10 * time.Second
-			err := addCRIProxyInjector(e2eCriProxy, func(apiName string) error {
+			err := addCRIProxyInjector(func(apiName string) error {
 				if apiName == criproxy.PullImage {
 					time.Sleep(10 * time.Second)
 				}

--- a/test/e2e_node/image_pull_test.go
+++ b/test/e2e_node/image_pull_test.go
@@ -59,7 +59,7 @@ var _ = SIGDescribe("Pull Image", feature.CriProxy, framework.WithSerial(), func
 		})
 
 		ginkgo.BeforeEach(func(ctx context.Context) {
-			if err := resetCRIProxyInjector(e2eCriProxy); err != nil {
+			if err := resetCRIProxyInjector(); err != nil {
 				ginkgo.Skip("Skip the test since the CRI Proxy is undefined.")
 			}
 
@@ -68,7 +68,7 @@ var _ = SIGDescribe("Pull Image", feature.CriProxy, framework.WithSerial(), func
 		})
 
 		ginkgo.AfterEach(func(ctx context.Context) {
-			err := resetCRIProxyInjector(e2eCriProxy)
+			err := resetCRIProxyInjector()
 			framework.ExpectNoError(err)
 
 			ginkgo.By("cleanup pods")
@@ -82,7 +82,7 @@ var _ = SIGDescribe("Pull Image", feature.CriProxy, framework.WithSerial(), func
 			timeout := 20 * time.Second
 			callCh := make(chan struct{})
 			callStatus := make(map[int]chan struct{})
-			err := addCRIProxyInjector(e2eCriProxy, func(apiName string) error {
+			err := addCRIProxyInjector(func(apiName string) error {
 				if apiName == criproxy.PullImage {
 					mu.Lock()
 					callID := len(callStatus)
@@ -142,7 +142,7 @@ var _ = SIGDescribe("Pull Image", feature.CriProxy, framework.WithSerial(), func
 		var testpods []*v1.Pod
 
 		ginkgo.BeforeEach(func(ctx context.Context) {
-			if err := resetCRIProxyInjector(e2eCriProxy); err != nil {
+			if err := resetCRIProxyInjector(); err != nil {
 				ginkgo.Skip("Skip the test since the CRI Proxy is undefined.")
 			}
 
@@ -151,7 +151,7 @@ var _ = SIGDescribe("Pull Image", feature.CriProxy, framework.WithSerial(), func
 		})
 
 		ginkgo.AfterEach(func(ctx context.Context) {
-			err := resetCRIProxyInjector(e2eCriProxy)
+			err := resetCRIProxyInjector()
 			framework.ExpectNoError(err)
 
 			ginkgo.By("cleanup pods")
@@ -166,7 +166,7 @@ var _ = SIGDescribe("Pull Image", feature.CriProxy, framework.WithSerial(), func
 			var mu sync.Mutex
 			callCh := make(chan struct{})
 			callStatus := make(map[int]chan struct{})
-			err := addCRIProxyInjector(e2eCriProxy, func(apiName string) error {
+			err := addCRIProxyInjector(func(apiName string) error {
 				if apiName == criproxy.PullImage {
 					mu.Lock()
 					callID := len(callStatus)

--- a/test/e2e_node/utils_linux_test.go
+++ b/test/e2e_node/utils_linux_test.go
@@ -17,13 +17,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// utils_linux_test.go is named with _test.go because the functions in this file use global variables from test files,
+// and this file only provides helper functions for the e2e module.
 package e2enode
 
 import (
 	"fmt"
 
 	libcontainercgroups "github.com/opencontainers/runc/libcontainer/cgroups"
-	"k8s.io/kubernetes/test/e2e_node/criproxy"
 )
 
 // IsCgroup2UnifiedMode returns whether we are running in cgroup v2 unified mode.
@@ -32,19 +33,19 @@ func IsCgroup2UnifiedMode() bool {
 }
 
 // addCRIProxyInjector registers an injector function for the CRIProxy.
-func addCRIProxyInjector(proxy *criproxy.RemoteRuntime, injector func(apiName string) error) error {
-	if proxy == nil {
+func addCRIProxyInjector(injector func(apiName string) error) error {
+	if e2eCriProxy == nil {
 		return fmt.Errorf("failed to add injector because the CRI Proxy is undefined")
 	}
-	proxy.AddInjector(injector)
+	e2eCriProxy.AddInjector(injector)
 	return nil
 }
 
 // resetCRIProxyInjector resets all injector functions for the CRIProxy.
-func resetCRIProxyInjector(proxy *criproxy.RemoteRuntime) error {
-	if proxy == nil {
+func resetCRIProxyInjector() error {
+	if e2eCriProxy == nil {
 		return fmt.Errorf("failed to reset injector because the CRI Proxy is undefined")
 	}
-	proxy.ResetInjectors()
+	e2eCriProxy.ResetInjectors()
 	return nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Thanks to @hoskeri for fixing the issue with e2eCriProxy references in [128514](https://github.com/kubernetes/kubernetes/pull/128514). But, since e2eCriProxy is a global variable, we prefer not to always pass it as a parameter. Directly referencing it makes the code more concise and easier to understand and maintain.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
