### PR TITLE
[FG:InPlacePodVerticalScaling] fix InPlacePodVerticalScaling e2e tests

### DIFF
--- a/test/e2e/node/pod_resize.go
+++ b/test/e2e/node/pod_resize.go
@@ -110,9 +110,9 @@ func doPodResizeAdmissionPluginsTests() {
 	}
 
 	for _, tc := range testcases {
-		ginkgo.It(tc.name, func(ctx context.Context) {
-			f := framework.NewDefaultFramework(tc.name)
+		f := framework.NewDefaultFramework(tc.name)
 
+		ginkgo.It(tc.name, func(ctx context.Context) {
 			containers := []e2epod.ResizableContainerInfo{
 				{
 					Name:      "c1",
@@ -369,8 +369,9 @@ var _ = SIGDescribe(framework.WithSerial(), "Pod InPlace Resize Container (sched
 })
 
 var _ = SIGDescribe("Pod InPlace Resize Container", feature.InPlacePodVerticalScaling, func() {
+	f := framework.NewDefaultFramework("pod-resize-tests")
+
 	ginkgo.BeforeEach(func(ctx context.Context) {
-		f := framework.NewDefaultFramework("pod-resize-tests")
 		node, err := e2enode.GetRandomReadySchedulableNode(ctx, f.ClientSet)
 		framework.ExpectNoError(err)
 		if framework.NodeOSDistroIs("windows") || e2enode.IsARM64(node) {


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test


#### What this PR does / why we need it:

I broke InPlacePodVerticalScaling e2e tests in #128266. This change fixes it.

Failure message:

```
 It looks like you are trying to add a [1m[BeforeEach][0m node
  to the Ginkgo spec tree in a leaf node [1mafter[0m the specs started running.

  To enable randomization and parallelization Ginkgo requires the spec tree
  to be fully constructed up front.  In practice, this means that you can
  only create nodes like [1m[BeforeEach][0m at the top-level or within the
  body of a [1mDescribe[0m, [1mContext[0m, or [1mWhen[0m.

  [1mLearn more at:[0m
  [38;5;14m[4mhttp://onsi.github.io/ginkgo/#mental-model-how-ginkgo-traverses-the-spec-hierarchy[0m
```

#### Which issue(s) this PR fixes:

Fixes #128607

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
