### PR TITLE
DRA API: opaque parameters length limit

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -15852,7 +15852,7 @@
         },
         "parameters": {
           "$ref": "#/definitions/io.k8s.apimachinery.pkg.runtime.RawExtension",
-          "description": "Parameters can contain arbitrary data. It is the responsibility of the driver developer to handle validation and versioning. Typically this includes self-identification and a version (\"kind\" + \"apiVersion\" for Kubernetes types), with conversion between different versions."
+          "description": "Parameters can contain arbitrary data. It is the responsibility of the driver developer to handle validation and versioning. Typically this includes self-identification and a version (\"kind\" + \"apiVersion\" for Kubernetes types), with conversion between different versions.\n\nThe length of the raw data must be smaller or equal to 10 Ki."
         }
       },
       "required": [
@@ -16608,7 +16608,7 @@
         },
         "parameters": {
           "$ref": "#/definitions/io.k8s.apimachinery.pkg.runtime.RawExtension",
-          "description": "Parameters can contain arbitrary data. It is the responsibility of the driver developer to handle validation and versioning. Typically this includes self-identification and a version (\"kind\" + \"apiVersion\" for Kubernetes types), with conversion between different versions."
+          "description": "Parameters can contain arbitrary data. It is the responsibility of the driver developer to handle validation and versioning. Typically this includes self-identification and a version (\"kind\" + \"apiVersion\" for Kubernetes types), with conversion between different versions.\n\nThe length of the raw data must be smaller or equal to 10 Ki."
         }
       },
       "required": [

--- a/api/openapi-spec/v3/apis__resource.k8s.io__v1alpha3_openapi.json
+++ b/api/openapi-spec/v3/apis__resource.k8s.io__v1alpha3_openapi.json
@@ -586,7 +586,7 @@
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.runtime.RawExtension"
               }
             ],
-            "description": "Parameters can contain arbitrary data. It is the responsibility of the driver developer to handle validation and versioning. Typically this includes self-identification and a version (\"kind\" + \"apiVersion\" for Kubernetes types), with conversion between different versions."
+            "description": "Parameters can contain arbitrary data. It is the responsibility of the driver developer to handle validation and versioning. Typically this includes self-identification and a version (\"kind\" + \"apiVersion\" for Kubernetes types), with conversion between different versions.\n\nThe length of the raw data must be smaller or equal to 10 Ki."
           }
         },
         "required": [

--- a/api/openapi-spec/v3/apis__resource.k8s.io__v1beta1_openapi.json
+++ b/api/openapi-spec/v3/apis__resource.k8s.io__v1beta1_openapi.json
@@ -608,7 +608,7 @@
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.runtime.RawExtension"
               }
             ],
-            "description": "Parameters can contain arbitrary data. It is the responsibility of the driver developer to handle validation and versioning. Typically this includes self-identification and a version (\"kind\" + \"apiVersion\" for Kubernetes types), with conversion between different versions."
+            "description": "Parameters can contain arbitrary data. It is the responsibility of the driver developer to handle validation and versioning. Typically this includes self-identification and a version (\"kind\" + \"apiVersion\" for Kubernetes types), with conversion between different versions.\n\nThe length of the raw data must be smaller or equal to 10 Ki."
           }
         },
         "required": [

--- a/pkg/apis/resource/types.go
+++ b/pkg/apis/resource/types.go
@@ -654,9 +654,15 @@ type OpaqueDeviceConfiguration struct {
 	// includes self-identification and a version ("kind" + "apiVersion" for
 	// Kubernetes types), with conversion between different versions.
 	//
+	// The length of the raw data must be smaller or equal to 10 Ki.
+	//
 	// +required
 	Parameters runtime.RawExtension
 }
+
+// OpaqueParametersMaxLength is the maximum length of the raw data in an
+// [OpaqueDeviceConfiguration.Parameters] field.
+const OpaqueParametersMaxLength = 10 * 1024
 
 // ResourceClaimStatus tracks whether the resource has been allocated and what
 // the result of that was.

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -47061,7 +47061,7 @@ func schema_k8sio_api_resource_v1alpha3_OpaqueDeviceConfiguration(ref common.Ref
 					},
 					"parameters": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Parameters can contain arbitrary data. It is the responsibility of the driver developer to handle validation and versioning. Typically this includes self-identification and a version (\"kind\" + \"apiVersion\" for Kubernetes types), with conversion between different versions.",
+							Description: "Parameters can contain arbitrary data. It is the responsibility of the driver developer to handle validation and versioning. Typically this includes self-identification and a version (\"kind\" + \"apiVersion\" for Kubernetes types), with conversion between different versions.\n\nThe length of the raw data must be smaller or equal to 10 Ki.",
 							Ref:         ref("k8s.io/apimachinery/pkg/runtime.RawExtension"),
 						},
 					},
@@ -48413,7 +48413,7 @@ func schema_k8sio_api_resource_v1beta1_OpaqueDeviceConfiguration(ref common.Refe
 					},
 					"parameters": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Parameters can contain arbitrary data. It is the responsibility of the driver developer to handle validation and versioning. Typically this includes self-identification and a version (\"kind\" + \"apiVersion\" for Kubernetes types), with conversion between different versions.",
+							Description: "Parameters can contain arbitrary data. It is the responsibility of the driver developer to handle validation and versioning. Typically this includes self-identification and a version (\"kind\" + \"apiVersion\" for Kubernetes types), with conversion between different versions.\n\nThe length of the raw data must be smaller or equal to 10 Ki.",
 							Ref:         ref("k8s.io/apimachinery/pkg/runtime.RawExtension"),
 						},
 					},

--- a/staging/src/k8s.io/api/resource/v1alpha3/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1alpha3/generated.proto
@@ -500,6 +500,8 @@ message OpaqueDeviceConfiguration {
   // includes self-identification and a version ("kind" + "apiVersion" for
   // Kubernetes types), with conversion between different versions.
   //
+  // The length of the raw data must be smaller or equal to 10 Ki.
+  //
   // +required
   optional .k8s.io.apimachinery.pkg.runtime.RawExtension parameters = 2;
 }

--- a/staging/src/k8s.io/api/resource/v1alpha3/types.go
+++ b/staging/src/k8s.io/api/resource/v1alpha3/types.go
@@ -652,9 +652,15 @@ type OpaqueDeviceConfiguration struct {
 	// includes self-identification and a version ("kind" + "apiVersion" for
 	// Kubernetes types), with conversion between different versions.
 	//
+	// The length of the raw data must be smaller or equal to 10 Ki.
+	//
 	// +required
 	Parameters runtime.RawExtension `json:"parameters" protobuf:"bytes,2,name=parameters"`
 }
+
+// OpaqueParametersMaxLength is the maximum length of the raw data in an
+// [OpaqueDeviceConfiguration.Parameters] field.
+const OpaqueParametersMaxLength = 10 * 1024
 
 // ResourceClaimStatus tracks whether the resource has been allocated and what
 // the result of that was.

--- a/staging/src/k8s.io/api/resource/v1alpha3/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/resource/v1alpha3/types_swagger_doc_generated.go
@@ -214,7 +214,7 @@ func (DeviceSelector) SwaggerDoc() map[string]string {
 var map_OpaqueDeviceConfiguration = map[string]string{
 	"":           "OpaqueDeviceConfiguration contains configuration parameters for a driver in a format defined by the driver vendor.",
 	"driver":     "Driver is used to determine which kubelet plugin needs to be passed these configuration parameters.\n\nAn admission policy provided by the driver developer could use this to decide whether it needs to validate them.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver.",
-	"parameters": "Parameters can contain arbitrary data. It is the responsibility of the driver developer to handle validation and versioning. Typically this includes self-identification and a version (\"kind\" + \"apiVersion\" for Kubernetes types), with conversion between different versions.",
+	"parameters": "Parameters can contain arbitrary data. It is the responsibility of the driver developer to handle validation and versioning. Typically this includes self-identification and a version (\"kind\" + \"apiVersion\" for Kubernetes types), with conversion between different versions.\n\nThe length of the raw data must be smaller or equal to 10 Ki.",
 }
 
 func (OpaqueDeviceConfiguration) SwaggerDoc() map[string]string {

--- a/staging/src/k8s.io/api/resource/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1beta1/generated.proto
@@ -508,6 +508,8 @@ message OpaqueDeviceConfiguration {
   // includes self-identification and a version ("kind" + "apiVersion" for
   // Kubernetes types), with conversion between different versions.
   //
+  // The length of the raw data must be smaller or equal to 10 Ki.
+  //
   // +required
   optional .k8s.io.apimachinery.pkg.runtime.RawExtension parameters = 2;
 }

--- a/staging/src/k8s.io/api/resource/v1beta1/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta1/types.go
@@ -660,9 +660,15 @@ type OpaqueDeviceConfiguration struct {
 	// includes self-identification and a version ("kind" + "apiVersion" for
 	// Kubernetes types), with conversion between different versions.
 	//
+	// The length of the raw data must be smaller or equal to 10 Ki.
+	//
 	// +required
 	Parameters runtime.RawExtension `json:"parameters" protobuf:"bytes,2,name=parameters"`
 }
+
+// OpaqueParametersMaxLength is the maximum length of the raw data in an
+// [OpaqueDeviceConfiguration.Parameters] field.
+const OpaqueParametersMaxLength = 10 * 1024
 
 // ResourceClaimStatus tracks whether the resource has been allocated and what
 // the result of that was.

--- a/staging/src/k8s.io/api/resource/v1beta1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/resource/v1beta1/types_swagger_doc_generated.go
@@ -223,7 +223,7 @@ func (DeviceSelector) SwaggerDoc() map[string]string {
 var map_OpaqueDeviceConfiguration = map[string]string{
 	"":           "OpaqueDeviceConfiguration contains configuration parameters for a driver in a format defined by the driver vendor.",
 	"driver":     "Driver is used to determine which kubelet plugin needs to be passed these configuration parameters.\n\nAn admission policy provided by the driver developer could use this to decide whether it needs to validate them.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver.",
-	"parameters": "Parameters can contain arbitrary data. It is the responsibility of the driver developer to handle validation and versioning. Typically this includes self-identification and a version (\"kind\" + \"apiVersion\" for Kubernetes types), with conversion between different versions.",
+	"parameters": "Parameters can contain arbitrary data. It is the responsibility of the driver developer to handle validation and versioning. Typically this includes self-identification and a version (\"kind\" + \"apiVersion\" for Kubernetes types), with conversion between different versions.\n\nThe length of the raw data must be smaller or equal to 10 Ki.",
 }
 
 func (OpaqueDeviceConfiguration) SwaggerDoc() map[string]string {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/kind api-change

#### What this PR does / why we need it:

All variable-length fields need a size limit. This was missed earlier for opaque parameters.

#### Which issue(s) this PR fixes:
Related-to: https://github.com/kubernetes/kubernetes/pull/128240#discussion_r1828591842

#### Special notes for your reviewer:


Because theoretically there
might now be existing objects with parameters that are larger than whatever
limit gets enforced now, the limit only gets checked when parameters get
created or modified.
    
This is similar to the validation of CEL expressions and for consistency, the
same 10 Ki limit as for those is chosen.
    
Because the limit is not enforced for stored parameters, it can be increased in
the future, with the caveat that users who need larger parameters then depend
on the newer Kubernetes release with a higher limit. Lowering the limit is
harder because creating deployments that worked in older Kubernetes will not
work anymore with newer Kubernetes.

#### Does this PR introduce a user-facing change?
```release-note
DRA: Restricted the length of opaque device configuration parameters. At admission time, Kubernetes enforces a 10KiB size limit.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/4381
```
