### PR TITLE
Fix error check

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/mutating/dispatcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/mutating/dispatcher.go
@@ -161,6 +161,11 @@ func (d *dispatcher) dispatchInvocations(
 		}
 
 		invocationKey, invocationKeyErr := keyFor(invocation)
+		if invocationKeyErr != nil {
+			// This should never happen. It occurs if there is a programming
+			// error causing the Param not to be a valid object.
+			return nil, k8serrors.NewInternalError(invocationKeyErr)
+		}
 		if reinvokeCtx.IsReinvoke() && !policyReinvokeCtx.ShouldReinvoke(invocationKey) {
 			continue
 		}
@@ -169,12 +174,6 @@ func (d *dispatcher) dispatchInvocations(
 		// Mutations for a single invocation of a MutatingAdmissionPolicy are evaluated
 		// in order.
 		for mutationIndex := range invocation.Policy.Spec.Mutations {
-			if invocationKeyErr != nil {
-				// This should never happen. It occurs if there is a programming
-				// error causing the Param not to be a valid object.
-				return nil, k8serrors.NewInternalError(invocationKeyErr)
-			}
-
 			lastVersionedAttr = versionedAttr
 			if versionedAttr.VersionedObject == nil { // Do not call patchers if there is no object to patch.
 				continue


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes the location of an errant error check within the mutating validation codebase

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

This PR was originally submitted to @jpbetz's fork, which has now been merged into this codebase

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
