### PR TITLE
[FG:InPlacePodVerticalScaling] Drop InPlacePodVerticalScaling support in windows

### DIFF
--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -5503,6 +5503,11 @@ func ValidatePodResize(newPod, oldPod *core.Pod, opts PodValidationOptions) fiel
 		return field.ErrorList{field.Forbidden(field.NewPath(""), "static pods cannot be resized")}
 	}
 
+	// windows pods are not supported.
+	if oldPod.Spec.OS != nil && oldPod.Spec.OS.Name == core.Windows {
+		return field.ErrorList{field.Forbidden(field.NewPath(""), "windows pods cannot be resized")}
+	}
+
 	// Part 2: Validate that the changes between oldPod.Spec.Containers[].Resources and
 	// newPod.Spec.Containers[].Resources are allowed.
 	specPath := field.NewPath("spec")


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This change drops support for InPlacePodVerticalScaling feature in Windows.

#### Which issue(s) this PR fixes:

Fixes #128617

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Drop support for InPlacePodVerticalScaling feature in Windows.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:


```docs
- KEP: https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/1287-in-place-update-pod-resources
```
