### PR TITLE
PreStop Test Suite

### DIFF
--- a/test/e2e_node/e2e_node_suite_test.go
+++ b/test/e2e_node/e2e_node_suite_test.go
@@ -57,6 +57,9 @@ import (
 	_ "k8s.io/kubernetes/test/e2e/feature"
 	_ "k8s.io/kubernetes/test/e2e/nodefeature"
 
+	// node subtests
+	_ "k8s.io/kubernetes/test/e2e_node/lifecyclehooks"
+
 	// reconfigure framework
 	_ "k8s.io/kubernetes/test/e2e/framework/debug/init"
 	_ "k8s.io/kubernetes/test/e2e/framework/metrics/init"

--- a/test/e2e_node/lifecyclehooks/prestop-hook.go
+++ b/test/e2e_node/lifecyclehooks/prestop-hook.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lifecyclehooks
+
+import (
+    "context"
+    "fmt"
+
+    v1 "k8s.io/api/core/v1"
+    metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+    "k8s.io/kubernetes/test/e2e/framework"
+    "k8s.io/kubernetes/test/e2e/framework/ssh"
+    e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+    "k8s.io/kubernetes/test/e2e_node/testdoc"
+    admissionapi "k8s.io/pod-security-admission/api"
+    imageutils "k8s.io/kubernetes/test/utils/image"
+    "github.com/onsi/ginkgo/v2"
+    "github.com/onsi/gomega"
+    "k8s.io/utils/ptr"
+)
+
+var _ =  SIGDescribe(framework.WithNodeConformance(),"PreStop Hook Test Suite", func() {
+    f := framework.NewDefaultFramework("prestop-hook-test-suite")
+    f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
+
+    ginkgo.It("should run prestop basic with the grace period", func(ctx context.Context) {
+        testdoc.TestName("Hooks:prestop_basic_execution_test")
+
+	testdoc.TestStep("When you have a PreStop hook defined on your container, it will execute before the container is terminated.")
+        const gracePeriod int64 = 30
+        client := e2epod.NewPodClient(f)
+        const volumeName = "host-data"
+        const hostPath = "/tmp/prestop-hook-test.log"
+        ginkgo.By("creating a pod with a termination grace period and a long-running PreStop hook")
+        pod := &v1.Pod{
+            ObjectMeta: metav1.ObjectMeta{
+                Name: "pod-termination-grace-period",
+            },
+            Spec: v1.PodSpec{
+                Containers: []v1.Container{
+                    {
+                        Name:  "busybox",
+                        Image: imageutils.GetE2EImage(imageutils.BusyBox),
+                        Command: []string{
+                            "sleep",
+                            "10000",
+                        },
+                    },
+                },
+                TerminationGracePeriodSeconds: ptr.To(gracePeriod),
+            },
+        }
+
+        // Add the PreStop hook to write a message to the hostPath
+        pod.Spec.Containers[0].Lifecycle = &v1.Lifecycle{
+            PreStop: &v1.LifecycleHandler{
+                Exec: &v1.ExecAction{
+                    Command: []string{"sh", "-c", fmt.Sprintf("echo 'PreStop Hook Executed' > %s", hostPath)},
+                },
+            },
+        }
+
+        // Define the hostPath volume
+        pod.Spec.Volumes = append(pod.Spec.Volumes, v1.Volume{
+            Name: volumeName,
+            VolumeSource: v1.VolumeSource{
+                HostPath: &v1.HostPathVolumeSource{
+                    Path: hostPath,
+                    Type: ptr.To(v1.HostPathFileOrCreate),
+                },
+            },
+        })
+
+        // Mount the hostPath volume to the container
+        pod.Spec.Containers[0].VolumeMounts = []v1.VolumeMount{
+            {Name: volumeName, MountPath: hostPath},
+        }
+        testdoc.TestStep("Imagine You Have a Pod with the Following Specification:")
+        testdoc.PodSpec(pod)
+        testdoc.TestStep("This Pod should start successfully and run for some time")
+        createdPod := client.CreateSync(ctx, pod)
+
+        testdoc.TestStep("When the container is terminated, the PreStop hook will be triggered within the grace period")
+
+        // Delete pod to trigger PreStop hook
+		client.DeleteSync(ctx, createdPod.Name, metav1.DeleteOptions{}, f.Timeouts.PodDelete)
+
+        // Verify PreStop hook output on the host via SSH
+        node, err := f.ClientSet.CoreV1().Nodes().Get(ctx, createdPod.Spec.NodeName, metav1.GetOptions{})
+        framework.ExpectNoError(err, "Failed to get node details")
+
+        cmd := fmt.Sprintf("cat %s", hostPath)
+        result, err := ssh.IssueSSHCommandWithResult(ctx, cmd, framework.TestContext.Provider, node)
+        framework.ExpectNoError(err, "SSH command failed")
+        gomega.Expect(result).ToNot(gomega.BeNil(), "SSH command returned nil result")
+        gomega.Expect(result.Code).To(gomega.Equal(0), "SSH command failed with error code")
+
+        testdoc.TestStep("The following log output confirms the successful execution of the PreStop hook:")
+	    testdoc.TestLog(fmt.Sprintf("%s", result.Stdout))
+		gomega.Expect(result.Stdout).To(gomega.Equal("PreStop Hook Executed\n"))
+
+        testdoc.TestStep("Once the PreStop hook is successfully executed, the container terminates successfully.")
+    })
+})

--- a/test/e2e_node/lifecyclehooks/utils.go
+++ b/test/e2e_node/lifecyclehooks/utils.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lifecyclehooks
+
+import "k8s.io/kubernetes/test/e2e/framework"
+
+//  SIGDescribe annotates the test with the SIG label.
+var SIGDescribe = framework.SIGDescribe("node")

--- a/test/e2e_node/testdoc/helper.go
+++ b/test/e2e_node/testdoc/helper.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testdoc
+
+import (
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+	"sigs.k8s.io/yaml"
+)
+
+// TestName logs the name of the test.
+func TestName(name string) {
+	fmt.Printf("<testdoc:name>%s</testdoc:name>\n", name)
+}
+
+// TestStep logs individual steps of the test.
+func TestStep(step string) {
+	fmt.Printf("<testdoc:step>%s</testdoc:step>\n", step)
+}
+
+// PodSpec logs the Pod specification in YAML format.
+func PodSpec(pod *v1.Pod) {
+	fmt.Printf("<testdoc:podspec>%s</testdoc:podspec>\n", getYaml(pod))
+}
+
+// TestLog logs general output for the test case.
+func TestLog(log string) {
+	fmt.Printf("<testdoc:log>%s</testdoc:log>\n", log)
+}
+
+// PodStatus logs the status of the Pod.
+func PodStatus(status string) {
+	fmt.Printf("<testdoc:status>%s</testdoc:status>\n", status)
+}
+
+// getYaml converts a Pod object to YAML format for logging purposes.
+// Uses framework.ExpectNoError for error handling.
+func getYaml(pod *v1.Pod) string {
+	data, err := yaml.Marshal(pod)
+	framework.ExpectNoError(err, "Failed to convert Pod to YAML")
+	return string(data)
+}

--- a/test/e2e_node/testdoc/readme.md
+++ b/test/e2e_node/testdoc/readme.md
@@ -1,0 +1,94 @@
+## Overview
+
+This script automates the process of updating markdown files with test documentation extracted from log output file. It identifies specific `Area` and `Behavior` markers in the log content, then navigates the directory structure to locate markdown files with placeholders for these behaviors. The script inserts test details (steps, pod specifications, and logs) into the markdown files at the designated placeholders, ensuring each test case is documented properly.
+
+This tool is particularly useful for maintaining up-to-date documentation for lifecycle events or tests in structured documentation projects.
+
+## Functionality
+
+- Structured Content Extraction: Parses the log content using custom tags (`<testdoc:name>`, `<testdoc:step>`, `<testdoc:podspec>`, and `<testdoc:log>`) to gather relevant test details.
+- Dynamic Directory Navigation: Determines the target directory based on the `Area` specified in the `<testdoc:name>` tag, and identifies the correct placeholder in markdown files based on `Behavior`.
+- Recursive File Processing: Iterates through the specified directory structure to find and update markdown files with matching placeholders.
+- Content Ordering: Ensures that `<testdoc:podspec>` and `<testdoc:step>` entries appear in the order found in the log file, followed by the `<testdoc:log>` content.
+
+## Usage
+
+Run the following command:
+
+```bash
+python script_name.py path/to/log_file path/to/root_directory_documentation
+```
+
+- Replace `script_name.py` with the actual name of the Python script file.
+- Replace `path/to/log_file` with the path to the log file (e.g., `log-output.txt`).
+- Replace `path/to/root_directory` with the root directory containing the markdown files to be updated.
+
+## Log File Format
+
+The log file should include structured content for each test case, as shown below:
+
+```plaintext
+<testdoc:name>Area:Behavior</testdoc:name>
+<testdoc:podspec>Details about the pod specification</testdoc:podspec>
+<testdoc:step>Step details for the test</testdoc:step>
+<testdoc:log>Log details</testdoc:log>
+```
+
+## Markdown Files Format
+
+Each markdown file should include placeholders that correspond to `Behavior` values, using the following format:
+
+```markdown
+<!-- Behavior start -->
+<!-- Behavior end -->
+```
+
+For example, if `Behavior` is `prestophook`, the placeholders should look like this:
+
+```markdown
+<!-- prestophook_basic start -->
+<!-- prestophook_basic end -->
+```
+
+The script will locate these markers and insert the extracted content between them.
+
+## Example
+
+Given a log file (`log-output.txt`) with the following content:
+
+```plaintext
+<testdoc:name>lifecyclehooks:prestophook</testdoc:name>
+<testdoc:podspec>Example pod specification...</testdoc:podspec>
+<testdoc:step>Step 1: Description...</testdoc:step>
+<testdoc:log>Log output details...</testdoc:log>
+```
+
+And a markdown file containing:
+
+```markdown
+# Lifecycle Hooks Documentation
+
+<!-- prestophook start -->
+<!-- prestophook end -->
+```
+
+Running the script as follows:
+
+```bash
+python script_name.py log-output.txt /path/to/documentation
+```
+
+will update the markdown file to:
+
+```markdown
+# Lifecycle Hooks Documentation
+
+<!-- prestophook start -->
+Example pod specification
+Step 1: Description
+
+### Logs for the test
+Log output details
+<!-- prestophook end -->
+```
+

--- a/test/e2e_node/testdoc/script.py
+++ b/test/e2e_node/testdoc/script.py
@@ -1,0 +1,137 @@
+# Copyright 2024 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import logging
+import argparse
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger(__name__)
+
+
+def extract_substrings(text, start_indices, end_indices, remove_tags=True):
+    if len(start_indices) != len(end_indices):
+        raise ValueError("Start and end index lists must have the same length.")
+
+    substrings = [text[start:end] for start, end in zip(start_indices, end_indices)]
+    if remove_tags:
+        substrings = [
+            s.replace("<testdoc:step>", "")
+             .replace("<testdoc:podspec>", "")
+             .replace("<testdoc:name>", "")
+             .replace("<testdoc:log>", "")
+            for s in substrings
+        ]
+    return substrings
+
+
+def find_strings_between(text, start, end):
+    start_indices = [i for i in range(len(text)) if text.startswith(start, i)]
+    end_indices = [i for i in range(len(text)) if text.startswith(end, i)]
+
+    if not start_indices or not end_indices:
+        return None, None
+
+    return extract_substrings(text, start_indices, end_indices), start_indices
+
+
+def read_and_replace_doc_content(file_path, behavior, steps, logs):
+    try:
+        with open(file_path, 'r+') as file:
+            content = file.read()
+
+            # Define the placeholder for this behavior
+            tag_start = f"<!-- {behavior} start -->"
+            tag_end = f"<!-- {behavior} end -->"
+
+            # Check if both start and end tags exist
+            start_index = content.find(tag_start)
+            end_index = content.find(tag_end, start_index)
+
+            if start_index != -1 and end_index != -1:
+                # Prepare content to insert
+                replacement_content = "\n".join(steps) + "\n\n### Logs for the test\n" + "\n".join(logs)
+                updated_content = content[:start_index + len(tag_start)] + "\n" + replacement_content + "\n" + content[end_index:]
+
+                # Write updated content back to the file
+                file.seek(0)
+                file.write(updated_content)
+                file.truncate()
+                logger.info(f"File '{file_path}' has been successfully updated for behavior '{behavior}'.")
+            else:
+                logger.warning(f"Placeholders for behavior '{behavior}' not found in '{file_path}'.")
+
+    except FileNotFoundError:
+        logger.warning(f"File '{file_path}' not found.")
+    except ValueError as e:
+        logger.error(f"Value error: {e}")
+    except Exception as e:
+        logger.error(f"An error occurred: {e}")
+
+
+def process_directory(root_directory, area, behavior, steps, logs):
+    target_dir = os.path.join(root_directory, area)
+    if not os.path.isdir(target_dir):
+        logger.warning(f"Directory '{target_dir}' does not exist.")
+        return
+
+    for root, _, files in os.walk(target_dir):
+        for file in files:
+            if file.endswith(".md"):
+                file_path = os.path.join(root, file)
+                logger.info(f"Processing file: {file_path}")
+                read_and_replace_doc_content(file_path, behavior, steps, logs)
+
+
+def main(log_file_path, root_directory):
+    try:
+        with open(log_file_path, "r") as file:
+            log_content = file.read()
+
+        # Extract test names and steps from the log content
+        names, start_indices = find_strings_between(log_content, "<testdoc:name>", "</testdoc:name>")
+        if not names:
+            logger.error("No <testdoc:name> tags found in the log file.")
+            return
+
+        for index, name in enumerate(names):
+            # Split name into area and behavior
+            if ":" not in name:
+                logger.warning(f"Invalid format for name '{name}'. Expected format 'Area:Behavior'. Skipping.")
+                continue
+
+            area, behavior = name.split(":", 1)
+            steps = find_strings_between(log_content[start_indices[index]:], "<testdoc:step>", "</testdoc:step>")[0] or []
+            podspecs = find_strings_between(log_content[start_indices[index]:], "<testdoc:podspec>", "</testdoc:podspec>")[0] or []
+            logs = find_strings_between(log_content[start_indices[index]:], "<testdoc:log>", "</testdoc:log>")[0] or []
+
+            # Combine podspecs and steps in the order they appear
+            combined_steps = podspecs + steps
+
+            # Process and update markdown files in the target directory for this area and behavior
+            process_directory(root_directory, area, behavior, combined_steps, logs)
+
+    except FileNotFoundError:
+        logger.error(f"Log file '{log_file_path}' not found.")
+    except Exception as e:
+        logger.error(f"An error occurred: {e}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Update markdown files with extracted log content.")
+    parser.add_argument("log_file_path", type=str, help="Path to the structured log file.")
+    parser.add_argument("root_directory", type=str, help="Root directory containing markdown documentation.")
+    args = parser.parse_args()
+
+    main(args.log_file_path, args.root_directory)


### PR DESCRIPTION
Description
This PR introduces the PreStop hook test suite, focusing on the basic PreStop hook functionality and its documentation integration. The suite includes a structured test documentation package designed to annotate key parts of the test, such as test names, steps, and logs. Additionally, a supporting script processes these annotated test outputs to auto-generate and populate the corresponding documentation seamlessly.

This PreStop hook test suite is part of a broader initiative to document various Pod lifecycle events through test-driven validation. By starting with the PreStop hook, this effort ensures accurate and automated documentation directly derived from tests, providing a consistent and reliable approach to lifecycle event observability and maintenance.

```release-note
NONE
```