### PR TITLE
X509 Authenticator: Only allow callers to specify root certificates

### DIFF
--- a/pkg/kubeapiserver/authenticator/config.go
+++ b/pkg/kubeapiserver/authenticator/config.go
@@ -106,8 +106,8 @@ func (config Config) New(serverLifecycle context.Context) (authenticator.Request
 	// front-proxy, BasicAuth methods, local first, then remote
 	// Add the front proxy authenticator if requested
 	if config.RequestHeaderConfig != nil {
-		requestHeaderAuthenticator := headerrequest.NewDynamicVerifyOptionsSecure(
-			config.RequestHeaderConfig.CAContentProvider.VerifyOptions,
+		requestHeaderAuthenticator := headerrequest.NewHeaderAuthenticatorWithClientCertificateCheck(
+			config.RequestHeaderConfig.CAContentProvider.Roots,
 			config.RequestHeaderConfig.AllowedClientNames,
 			config.RequestHeaderConfig.UsernameHeaders,
 			config.RequestHeaderConfig.UIDHeaders,
@@ -119,7 +119,7 @@ func (config Config) New(serverLifecycle context.Context) (authenticator.Request
 
 	// X509 methods
 	if config.ClientCAContentProvider != nil {
-		certAuth := x509.NewDynamic(config.ClientCAContentProvider.VerifyOptions, x509.CommonNameUserConversion)
+		certAuth := x509.NewAuthenticator(config.ClientCAContentProvider.Roots, x509.CommonNameUserConversion)
 		authenticators = append(authenticators, certAuth)
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/authentication/authenticatorfactory/delegating.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/authenticatorfactory/delegating.go
@@ -73,8 +73,8 @@ func (c DelegatingAuthenticatorConfig) New() (authenticator.Request, *spec.Secur
 	// front-proxy first, then remote
 	// Add the front proxy authenticator if requested
 	if c.RequestHeaderConfig != nil {
-		requestHeaderAuthenticator := headerrequest.NewDynamicVerifyOptionsSecure(
-			c.RequestHeaderConfig.CAContentProvider.VerifyOptions,
+		requestHeaderAuthenticator := headerrequest.NewHeaderAuthenticatorWithClientCertificateCheck(
+			c.RequestHeaderConfig.CAContentProvider.Roots,
 			c.RequestHeaderConfig.AllowedClientNames,
 			c.RequestHeaderConfig.UsernameHeaders,
 			c.RequestHeaderConfig.UIDHeaders,
@@ -86,7 +86,7 @@ func (c DelegatingAuthenticatorConfig) New() (authenticator.Request, *spec.Secur
 
 	// x509 client cert auth
 	if c.ClientCertificateCAContentProvider != nil {
-		authenticators = append(authenticators, x509.NewDynamic(c.ClientCertificateCAContentProvider.VerifyOptions, x509.CommonNameUserConversion))
+		authenticators = append(authenticators, x509.NewAuthenticator(c.ClientCertificateCAContentProvider.Roots, x509.CommonNameUserConversion))
 	}
 
 	if c.TokenAccessReviewClient != nil {

--- a/staging/src/k8s.io/apiserver/pkg/authentication/request/headerrequest/requestheader.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/request/headerrequest/requestheader.go
@@ -112,10 +112,10 @@ func trimHeaders(headerNames ...string) ([]string, error) {
 	return ret, nil
 }
 
-func NewDynamicVerifyOptionsSecure(verifyOptionFn x509request.VerifyOptionFunc, proxyClientNames, nameHeaders, uidHeaders, groupHeaders, extraHeaderPrefixes StringSliceProvider) authenticator.Request {
+func NewHeaderAuthenticatorWithClientCertificateCheck(rootsFn x509request.RootsFunc, proxyClientNames, nameHeaders, uidHeaders, groupHeaders, extraHeaderPrefixes StringSliceProvider) authenticator.Request {
 	headerAuthenticator := NewDynamic(nameHeaders, uidHeaders, groupHeaders, extraHeaderPrefixes)
 
-	return x509request.NewDynamicCAVerifier(verifyOptionFn, headerAuthenticator, proxyClientNames)
+	return x509request.NewDynamicCAVerifier(rootsFn, headerAuthenticator, proxyClientNames)
 }
 
 func (a *requestHeaderAuthRequestHandler) AuthenticateRequest(req *http.Request) (*authenticator.Response, bool, error) {

--- a/staging/src/k8s.io/apiserver/pkg/authentication/request/x509/verify_options.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/request/x509/verify_options.go
@@ -16,38 +16,6 @@ limitations under the License.
 
 package x509
 
-import (
-	"crypto/x509"
-	"fmt"
-
-	"k8s.io/client-go/util/cert"
-)
-
-// StaticVerifierFn is a VerifyOptionFunc that always returns the same value.  This allows verify options that cannot change.
-func StaticVerifierFn(opts x509.VerifyOptions) VerifyOptionFunc {
-	return func() (x509.VerifyOptions, bool) {
-		return opts, true
-	}
-}
-
-// NewStaticVerifierFromFile creates a new verification func from a file.  It reads the content and then fails.
-// It will return a nil function if you pass an empty CA file.
-func NewStaticVerifierFromFile(clientCA string) (VerifyOptionFunc, error) {
-	if len(clientCA) == 0 {
-		return nil, nil
-	}
-
-	// Wrap with an x509 verifier
-	var err error
-	opts := DefaultVerifyOptions()
-	opts.Roots, err = cert.NewPool(clientCA)
-	if err != nil {
-		return nil, fmt.Errorf("error loading certs from  %s: %v", clientCA, err)
-	}
-
-	return StaticVerifierFn(opts), nil
-}
-
 // StringSliceProvider is a way to get a string slice value.  It is heavily used for authentication headers among other places.
 type StringSliceProvider interface {
 	// Value returns the current string slice.  Callers should never mutate the returned value.

--- a/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/configmap_cafile_content.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/configmap_cafile_content.go
@@ -264,14 +264,14 @@ func (c *ConfigMapCAController) CurrentCABundleContent() []byte {
 	return c.caBundle.Load().(*caBundleAndVerifier).caBundle
 }
 
-// VerifyOptions provides verifyoptions compatible with authenticators
-func (c *ConfigMapCAController) VerifyOptions() (x509.VerifyOptions, bool) {
+// Roots provides root certificates for certificate verification
+func (c *ConfigMapCAController) Roots() (*x509.CertPool, bool) {
 	uncastObj := c.caBundle.Load()
 	if uncastObj == nil {
 		// This can happen if we've been unable load data from the apiserver for some reason.
 		// In this case, we should not accept any connections on the basis of this ca bundle.
-		return x509.VerifyOptions{}, false
+		return nil, false
 	}
 
-	return uncastObj.(*caBundleAndVerifier).verifyOptions, true
+	return uncastObj.(*caBundleAndVerifier).roots, true
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/interfaces.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/interfaces.go
@@ -43,8 +43,8 @@ type CAContentProvider interface {
 	// contained to the controllers initializing the value. By the time you get
 	// here, you should always be returning a value that won't fail.
 	CurrentCABundleContent() []byte
-	// VerifyOptions provides VerifyOptions for authenticators.
-	VerifyOptions() (x509.VerifyOptions, bool)
+	// Roots provides root certificates for certificate verification
+	Roots() (*x509.CertPool, bool)
 }
 
 // CertKeyContentProvider provides a certificate and matching private key.

--- a/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/server_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/server_test.go
@@ -215,6 +215,6 @@ func (c *nullCAContent) CurrentCABundleContent() (cabundle []byte) {
 	return nil
 }
 
-func (c *nullCAContent) VerifyOptions() (x509.VerifyOptions, bool) {
-	return x509.VerifyOptions{}, false
+func (c *nullCAContent) Roots() (*x509.CertPool, bool) {
+	return nil, false
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/static_content.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/static_content.go
@@ -53,8 +53,8 @@ func (c *staticCAContent) CurrentCABundleContent() (cabundle []byte) {
 	return c.caBundle.caBundle
 }
 
-func (c *staticCAContent) VerifyOptions() (x509.VerifyOptions, bool) {
-	return c.caBundle.verifyOptions, true
+func (c *staticCAContent) Roots() (*x509.CertPool, bool) {
+	return c.caBundle.roots, true
 }
 
 type staticCertKeyContent struct {

--- a/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/union_content.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/union_content.go
@@ -56,11 +56,11 @@ func (c unionCAContent) CurrentCABundleContent() []byte {
 	return bytes.Join(caBundles, []byte("\n"))
 }
 
-// CurrentCABundleContent provides ca bundle byte content
-func (c unionCAContent) VerifyOptions() (x509.VerifyOptions, bool) {
+// Roots provides root certificates for certificate verification.
+func (c unionCAContent) Roots() (*x509.CertPool, bool) {
 	currCABundle := c.CurrentCABundleContent()
 	if len(currCABundle) == 0 {
-		return x509.VerifyOptions{}, false
+		return nil, false
 	}
 
 	// TODO make more efficient.  This isn't actually used in any of our mainline paths.  It's called to build the TLSConfig
@@ -71,7 +71,7 @@ func (c unionCAContent) VerifyOptions() (x509.VerifyOptions, bool) {
 		panic(err)
 	}
 
-	return ret.verifyOptions, true
+	return ret.roots, true
 }
 
 // AddListener adds a listener to be notified when the CA content changes.


### PR DESCRIPTION
This commit makes the client certificate authenticator *less* configurable by removing the ability for users of the authenticator to pass full verification options.  No caller in kubernetes/kubernetes was actually using this capability, and it makes sense for the client client certificate authentication logic to maintain tight control over the x509 verification options.

*No externally-visible behavior of kube-apiserver is changed*

Having verification options centrally controlled in the x509 authenticator will simplify the task of supporting new types of client certificates.

/sig auth
/kind cleanup

```release-note
NONE
```
