### PR TITLE
KEP-4222: Fix JSON fallback for clients using default content-type and add E2E client test.

### DIFF
--- a/staging/src/k8s.io/client-go/rest/request.go
+++ b/staging/src/k8s.io/client-go/rest/request.go
@@ -156,14 +156,10 @@ func NewRequest(c *RESTClient) *Request {
 		timeout = c.Client.Timeout
 	}
 
-	contentConfig := c.content.GetClientContentConfig()
-	contentTypeNotSet := len(contentConfig.ContentType) == 0
-	if contentTypeNotSet {
-		contentConfig.ContentType = "application/json"
-		if clientfeatures.FeatureGates().Enabled(clientfeatures.ClientsAllowCBOR) && clientfeatures.FeatureGates().Enabled(clientfeatures.ClientsPreferCBOR) {
-			contentConfig.ContentType = "application/cbor"
-		}
-	}
+	// A request needs to know whether the content type was explicitly configured or selected by
+	// default in order to support the per-request Protobuf override used by clients generated
+	// with --prefers-protobuf.
+	contentConfig, contentTypeDefaulted := c.content.GetClientContentConfig()
 
 	r := &Request{
 		c:              c,
@@ -176,7 +172,7 @@ func NewRequest(c *RESTClient) *Request {
 		warningHandler: c.warningHandler,
 
 		contentConfig:     contentConfig,
-		contentTypeNotSet: contentTypeNotSet,
+		contentTypeNotSet: contentTypeDefaulted,
 	}
 
 	r.setAcceptHeader()

--- a/test/e2e/apimachinery/protocol.go
+++ b/test/e2e/apimachinery/protocol.go
@@ -26,12 +26,21 @@ import (
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic"
+	clientfeatures "k8s.io/client-go/features"
+	clientfeaturestesting "k8s.io/client-go/features/testing"
 	"k8s.io/client-go/kubernetes"
-	admissionapi "k8s.io/pod-security-admission/api"
-
+	aggregatorclientset "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset"
+	"k8s.io/kubernetes/test/e2e/feature"
 	"k8s.io/kubernetes/test/e2e/framework"
+	imageutils "k8s.io/kubernetes/test/utils/image"
+	admissionapi "k8s.io/pod-security-admission/api"
+	samplev1alpha1 "k8s.io/sample-apiserver/pkg/apis/wardle/v1alpha1"
+	samplev1alpha1client "k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1"
 )
 
 var _ = SIGDescribe("client-go should negotiate", func() {
@@ -95,4 +104,68 @@ var _ = SIGDescribe("client-go should negotiate", func() {
 			}
 		})
 	}
+})
+
+var _ = SIGDescribe("CBOR", feature.CBOR, func() {
+	f := framework.NewDefaultFramework("cbor")
+	f.NamespacePodSecurityLevel = admissionapi.LevelBaseline
+
+	// Must be serial to avoid conflict with other tests that set up a sample apiserver.
+	f.It("clients remain compatible with the 1.17 sample-apiserver", f.WithSerial(), func(ctx context.Context) {
+		clientfeaturestesting.SetFeatureDuringTest(g.GinkgoTB(), clientfeatures.ClientsAllowCBOR, true)
+		clientfeaturestesting.SetFeatureDuringTest(g.GinkgoTB(), clientfeatures.ClientsPreferCBOR, true)
+
+		clientConfig, err := framework.LoadConfig()
+		framework.ExpectNoError(err)
+
+		aggregatorClient, err := aggregatorclientset.NewForConfig(clientConfig)
+		framework.ExpectNoError(err)
+
+		dynamicClient, err := dynamic.NewForConfig(clientConfig)
+		framework.ExpectNoError(err)
+
+		objectNames := generateSampleAPIServerObjectNames(f.Namespace.Name)
+		g.DeferCleanup(func(ctx context.Context) {
+			cleanupSampleAPIServer(ctx, f.ClientSet, aggregatorClient, objectNames, samplev1alpha1.SchemeGroupVersion.Version+"."+samplev1alpha1.SchemeGroupVersion.Group)
+		})
+		SetUpSampleAPIServer(ctx, f, aggregatorClient, imageutils.GetE2EImage(imageutils.APIServer), objectNames, samplev1alpha1.SchemeGroupVersion.Group, samplev1alpha1.SchemeGroupVersion.Version)
+
+		flunder := samplev1alpha1.Flunder{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-flunder",
+			},
+		}
+
+		g.By("making requests with a generated client", func() {
+			sampleClient, err := samplev1alpha1client.NewForConfig(clientConfig)
+			framework.ExpectNoError(err)
+
+			_, err = sampleClient.Flunders(f.Namespace.Name).List(ctx, metav1.ListOptions{LabelSelector: "a,!a"})
+			framework.ExpectNoError(err, "Failed to list with generated client")
+
+			_, err = sampleClient.Flunders(f.Namespace.Name).Create(ctx, &flunder, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}})
+			o.Expect(err).To(o.MatchError(apierrors.IsUnsupportedMediaType, "Expected 415 (Unsupported Media Type) response on first write with generated client"))
+
+			_, err = sampleClient.Flunders(f.Namespace.Name).Create(ctx, &flunder, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}})
+			framework.ExpectNoError(err, "Expected subsequent writes to succeed with generated client")
+		})
+
+		g.By("making requests with a dynamic client", func() {
+			unstructuredFlunderContent, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&flunder)
+			framework.ExpectNoError(err)
+			unstructuredFlunder := &unstructured.Unstructured{Object: unstructuredFlunderContent}
+
+			flunderDynamicClient := dynamicClient.Resource(samplev1alpha1.SchemeGroupVersion.WithResource("flunders")).Namespace(f.Namespace.Name)
+
+			list, err := flunderDynamicClient.List(ctx, metav1.ListOptions{LabelSelector: "a,!a"})
+			framework.ExpectNoError(err, "Failed to list with dynamic client")
+			o.Expect(list.GetObjectKind().GroupVersionKind()).To(o.Equal(samplev1alpha1.SchemeGroupVersion.WithKind("FlunderList")))
+
+			_, err = flunderDynamicClient.Create(ctx, unstructuredFlunder, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}})
+			o.Expect(err).To(o.MatchError(apierrors.IsUnsupportedMediaType, "Expected 415 (Unsupported Media Type) response on first write with dynamic client"))
+
+			_, err = flunderDynamicClient.Create(ctx, unstructuredFlunder, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}})
+			framework.ExpectNoError(err, "Expected subsequent writes to succeed with dynamic client")
+		})
+	})
 })

--- a/test/e2e/feature/feature.go
+++ b/test/e2e/feature/feature.go
@@ -34,6 +34,10 @@ var (
 	// TODO: document the feature (owning SIG, when to use this feature for a test)
 	BoundServiceAccountTokenVolume = framework.WithFeature(framework.ValidFeatures.Add("BoundServiceAccountTokenVolume"))
 
+	// Owner: sig-api-machinery
+	// Marks tests that exercise the CBOR data format for serving or storage.
+	CBOR = framework.WithFeature(framework.ValidFeatures.Add("CBOR"))
+
 	// TODO: document the feature (owning SIG, when to use this feature for a test)
 	CloudProvider = framework.WithFeature(framework.ValidFeatures.Add("CloudProvider"))
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup
/sig api-machinery

#### What this PR does / why we need it:

With the ClientsAllowCBOR client-go feature gate enabled, a 415 response to a CBOR-encoded REST
causes all subsequent requests from the client to fall back to a JSON request encoding. This
mechanism had only worked as intended when CBOR was explicitly configured in the
ClientContentConfig. When both ClientsAllowCBOR and ClientsPreferCBOR are enabled, an
unconfigured (empty) content type defaults to CBOR instead of JSON. Both ways of configuring a
client to use the CBOR request encoding are now subject to the same fallback mechanism.

Clients must be able to use CBOR without a guarantee that all apiservers support it. The apiserver
aggregation layer avoids changing in any way that would require an aggregated apiservers to be
updated. This end-to-end test verifies that a client's content negotiation behaviors continue to
work over time when communicating with a 1.17 sample-apiserver.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
The fixed issue is in an unreleased feature targeting alpha in 1.32.

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://kep.k8s.io/4222
```
