### PR TITLE
kubelet/volume: remove OuterVolumeSpecName from ASW

### DIFF
--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -3049,25 +3049,19 @@ func TestSyncLabels(t *testing.T) {
 func waitForVolumeUnmount(
 	volumeManager kubeletvolume.VolumeManager,
 	pod *v1.Pod) error {
-	var podVolumes kubecontainer.VolumeMap
 	err := retryWithExponentialBackOff(
 		time.Duration(50*time.Millisecond),
 		func() (bool, error) {
 			// Verify volumes detached
-			podVolumes = volumeManager.GetPossiblyMountedVolumesForPod(
+			hasVolumes := volumeManager.HasPossiblyMountedVolumesForPod(
 				util.GetUniquePodName(pod))
-
-			if len(podVolumes) != 0 {
-				return false, nil
-			}
-
-			return true, nil
+			return !hasVolumes, nil
 		},
 	)
 
 	if err != nil {
 		return fmt.Errorf(
-			"Expected volumes to be unmounted. But some volumes are still mounted: %#v", podVolumes)
+			"Expected volumes to be unmounted. But some volumes are still mounted")
 	}
 
 	return nil

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -3054,7 +3054,7 @@ func waitForVolumeUnmount(
 		time.Duration(50*time.Millisecond),
 		func() (bool, error) {
 			// Verify volumes detached
-			podVolumes = volumeManager.GetMountedVolumesForPod(
+			podVolumes = volumeManager.GetPossiblyMountedVolumesForPod(
 				util.GetUniquePodName(pod))
 
 			if len(podVolumes) != 0 {

--- a/pkg/kubelet/kubelet_volumes.go
+++ b/pkg/kubelet/kubelet_volumes.go
@@ -76,9 +76,7 @@ func (kl *Kubelet) ListBlockVolumesForPod(podUID types.UID) (map[string]volume.B
 // podVolumesExist checks with the volume manager and returns true any of the
 // pods for the specified volume are mounted or are uncertain.
 func (kl *Kubelet) podVolumesExist(podUID types.UID) bool {
-	if mountedVolumes :=
-		kl.volumeManager.GetPossiblyMountedVolumesForPod(
-			volumetypes.UniquePodName(podUID)); len(mountedVolumes) > 0 {
+	if kl.volumeManager.HasPossiblyMountedVolumesForPod(volumetypes.UniquePodName(podUID)) {
 		return true
 	}
 	// TODO: This checks pod volume paths and whether they are mounted. If checking returns error, podVolumesExist will return true

--- a/pkg/kubelet/kubelet_volumes_test.go
+++ b/pkg/kubelet/kubelet_volumes_test.go
@@ -470,12 +470,9 @@ func TestVolumeUnmountAndDetachControllerDisabled(t *testing.T) {
 	kubelet.podManager.SetPods([]*v1.Pod{})
 
 	assert.NoError(t, kubelet.volumeManager.WaitForUnmount(context.Background(), pod))
-	if actual := kubelet.volumeManager.GetMountedVolumesForPod(util.GetUniquePodName(pod)); len(actual) > 0 {
-		t.Fatalf("expected volume unmount to wait for no volumes: %v", actual)
-	}
 
 	// Verify volumes unmounted
-	podVolumes = kubelet.volumeManager.GetMountedVolumesForPod(
+	podVolumes = kubelet.volumeManager.GetPossiblyMountedVolumesForPod(
 		util.GetUniquePodName(pod))
 
 	assert.Empty(t, podVolumes,

--- a/pkg/kubelet/kubelet_volumes_test.go
+++ b/pkg/kubelet/kubelet_volumes_test.go
@@ -472,11 +472,10 @@ func TestVolumeUnmountAndDetachControllerDisabled(t *testing.T) {
 	assert.NoError(t, kubelet.volumeManager.WaitForUnmount(context.Background(), pod))
 
 	// Verify volumes unmounted
-	podVolumes = kubelet.volumeManager.GetPossiblyMountedVolumesForPod(
+	hasMountedVolumes := kubelet.volumeManager.HasPossiblyMountedVolumesForPod(
 		util.GetUniquePodName(pod))
 
-	assert.Empty(t, podVolumes,
-		"Expected volumes to be unmounted and detached. But some volumes are still mounted: %#v", podVolumes)
+	assert.False(t, hasMountedVolumes, "Expected volumes to be unmounted and detached. But some volumes are still mounted")
 
 	assert.NoError(t, volumetest.VerifyTearDownCallCount(
 		1 /* expectedTearDownCallCount */, testKubelet.volumePlugin))
@@ -554,9 +553,9 @@ func TestVolumeAttachAndMountControllerEnabled(t *testing.T) {
 
 	podVolumes := kubelet.volumeManager.GetMountedVolumesForPod(
 		util.GetUniquePodName(pod))
-	allPodVolumes := kubelet.volumeManager.GetPossiblyMountedVolumesForPod(
+	hasVolumes := kubelet.volumeManager.HasPossiblyMountedVolumesForPod(
 		util.GetUniquePodName(pod))
-	assert.Equal(t, podVolumes, allPodVolumes, "GetMountedVolumesForPod and GetPossiblyMountedVolumesForPod should return the same volumes")
+	assert.True(t, hasVolumes, "HasPossiblyMountedVolumesForPod should return true")
 
 	expectedPodVolumes := []string{"vol1"}
 	assert.Len(t, podVolumes, len(expectedPodVolumes), "Volumes for pod %+v", pod)
@@ -641,9 +640,9 @@ func TestVolumeUnmountAndDetachControllerEnabled(t *testing.T) {
 
 	podVolumes := kubelet.volumeManager.GetMountedVolumesForPod(
 		util.GetUniquePodName(pod))
-	allPodVolumes := kubelet.volumeManager.GetPossiblyMountedVolumesForPod(
+	hasVolumes := kubelet.volumeManager.HasPossiblyMountedVolumesForPod(
 		util.GetUniquePodName(pod))
-	assert.Equal(t, podVolumes, allPodVolumes, "GetMountedVolumesForPod and GetPossiblyMountedVolumesForPod should return the same volumes")
+	assert.True(t, hasVolumes, "HasPossiblyMountedVolumesForPod should return true")
 
 	expectedPodVolumes := []string{"vol1"}
 	assert.Len(t, podVolumes, len(expectedPodVolumes), "Volumes for pod %+v", pod)
@@ -669,9 +668,9 @@ func TestVolumeUnmountAndDetachControllerEnabled(t *testing.T) {
 	// Verify volumes unmounted
 	podVolumes = kubelet.volumeManager.GetMountedVolumesForPod(
 		util.GetUniquePodName(pod))
-	allPodVolumes = kubelet.volumeManager.GetPossiblyMountedVolumesForPod(
+	hasVolumes = kubelet.volumeManager.HasPossiblyMountedVolumesForPod(
 		util.GetUniquePodName(pod))
-	assert.Equal(t, podVolumes, allPodVolumes, "GetMountedVolumesForPod and GetPossiblyMountedVolumesForPod should return the same volumes")
+	assert.False(t, hasVolumes, "HasPossiblyMountedVolumesForPod should return false")
 
 	assert.Empty(t, podVolumes,
 		"Expected volumes to be unmounted and detached. But some volumes are still mounted")

--- a/pkg/kubelet/volumemanager/cache/actual_state_of_world.go
+++ b/pkg/kubelet/volumemanager/cache/actual_state_of_world.go
@@ -149,9 +149,9 @@ type ActualStateOfWorld interface {
 	// current actual state of the world.
 	GetMountedVolumesForPod(podName volumetypes.UniquePodName) []MountedVolume
 
-	// GetMountedVolumeForPodByOuterVolumeSpecName returns the volume and true if
-	// the given outerVolumeSpecName is mounted on the given pod.
-	GetMountedVolumeForPodByOuterVolumeSpecName(podName volumetypes.UniquePodName, outerVolumeSpecName string) (MountedVolume, bool)
+	// GetMountedVolumeForPod returns the volume and true if
+	// the given name is mounted on the given pod.
+	GetMountedVolumeForPod(podName volumetypes.UniquePodName, volumeName v1.UniqueVolumeName) (MountedVolume, bool)
 
 	// GetPossiblyMountedVolumesForPod generates and returns a list of volumes for
 	// the specified pod that either are attached and mounted or are "uncertain",
@@ -1102,15 +1102,14 @@ func (asw *actualStateOfWorld) GetMountedVolumesForPod(
 	return mountedVolume
 }
 
-func (asw *actualStateOfWorld) GetMountedVolumeForPodByOuterVolumeSpecName(
-	podName volumetypes.UniquePodName, outerVolumeSpecName string) (MountedVolume, bool) {
+func (asw *actualStateOfWorld) GetMountedVolumeForPod(
+	podName volumetypes.UniquePodName, volumeName v1.UniqueVolumeName) (MountedVolume, bool) {
 	asw.RLock()
 	defer asw.RUnlock()
-	for _, volumeObj := range asw.attachedVolumes {
-		if podObj, hasPod := volumeObj.mountedPods[podName]; hasPod {
-			if podObj.volumeMountStateForPod == operationexecutor.VolumeMounted && podObj.outerVolumeSpecName == outerVolumeSpecName {
-				return getMountedVolume(&podObj, &volumeObj), true
-			}
+	volumeObj := asw.attachedVolumes[volumeName]
+	if podObj, hasPod := volumeObj.mountedPods[podName]; hasPod {
+		if podObj.volumeMountStateForPod == operationexecutor.VolumeMounted {
+			return getMountedVolume(&podObj, &volumeObj), true
 		}
 	}
 

--- a/pkg/kubelet/volumemanager/cache/desired_state_of_world.go
+++ b/pkg/kubelet/volumemanager/cache/desired_state_of_world.go
@@ -99,6 +99,9 @@ type DesiredStateOfWorld interface {
 	// attached volumes, false is returned.
 	PodExistsInVolume(podName types.UniquePodName, volumeName v1.UniqueVolumeName, seLinuxMountContext string) bool
 
+	// GetVolumeName returns the UniqueVolumeName for the given pod, indexed by outerVolumeSpecName.
+	GetVolumeNamesForPod(podName types.UniquePodName) map[string]v1.UniqueVolumeName
+
 	// GetVolumesToMount generates and returns a list of volumes that should be
 	// attached to this node and the pods they should be mounted to based on the
 	// current desired state of the world.
@@ -560,6 +563,20 @@ func (dsw *desiredStateOfWorld) GetPods() map[types.UniquePodName]bool {
 		}
 	}
 	return podList
+}
+
+func (dsw *desiredStateOfWorld) GetVolumeNamesForPod(podName types.UniquePodName) map[string]v1.UniqueVolumeName {
+	dsw.RLock()
+	defer dsw.RUnlock()
+
+	volumeNames := make(map[string]v1.UniqueVolumeName)
+	for volumeName, volumeObj := range dsw.volumesToMount {
+		podObj, ok := volumeObj.podsToMount[podName]
+		if ok {
+			volumeNames[podObj.outerVolumeSpecName] = volumeName
+		}
+	}
+	return volumeNames
 }
 
 func (dsw *desiredStateOfWorld) GetVolumesToMount() []VolumeToMount {

--- a/pkg/kubelet/volumemanager/cache/desired_state_of_world_test.go
+++ b/pkg/kubelet/volumemanager/cache/desired_state_of_world_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cache
 
 import (
+	"maps"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
@@ -1273,6 +1274,92 @@ func Test_AddPodToVolume_SELinux_MultiplePods(t *testing.T) {
 			verifyPodExistsInVolumeDsw(t, pod2Name, generatedVolumeName, tc.expectedSELinuxLabel, dsw)
 		})
 	}
+}
+
+func TestGetVolumeNamesForPod(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+	volumePluginMgr, _ := volumetesting.GetTestKubeletVolumePluginMgr(t)
+	seLinuxTranslator := util.NewFakeSELinuxLabelTranslator()
+	dsw := NewDesiredStateOfWorld(volumePluginMgr, seLinuxTranslator)
+
+	pod1 := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pod1",
+			UID:  "pod1-uid",
+		},
+		Spec: v1.PodSpec{
+			Volumes: []v1.Volume{
+				{
+					Name: "volume1-name",
+					VolumeSource: v1.VolumeSource{
+						GCEPersistentDisk: &v1.GCEPersistentDiskVolumeSource{
+							PDName: "fake-device1",
+						},
+					},
+				},
+				{
+					Name: "volume3-name",
+					VolumeSource: v1.VolumeSource{
+						GCEPersistentDisk: &v1.GCEPersistentDiskVolumeSource{
+							PDName: "fake-device3",
+						},
+					},
+				},
+			},
+		},
+	}
+	pod2 := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pod2",
+			UID:  "pod2-uid",
+		},
+		Spec: v1.PodSpec{
+			Volumes: []v1.Volume{
+				{
+					Name: "volume2-name",
+					VolumeSource: v1.VolumeSource{
+						GCEPersistentDisk: &v1.GCEPersistentDiskVolumeSource{
+							PDName: "fake-device2",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	addVolume := func(pod *v1.Pod, index int) {
+		volumeSpec := &volume.Spec{
+			Volume: &pod.Spec.Volumes[index],
+		}
+		podName := util.GetUniquePodName(pod)
+		_, err := dsw.AddPodToVolume(
+			logger, podName, pod, volumeSpec, volumeSpec.Name(), "" /* volumeGIDValue */, nil /* seLinuxContainerContexts */)
+		if err != nil {
+			t.Fatalf("AddPodToVolume failed. Expected: <no error> Actual: <%v>", err)
+		}
+	}
+
+	addVolume(pod1, 0)
+	addVolume(pod1, 1)
+	addVolume(pod2, 0)
+
+	verifyVolumeNames := func(pod *v1.Pod, expectedVolumeNames map[string]v1.UniqueVolumeName) {
+		t.Run(pod.Name, func(t *testing.T) {
+			podName := util.GetUniquePodName(pod)
+			actualVolumeNames := dsw.GetVolumeNamesForPod(podName)
+			if !maps.Equal(expectedVolumeNames, actualVolumeNames) {
+				t.Errorf("GetVolumeNamesForPod returned incorrect value. Expected: <%v> Actual: <%v>",
+					expectedVolumeNames, actualVolumeNames)
+			}
+		})
+	}
+	verifyVolumeNames(pod1, map[string]v1.UniqueVolumeName{
+		"volume1-name": "fake-plugin/fake-device1",
+		"volume3-name": "fake-plugin/fake-device3",
+	})
+	verifyVolumeNames(pod2, map[string]v1.UniqueVolumeName{
+		"volume2-name": "fake-plugin/fake-device2",
+	})
 }
 
 func verifyVolumeExistsDsw(

--- a/pkg/kubelet/volumemanager/volume_manager.go
+++ b/pkg/kubelet/volumemanager/volume_manager.go
@@ -126,13 +126,11 @@ type VolumeManager interface {
 	// volumes.
 	GetMountedVolumesForPod(podName types.UniquePodName) container.VolumeMap
 
-	// GetPossiblyMountedVolumesForPod returns a VolumeMap containing the volumes
-	// referenced by the specified pod that are either successfully attached
+	// HasPossiblyMountedVolumesForPod returns whether the pod has
+	// any volumes that are either successfully attached
 	// and mounted or are "uncertain", i.e. a volume plugin may be mounting
-	// them right now. The key in the map is the OuterVolumeSpecName (i.e.
-	// pod.Spec.Volumes[x].Name). It returns an empty VolumeMap if pod has no
-	// volumes.
-	GetPossiblyMountedVolumesForPod(podName types.UniquePodName) container.VolumeMap
+	// them right now.
+	HasPossiblyMountedVolumesForPod(podName types.UniquePodName) bool
 
 	// GetExtraSupplementalGroupsForPod returns a list of the extra
 	// supplemental groups for the Pod. These extra supplemental groups come
@@ -332,17 +330,8 @@ func (vm *volumeManager) GetMountedVolumesForPod(podName types.UniquePodName) co
 	return podVolumes
 }
 
-func (vm *volumeManager) GetPossiblyMountedVolumesForPod(podName types.UniquePodName) container.VolumeMap {
-	podVolumes := make(container.VolumeMap)
-	for _, mountedVolume := range vm.actualStateOfWorld.GetPossiblyMountedVolumesForPod(podName) {
-		podVolumes[mountedVolume.OuterVolumeSpecName] = container.VolumeInfo{
-			Mounter:             mountedVolume.Mounter,
-			BlockVolumeMapper:   mountedVolume.BlockVolumeMapper,
-			ReadOnly:            mountedVolume.VolumeSpec.ReadOnly,
-			InnerVolumeSpecName: mountedVolume.InnerVolumeSpecName,
-		}
-	}
-	return podVolumes
+func (vm *volumeManager) HasPossiblyMountedVolumesForPod(podName types.UniquePodName) bool {
+	return len(vm.actualStateOfWorld.GetPossiblyMountedVolumesForPod(podName)) > 0
 }
 
 func (vm *volumeManager) GetExtraSupplementalGroupsForPod(pod *v1.Pod) []int64 {

--- a/pkg/kubelet/volumemanager/volume_manager_fake.go
+++ b/pkg/kubelet/volumemanager/volume_manager_fake.go
@@ -78,9 +78,9 @@ func (f *FakeVolumeManager) GetMountedVolumesForPod(podName types.UniquePodName)
 	return nil
 }
 
-// GetPossiblyMountedVolumesForPod is not implemented
-func (f *FakeVolumeManager) GetPossiblyMountedVolumesForPod(podName types.UniquePodName) container.VolumeMap {
-	return nil
+// HasPossiblyMountedVolumesForPod is not implemented
+func (f *FakeVolumeManager) HasPossiblyMountedVolumesForPod(podName types.UniquePodName) bool {
+	return false
 }
 
 // GetExtraSupplementalGroupsForPod is not implemented


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

See commit message for detail.

To fix the issue mentioned in https://github.com/kubernetes/kubernetes/pull/122140 , I want to remove `outerVolumeSpecName` from ASW. This field had an out-of-sync issue before (https://github.com/kubernetes/kubernetes/issues/103143), and its fix seems already hacky. So I decide to just remove `outerVolumeSpecName` from ASW. This PR removes some of the usages.

As result, when accessing ASW with outer name, we need to access DSW to get the unique name first then access ASW with unique name.

Possible behavior changes to volumeManager (but should not be exposed to Kubernetes users)
* `verifyVolumesMountedFunc` now ensures both ASW and DSW contains the specified volumes, instead of only check ASW.
* `GetMountedVolumesForPod` now only returns desired and actually mounted volumes, instead of just mounted. This func should only be used when starting the Pod (not terminating), so all the actually mounted volumes should also be desired.
* `GetPossiblyMountedVolumesForPod` is renamed to `HasGetPossiblyMountedVolumesForPod`. During pod termination, we don't actually care about which volume is not cleaned up. All usage of `GetMountedVolumesForPod` in the tests to verify volume unmount is also replaced with `HasGetPossiblyMountedVolumesForPod` in this PR.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

The first two commits are rewritten since last @jsafrane approval to #122140 . So they may need another review. They are written based on the idea of #126575 , and also considering the performance consideration mentioned there.

/cc @jsafrane @liggitt @Lucaber 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
