### PR TITLE
Mark node-lifecycle e2e as serial

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -2293,8 +2293,8 @@
   release: v1.16
   file: test/e2e/node/taints.go
 - testname: Node, resource lifecycle
-  codename: '[sig-node] Node Lifecycle should run through the lifecycle of a node
-    [Conformance]'
+  codename: '[sig-node] Node Lifecycle [Serial] should run through the lifecycle of
+    a node [Conformance]'
   description: Creating and Reading a Node MUST succeed with required name retrieved.
     Patching a Node MUST succeed with its new label found. Listing Nodes with a labelSelector
     MUST succeed with only a single node found. Updating a Node MUST succeed with

--- a/test/e2e/node/node_lifecycle.go
+++ b/test/e2e/node/node_lifecycle.go
@@ -35,7 +35,7 @@ import (
 	"github.com/onsi/gomega"
 )
 
-var _ = SIGDescribe("Node Lifecycle", func() {
+var _ = SIGDescribe("Node Lifecycle", framework.WithSerial(), func() {
 
 	f := framework.NewDefaultFramework("fake-node")
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

Some tests use `GetRandomReadySchedulableNode` to get a ready node, when the test is running in parallel, it may cause other tests to fail because the node will be deleted and can not run a Pod.

- https://github.com/carlory/kubernetes/blob/mark-node-lifecycle-e2e-as-serial/test/e2e/framework/node/resource.go#L364
- https://storage.googleapis.com/k8s-triage/index.html?text=e2e-fake-node-

![image](https://github.com/user-attachments/assets/21bfbc54-aa86-4203-9323-b7189cdb4b29)

![image](https://github.com/user-attachments/assets/8161e0da-2100-4a5a-8964-28e412959059)



#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
