### PR TITLE
[test]: fake metrics client: nodemetricses/podmetricses expect nodemetricses/podmetricses as the resource name

### DIFF
--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1/fake/fake_nodemetrics.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1/fake/fake_nodemetrics.go
@@ -33,7 +33,7 @@ type FakeNodeMetricses struct {
 	Fake *FakeMetricsV1beta1
 }
 
-var nodemetricsesResource = v1beta1.SchemeGroupVersion.WithResource("nodes")
+var nodemetricsesResource = v1beta1.SchemeGroupVersion.WithResource("nodemetricses")
 
 var nodemetricsesKind = v1beta1.SchemeGroupVersion.WithKind("NodeMetrics")
 

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1/fake/fake_podmetrics.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1/fake/fake_podmetrics.go
@@ -34,7 +34,7 @@ type FakePodMetricses struct {
 	ns   string
 }
 
-var podmetricsesResource = v1beta1.SchemeGroupVersion.WithResource("pods")
+var podmetricsesResource = v1beta1.SchemeGroupVersion.WithResource("podmetricses")
 
 var podmetricsesKind = v1beta1.SchemeGroupVersion.WithKind("PodMetrics")
 

--- a/staging/src/k8s.io/metrics/pkg/client/clientset_test/clientset_test.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset_test/clientset_test.go
@@ -21,12 +21,27 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/metrics/pkg/apis/metrics/v1beta1"
 	"k8s.io/metrics/pkg/client/clientset/versioned/fake"
 )
 
 // TestFakeList is a basic sanity check that makes sure the fake Clientset is working properly.
 func TestFakeList(t *testing.T) {
-	client := fake.NewSimpleClientset()
+	nodename := "nodename"
+	nodeMetrics := &v1beta1.NodeMetrics{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: nodename,
+		},
+	}
+	podname := "podname"
+	podMetrics := &v1beta1.PodMetrics{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podname,
+			Namespace: "default",
+		},
+	}
+
+	client := fake.NewSimpleClientset(nodeMetrics, podMetrics)
 	if _, err := client.MetricsV1alpha1().PodMetricses("").List(context.TODO(), metav1.ListOptions{}); err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -37,6 +52,12 @@ func TestFakeList(t *testing.T) {
 		t.Errorf("Unexpected error: %v", err)
 	}
 	if _, err := client.MetricsV1beta1().NodeMetricses().List(context.TODO(), metav1.ListOptions{}); err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if _, err := client.MetricsV1beta1().NodeMetricses().Get(context.TODO(), nodename, metav1.GetOptions{}); err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if _, err := client.MetricsV1beta1().PodMetricses(podMetrics.Namespace).Get(context.TODO(), podname, metav1.GetOptions{}); err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Currently, both `FakeNodeMetricses` and `FakePodMetricses` of metrics fake client set the resource name to `nodes`, resp. `pods`. When creating a simple test with a fake node/pod metrics object the fake client fails to find the requested object since there's a mismatch in the resource hardcoded in the fake parts of the client and the resource that's decoded from the actual object. The former case currently gives `k8s.metrics.io/v1beta1, Resource=pods` and `k8s.metrics.io/v1beta1, Resource=nodes` instead of `k8s.metrics.io/v1beta1, Resource=podmetricses` and `k8s.metrics.io/v1beta1, Resource=nodemetricses`. Causing `nodes.metrics.k8s.io`, resp. `pods.metrics.k8s.io` not found error.

Originally, the resource was set correctly. However, it got changed through https://github.com/kubernetes/metrics/commit/c932cd3ea26e949fad6703fe8d6ffa4091ef786e#diff-c1c3deab7d257b9a7c3a69a596f4a4b93768053a9e66f7bca76e946842171257 on Aug 29, 2017. The same issue got reported in https://github.com/kubernetes/metrics/issues/37 on Jan 11, 2023. There's a workaround for overcoming this gap. Yet, the workaround requires additional code that's not necessary.

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/metrics/issues/37

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
