### PR TITLE
Fix pod scale down failure in EventHandlingPodUpdate scheduler_perf test

### DIFF
--- a/test/integration/scheduler_perf/event_handling/performance-config.yaml
+++ b/test/integration/scheduler_perf/event_handling/performance-config.yaml
@@ -228,13 +228,20 @@
     stageRequirement: Attempted
     labelSelector:
       type: unsched
-  # Update blocker pods' labels and scale down their resource requests 
-  # to make the unschedulable pods schedulable.
+  # Update blocker pods' labels to make the unschedulable pods schedulable.
   - opcode: updateAny
     countParam: $blockerPods
     templatePath: templates/podupdate-pod-blocker-update.yaml
     updatePerSecond: 100
     namespace: blocker
+  # Scale down blocker pods' resource requests to make the unschedulable pods schedulable.
+  - opcode: updateAny
+    countParam: $blockerPods
+    templatePath: templates/podupdate-pod-blocker-scale-down.yaml
+    updatePerSecond: 100
+    namespace: blocker
+    subresources:
+      - resize
   # Update pods blocked by SchedulingGates by removing the gate from themselves.
   - opcode: updateAny
     countParam: $measurePods

--- a/test/integration/scheduler_perf/event_handling/templates/podupdate-pod-blocker-scale-down.yaml
+++ b/test/integration/scheduler_perf/event_handling/templates/podupdate-pod-blocker-scale-down.yaml
@@ -9,5 +9,5 @@ spec:
     resources:
       requests:
         cpu: 0.0001
-        memory: {{ div 30000 .Count }}Mi
+        memory: 1Mi
   nodeName: scheduler-perf-node

--- a/test/integration/scheduler_perf/update.go
+++ b/test/integration/scheduler_perf/update.go
@@ -49,6 +49,10 @@ type updateAny struct {
 	UpdatePerSecond int
 	// Internal field of the struct used for caching the mapping.
 	cachedMapping *meta.RESTMapping
+	// List of subresources to update.
+	// If empty, update operation is performed on the actual resource.
+	// Optional
+	Subresources []string
 }
 
 var _ runnableOp = &updateAny{}
@@ -145,7 +149,7 @@ func (c *updateAny) update(tCtx ktesting.TContext, env map[string]any) error {
 		if c.cachedMapping.Scope.Name() != meta.RESTScopeNameNamespace {
 			return fmt.Errorf("namespace %q set for %q, but %q has scope %q", c.Namespace, c.TemplatePath, c.cachedMapping.GroupVersionKind, c.cachedMapping.Scope.Name())
 		}
-		_, err := resourceClient.Namespace(c.Namespace).Update(tCtx, obj, options)
+		_, err := resourceClient.Namespace(c.Namespace).Update(tCtx, obj, options, c.Subresources...)
 		if err != nil {
 			return fmt.Errorf("failed to update object in namespace %q: %w", c.Namespace, err)
 		}
@@ -158,7 +162,7 @@ func (c *updateAny) update(tCtx ktesting.TContext, env map[string]any) error {
 	if c.cachedMapping.Scope.Name() != meta.RESTScopeNameRoot {
 		return fmt.Errorf("namespace not set for %q, but %q has scope %q", c.TemplatePath, c.cachedMapping.GroupVersionKind, c.cachedMapping.Scope.Name())
 	}
-	_, err := resourceClient.Update(tCtx, obj, options)
+	_, err := resourceClient.Update(tCtx, obj, options, c.Subresources...)
 	if err != nil {
 		return fmt.Errorf("failed to update object: %w", err)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug
/kind failing-test

#### What this PR does / why we need it:

Changes around InPlacePodVerticalScaling feature (#128266) caused the EventHandlingPodUpdate to fail constantly in `ci-benchmark-scheduler-perf-master` periodic job. Now, scaling down is not possible through Pod/Update like before, but needs to have a subresource set to `resize`. This PR adds a possibility to set subresource in updateAny op as well as fixes the issue with test.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
