### PR TITLE
Move broadcast of key updates into sync, fixup of externaljwt generation / test

### DIFF
--- a/pkg/serviceaccount/externaljwt/plugin/plugin_test.go
+++ b/pkg/serviceaccount/externaljwt/plugin/plugin_test.go
@@ -258,7 +258,7 @@ func TestExternalTokenGenerator(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			ctx := context.Background()
 
-			sockname := fmt.Sprintf("@test-external-token-generator-%d.sock", i)
+			sockname := fmt.Sprintf("@test-external-token-generator-%d-%d.sock", time.Now().Nanosecond(), i)
 			t.Cleanup(func() { _ = os.Remove(sockname) })
 
 			addr := &net.UnixAddr{Name: sockname, Net: "unix"}

--- a/test/integration/serviceaccount/external_jwt_signer_test.go
+++ b/test/integration/serviceaccount/external_jwt_signer_test.go
@@ -59,7 +59,7 @@ func TestExternalJWTSigningAndAuth(t *testing.T) {
 	defer cancel()
 
 	// create and start mock signer.
-	socketPath := "@mock-external-jwt-signer.sock"
+	socketPath := fmt.Sprintf("@mock-external-jwt-signer-%d.sock", time.Now().Nanosecond())
 	t.Cleanup(func() { _ = os.Remove(socketPath) })
 	mockSigner := v1alpha1testing.NewMockSigner(t, socketPath)
 	defer mockSigner.CleanUp()
@@ -227,7 +227,7 @@ func TestExternalJWTSigningAndAuth(t *testing.T) {
 			}
 
 			if !tokenReviewResult.Status.Authenticated && tc.shouldPassAuth {
-				t.Fatal("Expected Authentication to succeed")
+				t.Fatalf("Expected Authentication to succeed, got %v", tokenReviewResult.Status.Error)
 			} else if tokenReviewResult.Status.Authenticated && !tc.shouldPassAuth {
 				t.Fatal("Expected Authentication to fail")
 			}

--- a/test/integration/serviceaccount/external_jwt_signer_test.go
+++ b/test/integration/serviceaccount/external_jwt_signer_test.go
@@ -121,14 +121,14 @@ func TestExternalJWTSigningAndAuth(t *testing.T) {
 				mockSigner.SigningKeyID = "updated-kid-1"
 
 				cpy := make(map[string]v1alpha1testing.KeyT)
-				for key, value := range *mockSigner.SupportedKeys.Load() {
+				for key, value := range mockSigner.GetSupportedKeys() {
 					cpy[key] = value
 				}
 				cpy["updated-kid-1"] = v1alpha1testing.KeyT{
 					Key:                      pubKey1Bytes,
 					ExcludeFromOidcDiscovery: true,
 				}
-				mockSigner.SupportedKeys.Store(&cpy)
+				mockSigner.SetSupportedKeys(cpy)
 			},
 			preValidationSignerUpdate: func() { /*no-op*/ },
 			wantTokenReqErr:           fmt.Errorf("failed to generate token: while validating header: key used for signing JWT (kid: updated-kid-1) is excluded from OIDC discovery docs"),
@@ -163,7 +163,7 @@ func TestExternalJWTSigningAndAuth(t *testing.T) {
 				mockSigner.SigningKey = key1
 			},
 			preValidationSignerUpdate: func() {
-				mockSigner.SupportedKeys.Store(&map[string]v1alpha1testing.KeyT{})
+				mockSigner.SetSupportedKeys(map[string]v1alpha1testing.KeyT{})
 			},
 			shouldPassAuth: false,
 		},
@@ -174,12 +174,12 @@ func TestExternalJWTSigningAndAuth(t *testing.T) {
 			},
 			preValidationSignerUpdate: func() {
 				cpy := make(map[string]v1alpha1testing.KeyT)
-				for key, value := range *mockSigner.SupportedKeys.Load() {
+				for key, value := range mockSigner.GetSupportedKeys() {
 					cpy[key] = value
 				}
 				cpy["kid-1"] = v1alpha1testing.KeyT{Key: pubKey1Bytes}
-				mockSigner.SupportedKeys.Store(&cpy)
-				mockSigner.AckKeyFetch <- true
+				mockSigner.SetSupportedKeys(cpy)
+				mockSigner.WaitForSupportedKeysFetch()
 			},
 			shouldPassAuth: true,
 		},
@@ -192,7 +192,7 @@ func TestExternalJWTSigningAndAuth(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to reset signer for the test %q: %v", tc.desc, err)
 			}
-			mockSigner.AckKeyFetch <- true
+			mockSigner.WaitForSupportedKeysFetch()
 
 			// Adjust parameters on mock signer for the test.
 			tc.preTestSignerUpdate()

--- a/third_party/protobuf/google/protobuf/timestamp.proto
+++ b/third_party/protobuf/google/protobuf/timestamp.proto
@@ -1,0 +1,144 @@
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+syntax = "proto3";
+
+package google.protobuf;
+
+option cc_enable_arenas = true;
+option go_package = "google.golang.org/protobuf/types/known/timestamppb";
+option java_package = "com.google.protobuf";
+option java_outer_classname = "TimestampProto";
+option java_multiple_files = true;
+option objc_class_prefix = "GPB";
+option csharp_namespace = "Google.Protobuf.WellKnownTypes";
+
+// A Timestamp represents a point in time independent of any time zone or local
+// calendar, encoded as a count of seconds and fractions of seconds at
+// nanosecond resolution. The count is relative to an epoch at UTC midnight on
+// January 1, 1970, in the proleptic Gregorian calendar which extends the
+// Gregorian calendar backwards to year one.
+//
+// All minutes are 60 seconds long. Leap seconds are "smeared" so that no leap
+// second table is needed for interpretation, using a [24-hour linear
+// smear](https://developers.google.com/time/smear).
+//
+// The range is from 0001-01-01T00:00:00Z to 9999-12-31T23:59:59.999999999Z. By
+// restricting to that range, we ensure that we can convert to and from [RFC
+// 3339](https://www.ietf.org/rfc/rfc3339.txt) date strings.
+//
+// # Examples
+//
+// Example 1: Compute Timestamp from POSIX `time()`.
+//
+//     Timestamp timestamp;
+//     timestamp.set_seconds(time(NULL));
+//     timestamp.set_nanos(0);
+//
+// Example 2: Compute Timestamp from POSIX `gettimeofday()`.
+//
+//     struct timeval tv;
+//     gettimeofday(&tv, NULL);
+//
+//     Timestamp timestamp;
+//     timestamp.set_seconds(tv.tv_sec);
+//     timestamp.set_nanos(tv.tv_usec * 1000);
+//
+// Example 3: Compute Timestamp from Win32 `GetSystemTimeAsFileTime()`.
+//
+//     FILETIME ft;
+//     GetSystemTimeAsFileTime(&ft);
+//     UINT64 ticks = (((UINT64)ft.dwHighDateTime) << 32) | ft.dwLowDateTime;
+//
+//     // A Windows tick is 100 nanoseconds. Windows epoch 1601-01-01T00:00:00Z
+//     // is 11644473600 seconds before Unix epoch 1970-01-01T00:00:00Z.
+//     Timestamp timestamp;
+//     timestamp.set_seconds((INT64) ((ticks / 10000000) - 11644473600LL));
+//     timestamp.set_nanos((INT32) ((ticks % 10000000) * 100));
+//
+// Example 4: Compute Timestamp from Java `System.currentTimeMillis()`.
+//
+//     long millis = System.currentTimeMillis();
+//
+//     Timestamp timestamp = Timestamp.newBuilder().setSeconds(millis / 1000)
+//         .setNanos((int) ((millis % 1000) * 1000000)).build();
+//
+// Example 5: Compute Timestamp from Java `Instant.now()`.
+//
+//     Instant now = Instant.now();
+//
+//     Timestamp timestamp =
+//         Timestamp.newBuilder().setSeconds(now.getEpochSecond())
+//             .setNanos(now.getNano()).build();
+//
+// Example 6: Compute Timestamp from current time in Python.
+//
+//     timestamp = Timestamp()
+//     timestamp.GetCurrentTime()
+//
+// # JSON Mapping
+//
+// In JSON format, the Timestamp type is encoded as a string in the
+// [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format. That is, the
+// format is "{year}-{month}-{day}T{hour}:{min}:{sec}[.{frac_sec}]Z"
+// where {year} is always expressed using four digits while {month}, {day},
+// {hour}, {min}, and {sec} are zero-padded to two digits each. The fractional
+// seconds, which can go up to 9 digits (i.e. up to 1 nanosecond resolution),
+// are optional. The "Z" suffix indicates the timezone ("UTC"); the timezone
+// is required. A proto3 JSON serializer should always use UTC (as indicated by
+// "Z") when printing the Timestamp type and a proto3 JSON parser should be
+// able to accept both UTC and other timezones (as indicated by an offset).
+//
+// For example, "2017-01-15T01:30:15.01Z" encodes 15.01 seconds past
+// 01:30 UTC on January 15, 2017.
+//
+// In JavaScript, one can convert a Date object to this format using the
+// standard
+// [toISOString()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString)
+// method. In Python, a standard `datetime.datetime` object can be converted
+// to this format using
+// [`strftime`](https://docs.python.org/2/library/time.html#time.strftime) with
+// the time format spec '%Y-%m-%dT%H:%M:%S.%fZ'. Likewise, in Java, one can use
+// the Joda Time's [`ISODateTimeFormat.dateTime()`](
+// http://joda-time.sourceforge.net/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTime()
+// ) to obtain a formatter capable of generating timestamps in this format.
+//
+message Timestamp {
+  // Represents seconds of UTC time since Unix epoch
+  // 1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
+  // 9999-12-31T23:59:59Z inclusive.
+  int64 seconds = 1;
+
+  // Non-negative fractions of a second at nanosecond resolution. Negative
+  // second values with fractions must still have non-negative nanos values
+  // that count forward in time. Must be from 0 to 999,999,999
+  // inclusive.
+  int32 nanos = 2;
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

1. Bugfix: Moves broadcast into syncKeys method, so any change to keys (periodic or on-demand) always notifies listeners immediately.
2. Test flake fix: Address race between setting new keys and ensuring they've been read (https://github.com/kubernetes/kubernetes/pull/128190#issuecomment-2462857707)
3. Add proto definition file needed for local generation (fixes https://github.com/kubernetes/kubernetes/issues/128672)



#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @enj
/sig auth