### PR TITLE
node: cm: use maps.Clone instead of reinvent it

### DIFF
--- a/pkg/kubelet/cm/containermap/container_map.go
+++ b/pkg/kubelet/cm/containermap/container_map.go
@@ -18,6 +18,7 @@ package containermap
 
 import (
 	"fmt"
+	"maps"
 )
 
 // cmItem (ContainerMap ITEM) is a pair podUID, containerName
@@ -36,11 +37,7 @@ func NewContainerMap() ContainerMap {
 
 // Clone creates a deep copy of the ContainerMap
 func (cm ContainerMap) Clone() ContainerMap {
-	ret := make(ContainerMap, len(cm))
-	for key, val := range cm {
-		ret[key] = val
-	}
-	return ret
+	return maps.Clone(cm)
 }
 
 // Add adds a mapping of (containerID)->(podUID, containerName) to the ContainerMap

--- a/pkg/kubelet/cm/containermap/container_map_test.go
+++ b/pkg/kubelet/cm/containermap/container_map_test.go
@@ -20,22 +20,6 @@ import (
 	"testing"
 )
 
-func TestContainerMapCloneEqual(t *testing.T) {
-	cm := NewContainerMap()
-	// add random fake data
-	cm.Add("fakePodUID-1", "fakeContainerName-a1", "fakeContainerID-A")
-	cm.Add("fakePodUID-2", "fakeContainerName-b2", "fakeContainerID-B")
-	cm.Add("fakePodUID-2", "fakeContainerName-c2", "fakeContainerID-C")
-	cm.Add("fakePodUID-3", "fakeContainerName-d3", "fakeContainerID-D")
-	cm.Add("fakePodUID-3", "fakeContainerName-e3", "fakeContainerID-E")
-	cm.Add("fakePodUID-3", "fakeContainerName-f3", "fakeContainerID-F")
-
-	cloned := cm.Clone()
-	if !areEqual(cm, cloned) {
-		t.Fatalf("clone %+#v different from original %+#v", cloned, cm)
-	}
-}
-
 func TestContainerMapCloneUnshared(t *testing.T) {
 	cm := NewContainerMap()
 	// add random fake data
@@ -142,20 +126,4 @@ func TestContainerMap(t *testing.T) {
 			t.Errorf("unexpected entries still in containerMap: %v", cm)
 		}
 	}
-}
-
-func areEqual(cm1, cm2 ContainerMap) bool {
-	if len(cm1) != len(cm2) {
-		return false
-	}
-	for key1, item1 := range cm1 {
-		item2, ok := cm2[key1]
-		if !ok {
-			return false
-		}
-		if item1 != item2 {
-			return false
-		}
-	}
-	return true
 }

--- a/pkg/kubelet/cm/cpumanager/cpu_assignment.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_assignment.go
@@ -18,6 +18,7 @@ package cpumanager
 
 import (
 	"fmt"
+	"maps"
 	"math"
 	"sort"
 
@@ -39,11 +40,7 @@ const (
 type mapIntInt map[int]int
 
 func (m mapIntInt) Clone() mapIntInt {
-	cp := make(mapIntInt, len(m))
-	for k, v := range m {
-		cp[k] = v
-	}
-	return cp
+	return maps.Clone(m)
 }
 
 func (m mapIntInt) Keys() []int {

--- a/pkg/kubelet/cm/devicemanager/pod_devices.go
+++ b/pkg/kubelet/cm/devicemanager/pod_devices.go
@@ -17,6 +17,7 @@ limitations under the License.
 package devicemanager
 
 import (
+	"maps"
 	"sync"
 
 	"k8s.io/klog/v2"
@@ -429,10 +430,7 @@ func NewResourceDeviceInstances() ResourceDeviceInstances {
 func (rdev ResourceDeviceInstances) Clone() ResourceDeviceInstances {
 	clone := NewResourceDeviceInstances()
 	for resourceName, resourceDevs := range rdev {
-		clone[resourceName] = make(map[string]pluginapi.Device)
-		for devID, dev := range resourceDevs {
-			clone[resourceName][devID] = dev
-		}
+		clone[resourceName] = maps.Clone(resourceDevs)
 	}
 	return clone
 }


### PR DESCRIPTION
/kind cleanup

#### What this PR does / why we need it:
As emerged during the review of https://github.com/kubernetes/kubernetes/pull/128657#discussion_r1832973928 , golang stdlib now features helpers in `maps` and `slices` package we can use instead of reinventing in our codebase

#### Which issue(s) this PR fixes:
Fixes N/A

#### Special notes for your reviewer:
N/A

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
