### PR TITLE
[FG:InPlacePodVerticalScaling] Handle edge cases around CPU MinShares

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2897,6 +2897,16 @@ func (kl *Kubelet) handlePodResourcesResize(pod *v1.Pod, podStatus *kubecontaine
 			}
 		}
 		allocatedPod = pod
+
+		// Special case when the updated allocation matches the actual resources. This can occur
+		// when reverting a resize that hasn't been actuated, or when making an equivalent change
+		// (such as CPU requests below MinShares). This is an optimization to clear the resize
+		// status immediately, rather than waiting for the next SyncPod iteration.
+		if allocatedResourcesMatchStatus(allocatedPod, podStatus) {
+			// In this case, consider the resize complete.
+			kl.statusManager.SetPodResizeStatus(pod.UID, "")
+			return allocatedPod, nil
+		}
 	}
 	if resizeStatus != "" {
 		kl.statusManager.SetPodResizeStatus(pod.UID, resizeStatus)

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -597,6 +597,13 @@ func (m *kubeGenericRuntimeManager) computePodResizeAction(pod *v1.Pod, containe
 	// Note: cgroup doesn't support memory request today, so we don't compare that. If canAdmitPod called  during
 	// handlePodResourcesResize finds 'fit', then desiredMemoryRequest == currentMemoryRequest.
 
+	// Special case for minimum CPU request
+	if desiredResources.cpuRequest <= cm.MinShares && currentResources.cpuRequest <= cm.MinShares {
+		// If both desired & current CPU requests are at or below MinShares,
+		// then consider these equal.
+		desiredResources.cpuRequest = currentResources.cpuRequest
+	}
+
 	if currentResources == desiredResources {
 		// No resize required.
 		return true
@@ -817,8 +824,14 @@ func (m *kubeGenericRuntimeManager) updatePodContainerResources(pod *v1.Pod, res
 			case v1.ResourceMemory:
 				return status.Resources.MemoryLimit.Equal(*container.Resources.Limits.Memory())
 			case v1.ResourceCPU:
-				return status.Resources.CPURequest.Equal(*container.Resources.Requests.Cpu()) &&
-					status.Resources.CPULimit.Equal(*container.Resources.Limits.Cpu())
+				if !status.Resources.CPULimit.Equal(*container.Resources.Limits.Cpu()) {
+					return false // limits don't match
+				} else if status.Resources.CPURequest.Equal(*container.Resources.Requests.Cpu()) {
+					return true // requests & limits both match
+				}
+				// Consider requests equal if both are at or below MinShares.
+				return status.Resources.CPURequest.MilliValue() <= cm.MinShares &&
+					container.Resources.Requests.Cpu().MilliValue() <= cm.MinShares
 			default:
 				return true // Shouldn't happen.
 			}

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -2204,6 +2204,8 @@ func TestComputePodActionsForPodResize(t *testing.T) {
 	m.machineInfo.MemoryCapacity = 17179860387 // 16GB
 	assert.NoError(t, err)
 
+	cpu1m := resource.MustParse("1m")
+	cpu2m := resource.MustParse("2m")
 	cpu100m := resource.MustParse("100m")
 	cpu200m := resource.MustParse("200m")
 	mem100M := resource.MustParse("100Mi")
@@ -2357,6 +2359,48 @@ func TestComputePodActionsForPodResize(t *testing.T) {
 				if cStatus := status.FindContainerStatusByName(c.Name); cStatus != nil {
 					cStatus.Resources = &kubecontainer.ContainerResources{
 						CPULimit: ptr.To(cpu200m.DeepCopy()),
+					}
+				}
+			},
+			getExpectedPodActionsFn: func(pod *v1.Pod, podStatus *kubecontainer.PodStatus) *podActions {
+				pa := podActions{
+					SandboxID:          podStatus.SandboxStatuses[0].Id,
+					ContainersToKill:   getKillMap(pod, podStatus, []int{}),
+					ContainersToStart:  []int{},
+					ContainersToUpdate: map[v1.ResourceName][]containerToUpdateInfo{},
+				}
+				return &pa
+			},
+		},
+		"Nothing when spec.Resources and status.Resources are equivalent": {
+			setupFn: func(pod *v1.Pod, status *kubecontainer.PodStatus) {
+				c := &pod.Spec.Containers[1]
+				c.Resources = v1.ResourceRequirements{} // best effort pod
+				if cStatus := status.FindContainerStatusByName(c.Name); cStatus != nil {
+					cStatus.Resources = &kubecontainer.ContainerResources{
+						CPURequest: ptr.To(cpu2m.DeepCopy()),
+					}
+				}
+			},
+			getExpectedPodActionsFn: func(pod *v1.Pod, podStatus *kubecontainer.PodStatus) *podActions {
+				pa := podActions{
+					SandboxID:          podStatus.SandboxStatuses[0].Id,
+					ContainersToKill:   getKillMap(pod, podStatus, []int{}),
+					ContainersToStart:  []int{},
+					ContainersToUpdate: map[v1.ResourceName][]containerToUpdateInfo{},
+				}
+				return &pa
+			},
+		},
+		"Update container CPU resources to equivalent value": {
+			setupFn: func(pod *v1.Pod, status *kubecontainer.PodStatus) {
+				c := &pod.Spec.Containers[1]
+				c.Resources = v1.ResourceRequirements{
+					Requests: v1.ResourceList{v1.ResourceCPU: cpu1m},
+				}
+				if cStatus := status.FindContainerStatusByName(c.Name); cStatus != nil {
+					cStatus.Resources = &kubecontainer.ContainerResources{
+						CPURequest: ptr.To(cpu2m.DeepCopy()),
 					}
 				}
 			},

--- a/test/e2e/common/node/pod_resize.go
+++ b/test/e2e/common/node/pod_resize.go
@@ -567,6 +567,24 @@ func doPodResizeTests(f *framework.Framework) {
 			},
 		},
 		{
+			name: "Burstable QoS pod, one container with cpu requests - resize with equivalent request",
+			containers: []e2epod.ResizableContainerInfo{
+				{
+					Name:      "c1",
+					Resources: &e2epod.ContainerResources{CPUReq: "2m"},
+				},
+			},
+			patchString: `{"spec":{"containers":[
+						{"name":"c1", "resources":{"requests":{"cpu":"1m"}}}
+					]}}`,
+			expected: []e2epod.ResizableContainerInfo{
+				{
+					Name:      "c1",
+					Resources: &e2epod.ContainerResources{CPUReq: "1m"},
+				},
+			},
+		},
+		{
 			name:         "Guaranteed QoS pod, one container - increase CPU (NotRequired) & memory (RestartContainer)",
 			testRollback: true,
 			containers: []e2epod.ResizableContainerInfo{
@@ -782,6 +800,22 @@ func doPodResizeTests(f *framework.Framework) {
 				},
 			},
 			addExtendedResource: true,
+		},
+		{
+			name: "BestEffort QoS pod - empty resize",
+			containers: []e2epod.ResizableContainerInfo{
+				{
+					Name:      "c1",
+					Resources: &e2epod.ContainerResources{},
+				},
+			},
+			patchString: `{}`,
+			expected: []e2epod.ResizableContainerInfo{
+				{
+					Name:      "c1",
+					Resources: &e2epod.ContainerResources{},
+				},
+			},
 		},
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

For CPU requests between 0-2m, the Kubelet always configures 2 CPU shares (on linux). This causes some problems when pod resize code compares desired & actual resources.

This PR special cases CPU Request comparisons to consider any value <= 2m / 2 CPU shares to be equivalent.

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubernetes/issues/114123
Fixes https://github.com/kubernetes/kubernetes/issues/126195

#### Special notes for your reviewer:

This PR supersedes https://github.com/kubernetes/kubernetes/pull/120791

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/sig node
/priority important-soon
/milestone v1.32
/assign @yujuhong 