### PR TITLE
[FG:InPlacePodVerticalScaling] Graduate to Beta

### DIFF
--- a/pkg/apis/core/fuzzer/fuzzer.go
+++ b/pkg/apis/core/fuzzer/fuzzer.go
@@ -309,6 +309,23 @@ var Funcs = func(codecs runtimeserializer.CodecFactory) []interface{} {
 			c.FuzzNoCustom(ct)                                          // fuzz self without calling this function again
 			ct.TerminationMessagePath = "/" + ct.TerminationMessagePath // Must be non-empty
 			ct.TerminationMessagePolicy = "File"
+			// Match defaulting in pkg/apis/core/v1/defaults.go.
+			_, hasCPUReq := ct.Resources.Requests[core.ResourceCPU]
+			_, hasCPULim := ct.Resources.Limits[core.ResourceCPU]
+			_, hasMemReq := ct.Resources.Requests[core.ResourceMemory]
+			_, hasMemLim := ct.Resources.Limits[core.ResourceMemory]
+			if hasCPUReq || hasCPULim {
+				ct.ResizePolicy = append(ct.ResizePolicy, core.ContainerResizePolicy{
+					ResourceName:  core.ResourceCPU,
+					RestartPolicy: core.NotRequired,
+				})
+			}
+			if hasMemReq || hasMemLim {
+				ct.ResizePolicy = append(ct.ResizePolicy, core.ContainerResizePolicy{
+					ResourceName:  core.ResourceMemory,
+					RestartPolicy: core.NotRequired,
+				})
+			}
 		},
 		func(ep *core.EphemeralContainer, c fuzz.Continue) {
 			c.FuzzNoCustom(ep)                                                                   // fuzz self without calling this function again

--- a/pkg/features/versioned_kube_features.go
+++ b/pkg/features/versioned_kube_features.go
@@ -404,6 +404,7 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 
 	InPlacePodVerticalScaling: {
 		{Version: version.MustParse("1.27"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.32"), Default: true, PreRelease: featuregate.Beta},
 	},
 
 	InPlacePodVerticalScalingAllocatedStatus: {

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -1260,6 +1260,11 @@ func verifyActions(t *testing.T, expected, actual *podActions, desc string) {
 			actual.ContainersToKill[k] = info
 		}
 	}
+
+	if expected.ContainersToUpdate == nil && actual.ContainersToUpdate != nil {
+		// No need to distinguish empty and nil maps for the test.
+		expected.ContainersToUpdate = map[v1.ResourceName][]containerToUpdateInfo{}
+	}
 	assert.Equal(t, expected, actual, desc)
 }
 

--- a/pkg/kubelet/status/status_manager.go
+++ b/pkg/kubelet/status/status_manager.go
@@ -179,6 +179,7 @@ func NewManager(kubeClient clientset.Interface, podManager PodManager, podDeleti
 		podDeletionSafety:       podDeletionSafety,
 		podStartupLatencyHelper: podStartupLatencyHelper,
 		stateFileDirectory:      stateFileDirectory,
+		state:                   state.NewNoopStateCheckpoint(),
 	}
 }
 
@@ -202,9 +203,6 @@ func isPodStatusByKubeletEqual(oldStatus, status *v1.PodStatus) bool {
 }
 
 func (m *manager) Start() {
-	// Initialize m.state to no-op state checkpoint manager
-	m.state = state.NewNoopStateCheckpoint()
-
 	// Create pod allocation checkpoint manager even if client is nil so as to allow local get/set of AllocatedResources & Resize
 	if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {
 		stateImpl, err := state.NewStateCheckpoint(m.stateFileDirectory, podStatusManagerStateFile)

--- a/test/e2e/common/node/pod_resize.go
+++ b/test/e2e/common/node/pod_resize.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/kubernetes/test/e2e/feature"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
@@ -1060,7 +1059,7 @@ func doPodResizeErrorTests(f *framework.Framework) {
 //       Above tests are performed by doSheduletTests() and doPodResizeResourceQuotaTests()
 //       in test/e2e/node/pod_resize.go
 
-var _ = SIGDescribe("Pod InPlace Resize Container", framework.WithSerial(), feature.InPlacePodVerticalScaling, "[NodeAlphaFeature:InPlacePodVerticalScaling]", func() {
+var _ = SIGDescribe("Pod InPlace Resize Container", framework.WithSerial(), func() {
 	f := framework.NewDefaultFramework("pod-resize-tests")
 
 	ginkgo.BeforeEach(func(ctx context.Context) {

--- a/test/e2e/feature/feature.go
+++ b/test/e2e/feature/feature.go
@@ -186,9 +186,6 @@ var (
 	// Ingress.networking.k8s.io to be present.
 	Ingress = framework.WithFeature(framework.ValidFeatures.Add("Ingress"))
 
-	// TODO: document the feature (owning SIG, when to use this feature for a test)
-	InPlacePodVerticalScaling = framework.WithFeature(framework.ValidFeatures.Add("InPlacePodVerticalScaling"))
-
 	// Owner: sig-network
 	// Marks tests that require a cluster with dual-stack pod and service networks.
 	IPv6DualStack = framework.WithFeature(framework.ValidFeatures.Add("IPv6DualStack"))

--- a/test/e2e/node/pod_resize.go
+++ b/test/e2e/node/pod_resize.go
@@ -27,7 +27,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	resourceapi "k8s.io/kubernetes/pkg/api/v1/resource"
-	"k8s.io/kubernetes/test/e2e/feature"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
@@ -356,7 +355,7 @@ func doPodResizeSchedulerTests(f *framework.Framework) {
 	})
 }
 
-var _ = SIGDescribe(framework.WithSerial(), "Pod InPlace Resize Container (scheduler-focused)", feature.InPlacePodVerticalScaling, func() {
+var _ = SIGDescribe(framework.WithSerial(), "Pod InPlace Resize Container (scheduler-focused)", func() {
 	f := framework.NewDefaultFramework("pod-resize-scheduler-tests")
 	ginkgo.BeforeEach(func(ctx context.Context) {
 		node, err := e2enode.GetRandomReadySchedulableNode(ctx, f.ClientSet)
@@ -368,7 +367,7 @@ var _ = SIGDescribe(framework.WithSerial(), "Pod InPlace Resize Container (sched
 	doPodResizeSchedulerTests(f)
 })
 
-var _ = SIGDescribe("Pod InPlace Resize Container", feature.InPlacePodVerticalScaling, func() {
+var _ = SIGDescribe("Pod InPlace Resize Container", func() {
 	f := framework.NewDefaultFramework("pod-resize-tests")
 
 	ginkgo.BeforeEach(func(ctx context.Context) {

--- a/test/featuregates_linter/test_data/versioned_feature_list.yaml
+++ b/test/featuregates_linter/test_data/versioned_feature_list.yaml
@@ -540,6 +540,10 @@
     lockToDefault: false
     preRelease: Alpha
     version: "1.27"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.32"
 - name: InPlacePodVerticalScalingAllocatedStatus
   versionedSpecs:
   - default: false


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

Graduate the `InPlacePodVerticalScaling` feature to beta.

For https://github.com/kubernetes/enhancements/issues/1287

#### Special notes for your reviewer:

Code freeze extension request: https://groups.google.com/g/kubernetes-sig-release/c/DvRlV9mBZ-Q/m/AGmOk6avBwAJ

This should not merge until the remaining beta-blockers are resolved. All of these have PRs inflight.

- [x] https://github.com/kubernetes/kubernetes/issues/117767
- [x] https://github.com/kubernetes/kubernetes/issues/114123
- [x] https://github.com/kubernetes/kubernetes/issues/126388
- [x] https://github.com/kubernetes/kubernetes/issues/127132
- [x] https://github.com/kubernetes/kubernetes/issues/127172 (remaining work is not beta-blocking)
- [x] https://github.com/kubernetes/kubernetes/issues/128068
- [x] https://github.com/kubernetes/kubernetes/issues/119838
- [x] https://github.com/kubernetes/kubernetes/issues/128677

NOTE: The following changes were originally in-scope for beta, but have been moved out:

- https://github.com/kubernetes/kubernetes/issues/128069 - This was always meant to be a best-effort call to inform the runtime of a resize, but the resize is still handled by the Kubelet. This should move to the GA scope, but we do not have a direct consumer or use case for it now.
- https://github.com/kubernetes/kubernetes/issues/128071 - This metric is not sufficiently well defined. With the addition of the `/resize` subresource, we automatically get a metric for total number of resize requests. We will revisit this for GA.
- https://github.com/kubernetes/kubernetes/issues/128070 - Unfortunately this isn't feasible in v1.32 due to a validation rollback issue (see https://github.com/kubernetes/kubernetes/pull/128367/files#r1834897969). We will make the validation changes in v1.32 to make this feasible in v1.33, but the actual implementation won't land until v1.33.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

original release note (reverted in https://github.com/kubernetes/kubernetes/pull/128875)
```
Promoted in-place Pod vertical scaling to beta. The `InPlacePodVerticalScaling` feature gate is now enabled by default.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/1287-in-place-update-pod-resources
```

/sig node
/priority important-soon
/milestone v1.32