### PR TITLE
csi: update snapshot controller to the v8.1.0

### DIFF
--- a/cluster/addons/volumesnapshots/volume-snapshot-controller/volume-snapshot-controller-deployment.yaml
+++ b/cluster/addons/volumesnapshots/volume-snapshot-controller/volume-snapshot-controller-deployment.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccount: volume-snapshot-controller
       containers:
         - name: volume-snapshot-controller
-          image: registry.k8s.io/sig-storage/snapshot-controller:v8.0.0
+          image: registry.k8s.io/sig-storage/snapshot-controller:v8.1.0
           args:
             - "--v=5"
             - "--metrics-path=/metrics"


### PR DESCRIPTION
https://github.com/kubernetes-csi/external-snapshotter/blob/v8.1.0/CHANGELOG/CHANGELOG-8.1.md

Volume group snapshot, k8s dependencies updated to 1.31, finalizer fixes..etc are part of this release

/kind cleanup

```release-note
NONE
```

```docs
NONE
```
