### PR TITLE
Make fake node as ready but unschedulable

### DIFF
--- a/test/e2e/node/node_lifecycle.go
+++ b/test/e2e/node/node_lifecycle.go
@@ -53,15 +53,21 @@ var _ = SIGDescribe("Node Lifecycle", func() {
 
 		nodeClient := f.ClientSet.CoreV1().Nodes()
 
+		// Create a fake node with a ready condition but unschedulable, so it won't be selected by
+		// the scheduler and won't be deleted by the cloud controller manager when the test runs on
+		// a specific cloud provider.
 		fakeNode := v1.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "e2e-fake-node-" + utilrand.String(5),
+			},
+			Spec: v1.NodeSpec{
+				Unschedulable: true,
 			},
 			Status: v1.NodeStatus{
 				Phase: v1.NodeRunning,
 				Conditions: []v1.NodeCondition{
 					{
-						Status:  v1.ConditionFalse,
+						Status:  v1.ConditionTrue,
 						Message: "Set from e2e test",
 						Reason:  "E2E",
 						Type:    v1.NodeReady,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

https://github.com/kubernetes/kubernetes/pull/128664 marked the fake node as NotReady in order not to break other tests when all tests run in parallel. 

But it introduced a new flaky issue when the test runs with a cloud provider, the cloud-controller-manager will delete the fake node, and the test will fail.

https://github.com/carlory/kubernetes/blob/fix-node-test/staging/src/k8s.io/cloud-provider/controllers/nodelifecycle/node_lifecycle_controller.go#L175

Audit log:

```
  "verb": "delete",
  "user": {
    "username": "system:serviceaccount:kube-system:node-controller",
    "uid": "3a7ef9e6-a6a7-4c25-a7b9-9f9e7556cbbf",
    "groups": [
      "system:serviceaccounts",
      "system:serviceaccounts:kube-system",
      "system:authenticated"
    ],
    "extra": {
      "authentication.kubernetes.io/credential-id": [
        "JTI=f6473d7c-1608-45cf-b36b-1b3f22ce9ae1"
      ]
    }
  },
  "sourceIPs": [
    "::1"
  ],
  "userAgent": "cloud-controller-manager/v1.30.0+9a986e09529c42a6c79ed14a1151abc44945fc60 (linux/amd64) kubernetes/9a986e0/system:servic
eaccount:kube-system:node-controller",
  "objectRef": {
    "resource": "nodes",
    "name": "e2e-fake-node-72n7j",
    "apiVersion": "v1"
  },
```

In order not to mark the test as serial and make sure the fake node is not deleted by cloud-controller-manager and no pods are scheduled on it, we need to mark the fake node as Ready again and set the unschedulable field to true.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
https://github.com/kubernetes/kubernetes/pull/128664#issuecomment-2464248362

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
