### PR TITLE
Document the existence of nftables as a kube-proxy mode.

### DIFF
--- a/cmd/kube-proxy/app/options.go
+++ b/cmd/kube-proxy/app/options.go
@@ -123,7 +123,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 			"rather than being surprised when they are permanently removed in the release after that. "+
 			"This parameter is ignored if a config file is specified by --config.")
 	fs.BoolVar(&o.InitAndExit, "init-only", o.InitAndExit, "If true, perform any initialization steps that must be done with full root privileges, and then exit. After doing this, you can run kube-proxy again with only the CAP_NET_ADMIN capability.")
-	fs.Var(&o.config.Mode, "proxy-mode", "Which proxy mode to use: on Linux this can be 'iptables' (default) or 'ipvs'. On Windows the only supported value is 'kernelspace'."+
+	fs.Var(&o.config.Mode, "proxy-mode", "Which proxy mode to use: on Linux this can be 'iptables' (default), 'ipvs', or 'nftables'. On Windows the only supported value is 'kernelspace'."+
 		"This parameter is ignored if a config file is specified by --config.")
 
 	fs.Int32Var(o.config.IPTables.MasqueradeBit, "iptables-masquerade-bit", ptr.Deref(o.config.IPTables.MasqueradeBit, 14), "If using the iptables or ipvs proxy mode, the bit of the fwmark space to mark packets requiring SNAT with.  Must be within the range [0, 31].")

--- a/pkg/proxy/apis/config/types.go
+++ b/pkg/proxy/apis/config/types.go
@@ -240,10 +240,10 @@ type KubeProxyConfiguration struct {
 
 // ProxyMode represents modes used by the Kubernetes proxy server.
 //
-// Currently, three modes of proxy are available on Linux platforms: 'iptables', 'ipvs',
-// and 'nftables'. One mode of proxy is available on Windows platforms: 'kernelspace'.
+// Three modes of proxy are available on Linux platforms: `iptables`, `ipvs`, and
+// `nftables`. One mode of proxy is available on Windows platforms: `kernelspace`.
 //
-// If the proxy mode is unspecified, the best-available proxy mode will be used (currently this
+// If the proxy mode is unspecified, a default proxy mode will be used (currently this
 // is `iptables` on Linux and `kernelspace` on Windows). If the selected proxy mode cannot be
 // used (due to lack of kernel support, missing userspace components, etc) then kube-proxy
 // will exit with an error.

--- a/staging/src/k8s.io/kube-proxy/config/v1alpha1/types.go
+++ b/staging/src/k8s.io/kube-proxy/config/v1alpha1/types.go
@@ -250,10 +250,10 @@ type KubeProxyConfiguration struct {
 
 // ProxyMode represents modes used by the Kubernetes proxy server.
 //
-// Currently, two modes of proxy are available on Linux platforms: 'iptables' and 'ipvs'.
-// One mode of proxy is available on Windows platforms: 'kernelspace'.
+// Three modes of proxy are available on Linux platforms: `iptables`, `ipvs`, and
+// `nftables`. One mode of proxy is available on Windows platforms: `kernelspace`.
 //
-// If the proxy mode is unspecified, the best-available proxy mode will be used (currently this
+// If the proxy mode is unspecified, a default proxy mode will be used (currently this
 // is `iptables` on Linux and `kernelspace` on Windows). If the selected proxy mode cannot be
 // used (due to lack of kernel support, missing userspace components, etc) then kube-proxy
 // will exit with an error.


### PR DESCRIPTION
#### What this PR does / why we need it:
We never updated (most of) the kube-proxy API/CLI documentation to mention nftables mode, which is now available by default.

I also changed the docs to not claim that the default mode is the "best available", since we currently expect to leave iptables as the default for backward-compatibility even after it is unambiguously not as good as nftables.

#### Which issue(s) this PR fixes:
none, pointed out by @brandond in https://github.com/kubernetes/enhancements/pull/4663#issuecomment-2463118426

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

(release notes should already mention that nftables mode is now beta)

/kind documentation
/kind feature
/sig network
/priority important-soon
/triage accepted