### PR TITLE
cleanup todo comment in node restriction integration tests

### DIFF
--- a/test/integration/auth/node_test.go
+++ b/test/integration/auth/node_test.go
@@ -625,8 +625,6 @@ func TestNodeAuthorizer(t *testing.T) {
 	// clean up node2
 	expectAllowed(t, deleteNode2(superuserClient))
 
-	// TODO(mikedanese): integration test node restriction of TokenRequest
-
 	// node1 allowed to operate on its own lease
 	expectAllowed(t, createNode1Lease(node1Client))
 	expectAllowed(t, getNode1Lease(node1Client))


### PR DESCRIPTION
/kind cleanup
/sig auth
/triage accepted

Removes the TODO comment that's no longer relevant. The tests were added in https://github.com/kubernetes/kubernetes/pull/128077.

```release-note
NONE
```