### PR TITLE
[FG:InPlacePodVerticalScaling] Fix InPlacePodVerticalScaling does not meet the requirement of qosClass being equal to Guaranteed after shrinking the memory

### DIFF
--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -2161,6 +2161,15 @@ func (kl *Kubelet) convertToAPIContainerStatuses(pod *v1.Pod, podStatus *kubecon
 			} else {
 				preserveOldResourcesValue(v1.ResourceCPU, oldStatus.Resources.Requests, resources.Requests)
 			}
+			if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {
+				if v1qos.GetPodQOS(pod) == v1.PodQOSGuaranteed {
+					if cStatus.Resources != nil && cStatus.Resources.MemoryLimit != nil {
+						resources.Requests[v1.ResourceMemory] = cStatus.Resources.MemoryLimit.DeepCopy()
+					} else {
+						preserveOldResourcesValue(v1.ResourceMemory, oldStatus.Resources.Requests, resources.Requests)
+					}
+				}
+			}
 		}
 
 		return &resources


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

InPlacePodVerticalScaling does not meet the requirement of qosClass being equal to Guaranteed after shrinking the memory. Cause is that when we attempt to set pod memory limit less than current memory usage , as it is now it will remain InProgress for Guaranteed Qos Pod . Requests parameter is modified but limit is kept with previous value. Background , discussion , demonstrating problem please check [here](https://github.com/kubernetes/kubernetes/issues/124786#issuecomment-2465656911)
 
#### Which issue(s) this PR fixes:

Fixes #124786. 

#### Special notes for your reviewer:

If the pod is guaranteed, set memory request equal to the limit in the status a per proposal [here](https://github.com/kubernetes/kubernetes/issues/124786#issuecomment-2412433717).

https://github.com/user-attachments/assets/aab6fec2-aa36-4776-9c50-bcfc4febeadd



#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
