### PR TITLE
KEP-3926: test the delete handler with unsafe deletion flow

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/delete_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/delete_test.go
@@ -917,7 +917,7 @@ func TestDeleteResourceWithUnsafeDeletionFlow(t *testing.T) {
 			}
 			// this is an invariant; when invoked, the unsafe deletion flow should always see the option enabled
 			if got := ptr.Deref(unsafeFlowObserved.Ignore, false); unsafeFlowObserved.Invoked == 1 && !got {
-				t.Errorf("IgnoreStoreReadErrorWithClusterBreakingPotential should be %t for the unsafe deletion flow, but got: %t", false, got)
+				t.Errorf("Invariant failed, IgnoreStoreReadErrorWithClusterBreakingPotential should always be set to %t for the unsafe deletion flow, but got: %t", true, got)
 			}
 
 			// certain annotation should be added in unsafe delete
@@ -1045,7 +1045,7 @@ func TestDeleteCollectionWithUnsafeDeletionFlow(t *testing.T) {
 			}
 
 			if want, got := test.deleterInvoked, observed.Invoked; want != got {
-				t.Errorf("expected the deleter to be ivoked %d times, but got: %d", want, got)
+				t.Errorf("expected the deleter to be invoked %d times, but got: %d", want, got)
 			}
 			// if invoked, the deleter should never see the ignore option enabled
 			if got := ptr.Deref(observed.Ignore, false); test.deleterInvoked == 1 && got {
@@ -1064,7 +1064,7 @@ func TestDeleteCollectionWithUnsafeDeletionFlow(t *testing.T) {
 func newRequest(t *testing.T, ignoreReadErr *bool) *http.Request {
 	t.Helper()
 
-	req, err := http.NewRequest(http.MethodGet, "/test", io.NopCloser(strings.NewReader("")))
+	req, err := http.NewRequest(http.MethodDelete, "/test", io.NopCloser(strings.NewReader("")))
 	if err != nil {
 		t.Fatalf("unexpected error creating a new http.Request: %v", err)
 	}
@@ -1125,7 +1125,10 @@ type deletionFlowTracker struct {
 	Ignore  *bool // the ignore option passed to Delete
 }
 
-// implements a fake GracefulDeleter
+// implements a fake GracefulDeleter.
+// TODO: this is not thread safe if concurrent Delete calls are made by a
+// test, tests are expected to invoke Delete serially, if that is to chage
+// we need to implement locking to keept it concurrency safe.
 type fakeRegistry struct {
 	tracker *deletionFlowTracker
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

For https://github.com/kubernetes/kubernetes/pull/127513
This augments https://github.com/kubernetes/kubernetes/pull/128722 with tests

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
