### PR TITLE
node: resourcemanager: API to check exclusive assignment availability

### DIFF
--- a/pkg/kubelet/allocation/allocation_manager.go
+++ b/pkg/kubelet/allocation/allocation_manager.go
@@ -37,6 +37,7 @@ import (
 	v1qos "k8s.io/kubernetes/pkg/apis/core/v1/helper/qos"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/allocation/state"
+	"k8s.io/kubernetes/pkg/kubelet/cm"
 	"k8s.io/kubernetes/pkg/kubelet/config"
 	"k8s.io/kubernetes/pkg/kubelet/events"
 	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
@@ -126,7 +127,8 @@ type manager struct {
 	allocationMutex        sync.Mutex
 	podsWithPendingResizes []types.UID
 
-	recorder record.EventRecorderLogger
+	recorder        record.EventRecorderLogger
+	resourceManager cm.ResourceManager
 }
 
 func NewManager(checkpointDirectory string,
@@ -137,6 +139,7 @@ func NewManager(checkpointDirectory string,
 	sourcesReady config.SourcesReady,
 	recorder record.EventRecorderLogger,
 	logger klog.Logger,
+	resourceManager cm.ResourceManager,
 ) Manager {
 	return &manager{
 		allocated: newStateImpl(logger, checkpointDirectory, allocatedPodsStateFile),
@@ -145,11 +148,12 @@ func NewManager(checkpointDirectory string,
 		admitHandlers: lifecycle.PodAdmitHandlers{},
 		sourcesReady:  sourcesReady,
 
-		ticker:         time.NewTicker(initialRetryDelay),
-		triggerPodSync: triggerPodSync,
-		getActivePods:  getActivePods,
-		getPodByUID:    getPodByUID,
-		recorder:       recorder,
+		ticker:          time.NewTicker(initialRetryDelay),
+		triggerPodSync:  triggerPodSync,
+		getActivePods:   getActivePods,
+		getPodByUID:     getPodByUID,
+		recorder:        recorder,
+		resourceManager: resourceManager,
 	}
 }
 

--- a/pkg/kubelet/allocation/allocation_manager_test.go
+++ b/pkg/kubelet/allocation/allocation_manager_test.go
@@ -943,7 +943,7 @@ func TestRetryPendingResizesGuanteedQOSPods(t *testing.T) {
 					Type:    v1.PodResizePending,
 					Status:  "True",
 					Reason:  "Infeasible",
-					Message: "Resize is infeasible for Guaranteed Pods alongside CPU Manager policy \"static\"",
+					Message: "Resize is infeasible for Guaranteed Pods when CPU allocation mode is exclusive",
 				},
 			},
 		},
@@ -963,7 +963,7 @@ func TestRetryPendingResizesGuanteedQOSPods(t *testing.T) {
 					Type:    v1.PodResizePending,
 					Status:  "True",
 					Reason:  "Infeasible",
-					Message: "Resize is infeasible for Guaranteed Pods alongside Memory Manager policy \"Static\"",
+					Message: "Resize is infeasible for Guaranteed Pods when memory allocation mode is exclusive",
 				},
 			},
 		},
@@ -983,7 +983,7 @@ func TestRetryPendingResizesGuanteedQOSPods(t *testing.T) {
 					Type:    v1.PodResizePending,
 					Status:  "True",
 					Reason:  "Infeasible",
-					Message: "Resize is infeasible for Guaranteed Pods alongside CPU Manager policy \"static\"",
+					Message: "Resize is infeasible for Guaranteed Pods when CPU allocation mode is exclusive",
 				},
 			},
 		},
@@ -3481,7 +3481,7 @@ func makeAllocationManager(t *testing.T, runtime *containertest.FakeRuntime, all
 	}
 
 	predicateHandler := lifecycle.NewPredicateAdmitHandler(getNode, lifecycle.NewAdmissionFailureHandlerStub(), containerManager.UpdatePluginResources)
-	resizeHandler := NewPodResizesAdmitHandler(containerManager, runtime, allocationManager)
+	resizeHandler := NewPodResizesAdmitHandler(containerManager, containerManager, runtime, allocationManager)
 	allocationManager.AddPodAdmitHandlers(lifecycle.PodAdmitHandlers{resizeHandler, predicateHandler})
 	return allocationManager
 }

--- a/pkg/kubelet/allocation/handlers.go
+++ b/pkg/kubelet/allocation/handlers.go
@@ -28,8 +28,6 @@ import (
 	v1qos "k8s.io/kubernetes/pkg/apis/core/v1/helper/qos"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/cm"
-	"k8s.io/kubernetes/pkg/kubelet/cm/cpumanager"
-	"k8s.io/kubernetes/pkg/kubelet/cm/memorymanager"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
 	"k8s.io/kubernetes/pkg/kubelet/metrics"
@@ -39,9 +37,10 @@ import (
 
 // NewPodResizesAdmitHandler returns a PodAdmitHandler which is used to evaluate
 // if a pod resize can be allocated by the kubelet.
-func NewPodResizesAdmitHandler(containerManager cm.ContainerManager, containerRuntime kubecontainer.Runtime, allocationManager Manager) lifecycle.PodAdmitHandler {
+func NewPodResizesAdmitHandler(containerManager cm.ContainerManager, resourceManager cm.ResourceManager, containerRuntime kubecontainer.Runtime, allocationManager Manager) lifecycle.PodAdmitHandler {
 	return &podResizesAdmitHandler{
 		containerManager:  containerManager,
+		resourceManager:   resourceManager,
 		containerRuntime:  containerRuntime,
 		allocationManager: allocationManager,
 	}
@@ -49,6 +48,7 @@ func NewPodResizesAdmitHandler(containerManager cm.ContainerManager, containerRu
 
 type podResizesAdmitHandler struct {
 	containerManager  cm.ContainerManager
+	resourceManager   cm.ResourceManager
 	containerRuntime  kubecontainer.Runtime
 	allocationManager Manager
 }
@@ -86,19 +86,21 @@ func (h *podResizesAdmitHandler) Admit(ctx context.Context, attrs *lifecycle.Pod
 	}
 
 	if v1qos.GetPodQOS(pod) == v1.PodQOSGuaranteed {
+		cpuMode, _ := h.resourceManager.AllocationMode(v1.ResourceCPU)
 		if !utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScalingExclusiveCPUs) &&
-			h.containerManager.GetNodeConfig().CPUManagerPolicy == string(cpumanager.PolicyStatic) &&
+			cpuMode == cm.ResourceAllocationModeExclusive &&
 			h.guaranteedPodResourceResizeRequired(pod, v1.ResourceCPU) {
-			msg := fmt.Sprintf("Resize is infeasible for Guaranteed Pods alongside CPU Manager policy \"%s\"", string(cpumanager.PolicyStatic))
-			logger.V(3).Info(msg, "pod", format.Pod(pod))
+			msg := fmt.Sprintf("Resize is infeasible for Guaranteed Pods when CPU allocation mode is %s", cpuMode)
+			logger.V(3).Info(msg, "pod", klog.KObj(pod), "podUID", pod.UID)
 			metrics.PodInfeasibleResizes.WithLabelValues("guaranteed_pod_cpu_manager_static_policy").Inc()
 			return lifecycle.PodAdmitResult{Admit: false, Reason: v1.PodReasonInfeasible, Message: msg}
 		}
+		memMode, _ := h.resourceManager.AllocationMode(v1.ResourceMemory)
 		if !utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScalingExclusiveMemory) &&
-			h.containerManager.GetNodeConfig().MemoryManagerPolicy == string(memorymanager.PolicyTypeStatic) &&
+			memMode == cm.ResourceAllocationModeExclusive &&
 			h.guaranteedPodResourceResizeRequired(pod, v1.ResourceMemory) {
-			msg := fmt.Sprintf("Resize is infeasible for Guaranteed Pods alongside Memory Manager policy \"%s\"", string(memorymanager.PolicyTypeStatic))
-			logger.V(3).Info(msg, "pod", format.Pod(pod))
+			msg := fmt.Sprintf("Resize is infeasible for Guaranteed Pods when memory allocation mode is %s", memMode)
+			logger.V(3).Info(msg, "pod", klog.KObj(pod), "podUID", pod.UID)
 			metrics.PodInfeasibleResizes.WithLabelValues("guaranteed_pod_memory_manager_static_policy").Inc()
 			return lifecycle.PodAdmitResult{Admit: false, Reason: v1.PodReasonInfeasible, Message: msg}
 		}

--- a/pkg/kubelet/cm/container_manager.go
+++ b/pkg/kubelet/cm/container_manager.go
@@ -162,6 +162,9 @@ type ContainerManager interface {
 	// ContainerHasExclusiveCPUs returns true if the provided container in the pod has exclusive cpu
 	ContainerHasExclusiveCPUs(logger klog.Logger, pod *v1.Pod, container *v1.Container) bool
 
+	// AllocationMode returns the allocation mode for the given resource, and whether this manager handles the resource.
+	AllocationMode(res v1.ResourceName) (ResourceAllocationMode, bool)
+
 	// Implements the PodResources Provider API
 	podresources.CPUsProvider
 	podresources.DevicesProvider

--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -1161,3 +1161,11 @@ func (cm *containerManagerImpl) UpdateAllocatedResourcesStatus(logger klog.Logge
 func (cm *containerManagerImpl) Updates() <-chan resourceupdates.Update {
 	return cm.resourceUpdates
 }
+
+func (cm *containerManagerImpl) AllocationMode(res v1.ResourceName) (ResourceAllocationMode, bool) {
+	// run from the cheapest to the most expensive
+	if cm.cpuManager.CanAllocateExclusively(res) || cm.memoryManager.CanAllocateExclusively(res) || cm.deviceManager.CanAllocateExclusively(res) {
+		return ResourceAllocationModeExclusive, true
+	}
+	return ResourceAllocationModeShared, false
+}

--- a/pkg/kubelet/cm/container_manager_stub.go
+++ b/pkg/kubelet/cm/container_manager_stub.go
@@ -216,6 +216,10 @@ func (cm *containerManagerStub) ContainerHasExclusiveCPUs(logger klog.Logger, po
 	return false
 }
 
+func (cm *containerManagerStub) AllocationMode(res v1.ResourceName) (ResourceAllocationMode, bool) {
+	return ResourceAllocationModeShared, false
+}
+
 func NewStubContainerManager() ContainerManager {
 	return &containerManagerStub{shouldResetExtendedResourceCapacity: false}
 }

--- a/pkg/kubelet/cm/container_manager_windows.go
+++ b/pkg/kubelet/cm/container_manager_windows.go
@@ -390,3 +390,11 @@ func (cm *containerManagerImpl) PodHasExclusiveCPUs(logger klog.Logger, pod *v1.
 func (cm *containerManagerImpl) ContainerHasExclusiveCPUs(logger klog.Logger, pod *v1.Pod, container *v1.Container) bool {
 	return containerHasExclusiveCPUs(logger, cm.cpuManager, pod, container)
 }
+
+func (cm *containerManagerImpl) AllocationMode(res v1.ResourceName) (ResourceAllocationMode, bool) {
+	// run from the cheapest to the most expensive
+	if cm.cpuManager.CanAllocateExclusively(res) || cm.memoryManager.CanAllocateExclusively(res) || cm.deviceManager.CanAllocateExclusively(res) {
+		return ResourceAllocationModeExclusive, true
+	}
+	return ResourceAllocationModeShared, false
+}

--- a/pkg/kubelet/cm/cpumanager/cpu_manager.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager.go
@@ -114,6 +114,9 @@ type Manager interface {
 
 	// GetResourceIsolationLevel returns the isolation level of the container.
 	GetResourceIsolationLevel(pod *v1.Pod, container *v1.Container) cmqos.ResourceIsolationLevel
+
+	// Returns true if this manager can allocate exclusively to a container the resource(s) it manages.
+	CanAllocateExclusively(res v1.ResourceName) bool
 }
 
 type manager struct {
@@ -596,4 +599,11 @@ func (m *manager) GetResourceIsolationLevel(pod *v1.Pod, container *v1.Container
 	}
 
 	return cmqos.ResourceIsolationContainer
+}
+
+func (m *manager) CanAllocateExclusively(res v1.ResourceName) bool {
+	if res != v1.ResourceCPU {
+		return false
+	}
+	return m.policy.CanAllocateExclusively()
 }

--- a/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
@@ -198,6 +198,10 @@ func (p *mockPolicy) GetAllocatableCPUs(m state.State) cpuset.CPUSet {
 	return cpuset.New()
 }
 
+func (p *mockPolicy) CanAllocateExclusively() bool {
+	return false
+}
+
 type mockRuntimeService struct {
 	err error
 }

--- a/pkg/kubelet/cm/cpumanager/fake_cpu_manager.go
+++ b/pkg/kubelet/cm/cpumanager/fake_cpu_manager.go
@@ -111,6 +111,10 @@ func (m *fakeManager) GetResourceIsolationLevel(pod *v1.Pod, container *v1.Conta
 	return cmqos.ResourceIsolationContainer
 }
 
+func (m *fakeManager) CanAllocateExclusively(res v1.ResourceName) bool {
+	return false
+}
+
 // NewFakeManager creates empty/fake cpu manager
 func NewFakeManager(logger klog.Logger) Manager {
 	logger = klog.LoggerWithName(logger, "cpu.fake")

--- a/pkg/kubelet/cm/cpumanager/policy.go
+++ b/pkg/kubelet/cm/cpumanager/policy.go
@@ -45,4 +45,6 @@ type Policy interface {
 	AllocatePod(logger klog.Logger, s state.State, pod *v1.Pod, operation lifecycle.Operation) error
 	// GetAllocatableCPUs returns the total set of CPUs available for allocation.
 	GetAllocatableCPUs(m state.State) cpuset.CPUSet
+	// CanAllocateExclusively returns true if the policy can allocate exclusively CPUs
+	CanAllocateExclusively() bool
 }

--- a/pkg/kubelet/cm/cpumanager/policy_none.go
+++ b/pkg/kubelet/cm/cpumanager/policy_none.go
@@ -80,3 +80,7 @@ func (p *nonePolicy) AllocatePod(_ klog.Logger, s state.State, pod *v1.Pod, _ li
 func (p *nonePolicy) GetAllocatableCPUs(m state.State) cpuset.CPUSet {
 	return cpuset.New()
 }
+
+func (p *nonePolicy) CanAllocateExclusively() bool {
+	return false
+}

--- a/pkg/kubelet/cm/cpumanager/policy_static.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static.go
@@ -1155,3 +1155,7 @@ func updateAllocationPerNUMAMetric(logger klog.Logger, topo *topology.CPUTopolog
 		metrics.CPUManagerAllocationPerNUMA.WithLabelValues(strconv.Itoa(numaNode)).Set(float64(count))
 	}
 }
+
+func (p *staticPolicy) CanAllocateExclusively() bool {
+	return true
+}

--- a/pkg/kubelet/cm/devicemanager/manager.go
+++ b/pkg/kubelet/cm/devicemanager/manager.go
@@ -1263,3 +1263,10 @@ func (m *ManagerImpl) isContainerAlreadyRunning(logger klog.Logger, podUID, cntN
 
 	return true
 }
+
+func (m *ManagerImpl) CanAllocateExclusively(res v1.ResourceName) bool {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	_, ok := m.healthyDevices[string(res)]
+	return ok
+}

--- a/pkg/kubelet/cm/devicemanager/types.go
+++ b/pkg/kubelet/cm/devicemanager/types.go
@@ -97,6 +97,9 @@ type Manager interface {
 
 	// Updates returns a channel that receives an Update when the device changed its status.
 	Updates() <-chan resourceupdates.Update
+
+	// Returns true if the manager can allocate exclusively the resource(s) to a container
+	CanAllocateExclusively(res v1.ResourceName) bool
 }
 
 // DeviceRunContainerOptions contains the combined container runtime settings to consume its allocated devices.

--- a/pkg/kubelet/cm/fake_container_manager.go
+++ b/pkg/kubelet/cm/fake_container_manager.go
@@ -294,8 +294,10 @@ func (cm *FakeContainerManager) UnprepareDynamicResources(context.Context, *v1.P
 func (cm *FakeContainerManager) PodMightNeedToUnprepareResources(UID types.UID) bool {
 	return false
 }
+
 func (cm *FakeContainerManager) UpdateAllocatedResourcesStatus(logger klog.Logger, pod *v1.Pod, status *v1.PodStatus) {
 }
+
 func (cm *FakeContainerManager) Updates() <-chan resourceupdates.Update {
 	return nil
 }
@@ -306,4 +308,21 @@ func (cm *FakeContainerManager) PodHasExclusiveCPUs(logger klog.Logger, pod *v1.
 
 func (cm *FakeContainerManager) ContainerHasExclusiveCPUs(logger klog.Logger, pod *v1.Pod, container *v1.Container) bool {
 	return false
+}
+
+func (cm *FakeContainerManager) AllocationMode(res v1.ResourceName) (ResourceAllocationMode, bool) {
+	switch res {
+	case v1.ResourceCPU:
+		if cm.nodeConfig.CPUManagerPolicy == string(cpumanager.PolicyStatic) {
+			return ResourceAllocationModeExclusive, true
+		}
+		return ResourceAllocationModeShared, true
+	case v1.ResourceMemory:
+		if cm.nodeConfig.MemoryManagerPolicy == string(memorymanager.PolicyTypeStatic) {
+			return ResourceAllocationModeExclusive, true
+		}
+		return ResourceAllocationModeShared, true
+	default:
+		return ResourceAllocationModeShared, false
+	}
 }

--- a/pkg/kubelet/cm/memorymanager/fake_memory_manager.go
+++ b/pkg/kubelet/cm/memorymanager/fake_memory_manager.go
@@ -85,6 +85,10 @@ func (m *fakeManager) State() state.Reader {
 	return m.state
 }
 
+func (m *fakeManager) CanAllocateExclusively(res v1.ResourceName) bool {
+	return false
+}
+
 // GetAllocatableMemory returns the amount of allocatable memory for each NUMA node
 func (m *fakeManager) GetAllocatableMemory(logger klog.Logger) []state.Block {
 	logger.Info("Get Allocatable Memory")

--- a/pkg/kubelet/cm/memorymanager/memory_manager.go
+++ b/pkg/kubelet/cm/memorymanager/memory_manager.go
@@ -106,6 +106,9 @@ type Manager interface {
 
 	// GetResourceIsolationLevel returns the isolation level of the container.
 	GetResourceIsolationLevel(pod *v1.Pod, container *v1.Container) cmqos.ResourceIsolationLevel
+
+	// Returns true if this manager can allocate exclusively to a container the resource(s) it manages.
+	CanAllocateExclusively(res v1.ResourceName) bool
 }
 
 type manager struct {
@@ -517,4 +520,11 @@ func (m *manager) GetResourceIsolationLevel(pod *v1.Pod, container *v1.Container
 	}
 
 	return cmqos.ResourceIsolationContainer
+}
+
+func (m *manager) CanAllocateExclusively(res v1.ResourceName) bool {
+	if res != v1.ResourceMemory && !corev1helper.IsHugePageResourceName(res) {
+		return false
+	}
+	return m.policy.CanAllocateExclusively()
 }

--- a/pkg/kubelet/cm/memorymanager/memory_manager_test.go
+++ b/pkg/kubelet/cm/memorymanager/memory_manager_test.go
@@ -125,6 +125,10 @@ func (p *mockPolicy) GetAllocatableMemory(state.State) []state.Block {
 	return []state.Block{}
 }
 
+func (p *mockPolicy) CanAllocateExclusively() bool {
+	return false
+}
+
 type mockRuntimeService struct {
 	err error
 }

--- a/pkg/kubelet/cm/memorymanager/policy.go
+++ b/pkg/kubelet/cm/memorymanager/policy.go
@@ -49,4 +49,6 @@ type Policy interface {
 	AllocatePod(logger klog.Logger, s state.State, pod *v1.Pod, operation lifecycle.Operation) error
 	// GetAllocatableMemory returns the amount of allocatable memory for each NUMA node
 	GetAllocatableMemory(s state.State) []state.Block
+	// CanAllocateExclusively returns true if the policy can allocate exclusively memory blocks
+	CanAllocateExclusively() bool
 }

--- a/pkg/kubelet/cm/memorymanager/policy_best_effort.go
+++ b/pkg/kubelet/cm/memorymanager/policy_best_effort.go
@@ -88,3 +88,8 @@ func (p *bestEffortPolicy) AllocatePod(_ klog.Logger, s state.State, pod *v1.Pod
 	// Pod-level resources are not supported on Windows.
 	return nil
 }
+
+// CanAllocateExclusively returns true if the policy can allocate exclusively memory blocks
+func (p *bestEffortPolicy) CanAllocateExclusively() bool {
+	return false
+}

--- a/pkg/kubelet/cm/memorymanager/policy_none.go
+++ b/pkg/kubelet/cm/memorymanager/policy_none.go
@@ -79,3 +79,8 @@ func (p *none) AllocatePod(_ klog.Logger, s state.State, pod *v1.Pod, _ lifecycl
 func (p *none) GetAllocatableMemory(s state.State) []state.Block {
 	return []state.Block{}
 }
+
+// CanAllocateExclusively returns true if the policy can allocate exclusively memory blocks
+func (p *none) CanAllocateExclusively() bool {
+	return false
+}

--- a/pkg/kubelet/cm/memorymanager/policy_static.go
+++ b/pkg/kubelet/cm/memorymanager/policy_static.go
@@ -424,6 +424,11 @@ func memoryBlocksToString(blocks []state.Block) string {
 	return "[" + repr + "]"
 }
 
+// CanAllocateExclusively returns true if the policy can allocate exclusively memory blocks
+func (p *staticPolicy) CanAllocateExclusively() bool {
+	return true
+}
+
 // Allocate call is idempotent
 func (p *staticPolicy) Allocate(ctx context.Context, s state.State, pod *v1.Pod, container *v1.Container, operation lifecycle.Operation) (rerr error) {
 	// allocate the memory only for guaranteed pods

--- a/pkg/kubelet/cm/node_container_manager_linux.go
+++ b/pkg/kubelet/cm/node_container_manager_linux.go
@@ -206,9 +206,9 @@ func (cm *containerManagerImpl) getCgroupConfig(rl v1.ResourceList, compressible
 	// doesn't know about it and deletes it, and then kubelet doesn't continue because the cgroup isn't configured as expected).
 	// An alternative is to delegate the `cpuset` cgroup to the kubelet, but that would require some plumbing in libcontainer,
 	// and this is sufficient.
-	// Only do so on None policy, as Static policy will do its own updating of the cpuset.
-	// Please see the comment on policy none's GetAllocatableCPUs
-	if cm.cpuManager.GetAllocatableCPUs().IsEmpty() {
+	// Only do so when the cpumanager is not exclusively allocating CPUs, as it will do its own updating of the cpuset when
+	// CPUs are exclusively allocated.
+	if !cm.cpuManager.CanAllocateExclusively(v1.ResourceCPU) {
 		rc.CPUSet = cm.cpuManager.GetAllCPUs()
 	}
 

--- a/pkg/kubelet/cm/testing/mocks.go
+++ b/pkg/kubelet/cm/testing/mocks.go
@@ -67,6 +67,66 @@ func (_m *MockContainerManager) EXPECT() *MockContainerManager_Expecter {
 	return &MockContainerManager_Expecter{mock: &_m.Mock}
 }
 
+// AllocationMode provides a mock function for the type MockContainerManager
+func (_mock *MockContainerManager) AllocationMode(res v1.ResourceName) (cm.ResourceAllocationMode, bool) {
+	ret := _mock.Called(res)
+
+	if len(ret) == 0 {
+		panic("no return value specified for AllocationMode")
+	}
+
+	var r0 cm.ResourceAllocationMode
+	var r1 bool
+	if returnFunc, ok := ret.Get(0).(func(v1.ResourceName) (cm.ResourceAllocationMode, bool)); ok {
+		return returnFunc(res)
+	}
+	if returnFunc, ok := ret.Get(0).(func(v1.ResourceName) cm.ResourceAllocationMode); ok {
+		r0 = returnFunc(res)
+	} else {
+		r0 = ret.Get(0).(cm.ResourceAllocationMode)
+	}
+	if returnFunc, ok := ret.Get(1).(func(v1.ResourceName) bool); ok {
+		r1 = returnFunc(res)
+	} else {
+		r1 = ret.Get(1).(bool)
+	}
+	return r0, r1
+}
+
+// MockContainerManager_AllocationMode_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AllocationMode'
+type MockContainerManager_AllocationMode_Call struct {
+	*mock.Call
+}
+
+// AllocationMode is a helper method to define mock.On call
+//   - res v1.ResourceName
+func (_e *MockContainerManager_Expecter) AllocationMode(res interface{}) *MockContainerManager_AllocationMode_Call {
+	return &MockContainerManager_AllocationMode_Call{Call: _e.mock.On("AllocationMode", res)}
+}
+
+func (_c *MockContainerManager_AllocationMode_Call) Run(run func(res v1.ResourceName)) *MockContainerManager_AllocationMode_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 v1.ResourceName
+		if args[0] != nil {
+			arg0 = args[0].(v1.ResourceName)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockContainerManager_AllocationMode_Call) Return(resourceAllocationMode cm.ResourceAllocationMode, b bool) *MockContainerManager_AllocationMode_Call {
+	_c.Call.Return(resourceAllocationMode, b)
+	return _c
+}
+
+func (_c *MockContainerManager_AllocationMode_Call) RunAndReturn(run func(res v1.ResourceName) (cm.ResourceAllocationMode, bool)) *MockContainerManager_AllocationMode_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ContainerHasExclusiveCPUs provides a mock function for the type MockContainerManager
 func (_mock *MockContainerManager) ContainerHasExclusiveCPUs(logger klog.Logger, pod *v1.Pod, container *v1.Container) bool {
 	ret := _mock.Called(logger, pod, container)

--- a/pkg/kubelet/cm/types.go
+++ b/pkg/kubelet/cm/types.go
@@ -139,3 +139,29 @@ type PodContainerManager interface {
 	// Set resource config values for the specified resource type on the pod cgroup
 	SetPodCgroupConfig(logger klog.Logger, pod *v1.Pod, resourceConfig *ResourceConfig) error
 }
+
+// ResourceAllocationMode describes the allocation behavior a resource manager is configured to provide.
+type ResourceAllocationMode int
+
+const (
+	// ResourceAllocationModeShared means resources are allocated from a shared pool.
+	ResourceAllocationModeShared ResourceAllocationMode = iota
+	// ResourceAllocationModeExclusive means resources are exclusively assigned.
+	ResourceAllocationModeExclusive
+)
+
+func (m ResourceAllocationMode) String() string {
+	switch m {
+	case ResourceAllocationModeExclusive:
+		return "exclusive"
+	default:
+		return "shared"
+	}
+}
+
+// ResourceManager provides resource allocation capability discovery.
+type ResourceManager interface {
+	// AllocationMode returns the allocation mode for the given resource.
+	// The bool return value indicates whether this manager handles the resource at all.
+	AllocationMode(resName v1.ResourceName) (ResourceAllocationMode, bool)
+}

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -739,6 +739,7 @@ func NewMainKubelet(ctx context.Context,
 		klet.sourcesReady,
 		kubeDeps.Recorder,
 		logger,
+		klet.containerManager,
 	)
 
 	klet.resourceAnalyzer = serverstats.NewResourceAnalyzer(ctx, klet, kubeCfg.VolumeStatsAggPeriod.Duration, kubeDeps.Recorder)
@@ -849,7 +850,7 @@ func NewMainKubelet(ctx context.Context,
 	klet.containerRuntime = runtime
 	klet.streamingRuntime = runtime
 	klet.runner = runtime
-	resizeAdmitHandler := allocation.NewPodResizesAdmitHandler(klet.containerManager, runtime, klet.allocationManager)
+	resizeAdmitHandler := allocation.NewPodResizesAdmitHandler(klet.containerManager, klet.containerManager, runtime, klet.allocationManager)
 
 	runtimeCache, err := kubecontainer.NewRuntimeCache(klet.containerRuntime, runtimeCacheRefreshPeriod)
 	if err != nil {

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -404,7 +404,7 @@ func newTestKubeletWithImageList(
 	kubelet.evictionManager = evictionManager
 	handlers := []lifecycle.PodAdmitHandler{}
 	handlers = append(handlers, evictionAdmitHandler)
-	handlers = append(handlers, allocation.NewPodResizesAdmitHandler(kubelet.containerManager, fakeRuntime, kubelet.allocationManager))
+	handlers = append(handlers, allocation.NewPodResizesAdmitHandler(kubelet.containerManager, kubelet.containerManager, fakeRuntime, kubelet.allocationManager))
 
 	// setup shutdown manager
 	shutdownManager := nodeshutdown.NewManager(&nodeshutdown.Config{


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
There are now at least two existing pieces of code which wants to know if resource managers (CPU, Memory) support exclusive assignment
- node container manager, to fix cgroup params
- VPA, for its internal needs

plus at least another one is coming:
- pod-level resources management (see https://github.com/kubernetes/kubernetes/pull/132634)

Currently, code needing to know if exclusive assignment is available has mostly two options:
- infer from available APIs. Works, keep somehow the responsability respected, but it's clumsy
- peeks in the global config, which introduces unnecessary coupling and possibly bugs (e.g. cpumanager policy is called "static", while the memorymanager policy is called "Static")

So, it seems the time to have an official API the code outside the resource/container manager can query safely, concisely and in a supported way.

#### Which issue(s) this PR fixes:
Fixes #129531

#### Special notes for your reviewer:
Prompted by https://github.com/kubernetes/kubernetes/pull/128727 et. al.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```