### PR TITLE
feature: Support resource/* Pattern Matching in RBAC Policy Rules

### DIFF
--- a/pkg/apis/rbac/helpers.go
+++ b/pkg/apis/rbac/helpers.go
@@ -48,6 +48,13 @@ func ResourceMatches(rule *PolicyRule, combinedRequestedResource, requestedSubre
 			return true
 
 		}
+		// if the rule isn't in the "resource/*" format, then we don't match and continue
+		if strings.HasSuffix(ruleResource, "/*") {
+			ruleResourcePrefix := strings.TrimSuffix(ruleResource, "/*")
+			if strings.HasPrefix(combinedRequestedResource, ruleResourcePrefix+"/") {
+				return true
+			}			
+		}		
 	}
 
 	return false

--- a/pkg/apis/rbac/helpers_test.go
+++ b/pkg/apis/rbac/helpers_test.go
@@ -160,6 +160,48 @@ func TestResourceMatches(t *testing.T) {
 			requestedSubresource:      "other/segment",
 			expected:                  false,
 		},
+		{
+			name:                      "matches resource/* pattern with subresource",
+			ruleResources:             []string{"foo/*"},
+			combinedRequestedResource: "foo/status",
+			requestedSubresource:      "status",
+			expected:                  true,
+		},
+		{
+			name:                      "does not match resource/* pattern without subresource",
+			ruleResources:             []string{"foo/*"},
+			combinedRequestedResource: "foo",
+			requestedSubresource:      "",
+			expected:                  false,
+		},
+		{
+			name:                      "does not match resource/* pattern with different resource",
+			ruleResources:             []string{"bar/*"},
+			combinedRequestedResource: "foo/status",
+			requestedSubresource:      "status",
+			expected:                  false,
+		},
+		{
+			name:                      "matches resource/* pattern with deeper subresource",
+			ruleResources:             []string{"foo/*"},
+			combinedRequestedResource: "foo/subresource/extra",
+			requestedSubresource:      "subresource/extra",
+			expected:                  true,
+		},
+		{
+			name:                      "matches resource/* with multiple resources",
+			ruleResources:             []string{"foo/*", "bar/*"},
+			combinedRequestedResource: "bar/status",
+			requestedSubresource:      "status",
+			expected:                  true,
+		},
+		{
+			name:                      "does not match when resource names differ",
+			ruleResources:             []string{"baz/*"},
+			combinedRequestedResource: "foo/status",
+			requestedSubresource:      "status",
+			expected:                  false,
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This PR enhances the Kubernetes RBAC (Role-Based Access Control) system by adding support for resource/* pattern matching in policy rules. Previously, only */subresource patterns were supported, which limited the flexibility of specifying access permissions for resources and their subresources.

This feature is similar to how AWS IAM policies manage permissions. Just like AWS IAM allows defining actions on resources using wildcards for flexible access control, Kubernetes RBAC can now offer similar ease of use and manageability for resources and their subresources.
```
rules:
  - apiGroups: [""]
    resources: ["pods"]
    verbs: ["get", "list"]
  - apiGroups: [""]
    resources: ["pods/*"]
    verbs: ["get", "list"]
```

#### Which issue(s) this PR fixes:
Fixes #N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```