### PR TITLE
Improve validation for missing storedVersion

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation.go
@@ -28,6 +28,7 @@ import (
 	"unicode/utf8"
 
 	celgo "github.com/google/cel-go/cel"
+
 	"k8s.io/apiextensions-apiserver/pkg/apihelpers"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -274,7 +275,7 @@ func ValidateCustomResourceDefinitionStoredVersions(storedVersions []string, ver
 	}
 
 	for v, i := range storedVersionsMap {
-		allErrs = append(allErrs, field.Invalid(fldPath.Index(i), v, "must appear in spec.versions"))
+		allErrs = append(allErrs, field.Invalid(fldPath.Index(i), v, fmt.Sprintf("missing from spec.versions; %[1]s was previously a storage version, and must remain in spec.versions until a storage migration ensures no data remains persisted in %[1]s and removes %[1]s from status.storedVersions", v)))
 	}
 
 	return allErrs

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation_test.go
@@ -11002,7 +11002,7 @@ func TestValidateCustomResourceDefinitionStoredVersions(t *testing.T) {
 			storageVersion: "v1",
 			storedVersions: []string{"v1alpha", "v1beta1", "v1"},
 			errors: []validationMatch{
-				invalidIndex(0, "status", "storedVersions").contains("Invalid value: \"v1alpha\": must appear in spec.versions"),
+				invalidIndex(0, "status", "storedVersions").contains("Invalid value: \"v1alpha\": missing from spec.versions"),
 			},
 		},
 		{


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Provide less confusing message when a status.storedVersions entry is missing from spec.versions

cc @robscott @jpbetz 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
