### PR TITLE
client-go: generalise extension method handlers

### DIFF
--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/deployment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/deployment.go
@@ -20,7 +20,6 @@ package v1
 
 import (
 	context "context"
-	fmt "fmt"
 
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
@@ -31,7 +30,6 @@ import (
 	applyconfigurationsautoscalingv1 "k8s.io/client-go/applyconfigurations/autoscaling/v1"
 	gentype "k8s.io/client-go/gentype"
 	scheme "k8s.io/client-go/kubernetes/scheme"
-	apply "k8s.io/client-go/util/apply"
 )
 
 // DeploymentsGetter has a method to return a DeploymentInterface.
@@ -83,57 +81,17 @@ func newDeployments(c *AppsV1Client, namespace string) *deployments {
 }
 
 // GetScale takes name of the deployment, and returns the corresponding autoscalingv1.Scale object, and an error if there is any.
-func (c *deployments) GetScale(ctx context.Context, deploymentName string, options metav1.GetOptions) (result *autoscalingv1.Scale, err error) {
-	result = &autoscalingv1.Scale{}
-	err = c.GetClient().Get().
-		UseProtobufAsDefault().
-		Namespace(c.GetNamespace()).
-		Resource("deployments").
-		Name(deploymentName).
-		SubResource("scale").
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do(ctx).
-		Into(result)
-	return
+func (c *deployments) GetScale(ctx context.Context, deploymentName string, options metav1.GetOptions) (*autoscalingv1.Scale, error) {
+	return gentype.GetSubresource[autoscalingv1.Scale](ctx, &c.Client.ResourceClient, deploymentName, "scale", options)
 }
 
 // UpdateScale takes the top resource name and the representation of a scale and updates it. Returns the server's representation of the scale, and an error, if there is any.
-func (c *deployments) UpdateScale(ctx context.Context, deploymentName string, scale *autoscalingv1.Scale, opts metav1.UpdateOptions) (result *autoscalingv1.Scale, err error) {
-	result = &autoscalingv1.Scale{}
-	err = c.GetClient().Put().
-		UseProtobufAsDefault().
-		Namespace(c.GetNamespace()).
-		Resource("deployments").
-		Name(deploymentName).
-		SubResource("scale").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Body(scale).
-		Do(ctx).
-		Into(result)
-	return
+func (c *deployments) UpdateScale(ctx context.Context, deploymentName string, scale *autoscalingv1.Scale, opts metav1.UpdateOptions) (*autoscalingv1.Scale, error) {
+	return gentype.UpdateSubresource(ctx, c.Client, deploymentName, scale, "scale", &autoscalingv1.Scale{}, opts)
 }
 
 // ApplyScale takes top resource name and the apply declarative configuration for scale,
 // applies it and returns the applied scale, and an error, if there is any.
 func (c *deployments) ApplyScale(ctx context.Context, deploymentName string, scale *applyconfigurationsautoscalingv1.ScaleApplyConfiguration, opts metav1.ApplyOptions) (result *autoscalingv1.Scale, err error) {
-	if scale == nil {
-		return nil, fmt.Errorf("scale provided to ApplyScale must not be nil")
-	}
-	patchOpts := opts.ToPatchOptions()
-	request, err := apply.NewRequest(c.GetClient(), scale)
-	if err != nil {
-		return nil, err
-	}
-
-	result = &autoscalingv1.Scale{}
-	err = request.
-		UseProtobufAsDefault().
-		Namespace(c.GetNamespace()).
-		Resource("deployments").
-		Name(deploymentName).
-		SubResource("scale").
-		VersionedParams(&patchOpts, scheme.ParameterCodec).
-		Do(ctx).
-		Into(result)
-	return
+	return gentype.ApplySubresource(ctx, c.Client, deploymentName, scale, "scale", &autoscalingv1.Scale{}, opts)
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/replicaset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/replicaset.go
@@ -20,7 +20,6 @@ package v1
 
 import (
 	context "context"
-	fmt "fmt"
 
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
@@ -31,7 +30,6 @@ import (
 	applyconfigurationsautoscalingv1 "k8s.io/client-go/applyconfigurations/autoscaling/v1"
 	gentype "k8s.io/client-go/gentype"
 	scheme "k8s.io/client-go/kubernetes/scheme"
-	apply "k8s.io/client-go/util/apply"
 )
 
 // ReplicaSetsGetter has a method to return a ReplicaSetInterface.
@@ -83,57 +81,17 @@ func newReplicaSets(c *AppsV1Client, namespace string) *replicaSets {
 }
 
 // GetScale takes name of the replicaSet, and returns the corresponding autoscalingv1.Scale object, and an error if there is any.
-func (c *replicaSets) GetScale(ctx context.Context, replicaSetName string, options metav1.GetOptions) (result *autoscalingv1.Scale, err error) {
-	result = &autoscalingv1.Scale{}
-	err = c.GetClient().Get().
-		UseProtobufAsDefault().
-		Namespace(c.GetNamespace()).
-		Resource("replicasets").
-		Name(replicaSetName).
-		SubResource("scale").
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do(ctx).
-		Into(result)
-	return
+func (c *replicaSets) GetScale(ctx context.Context, replicaSetName string, options metav1.GetOptions) (*autoscalingv1.Scale, error) {
+	return gentype.GetSubresource[autoscalingv1.Scale](ctx, &c.Client.ResourceClient, replicaSetName, "scale", options)
 }
 
 // UpdateScale takes the top resource name and the representation of a scale and updates it. Returns the server's representation of the scale, and an error, if there is any.
-func (c *replicaSets) UpdateScale(ctx context.Context, replicaSetName string, scale *autoscalingv1.Scale, opts metav1.UpdateOptions) (result *autoscalingv1.Scale, err error) {
-	result = &autoscalingv1.Scale{}
-	err = c.GetClient().Put().
-		UseProtobufAsDefault().
-		Namespace(c.GetNamespace()).
-		Resource("replicasets").
-		Name(replicaSetName).
-		SubResource("scale").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Body(scale).
-		Do(ctx).
-		Into(result)
-	return
+func (c *replicaSets) UpdateScale(ctx context.Context, replicaSetName string, scale *autoscalingv1.Scale, opts metav1.UpdateOptions) (*autoscalingv1.Scale, error) {
+	return gentype.UpdateSubresource(ctx, c.Client, replicaSetName, scale, "scale", &autoscalingv1.Scale{}, opts)
 }
 
 // ApplyScale takes top resource name and the apply declarative configuration for scale,
 // applies it and returns the applied scale, and an error, if there is any.
 func (c *replicaSets) ApplyScale(ctx context.Context, replicaSetName string, scale *applyconfigurationsautoscalingv1.ScaleApplyConfiguration, opts metav1.ApplyOptions) (result *autoscalingv1.Scale, err error) {
-	if scale == nil {
-		return nil, fmt.Errorf("scale provided to ApplyScale must not be nil")
-	}
-	patchOpts := opts.ToPatchOptions()
-	request, err := apply.NewRequest(c.GetClient(), scale)
-	if err != nil {
-		return nil, err
-	}
-
-	result = &autoscalingv1.Scale{}
-	err = request.
-		UseProtobufAsDefault().
-		Namespace(c.GetNamespace()).
-		Resource("replicasets").
-		Name(replicaSetName).
-		SubResource("scale").
-		VersionedParams(&patchOpts, scheme.ParameterCodec).
-		Do(ctx).
-		Into(result)
-	return
+	return gentype.ApplySubresource(ctx, c.Client, replicaSetName, scale, "scale", &autoscalingv1.Scale{}, opts)
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/statefulset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/statefulset.go
@@ -20,7 +20,6 @@ package v1beta2
 
 import (
 	context "context"
-	fmt "fmt"
 
 	appsv1beta2 "k8s.io/api/apps/v1beta2"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,7 +28,6 @@ import (
 	applyconfigurationsappsv1beta2 "k8s.io/client-go/applyconfigurations/apps/v1beta2"
 	gentype "k8s.io/client-go/gentype"
 	scheme "k8s.io/client-go/kubernetes/scheme"
-	apply "k8s.io/client-go/util/apply"
 )
 
 // StatefulSetsGetter has a method to return a StatefulSetInterface.
@@ -81,57 +79,17 @@ func newStatefulSets(c *AppsV1beta2Client, namespace string) *statefulSets {
 }
 
 // GetScale takes name of the statefulSet, and returns the corresponding appsv1beta2.Scale object, and an error if there is any.
-func (c *statefulSets) GetScale(ctx context.Context, statefulSetName string, options v1.GetOptions) (result *appsv1beta2.Scale, err error) {
-	result = &appsv1beta2.Scale{}
-	err = c.GetClient().Get().
-		UseProtobufAsDefault().
-		Namespace(c.GetNamespace()).
-		Resource("statefulsets").
-		Name(statefulSetName).
-		SubResource("scale").
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do(ctx).
-		Into(result)
-	return
+func (c *statefulSets) GetScale(ctx context.Context, statefulSetName string, options v1.GetOptions) (*appsv1beta2.Scale, error) {
+	return gentype.GetSubresource[appsv1beta2.Scale](ctx, &c.Client.ResourceClient, statefulSetName, "scale", options)
 }
 
 // UpdateScale takes the top resource name and the representation of a scale and updates it. Returns the server's representation of the scale, and an error, if there is any.
-func (c *statefulSets) UpdateScale(ctx context.Context, statefulSetName string, scale *appsv1beta2.Scale, opts v1.UpdateOptions) (result *appsv1beta2.Scale, err error) {
-	result = &appsv1beta2.Scale{}
-	err = c.GetClient().Put().
-		UseProtobufAsDefault().
-		Namespace(c.GetNamespace()).
-		Resource("statefulsets").
-		Name(statefulSetName).
-		SubResource("scale").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Body(scale).
-		Do(ctx).
-		Into(result)
-	return
+func (c *statefulSets) UpdateScale(ctx context.Context, statefulSetName string, scale *appsv1beta2.Scale, opts v1.UpdateOptions) (*appsv1beta2.Scale, error) {
+	return gentype.UpdateSubresource(ctx, c.Client, statefulSetName, scale, "scale", &appsv1beta2.Scale{}, opts)
 }
 
 // ApplyScale takes top resource name and the apply declarative configuration for scale,
 // applies it and returns the applied scale, and an error, if there is any.
 func (c *statefulSets) ApplyScale(ctx context.Context, statefulSetName string, scale *applyconfigurationsappsv1beta2.ScaleApplyConfiguration, opts v1.ApplyOptions) (result *appsv1beta2.Scale, err error) {
-	if scale == nil {
-		return nil, fmt.Errorf("scale provided to ApplyScale must not be nil")
-	}
-	patchOpts := opts.ToPatchOptions()
-	request, err := apply.NewRequest(c.GetClient(), scale)
-	if err != nil {
-		return nil, err
-	}
-
-	result = &appsv1beta2.Scale{}
-	err = request.
-		UseProtobufAsDefault().
-		Namespace(c.GetNamespace()).
-		Resource("statefulsets").
-		Name(statefulSetName).
-		SubResource("scale").
-		VersionedParams(&patchOpts, scheme.ParameterCodec).
-		Do(ctx).
-		Into(result)
-	return
+	return gentype.ApplySubresource(ctx, c.Client, statefulSetName, scale, "scale", &appsv1beta2.Scale{}, opts)
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1/certificatesigningrequest.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1/certificatesigningrequest.go
@@ -79,16 +79,6 @@ func newCertificateSigningRequests(c *CertificatesV1Client) *certificateSigningR
 }
 
 // UpdateApproval takes the top resource name and the representation of a certificateSigningRequest and updates it. Returns the server's representation of the certificateSigningRequest, and an error, if there is any.
-func (c *certificateSigningRequests) UpdateApproval(ctx context.Context, certificateSigningRequestName string, certificateSigningRequest *certificatesv1.CertificateSigningRequest, opts metav1.UpdateOptions) (result *certificatesv1.CertificateSigningRequest, err error) {
-	result = &certificatesv1.CertificateSigningRequest{}
-	err = c.GetClient().Put().
-		UseProtobufAsDefault().
-		Resource("certificatesigningrequests").
-		Name(certificateSigningRequestName).
-		SubResource("approval").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Body(certificateSigningRequest).
-		Do(ctx).
-		Into(result)
-	return
+func (c *certificateSigningRequests) UpdateApproval(ctx context.Context, certificateSigningRequestName string, certificateSigningRequest *certificatesv1.CertificateSigningRequest, opts metav1.UpdateOptions) (*certificatesv1.CertificateSigningRequest, error) {
+	return gentype.UpdateSubresource(ctx, c.Client, certificateSigningRequestName, certificateSigningRequest, "approval", &certificatesv1.CertificateSigningRequest{}, opts)
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/pod.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/pod.go
@@ -78,33 +78,11 @@ func newPods(c *CoreV1Client, namespace string) *pods {
 }
 
 // UpdateEphemeralContainers takes the top resource name and the representation of a pod and updates it. Returns the server's representation of the pod, and an error, if there is any.
-func (c *pods) UpdateEphemeralContainers(ctx context.Context, podName string, pod *corev1.Pod, opts metav1.UpdateOptions) (result *corev1.Pod, err error) {
-	result = &corev1.Pod{}
-	err = c.GetClient().Put().
-		UseProtobufAsDefault().
-		Namespace(c.GetNamespace()).
-		Resource("pods").
-		Name(podName).
-		SubResource("ephemeralcontainers").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Body(pod).
-		Do(ctx).
-		Into(result)
-	return
+func (c *pods) UpdateEphemeralContainers(ctx context.Context, podName string, pod *corev1.Pod, opts metav1.UpdateOptions) (*corev1.Pod, error) {
+	return gentype.UpdateSubresource(ctx, c.Client, podName, pod, "ephemeralcontainers", &corev1.Pod{}, opts)
 }
 
 // UpdateResize takes the top resource name and the representation of a pod and updates it. Returns the server's representation of the pod, and an error, if there is any.
-func (c *pods) UpdateResize(ctx context.Context, podName string, pod *corev1.Pod, opts metav1.UpdateOptions) (result *corev1.Pod, err error) {
-	result = &corev1.Pod{}
-	err = c.GetClient().Put().
-		UseProtobufAsDefault().
-		Namespace(c.GetNamespace()).
-		Resource("pods").
-		Name(podName).
-		SubResource("resize").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Body(pod).
-		Do(ctx).
-		Into(result)
-	return
+func (c *pods) UpdateResize(ctx context.Context, podName string, pod *corev1.Pod, opts metav1.UpdateOptions) (*corev1.Pod, error) {
+	return gentype.UpdateSubresource(ctx, c.Client, podName, pod, "resize", &corev1.Pod{}, opts)
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/replicationcontroller.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/replicationcontroller.go
@@ -79,32 +79,11 @@ func newReplicationControllers(c *CoreV1Client, namespace string) *replicationCo
 }
 
 // GetScale takes name of the replicationController, and returns the corresponding autoscalingv1.Scale object, and an error if there is any.
-func (c *replicationControllers) GetScale(ctx context.Context, replicationControllerName string, options metav1.GetOptions) (result *autoscalingv1.Scale, err error) {
-	result = &autoscalingv1.Scale{}
-	err = c.GetClient().Get().
-		UseProtobufAsDefault().
-		Namespace(c.GetNamespace()).
-		Resource("replicationcontrollers").
-		Name(replicationControllerName).
-		SubResource("scale").
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do(ctx).
-		Into(result)
-	return
+func (c *replicationControllers) GetScale(ctx context.Context, replicationControllerName string, options metav1.GetOptions) (*autoscalingv1.Scale, error) {
+	return gentype.GetSubresource[autoscalingv1.Scale](ctx, &c.Client.ResourceClient, replicationControllerName, "scale", options)
 }
 
 // UpdateScale takes the top resource name and the representation of a scale and updates it. Returns the server's representation of the scale, and an error, if there is any.
-func (c *replicationControllers) UpdateScale(ctx context.Context, replicationControllerName string, scale *autoscalingv1.Scale, opts metav1.UpdateOptions) (result *autoscalingv1.Scale, err error) {
-	result = &autoscalingv1.Scale{}
-	err = c.GetClient().Put().
-		UseProtobufAsDefault().
-		Namespace(c.GetNamespace()).
-		Resource("replicationcontrollers").
-		Name(replicationControllerName).
-		SubResource("scale").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Body(scale).
-		Do(ctx).
-		Into(result)
-	return
+func (c *replicationControllers) UpdateScale(ctx context.Context, replicationControllerName string, scale *autoscalingv1.Scale, opts metav1.UpdateOptions) (*autoscalingv1.Scale, error) {
+	return gentype.UpdateSubresource(ctx, c.Client, replicationControllerName, scale, "scale", &autoscalingv1.Scale{}, opts)
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/serviceaccount.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/serviceaccount.go
@@ -74,17 +74,6 @@ func newServiceAccounts(c *CoreV1Client, namespace string) *serviceAccounts {
 }
 
 // CreateToken takes the representation of a tokenRequest and creates it.  Returns the server's representation of the tokenRequest, and an error, if there is any.
-func (c *serviceAccounts) CreateToken(ctx context.Context, serviceAccountName string, tokenRequest *authenticationv1.TokenRequest, opts metav1.CreateOptions) (result *authenticationv1.TokenRequest, err error) {
-	result = &authenticationv1.TokenRequest{}
-	err = c.GetClient().Post().
-		UseProtobufAsDefault().
-		Namespace(c.GetNamespace()).
-		Resource("serviceaccounts").
-		Name(serviceAccountName).
-		SubResource("token").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Body(tokenRequest).
-		Do(ctx).
-		Into(result)
-	return
+func (c *serviceAccounts) CreateToken(ctx context.Context, serviceAccountName string, tokenRequest *authenticationv1.TokenRequest, opts metav1.CreateOptions) (*authenticationv1.TokenRequest, error) {
+	return gentype.CreateSubresource(ctx, c.Client, serviceAccountName, tokenRequest, "token", &authenticationv1.TokenRequest{}, opts)
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/deployment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/deployment.go
@@ -20,7 +20,6 @@ package v1beta1
 
 import (
 	context "context"
-	fmt "fmt"
 
 	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,7 +28,6 @@ import (
 	applyconfigurationsextensionsv1beta1 "k8s.io/client-go/applyconfigurations/extensions/v1beta1"
 	gentype "k8s.io/client-go/gentype"
 	scheme "k8s.io/client-go/kubernetes/scheme"
-	apply "k8s.io/client-go/util/apply"
 )
 
 // DeploymentsGetter has a method to return a DeploymentInterface.
@@ -81,57 +79,17 @@ func newDeployments(c *ExtensionsV1beta1Client, namespace string) *deployments {
 }
 
 // GetScale takes name of the deployment, and returns the corresponding extensionsv1beta1.Scale object, and an error if there is any.
-func (c *deployments) GetScale(ctx context.Context, deploymentName string, options v1.GetOptions) (result *extensionsv1beta1.Scale, err error) {
-	result = &extensionsv1beta1.Scale{}
-	err = c.GetClient().Get().
-		UseProtobufAsDefault().
-		Namespace(c.GetNamespace()).
-		Resource("deployments").
-		Name(deploymentName).
-		SubResource("scale").
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do(ctx).
-		Into(result)
-	return
+func (c *deployments) GetScale(ctx context.Context, deploymentName string, options v1.GetOptions) (*extensionsv1beta1.Scale, error) {
+	return gentype.GetSubresource[extensionsv1beta1.Scale](ctx, &c.Client.ResourceClient, deploymentName, "scale", options)
 }
 
 // UpdateScale takes the top resource name and the representation of a scale and updates it. Returns the server's representation of the scale, and an error, if there is any.
-func (c *deployments) UpdateScale(ctx context.Context, deploymentName string, scale *extensionsv1beta1.Scale, opts v1.UpdateOptions) (result *extensionsv1beta1.Scale, err error) {
-	result = &extensionsv1beta1.Scale{}
-	err = c.GetClient().Put().
-		UseProtobufAsDefault().
-		Namespace(c.GetNamespace()).
-		Resource("deployments").
-		Name(deploymentName).
-		SubResource("scale").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Body(scale).
-		Do(ctx).
-		Into(result)
-	return
+func (c *deployments) UpdateScale(ctx context.Context, deploymentName string, scale *extensionsv1beta1.Scale, opts v1.UpdateOptions) (*extensionsv1beta1.Scale, error) {
+	return gentype.UpdateSubresource(ctx, c.Client, deploymentName, scale, "scale", &extensionsv1beta1.Scale{}, opts)
 }
 
 // ApplyScale takes top resource name and the apply declarative configuration for scale,
 // applies it and returns the applied scale, and an error, if there is any.
 func (c *deployments) ApplyScale(ctx context.Context, deploymentName string, scale *applyconfigurationsextensionsv1beta1.ScaleApplyConfiguration, opts v1.ApplyOptions) (result *extensionsv1beta1.Scale, err error) {
-	if scale == nil {
-		return nil, fmt.Errorf("scale provided to ApplyScale must not be nil")
-	}
-	patchOpts := opts.ToPatchOptions()
-	request, err := apply.NewRequest(c.GetClient(), scale)
-	if err != nil {
-		return nil, err
-	}
-
-	result = &extensionsv1beta1.Scale{}
-	err = request.
-		UseProtobufAsDefault().
-		Namespace(c.GetNamespace()).
-		Resource("deployments").
-		Name(deploymentName).
-		SubResource("scale").
-		VersionedParams(&patchOpts, scheme.ParameterCodec).
-		Do(ctx).
-		Into(result)
-	return
+	return gentype.ApplySubresource(ctx, c.Client, deploymentName, scale, "scale", &extensionsv1beta1.Scale{}, opts)
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/replicaset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/replicaset.go
@@ -20,7 +20,6 @@ package v1beta1
 
 import (
 	context "context"
-	fmt "fmt"
 
 	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,7 +28,6 @@ import (
 	applyconfigurationsextensionsv1beta1 "k8s.io/client-go/applyconfigurations/extensions/v1beta1"
 	gentype "k8s.io/client-go/gentype"
 	scheme "k8s.io/client-go/kubernetes/scheme"
-	apply "k8s.io/client-go/util/apply"
 )
 
 // ReplicaSetsGetter has a method to return a ReplicaSetInterface.
@@ -81,57 +79,17 @@ func newReplicaSets(c *ExtensionsV1beta1Client, namespace string) *replicaSets {
 }
 
 // GetScale takes name of the replicaSet, and returns the corresponding extensionsv1beta1.Scale object, and an error if there is any.
-func (c *replicaSets) GetScale(ctx context.Context, replicaSetName string, options v1.GetOptions) (result *extensionsv1beta1.Scale, err error) {
-	result = &extensionsv1beta1.Scale{}
-	err = c.GetClient().Get().
-		UseProtobufAsDefault().
-		Namespace(c.GetNamespace()).
-		Resource("replicasets").
-		Name(replicaSetName).
-		SubResource("scale").
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do(ctx).
-		Into(result)
-	return
+func (c *replicaSets) GetScale(ctx context.Context, replicaSetName string, options v1.GetOptions) (*extensionsv1beta1.Scale, error) {
+	return gentype.GetSubresource[extensionsv1beta1.Scale](ctx, &c.Client.ResourceClient, replicaSetName, "scale", options)
 }
 
 // UpdateScale takes the top resource name and the representation of a scale and updates it. Returns the server's representation of the scale, and an error, if there is any.
-func (c *replicaSets) UpdateScale(ctx context.Context, replicaSetName string, scale *extensionsv1beta1.Scale, opts v1.UpdateOptions) (result *extensionsv1beta1.Scale, err error) {
-	result = &extensionsv1beta1.Scale{}
-	err = c.GetClient().Put().
-		UseProtobufAsDefault().
-		Namespace(c.GetNamespace()).
-		Resource("replicasets").
-		Name(replicaSetName).
-		SubResource("scale").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Body(scale).
-		Do(ctx).
-		Into(result)
-	return
+func (c *replicaSets) UpdateScale(ctx context.Context, replicaSetName string, scale *extensionsv1beta1.Scale, opts v1.UpdateOptions) (*extensionsv1beta1.Scale, error) {
+	return gentype.UpdateSubresource(ctx, c.Client, replicaSetName, scale, "scale", &extensionsv1beta1.Scale{}, opts)
 }
 
 // ApplyScale takes top resource name and the apply declarative configuration for scale,
 // applies it and returns the applied scale, and an error, if there is any.
 func (c *replicaSets) ApplyScale(ctx context.Context, replicaSetName string, scale *applyconfigurationsextensionsv1beta1.ScaleApplyConfiguration, opts v1.ApplyOptions) (result *extensionsv1beta1.Scale, err error) {
-	if scale == nil {
-		return nil, fmt.Errorf("scale provided to ApplyScale must not be nil")
-	}
-	patchOpts := opts.ToPatchOptions()
-	request, err := apply.NewRequest(c.GetClient(), scale)
-	if err != nil {
-		return nil, err
-	}
-
-	result = &extensionsv1beta1.Scale{}
-	err = request.
-		UseProtobufAsDefault().
-		Namespace(c.GetNamespace()).
-		Resource("replicasets").
-		Name(replicaSetName).
-		SubResource("scale").
-		VersionedParams(&patchOpts, scheme.ParameterCodec).
-		Do(ctx).
-		Into(result)
-	return
+	return gentype.ApplySubresource(ctx, c.Client, replicaSetName, scale, "scale", &extensionsv1beta1.Scale{}, opts)
 }

--- a/staging/src/k8s.io/client-go/rest/request.go
+++ b/staging/src/k8s.io/client-go/rest/request.go
@@ -351,6 +351,14 @@ func (r *Request) NamespaceIfScoped(namespace string, scoped bool) *Request {
 	return r
 }
 
+// SubResourceIfNotEmpty is a convenience function to set a subresource if it's not empty
+func (r *Request) SubResourceIfNotEmpty(subresources ...string) *Request {
+	if len(subresources) > 0 && subresources[0] != "" {
+		return r.SubResource(subresources...)
+	}
+	return r
+}
+
 // AbsPath overwrites an existing path with the segments provided. Trailing slashes are preserved
 // when a single segment is passed.
 func (r *Request) AbsPath(segments ...string) *Request {

--- a/staging/src/k8s.io/code-generator/examples/HyphenGroup/clientset/versioned/typed/example/v1/clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/examples/HyphenGroup/clientset/versioned/typed/example/v1/clustertesttype.go
@@ -78,28 +78,11 @@ func newClusterTestTypes(c *ExampleGroupV1Client) *clusterTestTypes {
 }
 
 // GetScale takes name of the clusterTestType, and returns the corresponding autoscalingv1.Scale object, and an error if there is any.
-func (c *clusterTestTypes) GetScale(ctx context.Context, clusterTestTypeName string, options metav1.GetOptions) (result *autoscalingv1.Scale, err error) {
-	result = &autoscalingv1.Scale{}
-	err = c.GetClient().Get().
-		Resource("clustertesttypes").
-		Name(clusterTestTypeName).
-		SubResource("scale").
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do(ctx).
-		Into(result)
-	return
+func (c *clusterTestTypes) GetScale(ctx context.Context, clusterTestTypeName string, options metav1.GetOptions) (*autoscalingv1.Scale, error) {
+	return gentype.GetSubresource[autoscalingv1.Scale](ctx, &c.Client.ResourceClient, clusterTestTypeName, "scale", options)
 }
 
 // UpdateScale takes the top resource name and the representation of a scale and updates it. Returns the server's representation of the scale, and an error, if there is any.
-func (c *clusterTestTypes) UpdateScale(ctx context.Context, clusterTestTypeName string, scale *autoscalingv1.Scale, opts metav1.UpdateOptions) (result *autoscalingv1.Scale, err error) {
-	result = &autoscalingv1.Scale{}
-	err = c.GetClient().Put().
-		Resource("clustertesttypes").
-		Name(clusterTestTypeName).
-		SubResource("scale").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Body(scale).
-		Do(ctx).
-		Into(result)
-	return
+func (c *clusterTestTypes) UpdateScale(ctx context.Context, clusterTestTypeName string, scale *autoscalingv1.Scale, opts metav1.UpdateOptions) (*autoscalingv1.Scale, error) {
+	return gentype.UpdateSubresource(ctx, c.Client, clusterTestTypeName, scale, "scale", &autoscalingv1.Scale{}, opts)
 }

--- a/staging/src/k8s.io/code-generator/examples/MixedCase/clientset/versioned/typed/example/v1/clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/examples/MixedCase/clientset/versioned/typed/example/v1/clustertesttype.go
@@ -79,42 +79,16 @@ func newClusterTestTypes(c *ExampleV1Client) *clusterTestTypes {
 }
 
 // GetScale takes name of the clusterTestType, and returns the corresponding autoscalingv1.Scale object, and an error if there is any.
-func (c *clusterTestTypes) GetScale(ctx context.Context, clusterTestTypeName string, options metav1.GetOptions) (result *autoscalingv1.Scale, err error) {
-	result = &autoscalingv1.Scale{}
-	err = c.GetClient().Get().
-		Resource("clustertesttypes").
-		Name(clusterTestTypeName).
-		SubResource("scale").
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do(ctx).
-		Into(result)
-	return
+func (c *clusterTestTypes) GetScale(ctx context.Context, clusterTestTypeName string, options metav1.GetOptions) (*autoscalingv1.Scale, error) {
+	return gentype.GetSubresource[autoscalingv1.Scale](ctx, &c.Client.ResourceClient, clusterTestTypeName, "scale", options)
 }
 
 // UpdateScale takes the top resource name and the representation of a scale and updates it. Returns the server's representation of the scale, and an error, if there is any.
-func (c *clusterTestTypes) UpdateScale(ctx context.Context, clusterTestTypeName string, scale *autoscalingv1.Scale, opts metav1.UpdateOptions) (result *autoscalingv1.Scale, err error) {
-	result = &autoscalingv1.Scale{}
-	err = c.GetClient().Put().
-		Resource("clustertesttypes").
-		Name(clusterTestTypeName).
-		SubResource("scale").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Body(scale).
-		Do(ctx).
-		Into(result)
-	return
+func (c *clusterTestTypes) UpdateScale(ctx context.Context, clusterTestTypeName string, scale *autoscalingv1.Scale, opts metav1.UpdateOptions) (*autoscalingv1.Scale, error) {
+	return gentype.UpdateSubresource(ctx, c.Client, clusterTestTypeName, scale, "scale", &autoscalingv1.Scale{}, opts)
 }
 
 // CreateScale takes the representation of a scale and creates it.  Returns the server's representation of the scale, and an error, if there is any.
-func (c *clusterTestTypes) CreateScale(ctx context.Context, clusterTestTypeName string, scale *autoscalingv1.Scale, opts metav1.CreateOptions) (result *autoscalingv1.Scale, err error) {
-	result = &autoscalingv1.Scale{}
-	err = c.GetClient().Post().
-		Resource("clustertesttypes").
-		Name(clusterTestTypeName).
-		SubResource("scale").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Body(scale).
-		Do(ctx).
-		Into(result)
-	return
+func (c *clusterTestTypes) CreateScale(ctx context.Context, clusterTestTypeName string, scale *autoscalingv1.Scale, opts metav1.CreateOptions) (*autoscalingv1.Scale, error) {
+	return gentype.CreateSubresource(ctx, c.Client, clusterTestTypeName, scale, "scale", &autoscalingv1.Scale{}, opts)
 }

--- a/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/typed/example/v1/clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/typed/example/v1/clustertesttype.go
@@ -78,28 +78,11 @@ func newClusterTestTypes(c *ExampleV1Client) *clusterTestTypes {
 }
 
 // GetScale takes name of the clusterTestType, and returns the corresponding autoscalingv1.Scale object, and an error if there is any.
-func (c *clusterTestTypes) GetScale(ctx context.Context, clusterTestTypeName string, options metav1.GetOptions) (result *autoscalingv1.Scale, err error) {
-	result = &autoscalingv1.Scale{}
-	err = c.GetClient().Get().
-		Resource("clustertesttypes").
-		Name(clusterTestTypeName).
-		SubResource("scale").
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do(ctx).
-		Into(result)
-	return
+func (c *clusterTestTypes) GetScale(ctx context.Context, clusterTestTypeName string, options metav1.GetOptions) (*autoscalingv1.Scale, error) {
+	return gentype.GetSubresource[autoscalingv1.Scale](ctx, &c.Client.ResourceClient, clusterTestTypeName, "scale", options)
 }
 
 // UpdateScale takes the top resource name and the representation of a scale and updates it. Returns the server's representation of the scale, and an error, if there is any.
-func (c *clusterTestTypes) UpdateScale(ctx context.Context, clusterTestTypeName string, scale *autoscalingv1.Scale, opts metav1.UpdateOptions) (result *autoscalingv1.Scale, err error) {
-	result = &autoscalingv1.Scale{}
-	err = c.GetClient().Put().
-		Resource("clustertesttypes").
-		Name(clusterTestTypeName).
-		SubResource("scale").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Body(scale).
-		Do(ctx).
-		Into(result)
-	return
+func (c *clusterTestTypes) UpdateScale(ctx context.Context, clusterTestTypeName string, scale *autoscalingv1.Scale, opts metav1.UpdateOptions) (*autoscalingv1.Scale, error) {
+	return gentype.UpdateSubresource(ctx, c.Client, clusterTestTypeName, scale, "scale", &autoscalingv1.Scale{}, opts)
 }

--- a/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/typed/example/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/typed/example/v1/testtype.go
@@ -76,14 +76,6 @@ func newTestTypes(c *ExampleV1Client, namespace string) *testTypes {
 }
 
 // GetClusterTestType takes name of the testType, and returns the corresponding testType object, and an error if there is any.
-func (c *testTypes) GetClusterTestType(ctx context.Context, name string, options metav1.GetOptions) (result *examplev1.TestType, err error) {
-	result = &examplev1.TestType{}
-	err = c.GetClient().Get().
-		Namespace(c.GetNamespace()).
-		Resource("testtypes").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do(ctx).
-		Into(result)
-	return
+func (c *testTypes) GetClusterTestType(ctx context.Context, name string, options metav1.GetOptions) (*examplev1.TestType, error) {
+	return gentype.Get[examplev1.TestType](ctx, &c.Client.ResourceClient, name, options)
 }

--- a/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/typed/extensions/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/typed/extensions/v1/testtype.go
@@ -20,14 +20,12 @@ package v1
 
 import (
 	context "context"
-	fmt "fmt"
 	time "time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	gentype "k8s.io/client-go/gentype"
-	apply "k8s.io/client-go/util/apply"
 	consistencydetector "k8s.io/client-go/util/consistencydetector"
 	watchlist "k8s.io/client-go/util/watchlist"
 	extensionsv1 "k8s.io/code-generator/examples/crd/apis/extensions/v1"
@@ -91,16 +89,8 @@ func newTestTypes(c *ExtensionsExampleV1Client, namespace string) *testTypes {
 }
 
 // GetExtended takes name of the testType, and returns the corresponding testType object, and an error if there is any.
-func (c *testTypes) GetExtended(ctx context.Context, name string, options metav1.GetOptions) (result *extensionsv1.TestType, err error) {
-	result = &extensionsv1.TestType{}
-	err = c.GetClient().Get().
-		Namespace(c.GetNamespace()).
-		Resource("testtypes").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do(ctx).
-		Into(result)
-	return
+func (c *testTypes) GetExtended(ctx context.Context, name string, options metav1.GetOptions) (*extensionsv1.TestType, error) {
+	return gentype.Get[extensionsv1.TestType](ctx, &c.Client.ResourceClient, name, options)
 }
 
 // ListExtended takes label and field selectors, and returns the list of TestTypes that match those selectors.
@@ -157,136 +147,42 @@ func (c *testTypes) watchList(ctx context.Context, opts metav1.ListOptions) (res
 }
 
 // CreateExtended takes the representation of a testType and creates it.  Returns the server's representation of the testType, and an error, if there is any.
-func (c *testTypes) CreateExtended(ctx context.Context, testType *extensionsv1.TestType, opts metav1.CreateOptions) (result *extensionsv1.TestType, err error) {
-	result = &extensionsv1.TestType{}
-	err = c.GetClient().Post().
-		Namespace(c.GetNamespace()).
-		Resource("testtypes").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Body(testType).
-		Do(ctx).
-		Into(result)
-	return
+func (c *testTypes) CreateExtended(ctx context.Context, testType *extensionsv1.TestType, opts metav1.CreateOptions) (*extensionsv1.TestType, error) {
+	return gentype.Create(ctx, c.Client, &extensionsv1.TestType{}, testType, opts)
 }
 
 // UpdateExtended takes the representation of a testType and updates it. Returns the server's representation of the testType, and an error, if there is any.
-func (c *testTypes) UpdateExtended(ctx context.Context, testType *extensionsv1.TestType, opts metav1.UpdateOptions) (result *extensionsv1.TestType, err error) {
-	result = &extensionsv1.TestType{}
-	err = c.GetClient().Put().
-		Namespace(c.GetNamespace()).
-		Resource("testtypes").
-		Name(testType.Name).
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Body(testType).
-		Do(ctx).
-		Into(result)
-	return
+func (c *testTypes) UpdateExtended(ctx context.Context, testType *extensionsv1.TestType, opts metav1.UpdateOptions) (*extensionsv1.TestType, error) {
+	return gentype.Update(ctx, c.Client, testType, &extensionsv1.TestType{}, opts)
 }
 
 // PatchExtended applies the patch and returns the patched testType.
-func (c *testTypes) PatchExtended(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *extensionsv1.TestType, err error) {
-	result = &extensionsv1.TestType{}
-	err = c.GetClient().Patch(pt).
-		Namespace(c.GetNamespace()).
-		Resource("testtypes").
-		Name(name).
-		SubResource(subresources...).
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Body(data).
-		Do(ctx).
-		Into(result)
-	return
+func (c *testTypes) PatchExtended(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (*extensionsv1.TestType, error) {
+	return gentype.Patch(ctx, c.Client, name, pt, data, &extensionsv1.TestType{}, opts, subresources...)
 }
 
 // ApplyExtended takes the given apply declarative configuration, applies it and returns the applied testType.
 func (c *testTypes) ApplyExtended(ctx context.Context, testType *applyconfigurationextensionsv1.TestTypeApplyConfiguration, opts metav1.ApplyOptions) (result *extensionsv1.TestType, err error) {
-	if testType == nil {
-		return nil, fmt.Errorf("testType provided to ApplyExtended must not be nil")
-	}
-	patchOpts := opts.ToPatchOptions()
-	name := testType.Name
-	if name == nil {
-		return nil, fmt.Errorf("testType.Name must be provided to ApplyExtended")
-	}
-	request, err := apply.NewRequest(c.GetClient(), testType)
-	if err != nil {
-		return nil, err
-	}
-	result = &extensionsv1.TestType{}
-	err = request.
-		Namespace(c.GetNamespace()).
-		Resource("testtypes").
-		Name(*name).
-		VersionedParams(&patchOpts, scheme.ParameterCodec).
-		Do(ctx).
-		Into(result)
-	return
+	return gentype.Apply(ctx, c.Client, testType, &extensionsv1.TestType{}, opts)
 }
 
 // GetSubresource takes name of the testType, and returns the corresponding extensionsv1.TestSubresource object, and an error if there is any.
-func (c *testTypes) GetSubresource(ctx context.Context, testTypeName string, options metav1.GetOptions) (result *extensionsv1.TestSubresource, err error) {
-	result = &extensionsv1.TestSubresource{}
-	err = c.GetClient().Get().
-		Namespace(c.GetNamespace()).
-		Resource("testtypes").
-		Name(testTypeName).
-		SubResource("testsubresource").
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do(ctx).
-		Into(result)
-	return
+func (c *testTypes) GetSubresource(ctx context.Context, testTypeName string, options metav1.GetOptions) (*extensionsv1.TestSubresource, error) {
+	return gentype.GetSubresource[extensionsv1.TestSubresource](ctx, &c.Client.ResourceClient, testTypeName, "testsubresource", options)
 }
 
 // CreateSubresource takes the representation of a testSubresource and creates it.  Returns the server's representation of the testSubresource, and an error, if there is any.
-func (c *testTypes) CreateSubresource(ctx context.Context, testTypeName string, testSubresource *extensionsv1.TestSubresource, opts metav1.CreateOptions) (result *extensionsv1.TestSubresource, err error) {
-	result = &extensionsv1.TestSubresource{}
-	err = c.GetClient().Post().
-		Namespace(c.GetNamespace()).
-		Resource("testtypes").
-		Name(testTypeName).
-		SubResource("testsubresource").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Body(testSubresource).
-		Do(ctx).
-		Into(result)
-	return
+func (c *testTypes) CreateSubresource(ctx context.Context, testTypeName string, testSubresource *extensionsv1.TestSubresource, opts metav1.CreateOptions) (*extensionsv1.TestSubresource, error) {
+	return gentype.CreateSubresource(ctx, c.Client, testTypeName, testSubresource, "testsubresource", &extensionsv1.TestSubresource{}, opts)
 }
 
 // UpdateSubresource takes the top resource name and the representation of a testSubresource and updates it. Returns the server's representation of the testSubresource, and an error, if there is any.
-func (c *testTypes) UpdateSubresource(ctx context.Context, testTypeName string, testSubresource *extensionsv1.TestSubresource, opts metav1.UpdateOptions) (result *extensionsv1.TestSubresource, err error) {
-	result = &extensionsv1.TestSubresource{}
-	err = c.GetClient().Put().
-		Namespace(c.GetNamespace()).
-		Resource("testtypes").
-		Name(testTypeName).
-		SubResource("subresource").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Body(testSubresource).
-		Do(ctx).
-		Into(result)
-	return
+func (c *testTypes) UpdateSubresource(ctx context.Context, testTypeName string, testSubresource *extensionsv1.TestSubresource, opts metav1.UpdateOptions) (*extensionsv1.TestSubresource, error) {
+	return gentype.UpdateSubresource(ctx, c.Client, testTypeName, testSubresource, "subresource", &extensionsv1.TestSubresource{}, opts)
 }
 
 // ApplySubresource takes top resource name and the apply declarative configuration for subresource,
 // applies it and returns the applied testSubresource, and an error, if there is any.
 func (c *testTypes) ApplySubresource(ctx context.Context, testTypeName string, testSubresource *applyconfigurationextensionsv1.TestSubresourceApplyConfiguration, opts metav1.ApplyOptions) (result *extensionsv1.TestSubresource, err error) {
-	if testSubresource == nil {
-		return nil, fmt.Errorf("testSubresource provided to ApplySubresource must not be nil")
-	}
-	patchOpts := opts.ToPatchOptions()
-	request, err := apply.NewRequest(c.GetClient(), testSubresource)
-	if err != nil {
-		return nil, err
-	}
-
-	result = &extensionsv1.TestSubresource{}
-	err = request.
-		Namespace(c.GetNamespace()).
-		Resource("testtypes").
-		Name(testTypeName).
-		SubResource("subresource").
-		VersionedParams(&patchOpts, scheme.ParameterCodec).
-		Do(ctx).
-		Into(result)
-	return
+	return gentype.ApplySubresource(ctx, c.Client, testTypeName, testSubresource, "subresource", &extensionsv1.TestSubresource{}, opts)
 }

--- a/staging/src/k8s.io/code-generator/examples/single/clientset/versioned/typed/api/v1/clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/examples/single/clientset/versioned/typed/api/v1/clustertesttype.go
@@ -78,28 +78,11 @@ func newClusterTestTypes(c *ExampleV1Client) *clusterTestTypes {
 }
 
 // GetScale takes name of the clusterTestType, and returns the corresponding autoscalingv1.Scale object, and an error if there is any.
-func (c *clusterTestTypes) GetScale(ctx context.Context, clusterTestTypeName string, options metav1.GetOptions) (result *autoscalingv1.Scale, err error) {
-	result = &autoscalingv1.Scale{}
-	err = c.GetClient().Get().
-		Resource("clustertesttypes").
-		Name(clusterTestTypeName).
-		SubResource("scale").
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do(ctx).
-		Into(result)
-	return
+func (c *clusterTestTypes) GetScale(ctx context.Context, clusterTestTypeName string, options metav1.GetOptions) (*autoscalingv1.Scale, error) {
+	return gentype.GetSubresource[autoscalingv1.Scale](ctx, &c.Client.ResourceClient, clusterTestTypeName, "scale", options)
 }
 
 // UpdateScale takes the top resource name and the representation of a scale and updates it. Returns the server's representation of the scale, and an error, if there is any.
-func (c *clusterTestTypes) UpdateScale(ctx context.Context, clusterTestTypeName string, scale *autoscalingv1.Scale, opts metav1.UpdateOptions) (result *autoscalingv1.Scale, err error) {
-	result = &autoscalingv1.Scale{}
-	err = c.GetClient().Put().
-		Resource("clustertesttypes").
-		Name(clusterTestTypeName).
-		SubResource("scale").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Body(scale).
-		Do(ctx).
-		Into(result)
-	return
+func (c *clusterTestTypes) UpdateScale(ctx context.Context, clusterTestTypeName string, scale *autoscalingv1.Scale, opts metav1.UpdateOptions) (*autoscalingv1.Scale, error) {
+	return gentype.UpdateSubresource(ctx, c.Client, clusterTestTypeName, scale, "scale", &autoscalingv1.Scale{}, opts)
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
#### What this PR does / why we need it:

This adds generic implementations of the extension functions. Because they can involve many more types than the basic types references by the clients (the main resource type, associated list type, and apply configuration type), the functions have to be declared as top-level functions. The existing struct functions are refactored to use the top-level functions.

delete and watch aren't supported for extensions (see
unsupportedExtensionVerbs in client-gen/generators/util/tags.go), so
they are removed entirely.

list requires more work and has interactions with fakes, so it is left
for later.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
