### PR TITLE
[FG:InPlacePodVerticalScaling] Equate CPU limits below the minimum effective limit (10m)

### DIFF
--- a/pkg/kubelet/cm/helpers_linux.go
+++ b/pkg/kubelet/cm/helpers_linux.go
@@ -50,6 +50,10 @@ const (
 	// defined here:
 	// https://github.com/torvalds/linux/blob/cac03ac368fabff0122853de2422d4e17a32de08/kernel/sched/core.c#L10546
 	MinQuotaPeriod = 1000
+
+	// From the inverse of the conversion in MilliCPUToQuota:
+	// MinQuotaPeriod * MilliCPUToCPU / QuotaPeriod
+	MinMilliCPULimit = 10
 )
 
 // MilliCPUToQuota converts milliCPU to CFS quota and period values.

--- a/pkg/kubelet/cm/helpers_unsupported.go
+++ b/pkg/kubelet/cm/helpers_unsupported.go
@@ -20,7 +20,7 @@ limitations under the License.
 package cm
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -31,8 +31,9 @@ const (
 	SharesPerCPU  = 0
 	MilliCPUToCPU = 0
 
-	QuotaPeriod    = 0
-	MinQuotaPeriod = 0
+	QuotaPeriod      = 0
+	MinQuotaPeriod   = 0
+	MinMilliCPULimit = 0
 )
 
 // MilliCPUToQuota converts milliCPU and period to CFS quota values.

--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -4797,22 +4797,33 @@ func TestConvertToAPIContainerStatusesForResources(t *testing.T) {
 			},
 		},
 		"BurstableQoSPod with below min CPU": {
-			Resources: v1.ResourceRequirements{Requests: v1.ResourceList{
-				v1.ResourceMemory: resource.MustParse("100M"),
-				v1.ResourceCPU:    resource.MustParse("1m"),
-			}},
+			Resources: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceMemory: resource.MustParse("100M"),
+					v1.ResourceCPU:    resource.MustParse("1m"),
+				},
+				Limits: v1.ResourceList{
+					v1.ResourceCPU: resource.MustParse("5m"),
+				},
+			},
 			ActualResources: &kubecontainer.ContainerResources{
 				CPURequest: resource.NewMilliQuantity(2, resource.DecimalSI),
+				CPULimit:   resource.NewMilliQuantity(10, resource.DecimalSI),
 			},
 			OldStatus: v1.ContainerStatus{
 				Name:    testContainerName,
 				Image:   "img",
 				ImageID: "img1234",
 				State:   v1.ContainerState{Running: &v1.ContainerStateRunning{}},
-				Resources: &v1.ResourceRequirements{Requests: v1.ResourceList{
-					v1.ResourceMemory: resource.MustParse("100M"),
-					v1.ResourceCPU:    resource.MustParse("1m"),
-				}},
+				Resources: &v1.ResourceRequirements{
+					Requests: v1.ResourceList{
+						v1.ResourceMemory: resource.MustParse("100M"),
+						v1.ResourceCPU:    resource.MustParse("1m"),
+					},
+					Limits: v1.ResourceList{
+						v1.ResourceCPU: resource.MustParse("5m"),
+					},
+				},
 			},
 			Expected: v1.ContainerStatus{
 				Name:        testContainerName,
@@ -4824,10 +4835,15 @@ func TestConvertToAPIContainerStatusesForResources(t *testing.T) {
 					v1.ResourceMemory: resource.MustParse("100M"),
 					v1.ResourceCPU:    resource.MustParse("1m"),
 				},
-				Resources: &v1.ResourceRequirements{Requests: v1.ResourceList{
-					v1.ResourceMemory: resource.MustParse("100M"),
-					v1.ResourceCPU:    resource.MustParse("1m"),
-				}},
+				Resources: &v1.ResourceRequirements{
+					Requests: v1.ResourceList{
+						v1.ResourceMemory: resource.MustParse("100M"),
+						v1.ResourceCPU:    resource.MustParse("1m"),
+					},
+					Limits: v1.ResourceList{
+						v1.ResourceCPU: resource.MustParse("5m"),
+					},
+				},
 			},
 		},
 		"GuaranteedQoSPod with CPU and memory CRI status, with ephemeral storage": {
@@ -6788,6 +6804,36 @@ func TestAllocatedResourcesMatchStatus(t *testing.T) {
 		},
 		statusResources: &kubecontainer.ContainerResources{
 			CPURequest: resource.NewMilliQuantity(2, resource.DecimalSI),
+		},
+		expectMatch: true,
+	}, {
+		name: "burstable: min cpu limit",
+		allocatedResources: v1.ResourceRequirements{
+			Requests: v1.ResourceList{
+				v1.ResourceCPU: resource.MustParse("10m"),
+			},
+			Limits: v1.ResourceList{
+				v1.ResourceCPU: resource.MustParse("10m"),
+			},
+		},
+		statusResources: &kubecontainer.ContainerResources{
+			CPURequest: resource.NewMilliQuantity(10, resource.DecimalSI),
+			CPULimit:   resource.NewMilliQuantity(10, resource.DecimalSI),
+		},
+		expectMatch: true,
+	}, {
+		name: "burstable: below min cpu limit",
+		allocatedResources: v1.ResourceRequirements{
+			Requests: v1.ResourceList{
+				v1.ResourceCPU: resource.MustParse("5m"),
+			},
+			Limits: v1.ResourceList{
+				v1.ResourceCPU: resource.MustParse("5m"),
+			},
+		},
+		statusResources: &kubecontainer.ContainerResources{
+			CPURequest: resource.NewMilliQuantity(5, resource.DecimalSI),
+			CPULimit:   resource.NewMilliQuantity(10, resource.DecimalSI),
 		},
 		expectMatch: true,
 	}, {

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -2215,6 +2215,7 @@ func TestComputePodActionsForPodResize(t *testing.T) {
 
 	cpu1m := resource.MustParse("1m")
 	cpu2m := resource.MustParse("2m")
+	cpu10m := resource.MustParse("10m")
 	cpu100m := resource.MustParse("100m")
 	cpu200m := resource.MustParse("200m")
 	mem100M := resource.MustParse("100Mi")
@@ -2406,10 +2407,12 @@ func TestComputePodActionsForPodResize(t *testing.T) {
 				c := &pod.Spec.Containers[1]
 				c.Resources = v1.ResourceRequirements{
 					Requests: v1.ResourceList{v1.ResourceCPU: cpu1m},
+					Limits:   v1.ResourceList{v1.ResourceCPU: cpu1m},
 				}
 				if cStatus := status.FindContainerStatusByName(c.Name); cStatus != nil {
 					cStatus.Resources = &kubecontainer.ContainerResources{
 						CPURequest: ptr.To(cpu2m.DeepCopy()),
+						CPULimit:   ptr.To(cpu10m.DeepCopy()),
 					}
 				}
 			},

--- a/test/e2e/common/node/pod_resize.go
+++ b/test/e2e/common/node/pod_resize.go
@@ -584,20 +584,20 @@ func doPodResizeTests(f *framework.Framework) {
 			},
 		},
 		{
-			name: "Burstable QoS pod, one container with cpu requests - resize with equivalent request",
+			name: "Burstable QoS pod, one container with cpu requests and limits - resize with equivalents",
 			containers: []e2epod.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: "2m"},
+					Resources: &e2epod.ContainerResources{CPUReq: "2m", CPULim: "10m"},
 				},
 			},
 			patchString: `{"spec":{"containers":[
-						{"name":"c1", "resources":{"requests":{"cpu":"1m"}}}
+						{"name":"c1", "resources":{"requests":{"cpu":"1m"},"limits":{"cpu":"5m"}}}
 					]}}`,
 			expected: []e2epod.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: "1m"},
+					Resources: &e2epod.ContainerResources{CPUReq: "1m", CPULim: "5m"},
 				},
 			},
 		},


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

We clamp the minimum CPU quota, which translates to an effective minimum CPU limit of `10m`. When we compare actual vs desired resources, we need to account for this clamping.

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubernetes/issues/128769

#### Special notes for your reviewer:

Extension request: https://groups.google.com/g/kubernetes-sig-release/c/DvRlV9mBZ-Q/m/AGmOk6avBwAJ

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/sig node
/priority important-soon
/milestone v1.32