### PR TITLE
kubeadm: fix a bug where upgrade dryrun can not select the network interface correctly

### DIFF
--- a/cmd/kubeadm/app/util/apiclient/dryrun.go
+++ b/cmd/kubeadm/app/util/apiclient/dryrun.go
@@ -754,7 +754,7 @@ func getPod(name, nodeName string) corev1.Pod {
 				"tier":      constants.ControlPlaneTier,
 			},
 			Annotations: map[string]string{
-				constants.KubeAPIServerAdvertiseAddressEndpointAnnotationKey: "127.0.0.1:6443",
+				constants.KubeAPIServerAdvertiseAddressEndpointAnnotationKey: "0.0.0.0:6443",
 			},
 		},
 		Spec: corev1.PodSpec{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
kubeadm: fix a bug where upgrade dryrun can not select the network interface correctly

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
without this patch:
```bash
# kubeadm upgrade apply -f v1.32.0-alpha.3.47+daef8c2419a638 --ignore-preflight-errors=Swap,SystemVerification,FileContent--proc-sys-net-bridge-bridge-nf-call-iptables --allow-release-candidate-upgrades=true --allow-experimental-upgrades=true --dry-run --v=6

I1113 03:42:38.737197     276 interface.go:209] Interface lo is up
I1113 03:42:38.737274     276 interface.go:257] Interface "lo" has 2 addresses :[127.0.0.1/8 ::1/128].
I1113 03:42:38.737298     276 interface.go:224] Checking addr  127.0.0.1/8.
I1113 03:42:38.737302     276 interface.go:234] Non-global unicast address found 127.0.0.1
I1113 03:42:38.737317     276 interface.go:224] Checking addr  ::1/128.
I1113 03:42:38.737320     276 interface.go:237] ::1 is not an IPv4 address
I1113 03:42:38.737389     276 interface.go:209] Interface lo is up
I1113 03:42:38.737410     276 interface.go:257] Interface "lo" has 2 addresses :[127.0.0.1/8 ::1/128].
I1113 03:42:38.737414     276 interface.go:224] Checking addr  127.0.0.1/8.
I1113 03:42:38.737417     276 interface.go:237] 127.0.0.1 is not an IPv6 address
I1113 03:42:38.737419     276 interface.go:224] Checking addr  ::1/128.
I1113 03:42:38.737422     276 interface.go:234] Non-global unicast address found ::1
unable to select an IP from lo network interface
[upgrade] FATAL
k8s.io/kubernetes/cmd/kubeadm/app/cmd/upgrade.newApplyData
        k8s.io/kubernetes/cmd/kubeadm/app/cmd/upgrade/apply.go:242
k8s.io/kubernetes/cmd/kubeadm/app/cmd/upgrade.newCmdApply.func2
        k8s.io/kubernetes/cmd/kubeadm/app/cmd/upgrade/apply.go:146
k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow.(*Runner).InitData
        k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow/runner.go:185
k8s.io/kubernetes/cmd/kubeadm/app/cmd/upgrade.newCmdApply.func1
        k8s.io/kubernetes/cmd/kubeadm/app/cmd/upgrade/apply.go:99
github.com/spf13/cobra.(*Command).execute
        github.com/spf13/cobra@v1.8.1/command.go:985
github.com/spf13/cobra.(*Command).ExecuteC
        github.com/spf13/cobra@v1.8.1/command.go:1117
github.com/spf13/cobra.(*Command).Execute
        github.com/spf13/cobra@v1.8.1/command.go:1041
k8s.io/kubernetes/cmd/kubeadm/app.Run
        k8s.io/kubernetes/cmd/kubeadm/app/kubeadm.go:47
main.main
        k8s.io/kubernetes/cmd/kubeadm/kubeadm.go:25
runtime.main
        runtime/proc.go:272
runtime.goexit
        runtime/asm_arm64.s:1223
```

https://github.com/kubernetes/kubernetes/blob/0926587bf00cd931ffafa98b4780903a1b512a7b/cmd/kubeadm/app/util/config/initconfiguration.go#L146-L157

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
