### PR TITLE
Fix a bug in framework.IgnoreNotFound 

### DIFF
--- a/test/e2e/framework/ginkgowrapper.go
+++ b/test/e2e/framework/ginkgowrapper.go
@@ -97,7 +97,12 @@ func IgnoreNotFound(in any) any {
 	inType := reflect.TypeOf(in)
 	inValue := reflect.ValueOf(in)
 	return reflect.MakeFunc(inType, func(args []reflect.Value) []reflect.Value {
-		out := inValue.Call(args)
+		var out []reflect.Value
+		if inType.IsVariadic() {
+			out = inValue.CallSlice(args)
+		} else {
+			out = inValue.Call(args)
+		}
 		if len(out) > 0 {
 			lastValue := out[len(out)-1]
 			last := lastValue.Interface()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

 Fix a bug in `framework.IgnoreNotFound` where it will panic when a function type's final input parameter is a "..." parameter.

For example,

```go
func myFunc(a, b int, c ...int) int {
	return a + b
}

func main() {
	args := []interface{}{Wrapper(myFunc), 10, 20, 1, 3}
	callback := reflect.ValueOf(args[0])

	callArgs := []reflect.Value{}
	for _, arg := range args[1:] {
		callArgs = append(callArgs, reflect.ValueOf(arg))
	}
	out := callback.Call(callArgs)
	resultInt := out[0].Interface().(int)
	fmt.Println("Result:", resultInt)
}

func Wrapper(in any) any {
	inType := reflect.TypeOf(in)
	inValue := reflect.ValueOf(in)
	return reflect.MakeFunc(inType, func(args []reflect.Value) []reflect.Value {
	         out = inValue.Call(args)
		return out
	}).Interface()
}
```

Output:

```
(base) ➜  ~ go run main.go
panic: reflect: cannot use []int as type int in Call

goroutine 1 [running]:
reflect.Value.call({0x100bed0e0?, 0x100c00c28?, 0x5?}, {0x100bb6c3a, 0x4}, {0x14000140050, 0x3, 0x100bb6850?})
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/reflect/value.go:448 +0x1450
reflect.Value.Call({0x100bed0e0?, 0x100c00c28?, 0x0?}, {0x14000140050?, 0x14000131218?, 0x100b97684?})
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/reflect/value.go:365 +0x94
main.IgnoreNotFound.func1({0x14000140050, 0x3, 0x3})
	/Users/kiki/main.go:45 +0x70
reflect.Value.call({0x100bed0e0?, 0x14000114240?, 0x14000131e08?}, {0x100bb6c3a, 0x4}, {0x14000100180, 0x4, 0x100bed0e0?})
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/reflect/value.go:581 +0x97c
reflect.Value.Call({0x100bed0e0?, 0x14000114240?, 0x1400004e658?}, {0x14000100180?, 0x100c00520?, 0x100b7a288?})
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/reflect/value.go:365 +0x94
main.main()
	/Users/kiki/main.go:33 +0x238
exit status 2
```


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
