### PR TITLE
Remove user privilege checks from preflight tests

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/init/preflight.go
+++ b/cmd/kubeadm/app/cmd/phases/init/preflight.go
@@ -62,6 +62,10 @@ func runPreflight(c workflow.RunData) error {
 	}
 
 	fmt.Println("[preflight] Running pre-flight checks")
+	// First, check if we're root separately from the other preflight checks and fail fast.
+	if err := preflight.RunRootCheckOnly(data.IgnorePreflightErrors()); err != nil {
+		return err
+	}
 	if err := preflight.RunInitNodeChecks(utilsexec.New(), data.Cfg(), data.IgnorePreflightErrors(), false, false); err != nil {
 		return err
 	}

--- a/cmd/kubeadm/app/cmd/phases/join/preflight.go
+++ b/cmd/kubeadm/app/cmd/phases/join/preflight.go
@@ -91,6 +91,10 @@ func runPreflight(c workflow.RunData) error {
 
 	// Start with general checks
 	klog.V(1).Infoln("[preflight] Running general checks")
+	// First, check if we're root separately from the other preflight checks and fail fast.
+	if err := preflight.RunRootCheckOnly(j.IgnorePreflightErrors()); err != nil {
+		return err
+	}
 	if err := preflight.RunJoinNodeChecks(utilsexec.New(), j.Cfg(), j.IgnorePreflightErrors()); err != nil {
 		return err
 	}

--- a/cmd/kubeadm/app/preflight/checks.go
+++ b/cmd/kubeadm/app/preflight/checks.go
@@ -909,13 +909,6 @@ func (MemCheck) Name() string {
 
 // InitNodeChecks returns checks specific to "kubeadm init"
 func InitNodeChecks(execer utilsexec.Interface, cfg *kubeadmapi.InitConfiguration, ignorePreflightErrors sets.Set[string], isSecondaryControlPlane bool, downloadCerts bool) ([]Checker, error) {
-	if !isSecondaryControlPlane {
-		// First, check if we're root separately from the other preflight checks and fail fast
-		if err := RunRootCheckOnly(ignorePreflightErrors); err != nil {
-			return nil, err
-		}
-	}
-
 	manifestsDir := filepath.Join(kubeadmconstants.KubernetesDir, kubeadmconstants.ManifestsSubDirName)
 	checks := []Checker{
 		NumCPUCheck{NumCPU: kubeadmconstants.ControlPlaneNumCPU},
@@ -1030,11 +1023,6 @@ func RunInitNodeChecks(execer utilsexec.Interface, cfg *kubeadmapi.InitConfigura
 
 // JoinNodeChecks returns checks specific to "kubeadm join"
 func JoinNodeChecks(execer utilsexec.Interface, cfg *kubeadmapi.JoinConfiguration, ignorePreflightErrors sets.Set[string]) ([]Checker, error) {
-	// First, check if we're root separately from the other preflight checks and fail fast
-	if err := RunRootCheckOnly(ignorePreflightErrors); err != nil {
-		return nil, err
-	}
-
 	checks := []Checker{
 		FileAvailableCheck{Path: filepath.Join(kubeadmconstants.KubernetesDir, kubeadmconstants.KubeletKubeConfigFileName)},
 		FileAvailableCheck{Path: filepath.Join(kubeadmconstants.KubernetesDir, kubeadmconstants.KubeletBootstrapKubeConfigFileName)},

--- a/cmd/kubeadm/app/preflight/checks_test.go
+++ b/cmd/kubeadm/app/preflight/checks_test.go
@@ -902,11 +902,6 @@ func TestInitIPCheck(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("unsupported OS")
 	}
-	// should be a privileged user for the `init` command, otherwise just skip it.
-	isPrivileged := IsPrivilegedUserCheck{}
-	if _, err := isPrivileged.Check(); err != nil {
-		t.Skip("not a privileged user")
-	}
 	internalcfg, err := configutil.DefaultedStaticInitConfiguration()
 	if err != nil {
 		t.Fatalf("unexpected failure when defaulting InitConfiguration: %v", err)
@@ -968,11 +963,6 @@ func TestJoinIPCheck(t *testing.T) {
 	// skip this test, if OS in not Linux, since it will ONLY pass on Linux.
 	if runtime.GOOS != "linux" {
 		t.Skip("unsupported OS")
-	}
-	// should be a privileged user for the `join` command, otherwise just skip it.
-	isPrivileged := IsPrivilegedUserCheck{}
-	if _, err := isPrivileged.Check(); err != nil {
-		t.Skip("not a privileged user")
 	}
 
 	opts := configutil.LoadOrDefaultConfigurationOptions{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR removes user-privilege checks for some preflight tests to make sure UT behaviour is consistent and shouldn't get skipped for non-root users.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubeadm/issues/3124

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
