### PR TITLE
Change way to create a pod in test

### DIFF
--- a/test/e2e/common/node/pods.go
+++ b/test/e2e/common/node/pods.go
@@ -851,7 +851,7 @@ var _ = SIGDescribe("Pods", func() {
 		ginkgo.By("Create set of pods")
 		// create a set of pods in test namespace
 		for _, podTestName := range podTestNames {
-			_, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx,
+			_ = podClient.Create(ctx,
 				e2epod.MustMixinRestrictedPodSecurity(&v1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: podTestName,
@@ -866,8 +866,7 @@ var _ = SIGDescribe("Pods", func() {
 							Name:  "token-test",
 						}},
 						RestartPolicy: v1.RestartPolicyNever,
-					}}), metav1.CreateOptions{})
-			framework.ExpectNoError(err, "failed to create pod")
+					}}))
 			framework.Logf("created %v", podTestName)
 		}
 
@@ -929,8 +928,7 @@ var _ = SIGDescribe("Pods", func() {
 			},
 		})
 		ginkgo.By("creating a Pod with a static label")
-		_, err = f.ClientSet.CoreV1().Pods(testNamespaceName).Create(ctx, testPod, metav1.CreateOptions{})
-		framework.ExpectNoError(err, "failed to create Pod %v in namespace %v", testPod.ObjectMeta.Name, testNamespaceName)
+		_ = podClient.Create(ctx, testPod)
 
 		ginkgo.By("watching for Pod to be ready")
 		ctxUntil, cancel := context.WithTimeout(ctx, f.Timeouts.PodStart)
@@ -1082,8 +1080,6 @@ var _ = SIGDescribe("Pods", func() {
 		the fields MUST equal the new values.
 	*/
 	framework.ConformanceIt("should patch a pod status", func(ctx context.Context) {
-		ns := f.Namespace.Name
-		podClient := f.ClientSet.CoreV1().Pods(ns)
 		podName := "pod-" + utilrand.String(5)
 		label := map[string]string{"e2e": podName}
 
@@ -1103,8 +1099,7 @@ var _ = SIGDescribe("Pods", func() {
 				},
 			},
 		})
-		pod, err := podClient.Create(ctx, testPod, metav1.CreateOptions{})
-		framework.ExpectNoError(err, "failed to create Pod %v in namespace %v", testPod.ObjectMeta.Name, ns)
+		pod := podClient.Create(ctx, testPod)
 		framework.ExpectNoError(e2epod.WaitForPodRunningInNamespace(ctx, f.ClientSet, pod), "Pod didn't start within time out period")
 
 		ginkgo.By("patching /status")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind failing-test

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR fixes local test failures for those tests:
"should delete a collection of pods"
"should run through the lifecycle of Pods and PodStatus"
"should patch a pod status"

with this kind of error.

<details><summary>Details</summary>
<p>

```
  [FAILED] 3 pods not found running.: Timed out after 300.001s.
  Expected all pods (need at least 3) in namespace "pods-4919" to be running and ready 
  0 / 3 pods were running and ready.
  Pods that were neither completed nor running:
      <[]v1.Pod | len:3, cap:4>: 
          - metadata:
              creationTimestamp: "2024-11-15T00:45:52Z"
              labels:
                type: Testing
              managedFields:
              - apiVersion: v1
                fieldsType: FieldsV1
                fieldsV1:
                  f:metadata:
                    f:labels:
                      .: {}
                      f:type: {}
                  f:spec:
                    f:containers:
                      k:{"name":"token-test"}:
                        .: {}
                        f:image: {}
                        f:imagePullPolicy: {}
                        f:name: {}
                        f:resources: {}
                        f:securityContext:
                          .: {}
                          f:allowPrivilegeEscalation: {}
                          f:capabilities:
                            .: {}
                            f:drop: {}
                        f:terminationMessagePath: {}
                        f:terminationMessagePolicy: {}
                    f:dnsPolicy: {}
                    f:enableServiceLinks: {}
                    f:restartPolicy: {}
                    f:schedulerName: {}
                    f:securityContext:
                      .: {}
                      f:runAsNonRoot: {}
                      f:runAsUser: {}
                      f:seccompProfile:
                        .: {}
                        f:type: {}
                    f:terminationGracePeriodSeconds: {}
                manager: e2e_node.test
                operation: Update
                time: "2024-11-15T00:45:52Z"
              name: test-pod-1
              namespace: pods-4919
              resourceVersion: "85"
              uid: 3b7e8d28-c214-4cf9-8b68-7c65338cb6c1
            spec:
              containers:
              - image: registry.k8s.io/e2e-test-images/agnhost:2.53
                imagePullPolicy: IfNotPresent
                name: token-test
                resources: {}
                securityContext:
                  allowPrivilegeEscalation: false
                  capabilities:
                    drop:
                    - ALL
                terminationMessagePath: /dev/termination-log
                terminationMessagePolicy: File
              dnsPolicy: ClusterFirst
              enableServiceLinks: true
              preemptionPolicy: PreemptLowerPriority
              priority: 0
              restartPolicy: Never
              schedulerName: default-scheduler
              securityContext:
                runAsNonRoot: true
                runAsUser: 1000
                seccompProfile:
                  type: RuntimeDefault
              terminationGracePeriodSeconds: 1
              tolerations:
              - effect: NoExecute
                key: node.kubernetes.io/not-ready
                operator: Exists
                tolerationSeconds: 300
              - effect: NoExecute
                key: node.kubernetes.io/unreachable
                operator: Exists
                tolerationSeconds: 300
            status:
              phase: Pending
              qosClass: BestEffort
          - metadata:
              creationTimestamp: "2024-11-15T00:45:52Z"
              labels:
                type: Testing
              managedFields:
              - apiVersion: v1
                fieldsType: FieldsV1
                fieldsV1:
                  f:metadata:
                    f:labels:
                      .: {}
                      f:type: {}
                  f:spec:
                    f:containers:
                      k:{"name":"token-test"}:
                        .: {}
                        f:image: {}
                        f:imagePullPolicy: {}
                        f:name: {}
                        f:resources: {}
                        f:securityContext:
                          .: {}
                          f:allowPrivilegeEscalation: {}
                          f:capabilities:
                            .: {}
                            f:drop: {}
                        f:terminationMessagePath: {}
                        f:terminationMessagePolicy: {}
                    f:dnsPolicy: {}
                    f:enableServiceLinks: {}
                    f:restartPolicy: {}
                    f:schedulerName: {}
                    f:securityContext:
                      .: {}
                      f:runAsNonRoot: {}
                      f:runAsUser: {}
                      f:seccompProfile:
                        .: {}
                        f:type: {}
                    f:terminationGracePeriodSeconds: {}
                manager: e2e_node.test
                operation: Update
                time: "2024-11-15T00:45:52Z"
              name: test-pod-2
              namespace: pods-4919
              resourceVersion: "86"
              uid: 1279375b-c600-439e-b2fb-99630b2d452e
            spec:
              containers:
              - image: registry.k8s.io/e2e-test-images/agnhost:2.53
                imagePullPolicy: IfNotPresent
                name: token-test
                resources: {}
                securityContext:
                  allowPrivilegeEscalation: false
                  capabilities:
                    drop:
                    - ALL
                terminationMessagePath: /dev/termination-log
                terminationMessagePolicy: File
              dnsPolicy: ClusterFirst
              enableServiceLinks: true
              preemptionPolicy: PreemptLowerPriority
              priority: 0
              restartPolicy: Never
              schedulerName: default-scheduler
              securityContext:
                runAsNonRoot: true
                runAsUser: 1000
                seccompProfile:
                  type: RuntimeDefault
              terminationGracePeriodSeconds: 1
              tolerations:
              - effect: NoExecute
                key: node.kubernetes.io/not-ready
                operator: Exists
                tolerationSeconds: 300
              - effect: NoExecute
                key: node.kubernetes.io/unreachable
                operator: Exists
                tolerationSeconds: 300
            status:
              phase: Pending
              qosClass: BestEffort
          - metadata:
              creationTimestamp: "2024-11-15T00:45:52Z"
              labels:
                type: Testing
              managedFields:
              - apiVersion: v1
                fieldsType: FieldsV1
                fieldsV1:
                  f:metadata:
                    f:labels:
                      .: {}
                      f:type: {}
                  f:spec:
                    f:containers:
                      k:{"name":"token-test"}:
                        .: {}
                        f:image: {}
                        f:imagePullPolicy: {}
                        f:name: {}
                        f:resources: {}
                        f:securityContext:
                          .: {}
                          f:allowPrivilegeEscalation: {}
                          f:capabilities:
                            .: {}
                            f:drop: {}
                        f:terminationMessagePath: {}
                        f:terminationMessagePolicy: {}
                    f:dnsPolicy: {}
                    f:enableServiceLinks: {}
                    f:restartPolicy: {}
                    f:schedulerName: {}
                    f:securityContext:
                      .: {}
                      f:runAsNonRoot: {}
                      f:runAsUser: {}
                      f:seccompProfile:
                        .: {}
                        f:type: {}
                    f:terminationGracePeriodSeconds: {}
                manager: e2e_node.test
                operation: Update
                time: "2024-11-15T00:45:52Z"
              name: test-pod-3
              namespace: pods-4919
              resourceVersion: "87"
              uid: bb38dd4a-3b3f-47ec-b7d2-2c2220aff53a
            spec:
              containers:
              - image: registry.k8s.io/e2e-test-images/agnhost:2.53
                imagePullPolicy: IfNotPresent
                name: token-test
                resources: {}
                securityContext:
                  allowPrivilegeEscalation: false
                  capabilities:
                    drop:
                    - ALL
                terminationMessagePath: /dev/termination-log
                terminationMessagePolicy: File
              dnsPolicy: ClusterFirst
              enableServiceLinks: true
              preemptionPolicy: PreemptLowerPriority
              priority: 0
              restartPolicy: Never
              schedulerName: default-scheduler
              securityContext:
                runAsNonRoot: true
                runAsUser: 1000
                seccompProfile:
                  type: RuntimeDefault
              terminationGracePeriodSeconds: 1
              tolerations:
              - effect: NoExecute
                key: node.kubernetes.io/not-ready
                operator: Exists
                tolerationSeconds: 300
              - effect: NoExecute
                key: node.kubernetes.io/unreachable
                operator: Exists
                tolerationSeconds: 300
            status:
              phase: Pending
              qosClass: BestEffort
```

This happens because they don't use a client for pods, which assign node when creating a pod.
https://github.com/kubernetes/kubernetes/blob/6ec421e2cfe09499e21134934d75fe71164bc08d/test/e2e/common/node/pods.go#L192
https://github.com/kubernetes/kubernetes/blob/3d7d06e7cd460487410ab440eca2ce99bd1270e3/test/e2e/framework/pod/pod_client.go#L247

</p>
</details> 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

This will fix test failures in cri-o.
https://github.com/cri-o/cri-o/issues/8668

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
