### PR TITLE
chore: remove repeated scheduler prefix metrics for CacheSizeMetrics

### DIFF
--- a/pkg/scheduler/backend/cache/cache.go
+++ b/pkg/scheduler/backend/cache/cache.go
@@ -757,4 +757,12 @@ func (cache *cacheImpl) updateMetrics() {
 	metrics.CacheSize.WithLabelValues("assumed_pods").Set(float64(len(cache.assumedPods)))
 	metrics.CacheSize.WithLabelValues("pods").Set(float64(len(cache.podStates)))
 	metrics.CacheSize.WithLabelValues("nodes").Set(float64(len(cache.nodes)))
+
+	// we intentionally keep them with the deprecation and will remove at v1.33.
+	//nolint:staticcheck
+	metrics.SchedulerCacheSize.WithLabelValues("assumed_pods").Set(float64(len(cache.assumedPods)))
+	//nolint:staticcheck
+	metrics.SchedulerCacheSize.WithLabelValues("pods").Set(float64(len(cache.podStates)))
+	//nolint:staticcheck
+	metrics.SchedulerCacheSize.WithLabelValues("nodes").Set(float64(len(cache.nodes)))
 }

--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -110,8 +110,11 @@ var (
 	FrameworkExtensionPointDuration *metrics.HistogramVec
 	PluginExecutionDuration         *metrics.HistogramVec
 
-	PermitWaitDuration    *metrics.HistogramVec
-	CacheSize             *metrics.GaugeVec
+	PermitWaitDuration *metrics.HistogramVec
+	CacheSize          *metrics.GaugeVec
+	// Deprecated: SchedulerCacheSize is deprecated,
+	// and will be removed at v1.33. Please use CacheSize instead.
+	SchedulerCacheSize    *metrics.GaugeVec
 	unschedulableReasons  *metrics.GaugeVec
 	PluginEvaluationTotal *metrics.CounterVec
 
@@ -308,10 +311,19 @@ func InitMetrics() {
 		},
 		[]string{"result"})
 
+	SchedulerCacheSize = metrics.NewGaugeVec(
+		&metrics.GaugeOpts{
+			Subsystem:         SchedulerSubsystem,
+			Name:              "scheduler_cache_size",
+			Help:              "Number of nodes, pods, and assumed (bound) pods in the scheduler cache.",
+			StabilityLevel:    metrics.ALPHA,
+			DeprecatedVersion: "1.33.0",
+		}, []string{"type"})
+
 	CacheSize = metrics.NewGaugeVec(
 		&metrics.GaugeOpts{
 			Subsystem:      SchedulerSubsystem,
-			Name:           "scheduler_cache_size",
+			Name:           "cache_size",
 			Help:           "Number of nodes, pods, and assumed (bound) pods in the scheduler cache.",
 			StabilityLevel: metrics.ALPHA,
 		}, []string{"type"})
@@ -368,6 +380,7 @@ func InitMetrics() {
 		Goroutines,
 		PermitWaitDuration,
 		CacheSize,
+		SchedulerCacheSize,
 		unschedulableReasons,
 		PluginEvaluationTotal,
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
- added scheduler_cache_size metric
- marked scheduler_scheduler_cache_size metric as deprecated
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Implemented scheduler_cache_size metric.
Also, scheduler_scheduler_cache_size metric is deprecated in favor of scheduler_cache_size, 
and will be removed at v1.34.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
