### PR TITLE
[deprecated][IGNORE ME] feat: Add flagz endpoint for kube-scheduler

### DIFF
--- a/cmd/kube-scheduler/app/config/config.go
+++ b/cmd/kube-scheduler/app/config/config.go
@@ -26,11 +26,15 @@ import (
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/events"
 	"k8s.io/client-go/tools/leaderelection"
+	"k8s.io/component-base/zpages/flagz"
 	kubeschedulerconfig "k8s.io/kubernetes/pkg/scheduler/apis/config"
 )
 
 // Config has all the context to run a Scheduler
 type Config struct {
+	// Flagz is the Reader interface to get flags for flagz page.
+	Flagz flagz.Reader
+
 	// ComponentConfig is the scheduler server's configuration object.
 	ComponentConfig kubeschedulerconfig.KubeSchedulerConfiguration
 

--- a/cmd/kube-scheduler/app/options/options.go
+++ b/cmd/kube-scheduler/app/options/options.go
@@ -46,6 +46,7 @@ import (
 	logsapi "k8s.io/component-base/logs/api/v1"
 	"k8s.io/component-base/metrics"
 	utilversion "k8s.io/component-base/version"
+	"k8s.io/component-base/zpages/flagz"
 	"k8s.io/klog/v2"
 	schedulerappconfig "k8s.io/kubernetes/cmd/kube-scheduler/app/config"
 	"k8s.io/kubernetes/pkg/scheduler"
@@ -298,6 +299,7 @@ func (o *Options) Config(ctx context.Context) (*schedulerappconfig.Config, error
 	}
 
 	c := &schedulerappconfig.Config{}
+	c.Flagz = flagz.NamedFlagSetsReader{FlagSets: *o.Flags}
 	if err := o.ApplyTo(logger, c); err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/component-base/zpages/flagz/flagreader.go
+++ b/staging/src/k8s.io/component-base/zpages/flagz/flagreader.go
@@ -25,7 +25,7 @@ type Reader interface {
 	GetFlagz() map[string]string
 }
 
-// NamedFlagSetsGetter implements Reader for cliflag.NamedFlagSets
+// NamedFlagSetsReader implements Reader for cliflag.NamedFlagSets
 type NamedFlagSetsReader struct {
 	FlagSets cliflag.NamedFlagSets
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:
Adds a /flagz endpoint for kube-apiserver

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Adds a /flagz endpoint for kube-scheduler endpoint
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
* KEP : https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/4828-component-flagz/README.md

Example response
```
~ curl -k --cert /etc/kubernetes/pki/apiserver-kubelet-client.crt --key /etc/kubernetes/pki/apiserver-kubelet-client.key https://localhost:10259/flagz
```
```
kube-scheduler flags
Warning: This endpoint is not meant to be machine parseable, has no formatting compatibility guarantees and is for debugging purposes only.

allow-metric-labels []
allow-metric-labels-manifest
authentication-kubeconfig /etc/kubernetes/scheduler.conf
authentication-skip-lookup false
authentication-token-webhook-cache-ttl 10s
authentication-tolerate-lookup-failure true
authorization-always-allow-paths [/healthz,/readyz,/livez]
authorization-kubeconfig /etc/kubernetes/scheduler.conf
authorization-webhook-cache-authorized-ttl 10s
authorization-webhook-cache-unauthorized-ttl 10s
bind-address 127.0.0.1
cert-dir
client-ca-file
config
contention-profiling true
disable-http2-serving false
disabled-metrics []
emulated-version []
feature-gates :ComponentFlagz=true
help false
http2-max-streams-per-connection 0
kube-api-burst 100
kube-api-content-type application/vnd.kubernetes.protobuf
kube-api-qps 50
kubeconfig /etc/kubernetes/scheduler.conf
leader-elect true
leader-elect-lease-duration 15s
leader-elect-renew-deadline 10s
leader-elect-resource-lock leases
leader-elect-resource-name kube-scheduler
leader-elect-resource-namespace kube-system
leader-elect-retry-period 2s
log-flush-frequency 5s
log-json-info-buffer-size 0
log-json-split-stream false
log-text-info-buffer-size 0
log-text-split-stream false
logging-format text
master
permit-address-sharing false
permit-port-sharing false
pod-max-in-unschedulable-pods-duration 5m0s
profiling true
requestheader-allowed-names []
requestheader-client-ca-file
requestheader-extra-headers-prefix [x-remote-extra-]
requestheader-group-headers [x-remote-group]
requestheader-uid-headers []
requestheader-username-headers [x-remote-user]
secure-port 10259
show-hidden-metrics-for-version
tls-cert-file
tls-cipher-suites []
tls-min-version
tls-private-key-file
tls-sni-cert-key []
v 0
version false
vmodule
write-config-to
```
<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
[KEP] https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/4828-component-flagz/README.md
```
