### PR TITLE
DRA: enable performance tracking with scheduler_perf

### DIFF
--- a/test/integration/scheduler_perf/dra/performance-config.yaml
+++ b/test/integration/scheduler_perf/dra/performance-config.yaml
@@ -23,7 +23,6 @@
 - name: SchedulingWithResourceClaimTemplate
   featureGates:
     DynamicResourceAllocation: true
-    # SchedulerQueueingHints: true
   workloadTemplate:
   - opcode: createNodes
     countParam: $nodesWithoutDRA
@@ -91,6 +90,19 @@
       measurePods: 1000
       maxClaimsPerNode: 10
   - name: 5000pods_500nodes
+    featureGates:
+      SchedulerQueueingHints: false
+    labels: [performance]
+    params:
+      nodesWithDRA: 500
+      nodesWithoutDRA: 0
+      initPods: 2500
+      measurePods: 2500
+      maxClaimsPerNode: 10
+  - name: 5000pods_500nodes_QueueingHintsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
+    labels: [performance]
     params:
       nodesWithDRA: 500
       nodesWithoutDRA: 0
@@ -108,7 +120,6 @@
 - name: SteadyStateClusterResourceClaimTemplate
   featureGates:
     DynamicResourceAllocation: true
-    # SchedulerQueueingHints: true
   workloadTemplate:
   - opcode: createNodes
     countParam: $nodesWithoutDRA
@@ -177,6 +188,19 @@
       maxClaimsPerNode: 10
       duration: 10s
   - name: empty_500nodes
+    featureGates:
+      SchedulerQueueingHints: false
+    labels: [performance]
+    params:
+      nodesWithDRA: 500
+      nodesWithoutDRA: 0
+      initClaims: 0
+      maxClaimsPerNode: 10
+      duration: 10s
+  - name: empty_500nodes_QueueingHintsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
+    labels: [performance]
     params:
       nodesWithDRA: 500
       nodesWithoutDRA: 0
@@ -199,6 +223,19 @@
       maxClaimsPerNode: 10
       duration: 10s
   - name: half_500nodes
+    featureGates:
+      SchedulerQueueingHints: false
+    labels: [performance]
+    params:
+      nodesWithDRA: 500
+      nodesWithoutDRA: 0
+      initClaims: 2500
+      maxClaimsPerNode: 10
+      duration: 10s
+  - name: half_500nodes_QueueingHintsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
+    labels: [performance]
     params:
       nodesWithDRA: 500
       nodesWithoutDRA: 0
@@ -221,6 +258,19 @@
       maxClaimsPerNode: 10
       duration: 10s
   - name: full_500nodes
+    featureGates:
+      SchedulerQueueingHints: false
+    labels: [performance]
+    params:
+      nodesWithDRA: 500
+      nodesWithoutDRA: 0
+      initClaims: 4990
+      maxClaimsPerNode: 10
+      duration: 10s
+  - name: full_500nodes_QueueingHintsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
+    labels: [performance]
     params:
       nodesWithDRA: 500
       nodesWithoutDRA: 0


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The performance of the basic "fill up the cluster" scenario (SchedulingWithResourceClaimTemplate) and the steady-state scenario (SteadyStateClusterResourceClaimTemplate) are relevant. The large configurations should run long enough to provide meaningful results.

Performance may be different with queueing hints enabled, so variants with that get added for those large configurations.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```