### PR TITLE
static pod upgrade test with hostNetwork

### DIFF
--- a/test/e2e/feature/feature.go
+++ b/test/e2e/feature/feature.go
@@ -368,7 +368,9 @@ var (
 	// TODO: document the feature (owning SIG, when to use this feature for a test)
 	StackdriverMonitoring = framework.WithFeature(framework.ValidFeatures.Add("StackdriverMonitoring"))
 
-	// TODO: document the feature (owning SIG, when to use this feature for a test)
+	// Tests marked with this feature require the kubelet to be running in standalone mode (--standalone-mode=true) like this:
+	// make test-e2e-node PARALLELISM=1 FOCUS="StandaloneMode" TEST_ARGS='--kubelet-flags="--fail-swap-on=false" --standalone-mode=true'
+	// Tests validating the behavior of kubelet when running without the API server.
 	StandaloneMode = framework.WithFeature(framework.ValidFeatures.Add("StandaloneMode"))
 
 	// TODO: document the feature (owning SIG, when to use this feature for a test)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig node


#### What this PR does / why we need it:

Follow up on the discussion: https://kubernetes.slack.com/archives/C0BP8PW9G/p1731955926900599

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

The way to run it:

```
make test-e2e-node PARALLELISM=1 FOCUS="StandaloneMode" TEST_ARGS='\
  --kubelet-flags="--fail-swap-on=false" \
  --standalone-mode=true \
' 
```
