### PR TITLE
Fix linting issue in TestNodeDeletionReleaseCIDR

### DIFF
--- a/pkg/controller/nodeipam/ipam/range_allocator_test.go
+++ b/pkg/controller/nodeipam/ipam/range_allocator_test.go
@@ -926,7 +926,9 @@ func TestNodeDeletionReleaseCIDR(t *testing.T) {
 			rangeAllocator.nodesSynced = test.AlwaysReady
 			rangeAllocator.recorder = testutil.NewFakeRecorder()
 
-			rangeAllocator.syncNode(tCtx, tc.nodeKey)
+			if err := rangeAllocator.syncNode(tCtx, tc.nodeKey); err != nil {
+				t.Fatalf("failed to run rangeAllocator.syncNode")
+			}
 
 			if len(rangeAllocator.cidrSets) != 1 {
 				t.Fatalf("Expected a single cidrSet, but got %d", len(rangeAllocator.cidrSets))


### PR DESCRIPTION
Lint error was introduced in
https://github.com/kubernetes/kubernetes/pull/128305 and backported in https://github.com/kubernetes/kubernetes/pull/128806

It was merged before I could fix it, so I thought I'd make a follow up PR to fix it.

I won't be backporting this lint as it's only in tests (unless it makes sense to backport?)

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind cleanup

#### What this PR does / why we need it:

I introduced a lint error and would like to fix it.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NOE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

cc @aojea 