### PR TITLE
feat: Add flagz endpoint for kubelet

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -86,6 +86,8 @@ import (
 	"k8s.io/component-base/tracing"
 	"k8s.io/component-base/version"
 	"k8s.io/component-base/version/verflag"
+	zpagesfeatures "k8s.io/component-base/zpages/features"
+	"k8s.io/component-base/zpages/flagz"
 	nodeutil "k8s.io/component-helpers/node/util"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
@@ -265,6 +267,13 @@ is checked every 20 seconds (also configurable with a flag).`,
 			kubeletDeps, err := UnsecuredDependencies(kubeletServer, utilfeature.DefaultFeatureGate)
 			if err != nil {
 				return fmt.Errorf("failed to construct kubelet dependencies: %w", err)
+			}
+
+			if utilfeature.DefaultFeatureGate.Enabled(zpagesfeatures.ComponentFlagz) {
+				if cleanFlagSet != nil {
+					namedFlagSet := map[string]*pflag.FlagSet{server.ComponentKubelet: cleanFlagSet}
+					kubeletDeps.Flagz = flagz.NamedFlagSetsReader{FlagSets: cliflag.NamedFlagSets{FlagSets: namedFlagSet}}
+				}
 			}
 
 			if err := checkPermissions(); err != nil {

--- a/pkg/kubelet/server/auth.go
+++ b/pkg/kubelet/server/auth.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apiserver/pkg/server/healthz"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/component-base/configz"
+	"k8s.io/component-base/zpages/flagz"
 	"k8s.io/component-base/zpages/statusz"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/features"
@@ -74,6 +75,7 @@ func isSubpath(subpath, path string) bool {
 //	/runningPods/*	=> verb=<api verb from request>, resource=nodes, name=<node name>, subresource(s)=pods,proxy
 //	/healthz/* 		=> verb=<api verb from request>, resource=nodes, name=<node name>, subresource(s)=healthz,proxy
 //	/configz 		=> verb=<api verb from request>, resource=nodes, name=<node name>, subresource(s)=configz,proxy
+//	/flagz 		    => verb=<api verb from request>, resource=nodes, name=<node name>, subresource(s)=configz,proxy
 func (n nodeAuthorizerAttributesGetter) GetRequestAttributes(u user.Info, r *http.Request) []authorizer.Attributes {
 
 	apiVerb := ""
@@ -120,6 +122,8 @@ func (n nodeAuthorizerAttributesGetter) GetRequestAttributes(u user.Info, r *htt
 		subresources = append(subresources, "checkpoint")
 	case isSubpath(requestPath, statusz.DefaultStatuszPath):
 		subresources = append(subresources, "statusz")
+	case isSubpath(requestPath, flagz.DefaultFlagzPath):
+		subresources = append(subresources, "configz")
 	default:
 		subresources = append(subresources, "proxy")
 	}

--- a/pkg/kubelet/server/auth_test.go
+++ b/pkg/kubelet/server/auth_test.go
@@ -125,6 +125,7 @@ func AuthzTestCases(fineGrained bool) []AuthzTestCase {
 		"/attach/{podNamespace}/{podID}/{uid}/{containerName}": {"proxy"},
 		"/checkpoint/{podNamespace}/{podID}/{containerName}":   {"checkpoint"},
 		"/configz": {"proxy"},
+		"/flagz":   {"configz"},
 		"/statusz": {"statusz"},
 		"/containerLogs/{podNamespace}/{podID}/{containerName}": {"proxy"},
 		"/debug/flags/v":                                     {"proxy"},

--- a/pkg/kubelet/server/server.go
+++ b/pkg/kubelet/server/server.go
@@ -69,6 +69,7 @@ import (
 	"k8s.io/component-base/metrics/legacyregistry"
 	"k8s.io/component-base/metrics/prometheus/slis"
 	zpagesfeatures "k8s.io/component-base/zpages/features"
+	"k8s.io/component-base/zpages/flagz"
 	"k8s.io/component-base/zpages/statusz"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/cri-client/pkg/util"
@@ -117,6 +118,7 @@ const (
 
 // Server is a http.Handler which exposes kubelet functionality over HTTP.
 type Server struct {
+	flagz                flagz.Reader
 	auth                 AuthInterface
 	host                 HostInterface
 	restfulCont          containerInterface
@@ -167,6 +169,7 @@ func ListenAndServeKubeletServer(
 	host HostInterface,
 	resourceAnalyzer stats.ResourceAnalyzer,
 	checkers []healthz.HealthChecker,
+	flagz flagz.Reader,
 	kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 	tlsOptions *TLSOptions,
 	auth AuthInterface,
@@ -175,7 +178,7 @@ func ListenAndServeKubeletServer(
 	address := netutils.ParseIPSloppy(kubeCfg.Address)
 	port := uint(kubeCfg.Port)
 	klog.InfoS("Starting to listen", "address", address, "port", port)
-	handler := NewServer(host, resourceAnalyzer, checkers, auth, kubeCfg)
+	handler := NewServer(host, resourceAnalyzer, checkers, flagz, auth, kubeCfg)
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.KubeletTracing) {
 		handler.InstallTracingFilter(tp)
@@ -210,11 +213,12 @@ func ListenAndServeKubeletReadOnlyServer(
 	host HostInterface,
 	resourceAnalyzer stats.ResourceAnalyzer,
 	checkers []healthz.HealthChecker,
+	flagz flagz.Reader,
 	address net.IP,
 	port uint,
 	tp oteltrace.TracerProvider) {
 	klog.InfoS("Starting to listen read-only", "address", address, "port", port)
-	s := NewServer(host, resourceAnalyzer, checkers, nil, nil)
+	s := NewServer(host, resourceAnalyzer, checkers, nil, nil, nil)
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.KubeletTracing) {
 		s.InstallTracingFilter(tp, otelrestful.WithPublicEndpoint())
@@ -291,10 +295,12 @@ func NewServer(
 	host HostInterface,
 	resourceAnalyzer stats.ResourceAnalyzer,
 	checkers []healthz.HealthChecker,
+	flagz flagz.Reader,
 	auth AuthInterface,
 	kubeCfg *kubeletconfiginternal.KubeletConfiguration) Server {
 
 	server := Server{
+		flagz:                flagz,
 		host:                 host,
 		resourceAnalyzer:     resourceAnalyzer,
 		auth:                 auth,
@@ -573,6 +579,13 @@ func (s *Server) InstallAuthRequiredHandlers() {
 	if utilfeature.DefaultFeatureGate.Enabled(zpagesfeatures.ComponentStatusz) {
 		s.addMetricsBucketMatcher("statusz")
 		statusz.Install(s.restfulCont, ComponentKubelet, statusz.NewRegistry(compatibility.DefaultBuildEffectiveVersion()))
+	}
+
+	if utilfeature.DefaultFeatureGate.Enabled(zpagesfeatures.ComponentFlagz) {
+		if s.flagz != nil {
+			s.addMetricsBucketMatcher("flagz")
+			flagz.Install(s.restfulCont, ComponentKubelet, s.flagz)
+		}
 	}
 
 	// The /runningpods endpoint is used for testing only.

--- a/staging/src/k8s.io/component-base/zpages/flagz/flagz.go
+++ b/staging/src/k8s.io/component-base/zpages/flagz/flagz.go
@@ -30,6 +30,8 @@ import (
 )
 
 const (
+	DefaultFlagzPath = "/flagz"
+
 	flagzHeaderFmt = `
 %s flags
 Warning: This endpoint is not meant to be machine parseable, has no formatting compatibility guarantees and is for debugging purposes only.
@@ -56,7 +58,7 @@ func Install(m mux, componentName string, flagReader Reader) {
 }
 
 func (reg *registry) installHandler(m mux, componentName string, flagReader Reader) {
-	m.Handle("/flagz", reg.handleFlags(componentName, flagReader))
+	m.Handle(DefaultFlagzPath, reg.handleFlags(componentName, flagReader))
 }
 
 func (reg *registry) handleFlags(componentName string, flagReader Reader) http.HandlerFunc {

--- a/staging/src/k8s.io/component-base/zpages/flagz/flagz_test.go
+++ b/staging/src/k8s.io/component-base/zpages/flagz/flagz_test.go
@@ -85,7 +85,7 @@ func TestFlagz(t *testing.T) {
 			mux := http.NewServeMux()
 			Install(mux, componentName, test.flagzReader)
 
-			req, err := http.NewRequest(http.MethodGet, "http://example.com/flagz", nil)
+			req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://example.com%s", DefaultFlagzPath), nil)
 			if err != nil {
 				t.Fatalf("case[%d] Unexpected error: %v", i, err)
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Adds a /flagz endpoint for kubelet
part of https://github.com/kubernetes/enhancements/issues/4828
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added a /flagz endpoint for kubelet endpoint
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
KEP : https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/4828-component-flagz/README.md
<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
kubectl get --raw "/api/v1/nodes/{nodename}/proxy/flagz"

```docs
kubelet flags
Warning: This endpoint is not meant to be machine parseable, has no formatting compatibility guarantees and is for debugging purposes only.

address=0.0.0.0
allowed-unsafe-sysctls=[]
anonymous-auth=true
application-metrics-count-limit=100
authentication-token-webhook=false
authentication-token-webhook-cache-ttl=2m0s
authorization-mode=AlwaysAllow
authorization-webhook-cache-authorized-ttl=5m0s
authorization-webhook-cache-unauthorized-ttl=30s
boot-id-file=/proc/sys/kernel/random/boot_id
bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf
cert-dir=/var/lib/kubelet/pki
cgroup-driver=cgroupfs
cgroup-root=
cgroups-per-qos=true
client-ca-file=
cloud-config=
cloud-provider=
cluster-dns=[]
cluster-domain=
config=/var/lib/kubelet/config.yaml
config-dir=
container-hints=/etc/cadvisor/container_hints.json
container-log-max-files=5
container-log-max-size=10Mi
container-runtime-endpoint=unix:///var/run/containerd/containerd.sock
containerd=/run/containerd/containerd.sock
containerd-namespace=k8s.io
contention-profiling=false
cpu-cfs-quota=true
cpu-cfs-quota-period=100ms
cpu-manager-policy=none
cpu-manager-policy-options=
cpu-manager-reconcile-period=10s
enable-controller-attach-detach=true
enable-debugging-handlers=true
enable-load-reader=false
enable-server=true
enforce-node-allocatable=[pods]
event-burst=100
event-qps=50
```
