### PR TITLE
Make node taints manageable by differents field managers (server-side apply)

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -8479,7 +8479,12 @@
             "$ref": "#/definitions/io.k8s.api.core.v1.Taint"
           },
           "type": "array",
-          "x-kubernetes-list-type": "atomic"
+          "x-kubernetes-list-map-keys": [
+            "key",
+            "effect"
+          ],
+          "x-kubernetes-list-type": "map",
+          "x-kubernetes-map-type": "granular"
         },
         "unschedulable": {
           "description": "Unschedulable controls node schedulability of new pods. By default, node is schedulable. More info: https://kubernetes.io/docs/concepts/nodes/node/#manual-node-administration",

--- a/api/openapi-spec/v3/api__v1_openapi.json
+++ b/api/openapi-spec/v3/api__v1_openapi.json
@@ -3998,7 +3998,12 @@
               "default": {}
             },
             "type": "array",
-            "x-kubernetes-list-type": "atomic"
+            "x-kubernetes-list-map-keys": [
+              "key",
+              "effect"
+            ],
+            "x-kubernetes-list-type": "map",
+            "x-kubernetes-map-type": "granular"
           },
           "unschedulable": {
             "description": "Unschedulable controls node schedulability of new pods. By default, node is schedulable. More info: https://kubernetes.io/docs/concepts/nodes/node/#manual-node-administration",

--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -5055,6 +5055,10 @@ type NodeSpec struct {
 
 	// If specified, the node's taints.
 	// +optional
+	// +listType=map
+	// +listMapKey=key
+	// +listMapKey=effect
+	// +mapType=granular
 	Taints []Taint
 
 	// Deprecated: Previously used to specify the source of the node's configuration for the DynamicKubeletConfig feature. This feature is removed.

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -25575,7 +25575,12 @@ func schema_k8sio_api_core_v1_NodeSpec(ref common.ReferenceCallback) common.Open
 					"taints": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "atomic",
+								"x-kubernetes-list-map-keys": []interface{}{
+									"key",
+									"effect",
+								},
+								"x-kubernetes-list-type": "map",
+								"x-kubernetes-map-type":  "granular",
 							},
 						},
 						SchemaProps: spec.SchemaProps{

--- a/staging/src/k8s.io/api/core/v1/generated.proto
+++ b/staging/src/k8s.io/api/core/v1/generated.proto
@@ -2764,7 +2764,10 @@ message NodeSpec {
 
   // If specified, the node's taints.
   // +optional
-  // +listType=atomic
+  // +listType=map
+  // +listMapKey=key
+  // +listMapKey=effect
+  // +mapType=granular
   repeated Taint taints = 5;
 
   // Deprecated: Previously used to specify the source of the node's configuration for the DynamicKubeletConfig feature. This feature is removed.

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -6032,7 +6032,10 @@ type NodeSpec struct {
 	Unschedulable bool `json:"unschedulable,omitempty" protobuf:"varint,4,opt,name=unschedulable"`
 	// If specified, the node's taints.
 	// +optional
-	// +listType=atomic
+	// +listType=map
+	// +listMapKey=key
+	// +listMapKey=effect
+	// +mapType=granular
 	Taints []Taint `json:"taints,omitempty" protobuf:"bytes,5,opt,name=taints"`
 
 	// Deprecated: Previously used to specify the source of the node's configuration for the DynamicKubeletConfig feature. This feature is removed.

--- a/staging/src/k8s.io/client-go/applyconfigurations/internal/internal.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/internal/internal.go
@@ -6372,7 +6372,10 @@ var schemaYAML = typed.YAMLObject(`types:
         list:
           elementType:
             namedType: io.k8s.api.core.v1.Taint
-          elementRelationship: atomic
+          elementRelationship: associative
+          keys:
+          - key
+          - effect
     - name: unschedulable
       type:
         scalar: boolean


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/kind api-change

#### What this PR does / why we need it:
This allows API client using server-side apply (field managers) to own individual taints on nodes.

This makes it easier to implement controller / installer which want to taints nodes without overriding other controllers taints (and given that the node controller use taints for node conditions, any other 3rd-party controller will have to handle this).
For instance, this would make kubernetes-sigs/kubespray#11697 easier

More fundamentally, Taints are a way to affirm different "things" about a node, which have in common to affect pod scheduling and execution on that node. But those "things" are often quite different in nature, for instance:
-  node.kubernetes.io/* taints express a state about the node.
- node-role.kubernetes.io/* taints express that node are reserved for some type of Pods.

This is two different "things" about nodes, which are not controlled by the same actor (AFAIK, that would be respectively kubelet and a cluster installer) and there is no a priori reason they should know about each other)

The keys used are sourced from validation : 
https://github.com/kubernetes/kubernetes/blob/c9092f69fc0c099062dd23cd6ee226bcd52ec790/staging/src/k8s.io/kubectl/pkg/cmd/taint/utils.go#L59

#### Which issue(s) this PR fixes:
Fixes #117142

#### Special notes for your reviewer:
I'm not completely sure if I should modify the annotations on both of these files, this is my first time modifying API types (or PR in this repo, for that matter ^^)
- pkg/apis/core/types.go
- staging/src/k8s.io/api/core/v1/types.go

Please point out if one of them should not in fact have the annotations

~~From the discussion on the linked issue, it seems that this changes would not be breaking (thanks to kubernetes-sigs/structured-merge-diff#170 AFAICT). It's not completely clear to me though.~~

It's a breaking change for clients using SSA to delete the entire list of taints ; see  https://kubernetes.slack.com/archives/C5P3FE08M/p1725346405608099?thread_ts=1725305303.808579&cid=C5P3FE08M for arguments of why it's unlikely clients would do so.

#### Does this PR introduce a user-facing change?
```release-note
Node Taints can be managed individually (by different field managers) when using Server Side Apply.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [Design proposal (taints and tolerations)]: https://github.com/kubernetes/kubernetes/pull/18263  
- [Usage]: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/#example-use-cases
```

API review checklist:
- [ ] Agreements from sigs:
   - [x] sig api-machinery
   - [ ] sig node
- [ ] KEP / tracking issue: I'm unsure if this apply here ("Any change to the meaning, validation, or behavior of a field" -> does that include server-side apply semantics ?)
- [x] Api Change guidelines -> I think I addressed this in  https://github.com/kubernetes/kubernetes/pull/128866#issuecomment-2500234621

/sig node
/sig api-machinery
