### PR TITLE
e2e: node: test skip permafailing test

### DIFF
--- a/test/e2e_node/device_plugin_test.go
+++ b/test/e2e_node/device_plugin_test.go
@@ -935,6 +935,8 @@ func testDevicePluginNodeReboot(f *framework.Framework, pluginSockDir string) {
 		// intentionally a scenario is created where after node reboot, application pods requesting devices appear before the device plugin pod
 		// exposing those devices as resource has restarted. The expected behavior is that the application pod fails at admission time.
 		framework.It("Keeps device plugin assignments across node reboots (no pod restart, no device plugin re-registration)", framework.WithFlaky(), func(ctx context.Context) {
+			e2eskipper.Skipf("permafailing. Needs a deep dive and possibly a redesign - see issues 128443 and 128895")
+
 			podRECMD := fmt.Sprintf("devs=$(ls /tmp/ | egrep '^Dev-[0-9]+$') && echo stub devices: $devs && sleep %s", sleepIntervalForever)
 			pod1 := e2epod.NewPodClient(f).CreateSync(ctx, makeBusyboxPod(SampleDeviceResourceName, podRECMD))
 			deviceIDRE := "stub devices: (Dev-[0-9]+)"


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:
Skip permafailing and possibly now obsolete device manager test until there's time to deep dive into it, to reduce the pressure and the noise in the 1.32 stabilization cycle.

#### Which issue(s) this PR fixes:
Fixes N/A (see notes)

#### Special notes for your reviewer:
Please see k/k issue #128443 for more context. This is a skip and investigation is ongoing. I can't claim this PR fixes anything.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
