### PR TITLE
Revert "[FG:InPlacePodVerticalScaling] Graduate to Beta"

### DIFF
--- a/pkg/apis/core/fuzzer/fuzzer.go
+++ b/pkg/apis/core/fuzzer/fuzzer.go
@@ -309,23 +309,6 @@ var Funcs = func(codecs runtimeserializer.CodecFactory) []interface{} {
 			c.FuzzNoCustom(ct)                                          // fuzz self without calling this function again
 			ct.TerminationMessagePath = "/" + ct.TerminationMessagePath // Must be non-empty
 			ct.TerminationMessagePolicy = "File"
-			// Match defaulting in pkg/apis/core/v1/defaults.go.
-			_, hasCPUReq := ct.Resources.Requests[core.ResourceCPU]
-			_, hasCPULim := ct.Resources.Limits[core.ResourceCPU]
-			_, hasMemReq := ct.Resources.Requests[core.ResourceMemory]
-			_, hasMemLim := ct.Resources.Limits[core.ResourceMemory]
-			if hasCPUReq || hasCPULim {
-				ct.ResizePolicy = append(ct.ResizePolicy, core.ContainerResizePolicy{
-					ResourceName:  core.ResourceCPU,
-					RestartPolicy: core.NotRequired,
-				})
-			}
-			if hasMemReq || hasMemLim {
-				ct.ResizePolicy = append(ct.ResizePolicy, core.ContainerResizePolicy{
-					ResourceName:  core.ResourceMemory,
-					RestartPolicy: core.NotRequired,
-				})
-			}
 		},
 		func(ep *core.EphemeralContainer, c fuzz.Continue) {
 			c.FuzzNoCustom(ep)                                                                   // fuzz self without calling this function again

--- a/pkg/features/versioned_kube_features.go
+++ b/pkg/features/versioned_kube_features.go
@@ -404,7 +404,6 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 
 	InPlacePodVerticalScaling: {
 		{Version: version.MustParse("1.27"), Default: false, PreRelease: featuregate.Alpha},
-		{Version: version.MustParse("1.32"), Default: true, PreRelease: featuregate.Beta},
 	},
 
 	InPlacePodVerticalScalingAllocatedStatus: {

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -1264,11 +1264,6 @@ func verifyActions(t *testing.T, expected, actual *podActions, desc string) {
 			actual.ContainersToKill[k] = info
 		}
 	}
-
-	if expected.ContainersToUpdate == nil && actual.ContainersToUpdate != nil {
-		// No need to distinguish empty and nil maps for the test.
-		expected.ContainersToUpdate = map[v1.ResourceName][]containerToUpdateInfo{}
-	}
 	assert.Equal(t, expected, actual, desc)
 }
 

--- a/pkg/kubelet/status/status_manager.go
+++ b/pkg/kubelet/status/status_manager.go
@@ -179,7 +179,6 @@ func NewManager(kubeClient clientset.Interface, podManager PodManager, podDeleti
 		podDeletionSafety:       podDeletionSafety,
 		podStartupLatencyHelper: podStartupLatencyHelper,
 		stateFileDirectory:      stateFileDirectory,
-		state:                   state.NewNoopStateCheckpoint(),
 	}
 }
 
@@ -203,6 +202,9 @@ func isPodStatusByKubeletEqual(oldStatus, status *v1.PodStatus) bool {
 }
 
 func (m *manager) Start() {
+	// Initialize m.state to no-op state checkpoint manager
+	m.state = state.NewNoopStateCheckpoint()
+
 	// Create pod allocation checkpoint manager even if client is nil so as to allow local get/set of AllocatedResources & Resize
 	if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {
 		stateImpl, err := state.NewStateCheckpoint(m.stateFileDirectory, podStatusManagerStateFile)

--- a/test/e2e/common/node/pod_resize.go
+++ b/test/e2e/common/node/pod_resize.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/kubernetes/test/e2e/feature"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
@@ -1173,7 +1174,7 @@ func doPodResizeErrorTests(f *framework.Framework) {
 //       Above tests are performed by doSheduletTests() and doPodResizeResourceQuotaTests()
 //       in test/e2e/node/pod_resize.go
 
-var _ = SIGDescribe("Pod InPlace Resize Container", framework.WithSerial(), func() {
+var _ = SIGDescribe("Pod InPlace Resize Container", framework.WithSerial(), feature.InPlacePodVerticalScaling, "[NodeAlphaFeature:InPlacePodVerticalScaling]", func() {
 	f := framework.NewDefaultFramework("pod-resize-tests")
 
 	ginkgo.BeforeEach(func(ctx context.Context) {

--- a/test/e2e/feature/feature.go
+++ b/test/e2e/feature/feature.go
@@ -186,6 +186,9 @@ var (
 	// Ingress.networking.k8s.io to be present.
 	Ingress = framework.WithFeature(framework.ValidFeatures.Add("Ingress"))
 
+	// TODO: document the feature (owning SIG, when to use this feature for a test)
+	InPlacePodVerticalScaling = framework.WithFeature(framework.ValidFeatures.Add("InPlacePodVerticalScaling"))
+
 	// Owner: sig-network
 	// Marks tests that require a cluster with dual-stack pod and service networks.
 	IPv6DualStack = framework.WithFeature(framework.ValidFeatures.Add("IPv6DualStack"))

--- a/test/e2e/node/pod_resize.go
+++ b/test/e2e/node/pod_resize.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	resourceapi "k8s.io/kubernetes/pkg/api/v1/resource"
+	"k8s.io/kubernetes/test/e2e/feature"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
@@ -355,7 +356,7 @@ func doPodResizeSchedulerTests(f *framework.Framework) {
 	})
 }
 
-var _ = SIGDescribe(framework.WithSerial(), "Pod InPlace Resize Container (scheduler-focused)", func() {
+var _ = SIGDescribe(framework.WithSerial(), "Pod InPlace Resize Container (scheduler-focused)", feature.InPlacePodVerticalScaling, func() {
 	f := framework.NewDefaultFramework("pod-resize-scheduler-tests")
 	ginkgo.BeforeEach(func(ctx context.Context) {
 		node, err := e2enode.GetRandomReadySchedulableNode(ctx, f.ClientSet)
@@ -367,7 +368,7 @@ var _ = SIGDescribe(framework.WithSerial(), "Pod InPlace Resize Container (sched
 	doPodResizeSchedulerTests(f)
 })
 
-var _ = SIGDescribe("Pod InPlace Resize Container", func() {
+var _ = SIGDescribe("Pod InPlace Resize Container", feature.InPlacePodVerticalScaling, func() {
 	f := framework.NewDefaultFramework("pod-resize-tests")
 
 	ginkgo.BeforeEach(func(ctx context.Context) {

--- a/test/featuregates_linter/test_data/versioned_feature_list.yaml
+++ b/test/featuregates_linter/test_data/versioned_feature_list.yaml
@@ -540,10 +540,6 @@
     lockToDefault: false
     preRelease: Alpha
     version: "1.27"
-  - default: true
-    lockToDefault: false
-    preRelease: Beta
-    version: "1.32"
 - name: InPlacePodVerticalScalingAllocatedStatus
   versionedSpecs:
   - default: false


### PR DESCRIPTION
Reverts kubernetes/kubernetes#128682

https://storage.googleapis.com/k8s-triage/index.html?test=%5C%5Bsig-node%5C%5D.*Serial

<img width="909" alt="image" src="https://github.com/user-attachments/assets/aef8273a-6876-46e3-b4df-ab661b703939">


Fixes #128783  #128874

```release-note
None
```
