### PR TITLE
testing: skip test if cri proxy is disabled/undefined

### DIFF
--- a/test/e2e_node/container_restart_test.go
+++ b/test/e2e_node/container_restart_test.go
@@ -53,11 +53,9 @@ var _ = SIGDescribe("Container Restart", feature.CriProxy, framework.WithSerial(
 			if err := resetCRIProxyInjector(e2eCriProxy); err != nil {
 				ginkgo.Skip("Skip the test since the CRI Proxy is undefined.")
 			}
-		})
-
-		ginkgo.AfterEach(func() {
-			err := resetCRIProxyInjector(e2eCriProxy)
-			framework.ExpectNoError(err)
+			ginkgo.DeferCleanup(func() error {
+				return resetCRIProxyInjector(e2eCriProxy)
+			})
 		})
 
 		ginkgo.It("Container restart backs off.", func(ctx context.Context) {
@@ -77,11 +75,9 @@ var _ = SIGDescribe("Container Restart", feature.CriProxy, framework.WithSerial(
 			if err := resetCRIProxyInjector(e2eCriProxy); err != nil {
 				ginkgo.Skip("Skip the test since the CRI Proxy is undefined.")
 			}
-		})
-
-		ginkgo.AfterEach(func() {
-			err := resetCRIProxyInjector(e2eCriProxy)
-			framework.ExpectNoError(err)
+			ginkgo.DeferCleanup(func() error {
+				return resetCRIProxyInjector(e2eCriProxy)
+			})
 		})
 
 		ginkgo.It("Alternate restart backs off.", func(ctx context.Context) {

--- a/test/e2e_node/criproxy_test.go
+++ b/test/e2e_node/criproxy_test.go
@@ -51,11 +51,9 @@ var _ = SIGDescribe(feature.CriProxy, framework.WithSerial(), func() {
 			if err := resetCRIProxyInjector(e2eCriProxy); err != nil {
 				ginkgo.Skip("Skip the test since the CRI Proxy is undefined.")
 			}
-		})
-
-		ginkgo.AfterEach(func() {
-			err := resetCRIProxyInjector(e2eCriProxy)
-			framework.ExpectNoError(err)
+			ginkgo.DeferCleanup(func() error {
+				return resetCRIProxyInjector(e2eCriProxy)
+			})
 		})
 
 		ginkgo.It("Pod failed to start due to an image pull error.", func(ctx context.Context) {
@@ -89,11 +87,9 @@ var _ = SIGDescribe(feature.CriProxy, framework.WithSerial(), func() {
 			if err := resetCRIProxyInjector(e2eCriProxy); err != nil {
 				ginkgo.Skip("Skip the test since the CRI Proxy is undefined.")
 			}
-		})
-
-		ginkgo.AfterEach(func() {
-			err := resetCRIProxyInjector(e2eCriProxy)
-			framework.ExpectNoError(err)
+			ginkgo.DeferCleanup(func() error {
+				return resetCRIProxyInjector(e2eCriProxy)
+			})
 		})
 
 	})
@@ -103,11 +99,9 @@ var _ = SIGDescribe(feature.CriProxy, framework.WithSerial(), func() {
 			if err := resetCRIProxyInjector(e2eCriProxy); err != nil {
 				ginkgo.Skip("Skip the test since the CRI Proxy is undefined.")
 			}
-		})
-
-		ginkgo.AfterEach(func() {
-			err := resetCRIProxyInjector(e2eCriProxy)
-			framework.ExpectNoError(err)
+			ginkgo.DeferCleanup(func() error {
+				return resetCRIProxyInjector(e2eCriProxy)
+			})
 		})
 
 		ginkgo.It("Image pull time exceeded 10 seconds", func(ctx context.Context) {

--- a/test/e2e_node/image_pull_test.go
+++ b/test/e2e_node/image_pull_test.go
@@ -63,19 +63,11 @@ var _ = SIGDescribe("Pull Image", feature.CriProxy, framework.WithSerial(), func
 			if err := resetCRIProxyInjector(e2eCriProxy); err != nil {
 				ginkgo.Skip("Skip the test since the CRI Proxy is undefined.")
 			}
-
+			ginkgo.DeferCleanup(func() error {
+				return resetCRIProxyInjector(e2eCriProxy)
+			})
 			testpods = prepareAndCleanup(ctx, f)
 			gomega.Expect(len(testpods)).To(gomega.BeNumerically("<=", 5))
-		})
-
-		ginkgo.AfterEach(func(ctx context.Context) {
-			err := resetCRIProxyInjector(e2eCriProxy)
-			framework.ExpectNoError(err)
-
-			ginkgo.By("cleanup pods")
-			for _, pod := range testpods {
-				deletePodSyncByName(ctx, f, pod.Name)
-			}
 		})
 
 		ginkgo.It("should pull immediately if no more than 5 pods", func(ctx context.Context) {
@@ -107,7 +99,8 @@ var _ = SIGDescribe("Pull Image", feature.CriProxy, framework.WithSerial(), func
 			framework.ExpectNoError(err)
 
 			for _, testpod := range testpods {
-				_ = e2epod.NewPodClient(f).Create(ctx, testpod)
+				pod := e2epod.NewPodClient(f).Create(ctx, testpod)
+				ginkgo.DeferCleanup(deletePodSyncByName, f, pod.Name)
 			}
 
 			imagePulled, podStartTime, podEndTime, err := getPodImagePullDurations(ctx, f, testpods)
@@ -146,19 +139,11 @@ var _ = SIGDescribe("Pull Image", feature.CriProxy, framework.WithSerial(), func
 			if err := resetCRIProxyInjector(e2eCriProxy); err != nil {
 				ginkgo.Skip("Skip the test since the CRI Proxy is undefined.")
 			}
-
+			ginkgo.DeferCleanup(func() error {
+				return resetCRIProxyInjector(e2eCriProxy)
+			})
 			testpods = prepareAndCleanup(ctx, f)
 			gomega.Expect(len(testpods)).To(gomega.BeNumerically("<=", 5))
-		})
-
-		ginkgo.AfterEach(func(ctx context.Context) {
-			err := resetCRIProxyInjector(e2eCriProxy)
-			framework.ExpectNoError(err)
-
-			ginkgo.By("cleanup pods")
-			for _, pod := range testpods {
-				deletePodSyncByName(ctx, f, pod.Name)
-			}
 		})
 
 		ginkgo.It("should be waiting more", func(ctx context.Context) {
@@ -197,7 +182,9 @@ var _ = SIGDescribe("Pull Image", feature.CriProxy, framework.WithSerial(), func
 
 			var pods []*v1.Pod
 			for _, testpod := range testpods {
-				pods = append(pods, e2epod.NewPodClient(f).Create(ctx, testpod))
+				pod := e2epod.NewPodClient(f).Create(ctx, testpod)
+				ginkgo.DeferCleanup(deletePodSyncByName, f, pod.Name)
+				pods = append(pods, pod)
 			}
 			for _, pod := range pods {
 				err := e2epod.WaitForPodCondition(ctx, f.ClientSet, f.Namespace.Name, pod.Name, "Running", 2*time.Minute, func(pod *v1.Pod) (bool, error) {


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:

Printouts reporting failures to reset injector because the CRI Proxy is undefined , seems do not appear in [triage](https://storage.googleapis.com/k8s-triage/index.html?text=CRI%20Proxy%20is%20undefined) however logs seen [here](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/128880/pull-kubernetes-node-kubelet-serial-containerd/1859223507045453825#1:build-log.txt%3A2392)

#### Which issue(s) this PR fixes:

Relates to #128835

#### Special notes for your reviewer:

Following same approach as followed [here](https://github.com/kubernetes/kubernetes/pull/128851)

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
