### PR TITLE
[WIP] Add integration test showing possible ResourceQuota race

### DIFF
--- a/hack/make-rules/test-integration.sh
+++ b/hack/make-rules/test-integration.sh
@@ -43,7 +43,7 @@ fi
 # Give integration tests longer to run by default.
 KUBE_TIMEOUT=${KUBE_TIMEOUT:--timeout=600s}
 LOG_LEVEL=${LOG_LEVEL:-2}
-KUBE_TEST_ARGS=${KUBE_TEST_ARGS:-}
+KUBE_TEST_ARGS="-run TestQuotaLimitResourceClaim"
 # Default glog module settings.
 KUBE_TEST_VMODULE=${KUBE_TEST_VMODULE:-""}
 
@@ -92,7 +92,7 @@ runTests() {
   # empty here to ensure that we aren't unintentionally consuming them from the
   # previous make invocation.
   KUBE_TEST_ARGS="${SHORT:--short=true} --vmodule=${KUBE_TEST_VMODULE} ${KUBE_TEST_ARGS}" \
-      WHAT="${WHAT:-$(kube::test::find_integration_test_pkgs | paste -sd' ' -)}" \
+      WHAT="./test/integration/quota" \
       GOFLAGS="${GOFLAGS:-}" \
       KUBE_TIMEOUT="${KUBE_TIMEOUT}" \
       KUBE_RACE="" \

--- a/pkg/controller/resourcequota/resource_quota_controller.go
+++ b/pkg/controller/resourcequota/resource_quota_controller.go
@@ -392,6 +392,7 @@ func (rq *Controller) syncResourceQuota(ctx context.Context, resourceQuota *v1.R
 
 	// there was a change observed by this controller that requires we update quota
 	if dirty {
+		klog.Infof("updating used quota from %+v to %+v", resourceQuota.Status.Used, usage.Status.Used)
 		_, err = rq.rqClient.ResourceQuotas(usage.Namespace).UpdateStatus(ctx, usage, metav1.UpdateOptions{})
 		if err != nil {
 			errs = append(errs, err)

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/resourcequota/controller.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/resourcequota/controller.go
@@ -196,6 +196,10 @@ func (e *quotaEvaluator) checkAttributes(ns string, admissionAttributes []*admis
 		}
 		return
 	}
+	klog.Infof("checking usage against %d quotas", len(quotas))
+	for _, q := range quotas {
+		klog.Infof("checking usage against quota %+v", q)
+	}
 	// if limited resources are disabled, we can just return safely when there are no quotas.
 	limitedResourcesDisabled := len(e.config.LimitedResources) == 0
 	if len(quotas) == 0 && limitedResourcesDisabled {

--- a/test/integration/quota/quota_test.go
+++ b/test/integration/quota/quota_test.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"sync"
 	"testing"
 	"time"
 
@@ -176,7 +175,7 @@ func waitForQuota(t *testing.T, quota *v1.ResourceQuota, clientset *clientset.Cl
 
 // waitForUsedResourceQuota polls a ResourceQuota status for an expected used value
 func waitForUsedResourceQuota(t *testing.T, c clientset.Interface, ns, quotaName string, used v1.ResourceList) {
-	err := wait.Poll(1*time.Second, resourceQuotaTimeout, func() (bool, error) {
+	err := wait.Poll(100*time.Millisecond, resourceQuotaTimeout, func() (bool, error) {
 		resourceQuota, err := c.CoreV1().ResourceQuotas(ns).Get(context.TODO(), quotaName, metav1.GetOptions{})
 		if err != nil {
 			return false, err
@@ -631,6 +630,7 @@ func TestQuotaLimitResourceClaim(t *testing.T) {
 		InformersStarted:          informersStarted,
 		Registry:                  generic.NewRegistry(qc.Evaluators()),
 	}
+	t.Logf("resource quota controller's Store is: %p", resourceQuotaControllerOptions.ResourceQuotaInformer.Informer().GetStore())
 	resourceQuotaController, err := resourcequotacontroller.NewController(tCtx, resourceQuotaControllerOptions)
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
@@ -643,71 +643,42 @@ func TestQuotaLimitResourceClaim(t *testing.T) {
 	informers.Start(tCtx.Done())
 	close(informersStarted)
 
-	wg := new(sync.WaitGroup)
-	namespaces := 800
-	for range namespaces {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	ns := framework.CreateNamespaceOrDie(clientset, "quota", t)
+	defer framework.DeleteNamespaceOrDie(clientset, ns, t)
 
-			ns, err := clientset.CoreV1().Namespaces().Create(tCtx, &v1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "quota-"}}, metav1.CreateOptions{})
-			if err != nil {
-				t.Errorf("Failed to create namespace: %v", err)
-				return
-			}
-			// t.Logf("created namespace %s", ns.Name)
-			defer func() {
-				err := clientset.CoreV1().Namespaces().Delete(tCtx, ns.Name, metav1.DeleteOptions{})
-				if err != nil {
-					t.Errorf("Failed to delete namespace %s: %v", ns.Name, err)
-				}
-			}()
-
-			// Creating the first resource claim should succeed
-			resourceClaim := newResourceClaim("claim-0")
-			_, err = clientset.ResourceV1beta1().ResourceClaims(ns.Name).Create(tCtx, resourceClaim, metav1.CreateOptions{})
-			if err != nil {
-				t.Errorf("creating first ResourceClaim in namespace %s should not have returned error: %v", ns.Name, err)
-				return
-			}
-
-			// now create a covering quota
-			quota := &v1.ResourceQuota{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "quota",
-					Namespace: ns.Name,
-				},
-				Spec: v1.ResourceQuotaSpec{
-					Hard: v1.ResourceList{
-						"count/resourceclaims.resource.k8s.io": resource.MustParse("1"),
-					},
-				},
-			}
-
-			if err := waitForQuotaErr(quota, clientset); err != nil {
-				t.Error(err)
-				return
-			}
-
-			// wait for ResourceQuota status to be updated before proceeding, otherwise the test will race with resource quota controller
-			expectedQuotaUsed := v1.ResourceList{
-				"count/resourceclaims.resource.k8s.io": resource.MustParse("1"),
-			}
-			if err := waitForUsedResourceQuotaErr(t, clientset, quota.Namespace, quota.Name, expectedQuotaUsed); err != nil {
-				t.Error(err)
-				return
-			}
-
-			// Creating another ResourceClaim using node ports should fail because node prot quota is exceeded
-			resourceClaim2 := newResourceClaim("claim-1")
-			if err := testResourceClaimForbidden(clientset, ns.Name, resourceClaim2); err != nil {
-				t.Error(err)
-				return
-			}
-		}()
+	// Creating the first resource claim should succeed
+	resourceClaim := newResourceClaim("claim-0")
+	t.Logf("Creating ResourceClaim %s", resourceClaim.Name)
+	_, err = clientset.ResourceV1beta1().ResourceClaims(ns.Name).Create(tCtx, resourceClaim, metav1.CreateOptions{})
+	if err != nil {
+		t.Errorf("creating first ResourceClaim in namespace %s should not have returned error: %v", ns.Name, err)
+		return
 	}
 
-	wg.Wait()
+	// now create a covering quota
+	quota := &v1.ResourceQuota{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "quota",
+			Namespace: ns.Name,
+		},
+		Spec: v1.ResourceQuotaSpec{
+			Hard: v1.ResourceList{
+				"count/resourceclaims.resource.k8s.io": resource.MustParse("1"),
+			},
+		},
+	}
+	waitForQuota(t, quota, clientset)
+
+	// wait for ResourceQuota status to be updated before proceeding, otherwise the test will race with resource quota controller
+	expectedQuotaUsed := v1.ResourceList{
+		"count/resourceclaims.resource.k8s.io": resource.MustParse("1"),
+	}
+	waitForUsedResourceQuota(t, clientset, quota.Namespace, quota.Name, expectedQuotaUsed)
+
+	// Creating another ResourceClaim using node ports should fail because node prot quota is exceeded
+	resourceClaim2 := resourceClaim.DeepCopy()
+	resourceClaim2.Name = "claim-1"
+	testResourceClaimForbidden(t, clientset, ns.Name, resourceClaim2)
 }
 
 func newResourceClaim(name string) *resourceapi.ResourceClaim {
@@ -719,81 +690,17 @@ func newResourceClaim(name string) *resourceapi.ResourceClaim {
 }
 
 // testResourceClaimForbidden attempts to create a ResourceClaim expecting 403 Forbidden due to resource quota limits being exceeded.
-func testResourceClaimForbidden(clientset clientset.Interface, namespace string, resourceClaim *resourceapi.ResourceClaim) error {
+func testResourceClaimForbidden(t *testing.T, clientset clientset.Interface, namespace string, resourceClaim *resourceapi.ResourceClaim) {
+	t.Logf("Creating ResourceClaim %s", resourceClaim.Name)
 	_, err := clientset.ResourceV1beta1().ResourceClaims(namespace).Create(context.TODO(), resourceClaim, metav1.CreateOptions{})
 	if apierrors.IsForbidden(err) {
-		return nil
+		return
 	}
 
 	if err == nil {
-		return fmt.Errorf("creating ResourceClaim should have returned error but got nil in namespace %s", namespace)
+		t.Errorf("creating ResourceClaim should have returned error but got nil in namespace %s", namespace)
+		return
 	}
 
-	return fmt.Errorf("creating ResourceClaim in namespace %s should return Forbidden due to resource quota limits but got: %v", namespace, err)
-}
-
-func waitForQuotaErr(quota *v1.ResourceQuota, clientset *clientset.Clientset) error {
-	w, err := clientset.CoreV1().ResourceQuotas(quota.Namespace).Watch(context.TODO(), metav1.SingleObject(metav1.ObjectMeta{Name: quota.Name}))
-	if err != nil {
-		return fmt.Errorf("failed to watch ResourceQuota %s/%s: %w", quota.Namespace, quota.Name, err)
-	}
-
-	if _, err := clientset.CoreV1().ResourceQuotas(quota.Namespace).Create(context.TODO(), quota, metav1.CreateOptions{}); err != nil {
-		return fmt.Errorf("failed to watch ResourceQuota %s/%s: %w", quota.Namespace, quota.Name, err)
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
-	defer cancel()
-	_, err = watchtools.UntilWithoutRetry(ctx, w, func(event watch.Event) (bool, error) {
-		switch event.Type {
-		case watch.Modified:
-		default:
-			return false, nil
-		}
-		switch cast := event.Object.(type) {
-		case *v1.ResourceQuota:
-			if len(cast.Status.Hard) > 0 {
-				return true, nil
-			}
-		}
-
-		return false, nil
-	})
-	if err != nil {
-		return fmt.Errorf("failed to watch ResourceQuota %s/%s: %w", quota.Namespace, quota.Name, err)
-	}
-	return nil
-}
-
-func waitForUsedResourceQuotaErr(t *testing.T, c clientset.Interface, ns, quotaName string, used v1.ResourceList) error {
-	err := wait.Poll(1*time.Second, resourceQuotaTimeout, func() (bool, error) {
-		resourceQuota, err := c.CoreV1().ResourceQuotas(ns).Get(context.TODO(), quotaName, metav1.GetOptions{})
-		if err != nil {
-			return false, err
-		}
-
-		// used may not yet be calculated
-		if resourceQuota.Status.Used == nil {
-			return false, nil
-		}
-
-		// verify that the quota shows the expected used resource values
-		for k, v := range used {
-			actualValue, found := resourceQuota.Status.Used[k]
-			if !found {
-				t.Logf("resource %s was not found in ResourceQuota status", k)
-				return false, nil
-			}
-
-			if !actualValue.Equal(v) {
-				t.Logf("resource %s, expected %s, actual %s", k, v.String(), actualValue.String())
-				return false, nil
-			}
-		}
-		return true, nil
-	})
-	if err != nil {
-		return fmt.Errorf("error waiting or ResourceQuota status: %v", err)
-	}
-	return nil
+	t.Errorf("creating ResourceClaim in namespace %s should return Forbidden due to resource quota limits but got: %v", namespace, err)
 }

--- a/test/integration/quota/quota_test.go
+++ b/test/integration/quota/quota_test.go
@@ -652,13 +652,14 @@ func TestQuotaLimitResourceClaim(t *testing.T) {
 			defer wg.Done()
 
 			ns := framework.CreateNamespaceOrDie(clientset, "quota-"+utilrand.String(5), t)
+			t.Logf("created namespace %s", ns.Name)
 			defer framework.DeleteNamespaceOrDie(clientset, ns, t)
 
 			// Creating the first resource claim should succeed
 			resourceClaim := newResourceClaim("claim-0")
-			_, err = clientset.ResourceV1beta1().ResourceClaims(ns.Name).Create(tCtx, resourceClaim, metav1.CreateOptions{})
+			_, err := clientset.ResourceV1beta1().ResourceClaims(ns.Name).Create(tCtx, resourceClaim, metav1.CreateOptions{})
 			if err != nil {
-				t.Errorf("creating first ResourceClaim should not have returned error: %v", err)
+				t.Errorf("creating first ResourceClaim in namespace %s should not have returned error: %v", ns.Name, err)
 			}
 
 			// now create a covering quota
@@ -703,13 +704,14 @@ func newResourceClaim(name string) *resourceapi.ResourceClaim {
 func testResourceClaimForbidden(clientset clientset.Interface, namespace string, resourceClaim *resourceapi.ResourceClaim, t *testing.T) {
 	_, err := clientset.ResourceV1beta1().ResourceClaims(namespace).Create(context.TODO(), resourceClaim, metav1.CreateOptions{})
 	if apierrors.IsForbidden(err) {
+		t.Logf("namespace %s OK", namespace)
 		return
 	}
 
 	if err == nil {
-		t.Error("creating ResourceClaim should have returned error but got nil")
+		t.Errorf("creating ResourceClaim should have returned error but got nil in namespace %s", namespace)
 		return
 	}
 
-	t.Errorf("creating ResourceClaim should return Forbidden due to resource quota limits but got: %v", err)
+	t.Errorf("creating ResourceClaim in namespace %s should return Forbidden due to resource quota limits but got: %v", namespace, err)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind flake

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR adds a (failing) integration test that reliably triggers the bug causing the e2e flake described by #128410. I intend to iterate on a fix for the issue in this PR as I continue to dig into why this is failing.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
