### PR TITLE
fix flaky behavior due to the test ordering between DynamicProvisioner and Retroactive StorageClass Assignment

### DIFF
--- a/test/e2e/storage/pvc_storageclass.go
+++ b/test/e2e/storage/pvc_storageclass.go
@@ -56,14 +56,14 @@ var _ = utils.SIGDescribe("Retroactive StorageClass Assignment", func() {
 		ginkgo.DeferCleanup(func(cleanupContext context.Context) {
 			// Restore existing default StorageClasses at the end of the test
 			for _, sc := range defaultSCs {
-				setStorageClassDefault(cleanupContext, client, sc.Name, "true")
+				updateDefaultStorageClass(cleanupContext, client, sc.Name, "true")
 			}
 		})
 
 		// Unset all default StorageClasses
 		for _, sc := range defaultSCs {
 			klog.InfoS("Unsetting default StorageClass", "StorageClass", sc.Name)
-			setStorageClassDefault(ctx, client, sc.Name, "false")
+			updateDefaultStorageClass(ctx, client, sc.Name, "false")
 		}
 
 		// Ensure no default StorageClasses exist
@@ -106,19 +106,6 @@ func getDefaultStorageClasses(ctx context.Context, client clientset.Interface) (
 		}
 	}
 	return defaultSCs, nil
-}
-
-func setStorageClassDefault(ctx context.Context, client clientset.Interface, scName string, isDefault string) {
-	sc, err := client.StorageV1().StorageClasses().Get(ctx, scName, metav1.GetOptions{})
-	framework.ExpectNoError(err, "Error getting StorageClass")
-
-	if sc.Annotations == nil {
-		sc.Annotations = make(map[string]string)
-	}
-	sc.Annotations[storageutil.IsDefaultStorageClassAnnotation] = isDefault
-
-	_, err = client.StorageV1().StorageClasses().Update(ctx, sc, metav1.UpdateOptions{})
-	framework.ExpectNoError(err, "Error updating StorageClass")
 }
 
 func ensureNoDefaultStorageClasses(ctx context.Context, client clientset.Interface) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind flake

https://storage.googleapis.com/k8s-triage/index.html?test=Retroactive%20StorageClass%20Assignment%20should%20assign%20default%20StorageClass%20to%20PVCs%20retroactively

![image](https://github.com/user-attachments/assets/80436c52-b819-492c-8d83-3f09afdbe85e)


#### What this PR does / why we need it:

See https://github.com/kubernetes/kubernetes/issues/128849#issuecomment-2490062732 



Test 1: `DynamicProvisioner`

```go
ginkgo.DeferCleanup(updateDefaultStorageClass, c, scName, "true")
updateDefaultStorageClass(ctx, c, scName, "false")
```

Test 2: `Retroactive StorageClass Assignment`

```go
ginkgo.DeferCleanup(func(cleanupContext context.Context) {
	// Restore existing default StorageClasses at the end of the test
	for _, sc := range defaultSCs {
		setStorageClassDefault(cleanupContext, client, sc.Name, "true")
	}
})

// Unset all default StorageClasses
for _, sc := range defaultSCs {
	klog.InfoS("Unsetting default StorageClass", "StorageClass", sc.Name)
	setStorageClassDefault(ctx, client, sc.Name, "false")
}
```

The `updateDefaultStorageClass` function sets `storageclass.beta.kubernetes.io/is-default-class` and `storageclass.kubernetes.io/is-default-class` annotations on the StorageClass. but the `setStorageClassDefault` function only sets `storageclass.kubernetes.io/is-default-class` annotation. Even though `storageclass.beta.kubernetes.io/is-default-class` is deprecated, it is still working in the cluster. so there is a flaky test failure in the `Retroactive StorageClass Assignment` test when it is excuted after `DynamicProvisioner` test.

In order to fix this issue, we need to replace the `setStorageClassDefault` function with `updateDefaultStorageClass` function in the `Retroactive StorageClass Assignment` test.




#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #128849

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
