### PR TITLE
Use generic sets rather than deprecated sets.String

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/printers/jsonpath_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/printers/jsonpath_test.go
@@ -46,7 +46,7 @@ func TestPrinters(t *testing.T) {
 	}
 
 	// Set of strings representing objects that should produce an error.
-	expectedErrors := sets.NewString("emptyPodList", "nonEmptyPodList", "endpoints")
+	expectedErrors := sets.New[string]("emptyPodList", "nonEmptyPodList", "endpoints")
 
 	for oName, obj := range objects {
 		b := &bytes.Buffer{}

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/builder.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/builder.go
@@ -1198,7 +1198,7 @@ func (b *Builder) Do() *Result {
 // strings in the original order.
 func SplitResourceArgument(arg string) []string {
 	out := []string{}
-	set := sets.NewString()
+	set := sets.New[string]()
 	for _, s := range strings.Split(arg, ",") {
 		if set.Has(s) {
 			continue

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/result.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/result.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -144,7 +144,7 @@ func (r *Result) Object() (runtime.Object, error) {
 		return nil, err
 	}
 
-	versions := sets.String{}
+	versions := sets.New[string]()
 	objects := []runtime.Object{}
 	for _, info := range infos {
 		if info.Object != nil {
@@ -165,7 +165,7 @@ func (r *Result) Object() (runtime.Object, error) {
 
 	version := ""
 	if len(versions) == 1 {
-		version = versions.List()[0]
+		version = versions.UnsortedList()[0]
 	}
 
 	return toV1List(objects, version), err

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apiresources/apiresources.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apiresources/apiresources.go
@@ -123,11 +123,11 @@ func NewCmdAPIResources(restClientGetter genericclioptions.RESTClientGetter, ioS
 
 // Validate checks to the APIResourceOptions to see if there is sufficient information run the command
 func (o *APIResourceOptions) Validate() error {
-	supportedOutputTypes := sets.NewString("", "wide", "name")
+	supportedOutputTypes := sets.New[string]("", "wide", "name")
 	if !supportedOutputTypes.Has(o.Output) {
 		return fmt.Errorf("--output %v is not available", o.Output)
 	}
-	supportedSortTypes := sets.NewString("", "name", "kind")
+	supportedSortTypes := sets.New[string]("", "name", "kind")
 	if len(o.SortBy) > 0 {
 		if !supportedSortTypes.Has(o.SortBy) {
 			return fmt.Errorf("--sort-by accepts only name or kind")
@@ -193,11 +193,11 @@ func (o *APIResourceOptions) RunAPIResources() error {
 				continue
 			}
 			// filter to resources that support the specified verbs
-			if len(o.Verbs) > 0 && !sets.NewString(resource.Verbs...).HasAll(o.Verbs...) {
+			if len(o.Verbs) > 0 && !sets.New[string](resource.Verbs...).HasAll(o.Verbs...) {
 				continue
 			}
 			// filter to resources that belong to the specified categories
-			if len(o.Categories) > 0 && !sets.NewString(resource.Categories...).HasAll(o.Categories...) {
+			if len(o.Categories) > 0 && !sets.New[string](resource.Categories...).HasAll(o.Categories...) {
 				continue
 			}
 			resources = append(resources, groupResource{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/auth/cani.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/auth/cani.go
@@ -105,10 +105,10 @@ var (
 		# List all allowed actions in namespace "foo"
 		kubectl auth can-i --list --namespace=foo`)
 
-	resourceVerbs       = sets.NewString("get", "list", "watch", "create", "update", "patch", "delete", "deletecollection", "use", "bind", "impersonate", "*", "approve", "sign", "escalate", "attest")
-	nonResourceURLVerbs = sets.NewString("get", "put", "post", "head", "options", "delete", "patch", "*")
+	resourceVerbs       = sets.New[string]("get", "list", "watch", "create", "update", "patch", "delete", "deletecollection", "use", "bind", "impersonate", "*", "approve", "sign", "escalate", "attest")
+	nonResourceURLVerbs = sets.New[string]("get", "put", "post", "head", "options", "delete", "patch", "*")
 	// holds all the server-supported resources that cannot be discovered by clients. i.e. users and groups for the impersonate verb
-	nonStandardResourceNames = sets.NewString("users", "groups")
+	nonStandardResourceNames = sets.New[string]("users", "groups")
 )
 
 // NewCmdCanI returns an initialized Command for 'auth can-i' sub command

--- a/staging/src/k8s.io/kubectl/pkg/cmd/auth/whoami.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/auth/whoami.go
@@ -250,7 +250,7 @@ func printTableSelfSubjectAccessReview(obj runtime.Object, out io.Writer) error 
 	}
 
 	if len(ui.Extra) > 0 {
-		for _, k := range sets.StringKeySet(ui.Extra).List() {
+		for _, k := range sets.List(sets.KeySet(ui.Extra)) {
 			v := ui.Extra[k]
 			_, err := fmt.Fprintf(w, "Extra: %s\t%v\n", k, v)
 			if err != nil {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/get_contexts.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/get_contexts.go
@@ -89,7 +89,7 @@ func NewCmdConfigGetContexts(streams genericiooptions.IOStreams, configAccess cl
 
 // Complete assigns GetContextsOptions from the args.
 func (o *GetContextsOptions) Complete(cmd *cobra.Command, args []string) error {
-	supportedOutputTypes := sets.NewString("", "name")
+	supportedOutputTypes := sets.New[string]("", "name")
 	if !supportedOutputTypes.Has(o.outputFormat) {
 		return fmt.Errorf("--output %v is not available in kubectl config get-contexts; resetting to default output format", o.outputFormat)
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/navigation_step_parser.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/navigation_step_parser.go
@@ -55,7 +55,7 @@ func newNavigationSteps(path string) (*navigationSteps, error) {
 			if err != nil {
 				return nil, err
 			}
-			nextPart := findNameStep(individualParts[currPartIndex:], sets.StringKeySet(mapValueOptions))
+			nextPart := findNameStep(individualParts[currPartIndex:], sets.KeySet(mapValueOptions))
 
 			steps = append(steps, navigationStep{nextPart, mapValueType})
 			currPartIndex += len(strings.Split(nextPart, "."))
@@ -98,7 +98,7 @@ func (s *navigationSteps) moreStepsRemaining() bool {
 
 // findNameStep takes the list of parts and a set of valid tags that can be used after the name.  It then walks the list of parts
 // until it find a valid "next" tag or until it reaches the end of the parts and then builds the name back up out of the individual parts
-func findNameStep(parts []string, typeOptions sets.String) string {
+func findNameStep(parts []string, typeOptions sets.Set[string]) string {
 	if len(parts) == 0 {
 		return ""
 	}
@@ -136,7 +136,7 @@ func getPotentialTypeValues(typeValue reflect.Type) (map[string]reflect.Type, er
 	return ret, nil
 }
 
-func findKnownValue(parts []string, valueOptions sets.String) int {
+func findKnownValue(parts []string, valueOptions sets.Set[string]) int {
 	for i := range parts {
 		if valueOptions.Has(parts[i]) {
 			return i

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_role.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_role.go
@@ -425,7 +425,7 @@ func generateResourcePolicyRules(mapper meta.RESTMapper, verbs []string, resourc
 
 	// Create separate rule for each of the api group.
 	rules := []rbacv1.PolicyRule{}
-	for _, g := range sets.StringKeySet(groupResourceMapping).List() {
+	for _, g := range sets.List(sets.KeySet(groupResourceMapping)) {
 		rule := rbacv1.PolicyRule{}
 		rule.Verbs = verbs
 		rule.Resources = groupResourceMapping[g]

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_token.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_token.go
@@ -149,7 +149,7 @@ func NewCmdCreateToken(f cmdutil.Factory, ioStreams genericiooptions.IOStreams) 
 	cmd.Flags().DurationVar(&o.Duration, "duration", o.Duration, "Requested lifetime of the issued token. If not set or if set to 0, the lifetime will be determined by the server automatically. The server may return a token with a longer or shorter lifetime.")
 
 	cmd.Flags().StringVar(&o.BoundObjectKind, "bound-object-kind", o.BoundObjectKind, "Kind of an object to bind the token to. "+
-		"Supported kinds are "+strings.Join(sets.StringKeySet(boundObjectKindToAPIVersions()).List(), ", ")+". "+
+		"Supported kinds are "+strings.Join(sets.List(sets.KeySet(boundObjectKindToAPIVersions())), ", ")+". "+
 		"If set, --bound-object-name must be provided.")
 	cmd.Flags().StringVar(&o.BoundObjectName, "bound-object-name", o.BoundObjectName, "Name of an object to bind the token to. "+
 		"The token will expire when the object is deleted. "+
@@ -227,7 +227,7 @@ func (o *TokenOptions) Validate() error {
 		}
 	} else {
 		if _, ok := boundObjectKindToAPIVersions()[o.BoundObjectKind]; !ok {
-			return fmt.Errorf("supported --bound-object-kind values are %s", strings.Join(sets.StringKeySet(boundObjectKindToAPIVersions()).List(), ", "))
+			return fmt.Errorf("supported --bound-object-kind values are %s", strings.Join(sets.List(sets.KeySet(boundObjectKindToAPIVersions())), ", "))
 		}
 		if len(o.BoundObjectName) == 0 {
 			return fmt.Errorf("--bound-object-name is required if --bound-object-kind is provided")

--- a/staging/src/k8s.io/kubectl/pkg/cmd/describe/describe.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/describe/describe.go
@@ -193,7 +193,7 @@ func (o *DescribeOptions) Run() error {
 		allErrs = append(allErrs, err)
 	}
 
-	errs := sets.NewString()
+	errs := sets.New[string]()
 	first := true
 	for _, info := range infos {
 		mapping := info.ResourceMapping()

--- a/staging/src/k8s.io/kubectl/pkg/cmd/drain/drain.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/drain/drain.go
@@ -326,7 +326,7 @@ func (o *DrainCmdOptions) RunDrain() error {
 		return err
 	}
 
-	drainedNodes := sets.NewString()
+	drainedNodes := sets.New[string]()
 	var fatal []error
 
 	remainingNodes := []string{}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/edit/edit_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/edit/edit_test.go
@@ -172,7 +172,7 @@ func TestEdit(t *testing.T) {
 	t.Setenv("KUBE_EDITOR", "testdata/test_editor.sh")
 	t.Setenv("KUBE_EDITOR_CALLBACK", server.URL+"/callback")
 
-	testcases := sets.NewString()
+	testcases := sets.New[string]()
 	filepath.Walk("testdata", func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
@@ -194,7 +194,7 @@ func TestEdit(t *testing.T) {
 		t.Fatalf("Error locating edit testcases")
 	}
 
-	for _, testcaseName := range testcases.List() {
+	for _, testcaseName := range testcases.UnsortedList() {
 		t.Run(testcaseName, func(t *testing.T) {
 			i = 0
 			name = testcaseName

--- a/staging/src/k8s.io/kubectl/pkg/cmd/events/events.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/events/events.go
@@ -188,7 +188,7 @@ func (flags *EventsFlags) ToOptions() (*EventsOptions, error) {
 	}
 
 	if len(o.FilterTypes) > 0 {
-		o.FilterTypes = sets.NewString(o.FilterTypes...).List()
+		o.FilterTypes = sets.List(sets.New[string](o.FilterTypes...))
 	}
 
 	var printer printers.ResourcePrinter

--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/get.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/get.go
@@ -486,7 +486,7 @@ func (o *GetOptions) Run(f cmdutil.Factory, args []string) error {
 	}
 
 	allErrs := []error{}
-	errs := sets.NewString()
+	errs := sets.New[string]()
 	infos, err := r.Infos()
 	if err != nil {
 		allErrs = append(allErrs, err)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/patch/patch.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/patch/patch.go
@@ -137,7 +137,7 @@ func NewCmdPatch(f cmdutil.Factory, ioStreams genericiooptions.IOStreams) *cobra
 
 	cmd.Flags().StringVarP(&o.Patch, "patch", "p", "", "The patch to be applied to the resource JSON file.")
 	cmd.Flags().StringVar(&o.PatchFile, "patch-file", "", "A file containing a patch to be applied to the resource.")
-	cmd.Flags().StringVar(&o.PatchType, "type", "strategic", fmt.Sprintf("The type of patch being provided; one of %v", sets.StringKeySet(patchTypes).List()))
+	cmd.Flags().StringVar(&o.PatchType, "type", "strategic", fmt.Sprintf("The type of patch being provided; one of %v", sets.List(sets.KeySet(patchTypes))))
 	cmdutil.AddDryRunFlag(cmd)
 	cmdutil.AddFilenameOptionFlags(cmd, &o.FilenameOptions, "identifying the resource to update")
 	cmd.Flags().BoolVar(&o.Local, "local", o.Local, "If true, patch will operate on the content of the file, not the server-side resource.")
@@ -194,7 +194,7 @@ func (o *PatchOptions) Validate() error {
 	}
 	if len(o.PatchType) != 0 {
 		if _, ok := patchTypes[strings.ToLower(o.PatchType)]; !ok {
-			return fmt.Errorf("--type must be one of %v, not %q", sets.StringKeySet(patchTypes).List(), o.PatchType)
+			return fmt.Errorf("--type must be one of %v, not %q", sets.List(sets.KeySet(patchTypes)), o.PatchType)
 		}
 	}
 	return nil

--- a/staging/src/k8s.io/kubectl/pkg/cmd/portforward/portforward.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/portforward/portforward.go
@@ -247,7 +247,7 @@ func convertPodNamedPortToNumber(ports []string, pod corev1.Pod) ([]string, erro
 	return converted, nil
 }
 
-func checkUDPPorts(udpOnlyPorts sets.Int, ports []string, obj metav1.Object) error {
+func checkUDPPorts(udpOnlyPorts sets.Set[int], ports []string, obj metav1.Object) error {
 	for _, port := range ports {
 		_, remotePort := splitPort(port)
 		portNum, err := strconv.Atoi(remotePort)
@@ -281,8 +281,8 @@ func checkUDPPorts(udpOnlyPorts sets.Int, ports []string, obj metav1.Object) err
 // checkUDPPortInService returns an error if remote port in Service is a UDP port
 // TODO: remove this check after #47862 is solved
 func checkUDPPortInService(ports []string, svc *corev1.Service) error {
-	udpPorts := sets.NewInt()
-	tcpPorts := sets.NewInt()
+	udpPorts := sets.New[int]()
+	tcpPorts := sets.New[int]()
 	for _, port := range svc.Spec.Ports {
 		portNum := int(port.Port)
 		switch port.Protocol {
@@ -298,8 +298,8 @@ func checkUDPPortInService(ports []string, svc *corev1.Service) error {
 // checkUDPPortInPod returns an error if remote port in Pod is a UDP port
 // TODO: remove this check after #47862 is solved
 func checkUDPPortInPod(ports []string, pod *corev1.Pod) error {
-	udpPorts := sets.NewInt()
-	tcpPorts := sets.NewInt()
+	udpPorts := sets.New[int]()
+	tcpPorts := sets.New[int]()
 	for _, ct := range pod.Spec.Containers {
 		for _, ctPort := range ct.Ports {
 			portNum := int(ctPort.ContainerPort)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/env/env_parse.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/env/env_parse.go
@@ -61,7 +61,7 @@ func SplitEnvironmentFromResources(args []string) (resources, envArgs []string, 
 // envVarType is for making errors more specific to user intentions.
 func parseIntoEnvVar(spec []string, defaultReader io.Reader, envVarType string) ([]v1.EnvVar, []string, bool, error) {
 	env := []v1.EnvVar{}
-	exists := sets.NewString()
+	exists := sets.New[string]()
 	var remove []string
 	usedStdin := false
 	for _, envSpec := range spec {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/env/env_resolve.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/env/env_resolve.go
@@ -158,11 +158,11 @@ func splitMaybeSubscriptedPath(fieldPath string) (string, string, bool) {
 // formatMap formats map[string]string to a string.
 func formatMap(m map[string]string) (fmtStr string) {
 	// output with keys in sorted order to provide stable output
-	keys := sets.NewString()
+	keys := sets.New[string]()
 	for key := range m {
 		keys.Insert(key)
 	}
-	for _, key := range keys.List() {
+	for _, key := range sets.List(keys) {
 		fmtStr += fmt.Sprintf("%v=%q\n", key, m[key])
 	}
 	fmtStr = strings.TrimSuffix(fmtStr, "\n")

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/helper.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/helper.go
@@ -19,7 +19,7 @@ package set
 import (
 	"strings"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
@@ -139,7 +139,7 @@ func findEnv(env []v1.EnvVar, name string) (v1.EnvVar, bool) {
 // If a variable is both added and removed, the removal takes precedence.
 func updateEnv(existing []v1.EnvVar, env []v1.EnvVar, remove []string) []v1.EnvVar {
 	out := []v1.EnvVar{}
-	covered := sets.NewString(remove...)
+	covered := sets.New[string](remove...)
 	for _, e := range existing {
 		if covered.Has(e.Name) {
 			continue

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_subject.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_subject.go
@@ -206,7 +206,7 @@ func (o *SubjectOptions) Validate() error {
 func (o *SubjectOptions) Run(fn updateSubjects) error {
 	patches := CalculatePatches(o.Infos, scheme.DefaultJSONEncoder(), func(obj runtime.Object) ([]byte, error) {
 		subjects := []rbacv1.Subject{}
-		for _, user := range sets.NewString(o.Users...).List() {
+		for _, user := range sets.List(sets.New[string](o.Users...)) {
 			subject := rbacv1.Subject{
 				Kind:     rbacv1.UserKind,
 				APIGroup: rbacv1.GroupName,
@@ -214,7 +214,7 @@ func (o *SubjectOptions) Run(fn updateSubjects) error {
 			}
 			subjects = append(subjects, subject)
 		}
-		for _, group := range sets.NewString(o.Groups...).List() {
+		for _, group := range sets.List(sets.New[string](o.Groups...)) {
 			subject := rbacv1.Subject{
 				Kind:     rbacv1.GroupKind,
 				APIGroup: rbacv1.GroupName,
@@ -222,7 +222,7 @@ func (o *SubjectOptions) Run(fn updateSubjects) error {
 			}
 			subjects = append(subjects, subject)
 		}
-		for _, sa := range sets.NewString(o.ServiceAccounts...).List() {
+		for _, sa := range sets.List(sets.New[string](o.ServiceAccounts...)) {
 			tokens := strings.Split(sa, ":")
 			namespace := tokens[0]
 			name := tokens[1]

--- a/staging/src/k8s.io/kubectl/pkg/cmd/taint/utils.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/taint/utils.go
@@ -38,7 +38,7 @@ const (
 // It also validates the spec. For example, the form `<key>` may be used to remove a taint, but not to add one.
 func parseTaints(spec []string) ([]corev1.Taint, []corev1.Taint, error) {
 	var taints, taintsToRemove []corev1.Taint
-	uniqueTaints := map[corev1.TaintEffect]sets.String{}
+	uniqueTaints := map[corev1.TaintEffect]sets.Set[string]{}
 
 	for _, taintSpec := range spec {
 		if strings.HasSuffix(taintSpec, "-") {
@@ -62,7 +62,7 @@ func parseTaints(spec []string) ([]corev1.Taint, []corev1.Taint, error) {
 			}
 			// add taint to existingTaints for uniqueness check
 			if len(uniqueTaints[newTaint.Effect]) == 0 {
-				uniqueTaints[newTaint.Effect] = sets.String{}
+				uniqueTaints[newTaint.Effect] = sets.Set[string]{}
 			}
 			uniqueTaints[newTaint.Effect].Insert(newTaint.Key)
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
@@ -222,7 +222,7 @@ func checkErr(err error, handleErr func(string, int)) {
 
 func statusCausesToAggrError(scs []metav1.StatusCause) utilerrors.Aggregate {
 	errs := make([]error, 0, len(scs))
-	errorMsgs := sets.NewString()
+	errorMsgs := sets.New[string]()
 	for _, sc := range scs {
 		// check for duplicate error messages and skip them
 		msg := fmt.Sprintf("%s: %s", sc.Field, sc.Message)

--- a/staging/src/k8s.io/kubectl/pkg/describe/describe.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe.go
@@ -317,7 +317,7 @@ func printUnstructuredContent(w PrefixWriter, level int, content map[string]inte
 		switch typedValue := value.(type) {
 		case map[string]interface{}:
 			skipExpr := fmt.Sprintf("%s.%s", skipPrefix, field)
-			if slice.ContainsString(skip, skipExpr, nil) {
+			if slice.Contains[string](skip, skipExpr, nil) {
 				continue
 			}
 			w.Write(level, "%s:\n", smartLabelFor(field))
@@ -325,7 +325,7 @@ func printUnstructuredContent(w PrefixWriter, level int, content map[string]inte
 
 		case []interface{}:
 			skipExpr := fmt.Sprintf("%s.%s", skipPrefix, field)
-			if slice.ContainsString(skip, skipExpr, nil) {
+			if slice.Contains[string](skip, skipExpr, nil) {
 				continue
 			}
 			w.Write(level, "%s:\n", smartLabelFor(field))
@@ -340,7 +340,7 @@ func printUnstructuredContent(w PrefixWriter, level int, content map[string]inte
 
 		default:
 			skipExpr := fmt.Sprintf("%s.%s", skipPrefix, field)
-			if slice.ContainsString(skip, skipExpr, nil) {
+			if slice.Contains[string](skip, skipExpr, nil) {
 				continue
 			}
 			w.Write(level, "%s:\t%v\n", smartLabelFor(field), typedValue)
@@ -365,7 +365,7 @@ func smartLabelFor(field string) string {
 			continue
 		}
 
-		if slice.ContainsString(commonAcronyms, strings.ToUpper(part), nil) {
+		if slice.Contains[string](commonAcronyms, strings.ToUpper(part), nil) {
 			part = strings.ToUpper(part)
 		} else {
 			part = strings.Title(part)

--- a/staging/src/k8s.io/kubectl/pkg/util/fieldpath/fieldpath.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/fieldpath/fieldpath.go
@@ -30,11 +30,11 @@ import (
 // FormatMap formats map[string]string to a string.
 func FormatMap(m map[string]string) (fmtStr string) {
 	// output with keys in sorted order to provide stable output
-	keys := sets.NewString()
+	keys := sets.New[string]()
 	for key := range m {
 		keys.Insert(key)
 	}
-	for _, key := range keys.List() {
+	for _, key := range sets.List(keys) {
 		fmtStr += fmt.Sprintf("%v=%q\n", key, m[key])
 	}
 	fmtStr = strings.TrimSuffix(fmtStr, "\n")

--- a/staging/src/k8s.io/kubectl/pkg/util/qos/qos.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/qos/qos.go
@@ -22,7 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
-var supportedQoSComputeResources = sets.NewString(string(core.ResourceCPU), string(core.ResourceMemory))
+var supportedQoSComputeResources = sets.New[string](string(core.ResourceCPU), string(core.ResourceMemory))
 
 func isSupportedQoSComputeResource(name core.ResourceName) bool {
 	return supportedQoSComputeResources.Has(string(name))

--- a/staging/src/k8s.io/kubectl/pkg/util/rbac/rbac.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/rbac/rbac.go
@@ -17,10 +17,11 @@ limitations under the License.
 package rbac
 
 import (
-	rbacv1 "k8s.io/api/rbac/v1"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"reflect"
 	"strings"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 type simpleResource struct {
@@ -43,7 +44,7 @@ func CompactRules(rules []rbacv1.PolicyRule) ([]rbacv1.PolicyRule, error) {
 				if existingRule.Verbs == nil {
 					existingRule.Verbs = []string{}
 				}
-				existingVerbs := sets.NewString(existingRule.Verbs...)
+				existingVerbs := sets.New[string](existingRule.Verbs...)
 				for _, verb := range rule.Verbs {
 					if !existingVerbs.Has(verb) {
 						existingRule.Verbs = append(existingRule.Verbs, verb)

--- a/staging/src/k8s.io/kubectl/pkg/util/resource/resource.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/resource/resource.go
@@ -254,7 +254,7 @@ func convertResourceEphemeralStorageToString(ephemeralStorage *resource.Quantity
 	return strconv.FormatInt(m, 10), nil
 }
 
-var standardContainerResources = sets.NewString(
+var standardContainerResources = sets.New[string](
 	string(corev1.ResourceCPU),
 	string(corev1.ResourceMemory),
 	string(corev1.ResourceEphemeralStorage),

--- a/staging/src/k8s.io/kubectl/pkg/util/slice/slice.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/slice/slice.go
@@ -23,8 +23,23 @@ import (
 // SortInts64 sorts []int64 in increasing order
 func SortInts64(a []int64) { sort.Slice(a, func(i, j int) bool { return a[i] < a[j] }) }
 
+// Contains checks if a given slice of type T contains the provided item.
+// If a modifier func is provided, it is called with the slice item before the comparation.
+func Contains[T comparable](slice []T, s T, modifier func(s T) T) bool {
+	for _, item := range slice {
+		if item == s {
+			return true
+		}
+		if modifier != nil && modifier(item) == s {
+			return true
+		}
+	}
+	return false
+}
+
 // ContainsString checks if a given slice of strings contains the provided string.
 // If a modifier func is provided, it is called with the slice item before the comparation.
+// Deprecated: Use Contains[T] instead
 func ContainsString(slice []string, s string, modifier func(s string) string) bool {
 	for _, item := range slice {
 		if item == s {


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
`sets.String` was deprecated long time ago and this PR migrates to the generic sets for kubectl and cli-runtime.

```go
sets.NewString => sets.New[string]
.List() => sets.List() // if order matters, sets.List also lists in an alphabetical order for strings
.List() => .UnsortedList() // if order does not matter
sets.String => sets.Set[string]
sets.Int => sets.Set[int]
sets.StringKeySet => sets.KeySet[string]
```

This PR must be no-op.
#### Which issue(s) this PR fixes:
Fixes #

#### Does this PR introduce a user-facing change?
```release-note
None
```