### PR TITLE
Move zpages common code to an httputil package

### DIFF
--- a/staging/src/k8s.io/component-base/zpages/flagz/flagz_test.go
+++ b/staging/src/k8s.io/component-base/zpages/flagz/flagz_test.go
@@ -35,7 +35,7 @@ Warning: This endpoint is not meant to be machine parseable, has no formatting c
 
 func TestFlagz(t *testing.T) {
 	componentName := "test-server"
-	flagzSeparators = []string{"="}
+	delimiters = []string{"="}
 	wantHeaderLines := strings.Split(fmt.Sprintf(wantTmpl, componentName), "\n")
 	tests := []struct {
 		name        string

--- a/staging/src/k8s.io/component-base/zpages/httputil/httputil.go
+++ b/staging/src/k8s.io/component-base/zpages/httputil/httputil.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package httputil
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/munnerz/goautoneg"
+)
+
+// ErrUnsupportedMediaType is the error returned when the request's
+// Accept header does not contain "text/plain".
+var ErrUnsupportedMediaType = fmt.Errorf("media type not acceptable, must be: text/plain")
+
+// AcceptableMediaType checks if the request's Accept header contains
+// a supported media type with optional "charset=utf-8" parameter.
+func AcceptableMediaType(r *http.Request) bool {
+	accepts := goautoneg.ParseAccept(r.Header.Get("Accept"))
+	for _, accept := range accepts {
+		if !mediaTypeMatches(accept) {
+			continue
+		}
+		if len(accept.Params) == 0 {
+			return true
+		}
+		if len(accept.Params) == 1 {
+			if charset, ok := accept.Params["charset"]; ok && strings.EqualFold(charset, "utf-8") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func mediaTypeMatches(a goautoneg.Accept) bool {
+	return (a.Type == "text" || a.Type == "*") &&
+		(a.SubType == "plain" || a.SubType == "*")
+}

--- a/staging/src/k8s.io/component-base/zpages/httputil/httputil_test.go
+++ b/staging/src/k8s.io/component-base/zpages/httputil/httputil_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package httputil
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestAcceptableMediaTypes(t *testing.T) {
+	tests := []struct {
+		name      string
+		reqHeader string
+		want      bool
+	}{
+		{
+			name:      "valid text/plain header",
+			reqHeader: "text/plain",
+			want:      true,
+		},
+		{
+			name:      "valid text/* header",
+			reqHeader: "text/*",
+			want:      true,
+		},
+		{
+			name:      "valid */plain header",
+			reqHeader: "*/plain",
+			want:      true,
+		},
+		{
+			name:      "valid accept args",
+			reqHeader: "text/plain; charset=utf-8",
+			want:      true,
+		},
+		{
+			name:      "invalid text/foo header",
+			reqHeader: "text/foo",
+			want:      false,
+		},
+		{
+			name:      "invalid text/plain params",
+			reqHeader: "text/plain; foo=bar",
+			want:      false,
+		},
+	}
+	for _, tt := range tests {
+		req, err := http.NewRequest(http.MethodGet, "http://example.com/statusz", nil)
+		if err != nil {
+			t.Fatalf("Unexpected error while creating request: %v", err)
+		}
+
+		req.Header.Set("Accept", tt.reqHeader)
+		got := AcceptableMediaType(req)
+
+		if got != tt.want {
+			t.Errorf("Unexpected response from AcceptableMediaType(), want %v, got = %v", tt.want, got)
+		}
+	}
+}

--- a/staging/src/k8s.io/component-base/zpages/statusz/statusz.go
+++ b/staging/src/k8s.io/component-base/zpages/statusz/statusz.go
@@ -22,17 +22,14 @@ import (
 	"html/template"
 	"math/rand"
 	"net/http"
-	"strings"
 	"time"
 
-	"github.com/munnerz/goautoneg"
-
+	"k8s.io/component-base/zpages/httputil"
 	"k8s.io/klog/v2"
 )
 
 var (
-	delimiters              = []string{":", ": ", "=", " "}
-	errUnsupportedMediaType = fmt.Errorf("media type not acceptable, must be: text/plain")
+	delimiters = []string{":", ": ", "=", " "}
 )
 
 const (
@@ -88,8 +85,8 @@ func initializeTemplates() (*template.Template, error) {
 
 func handleStatusz(componentName string, dataTmpl *template.Template, reg statuszRegistry) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		if !acceptableMediaType(r) {
-			http.Error(w, errUnsupportedMediaType.Error(), http.StatusNotAcceptable)
+		if !httputil.AcceptableMediaType(r) {
+			http.Error(w, httputil.ErrUnsupportedMediaType.Error(), http.StatusNotAcceptable)
 			return
 		}
 
@@ -104,30 +101,6 @@ func handleStatusz(componentName string, dataTmpl *template.Template, reg status
 		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 		fmt.Fprint(w, data)
 	}
-}
-
-// TODO(richabanker) : Move this to a common place to be reused for all zpages.
-func acceptableMediaType(r *http.Request) bool {
-	accepts := goautoneg.ParseAccept(r.Header.Get("Accept"))
-	for _, accept := range accepts {
-		if !mediaTypeMatches(accept) {
-			continue
-		}
-		if len(accept.Params) == 0 {
-			return true
-		}
-		if len(accept.Params) == 1 {
-			if charset, ok := accept.Params["charset"]; ok && strings.EqualFold(charset, "utf-8") {
-				return true
-			}
-		}
-	}
-	return false
-}
-
-func mediaTypeMatches(a goautoneg.Accept) bool {
-	return (a.Type == "text" || a.Type == "*") &&
-		(a.SubType == "plain" || a.SubType == "*")
 }
 
 func populateStatuszData(tmpl *template.Template, reg statuszRegistry) (string, error) {

--- a/staging/src/k8s.io/component-base/zpages/statusz/statusz_test.go
+++ b/staging/src/k8s.io/component-base/zpages/statusz/statusz_test.go
@@ -152,58 +152,6 @@ func TestStatusz(t *testing.T) {
 	}
 }
 
-func TestAcceptableMediaTypes(t *testing.T) {
-	tests := []struct {
-		name      string
-		reqHeader string
-		want      bool
-	}{
-		{
-			name:      "valid text/plain header",
-			reqHeader: "text/plain",
-			want:      true,
-		},
-		{
-			name:      "valid text/* header",
-			reqHeader: "text/*",
-			want:      true,
-		},
-		{
-			name:      "valid */plain header",
-			reqHeader: "*/plain",
-			want:      true,
-		},
-		{
-			name:      "valid accept args",
-			reqHeader: "text/plain; charset=utf-8",
-			want:      true,
-		},
-		{
-			name:      "invalid text/foo header",
-			reqHeader: "text/foo",
-			want:      false,
-		},
-		{
-			name:      "invalid text/plain params",
-			reqHeader: "text/plain; foo=bar",
-			want:      false,
-		},
-	}
-	for _, tt := range tests {
-		req, err := http.NewRequest(http.MethodGet, "http://example.com/statusz", nil)
-		if err != nil {
-			t.Fatalf("Unexpected error while creating request: %v", err)
-		}
-
-		req.Header.Set("Accept", tt.reqHeader)
-		got := acceptableMediaType(req)
-
-		if got != tt.want {
-			t.Errorf("Unexpected response from acceptableMediaType(), want %v, got = %v", tt.want, got)
-		}
-	}
-}
-
 func parseVersion(t *testing.T, v string) *version.Version {
 	parsed, err := version.ParseMajorMinor(v)
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:
Moves common code for statusz and flagz under httputil package

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Issues 
- https://github.com/kubernetes/enhancements/issues/4827 
- https://github.com/kubernetes/enhancements/issues/4828

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
