### PR TITLE
fix: kube-proxy EndpointSliceCache memory is leaked

### DIFF
--- a/pkg/proxy/endpointslicecache.go
+++ b/pkg/proxy/endpointslicecache.go
@@ -149,6 +149,9 @@ func (cache *EndpointSliceCache) checkoutChanges() map[types.NamespacedName]*end
 			}
 
 			delete(esTracker.pending, name)
+			if len(esTracker.applied) == 0 && len(esTracker.pending) == 0 {
+				delete(cache.trackerByServiceMap, serviceNN)
+			}
 		}
 
 		change.current = cache.getEndpointsMap(serviceNN, esTracker.applied)


### PR DESCRIPTION
fix: kube-proxy EndpointSliceCache memory is leaked
Signed-off-by: zhikuodu <duzhk@qq.com>

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
kube-proxy: EndpointSliceCache memory is leaked.

#### Which issue(s) this PR fixes:

Fixes #128928

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed: kube-proxy EndpointSliceCache memory is leaked
```
