### PR TITLE
update methods to return empty slices instead of nil.

### DIFF
--- a/pkg/registry/networking/ingress/strategy.go
+++ b/pkg/registry/networking/ingress/strategy.go
@@ -124,7 +124,7 @@ func (ingressStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Obje
 
 // WarningsOnUpdate returns warnings for the given update.
 func (ingressStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object) []string {
-	return nil
+	return []string{}
 }
 
 // AllowUnconditionalUpdate is the default update policy for Ingress objects.
@@ -172,5 +172,5 @@ func (ingressStatusStrategy) ValidateUpdate(ctx context.Context, obj, old runtim
 
 // WarningsOnUpdate returns warnings for the given update.
 func (ingressStatusStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object) []string {
-	return nil
+	return []string{}
 }

--- a/pkg/registry/networking/ingressclass/strategy.go
+++ b/pkg/registry/networking/ingressclass/strategy.go
@@ -72,7 +72,7 @@ func (ingressClassStrategy) Validate(ctx context.Context, obj runtime.Object) fi
 
 // WarningsOnCreate returns warnings for the creation of the given object.
 func (ingressClassStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []string {
-	return nil
+	return []string{}
 }
 
 // Canonicalize normalizes the object after validation.
@@ -95,7 +95,7 @@ func (ingressClassStrategy) ValidateUpdate(ctx context.Context, obj, old runtime
 
 // WarningsOnUpdate returns warnings for the given update.
 func (ingressClassStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object) []string {
-	return nil
+	return []string{}
 }
 
 // AllowUnconditionalUpdate is the default update policy for IngressClass


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/sig testing
#### What this PR does / why we need it:
### 1. **Issue**
The `WarningsOnUpdate` and `WarningsOnCreate` methods in the old code returned `nil` when there were no warnings. Returning `nil` could potentially lead to issues such as:

- **Null pointer exceptions**: If the calling code directly iterates over the return value without checking for `nil`, it may cause a runtime panic.
- **Inconsistent handling**: Other parts of the code might expect an empty slice (`[]string{}`) instead of `nil`, leading to subtle bugs.
- **Extra boilerplate**: The calling code would need to add explicit `nil` checks to handle the returned value safely.

---

### 2. **How to Improve**
The method should return an **empty slice** (`[]string{}`) instead of `nil`. This ensures:

- **Safety**: Avoids potential runtime errors when iterating over the result.
- **Consistency**: Aligns with Go's idiomatic practices where functions return empty slices instead of `nil`.
- **Ease of use**: Simplifies calling code by removing the need for explicit `nil` checks.

---

### 3. **What I Did**
I modified both methods to return an **empty slice** instead of `nil`. 
This ensures the methods always return a usable value, even if there are no warnings, enhancing the robustness and maintainability of the code.

#### Which issue(s) this PR fixes:
Fixes #128937 

#### Special notes for your reviewer:
I've changed both WarningsOnUpdate and WarningsOnCreate. However, It's not strictly necessary to update WarningsOnCreate, though doing so would still improve consistency.
#### Does this PR introduce a user-facing change?
```
NONE
```