### PR TITLE
test: don't panic during an Eventually retry loop

### DIFF
--- a/test/e2e/instrumentation/metrics.go
+++ b/test/e2e/instrumentation/metrics.go
@@ -44,10 +44,7 @@ var _ = common.SIGDescribe("Metrics", func() {
 		ec = f.KubemarkExternalClusterClientSet
 		gomega.Eventually(ctx, func() error {
 			grabber, err = e2emetrics.NewMetricsGrabber(ctx, c, ec, f.ClientConfig(), true, true, true, true, true, true)
-			if err != nil {
-				framework.ExpectNoError(err, "failed to create metrics grabber")
-			}
-			return nil
+			return err
 		}, 5*time.Minute, 10*time.Second).Should(gomega.BeNil())
 	})
 

--- a/test/e2e/node/gpu.go
+++ b/test/e2e/node/gpu.go
@@ -295,7 +295,10 @@ func SetupEnvironmentAndSkipIfNeeded(ctx context.Context, f *framework.Framework
 func areGPUsAvailableOnAllSchedulableNodes(ctx context.Context, clientSet clientset.Interface) bool {
 	framework.Logf("Getting list of Nodes from API server")
 	nodeList, err := clientSet.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
-	framework.ExpectNoError(err, "getting node list")
+	if err != nil {
+		framework.Logf("Unexpected error getting node list: %v", err)
+		return false
+	}
 	for _, node := range nodeList.Items {
 		if node.Spec.Unschedulable {
 			continue

--- a/test/e2e/storage/testsuites/volume_modify.go
+++ b/test/e2e/storage/testsuites/volume_modify.go
@@ -281,7 +281,7 @@ func SetPVCVACName(ctx context.Context, origPVC *v1.PersistentVolumeClaim, name 
 
 		patchedPVC, err = c.CoreV1().PersistentVolumeClaims(origPVC.Namespace).Patch(ctx, pvcName, types.JSONPatchType, patchBytes, metav1.PatchOptions{})
 		return err
-	}, timeout, modifyPollInterval).Should(gomega.BeNil())
+	}, timeout, modifyPollInterval).Should(gomega.Succeed())
 
 	return patchedPVC
 }

--- a/test/e2e/storage/testsuites/volume_modify.go
+++ b/test/e2e/storage/testsuites/volume_modify.go
@@ -274,14 +274,14 @@ func SetPVCVACName(ctx context.Context, origPVC *v1.PersistentVolumeClaim, name 
 	pvcName := origPVC.Name
 	var patchedPVC *v1.PersistentVolumeClaim
 
-	gomega.Eventually(ctx, func(g gomega.Gomega) {
+	gomega.Eventually(ctx, func() error {
 		var err error
 		patch := []map[string]interface{}{{"op": "replace", "path": "/spec/volumeAttributesClassName", "value": name}}
 		patchBytes, _ := json.Marshal(patch)
 
 		patchedPVC, err = c.CoreV1().PersistentVolumeClaims(origPVC.Namespace).Patch(ctx, pvcName, types.JSONPatchType, patchBytes, metav1.PatchOptions{})
-		framework.ExpectNoError(err, "While patching PVC to add VAC name")
-	}, timeout, modifyPollInterval).Should(gomega.Succeed())
+		return err
+	}, timeout, modifyPollInterval).Should(gomega.BeNil())
 
 	return patchedPVC
 }

--- a/test/e2e/windows/eviction.go
+++ b/test/e2e/windows/eviction.go
@@ -178,7 +178,10 @@ var _ = sigDescribe(feature.Windows, "Eviction", framework.WithSerial(), framewo
 		framework.Logf("Waiting for pod2 to get evicted")
 		gomega.Eventually(ctx, func() bool {
 			eventList, err := f.ClientSet.CoreV1().Events(f.Namespace.Name).List(ctx, metav1.ListOptions{})
-			framework.ExpectNoError(err)
+			if err != nil {
+				framework.Logf("Error getting events: %v", err)
+				return false
+			}
 			for _, e := range eventList.Items {
 				// Look for an event that shows FailedScheduling
 				if e.Type == "Warning" && e.Reason == "Evicted" && strings.Contains(e.Message, "pod2") {

--- a/test/e2e/windows/memory_limits.go
+++ b/test/e2e/windows/memory_limits.go
@@ -19,6 +19,7 @@ package windows
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"time"
 
 	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
@@ -162,21 +163,20 @@ func overrideAllocatableMemoryTest(ctx context.Context, f *framework.Framework, 
 	framework.Logf("Ensuring that pod %s fails to schedule", podName)
 	failurePod, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, failurePod, metav1.CreateOptions{})
 	framework.ExpectNoError(err)
-	gomega.Eventually(ctx, func() bool {
+	gomega.Eventually(ctx, func() error {
 		eventList, err := f.ClientSet.CoreV1().Events(f.Namespace.Name).List(ctx, metav1.ListOptions{})
 		if err != nil {
-			framework.Logf("Error getting events: %v", err)
-			return false
+			return fmt.Errorf("error getting events: %w", err)
 		}
 		for _, e := range eventList.Items {
 			// Look for an event that shows FailedScheduling
 			if e.Type == "Warning" && e.Reason == "FailedScheduling" && e.InvolvedObject.Name == failurePod.ObjectMeta.Name {
 				framework.Logf("Found %+v event with message %+v", e.Reason, e.Message)
-				return true
+				return nil
 			}
 		}
-		return false
-	}, 3*time.Minute, 10*time.Second).Should(gomega.BeTrueBecause("Expected %s pod to be failed scheduling", podName))
+		return fmt.Errorf("did not find any FailedScheduling event for pod %s", failurePod.ObjectMeta.Name)
+	}, 3*time.Minute, 10*time.Second).Should(gomega.Succeed())
 }
 
 func getNodeMemory(ctx context.Context, f *framework.Framework, node v1.Node) nodeMemory {

--- a/test/e2e/windows/memory_limits.go
+++ b/test/e2e/windows/memory_limits.go
@@ -164,7 +164,10 @@ func overrideAllocatableMemoryTest(ctx context.Context, f *framework.Framework, 
 	framework.ExpectNoError(err)
 	gomega.Eventually(ctx, func() bool {
 		eventList, err := f.ClientSet.CoreV1().Events(f.Namespace.Name).List(ctx, metav1.ListOptions{})
-		framework.ExpectNoError(err)
+		if err != nil {
+			framework.Logf("Error getting events: %v", err)
+			return false
+		}
 		for _, e := range eventList.Items {
 			// Look for an event that shows FailedScheduling
 			if e.Type == "Warning" && e.Reason == "FailedScheduling" && e.InvolvedObject.Name == failurePod.ObjectMeta.Name {

--- a/test/e2e_node/util.go
+++ b/test/e2e_node/util.go
@@ -239,7 +239,10 @@ func waitForKubeletToStart(ctx context.Context, f *framework.Framework) {
 	// Wait for the Kubelet to be ready.
 	gomega.Eventually(ctx, func(ctx context.Context) bool {
 		nodes, err := e2enode.TotalReady(ctx, f.ClientSet)
-		framework.ExpectNoError(err)
+		if err != nil {
+			framework.Logf("Error getting ready nodes: %v", err)
+			return false
+		}
 		return nodes == 1
 	}, time.Minute, time.Second).Should(gomega.BeTrueBecause("expected kubelet to be in ready state"))
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

This PR replaces invocations of `framework.ExpectNoError` inside `Eventually` retry funcs so that we actually mark those errors as ephemeral. `framework.ExpectNoError` wraps `ginkgo.Fail`, which wraps a run-time panic. This would indicate that the parent `Eventually` function would be short-circuited instead of retrying and relying upon the timeout configuration to ultimately enforce failure.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
