### PR TITLE
feature(kubectl): use autoscalingv2 in kubectl autoscale

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/autoscale/autoscale_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/autoscale/autoscale_test.go
@@ -23,6 +23,8 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -87,14 +89,15 @@ func TestAutoscaleValidate(t *testing.T) {
 }
 
 type createHorizontalPodAutoscalerTestCase struct {
-	name        string
-	options     *AutoscaleOptions
-	refName     string
-	mapping     *meta.RESTMapping
-	expectedHPA *autoscalingv1.HorizontalPodAutoscaler
+	name          string
+	options       *AutoscaleOptions
+	refName       string
+	mapping       *meta.RESTMapping
+	expectedHPAV2 *autoscalingv2.HorizontalPodAutoscaler
+	expectedHPAV1 *autoscalingv1.HorizontalPodAutoscaler
 }
 
-func TestCreateHorizontalPodAutoscaler(t *testing.T) {
+func TestCreateHorizontalPodAutoscalerV2(t *testing.T) {
 	tests := []createHorizontalPodAutoscalerTestCase{
 		{
 			name: "create with all options",
@@ -112,7 +115,279 @@ func TestCreateHorizontalPodAutoscaler(t *testing.T) {
 					Kind:    "Deployment",
 				},
 			},
-			expectedHPA: &autoscalingv1.HorizontalPodAutoscaler{
+			expectedHPAV2: &autoscalingv2.HorizontalPodAutoscaler{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "custom-name",
+				},
+				Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+					ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
+						APIVersion: "apps/v1",
+						Kind:       "Deployment",
+						Name:       "deployment-1",
+					},
+					MinReplicas: ptr.To(int32(2)),
+					MaxReplicas: int32(10),
+					Metrics: []autoscalingv2.MetricSpec{
+						// Reference: https://pkg.go.dev/k8s.io/api/autoscaling/v2#MetricSpec
+						{
+							Type: autoscalingv2.ResourceMetricSourceType,
+							Resource: &autoscalingv2.ResourceMetricSource{
+								// Reference: https://pkg.go.dev/k8s.io/api/autoscaling/v2#ResourceMetricSource
+								Name: corev1.ResourceCPU,
+								Target: autoscalingv2.MetricTarget{
+									// Reference: https://pkg.go.dev/k8s.io/api/autoscaling/v2#MetricTarget
+									Type:               autoscalingv2.UtilizationMetricType,
+									AverageUtilization: ptr.To(int32(80)),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "create without min replicas",
+			options: &AutoscaleOptions{
+				Name:       "custom-name-2",
+				Max:        10,
+				Min:        -1,
+				CPUPercent: 80,
+			},
+			refName: "deployment-2",
+			mapping: &meta.RESTMapping{
+				GroupVersionKind: schema.GroupVersionKind{
+					Group:   "apps",
+					Version: "v1",
+					Kind:    "Deployment",
+				},
+			},
+			expectedHPAV2: &autoscalingv2.HorizontalPodAutoscaler{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "custom-name-2",
+				},
+				Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+					ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
+						APIVersion: "apps/v1",
+						Kind:       "Deployment",
+						Name:       "deployment-2",
+					},
+					MinReplicas: nil,
+					MaxReplicas: int32(10),
+					Metrics: []autoscalingv2.MetricSpec{
+						// Reference: https://pkg.go.dev/k8s.io/api/autoscaling/v2#MetricSpec
+						{
+							Type: autoscalingv2.ResourceMetricSourceType,
+							Resource: &autoscalingv2.ResourceMetricSource{
+								// Reference: https://pkg.go.dev/k8s.io/api/autoscaling/v2#ResourceMetricSource
+								Name: corev1.ResourceCPU,
+								Target: autoscalingv2.MetricTarget{
+									// Reference: https://pkg.go.dev/k8s.io/api/autoscaling/v2#MetricTarget
+									Type:               autoscalingv2.UtilizationMetricType,
+									AverageUtilization: ptr.To(int32(80)),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "create without max replicas",
+			options: &AutoscaleOptions{
+				Name:       "custom-name-3",
+				Max:        -1,
+				Min:        2,
+				CPUPercent: 80,
+			},
+			refName: "deployment-3",
+			mapping: &meta.RESTMapping{
+				GroupVersionKind: schema.GroupVersionKind{
+					Group:   "apps",
+					Version: "v1",
+					Kind:    "Deployment",
+				},
+			},
+			expectedHPAV2: &autoscalingv2.HorizontalPodAutoscaler{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "custom-name-3",
+				},
+				Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+					ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
+						APIVersion: "apps/v1",
+						Kind:       "Deployment",
+						Name:       "deployment-3",
+					},
+					MinReplicas: ptr.To(int32(2)),
+					MaxReplicas: int32(-1),
+					Metrics: []autoscalingv2.MetricSpec{
+						// Reference: https://pkg.go.dev/k8s.io/api/autoscaling/v2#MetricSpec
+						{
+							Type: autoscalingv2.ResourceMetricSourceType,
+							Resource: &autoscalingv2.ResourceMetricSource{
+								// Reference: https://pkg.go.dev/k8s.io/api/autoscaling/v2#ResourceMetricSource
+								Name: corev1.ResourceCPU,
+								Target: autoscalingv2.MetricTarget{
+									// Reference: https://pkg.go.dev/k8s.io/api/autoscaling/v2#MetricTarget
+									Type:               autoscalingv2.UtilizationMetricType,
+									AverageUtilization: ptr.To(int32(80)),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "create without cpu utilization",
+			options: &AutoscaleOptions{
+				Name:       "custom-name-4",
+				Max:        10,
+				Min:        2,
+				CPUPercent: -1,
+			},
+			refName: "deployment-4",
+			mapping: &meta.RESTMapping{
+				GroupVersionKind: schema.GroupVersionKind{
+					Group:   "apps",
+					Version: "v1",
+					Kind:    "Deployment",
+				},
+			},
+			expectedHPAV2: &autoscalingv2.HorizontalPodAutoscaler{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "custom-name-4",
+				},
+				Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+					ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
+						APIVersion: "apps/v1",
+						Kind:       "Deployment",
+						Name:       "deployment-4",
+					},
+					MinReplicas: ptr.To(int32(2)),
+					MaxReplicas: int32(10),
+				},
+			},
+		},
+		{
+			name: "create with replicaset reference",
+			options: &AutoscaleOptions{
+				Name:       "replicaset-hpa",
+				Max:        5,
+				Min:        1,
+				CPUPercent: 70,
+			},
+			refName: "frontend",
+			mapping: &meta.RESTMapping{
+				GroupVersionKind: schema.GroupVersionKind{
+					Group:   "apps",
+					Version: "v1",
+					Kind:    "ReplicaSet",
+				},
+			},
+			expectedHPAV2: &autoscalingv2.HorizontalPodAutoscaler{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "replicaset-hpa",
+				},
+				Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+					ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
+						APIVersion: "apps/v1",
+						Kind:       "ReplicaSet",
+						Name:       "frontend",
+					},
+					MinReplicas: ptr.To(int32(1)),
+					MaxReplicas: int32(5),
+					Metrics: []autoscalingv2.MetricSpec{
+						// Reference: https://pkg.go.dev/k8s.io/api/autoscaling/v2#MetricSpec
+						{
+							Type: autoscalingv2.ResourceMetricSourceType,
+							Resource: &autoscalingv2.ResourceMetricSource{
+								// Reference: https://pkg.go.dev/k8s.io/api/autoscaling/v2#ResourceMetricSource
+								Name: corev1.ResourceCPU,
+								Target: autoscalingv2.MetricTarget{
+									// Reference: https://pkg.go.dev/k8s.io/api/autoscaling/v2#MetricTarget
+									Type:               autoscalingv2.UtilizationMetricType,
+									AverageUtilization: ptr.To(int32(70)),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "create with statefulset reference",
+			options: &AutoscaleOptions{
+				Name:       "statefulset-hpa",
+				Max:        8,
+				Min:        2,
+				CPUPercent: 60,
+			},
+			refName: "web",
+			mapping: &meta.RESTMapping{
+				GroupVersionKind: schema.GroupVersionKind{
+					Group:   "apps",
+					Version: "v1",
+					Kind:    "StatefulSet",
+				},
+			},
+			expectedHPAV2: &autoscalingv2.HorizontalPodAutoscaler{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "statefulset-hpa",
+				},
+				Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+					ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
+						APIVersion: "apps/v1",
+						Kind:       "StatefulSet",
+						Name:       "web",
+					},
+					MinReplicas: ptr.To(int32(2)),
+					MaxReplicas: int32(8),
+					Metrics: []autoscalingv2.MetricSpec{
+						// Reference: https://pkg.go.dev/k8s.io/api/autoscaling/v2#MetricSpec
+						{
+							Type: autoscalingv2.ResourceMetricSourceType,
+							Resource: &autoscalingv2.ResourceMetricSource{
+								// Reference: https://pkg.go.dev/k8s.io/api/autoscaling/v2#ResourceMetricSource
+								Name: corev1.ResourceCPU,
+								Target: autoscalingv2.MetricTarget{
+									// Reference: https://pkg.go.dev/k8s.io/api/autoscaling/v2#MetricTarget
+									Type:               autoscalingv2.UtilizationMetricType,
+									AverageUtilization: ptr.To(int32(60)),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			hpa := tc.options.createHorizontalPodAutoscalerV2(tc.refName, tc.mapping)
+			assert.Equal(t, tc.expectedHPAV2, hpa)
+		})
+	}
+}
+
+func TestCreateHorizontalPodAutoscalerV1(t *testing.T) {
+	tests := []createHorizontalPodAutoscalerTestCase{
+		{
+			name: "create with all options",
+			options: &AutoscaleOptions{
+				Name:       "custom-name",
+				Max:        10,
+				Min:        2,
+				CPUPercent: 80,
+			},
+			refName: "deployment-1",
+			mapping: &meta.RESTMapping{
+				GroupVersionKind: schema.GroupVersionKind{
+					Group:   "apps",
+					Version: "v1",
+					Kind:    "Deployment",
+				},
+			},
+			expectedHPAV1: &autoscalingv1.HorizontalPodAutoscaler{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "custom-name",
 				},
@@ -144,7 +419,7 @@ func TestCreateHorizontalPodAutoscaler(t *testing.T) {
 					Kind:    "Deployment",
 				},
 			},
-			expectedHPA: &autoscalingv1.HorizontalPodAutoscaler{
+			expectedHPAV1: &autoscalingv1.HorizontalPodAutoscaler{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "custom-name-2",
 				},
@@ -176,7 +451,7 @@ func TestCreateHorizontalPodAutoscaler(t *testing.T) {
 					Kind:    "Deployment",
 				},
 			},
-			expectedHPA: &autoscalingv1.HorizontalPodAutoscaler{
+			expectedHPAV1: &autoscalingv1.HorizontalPodAutoscaler{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "custom-name-3",
 				},
@@ -208,7 +483,7 @@ func TestCreateHorizontalPodAutoscaler(t *testing.T) {
 					Kind:    "Deployment",
 				},
 			},
-			expectedHPA: &autoscalingv1.HorizontalPodAutoscaler{
+			expectedHPAV1: &autoscalingv1.HorizontalPodAutoscaler{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "custom-name-4",
 				},
@@ -218,9 +493,8 @@ func TestCreateHorizontalPodAutoscaler(t *testing.T) {
 						Kind:       "Deployment",
 						Name:       "deployment-4",
 					},
-					MinReplicas:                    ptr.To(int32(2)),
-					MaxReplicas:                    int32(10),
-					TargetCPUUtilizationPercentage: nil,
+					MinReplicas: ptr.To(int32(2)),
+					MaxReplicas: int32(10),
 				},
 			},
 		},
@@ -240,7 +514,7 @@ func TestCreateHorizontalPodAutoscaler(t *testing.T) {
 					Kind:    "ReplicaSet",
 				},
 			},
-			expectedHPA: &autoscalingv1.HorizontalPodAutoscaler{
+			expectedHPAV1: &autoscalingv1.HorizontalPodAutoscaler{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "replicaset-hpa",
 				},
@@ -272,7 +546,7 @@ func TestCreateHorizontalPodAutoscaler(t *testing.T) {
 					Kind:    "StatefulSet",
 				},
 			},
-			expectedHPA: &autoscalingv1.HorizontalPodAutoscaler{
+			expectedHPAV1: &autoscalingv1.HorizontalPodAutoscaler{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "statefulset-hpa",
 				},
@@ -291,8 +565,8 @@ func TestCreateHorizontalPodAutoscaler(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			hpa := tc.options.createHorizontalPodAutoscaler(tc.refName, tc.mapping)
-			assert.Equal(t, tc.expectedHPA, hpa)
+			hpa := tc.options.createHorizontalPodAutoscalerV1(tc.refName, tc.mapping)
+			assert.Equal(t, tc.expectedHPAV1, hpa)
 		})
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
- upgrade autoscalingv1 to autoscalingv2 in kubectl autoscale cmd
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubectl/issues/1455

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
upgrade autoscalingv1 to autoscalingv2 in kubectl autoscale cmd, The cmd will attempt to use the autoscaling/v2 API first. If the autoscaling/v2 API is not available or an error occurs, it will fall back to the autoscaling/v1 API.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
