### PR TITLE
Clone btree to serve continuations used for pagination

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
@@ -840,7 +840,11 @@ func (c *Cacher) listItems(ctx context.Context, listRV uint64, key string, pred 
 			return listResp{}, "", err
 		}
 		if exists {
-			return listResp{Items: []interface{}{obj}, ResourceVersion: readResourceVersion}, "", nil
+			return listResp{
+				Items:           []interface{}{obj},
+				ItemCount:       1,
+				ResourceVersion: readResourceVersion,
+			}, "", nil
 		}
 		return listResp{ResourceVersion: readResourceVersion}, "", nil
 	}
@@ -848,7 +852,10 @@ func (c *Cacher) listItems(ctx context.Context, listRV uint64, key string, pred 
 }
 
 type listResp struct {
-	Items           []interface{}
+	Items   []interface{}
+	HasMore bool
+	// Return ItemCount but only if pred.Empty()
+	ItemCount       int64
 	ResourceVersion uint64
 }
 
@@ -953,19 +960,21 @@ func (c *Cacher) GetList(ctx context.Context, key string, opts storage.ListOptio
 	//   so we try to delay this action as much as possible
 	var selectedObjects []runtime.Object
 	var lastSelectedObjectKey string
-	var hasMoreListItems bool
+	hasMoreListItems := resp.HasMore
 	limit := computeListLimit(opts)
 	for i, obj := range resp.Items {
 		elem, ok := obj.(*storeElement)
 		if !ok {
 			return fmt.Errorf("non *storeElement returned from storage: %v", obj)
 		}
-		if pred.MatchesObjectAttributes(elem.Labels, elem.Fields) {
+		if opts.Predicate.MatchesObjectAttributes(elem.Labels, elem.Fields) {
 			selectedObjects = append(selectedObjects, elem.Object)
 			lastSelectedObjectKey = elem.Key
 		}
 		if limit > 0 && int64(len(selectedObjects)) >= limit {
-			hasMoreListItems = i < len(resp.Items)-1
+			if i < len(resp.Items)-1 {
+				hasMoreListItems = true
+			}
 			break
 		}
 	}
@@ -982,7 +991,7 @@ func (c *Cacher) GetList(ctx context.Context, key string, opts storage.ListOptio
 	}
 	span.AddEvent("Filtered items", attribute.Int("count", listVal.Len()))
 	if c.versioner != nil {
-		continueValue, remainingItemCount, err := storage.PrepareContinueToken(lastSelectedObjectKey, key, int64(resp.ResourceVersion), int64(len(resp.Items)), hasMoreListItems, opts)
+		continueValue, remainingItemCount, err := storage.PrepareContinueToken(lastSelectedObjectKey, key, int64(resp.ResourceVersion), resp.ItemCount, hasMoreListItems, opts)
 		if err != nil {
 			return err
 		}

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
@@ -784,31 +784,36 @@ func (c *Cacher) Get(ctx context.Context, key string, opts storage.GetOptions, o
 // NOTICE: Keep in sync with shouldListFromStorage function in
 //
 //	staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/list_work_estimator.go
-func shouldDelegateList(opts storage.ListOptions) bool {
+func (c *Cacher) shouldDelegateList(opts storage.ListOptions) (bool, error) {
 	// see https://kubernetes.io/docs/reference/using-api/api-concepts/#semantics-for-get-and-list
 	switch opts.ResourceVersionMatch {
 	case metav1.ResourceVersionMatchExact:
-		return true
+		return true, nil
 	case metav1.ResourceVersionMatchNotOlderThan:
 	case "":
 		// Legacy exact match
 		if opts.Predicate.Limit > 0 && len(opts.ResourceVersion) > 0 && opts.ResourceVersion != "0" {
-			return true
+			return true, nil
 		}
 	default:
-		return true
+		return true, nil
 	}
 	// Continue
 	if len(opts.Predicate.Continue) > 0 {
-		return true
+		_, rv, err := storage.DecodeContinue(opts.Predicate.Continue, c.resourcePrefix)
+		if err != nil {
+			return false, err
+		}
+		_, isCached := c.watchCache.storeSnapshots.Get(uint64(rv))
+		return !isCached, nil
 	}
 	// Consistent Read
 	if opts.ResourceVersion == "" {
 		consistentListFromCacheEnabled := utilfeature.DefaultFeatureGate.Enabled(features.ConsistentListFromCache)
 		requestWatchProgressSupported := etcdfeature.DefaultFeatureSupportChecker.Supports(storage.RequestWatchProgress)
-		return !consistentListFromCacheEnabled || !requestWatchProgressSupported
+		return !consistentListFromCacheEnabled || !requestWatchProgressSupported, nil
 	}
-	return false
+	return false, nil
 }
 
 // computeListLimit determines whether the cacher should
@@ -833,8 +838,8 @@ func shouldDelegateListOnNotReadyCache(opts storage.ListOptions) bool {
 	return noLabelSelector && noFieldSelector && hasLimit
 }
 
-func (c *Cacher) listItems(ctx context.Context, listRV uint64, key string, pred storage.SelectionPredicate, recursive bool) (listResp, string, error) {
-	if !recursive {
+func (c *Cacher) listItems(ctx context.Context, listRV uint64, key string, opts storage.ListOptions) (listResp, string, error) {
+	if !opts.Recursive {
 		obj, exists, readResourceVersion, err := c.watchCache.WaitUntilFreshAndGet(ctx, listRV, key)
 		if err != nil {
 			return listResp{}, "", err
@@ -848,7 +853,7 @@ func (c *Cacher) listItems(ctx context.Context, listRV uint64, key string, pred 
 		}
 		return listResp{ResourceVersion: readResourceVersion}, "", nil
 	}
-	return c.watchCache.WaitUntilFreshAndList(ctx, listRV, key, pred.MatcherIndex(ctx))
+	return c.watchCache.WaitUntilFreshAndList(ctx, listRV, key, opts, opts.Predicate.MatcherIndex(ctx))
 }
 
 type listResp struct {
@@ -861,16 +866,18 @@ type listResp struct {
 
 // GetList implements storage.Interface
 func (c *Cacher) GetList(ctx context.Context, key string, opts storage.ListOptions, listObj runtime.Object) error {
-	recursive := opts.Recursive
 	resourceVersion := opts.ResourceVersion
-	pred := opts.Predicate
-	if shouldDelegateList(opts) {
+	deletage, err := c.shouldDelegateList(opts)
+	if err != nil {
+		return err
+	}
+	if deletage {
 		return c.storage.GetList(ctx, key, opts, listObj)
 	}
 
 	listRV, err := c.versioner.ParseResourceVersion(resourceVersion)
 	if err != nil {
-		return err
+		return errors.NewBadRequest(fmt.Sprintf("invalid resource version: %v", err))
 	}
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.ResilientWatchCacheInitialization) {
@@ -934,7 +941,7 @@ func (c *Cacher) GetList(ctx context.Context, key string, opts storage.ListOptio
 		return fmt.Errorf("need a pointer to slice, got %v", listVal.Kind())
 	}
 
-	resp, indexUsed, err := c.listItems(ctx, listRV, preparedKey, pred, recursive)
+	resp, indexUsed, err := c.listItems(ctx, listRV, preparedKey, opts)
 	success := "true"
 	fallback := "false"
 	if err != nil {

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/store.go
@@ -72,8 +72,11 @@ type storeIndexer interface {
 	ByIndex(indexName, indexedValue string) ([]interface{}, error)
 }
 
+// orderedLister is interface wrapping btree implementation of store, allowing for fast prefix listing and fast lazy cloning.
 type orderedLister interface {
+	Count(prefix, continueKey string) (count int)
 	ListPrefix(prefix, continueKey string, limit int) (items []interface{}, hasMore bool)
+	Clone() orderedLister
 }
 
 func newStoreIndexer(indexers *cache.Indexers) storeIndexer {

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/store_test.go
@@ -175,3 +175,30 @@ func testStoreIndexers() *cache.Indexers {
 	indexers["by_val"] = testStoreIndexFunc
 	return &indexers
 }
+
+func TestStoreSnapshotter(t *testing.T) {
+	cache := newStoreSnapshotter()
+	cache.Set(20, fakeOrderedLister{})
+	cache.Set(30, fakeOrderedLister{})
+	cache.Set(40, fakeOrderedLister{})
+	assert.Len(t, cache.snapshots, 3)
+	assert.Len(t, cache.revisions, 3)
+	cache.Clean(20)
+	assert.Len(t, cache.snapshots, 2)
+	assert.Len(t, cache.revisions, 2)
+	cache.Set(20, fakeOrderedLister{})
+	cache.Set(20, fakeOrderedLister{})
+	assert.Len(t, cache.snapshots, 3)
+	assert.Len(t, cache.revisions, 3)
+	cache.Clean(40)
+	assert.Empty(t, cache.snapshots)
+	assert.Empty(t, cache.revisions)
+}
+
+type fakeOrderedLister struct{}
+
+func (f fakeOrderedLister) Clone() orderedLister { return f }
+func (f fakeOrderedLister) ListPrefix(prefixKey, continueKey string, limit int) ([]interface{}, bool) {
+	return nil, false
+}
+func (f fakeOrderedLister) Count(prefixKey, continueKey string) int { return 0 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
@@ -474,14 +474,18 @@ func (w *watchCache) WaitUntilFreshAndList(ctx context.Context, resourceVersion 
 			result, err = filterPrefixAndOrder(key, result)
 			return listResp{
 				Items:           result,
+				HasMore:         false,
+				ItemCount:       int64(len(result)),
 				ResourceVersion: w.resourceVersion,
 			}, matchValue.IndexName, err
 		}
 	}
 	if store, ok := w.store.(orderedLister); ok {
-		result, _ := store.ListPrefix(key, "", 0)
+		result, hasMore := store.ListPrefix(key, "", 0)
 		return listResp{
 			Items:           result,
+			HasMore:         hasMore,
+			ItemCount:       int64(len(result)),
 			ResourceVersion: w.resourceVersion,
 		}, "", nil
 	}
@@ -489,6 +493,8 @@ func (w *watchCache) WaitUntilFreshAndList(ctx context.Context, resourceVersion 
 	result, err = filterPrefixAndOrder(key, result)
 	return listResp{
 		Items:           result,
+		HasMore:         false,
+		ItemCount:       int64(len(result)),
 		ResourceVersion: w.resourceVersion,
 	}, "", err
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/store_tests.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/store_tests.go
@@ -822,7 +822,7 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 			expectContinue:             true,
 			expectedRemainingItemCount: utilpointer.Int64(1),
 			rv:                         list.ResourceVersion,
-			expectRV:                   list.ResourceVersion,
+			expectRVFunc:               resourceVersionNotOlderThan(list.ResourceVersion),
 		},
 		{
 			name:   "test List with limit at current resource version and match=Exact",

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/watcher_tests.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/watcher_tests.go
@@ -331,8 +331,8 @@ func RunTestDelayedWatchDelivery(ctx context.Context, t *testing.T, store storag
 	// should be delivered to the watcher can be created before it will
 	// block the implementation and as a result force the watcher to be
 	// closed (as otherwise events would have to be dropped).
-	// For now, this number is smallest for Cacher and it equals 21 for it.
-	totalPods := 21
+	// For now, this number is smallest for Cacher and it equals 50 for it.
+	totalPods := 50
 	for i := 0; i < totalPods; i++ {
 		out := &example.Pod{}
 		pod := &example.Pod{


### PR DESCRIPTION
/kind feature

```release-note
NONE
```
```
goos: linux
goarch: amd64
pkg: k8s.io/apiserver/pkg/storage/cacher
cpu: AMD Ryzen 5 7600X 6-Core Processor
                                                  │  watchcache   │           watchcache-btree            │       watchcache-btree-continue       │
                                                  │    sec/op     │    sec/op      vs base                │    sec/op      vs base                │
StoreListCreate/RV=NotOlderThan-12                    698.8µ ± 4%     227.9µ ± 2%  -67.39% (p=0.000 n=10)     193.7µ ± 2%  -72.27% (p=0.000 n=10)
StoreListCreate/RV=ExactMatch-12                      356.4µ ± 2%     358.7µ ± 2%        ~ (p=0.631 n=10)     364.7µ ± 1%   +2.31% (p=0.005 n=10)
StoreList/RV=Empty-12                                 982.5µ ± 6%     722.9µ ± 4%  -26.43% (p=0.000 n=10)     800.7µ ± 1%  -18.51% (p=0.000 n=10)
StoreList/RV=NotOlderThan-12                          972.3µ ± 2%     700.7µ ± 2%  -27.93% (p=0.000 n=10)     765.1µ ± 3%  -21.31% (p=0.000 n=10)
StoreList/RV=MatchExact-12                          16552.5µ ± 3%   16377.3µ ± 2%        ~ (p=0.218 n=10)   16931.0µ ± 2%        ~ (p=0.075 n=10)
StoreList/Paginate/RV=Empty-12                       18.551m ± 1%    18.495m ± 1%        ~ (p=0.353 n=10)     2.389m ± 2%  -87.12% (p=0.000 n=10)
StoreList/Paginate/RV=NotOlderThan-12                18.389m ± 3%    18.451m ± 1%        ~ (p=0.971 n=10)     2.406m ± 2%  -86.91% (p=0.000 n=10)
StoreList/Paginate/RV=MatchExact-12                  18.280m ± 1%    18.468m ± 1%   +1.03% (p=0.003 n=10)    18.907m ± 1%   +3.43% (p=0.000 n=10)
StoreList/NodeIndexed/RV=Empty-12                     1.791m ± 3%     1.796m ± 2%        ~ (p=0.796 n=10)     1.761m ± 3%   -1.67% (p=0.015 n=10)
StoreList/NodeIndexed/RV=NotOlderThan-12              1.234m ± 4%     1.250m ± 3%        ~ (p=0.796 n=10)     1.260m ± 2%        ~ (p=0.105 n=10)
StoreList/NodeIndexed/RV=MatchExact-12              7459.99m ± 1%   7455.16m ± 1%        ~ (p=0.796 n=10)   7312.73m ± 1%   -1.97% (p=0.000 n=10)
StoreList/NodeIndexed/Paginate/RV=Empty-12           70.410m ± 1%    64.656m ± 4%   -8.17% (p=0.000 n=10)     3.114m ± 4%  -95.58% (p=0.000 n=10)
StoreList/NodeIndexed/Paginate/RV=NotOlderThan-12    69.420m ± 1%    63.594m ± 1%   -8.39% (p=0.000 n=10)     2.471m ± 4%  -96.44% (p=0.000 n=10)
StoreList/NodeIndexed/Paginate/RV=MatchExact-12     8076.67m ± 1%   8087.91m ± 1%        ~ (p=0.165 n=10)   7686.99m ± 1%   -4.82% (p=0.000 n=10)
StoreList/Namespace/RV=Empty-12                       6.421m ± 1%     1.675m ± 1%  -73.91% (p=0.000 n=10)     1.596m ± 2%  -75.14% (p=0.000 n=10)
StoreList/Namespace/RV=NotOlderThan-12                5.670m ± 2%     1.069m ± 1%  -81.14% (p=0.000 n=10)     1.065m ± 2%  -81.21% (p=0.000 n=10)
StoreList/Namespace/RV=MatchExact-12                 15.845m ± 2%    16.334m ± 3%   +3.09% (p=0.000 n=10)    16.009m ± 2%        ~ (p=0.280 n=10)
geomean                                               13.05m          9.789m       -24.98%                    5.304m       -59.35%

                                                  │   watchcache   │            watchcache-btree            │       watchcache-btree-continue        │
                                                  │      B/op      │      B/op       vs base                │      B/op       vs base                │
StoreListCreate/RV=NotOlderThan-12                   293.72Ki ± 4%    233.06Ki ± 4%  -20.65% (p=0.000 n=10)     42.71Ki ± 0%  -85.46% (p=0.000 n=10)
StoreListCreate/RV=ExactMatch-12                     115.00Ki ± 0%    114.89Ki ± 0%   -0.09% (p=0.000 n=10)    114.93Ki ± 2%        ~ (p=0.670 n=10)
StoreList/RV=Empty-12                                 6.179Mi ± 0%     6.023Mi ± 0%   -2.53% (p=0.000 n=10)     6.023Mi ± 0%   -2.53% (p=0.000 n=10)
StoreList/RV=NotOlderThan-12                          6.163Mi ± 0%     6.007Mi ± 0%   -2.53% (p=0.000 n=10)     6.007Mi ± 0%   -2.54% (p=0.000 n=10)
StoreList/RV=MatchExact-12                           60.324Mi ± 0%    60.294Mi ± 0%        ~ (p=0.529 n=10)    60.212Mi ± 0%        ~ (p=0.143 n=10)
StoreList/Paginate/RV=Empty-12                       64.286Mi ± 0%    64.051Mi ± 0%   -0.37% (p=0.000 n=10)     8.651Mi ± 1%  -86.54% (p=0.000 n=10)
StoreList/Paginate/RV=NotOlderThan-12                64.266Mi ± 0%    64.039Mi ± 0%   -0.35% (p=0.000 n=10)     8.636Mi ± 0%  -86.56% (p=0.000 n=10)
StoreList/Paginate/RV=MatchExact-12                   63.64Mi ± 0%     63.56Mi ± 0%   -0.12% (p=0.000 n=10)     63.73Mi ± 0%   +0.15% (p=0.000 n=10)
StoreList/NodeIndexed/RV=Empty-12                     7.928Mi ± 1%     7.929Mi ± 1%   +0.01% (p=0.035 n=10)     7.928Mi ± 0%        ~ (p=0.971 n=10)
StoreList/NodeIndexed/RV=NotOlderThan-12              6.328Mi ± 0%     6.328Mi ± 0%        ~ (p=0.739 n=10)     6.329Mi ± 0%   +0.02% (p=0.035 n=10)
StoreList/NodeIndexed/RV=MatchExact-12              5923.83Mi ± 0%   5920.72Mi ± 0%        ~ (p=0.315 n=10)   5924.82Mi ± 0%        ~ (p=0.631 n=10)
StoreList/NodeIndexed/Paginate/RV=Empty-12           283.98Mi ± 0%    256.99Mi ± 0%   -9.51% (p=0.000 n=10)     11.90Mi ± 0%  -95.81% (p=0.000 n=10)
StoreList/NodeIndexed/Paginate/RV=NotOlderThan-12    282.23Mi ± 0%    255.27Mi ± 0%   -9.55% (p=0.000 n=10)     10.27Mi ± 0%  -96.36% (p=0.000 n=10)
StoreList/NodeIndexed/Paginate/RV=MatchExact-12     6218.59Mi ± 0%   6192.72Mi ± 0%   -0.42% (p=0.000 n=10)   6203.27Mi ± 0%   -0.25% (p=0.000 n=10)
StoreList/Namespace/RV=Empty-12                      23.745Mi ± 0%     8.123Mi ± 0%  -65.79% (p=0.000 n=10)     8.123Mi ± 0%  -65.79% (p=0.000 n=10)
StoreList/Namespace/RV=NotOlderThan-12               22.143Mi ± 0%     6.521Mi ± 0%  -70.55% (p=0.000 n=10)     6.521Mi ± 0%  -70.55% (p=0.000 n=10)
StoreList/Namespace/RV=MatchExact-12                 63.389Mi ± 0%    63.318Mi ± 0%   -0.11% (p=0.000 n=10)    63.360Mi ± 0%   -0.05% (p=0.000 n=10)
geomean                                               33.76Mi          28.64Mi       -15.15%                    14.15Mi       -58.07%

                                                  │   watchcache   │           watchcache-btree            │       watchcache-btree-continue        │
                                                  │   allocs/op    │   allocs/op     vs base               │   allocs/op     vs base                │
StoreListCreate/RV=NotOlderThan-12                      561.0 ± 0%       559.0 ± 0%  -0.36% (p=0.000 n=10)       558.0 ± 0%   -0.53% (p=0.000 n=10)
StoreListCreate/RV=ExactMatch-12                        874.5 ± 0%       875.0 ± 0%       ~ (p=0.407 n=10)       875.5 ± 0%        ~ (p=0.196 n=10)
StoreList/RV=Empty-12                                   346.5 ± 1%       345.0 ± 2%       ~ (p=0.236 n=10)       344.5 ± 0%   -0.58% (p=0.001 n=10)
StoreList/RV=NotOlderThan-12                            88.00 ± 1%       87.00 ± 1%  -1.14% (p=0.002 n=10)       87.00 ± 0%   -1.14% (p=0.000 n=10)
StoreList/RV=MatchExact-12                           460591.5 ± 0%    456773.5 ± 0%  -0.83% (p=0.000 n=10)    460860.0 ± 0%   +0.06% (p=0.000 n=10)
StoreList/Paginate/RV=Empty-12                        490.62k ± 0%     486.82k ± 0%  -0.77% (p=0.000 n=10)      34.45k ± 0%  -92.98% (p=0.000 n=10)
StoreList/Paginate/RV=NotOlderThan-12                 490.37k ± 0%     486.56k ± 0%  -0.78% (p=0.000 n=10)      34.21k ± 0%  -93.02% (p=0.000 n=10)
StoreList/Paginate/RV=MatchExact-12                   492.87k ± 0%     489.10k ± 0%  -0.77% (p=0.000 n=10)     493.96k ± 0%   +0.22% (p=0.000 n=10)
StoreList/NodeIndexed/RV=Empty-12                      32.08k ± 0%      32.10k ± 0%       ~ (p=0.061 n=10)      32.09k ± 0%        ~ (p=0.271 n=10)
StoreList/NodeIndexed/RV=NotOlderThan-12               6.614k ± 1%      6.614k ± 1%       ~ (p=0.642 n=10)      6.622k ± 0%   +0.14% (p=0.033 n=10)
StoreList/NodeIndexed/RV=MatchExact-12              46960.49k ± 0%   46580.64k ± 0%  -0.81% (p=0.000 n=10)   46973.40k ± 0%   +0.03% (p=0.000 n=10)
StoreList/NodeIndexed/Paginate/RV=Empty-12           2147.20k ± 0%    1947.92k ± 0%  -9.28% (p=0.000 n=10)      52.92k ± 0%  -97.54% (p=0.000 n=10)
StoreList/NodeIndexed/Paginate/RV=NotOlderThan-12    2118.89k ± 0%    1920.06k ± 0%  -9.38% (p=0.000 n=10)      26.98k ± 0%  -98.73% (p=0.000 n=10)
StoreList/NodeIndexed/Paginate/RV=MatchExact-12     47927.16k ± 0%   47460.51k ± 0%  -0.97% (p=0.000 n=10)   47840.12k ± 0%   -0.18% (p=0.000 n=10)
StoreList/Namespace/RV=Empty-12                        31.84k ± 0%      31.72k ± 0%  -0.39% (p=0.000 n=10)      31.72k ± 0%   -0.38% (p=0.000 n=10)
StoreList/Namespace/RV=NotOlderThan-12                 6.314k ± 0%      6.218k ± 0%  -1.53% (p=0.000 n=10)      6.223k ± 0%   -1.45% (p=0.000 n=10)
StoreList/Namespace/RV=MatchExact-12                  490.13k ± 0%     486.39k ± 0%  -0.76% (p=0.000 n=10)     489.96k ± 0%   -0.04% (p=0.000 n=10)
geomean                                                78.82k           77.48k       -1.69%                     35.79k       -54.60%

```


/cc @MadhavJivrajani 
