### PR TITLE
Fix a race in externalsigner_mock

### DIFF
--- a/pkg/serviceaccount/externaljwt/plugin/testing/v1alpha1/externalsigner_mock.go
+++ b/pkg/serviceaccount/externaljwt/plugin/testing/v1alpha1/externalsigner_mock.go
@@ -150,6 +150,7 @@ func (m *MockSigner) FetchKeys(ctx context.Context, req *v1alpha1.FetchKeysReque
 	keys := []*v1alpha1.Key{}
 
 	m.supportedKeysLock.RLock()
+	defer m.supportedKeysLock.RUnlock()
 	for id, k := range m.supportedKeys {
 		keys = append(keys, &v1alpha1.Key{
 			KeyId:                    id,
@@ -158,7 +159,6 @@ func (m *MockSigner) FetchKeys(ctx context.Context, req *v1alpha1.FetchKeysReque
 		})
 	}
 	m.supportedKeysFetched.Broadcast()
-	m.supportedKeysLock.RUnlock()
 
 	return &v1alpha1.FetchKeysResponse{
 		RefreshHintSeconds: 5,

--- a/test/integration/serviceaccount/external_jwt_signer_test.go
+++ b/test/integration/serviceaccount/external_jwt_signer_test.go
@@ -180,6 +180,8 @@ func TestExternalJWTSigningAndAuth(t *testing.T) {
 				cpy["kid-1"] = v1alpha1testing.KeyT{Key: pubKey1Bytes}
 				mockSigner.SetSupportedKeys(cpy)
 				mockSigner.WaitForSupportedKeysFetch()
+				// allow some time for plugin to be ready with new keys before proceeding
+				time.Sleep(2 * time.Second)
 			},
 			shouldPassAuth: true,
 		},


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

/kind flake


#### What this PR does / why we need it:

TestExternalJWTSigningAndAuth is flakey due to a data race. This PR addresses the same.

#### Which issue(s) this PR fixes:

Fixes #128871

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
