### PR TITLE
feat: resolve environment variables in `httpGet` probe path

### DIFF
--- a/pkg/kubelet/container/helpers.go
+++ b/pkg/kubelet/container/helpers.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"hash/fnv"
+	"k8s.io/kubernetes/pkg/kubelet/prober"
 	"strings"
 
 	"k8s.io/klog/v2"
@@ -40,7 +41,7 @@ import (
 
 // HandlerRunner runs a lifecycle handler for a container.
 type HandlerRunner interface {
-	Run(ctx context.Context, containerID ContainerID, pod *v1.Pod, container *v1.Container, handler *v1.LifecycleHandler) (string, error)
+	Run(ctx context.Context, containerID ContainerID, pod *v1.Pod, container *v1.Container, handler *v1.LifecycleHandler, getEnvVarsFunc prober.GetEnvVarsFunc) (string, error)
 }
 
 // RuntimeHelper wraps kubelet to make container runtime
@@ -69,6 +70,9 @@ type RuntimeHelper interface {
 
 	// SetPodWatchCondition flags a pod to be inspected until the condition is met.
 	SetPodWatchCondition(types.UID, string, func(*PodStatus) bool)
+
+	// MakeEnvironmentVariables Make the environment variables for a pod in the given namespace.
+	MakeEnvironmentVariables(pod *v1.Pod, container *v1.Container, podIP string, podIPs []string) ([]EnvVar, error)
 }
 
 // ShouldContainerBeRestarted checks whether a container needs to be restarted.

--- a/pkg/kubelet/container/helpers.go
+++ b/pkg/kubelet/container/helpers.go
@@ -21,7 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"hash/fnv"
-	"k8s.io/kubernetes/pkg/kubelet/prober"
+	httpprobe "k8s.io/kubernetes/pkg/probe/http"
 	"strings"
 
 	"k8s.io/klog/v2"
@@ -41,7 +41,7 @@ import (
 
 // HandlerRunner runs a lifecycle handler for a container.
 type HandlerRunner interface {
-	Run(ctx context.Context, containerID ContainerID, pod *v1.Pod, container *v1.Container, handler *v1.LifecycleHandler, getEnvVarsFunc prober.GetEnvVarsFunc) (string, error)
+	Run(ctx context.Context, containerID ContainerID, pod *v1.Pod, container *v1.Container, handler *v1.LifecycleHandler, getEnvsFunc httpprobe.GetEnvsFunc) (string, error)
 }
 
 // RuntimeHelper wraps kubelet to make container runtime

--- a/pkg/kubelet/container/helpers.go
+++ b/pkg/kubelet/container/helpers.go
@@ -431,12 +431,12 @@ type GetEnvsHelper interface {
 // GetEnvsHelperFunc helper variable to create GetEnvsFunc using GetEnvsHelper
 var GetEnvsHelperFunc = func(helper GetEnvsHelper) GetEnvsFunc {
 	return func(pod *v1.Pod, container *v1.Container, podIP string, podIPs []string) map[string]string {
+		envs := make(map[string]string)
 		envVars, err := helper.MakeEnvironmentVariables(pod, container, podIP, podIPs)
 		if err != nil {
-			klog.ErrorS(err, "Failed to get environment variables", "podUID", pod.UID, "container", container)
-			return nil
+			klog.ErrorS(err, "Failed to get environment variables", "podName", pod.Name, "containerName", container.Name)
+			return envs
 		}
-		envs := make(map[string]string)
 		for _, envVar := range envVars {
 			envs[envVar.Name] = envVar.Value
 		}

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2016,8 +2016,12 @@ func (kl *Kubelet) SyncPod(ctx context.Context, updateType kubetypes.SyncPodType
 	// Fetch the pull secrets for the pod
 	pullSecrets := kl.getPullSecretsForPod(pod)
 
+	// Func to get environment variables' values to use in httpGet path expansion
+	getEnvVarsFunc := func(pod *v1.Pod, container *v1.Container, podIP string, podIPs []string) ([]kubecontainer.EnvVar, error) {
+		return kl.makeEnvironmentVariables(pod, container, podIP, podIPs)
+	}
 	// Ensure the pod is being probed
-	kl.probeManager.AddPod(pod)
+	kl.probeManager.AddPod(pod, getEnvVarsFunc)
 
 	// TODO(#113606): use cancellation from the incoming context parameter, which comes from the pod worker.
 	// Currently, using cancellation from that context causes test failures. To remove this WithoutCancel,

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2018,7 +2018,7 @@ func (kl *Kubelet) SyncPod(ctx context.Context, updateType kubetypes.SyncPodType
 
 	// Func to get environment variables to use in httpGet path expansion
 	getEnvVarsFunc := func(pod *v1.Pod, container *v1.Container, podIP string, podIPs []string) ([]kubecontainer.EnvVar, error) {
-		return kl.makeEnvironmentVariables(pod, container, podIP, podIPs)
+		return kl.MakeEnvironmentVariables(pod, container, podIP, podIPs)
 	}
 	// Ensure the pod is being probed
 	kl.probeManager.AddPod(pod, getEnvVarsFunc)

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2016,12 +2016,8 @@ func (kl *Kubelet) SyncPod(ctx context.Context, updateType kubetypes.SyncPodType
 	// Fetch the pull secrets for the pod
 	pullSecrets := kl.getPullSecretsForPod(pod)
 
-	// Func to get environment variables to use in httpGet path expansion
-	getEnvVarsFunc := func(pod *v1.Pod, container *v1.Container, podIP string, podIPs []string) ([]kubecontainer.EnvVar, error) {
-		return kl.MakeEnvironmentVariables(pod, container, podIP, podIPs)
-	}
 	// Ensure the pod is being probed
-	kl.probeManager.AddPod(pod, getEnvVarsFunc)
+	kl.probeManager.AddPod(pod, httpprobe.GetEnvsHelperFunc(kl))
 
 	// TODO(#113606): use cancellation from the incoming context parameter, which comes from the pod worker.
 	// Currently, using cancellation from that context causes test failures. To remove this WithoutCancel,

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2017,7 +2017,7 @@ func (kl *Kubelet) SyncPod(ctx context.Context, updateType kubetypes.SyncPodType
 	pullSecrets := kl.getPullSecretsForPod(pod)
 
 	// Ensure the pod is being probed
-	kl.probeManager.AddPod(pod, httpprobe.GetEnvsHelperFunc(kl))
+	kl.probeManager.AddPod(pod, kubecontainer.GetEnvsHelperFunc(kl))
 
 	// TODO(#113606): use cancellation from the incoming context parameter, which comes from the pod worker.
 	// Currently, using cancellation from that context causes test failures. To remove this WithoutCancel,

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2016,7 +2016,7 @@ func (kl *Kubelet) SyncPod(ctx context.Context, updateType kubetypes.SyncPodType
 	// Fetch the pull secrets for the pod
 	pullSecrets := kl.getPullSecretsForPod(pod)
 
-	// Func to get environment variables' values to use in httpGet path expansion
+	// Func to get environment variables to use in httpGet path expansion
 	getEnvVarsFunc := func(pod *v1.Pod, container *v1.Container, podIP string, podIPs []string) ([]kubecontainer.EnvVar, error) {
 		return kl.makeEnvironmentVariables(pod, container, podIP, podIPs)
 	}

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -628,7 +628,7 @@ func (kl *Kubelet) GenerateRunContainerOptions(ctx context.Context, pod *v1.Pod,
 	}
 	opts.Devices = append(opts.Devices, blkVolumes...)
 
-	envs, err := kl.makeEnvironmentVariables(pod, container, podIP, podIPs)
+	envs, err := kl.MakeEnvironmentVariables(pod, container, podIP, podIPs)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -709,8 +709,8 @@ func (kl *Kubelet) getServiceEnvVarMap(ns string, enableServiceLinks bool) (map[
 	return m, nil
 }
 
-// Make the environment variables for a pod in the given namespace.
-func (kl *Kubelet) makeEnvironmentVariables(pod *v1.Pod, container *v1.Container, podIP string, podIPs []string) ([]kubecontainer.EnvVar, error) {
+// MakeEnvironmentVariables Make the environment variables for a pod in the given namespace.
+func (kl *Kubelet) MakeEnvironmentVariables(pod *v1.Pod, container *v1.Container, podIP string, podIPs []string) ([]kubecontainer.EnvVar, error) {
 	if pod.Spec.EnableServiceLinks == nil {
 		return nil, fmt.Errorf("nil pod.spec.enableServiceLinks encountered, cannot construct envvars")
 	}

--- a/pkg/kubelet/kubelet_pods_linux_test.go
+++ b/pkg/kubelet/kubelet_pods_linux_test.go
@@ -489,7 +489,7 @@ func TestMakeMountsEtcHostsFile(t *testing.T) {
 			Annotations: map[string]string{},
 		},
 		Spec: v1.PodSpec{
-			EnableServiceLinks: ptr.To(false), // to avoid errors with kl.makeEnvironmentVariables
+			EnableServiceLinks: ptr.To(false), // to avoid errors with kl.MakeEnvironmentVariables
 		},
 	}
 	testContainer := v1.Container{

--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -2034,7 +2034,7 @@ func TestMakeEnvironmentVariables(t *testing.T) {
 				testPod.Annotations[kubetypes.ConfigSourceAnnotationKey] = "file"
 			}
 
-			result, err := kl.makeEnvironmentVariables(testPod, tc.container, podIP, tc.podIPs)
+			result, err := kl.MakeEnvironmentVariables(testPod, tc.container, podIP, tc.podIPs)
 			select {
 			case e := <-fakeRecorder.Events:
 				assert.Equal(t, tc.expectedEvent, e)

--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	httpprobe "k8s.io/kubernetes/pkg/probe/http"
 	"math/rand"
 	"net/url"
 	"os"
@@ -315,7 +314,7 @@ func (m *kubeGenericRuntimeManager) startContainer(ctx context.Context, podSandb
 
 		// this func is used to expand path in http probe
 		getEnvsFunc := func(pod *v1.Pod, container *v1.Container, podIP string, podIPs []string) map[string]string {
-			return httpprobe.KeyValuesToMap(containerConfig.Envs)
+			return kubecontainer.KeyValuesToMap(containerConfig.Envs)
 		}
 		msg, handlerErr := m.runner.Run(ctx, kubeContainerID, pod, container, container.Lifecycle.PostStart, getEnvsFunc)
 		if handlerErr != nil {
@@ -694,7 +693,7 @@ func (m *kubeGenericRuntimeManager) executePreStopHook(ctx context.Context, pod 
 	go func() {
 		defer close(done)
 		defer utilruntime.HandleCrash()
-		if _, err := m.runner.Run(ctx, containerID, pod, containerSpec, containerSpec.Lifecycle.PreStop, httpprobe.GetEnvsHelperFunc(m.runtimeHelper)); err != nil {
+		if _, err := m.runner.Run(ctx, containerID, pod, containerSpec, containerSpec.Lifecycle.PreStop, kubecontainer.GetEnvsHelperFunc(m.runtimeHelper)); err != nil {
 			klog.ErrorS(err, "PreStop hook failed", "pod", klog.KObj(pod), "podUID", pod.UID,
 				"containerName", containerSpec.Name, "containerID", containerID.String())
 			// do not record the message in the event so that secrets won't leak from the server.

--- a/pkg/kubelet/lifecycle/handlers.go
+++ b/pkg/kubelet/lifecycle/handlers.go
@@ -69,7 +69,7 @@ func NewHandlerRunner(httpDoer kubetypes.HTTPDoer, commandRunner kubecontainer.C
 	}
 }
 
-func (hr *handlerRunner) Run(ctx context.Context, containerID kubecontainer.ContainerID, pod *v1.Pod, container *v1.Container, handler *v1.LifecycleHandler, getEnvsFunc httpprobe.GetEnvsFunc) (string, error) {
+func (hr *handlerRunner) Run(ctx context.Context, containerID kubecontainer.ContainerID, pod *v1.Pod, container *v1.Container, handler *v1.LifecycleHandler, getEnvsFunc kubecontainer.GetEnvsFunc) (string, error) {
 	switch {
 	case handler.Exec != nil:
 		var msg string
@@ -142,7 +142,7 @@ func (hr *handlerRunner) runSleepHandler(ctx context.Context, seconds int64) err
 	}
 }
 
-func (hr *handlerRunner) runHTTPHandler(ctx context.Context, pod *v1.Pod, container *v1.Container, handler *v1.LifecycleHandler, eventRecorder record.EventRecorder, getEnvsFunc httpprobe.GetEnvsFunc) error {
+func (hr *handlerRunner) runHTTPHandler(ctx context.Context, pod *v1.Pod, container *v1.Container, handler *v1.LifecycleHandler, eventRecorder record.EventRecorder, getEnvsFunc kubecontainer.GetEnvsFunc) error {
 	host := handler.HTTPGet.Host
 	podIP := host
 	podIPs := make([]string, 0)

--- a/pkg/kubelet/lifecycle/handlers.go
+++ b/pkg/kubelet/lifecycle/handlers.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"k8s.io/kubernetes/pkg/kubelet/prober"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -69,7 +70,7 @@ func NewHandlerRunner(httpDoer kubetypes.HTTPDoer, commandRunner kubecontainer.C
 	}
 }
 
-func (hr *handlerRunner) Run(ctx context.Context, containerID kubecontainer.ContainerID, pod *v1.Pod, container *v1.Container, handler *v1.LifecycleHandler) (string, error) {
+func (hr *handlerRunner) Run(ctx context.Context, containerID kubecontainer.ContainerID, pod *v1.Pod, container *v1.Container, handler *v1.LifecycleHandler, getEnvVarsFunc prober.GetEnvVarsFunc) (string, error) {
 	switch {
 	case handler.Exec != nil:
 		var msg string
@@ -81,7 +82,7 @@ func (hr *handlerRunner) Run(ctx context.Context, containerID kubecontainer.Cont
 		}
 		return msg, err
 	case handler.HTTPGet != nil:
-		err := hr.runHTTPHandler(ctx, pod, container, handler, hr.eventRecorder)
+		err := hr.runHTTPHandler(ctx, pod, container, handler, hr.eventRecorder, getEnvVarsFunc)
 		var msg string
 		if err != nil {
 			msg = fmt.Sprintf("HTTP lifecycle hook (%s) for Container %q in Pod %q failed - error: %v", handler.HTTPGet.Path, container.Name, format.Pod(pod), err)
@@ -142,9 +143,10 @@ func (hr *handlerRunner) runSleepHandler(ctx context.Context, seconds int64) err
 	}
 }
 
-func (hr *handlerRunner) runHTTPHandler(ctx context.Context, pod *v1.Pod, container *v1.Container, handler *v1.LifecycleHandler, eventRecorder record.EventRecorder) error {
+func (hr *handlerRunner) runHTTPHandler(ctx context.Context, pod *v1.Pod, container *v1.Container, handler *v1.LifecycleHandler, eventRecorder record.EventRecorder, getEnvVarsFunc prober.GetEnvVarsFunc) error {
 	host := handler.HTTPGet.Host
 	podIP := host
+	podIPs := make([]string, 0)
 	if len(host) == 0 {
 		status, err := hr.containerManager.GetPodStatus(ctx, pod.UID, pod.Name, pod.Namespace)
 		if err != nil {
@@ -156,9 +158,17 @@ func (hr *handlerRunner) runHTTPHandler(ctx context.Context, pod *v1.Pod, contai
 		}
 		host = status.IPs[0]
 		podIP = host
+		podIPs = status.IPs
 	}
 
-	req, err := httpprobe.NewRequestForHTTPGetAction(handler.HTTPGet, container, podIP, "lifecycle", make(map[string]string))
+	envs := make(map[string]string)
+	envVars, err := getEnvVarsFunc(pod, container, podIP, podIPs)
+	if err == nil {
+		for _, env := range envVars {
+			envs[env.Name] = env.Value
+		}
+	}
+	req, err := httpprobe.NewRequestForHTTPGetAction(handler.HTTPGet, container, podIP, "lifecycle", envs)
 	if err != nil {
 		return err
 	}

--- a/pkg/kubelet/lifecycle/handlers.go
+++ b/pkg/kubelet/lifecycle/handlers.go
@@ -158,7 +158,7 @@ func (hr *handlerRunner) runHTTPHandler(ctx context.Context, pod *v1.Pod, contai
 		podIP = host
 	}
 
-	req, err := httpprobe.NewRequestForHTTPGetAction(handler.HTTPGet, container, podIP, "lifecycle")
+	req, err := httpprobe.NewRequestForHTTPGetAction(handler.HTTPGet, container, podIP, "lifecycle", make(map[string]string))
 	if err != nil {
 		return err
 	}

--- a/pkg/kubelet/prober/common_test.go
+++ b/pkg/kubelet/prober/common_test.go
@@ -41,8 +41,8 @@ const (
 )
 
 var testContainerID = kubecontainer.ContainerID{Type: "test", ID: "cOnTaInEr_Id"}
-var testGetEnvVarsFunc = func(pod *v1.Pod, container *v1.Container, podIP string, podIPs []string) ([]kubecontainer.EnvVar, error) {
-	return make([]kubecontainer.EnvVar, 0), nil
+var testGetEnvVarsFunc = func(pod *v1.Pod, container *v1.Container, podIP string, podIPs []string) map[string]string {
+	return make(map[string]string)
 }
 
 func getTestRunningStatus() v1.PodStatus {

--- a/pkg/kubelet/prober/common_test.go
+++ b/pkg/kubelet/prober/common_test.go
@@ -41,6 +41,9 @@ const (
 )
 
 var testContainerID = kubecontainer.ContainerID{Type: "test", ID: "cOnTaInEr_Id"}
+var testGetEnvVarsFunc = func(pod *v1.Pod, container *v1.Container, podIP string, podIPs []string) ([]kubecontainer.EnvVar, error) {
+	return make([]kubecontainer.EnvVar, 0), nil
+}
 
 func getTestRunningStatus() v1.PodStatus {
 	return getTestRunningStatusWithStarted(true)
@@ -136,7 +139,7 @@ func newTestManager() *manager {
 func newTestWorker(m *manager, probeType probeType, probeSpec v1.Probe) *worker {
 	pod := getTestPod()
 	setTestProbe(pod, probeType, probeSpec)
-	return newWorker(m, probeType, pod, pod.Spec.Containers[0])
+	return newWorker(m, probeType, pod, pod.Spec.Containers[0], testGetEnvVarsFunc)
 }
 
 type fakeExecProber struct {

--- a/pkg/kubelet/prober/prober.go
+++ b/pkg/kubelet/prober/prober.go
@@ -79,7 +79,7 @@ func (pb *prober) recordContainerEvent(pod *v1.Pod, container *v1.Container, eve
 }
 
 // probe probes the container.
-func (pb *prober) probe(ctx context.Context, probeType probeType, pod *v1.Pod, status v1.PodStatus, container v1.Container, containerID kubecontainer.ContainerID, envVars map[string]string) (results.Result, error) {
+func (pb *prober) probe(ctx context.Context, probeType probeType, pod *v1.Pod, status v1.PodStatus, container v1.Container, containerID kubecontainer.ContainerID, envs map[string]string) (results.Result, error) {
 	var probeSpec *v1.Probe
 	switch probeType {
 	case readiness:
@@ -97,7 +97,7 @@ func (pb *prober) probe(ctx context.Context, probeType probeType, pod *v1.Pod, s
 		return results.Success, nil
 	}
 
-	result, output, err := pb.runProbeWithRetries(ctx, probeType, probeSpec, pod, status, container, containerID, envVars, maxProbeRetries)
+	result, output, err := pb.runProbeWithRetries(ctx, probeType, probeSpec, pod, status, container, containerID, envs, maxProbeRetries)
 	if err != nil || (result != probe.Success && result != probe.Warning) {
 		// Probe failed in one way or another.
 		if err != nil {
@@ -120,12 +120,12 @@ func (pb *prober) probe(ctx context.Context, probeType probeType, pod *v1.Pod, s
 
 // runProbeWithRetries tries to probe the container in a finite loop, it returns the last result
 // if it never succeeds.
-func (pb *prober) runProbeWithRetries(ctx context.Context, probeType probeType, p *v1.Probe, pod *v1.Pod, status v1.PodStatus, container v1.Container, containerID kubecontainer.ContainerID, envVars map[string]string, retries int) (probe.Result, string, error) {
+func (pb *prober) runProbeWithRetries(ctx context.Context, probeType probeType, p *v1.Probe, pod *v1.Pod, status v1.PodStatus, container v1.Container, containerID kubecontainer.ContainerID, envs map[string]string, retries int) (probe.Result, string, error) {
 	var err error
 	var result probe.Result
 	var output string
 	for i := 0; i < retries; i++ {
-		result, output, err = pb.runProbe(ctx, probeType, p, pod, status, container, containerID, envVars)
+		result, output, err = pb.runProbe(ctx, probeType, p, pod, status, container, containerID, envs)
 		if err == nil {
 			return result, output, nil
 		}
@@ -133,7 +133,7 @@ func (pb *prober) runProbeWithRetries(ctx context.Context, probeType probeType, 
 	return result, output, err
 }
 
-func (pb *prober) runProbe(ctx context.Context, probeType probeType, p *v1.Probe, pod *v1.Pod, status v1.PodStatus, container v1.Container, containerID kubecontainer.ContainerID, envVars map[string]string) (probe.Result, string, error) {
+func (pb *prober) runProbe(ctx context.Context, probeType probeType, p *v1.Probe, pod *v1.Pod, status v1.PodStatus, container v1.Container, containerID kubecontainer.ContainerID, envs map[string]string) (probe.Result, string, error) {
 	timeout := time.Duration(p.TimeoutSeconds) * time.Second
 	switch {
 	case p.Exec != nil:
@@ -142,7 +142,7 @@ func (pb *prober) runProbe(ctx context.Context, probeType probeType, p *v1.Probe
 		return pb.exec.Probe(pb.newExecInContainer(ctx, container, containerID, command, timeout))
 
 	case p.HTTPGet != nil:
-		req, err := httpprobe.NewRequestForHTTPGetAction(p.HTTPGet, &container, status.PodIP, "probe", envVars)
+		req, err := httpprobe.NewRequestForHTTPGetAction(p.HTTPGet, &container, status.PodIP, "probe", envs)
 		if err != nil {
 			return probe.Unknown, "", err
 		}

--- a/pkg/kubelet/prober/prober_manager.go
+++ b/pkg/kubelet/prober/prober_manager.go
@@ -71,7 +71,7 @@ var ProberDuration = metrics.NewHistogramVec(
 type Manager interface {
 	// AddPod creates new probe workers for every container probe. This should be called for every
 	// pod created.
-	AddPod(pod *v1.Pod)
+	AddPod(pod *v1.Pod, getEnvVarsFunc getEnvVarsFunc)
 
 	// StopLivenessAndStartup handles stopping liveness and startup probes during termination.
 	StopLivenessAndStartup(pod *v1.Pod)
@@ -178,7 +178,7 @@ func getRestartableInitContainers(pod *v1.Pod) []v1.Container {
 	return restartableInitContainers
 }
 
-func (m *manager) AddPod(pod *v1.Pod) {
+func (m *manager) AddPod(pod *v1.Pod, getEnvVarsFunc getEnvVarsFunc) {
 	m.workerLock.Lock()
 	defer m.workerLock.Unlock()
 
@@ -193,7 +193,7 @@ func (m *manager) AddPod(pod *v1.Pod) {
 					"pod", klog.KObj(pod), "containerName", c.Name)
 				return
 			}
-			w := newWorker(m, startup, pod, c)
+			w := newWorker(m, startup, pod, c, getEnvVarsFunc)
 			m.workers[key] = w
 			go w.run()
 		}
@@ -205,7 +205,7 @@ func (m *manager) AddPod(pod *v1.Pod) {
 					"pod", klog.KObj(pod), "containerName", c.Name)
 				return
 			}
-			w := newWorker(m, readiness, pod, c)
+			w := newWorker(m, readiness, pod, c, getEnvVarsFunc)
 			m.workers[key] = w
 			go w.run()
 		}
@@ -217,7 +217,7 @@ func (m *manager) AddPod(pod *v1.Pod) {
 					"pod", klog.KObj(pod), "containerName", c.Name)
 				return
 			}
-			w := newWorker(m, liveness, pod, c)
+			w := newWorker(m, liveness, pod, c, getEnvVarsFunc)
 			m.workers[key] = w
 			go w.run()
 		}

--- a/pkg/kubelet/prober/prober_manager.go
+++ b/pkg/kubelet/prober/prober_manager.go
@@ -71,7 +71,7 @@ var ProberDuration = metrics.NewHistogramVec(
 type Manager interface {
 	// AddPod creates new probe workers for every container probe. This should be called for every
 	// pod created.
-	AddPod(pod *v1.Pod, getEnvVarsFunc getEnvVarsFunc)
+	AddPod(pod *v1.Pod, getEnvVarsFunc GetEnvVarsFunc)
 
 	// StopLivenessAndStartup handles stopping liveness and startup probes during termination.
 	StopLivenessAndStartup(pod *v1.Pod)
@@ -178,7 +178,7 @@ func getRestartableInitContainers(pod *v1.Pod) []v1.Container {
 	return restartableInitContainers
 }
 
-func (m *manager) AddPod(pod *v1.Pod, getEnvVarsFunc getEnvVarsFunc) {
+func (m *manager) AddPod(pod *v1.Pod, getEnvVarsFunc GetEnvVarsFunc) {
 	m.workerLock.Lock()
 	defer m.workerLock.Unlock()
 

--- a/pkg/kubelet/prober/prober_manager.go
+++ b/pkg/kubelet/prober/prober_manager.go
@@ -17,7 +17,6 @@ limitations under the License.
 package prober
 
 import (
-	httpprobe "k8s.io/kubernetes/pkg/probe/http"
 	"sync"
 	"time"
 
@@ -72,7 +71,7 @@ var ProberDuration = metrics.NewHistogramVec(
 type Manager interface {
 	// AddPod creates new probe workers for every container probe. This should be called for every
 	// pod created.
-	AddPod(pod *v1.Pod, getEnvsFunc httpprobe.GetEnvsFunc)
+	AddPod(pod *v1.Pod, getEnvsFunc kubecontainer.GetEnvsFunc)
 
 	// StopLivenessAndStartup handles stopping liveness and startup probes during termination.
 	StopLivenessAndStartup(pod *v1.Pod)
@@ -179,7 +178,7 @@ func getRestartableInitContainers(pod *v1.Pod) []v1.Container {
 	return restartableInitContainers
 }
 
-func (m *manager) AddPod(pod *v1.Pod, getEnvsFunc httpprobe.GetEnvsFunc) {
+func (m *manager) AddPod(pod *v1.Pod, getEnvsFunc kubecontainer.GetEnvsFunc) {
 	m.workerLock.Lock()
 	defer m.workerLock.Unlock()
 

--- a/pkg/kubelet/prober/prober_manager_test.go
+++ b/pkg/kubelet/prober/prober_manager_test.go
@@ -95,13 +95,13 @@ func TestAddRemovePods(t *testing.T) {
 	}
 
 	// Adding a pod with no probes should be a no-op.
-	m.AddPod(&noProbePod)
+	m.AddPod(&noProbePod, testGetEnvVarsFunc)
 	if err := expectProbes(m, nil); err != nil {
 		t.Error(err)
 	}
 
 	// Adding a pod with probes.
-	m.AddPod(&probePod)
+	m.AddPod(&probePod, testGetEnvVarsFunc)
 	probePaths := []probeKey{
 		{"probe_pod", "readiness", readiness},
 		{"probe_pod", "liveness", liveness},
@@ -195,7 +195,7 @@ func TestAddRemovePodsWithRestartableInitContainer(t *testing.T) {
 			}
 
 			// Adding a pod with probes.
-			m.AddPod(&probePod)
+			m.AddPod(&probePod, testGetEnvVarsFunc)
 			if err := expectProbes(m, tc.probePaths); err != nil {
 				t.Error(err)
 			}
@@ -255,8 +255,8 @@ func TestCleanupPods(t *testing.T) {
 			}},
 		},
 	}
-	m.AddPod(&podToCleanup)
-	m.AddPod(&podToKeep)
+	m.AddPod(&podToCleanup, testGetEnvVarsFunc)
+	m.AddPod(&podToKeep, testGetEnvVarsFunc)
 
 	desiredPods := map[types.UID]sets.Empty{}
 	desiredPods[podToKeep.UID] = sets.Empty{}
@@ -298,7 +298,7 @@ func TestCleanupRepeated(t *testing.T) {
 	for i := 0; i < numTestPods; i++ {
 		pod := podTemplate
 		pod.UID = types.UID(strconv.Itoa(i))
-		m.AddPod(&pod)
+		m.AddPod(&pod, testGetEnvVarsFunc)
 	}
 
 	for i := 0; i < 10; i++ {
@@ -582,7 +582,7 @@ func TestUpdateReadiness(t *testing.T) {
 
 	m.statusManager.SetPodStatus(testPod, getTestRunningStatus())
 
-	m.AddPod(testPod)
+	m.AddPod(testPod, testGetEnvVarsFunc)
 	probePaths := []probeKey{{testPodUID, testContainerName, readiness}}
 	if err := expectProbes(m, probePaths); err != nil {
 		t.Error(err)

--- a/pkg/kubelet/prober/prober_test.go
+++ b/pkg/kubelet/prober/prober_test.go
@@ -236,7 +236,7 @@ func TestProbe(t *testing.T) {
 				prober.exec = fakeExecProber{test.execResult, nil}
 			}
 
-			result, err := prober.probe(ctx, probeType, &v1.Pod{}, v1.PodStatus{}, testContainer, containerID)
+			result, err := prober.probe(ctx, probeType, &v1.Pod{}, v1.PodStatus{}, testContainer, containerID, make(map[string]string))
 			if test.expectError && err == nil {
 				t.Errorf("[%s] Expected probe error but no error was returned.", testID)
 			}
@@ -250,7 +250,7 @@ func TestProbe(t *testing.T) {
 			if len(test.expectCommand) > 0 {
 				prober.exec = execprobe.New()
 				prober.runner = &containertest.FakeContainerCommandRunner{}
-				_, err := prober.probe(ctx, probeType, &v1.Pod{}, v1.PodStatus{}, testContainer, containerID)
+				_, err := prober.probe(ctx, probeType, &v1.Pod{}, v1.PodStatus{}, testContainer, containerID, make(map[string]string))
 				if err != nil {
 					t.Errorf("[%s] Didn't expect probe error but got: %v", testID, err)
 					continue

--- a/pkg/kubelet/prober/scale_test.go
+++ b/pkg/kubelet/prober/scale_test.go
@@ -141,7 +141,7 @@ func TestTCPPortExhaustion(t *testing.T) {
 				}
 				podManager.AddPod(&pod)
 				m.statusManager.SetPodStatus(&pod, pod.Status)
-				m.AddPod(&pod)
+				m.AddPod(&pod, testGetEnvVarsFunc)
 			}
 			t.Logf("Adding %d pods with %d containers each in %v", numTestPods, numContainers, time.Since(now))
 

--- a/pkg/kubelet/prober/testing/fake_manager.go
+++ b/pkg/kubelet/prober/testing/fake_manager.go
@@ -20,7 +20,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
-	httpprobe "k8s.io/kubernetes/pkg/probe/http"
+	"k8s.io/kubernetes/pkg/kubelet/container"
 )
 
 // FakeManager simulates a prober.Manager for testing.
@@ -29,7 +29,7 @@ type FakeManager struct{}
 // Unused methods below.
 
 // AddPod simulates adding a Pod.
-func (FakeManager) AddPod(_ *v1.Pod, _ httpprobe.GetEnvsFunc) {}
+func (FakeManager) AddPod(_ *v1.Pod, _ container.GetEnvsFunc) {}
 
 // RemovePod simulates removing a Pod.
 func (FakeManager) RemovePod(_ *v1.Pod) {}

--- a/pkg/kubelet/prober/testing/fake_manager.go
+++ b/pkg/kubelet/prober/testing/fake_manager.go
@@ -20,7 +20,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/kubernetes/pkg/kubelet/prober"
+	httpprobe "k8s.io/kubernetes/pkg/probe/http"
 )
 
 // FakeManager simulates a prober.Manager for testing.
@@ -29,7 +29,7 @@ type FakeManager struct{}
 // Unused methods below.
 
 // AddPod simulates adding a Pod.
-func (FakeManager) AddPod(_ *v1.Pod, _ prober.GetEnvVarsFunc) {}
+func (FakeManager) AddPod(_ *v1.Pod, _ httpprobe.GetEnvsFunc) {}
 
 // RemovePod simulates removing a Pod.
 func (FakeManager) RemovePod(_ *v1.Pod) {}

--- a/pkg/kubelet/prober/testing/fake_manager.go
+++ b/pkg/kubelet/prober/testing/fake_manager.go
@@ -20,6 +20,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/kubernetes/pkg/kubelet/prober"
 )
 
 // FakeManager simulates a prober.Manager for testing.
@@ -28,7 +29,7 @@ type FakeManager struct{}
 // Unused methods below.
 
 // AddPod simulates adding a Pod.
-func (FakeManager) AddPod(_ *v1.Pod) {}
+func (FakeManager) AddPod(_ *v1.Pod, _ prober.GetEnvVarsFunc) {}
 
 // RemovePod simulates removing a Pod.
 func (FakeManager) RemovePod(_ *v1.Pod) {}

--- a/pkg/kubelet/prober/worker.go
+++ b/pkg/kubelet/prober/worker.go
@@ -57,7 +57,7 @@ type worker struct {
 	initialValue results.Result
 
 	// Func to get environment variables' values used in httpGet path expansion
-	getEnvVarsFunc getEnvVarsFunc
+	getEnvVarsFunc GetEnvVarsFunc
 	// Map to store environment variables used in httpGet path expansion
 	envVars map[string]string
 
@@ -86,7 +86,7 @@ type worker struct {
 	proberDurationUnknownMetricLabels    metrics.Labels
 }
 
-type getEnvVarsFunc func(pod *v1.Pod, container *v1.Container, podIP string, podIPs []string) ([]kubecontainer.EnvVar, error)
+type GetEnvVarsFunc func(pod *v1.Pod, container *v1.Container, podIP string, podIPs []string) ([]kubecontainer.EnvVar, error)
 
 // Creates and starts a new probe worker.
 func newWorker(
@@ -94,7 +94,7 @@ func newWorker(
 	probeType probeType,
 	pod *v1.Pod,
 	container v1.Container,
-	getEnvVarsFunc getEnvVarsFunc) *worker {
+	getEnvVarsFunc GetEnvVarsFunc) *worker {
 
 	w := &worker{
 		stopCh:          make(chan struct{}, 1), // Buffer so stop() can be non-blocking.

--- a/pkg/kubelet/prober/worker.go
+++ b/pkg/kubelet/prober/worker.go
@@ -213,10 +213,10 @@ func (w *worker) getEnvVars() {
 			podIPs = append(podIPs, podIP.IP)
 		}
 	}
-	envVarsList, err := w.getEnvVarsFunc(w.pod, &w.container, podIP, podIPs)
+	envVars, err := w.getEnvVarsFunc(w.pod, &w.container, podIP, podIPs)
 	if err == nil {
-		for _, envVar := range envVarsList {
-			w.envVars[envVar.Name] = w.envVars[envVar.Value]
+		for _, envVar := range envVars {
+			w.envVars[envVar.Name] = envVar.Value
 		}
 	}
 }

--- a/pkg/kubelet/prober/worker.go
+++ b/pkg/kubelet/prober/worker.go
@@ -56,9 +56,9 @@ type worker struct {
 	// The probe value during the initial delay.
 	initialValue results.Result
 
-	// Func to get environment variables' values used in httpGet path expansion
+	// Func to get environment variables to use in httpGet path expansion
 	getEnvVarsFunc GetEnvVarsFunc
-	// Map to store environment variables used in httpGet path expansion
+	// Map to store environment variables to use in httpGet path expansion
 	envVars map[string]string
 
 	// Where to store this workers results.

--- a/pkg/kubelet/prober/worker.go
+++ b/pkg/kubelet/prober/worker.go
@@ -321,7 +321,7 @@ func (w *worker) doProbe(ctx context.Context) (keepGoing bool) {
 	}
 
 	// Note, exec probe does NOT have access to pod environment variables or downward API
-	result, err := w.probeManager.prober.probe(ctx, w.probeType, w.pod, status, w.container, w.containerID)
+	result, err := w.probeManager.prober.probe(ctx, w.probeType, w.pod, status, w.container, w.containerID, w.envVars)
 	if err != nil {
 		// Prober error, throw away the result.
 		return true

--- a/pkg/kubelet/prober/worker_test.go
+++ b/pkg/kubelet/prober/worker_test.go
@@ -594,12 +594,12 @@ func TestGetEnvVars(t *testing.T) {
 		{[]kubecontainer.EnvVar{}, nil, map[string]string{}, &v1.PodStatus{}},
 		{[]kubecontainer.EnvVar{{"k1", "v1"}, {"k2", "v2"}}, nil, map[string]string{"k1": "v1", "k2": "v2"}, &v1.PodStatus{}},
 		{[]kubecontainer.EnvVar{{"k1", "v1"}, {"k2", "v2"}}, nil, map[string]string{"k1": "v1", "k2": "v2"}, &v1.PodStatus{PodIP: "127.0.0.1", PodIPs: []v1.PodIP{{"127.0.0.1"}, {"127.0.0.2"}}}},
-		{nil, errors.New("GetEnvVarsFunc failed"), map[string]string{}, &v1.PodStatus{}},
+		{nil, errors.New("GetEnvsFunc failed"), map[string]string{}, &v1.PodStatus{}},
 	}
 	for _, test := range testCases {
 		m := newTestManager()
 		w := newTestWorker(m, startup, v1.Probe{})
-		w.getEnvVarsFunc = func(pod *v1.Pod, container *v1.Container, podIP string, podIPs []string) ([]kubecontainer.EnvVar, error) {
+		w.getEnvsFunc = func(pod *v1.Pod, container *v1.Container, podIP string, podIPs []string) ([]kubecontainer.EnvVar, error) {
 			return test.envVars, test.err
 		}
 		if test.podStatus != nil {
@@ -607,6 +607,6 @@ func TestGetEnvVars(t *testing.T) {
 		}
 
 		w.getEnvVars()
-		assert.Equal(t, test.expected, w.envVars, "Environment variable map doesn't match expected value. Expected: %v, got: %v", test.expected, w.envVars)
+		assert.Equal(t, test.expected, w.envs, "Environment variable map doesn't match expected value. Expected: %v, got: %v", test.expected, w.envs)
 	}
 }

--- a/pkg/kubelet/prober/worker_test.go
+++ b/pkg/kubelet/prober/worker_test.go
@@ -581,7 +581,7 @@ func TestStartupProbeDisabledByStarted(t *testing.T) {
 	expectResult(t, w, results.Success, msg)
 }
 
-func TestGetEnvVars(t *testing.T) {
+func TestGetEnvs(t *testing.T) {
 	testCases := []struct {
 		envs      map[string]string
 		expected  map[string]string

--- a/pkg/probe/http/request_test.go
+++ b/pkg/probe/http/request_test.go
@@ -135,3 +135,30 @@ func TestHeaderConversion(t *testing.T) {
 		}
 	}
 }
+
+func TestExpandPath(t *testing.T) {
+	envVars := map[string]string{
+		"VAR_A": "var-a",
+		"VAR_B": "var-b",
+		"VAR_C": "var-c",
+		"VAR_D": "var-d",
+	}
+	testCases := []struct {
+		path         string
+		expectedPath string
+	}{
+		{"", ""},
+		{"/path/to", "/path/to"},
+		{"/bad/path/$(VAR_A", "/bad/path/$(VAR_A"},
+		{"/path/to/$(VAR_A)", "/path/to/var-a"},
+		{"$(VAR_A)/path/to/$(VAR_B)", "var-a/path/to/var-b"},
+		{"$(VAR_A)/path/to/$(VAR_B)?c=$(VAR_C)", "var-a/path/to/var-b?c=var-c"},
+		{"$(VAR_A)/path/to/$(VAR_B)?c=$(VAR_C)&d=$(VAR_D)", "var-a/path/to/var-b?c=var-c&d=var-d"},
+	}
+	for _, test := range testCases {
+		expandedPath := expandPath(test.path, envVars)
+		if expandedPath != test.expectedPath {
+			t.Errorf("Expected %s, got %s", test.expectedPath, expandedPath)
+		}
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR adds support for environment variable interpolation in `httpGet` probe path in a way consistent with [Kubernetes standards](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/#using-environment-variables-inside-of-your-config).

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #128900

#### Special notes for your reviewer:

I've added a few unit tests but I don't know how to add e2e tests, I would appreciate if you could point me where I can add e2e tests.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
httpGet probe path now supports environment variable interpolation in a Kubernetes-native way.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
