### PR TITLE
feat(kubelet): Evented desired state of world populator

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -892,6 +892,12 @@ const (
 	// Initial implementation focused on ReadWriteOncePod volumes.
 	SELinuxMountReadWriteOncePod featuregate.Feature = "SELinuxMountReadWriteOncePod"
 
+	// owner: @bouaouda-achraf
+	// kep: https://kep.k8s.io/4979
+	// Dynamically adjust the Desired State of the World Populator (DSWP)
+	// sleep period during inactivity and trigger populator logic based on pod events.
+	EventedDesiredStateOfWorldPopulator featuregate.Feature = "EventedDesiredStateOfWorldPopulator"
+
 	// owner: @Sh4d1,@RyanAoh,@rikatz
 	// kep: http://kep.k8s.io/1860
 	// LoadBalancerIPMode enables the IPMode field in the LoadBalancerIngress status of a Service
@@ -1178,6 +1184,10 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 
 	EventedPLEG: {
 		{Version: version.MustParse("1.26"), Default: false, PreRelease: featuregate.Alpha},
+	},
+
+	EventedDesiredStateOfWorldPopulator: {
+		{Version: version.MustParse("1.34"), Default: false, PreRelease: featuregate.Alpha},
 	},
 
 	ExecProbeTimeout: {

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -731,6 +731,7 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 		klet.resyncInterval,
 		backOffPeriod,
 		klet.podCache,
+		klet.podManager.GetPodStateChannel(),
 	)
 
 	var singleProcessOOMKill *bool

--- a/pkg/kubelet/metrics/metrics.go
+++ b/pkg/kubelet/metrics/metrics.go
@@ -51,6 +51,7 @@ const (
 	PLEGDiscardEventsKey               = "pleg_discard_events"
 	PLEGRelistIntervalKey              = "pleg_relist_interval_seconds"
 	PLEGLastSeenKey                    = "pleg_last_seen_seconds"
+	EventedDSWPPodCountKey             = "evented_dswp_pod_count"
 	EventedPLEGConnErrKey              = "evented_pleg_connection_error_count"
 	EventedPLEGConnKey                 = "evented_pleg_connection_success_count"
 	EventedPLEGConnLatencyKey          = "evented_pleg_connection_latency_seconds"
@@ -383,6 +384,16 @@ var (
 			Subsystem:      KubeletSubsystem,
 			Name:           EventedPLEGConnKey,
 			Help:           "The number of times a streaming client was obtained to receive CRI Events.",
+			StabilityLevel: metrics.ALPHA,
+		},
+	)
+
+	// EventedDSWPPodCount is a Counter that tracks the number of DSWP event.
+	EventedDSWPPodCount = metrics.NewCounter(
+		&metrics.CounterOpts{
+			Subsystem:      KubeletSubsystem,
+			Name:           EventedDSWPPodCountKey,
+			Help:           "The number of the DSWP event.",
 			StabilityLevel: metrics.ALPHA,
 		},
 	)
@@ -1099,6 +1110,7 @@ func Register(collectors ...metrics.StableCollector) {
 		legacyregistry.MustRegister(PLEGLastSeen)
 		legacyregistry.MustRegister(EventedPLEGConnErr)
 		legacyregistry.MustRegister(EventedPLEGConn)
+		legacyregistry.MustRegister(EventedDSWPPodCount)
 		legacyregistry.MustRegister(EventedPLEGConnLatency)
 		legacyregistry.MustRegister(RuntimeOperations)
 		legacyregistry.MustRegister(RuntimeOperationsDuration)

--- a/pkg/kubelet/pod/pod_events.go
+++ b/pkg/kubelet/pod/pod_events.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pod
+
+import (
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// EventType defines the type of pod state change event
+type EventType string
+
+const (
+	PodAdded      EventType = "PodAdded"
+	PodUpdated    EventType = "PodUpdated"
+	PodRemoved    EventType = "PodRemoved"
+	PodTerminated EventType = "PodTerminated"
+)
+
+// PodStateEvent represents a state change event for a pod
+type PodStateEvent struct {
+	Type EventType
+	Pod  *v1.Pod
+	// UID is the unique identifier for the pod
+	UID types.UID
+}
+
+// PodStateChannel is a channel used to communicate pod state changes
+type PodStateChannel chan PodStateEvent

--- a/pkg/kubelet/pod/pod_manager_test.go
+++ b/pkg/kubelet/pod/pod_manager_test.go
@@ -100,6 +100,7 @@ func TestAddOrUpdatePod(t *testing.T) {
 				podByFullName:       make(map[string]*v1.Pod),
 				mirrorPodByFullName: make(map[string]*v1.Pod),
 				translationByUID:    make(map[kubetypes.MirrorPodUID]kubetypes.ResolvedPodUID),
+				stateChannel:        make(PodStateChannel, 500),
 			}
 			pm.AddPod(test.pod)
 			verify(t, pm, test.isMirror, test.pod)

--- a/pkg/kubelet/pod/testing/mock_manager.go
+++ b/pkg/kubelet/pod/testing/mock_manager.go
@@ -22,6 +22,8 @@ import (
 	mock "github.com/stretchr/testify/mock"
 	kubelettypes "k8s.io/kubernetes/pkg/kubelet/types"
 
+	pod "k8s.io/kubernetes/pkg/kubelet/pod"
+
 	types "k8s.io/apimachinery/pkg/types"
 
 	v1 "k8s.io/api/core/v1"
@@ -427,6 +429,53 @@ func (_c *MockManager_GetPodByUID_Call) Return(_a0 *v1.Pod, _a1 bool) *MockManag
 }
 
 func (_c *MockManager_GetPodByUID_Call) RunAndReturn(run func(types.UID) (*v1.Pod, bool)) *MockManager_GetPodByUID_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetPodStateChannel provides a mock function with no fields
+func (_m *MockManager) GetPodStateChannel() pod.PodStateChannel {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetPodStateChannel")
+	}
+
+	var r0 pod.PodStateChannel
+	if rf, ok := ret.Get(0).(func() pod.PodStateChannel); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(pod.PodStateChannel)
+		}
+	}
+
+	return r0
+}
+
+// MockManager_GetPodStateChannel_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetPodStateChannel'
+type MockManager_GetPodStateChannel_Call struct {
+	*mock.Call
+}
+
+// GetPodStateChannel is a helper method to define mock.On call
+func (_e *MockManager_Expecter) GetPodStateChannel() *MockManager_GetPodStateChannel_Call {
+	return &MockManager_GetPodStateChannel_Call{Call: _e.mock.On("GetPodStateChannel")}
+}
+
+func (_c *MockManager_GetPodStateChannel_Call) Run(run func()) *MockManager_GetPodStateChannel_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockManager_GetPodStateChannel_Call) Return(_a0 pod.PodStateChannel) *MockManager_GetPodStateChannel_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockManager_GetPodStateChannel_Call) RunAndReturn(run func() pod.PodStateChannel) *MockManager_GetPodStateChannel_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/kubelet/volumemanager/volume_manager.go
+++ b/pkg/kubelet/volumemanager/volume_manager.go
@@ -41,6 +41,7 @@ import (
 	csitrans "k8s.io/csi-translation-lib"
 	"k8s.io/kubernetes/pkg/kubelet/config"
 	"k8s.io/kubernetes/pkg/kubelet/container"
+	"k8s.io/kubernetes/pkg/kubelet/pod"
 	"k8s.io/kubernetes/pkg/kubelet/volumemanager/cache"
 	"k8s.io/kubernetes/pkg/kubelet/volumemanager/metrics"
 	"k8s.io/kubernetes/pkg/kubelet/volumemanager/populator"
@@ -168,6 +169,7 @@ type PodStateProvider interface {
 type PodManager interface {
 	GetPodByUID(k8stypes.UID) (*v1.Pod, bool)
 	GetPods() []*v1.Pod
+	GetPodStateChannel() pod.PodStateChannel
 }
 
 // NewVolumeManager returns a new concrete instance implementing the

--- a/pkg/kubelet/volumemanager/volume_manager_test.go
+++ b/pkg/kubelet/volumemanager/volume_manager_test.go
@@ -412,7 +412,6 @@ func newTestVolumeManager(t *testing.T, tmpDir string, podManager kubepod.Manage
 	// TODO (#51147) inject mock prober
 	fakeVolumeHost := volumetest.NewFakeKubeletVolumeHost(t, tmpDir, kubeClient, nil)
 	fakeVolumeHost.WithNode(node)
-
 	plugMgr.InitPlugins([]volume.VolumePlugin{attachablePlug, unattachablePlug}, nil /* prober */, fakeVolumeHost)
 	stateProvider := &fakePodStateProvider{}
 	fakePathHandler := volumetest.NewBlockVolumePathHandler()

--- a/staging/src/k8s.io/apimachinery/pkg/util/wait/backoff.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/wait/backoff.go
@@ -223,6 +223,11 @@ func JitterUntilWithContext(ctx context.Context, f func(context.Context), period
 	BackoffUntilWithContext(ctx, f, NewJitteredBackoffManager(period, jitterFactor, &clock.RealClock{}), sliding)
 }
 
+// Function that changes the sleep period during runtime (based on conditions)
+func DyanmicPeriodUntil(ctx context.Context, f func(), period func() time.Duration, jitterFactor float64, sliding bool) {
+	BackoffUntil(f, NewDynamicPeriodBackoffManagerImpl(period, jitterFactor, &clock.RealClock{}), sliding, ctx.Done())
+}
+
 // BackoffUntil loops until stop channel is closed, run f every duration given by BackoffManager.
 //
 // If sliding is true, the period is computed after f runs. If it is false then
@@ -257,6 +262,12 @@ func BackoffUntilWithContext(ctx context.Context, f func(ctx context.Context), b
 
 		if sliding {
 			t = backoff.Backoff()
+		}
+
+		// dynamically change the sleep period
+		dynamicPeriod, ok := backoff.(*dynamicPeriodBackoffManagerImpl)
+		if ok {
+			t.Reset(dynamicPeriod.duration())
 		}
 
 		// NOTE: b/c there is no priority selection in golang
@@ -415,6 +426,22 @@ type jitteredBackoffManagerImpl struct {
 	backoffTimer clock.Timer
 }
 
+type dynamicPeriodBackoffManagerImpl struct {
+	clock        clock.Clock
+	duration     func() time.Duration
+	jitter       float64
+	backoffTimer clock.Timer
+}
+
+func NewDynamicPeriodBackoffManagerImpl(duration func() time.Duration, jitter float64, c clock.Clock) BackoffManager {
+	return &dynamicPeriodBackoffManagerImpl{
+		clock:        c,
+		duration:     duration,
+		jitter:       jitter,
+		backoffTimer: nil,
+	}
+}
+
 // NewJitteredBackoffManager returns a BackoffManager that backoffs with given duration plus given jitter. If the jitter
 // is negative, backoff will not be jittered.
 //
@@ -439,6 +466,14 @@ func NewJitteredBackoffManager(duration time.Duration, jitter float64, c clock.C
 	}
 }
 
+func (d *dynamicPeriodBackoffManagerImpl) getNextBackoff() time.Duration {
+	jitteredPeriod := d.duration()
+	if d.jitter > 0.0 {
+		jitteredPeriod = Jitter(d.duration(), d.jitter)
+	}
+	return jitteredPeriod
+}
+
 func (j *jitteredBackoffManagerImpl) getNextBackoff() time.Duration {
 	jitteredPeriod := j.duration
 	if j.jitter > 0.0 {
@@ -457,6 +492,16 @@ func (j *jitteredBackoffManagerImpl) Backoff() clock.Timer {
 		j.backoffTimer.Reset(backoff)
 	}
 	return j.backoffTimer
+}
+
+func (d *dynamicPeriodBackoffManagerImpl) Backoff() clock.Timer {
+	backoff := d.getNextBackoff()
+	if d.backoffTimer == nil {
+		d.backoffTimer = d.clock.NewTimer(backoff)
+	} else {
+		d.backoffTimer.Reset(backoff)
+	}
+	return d.backoffTimer
 }
 
 // ExponentialBackoff repeats a condition check with exponential backoff.

--- a/staging/src/k8s.io/apimachinery/pkg/util/wait/wait_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/wait/wait_test.go
@@ -694,6 +694,35 @@ func TestPollUntil(t *testing.T) {
 	wg.Wait()
 }
 
+func TestDyanmicPeriodUntil(t *testing.T) {
+	i := 0
+	loopPeriod := 1 * time.Second
+	startIterationNow := time.Now()
+	jitered := 0.0
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	DyanmicPeriodUntil(ctx, func() {
+		t.Logf("Current date and time is: %v ", startIterationNow.String())
+		//  i = 0,1,2,3,4 = 1 second
+		//  i = 5,6,7,8,9 = 2 seconds
+		if i < 5 {
+			t.Logf("i <= 5 , i = %v", i)
+		} else if i >= 5 && i < 10 {
+			t.Logf("i >= 5 , i = %v ", i)
+			loopPeriod = 2 * time.Second
+		} else if i >= 10 {
+			difference := time.Since(startIterationNow)
+
+			if difference.Seconds() < 15 {
+				t.Errorf("end - start = %v,  expected >= %v ", difference.Seconds(), 15)
+			}
+			cancelFunc()
+		}
+		i++
+	}, func() time.Duration {
+		return loopPeriod
+	}, jitered, true)
+}
+
 func TestBackoff_Step(t *testing.T) {
 	tests := []struct {
 		initial *Backoff

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -483,6 +483,12 @@
     lockToDefault: true
     preRelease: GA
     version: "1.31"
+- name: EventedDesiredStateOfWorldPopulator
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.34"
 - name: EventedPLEG
   versionedSpecs:
   - default: false


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
Dynamically adjust the Desired State of the World Populator (DSWP) sleep period during inactivity and trigger populator logic based on pod events. 

#### Which issue(s) this PR fixes:
This is an implemention of the ["Optimize DSWP loop with dynamic sleep period and pod event state integration"](https://github.com/kubernetes/enhancements/issues/4979)

Fixes # https://github.com/kubernetes/enhancements/issues/4979

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Discussion Link: 
  - [Sig storage Meeting" (Thursday, September 12, 2024) ](https://docs.google.com/document/d/1-8KEG8AjAgKznS9NFm3qWqkGyCHmvU6HVl0sk5hwoAE/edit?tab=t.0)
  - [Initial doc](https://docs.google.com/document/d/1BmZnR9WFnQ8vSz_haw_x9jUwHVo2Gd8o/edit?usp=sharing&ouid=112685890921801424576&rtpof=true&sd=true)
  - [Issue comment](https://github.com/kubernetes/kubernetes/issues/126049#issuecomment-2361615997)
  
#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
KEP: https://github.com/kubernetes/enhancements/pull/4980 
[kubelet.log](https://github.com/user-attachments/files/19837808/kubelet.log)  : when enabling the feature and "kubectl  run  busybox --image=busybox ..." and then delete it .  
