### PR TITLE
partial revert: cloud providers: enhance context support

### DIFF
--- a/staging/src/k8s.io/cloud-provider/controllers/service/controller.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/service/controller.go
@@ -109,6 +109,9 @@ func New(
 	clusterName string,
 	featureGate featuregate.FeatureGate,
 ) (*Controller, error) {
+	broadcaster := record.NewBroadcaster()
+	recorder := broadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "service-controller"})
+
 	registerMetrics()
 
 	s := &Controller{
@@ -116,6 +119,8 @@ func New(
 		kubeClient:       kubeClient,
 		clusterName:      clusterName,
 		cache:            &serviceCache{serviceMap: make(map[string]*cachedService)},
+		eventBroadcaster: broadcaster,
+		eventRecorder:    recorder,
 		nodeLister:       nodeInformer.Lister(),
 		nodeListerSynced: nodeInformer.Informer().HasSynced,
 		serviceQueue: workqueue.NewTypedRateLimitingQueueWithConfig(
@@ -221,9 +226,6 @@ func (c *Controller) enqueueNode(obj interface{}) {
 // It's an error to call Run() more than once for a given ServiceController
 // object.
 func (c *Controller) Run(ctx context.Context, workers int, controllerManagerMetrics *controllersmetrics.ControllerManagerMetrics) {
-	c.eventBroadcaster = record.NewBroadcaster(record.WithContext(ctx))
-	c.eventRecorder = c.eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "service-controller"})
-
 	defer runtime.HandleCrash()
 	defer c.serviceQueue.ShutDown()
 	defer c.nodeQueue.ShutDown()


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

50c12437604b0cd5a73514389409fc2fde8b91bd moved construction of the event recorder into the Run method because then it can be constructed with a proper context. This was based on the assumption that the recorder would only be needed if the controllers actually run.

That assumption was true for most controllers, but not k8s.io/cloud-provider/controllers/service. That controller emits events inside its informer callbacks, which get registered already during construction. If that controller got constructed without calling Run, the informer callbacks panic with a nil access to the recorder (https://github.com/kubernetes/kubernetes/issues/128935).

That the controller emits events inside informer callbacks is unusual. https://github.com/kubernetes/kubernetes/pull/128179 cleaned up the controller such that this issue gets avoided in 1.32. But for a fix in 1.31.x it is better to revert to the previous behavior and construct the event recorder during construction.

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/kubernetes/issues/128935

#### Does this PR introduce a user-facing change?
```release-note
kube-controller-manager: avoid a panic in k8s.io/cloud-provider/controllers/service/controller.go
```

/cc @liggitt @aojea @krotz-dieter