### PR TITLE
Shift adding PodScheduled from kube-apiserver to kube-scheduler

### DIFF
--- a/pkg/kubelet/status/status_manager.go
+++ b/pkg/kubelet/status/status_manager.go
@@ -675,9 +675,6 @@ func (m *manager) updateStatusInternal(pod *v1.Pod, status v1.PodStatus, forceUp
 	// Set PodReadyToStartContainersCondition.LastTransitionTime.
 	updateLastTransitionTime(&status, &oldStatus, v1.PodReadyToStartContainers)
 
-	// Set PodScheduledCondition.LastTransitionTime.
-	updateLastTransitionTime(&status, &oldStatus, v1.PodScheduled)
-
 	// Set DisruptionTarget.LastTransitionTime.
 	updateLastTransitionTime(&status, &oldStatus, v1.DisruptionTarget)
 

--- a/pkg/registry/core/pod/storage/storage.go
+++ b/pkg/registry/core/pod/storage/storage.go
@@ -34,7 +34,6 @@ import (
 	storeerr "k8s.io/apiserver/pkg/storage/errors"
 	"k8s.io/apiserver/pkg/util/dryrun"
 	policyclient "k8s.io/client-go/kubernetes/typed/policy/v1"
-	podutil "k8s.io/kubernetes/pkg/api/pod"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/core/validation"
 	"k8s.io/kubernetes/pkg/kubelet/client"
@@ -245,10 +244,6 @@ func (r *BindingREST) setPodHostAndAnnotations(ctx context.Context, podUID types
 		for k, v := range annotations {
 			pod.Annotations[k] = v
 		}
-		podutil.UpdatePodCondition(&pod.Status, &api.PodCondition{
-			Type:   api.PodScheduled,
-			Status: api.ConditionTrue,
-		})
 		finalPod = pod
 		return pod, nil
 	}), dryRun, nil)


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
This PR fixes a bug where the PodScheduled condition was being created by kube-apiserver. When the scheduler fails to schedule a Pod, the kube-scheduler creates the [PodScheduled condition](https://github.com/kubernetes/kubernetes/blob/master/pkg/scheduler/schedule_one.go#L1100). Logically, using the same argument, kube-scheduler should create the PodScheduled condition.

Another argument on why kube-scheduler should create this condition is that the kube-scheduler assigns the node to the pod and not the kube-apiserver.

In addition to the above correction, it fixes https://github.com/kubernetes/kubernetes/issues/127508. 

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubernetes/issues/127508

#### Does this PR introduce a user-facing change?
No

```release-note
PodScheduled condition is now created by kube-scheduler instead of kube-apiserver
```

I am new contributor. Please suggest me the right solution if this is not the correct solution. 
