### PR TITLE
Record dataTimestamp as float

### DIFF
--- a/pkg/serviceaccount/externaljwt/metrics/metrics.go
+++ b/pkg/serviceaccount/externaljwt/metrics/metrics.go
@@ -116,8 +116,8 @@ func RecordTokenGenAttempt(err error) {
 	tokenGenReqTotal.WithLabelValues(getErrorCode(err)).Inc()
 }
 
-func RecordKeyDataTimeStamp(timestamp int64) {
-	dataTimeStamp.WithLabelValues().Set(float64(timestamp))
+func RecordKeyDataTimeStamp(timestamp float64) {
+	dataTimeStamp.WithLabelValues().Set(timestamp)
 }
 
 type gRPCError interface {

--- a/pkg/serviceaccount/externaljwt/metrics/metrics_test.go
+++ b/pkg/serviceaccount/externaljwt/metrics/metrics_test.go
@@ -195,13 +195,13 @@ func TestTokenGenMetrics(t *testing.T) {
 
 func TestRecordKeyDataTimeStamp(t *testing.T) {
 
-	dataTimeStamp1 := time.Now().Unix()
-	dataTimeStamp2 := time.Now().Add(time.Second * 1200).Unix()
+	dataTimeStamp1 := float64(time.Now().Unix())
+	dataTimeStamp2 := float64(time.Now().Add(time.Second * 1200).Unix())
 
 	testCases := []struct {
 		desc    string
 		metrics []string
-		want    int64
+		want    float64
 		emit    func()
 	}{
 		{

--- a/pkg/serviceaccount/externaljwt/plugin/keycache.go
+++ b/pkg/serviceaccount/externaljwt/plugin/keycache.go
@@ -156,7 +156,7 @@ func (p *keyCache) syncKeys(ctx context.Context) error {
 		}
 
 		p.verificationKeys.Store(newPublicKeys)
-		externaljwtmetrics.RecordKeyDataTimeStamp(newPublicKeys.DataTimestamp.Unix())
+		externaljwtmetrics.RecordKeyDataTimeStamp(float64(newPublicKeys.DataTimestamp.UnixNano()) / float64(1000000000))
 
 		if keysChanged(oldPublicKeys, newPublicKeys) {
 			p.broadcastUpdate()

--- a/pkg/serviceaccount/externaljwt/plugin/testing/v1alpha1/externalsigner_mock.go
+++ b/pkg/serviceaccount/externaljwt/plugin/testing/v1alpha1/externalsigner_mock.go
@@ -160,9 +160,10 @@ func (m *MockSigner) FetchKeys(ctx context.Context, req *v1alpha1.FetchKeysReque
 	m.supportedKeysFetched.Broadcast()
 	m.supportedKeysLock.RUnlock()
 
+	now := time.Now()
 	return &v1alpha1.FetchKeysResponse{
 		RefreshHintSeconds: 5,
-		DataTimestamp:      &timestamppb.Timestamp{Seconds: time.Now().Unix()},
+		DataTimestamp:      &timestamppb.Timestamp{Seconds: now.Unix(), Nanos: int32(now.Nanosecond())},
 		Keys:               keys,
 	}, nil
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Records dataTimestamp from external signers at float granularity

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/sig auth
/cc @ahmedtd 
/milestone v1.33