### PR TITLE
Adjust performance test throughput threshold limits

### DIFF
--- a/test/integration/scheduler_perf/affinity/performance-config.yaml
+++ b/test/integration/scheduler_perf/affinity/performance-config.yaml
@@ -65,7 +65,7 @@
     featureGates:
       SchedulerQueueingHints: false
     labels: [performance]
-    threshold: 70
+    threshold: 60
     params:
       initNodes: 5000
       initPods: 1000
@@ -74,7 +74,7 @@
     featureGates:
       SchedulerQueueingHints: true
     labels: [performance]
-    threshold: 70
+    threshold: 60
     params:
       initNodes: 5000
       initPods: 1000

--- a/test/integration/scheduler_perf/misc/performance-config.yaml
+++ b/test/integration/scheduler_perf/misc/performance-config.yaml
@@ -355,7 +355,7 @@
       measurePods: 500
   - name: 5000Nodes
     labels: [performance]
-    threshold: 200
+    threshold: 160
     featureGates:
       SchedulerQueueingHints: false
       SchedulerAsyncPreemption: false
@@ -364,7 +364,7 @@
       initPods: 20000
       measurePods: 5000
   - name: 5000Nodes_AsyncPreemptionEnabled
-    threshold: 200
+    threshold: 160
     labels: [performance]
     featureGates:
       SchedulerAsyncPreemption: true
@@ -376,7 +376,7 @@
     featureGates:
       SchedulerQueueingHints: true
     labels: [performance]
-    threshold: 120
+    threshold: 160
     params:
       initNodes: 5000
       initPods: 20000
@@ -425,7 +425,7 @@
     featureGates:
       SchedulerQueueingHints: false
     labels: [performance]
-    threshold: 200
+    threshold: 140
     params:
       initNodes: 5000
       measurePods: 10000
@@ -433,7 +433,7 @@
     featureGates:
       SchedulerQueueingHints: true
     labels: [performance]
-    threshold: 250
+    threshold: 170
     params:
       initNodes: 5000
       measurePods: 10000


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/kind flake

#### What this PR does / why we need it:
Adjust throughput threshold for new tests based on historical times to avoid flakiness.

#### Which issue(s) this PR fixes:
Part of #128221

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
