### PR TITLE
Use ptr.To instead of &[]T{}[0] or deprecated utils/pointer pkg

### DIFF
--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -47,7 +47,6 @@ import (
 	"k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/capabilities"
 	"k8s.io/kubernetes/pkg/features"
-	utilpointer "k8s.io/utils/pointer"
 	"k8s.io/utils/ptr"
 )
 
@@ -2715,7 +2714,7 @@ func TestValidatePersistentVolumeClaimUpdate(t *testing.T) {
 		Phase: core.ClaimBound,
 	})
 	validClaimEmptyVolumeAttributesClass := testVolumeClaimWithStatus("foo", "ns", core.PersistentVolumeClaimSpec{
-		VolumeAttributesClassName: utilpointer.String(""),
+		VolumeAttributesClassName: ptr.To(""),
 		AccessModes: []core.PersistentVolumeAccessMode{
 			core.ReadWriteOnce,
 			core.ReadOnlyMany,
@@ -2729,7 +2728,7 @@ func TestValidatePersistentVolumeClaimUpdate(t *testing.T) {
 		Phase: core.ClaimBound,
 	})
 	validClaimVolumeAttributesClass1 := testVolumeClaimWithStatus("foo", "ns", core.PersistentVolumeClaimSpec{
-		VolumeAttributesClassName: utilpointer.String("vac1"),
+		VolumeAttributesClassName: ptr.To("vac1"),
 		AccessModes: []core.PersistentVolumeAccessMode{
 			core.ReadWriteOnce,
 			core.ReadOnlyMany,
@@ -2743,7 +2742,7 @@ func TestValidatePersistentVolumeClaimUpdate(t *testing.T) {
 		Phase: core.ClaimBound,
 	})
 	validClaimVolumeAttributesClass2 := testVolumeClaimWithStatus("foo", "ns", core.PersistentVolumeClaimSpec{
-		VolumeAttributesClassName: utilpointer.String("vac2"),
+		VolumeAttributesClassName: ptr.To("vac2"),
 		AccessModes: []core.PersistentVolumeAccessMode{
 			core.ReadWriteOnce,
 			core.ReadOnlyMany,
@@ -3085,7 +3084,7 @@ func TestValidationOptionsForPersistentVolumeClaim(t *testing.T) {
 			},
 		},
 		"volume attributes class allowed because feature enable": {
-			oldPvc:                      pvcWithVolumeAttributesClassName(utilpointer.String("foo")),
+			oldPvc:                      pvcWithVolumeAttributesClassName(ptr.To("foo")),
 			enableVolumeAttributesClass: true,
 			expectValidationOpts: PersistentVolumeClaimSpecValidationOptions{
 				EnableRecoverFromExpansionFailure: true,
@@ -3093,7 +3092,7 @@ func TestValidationOptionsForPersistentVolumeClaim(t *testing.T) {
 			},
 		},
 		"volume attributes class validated because used and feature disabled": {
-			oldPvc:                      pvcWithVolumeAttributesClassName(utilpointer.String("foo")),
+			oldPvc:                      pvcWithVolumeAttributesClassName(ptr.To("foo")),
 			enableVolumeAttributesClass: false,
 			expectValidationOpts: PersistentVolumeClaimSpecValidationOptions{
 				EnableRecoverFromExpansionFailure: true,
@@ -3125,7 +3124,7 @@ func TestValidationOptionsForPersistentVolumeClaimTemplate(t *testing.T) {
 			expectValidationOpts: PersistentVolumeClaimSpecValidationOptions{},
 		},
 		"volume attributes class allowed because feature enable": {
-			oldPvcTemplate:              pvcTemplateWithVolumeAttributesClassName(utilpointer.String("foo")),
+			oldPvcTemplate:              pvcTemplateWithVolumeAttributesClassName(ptr.To("foo")),
 			enableVolumeAttributesClass: true,
 			expectValidationOpts: PersistentVolumeClaimSpecValidationOptions{
 				EnableVolumeAttributesClass: true,
@@ -3160,7 +3159,7 @@ func TestValidateKeyToPath(t *testing.T) {
 		kp: core.KeyToPath{Key: "k", Path: "p/..p/p../p..p"},
 		ok: true,
 	}, {
-		kp: core.KeyToPath{Key: "k", Path: "p", Mode: utilpointer.Int32(0644)},
+		kp: core.KeyToPath{Key: "k", Path: "p", Mode: ptr.To(int32(0644))},
 		ok: true,
 	}, {
 		kp:      core.KeyToPath{Key: "", Path: "p"},
@@ -3187,11 +3186,11 @@ func TestValidateKeyToPath(t *testing.T) {
 		ok:      false,
 		errtype: field.ErrorTypeInvalid,
 	}, {
-		kp:      core.KeyToPath{Key: "k", Path: "p", Mode: utilpointer.Int32(01000)},
+		kp:      core.KeyToPath{Key: "k", Path: "p", Mode: ptr.To(int32(01000))},
 		ok:      false,
 		errtype: field.ErrorTypeInvalid,
 	}, {
-		kp:      core.KeyToPath{Key: "k", Path: "p", Mode: utilpointer.Int32(-1)},
+		kp:      core.KeyToPath{Key: "k", Path: "p", Mode: ptr.To(int32(-1))},
 		ok:      false,
 		errtype: field.ErrorTypeInvalid,
 	},
@@ -4148,7 +4147,7 @@ func TestValidateVolumes(t *testing.T) {
 				VolumeSource: core.VolumeSource{
 					Secret: &core.SecretVolumeSource{
 						SecretName:  "my-secret",
-						DefaultMode: utilpointer.Int32(0644),
+						DefaultMode: ptr.To(int32(0644)),
 					},
 				},
 			},
@@ -4162,7 +4161,7 @@ func TestValidateVolumes(t *testing.T) {
 						Items: []core.KeyToPath{{
 							Key:  "key",
 							Path: "filename",
-							Mode: utilpointer.Int32(0644),
+							Mode: ptr.To(int32(0644)),
 						}},
 					},
 				},
@@ -4233,7 +4232,7 @@ func TestValidateVolumes(t *testing.T) {
 				VolumeSource: core.VolumeSource{
 					Secret: &core.SecretVolumeSource{
 						SecretName:  "s",
-						DefaultMode: utilpointer.Int32(01000),
+						DefaultMode: ptr.To(int32(01000)),
 					},
 				},
 			},
@@ -4248,7 +4247,7 @@ func TestValidateVolumes(t *testing.T) {
 				VolumeSource: core.VolumeSource{
 					Secret: &core.SecretVolumeSource{
 						SecretName:  "s",
-						DefaultMode: utilpointer.Int32(-1),
+						DefaultMode: ptr.To(int32(-1)),
 					},
 				},
 			},
@@ -4279,7 +4278,7 @@ func TestValidateVolumes(t *testing.T) {
 						LocalObjectReference: core.LocalObjectReference{
 							Name: "my-cfgmap",
 						},
-						DefaultMode: utilpointer.Int32(0644),
+						DefaultMode: ptr.To(int32(0644)),
 					},
 				},
 			},
@@ -4294,7 +4293,7 @@ func TestValidateVolumes(t *testing.T) {
 						Items: []core.KeyToPath{{
 							Key:  "key",
 							Path: "filename",
-							Mode: utilpointer.Int32(0644),
+							Mode: ptr.To(int32(0644)),
 						}},
 					},
 				},
@@ -4366,7 +4365,7 @@ func TestValidateVolumes(t *testing.T) {
 				VolumeSource: core.VolumeSource{
 					ConfigMap: &core.ConfigMapVolumeSource{
 						LocalObjectReference: core.LocalObjectReference{Name: "c"},
-						DefaultMode:          utilpointer.Int32(01000),
+						DefaultMode:          ptr.To(int32(01000)),
 					},
 				},
 			},
@@ -4381,7 +4380,7 @@ func TestValidateVolumes(t *testing.T) {
 				VolumeSource: core.VolumeSource{
 					ConfigMap: &core.ConfigMapVolumeSource{
 						LocalObjectReference: core.LocalObjectReference{Name: "c"},
-						DefaultMode:          utilpointer.Int32(-1),
+						DefaultMode:          ptr.To(int32(-1)),
 					},
 				},
 			},
@@ -4723,7 +4722,7 @@ func TestValidateVolumes(t *testing.T) {
 				Name: "downapi",
 				VolumeSource: core.VolumeSource{
 					DownwardAPI: &core.DownwardAPIVolumeSource{
-						DefaultMode: utilpointer.Int32(0644),
+						DefaultMode: ptr.To(int32(0644)),
 					},
 				},
 			},
@@ -4734,7 +4733,7 @@ func TestValidateVolumes(t *testing.T) {
 				VolumeSource: core.VolumeSource{
 					DownwardAPI: &core.DownwardAPIVolumeSource{
 						Items: []core.DownwardAPIVolumeFile{{
-							Mode: utilpointer.Int32(0644),
+							Mode: ptr.To(int32(0644)),
 							Path: "path",
 							FieldRef: &core.ObjectFieldSelector{
 								APIVersion: "v1",
@@ -4751,7 +4750,7 @@ func TestValidateVolumes(t *testing.T) {
 				VolumeSource: core.VolumeSource{
 					DownwardAPI: &core.DownwardAPIVolumeSource{
 						Items: []core.DownwardAPIVolumeFile{{
-							Mode: utilpointer.Int32(01000),
+							Mode: ptr.To(int32(01000)),
 							Path: "path",
 							FieldRef: &core.ObjectFieldSelector{
 								APIVersion: "v1",
@@ -4772,7 +4771,7 @@ func TestValidateVolumes(t *testing.T) {
 				VolumeSource: core.VolumeSource{
 					DownwardAPI: &core.DownwardAPIVolumeSource{
 						Items: []core.DownwardAPIVolumeFile{{
-							Mode: utilpointer.Int32(-1),
+							Mode: ptr.To(int32(-1)),
 							Path: "path",
 							FieldRef: &core.ObjectFieldSelector{
 								APIVersion: "v1",
@@ -4920,7 +4919,7 @@ func TestValidateVolumes(t *testing.T) {
 				Name: "downapi",
 				VolumeSource: core.VolumeSource{
 					DownwardAPI: &core.DownwardAPIVolumeSource{
-						DefaultMode: utilpointer.Int32(01000),
+						DefaultMode: ptr.To(int32(01000)),
 					},
 				},
 			},
@@ -4934,7 +4933,7 @@ func TestValidateVolumes(t *testing.T) {
 				Name: "downapi",
 				VolumeSource: core.VolumeSource{
 					DownwardAPI: &core.DownwardAPIVolumeSource{
-						DefaultMode: utilpointer.Int32(-1),
+						DefaultMode: ptr.To(int32(-1)),
 					},
 				},
 			},
@@ -4951,7 +4950,7 @@ func TestValidateVolumes(t *testing.T) {
 				VolumeSource: core.VolumeSource{
 					FC: &core.FCVolumeSource{
 						TargetWWNs: []string{"some_wwn"},
-						Lun:        utilpointer.Int32(1),
+						Lun:        ptr.To(int32(1)),
 						FSType:     "ext4",
 						ReadOnly:   false,
 					},
@@ -4976,7 +4975,7 @@ func TestValidateVolumes(t *testing.T) {
 				VolumeSource: core.VolumeSource{
 					FC: &core.FCVolumeSource{
 						TargetWWNs: []string{},
-						Lun:        utilpointer.Int32(1),
+						Lun:        ptr.To(int32(1)),
 						WWIDs:      []string{},
 						FSType:     "ext4",
 						ReadOnly:   false,
@@ -4995,7 +4994,7 @@ func TestValidateVolumes(t *testing.T) {
 				VolumeSource: core.VolumeSource{
 					FC: &core.FCVolumeSource{
 						TargetWWNs: []string{"some_wwn"},
-						Lun:        utilpointer.Int32(1),
+						Lun:        ptr.To(int32(1)),
 						WWIDs:      []string{"some_wwid"},
 						FSType:     "ext4",
 						ReadOnly:   false,
@@ -5032,7 +5031,7 @@ func TestValidateVolumes(t *testing.T) {
 				VolumeSource: core.VolumeSource{
 					FC: &core.FCVolumeSource{
 						TargetWWNs: []string{"wwn"},
-						Lun:        utilpointer.Int32(256),
+						Lun:        ptr.To(int32(256)),
 						FSType:     "ext4",
 						ReadOnly:   false,
 					},
@@ -7538,7 +7537,7 @@ func Test_validateProbe(t *testing.T) {
 		args: args{
 			probe: &core.Probe{
 				ProbeHandler:                  core.ProbeHandler{Exec: &core.ExecAction{Command: []string{"echo"}}},
-				TerminationGracePeriodSeconds: utilpointer.Int64(-1),
+				TerminationGracePeriodSeconds: ptr.To(int64(-1)),
 			},
 			fldPath: fldPath,
 		},
@@ -7547,7 +7546,7 @@ func Test_validateProbe(t *testing.T) {
 		args: args{
 			probe: &core.Probe{
 				ProbeHandler:                  core.ProbeHandler{Exec: &core.ExecAction{Command: []string{"echo"}}},
-				TerminationGracePeriodSeconds: utilpointer.Int64(0),
+				TerminationGracePeriodSeconds: ptr.To(int64(0)),
 			},
 			fldPath: fldPath,
 		},
@@ -7556,7 +7555,7 @@ func Test_validateProbe(t *testing.T) {
 		args: args{
 			probe: &core.Probe{
 				ProbeHandler:                  core.ProbeHandler{Exec: &core.ExecAction{Command: []string{"echo"}}},
-				TerminationGracePeriodSeconds: utilpointer.Int64(1),
+				TerminationGracePeriodSeconds: ptr.To(int64(1)),
 			},
 			fldPath: fldPath,
 		},
@@ -7845,7 +7844,7 @@ func TestValidateEphemeralContainers(t *testing.T) {
 				EnvFrom: []core.EnvFromSource{{
 					ConfigMapRef: &core.ConfigMapEnvSource{
 						LocalObjectReference: core.LocalObjectReference{Name: "dummy"},
-						Optional:             &[]bool{true}[0],
+						Optional:             ptr.To(true),
 					},
 				}},
 				Env: []core.EnvVar{
@@ -8234,7 +8233,7 @@ func TestValidateEphemeralContainers(t *testing.T) {
 }
 
 func TestValidateWindowsPodSecurityContext(t *testing.T) {
-	validWindowsSC := &core.PodSecurityContext{WindowsOptions: &core.WindowsSecurityContextOptions{RunAsUserName: utilpointer.String("dummy")}}
+	validWindowsSC := &core.PodSecurityContext{WindowsOptions: &core.WindowsSecurityContextOptions{RunAsUserName: ptr.To("dummy")}}
 	invalidWindowsSC := &core.PodSecurityContext{SELinuxOptions: &core.SELinuxOptions{Role: "dummyRole"}}
 	cases := map[string]struct {
 		podSec      *core.PodSpec
@@ -8282,7 +8281,7 @@ func TestValidateLinuxPodSecurityContext(t *testing.T) {
 		RunAsUser: &runAsUser,
 	}
 	invalidLinuxSC := &core.PodSecurityContext{
-		WindowsOptions: &core.WindowsSecurityContextOptions{RunAsUserName: utilpointer.String("myUser")},
+		WindowsOptions: &core.WindowsSecurityContextOptions{RunAsUserName: ptr.To("myUser")},
 	}
 
 	cases := map[string]struct {
@@ -8717,7 +8716,7 @@ func TestValidateContainers(t *testing.T) {
 						Port: intstr.FromInt32(80),
 					},
 				},
-				TerminationGracePeriodSeconds: utilpointer.Int64(10),
+				TerminationGracePeriodSeconds: ptr.To(int64(10)),
 			},
 			ImagePullPolicy:          "IfNotPresent",
 			TerminationMessagePolicy: "File",
@@ -8806,7 +8805,7 @@ func TestValidateContainers(t *testing.T) {
 				PeriodSeconds:                 -1,
 				SuccessThreshold:              -1,
 				FailureThreshold:              -1,
-				TerminationGracePeriodSeconds: utilpointer.Int64(-1),
+				TerminationGracePeriodSeconds: ptr.To(int64(-1)),
 			},
 			ImagePullPolicy:          "IfNotPresent",
 			TerminationMessagePolicy: "File",
@@ -8837,7 +8836,7 @@ func TestValidateContainers(t *testing.T) {
 				PeriodSeconds:                 -1,
 				SuccessThreshold:              -1,
 				FailureThreshold:              -1,
-				TerminationGracePeriodSeconds: utilpointer.Int64(-1),
+				TerminationGracePeriodSeconds: ptr.To(int64(-1)),
 			},
 			ImagePullPolicy:          "IfNotPresent",
 			TerminationMessagePolicy: "File",
@@ -8871,7 +8870,7 @@ func TestValidateContainers(t *testing.T) {
 				PeriodSeconds:                 -1,
 				SuccessThreshold:              -1,
 				FailureThreshold:              -1,
-				TerminationGracePeriodSeconds: utilpointer.Int64(-1),
+				TerminationGracePeriodSeconds: ptr.To(int64(-1)),
 			},
 			ImagePullPolicy:          "IfNotPresent",
 			TerminationMessagePolicy: "File",
@@ -9377,7 +9376,7 @@ func TestValidateInitContainers(t *testing.T) {
 				PeriodSeconds:                 -1,
 				SuccessThreshold:              -1,
 				FailureThreshold:              -1,
-				TerminationGracePeriodSeconds: utilpointer.Int64(-1),
+				TerminationGracePeriodSeconds: ptr.To(int64(-1)),
 			},
 		}},
 		field.ErrorList{{Type: field.ErrorTypeForbidden, Field: "initContainers[0].startupProbe", BadValue: ""}},
@@ -9457,10 +9456,10 @@ func TestValidateInitContainers(t *testing.T) {
 						Port: intstr.FromInt32(80),
 					},
 				},
-				TerminationGracePeriodSeconds: utilpointer.Int64(10),
+				TerminationGracePeriodSeconds: ptr.To(int64(10)),
 			},
 		}},
-		field.ErrorList{{Type: field.ErrorTypeInvalid, Field: "initContainers[0].readinessProbe.terminationGracePeriodSeconds", BadValue: utilpointer.Int64(10)}},
+		field.ErrorList{{Type: field.ErrorTypeInvalid, Field: "initContainers[0].readinessProbe.terminationGracePeriodSeconds", BadValue: ptr.To(int64(10))}},
 	}, {
 		"invalid liveness probe, successThreshold != 1",
 		line(),
@@ -10103,7 +10102,7 @@ func TestValidatePodSpec(t *testing.T) {
 		),
 		"populate ShareProcessNamespace": podtest.MakePod("",
 			podtest.SetSecurityContext(&core.PodSecurityContext{
-				ShareProcessNamespace: &[]bool{true}[0],
+				ShareProcessNamespace: ptr.To(true),
 			}),
 		),
 		"populate RuntimeClassName": podtest.MakePod("",
@@ -10221,7 +10220,7 @@ func TestValidatePodSpec(t *testing.T) {
 		"ShareProcessNamespace and HostPID both set": *podtest.MakePod("",
 			podtest.SetSecurityContext(&core.PodSecurityContext{
 				HostPID:               true,
-				ShareProcessNamespace: &[]bool{true}[0],
+				ShareProcessNamespace: ptr.To(true),
 			}),
 		),
 		"bad RuntimeClassName": *podtest.MakePod("",
@@ -10455,10 +10454,10 @@ func TestValidatePod(t *testing.T) {
 				}),
 		),
 		"populate forgiveness tolerations with exists operator in annotations.": *podtest.MakePod("123",
-			podtest.SetTolerations(core.Toleration{Key: "foo", Operator: "Exists", Value: "", Effect: "NoExecute", TolerationSeconds: &[]int64{60}[0]}),
+			podtest.SetTolerations(core.Toleration{Key: "foo", Operator: "Exists", Value: "", Effect: "NoExecute", TolerationSeconds: ptr.To(int64(60))}),
 		),
 		"populate forgiveness tolerations with equal operator in annotations.": *podtest.MakePod("123",
-			podtest.SetTolerations(core.Toleration{Key: "foo", Operator: "Equal", Value: "bar", Effect: "NoExecute", TolerationSeconds: &[]int64{60}[0]}),
+			podtest.SetTolerations(core.Toleration{Key: "foo", Operator: "Equal", Value: "bar", Effect: "NoExecute", TolerationSeconds: ptr.To(int64(60))}),
 		),
 		"populate tolerations equal operator in annotations.": *podtest.MakePod("123",
 			podtest.SetTolerations(core.Toleration{Key: "foo", Operator: "Equal", Value: "bar", Effect: "NoSchedule"}),
@@ -10477,7 +10476,7 @@ func TestValidatePod(t *testing.T) {
 		),
 		"negative tolerationSeconds is OK for toleration.": *podtest.MakePod("123",
 			podtest.SetTolerations(
-				core.Toleration{Key: "node.kubernetes.io/not-ready", Operator: "Exists", Effect: "NoExecute", TolerationSeconds: &[]int64{-2}[0]}),
+				core.Toleration{Key: "node.kubernetes.io/not-ready", Operator: "Exists", Effect: "NoExecute", TolerationSeconds: ptr.To(int64(-2))}),
 		),
 		"runtime default seccomp profile": *podtest.MakePod("123",
 			podtest.SetAnnotations(map[string]string{
@@ -10540,7 +10539,7 @@ func TestValidatePod(t *testing.T) {
 			podtest.SetSecurityContext(&core.PodSecurityContext{
 				SeccompProfile: &core.SeccompProfile{
 					Type:             core.SeccompProfileTypeLocalhost,
-					LocalhostProfile: utilpointer.String("filename.json"),
+					LocalhostProfile: ptr.To("filename.json"),
 				},
 			}),
 		),
@@ -10549,7 +10548,7 @@ func TestValidatePod(t *testing.T) {
 				podtest.SetContainerSecurityContext(core.SecurityContext{
 					SeccompProfile: &core.SeccompProfile{
 						Type:             core.SeccompProfileTypeLocalhost,
-						LocalhostProfile: utilpointer.String("filename.json"),
+						LocalhostProfile: ptr.To("filename.json"),
 					},
 				}),
 			)),
@@ -10710,7 +10709,7 @@ func TestValidatePod(t *testing.T) {
 							{
 								ClusterTrustBundle: &core.ClusterTrustBundleProjection{
 									Path: "foo-path",
-									Name: utilpointer.String("foo"),
+									Name: ptr.To("foo"),
 								},
 							},
 						},
@@ -10727,7 +10726,7 @@ func TestValidatePod(t *testing.T) {
 							{
 								ClusterTrustBundle: &core.ClusterTrustBundleProjection{
 									Path:       "foo-path",
-									SignerName: utilpointer.String("example.com/foo"),
+									SignerName: ptr.To("example.com/foo"),
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
 											"version": "live",
@@ -11742,7 +11741,7 @@ func TestValidatePod(t *testing.T) {
 		"effect must be 'NoExecute' when `TolerationSeconds` is set": {
 			expectedError: "spec.tolerations[0].effect",
 			spec: *podtest.MakePod("pod-forgiveness-invalid",
-				podtest.SetTolerations(core.Toleration{Key: "node.kubernetes.io/not-ready", Operator: "Exists", Effect: "NoSchedule", TolerationSeconds: &[]int64{20}[0]}),
+				podtest.SetTolerations(core.Toleration{Key: "node.kubernetes.io/not-ready", Operator: "Exists", Effect: "NoSchedule", TolerationSeconds: ptr.To(int64(20))}),
 			),
 		},
 		"must be a valid pod seccomp profile": {
@@ -12126,13 +12125,13 @@ func TestValidatePod(t *testing.T) {
 								{
 									ClusterTrustBundle: &core.ClusterTrustBundleProjection{
 										Path:       "foo-path",
-										SignerName: utilpointer.String("example.com/foo"),
+										SignerName: ptr.To("example.com/foo"),
 										LabelSelector: &metav1.LabelSelector{
 											MatchLabels: map[string]string{
 												"version": "live",
 											},
 										},
-										Name: utilpointer.String("foo"),
+										Name: ptr.To("foo"),
 									},
 								},
 							},
@@ -12152,7 +12151,7 @@ func TestValidatePod(t *testing.T) {
 								{
 									ClusterTrustBundle: &core.ClusterTrustBundleProjection{
 										Path: "foo-path",
-										Name: utilpointer.String(""),
+										Name: ptr.To(""),
 									},
 								},
 							},
@@ -12172,7 +12171,7 @@ func TestValidatePod(t *testing.T) {
 								{
 									ClusterTrustBundle: &core.ClusterTrustBundleProjection{
 										Path:       "foo-path",
-										SignerName: utilpointer.String(""),
+										SignerName: ptr.To(""),
 										LabelSelector: &metav1.LabelSelector{
 											MatchLabels: map[string]string{
 												"foo": "bar",
@@ -12197,7 +12196,7 @@ func TestValidatePod(t *testing.T) {
 								{
 									ClusterTrustBundle: &core.ClusterTrustBundleProjection{
 										Path:       "foo-path",
-										SignerName: utilpointer.String("example.com/foo/invalid"),
+										SignerName: ptr.To("example.com/foo/invalid"),
 									},
 								},
 							},
@@ -12767,18 +12766,18 @@ func TestValidatePodUpdate(t *testing.T) {
 			),
 			old: *podtest.MakePod("foo",
 				podtest.SetNodeName("node1"),
-				podtest.SetTolerations(core.Toleration{Key: "key1", Value: "value1", Operator: "Equal", Effect: "NoExecute", TolerationSeconds: &[]int64{10}[0]}),
+				podtest.SetTolerations(core.Toleration{Key: "key1", Value: "value1", Operator: "Equal", Effect: "NoExecute", TolerationSeconds: ptr.To(int64(10))}),
 			),
 			err:  "spec.tolerations: Forbidden",
 			test: "existing toleration value modified in pod spec updates with modified tolerationSeconds",
 		}, {
 			new: *podtest.MakePod("foo",
 				podtest.SetNodeName("node1"),
-				podtest.SetTolerations(core.Toleration{Key: "key1", Value: "value1", Operator: "Equal", Effect: "NoExecute", TolerationSeconds: &[]int64{10}[0]}),
+				podtest.SetTolerations(core.Toleration{Key: "key1", Value: "value1", Operator: "Equal", Effect: "NoExecute", TolerationSeconds: ptr.To(int64(10))}),
 			),
 			old: *podtest.MakePod("foo",
 				podtest.SetNodeName("node1"),
-				podtest.SetTolerations(core.Toleration{Key: "key1", Value: "value1", Operator: "Equal", Effect: "NoExecute", TolerationSeconds: &[]int64{20}[0]}),
+				podtest.SetTolerations(core.Toleration{Key: "key1", Value: "value1", Operator: "Equal", Effect: "NoExecute", TolerationSeconds: ptr.To(int64(20))}),
 			),
 			err:  "",
 			test: "modified tolerationSeconds in existing toleration value in pod spec updates",
@@ -12807,13 +12806,13 @@ func TestValidatePodUpdate(t *testing.T) {
 			new: *podtest.MakePod("foo",
 				podtest.SetNodeName("node1"),
 				podtest.SetTolerations(
-					core.Toleration{Key: "key1", Value: "value1", Operator: "Equal", Effect: "NoExecute", TolerationSeconds: &[]int64{20}[0]},
-					core.Toleration{Key: "key2", Value: "value2", Operator: "Equal", Effect: "NoExecute", TolerationSeconds: &[]int64{30}[0]}),
+					core.Toleration{Key: "key1", Value: "value1", Operator: "Equal", Effect: "NoExecute", TolerationSeconds: ptr.To(int64(20))},
+					core.Toleration{Key: "key2", Value: "value2", Operator: "Equal", Effect: "NoExecute", TolerationSeconds: ptr.To(int64(30))}),
 			),
 			old: *podtest.MakePod("foo",
 				podtest.SetNodeName("node1"),
 				podtest.SetTolerations(
-					core.Toleration{Key: "key1", Value: "value1", Operator: "Equal", Effect: "NoExecute", TolerationSeconds: &[]int64{10}[0]}),
+					core.Toleration{Key: "key1", Value: "value1", Operator: "Equal", Effect: "NoExecute", TolerationSeconds: ptr.To(int64(10))}),
 			),
 			err:  "",
 			test: "added valid new toleration to existing tolerations in pod spec updates",
@@ -12821,13 +12820,13 @@ func TestValidatePodUpdate(t *testing.T) {
 			new: *podtest.MakePod("foo",
 				podtest.SetNodeName("node1"),
 				podtest.SetTolerations(
-					core.Toleration{Key: "key1", Value: "value1", Operator: "Equal", Effect: "NoExecute", TolerationSeconds: &[]int64{20}[0]},
-					core.Toleration{Key: "key2", Value: "value2", Operator: "Equal", Effect: "NoSchedule", TolerationSeconds: &[]int64{30}[0]},
+					core.Toleration{Key: "key1", Value: "value1", Operator: "Equal", Effect: "NoExecute", TolerationSeconds: ptr.To(int64(20))},
+					core.Toleration{Key: "key2", Value: "value2", Operator: "Equal", Effect: "NoSchedule", TolerationSeconds: ptr.To(int64(30))},
 				),
 			),
 			old: *podtest.MakePod("foo",
 				podtest.SetNodeName("node1"),
-				podtest.SetTolerations(core.Toleration{Key: "key1", Value: "value1", Operator: "Equal", Effect: "NoExecute", TolerationSeconds: &[]int64{10}[0]}),
+				podtest.SetTolerations(core.Toleration{Key: "key1", Value: "value1", Operator: "Equal", Effect: "NoExecute", TolerationSeconds: ptr.To(int64(10))}),
 			),
 			err:  "spec.tolerations[1].effect",
 			test: "added invalid new toleration to existing tolerations in pod spec updates",
@@ -14164,7 +14163,7 @@ func TestValidatePodStatusUpdate(t *testing.T) {
 		*podtest.MakePod("foo",
 			podtest.SetStatus(core.PodStatus{
 				ResourceClaimStatuses: []core.PodResourceClaimStatus{
-					{Name: "no-such-claim", ResourceClaimName: utilpointer.String("my-claim")},
+					{Name: "no-such-claim", ResourceClaimName: ptr.To("my-claim")},
 				},
 			}),
 		),
@@ -14176,7 +14175,7 @@ func TestValidatePodStatusUpdate(t *testing.T) {
 			podtest.SetResourceClaims(core.PodResourceClaim{Name: "my-claim"}),
 			podtest.SetStatus(core.PodStatus{
 				ResourceClaimStatuses: []core.PodResourceClaimStatus{
-					{Name: "my-claim", ResourceClaimName: utilpointer.String("%$!#")},
+					{Name: "my-claim", ResourceClaimName: ptr.To("%$!#")},
 				},
 			}),
 		),
@@ -14193,7 +14192,7 @@ func TestValidatePodStatusUpdate(t *testing.T) {
 			),
 			podtest.SetStatus(core.PodStatus{
 				ResourceClaimStatuses: []core.PodResourceClaimStatus{
-					{Name: "my-claim", ResourceClaimName: utilpointer.String("foo-my-claim-12345")},
+					{Name: "my-claim", ResourceClaimName: ptr.To("foo-my-claim-12345")},
 					{Name: "my-other-claim", ResourceClaimName: nil},
 					{Name: "my-other-claim", ResourceClaimName: nil},
 				},
@@ -14212,7 +14211,7 @@ func TestValidatePodStatusUpdate(t *testing.T) {
 			),
 			podtest.SetStatus(core.PodStatus{
 				ResourceClaimStatuses: []core.PodResourceClaimStatus{
-					{Name: "my-claim", ResourceClaimName: utilpointer.String("foo-my-claim-12345")},
+					{Name: "my-claim", ResourceClaimName: ptr.To("foo-my-claim-12345")},
 					{Name: "my-other-claim", ResourceClaimName: nil},
 				},
 			}),
@@ -15159,7 +15158,7 @@ func TestValidateServiceCreate(t *testing.T) {
 		tweakSvc: func(s *core.Service) {
 			s.Spec.Type = core.ServiceTypeLoadBalancer
 			s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-			s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+			s.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 			s.Spec.Ports[0].Protocol = "UDP"
 		},
 		numErrs: 0,
@@ -15168,7 +15167,7 @@ func TestValidateServiceCreate(t *testing.T) {
 		tweakSvc: func(s *core.Service) {
 			s.Spec.Type = core.ServiceTypeLoadBalancer
 			s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-			s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+			s.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 			s.Spec.Ports[0] = core.ServicePort{Name: "q", Port: 12345, Protocol: "UDP", TargetPort: intstr.FromInt32(12345)}
 		},
 		numErrs: 0,
@@ -15177,7 +15176,7 @@ func TestValidateServiceCreate(t *testing.T) {
 		tweakSvc: func(s *core.Service) {
 			s.Spec.Type = core.ServiceTypeLoadBalancer
 			s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-			s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+			s.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 			s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "q", Port: 12345, Protocol: "UDP", TargetPort: intstr.FromInt32(12345)})
 		},
 		numErrs: 0,
@@ -15225,7 +15224,7 @@ func TestValidateServiceCreate(t *testing.T) {
 		tweakSvc: func(s *core.Service) {
 			s.Spec.Type = core.ServiceTypeLoadBalancer
 			s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-			s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+			s.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 		},
 		numErrs: 0,
 	}, {
@@ -15233,7 +15232,7 @@ func TestValidateServiceCreate(t *testing.T) {
 		tweakSvc: func(s *core.Service) {
 			s.Spec.Type = core.ServiceTypeLoadBalancer
 			s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-			s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(false)
+			s.Spec.AllocateLoadBalancerNodePorts = ptr.To(false)
 		},
 		numErrs: 0,
 	}, {
@@ -15248,7 +15247,7 @@ func TestValidateServiceCreate(t *testing.T) {
 		tweakSvc: func(s *core.Service) {
 			s.Spec.Type = core.ServiceTypeLoadBalancer
 			s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-			s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+			s.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 			s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "q", Port: 12345, Protocol: "TCP", TargetPort: intstr.FromInt32(12345)})
 		},
 		numErrs: 0,
@@ -15257,7 +15256,7 @@ func TestValidateServiceCreate(t *testing.T) {
 		tweakSvc: func(s *core.Service) {
 			s.Spec.Type = core.ServiceTypeLoadBalancer
 			s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-			s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+			s.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 			s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "q", Port: 12345, Protocol: "TCP", TargetPort: intstr.FromInt32(12345)})
 		},
 		numErrs: 0,
@@ -15315,7 +15314,7 @@ func TestValidateServiceCreate(t *testing.T) {
 		tweakSvc: func(s *core.Service) {
 			s.Spec.Type = core.ServiceTypeLoadBalancer
 			s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-			s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+			s.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 		},
 		numErrs: 0,
 	}, {
@@ -15323,7 +15322,7 @@ func TestValidateServiceCreate(t *testing.T) {
 		tweakSvc: func(s *core.Service) {
 			s.Spec.Type = core.ServiceTypeLoadBalancer
 			s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-			s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+			s.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 			s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "q", Port: 12345, Protocol: "TCP", TargetPort: intstr.FromInt32(12345)})
 		},
 		numErrs: 0,
@@ -15332,7 +15331,7 @@ func TestValidateServiceCreate(t *testing.T) {
 		tweakSvc: func(s *core.Service) {
 			s.Spec.Type = core.ServiceTypeLoadBalancer
 			s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-			s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+			s.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 			s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "q", Port: 12345, Protocol: "TCP", NodePort: 12345, TargetPort: intstr.FromInt32(12345)})
 		},
 		numErrs: 0,
@@ -15380,7 +15379,7 @@ func TestValidateServiceCreate(t *testing.T) {
 		tweakSvc: func(s *core.Service) {
 			s.Spec.Type = core.ServiceTypeLoadBalancer
 			s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-			s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+			s.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 			s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "q", Port: 12345, Protocol: "TCP", TargetPort: intstr.FromInt32(12345)})
 		},
 		numErrs: 0,
@@ -15391,7 +15390,7 @@ func TestValidateServiceCreate(t *testing.T) {
 		tweakSvc: func(s *core.Service) {
 			s.Spec.Type = core.ServiceTypeLoadBalancer
 			s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-			s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+			s.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 			s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "kubelet", Port: 10250, Protocol: "TCP", TargetPort: intstr.FromInt32(12345)})
 		},
 		numErrs: 1,
@@ -15400,7 +15399,7 @@ func TestValidateServiceCreate(t *testing.T) {
 		tweakSvc: func(s *core.Service) {
 			s.Spec.Type = core.ServiceTypeLoadBalancer
 			s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-			s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+			s.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 			s.Annotations[core.AnnotationLoadBalancerSourceRangesKey] = "1.2.3.0/24,  5.6.0.0/16"
 		},
 		numErrs: 0,
@@ -15409,7 +15408,7 @@ func TestValidateServiceCreate(t *testing.T) {
 		tweakSvc: func(s *core.Service) {
 			s.Spec.Type = core.ServiceTypeLoadBalancer
 			s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-			s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+			s.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 			s.Annotations[core.AnnotationLoadBalancerSourceRangesKey] = ""
 		},
 		numErrs: 0,
@@ -15418,7 +15417,7 @@ func TestValidateServiceCreate(t *testing.T) {
 		tweakSvc: func(s *core.Service) {
 			s.Spec.Type = core.ServiceTypeLoadBalancer
 			s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-			s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+			s.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 			s.Annotations[core.AnnotationLoadBalancerSourceRangesKey] = "  "
 		},
 		numErrs: 0,
@@ -15427,7 +15426,7 @@ func TestValidateServiceCreate(t *testing.T) {
 		tweakSvc: func(s *core.Service) {
 			s.Spec.Type = core.ServiceTypeLoadBalancer
 			s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-			s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+			s.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 			s.Annotations[core.AnnotationLoadBalancerSourceRangesKey] = "foo.bar"
 		},
 		numErrs: 1,
@@ -15436,7 +15435,7 @@ func TestValidateServiceCreate(t *testing.T) {
 		tweakSvc: func(s *core.Service) {
 			s.Spec.Type = core.ServiceTypeLoadBalancer
 			s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-			s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+			s.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 			s.Annotations[core.AnnotationLoadBalancerSourceRangesKey] = "1.2.3.4/33"
 		},
 		numErrs: 1,
@@ -15457,7 +15456,7 @@ func TestValidateServiceCreate(t *testing.T) {
 		tweakSvc: func(s *core.Service) {
 			s.Spec.Type = core.ServiceTypeLoadBalancer
 			s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-			s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+			s.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 			s.Spec.LoadBalancerSourceRanges = []string{"1.2.3.0/24", "5.6.0.0/16"}
 		},
 		numErrs: 0,
@@ -15466,7 +15465,7 @@ func TestValidateServiceCreate(t *testing.T) {
 		tweakSvc: func(s *core.Service) {
 			s.Spec.Type = core.ServiceTypeLoadBalancer
 			s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-			s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+			s.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 			s.Spec.LoadBalancerSourceRanges = []string{"1.2.3.0/24  ", " 5.6.0.0/16"}
 		},
 		numErrs: 0,
@@ -15475,7 +15474,7 @@ func TestValidateServiceCreate(t *testing.T) {
 		tweakSvc: func(s *core.Service) {
 			s.Spec.Type = core.ServiceTypeLoadBalancer
 			s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-			s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+			s.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 			s.Spec.LoadBalancerSourceRanges = []string{"   "}
 		},
 		numErrs: 1,
@@ -15484,7 +15483,7 @@ func TestValidateServiceCreate(t *testing.T) {
 		tweakSvc: func(s *core.Service) {
 			s.Spec.Type = core.ServiceTypeLoadBalancer
 			s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-			s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+			s.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 			s.Spec.LoadBalancerSourceRanges = []string{"foo.bar"}
 		},
 		numErrs: 1,
@@ -15493,7 +15492,7 @@ func TestValidateServiceCreate(t *testing.T) {
 		tweakSvc: func(s *core.Service) {
 			s.Spec.Type = core.ServiceTypeLoadBalancer
 			s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-			s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+			s.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 			s.Spec.LoadBalancerSourceRanges = []string{"1.2.3.4/33"}
 		},
 		numErrs: 1,
@@ -15508,7 +15507,7 @@ func TestValidateServiceCreate(t *testing.T) {
 		tweakSvc: func(s *core.Service) {
 			s.Spec.Type = core.ServiceTypeLoadBalancer
 			s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-			s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+			s.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 			s.Annotations[core.AnnotationLoadBalancerSourceRangesKey] = "foo.bar"
 			s.Spec.LoadBalancerSourceRanges = []string{"1.2.3.0/24", "5.6.0.0/16"}
 		},
@@ -15559,7 +15558,7 @@ func TestValidateServiceCreate(t *testing.T) {
 			s.Spec.ClusterIPs = []string{"None"}
 			s.Spec.Type = core.ServiceTypeLoadBalancer
 			s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-			s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+			s.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 		},
 		numErrs: 1,
 	}, {
@@ -15578,7 +15577,7 @@ func TestValidateServiceCreate(t *testing.T) {
 			name: "invalid externalTraffic field",
 			tweakSvc: func(s *core.Service) {
 				s.Spec.Type = core.ServiceTypeLoadBalancer
-				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+				s.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 				s.Spec.ExternalTrafficPolicy = "invalid"
 			},
 			numErrs: 1,
@@ -15634,7 +15633,7 @@ func TestValidateServiceCreate(t *testing.T) {
 			name: "negative healthCheckNodePort field",
 			tweakSvc: func(s *core.Service) {
 				s.Spec.Type = core.ServiceTypeLoadBalancer
-				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+				s.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 				s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyLocal
 				s.Spec.HealthCheckNodePort = -1
 			},
@@ -15643,7 +15642,7 @@ func TestValidateServiceCreate(t *testing.T) {
 			name: "negative healthCheckNodePort field",
 			tweakSvc: func(s *core.Service) {
 				s.Spec.Type = core.ServiceTypeLoadBalancer
-				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+				s.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 				s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyLocal
 				s.Spec.HealthCheckNodePort = 31100
 			},
@@ -15657,7 +15656,7 @@ func TestValidateServiceCreate(t *testing.T) {
 				s.Spec.SessionAffinity = core.ServiceAffinityClientIP
 				s.Spec.SessionAffinityConfig = &core.SessionAffinityConfig{
 					ClientIP: &core.ClientIPConfig{
-						TimeoutSeconds: utilpointer.Int32(-1),
+						TimeoutSeconds: ptr.To(int32(-1)),
 					},
 				}
 			},
@@ -15667,11 +15666,11 @@ func TestValidateServiceCreate(t *testing.T) {
 			tweakSvc: func(s *core.Service) {
 				s.Spec.Type = core.ServiceTypeLoadBalancer
 				s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+				s.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 				s.Spec.SessionAffinity = core.ServiceAffinityNone
 				s.Spec.SessionAffinityConfig = &core.SessionAffinityConfig{
 					ClientIP: &core.ClientIPConfig{
-						TimeoutSeconds: utilpointer.Int32(90),
+						TimeoutSeconds: ptr.To(int32(90)),
 					},
 				}
 			},
@@ -16025,7 +16024,7 @@ func TestValidateServiceCreate(t *testing.T) {
 					Port:        12345,
 					TargetPort:  intstr.FromInt32(12345),
 					Protocol:    "TCP",
-					AppProtocol: utilpointer.String("HTTP"),
+					AppProtocol: ptr.To("HTTP"),
 				}}
 			},
 			numErrs: 0,
@@ -16036,7 +16035,7 @@ func TestValidateServiceCreate(t *testing.T) {
 					Port:        12345,
 					TargetPort:  intstr.FromInt32(12345),
 					Protocol:    "TCP",
-					AppProtocol: utilpointer.String("example.com/protocol"),
+					AppProtocol: ptr.To("example.com/protocol"),
 				}}
 			},
 			numErrs: 0,
@@ -16047,7 +16046,7 @@ func TestValidateServiceCreate(t *testing.T) {
 					Port:        12345,
 					TargetPort:  intstr.FromInt32(12345),
 					Protocol:    "TCP",
-					AppProtocol: utilpointer.String("example.com/protocol_with{invalid}[characters]"),
+					AppProtocol: ptr.To("example.com/protocol_with{invalid}[characters]"),
 				}}
 			},
 			numErrs: 1,
@@ -16071,7 +16070,7 @@ func TestValidateServiceCreate(t *testing.T) {
 		}, {
 			name: "Use AllocateLoadBalancerNodePorts when type is not LoadBalancer",
 			tweakSvc: func(s *core.Service) {
-				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+				s.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 			},
 			numErrs: 1,
 		}, {
@@ -16079,8 +16078,8 @@ func TestValidateServiceCreate(t *testing.T) {
 			tweakSvc: func(s *core.Service) {
 				s.Spec.Type = core.ServiceTypeLoadBalancer
 				s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
-				s.Spec.LoadBalancerClass = utilpointer.String("test.com/test-load-balancer-class")
+				s.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
+				s.Spec.LoadBalancerClass = ptr.To("test.com/test-load-balancer-class")
 			},
 			numErrs: 0,
 		}, {
@@ -16088,15 +16087,15 @@ func TestValidateServiceCreate(t *testing.T) {
 			tweakSvc: func(s *core.Service) {
 				s.Spec.Type = core.ServiceTypeLoadBalancer
 				s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
-				s.Spec.LoadBalancerClass = utilpointer.String("Bad/LoadBalancerClass")
+				s.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
+				s.Spec.LoadBalancerClass = ptr.To("Bad/LoadBalancerClass")
 			},
 			numErrs: 1,
 		}, {
 			name: "invalid: set LoadBalancerClass when type is not LoadBalancer",
 			tweakSvc: func(s *core.Service) {
 				s.Spec.Type = core.ServiceTypeClusterIP
-				s.Spec.LoadBalancerClass = utilpointer.String("test.com/test-load-balancer-class")
+				s.Spec.LoadBalancerClass = ptr.To("test.com/test-load-balancer-class")
 			},
 			numErrs: 1,
 		}, {
@@ -16109,13 +16108,13 @@ func TestValidateServiceCreate(t *testing.T) {
 		}, {
 			name: "valid: trafficDistribution field set to PreferClose",
 			tweakSvc: func(s *core.Service) {
-				s.Spec.TrafficDistribution = utilpointer.String("PreferClose")
+				s.Spec.TrafficDistribution = ptr.To("PreferClose")
 			},
 			numErrs: 0,
 		}, {
 			name: "invalid: trafficDistribution field set to Random",
 			tweakSvc: func(s *core.Service) {
-				s.Spec.TrafficDistribution = utilpointer.String("Random")
+				s.Spec.TrafficDistribution = ptr.To("Random")
 			},
 			numErrs: 1,
 		},
@@ -16145,7 +16144,7 @@ func TestValidateServiceExternalTrafficPolicy(t *testing.T) {
 		name: "valid loadBalancer service with externalTrafficPolicy and healthCheckNodePort set",
 		tweakSvc: func(s *core.Service) {
 			s.Spec.Type = core.ServiceTypeLoadBalancer
-			s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+			s.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 			s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyLocal
 			s.Spec.HealthCheckNodePort = 34567
 		},
@@ -16167,7 +16166,7 @@ func TestValidateServiceExternalTrafficPolicy(t *testing.T) {
 		name: "cannot set healthCheckNodePort field on loadBalancer service with externalTrafficPolicy!=Local",
 		tweakSvc: func(s *core.Service) {
 			s.Spec.Type = core.ServiceTypeLoadBalancer
-			s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+			s.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 			s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
 			s.Spec.HealthCheckNodePort = 34567
 		},
@@ -17656,7 +17655,7 @@ func TestValidateServiceUpdate(t *testing.T) {
 			newSvc.Spec.SessionAffinity = "ClientIP"
 			newSvc.Spec.SessionAffinityConfig = &core.SessionAffinityConfig{
 				ClientIP: &core.ClientIPConfig{
-					TimeoutSeconds: utilpointer.Int32(90),
+					TimeoutSeconds: ptr.To(int32(90)),
 				},
 			}
 		},
@@ -17672,7 +17671,7 @@ func TestValidateServiceUpdate(t *testing.T) {
 		tweakSvc: func(oldSvc, newSvc *core.Service) {
 			newSvc.Spec.Type = core.ServiceTypeLoadBalancer
 			newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-			newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+			newSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 		},
 		numErrs: 0,
 	}, {
@@ -17692,10 +17691,10 @@ func TestValidateServiceUpdate(t *testing.T) {
 		name: "add loadBalancerSourceRanges",
 		tweakSvc: func(oldSvc, newSvc *core.Service) {
 			oldSvc.Spec.Type = core.ServiceTypeLoadBalancer
-			oldSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+			oldSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 			newSvc.Spec.Type = core.ServiceTypeLoadBalancer
 			newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-			newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+			newSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 			newSvc.Spec.LoadBalancerSourceRanges = []string{"10.0.0.0/8"}
 		},
 		numErrs: 0,
@@ -17703,11 +17702,11 @@ func TestValidateServiceUpdate(t *testing.T) {
 		name: "update loadBalancerSourceRanges",
 		tweakSvc: func(oldSvc, newSvc *core.Service) {
 			oldSvc.Spec.Type = core.ServiceTypeLoadBalancer
-			oldSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+			oldSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 			oldSvc.Spec.LoadBalancerSourceRanges = []string{"10.0.0.0/8"}
 			newSvc.Spec.Type = core.ServiceTypeLoadBalancer
 			newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-			newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+			newSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 			newSvc.Spec.LoadBalancerSourceRanges = []string{"10.100.0.0/16"}
 		},
 		numErrs: 0,
@@ -17718,7 +17717,7 @@ func TestValidateServiceUpdate(t *testing.T) {
 			newSvc.Spec.ClusterIPs = []string{"None"}
 			newSvc.Spec.Type = core.ServiceTypeLoadBalancer
 			newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-			newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+			newSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 		},
 		numErrs: 1,
 	}, {
@@ -17815,7 +17814,7 @@ func TestValidateServiceUpdate(t *testing.T) {
 				oldSvc.Spec.Type = core.ServiceTypeClusterIP
 				newSvc.Spec.Type = core.ServiceTypeLoadBalancer
 				newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+				newSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 
 				oldSvc.Spec.ClusterIP = "1.2.3.4"
 				oldSvc.Spec.ClusterIPs = []string{"1.2.3.4"}
@@ -17830,7 +17829,7 @@ func TestValidateServiceUpdate(t *testing.T) {
 				oldSvc.Spec.Type = core.ServiceTypeClusterIP
 				newSvc.Spec.Type = core.ServiceTypeLoadBalancer
 				newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+				newSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 
 				oldSvc.Spec.ClusterIP = ""
 				oldSvc.Spec.ClusterIPs = nil
@@ -17843,20 +17842,20 @@ func TestValidateServiceUpdate(t *testing.T) {
 			name: "Service with LoadBalancer type can change its AllocateLoadBalancerNodePorts from true to false",
 			tweakSvc: func(oldSvc, newSvc *core.Service) {
 				oldSvc.Spec.Type = core.ServiceTypeLoadBalancer
-				oldSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+				oldSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 				newSvc.Spec.Type = core.ServiceTypeLoadBalancer
 				newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(false)
+				newSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(false)
 			},
 			numErrs: 0,
 		}, {
 			name: "Service with LoadBalancer type can change its AllocateLoadBalancerNodePorts from false to true",
 			tweakSvc: func(oldSvc, newSvc *core.Service) {
 				oldSvc.Spec.Type = core.ServiceTypeLoadBalancer
-				oldSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(false)
+				oldSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(false)
 				newSvc.Spec.Type = core.ServiceTypeLoadBalancer
 				newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+				newSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 			},
 			numErrs: 0,
 		}, {
@@ -17919,7 +17918,7 @@ func TestValidateServiceUpdate(t *testing.T) {
 				oldSvc.Spec.Type = core.ServiceTypeNodePort
 				newSvc.Spec.Type = core.ServiceTypeLoadBalancer
 				newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+				newSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 
 				oldSvc.Spec.ClusterIP = "1.2.3.4"
 				oldSvc.Spec.ClusterIPs = []string{"1.2.3.4"}
@@ -17934,7 +17933,7 @@ func TestValidateServiceUpdate(t *testing.T) {
 				oldSvc.Spec.Type = core.ServiceTypeNodePort
 				newSvc.Spec.Type = core.ServiceTypeLoadBalancer
 				newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+				newSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 
 				oldSvc.Spec.ClusterIP = ""
 				oldSvc.Spec.ClusterIPs = nil
@@ -17947,10 +17946,10 @@ func TestValidateServiceUpdate(t *testing.T) {
 			name: "Service with LoadBalancer type cannot change its set ClusterIP",
 			tweakSvc: func(oldSvc, newSvc *core.Service) {
 				oldSvc.Spec.Type = core.ServiceTypeLoadBalancer
-				oldSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+				oldSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 				newSvc.Spec.Type = core.ServiceTypeLoadBalancer
 				newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+				newSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 
 				oldSvc.Spec.ClusterIP = "1.2.3.4"
 				oldSvc.Spec.ClusterIPs = []string{"1.2.3.4"}
@@ -17963,10 +17962,10 @@ func TestValidateServiceUpdate(t *testing.T) {
 			name: "Service with LoadBalancer type can change its empty ClusterIP",
 			tweakSvc: func(oldSvc, newSvc *core.Service) {
 				oldSvc.Spec.Type = core.ServiceTypeLoadBalancer
-				oldSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+				oldSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 				newSvc.Spec.Type = core.ServiceTypeLoadBalancer
 				newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+				newSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 
 				oldSvc.Spec.ClusterIP = ""
 				oldSvc.Spec.ClusterIPs = nil
@@ -17979,7 +17978,7 @@ func TestValidateServiceUpdate(t *testing.T) {
 			name: "Service with LoadBalancer type cannot change its set ClusterIP when changing type to ClusterIP",
 			tweakSvc: func(oldSvc, newSvc *core.Service) {
 				oldSvc.Spec.Type = core.ServiceTypeLoadBalancer
-				oldSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+				oldSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 				newSvc.Spec.Type = core.ServiceTypeClusterIP
 
 				oldSvc.Spec.ClusterIP = "1.2.3.4"
@@ -17993,7 +17992,7 @@ func TestValidateServiceUpdate(t *testing.T) {
 			name: "Service with LoadBalancer type can change its empty ClusterIP when changing type to ClusterIP",
 			tweakSvc: func(oldSvc, newSvc *core.Service) {
 				oldSvc.Spec.Type = core.ServiceTypeLoadBalancer
-				oldSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+				oldSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 				newSvc.Spec.Type = core.ServiceTypeClusterIP
 
 				oldSvc.Spec.ClusterIP = ""
@@ -18007,7 +18006,7 @@ func TestValidateServiceUpdate(t *testing.T) {
 			name: "Service with LoadBalancer type cannot change its set ClusterIP when changing type to NodePort",
 			tweakSvc: func(oldSvc, newSvc *core.Service) {
 				oldSvc.Spec.Type = core.ServiceTypeLoadBalancer
-				oldSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+				oldSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 				newSvc.Spec.Type = core.ServiceTypeNodePort
 				newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
 
@@ -18022,7 +18021,7 @@ func TestValidateServiceUpdate(t *testing.T) {
 			name: "Service with LoadBalancer type can change its empty ClusterIP when changing type to NodePort",
 			tweakSvc: func(oldSvc, newSvc *core.Service) {
 				oldSvc.Spec.Type = core.ServiceTypeLoadBalancer
-				oldSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+				oldSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 				newSvc.Spec.Type = core.ServiceTypeNodePort
 				newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
 
@@ -18470,58 +18469,58 @@ func TestValidateServiceUpdate(t *testing.T) {
 			name: "update to valid app protocol",
 			tweakSvc: func(oldSvc, newSvc *core.Service) {
 				oldSvc.Spec.Ports = []core.ServicePort{{Name: "a", Port: 443, TargetPort: intstr.FromInt32(3000), Protocol: "TCP"}}
-				newSvc.Spec.Ports = []core.ServicePort{{Name: "a", Port: 443, TargetPort: intstr.FromInt32(3000), Protocol: "TCP", AppProtocol: utilpointer.String("https")}}
+				newSvc.Spec.Ports = []core.ServicePort{{Name: "a", Port: 443, TargetPort: intstr.FromInt32(3000), Protocol: "TCP", AppProtocol: ptr.To("https")}}
 			},
 			numErrs: 0,
 		}, {
 			name: "update to invalid app protocol",
 			tweakSvc: func(oldSvc, newSvc *core.Service) {
 				oldSvc.Spec.Ports = []core.ServicePort{{Name: "a", Port: 443, TargetPort: intstr.FromInt32(3000), Protocol: "TCP"}}
-				newSvc.Spec.Ports = []core.ServicePort{{Name: "a", Port: 443, TargetPort: intstr.FromInt32(3000), Protocol: "TCP", AppProtocol: utilpointer.String("~https")}}
+				newSvc.Spec.Ports = []core.ServicePort{{Name: "a", Port: 443, TargetPort: intstr.FromInt32(3000), Protocol: "TCP", AppProtocol: ptr.To("~https")}}
 			},
 			numErrs: 1,
 		}, {
 			name: "Set AllocateLoadBalancerNodePorts when type is not LoadBalancer",
 			tweakSvc: func(oldSvc, newSvc *core.Service) {
-				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+				newSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 			},
 			numErrs: 1,
 		}, {
 			name: "update LoadBalancer type of service without change LoadBalancerClass",
 			tweakSvc: func(oldSvc, newSvc *core.Service) {
 				oldSvc.Spec.Type = core.ServiceTypeLoadBalancer
-				oldSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
-				oldSvc.Spec.LoadBalancerClass = utilpointer.String("test.com/test-old")
+				oldSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
+				oldSvc.Spec.LoadBalancerClass = ptr.To("test.com/test-old")
 
 				newSvc.Spec.Type = core.ServiceTypeLoadBalancer
 				newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
-				newSvc.Spec.LoadBalancerClass = utilpointer.String("test.com/test-old")
+				newSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
+				newSvc.Spec.LoadBalancerClass = ptr.To("test.com/test-old")
 			},
 			numErrs: 0,
 		}, {
 			name: "invalid: change LoadBalancerClass when update service",
 			tweakSvc: func(oldSvc, newSvc *core.Service) {
 				oldSvc.Spec.Type = core.ServiceTypeLoadBalancer
-				oldSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
-				oldSvc.Spec.LoadBalancerClass = utilpointer.String("test.com/test-old")
+				oldSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
+				oldSvc.Spec.LoadBalancerClass = ptr.To("test.com/test-old")
 
 				newSvc.Spec.Type = core.ServiceTypeLoadBalancer
 				newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
-				newSvc.Spec.LoadBalancerClass = utilpointer.String("test.com/test-new")
+				newSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
+				newSvc.Spec.LoadBalancerClass = ptr.To("test.com/test-new")
 			},
 			numErrs: 1,
 		}, {
 			name: "invalid: unset LoadBalancerClass when update service",
 			tweakSvc: func(oldSvc, newSvc *core.Service) {
 				oldSvc.Spec.Type = core.ServiceTypeLoadBalancer
-				oldSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
-				oldSvc.Spec.LoadBalancerClass = utilpointer.String("test.com/test-old")
+				oldSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
+				oldSvc.Spec.LoadBalancerClass = ptr.To("test.com/test-old")
 
 				newSvc.Spec.Type = core.ServiceTypeLoadBalancer
 				newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+				newSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 				newSvc.Spec.LoadBalancerClass = nil
 			},
 			numErrs: 1,
@@ -18529,13 +18528,13 @@ func TestValidateServiceUpdate(t *testing.T) {
 			name: "invalid: set LoadBalancerClass when update service",
 			tweakSvc: func(oldSvc, newSvc *core.Service) {
 				oldSvc.Spec.Type = core.ServiceTypeLoadBalancer
-				oldSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+				oldSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 				oldSvc.Spec.LoadBalancerClass = nil
 
 				newSvc.Spec.Type = core.ServiceTypeLoadBalancer
 				newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
-				newSvc.Spec.LoadBalancerClass = utilpointer.String("test.com/test-new")
+				newSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
+				newSvc.Spec.LoadBalancerClass = ptr.To("test.com/test-new")
 			},
 			numErrs: 1,
 		}, {
@@ -18545,8 +18544,8 @@ func TestValidateServiceUpdate(t *testing.T) {
 
 				newSvc.Spec.Type = core.ServiceTypeLoadBalancer
 				newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
-				newSvc.Spec.LoadBalancerClass = utilpointer.String("test.com/test-load-balancer-class")
+				newSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
+				newSvc.Spec.LoadBalancerClass = ptr.To("test.com/test-load-balancer-class")
 			},
 			numErrs: 0,
 		}, {
@@ -18556,7 +18555,7 @@ func TestValidateServiceUpdate(t *testing.T) {
 
 				newSvc.Spec.Type = core.ServiceTypeLoadBalancer
 				newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+				newSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 				newSvc.Spec.LoadBalancerClass = nil
 			},
 			numErrs: 0,
@@ -18567,8 +18566,8 @@ func TestValidateServiceUpdate(t *testing.T) {
 
 				newSvc.Spec.Type = core.ServiceTypeLoadBalancer
 				newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
-				newSvc.Spec.LoadBalancerClass = utilpointer.String("Bad/LoadBalancerclass")
+				newSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
+				newSvc.Spec.LoadBalancerClass = ptr.To("Bad/LoadBalancerclass")
 			},
 			numErrs: 2,
 		}, {
@@ -18577,7 +18576,7 @@ func TestValidateServiceUpdate(t *testing.T) {
 				oldSvc.Spec.Type = core.ServiceTypeClusterIP
 
 				newSvc.Spec.Type = core.ServiceTypeClusterIP
-				newSvc.Spec.LoadBalancerClass = utilpointer.String("test.com/test-load-balancer-class")
+				newSvc.Spec.LoadBalancerClass = ptr.To("test.com/test-load-balancer-class")
 			},
 			numErrs: 2,
 		}, {
@@ -18586,7 +18585,7 @@ func TestValidateServiceUpdate(t *testing.T) {
 				oldSvc.Spec.Type = core.ServiceTypeExternalName
 
 				newSvc.Spec.Type = core.ServiceTypeExternalName
-				newSvc.Spec.LoadBalancerClass = utilpointer.String("test.com/test-load-balancer-class")
+				newSvc.Spec.LoadBalancerClass = ptr.To("test.com/test-load-balancer-class")
 			},
 			numErrs: 3,
 		}, {
@@ -18596,41 +18595,41 @@ func TestValidateServiceUpdate(t *testing.T) {
 
 				newSvc.Spec.Type = core.ServiceTypeNodePort
 				newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				newSvc.Spec.LoadBalancerClass = utilpointer.String("test.com/test-load-balancer-class")
+				newSvc.Spec.LoadBalancerClass = ptr.To("test.com/test-load-balancer-class")
 			},
 			numErrs: 2,
 		}, {
 			name: "invalid: set LoadBalancerClass when update from LoadBalancer service to non LoadBalancer type of service",
 			tweakSvc: func(oldSvc, newSvc *core.Service) {
 				oldSvc.Spec.Type = core.ServiceTypeLoadBalancer
-				oldSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
-				oldSvc.Spec.LoadBalancerClass = utilpointer.String("test.com/test-load-balancer-class")
+				oldSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
+				oldSvc.Spec.LoadBalancerClass = ptr.To("test.com/test-load-balancer-class")
 
 				newSvc.Spec.Type = core.ServiceTypeClusterIP
-				newSvc.Spec.LoadBalancerClass = utilpointer.String("test.com/test-load-balancer-class")
+				newSvc.Spec.LoadBalancerClass = ptr.To("test.com/test-load-balancer-class")
 			},
 			numErrs: 2,
 		}, {
 			name: "invalid: set LoadBalancerClass when update from LoadBalancer service to non LoadBalancer type of service",
 			tweakSvc: func(oldSvc, newSvc *core.Service) {
 				oldSvc.Spec.Type = core.ServiceTypeLoadBalancer
-				oldSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
-				oldSvc.Spec.LoadBalancerClass = utilpointer.String("test.com/test-load-balancer-class")
+				oldSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
+				oldSvc.Spec.LoadBalancerClass = ptr.To("test.com/test-load-balancer-class")
 
 				newSvc.Spec.Type = core.ServiceTypeExternalName
-				newSvc.Spec.LoadBalancerClass = utilpointer.String("test.com/test-load-balancer-class")
+				newSvc.Spec.LoadBalancerClass = ptr.To("test.com/test-load-balancer-class")
 			},
 			numErrs: 3,
 		}, {
 			name: "invalid: set LoadBalancerClass when update from LoadBalancer service to non LoadBalancer type of service",
 			tweakSvc: func(oldSvc, newSvc *core.Service) {
 				oldSvc.Spec.Type = core.ServiceTypeLoadBalancer
-				oldSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
-				oldSvc.Spec.LoadBalancerClass = utilpointer.String("test.com/test-load-balancer-class")
+				oldSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
+				oldSvc.Spec.LoadBalancerClass = ptr.To("test.com/test-load-balancer-class")
 
 				newSvc.Spec.Type = core.ServiceTypeNodePort
 				newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				newSvc.Spec.LoadBalancerClass = utilpointer.String("test.com/test-load-balancer-class")
+				newSvc.Spec.LoadBalancerClass = ptr.To("test.com/test-load-balancer-class")
 			},
 			numErrs: 2,
 		}, {
@@ -20504,7 +20503,7 @@ func TestValidateEndpointsCreate(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "mysvc", Namespace: "namespace"},
 				Subsets: []core.EndpointSubset{{
 					Addresses: []core.EndpointAddress{{IP: "10.10.1.1"}},
-					Ports:     []core.EndpointPort{{Port: 8675, Protocol: "TCP", AppProtocol: utilpointer.String("HTTP")}},
+					Ports:     []core.EndpointPort{{Port: 8675, Protocol: "TCP", AppProtocol: ptr.To("HTTP")}},
 				}},
 			},
 		},
@@ -20672,7 +20671,7 @@ func TestValidateEndpointsCreate(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "mysvc", Namespace: "namespace"},
 				Subsets: []core.EndpointSubset{{
 					Addresses: []core.EndpointAddress{{IP: "10.10.1.1"}},
-					Ports:     []core.EndpointPort{{Name: "p", Port: 93, Protocol: "TCP", AppProtocol: utilpointer.String("lots-of[invalid]-{chars}")}},
+					Ports:     []core.EndpointPort{{Name: "p", Port: 93, Protocol: "TCP", AppProtocol: ptr.To("lots-of[invalid]-{chars}")}},
 				}},
 			},
 			errorType:   "FieldValueInvalid",
@@ -20707,7 +20706,7 @@ func TestValidateEndpointsUpdate(t *testing.T) {
 				ep.Subsets[0].Ports = []core.EndpointPort{{Name: "a", Port: 8675, Protocol: "TCP"}}
 			},
 			tweakNewEndpoints: func(ep *core.Endpoints) {
-				ep.Subsets[0].Ports = []core.EndpointPort{{Name: "a", Port: 8675, Protocol: "TCP", AppProtocol: utilpointer.String("https")}}
+				ep.Subsets[0].Ports = []core.EndpointPort{{Name: "a", Port: 8675, Protocol: "TCP", AppProtocol: ptr.To("https")}}
 			},
 			numExpectedErrors: 0,
 		},
@@ -20716,7 +20715,7 @@ func TestValidateEndpointsUpdate(t *testing.T) {
 				ep.Subsets[0].Ports = []core.EndpointPort{{Name: "a", Port: 8675, Protocol: "TCP"}}
 			},
 			tweakNewEndpoints: func(ep *core.Endpoints) {
-				ep.Subsets[0].Ports = []core.EndpointPort{{Name: "a", Port: 8675, Protocol: "TCP", AppProtocol: utilpointer.String("~https")}}
+				ep.Subsets[0].Ports = []core.EndpointPort{{Name: "a", Port: 8675, Protocol: "TCP", AppProtocol: ptr.To("~https")}}
 			},
 			numExpectedErrors: 1,
 		},
@@ -20753,7 +20752,7 @@ func TestValidateWindowsSecurityContext(t *testing.T) {
 		errorType:   "FieldValueForbidden",
 	}, {
 		name:        "pod with SeccompProfile",
-		sc:          &core.PodSpec{Containers: []core.Container{{SecurityContext: &core.SecurityContext{SeccompProfile: &core.SeccompProfile{LocalhostProfile: utilpointer.String("dummy")}}}}},
+		sc:          &core.PodSpec{Containers: []core.Container{{SecurityContext: &core.SecurityContext{SeccompProfile: &core.SeccompProfile{LocalhostProfile: ptr.To("dummy")}}}}},
 		expectError: true,
 		errorMsg:    "cannot be set for a windows pod",
 		errorType:   "FieldValueForbidden",
@@ -20765,7 +20764,7 @@ func TestValidateWindowsSecurityContext(t *testing.T) {
 		errorType:   "FieldValueForbidden",
 	}, {
 		name:        "pod with WindowsOptions, no error",
-		sc:          &core.PodSpec{Containers: []core.Container{{SecurityContext: &core.SecurityContext{WindowsOptions: &core.WindowsSecurityContextOptions{RunAsUserName: utilpointer.String("dummy")}}}}},
+		sc:          &core.PodSpec{Containers: []core.Container{{SecurityContext: &core.SecurityContext{WindowsOptions: &core.WindowsSecurityContextOptions{RunAsUserName: ptr.To("dummy")}}}}},
 		expectError: false,
 	},
 	}
@@ -21129,7 +21128,7 @@ func TestValidateTLSSecret(t *testing.T) {
 func TestValidateLinuxSecurityContext(t *testing.T) {
 	runAsUser := int64(1)
 	validLinuxSC := &core.SecurityContext{
-		Privileged: utilpointer.Bool(false),
+		Privileged: ptr.To(false),
 		Capabilities: &core.Capabilities{
 			Add:  []core.Capability{"foo"},
 			Drop: []core.Capability{"bar"},
@@ -21143,7 +21142,7 @@ func TestValidateLinuxSecurityContext(t *testing.T) {
 		RunAsUser: &runAsUser,
 	}
 	invalidLinuxSC := &core.SecurityContext{
-		WindowsOptions: &core.WindowsSecurityContextOptions{RunAsUserName: utilpointer.String("myUser")},
+		WindowsOptions: &core.WindowsSecurityContextOptions{RunAsUserName: ptr.To("myUser")},
 	}
 	cases := map[string]struct {
 		sc          *core.PodSpec
@@ -21183,7 +21182,7 @@ func TestValidateSecurityContext(t *testing.T) {
 	runAsUser := int64(1)
 	fullValidSC := func() *core.SecurityContext {
 		return &core.SecurityContext{
-			Privileged: utilpointer.Bool(false),
+			Privileged: ptr.To(false),
 			Capabilities: &core.Capabilities{
 				Add:  []core.Capability{"foo"},
 				Drop: []core.Capability{"bar"},
@@ -21239,19 +21238,19 @@ func TestValidateSecurityContext(t *testing.T) {
 	}
 
 	privRequestWithGlobalDeny := fullValidSC()
-	privRequestWithGlobalDeny.Privileged = utilpointer.Bool(true)
+	privRequestWithGlobalDeny.Privileged = ptr.To(true)
 
 	negativeRunAsUser := fullValidSC()
 	negativeUser := int64(-1)
 	negativeRunAsUser.RunAsUser = &negativeUser
 
 	privWithoutEscalation := fullValidSC()
-	privWithoutEscalation.Privileged = utilpointer.Bool(true)
-	privWithoutEscalation.AllowPrivilegeEscalation = utilpointer.Bool(false)
+	privWithoutEscalation.Privileged = ptr.To(true)
+	privWithoutEscalation.AllowPrivilegeEscalation = ptr.To(false)
 
 	capSysAdminWithoutEscalation := fullValidSC()
 	capSysAdminWithoutEscalation.Capabilities.Add = []core.Capability{"CAP_SYS_ADMIN"}
-	capSysAdminWithoutEscalation.AllowPrivilegeEscalation = utilpointer.Bool(false)
+	capSysAdminWithoutEscalation.AllowPrivilegeEscalation = ptr.To(false)
 
 	errorCases := map[string]struct {
 		sc           *core.SecurityContext
@@ -21907,17 +21906,17 @@ func TestValidateOrSetClientIPAffinityConfig(t *testing.T) {
 	successCases := map[string]*core.SessionAffinityConfig{
 		"non-empty config, valid timeout: 1": {
 			ClientIP: &core.ClientIPConfig{
-				TimeoutSeconds: utilpointer.Int32(1),
+				TimeoutSeconds: ptr.To(int32(1)),
 			},
 		},
 		"non-empty config, valid timeout: core.MaxClientIPServiceAffinitySeconds-1": {
 			ClientIP: &core.ClientIPConfig{
-				TimeoutSeconds: utilpointer.Int32(core.MaxClientIPServiceAffinitySeconds - 1),
+				TimeoutSeconds: ptr.To(int32(core.MaxClientIPServiceAffinitySeconds - 1)),
 			},
 		},
 		"non-empty config, valid timeout: core.MaxClientIPServiceAffinitySeconds": {
 			ClientIP: &core.ClientIPConfig{
-				TimeoutSeconds: utilpointer.Int32(core.MaxClientIPServiceAffinitySeconds),
+				TimeoutSeconds: ptr.To(int32(core.MaxClientIPServiceAffinitySeconds)),
 			},
 		},
 	}
@@ -21940,17 +21939,17 @@ func TestValidateOrSetClientIPAffinityConfig(t *testing.T) {
 		},
 		"non-empty config, invalid timeout: core.MaxClientIPServiceAffinitySeconds+1": {
 			ClientIP: &core.ClientIPConfig{
-				TimeoutSeconds: utilpointer.Int32(core.MaxClientIPServiceAffinitySeconds + 1),
+				TimeoutSeconds: ptr.To(int32(core.MaxClientIPServiceAffinitySeconds + 1)),
 			},
 		},
 		"non-empty config, invalid timeout: -1": {
 			ClientIP: &core.ClientIPConfig{
-				TimeoutSeconds: utilpointer.Int32(-1),
+				TimeoutSeconds: ptr.To(int32(-1)),
 			},
 		},
 		"non-empty config, invalid timeout: 0": {
 			ClientIP: &core.ClientIPConfig{
-				TimeoutSeconds: utilpointer.Int32(0),
+				TimeoutSeconds: ptr.To(int32(0)),
 			},
 		},
 	}
@@ -22394,19 +22393,19 @@ func TestVolumeAttributesClass(t *testing.T) {
 			testName:                    "Feature gate enabled and an empty volumeAttributesClassName specified",
 			expectedFail:                false,
 			enableVolumeAttributesClass: true,
-			claimSpec:                   pvcSpecWithVolumeAttributesClassName(utilpointer.String("")),
+			claimSpec:                   pvcSpecWithVolumeAttributesClassName(ptr.To("")),
 		},
 		{
 			testName:                    "Feature gate enabled and valid volumeAttributesClassName specified",
 			expectedFail:                false,
 			enableVolumeAttributesClass: true,
-			claimSpec:                   pvcSpecWithVolumeAttributesClassName(utilpointer.String("foo")),
+			claimSpec:                   pvcSpecWithVolumeAttributesClassName(ptr.To("foo")),
 		},
 		{
 			testName:                    "Feature gate enabled and invalid volumeAttributesClassName specified",
 			expectedFail:                true,
 			enableVolumeAttributesClass: true,
-			claimSpec:                   pvcSpecWithVolumeAttributesClassName(utilpointer.String("-invalid-")),
+			claimSpec:                   pvcSpecWithVolumeAttributesClassName(ptr.To("-invalid-")),
 		},
 	}
 	for _, tc := range testCases {
@@ -22452,7 +22451,7 @@ func TestValidateTopologySpreadConstraints(t *testing.T) {
 			MaxSkew:           1,
 			TopologyKey:       "k8s.io/zone",
 			WhenUnsatisfiable: core.DoNotSchedule,
-			MinDomains:        utilpointer.Int32(3),
+			MinDomains:        ptr.To(int32(3)),
 		}},
 		wantFieldErrors: field.ErrorList{},
 	}, {
@@ -22482,29 +22481,29 @@ func TestValidateTopologySpreadConstraints(t *testing.T) {
 			MaxSkew:           1,
 			TopologyKey:       "k8s.io/zone",
 			WhenUnsatisfiable: core.DoNotSchedule,
-			MinDomains:        utilpointer.Int32(-1),
+			MinDomains:        ptr.To(int32(-1)),
 		}},
-		wantFieldErrors: []*field.Error{field.Invalid(fieldPathMinDomains, utilpointer.Int32(-1), isNotPositiveErrorMsg)},
+		wantFieldErrors: []*field.Error{field.Invalid(fieldPathMinDomains, ptr.To(int32(-1)), isNotPositiveErrorMsg)},
 	}, {
 		name: "cannot use non-nil MinDomains with ScheduleAnyway",
 		constraints: []core.TopologySpreadConstraint{{
 			MaxSkew:           1,
 			TopologyKey:       "k8s.io/zone",
 			WhenUnsatisfiable: core.ScheduleAnyway,
-			MinDomains:        utilpointer.Int32(10),
+			MinDomains:        ptr.To(int32(10)),
 		}},
-		wantFieldErrors: []*field.Error{field.Invalid(fieldPathMinDomains, utilpointer.Int32(10), fmt.Sprintf("can only use minDomains if whenUnsatisfiable=%s, not %s", string(core.DoNotSchedule), string(core.ScheduleAnyway)))},
+		wantFieldErrors: []*field.Error{field.Invalid(fieldPathMinDomains, ptr.To(int32(10)), fmt.Sprintf("can only use minDomains if whenUnsatisfiable=%s, not %s", string(core.DoNotSchedule), string(core.ScheduleAnyway)))},
 	}, {
 		name: "use negative MinDomains with ScheduleAnyway(invalid)",
 		constraints: []core.TopologySpreadConstraint{{
 			MaxSkew:           1,
 			TopologyKey:       "k8s.io/zone",
 			WhenUnsatisfiable: core.ScheduleAnyway,
-			MinDomains:        utilpointer.Int32(-1),
+			MinDomains:        ptr.To(int32(-1)),
 		}},
 		wantFieldErrors: []*field.Error{
-			field.Invalid(fieldPathMinDomains, utilpointer.Int32(-1), isNotPositiveErrorMsg),
-			field.Invalid(fieldPathMinDomains, utilpointer.Int32(-1), fmt.Sprintf("can only use minDomains if whenUnsatisfiable=%s, not %s", string(core.DoNotSchedule), string(core.ScheduleAnyway))),
+			field.Invalid(fieldPathMinDomains, ptr.To(int32(-1)), isNotPositiveErrorMsg),
+			field.Invalid(fieldPathMinDomains, ptr.To(int32(-1)), fmt.Sprintf("can only use minDomains if whenUnsatisfiable=%s, not %s", string(core.DoNotSchedule), string(core.ScheduleAnyway))),
 		},
 	}, {
 		name: "missing TopologyKey",
@@ -23247,7 +23246,7 @@ func TestValidateSeccompAnnotationsAndFieldsMatch(t *testing.T) {
 	}, {
 		description:     "localhost/test.json annotation and SeccompProfileTypeLocalhost with correct profile should return empty",
 		annotationValue: "localhost/test.json",
-		seccompField:    &core.SeccompProfile{Type: core.SeccompProfileTypeLocalhost, LocalhostProfile: utilpointer.String("test.json")},
+		seccompField:    &core.SeccompProfile{Type: core.SeccompProfileTypeLocalhost, LocalhostProfile: ptr.To("test.json")},
 		expectedErr:     nil,
 	}, {
 		description:     "localhost/test.json annotation and SeccompProfileTypeLocalhost without profile should error",
@@ -23258,7 +23257,7 @@ func TestValidateSeccompAnnotationsAndFieldsMatch(t *testing.T) {
 	}, {
 		description:     "localhost/test.json annotation and SeccompProfileTypeLocalhost with different profile should error",
 		annotationValue: "localhost/test.json",
-		seccompField:    &core.SeccompProfile{Type: core.SeccompProfileTypeLocalhost, LocalhostProfile: utilpointer.String("different.json")},
+		seccompField:    &core.SeccompProfile{Type: core.SeccompProfileTypeLocalhost, LocalhostProfile: ptr.To("different.json")},
 		fldPath:         rootFld,
 		expectedErr:     field.Forbidden(rootFld.Child("localhostProfile"), "seccomp profile in annotation and field must match"),
 	}, {


### PR DESCRIPTION
.. to get pointer to a const value

Kubernetes has an util ptr.To that could make the code more readable. Inspired by https://xeiaso.net/notes/2024/go-pointer-constant/.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Cleans up `validation_test.go` of a quirky pointer to a constant value and removes dependency on deprecated package.

#### Special notes for your reviewer:
Updated using regular expressions. Tests contained within the file pass locally.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
