### PR TITLE
Add statusz endpoint for kube-scheduler

### DIFF
--- a/cmd/kube-scheduler/app/server.go
+++ b/cmd/kube-scheduler/app/server.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/apiserver/pkg/server/healthz"
 	"k8s.io/apiserver/pkg/server/mux"
 	"k8s.io/apiserver/pkg/server/routes"
+	"k8s.io/apiserver/pkg/util/compatibility"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -59,6 +60,7 @@ import (
 	"k8s.io/component-base/version/verflag"
 	zpagesfeatures "k8s.io/component-base/zpages/features"
 	"k8s.io/component-base/zpages/flagz"
+	"k8s.io/component-base/zpages/statusz"
 	"k8s.io/klog/v2"
 	schedulerserverconfig "k8s.io/kubernetes/cmd/kube-scheduler/app/config"
 	"k8s.io/kubernetes/cmd/kube-scheduler/app/options"
@@ -371,6 +373,11 @@ func newEndpointsHandler(config *kubeschedulerconfig.KubeSchedulerConfiguration,
 			flagz.Install(pathRecorderMux, kubeScheduler, flagReader)
 		}
 	}
+
+	if utilfeature.DefaultFeatureGate.Enabled(zpagesfeatures.ComponentStatusz) {
+		statusz.Install(pathRecorderMux, kubeScheduler, statusz.NewRegistry(compatibility.DefaultBuildEffectiveVersion()))
+	}
+
 	return pathRecorderMux
 }
 

--- a/test/integration/scheduler/serving/endpoints_test.go
+++ b/test/integration/scheduler/serving/endpoints_test.go
@@ -39,6 +39,8 @@ import (
 
 func TestEndpointHandlers(t *testing.T) {
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ComponentFlagz, true)
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ComponentStatusz, true)
+
 	server, configStr, _, err := startTestAPIServer(t)
 	if err != nil {
 		t.Fatalf("Failed to start kube-apiserver server: %v", err)
@@ -125,6 +127,16 @@ func TestEndpointHandlers(t *testing.T) {
 			wantResponseCode: http.StatusOK,
 			wantResponseBodyRegx: `^\n` +
 				`kube-scheduler flags\n` +
+				`Warning: This endpoint is not meant to be machine parseable, ` +
+				`has no formatting compatibility guarantees and is for debugging purposes only.`,
+		},
+		{
+			name:             "/statusz",
+			path:             "/statusz",
+			requestHeader:    map[string]string{"Accept": "text/plain"},
+			wantResponseCode: http.StatusOK,
+			wantResponseBodyRegx: `^\n` +
+				`kube-scheduler statusz\n` +
 				`Warning: This endpoint is not meant to be machine parseable, ` +
 				`has no formatting compatibility guarantees and is for debugging purposes only.`,
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

Added a `/statusz` endpoint to kube-scheduler

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #128745

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added a `/statusz` endpoint for kube-scheduler
```



#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
KEP : https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/4827-component-statusz/README.md
```

Example Request
```
1. Set under kube-scheduler.yaml // Enable ComponentStatusz feature flag.
`- --feature-gate=ComponentStatusz=true`
3. curl -k --cert /etc/kubernetes/pki/apiserver-kubelet-client.crt --key /etc/kubernetes/pki/apiserver-kubelet-client.key https://localhost:10259/statusz   
```

Example Response
```
kube-scheduler statusz
Warning: This endpoint is not meant to be machine parseable, has no formatting compatibility guarantees and is for debugging purposes only.

Started= Wed Nov 27 19:40:52 UTC 2024
Up= 1 hr 30 min 40 sec
Go version= go1.23.3
Binary version= 1.32.0-beta.0.529&#43;02fb00959d6b3c-dirty
Emulation version= 1.32.0-beta.0.529
```
