### PR TITLE
Add statusz endpoint for kube-controller-manager

### DIFF
--- a/test/integration/serving/serving_test.go
+++ b/test/integration/serving/serving_test.go
@@ -22,6 +22,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"path"
@@ -382,8 +383,13 @@ users:
 			if want, got := tt.wantSecureCode != nil, secureInfo != nil; want != got {
 				t.Errorf("SecureServing enabled: expected=%v got=%v", want, got)
 			} else if want {
-				url := fmt.Sprintf("https://%s%s", secureInfo.Listener.Addr().String(), tt.path)
-				url = strings.ReplaceAll(url, "[::]", "127.0.0.1") // switch to IPv4 because the self-signed cert does not support [::]
+				// only interested on the port, because we are using always localhost
+				_, port, err := net.SplitHostPort(secureInfo.Listener.Addr().String())
+				if err != nil {
+					t.Fatalf("could not get host and port from %s : %v", secureInfo.Listener.Addr().String(), err)
+				}
+				// use IPv4 because the self-signed cert does not support [::]
+				url := fmt.Sprintf("https://127.0.0.1:%s%s", port, tt.path)
 
 				// read self-signed server cert disk
 				pool := x509.NewCertPool()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
-->
/kind feature

#### What this PR does / why we need it:
Added a `/statusz` endpoint to kube-controller-manager
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/128750 and https://github.com/kubernetes/enhancements/issues/4828

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added a `/statusz` endpoint for kube-controller-manager
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP] : https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/4828-component-flagz/README.md

```

```
Example request:
root@kind-control-plane:/etc/kubernetes/manifests# curl -k --cert /etc/kubernetes/pki/apiserver-kubelet-client.crt --key /etc/kubernetes/pki/apiserver-kubelet-client.key https://localhost:10257/statusz 
```

```
Example response
controller-manager statusz
Warning: This endpoint is not meant to be machine parseable, has no formatting compatibility guarantees and is for debugging purposes only.

Started:  Wed Nov 27 22:09:26 UTC 2024
Up:  0 hr 01 min 50 sec
Go version:  go1.23.3
Binary version:  1.32.0-beta.0.529&#43;ee503d2e89a129-dirty
Emulation version:  1.32.0-beta.0.529
```
