### PR TITLE
device manager: do not clean admitted pods from the state

### DIFF
--- a/pkg/kubelet/cm/devicemanager/topology_hints.go
+++ b/pkg/kubelet/cm/devicemanager/topology_hints.go
@@ -31,6 +31,10 @@ import (
 // ensures the Device Manager is consulted when Topology Aware Hints for each
 // container are created.
 func (m *ManagerImpl) GetTopologyHints(pod *v1.Pod, container *v1.Container) map[string][]topologymanager.TopologyHint {
+	// The pod is during the admission phase. We need to save the pod to avoid it
+	// being cleaned before the admission ended
+	m.setPodPendingAdmission(pod)
+
 	// Garbage collect any stranded device resources before providing TopologyHints
 	m.UpdateAllocatedDevices()
 
@@ -83,6 +87,10 @@ func (m *ManagerImpl) GetTopologyHints(pod *v1.Pod, container *v1.Container) map
 // GetPodTopologyHints implements the topologymanager.HintProvider Interface which
 // ensures the Device Manager is consulted when Topology Aware Hints for Pod are created.
 func (m *ManagerImpl) GetPodTopologyHints(pod *v1.Pod) map[string][]topologymanager.TopologyHint {
+	// The pod is during the admission phase. We need to save the pod to avoid it
+	// being cleaned before the admission ended
+	m.setPodPendingAdmission(pod)
+
 	// Garbage collect any stranded device resources before providing TopologyHints
 	m.UpdateAllocatedDevices()
 


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test
/kind regression

#### What this PR does / why we need it:

Reverting part of the https://github.com/kubernetes/kubernetes/pull/127506

The initial fix is part of the #103979. It's reverted by https://github.com/kubernetes/kubernetes/pull/127506/commits/212c4c485172ebda99cd639969f1cc1c32ba6ba7, which resulted in #128443.

See more details in https://github.com/kubernetes/kubernetes/pull/120661, https://github.com/kubernetes/kubernetes/pull/127506 and https://github.com/kubernetes/kubernetes/pull/104577

#### Which issue(s) this PR fixes:

Fixes #128443

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

