### PR TITLE
Replaced util.NewIOHandler() with fakeIOHandler to make UT pass on different host envs

### DIFF
--- a/pkg/volume/fc/fc_util_linux_test.go
+++ b/pkg/volume/fc/fc_util_linux_test.go
@@ -1,0 +1,72 @@
+//go:build linux
+// +build linux
+
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fc
+
+import (
+	"testing"
+
+	"k8s.io/kubernetes/pkg/volume/util"
+)
+
+func TestSearchDiskMultipathDevice(t *testing.T) {
+	tests := []struct {
+		name        string
+		wwns        []string
+		lun         string
+		expectError bool
+	}{
+		{
+			name: "Non PCI disk 0",
+			wwns: []string{"500507681021a537"},
+			lun:  "0",
+		},
+		{
+			name: "Non PCI disk 1",
+			wwns: []string{"500507681022a554"},
+			lun:  "2",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fakeMounter := fcDiskMounter{
+				fcDisk: &fcDisk{
+					wwns: test.wwns,
+					lun:  test.lun,
+					io:   &fakeIOHandler{},
+				},
+				deviceUtil: util.NewDeviceHandler(&fakeIOHandler{}),
+			}
+			devicePath, err := searchDisk(fakeMounter)
+			if test.expectError && err == nil {
+				t.Errorf("expected error but got none")
+			}
+			if !test.expectError && err != nil {
+				t.Errorf("got unexpected error: %s", err)
+			}
+			// if no disk matches input wwn and lun, exit
+			if devicePath == "" && !test.expectError {
+				t.Errorf("no fc disk found")
+			}
+			if devicePath != "/dev/dm-1" {
+				t.Errorf("multipath device not found dm-1 expected got [%s]", devicePath)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind failing-test

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
In some envs, `searchDisk` func returns a `multipath devicemapper device` instead of raw disk. Added check for same to fix UT.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #128963

#### Special notes for your reviewer:
This issue is observed on `ppc64le` arch.
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
