### PR TITLE
Automated cherry pick of #128286: fix isLikelyNotMountPointStatx relative path issue

### DIFF
--- a/staging/src/k8s.io/mount-utils/mount_linux.go
+++ b/staging/src/k8s.io/mount-utils/mount_linux.go
@@ -393,7 +393,7 @@ func (*Mounter) List() ([]MountPoint, error) {
 
 func statx(file string) (unix.Statx_t, error) {
 	var stat unix.Statx_t
-	if err := unix.Statx(0, file, unix.AT_STATX_DONT_SYNC, 0, &stat); err != nil {
+	if err := unix.Statx(unix.AT_FDCWD, file, unix.AT_STATX_DONT_SYNC, 0, &stat); err != nil {
 		if err == unix.ENOSYS {
 			return stat, errStatxNotSupport
 		}

--- a/staging/src/k8s.io/mount-utils/mount_linux_test.go
+++ b/staging/src/k8s.io/mount-utils/mount_linux_test.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"sync"
@@ -33,6 +34,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	utilexec "k8s.io/utils/exec"
 	testexec "k8s.io/utils/exec/testing"
+	"k8s.io/utils/ptr"
 )
 
 func TestReadProcMountsFrom(t *testing.T) {
@@ -825,5 +827,118 @@ func makeFakeCommandAction(stdout string, err error, cmdFn func()) testexec.Fake
 	}
 	return func(cmd string, args ...string) utilexec.Cmd {
 		return testexec.InitFakeCmd(&c, cmd, args...)
+	}
+}
+
+func TestIsLikelyNotMountPoint(t *testing.T) {
+	mounter := Mounter{"fake/path", ptr.To(true), true, true}
+
+	tests := []struct {
+		fileName       string
+		targetLinkName string
+		setUp          func(base, fileName, targetLinkName string) error
+		cleanUp        func(base, fileName, targetLinkName string) error
+		expectedResult bool
+		expectError    bool
+	}{
+		{
+			"Dir",
+			"",
+			func(base, fileName, targetLinkName string) error {
+				return os.Mkdir(filepath.Join(base, fileName), 0o750)
+			},
+			func(base, fileName, targetLinkName string) error {
+				return os.Remove(filepath.Join(base, fileName))
+			},
+			true,
+			false,
+		},
+		{
+			"InvalidDir",
+			"",
+			func(base, fileName, targetLinkName string) error {
+				return nil
+			},
+			func(base, fileName, targetLinkName string) error {
+				return nil
+			},
+			true,
+			true,
+		},
+		{
+			"ValidSymLink",
+			"targetSymLink",
+			func(base, fileName, targetLinkName string) error {
+				targeLinkPath := filepath.Join(base, targetLinkName)
+				if err := os.Mkdir(targeLinkPath, 0o750); err != nil {
+					return err
+				}
+
+				filePath := filepath.Join(base, fileName)
+				if err := os.Symlink(targeLinkPath, filePath); err != nil {
+					return err
+				}
+				return nil
+			},
+			func(base, fileName, targetLinkName string) error {
+				if err := os.Remove(filepath.Join(base, fileName)); err != nil {
+					return err
+				}
+				return os.Remove(filepath.Join(base, targetLinkName))
+			},
+			true,
+			false,
+		},
+		{
+			"InvalidSymLink",
+			"targetSymLink2",
+			func(base, fileName, targetLinkName string) error {
+				targeLinkPath := filepath.Join(base, targetLinkName)
+				if err := os.Mkdir(targeLinkPath, 0o750); err != nil {
+					return err
+				}
+
+				filePath := filepath.Join(base, fileName)
+				if err := os.Symlink(targeLinkPath, filePath); err != nil {
+					return err
+				}
+				return os.Remove(targeLinkPath)
+			},
+			func(base, fileName, targetLinkName string) error {
+				return os.Remove(filepath.Join(base, fileName))
+			},
+			true,
+			true,
+		},
+	}
+
+	for _, test := range tests {
+		// test with absolute and relative path
+		baseList := []string{t.TempDir(), "./"}
+		for _, base := range baseList {
+			if err := test.setUp(base, test.fileName, test.targetLinkName); err != nil {
+				t.Fatalf("unexpected error in setUp(%s, %s): %v", test.fileName, test.targetLinkName, err)
+			}
+
+			filePath := filepath.Join(base, test.fileName)
+			result, err := mounter.IsLikelyNotMountPoint(filePath)
+			if result != test.expectedResult {
+				t.Errorf("Expect result not equal with IsLikelyNotMountPoint(%s) return: %t, expected: %t", filePath, result, test.expectedResult)
+			}
+
+			if base == "./" {
+				if err := test.cleanUp(base, test.fileName, test.targetLinkName); err != nil {
+					t.Fatalf("unexpected error in cleanUp(%s, %s): %v", test.fileName, test.targetLinkName, err)
+				}
+			}
+
+			if (err != nil) != test.expectError {
+				if test.expectError {
+					t.Errorf("Expect error during IsLikelyNotMountPoint(%s)", filePath)
+				} else {
+					t.Errorf("Expect error is nil during IsLikelyNotMountPoint(%s): %v", filePath, err)
+				}
+			}
+		}
 	}
 }


### PR DESCRIPTION
Cherry pick of #128286 on release-1.30.

#128286: fix isLikelyNotMountPointStatx relative path issue

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.