### PR TITLE
kubeadm: Do not read kubeconfig from disk repeatedly in the init phase

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/init/bootstraptoken.go
+++ b/cmd/kubeadm/app/cmd/phases/init/bootstraptoken.go
@@ -72,6 +72,10 @@ func runBootstrapToken(c workflow.RunData) error {
 	if err != nil {
 		return err
 	}
+	kubeconfig, err := data.KubeConfig()
+	if err != nil {
+		return err
+	}
 
 	if !data.SkipTokenPrint() {
 		tokens := data.Tokens()
@@ -106,7 +110,7 @@ func runBootstrapToken(c workflow.RunData) error {
 	}
 
 	// Create the cluster-info ConfigMap with the associated RBAC rules
-	if err := clusterinfophase.CreateBootstrapConfigMapIfNotExists(client, data.KubeConfigPath()); err != nil {
+	if err := clusterinfophase.CreateBootstrapConfigMapIfNotExists(client, kubeconfig); err != nil {
 		return errors.Wrap(err, "error creating bootstrap ConfigMap")
 	}
 	if err := clusterinfophase.CreateClusterInfoRBACRules(client); err != nil {

--- a/cmd/kubeadm/app/cmd/phases/init/data.go
+++ b/cmd/kubeadm/app/cmd/phases/init/data.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	clientset "k8s.io/client-go/kubernetes"
 
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 )
 
@@ -38,6 +39,7 @@ type InitData interface {
 	IgnorePreflightErrors() sets.Set[string]
 	CertificateWriteDir() string
 	CertificateDir() string
+	KubeConfig() (*clientcmdapi.Config, error)
 	KubeConfigDir() string
 	KubeConfigPath() string
 	ManifestDir() string

--- a/cmd/kubeadm/app/cmd/phases/init/data_test.go
+++ b/cmd/kubeadm/app/cmd/phases/init/data_test.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	clientset "k8s.io/client-go/kubernetes"
 
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 )
 
@@ -41,6 +42,7 @@ func (t *testInitData) SkipTokenPrint() bool                                 { r
 func (t *testInitData) IgnorePreflightErrors() sets.Set[string]              { return nil }
 func (t *testInitData) CertificateWriteDir() string                          { return "" }
 func (t *testInitData) CertificateDir() string                               { return "" }
+func (t *testInitData) KubeConfig() (*clientcmdapi.Config, error)            { return nil, nil }
 func (t *testInitData) KubeConfigDir() string                                { return "" }
 func (t *testInitData) KubeConfigPath() string                               { return "" }
 func (t *testInitData) ManifestDir() string                                  { return "" }

--- a/cmd/kubeadm/app/phases/bootstraptoken/clusterinfo/clusterinfo_test.go
+++ b/cmd/kubeadm/app/phases/bootstraptoken/clusterinfo/clusterinfo_test.go
@@ -17,8 +17,8 @@ limitations under the License.
 package clusterinfo
 
 import (
+	"bytes"
 	"context"
-	"os"
 	"testing"
 	"text/template"
 	"time"
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apiserver/pkg/authentication/user"
 	clientsetfake "k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/clientcmd"
 	bootstrapapi "k8s.io/cluster-bootstrap/token/api"
 
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
@@ -55,32 +56,22 @@ users:
 func TestCreateBootstrapConfigMapIfNotExists(t *testing.T) {
 	tests := []struct {
 		name      string
-		fileExist bool
 		createErr error
 		expectErr bool
 	}{
 		{
 			"successful case should have no error",
-			true,
 			nil,
 			false,
 		},
 		{
 			"if configmap already exists, return error",
-			true,
 			apierrors.NewAlreadyExists(schema.GroupResource{Resource: "configmaps"}, "test"),
 			true,
 		},
 		{
 			"unexpected error should be returned",
-			true,
 			apierrors.NewUnauthorized("go away!"),
-			true,
-		},
-		{
-			"if the file does not exist, return error",
-			false,
-			nil,
 			true,
 		},
 	}
@@ -93,18 +84,10 @@ func TestCreateBootstrapConfigMapIfNotExists(t *testing.T) {
 	}
 
 	for _, server := range servers {
-		file, err := os.CreateTemp("", "")
-		if err != nil {
-			t.Fatalf("could not create tempfile: %v", err)
-		}
-		defer os.Remove(file.Name())
+		var buf bytes.Buffer
 
-		if err := testConfigTempl.Execute(file, server); err != nil {
+		if err := testConfigTempl.Execute(&buf, server); err != nil {
 			t.Fatalf("could not write to tempfile: %v", err)
-		}
-
-		if err := file.Close(); err != nil {
-			t.Fatalf("could not close tempfile: %v", err)
 		}
 
 		// Override the default timeouts to be shorter
@@ -124,11 +107,12 @@ func TestCreateBootstrapConfigMapIfNotExists(t *testing.T) {
 					})
 				}
 
-				fileName := file.Name()
-				if !tc.fileExist {
-					fileName = "notexistfile"
+				kubeconfig, err := clientcmd.Load(buf.Bytes())
+				if err != nil {
+					t.Fatal(err)
 				}
-				err := CreateBootstrapConfigMapIfNotExists(client, fileName)
+
+				err = CreateBootstrapConfigMapIfNotExists(client, kubeconfig)
 				if tc.expectErr && err == nil {
 					t.Errorf("CreateBootstrapConfigMapIfNotExists(%s) wanted error, got nil", tc.name)
 				} else if !tc.expectErr && err != nil {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`kubeadm init phase bootstrap-token` reads a given kubeconfig twice, which is an issue if the kubeconfig is sourced from `/dev/stdin`, which doesn't allow for repeated reads (an in general it's redundant to reach out to the disk twice).


#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/kubeadm/issues/3129


#### Special notes for your reviewer:

I ran Go tests just for the function that has a changed signature. Tried running the full suite, but ran into issues I didn't think were related to this PR.

#### Does this PR introduce a user-facing change?

```release-note
kubeadm: avoid loading the file passed to `--kubeconfig` during `kubeadm init` phases more than once.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

