### PR TITLE
apidiff support internal go modules

### DIFF
--- a/hack/apidiff.sh
+++ b/hack/apidiff.sh
@@ -206,7 +206,7 @@ inWorktree "${KUBE_TEMP}/base" "${base}" run "${KUBE_TEMP}/before"
 # be non-zero if there are incompatible changes.
 #
 # The report is Markdown-formatted and can be copied into a PR comment verbatim.
-res=0
+failures=()
 echo
 compare () {
     what="$1"
@@ -226,7 +226,7 @@ compare () {
     fi
     incompatible=$(apidiff -incompatible -m "${before}" "${after}" 2>&1) || true
     if [ -n "$incompatible" ]; then
-        res=1
+        failures+=("${what}")
     fi
 }
 
@@ -263,7 +263,11 @@ tryBuild () {
     )
 }
 
-if [ $res -ne 0 ]; then
+res=0
+if [ ${#failures[@]} -gt 0 ]; then
+    res=1
+    echo "Detected incompatible changes on modules:"
+    printf '%s\n' "${failures[@]}"
     cat <<EOF
 
 Some notes about API differences:

--- a/hack/apidiff.sh
+++ b/hack/apidiff.sh
@@ -158,8 +158,9 @@ run () {
         (
             cd "${d}"
             apidiff -m -w "${out}/$(output_name "${d}")" .
-        )
+        ) &
     done
+    wait
 }
 
 # inWorktree checks out a specific revision, then invokes the given

--- a/hack/apidiff.sh
+++ b/hack/apidiff.sh
@@ -149,6 +149,10 @@ run () {
     out="$1"
     mkdir -p "$out"
     for d in "${targets[@]}"; do
+        if ! [ -d "${d}" ]; then
+            echo "module ${d} does not exist, skipping ..."
+            continue
+        fi
         # cd to the path for modules that are intree but not part of the go workspace
         # per example staging/src/k8s.io/code-generator/examples
         (
@@ -208,6 +212,10 @@ compare () {
     what="$1"
     before="$2"
     after="$3"
+    if [ ! -f "${before}" ] || [ ! -f "${after}" ]; then
+        echo "can not compare changes, module didn't exist before or after"
+        return
+    fi
     changes=$(apidiff -m "${before}" "${after}" 2>&1 | grep -v -e "^Ignoring internal package") || true
     echo "## ${what}"
     if [ -z "$changes" ]; then

--- a/hack/apidiff.sh
+++ b/hack/apidiff.sh
@@ -156,7 +156,12 @@ run () {
     out="$1"
     mkdir -p "$out"
     for d in "${targets[@]}"; do
-        apidiff -m -w "${out}/$(output_name "${d}")" "${d}"
+        # cd to the path for modules that are intree but not part of the go workspace
+        # per example staging/src/k8s.io/code-generator/examples
+        (
+            cd "${d}"
+            apidiff -m -w "${out}/$(output_name "${d}")" .
+        )
     done
 }
 

--- a/hack/apidiff.sh
+++ b/hack/apidiff.sh
@@ -225,7 +225,7 @@ compare () {
         echo "$changes"
         echo
     fi
-    incompatible=$(apidiff -incompatible -m "${before}" "${after}" 2>&1) || true
+    incompatible=$(apidiff -incompatible -m "${before}" "${after}" 2>&1 | grep -v -e "^Ignoring internal package") || true
     if [ -n "$incompatible" ]; then
         failures+=("${what}")
     fi


### PR DESCRIPTION
The kubernetes repository contains some internal golang modules that are not part of the golang global workspace. Because apidiff is currently run from the root of the repository, it does not work against this internal modules.

Instead of executing apidiff from the root we can just cd into the passed path of the module to avoid this limitation.

/kind bug
/kind feature

```release-note
NONE
```


Before this change

```sh
./hack/apidiff.sh -t 26c08dde527c0d4453e95f49e3c6ef7663042f7b -r v1.30.1  ./staging/src/k8s.io/code-generator/examples/
Checking 26c08dde527c0d4453e95f49e3c6ef7663042f7b (= v1.32.0-beta.0-516-g26c08dde527) for API changes since 7f6f9261e634f9358385528d08cf989a455d4372 (= v1.30.1).
Installing apidiff into /tmp/tmp.8QlBWAL8Pi.
Preparing worktree (detached HEAD 26c08dde527)
Updating files: 100% (26242/26242), done.
HEAD is now at 26c08dde527 Wait for updated keys to be observed
loading ./staging/src/k8s.io/code-generator/examples: -: pattern ./staging/src/k8s.io/code-generator/examples/...: directory prefix staging/src/k8s.io/code-generator/examples does not contain modules listed in go.work or their selected dependencies
!!! [1128 15:27:50] Call tree:
!!! [1128 15:27:50]  1: ./hack/apidiff.sh:184 run(...)
!!! [1128 15:27:50]  2: ./hack/apidiff.sh:194 inWorktree(...)
!!! [1128 15:27:50]  3: ./hack/apidiff.sh:199 inTarget(...)
!!! [1128 15:27:50] Call tree:
!!! [1128 15:27:50]  1: ./hack/apidiff.sh:194 inWorktree(...)
!!! [1128 15:27:50]  2: ./hack/apidiff.sh:199 inTarget(...)

```

with this change
```sh
./hack/apidiff.sh -t v1.32.0-rc.0 -r v1.32.0-beta.0 ./staging/src/k8s.io/code-generator/examples/ ./staging/src/k8s.io/client-go/
Checking d0627a38043fc62a96e6f21b940c2ee714ef97c8 (= v1.32.0-rc.0) for API changes since 0c41a48301eb3619da6460dfdf2db6eb92560807 (= v1.32.0-beta.0).
Installing apidiff into /tmp/tmp.dJEmEGpfDg.
Preparing worktree (detached HEAD 8046362e6ff)
Updating files: 100% (26242/26242), done.
HEAD is now at 8046362e6ff Release commit for Kubernetes v1.32.0-rc.0
Preparing worktree (detached HEAD 2d6c8a129df)
Updating files: 100% (26110/26110), done.
HEAD is now at 2d6c8a129df Merge pull request #127134 from jpbetz/mutating-admission

## ./staging/src/k8s.io/code-generator/examples/
Incompatible changes:
- ./MixedCase/clientset/versioned/typed/example/v1/fake.FakeClusterTestTypes: removed
- ./MixedCase/clientset/versioned/typed/example/v1/fake.FakeTestTypes: removed
- ./HyphenGroup/clientset/versioned/typed/example/v1/fake.FakeClusterTestTypes: removed
- ./HyphenGroup/clientset/versioned/typed/example/v1/fake.FakeTestTypes: removed
- ./apiserver/clientset/versioned/typed/example2/v1/fake.FakeTestTypes: removed
- ./apiserver/clientset/versioned/typed/example3.io/v1/fake.FakeTestTypes: removed
- ./crd/clientset/versioned/typed/extensions/v1/fake.FakeTestTypes: removed
- ./crd/clientset/versioned/typed/conflicting/v1/fake.FakeTestTypes: removed
- ./apiserver/clientset/versioned/typed/example/v1/fake.FakeTestTypes: removed
- ./apiserver/clientset/versioned/typed/core/v1/fake.FakeTestTypes: removed
- ./crd/clientset/versioned/typed/example2/v1/fake.FakeTestTypes: removed
- ./single/clientset/versioned/typed/api/v1/fake.FakeClusterTestTypes: removed
- ./single/clientset/versioned/typed/api/v1/fake.FakeTestTypes: removed
- ./crd/clientset/versioned/typed/example/v1/fake.FakeClusterTestTypes: removed
- ./crd/clientset/versioned/typed/example/v1/fake.FakeTestTypes: removed

## ./staging/src/k8s.io/client-go/
Incompatible changes:
- package k8s.io/client-go/kubernetes/typed/coordination/v1alpha1/fake: removed
- ./kubernetes/typed/authentication/v1alpha1/fake.FakeSelfSubjectReviews: removed
- ./kubernetes/typed/authentication/v1beta1/fake.FakeSelfSubjectReviews: removed
- ./kubernetes/typed/authentication/v1beta1/fake.FakeTokenReviews: removed
- ./kubernetes/typed/discovery/v1beta1/fake.FakeEndpointSlices: removed
- ./kubernetes/typed/flowcontrol/v1beta3/fake.FakeFlowSchemas: removed
- ./kubernetes/typed/flowcontrol/v1beta3/fake.FakePriorityLevelConfigurations: removed
- package k8s.io/client-go/kubernetes/typed/coordination/v1alpha1: removed
- ./features.TestOnlyClientAllowsCBOR: removed
- ./features.TestOnlyClientPrefersCBOR: removed
- ./features.TestOnlyFeatureGates: removed
- ./kubernetes/typed/networking/v1beta1/fake.FakeIPAddresses: removed
- ./kubernetes/typed/networking/v1beta1/fake.FakeIngressClasses: removed
- ./kubernetes/typed/networking/v1beta1/fake.FakeIngresses: removed
- ./kubernetes/typed/networking/v1beta1/fake.FakeServiceCIDRs: removed
- ./kubernetes/typed/storage/v1beta1/fake.FakeCSIDrivers: removed
- ./kubernetes/typed/storage/v1beta1/fake.FakeCSINodes: removed
- ./kubernetes/typed/storage/v1beta1/fake.FakeCSIStorageCapacities: removed
- ./kubernetes/typed/storage/v1beta1/fake.FakeStorageClasses: removed
- ./kubernetes/typed/storage/v1beta1/fake.FakeVolumeAttachments: removed
- ./kubernetes/typed/storage/v1beta1/fake.FakeVolumeAttributesClasses: removed
- ./kubernetes/typed/rbac/v1alpha1/fake.FakeClusterRoleBindings: removed
- ./kubernetes/typed/rbac/v1alpha1/fake.FakeClusterRoles: removed
- ./kubernetes/typed/rbac/v1alpha1/fake.FakeRoleBindings: removed
- ./kubernetes/typed/rbac/v1alpha1/fake.FakeRoles: removed
- ./kubernetes/typed/apps/v1/fake.FakeControllerRevisions: removed
- ./kubernetes/typed/apps/v1/fake.FakeDaemonSets: removed
- ./kubernetes/typed/apps/v1/fake.FakeDeployments: removed
- ./kubernetes/typed/apps/v1/fake.FakeReplicaSets: removed
- ./kubernetes/typed/apps/v1/fake.FakeStatefulSets: removed
- ./kubernetes/typed/batch/v1beta1/fake.FakeCronJobs: removed
- ./kubernetes/typed/storagemigration/v1alpha1/fake.FakeStorageVersionMigrations: removed
- package k8s.io/client-go/informers/coordination/v1alpha1: removed
- ./kubernetes/typed/flowcontrol/v1beta2/fake.FakeFlowSchemas: removed
- ./kubernetes/typed/flowcontrol/v1beta2/fake.FakePriorityLevelConfigurations: removed
- ./kubernetes/typed/storage/v1alpha1/fake.FakeCSIStorageCapacities: removed
- ./kubernetes/typed/storage/v1alpha1/fake.FakeVolumeAttachments: removed
- ./kubernetes/typed/storage/v1alpha1/fake.FakeVolumeAttributesClasses: removed
- ./kubernetes.(*Clientset).CoordinationV1alpha1: removed
- ./kubernetes.Interface.CoordinationV1alpha1: removed
- ./kubernetes.Interface.CoordinationV1alpha2: added
- ./kubernetes.Interface.ResourceV1beta1: added
- ./kubernetes/typed/node/v1/fake.FakeRuntimeClasses: removed
- ./kubernetes/typed/scheduling/v1beta1/fake.FakePriorityClasses: removed
- ./kubernetes/typed/policy/v1beta1/fake.FakeEvictions: removed
- ./kubernetes/typed/policy/v1beta1/fake.FakePodDisruptionBudgets: removed
- ./kubernetes/typed/authentication/v1/fake.FakeSelfSubjectReviews: removed
- ./kubernetes/typed/authentication/v1/fake.FakeTokenReviews: removed
- ./kubernetes/typed/certificates/v1beta1/fake.FakeCertificateSigningRequests: removed
- ./kubernetes/typed/storage/v1/fake.FakeCSIDrivers: removed
- ./kubernetes/typed/storage/v1/fake.FakeCSINodes: removed
- ./kubernetes/typed/storage/v1/fake.FakeCSIStorageCapacities: removed
- ./kubernetes/typed/storage/v1/fake.FakeStorageClasses: removed
- ./kubernetes/typed/storage/v1/fake.FakeVolumeAttachments: removed
- ./kubernetes/typed/flowcontrol/v1beta1/fake.FakeFlowSchemas: removed
- ./kubernetes/typed/flowcontrol/v1beta1/fake.FakePriorityLevelConfigurations: removed
- package k8s.io/client-go/applyconfigurations/coordination/v1alpha1: removed
- ./kubernetes/typed/certificates/v1alpha1/fake.FakeClusterTrustBundles: removed
- ./kubernetes/typed/extensions/v1beta1/fake.FakeDaemonSets: removed
- ./kubernetes/typed/extensions/v1beta1/fake.FakeDeployments: removed
- ./kubernetes/typed/extensions/v1beta1/fake.FakeIngresses: removed
- ./kubernetes/typed/extensions/v1beta1/fake.FakeNetworkPolicies: removed
- ./kubernetes/typed/extensions/v1beta1/fake.FakeReplicaSets: removed
- ./kubernetes/typed/scheduling/v1alpha1/fake.FakePriorityClasses: removed
- ./kubernetes/typed/flowcontrol/v1/fake.FakeFlowSchemas: removed
- ./kubernetes/typed/flowcontrol/v1/fake.FakePriorityLevelConfigurations: removed
- ./kubernetes/typed/policy/v1/fake.FakeEvictions: removed
- ./kubernetes/typed/policy/v1/fake.FakePodDisruptionBudgets: removed
- ./kubernetes/typed/autoscaling/v2beta2/fake.FakeHorizontalPodAutoscalers: removed
- ./kubernetes/typed/networking/v1/fake.FakeIngressClasses: removed
- ./kubernetes/typed/networking/v1/fake.FakeIngresses: removed
- ./kubernetes/typed/networking/v1/fake.FakeNetworkPolicies: removed
- ./kubernetes/typed/node/v1beta1/fake.FakeRuntimeClasses: removed
- ./kubernetes/typed/autoscaling/v2/fake.FakeHorizontalPodAutoscalers: removed
- ./kubernetes/typed/autoscaling/v2beta1/fake.FakeHorizontalPodAutoscalers: removed
- ./kubernetes/typed/admissionregistration/v1/fake.FakeMutatingWebhookConfigurations: removed
- ./kubernetes/typed/admissionregistration/v1/fake.FakeValidatingAdmissionPolicies: removed
- ./kubernetes/typed/admissionregistration/v1/fake.FakeValidatingAdmissionPolicyBindings: removed
- ./kubernetes/typed/admissionregistration/v1/fake.FakeValidatingWebhookConfigurations: removed
- ./kubernetes/typed/certificates/v1/fake.FakeCertificateSigningRequests: removed
- ./kubernetes/typed/networking/v1alpha1/fake.FakeIPAddresses: removed
- ./kubernetes/typed/networking/v1alpha1/fake.FakeServiceCIDRs: removed
- ./kubernetes/typed/apps/v1beta2/fake.FakeControllerRevisions: removed
- ./kubernetes/typed/apps/v1beta2/fake.FakeDaemonSets: removed
- ./kubernetes/typed/apps/v1beta2/fake.FakeDeployments: removed
- ./kubernetes/typed/apps/v1beta2/fake.FakeReplicaSets: removed
- ./kubernetes/typed/apps/v1beta2/fake.FakeStatefulSets: removed
- ./kubernetes/typed/admissionregistration/v1alpha1/fake.FakeMutatingAdmissionPolicies: removed
- ./kubernetes/typed/admissionregistration/v1alpha1/fake.FakeMutatingAdmissionPolicyBindings: removed
- ./kubernetes/typed/admissionregistration/v1alpha1/fake.FakeValidatingAdmissionPolicies: removed
- ./kubernetes/typed/admissionregistration/v1alpha1/fake.FakeValidatingAdmissionPolicyBindings: removed
- ./kubernetes/typed/core/v1/fake.FakeComponentStatuses: removed
- ./kubernetes/typed/core/v1/fake.FakeConfigMaps: removed
- ./kubernetes/typed/core/v1/fake.FakeEndpoints: removed
- ./kubernetes/typed/core/v1/fake.FakeEvents: removed
- ./kubernetes/typed/core/v1/fake.FakeLimitRanges: removed
- ./kubernetes/typed/core/v1/fake.FakeNamespaces: removed
- ./kubernetes/typed/core/v1/fake.FakeNodes: removed
- ./kubernetes/typed/core/v1/fake.FakePersistentVolumeClaims: removed
- ./kubernetes/typed/core/v1/fake.FakePersistentVolumes: removed
- ./kubernetes/typed/core/v1/fake.FakePodTemplates: removed
- ./kubernetes/typed/core/v1/fake.FakePods: removed
- ./kubernetes/typed/core/v1/fake.FakeReplicationControllers: removed
- ./kubernetes/typed/core/v1/fake.FakeResourceQuotas: removed
- ./kubernetes/typed/core/v1/fake.FakeSecrets: removed
- ./kubernetes/typed/core/v1/fake.FakeServiceAccounts: removed
- ./kubernetes/typed/core/v1/fake.FakeServices: removed
- ./kubernetes/typed/scheduling/v1/fake.FakePriorityClasses: removed
- ./tools/leaderelection.NewCandidate: changed from func(k8s.io/client-go/kubernetes.Interface, string, string, string, string, string, []k8s.io/api/coordination/v1.CoordinatedLeaseStrategy) (*LeaseCandidate, CacheSyncWaiter, error) to func(k8s.io/client-go/kubernetes.Interface, string, string, string, string, string, k8s.io/api/coordination/v1.CoordinatedLeaseStrategy) (*LeaseCandidate, CacheSyncWaiter, error)
- ./kubernetes/typed/events/v1beta1/fake.FakeEvents: removed
- ./kubernetes/typed/rbac/v1/fake.FakeClusterRoleBindings: removed
- ./kubernetes/typed/rbac/v1/fake.FakeClusterRoles: removed
- ./kubernetes/typed/rbac/v1/fake.FakeRoleBindings: removed
- ./kubernetes/typed/rbac/v1/fake.FakeRoles: removed
- ./kubernetes/fake.(*Clientset).CoordinationV1alpha1: removed
- ./kubernetes/typed/discovery/v1/fake.FakeEndpointSlices: removed
- ./kubernetes/typed/core/v1.PodInterface.UpdateResize: added
- package k8s.io/client-go/listers/coordination/v1alpha1: removed
- ./informers/resource.Interface.V1beta1: added
- ./kubernetes/typed/authorization/v1beta1/fake.FakeLocalSubjectAccessReviews: removed
- ./kubernetes/typed/authorization/v1beta1/fake.FakeSelfSubjectAccessReviews: removed
- ./kubernetes/typed/authorization/v1beta1/fake.FakeSelfSubjectRulesReviews: removed
- ./kubernetes/typed/authorization/v1beta1/fake.FakeSubjectAccessReviews: removed
- ./kubernetes/typed/resource/v1alpha3/fake.FakeDeviceClasses: removed
- ./kubernetes/typed/resource/v1alpha3/fake.FakeResourceClaimTemplates: removed
- ./kubernetes/typed/resource/v1alpha3/fake.FakeResourceClaims: removed
- ./kubernetes/typed/resource/v1alpha3/fake.FakeResourceSlices: removed
- ./kubernetes/typed/batch/v1/fake.FakeCronJobs: removed
- ./kubernetes/typed/batch/v1/fake.FakeJobs: removed
- ./kubernetes/typed/events/v1/fake.FakeEvents: removed
- ./informers/coordination.Interface.V1alpha1: removed
- ./informers/coordination.Interface.V1alpha2: added
- ./kubernetes/typed/apps/v1beta1/fake.FakeControllerRevisions: removed
- ./kubernetes/typed/apps/v1beta1/fake.FakeDeployments: removed
- ./kubernetes/typed/apps/v1beta1/fake.FakeStatefulSets: removed
- ./kubernetes/typed/apiserverinternal/v1alpha1/fake.FakeStorageVersions: removed
- ./kubernetes/typed/coordination/v1/fake.FakeLeases: removed
- ./kubernetes/typed/node/v1alpha1/fake.FakeRuntimeClasses: removed
- ./kubernetes/typed/admissionregistration/v1beta1/fake.FakeMutatingWebhookConfigurations: removed
- ./kubernetes/typed/admissionregistration/v1beta1/fake.FakeValidatingAdmissionPolicies: removed
- ./kubernetes/typed/admissionregistration/v1beta1/fake.FakeValidatingAdmissionPolicyBindings: removed
- ./kubernetes/typed/admissionregistration/v1beta1/fake.FakeValidatingWebhookConfigurations: removed
- ./kubernetes/typed/rbac/v1beta1/fake.FakeClusterRoleBindings: removed
- ./kubernetes/typed/rbac/v1beta1/fake.FakeClusterRoles: removed
- ./kubernetes/typed/rbac/v1beta1/fake.FakeRoleBindings: removed
- ./kubernetes/typed/rbac/v1beta1/fake.FakeRoles: removed
- ./kubernetes/typed/autoscaling/v1/fake.FakeHorizontalPodAutoscalers: removed
- ./kubernetes/typed/coordination/v1beta1/fake.FakeLeases: removed
- ./kubernetes/typed/authorization/v1/fake.FakeLocalSubjectAccessReviews: removed
- ./kubernetes/typed/authorization/v1/fake.FakeSelfSubjectAccessReviews: removed
- ./kubernetes/typed/authorization/v1/fake.FakeSelfSubjectRulesReviews: removed
- ./kubernetes/typed/authorization/v1/fake.FakeSubjectAccessReviews: removed
Compatible changes:
- ./features.ClientsAllowCBOR: added
- ./features.ClientsPreferCBOR: added
- ./applyconfigurations/core/v1.(*PodSpecApplyConfiguration).WithResources: added
- ./applyconfigurations/core/v1.PodSpecApplyConfiguration.Resources: added
- ./kubernetes.(*Clientset).CoordinationV1alpha2: added
- ./kubernetes.(*Clientset).ResourceV1beta1: added
- ./util/flowcontrol.Backoff.HasExpiredFunc: added
- ./kubernetes/fake.(*Clientset).CoordinationV1alpha2: added
- ./kubernetes/fake.(*Clientset).ResourceV1beta1: added
- ./applyconfigurations/resource/v1alpha3.(*ResourceClaimStatusApplyConfiguration).WithDevices: added
- ./applyconfigurations/resource/v1alpha3.AllocatedDeviceStatus: added
- ./applyconfigurations/resource/v1alpha3.AllocatedDeviceStatusApplyConfiguration: added
- ./applyconfigurations/resource/v1alpha3.NetworkDeviceData: added
- ./applyconfigurations/resource/v1alpha3.NetworkDeviceDataApplyConfiguration: added
- ./applyconfigurations/resource/v1alpha3.ResourceClaimStatusApplyConfiguration.Devices: added
- ./gentype.FakeClient: added
- ./gentype.FakeClientWithApply: added
- ./gentype.FakeClientWithList: added
- ./gentype.FakeClientWithListAndApply: added
- ./gentype.FromPointerSlice: added
- ./gentype.NewFakeClient: added
- ./gentype.NewFakeClientWithApply: added
- ./gentype.NewFakeClientWithList: added
- ./gentype.NewFakeClientWithListAndApply: added
- ./gentype.ToPointerSlice: added
- ./applyconfigurations/meta/v1.(*DeleteOptionsApplyConfiguration).WithIgnoreStoreReadErrorWithClusterBreakingPotential: added
- ./applyconfigurations/meta/v1.DeleteOptionsApplyConfiguration.IgnoreStoreReadErrorWithClusterBreakingPotential: added
- package k8s.io/client-go/listers/resource/v1beta1: added
- package k8s.io/client-go/kubernetes/typed/resource/v1beta1/fake: added
- package k8s.io/client-go/applyconfigurations/coordination/v1alpha2: added
- package k8s.io/client-go/informers/coordination/v1alpha2: added
- package k8s.io/client-go/kubernetes/typed/resource/v1beta1: added
- package k8s.io/client-go/informers/resource/v1beta1: added
- package k8s.io/client-go/listers/coordination/v1alpha2: added
- package k8s.io/client-go/kubernetes/typed/coordination/v1alpha2/fake: added
- package k8s.io/client-go/applyconfigurations/resource/v1beta1: added
- package k8s.io/client-go/kubernetes/typed/coordination/v1alpha2: added

Detected incompatible changes on modules:
./staging/src/k8s.io/code-generator/examples/
./staging/src/k8s.io/client-go/

Some notes about API differences:

Changes in internal packages are usually okay.
However, remember that custom schedulers
and scheduler plugins depend on pkg/scheduler/framework.

API changes in staging repos are more critical.
Try to avoid them as much as possible.
But sometimes changing an API is the lesser evil
and/or the impact on downstream consumers is low.
Use common sense and code searches.

```
