### PR TITLE
flowcontrol: reduce log noise in apf during kube-apiserver startup

### DIFF
--- a/pkg/registry/flowcontrol/ensurer/strategy.go
+++ b/pkg/registry/flowcontrol/ensurer/strategy.go
@@ -290,8 +290,8 @@ func EnsureConfiguration[ObjectType configurationObjectType](ctx context.Context
 		return nil
 	}
 
-	if _, err = ops.Update(ctx, newObject, metav1.UpdateOptions{FieldManager: fieldManager}); err == nil {
-		klog.V(2).Infof("Updated the %T type=%s name=%q diff: %s", bootstrap, configurationType, name, cmp.Diff(current, bootstrap))
+	if updated, err := ops.Update(ctx, newObject, metav1.UpdateOptions{FieldManager: fieldManager}); err == nil {
+		klog.V(2).Infof("Updated the %T type=%s name=%q diff: %s", bootstrap, configurationType, name, cmp.Diff(current, updated))
 		return nil
 	}
 

--- a/pkg/registry/flowcontrol/ensurer/strategy.go
+++ b/pkg/registry/flowcontrol/ensurer/strategy.go
@@ -251,6 +251,8 @@ func EnsureConfigurations[ObjectType configurationObjectType](ctx context.Contex
 
 // EnsureConfiguration applies the given maintenance strategy to the given object.
 func EnsureConfiguration[ObjectType configurationObjectType](ctx context.Context, ops ObjectOps[ObjectType], bootstrap ObjectType, strategy EnsureStrategy[ObjectType]) error {
+	logger := klog.FromContext(ctx)
+
 	name := bootstrap.GetName()
 	configurationType := strategy.Name()
 
@@ -267,36 +269,36 @@ func EnsureConfiguration[ObjectType configurationObjectType](ctx context.Context
 
 		// we always re-create a missing configuration object
 		if _, err = ops.Create(ctx, ops.DeepCopy(bootstrap), metav1.CreateOptions{FieldManager: fieldManager}); err == nil {
-			klog.V(2).InfoS(fmt.Sprintf("Successfully created %T", bootstrap), "type", configurationType, "name", name)
+			logger.V(2).Info(fmt.Sprintf("Successfully created %T", bootstrap), "type", configurationType, "name", name)
 			return nil
 		}
 
 		if !apierrors.IsAlreadyExists(err) {
 			return fmt.Errorf("cannot create %T type=%s name=%q error=%w", bootstrap, configurationType, name, err)
 		}
-		klog.V(5).InfoS(fmt.Sprintf("Something created the %T concurrently", bootstrap), "type", configurationType, "name", name)
+		logger.V(5).Info(fmt.Sprintf("Something created the %T concurrently", bootstrap), "type", configurationType, "name", name)
 	}
 
-	klog.V(5).InfoS(fmt.Sprintf("The %T already exists, checking whether it is up to date", bootstrap), "type", configurationType, "name", name)
+	logger.V(5).Info(fmt.Sprintf("The %T already exists, checking whether it is up to date", bootstrap), "type", configurationType, "name", name)
 	newObject, update, err := strategy.ReviseIfNeeded(ops, current, bootstrap)
 	if err != nil {
 		return fmt.Errorf("failed to determine whether auto-update is required for %T type=%s name=%q error=%w", bootstrap, configurationType, name, err)
 	}
 	if !update {
-		if klogV := klog.V(5); klogV.Enabled() {
-			klogV.InfoS("No update required", "wrapper", bootstrap.GetObjectKind().GroupVersionKind().Kind, "type", configurationType, "name", name,
+		if v5 := logger.V(5); v5.Enabled() {
+			v5.Info("No update required", "wrapper", bootstrap.GetObjectKind().GroupVersionKind().Kind, "type", configurationType, "name", name,
 				"diff", cmp.Diff(current, bootstrap))
 		}
 		return nil
 	}
 
 	if updated, err := ops.Update(ctx, newObject, metav1.UpdateOptions{FieldManager: fieldManager}); err == nil {
-		klog.V(2).Infof("Updated the %T type=%s name=%q diff: %s", bootstrap, configurationType, name, cmp.Diff(current, updated))
+		logger.V(2).Info(fmt.Sprintf("Updated the %T", bootstrap), "type", configurationType, "name", name, "diff", cmp.Diff(current, updated))
 		return nil
 	}
 
 	if apierrors.IsConflict(err) {
-		klog.V(2).InfoS(fmt.Sprintf("Something updated the %T concurrently, I will check its spec later", bootstrap), "type", configurationType, "name", name)
+		logger.V(2).Info(fmt.Sprintf("Something updated the %T concurrently, I will check its spec later", bootstrap), "type", configurationType, "name", name)
 		return nil
 	}
 
@@ -308,6 +310,8 @@ func EnsureConfiguration[ObjectType configurationObjectType](ctx context.Context
 // have a name in the given set.  A refusal due to concurrent update is logged
 // and not considered an error; the object will be reconsidered later.
 func RemoveUnwantedObjects[ObjectType configurationObjectType](ctx context.Context, objectOps ObjectOps[ObjectType], boots []ObjectType) error {
+	logger := klog.FromContext(ctx)
+
 	current, err := objectOps.List(labels.Everything())
 	if err != nil {
 		return err
@@ -325,27 +329,27 @@ func RemoveUnwantedObjects[ObjectType configurationObjectType](ctx context.Conte
 			// the configuration object does not have the annotation key,
 			// it's probably a user defined configuration object,
 			// so we can skip it.
-			klog.V(5).InfoS("Skipping deletion of APF object with no "+flowcontrolv1.AutoUpdateAnnotationKey+" annotation", "name", name)
+			logger.V(5).Info("Skipping deletion of APF object with no "+flowcontrolv1.AutoUpdateAnnotationKey+" annotation", "name", name)
 			continue
 		}
 		autoUpdate, err = strconv.ParseBool(value)
 		if err != nil {
 			// Log this because it is not an expected situation.
-			klog.V(4).InfoS("Skipping deletion of APF object with malformed "+flowcontrolv1.AutoUpdateAnnotationKey+" annotation", "name", name, "annotationValue", value, "parseError", err)
+			logger.V(4).Info("Skipping deletion of APF object with malformed "+flowcontrolv1.AutoUpdateAnnotationKey+" annotation", "name", name, "annotationValue", value, "parseError", err)
 			continue
 		}
 		if !autoUpdate {
-			klog.V(5).InfoS("Skipping deletion of APF object with "+flowcontrolv1.AutoUpdateAnnotationKey+"=false annotation", "name", name)
+			logger.V(5).Info("Skipping deletion of APF object with "+flowcontrolv1.AutoUpdateAnnotationKey+"=false annotation", "name", name)
 			continue
 		}
 		// TODO: expectedResourceVersion := object.GetResourceVersion()
 		err = objectOps.Delete(ctx, object.GetName(), metav1.DeleteOptions{ /* TODO: expectedResourceVersion */ })
 		if err == nil {
-			klog.V(2).InfoS(fmt.Sprintf("Successfully deleted the unwanted %s", object.GetObjectKind().GroupVersionKind().Kind), "name", name)
+			logger.V(2).Info(fmt.Sprintf("Successfully deleted the unwanted %s", object.GetObjectKind().GroupVersionKind().Kind), "name", name)
 			continue
 		}
 		if apierrors.IsNotFound(err) {
-			klog.V(5).InfoS("Unwanted APF object was concurrently deleted", "name", name)
+			logger.V(5).Info("Unwanted APF object was concurrently deleted", "name", name)
 		} else {
 			return fmt.Errorf("failed to delete unwatned APF object %q - %w", name, err)
 		}

--- a/pkg/registry/flowcontrol/ensurer/strategy.go
+++ b/pkg/registry/flowcontrol/ensurer/strategy.go
@@ -279,15 +279,11 @@ func EnsureConfiguration[ObjectType configurationObjectType](ctx context.Context
 		logger.V(5).Info(fmt.Sprintf("Something created the %T concurrently", bootstrap))
 	}
 
-	logger.V(5).Info(fmt.Sprintf("The %T already exists, checking whether it is up to date", bootstrap))
 	newObject, update, err := strategy.ReviseIfNeeded(ops, current, bootstrap)
 	if err != nil {
 		return fmt.Errorf("failed to determine whether auto-update is required for %T type=%s name=%q error=%w", bootstrap, configurationType, name, err)
 	}
 	if !update {
-		if loggerV := logger.V(5); loggerV.Enabled() {
-			loggerV.Info("No update required", "wrapper", bootstrap.GetObjectKind().GroupVersionKind().Kind)
-		}
 		return nil
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -912,7 +912,7 @@ func (c completedConfig) New(name string, delegationTarget DelegationTarget) (*G
 	} else if c.FlowControl != nil {
 		err := s.AddPostStartHook(priorityAndFairnessConfigConsumerHookName, func(hookContext PostStartHookContext) error {
 			if err := c.FlowControl.Start(hookContext); err != nil {
-				klog.ErrorS(err, "failed starting flow control")
+				klog.FromContext(hookContext).Error(err, "Failed starting flow control")
 				return nil // don't klog.Fatal. This only happens when context is cancelled or informers don't get ready.
 			}
 			return nil

--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -911,10 +911,13 @@ func (c completedConfig) New(name string, delegationTarget DelegationTarget) (*G
 	if s.isPostStartHookRegistered(priorityAndFairnessConfigConsumerHookName) {
 	} else if c.FlowControl != nil {
 		err := s.AddPostStartHook(priorityAndFairnessConfigConsumerHookName, func(hookContext PostStartHookContext) error {
-			if err := c.FlowControl.Start(hookContext); err != nil {
-				klog.FromContext(hookContext).Error(err, "Failed starting flow control")
-				return nil // don't klog.Fatal. This only happens when context is cancelled or informers don't get ready.
-			}
+			go func() {
+				if err := c.FlowControl.Start(hookContext); err != nil {
+					klog.FromContext(hookContext).Error(err, "Failed starting flow control")
+					// nothing more we can do here.
+				}
+			}()
+
 			return nil
 		})
 		if err != nil {

--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -911,7 +911,10 @@ func (c completedConfig) New(name string, delegationTarget DelegationTarget) (*G
 	if s.isPostStartHookRegistered(priorityAndFairnessConfigConsumerHookName) {
 	} else if c.FlowControl != nil {
 		err := s.AddPostStartHook(priorityAndFairnessConfigConsumerHookName, func(hookContext PostStartHookContext) error {
-			go c.FlowControl.Run(hookContext)
+			if err := c.FlowControl.Start(hookContext); err != nil {
+				klog.ErrorS(err, "failed starting flow control")
+				return nil // don't klog.Fatal. This only happens when context is cancelled or informers don't get ready.
+			}
 			return nil
 		})
 		if err != nil {

--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -911,7 +911,7 @@ func (c completedConfig) New(name string, delegationTarget DelegationTarget) (*G
 	if s.isPostStartHookRegistered(priorityAndFairnessConfigConsumerHookName) {
 	} else if c.FlowControl != nil {
 		err := s.AddPostStartHook(priorityAndFairnessConfigConsumerHookName, func(hookContext PostStartHookContext) error {
-			go c.FlowControl.Run(hookContext.Done())
+			go c.FlowControl.Run(hookContext)
 			return nil
 		})
 		if err != nil {

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/priority-and-fairness_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/priority-and-fairness_test.go
@@ -292,7 +292,6 @@ func TestApfExecuteMultipleRequests(t *testing.T) {
 		preEnqueue.Wait()
 		if int(atomicReadOnlyWaiting) != concurrentRequests {
 			t.Errorf("Wanted %d requests in queue, got %d", 1, atomicReadOnlyWaiting)
-
 		}
 		postEnqueue.Done()
 		postEnqueue.Wait()

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/priority-and-fairness_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/priority-and-fairness_test.go
@@ -115,7 +115,7 @@ func (t fakeApfFilter) Handle(ctx context.Context,
 	}
 }
 
-func (t fakeApfFilter) Run(stopCh <-chan struct{}) error {
+func (t fakeApfFilter) Run(_ context.Context) error {
 	return nil
 }
 
@@ -407,7 +407,7 @@ func (f *fakeWatchApfFilter) Handle(ctx context.Context,
 	f.inflight--
 }
 
-func (f *fakeWatchApfFilter) Run(stopCh <-chan struct{}) error {
+func (f *fakeWatchApfFilter) Run(_ context.Context) error {
 	return nil
 }
 
@@ -695,8 +695,8 @@ func TestPriorityAndFairnessWithPanicRecoveryAndTimeoutFilter(t *testing.T) {
 		)
 
 		apfConfiguration := newConfiguration(fsName, plName, userName, plConcurrencyShares, 0)
-		stopCh := make(chan struct{})
-		controller, controllerCompletedCh := startAPFController(t, stopCh, apfConfiguration, serverConcurrency, plName, plConcurrency)
+		ctx, cancel := context.WithCancel(context.Background())
+		controller, controllerCompletedCh := startAPFController(t, ctx, apfConfiguration, serverConcurrency, plName, plConcurrency)
 
 		headerMatcher := headerMatcher{}
 		// we will raise a panic for the first request.
@@ -750,7 +750,7 @@ func TestPriorityAndFairnessWithPanicRecoveryAndTimeoutFilter(t *testing.T) {
 			t.Errorf("Expected the server handler to have completed: %q", secondRequestPathShouldWork)
 		}
 
-		close(stopCh)
+		cancel()
 		t.Log("Waiting for the controller to shutdown")
 
 		controllerErr := <-controllerCompletedCh
@@ -769,8 +769,8 @@ func TestPriorityAndFairnessWithPanicRecoveryAndTimeoutFilter(t *testing.T) {
 		)
 
 		apfConfiguration := newConfiguration(fsName, plName, userName, plConcurrencyShares, 0)
-		stopCh := make(chan struct{})
-		controller, controllerCompletedCh := startAPFController(t, stopCh, apfConfiguration, serverConcurrency, plName, plConcurrency)
+		ctx, cancel := context.WithCancel(context.Background())
+		controller, controllerCompletedCh := startAPFController(t, ctx, apfConfiguration, serverConcurrency, plName, plConcurrency)
 
 		headerMatcher := headerMatcher{}
 		rquestTimesOutPath := "/request/time-out-as-designed"
@@ -823,7 +823,7 @@ func TestPriorityAndFairnessWithPanicRecoveryAndTimeoutFilter(t *testing.T) {
 			t.Errorf("Expected HTTP status code: %d for request: %q, but got: %#v", http.StatusGatewayTimeout, rquestTimesOutPath, response)
 		}
 
-		close(stopCh)
+		cancel()
 		t.Log("Waiting for the controller to shutdown")
 
 		controllerErr := <-controllerCompletedCh
@@ -842,8 +842,8 @@ func TestPriorityAndFairnessWithPanicRecoveryAndTimeoutFilter(t *testing.T) {
 		)
 
 		apfConfiguration := newConfiguration(fsName, plName, userName, plConcurrencyShares, 0)
-		stopCh := make(chan struct{})
-		controller, controllerCompletedCh := startAPFController(t, stopCh, apfConfiguration, serverConcurrency, plName, plConcurrency)
+		ctx, cancel := context.WithCancel(context.Background())
+		controller, controllerCompletedCh := startAPFController(t, ctx, apfConfiguration, serverConcurrency, plName, plConcurrency)
 
 		headerMatcher := headerMatcher{}
 		reqHandlerErrCh, callerRoundTripDoneCh := make(chan error, 1), make(chan struct{})
@@ -902,7 +902,7 @@ func TestPriorityAndFairnessWithPanicRecoveryAndTimeoutFilter(t *testing.T) {
 			t.Errorf("Expected HTTP status code: %d for request: %q, but got: %#v", http.StatusGatewayTimeout, rquestTimesOutPath, response)
 		}
 
-		close(stopCh)
+		cancel()
 		t.Log("Waiting for the controller to shutdown")
 
 		controllerErr := <-controllerCompletedCh
@@ -921,8 +921,8 @@ func TestPriorityAndFairnessWithPanicRecoveryAndTimeoutFilter(t *testing.T) {
 		)
 
 		apfConfiguration := newConfiguration(fsName, plName, userName, plConcurrencyShares, 0)
-		stopCh := make(chan struct{})
-		controller, controllerCompletedCh := startAPFController(t, stopCh, apfConfiguration, serverConcurrency, plName, plConcurrency)
+		ctx, cancel := context.WithCancel(context.Background())
+		controller, controllerCompletedCh := startAPFController(t, ctx, apfConfiguration, serverConcurrency, plName, plConcurrency)
 
 		headerMatcher := headerMatcher{}
 		rquestTimesOutPath := "/request/time-out-as-designed"
@@ -974,7 +974,7 @@ func TestPriorityAndFairnessWithPanicRecoveryAndTimeoutFilter(t *testing.T) {
 
 		expectResetStreamError(t, err)
 
-		close(stopCh)
+		cancel()
 		t.Log("Waiting for the controller to shutdown")
 
 		controllerErr := <-controllerCompletedCh
@@ -999,8 +999,8 @@ func TestPriorityAndFairnessWithPanicRecoveryAndTimeoutFilter(t *testing.T) {
 		)
 
 		apfConfiguration := newConfiguration(fsName, plName, userName, plConcurrencyShares, queueLength)
-		stopCh := make(chan struct{})
-		controller, controllerCompletedCh := startAPFController(t, stopCh, apfConfiguration, serverConcurrency, plName, plConcurrency)
+		ctx, cancel := context.WithCancel(context.Background())
+		controller, controllerCompletedCh := startAPFController(t, ctx, apfConfiguration, serverConcurrency, plName, plConcurrency)
 
 		headerMatcher := headerMatcher{}
 		firstRequestTimesOutPath, secondRequestEnqueuedPath := "/request/first/time-out-as-designed", "/request/second/enqueued-as-designed"
@@ -1110,7 +1110,7 @@ func TestPriorityAndFairnessWithPanicRecoveryAndTimeoutFilter(t *testing.T) {
 			t.Errorf("Expected HTTP status code: %d or %d for request: %q, but got: %#+v", http.StatusTooManyRequests, http.StatusGatewayTimeout, secondRequestEnqueuedPath, secondReqResult.response)
 		}
 
-		close(stopCh)
+		cancel()
 		t.Log("Waiting for the controller to shutdown")
 
 		controllerErr := <-controllerCompletedCh
@@ -1124,14 +1124,14 @@ func fmtError(err error) string {
 	return fmt.Sprintf("%#+v=%q", err, err.Error())
 }
 
-func startAPFController(t *testing.T, stopCh <-chan struct{}, apfConfiguration []runtime.Object, serverConcurrency int,
+func startAPFController(t *testing.T, ctx context.Context, apfConfiguration []runtime.Object, serverConcurrency int,
 	plName string, plConcurrency int) (utilflowcontrol.Interface, <-chan error) {
 	clientset := newClientset(t, apfConfiguration...)
 	// this test does not rely on resync, so resync period is set to zero
 	factory := informers.NewSharedInformerFactory(clientset, 0)
 	controller := utilflowcontrol.New(factory, clientset.FlowcontrolV1(), serverConcurrency)
 
-	factory.Start(stopCh)
+	factory.Start(ctx.Done())
 
 	// wait for the informer cache to sync.
 	timeout, cancel := context.WithTimeout(context.TODO(), 5*time.Second)
@@ -1144,7 +1144,7 @@ func startAPFController(t *testing.T, stopCh <-chan struct{}, apfConfiguration [
 	controllerCompletedCh := make(chan error)
 	var controllerErr error
 	go func() {
-		controllerErr = controller.Run(stopCh)
+		controllerErr = controller.Run(ctx)
 		controllerCompletedCh <- controllerErr
 	}()
 

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_controller.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_controller.go
@@ -370,7 +370,8 @@ func (cfgCtlr *configController) Start(ctx context.Context) error {
 	go func() {
 		<-ctx.Done()
 		// Let the config worker stop when we are done
-		defer cfgCtlr.configQueue.ShutDown()
+		klog.Info("Shutting down API Priority and Fairness config worker")
+		cfgCtlr.configQueue.ShutDown()
 	}()
 
 	klog.Info("Starting API Priority and Fairness config controller")
@@ -605,7 +606,7 @@ func (cfgCtlr *configController) digestConfigObjects(ctx context.Context, newPLs
 		// if we are going to issue an update, be sure we track every name we update so we know if we update it too often.
 		currResult.updatedItems.Insert(fsu.flowSchema.Name)
 		logger.V(4).Info("Writing Condition to FlowSchema", "controller", cfgCtlr.name,
-			"flowSchema", fsu.flowSchema.Name, "condition", fsu.condition, "oldValue", fsu.oldValue, "newValue", fsu.condition)
+			"flowSchema", fsu.flowSchema.Name, "condition", fsu.condition, "rv", fsu.flowSchema.ResourceVersion, "oldValue", fsu.oldValue, "newValue", fsu.condition)
 
 		if err := apply(cfgCtlr.flowcontrolClient.FlowSchemas(), fsu, cfgCtlr.asFieldManager); err != nil {
 			if apierrors.IsNotFound(err) {

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_controller.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_controller.go
@@ -367,13 +367,6 @@ func newTestableController(config TestableConfig) *configController {
 }
 
 func (cfgCtlr *configController) Start(ctx context.Context) error {
-	go func() {
-		<-ctx.Done()
-		// Let the config worker stop when we are done
-		klog.Info("Shutting down API Priority and Fairness config worker")
-		cfgCtlr.configQueue.ShutDown()
-	}()
-
 	klog.Info("Starting API Priority and Fairness config controller")
 	if ok := cache.WaitForCacheSync(ctx.Done(), cfgCtlr.plInformerSynced, cfgCtlr.fsInformerSynced); !ok {
 		return fmt.Errorf("never achieved initial sync")
@@ -384,6 +377,13 @@ func (cfgCtlr *configController) Start(ctx context.Context) error {
 
 	klog.Info("Running API Priority and Fairness periodic rebalancing process")
 	go wait.UntilWithContext(ctx, cfgCtlr.updateBorrowing, borrowingAdjustmentPeriod)
+
+	go func() {
+		<-ctx.Done()
+		// Let the config worker stop when we are done
+		klog.Info("Shutting down API Priority and Fairness config worker")
+		cfgCtlr.configQueue.ShutDown()
+	}()
 
 	return nil
 }

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_filter.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_filter.go
@@ -67,8 +67,9 @@ type Interface interface {
 		execFn func(),
 	)
 
-	// Start forks goroutines that monitor config objects from the main apiservers
-	// and causes any needed changes to local behavior. This method does not block.
+	// Start waits for informer sync, forks goroutines that monitor config
+	// objects from the main apiservers and causes any needed changes to local
+	// behavior, and then returns without blocking when the controller is running.
 	Start(ctx context.Context) error
 
 	// Install installs debugging endpoints to the web-server.

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_filter.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_filter.go
@@ -70,7 +70,7 @@ type Interface interface {
 	// Run monitors config objects from the main apiservers and causes
 	// any needed changes to local behavior.  This method ceases
 	// activity and returns after the given channel is closed.
-	Run(stopCh <-chan struct{}) error
+	Run(ctx context.Context) error
 
 	// Install installs debugging endpoints to the web-server.
 	Install(c *mux.PathRecorderMux)

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_filter.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_filter.go
@@ -67,10 +67,9 @@ type Interface interface {
 		execFn func(),
 	)
 
-	// Run monitors config objects from the main apiservers and causes
-	// any needed changes to local behavior.  This method ceases
-	// activity and returns after the given channel is closed.
-	Run(ctx context.Context) error
+	// Start monitors config objects from the main apiservers and causes
+	// any needed changes to local behavior. This method does not block.
+	Start(ctx context.Context) error
 
 	// Install installs debugging endpoints to the web-server.
 	Install(c *mux.PathRecorderMux)

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_filter.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_filter.go
@@ -67,8 +67,8 @@ type Interface interface {
 		execFn func(),
 	)
 
-	// Start monitors config objects from the main apiservers and causes
-	// any needed changes to local behavior. This method does not block.
+	// Start forks goroutines that monitor config objects from the main apiservers
+	// and causes any needed changes to local behavior. This method does not block.
 	Start(ctx context.Context) error
 
 	// Install installs debugging endpoints to the web-server.

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_filter_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_filter_test.go
@@ -33,6 +33,7 @@ import (
 	fcrequest "k8s.io/apiserver/pkg/util/flowcontrol/request"
 	"k8s.io/client-go/informers"
 	clientsetfake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/klog/v2/ktesting"
 	"k8s.io/utils/ptr"
 )
 
@@ -115,8 +116,7 @@ func TestQueueWaitTimeLatencyTracker(t *testing.T) {
 		QueueSetFactory:        fqs.NewQueueSetFactory(clk),
 	})
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	_, ctx := ktesting.NewTestContext(t)
 
 	informerFactory.Start(ctx.Done())
 	status := informerFactory.WaitForCacheSync(ctx.Done())

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_filter_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_filter_test.go
@@ -124,9 +124,9 @@ func TestQueueWaitTimeLatencyTracker(t *testing.T) {
 		t.Fatalf("WaitForCacheSync did not successfully complete, resources=%#v", names)
 	}
 
-	go func() {
-		controller.Run(ctx)
-	}()
+	if err := controller.Start(ctx); err != nil {
+		t.Fatalf("error starting controller: %v", err)
+	}
 
 	// ensure that the controller has run its first loop.
 	err := wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 5*time.Second, true, func(ctx context.Context) (bool, error) {

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/borrowing_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/borrowing_test.go
@@ -36,6 +36,7 @@ import (
 	fcrequest "k8s.io/apiserver/pkg/util/flowcontrol/request"
 	"k8s.io/client-go/informers"
 	clientsetfake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/klog/v2/ktesting"
 	"k8s.io/utils/ptr"
 )
 
@@ -149,8 +150,9 @@ func TestBorrowing(t *testing.T) {
 				QueueSetFactory:        fqs.NewQueueSetFactory(clk),
 			})
 
-			ctx, cancel := context.WithTimeout(context.Background(), 50*time.Second)
-			defer cancel()
+			_, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithTimeout(ctx, 50*time.Second)
+
 			informerFactory.Start(ctx.Done())
 
 			status := informerFactory.WaitForCacheSync(ctx.Done())

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/borrowing_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/borrowing_test.go
@@ -150,10 +150,9 @@ func TestBorrowing(t *testing.T) {
 			})
 
 			ctx, cancel := context.WithTimeout(context.Background(), 50*time.Second)
-			stopCh := ctx.Done()
 			controllerCompletionCh := make(chan error)
 
-			informerFactory.Start(stopCh)
+			informerFactory.Start(ctx.Done())
 
 			status := informerFactory.WaitForCacheSync(ctx.Done())
 			if names := unsynced(status); len(names) > 0 {
@@ -161,7 +160,7 @@ func TestBorrowing(t *testing.T) {
 			}
 
 			go func() {
-				controllerCompletionCh <- controller.Run(stopCh)
+				controllerCompletionCh <- controller.Run(ctx)
 			}()
 
 			// ensure that the controller has run its first loop.

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/controller_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/controller_test.go
@@ -40,6 +40,7 @@ import (
 	clientsetfake "k8s.io/client-go/kubernetes/fake"
 	fcclient "k8s.io/client-go/kubernetes/typed/flowcontrol/v1"
 	"k8s.io/klog/v2"
+	"k8s.io/klog/v2/ktesting"
 	"k8s.io/utils/clock"
 	"k8s.io/utils/ptr"
 )
@@ -389,7 +390,8 @@ func TestAPFControllerWithGracefulShutdown(t *testing.T) {
 		QueueSetFactory:        cts,
 	})
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	_, ctx := ktesting.NewTestContext(t)
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
 	informerFactory.Start(ctx.Done())

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/exempt_borrowing_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/exempt_borrowing_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package flowcontrol
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -27,13 +26,13 @@ import (
 	"k8s.io/apiserver/pkg/util/flowcontrol/metrics"
 	"k8s.io/client-go/informers"
 	clientsetfake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/klog/v2/ktesting"
 
 	flowcontrol "k8s.io/api/flowcontrol/v1"
 )
 
 func TestUpdateBorrowing(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	_, ctx := ktesting.NewTestContext(t)
 
 	startTime := time.Now()
 	clk, _ := testeventclock.NewFake(startTime, 0, nil)
@@ -110,7 +109,7 @@ func TestUpdateBorrowing(t *testing.T) {
 	clk.SetTime(startTime.Add(2 * borrowingAdjustmentPeriod))
 	ctlr.updateBorrowing(ctx)
 	clk.SetTime(startTime.Add(3 * borrowingAdjustmentPeriod))
-	ctlr.updateBorrowing(context.Background())
+	ctlr.updateBorrowing(ctx)
 	if expected, actual := expectedExempt, stateExempt.currentCL; expected != actual {
 		t.Errorf("Scenario 2: expected %d, got %d for exempt", expected, actual)
 	} else {

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/max_seats_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/max_seats_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package flowcontrol
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -28,6 +27,7 @@ import (
 	"k8s.io/apiserver/pkg/util/flowcontrol/metrics"
 	"k8s.io/client-go/informers"
 	clientsetfake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/klog/v2/ktesting"
 	"k8s.io/utils/ptr"
 )
 
@@ -97,6 +97,8 @@ func Test_GetMaxSeats(t *testing.T) {
 
 	for _, testcase := range testcases {
 		t.Run(testcase.name, func(t *testing.T) {
+			_, ctx := ktesting.NewTestContext(t)
+
 			clientset := clientsetfake.NewSimpleClientset()
 			informerFactory := informers.NewSharedInformerFactory(clientset, time.Second)
 			flowcontrolClient := clientset.FlowcontrolV1()
@@ -131,7 +133,7 @@ func Test_GetMaxSeats(t *testing.T) {
 					},
 				},
 			}
-			if _, err := c.digestConfigObjects(context.Background(), []*flowcontrolv1.PriorityLevelConfiguration{testPriorityLevel}, nil); err != nil {
+			if _, err := c.digestConfigObjects(ctx, []*flowcontrolv1.PriorityLevelConfiguration{testPriorityLevel}, nil); err != nil {
 				t.Errorf("unexpected error from digestConfigObjects: %v", err)
 			}
 			maxSeats := c.GetMaxSeats("test-pl")

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/max_seats_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/max_seats_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package flowcontrol
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -130,7 +131,7 @@ func Test_GetMaxSeats(t *testing.T) {
 					},
 				},
 			}
-			if _, err := c.digestConfigObjects([]*flowcontrolv1.PriorityLevelConfiguration{testPriorityLevel}, nil); err != nil {
+			if _, err := c.digestConfigObjects(context.Background(), []*flowcontrolv1.PriorityLevelConfiguration{testPriorityLevel}, nil); err != nil {
 				t.Errorf("unexpected error from digestConfigObjects: %v", err)
 			}
 			maxSeats := c.GetMaxSeats("test-pl")

--- a/test/integration/apiserver/flowcontrol/fight_test.go
+++ b/test/integration/apiserver/flowcontrol/fight_test.go
@@ -144,7 +144,9 @@ func (ft *fightTest) createController(invert bool, i int) {
 	})
 	ft.ctlrs[invert][i] = ctlr
 	informerFactory.Start(ft.ctx.Done())
-	go ctlr.Run(ft.ctx)
+	if err := ctlr.Start(ft.ctx); err != nil {
+		ft.t.Fatalf("error starting controller: %v", err)
+	}
 }
 
 func (ft *fightTest) evaluate(tBeforeCreate, tAfterCreate time.Time) {

--- a/test/integration/apiserver/flowcontrol/fight_test.go
+++ b/test/integration/apiserver/flowcontrol/fight_test.go
@@ -33,6 +33,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2/ktesting"
 	"k8s.io/utils/clock"
 	testclocks "k8s.io/utils/clock/testing"
 )
@@ -74,7 +75,8 @@ type fightTest struct {
 
 func newFightTest(t *testing.T, loopbackConfig *rest.Config, teamSize int) *fightTest {
 	now := time.Now()
-	ctx, cancel := context.WithCancel(context.Background())
+	_, ctx := ktesting.NewTestContext(t)
+	ctx, cancel := context.WithCancel(ctx)
 	ft := &fightTest{
 		t:              t,
 		ctx:            ctx,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Flowcontrol bootstrapping logged status diffs with invalid status changes. This PR hides metadata and status before creating the diff, and turns the multiline condition diff log into a oneliner.

Further drive-by cleanups:
- switch ensurer to contextual logging
- simplify config controller startup logic, and with that removing lots of unneeded error channel handling in tests.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Reduce kube-apiserver flowcontrol log noise.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
