### PR TITLE
kubelet: print stack when receive signal SIGUSR1

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -284,8 +284,10 @@ is checked every 20 seconds (also configurable with a flag).`,
 			// log the kubelet's config for inspection
 			klog.V(5).InfoS("KubeletConfiguration", "configuration", klog.Format(config))
 
+			// set up path to for kubelet dump
+			dumpPath := filepath.Join(os.TempDir(), fmt.Sprintf("kubelet.%d.stacks.log", os.Getpid()))
 			// set up signal context for kubelet shutdown
-			ctx := genericapiserver.SetupSignalContext()
+			ctx := genericapiserver.SetupSignalContextV2(dumpPath)
 
 			utilfeature.DefaultMutableFeatureGate.AddMetrics()
 			// run the kubelet

--- a/staging/src/k8s.io/apiserver/pkg/server/signal_posix.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/signal_posix.go
@@ -20,8 +20,34 @@ limitations under the License.
 package server
 
 import (
+	"context"
 	"os"
+	"os/signal"
 	"syscall"
+
+	"k8s.io/klog/v2"
 )
 
 var shutdownSignals = []os.Signal{os.Interrupt, syscall.SIGTERM}
+var signals = []os.Signal{os.Interrupt, syscall.SIGTERM, syscall.SIGUSR1}
+var handlers chan os.Signal
+
+func SetupSignalContextV2(name string) context.Context {
+	close(onlyOneSignalHandler) // panics when called twice
+	handlers = make(chan os.Signal, 3)
+	ctx, cancel := context.WithCancel(context.Background())
+	signal.Notify(handlers, signals...)
+	go func() {
+		for s := range handlers {
+			klog.Infof("received signal %v", s)
+			if s == syscall.SIGUSR1 {
+				dumpStacks(name)
+			} else {
+				cancel()
+				<-handlers
+				os.Exit(1) // second signal. Exit directly.
+			}
+		}
+	}()
+	return ctx
+}


### PR DESCRIPTION
#### What type of PR is this?
Add one of the following kinds:
/kind feature

#### What this PR does / why we need it:
containerd and cri-o support to print go routine stack into a file to show where is hanging.
#### Which issue(s) this PR fixes:
https://github.com/kubernetes/kubernetes/issues/128976
