### PR TITLE
[RFC] Kube proxy Dual Stack Healthz and Metrics

### DIFF
--- a/pkg/proxy/ipvs/proxier_test.go
+++ b/pkg/proxy/ipvs/proxier_test.go
@@ -5620,7 +5620,7 @@ func TestNoEndpointsMetric(t *testing.T) {
 		fp.OnEndpointSliceAdd(endpointSlice)
 		fp.syncProxyRules()
 
-		syncProxyRulesNoLocalEndpointsTotalInternal, err := testutil.GetGaugeMetricValue(metrics.SyncProxyRulesNoLocalEndpointsTotal.WithLabelValues("internal"))
+		syncProxyRulesNoLocalEndpointsTotalInternal, err := testutil.GetGaugeMetricValue(metrics.SyncProxyRulesNoLocalEndpointsTotal.WithLabelValues("internal", string(fp.ipFamily)))
 		if err != nil {
 			t.Errorf("failed to get %s value(internal), err: %v", metrics.SyncProxyRulesNoLocalEndpointsTotal.Name, err)
 		}
@@ -5629,7 +5629,7 @@ func TestNoEndpointsMetric(t *testing.T) {
 			t.Errorf("sync_proxy_rules_no_endpoints_total metric mismatch(internal): got=%d, expected %d", int(syncProxyRulesNoLocalEndpointsTotalInternal), tc.expectedSyncProxyRulesNoLocalEndpointsTotalInternal)
 		}
 
-		syncProxyRulesNoLocalEndpointsTotalExternal, err := testutil.GetGaugeMetricValue(metrics.SyncProxyRulesNoLocalEndpointsTotal.WithLabelValues("external"))
+		syncProxyRulesNoLocalEndpointsTotalExternal, err := testutil.GetGaugeMetricValue(metrics.SyncProxyRulesNoLocalEndpointsTotal.WithLabelValues("external", string(fp.ipFamily)))
 		if err != nil {
 			t.Errorf("failed to get %s value(external), err: %v", metrics.SyncProxyRulesNoLocalEndpointsTotal.Name, err)
 		}

--- a/pkg/proxy/metrics/metrics.go
+++ b/pkg/proxy/metrics/metrics.go
@@ -32,7 +32,7 @@ const kubeProxySubsystem = "kubeproxy"
 var (
 	// SyncProxyRulesLatency is the latency of one round of kube-proxy syncing proxy
 	// rules. (With the iptables proxy, this includes both full and partial syncs.)
-	SyncProxyRulesLatency = metrics.NewHistogram(
+	SyncProxyRulesLatency = metrics.NewHistogramVec(
 		&metrics.HistogramOpts{
 			Subsystem:      kubeProxySubsystem,
 			Name:           "sync_proxy_rules_duration_seconds",
@@ -40,10 +40,11 @@ var (
 			Buckets:        metrics.ExponentialBuckets(0.001, 2, 15),
 			StabilityLevel: metrics.ALPHA,
 		},
+		[]string{"ipFamily"},
 	)
 
 	// SyncFullProxyRulesLatency is the latency of one round of full rule syncing.
-	SyncFullProxyRulesLatency = metrics.NewHistogram(
+	SyncFullProxyRulesLatency = metrics.NewHistogramVec(
 		&metrics.HistogramOpts{
 			Subsystem:      kubeProxySubsystem,
 			Name:           "sync_full_proxy_rules_duration_seconds",
@@ -51,10 +52,11 @@ var (
 			Buckets:        metrics.ExponentialBuckets(0.001, 2, 15),
 			StabilityLevel: metrics.ALPHA,
 		},
+		[]string{"ipFamily"},
 	)
 
 	// SyncPartialProxyRulesLatency is the latency of one round of partial rule syncing.
-	SyncPartialProxyRulesLatency = metrics.NewHistogram(
+	SyncPartialProxyRulesLatency = metrics.NewHistogramVec(
 		&metrics.HistogramOpts{
 			Subsystem:      kubeProxySubsystem,
 			Name:           "sync_partial_proxy_rules_duration_seconds",
@@ -62,17 +64,19 @@ var (
 			Buckets:        metrics.ExponentialBuckets(0.001, 2, 15),
 			StabilityLevel: metrics.ALPHA,
 		},
+		[]string{"ipFamily"},
 	)
 
 	// SyncProxyRulesLastTimestamp is the timestamp proxy rules were last
 	// successfully synced.
-	SyncProxyRulesLastTimestamp = metrics.NewGauge(
+	SyncProxyRulesLastTimestamp = metrics.NewGaugeVec(
 		&metrics.GaugeOpts{
 			Subsystem:      kubeProxySubsystem,
 			Name:           "sync_proxy_rules_last_timestamp_seconds",
 			Help:           "The last time proxy rules were successfully synced",
 			StabilityLevel: metrics.ALPHA,
 		},
+		[]string{"ipFamily"},
 	)
 
 	// NetworkProgrammingLatency is defined as the time it took to program the network - from the time
@@ -82,7 +86,7 @@ var (
 	// Note that the metrics is partially based on the time exported by the endpoints controller on
 	// the master machine. The measurement may be inaccurate if there is a clock drift between the
 	// node and master machine.
-	NetworkProgrammingLatency = metrics.NewHistogram(
+	NetworkProgrammingLatency = metrics.NewHistogramVec(
 		&metrics.HistogramOpts{
 			Subsystem: kubeProxySubsystem,
 			Name:      "network_programming_duration_seconds",
@@ -95,6 +99,7 @@ var (
 			),
 			StabilityLevel: metrics.ALPHA,
 		},
+		[]string{"ipFamily"},
 	)
 
 	// EndpointChangesPending is the number of pending endpoint changes that
@@ -151,24 +156,26 @@ var (
 
 	// IPTablesRestoreFailuresTotal is the number of iptables restore failures that the proxy has
 	// seen.
-	IPTablesRestoreFailuresTotal = metrics.NewCounter(
+	IPTablesRestoreFailuresTotal = metrics.NewCounterVec(
 		&metrics.CounterOpts{
 			Subsystem:      kubeProxySubsystem,
 			Name:           "sync_proxy_rules_iptables_restore_failures_total",
 			Help:           "Cumulative proxy iptables restore failures",
 			StabilityLevel: metrics.ALPHA,
 		},
+		[]string{"ipFamily"},
 	)
 
 	// IPTablesPartialRestoreFailuresTotal is the number of iptables *partial* restore
 	// failures (resulting in a fall back to a full restore) that the proxy has seen.
-	IPTablesPartialRestoreFailuresTotal = metrics.NewCounter(
+	IPTablesPartialRestoreFailuresTotal = metrics.NewCounterVec(
 		&metrics.CounterOpts{
 			Subsystem:      kubeProxySubsystem,
 			Name:           "sync_proxy_rules_iptables_partial_restore_failures_total",
 			Help:           "Cumulative proxy iptables partial restore failures",
 			StabilityLevel: metrics.ALPHA,
 		},
+		[]string{"ipFamily"},
 	)
 
 	// IPTablesRulesTotal is the total number of iptables rules that the iptables
@@ -180,7 +187,7 @@ var (
 			Help:           "Total number of iptables rules owned by kube-proxy",
 			StabilityLevel: metrics.ALPHA,
 		},
-		[]string{"table"},
+		[]string{"table", "ipFamily"},
 	)
 
 	// IPTablesRulesLastSync is the number of iptables rules that the iptables proxy
@@ -192,29 +199,31 @@ var (
 			Help:           "Number of iptables rules written by kube-proxy in last sync",
 			StabilityLevel: metrics.ALPHA,
 		},
-		[]string{"table"},
+		[]string{"table", "ipFamily"},
 	)
 
 	// NFTablesSyncFailuresTotal is the number of nftables sync failures that the
 	// proxy has seen.
-	NFTablesSyncFailuresTotal = metrics.NewCounter(
+	NFTablesSyncFailuresTotal = metrics.NewCounterVec(
 		&metrics.CounterOpts{
 			Subsystem:      kubeProxySubsystem,
 			Name:           "sync_proxy_rules_nftables_sync_failures_total",
 			Help:           "Cumulative proxy nftables sync failures",
 			StabilityLevel: metrics.ALPHA,
 		},
+		[]string{"ipFamily"},
 	)
 
 	// NFTablesCleanupFailuresTotal is the number of nftables stale chain cleanup
 	// failures that the proxy has seen.
-	NFTablesCleanupFailuresTotal = metrics.NewCounter(
+	NFTablesCleanupFailuresTotal = metrics.NewCounterVec(
 		&metrics.CounterOpts{
 			Subsystem:      kubeProxySubsystem,
 			Name:           "sync_proxy_rules_nftables_cleanup_failures_total",
 			Help:           "Cumulative proxy nftables cleanup failures",
 			StabilityLevel: metrics.ALPHA,
 		},
+		[]string{"ipFamily"},
 	)
 
 	// ProxyHealthzTotal is the number of returned HTTP Status for each
@@ -244,13 +253,14 @@ var (
 	// SyncProxyRulesLastQueuedTimestamp is the last time a proxy sync was
 	// requested. If this is much larger than
 	// kubeproxy_sync_proxy_rules_last_timestamp_seconds, then something is hung.
-	SyncProxyRulesLastQueuedTimestamp = metrics.NewGauge(
+	SyncProxyRulesLastQueuedTimestamp = metrics.NewGaugeVec(
 		&metrics.GaugeOpts{
 			Subsystem:      kubeProxySubsystem,
 			Name:           "sync_proxy_rules_last_queued_timestamp_seconds",
 			Help:           "The last time a sync of proxy rules was queued",
 			StabilityLevel: metrics.ALPHA,
 		},
+		[]string{"ipFamily"},
 	)
 
 	// SyncProxyRulesNoLocalEndpointsTotal is the total number of rules that do
@@ -263,7 +273,7 @@ var (
 			Help:           "Number of services with a Local traffic policy and no endpoints",
 			StabilityLevel: metrics.ALPHA,
 		},
-		[]string{"traffic_policy"},
+		[]string{"traffic_policy", "ipFamily"},
 	)
 
 	// localhostNodePortsAcceptedPacketsDescription describe the metrics for the number of packets accepted

--- a/pkg/proxy/nftables/proxier.go
+++ b/pkg/proxy/nftables/proxier.go
@@ -743,7 +743,7 @@ func (proxier *Proxier) Sync() {
 	if proxier.healthzServer != nil {
 		proxier.healthzServer.QueuedUpdate(proxier.ipFamily)
 	}
-	metrics.SyncProxyRulesLastQueuedTimestamp.SetToCurrentTime()
+	metrics.SyncProxyRulesLastQueuedTimestamp.WithLabelValues(string(proxier.ipFamily)).SetToCurrentTime()
 	proxier.syncRunner.Run()
 }
 
@@ -755,7 +755,7 @@ func (proxier *Proxier) SyncLoop() {
 	}
 
 	// synthesize "last change queued" time as the informers are syncing.
-	metrics.SyncProxyRulesLastQueuedTimestamp.SetToCurrentTime()
+	metrics.SyncProxyRulesLastQueuedTimestamp.WithLabelValues(string(proxier.ipFamily)).SetToCurrentTime()
 	proxier.syncRunner.Loop(wait.NeverStop)
 }
 
@@ -1159,11 +1159,11 @@ func (proxier *Proxier) syncProxyRules() {
 	// Keep track of how long syncs take.
 	start := time.Now()
 	defer func() {
-		metrics.SyncProxyRulesLatency.Observe(metrics.SinceInSeconds(start))
+		metrics.SyncProxyRulesLatency.WithLabelValues(string(proxier.ipFamily)).Observe(metrics.SinceInSeconds(start))
 		if tryPartialSync {
-			metrics.SyncPartialProxyRulesLatency.Observe(metrics.SinceInSeconds(start))
+			metrics.SyncPartialProxyRulesLatency.WithLabelValues(string(proxier.ipFamily)).Observe(metrics.SinceInSeconds(start))
 		} else {
-			metrics.SyncFullProxyRulesLatency.Observe(metrics.SinceInSeconds(start))
+			metrics.SyncFullProxyRulesLatency.WithLabelValues(string(proxier.ipFamily)).Observe(metrics.SinceInSeconds(start))
 		}
 		proxier.logger.V(2).Info("SyncProxyRules complete", "elapsed", time.Since(start))
 	}()
@@ -1208,7 +1208,7 @@ func (proxier *Proxier) syncProxyRules() {
 				// the chains still exist, they'll just get added back
 				// (with a later timestamp) at the end of the sync.
 				proxier.logger.Error(err, "Unable to delete stale chains; will retry later")
-				metrics.NFTablesCleanupFailuresTotal.Inc()
+				metrics.NFTablesCleanupFailuresTotal.WithLabelValues(string(proxier.ipFamily)).Inc()
 			}
 		}
 	}
@@ -1803,7 +1803,7 @@ func (proxier *Proxier) syncProxyRules() {
 	err = proxier.nftables.Run(context.TODO(), tx)
 	if err != nil {
 		proxier.logger.Error(err, "nftables sync failed")
-		metrics.NFTablesSyncFailuresTotal.Inc()
+		metrics.NFTablesSyncFailuresTotal.WithLabelValues(string(proxier.ipFamily)).Inc()
 
 		// staleChains is now incorrect since we didn't actually flush the
 		// chains in it. We can recompute it next time.
@@ -1816,17 +1816,17 @@ func (proxier *Proxier) syncProxyRules() {
 	for name, lastChangeTriggerTimes := range endpointUpdateResult.LastChangeTriggerTimes {
 		for _, lastChangeTriggerTime := range lastChangeTriggerTimes {
 			latency := metrics.SinceInSeconds(lastChangeTriggerTime)
-			metrics.NetworkProgrammingLatency.Observe(latency)
+			metrics.NetworkProgrammingLatency.WithLabelValues(string(proxier.ipFamily)).Observe(latency)
 			proxier.logger.V(4).Info("Network programming", "endpoint", klog.KRef(name.Namespace, name.Name), "elapsed", latency)
 		}
 	}
 
-	metrics.SyncProxyRulesNoLocalEndpointsTotal.WithLabelValues("internal").Set(float64(serviceNoLocalEndpointsTotalInternal))
-	metrics.SyncProxyRulesNoLocalEndpointsTotal.WithLabelValues("external").Set(float64(serviceNoLocalEndpointsTotalExternal))
+	metrics.SyncProxyRulesNoLocalEndpointsTotal.WithLabelValues("internal", string(proxier.ipFamily)).Set(float64(serviceNoLocalEndpointsTotalInternal))
+	metrics.SyncProxyRulesNoLocalEndpointsTotal.WithLabelValues("external", string(proxier.ipFamily)).Set(float64(serviceNoLocalEndpointsTotalExternal))
 	if proxier.healthzServer != nil {
 		proxier.healthzServer.Updated(proxier.ipFamily)
 	}
-	metrics.SyncProxyRulesLastTimestamp.SetToCurrentTime()
+	metrics.SyncProxyRulesLastTimestamp.WithLabelValues(string(proxier.ipFamily)).SetToCurrentTime()
 
 	// Update service healthchecks.  The endpoints list might include services that are
 	// not "OnlyLocal", but the services list will not, and the serviceHealthServer

--- a/pkg/proxy/nftables/proxier_test.go
+++ b/pkg/proxy/nftables/proxier_test.go
@@ -4454,7 +4454,7 @@ func TestNoEndpointsMetric(t *testing.T) {
 
 			fp.OnEndpointSliceAdd(endpointSlice)
 			fp.syncProxyRules()
-			syncProxyRulesNoLocalEndpointsTotalInternal, err := testutil.GetGaugeMetricValue(metrics.SyncProxyRulesNoLocalEndpointsTotal.WithLabelValues("internal"))
+			syncProxyRulesNoLocalEndpointsTotalInternal, err := testutil.GetGaugeMetricValue(metrics.SyncProxyRulesNoLocalEndpointsTotal.WithLabelValues("internal", string(fp.ipFamily)))
 			if err != nil {
 				t.Errorf("failed to get %s value, err: %v", metrics.SyncProxyRulesNoLocalEndpointsTotal.Name, err)
 			}
@@ -4463,7 +4463,7 @@ func TestNoEndpointsMetric(t *testing.T) {
 				t.Errorf("sync_proxy_rules_no_endpoints_total metric mismatch(internal): got=%d, expected %d", int(syncProxyRulesNoLocalEndpointsTotalInternal), tc.expectedSyncProxyRulesNoLocalEndpointsTotalInternal)
 			}
 
-			syncProxyRulesNoLocalEndpointsTotalExternal, err := testutil.GetGaugeMetricValue(metrics.SyncProxyRulesNoLocalEndpointsTotal.WithLabelValues("external"))
+			syncProxyRulesNoLocalEndpointsTotalExternal, err := testutil.GetGaugeMetricValue(metrics.SyncProxyRulesNoLocalEndpointsTotal.WithLabelValues("external", string(fp.ipFamily)))
 			if err != nil {
 				t.Errorf("failed to get %s value(external), err: %v", metrics.SyncProxyRulesNoLocalEndpointsTotal.Name, err)
 			}

--- a/pkg/proxy/winkernel/proxier.go
+++ b/pkg/proxy/winkernel/proxier.go
@@ -933,7 +933,7 @@ func (proxier *Proxier) Sync() {
 	if proxier.healthzServer != nil {
 		proxier.healthzServer.QueuedUpdate(proxier.ipFamily)
 	}
-	metrics.SyncProxyRulesLastQueuedTimestamp.SetToCurrentTime()
+	metrics.SyncProxyRulesLastQueuedTimestamp.WithLabelValues(string(proxier.ipFamily)).SetToCurrentTime()
 	proxier.syncRunner.Run()
 }
 
@@ -944,7 +944,7 @@ func (proxier *Proxier) SyncLoop() {
 		proxier.healthzServer.Updated(proxier.ipFamily)
 	}
 	// synthesize "last change queued" time as the informers are syncing.
-	metrics.SyncProxyRulesLastQueuedTimestamp.SetToCurrentTime()
+	metrics.SyncProxyRulesLastQueuedTimestamp.WithLabelValues(string(proxier.ipFamily)).SetToCurrentTime()
 	proxier.syncRunner.Loop(wait.NeverStop)
 }
 
@@ -1140,7 +1140,7 @@ func (proxier *Proxier) syncProxyRules() {
 	// Keep track of how long syncs take.
 	start := time.Now()
 	defer func() {
-		metrics.SyncProxyRulesLatency.Observe(metrics.SinceInSeconds(start))
+		metrics.SyncProxyRulesLatency.WithLabelValues(string(proxier.ipFamily)).Observe(metrics.SinceInSeconds(start))
 		klog.V(4).InfoS("Syncing proxy rules complete", "elapsed", time.Since(start))
 	}()
 
@@ -1695,7 +1695,7 @@ func (proxier *Proxier) syncProxyRules() {
 	if proxier.healthzServer != nil {
 		proxier.healthzServer.Updated(proxier.ipFamily)
 	}
-	metrics.SyncProxyRulesLastTimestamp.SetToCurrentTime()
+	metrics.SyncProxyRulesLastTimestamp.WithLabelValues(string(proxier.ipFamily)).SetToCurrentTime()
 
 	// Update service healthchecks.  The endpoints list might include services that are
 	// not "OnlyLocal", but the services list will not, and the serviceHealthServer


### PR DESCRIPTION
/kind bug
/kind feature

Fixes #116486
Alternative to #128303

Kube-proxy runs separate instances for IPv4 and IPv6, effectively using one proxy per IP family. However, its health checks, liveness checks, and metrics server endpoints don't reflect this separation and mixes the information providing information that can be wrong and misleading.

One solution is to create separate server endpoints for each IP family. However, this tightly couples the control plane (server endpoints) to the data plane (proxies), and forces all consumers of this information to adapt to a dual-stack model, that may not be possible to implement in certain environments that have restrictions about the usage of dual stack.

Instead, we propose a backward-compatible change to the existing server endpoints' schema. This change will add information about the relevant IP family to each data point, allowing consumers to distinguish between IPv4 and IPv6 data without requiring them to adopt a dual-stack approach. 

```release-note
kube-proxy extends the schema of its healthz/ livez/ and metrics/ endpoints to incorporate information about the corresponding IP family
```



