### PR TITLE
prune-junit-xml: join stdout when merging tests

### DIFF
--- a/cmd/prune-junit-xml/prunexml.go
+++ b/cmd/prune-junit-xml/prunexml.go
@@ -135,6 +135,8 @@ func pruneTESTS(suites *junitxml.JUnitTestSuites) {
 		updatedTestcase.Classname = match[1]
 		updatedTestcase.Name = match[2]
 		updatedTestcase.Time = suite.Time
+		updatedSystemOut := ""
+		updatedSystemErr := ""
 		for _, testcase := range suite.TestCases {
 			// The top level testcase element in a JUnit xml file does not have the / character.
 			if testcase.Failure != nil {
@@ -142,10 +144,14 @@ func pruneTESTS(suites *junitxml.JUnitTestSuites) {
 				updatedTestcaseFailure.Message = joinTexts(updatedTestcaseFailure.Message, testcase.Failure.Message)
 				updatedTestcaseFailure.Contents = joinTexts(updatedTestcaseFailure.Contents, testcase.Failure.Contents)
 				updatedTestcaseFailure.Type = joinTexts(updatedTestcaseFailure.Type, testcase.Failure.Type)
+				updatedSystemOut = joinTexts(updatedSystemOut, testcase.SystemOut)
+				updatedSystemErr = joinTexts(updatedSystemErr, testcase.SystemErr)
 			}
 		}
 		if failflag {
 			updatedTestcase.Failure = &updatedTestcaseFailure
+			updatedTestcase.SystemOut = updatedSystemOut
+			updatedTestcase.SystemErr = updatedSystemErr
 		}
 		suite.TestCases = append(updatedTestcases, updatedTestcase)
 		updatedTestsuites = append(updatedTestsuites, suite)

--- a/cmd/prune-junit-xml/prunexml.go
+++ b/cmd/prune-junit-xml/prunexml.go
@@ -153,8 +153,15 @@ func pruneTESTS(suites *junitxml.JUnitTestSuites) {
 	suites.Suites = updatedTestsuites
 }
 
-// joinTexts returns "<a>; <b>" if both are non-empty,
+// joinTexts returns "<a><empty line><b>" if both are non-empty,
 // otherwise just the non-empty string, if there is one.
+//
+// If <b> is contained completely in <a>, <a> gets returned because repeating
+// exactly the same string again doesn't add any information. Typically
+// this occurs when joining the failure message because that is the fixed
+// string "Failed" for all tests, regardless of what the test logged.
+// The test log output is typically different because it cointains "=== RUN
+// <test name>" and thus doesn't get dropped.
 func joinTexts(a, b string) string {
 	if a == "" {
 		return b
@@ -162,7 +169,14 @@ func joinTexts(a, b string) string {
 	if b == "" {
 		return a
 	}
-	return a + "; " + b
+	if strings.Contains(a, b) {
+		return a
+	}
+	sep := "\n"
+	if !strings.HasSuffix(a, "\n") {
+		sep = "\n\n"
+	}
+	return a + sep + b
 }
 
 func fetchXML(xmlReader io.Reader) (*junitxml.JUnitTestSuites, error) {

--- a/cmd/prune-junit-xml/prunexml_test.go
+++ b/cmd/prune-junit-xml/prunexml_test.go
@@ -108,6 +108,20 @@ func TestPruneTESTS(t *testing.T) {
 			<failure message="FailedB" type="">FailureContentB</failure>
 		</testcase>
 	</testsuite>
+	<testsuite tests="3" failures="3" time="40.050000" name="k8s.io/kubernetes/test/integration/apimachinery3" timestamp="">
+		<properties>
+			<property name="go.version" value="go1.18 linux/amd64"></property>
+		</properties>
+		<testcase classname="k8s.io/kubernetes/test/integration/apimachinery3" name="TestWatchRestartsIfTimeoutNotReached/group/InformerWatcher_survives_closed_watches" time="40.050000">
+			<failure message="Failed" type="">RUNNING TestWatchRestartsIfTimeoutNotReached/group/InformerWatcher_survives_closed_watchesA&#xA;expected foo, got bar</failure>
+                </testcase>
+		<testcase classname="k8s.io/kubernetes/test/integration/apimachinery3" name="TestWatchRestartsIfTimeoutNotReached/group" time="40.050000">
+			<failure message="Failed" type="">sub-test failed</failure>
+		</testcase>
+		<testcase classname="k8s.io/kubernetes/test/integration/apimachinery3" name="TestWatchRestartsIfTimeoutNotReached" time="40.050000">
+			<failure message="Failed" type="">sub-test failed</failure>
+		</testcase>
+	</testsuite>
 </testsuites>`
 
 	outputXML := `<?xml version="1.0" encoding="UTF-8"?>
@@ -131,7 +145,15 @@ func TestPruneTESTS(t *testing.T) {
 			<property name="go.version" value="go1.18 linux/amd64"></property>
 		</properties>
 		<testcase classname="k8s.io/kubernetes/test/integration" name="apimachinery2" time="30.050000">
-			<failure message="FailedA; FailedB" type="">FailureContentA; FailureContentB</failure>
+			<failure message="FailedA&#xA;&#xA;FailedB" type="">FailureContentA&#xA;&#xA;FailureContentB</failure>
+		</testcase>
+	</testsuite>
+	<testsuite tests="3" failures="3" time="40.050000" name="k8s.io/kubernetes/test/integration/apimachinery3" timestamp="">
+		<properties>
+			<property name="go.version" value="go1.18 linux/amd64"></property>
+		</properties>
+		<testcase classname="k8s.io/kubernetes/test/integration" name="apimachinery3" time="40.050000">
+			<failure message="Failed" type="">RUNNING TestWatchRestartsIfTimeoutNotReached/group/InformerWatcher_survives_closed_watchesA&#xA;expected foo, got bar&#xA;&#xA;sub-test failed</failure>
 		</testcase>
 	</testsuite>
 </testsuites>`

--- a/cmd/prune-junit-xml/prunexml_test.go
+++ b/cmd/prune-junit-xml/prunexml_test.go
@@ -100,7 +100,10 @@ func TestPruneTESTS(t *testing.T) {
 		<properties>
 			<property name="go.version" value="go1.18 linux/amd64"></property>
 		</properties>
-		<testcase classname="k8s.io/kubernetes/test/integration/apimachinery2" name="TestWatchRestartsIfTimeoutNotReached/group/InformerWatcher_survives_closed_watches" time="30.050000"></testcase>
+		<testcase classname="k8s.io/kubernetes/test/integration/apimachinery2" name="TestWatchRestartsIfTimeoutNotReached/group/InformerWatcher_survives_closed_watches" time="30.050000">
+			<system-out>out A</system-out>
+			<system-err>err B</system-err>
+                </testcase>
 		<testcase classname="k8s.io/kubernetes/test/integration/apimachinery2" name="TestSchedulerInformers" time="-0.000000">
 			<failure message="FailedA" type="">FailureContentA</failure>
 		</testcase>
@@ -114,9 +117,13 @@ func TestPruneTESTS(t *testing.T) {
 		</properties>
 		<testcase classname="k8s.io/kubernetes/test/integration/apimachinery3" name="TestWatchRestartsIfTimeoutNotReached/group/InformerWatcher_survives_closed_watches" time="40.050000">
 			<failure message="Failed" type="">RUNNING TestWatchRestartsIfTimeoutNotReached/group/InformerWatcher_survives_closed_watchesA&#xA;expected foo, got bar</failure>
+			<system-out>out A</system-out>
+			<system-err>err A</system-err>
                 </testcase>
 		<testcase classname="k8s.io/kubernetes/test/integration/apimachinery3" name="TestWatchRestartsIfTimeoutNotReached/group" time="40.050000">
 			<failure message="Failed" type="">sub-test failed</failure>
+			<system-out>out B</system-out>
+			<system-err>err B</system-err>
 		</testcase>
 		<testcase classname="k8s.io/kubernetes/test/integration/apimachinery3" name="TestWatchRestartsIfTimeoutNotReached" time="40.050000">
 			<failure message="Failed" type="">sub-test failed</failure>
@@ -154,6 +161,8 @@ func TestPruneTESTS(t *testing.T) {
 		</properties>
 		<testcase classname="k8s.io/kubernetes/test/integration" name="apimachinery3" time="40.050000">
 			<failure message="Failed" type="">RUNNING TestWatchRestartsIfTimeoutNotReached/group/InformerWatcher_survives_closed_watchesA&#xA;expected foo, got bar&#xA;&#xA;sub-test failed</failure>
+			<system-out>out A&#xA;&#xA;out B</system-out>
+			<system-err>err A&#xA;&#xA;err B</system-err>
 		</testcase>
 	</testsuite>
 </testsuites>`


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The intent in https://github.com/kubernetes/kubernetes/pull/127929 was to strip log messages out of the JUnit failure text and then keep the complete text as stdout. That didn't work when merging different tests at the package level because that step dropped the stdout of each test.

##### With current master and unstructured multi-line log entries, stripping out the log messages leaves additional lines behind:

https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-integration-master/1850686612854280192

```
k8s.io/kubernetes/test/integration: examples expand_less 	7m31s
{Failed;Failed;  === RUN   TestFrontProxyConfig/WithUID
    testserver.go:582: Resolved testserver package path to: "/home/prow/go/src/k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
    testserver.go:402: runtime-config=map[api/all:true]
    testserver.go:403: Starting kube-apiserver on port 39919...
    testserver.go:438: Waiting for /healthz to be ok...
[-]poststarthook/start-apiextensions-controllers failed: not finished
[-]poststarthook/crd-informer-synced failed: not finished
...
[-]autoregister-completion failed: missing APIService: [v1. v1.admissionregistration.k8s.io v1.apiextensions.k8s.io v1.apps v1.authentication.k8s.io v1.authorization.k8s.io v1.autoscaling v1.batch v1.certificates.k8s.io v1.coordination.k8s.io v1.discovery.k8s.io v1.events.k8s.io v1.flowcontrol.apiserver.k8s.io v1.networking.k8s.io v1.node.k8s.io v1.policy v1.rbac.authorization.k8s.io v1.scheduling.k8s.io v1.storage.k8s.io v1alpha1.admissionregistration.k8s.io v1alpha1.authentication.k8s.io v1alpha1.coordination.k8s.io v1alpha1.internal.apiserver.k8s.io v1alpha1.storage.k8s.io v1alpha3.resource.k8s.io v1beta1.admissionregistration.k8s.io v1beta1.authentication.k8s.io v1beta1.networking.k8s.io v1beta1.storage.k8s.io v1beta3.flowcontrol.apiserver.k8s.io v2.autoscaling]
  	Type:               "Dangling",
- 	Status:             "",
+ 	Status:             "False",
- 	LastTransitionTime: v1.Time{},
+ 	LastTransitionTime: v1.Time{Time: s"2024-10-28 00:38:08.456636897 +0000 UTC m=+377.378006483"},
- 	Reason:             "",
+ 	Reason:             "Found",
- 	Message:            "",
+ 	Message:            `This FlowSchema references the PriorityLevelConfiguration object named "system" and it exists`,
  }
...
```

##### When converting that log call to structured logging, the extra diff gets filtered out properly:

https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/129035/pull-kubernetes-integration/1862558341121708032

##### Smarter merging of texts and preserving the full stdout text

See commit messages for details.

https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/129035/pull-kubernetes-integration/1863500189038284800

```
k8s.io/kubernetes/test/integration: examples
{Failed  === RUN   TestFrontProxyConfig/WithoutUID
...
--- FAIL: TestFrontProxyConfig/WithoutUID (65.73s)

=== RUN   TestFrontProxyConfig/WithUID
    testserver.go:582: Resolved testserver package path to: "/home/prow/go/src/k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
...
=== RUN   TestFrontProxyConfig
--- FAIL: TestFrontProxyConfig (131.02s)
}
open stdout
```

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
