### PR TITLE
Automated cherry pick of #129011: skip TestCreateBlobDisk test

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_blobDiskController_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_blobDiskController_test.go
@@ -331,7 +331,10 @@ func TestFindSANameForDisk(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+// Skipping this test due to failing ci but not removing to keep for future reference if needed
+// GH Issue: https://github.com/kubernetes/kubernetes/issues/129007
 func TestCreateBlobDisk(t *testing.T) {
+	t.Skip("skipping test due some Azure API changes and failing ci")
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	b := GetTestBlobDiskController(t)


### PR DESCRIPTION
Cherry pick of #129011 on release-1.28.

#129011: skip TestCreateBlobDisk test

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```