### PR TITLE
flowcontrol: remove test dependencies from go binaries

### DIFF
--- a/staging/src/k8s.io/client-go/util/flowcontrol/backoff.go
+++ b/staging/src/k8s.io/client-go/util/flowcontrol/backoff.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"k8s.io/utils/clock"
-	testingclock "k8s.io/utils/clock/testing"
 )
 
 type backoffEntry struct {
@@ -49,7 +48,7 @@ type Backoff struct {
 	maxJitterFactor float64
 }
 
-func NewFakeBackOff(initial, max time.Duration, tc *testingclock.FakeClock) *Backoff {
+func NewFakeBackOff(initial, max time.Duration, tc clock.Clock) *Backoff {
 	return newBackoff(tc, initial, max, 0.0)
 }
 
@@ -57,7 +56,7 @@ func NewBackOff(initial, max time.Duration) *Backoff {
 	return NewBackOffWithJitter(initial, max, 0.0)
 }
 
-func NewFakeBackOffWithJitter(initial, max time.Duration, tc *testingclock.FakeClock, maxJitterFactor float64) *Backoff {
+func NewFakeBackOffWithJitter(initial, max time.Duration, tc clock.Clock, maxJitterFactor float64) *Backoff {
 	return newBackoff(tc, initial, max, maxJitterFactor)
 }
 


### PR DESCRIPTION
remove testing dependencies on flowcontrol

NewFakeBackoff constructor is used to inject a clock for testing,
however, the function signature cast the input variable to the testing
clock type instead of the clock interface, injecting testing
depednencies into binaries.

Replace the testing type from the function parameter and use the clock.Clock
interface to keep backwards compatibility.

/kind bug
/kind cleanup
```release-note
NONE
```

/area code-organization