### PR TITLE
kubectl debug: Add --rm flag to remove debug pod on exit

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug_test.go
@@ -2913,6 +2913,45 @@ func TestCompleteAndValidate(t *testing.T) {
 			args:      "node/mynode --target --image=busybox",
 			wantError: true,
 		},
+		{
+			name: "Remove: valid with -i",
+			args: "node/mynode --rm -i --image=busybox",
+			wantOpts: &DebugOptions{
+				Args:               []string{},
+				Attach:             true,
+				Image:              "busybox",
+				Interactive:        true,
+				KeepInitContainers: true,
+				Namespace:          "test",
+				ShareProcesses:     true,
+				Profile:            ProfileLegacy,
+				TargetNames:        []string{"node/mynode"},
+				TTY:                false,
+				Remove:             true,
+			},
+		},
+		{
+			name: "Remove: valid with --attach",
+			args: "node/mynode --rm --attach --image=busybox",
+			wantOpts: &DebugOptions{
+				Args:               []string{},
+				Attach:             true,
+				Image:              "busybox",
+				KeepInitContainers: true,
+				Interactive:        false,
+				Namespace:          "test",
+				ShareProcesses:     true,
+				Profile:            ProfileLegacy,
+				TargetNames:        []string{"node/mynode"},
+				TTY:                false,
+				Remove:             true,
+			},
+		},
+		{
+			name:      "Remove: invalid without -i or --attach ",
+			args:      "mypod --rm --image=busybox",
+			wantError: true,
+		},
 	}
 
 	for _, tc := range tests {
@@ -3001,6 +3040,34 @@ func TestRun(t *testing.T) {
 			attachError:    true,
 			wantEphemerals: 1,
 			wantError:      true,
+		},
+		{
+			name: "remove debug pod for pod with -i --rm --copy-to",
+			modifier: func(o *DebugOptions) {
+				o.Interactive = true
+				o.Remove = true
+				o.CopyTo = "copied"
+			},
+			arg:           podName,
+			wantDebugPods: 0, // should be removed
+		},
+		{
+			name: "remove debug pod for node with --rm --attach",
+			modifier: func(o *DebugOptions) {
+				o.Attach = true
+				o.Remove = true
+			},
+			arg:           "node/" + nodeName,
+			wantDebugPods: 0, // should be removed
+		},
+		{
+			name: "error when debug pod with -i --rm but without --copy-to",
+			modifier: func(o *DebugOptions) {
+				o.Interactive = true
+				o.Remove = true
+			},
+			arg:       podName,
+			wantError: true, // ephemeral containers cannot be removed
 		},
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR adds the `--rm` flag to `kubectl debug`, similar to the same flag in `kubectl run` and `docker run`, allowing automatic deletion of the debug pod on exit. Since ephemeral containers cannot be removed, this flag is only valid when debugging a node or a pod with `--copy-to`. It also requires `--attach` or `-i/--stdin`, similar to `kubectl run --rm`.


#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubectl/issues/1681
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

I added a unit test for DebugOptions.Run() in the first commit, then I implemented the `--rm` flag in the  second commit.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
`kubectl debug` now supports the `--rm` flag to remove debug pod on exit. 
This flag is only valid when debugging a node or a pod with `--copy-to`,
as ephemeral containers cannot be deleted. It also requires `--attach` or `-i/--stdin`.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```