### PR TITLE
Trigger all pods rescheduling on nominated node changes

### DIFF
--- a/pkg/scheduler/framework/plugins/nodeports/node_ports.go
+++ b/pkg/scheduler/framework/plugins/nodeports/node_ports.go
@@ -143,7 +143,7 @@ func (pl *NodePorts) isSchedulableAfterPodDeleted(logger klog.Logger, pod *v1.Po
 	}
 
 	// If the deleted pod is unscheduled, it doesn't make the target pod schedulable.
-	if deletedPod.Spec.NodeName == "" {
+	if deletedPod.Spec.NodeName == "" && deletedPod.Status.NominatedNodeName == "" {
 		logger.V(4).Info("the deleted pod is unscheduled and it doesn't make the target pod schedulable", "pod", klog.KObj(pod), "deletedPod", klog.KObj(deletedPod))
 		return framework.QueueSkip, nil
 	}

--- a/pkg/scheduler/framework/plugins/noderesources/fit.go
+++ b/pkg/scheduler/framework/plugins/noderesources/fit.go
@@ -294,7 +294,7 @@ func (f *Fit) isSchedulableAfterPodEvent(logger klog.Logger, pod *v1.Pod, oldObj
 	}
 
 	if modifiedPod == nil {
-		if originalPod.Spec.NodeName == "" {
+		if originalPod.Spec.NodeName == "" && originalPod.Status.NominatedNodeName == "" {
 			logger.V(5).Info("the deleted pod was unscheduled and it wouldn't make the unscheduled pod schedulable", "pod", klog.KObj(pod), "deletedPod", klog.KObj(originalPod))
 			return framework.QueueSkip, nil
 		}

--- a/pkg/scheduler/framework/plugins/nodevolumelimits/csi.go
+++ b/pkg/scheduler/framework/plugins/nodevolumelimits/csi.go
@@ -104,7 +104,7 @@ func (pl *CSILimits) isSchedulableAfterPodDeleted(logger klog.Logger, pod *v1.Po
 		return framework.QueueSkip, nil
 	}
 
-	if deletedPod.Spec.NodeName == "" {
+	if deletedPod.Spec.NodeName == "" && deletedPod.Status.NominatedNodeName == "" {
 		return framework.QueueSkip, nil
 	}
 

--- a/pkg/scheduler/framework/runtime/framework.go
+++ b/pkg/scheduler/framework/runtime/framework.go
@@ -1011,7 +1011,7 @@ func (f *frameworkImpl) RunFilterPluginsWithNominatedPods(ctx context.Context, s
 		nodeInfoToUse := info
 		if i == 0 {
 			var err error
-			podsAdded, stateToUse, nodeInfoToUse, err = addNominatedPods(ctx, f, pod, state, info)
+			podsAdded, stateToUse, nodeInfoToUse, err = addGENominatedPods(ctx, f, pod, state, info)
 			if err != nil {
 				return framework.AsStatus(err)
 			}
@@ -1028,10 +1028,10 @@ func (f *frameworkImpl) RunFilterPluginsWithNominatedPods(ctx context.Context, s
 	return status
 }
 
-// addNominatedPods adds pods with equal or greater priority which are nominated
+// addGENominatedPods adds pods with equal or greater priority which are nominated
 // to run on the node. It returns 1) whether any pod was added, 2) augmented cycleState,
 // 3) augmented nodeInfo.
-func addNominatedPods(ctx context.Context, fh framework.Handle, pod *v1.Pod, state *framework.CycleState, nodeInfo *framework.NodeInfo) (bool, *framework.CycleState, *framework.NodeInfo, error) {
+func addGENominatedPods(ctx context.Context, fh framework.Handle, pod *v1.Pod, state *framework.CycleState, nodeInfo *framework.NodeInfo) (bool, *framework.CycleState, *framework.NodeInfo, error) {
 	if fh == nil {
 		// This may happen only in tests.
 		return false, state, nodeInfo, nil

--- a/test/integration/scheduler/eventhandler/eventhandler_test.go
+++ b/test/integration/scheduler/eventhandler/eventhandler_test.go
@@ -18,13 +18,19 @@ package eventhandler
 
 import (
 	"context"
+	"fmt"
 	"testing"
+	"time"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/component-helpers/scheduling/corev1"
 	configv1 "k8s.io/kube-scheduler/config/v1"
+	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/scheduler"
 	configtesting "k8s.io/kubernetes/pkg/scheduler/apis/config/testing"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
@@ -32,8 +38,11 @@ import (
 	st "k8s.io/kubernetes/pkg/scheduler/testing"
 	schedulerutils "k8s.io/kubernetes/test/integration/scheduler"
 	testutils "k8s.io/kubernetes/test/integration/util"
+	testingclock "k8s.io/utils/clock/testing"
 	"k8s.io/utils/ptr"
 )
+
+var lowPriority, mediumPriority, highPriority int32 = 100, 200, 300
 
 var _ framework.FilterPlugin = &fooPlugin{}
 
@@ -133,5 +142,138 @@ func TestUpdateNodeEvent(t *testing.T) {
 
 	if err := testutils.WaitForPodToSchedule(testCtx.Ctx, testCtx.ClientSet, pod); err != nil {
 		t.Errorf("Pod %v was not scheduled: %v", pod.Name, err)
+	}
+}
+
+func TestUpdateNominatedNodeName(t *testing.T) {
+	fakeClock := testingclock.NewFakeClock(time.Now())
+	testBackoff := time.Minute
+	testContext := testutils.InitTestAPIServer(t, "test-event", nil)
+	capacity := map[v1.ResourceName]string{
+		v1.ResourceMemory: "32",
+	}
+	var cleanupPods []*v1.Pod
+
+	testNode := st.MakeNode().Name("node-0").Label("kubernetes.io/hostname", "node-0").Capacity(capacity).Obj()
+	// Note that the low priority pod that cannot fit with the mid priority, but can fit with the high priority one.
+	podLow := testutils.InitPausePod(&testutils.PausePodConfig{
+		Name:      "test-lp-pod",
+		Namespace: testContext.NS.Name,
+		Priority:  &lowPriority,
+		Resources: &v1.ResourceRequirements{Requests: v1.ResourceList{
+			v1.ResourceMemory: *resource.NewQuantity(20, resource.DecimalSI)},
+		}})
+	cleanupPods = append(cleanupPods, podLow)
+	podMidNominated := testutils.InitPausePod(&testutils.PausePodConfig{
+		Name:      "test-nominated-pod",
+		Namespace: testContext.NS.Name,
+		Priority:  &mediumPriority,
+		Resources: &v1.ResourceRequirements{Requests: v1.ResourceList{
+			v1.ResourceMemory: *resource.NewQuantity(25, resource.DecimalSI)},
+		}})
+	cleanupPods = append(cleanupPods, podMidNominated)
+	podHigh := testutils.InitPausePod(&testutils.PausePodConfig{
+		Name:      "test-hp-pod",
+		Namespace: testContext.NS.Name,
+		Priority:  &highPriority,
+		Resources: &v1.ResourceRequirements{Requests: v1.ResourceList{
+			v1.ResourceMemory: *resource.NewQuantity(10, resource.DecimalSI)},
+		}})
+	cleanupPods = append(cleanupPods, podHigh)
+
+	tests := []struct {
+		name       string
+		updateFunc func(testCtx *testutils.TestContext)
+	}{
+		{
+			name: "Preempt nominated pod",
+			updateFunc: func(testCtx *testutils.TestContext) {
+				// Create high-priority pod and wait until it's scheduled (unnominate mid-priority pod)
+				pod, err := testutils.CreatePausePod(testCtx.ClientSet, podHigh)
+				if err != nil {
+					t.Fatalf("Creating pod error: %v", err)
+				}
+				if err = testutils.WaitForPodToSchedule(testCtx.Ctx, testCtx.ClientSet, pod); err != nil {
+					t.Fatalf("Pod %v was not scheduled: %v", pod.Name, err)
+				}
+			},
+		},
+		{
+			name: "Remove nominated pod",
+			updateFunc: func(testCtx *testutils.TestContext) {
+				if err := testutils.DeletePod(testCtx.ClientSet, podMidNominated.Name, podMidNominated.Namespace); err != nil {
+					t.Fatalf("Deleting pod error: %v", err)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		for _, qHintEnabled := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s, with queuehint(%v)", tt.name, qHintEnabled), func(t *testing.T) {
+				featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.SchedulerQueueingHints, qHintEnabled)
+
+				testCtx, teardown := schedulerutils.InitTestSchedulerForFrameworkTest(t, testContext, 0, true,
+					scheduler.WithClock(fakeClock),
+					// UpdateFunc needs to be called when the nominated pod is still in the backoff queue, thus small, but non 0 value.
+					scheduler.WithPodInitialBackoffSeconds(int64(testBackoff.Seconds())),
+					scheduler.WithPodMaxBackoffSeconds(int64(testBackoff.Seconds())),
+				)
+				defer teardown()
+
+				_, err := testutils.CreateNode(testCtx.ClientSet, testNode)
+				if err != nil {
+					t.Fatalf("Creating node error: %v", err)
+				}
+
+				// Create initial low-priority pod and wait until it's scheduled.
+				pod, err := testutils.CreatePausePod(testCtx.ClientSet, podLow)
+				if err != nil {
+					t.Fatalf("Creating pod error: %v", err)
+				}
+				if err := testutils.WaitForPodToSchedule(testCtx.Ctx, testCtx.ClientSet, pod); err != nil {
+					t.Fatalf("Pod %v was not scheduled: %v", pod.Name, err)
+				}
+
+				// Create mid-priority pod and wait until it becomes nominated (preempt low-priority pod) and remain uschedulable.
+				pod, err = testutils.CreatePausePod(testCtx.ClientSet, podMidNominated)
+				if err != nil {
+					t.Fatalf("Creating pod error: %v", err)
+				}
+				if err := testutils.WaitForNominatedNodeName(testCtx.Ctx, testCtx.ClientSet, pod); err != nil {
+					t.Errorf("NominatedNodeName field was not set for pod %v: %v", pod.Name, err)
+				}
+				if err := testutils.WaitForPodUnschedulable(testCtx.Ctx, testCtx.ClientSet, pod); err != nil {
+					t.Errorf("Pod %v haven't become unschedulabe: %v", pod.Name, err)
+				}
+
+				// Remove the initial low-priority pod, which will move the nominated unschedulable pod back to the backoff queue.
+				if err := testutils.DeletePod(testCtx.ClientSet, podLow.Name, podLow.Namespace); err != nil {
+					t.Fatalf("Deleting pod error: %v", err)
+				}
+
+				// Create another low-priority pods which cannot be scheduled because the mid-priority pod is nominated on the node and the node doesn't have enough resource to have two pods both.
+				pod, err = testutils.CreatePausePod(testCtx.ClientSet, podLow)
+				if err != nil {
+					t.Fatalf("Creating pod error: %v", err)
+				}
+				if err := testutils.WaitForPodUnschedulable(testCtx.Ctx, testCtx.ClientSet, pod); err != nil {
+					t.Fatalf("Pod %v was not scheduled: %v", pod.Name, err)
+				}
+
+				// Update causing the nominated pod to be removed or to get its nominated node name removed, which should trigger scheduling of the low priority pod.
+				// Note that the update has to happen since the nominated pod is still in the backoffQ to actually test updates of nominated, but not bound yet pods.
+				tt.updateFunc(testCtx)
+
+				// Advance time by the maxPodBackoffSeconds to move low priority pod out of the backoff queue.
+				fakeClock.Step(testBackoff)
+
+				// Expect the low-priority pod is notified about unnominated mid-pririty pod and gets scheduled, as it should fit this time.
+				if err := testutils.WaitForPodToSchedule(testCtx.Ctx, testCtx.ClientSet, podLow); err != nil {
+					t.Fatalf("Pod %v was not scheduled: %v", podLow.Name, err)
+				}
+				testutils.CleanupPods(testCtx.Ctx, testCtx.ClientSet, t, cleanupPods)
+			})
+		}
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Removal (change) of nominated node in a pod should trigger rescheduling of other pods which could have been blocked by this pod. It's becasue lower or equal priority pods treat nominated pods (pods that have nominated node assigned) as if they were assigned.

#### Which issue(s) this PR fixes:

Fixes #126700

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Revised scheduling behavior to correctly handle nominated node changes. Trigger rescheduling of pods if necessary when pods with nominated node names got deleted or nominated on a different node.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
