### PR TITLE
Isolate mock signer for externaljwt tests

### DIFF
--- a/pkg/controlplane/apiserver/options/options_test.go
+++ b/pkg/controlplane/apiserver/options/options_test.go
@@ -345,15 +345,10 @@ func TestCompleteForServiceAccount(t *testing.T) {
 		t.Fatalf("Failed to encode private key: %v", err)
 	}
 
-	// create and start mock signer.
-	socketPath := "@mock-external-jwt-signer.sock"
-	mockSigner := v1alpha1testing.NewMockSigner(t, socketPath)
-	defer mockSigner.CleanUp()
-
 	testCases := []struct {
 		desc                     string
 		issuers                  []string
-		signingEndpoint          string
+		externalSigner           bool
 		signingKeyFiles          string
 		maxExpiration            time.Duration
 		externalMaxExpirationSec int64
@@ -366,11 +361,11 @@ func TestCompleteForServiceAccount(t *testing.T) {
 		externalPublicKeyGetterPresent bool
 	}{
 		{
-			desc: "no endpoint or key file",
+			desc: "endpoint and key file",
 			issuers: []string{
 				"iss",
 			},
-			signingEndpoint: socketPath,
+			externalSigner:  true,
 			signingKeyFiles: "private_key.pem",
 			maxExpiration:   time.Second * 3600,
 
@@ -381,7 +376,7 @@ func TestCompleteForServiceAccount(t *testing.T) {
 			issuers: []string{
 				"iss",
 			},
-			signingEndpoint: socketPath,
+			externalSigner:  true,
 			signingKeyFiles: "private_key.pem",
 			maxExpiration:   time.Second * 10,
 
@@ -392,7 +387,7 @@ func TestCompleteForServiceAccount(t *testing.T) {
 			issuers: []string{
 				"iss",
 			},
-			signingEndpoint: "",
+			externalSigner:  false,
 			signingKeyFiles: "private_key.pem",
 			maxExpiration:   time.Second * 3600,
 
@@ -405,7 +400,7 @@ func TestCompleteForServiceAccount(t *testing.T) {
 			issuers: []string{
 				"iss",
 			},
-			signingEndpoint:          socketPath,
+			externalSigner:           true,
 			signingKeyFiles:          "",
 			maxExpiration:            0,
 			externalMaxExpirationSec: 600, // 10m
@@ -419,7 +414,7 @@ func TestCompleteForServiceAccount(t *testing.T) {
 			issuers: []string{
 				"iss",
 			},
-			signingEndpoint:          socketPath,
+			externalSigner:           true,
 			signingKeyFiles:          "",
 			maxExpiration:            time.Second * 3600,
 			externalMaxExpirationSec: 600, // 10m
@@ -431,7 +426,7 @@ func TestCompleteForServiceAccount(t *testing.T) {
 			issuers: []string{
 				"iss",
 			},
-			signingEndpoint:          socketPath,
+			externalSigner:           true,
 			signingKeyFiles:          "",
 			maxExpiration:            0,
 			externalMaxExpirationSec: 300, // 5m
@@ -443,7 +438,7 @@ func TestCompleteForServiceAccount(t *testing.T) {
 			issuers: []string{
 				"iss",
 			},
-			signingEndpoint:          socketPath,
+			externalSigner:           true,
 			signingKeyFiles:          "",
 			maxExpiration:            0,
 			externalMaxExpirationSec: 900, // 15m
@@ -456,7 +451,7 @@ func TestCompleteForServiceAccount(t *testing.T) {
 			issuers: []string{
 				"iss",
 			},
-			signingEndpoint:          socketPath,
+			externalSigner:           true,
 			signingKeyFiles:          "",
 			maxExpiration:            0,
 			externalMaxExpirationSec: 900, // 15m
@@ -468,8 +463,20 @@ func TestCompleteForServiceAccount(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
+
 			options := NewOptions()
-			options.ServiceAccountSigningEndpoint = tc.signingEndpoint
+			if tc.externalSigner {
+				// create and start mock signer.
+				socketPath := fmt.Sprintf("@mock-external-jwt-signer-%d.sock", time.Now().Nanosecond())
+				mockSigner := v1alpha1testing.NewMockSigner(t, socketPath)
+				defer mockSigner.CleanUp()
+
+				mockSigner.MaxTokenExpirationSeconds = tc.externalMaxExpirationSec
+				mockSigner.MetadataError = tc.metadataError
+				mockSigner.FetchError = tc.fetchError
+
+				options.ServiceAccountSigningEndpoint = socketPath
+			}
 			options.ServiceAccountSigningKeyFile = tc.signingKeyFiles
 			options.Authentication = &kubeoptions.BuiltInAuthenticationOptions{
 				ServiceAccounts: &kubeoptions.ServiceAccountAuthenticationOptions{
@@ -478,16 +485,13 @@ func TestCompleteForServiceAccount(t *testing.T) {
 				},
 			}
 
-			_ = mockSigner.Reset()
-			mockSigner.MaxTokenExpirationSeconds = tc.externalMaxExpirationSec
-			mockSigner.MetadataError = tc.metadataError
-			mockSigner.FetchError = tc.fetchError
-
 			co := completedOptions{
 				Options: *options,
 			}
 
-			err := options.completeServiceAccountOptions(context.Background(), &co)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			err := options.completeServiceAccountOptions(ctx, &co)
 
 			if tc.wantError != nil {
 				if err == nil || tc.wantError.Error() != err.Error() {

--- a/pkg/serviceaccount/externaljwt/plugin/testing/v1alpha1/externalsigner_mock.go
+++ b/pkg/serviceaccount/externaljwt/plugin/testing/v1alpha1/externalsigner_mock.go
@@ -24,6 +24,7 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -225,7 +226,7 @@ func (m *MockSigner) start(t *testing.T) error {
 
 	klog.Infof("Starting Mock Signer at socketPath %s", m.socketPath)
 	go func() {
-		if err := m.server.Serve(m.listener); err != nil {
+		if err := m.server.Serve(m.listener); err != nil && !errors.Is(err, grpc.ErrServerStopped) {
 			t.Error(err)
 		}
 	}()
@@ -264,7 +265,7 @@ func (m *MockSigner) waitForMockServerToStart() error {
 
 // CleanUp stops gRPC server and the underlying listener.
 func (m *MockSigner) CleanUp() {
-	m.server.Stop()
+	m.server.GracefulStop()
 	_ = m.listener.Close()
 	_ = os.Remove(m.socketPath)
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind flake

Fixes flake reported in https://github.com/kubernetes/kubernetes/pull/128190#issuecomment-2505204717

#### What this PR does / why we need it:

Makes a new mock signer for each instance of the options test to avoid race flakes resetting mock fields between test cases

Switches the mock signer to close gracefully on cleanup

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/sig auth
