### PR TITLE
e2e_node: Simplify the code logic

### DIFF
--- a/test/e2e/framework/pod/wait.go
+++ b/test/e2e/framework/pod/wait.go
@@ -801,7 +801,7 @@ func WaitForPodScheduled(ctx context.Context, c clientset.Interface, namespace, 
 func WaitForPodContainerStarted(ctx context.Context, c clientset.Interface, namespace, podName string, containerIndex int, timeout time.Duration) error {
 	conditionDesc := fmt.Sprintf("container %d started", containerIndex)
 	return WaitForPodCondition(ctx, c, namespace, podName, conditionDesc, timeout, func(pod *v1.Pod) (bool, error) {
-		if containerIndex > len(pod.Status.ContainerStatuses)-1 {
+		if containerIndex >= len(pod.Status.ContainerStatuses) {
 			return false, nil
 		}
 		containerStatus := pod.Status.ContainerStatuses[containerIndex]
@@ -813,7 +813,7 @@ func WaitForPodContainerStarted(ctx context.Context, c clientset.Interface, name
 func WaitForPodInitContainerStarted(ctx context.Context, c clientset.Interface, namespace, podName string, initContainerIndex int, timeout time.Duration) error {
 	conditionDesc := fmt.Sprintf("init container %d started", initContainerIndex)
 	return WaitForPodCondition(ctx, c, namespace, podName, conditionDesc, timeout, func(pod *v1.Pod) (bool, error) {
-		if initContainerIndex > len(pod.Status.InitContainerStatuses)-1 {
+		if initContainerIndex >= len(pod.Status.InitContainerStatuses) {
 			return false, nil
 		}
 		initContainerStatus := pod.Status.InitContainerStatuses[initContainerIndex]

--- a/test/e2e_node/util.go
+++ b/test/e2e_node/util.go
@@ -577,7 +577,7 @@ func getPidFromPidFile(pidFile string) (int, error) {
 func WaitForPodInitContainerRestartCount(ctx context.Context, c clientset.Interface, namespace, podName string, initContainerIndex int, desiredRestartCount int32, timeout time.Duration) error {
 	conditionDesc := fmt.Sprintf("init container %d started", initContainerIndex)
 	return e2epod.WaitForPodCondition(ctx, c, namespace, podName, conditionDesc, timeout, func(pod *v1.Pod) (bool, error) {
-		if initContainerIndex > len(pod.Status.InitContainerStatuses)-1 {
+		if initContainerIndex >= len(pod.Status.InitContainerStatuses) {
 			return false, nil
 		}
 		containerStatus := pod.Status.InitContainerStatuses[initContainerIndex]
@@ -590,7 +590,7 @@ func WaitForPodInitContainerRestartCount(ctx context.Context, c clientset.Interf
 func WaitForPodContainerRestartCount(ctx context.Context, c clientset.Interface, namespace, podName string, containerIndex int, desiredRestartCount int32, timeout time.Duration) error {
 	conditionDesc := fmt.Sprintf("container %d started", containerIndex)
 	return e2epod.WaitForPodCondition(ctx, c, namespace, podName, conditionDesc, timeout, func(pod *v1.Pod) (bool, error) {
-		if containerIndex > len(pod.Status.ContainerStatuses)-1 {
+		if containerIndex >= len(pod.Status.ContainerStatuses) {
 			return false, nil
 		}
 		containerStatus := pod.Status.ContainerStatuses[containerIndex]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Simplify the condition check, related discussions can be found here: https://github.com/kubernetes/kubernetes/pull/126653#discussion_r1833222008

I believe the original formulation `if containerIndex > len(pod.Status.ContainerStatuses)-1 {` might be slightly clearer because it more explicitly communicates the intent to prevent out-of-bounds access when indexing an array. This approach generally aligns better with the intuition and conventions of most developers. If keeping the original version is indeed better, I will close this PR.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
