### PR TITLE
staticpolicy:smtalign: count for pre-allocated cpus for container

### DIFF
--- a/pkg/kubelet/cm/cpumanager/policy_static.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static.go
@@ -591,14 +591,19 @@ func (p *staticPolicy) Allocate(logger logr.Logger, s state.State, pod *v1.Pod, 
 		}
 	}()
 
-	if err := p.enforceSMTAlignment(s, numCPUs); err != nil {
-		return err
-	}
-
+	// Checking the checkpoint state before SMT alignment validation means that
+	// existing allocations are preserved even if they violate the current policy.
+	// For example, if kubelet previously ran with full-pcpus-only=false and is
+	// restarted with full-pcpus-only=true, checkpointed allocations that don't
+	// satisfy SMT alignment are accepted to avoid disrupting running workloads.
 	if cset, ok := s.GetCPUSet(string(pod.UID), container.Name); ok {
 		p.updateCPUsToReuse(pod, container, cset)
 		logger.Info("Static policy: container already present in state, skipping")
 		return nil
+	}
+
+	if err := p.enforceSMTAlignment(s, numCPUs); err != nil {
+		return err
 	}
 
 	// Call Topology Manager to get the aligned socket affinity across all hint providers.

--- a/pkg/kubelet/cm/cpumanager/policy_static.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static.go
@@ -290,10 +290,6 @@ func (p *staticPolicy) GetAvailableCPUs(s state.State) cpuset.CPUSet {
 	return s.GetDefaultCPUSet().Difference(p.reservedCPUs)
 }
 
-func (p *staticPolicy) GetAvailablePhysicalCPUs(s state.State) cpuset.CPUSet {
-	return s.GetDefaultCPUSet().Difference(p.reservedPhysicalCPUs)
-}
-
 func (p *staticPolicy) updateCPUsToReuse(pod *v1.Pod, container *v1.Container, cset cpuset.CPUSet) {
 	// If pod entries to m.cpusToReuse other than the current pod exist, delete them.
 	for podUID := range p.cpusToReuse {
@@ -540,7 +536,7 @@ func (p *staticPolicy) enforceSMTAlignment(s state.State, numCPUs int) error {
 		}
 	}
 
-	availablePhysicalCPUs := p.GetAvailablePhysicalCPUs(s).Size()
+	availablePhysicalCPUs := s.GetDefaultCPUSet().Difference(p.reservedPhysicalCPUs).Size()
 
 	// It's legal to reserve CPUs which are not core siblings. In this case the CPU allocator can descend to single cores
 	// when picking CPUs. This will void the guarantee of FullPhysicalCPUsOnly. To prevent this, we need to additionally consider

--- a/pkg/kubelet/cm/cpumanager/policy_static_test.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static_test.go
@@ -595,6 +595,42 @@ func TestStaticPolicyAdd(t *testing.T) {
 			expCPUAlloc:     true,
 			expCSet:         cpuset.New(1, 2, 3, 4, 5, 7, 8, 9, 10, 11),
 		},
+		{
+			// The purpose of this test is to verify that SMTAlignment consider
+			// pre-allocated CPUs assigned to the container.
+			// for example, in case of kubelet restart.
+			description: "GuPodManyCores, DualSocketHT, ExpectReAllocCPUs",
+			topo:        topoDualSocketHT,
+			options: map[string]string{
+				FullPCPUsOnlyOption: "true",
+			},
+			numReservedCPUs: 4,
+			reservedCPUs:    newCPUSetPtr(0, 1, 6, 7),
+			pod:             makePod("fakePod", "fakeContainer", "6", "6"),
+			stAssignments: state.ContainerCPUAssignments{
+				"fakePod": map[string]cpuset.CPUSet{
+					"fakeContainer": cpuset.New(2, 3, 4, 8, 9, 10),
+				},
+			},
+			stDefaultCPUSet: cpuset.New(0, 1, 5, 6, 7, 11),
+			expErr:          nil,
+			expCPUAlloc:     true,
+			expCSet:         cpuset.New(2, 3, 4, 8, 9, 10),
+		},
+		{
+			description: "GuPodManyCores, DualSocketHT, NotEnoughAvailable, NoAlloc",
+			topo:        topoDualSocketHT,
+			options: map[string]string{
+				FullPCPUsOnlyOption: "true",
+			},
+			numReservedCPUs: 4,
+			reservedCPUs:    newCPUSetPtr(0, 1, 6, 7),
+			pod:             makePod("fakePod", "fakeContainer", "10", "10"),
+			stAssignments:   state.ContainerCPUAssignments{},
+			stDefaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11),
+			expErr:          SMTAlignmentError{RequestedCPUs: 10, CpusPerCore: 2, AvailablePhysicalCPUs: 8, CausedByPhysicalCPUs: true},
+			expCPUAlloc:     false,
+		},
 	}
 	alignBySocketOptionTestCases := []staticPolicyTest{
 		{

--- a/pkg/kubelet/cm/cpumanager/state/state.go
+++ b/pkg/kubelet/cm/cpumanager/state/state.go
@@ -20,6 +20,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
+	"slices"
+	"strings"
 
 	"k8s.io/utils/cpuset"
 )
@@ -35,6 +37,32 @@ func (as ContainerCPUAssignments) Clone() ContainerCPUAssignments {
 		maps.Copy(ret[pod], as[pod])
 	}
 	return ret
+}
+
+// String returns a string representation of ContainerCPUAssignments.
+// Pod and container names are sorted alphabetically to ensure deterministic output.
+// The sorting overhead is acceptable since this method is used for logging and debugging only.
+func (as ContainerCPUAssignments) String() string {
+	var sb strings.Builder
+	sb.WriteString("{")
+
+	for i, pod := range slices.Sorted(maps.Keys(as)) {
+		if i > 0 {
+			sb.WriteString(",")
+		}
+		containerMap := as[pod]
+		fmt.Fprintf(&sb, "%q:{", pod)
+
+		for j, container := range slices.Sorted(maps.Keys(containerMap)) {
+			if j > 0 {
+				sb.WriteString(",")
+			}
+			fmt.Fprintf(&sb, "%q:%q", container, containerMap[container].String())
+		}
+		sb.WriteString("}")
+	}
+	sb.WriteString("}")
+	return sb.String()
 }
 
 // PodCPUAssignments contains pod-level CPU assignments.

--- a/pkg/kubelet/cm/cpumanager/state/state_test.go
+++ b/pkg/kubelet/cm/cpumanager/state/state_test.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"k8s.io/utils/cpuset"
 )
 
@@ -33,5 +34,66 @@ func TestClone(t *testing.T) {
 	actual := expect.Clone()
 	if &expect == &actual || !reflect.DeepEqual(expect, actual) {
 		t.Fail()
+	}
+}
+
+func TestString(t *testing.T) {
+	testCases := []struct {
+		name           string
+		assignments    ContainerCPUAssignments
+		expectedOutput string
+	}{
+		{
+			name: "two pods with multiple containers",
+			assignments: ContainerCPUAssignments{
+				"pod1": {
+					"container1": cpuset.New(1, 2),
+					"container2": cpuset.New(3, 4),
+				},
+				"pod2": {
+					"container3": cpuset.New(5),
+				},
+			},
+			expectedOutput: `{"pod1":{"container1":"1-2","container2":"3-4"},"pod2":{"container3":"5"}}`,
+		},
+		{
+			name: "three pods with multiple containers",
+			assignments: ContainerCPUAssignments{
+				"pod1": {
+					"container1": cpuset.New(1, 5),
+				},
+				"pod3": {
+					"container5": cpuset.New(9),
+					"container2": cpuset.New(3, 4, 5, 6, 7, 8),
+				},
+				"pod2": {
+					"container3": cpuset.New(5),
+					"container2": cpuset.New(3, 8),
+				},
+			},
+			expectedOutput: `{"pod1":{"container1":"1,5"},"pod2":{"container2":"3,8","container3":"5"},"pod3":{"container2":"3-8","container5":"9"}}`,
+		},
+		{
+			name:           "empty assignments",
+			assignments:    ContainerCPUAssignments{},
+			expectedOutput: `{}`,
+		},
+		{
+			name: "single pod single container",
+			assignments: ContainerCPUAssignments{
+				"pod1": {
+					"container1": cpuset.New(0, 1, 2),
+				},
+			},
+			expectedOutput: `{"pod1":{"container1":"0-2"}}`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if diff := cmp.Diff(tc.assignments.String(), tc.expectedOutput); diff != "" {
+				t.Errorf("String() output mismatch.\n diff=%s got(+) want(-)", diff)
+			}
+		})
 	}
 }

--- a/test/e2e_node/cpu_manager_test.go
+++ b/test/e2e_node/cpu_manager_test.go
@@ -47,6 +47,7 @@ import (
 
 	"k8s.io/kubernetes/test/e2e/feature"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 )
@@ -1008,6 +1009,66 @@ var _ = SIGDescribe("CPU Manager", ginkgo.Ordered, ginkgo.ContinueOnFailure, fra
 				gomega.Expect(pod).To(HaveContainerCPUsAlignedTo(cnt.Name, smtLevel))
 				gomega.Expect(pod).To(HaveContainerCPUsThreadSiblings(cnt.Name))
 			}
+		})
+
+		ginkgo.It("should count for pre-allocated CPUs after kubelet restart", func(ctx context.Context) {
+			// This test verifies that pods with pre-allocated CPUs (from the checkpoint file)
+			// are not rejected after kubelet restart when SMT alignment is enabled.
+			// Regression test for the fix where the container presence check was moved
+			// before the SMT alignment check.
+
+			// The key is to request enough CPUs so that if pre-allocated CPUs are not
+			// counted, the SMT alignment check would fail due to insufficient available
+			// physical CPUs.
+
+			// Calculate the maximum SMT-aligned CPUs we can request
+			// We need to request most of the allocatable CPUs to trigger the bug
+			nodeCPUDetails := cpuDetailsFromNode(getLocalNode(ctx, f))
+			allocatableCPUs := int(nodeCPUDetails.Allocatable) - reservedCPUs.Size()
+
+			// Round down to the nearest multiple of smtLevel for SMT alignment
+			cpuCount := (allocatableCPUs / smtLevel) * smtLevel
+
+			// We need at least 2*smtLevel CPUs to make this test meaningful
+			// (one set for the pod, leaving less than smtLevel available which would fail the check)
+			if cpuCount < 2*smtLevel {
+				e2eskipper.Skipf("Not enough allocatable CPUs for this test: need at least %d, have %d", 2*smtLevel, allocatableCPUs)
+			}
+
+			ginkgo.By(fmt.Sprintf("creating the testing pod cpuRequest=%d (allocatable=%d, reserved=%d)", cpuCount, allocatableCPUs, reservedCPUs.Size()))
+			pod := makeCPUManagerPod("gu-pod", []ctnAttribute{
+				{
+					ctnName:    "gu-container",
+					cpuRequest: fmt.Sprintf("%d", cpuCount),
+					cpuLimit:   fmt.Sprintf("%d", cpuCount),
+				},
+			})
+			ginkgo.By("creating the test pod")
+			pod = e2epod.NewPodClient(f).CreateSync(ctx, pod)
+			podMap[string(pod.UID)] = pod
+
+			ginkgo.By("verifying the pod is running with allocated CPUs")
+			cpusBeforeRestart, err := getContainerAllowedCPUs(pod, "gu-container", false)
+			framework.ExpectNoError(err, "cannot get CPUs for container gu-container before restart")
+			framework.Logf("CPUs before kubelet restart: %s (count=%d)", cpusBeforeRestart.String(), cpusBeforeRestart.Size())
+			gomega.Expect(cpusBeforeRestart.Size()).To(gomega.Equal(cpuCount))
+
+			ginkgo.By("restarting the kubelet")
+			restartKubelet := mustStopKubelet(ctx, f)
+			restartKubelet(ctx)
+
+			ginkgo.By("ensuring kubelet is healthy after restart")
+			gomega.Eventually(ctx, func() bool {
+				return e2enode.HealthCheck(kubeletHealthCheckURL)
+			}).WithTimeout(f.Timeouts.PodStart).WithPolling(f.Timeouts.Poll).Should(gomega.BeTrueBecause("kubelet should be healthy after restart"))
+
+			ginkgo.By("verifying pod is still running after kubelet restart")
+			pod, err = e2epod.NewPodClient(f).Get(ctx, pod.Name, metav1.GetOptions{})
+			framework.ExpectNoError(err, "failed to get pod after kubelet restart")
+			gomega.Expect(pod).To(BeAPodInPhase(v1.PodRunning), "pod should still be running after kubelet restart")
+
+			ginkgo.By("verifying container still has the same CPUs after restart")
+			gomega.Expect(pod).To(HaveContainerCPUsEqualTo("gu-container", cpusBeforeRestart))
 		})
 	})
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When CPUManager is configured with full-pcpus-only option,
it validates the number of available CPUs on the system.

There's a subtle bug in this check, where after kubelet restart
the containers already assigned with CPUs because
kubelet reads the checkpoint file and builds the container's
assignment map on startup.

We are not counting for these pre-allocated CPUs,
which could lead to false-positive, and prevent
the pod from being admitted.




#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://github.com/kubernetes/kubernetes/issues/129078

#### Special notes for your reviewer:
N/A

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
N/A
```
