### PR TITLE
Fix volume expansion offline e2e

### DIFF
--- a/test/e2e/storage/testsuites/volume_expand.go
+++ b/test/e2e/storage/testsuites/volume_expand.go
@@ -444,9 +444,11 @@ func WaitForPendingFSResizeCondition(ctx context.Context, pvc *v1.PersistentVolu
 		if len(inProgressConditions) == 0 {
 			return true, nil
 		}
-		conditionType := inProgressConditions[0].Type
-		if conditionType == v1.PersistentVolumeClaimFileSystemResizePending {
-			return true, nil
+		for _, condition := range inProgressConditions {
+			conditionType := condition.Type
+			if conditionType == v1.PersistentVolumeClaimFileSystemResizePending {
+				return true, nil
+			}
 		}
 		return false, nil
 	})


### PR DESCRIPTION
Do not depend on first condition on PVC, but any condition. 

With newer resizer, when Recovery is enabled https://github.com/kubernetes-csi/external-resizer/pull/456, the filesystem resize pending condition is not the first condition. It is usually second condition.