### PR TITLE
Add Podresize endpoints to pending_eligible_endpoints.yaml

### DIFF
--- a/test/conformance/testdata/pending_eligible_endpoints.yaml
+++ b/test/conformance/testdata/pending_eligible_endpoints.yaml
@@ -1,1 +1,4 @@
 ---
+- patchCoreV1NamespacedPodResize
+- readCoreV1NamespacedPodResize
+- replaceCoreV1NamespacedPodResize


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

APISnoop is now tracking three new  subresource endpoints for `Podresize` that are not ready for Conformance. To return APISnoop to 100% Conformance coverage these endpoints need to be added to [test/conformance/testdata/pending_eligible_endpoints.yaml](https://github.com/kubernetes/kubernetes/blob/master/test/conformance/testdata/pending_eligible_endpoints.yaml)

#### Special notes for your reviewer:

- https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/1287-in-place-update-pod-resources/kep.yaml

```
milestone:
  alpha: "v1.27"
  beta: "v1.32"
  stable: "TBD"
```

Podresize endpoints:

- https://apisnoop.cncf.io/1.32.0/stable/core/patchCoreV1NamespacedPodResize
- https://apisnoop.cncf.io/1.32.0/stable/core/readCoreV1NamespacedPodResize
- https://apisnoop.cncf.io/1.32.0/stable/core/replaceCoreV1NamespacedPodResize

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
