### PR TITLE
Fix waitForDelete in drain package to return error of type ErrorInterrupted

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/drain/drain.go
+++ b/staging/src/k8s.io/kubectl/pkg/drain/drain.go
@@ -447,8 +447,8 @@ func waitForDelete(params waitForDeleteParams) ([]corev1.Pod, error) {
 	})
 
 	if err != nil {
-        return pods, wait.ErrorInterrupted(err)
-    }
+		return pods, wait.ErrorInterrupted(err)
+	}
 
 	return pods, err
 }

--- a/staging/src/k8s.io/kubectl/pkg/drain/drain.go
+++ b/staging/src/k8s.io/kubectl/pkg/drain/drain.go
@@ -433,7 +433,7 @@ func waitForDelete(params waitForDeleteParams) ([]corev1.Pod, error) {
 				if params.onFinishFn != nil {
 					params.onFinishFn(&pod, params.usingEviction, err)
 				}
-				return false, err
+				return false, wait.ErrorInterrupted(err)
 			} else {
 				if shouldSkipPod(*p, params.skipWaitForDeleteTimeoutSeconds) {
 					fmt.Fprintf(params.out, podSkipMsgTemplate, pod.Name, params.skipWaitForDeleteTimeoutSeconds)
@@ -445,6 +445,11 @@ func waitForDelete(params waitForDeleteParams) ([]corev1.Pod, error) {
 		pods = pendingPods
 		return len(pods) == 0, nil
 	})
+
+	if err != nil {
+        return pods, wait.ErrorInterrupted(err)
+    }
+
 	return pods, err
 }
 

--- a/staging/src/k8s.io/kubectl/pkg/drain/drain_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/drain/drain_test.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes/fake"
 	ktest "k8s.io/client-go/testing"
 )
@@ -49,7 +50,7 @@ func TestDeletePods(t *testing.T) {
 		ctxTimeoutEarly   bool
 		expectPendingPods bool
 		expectError       bool
-		expectedError     *error
+		expectedError     error
 		getPodFn          func(namespace, name string) (*corev1.Pod, error)
 	}{
 		{
@@ -100,7 +101,7 @@ func TestDeletePods(t *testing.T) {
 			timeout:           3 * time.Second,
 			expectPendingPods: true,
 			expectError:       true,
-			expectedError:     &context.DeadlineExceeded,
+			expectedError:     wait.ErrorInterrupted(context.DeadlineExceeded),
 			getPodFn: func(namespace, name string) (*corev1.Pod, error) {
 				oldPodMap, _ := createPods(false)
 				if oldPod, found := oldPodMap[name]; found {
@@ -116,7 +117,7 @@ func TestDeletePods(t *testing.T) {
 			ctxTimeoutEarly:   true,
 			expectPendingPods: true,
 			expectError:       true,
-			expectedError:     &context.Canceled,
+			expectedError:     context.Canceled,
 			getPodFn: func(namespace, name string) (*corev1.Pod, error) {
 				oldPodMap, _ := createPods(false)
 				if oldPod, found := oldPodMap[name]; found {
@@ -148,7 +149,7 @@ func TestDeletePods(t *testing.T) {
 			timeout:           5 * time.Second,
 			expectPendingPods: true,
 			expectError:       true,
-			expectedError:     nil,
+			expectedError:     wait.ErrorInterrupted(errors.New("This is a random error for testing")),
 			getPodFn: func(namespace, name string) (*corev1.Pod, error) {
 				return &corev1.Pod{}, errors.New("This is a random error for testing")
 			},
@@ -177,20 +178,13 @@ func TestDeletePods(t *testing.T) {
 				out:                             os.Stdout,
 				skipWaitForDeleteTimeoutSeconds: 10,
 			}
-			start := time.Now()
 			pendingPods, err := waitForDelete(params)
-			elapsed := time.Since(start)
 
-			if test.expectError {
-				if err == nil {
-					t.Fatalf("%s: unexpected non-error", test.description)
-				} else if test.expectedError != nil {
-					if test.ctxTimeoutEarly {
-						if elapsed >= test.timeout {
-							t.Fatalf("%s: the supplied context did not effectively cancel the waitForDelete", test.description)
-						}
-					} else if *test.expectedError != err {
-						t.Fatalf("%s: the error does not match expected error", test.description)
+				if test.expectError {
+					if err == nil {
+						if !errors.Is(err, wait.ErrorInterrupted(test.expectedError)) {
+							t.Fatalf("%s: expected error %v, got %v", test.description, test.expectedError, err)
+	
 					}
 				}
 			}

--- a/staging/src/k8s.io/kubectl/pkg/drain/drain_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/drain/drain_test.go
@@ -180,11 +180,11 @@ func TestDeletePods(t *testing.T) {
 			}
 			pendingPods, err := waitForDelete(params)
 
-				if test.expectError {
-					if err == nil {
-						if !errors.Is(err, wait.ErrorInterrupted(test.expectedError)) {
-							t.Fatalf("%s: expected error %v, got %v", test.description, test.expectedError, err)
-	
+			if test.expectError {
+				if err == nil {
+					if !errors.Is(err, wait.ErrorInterrupted(test.expectedError)) {
+						t.Fatalf("%s: expected error %v, got %v", test.description, test.expectedError, err)
+
 					}
 				}
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR updates the `waitForDelete` function in the drain package to return an error of type `ErrorInterrupted` during timeout or cancellation scenarios. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes [kubernetes/kubectl(#1627)](https://github.com/kubernetes/kubectl/issues/1627)

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
none
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
