### PR TITLE
Adjust the log level of the FilterActivePods method

### DIFF
--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -979,8 +979,6 @@ func FilterActivePods(logger klog.Logger, pods []*v1.Pod) []*v1.Pod {
 	for _, p := range pods {
 		if IsPodActive(p) {
 			result = append(result, p)
-		} else {
-			logger.V(4).Info("Ignoring inactive pod", "pod", klog.KObj(p), "phase", p.Status.Phase, "deletionTime", klog.SafePtr(p.DeletionTimestamp))
 		}
 	}
 	return result


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

In a Kubernetes cluster, if a large number of Jobs are in the `Completed` state and their `ttlSecondsAfterFinished` is set too high, these Jobs will remain in the system for an extended period. As a result, the `FilterActivePods` method will generate numerous `Ignoring inactive pod` logs. This rapid accumulation of logs can consume excessive disk space, put pressure on the logging system, and potentially lead to performance issues.

```
I1206 04:52:22.945966       1 controller_utils.go:933] Ignoring inactive pod default/job-1779771-ex-340306449-task-340751605-0 in state Succeeded, deletion time <nil>
I1206 04:52:22.945974       1 controller_utils.go:933] Ignoring inactive pod default/job-507620-ex-340289739-task-340734895-0 in state Succeeded, deletion time <nil>
I1206 04:52:22.945982       1 controller_utils.go:933] Ignoring inactive pod default/job-956581-ex-340259397-task-340704555-0 in state Failed, deletion time <nil>
I1206 04:52:22.945992       1 controller_utils.go:933] Ignoring inactive pod default/job-235525-ex-340308815-task-340753971-0 in state Succeeded, deletion time <nil>
I1206 04:52:22.945998       1 controller_utils.go:933] Ignoring inactive pod default/job-7994-ex-340297985-task-340743141-0 in state Succeeded, deletion time <nil>
I1206 04:52:22.946004       1 controller_utils.go:933] Ignoring inactive pod default/job-1829554-ex-340177089-task-340622159-0 in state Failed, deletion time <nil>
I1206 04:52:22.946015       1 controller_utils.go:933] Ignoring inactive pod default/job-1169664-ex-339666717-task-340111899-0 in state Succeeded, deletion time <nil>
I1206 04:52:22.946022       1 controller_utils.go:933] Ignoring inactive pod default/job-1881547-ex-340147968-task-340593130-0 in state Failed, deletion time <nil>
I1206 04:52:22.946029       1 controller_utils.go:933] Ignoring inactive pod default/job-1688208-ex-340117388-task-340562550-0 in state Succeeded, deletion time <nil>
I1206 04:52:22.946035       1 controller_utils.go:933] Ignoring inactive pod default/job-365313-ex-340316940-task-340762096-0 in state Succeeded, deletion time <nil>
I1206 04:52:22.946043       1 controller_utils.go:933] Ignoring inactive pod default/job-603569-ex-340302211-task-340747367-0 in state Succeeded, deletion time <nil>
I1206 04:52:22.946051       1 controller_utils.go:933] Ignoring inactive pod default/job-1111104-ex-340305745-task-340750901-0 in state Succeeded, deletion time <nil>
```

![image](https://github.com/user-attachments/assets/aa035a65-b914-4b6b-b84a-c439a40182a6)


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
