### PR TITLE
Drop use of winreadlinkvolume godebug option

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,8 +10,6 @@ go 1.23.0
 
 godebug default=go1.23
 
-godebug winreadlinkvolume=0
-
 godebug winsymlink=0
 
 require (

--- a/go.work
+++ b/go.work
@@ -4,8 +4,6 @@ go 1.23.0
 
 godebug default=go1.23
 
-godebug winreadlinkvolume=0
-
 godebug winsymlink=0
 
 use (

--- a/staging/src/k8s.io/api/go.mod
+++ b/staging/src/k8s.io/api/go.mod
@@ -6,8 +6,6 @@ go 1.23.0
 
 godebug default=go1.23
 
-godebug winreadlinkvolume=0
-
 godebug winsymlink=0
 
 require (

--- a/staging/src/k8s.io/apiextensions-apiserver/go.mod
+++ b/staging/src/k8s.io/apiextensions-apiserver/go.mod
@@ -6,8 +6,6 @@ go 1.23.0
 
 godebug default=go1.23
 
-godebug winreadlinkvolume=0
-
 godebug winsymlink=0
 
 require (

--- a/staging/src/k8s.io/apimachinery/go.mod
+++ b/staging/src/k8s.io/apimachinery/go.mod
@@ -6,8 +6,6 @@ go 1.23.0
 
 godebug default=go1.23
 
-godebug winreadlinkvolume=0
-
 godebug winsymlink=0
 
 require (

--- a/staging/src/k8s.io/apiserver/go.mod
+++ b/staging/src/k8s.io/apiserver/go.mod
@@ -6,8 +6,6 @@ go 1.23.0
 
 godebug default=go1.23
 
-godebug winreadlinkvolume=0
-
 godebug winsymlink=0
 
 require (

--- a/staging/src/k8s.io/cli-runtime/go.mod
+++ b/staging/src/k8s.io/cli-runtime/go.mod
@@ -6,8 +6,6 @@ go 1.23.0
 
 godebug default=go1.23
 
-godebug winreadlinkvolume=0
-
 godebug winsymlink=0
 
 require (

--- a/staging/src/k8s.io/client-go/go.mod
+++ b/staging/src/k8s.io/client-go/go.mod
@@ -6,8 +6,6 @@ go 1.23.0
 
 godebug default=go1.23
 
-godebug winreadlinkvolume=0
-
 godebug winsymlink=0
 
 require (

--- a/staging/src/k8s.io/cloud-provider/go.mod
+++ b/staging/src/k8s.io/cloud-provider/go.mod
@@ -6,8 +6,6 @@ go 1.23.0
 
 godebug default=go1.23
 
-godebug winreadlinkvolume=0
-
 godebug winsymlink=0
 
 require (

--- a/staging/src/k8s.io/cluster-bootstrap/go.mod
+++ b/staging/src/k8s.io/cluster-bootstrap/go.mod
@@ -6,8 +6,6 @@ go 1.23.0
 
 godebug default=go1.23
 
-godebug winreadlinkvolume=0
-
 godebug winsymlink=0
 
 require (

--- a/staging/src/k8s.io/code-generator/go.mod
+++ b/staging/src/k8s.io/code-generator/go.mod
@@ -6,8 +6,6 @@ go 1.23.0
 
 godebug default=go1.23
 
-godebug winreadlinkvolume=0
-
 godebug winsymlink=0
 
 require (

--- a/staging/src/k8s.io/component-base/go.mod
+++ b/staging/src/k8s.io/component-base/go.mod
@@ -6,8 +6,6 @@ go 1.23.0
 
 godebug default=go1.23
 
-godebug winreadlinkvolume=0
-
 godebug winsymlink=0
 
 require (

--- a/staging/src/k8s.io/component-helpers/go.mod
+++ b/staging/src/k8s.io/component-helpers/go.mod
@@ -6,8 +6,6 @@ go 1.23.0
 
 godebug default=go1.23
 
-godebug winreadlinkvolume=0
-
 godebug winsymlink=0
 
 require (

--- a/staging/src/k8s.io/controller-manager/go.mod
+++ b/staging/src/k8s.io/controller-manager/go.mod
@@ -6,8 +6,6 @@ go 1.23.0
 
 godebug default=go1.23
 
-godebug winreadlinkvolume=0
-
 godebug winsymlink=0
 
 require (

--- a/staging/src/k8s.io/cri-api/go.mod
+++ b/staging/src/k8s.io/cri-api/go.mod
@@ -6,8 +6,6 @@ go 1.23.0
 
 godebug default=go1.23
 
-godebug winreadlinkvolume=0
-
 godebug winsymlink=0
 
 require (

--- a/staging/src/k8s.io/cri-client/go.mod
+++ b/staging/src/k8s.io/cri-client/go.mod
@@ -6,8 +6,6 @@ go 1.23.0
 
 godebug default=go1.23
 
-godebug winreadlinkvolume=0
-
 godebug winsymlink=0
 
 require (

--- a/staging/src/k8s.io/csi-translation-lib/go.mod
+++ b/staging/src/k8s.io/csi-translation-lib/go.mod
@@ -6,8 +6,6 @@ go 1.23.0
 
 godebug default=go1.23
 
-godebug winreadlinkvolume=0
-
 godebug winsymlink=0
 
 require (

--- a/staging/src/k8s.io/dynamic-resource-allocation/go.mod
+++ b/staging/src/k8s.io/dynamic-resource-allocation/go.mod
@@ -6,8 +6,6 @@ go 1.23.0
 
 godebug default=go1.23
 
-godebug winreadlinkvolume=0
-
 godebug winsymlink=0
 
 require (

--- a/staging/src/k8s.io/endpointslice/go.mod
+++ b/staging/src/k8s.io/endpointslice/go.mod
@@ -6,8 +6,6 @@ go 1.23.0
 
 godebug default=go1.23
 
-godebug winreadlinkvolume=0
-
 godebug winsymlink=0
 
 require (

--- a/staging/src/k8s.io/externaljwt/go.mod
+++ b/staging/src/k8s.io/externaljwt/go.mod
@@ -6,8 +6,6 @@ go 1.23.0
 
 godebug default=go1.23
 
-godebug winreadlinkvolume=0
-
 godebug winsymlink=0
 
 require (

--- a/staging/src/k8s.io/kms/go.mod
+++ b/staging/src/k8s.io/kms/go.mod
@@ -6,8 +6,6 @@ go 1.23.0
 
 godebug default=go1.23
 
-godebug winreadlinkvolume=0
-
 godebug winsymlink=0
 
 require (

--- a/staging/src/k8s.io/kube-aggregator/go.mod
+++ b/staging/src/k8s.io/kube-aggregator/go.mod
@@ -6,8 +6,6 @@ go 1.23.0
 
 godebug default=go1.23
 
-godebug winreadlinkvolume=0
-
 godebug winsymlink=0
 
 require (

--- a/staging/src/k8s.io/kube-controller-manager/go.mod
+++ b/staging/src/k8s.io/kube-controller-manager/go.mod
@@ -6,8 +6,6 @@ go 1.23.0
 
 godebug default=go1.23
 
-godebug winreadlinkvolume=0
-
 godebug winsymlink=0
 
 require (

--- a/staging/src/k8s.io/kube-proxy/go.mod
+++ b/staging/src/k8s.io/kube-proxy/go.mod
@@ -6,8 +6,6 @@ go 1.23.0
 
 godebug default=go1.23
 
-godebug winreadlinkvolume=0
-
 godebug winsymlink=0
 
 require (

--- a/staging/src/k8s.io/kube-scheduler/go.mod
+++ b/staging/src/k8s.io/kube-scheduler/go.mod
@@ -6,8 +6,6 @@ go 1.23.0
 
 godebug default=go1.23
 
-godebug winreadlinkvolume=0
-
 godebug winsymlink=0
 
 require (

--- a/staging/src/k8s.io/kubectl/go.mod
+++ b/staging/src/k8s.io/kubectl/go.mod
@@ -6,8 +6,6 @@ go 1.23.0
 
 godebug default=go1.23
 
-godebug winreadlinkvolume=0
-
 godebug winsymlink=0
 
 require (

--- a/staging/src/k8s.io/kubelet/go.mod
+++ b/staging/src/k8s.io/kubelet/go.mod
@@ -6,8 +6,6 @@ go 1.23.0
 
 godebug default=go1.23
 
-godebug winreadlinkvolume=0
-
 godebug winsymlink=0
 
 require (

--- a/staging/src/k8s.io/metrics/go.mod
+++ b/staging/src/k8s.io/metrics/go.mod
@@ -6,8 +6,6 @@ go 1.23.0
 
 godebug default=go1.23
 
-godebug winreadlinkvolume=0
-
 godebug winsymlink=0
 
 require (

--- a/staging/src/k8s.io/mount-utils/go.mod
+++ b/staging/src/k8s.io/mount-utils/go.mod
@@ -6,8 +6,6 @@ go 1.23.0
 
 godebug default=go1.23
 
-godebug winreadlinkvolume=0
-
 godebug winsymlink=0
 
 require (

--- a/staging/src/k8s.io/pod-security-admission/go.mod
+++ b/staging/src/k8s.io/pod-security-admission/go.mod
@@ -6,8 +6,6 @@ go 1.23.0
 
 godebug default=go1.23
 
-godebug winreadlinkvolume=0
-
 godebug winsymlink=0
 
 require (

--- a/staging/src/k8s.io/sample-apiserver/go.mod
+++ b/staging/src/k8s.io/sample-apiserver/go.mod
@@ -6,8 +6,6 @@ go 1.23.0
 
 godebug default=go1.23
 
-godebug winreadlinkvolume=0
-
 godebug winsymlink=0
 
 require (

--- a/staging/src/k8s.io/sample-cli-plugin/go.mod
+++ b/staging/src/k8s.io/sample-cli-plugin/go.mod
@@ -6,8 +6,6 @@ go 1.23.0
 
 godebug default=go1.23
 
-godebug winreadlinkvolume=0
-
 godebug winsymlink=0
 
 require (

--- a/staging/src/k8s.io/sample-controller/go.mod
+++ b/staging/src/k8s.io/sample-controller/go.mod
@@ -6,8 +6,6 @@ go 1.23.0
 
 godebug default=go1.23
 
-godebug winreadlinkvolume=0
-
 godebug winsymlink=0
 
 require (


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Drops use of the `winreadlinkvolume` compatibility switch, based on feedback from Microsoft AKS team that use of volume identifiers is more consistent and reliable, and that opting back into go 1.22 `winreadlinkvolume` behavior is known to break some CSI drivers. xref https://github.com/kubernetes/kubernetes/issues/129080#issuecomment-2522268585

The `winsymlink` compatibility switch is still required to make kubelet work properly with go 1.23 currently. https://github.com/kubernetes/kubernetes/issues/129084 tracks adjusting as needed and removing that switch.

In terms of testing, rc.1 was released without either of these switches. rc.2 was released with both of these switches. We (GKE) ran and passed windows CSI storage tests with both of the configurations:
* just `winsymlink=0` (as part of validating https://github.com/kubernetes/kubernetes/pull/129083)
* both `winsymlink=0 winreadlinkvolume=0` (in rc.2)

That gives me confidence in dropping `winreadlinkvolume=0` while still passing all the tests we know of that people have been running on the release candidates.

#### Does this PR introduce a user-facing change?
```release-note
kubelet: on Windows, consistently resolve filesystem links to volume identifiers instead of inconsistently normalizing to drive letters
```

/sig storage windows release
/cc @msau42 @marosset @andyzhangx 
/hold for reviews and discussion
