### PR TITLE
local-up-cluster: only wait for coredns if enabled

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -1430,7 +1430,9 @@ if [[ "${START_MODE}" != "kubeletonly" ]]; then
         ;;
       Linux)
         start_kubeproxy
-        wait_coredns_available
+        if [[ "${ENABLE_CLUSTER_DNS}" = true ]]; then
+          wait_coredns_available
+        fi
         ;;
       *)
         print_color "Unsupported host OS.  Must be Linux or Mac OS X, kube-proxy aborted."


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Only waits for CoreDNS if enabled. If coredns is disabled and a local-up-cluster is started, then the script waits forever and eventually errors out.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
