### PR TITLE
test: deployment patch status test should  check the modified fields

### DIFF
--- a/test/e2e/apps/deployment.go
+++ b/test/e2e/apps/deployment.go
@@ -396,9 +396,6 @@ var _ = SIGDescribe("Deployment", func() {
 
 		ginkgo.By("patching the DeploymentStatus")
 		deploymentStatusPatch, err := json.Marshal(map[string]interface{}{
-			"metadata": map[string]interface{}{
-				"labels": map[string]string{"test-deployment": "patched-status"},
-			},
 			"status": map[string]interface{}{
 				"readyReplicas":     testDeploymentNoReplicas,
 				"availableReplicas": testDeploymentAvailableReplicas,
@@ -416,7 +413,9 @@ var _ = SIGDescribe("Deployment", func() {
 			case watch.Modified:
 				if deployment, ok := event.Object.(*appsv1.Deployment); ok {
 					found := deployment.ObjectMeta.Name == testDeployment.Name &&
-						deployment.ObjectMeta.Labels["test-deployment-static"] == "true"
+						deployment.Status.ReadyReplicas == testDeploymentNoReplicas &&
+						deployment.Status.AvailableReplicas == testDeploymentAvailableReplicas
+
 					return found, nil
 				}
 			default:


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/sig testing
/sig architecture

#### What this PR does / why we need it:
It was found in https://github.com/kubernetes/kubernetes/pull/107635 that we're not matching the correct data when patching deployment status. 

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
/assign @sayaoailun @riaankleinhans 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
