### PR TITLE
client-go: finish context support

### DIFF
--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -322,12 +322,8 @@ linters:
             # Packages matched here do not have to be listed above because
             # "contextual" implies "structured".
             contextual k8s.io/api/.*
-            contextual k8s.io/apimachinery/pkg/util/runtime/.*
-            contextual k8s.io/client-go/metadata/.*
-            contextual k8s.io/client-go/rest/.*
-            contextual k8s.io/client-go/tools/cache/.*
-            contextual k8s.io/client-go/tools/events/.*
-            contextual k8s.io/client-go/tools/record/.*
+            contextual k8s.io/apimachinery/.*
+            contextual k8s.io/client-go/.*
             contextual k8s.io/component-base/featuregate/*
             contextual k8s.io/component-helpers/.*
             contextual k8s.io/cri-api/.*
@@ -362,6 +358,11 @@ linters:
             contextual k8s.io/kubernetes/test/e2e/dra/.*
             contextual k8s.io/kubernetes/test/images/sample-device-plugin/.*
             contextual k8s.io/kubernetes/pkg/kubelet/.*
+            
+            # https://github.com/kubernetes/kubernetes/pull/129336 pending,
+            # unclear whether it'll ever get merged (more discussion around
+            # API design needed).
+            -contextual k8s.io/client-go/plugin/pkg/client/auth/.*
       sorted:
         # Installed there by hack/verify-golangci-lint.sh.
         path: _output/local/bin/sorted.so

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -335,12 +335,8 @@ linters:
             # Packages matched here do not have to be listed above because
             # "contextual" implies "structured".
             contextual k8s.io/api/.*
-            contextual k8s.io/apimachinery/pkg/util/runtime/.*
-            contextual k8s.io/client-go/metadata/.*
-            contextual k8s.io/client-go/rest/.*
-            contextual k8s.io/client-go/tools/cache/.*
-            contextual k8s.io/client-go/tools/events/.*
-            contextual k8s.io/client-go/tools/record/.*
+            contextual k8s.io/apimachinery/.*
+            contextual k8s.io/client-go/.*
             contextual k8s.io/component-base/featuregate/*
             contextual k8s.io/component-helpers/.*
             contextual k8s.io/cri-api/.*
@@ -375,6 +371,11 @@ linters:
             contextual k8s.io/kubernetes/test/e2e/dra/.*
             contextual k8s.io/kubernetes/test/images/sample-device-plugin/.*
             contextual k8s.io/kubernetes/pkg/kubelet/.*
+            
+            # https://github.com/kubernetes/kubernetes/pull/129336 pending,
+            # unclear whether it'll ever get merged (more discussion around
+            # API design needed).
+            -contextual k8s.io/client-go/plugin/pkg/client/auth/.*
       sorted:
         # Installed there by hack/verify-golangci-lint.sh.
         path: _output/local/bin/sorted.so

--- a/hack/logcheck.conf
+++ b/hack/logcheck.conf
@@ -25,12 +25,8 @@ structured k8s.io/kubernetes/pkg/credentialprovider/plugin/.*
 # Packages matched here do not have to be listed above because
 # "contextual" implies "structured".
 contextual k8s.io/api/.*
-contextual k8s.io/apimachinery/pkg/util/runtime/.*
-contextual k8s.io/client-go/metadata/.*
-contextual k8s.io/client-go/rest/.*
-contextual k8s.io/client-go/tools/cache/.*
-contextual k8s.io/client-go/tools/events/.*
-contextual k8s.io/client-go/tools/record/.*
+contextual k8s.io/apimachinery/.*
+contextual k8s.io/client-go/.*
 contextual k8s.io/component-base/featuregate/*
 contextual k8s.io/component-helpers/.*
 contextual k8s.io/cri-api/.*
@@ -65,3 +61,8 @@ contextual k8s.io/kubernetes/pkg/securitycontext/.*
 contextual k8s.io/kubernetes/test/e2e/dra/.*
 contextual k8s.io/kubernetes/test/images/sample-device-plugin/.*
 contextual k8s.io/kubernetes/pkg/kubelet/.*
+
+# https://github.com/kubernetes/kubernetes/pull/129336 pending,
+# unclear whether it'll ever get merged (more discussion around
+# API design needed).
+-contextual k8s.io/client-go/plugin/pkg/client/auth/.*

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/helpers.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/helpers.go
@@ -523,6 +523,7 @@ func NewJSONFallbackEncoder(encoder runtime.Encoder) runtime.Encoder {
 	}
 	identifier, err := gojson.Marshal(result)
 	if err != nil {
+		//nolint:logcheck // Should not be reached.
 		klog.Fatalf("Failed marshaling identifier for jsonFallbackEncoder: %v", err)
 	}
 	return &jsonFallbackEncoder{

--- a/staging/src/k8s.io/apimachinery/pkg/labels/selector.go
+++ b/staging/src/k8s.io/apimachinery/pkg/labels/selector.go
@@ -269,13 +269,15 @@ func (r *Requirement) Matches(ls Labels) bool {
 		}
 		lsValue, err := strconv.ParseInt(val, 10, 64)
 		if err != nil {
-			klog.V(10).Infof("ParseInt failed for value %+v in label %+v, %+v", val, ls, err)
+			//nolint:logcheck // Extending the API is not worth it for contextual, structured logging of this.
+			klog.V(10).InfoS("ParseInt failed", "value", val, "label", ls, "err", err)
 			return false
 		}
 
 		// There should be only one strValue in r.strValues, and can be converted to an integer.
 		if len(r.strValues) != 1 {
-			klog.V(10).Infof("Invalid values count %+v of requirement %#v, for 'Gt', 'Lt' operators, exactly one value is required", len(r.strValues), r)
+			//nolint:logcheck // Extending the API is not worth it for contextual, structured logging of this.
+			klog.V(10).InfoS("Invalid values count: for 'Gt', 'Lt' operators, exactly one value is required", "count", len(r.strValues), "requirement", r)
 			return false
 		}
 
@@ -283,7 +285,8 @@ func (r *Requirement) Matches(ls Labels) bool {
 		for i := range r.strValues {
 			rValue, err = strconv.ParseInt(r.strValues[i], 10, 64)
 			if err != nil {
-				klog.V(10).Infof("ParseInt failed for value %+v in requirement %#v, for 'Gt', 'Lt' operators, the value must be an integer", r.strValues[i], r)
+				//nolint:logcheck // Extending the API is not worth it for contextual, structured logging of this.
+				klog.V(10).InfoS("ParseInt failed: for 'Gt', 'Lt' operators, the value must be an integer", "value", r.strValues[i], "requirement", r, "err", err)
 				return false
 			}
 		}

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/codec.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/codec.go
@@ -226,6 +226,7 @@ func identifier(e Encoder) Identifier {
 	}
 	identifier, err := json.Marshal(result)
 	if err != nil {
+		//nolint:logcheck // Should not be reached.
 		klog.Fatalf("Failed marshaling identifier for base64Serializer: %v", err)
 	}
 	return Identifier(identifier)
@@ -390,6 +391,7 @@ func (v multiGroupVersioner) Identifier() string {
 	}
 	identifier, err := json.Marshal(result)
 	if err != nil {
+		//nolint:logcheck // Should not be reached.
 		klog.Fatalf("Failed marshaling Identifier for %#v: %v", v, err)
 	}
 	return string(identifier)

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/converter.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/converter.go
@@ -251,9 +251,11 @@ func (c *unstructuredConverter) FromUnstructuredWithValidation(u map[string]inte
 		newObj := reflect.New(t.Elem()).Interface()
 		newErr := fromUnstructuredViaJSON(u, newObj)
 		if (err != nil) != (newErr != nil) {
+			//nolint:logcheck // Should not be reached.
 			klog.Fatalf("FromUnstructured unexpected error for %v: error: %v", u, err)
 		}
 		if err == nil && !c.comparison.DeepEqual(obj, newObj) {
+			//nolint:logcheck // Should not be reached.
 			klog.Fatalf("FromUnstructured mismatch\nobj1: %#v\nobj2: %#v", obj, newObj)
 		}
 	}
@@ -599,9 +601,11 @@ func (c *unstructuredConverter) ToUnstructured(obj interface{}) (map[string]inte
 		newUnstr := map[string]interface{}{}
 		newErr := toUnstructuredViaJSON(obj, &newUnstr)
 		if (err != nil) != (newErr != nil) {
+			//nolint:logcheck // Should not be reached.
 			klog.Fatalf("ToUnstructured unexpected error for %v: error: %v; newErr: %v", obj, err, newErr)
 		}
 		if err == nil && !c.comparison.DeepEqual(u, newUnstr) {
+			//nolint:logcheck // Should not be reached.
 			klog.Fatalf("ToUnstructured mismatch\nobj1: %#v\nobj2: %#v", u, newUnstr)
 		}
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/json.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/json.go
@@ -70,6 +70,7 @@ func identifier(options SerializerOptions) runtime.Identifier {
 	}
 	identifier, err := json.Marshal(result)
 	if err != nil {
+		//nolint:logcheck // Should not be reached.
 		klog.Fatalf("Failed marshaling identifier for json Serializer: %v", err)
 	}
 	return runtime.Identifier(identifier)

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/protobuf/protobuf.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/protobuf/protobuf.go
@@ -199,6 +199,7 @@ func (s *Serializer) encode(obj runtime.Object, w io.Writer, memAlloc runtime.Me
 
 func (s *Serializer) doEncode(obj runtime.Object, w io.Writer, memAlloc runtime.MemoryAllocator) error {
 	if memAlloc == nil {
+		//nolint:logcheck // Should not be reached in normal operations.
 		klog.Error("a mandatory memory allocator wasn't provided, this might have a negative impact on performance, check invocations of EncodeWithAllocator method, falling back on runtime.SimpleAllocator")
 		memAlloc = &runtime.SimpleAllocator{}
 	}
@@ -497,6 +498,7 @@ func doEncodeWithHeader(obj any, w io.Writer, field byte, precomputedSize int, h
 // precomputedObjSize should not include header bytes (field identifier, size).
 func doEncode(obj any, w io.Writer, precomputedObjSize *int, memAlloc runtime.MemoryAllocator) (int, error) {
 	if memAlloc == nil {
+		//nolint:logcheck // Should not be reached in normal operations.
 		klog.Error("a mandatory memory allocator wasn't provided, this might have a negative impact on performance, check invocations of EncodeWithAllocator method, falling back on runtime.SimpleAllocator")
 		memAlloc = &runtime.SimpleAllocator{}
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning/versioning.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning/versioning.go
@@ -116,6 +116,7 @@ func identifier(encodeGV runtime.GroupVersioner, encoder runtime.Encoder) runtim
 	}
 	identifier, err := json.Marshal(result)
 	if err != nil {
+		//nolint:logcheck // Should not be reached.
 		klog.Fatalf("Failed marshaling identifier for codec: %v", err)
 	}
 	identifiersMap.Store(result, runtime.Identifier(identifier))
@@ -222,6 +223,7 @@ func (c *codec) doEncode(obj runtime.Object, w io.Writer, memAlloc runtime.Memor
 				return encoder.EncodeWithAllocator(obj, w, memAlloc)
 			}
 		} else {
+			//nolint:logcheck // Extending the API is not worth it for contextual, structured logging of this.
 			klog.V(6).Infof("a memory allocator was provided but the encoder %s doesn't implement the runtime.EncoderWithAllocator, using regular encoder.Encode method", c.encoder.Identifier())
 		}
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/util/httpstream/wsstream/wsstream.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/httpstream/wsstream/wsstream.go
@@ -83,6 +83,7 @@ func NewDefaultReaderProtocols() map[string]ReaderProtocolConfig {
 type Reader = streamws.Reader
 
 func NewReader(r io.Reader, ping bool, protocols map[string]ReaderProtocolConfig) *Reader {
+	//nolint:logcheck // Intentionally using the non-contextual variant here.
 	return streamws.NewReader(r, ping, protocols)
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/util/intstr/intstr.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/intstr/intstr.go
@@ -59,6 +59,7 @@ const (
 // Deprecated: use FromInt32 instead.
 func FromInt(val int) IntOrString {
 	if val > math.MaxInt32 || val < math.MinInt32 {
+		//nolint:logcheck // Should not be reached.
 		klog.Errorf("value: %d overflows int32\n%s\n", val, debug.Stack())
 	}
 	return IntOrString{Type: Int, IntVal: int32(val)}

--- a/staging/src/k8s.io/apimachinery/pkg/util/managedfields/internal/fieldmanager.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/managedfields/internal/fieldmanager.go
@@ -155,6 +155,7 @@ func (f *FieldManager) UpdateNoErrors(liveObj, newObj runtime.Object, manager st
 		if liveAccessor, aErr := meta.Accessor(liveObj); aErr == nil {
 			if newAccessor, aErr := meta.Accessor(newObj); aErr == nil {
 				atMostEverySecond.Do(func() {
+					//nolint:logcheck // Should not be reached.
 					klog.ErrorS(err, "[SHOULD NOT HAPPEN] failed to update managedFields (restored previous managedFields from live object)", "versionKind",
 						newObj.GetObjectKind().GroupVersionKind(), "namespace", newAccessor.GetNamespace(), "name", newAccessor.GetName())
 				})

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/ip.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/ip.go
@@ -105,6 +105,7 @@ func IsValidIP(fldPath *field.Path, value string) field.ErrorList {
 func GetWarningsForIP(fldPath *field.Path, value string) []string {
 	ip := netutils.ParseIPSloppy(value)
 	if ip == nil {
+		//nolint:logcheck // Should not be reached.
 		klog.ErrorS(nil, "GetWarningsForIP called on value that was not validated with IsValidIPForLegacyField", "field", fldPath, "value", value)
 		return nil
 	}
@@ -211,6 +212,7 @@ func IsValidCIDR(fldPath *field.Path, value string) field.ErrorList {
 func GetWarningsForCIDR(fldPath *field.Path, value string) []string {
 	ip, ipnet, err := netutils.ParseCIDRSloppy(value)
 	if err != nil {
+		//nolint:logcheck // Should not be reached.
 		klog.ErrorS(err, "GetWarningsForCIDR called on value that was not validated with IsValidCIDRForLegacyField", "field", fldPath, "value", value)
 		return nil
 	}

--- a/staging/src/k8s.io/client-go/dynamic/simple.go
+++ b/staging/src/k8s.io/client-go/dynamic/simple.go
@@ -19,6 +19,8 @@ package dynamic
 import (
 	"context"
 	"fmt"
+	"net/http"
+
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -28,7 +30,6 @@ import (
 	"k8s.io/client-go/features"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/apply"
-	"net/http"
 )
 
 type DynamicClient struct {

--- a/staging/src/k8s.io/client-go/tools/events/event_broadcaster.go
+++ b/staging/src/k8s.io/client-go/tools/events/event_broadcaster.go
@@ -391,7 +391,7 @@ func (e *eventBroadcasterImpl) StartStructuredLogging(verbosity klog.Level) func
 // To adjust verbosity, use the logger's V method (i.e. pass `logger.V(3)` instead of `logger`).
 // The returned function can be ignored or used to stop recording, if desired.
 func (e *eventBroadcasterImpl) StartLogging(logger klog.Logger) (func(), error) {
-	return e.StartEventWatcher(
+	return e.startEventWatcher(logger,
 		func(obj runtime.Object) {
 			event, ok := obj.(*eventsv1.Event)
 			if !ok {
@@ -405,12 +405,16 @@ func (e *eventBroadcasterImpl) StartLogging(logger klog.Logger) (func(), error) 
 // StartEventWatcher starts sending events received from this EventBroadcaster to the given event handler function.
 // The return value is used to stop recording
 func (e *eventBroadcasterImpl) StartEventWatcher(eventHandler func(event runtime.Object)) (func(), error) {
+	return e.startEventWatcher(klog.Background(), eventHandler)
+}
+
+func (e *eventBroadcasterImpl) startEventWatcher(logger klog.Logger, eventHandler func(event runtime.Object)) (func(), error) {
 	watcher, err := e.Watch()
 	if err != nil {
 		return nil, err
 	}
 	go func() {
-		defer utilruntime.HandleCrash()
+		defer utilruntime.HandleCrashWithLogger(logger)
 		for {
 			watchEvent, ok := <-watcher.ResultChan()
 			if !ok {
@@ -491,7 +495,7 @@ func NewEventBroadcasterAdapter(client clientset.Interface) EventBroadcasterAdap
 // migration of individual components to the new Event API.
 func NewEventBroadcasterAdapterWithContext(ctx context.Context, client clientset.Interface) EventBroadcasterAdapter {
 	eventClient := &eventBroadcasterAdapterImpl{}
-	if _, err := client.Discovery().ServerResourcesForGroupVersion(eventsv1.SchemeGroupVersion.String()); err == nil {
+	if _, err := client.Discovery().ServerResourcesForGroupVersionWithContext(ctx, eventsv1.SchemeGroupVersion.String()); err == nil {
 		eventClient.eventsv1Client = client.EventsV1()
 		eventClient.eventsv1Broadcaster = NewBroadcaster(&EventSinkImpl{Interface: eventClient.eventsv1Client})
 	}

--- a/staging/src/k8s.io/client-go/tools/pager/pager.go
+++ b/staging/src/k8s.io/client-go/tools/pager/pager.go
@@ -219,7 +219,7 @@ func (p *ListPager) eachListChunkBuffered(ctx context.Context, options metav1.Li
 	chunkC := make(chan runtime.Object, p.PageBufferSize)
 	bgResultC := make(chan error, 1)
 	go func() {
-		defer utilruntime.HandleCrash()
+		defer utilruntime.HandleCrashWithContext(ctx)
 
 		var err error
 		defer func() {

--- a/staging/src/k8s.io/client-go/tools/portforward/fallback_dialer.go
+++ b/staging/src/k8s.io/client-go/tools/portforward/fallback_dialer.go
@@ -82,6 +82,7 @@ func (f *FallbackDialer) Dial(protocols ...string) (httpstream.Connection, strin
 func (f *StreamingFallbackDialer) Dial(protocols ...string) (streamhttp.Connection, string, error) {
 	conn, version, err := f.primary.Dial(protocols...)
 	if err != nil && f.shouldFallback(err) {
+		//nolint:logcheck // This code is only used by kubectl and E2E testing where contextual logging is not that useful.
 		klog.V(4).Infof("fallback to secondary dialer from primary dialer err: %v", err)
 		return f.secondary.Dial(protocols...)
 	}

--- a/staging/src/k8s.io/client-go/tools/portforward/portforward.go
+++ b/staging/src/k8s.io/client-go/tools/portforward/portforward.go
@@ -213,11 +213,20 @@ func NewOnAddressesWithContext(ctx context.Context, dialer httpstream.Dialer, ad
 
 // NewOnAddressesForStreaming creates a new PortForwarder with custom listen
 // addresses for in-tree callers that use k8s.io/streaming/pkg/httpstream types.
+//
+//logcheck:context // NewOnAddressesForStreamingWithContext should be used instead of NewOnAddressesForStreaming in code which supports contextual logging.
 func NewOnAddressesForStreaming(dialer streamhttp.Dialer, addresses []string, ports []string, stopChan <-chan struct{}, readyChan chan struct{}, out, errOut io.Writer) (*PortForwarder, error) {
-	return NewOnAddresses(&compatDialerAdapter{delegate: dialer}, addresses, ports, stopChan, readyChan, out, errOut)
+	return NewOnAddressesForStreamingWithContext(wait.ContextForChannel(stopChan), dialer, addresses, ports, readyChan, out, errOut)
+}
+
+// NewOnAddressesForStreamingWithContext creates a new PortForwarder with custom listen
+// addresses for in-tree callers that use k8s.io/streaming/pkg/httpstream types.
+func NewOnAddressesForStreamingWithContext(ctx context.Context, dialer streamhttp.Dialer, addresses []string, ports []string, readyChan chan struct{}, out, errOut io.Writer) (*PortForwarder, error) {
+	return NewOnAddressesWithContext(ctx, &compatDialerAdapter{logger: klog.FromContext(ctx), delegate: dialer}, addresses, ports, readyChan, out, errOut)
 }
 
 type compatDialerAdapter struct {
+	logger   klog.Logger
 	delegate streamhttp.Dialer
 }
 
@@ -226,10 +235,11 @@ func (d *compatDialerAdapter) Dial(protocols ...string) (httpstream.Connection, 
 	if err != nil {
 		return nil, "", err
 	}
-	return &compatConnectionAdapter{delegate: conn}, protocol, nil
+	return &compatConnectionAdapter{logger: d.logger, delegate: conn}, protocol, nil
 }
 
 type compatConnectionAdapter struct {
+	logger   klog.Logger
 	delegate streamhttp.Connection
 }
 
@@ -267,7 +277,7 @@ func (c *compatConnectionAdapter) RemoveStreams(streams ...httpstream.Stream) {
 			streamingStreams = append(streamingStreams, s)
 			continue
 		}
-		klog.V(5).Infof("dropping unadaptable stream %T in portforward RemoveStreams", stream)
+		c.logger.V(5).Info("dropping unadaptable stream in portforward RemoveStreams", "streamType", fmt.Sprintf("%T", stream))
 	}
 	c.delegate.RemoveStreams(streamingStreams...)
 }

--- a/staging/src/k8s.io/client-go/tools/record/event.go
+++ b/staging/src/k8s.io/client-go/tools/record/event.go
@@ -298,7 +298,7 @@ func (e *eventBroadcasterImpl) recordToSink(sink EventSink, event *v1.Event, eve
 	event = &eventCopy
 	result, err := eventCorrelator.EventCorrelate(event)
 	if err != nil {
-		utilruntime.HandleError(err)
+		utilruntime.HandleErrorWithContext(e.cancelationCtx, err, "Event correlation failed")
 	}
 	if result.Skip {
 		return
@@ -408,7 +408,7 @@ func (e *eventBroadcasterImpl) StartEventWatcher(eventHandler func(*v1.Event)) w
 		return watch.NewEmptyWatch()
 	}
 	go func() {
-		defer utilruntime.HandleCrash()
+		defer utilruntime.HandleCrashWithContext(e.cancelationCtx)
 		for {
 			select {
 			case <-e.cancelationCtx.Done():

--- a/staging/src/k8s.io/client-go/transport/spdy/spdy.go
+++ b/staging/src/k8s.io/client-go/transport/spdy/spdy.go
@@ -220,6 +220,7 @@ func (c *streamingConnectionAdapter) RemoveStreams(streams ...streamhttp.Stream)
 			compatStreams = append(compatStreams, s)
 			continue
 		}
+		//nolint:logcheck // Extending the httpstream.Connection API is not worth it for contextual, structured logging of this.
 		klog.V(5).Infof("dropping unadaptable streaming stream %T in RemoveStreams", stream)
 	}
 	c.delegate.RemoveStreams(compatStreams...)
@@ -301,6 +302,7 @@ func (c *compatConnectionAdapter) RemoveStreams(streams ...httpstream.Stream) {
 			streamingStreams = append(streamingStreams, s)
 			continue
 		}
+		//nolint:logcheck // Extending the API is not worth it for contextual, structured logging of this.
 		klog.V(5).Infof("dropping unadaptable compat stream %T in RemoveStreams", stream)
 	}
 	c.delegate.RemoveStreams(streamingStreams...)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The main purpose is to replace context.TODO with a context provided by the caller. A secondary purpose is to enable contextual logging.

#### Special notes for your reviewer:

See https://github.com/kubernetes/kubernetes/pull/129109 for an introduction of the approach taken most of the time when adding alternative context-aware APIs. See commit messages for additional information.

Most likely this will be merged by creating smaller PRs.

#### Does this PR introduce a user-facing change?
```release-note
client-go: with very few exceptions, context.TODO calls got removed by introducing new APIs where the caller passes in the context. Log calls use the logger provided by the caller when available.
```
