### PR TITLE
KEP-3926: Add tests for storage list error aggregation and surface the abort reason in list errors

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/corrupt_obj_deleter.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/corrupt_obj_deleter.go
@@ -63,11 +63,11 @@ func WithCorruptObjErrorHandlingTransformer(transformer value.Transformer) value
 // corrupt object error(s) that the list operation encounters while
 // retrieving objects from the storage.
 // maxCount: it is the maximum number of error that will be aggregated
-func corruptObjErrAggregatorFactory(maxCount int) func() ListErrorAggregator {
+func corruptObjErrAggregatorFactory(maxCount int) func() storage.ListErrorAggregator {
 	if maxCount <= 0 {
 		return defaultListErrorAggregatorFactory
 	}
-	return func() ListErrorAggregator {
+	return func() storage.ListErrorAggregator {
 		return &corruptObjErrAggregator{maxCount: maxCount}
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/corrupt_obj_deleter.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/corrupt_obj_deleter.go
@@ -234,6 +234,9 @@ func (e *aggregatedStorageError) Error() string {
 		fmt.Fprintf(&b, "\t%s\n", err.Error())
 	}
 	b.WriteString("}")
+	if e.abortErr != nil {
+		fmt.Fprintf(&b, ", aborted: %v", e.abortErr)
+	}
 	return b.String()
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/corrupt_obj_deleter.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/corrupt_obj_deleter.go
@@ -63,11 +63,11 @@ func WithCorruptObjErrorHandlingTransformer(transformer value.Transformer) value
 // corrupt object error(s) that the list operation encounters while
 // retrieving objects from the storage.
 // maxCount: it is the maximum number of error that will be aggregated
-func corruptObjErrAggregatorFactory(maxCount int) func() storage.ListItemErrors {
+func corruptObjErrAggregatorFactory(maxCount int) func() listItemErrors {
 	if maxCount <= 0 {
 		return defaultListErrorAggregatorFactory
 	}
-	return func() storage.ListItemErrors {
+	return func() listItemErrors {
 		return &corruptObjErrAggregator{maxCount: maxCount}
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/corrupt_obj_deleter.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/corrupt_obj_deleter.go
@@ -59,6 +59,10 @@ func WithCorruptObjErrorHandlingTransformer(transformer value.Transformer) value
 	return &corruptObjErrorInterpretingTransformer{Transformer: transformer}
 }
 
+// maxCorruptObjErrsToAggregate caps the number of corrupt object errors
+// aggregated during a LIST operation.
+const maxCorruptObjErrsToAggregate = 100
+
 // corruptObjErrAggregatorFactory returns an error aggregator that aggregates
 // corrupt object error(s) that the list operation encounters while
 // retrieving objects from the storage.

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/corrupt_obj_deleter.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/corrupt_obj_deleter.go
@@ -82,7 +82,7 @@ type corruptObjErrAggregator struct {
 }
 
 func (a *corruptObjErrAggregator) Append(key string, err error) bool {
-	if a.abortErr != nil || len(a.errs) >= a.maxCount {
+	if a.abortErr != nil {
 		return true
 	}
 
@@ -90,8 +90,8 @@ func (a *corruptObjErrAggregator) Append(key string, err error) bool {
 	if errors.As(err, &corruptObjErr) {
 		a.errs = append(a.errs, storage.NewCorruptObjError(key, corruptObjErr))
 		if len(a.errs) >= a.maxCount {
-			// add a sentinel error to indicate there are more
-			a.errs = append(a.errs, errTooMany)
+			// treat exceeding the limit as an abort condition
+			a.abortErr = errTooMany
 			return true
 		}
 		return false
@@ -108,7 +108,7 @@ func (a *corruptObjErrAggregator) Aggregate() error {
 		return a.abortErr
 	case len(a.errs) > 0:
 		err := utilerrors.NewAggregate(a.errs)
-		return &aggregatedStorageError{errs: err, resourcePrefix: "list"}
+		return &aggregatedStorageError{errs: err, abortErr: a.abortErr, resourcePrefix: "list"}
 	default:
 		return nil
 	}
@@ -221,6 +221,9 @@ func (e *corruptObjectError) Error() string {
 type aggregatedStorageError struct {
 	resourcePrefix string
 	errs           utilerrors.Aggregate
+	// abortErr is the reason the aggregation stopped, if any.
+	// It is nil when all items were processed without hitting a limit or unexpected error.
+	abortErr error
 }
 
 func (e *aggregatedStorageError) Error() string {
@@ -247,14 +250,19 @@ func (e *aggregatedStorageError) NewAPIStatusError(qualifiedResource schema.Grou
 				// TODO: do we need to expose the internal error message here?
 				Message: err.Error(),
 			})
-			continue
 		}
-		if errors.Is(err, errTooMany) {
-			causes = append(causes, metav1.StatusCause{
-				Type:    metav1.CauseTypeTooMany,
-				Message: errTooMany.Error(),
-			})
-		}
+	}
+	switch {
+	case errors.Is(e.abortErr, errTooMany):
+		causes = append(causes, metav1.StatusCause{
+			Type:    metav1.CauseTypeTooMany,
+			Message: errTooMany.Error(),
+		})
+	case e.abortErr != nil:
+		causes = append(causes, metav1.StatusCause{
+			Type:    metav1.CauseTypeUnexpectedServerResponse,
+			Message: e.abortErr.Error(),
+		})
 	}
 
 	return &apierrors.StatusError{

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/corrupt_obj_deleter_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/corrupt_obj_deleter_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package etcd3
+
+import (
+	"errors"
+	"testing"
+
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+)
+
+func TestAggregatedStorageErrorMessage(t *testing.T) {
+	tests := []struct {
+		name     string
+		abortErr error
+		want     string
+	}{
+		{
+			name: "aggregation completed without an abort",
+			want: "unable to transform or decode 2 objects: {\n\tfoo is corrupt\n\tbar is corrupt\n}",
+		},
+		{
+			name:     "aggregation aborted after reaching the limit",
+			abortErr: errTooMany,
+			want:     "unable to transform or decode 2 objects: {\n\tfoo is corrupt\n\tbar is corrupt\n}, aborted: too many errors, the list is truncated",
+		},
+		{
+			name:     "aggregation aborted due to an unexpected error",
+			abortErr: errors.New("etcd is down"),
+			want:     "unable to transform or decode 2 objects: {\n\tfoo is corrupt\n\tbar is corrupt\n}, aborted: etcd is down",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := &aggregatedStorageError{
+				resourcePrefix: "list",
+				errs:           utilerrors.NewAggregate([]error{errors.New("foo is corrupt"), errors.New("bar is corrupt")}),
+				abortErr:       test.abortErr,
+			}
+			if want, got := test.want, err.Error(); want != got {
+				t.Errorf("unexpected error message, want:\n%s\ngot:\n%s", want, got)
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
@@ -87,7 +87,7 @@ type store struct {
 	watcher            *watcher
 	leaseManager       *leaseManager
 	decoder            Decoder
-	listErrAggrFactory func() ListErrorAggregator
+	listErrAggrFactory func() storage.ListErrorAggregator
 
 	resourcePrefix string
 	newListFunc    func() runtime.Object
@@ -113,25 +113,10 @@ type objState struct {
 	stale bool
 }
 
-// ListErrorAggregator aggregates the error(s) that the LIST operation
-// encounters while retrieving object(s) from the storage
-type ListErrorAggregator interface {
-	// Aggregate aggregates the given error from list operation
-	// key: it identifies the given object in the storage.
-	// err: it represents the error the list operation encountered while
-	// retrieving the given object from the storage.
-	// done: true if the aggregation is done and the list operation should
-	// abort, otherwise the list operation will continue
-	Aggregate(key string, err error) bool
-
-	// Err returns the aggregated error
-	Err() error
-}
-
 // defaultListErrorAggregatorFactory returns the default list error
 // aggregator that maintains backward compatibility, which is abort
 // the list operation as soon as it encounters the first error
-func defaultListErrorAggregatorFactory() ListErrorAggregator { return &abortOnFirstError{} }
+func defaultListErrorAggregatorFactory() storage.ListErrorAggregator { return &abortOnFirstError{} }
 
 // LIST aborts on the first error it encounters (backward compatible)
 type abortOnFirstError struct {

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
@@ -87,7 +87,7 @@ type store struct {
 	watcher            *watcher
 	leaseManager       *leaseManager
 	decoder            Decoder
-	listErrAggrFactory func() storage.ListErrorAggregator
+	listErrAggrFactory func() storage.ListItemErrors
 
 	resourcePrefix string
 	newListFunc    func() runtime.Object
@@ -116,18 +116,18 @@ type objState struct {
 // defaultListErrorAggregatorFactory returns the default list error
 // aggregator that maintains backward compatibility, which is abort
 // the list operation as soon as it encounters the first error
-func defaultListErrorAggregatorFactory() storage.ListErrorAggregator { return &abortOnFirstError{} }
+func defaultListErrorAggregatorFactory() storage.ListItemErrors { return &abortOnFirstError{} }
 
 // LIST aborts on the first error it encounters (backward compatible)
 type abortOnFirstError struct {
 	err error
 }
 
-func (a *abortOnFirstError) Aggregate(key string, err error) bool {
+func (a *abortOnFirstError) Append(key string, err error) bool {
 	a.err = err
 	return true
 }
-func (a *abortOnFirstError) Err() error { return a.err }
+func (a *abortOnFirstError) Aggregate() error { return a.err }
 
 // New returns an etcd3 implementation of storage.Interface.
 func New(c *kubernetes.Client, compactor Compactor, codec runtime.Codec, newFunc, newListFunc func() runtime.Object, prefix, resourcePrefix string, groupResource schema.GroupResource, transformer value.Transformer, leaseManagerConfig LeaseManagerConfig, decoder Decoder, versioner storage.Versioner) (*store, error) {
@@ -957,8 +957,8 @@ func (s *store) streamChunks(ctx context.Context, keyPrefix string, withRev int6
 	}, true
 }
 
-func (s *store) finalizeList(listObj runtime.Object, pred storage.SelectionPredicate, rev uint64, continueValue string, remainingItemCount *int64, aggregator ListErrorAggregator, v reflect.Value) error {
-	if err := aggregator.Err(); err != nil {
+func (s *store) finalizeList(listObj runtime.Object, pred storage.SelectionPredicate, rev uint64, continueValue string, remainingItemCount *int64, aggregator storage.ListItemErrors, v reflect.Value) error {
+	if err := aggregator.Aggregate(); err != nil {
 		return err
 	}
 	if v.IsNil() {
@@ -974,11 +974,11 @@ func (s *store) finalizeList(listObj runtime.Object, pred storage.SelectionPredi
 	return nil
 }
 
-func (s *store) processListItem(ctx context.Context, kv *mvccpb.KeyValue, pred storage.SelectionPredicate, newItemFunc func() runtime.Object, aggregator ListErrorAggregator, v reflect.Value) (bool, error) {
+func (s *store) processListItem(ctx context.Context, kv *mvccpb.KeyValue, pred storage.SelectionPredicate, newItemFunc func() runtime.Object, aggregator storage.ListItemErrors, v reflect.Value) (bool, error) {
 	data, _, err := s.transformer.TransformFromStorage(ctx, kv.Value, authenticatedDataString(kv.Key))
 	if err != nil {
-		if done := aggregator.Aggregate(string(kv.Key), storage.NewInternalError(fmt.Errorf("unable to transform key %q: %w", kv.Key, err))); done {
-			return false, aggregator.Err()
+		if done := aggregator.Append(string(kv.Key), storage.NewInternalError(fmt.Errorf("unable to transform key %q: %w", kv.Key, err))); done {
+			return false, aggregator.Aggregate()
 		}
 		return false, nil
 	}
@@ -994,8 +994,8 @@ func (s *store) processListItem(ctx context.Context, kv *mvccpb.KeyValue, pred s
 	obj, err := s.decoder.DecodeListItem(ctx, data, uint64(kv.ModRevision), newItemFunc)
 	if err != nil {
 		recordDecodeError(s.groupResource, string(kv.Key))
-		if done := aggregator.Aggregate(string(kv.Key), err); done {
-			return false, aggregator.Err()
+		if done := aggregator.Append(string(kv.Key), err); done {
+			return false, aggregator.Aggregate()
 		}
 		return false, nil
 	}
@@ -1009,7 +1009,7 @@ func (s *store) processListItem(ctx context.Context, kv *mvccpb.KeyValue, pred s
 }
 
 // appendChunk appends the kvs matching pred to v.
-func (s *store) appendChunk(ctx context.Context, kvs []*mvccpb.KeyValue, pred storage.SelectionPredicate, newItemFunc func() runtime.Object, aggregator ListErrorAggregator, v reflect.Value, paging bool) (lastKey []byte, evaluated int, limitReached bool, err error) {
+func (s *store) appendChunk(ctx context.Context, kvs []*mvccpb.KeyValue, pred storage.SelectionPredicate, newItemFunc func() runtime.Object, aggregator storage.ListItemErrors, v reflect.Value, paging bool) (lastKey []byte, evaluated int, limitReached bool, err error) {
 	// avoid small allocations for the result slice, since this can be called in many
 	// different contexts and we don't know how significantly the result will be filtered
 	if pred.Empty() {

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
@@ -87,7 +87,7 @@ type store struct {
 	watcher            *watcher
 	leaseManager       *leaseManager
 	decoder            Decoder
-	listErrAggrFactory func() storage.ListItemErrors
+	listErrAggrFactory func() listItemErrors
 
 	resourcePrefix string
 	newListFunc    func() runtime.Object
@@ -113,10 +113,24 @@ type objState struct {
 	stale bool
 }
 
+// listItemErrors stores a slice of item storage errors during LIST operations.
+// They are iteratively added, and eventually returned as an aggregated error. On
+// each Append, it signals whether it considers itself full or the error to be fatal.
+// In either case, the caller is supposed to not keep collecting, but return the
+// collection.
+type listItemErrors interface {
+	// Append adds an item storage error for the given storage key during a LIST operation.
+	// The caller is expected to stop appending as soon as true is returned.
+	Append(key string, err error) bool
+
+	// Aggregate returns the aggregated error
+	Aggregate() error
+}
+
 // defaultListErrorAggregatorFactory returns the default list error
 // aggregator that maintains backward compatibility, which is abort
 // the list operation as soon as it encounters the first error
-func defaultListErrorAggregatorFactory() storage.ListItemErrors { return &abortOnFirstError{} }
+func defaultListErrorAggregatorFactory() listItemErrors { return &abortOnFirstError{} }
 
 // LIST aborts on the first error it encounters (backward compatible)
 type abortOnFirstError struct {
@@ -957,7 +971,7 @@ func (s *store) streamChunks(ctx context.Context, keyPrefix string, withRev int6
 	}, true
 }
 
-func (s *store) finalizeList(listObj runtime.Object, pred storage.SelectionPredicate, rev uint64, continueValue string, remainingItemCount *int64, aggregator storage.ListItemErrors, v reflect.Value) error {
+func (s *store) finalizeList(listObj runtime.Object, pred storage.SelectionPredicate, rev uint64, continueValue string, remainingItemCount *int64, aggregator listItemErrors, v reflect.Value) error {
 	if err := aggregator.Aggregate(); err != nil {
 		return err
 	}
@@ -974,7 +988,7 @@ func (s *store) finalizeList(listObj runtime.Object, pred storage.SelectionPredi
 	return nil
 }
 
-func (s *store) processListItem(ctx context.Context, kv *mvccpb.KeyValue, pred storage.SelectionPredicate, newItemFunc func() runtime.Object, aggregator storage.ListItemErrors, v reflect.Value) (bool, error) {
+func (s *store) processListItem(ctx context.Context, kv *mvccpb.KeyValue, pred storage.SelectionPredicate, newItemFunc func() runtime.Object, aggregator listItemErrors, v reflect.Value) (bool, error) {
 	data, _, err := s.transformer.TransformFromStorage(ctx, kv.Value, authenticatedDataString(kv.Key))
 	if err != nil {
 		if done := aggregator.Append(string(kv.Key), storage.NewInternalError(fmt.Errorf("unable to transform key %q: %w", kv.Key, err))); done {
@@ -1009,7 +1023,7 @@ func (s *store) processListItem(ctx context.Context, kv *mvccpb.KeyValue, pred s
 }
 
 // appendChunk appends the kvs matching pred to v.
-func (s *store) appendChunk(ctx context.Context, kvs []*mvccpb.KeyValue, pred storage.SelectionPredicate, newItemFunc func() runtime.Object, aggregator storage.ListItemErrors, v reflect.Value, paging bool) (lastKey []byte, evaluated int, limitReached bool, err error) {
+func (s *store) appendChunk(ctx context.Context, kvs []*mvccpb.KeyValue, pred storage.SelectionPredicate, newItemFunc func() runtime.Object, aggregator listItemErrors, v reflect.Value, paging bool) (lastKey []byte, evaluated int, limitReached bool, err error) {
 	// avoid small allocations for the result slice, since this can be called in many
 	// different contexts and we don't know how significantly the result will be filtered
 	if pred.Empty() {

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
@@ -165,7 +165,7 @@ func New(c *kubernetes.Client, compactor Compactor, codec runtime.Codec, newFunc
 
 	listErrAggrFactory := defaultListErrorAggregatorFactory
 	if utilfeature.DefaultFeatureGate.Enabled(features.AllowUnsafeMalformedObjectDeletion) {
-		listErrAggrFactory = corruptObjErrAggregatorFactory(100)
+		listErrAggrFactory = corruptObjErrAggregatorFactory(maxCorruptObjErrsToAggregate)
 	}
 
 	w := &watcher{

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
@@ -265,19 +265,15 @@ func TestKeySchema(t *testing.T) {
 
 func TestGetListWithErrorAggregation(t *testing.T) {
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.AllowUnsafeMalformedObjectDeletion, true)
-	storagetesting.RunTestGetListWithErrorAggregation(t, func(t *testing.T) (context.Context, storagetesting.InterfaceWithCorruptTransformer) {
-		ctx, s, _ := testSetup(t)
-		store := NewStoreWithUnsafeCorruptObjectDeletion(s, s.groupResource)
-		return ctx, &storeWithCorruptedTransformer{Interface: store, store: s}
-	})
+	ctx, s, _ := testSetup(t)
+	store := NewStoreWithUnsafeCorruptObjectDeletion(s, s.groupResource)
+	storagetesting.RunTestGetListWithErrorAggregation(ctx, t, &storeWithCorruptedTransformer{Interface: store, store: s})
 }
 
-func TestGetListBackwardCompatibility(t *testing.T) {
+func TestGetListWithoutErrorAggregation(t *testing.T) {
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.AllowUnsafeMalformedObjectDeletion, false)
-	storagetesting.RunTestGetListBackwardCompatibility(t, func(t *testing.T) (context.Context, storagetesting.InterfaceWithCorruptTransformer) {
-		ctx, s, _ := testSetup(t)
-		return ctx, &storeWithCorruptedTransformer{Interface: s, store: s}
-	})
+	ctx, s, _ := testSetup(t)
+	storagetesting.RunTestGetListWithoutErrorAggregation(ctx, t, &storeWithCorruptedTransformer{Interface: s, store: s})
 }
 
 type storeWithPrefixTransformer struct {

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
@@ -301,8 +301,9 @@ type storeWithTransformerOverride struct {
 
 func (s *storeWithTransformerOverride) UpdateTransformer(modifier storagetesting.TransformerModifier) func() {
 	orig := s.store.transformer
-	s.store.transformer = modifier(orig)
-	s.store.watcher.transformer = modifier(orig)
+	next := modifier(orig)
+	s.store.transformer = next
+	s.store.watcher.transformer = next
 	return func() {
 		s.store.transformer = orig
 		s.store.watcher.transformer = orig

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
@@ -264,14 +264,19 @@ func TestKeySchema(t *testing.T) {
 }
 
 func TestGetListWithErrorAggregation(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.AllowUnsafeMalformedObjectDeletion, true)
 	storagetesting.RunTestGetListWithErrorAggregation(t, func(t *testing.T) (context.Context, storagetesting.InterfaceWithCorruptTransformer) {
 		ctx, s, _ := testSetup(t)
-		var store storage.Interface = s
-		if utilfeature.DefaultFeatureGate.Enabled(features.AllowUnsafeMalformedObjectDeletion) {
-			store = NewStoreWithUnsafeCorruptObjectDeletion(store, s.groupResource)
-		}
-
+		store := NewStoreWithUnsafeCorruptObjectDeletion(s, s.groupResource)
 		return ctx, &storeWithCorruptedTransformer{Interface: store, store: s}
+	})
+}
+
+func TestGetListBackwardCompatibility(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.AllowUnsafeMalformedObjectDeletion, false)
+	storagetesting.RunTestGetListBackwardCompatibility(t, func(t *testing.T) (context.Context, storagetesting.InterfaceWithCorruptTransformer) {
+		ctx, s, _ := testSetup(t)
+		return ctx, &storeWithCorruptedTransformer{Interface: s, store: s}
 	})
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
@@ -267,13 +267,15 @@ func TestGetListWithErrorAggregation(t *testing.T) {
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.AllowUnsafeMalformedObjectDeletion, true)
 	ctx, s, _ := testSetup(t)
 	store := NewStoreWithUnsafeCorruptObjectDeletion(s, s.groupResource)
-	storagetesting.RunTestGetListWithErrorAggregation(ctx, t, &storeWithCorruptedTransformer{Interface: store, store: s})
+	corruptErr := &corruptObjectError{err: fmt.Errorf("bits flipped"), errType: untransformable}
+	storagetesting.RunTestGetListWithErrorAggregation(ctx, t, &storeWithTransformerOverride{Interface: store, store: s}, corruptErr)
 }
 
 func TestGetListWithoutErrorAggregation(t *testing.T) {
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.AllowUnsafeMalformedObjectDeletion, false)
 	ctx, s, _ := testSetup(t)
-	storagetesting.RunTestGetListWithoutErrorAggregation(ctx, t, &storeWithCorruptedTransformer{Interface: s, store: s})
+	corruptErr := &corruptObjectError{err: fmt.Errorf("bits flipped"), errType: untransformable}
+	storagetesting.RunTestGetListWithoutErrorAggregation(ctx, t, &storeWithTransformerOverride{Interface: s, store: s}, corruptErr)
 }
 
 type storeWithPrefixTransformer struct {
@@ -291,37 +293,19 @@ func (s *storeWithPrefixTransformer) UpdatePrefixTransformer(modifier storagetes
 	}
 }
 
-type corruptedTransformer struct {
-	value.Transformer
-}
-
-func (f *corruptedTransformer) TransformFromStorage(ctx context.Context, data []byte, dataCtx value.Context) (out []byte, stale bool, err error) {
-	out, stale, err = f.Transformer.TransformFromStorage(ctx, data, dataCtx)
-
-	switch {
-	case err != nil: // unexpected error
-		return out, stale, err
-	case strings.Contains(string(data), storagetesting.CorruptErrKey):
-		return out, stale, &corruptObjectError{err: fmt.Errorf("bits flipped"), errType: untransformable}
-	case strings.Contains(string(data), storagetesting.UnexpectedErrKey):
-		return out, stale, fmt.Errorf("bits flipped")
-	}
-	return out, stale, err
-}
-
-type storeWithCorruptedTransformer struct {
+type storeWithTransformerOverride struct {
 	storage.Interface
 	// we need the original *store instance to mutate the transformer
 	store *store
 }
 
-func (s *storeWithCorruptedTransformer) CorruptTransformer() func() {
-	ct := &corruptedTransformer{Transformer: s.store.transformer}
-	s.store.transformer = ct
-	s.store.watcher.transformer = ct
+func (s *storeWithTransformerOverride) UpdateTransformer(modifier storagetesting.TransformerModifier) func() {
+	orig := s.store.transformer
+	s.store.transformer = modifier(orig)
+	s.store.watcher.transformer = modifier(orig)
 	return func() {
-		s.store.transformer = ct.Transformer
-		s.store.watcher.transformer = ct.Transformer
+		s.store.transformer = orig
+		s.store.watcher.transformer = orig
 	}
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
@@ -263,6 +263,23 @@ func TestKeySchema(t *testing.T) {
 	storagetesting.RunTestKeySchema(ctx, t, store)
 }
 
+func TestGetListWithErrorAggregation(t *testing.T) {
+	storagetesting.RunTestGetListWithErrorAggregation(t, func(t *testing.T) (context.Context, *storagetesting.ErrorAggregatorFactory, storagetesting.InterfaceWithCorruptTransformer) {
+		ctx, s, _ := testSetup(t)
+		var store storage.Interface = s
+		if utilfeature.DefaultFeatureGate.Enabled(features.AllowUnsafeMalformedObjectDeletion) {
+			store = NewStoreWithUnsafeCorruptObjectDeletion(store, s.groupResource)
+		}
+
+		// wrap the original error aggregator the store is using so the test can
+		// keep track of the values GetList passes to the original aggregator.
+		factory := storagetesting.WrapListErrorAggregatorFactory(s.listErrAggrFactory)
+		s.listErrAggrFactory = factory.WithRecorder()
+
+		return ctx, factory, &storeWithCorruptedTransformer{Interface: store, store: s}
+	})
+}
+
 type storeWithPrefixTransformer struct {
 	*store
 }
@@ -283,20 +300,32 @@ type corruptedTransformer struct {
 }
 
 func (f *corruptedTransformer) TransformFromStorage(ctx context.Context, data []byte, dataCtx value.Context) (out []byte, stale bool, err error) {
-	return nil, true, &corruptObjectError{err: fmt.Errorf("bits flipped"), errType: untransformable}
+	out, stale, err = f.Transformer.TransformFromStorage(ctx, data, dataCtx)
+
+	switch {
+	case err != nil: // unexpected error
+		return out, stale, err
+	case strings.Contains(string(data), storagetesting.CorruptErrKey):
+		return out, stale, &corruptObjectError{err: fmt.Errorf("bits flipped"), errType: untransformable}
+	case strings.Contains(string(data), storagetesting.UnexpectedErrKey):
+		return out, stale, fmt.Errorf("bits flipped")
+	}
+	return out, stale, err
 }
 
 type storeWithCorruptedTransformer struct {
-	*store
+	storage.Interface
+	// we need the original *store instance to mutate the transformer
+	store *store
 }
 
 func (s *storeWithCorruptedTransformer) CorruptTransformer() func() {
-	ct := &corruptedTransformer{Transformer: s.transformer}
-	s.transformer = ct
-	s.watcher.transformer = ct
+	ct := &corruptedTransformer{Transformer: s.store.transformer}
+	s.store.transformer = ct
+	s.store.watcher.transformer = ct
 	return func() {
-		s.transformer = ct.Transformer
-		s.watcher.transformer = ct.Transformer
+		s.store.transformer = ct.Transformer
+		s.store.watcher.transformer = ct.Transformer
 	}
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
@@ -264,19 +264,14 @@ func TestKeySchema(t *testing.T) {
 }
 
 func TestGetListWithErrorAggregation(t *testing.T) {
-	storagetesting.RunTestGetListWithErrorAggregation(t, func(t *testing.T) (context.Context, *storagetesting.ErrorAggregatorFactory, storagetesting.InterfaceWithCorruptTransformer) {
+	storagetesting.RunTestGetListWithErrorAggregation(t, func(t *testing.T) (context.Context, storagetesting.InterfaceWithCorruptTransformer) {
 		ctx, s, _ := testSetup(t)
 		var store storage.Interface = s
 		if utilfeature.DefaultFeatureGate.Enabled(features.AllowUnsafeMalformedObjectDeletion) {
 			store = NewStoreWithUnsafeCorruptObjectDeletion(store, s.groupResource)
 		}
 
-		// wrap the original error aggregator the store is using so the test can
-		// keep track of the values GetList passes to the original aggregator.
-		factory := storagetesting.WrapListErrorAggregatorFactory(s.listErrAggrFactory)
-		s.listErrAggrFactory = factory.WithRecorder()
-
-		return ctx, factory, &storeWithCorruptedTransformer{Interface: store, store: s}
+		return ctx, &storeWithCorruptedTransformer{Interface: store, store: s}
 	})
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher_test.go
@@ -112,7 +112,7 @@ func TestWatch(t *testing.T) {
 	t.Run("WatchWithUnsafeDelete", func(t *testing.T) {
 		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.AllowUnsafeMalformedObjectDeletion, true)
 		ctx, store, _ := testSetup(t)
-		storagetesting.RunTestWatchWithUnsafeDelete(ctx, t, &storeWithCorruptedTransformer{store})
+		storagetesting.RunTestWatchWithUnsafeDelete(ctx, t, &storeWithCorruptedTransformer{Interface: store, store: store})
 	})
 	t.Run("WatchDispatchBookmarkEvents", func(t *testing.T) {
 		clusterConfig := testserver.NewTestConfig(t)

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher_test.go
@@ -112,7 +112,8 @@ func TestWatch(t *testing.T) {
 	t.Run("WatchWithUnsafeDelete", func(t *testing.T) {
 		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.AllowUnsafeMalformedObjectDeletion, true)
 		ctx, store, _ := testSetup(t)
-		storagetesting.RunTestWatchWithUnsafeDelete(ctx, t, &storeWithCorruptedTransformer{Interface: store, store: store})
+		corruptErr := &corruptObjectError{err: fmt.Errorf("bits flipped"), errType: untransformable}
+		storagetesting.RunTestWatchWithUnsafeDelete(ctx, t, &storeWithTransformerOverride{Interface: store, store: store}, corruptErr)
 	})
 	t.Run("WatchDispatchBookmarkEvents", func(t *testing.T) {
 		clusterConfig := testserver.NewTestConfig(t)

--- a/staging/src/k8s.io/apiserver/pkg/storage/interfaces.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/interfaces.go
@@ -425,3 +425,18 @@ func PrepareKey(resourcePrefix, key string, recursive bool) (string, error) {
 	}
 	return key, nil
 }
+
+// ListErrorAggregator aggregates the error(s) that the LIST operation
+// encounters while retrieving object(s) from the storage
+type ListErrorAggregator interface {
+	// Aggregate aggregates the given error from list operation
+	// key: it identifies the given object in the storage.
+	// err: it represents the error the list operation encountered while
+	// retrieving the given object from the storage.
+	// done: true if the aggregation is done and the list operation should
+	// abort, otherwise the list operation will continue
+	Aggregate(key string, err error) bool
+
+	// Err returns the aggregated error
+	Err() error
+}

--- a/staging/src/k8s.io/apiserver/pkg/storage/interfaces.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/interfaces.go
@@ -426,17 +426,16 @@ func PrepareKey(resourcePrefix, key string, recursive bool) (string, error) {
 	return key, nil
 }
 
-// ListErrorAggregator aggregates the error(s) that the LIST operation
-// encounters while retrieving object(s) from the storage
-type ListErrorAggregator interface {
-	// Aggregate aggregates the given error from list operation
-	// key: it identifies the given object in the storage.
-	// err: it represents the error the list operation encountered while
-	// retrieving the given object from the storage.
-	// done: true if the aggregation is done and the list operation should
-	// abort, otherwise the list operation will continue
-	Aggregate(key string, err error) bool
+// ListItemErrors stores a slice of item storage errors during LIST operations.
+// They are iteratively added, and eventually returned as an aggregated error. On
+// each Append, it signals whether it considers itself full or the error to be fatal.
+// In either case, the caller is supposed to not keep collecting, but return the
+// collection.
+type ListItemErrors interface {
+	// Append adds an item storage error for the given storage key during a LIST operation.
+	// The caller is expected to stop appending as soon as true is returned.
+	Append(key string, err error) bool
 
-	// Err returns the aggregated error
-	Err() error
+	// Aggregate returns the aggregated error
+	Aggregate() error
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/interfaces.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/interfaces.go
@@ -425,17 +425,3 @@ func PrepareKey(resourcePrefix, key string, recursive bool) (string, error) {
 	}
 	return key, nil
 }
-
-// ListItemErrors stores a slice of item storage errors during LIST operations.
-// They are iteratively added, and eventually returned as an aggregated error. On
-// each Append, it signals whether it considers itself full or the error to be fatal.
-// In either case, the caller is supposed to not keep collecting, but return the
-// collection.
-type ListItemErrors interface {
-	// Append adds an item storage error for the given storage key during a LIST operation.
-	// The caller is expected to stop appending as soon as true is returned.
-	Append(key string, err error) bool
-
-	// Aggregate returns the aggregated error
-	Aggregate() error
-}

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/store_tests.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/store_tests.go
@@ -3112,7 +3112,9 @@ func RunTestGetListWithErrorAggregation(ctx context.Context, t *testing.T, store
 					Name:      objNameFn(j),
 					Namespace: ns,
 				}}
-				_, _ = testPropagateStore(ctx, t, store, obj)
+				if err := store.Create(ctx, computePodKey(obj), obj, &example.Pod{}, 0); err != nil {
+					t.Fatalf("Create failed: %v", err)
+				}
 			}
 
 			// step 2: list the N objects, we expect no error
@@ -3166,7 +3168,9 @@ func RunTestGetListWithoutErrorAggregation(ctx context.Context, t *testing.T, st
 			Name:      objNameFn(i),
 			Namespace: "ns",
 		}}
-		testPropagateStore(ctx, t, store, obj)
+		if err := store.Create(ctx, computePodKey(obj), obj, &example.Pod{}, 0); err != nil {
+			t.Fatalf("Create failed: %v", err)
+		}
 	}
 
 	// Step 2: list all objects, expect no error before corruption

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/store_tests.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/store_tests.go
@@ -45,7 +45,6 @@ import (
 	"k8s.io/apiserver/pkg/storage"
 	"k8s.io/apiserver/pkg/storage/value"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/utils/ptr"
 )
 
@@ -2826,8 +2825,7 @@ func RunTestGetListWithErrorAggregation(t *testing.T, newStoreFn func(*testing.T
 	}
 
 	tests := []struct {
-		name           string
-		featureEnabled bool
+		name string
 		// number of Pod objects to be created when the test starts, the
 		// objects are named as "foo-{i}" where 1 <= i <= n
 		n int
@@ -2841,51 +2839,7 @@ func RunTestGetListWithErrorAggregation(t *testing.T, newStoreFn func(*testing.T
 		verifier func(t *testing.T, list *example.PodList, err error)
 	}{
 		{
-			name: "feature disabled, should maintain backward compatibility",
-			// when the feature is disabled, we should maintain
-			// backward compatibility, which is to abort on the first error
-			featureEnabled: false,
-			// we initially create n=7 objects with ids {1, 2, 3 ... 7}, they are put in the following disjoint sets:
-			// - good: {1, 3, 5, 7}, these objects will never become corrupt
-			// - corrupt: {2, 4, 6}, these objects are marked to become corrupt
-			n: 7,
-			corrupter: func(i int) string {
-				if i%2 == 0 {
-					return CorruptErrKey
-				}
-				return ""
-			},
-			// the following sequence of events are expected to occur in order while retrieving the n objects:
-			//
-			// -- |- 1: no error, successfully decoded
-			//    |- 2: yields an expected corruptObjErr, GetList aborts immediately
-			//
-			//  a) GetList encounters corruptObjErr while retrieving {2} and immediately aborts
-			//  b) GetList successfully decodes {1}
-			verifier: func(t *testing.T, list *example.PodList, err error) {
-				// a) the error returned from GetList should be a bare
-				// storage.InternalError, not wrapped — proves no aggregation
-				// nolint:errorlint // the aggregator should return the error as is
-				intErr, ok := err.(storage.InternalError)
-				if !ok {
-					t.Fatalf("expected the error to be %T, but got: %#v", storage.InternalError{}, err)
-				}
-				if want, got := fmt.Sprintf(`unable to transform key "%s"`, keyFn(2)), intErr.Error(); !strings.HasPrefix(got, want) {
-					t.Errorf("expected the error to start with %q, but got: %v", want, got)
-				}
-
-				// b) GetList successfully decodes {1}
-				if want, got := 1, len(list.Items); want != got {
-					t.Errorf("expected the list to have %d item(s), but got: %d", want, got)
-				}
-				if want, got := objNameFn(1), list.Items[0].Name; want != got {
-					t.Errorf("expected an object name of %q, but got: %q", want, got)
-				}
-			},
-		},
-		{
-			name:           "feature enabled, first error is an unexpected error, no aggregation expected",
-			featureEnabled: true,
+			name: "first error is an unexpected error, no aggregation expected",
 			// we initially create n=7 objects with ids {1, 2, 3 ... 7}, they are put in the following disjoint sets:
 			// - good: {1, 3, 5, 7}, these objects will never become corrupt
 			// - unexpected: {2}, this object is marked to yield an unexpected error (not corruptObjErr)
@@ -2927,8 +2881,8 @@ func RunTestGetListWithErrorAggregation(t *testing.T, newStoreFn func(*testing.T
 			},
 		},
 		{
-			name:           "feature enabled, should aggregate corrupt object errors",
-			featureEnabled: true,
+			name: "feature enabled, should aggregate corrupt object errors",
+
 			// we initially create n=7 objects with ids {1, 2, 3 ... 7}, they are put in the following disjoint sets:
 			// - good: {1, 3, 5, 7}, these objects will never become corrupt
 			// - corrupt: {2, 4, 6}, these objects are marked to become corrupt
@@ -2974,8 +2928,8 @@ func RunTestGetListWithErrorAggregation(t *testing.T, newStoreFn func(*testing.T
 			},
 		},
 		{
-			name:           "feature enabled, aggregation should abort as soon as it encounters an unexpected error",
-			featureEnabled: true,
+			name: "feature enabled, aggregation should abort as soon as it encounters an unexpected error",
+
 			// we initially create n=7 objects with ids {1, 2, 3 ... 7}, they are put in the following disjoint sets:
 			// - good: {1, 3, 5, 7}, these objects will never become corrupt
 			// - unexpected: {4}, this object is marked to yield an unexpected error (not corruptObjErr)
@@ -3035,8 +2989,8 @@ func RunTestGetListWithErrorAggregation(t *testing.T, newStoreFn func(*testing.T
 			},
 		},
 		{
-			name:           "feature enabled, error aggregation should not exceed the maximum limit",
-			featureEnabled: true,
+			name: "feature enabled, error aggregation should not exceed the maximum limit",
+
 			// aggregation limit is currently hard coded to 100
 			// we initially create n=210 objects with ids {1, 2, 3 ... 210}, they are put in the following disjoint sets:
 			// - good: {1, 3, 5 ... 195, 197, 199, ... 207, 209}, these 105 objects will never become corrupt
@@ -3079,8 +3033,8 @@ func RunTestGetListWithErrorAggregation(t *testing.T, newStoreFn func(*testing.T
 			},
 		},
 		{
-			name:           "feature enabled, there are exactly 100 (error aggregation limit) corrupt errors",
-			featureEnabled: true,
+			name: "feature enabled, there are exactly 100 (error aggregation limit) corrupt errors",
+
 			// aggregation limit is currently hard coded to 100
 			// we initially create n=100 objects with ids {1, 2, 3 ... 100}, they are put in the following disjoint sets:
 			// - good: {}, all the objects are marked to become corrupt
@@ -3121,7 +3075,6 @@ func RunTestGetListWithErrorAggregation(t *testing.T, newStoreFn func(*testing.T
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.AllowUnsafeMalformedObjectDeletion, test.featureEnabled)
 			ctx, store := newStoreFn(t)
 
 			// Step 1: add N objects to the store foo-{1 ... n}
@@ -3170,6 +3123,80 @@ func RunTestGetListWithErrorAggregation(t *testing.T, newStoreFn func(*testing.T
 			// step 5: verify what we expect from GetList
 			test.verifier(t, out, err)
 		})
+	}
+}
+
+// RunTestGetListBackwardCompatibility tests that when the AllowUnsafeMalformedObjectDeletion
+// feature is disabled, GetList maintains backward compatibility by aborting on the first error.
+func RunTestGetListBackwardCompatibility(t *testing.T, newStoreFn func(*testing.T) (context.Context, InterfaceWithCorruptTransformer)) {
+	prefix := "/pods/ns/"
+	objNameFn := func(id int) string {
+		return fmt.Sprintf("foo-%06d", id)
+	}
+	keyFn := func(id int) string {
+		return fmt.Sprintf("%s%s", prefix, objNameFn(id))
+	}
+
+	ctx, store := newStoreFn(t)
+
+	// Step 1: create 7 objects, where even-numbered ones are corrupt
+	// - good: {1, 3, 5, 7}
+	// - corrupt: {2, 4, 6}
+	n := 7
+	for i := 1; i <= n; i++ {
+		obj := &example.Pod{ObjectMeta: metav1.ObjectMeta{
+			Name:      objNameFn(i),
+			Namespace: "ns",
+		}}
+		if i%2 == 0 {
+			obj.Annotations = map[string]string{
+				CorruptErrKey: "",
+			}
+		}
+		testPropagateStore(ctx, t, store, obj)
+	}
+
+	// Step 2: list all objects, expect no error before corruption
+	out := &example.PodList{}
+	storageOpts := storage.ListOptions{
+		Predicate: storage.Everything,
+		Recursive: true,
+	}
+	err := store.GetList(ctx, prefix, storageOpts, out)
+	if err != nil {
+		t.Fatalf("GetList failed with unexpected error: %v", err)
+	}
+	if want, got := n, len(out.Items); want != got {
+		t.Fatalf("Expected length: %d, but got: %d", want, got)
+	}
+
+	// Step 3: corrupt the transformer so marked objects fail to decode
+	revertTransformer := store.CorruptTransformer()
+	defer revertTransformer()
+
+	// Step 4: list again, expect GetList to abort on the first corrupt object
+	out = &example.PodList{}
+	err = store.GetList(ctx, prefix, storageOpts, out)
+	if err == nil {
+		t.Fatalf("Expected GetList to return error")
+	}
+
+	// Verify: the error should be a bare storage.InternalError (no aggregation)
+	// nolint:errorlint // the aggregator should return the error as is
+	intErr, ok := err.(storage.InternalError)
+	if !ok {
+		t.Fatalf("expected the error to be %T, but got: %#v", storage.InternalError{}, err)
+	}
+	if want, got := fmt.Sprintf(`unable to transform key "%s"`, keyFn(2)), intErr.Error(); !strings.HasPrefix(got, want) {
+		t.Errorf("expected the error to start with %q, but got: %v", want, got)
+	}
+
+	// Verify: GetList successfully decodes {1} before aborting
+	if want, got := 1, len(out.Items); want != got {
+		t.Errorf("expected the list to have %d item(s), but got: %d", want, got)
+	}
+	if want, got := objNameFn(1), out.Items[0].Name; want != got {
+		t.Errorf("expected an object name of %q, but got: %q", want, got)
 	}
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/store_tests.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/store_tests.go
@@ -2812,15 +2812,14 @@ const (
 )
 
 // RunTestGetListWithErrorAggregation tests aggregation of errors while the list operation is in progress
-func RunTestGetListWithErrorAggregation(t *testing.T, newStoreFn func(*testing.T) (context.Context, InterfaceWithCorruptTransformer)) {
-	prefix := "/pods/ns/"
+func RunTestGetListWithErrorAggregation(ctx context.Context, t *testing.T, store InterfaceWithCorruptTransformer) {
 	// the test creates n objects and assigns each object unique id i ie. 1 <= i <= n
 	objNameFn := func(id int) string {
 		// pad with leading zeros so that for i, j where i < j, object
 		// foo-{j} follows object foo-{i} in lexicographical order
 		return fmt.Sprintf("foo-%06d", id)
 	}
-	keyFn := func(id int) string {
+	keyFn := func(prefix string, id int) string {
 		return fmt.Sprintf("%s%s", prefix, objNameFn(id))
 	}
 
@@ -2836,7 +2835,7 @@ func RunTestGetListWithErrorAggregation(t *testing.T, newStoreFn func(*testing.T
 		// verifies the result from GetList
 		// list: result of GetList operation is saved into list
 		// err: error returned from GetList
-		verifier func(t *testing.T, list *example.PodList, err error)
+		verifier func(t *testing.T, prefix string, list *example.PodList, err error)
 	}{
 		{
 			name: "first error is an unexpected error, no aggregation expected",
@@ -2863,7 +2862,7 @@ func RunTestGetListWithErrorAggregation(t *testing.T, newStoreFn func(*testing.T
 			//  a) GetList encounters an unexpected (not corruptObjErr)
 			//  error while retrieving {2} and immediately aborts
 			//  b) GetList successfully decodes {1}
-			verifier: func(t *testing.T, list *example.PodList, err error) {
+			verifier: func(t *testing.T, _ string, list *example.PodList, err error) {
 				// a) the error returned from GetList should be a bare
 				// storage.InternalError, not wrapped — proves no aggregation
 				// nolint:errorlint // the aggregator should return the error as is
@@ -2896,7 +2895,7 @@ func RunTestGetListWithErrorAggregation(t *testing.T, newStoreFn func(*testing.T
 			// while retrieving the n objects, we expect the following from GetList:
 			//  a) GetList encounters corruptObjErr while retrieving objects in the corrupt set
 			//  b) GetList successfully decodes object(s) in the good set
-			verifier: func(t *testing.T, list *example.PodList, listErr error) {
+			verifier: func(t *testing.T, prefix string, list *example.PodList, listErr error) {
 				// the error returned from GetList should be an API status object
 				var statusGot apierrors.APIStatus
 				if !errors.As(listErr, &statusGot) {
@@ -2904,7 +2903,7 @@ func RunTestGetListWithErrorAggregation(t *testing.T, newStoreFn func(*testing.T
 				}
 
 				details := statusGot.Status().Details
-				corrupt := []string{keyFn(2), keyFn(4), keyFn(6)}
+				corrupt := []string{keyFn(prefix, 2), keyFn(prefix, 4), keyFn(prefix, 6)}
 				// a) all the corruptObjErr errors should be aggregated
 				if details == nil || len(details.Causes) != len(corrupt) {
 					t.Fatalf("expected the API status to include the corrupt object errors, but got: %v", details)
@@ -2956,7 +2955,7 @@ func RunTestGetListWithErrorAggregation(t *testing.T, newStoreFn func(*testing.T
 			//  b) GetList encounters an unexpected (not corruptObjErr) error while
 			//  retrieving {4} in the unexpected set, and immediately aborts
 			//  c) GetList successfully decodes {1,3} in the good set before it aborts
-			verifier: func(t *testing.T, list *example.PodList, err error) {
+			verifier: func(t *testing.T, prefix string, list *example.PodList, err error) {
 				// the error returned from GetList should be an API status object
 				var statusGot apierrors.APIStatus
 				if !errors.As(err, &statusGot) {
@@ -2969,7 +2968,7 @@ func RunTestGetListWithErrorAggregation(t *testing.T, newStoreFn func(*testing.T
 				if details == nil || len(details.Causes) != 2 {
 					t.Fatalf("expected 2 causes (1 corrupt + 1 abort), but got: %v", details)
 				}
-				if want, got := keyFn(2), details.Causes[0].Field; want != got {
+				if want, got := keyFn(prefix, 2), details.Causes[0].Field; want != got {
 					t.Errorf("expected corrupt object key %q, but got: %q", want, got)
 				}
 				if want, got := metav1.CauseTypeUnexpectedServerResponse, details.Causes[1].Type; want != got {
@@ -3006,7 +3005,7 @@ func RunTestGetListWithErrorAggregation(t *testing.T, newStoreFn func(*testing.T
 			//  a) GetList continues to aggregate the corruptObjErr errors
 			//  until it reaches the maximum limit, and then it immediately aborts
 			//  b) GetList successfully decodes the first 100 objects in the good set into list
-			verifier: func(t *testing.T, list *example.PodList, err error) {
+			verifier: func(t *testing.T, _ string, list *example.PodList, err error) {
 				limit := 100
 				var statusGot apierrors.APIStatus
 				if !errors.As(err, &statusGot) {
@@ -3045,7 +3044,7 @@ func RunTestGetListWithErrorAggregation(t *testing.T, newStoreFn func(*testing.T
 			//  a) GetList continues to aggregate the corruptObjErr errors
 			//  until it reaches the maximum limit, and then it immediately aborts
 			//  b) GetList successfully decodes zero objects
-			verifier: func(t *testing.T, list *example.PodList, err error) {
+			verifier: func(t *testing.T, _ string, list *example.PodList, err error) {
 				limit := 100
 				var statusGot apierrors.APIStatus
 				if !errors.As(err, &statusGot) {
@@ -3073,21 +3072,22 @@ func RunTestGetListWithErrorAggregation(t *testing.T, newStoreFn func(*testing.T
 		},
 	}
 
-	for _, test := range tests {
+	for i, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			ctx, store := newStoreFn(t)
+			ns := fmt.Sprintf("ns-%d", i)
+			prefix := fmt.Sprintf("/pods/%s/", ns)
 
 			// Step 1: add N objects to the store foo-{1 ... n}
 			// we construct the names of the objects in a way that ensures
 			// that the order of creation is also the lexicographical
 			// order by which etcd List operation returns the objects
-			for i := 1; i <= test.n; i++ {
+			for j := 1; j <= test.n; j++ {
 				obj := &example.Pod{ObjectMeta: metav1.ObjectMeta{
-					Name:      objNameFn(i),
-					Namespace: "ns",
+					Name:      objNameFn(j),
+					Namespace: ns,
 				}}
 				// add the annotation that will mark the object to become corrupt
-				if marker := test.corrupter(i); len(marker) > 0 {
+				if marker := test.corrupter(j); len(marker) > 0 {
 					obj.Annotations = map[string]string{
 						marker: "",
 					}
@@ -3121,14 +3121,14 @@ func RunTestGetListWithErrorAggregation(t *testing.T, newStoreFn func(*testing.T
 			}
 
 			// step 5: verify what we expect from GetList
-			test.verifier(t, out, err)
+			test.verifier(t, prefix, out, err)
 		})
 	}
 }
 
-// RunTestGetListBackwardCompatibility tests that when the AllowUnsafeMalformedObjectDeletion
+// RunTestGetListWithoutErrorAggregation tests that when the AllowUnsafeMalformedObjectDeletion
 // feature is disabled, GetList maintains backward compatibility by aborting on the first error.
-func RunTestGetListBackwardCompatibility(t *testing.T, newStoreFn func(*testing.T) (context.Context, InterfaceWithCorruptTransformer)) {
+func RunTestGetListWithoutErrorAggregation(ctx context.Context, t *testing.T, store InterfaceWithCorruptTransformer) {
 	prefix := "/pods/ns/"
 	objNameFn := func(id int) string {
 		return fmt.Sprintf("foo-%06d", id)
@@ -3136,8 +3136,6 @@ func RunTestGetListBackwardCompatibility(t *testing.T, newStoreFn func(*testing.
 	keyFn := func(id int) string {
 		return fmt.Sprintf("%s%s", prefix, objNameFn(id))
 	}
-
-	ctx, store := newStoreFn(t)
 
 	// Step 1: create 7 objects, where even-numbered ones are corrupt
 	// - good: {1, 3, 5, 7}

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/store_tests.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/store_tests.go
@@ -3010,13 +3010,16 @@ func RunTestGetListWithErrorAggregation(t *testing.T, newStoreFn func(*testing.T
 				}
 
 				details := statusGot.Status().Details
-				// a) only the corruptObjErr from object {2} should be aggregated;
-				// the aggregator saw the corrupt error before aborting on the unexpected one
-				if details == nil || len(details.Causes) != 1 {
-					t.Errorf("expected the API status to include exactly 1 corrupt object error, but got: %v", details)
+				// a) the corrupt error from {2} plus the unexpected abort error from {4}
+				// should both be surfaced as causes
+				if details == nil || len(details.Causes) != 2 {
+					t.Fatalf("expected 2 causes (1 corrupt + 1 abort), but got: %v", details)
 				}
 				if want, got := keyFn(2), details.Causes[0].Field; want != got {
-					t.Errorf("expected an object name of %q, but got: %q", want, got)
+					t.Errorf("expected corrupt object key %q, but got: %q", want, got)
+				}
+				if want, got := metav1.CauseTypeUnexpectedServerResponse, details.Causes[1].Type; want != got {
+					t.Errorf("expected abort cause type %q, but got: %q", want, got)
 				}
 
 				// b) verify that GetList successfully decodes objects before the abort

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/store_tests.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/store_tests.go
@@ -2807,9 +2807,13 @@ func RunTestGetListRecursivePrefix(ctx context.Context, t *testing.T, store stor
 type errorInjector func(key string) error
 
 // idOf extracts the numeric suffix from an object key like ".../foo-000002" -> 2.
-func idOf(key string) int {
+func idOf(t *testing.T, key string) int {
+	t.Helper()
 	name := key[strings.LastIndex(key, "/")+1:]
-	n, _ := strconv.Atoi(strings.TrimPrefix(name, "foo-"))
+	n, err := strconv.Atoi(strings.TrimPrefix(name, "foo-"))
+	if err != nil {
+		t.Fatalf("failed to parse the object id from key %q: %v", key, err)
+	}
 	return n
 }
 
@@ -2857,7 +2861,7 @@ func RunTestGetListWithErrorAggregation(ctx context.Context, t *testing.T, store
 		n int
 		// inject decides, per object key, whether transformation fails and with
 		// which error. Returning nil means the object transforms normally.
-		inject errorInjector
+		inject func(t *testing.T, key string) error
 		// verifies the result from GetList
 		// list: result of GetList operation is saved into list
 		// err: error returned from GetList
@@ -2870,8 +2874,8 @@ func RunTestGetListWithErrorAggregation(ctx context.Context, t *testing.T, store
 			// - unexpected: {2}, this object is marked to yield an unexpected error (not corruptObjErr)
 			// - corrupt: {4, 6}, these objects are marked to become corrupt
 			n: 7,
-			inject: func(key string) error {
-				switch id := idOf(key); {
+			inject: func(t *testing.T, key string) error {
+				switch id := idOf(t, key); {
 				case id == 2:
 					return errUnexpected
 				case id%2 == 0:
@@ -2912,8 +2916,8 @@ func RunTestGetListWithErrorAggregation(ctx context.Context, t *testing.T, store
 			// - good: {1, 3, 5, 7}, these objects will never become corrupt
 			// - corrupt: {2, 4, 6}, these objects are marked to become corrupt
 			n: 7,
-			inject: func(key string) error {
-				if idOf(key)%2 == 0 {
+			inject: func(t *testing.T, key string) error {
+				if idOf(t, key)%2 == 0 {
 					return corruptErr
 				}
 				return nil
@@ -2960,8 +2964,8 @@ func RunTestGetListWithErrorAggregation(ctx context.Context, t *testing.T, store
 			// - unexpected: {4}, this object is marked to yield an unexpected error (not corruptObjErr)
 			// - corrupt: {2, 6}, these objects are marked to become corrupt
 			n: 7,
-			inject: func(key string) error {
-				switch id := idOf(key); {
+			inject: func(t *testing.T, key string) error {
+				switch id := idOf(t, key); {
 				case id == 4:
 					return errUnexpected
 				case id%2 == 0:
@@ -3021,8 +3025,8 @@ func RunTestGetListWithErrorAggregation(ctx context.Context, t *testing.T, store
 			// - good: {1, 3, 5 ... 195, 197, 199, ... 207, 209}, these 105 objects will never become corrupt
 			// - corrupt: {2, 4, 6 ... 196, 198, 200, ... 208, 210}, these 105 objects are marked to become corrupt
 			n: 210,
-			inject: func(key string) error {
-				if idOf(key)%2 == 0 {
+			inject: func(t *testing.T, key string) error {
+				if idOf(t, key)%2 == 0 {
 					return corruptErr
 				}
 				return nil
@@ -3065,7 +3069,7 @@ func RunTestGetListWithErrorAggregation(ctx context.Context, t *testing.T, store
 			// - good: {}, all the objects are marked to become corrupt
 			// - corrupt: {1, 2, 3 ... 99, 100}, these objects are marked to become corrupt
 			n:      100,
-			inject: func(key string) error { return corruptErr },
+			inject: func(t *testing.T, key string) error { return corruptErr },
 			//  while listing the n objects, we expect the following:
 			//  a) GetList continues to aggregate the corruptObjErr errors
 			//  until it reaches the maximum limit, and then it immediately aborts
@@ -3132,7 +3136,9 @@ func RunTestGetListWithErrorAggregation(ctx context.Context, t *testing.T, store
 			}
 
 			// step 3: change the transformer so the marked objects appear corrupt
-			revertTransformer := store.UpdateTransformer(newErrInjectingModifier(test.inject))
+			revertTransformer := store.UpdateTransformer(newErrInjectingModifier(func(key string) error {
+				return test.inject(t, key)
+			}))
 			defer revertTransformer()
 
 			// step 4: invoke GetList again, this time it should encounter the corrupt object(s)
@@ -3189,7 +3195,7 @@ func RunTestGetListWithoutErrorAggregation(ctx context.Context, t *testing.T, st
 
 	// Step 3: corrupt the transformer so even-numbered objects fail to decode
 	revertTransformer := store.UpdateTransformer(newErrInjectingModifier(func(key string) error {
-		if idOf(key)%2 == 0 {
+		if idOf(t, key)%2 == 0 {
 			return corruptErr
 		}
 		return nil

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/store_tests.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/store_tests.go
@@ -3036,6 +3036,8 @@ func RunTestGetListWithErrorAggregation(ctx context.Context, t *testing.T, store
 			//  until it reaches the maximum limit, and then it immediately aborts
 			//  b) GetList successfully decodes the first 100 objects in the good set into list
 			verifier: func(t *testing.T, _ string, list *example.PodList, err error) {
+				// must match the aggregation limit that etcd3 configures via
+				// corruptObjErrAggregatorFactory when the feature is enabled
 				limit := 100
 				var statusGot apierrors.APIStatus
 				if !errors.As(err, &statusGot) {
@@ -3056,7 +3058,7 @@ func RunTestGetListWithErrorAggregation(ctx context.Context, t *testing.T, store
 				}
 
 				// b) before the limit is hit and GetList aborts, it successfully decodes 100 objects
-				if want, got := 100, len(list.Items); want != got {
+				if want, got := limit, len(list.Items); want != got {
 					t.Errorf("expected GetList to successfully decode %d object(s), but got: %d", want, got)
 				}
 			},
@@ -3075,6 +3077,8 @@ func RunTestGetListWithErrorAggregation(ctx context.Context, t *testing.T, store
 			//  until it reaches the maximum limit, and then it immediately aborts
 			//  b) GetList successfully decodes zero objects
 			verifier: func(t *testing.T, _ string, list *example.PodList, err error) {
+				// must match the aggregation limit that etcd3 configures via
+				// corruptObjErrAggregatorFactory when the feature is enabled
 				limit := 100
 				var statusGot apierrors.APIStatus
 				if !errors.As(err, &statusGot) {

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/store_tests.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/store_tests.go
@@ -45,6 +45,7 @@ import (
 	"k8s.io/apiserver/pkg/storage"
 	"k8s.io/apiserver/pkg/storage/value"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/utils/ptr"
 )
 
@@ -2798,6 +2799,444 @@ func RunTestGetListRecursivePrefix(ctx context.Context, t *testing.T, store stor
 					expectNoDiff(t, "incorrect list pods", tt.expectedOut, out.Items)
 				})
 			}
+		})
+	}
+}
+
+// This wraps the current list error aggregator factory to enable the test to
+// record the values GetList passed to the error aggregator
+func WrapListErrorAggregatorFactory(factory func() storage.ListItemErrors) *ErrorAggregatorFactory {
+	return &ErrorAggregatorFactory{factory: factory}
+}
+
+// This wraps the actual error aggregation factory in use by the store implemenation
+// so we can record the values GetList passes to its error aggregator.
+type ErrorAggregatorFactory struct {
+	// this is the original error aggregation factory in use by the store implementation
+	factory func() storage.ListItemErrors
+
+	// every time GetList invokes the factory, we wrap it by a recorder, this
+	// is stored here so the test can access the values recorded
+	// TODO: this forces the test be serial, but we are okay for now since this
+	// is used by a single test that calls GetList serially, in the future we could
+	// change the signature of the factory to take the request context object, this
+	// will allow the test to store its recorder (ListErrorAggregator) into the
+	// request Context object, to enable multiple tests to run concurrently
+	recorder *listErrorAggregatorRecorder
+}
+
+func (f *ErrorAggregatorFactory) WithRecorder() func() storage.ListItemErrors {
+	return func() storage.ListItemErrors {
+		f.recorder = &listErrorAggregatorRecorder{ListItemErrors: f.factory()}
+		return f.recorder
+	}
+}
+
+// it wraps the actual ListErrorAggregator in use by the store and
+// records the values GetList passes to the the error aggregator
+type listErrorAggregatorRecorder struct {
+	// the ListItemErrors we are going to observe
+	storage.ListItemErrors
+	// Keep track of the values GetList passes to the aggregator
+	errs []error
+	keys []string
+}
+
+func (f *listErrorAggregatorRecorder) Append(key string, err error) bool {
+	f.errs = append(f.errs, err)
+	f.keys = append(f.keys, key)
+	return f.ListItemErrors.Append(key, err)
+}
+
+const (
+	// if the following annotation is present, the object is marked to become corrupt
+	CorruptErrKey = "testing.transformer.k8s.io/corrupt-error"
+
+	// if the following annotation is present, the object is marked
+	// to fail with an unexpected non-corrupt error
+	UnexpectedErrKey = "testing.transformer.k8s.io/unexpected-error"
+)
+
+// RunTestGetListWithErrorAggregation tests aggregation of errors while the list operation is in progress
+func RunTestGetListWithErrorAggregation(t *testing.T, newStoreFn func(*testing.T) (context.Context, *ErrorAggregatorFactory, InterfaceWithCorruptTransformer)) {
+	prefix := "/pods/ns/"
+	// the test creates n objects and assigns each object unique id i ie. 1 <= i <= n
+	objNameFn := func(id int) string {
+		// pad with leading zeros so that for i, j where i < j, object
+		// foo-{j} follows object foo-{i} in lexicographical order
+		return fmt.Sprintf("foo-%06d", id)
+	}
+	keyFn := func(id int) string {
+		return fmt.Sprintf("%s%s", prefix, objNameFn(id))
+	}
+
+	tests := []struct {
+		name           string
+		featureEnabled bool
+		// number of Pod objects to be created when the test starts, the
+		// objects are named as "foo-{i}" where 1 <= i <= n
+		n int
+		// the function decides whether the object represented
+		// by the given id should be marked to become corrupt or
+		// fail to transform with an unexpected error
+		corrupter func(id int) string
+		// verifies the result from GetList
+		// recorder: records the values GetList passes to the error aggregator
+		// list: result of GetList operation is saved into list
+		// err: error returned from GetList
+		verifier func(t *testing.T, _ *listErrorAggregatorRecorder, list *example.PodList, err error)
+	}{
+		{
+			name: "feature disabled, should maintain backward compatibility",
+			// when the feature is disabled, we should maintain
+			// backward compatibility, which is to abort on the first error
+			featureEnabled: false,
+			// we initially create n=7 objects with ids {1, 2, 3 ... 7}, they are put in the following disjoint sets:
+			// - good: {1, 3, 5, 7}, these objects will never become corrupt
+			// - corrupt: {2, 4, 6}, these objects are marked to become corrupt
+			n: 7,
+			corrupter: func(i int) string {
+				if i%2 == 0 {
+					return CorruptErrKey
+				}
+				return ""
+			},
+			// the following sequence of events are expected to occur in order while retrieving the n objects:
+			//
+			// -- |- 1: no error, successfully decoded
+			//    |- 2: yields an expected corruptObjErr, GetList aborts immediately
+			//
+			//  a) GetList encounters corruptObjErr while retrieving {2} and immediately aborts
+			//  b) GetList successfully decodes {1}
+			verifier: func(t *testing.T, recorder *listErrorAggregatorRecorder, list *example.PodList, err error) {
+				// a) the error returned from GetList should not be wrapped
+				// nolint:errorlint // the aggregator should return the error as is
+				intErr, ok := err.(storage.InternalError)
+				if !ok {
+					t.Fatalf("expected the error to be %T, but got: %#v", storage.InternalError{}, err)
+				}
+				if want, got := fmt.Sprintf(`unable to transform key "%s"`, keyFn(2)), intErr.Error(); !strings.HasPrefix(got, want) {
+					t.Errorf("expected the error to start with %q, but got: %v", want, got)
+				}
+				// the error observed by the recorder should be
+				// the same error returned by GetList
+				if want, got := 1, len(recorder.errs); want != got {
+					t.Fatalf("expected exactly %d error(s), but got: %d", want, got)
+				}
+				// nolint:errorlint // the aggregator in use should return
+				// the error as is, so the test is asserting with identity.
+				if want, got := err, recorder.errs[0]; want != got {
+					t.Errorf("expected the aggregator to return the original error as is: %v, but got: %v", want, got)
+				}
+
+				// b) GetList successfully decodes {1}
+				if want, got := 1, len(list.Items); want != got {
+					t.Errorf("expected the list to have %d item(s), but got: %d", want, got)
+				}
+				if want, got := objNameFn(1), list.Items[0].Name; want != got {
+					t.Errorf("expected an object name of %q, but got: %q", want, got)
+				}
+			},
+		},
+		{
+			name:           "feature enabled, first error is an unexpected error, no aggregation expected",
+			featureEnabled: true,
+			// we initially create n=7 objects with ids {1, 2, 3 ... 7}, they are put in the following disjoint sets:
+			// - good: {1, 3, 5, 7}, these objects will never become corrupt
+			// - unexpected: {2}, this object is marked to yield an unexpected error (not corruptObjErr)
+			// - corrupt: {4, 6}, these objects are marked to become corrupt
+			n: 7,
+			corrupter: func(i int) string {
+				switch {
+				case i == 2:
+					return UnexpectedErrKey
+				case i%2 == 0:
+					return CorruptErrKey
+				default:
+					return ""
+				}
+			},
+			// the following sequence of events are expected to occur in order while retrieving the n objects:
+			//
+			// -- |- 1: no error, successfully decoded
+			//    |- 2: unexpected error, GetList aborts
+			//
+			//  a) GetList encounters an unexpected (not corruptObjErr)
+			//  error while retrieving {2} and immediately aborts
+			//  b) GetList successfully decodes {1}
+			verifier: func(t *testing.T, recorder *listErrorAggregatorRecorder, list *example.PodList, err error) {
+				// a) the error observed by the recorder should be the same
+				// error returned by GetList, and it should not be wrapped
+				if want, got := 1, len(recorder.errs); want != got {
+					t.Fatalf("expected exactly %d error(s), but got: %d", want, got)
+				}
+				// nolint:errorlint // the aggregator in use should return
+				// the error as is, so the test is asserting with identity.
+				if want, got := err, recorder.errs[0]; want != got {
+					t.Errorf("expected GetList to return the original error as is: %v, but got: %v", want, got)
+				}
+
+				// b) GetList should successfully decode object 1 from the good set
+				if want, got := 1, len(list.Items); want != got {
+					t.Fatalf("expected the list to have %d item(s), but got: %d", want, got)
+				}
+				if want, got := objNameFn(1), list.Items[0].Name; want != got {
+					t.Errorf("expected an object name of %q, but got: %q", want, got)
+				}
+			},
+		},
+		{
+			name:           "feature enabled, should aggregate corrupt object errors",
+			featureEnabled: true,
+			// we initially create n=7 objects with ids {1, 2, 3 ... 7}, they are put in the following disjoint sets:
+			// - good: {1, 3, 5, 7}, these objects will never become corrupt
+			// - corrupt: {2, 4, 6}, these objects are marked to become corrupt
+			n: 7,
+			corrupter: func(i int) string {
+				if i%2 == 0 {
+					return CorruptErrKey
+				}
+				return ""
+			},
+			// while retrieving the n objects, we expect the following from GetList:
+			//  a) GetList encounters corruptObjErr while retrieving objects in the corrupt set
+			//  b) GetList successfully decodes object(s) in the good set
+			verifier: func(t *testing.T, _ *listErrorAggregatorRecorder, list *example.PodList, listErr error) {
+				// the error returned from GetList should be an API status object
+				var statusGot apierrors.APIStatus
+				if !errors.As(listErr, &statusGot) {
+					t.Fatalf("expected an API status error object, but got: %v", listErr)
+				}
+
+				details := statusGot.Status().Details
+				corrupt := []string{keyFn(2), keyFn(4), keyFn(6)}
+				// a) all the corruptObjErr errors should be aggregated
+				if details == nil || len(details.Causes) != len(corrupt) {
+					t.Fatalf("expected the API status to include the corrupt object errors, but got: %v", details)
+				}
+				for i, key := range corrupt {
+					if want, got := key, details.Causes[i].Field; want != got {
+						t.Errorf("expected an object name of %q, but got: %q", want, got)
+					}
+				}
+
+				// b) GetList should successfully decode all objects in the good set
+				good := []int{1, 3, 5, 7}
+				if want, got := len(good), len(list.Items); want != got {
+					t.Fatalf("expected the list to have %d item(s), but got: %d", want, got)
+				}
+				for i, id := range good {
+					if want, got := objNameFn(id), list.Items[i].Name; want != got {
+						t.Errorf("expected an object name of %q, but got: %q", want, got)
+					}
+				}
+			},
+		},
+		{
+			name:           "feature enabled, aggregation should abort as soon as it encounters an unexpected error",
+			featureEnabled: true,
+			// we initially create n=7 objects with ids {1, 2, 3 ... 7}, they are put in the following disjoint sets:
+			// - good: {1, 3, 5, 7}, these objects will never become corrupt
+			// - unexpected: {4}, this object is marked to yield an unexpected error (not corruptObjErr)
+			// - corrupt: {2, 6}, these objects are marked to become corrupt
+			n: 7,
+			corrupter: func(i int) string {
+				switch {
+				case i == 4:
+					return UnexpectedErrKey
+				case i%2 == 0:
+					return CorruptErrKey
+				default:
+					return ""
+				}
+			},
+			// the following sequence of events are expected to occur in order while retrieving the n objects:
+			//
+			// --|- 1: no error, successfully decoded
+			//   |- 2: yields an expected corruptObjErr, GetList aggregates this error
+			//   |- 3: no error, successfully decoded
+			//   |- 4: unexpected error, GetList aborts
+			//
+			//  a) GetList encounters a corruptObjErr error while retrieving {2} in the corrupt set
+			//  b) GetList encounters an unexpected (not corruptObjErr) error while
+			//  retrieving {4} in the unexpected set, and immediately aborts
+			//  c) GetList successfully decodes {1,3} in the good set before it aborts
+			verifier: func(t *testing.T, recorder *listErrorAggregatorRecorder, list *example.PodList, err error) {
+				// the error returned from GetList should be an API status object
+				var statusGot apierrors.APIStatus
+				if !errors.As(err, &statusGot) {
+					t.Fatalf("expected an API status error object, but got: %v", err)
+				}
+
+				details := statusGot.Status().Details
+				// a) only the corruptObjErr from object {2} should be aggregated
+				if details == nil || len(details.Causes) != 1 {
+					t.Errorf("expected the API status to include the corrupt object error aggregated, but got: %v", details)
+				}
+				if want, got := keyFn(2), details.Causes[0].Field; want != got {
+					t.Errorf("expected an object name of %q, but got: %q", want, got)
+				}
+
+				// b) the recorder should observe the unexpected error as well
+				if want, got := 2, len(recorder.errs); want != got {
+					t.Fatalf("expected GetList to pass the unexpected error to the aggregator, want %d error(s), but got: %d", want, got)
+				}
+
+				// c) verify that GetList successfully decodes
+				ids := []int{1, 3}
+				if want, got := len(ids), len(list.Items); want != got {
+					t.Errorf("expected GetList to successfully decode %d object(s), but got: %d", want, got)
+				}
+				for i, id := range ids {
+					if want, got := objNameFn(id), list.Items[i].Name; want != got {
+						t.Errorf("expected an object name of %q, but got: %q", want, got)
+					}
+				}
+			},
+		},
+		{
+			name:           "feature enabled, error aggregation should not exceed the maximum limit",
+			featureEnabled: true,
+			// aggregation limit is currently hard coded to 100
+			// we initially create n=210 objects with ids {1, 2, 3 ... 210}, they are put in the following disjoint sets:
+			// - good: {1, 3, 5 ... 195, 197, 199, ... 207, 209}, these 105 objects will never become corrupt
+			// - corrupt: {2, 4, 6 ... 196, 198, 200, ... 208, 210}, these 105 objects are marked to become corrupt
+			n: 210,
+			corrupter: func(i int) string {
+				if i%2 == 0 {
+					return CorruptErrKey
+				}
+				return ""
+			},
+			// while listing the n objects, we expect the following:
+			//  a) GetList continues to aggregate the corruptObjErr errors
+			//  until it reaches the maximum limit, and then it immediately aborts
+			//  b) GetList successfully decodes the first 100 objects in the good set into list
+			verifier: func(t *testing.T, recorder *listErrorAggregatorRecorder, list *example.PodList, err error) {
+				// a) the recorder should observe exactly N errors, N=limit
+				limit := 100
+				if want, got := limit, len(recorder.errs); want != got {
+					t.Errorf("expected GetList to aggregate exactly %d error(s), but got: %d", want, got)
+				}
+
+				var statusGot apierrors.APIStatus
+				if !errors.As(err, &statusGot) {
+					t.Fatalf("expected an API status error object, but got: %v", err)
+				}
+				details := statusGot.Status().Details
+				// the (limit+1)th entry should be the sentinel error
+				if want := limit + 1; details == nil || len(details.Causes) != want {
+					t.Fatalf("expected GetList to append the sentinel error to the list, want: %d, but got: %d", want, len(details.Causes))
+				}
+				want := metav1.StatusCause{
+					Type:    metav1.CauseTypeTooMany,
+					Message: "too many errors, the list is truncated",
+				}
+				if got := details.Causes[limit]; !cmp.Equal(want, got) {
+					t.Errorf("expected the sentinel error, diff: %s", cmp.Diff(want, got))
+				}
+
+				// b) before the limit is hit and GetList aborts, it successfully decodes 100 objects
+				if want, got := 100, len(list.Items); want != got {
+					t.Errorf("expected GetList to successfully decode %d object(s), but got: %d", want, got)
+				}
+			},
+		},
+		{
+			name:           "feature enabled, there are exactly 100 (error aggregation limit) corrupt errors",
+			featureEnabled: true,
+			// aggregation limit is currently hard coded to 100
+			// we initially create n=100 objects with ids {1, 2, 3 ... 100}, they are put in the following disjoint sets:
+			// - good: {}, all the objects are marked to become corrupt
+			// - corrupt: {1, 2, 3 ... 99, 100}, these objects are marked to become corrupt
+			n:         100,
+			corrupter: func(i int) string { return CorruptErrKey },
+			//  while listing the n objects, we expect the following:
+			//  a) GetList continues to aggregate the corruptObjErr errors
+			//  until it reaches the maximum limit, and then it immediately aborts
+			//  b) GetList successfully decodes zero objects
+			verifier: func(t *testing.T, recorder *listErrorAggregatorRecorder, list *example.PodList, err error) {
+				// a) the recorder should observe the corrupt errors
+				limit := 100
+				if want, got := limit, len(recorder.errs); want != got {
+					t.Errorf("expected GetList to aggregate exactly %d error(s), but got: %d", want, got)
+				}
+
+				var statusGot apierrors.APIStatus
+				if !errors.As(err, &statusGot) {
+					t.Fatalf("expected an API status error object, but got: %v", err)
+				}
+				// the (limit+1)th entry should be the sentinel error
+				details := statusGot.Status().Details
+				if want := limit + 1; details == nil || len(details.Causes) != want {
+					t.Errorf("expected GetList to append the sentinel error to the list, want: %d, but got: %d", want, len(details.Causes))
+				}
+				want := metav1.StatusCause{
+					Type:    metav1.CauseTypeTooMany,
+					Message: "too many errors, the list is truncated",
+				}
+				if got := details.Causes[limit]; !cmp.Equal(want, got) {
+					t.Errorf("expected the sentinel error, diff: %s", cmp.Diff(want, got))
+				}
+
+				// b) before the limit is hit and GetList aborts, it successfully decodes 0 objects
+				if want, got := 0, len(list.Items); want != got {
+					t.Errorf("expected GetList to successfully decode %d object(s), but got: %d", want, got)
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.AllowUnsafeMalformedObjectDeletion, test.featureEnabled)
+			ctx, factory, store := newStoreFn(t)
+
+			// Step 1: add N objects to the store foo-{1 ... n}
+			// we construct the names of the objects in a way that ensures
+			// that the order of creation is also the lexicographical
+			// order by which etcd List operation returns the objects
+			for i := 1; i <= test.n; i++ {
+				obj := &example.Pod{ObjectMeta: metav1.ObjectMeta{
+					Name:      objNameFn(i),
+					Namespace: "ns",
+				}}
+				// add the annotation that will mark the object to become corrupt
+				if marker := test.corrupter(i); len(marker) > 0 {
+					obj.Annotations = map[string]string{
+						marker: "",
+					}
+				}
+				testPropagateStore(ctx, t, store, obj)
+			}
+
+			// step 2: list the N objects, we expect no error
+			out := &example.PodList{}
+			storageOpts := storage.ListOptions{
+				Predicate: storage.Everything,
+				Recursive: true,
+			}
+			err := store.GetList(ctx, prefix, storageOpts, out)
+			if err != nil {
+				t.Fatalf("GetList failed with unexpected error: %v", err)
+			}
+			if want, got := test.n, len(out.Items); want != got {
+				t.Fatalf("Expected length: %d, but got: %d", want, got)
+			}
+
+			// step 3: change the transformer so the marked objects appear corrupt
+			revertTransformer := store.CorruptTransformer()
+			defer revertTransformer()
+
+			// step 4: invoke GetList again, this time it should encounter the corrupt object(s)
+			out = &example.PodList{}
+			err = store.GetList(ctx, prefix, storageOpts, out)
+			if err == nil {
+				t.Fatalf("Expected GetList to return error")
+			}
+
+			// step 5: verify what we expect from GetList
+			test.verifier(t, factory.recorder, out, err)
 		})
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/store_tests.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/store_tests.go
@@ -2803,51 +2803,6 @@ func RunTestGetListRecursivePrefix(ctx context.Context, t *testing.T, store stor
 	}
 }
 
-// This wraps the current list error aggregator factory to enable the test to
-// record the values GetList passed to the error aggregator
-func WrapListErrorAggregatorFactory(factory func() storage.ListItemErrors) *ErrorAggregatorFactory {
-	return &ErrorAggregatorFactory{factory: factory}
-}
-
-// This wraps the actual error aggregation factory in use by the store implemenation
-// so we can record the values GetList passes to its error aggregator.
-type ErrorAggregatorFactory struct {
-	// this is the original error aggregation factory in use by the store implementation
-	factory func() storage.ListItemErrors
-
-	// every time GetList invokes the factory, we wrap it by a recorder, this
-	// is stored here so the test can access the values recorded
-	// TODO: this forces the test be serial, but we are okay for now since this
-	// is used by a single test that calls GetList serially, in the future we could
-	// change the signature of the factory to take the request context object, this
-	// will allow the test to store its recorder (ListErrorAggregator) into the
-	// request Context object, to enable multiple tests to run concurrently
-	recorder *listErrorAggregatorRecorder
-}
-
-func (f *ErrorAggregatorFactory) WithRecorder() func() storage.ListItemErrors {
-	return func() storage.ListItemErrors {
-		f.recorder = &listErrorAggregatorRecorder{ListItemErrors: f.factory()}
-		return f.recorder
-	}
-}
-
-// it wraps the actual ListErrorAggregator in use by the store and
-// records the values GetList passes to the the error aggregator
-type listErrorAggregatorRecorder struct {
-	// the ListItemErrors we are going to observe
-	storage.ListItemErrors
-	// Keep track of the values GetList passes to the aggregator
-	errs []error
-	keys []string
-}
-
-func (f *listErrorAggregatorRecorder) Append(key string, err error) bool {
-	f.errs = append(f.errs, err)
-	f.keys = append(f.keys, key)
-	return f.ListItemErrors.Append(key, err)
-}
-
 const (
 	// if the following annotation is present, the object is marked to become corrupt
 	CorruptErrKey = "testing.transformer.k8s.io/corrupt-error"
@@ -2858,7 +2813,7 @@ const (
 )
 
 // RunTestGetListWithErrorAggregation tests aggregation of errors while the list operation is in progress
-func RunTestGetListWithErrorAggregation(t *testing.T, newStoreFn func(*testing.T) (context.Context, *ErrorAggregatorFactory, InterfaceWithCorruptTransformer)) {
+func RunTestGetListWithErrorAggregation(t *testing.T, newStoreFn func(*testing.T) (context.Context, InterfaceWithCorruptTransformer)) {
 	prefix := "/pods/ns/"
 	// the test creates n objects and assigns each object unique id i ie. 1 <= i <= n
 	objNameFn := func(id int) string {
@@ -2881,10 +2836,9 @@ func RunTestGetListWithErrorAggregation(t *testing.T, newStoreFn func(*testing.T
 		// fail to transform with an unexpected error
 		corrupter func(id int) string
 		// verifies the result from GetList
-		// recorder: records the values GetList passes to the error aggregator
 		// list: result of GetList operation is saved into list
 		// err: error returned from GetList
-		verifier func(t *testing.T, _ *listErrorAggregatorRecorder, list *example.PodList, err error)
+		verifier func(t *testing.T, list *example.PodList, err error)
 	}{
 		{
 			name: "feature disabled, should maintain backward compatibility",
@@ -2908,8 +2862,9 @@ func RunTestGetListWithErrorAggregation(t *testing.T, newStoreFn func(*testing.T
 			//
 			//  a) GetList encounters corruptObjErr while retrieving {2} and immediately aborts
 			//  b) GetList successfully decodes {1}
-			verifier: func(t *testing.T, recorder *listErrorAggregatorRecorder, list *example.PodList, err error) {
-				// a) the error returned from GetList should not be wrapped
+			verifier: func(t *testing.T, list *example.PodList, err error) {
+				// a) the error returned from GetList should be a bare
+				// storage.InternalError, not wrapped — proves no aggregation
 				// nolint:errorlint // the aggregator should return the error as is
 				intErr, ok := err.(storage.InternalError)
 				if !ok {
@@ -2917,16 +2872,6 @@ func RunTestGetListWithErrorAggregation(t *testing.T, newStoreFn func(*testing.T
 				}
 				if want, got := fmt.Sprintf(`unable to transform key "%s"`, keyFn(2)), intErr.Error(); !strings.HasPrefix(got, want) {
 					t.Errorf("expected the error to start with %q, but got: %v", want, got)
-				}
-				// the error observed by the recorder should be
-				// the same error returned by GetList
-				if want, got := 1, len(recorder.errs); want != got {
-					t.Fatalf("expected exactly %d error(s), but got: %d", want, got)
-				}
-				// nolint:errorlint // the aggregator in use should return
-				// the error as is, so the test is asserting with identity.
-				if want, got := err, recorder.errs[0]; want != got {
-					t.Errorf("expected the aggregator to return the original error as is: %v, but got: %v", want, got)
 				}
 
 				// b) GetList successfully decodes {1}
@@ -2964,16 +2909,12 @@ func RunTestGetListWithErrorAggregation(t *testing.T, newStoreFn func(*testing.T
 			//  a) GetList encounters an unexpected (not corruptObjErr)
 			//  error while retrieving {2} and immediately aborts
 			//  b) GetList successfully decodes {1}
-			verifier: func(t *testing.T, recorder *listErrorAggregatorRecorder, list *example.PodList, err error) {
-				// a) the error observed by the recorder should be the same
-				// error returned by GetList, and it should not be wrapped
-				if want, got := 1, len(recorder.errs); want != got {
-					t.Fatalf("expected exactly %d error(s), but got: %d", want, got)
-				}
-				// nolint:errorlint // the aggregator in use should return
-				// the error as is, so the test is asserting with identity.
-				if want, got := err, recorder.errs[0]; want != got {
-					t.Errorf("expected GetList to return the original error as is: %v, but got: %v", want, got)
+			verifier: func(t *testing.T, list *example.PodList, err error) {
+				// a) the error returned from GetList should be a bare
+				// storage.InternalError, not wrapped — proves no aggregation
+				// nolint:errorlint // the aggregator should return the error as is
+				if _, ok := err.(storage.InternalError); !ok {
+					t.Fatalf("expected the error to be %T, but got: %#v", storage.InternalError{}, err)
 				}
 
 				// b) GetList should successfully decode object 1 from the good set
@@ -3001,7 +2942,7 @@ func RunTestGetListWithErrorAggregation(t *testing.T, newStoreFn func(*testing.T
 			// while retrieving the n objects, we expect the following from GetList:
 			//  a) GetList encounters corruptObjErr while retrieving objects in the corrupt set
 			//  b) GetList successfully decodes object(s) in the good set
-			verifier: func(t *testing.T, _ *listErrorAggregatorRecorder, list *example.PodList, listErr error) {
+			verifier: func(t *testing.T, list *example.PodList, listErr error) {
 				// the error returned from GetList should be an API status object
 				var statusGot apierrors.APIStatus
 				if !errors.As(listErr, &statusGot) {
@@ -3061,7 +3002,7 @@ func RunTestGetListWithErrorAggregation(t *testing.T, newStoreFn func(*testing.T
 			//  b) GetList encounters an unexpected (not corruptObjErr) error while
 			//  retrieving {4} in the unexpected set, and immediately aborts
 			//  c) GetList successfully decodes {1,3} in the good set before it aborts
-			verifier: func(t *testing.T, recorder *listErrorAggregatorRecorder, list *example.PodList, err error) {
+			verifier: func(t *testing.T, list *example.PodList, err error) {
 				// the error returned from GetList should be an API status object
 				var statusGot apierrors.APIStatus
 				if !errors.As(err, &statusGot) {
@@ -3069,20 +3010,16 @@ func RunTestGetListWithErrorAggregation(t *testing.T, newStoreFn func(*testing.T
 				}
 
 				details := statusGot.Status().Details
-				// a) only the corruptObjErr from object {2} should be aggregated
+				// a) only the corruptObjErr from object {2} should be aggregated;
+				// the aggregator saw the corrupt error before aborting on the unexpected one
 				if details == nil || len(details.Causes) != 1 {
-					t.Errorf("expected the API status to include the corrupt object error aggregated, but got: %v", details)
+					t.Errorf("expected the API status to include exactly 1 corrupt object error, but got: %v", details)
 				}
 				if want, got := keyFn(2), details.Causes[0].Field; want != got {
 					t.Errorf("expected an object name of %q, but got: %q", want, got)
 				}
 
-				// b) the recorder should observe the unexpected error as well
-				if want, got := 2, len(recorder.errs); want != got {
-					t.Fatalf("expected GetList to pass the unexpected error to the aggregator, want %d error(s), but got: %d", want, got)
-				}
-
-				// c) verify that GetList successfully decodes
+				// b) verify that GetList successfully decodes objects before the abort
 				ids := []int{1, 3}
 				if want, got := len(ids), len(list.Items); want != got {
 					t.Errorf("expected GetList to successfully decode %d object(s), but got: %d", want, got)
@@ -3112,21 +3049,17 @@ func RunTestGetListWithErrorAggregation(t *testing.T, newStoreFn func(*testing.T
 			//  a) GetList continues to aggregate the corruptObjErr errors
 			//  until it reaches the maximum limit, and then it immediately aborts
 			//  b) GetList successfully decodes the first 100 objects in the good set into list
-			verifier: func(t *testing.T, recorder *listErrorAggregatorRecorder, list *example.PodList, err error) {
-				// a) the recorder should observe exactly N errors, N=limit
+			verifier: func(t *testing.T, list *example.PodList, err error) {
 				limit := 100
-				if want, got := limit, len(recorder.errs); want != got {
-					t.Errorf("expected GetList to aggregate exactly %d error(s), but got: %d", want, got)
-				}
-
 				var statusGot apierrors.APIStatus
 				if !errors.As(err, &statusGot) {
 					t.Fatalf("expected an API status error object, but got: %v", err)
 				}
 				details := statusGot.Status().Details
-				// the (limit+1)th entry should be the sentinel error
+				// a) the returned error should contain limit+1 causes:
+				// limit corrupt errors + the sentinel "too many" entry
 				if want := limit + 1; details == nil || len(details.Causes) != want {
-					t.Fatalf("expected GetList to append the sentinel error to the list, want: %d, but got: %d", want, len(details.Causes))
+					t.Fatalf("expected %d causes (limit + sentinel), but got: %d", want, len(details.Causes))
 				}
 				want := metav1.StatusCause{
 					Type:    metav1.CauseTypeTooMany,
@@ -3155,21 +3088,17 @@ func RunTestGetListWithErrorAggregation(t *testing.T, newStoreFn func(*testing.T
 			//  a) GetList continues to aggregate the corruptObjErr errors
 			//  until it reaches the maximum limit, and then it immediately aborts
 			//  b) GetList successfully decodes zero objects
-			verifier: func(t *testing.T, recorder *listErrorAggregatorRecorder, list *example.PodList, err error) {
-				// a) the recorder should observe the corrupt errors
+			verifier: func(t *testing.T, list *example.PodList, err error) {
 				limit := 100
-				if want, got := limit, len(recorder.errs); want != got {
-					t.Errorf("expected GetList to aggregate exactly %d error(s), but got: %d", want, got)
-				}
-
 				var statusGot apierrors.APIStatus
 				if !errors.As(err, &statusGot) {
 					t.Fatalf("expected an API status error object, but got: %v", err)
 				}
-				// the (limit+1)th entry should be the sentinel error
+				// a) the returned error should contain limit+1 causes:
+				// limit corrupt errors + the sentinel "too many" entry
 				details := statusGot.Status().Details
 				if want := limit + 1; details == nil || len(details.Causes) != want {
-					t.Errorf("expected GetList to append the sentinel error to the list, want: %d, but got: %d", want, len(details.Causes))
+					t.Fatalf("expected %d causes (limit + sentinel), but got: %d", want, len(details.Causes))
 				}
 				want := metav1.StatusCause{
 					Type:    metav1.CauseTypeTooMany,
@@ -3179,7 +3108,7 @@ func RunTestGetListWithErrorAggregation(t *testing.T, newStoreFn func(*testing.T
 					t.Errorf("expected the sentinel error, diff: %s", cmp.Diff(want, got))
 				}
 
-				// b) before the limit is hit and GetList aborts, it successfully decodes 0 objects
+				// b) all objects are corrupt, so GetList should decode 0 objects
 				if want, got := 0, len(list.Items); want != got {
 					t.Errorf("expected GetList to successfully decode %d object(s), but got: %d", want, got)
 				}
@@ -3190,7 +3119,7 @@ func RunTestGetListWithErrorAggregation(t *testing.T, newStoreFn func(*testing.T
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.AllowUnsafeMalformedObjectDeletion, test.featureEnabled)
-			ctx, factory, store := newStoreFn(t)
+			ctx, store := newStoreFn(t)
 
 			// Step 1: add N objects to the store foo-{1 ... n}
 			// we construct the names of the objects in a way that ensures
@@ -3236,7 +3165,7 @@ func RunTestGetListWithErrorAggregation(t *testing.T, newStoreFn func(*testing.T
 			}
 
 			// step 5: verify what we expect from GetList
-			test.verifier(t, factory.recorder, out, err)
+			test.verifier(t, out, err)
 		})
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/store_tests.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/store_tests.go
@@ -2802,43 +2802,35 @@ func RunTestGetListRecursivePrefix(ctx context.Context, t *testing.T, store stor
 	}
 }
 
-const (
-	// if the following annotation is present, the object is marked to become corrupt
-	corruptErrKey = "testing.transformer.k8s.io/corrupt-error"
+// errorInjector decides, per object storage key, whether transformation should
+// fail and with which error. Returning nil delegates to default behavior.
+type errorInjector func(key string) error
 
-	// if the following annotation is present, the object is marked
-	// to fail with an unexpected non-corrupt error
-	unexpectedErrKey = "testing.transformer.k8s.io/unexpected-error"
-)
+// idOf extracts the numeric suffix from an object key like ".../foo-000002" -> 2.
+func idOf(key string) int {
+	name := key[strings.LastIndex(key, "/")+1:]
+	n, _ := strconv.Atoi(strings.TrimPrefix(name, "foo-"))
+	return n
+}
 
-// errInjectingTransformer wraps an existing transformer and injects errors
-// for objects whose raw data contains specific marker strings. This lets the
-// shared test code own both the markers (annotations on test objects) and the
-// transformer behavior (error injection), keeping the full test fixture in one place.
+// errInjectingTransformer wraps an existing transformer and lets an errorInjector
+// fail transformation for selected keys on read. Writes (TransformToStorage)
+// delegate to the embedded transformer.
 type errInjectingTransformer struct {
 	value.Transformer
-	// corruptErr is the error returned for objects marked with corruptErrKey.
-	// The caller provides this because the concrete error type (e.g. corruptObjectError)
-	// may be unexported in the storage backend package.
-	corruptErr error
+	inject errorInjector
 }
 
 func (t *errInjectingTransformer) TransformFromStorage(ctx context.Context, data []byte, dataCtx value.Context) (out []byte, stale bool, err error) {
-	out, stale, err = t.Transformer.TransformFromStorage(ctx, data, dataCtx)
-	switch {
-	case err != nil:
-		return out, stale, err
-	case strings.Contains(string(data), corruptErrKey):
-		return out, stale, t.corruptErr
-	case strings.Contains(string(data), unexpectedErrKey):
-		return out, stale, fmt.Errorf("bits flipped")
+	if injErr := t.inject(string(dataCtx.AuthenticatedData())); injErr != nil {
+		return nil, false, injErr
 	}
-	return out, stale, err
+	return t.Transformer.TransformFromStorage(ctx, data, dataCtx)
 }
 
-func newErrInjectingModifier(corruptErr error) TransformerModifier {
+func newErrInjectingModifier(inject errorInjector) TransformerModifier {
 	return func(orig value.Transformer) value.Transformer {
-		return &errInjectingTransformer{Transformer: orig, corruptErr: corruptErr}
+		return &errInjectingTransformer{Transformer: orig, inject: inject}
 	}
 }
 
@@ -2854,15 +2846,18 @@ func RunTestGetListWithErrorAggregation(ctx context.Context, t *testing.T, store
 		return fmt.Sprintf("%s%s", prefix, objNameFn(id))
 	}
 
+	// errUnexpected is a non-corrupt transform error. The aggregator treats it as
+	// fatal and aborts the list, unlike corruptErr which is collected.
+	errUnexpected := errors.New("bits flipped")
+
 	tests := []struct {
 		name string
 		// number of Pod objects to be created when the test starts, the
 		// objects are named as "foo-{i}" where 1 <= i <= n
 		n int
-		// the function decides whether the object represented
-		// by the given id should be marked to become corrupt or
-		// fail to transform with an unexpected error
-		corrupter func(id int) string
+		// inject decides, per object key, whether transformation fails and with
+		// which error. Returning nil means the object transforms normally.
+		inject errorInjector
 		// verifies the result from GetList
 		// list: result of GetList operation is saved into list
 		// err: error returned from GetList
@@ -2875,14 +2870,14 @@ func RunTestGetListWithErrorAggregation(ctx context.Context, t *testing.T, store
 			// - unexpected: {2}, this object is marked to yield an unexpected error (not corruptObjErr)
 			// - corrupt: {4, 6}, these objects are marked to become corrupt
 			n: 7,
-			corrupter: func(i int) string {
-				switch {
-				case i == 2:
-					return unexpectedErrKey
-				case i%2 == 0:
-					return corruptErrKey
+			inject: func(key string) error {
+				switch id := idOf(key); {
+				case id == 2:
+					return errUnexpected
+				case id%2 == 0:
+					return corruptErr
 				default:
-					return ""
+					return nil
 				}
 			},
 			// the following sequence of events are expected to occur in order while retrieving the n objects:
@@ -2917,11 +2912,11 @@ func RunTestGetListWithErrorAggregation(ctx context.Context, t *testing.T, store
 			// - good: {1, 3, 5, 7}, these objects will never become corrupt
 			// - corrupt: {2, 4, 6}, these objects are marked to become corrupt
 			n: 7,
-			corrupter: func(i int) string {
-				if i%2 == 0 {
-					return corruptErrKey
+			inject: func(key string) error {
+				if idOf(key)%2 == 0 {
+					return corruptErr
 				}
-				return ""
+				return nil
 			},
 			// while retrieving the n objects, we expect the following from GetList:
 			//  a) GetList encounters corruptObjErr while retrieving objects in the corrupt set
@@ -2965,14 +2960,14 @@ func RunTestGetListWithErrorAggregation(ctx context.Context, t *testing.T, store
 			// - unexpected: {4}, this object is marked to yield an unexpected error (not corruptObjErr)
 			// - corrupt: {2, 6}, these objects are marked to become corrupt
 			n: 7,
-			corrupter: func(i int) string {
-				switch {
-				case i == 4:
-					return unexpectedErrKey
-				case i%2 == 0:
-					return corruptErrKey
+			inject: func(key string) error {
+				switch id := idOf(key); {
+				case id == 4:
+					return errUnexpected
+				case id%2 == 0:
+					return corruptErr
 				default:
-					return ""
+					return nil
 				}
 			},
 			// the following sequence of events are expected to occur in order while retrieving the n objects:
@@ -3026,11 +3021,11 @@ func RunTestGetListWithErrorAggregation(ctx context.Context, t *testing.T, store
 			// - good: {1, 3, 5 ... 195, 197, 199, ... 207, 209}, these 105 objects will never become corrupt
 			// - corrupt: {2, 4, 6 ... 196, 198, 200, ... 208, 210}, these 105 objects are marked to become corrupt
 			n: 210,
-			corrupter: func(i int) string {
-				if i%2 == 0 {
-					return corruptErrKey
+			inject: func(key string) error {
+				if idOf(key)%2 == 0 {
+					return corruptErr
 				}
-				return ""
+				return nil
 			},
 			// while listing the n objects, we expect the following:
 			//  a) GetList continues to aggregate the corruptObjErr errors
@@ -3069,8 +3064,8 @@ func RunTestGetListWithErrorAggregation(ctx context.Context, t *testing.T, store
 			// we initially create n=100 objects with ids {1, 2, 3 ... 100}, they are put in the following disjoint sets:
 			// - good: {}, all the objects are marked to become corrupt
 			// - corrupt: {1, 2, 3 ... 99, 100}, these objects are marked to become corrupt
-			n:         100,
-			corrupter: func(i int) string { return corruptErrKey },
+			n:      100,
+			inject: func(key string) error { return corruptErr },
 			//  while listing the n objects, we expect the following:
 			//  a) GetList continues to aggregate the corruptObjErr errors
 			//  until it reaches the maximum limit, and then it immediately aborts
@@ -3117,13 +3112,7 @@ func RunTestGetListWithErrorAggregation(ctx context.Context, t *testing.T, store
 					Name:      objNameFn(j),
 					Namespace: ns,
 				}}
-				// add the annotation that will mark the object to become corrupt
-				if marker := test.corrupter(j); len(marker) > 0 {
-					obj.Annotations = map[string]string{
-						marker: "",
-					}
-				}
-				testPropagateStore(ctx, t, store, obj)
+				_, _ = testPropagateStore(ctx, t, store, obj)
 			}
 
 			// step 2: list the N objects, we expect no error
@@ -3141,7 +3130,7 @@ func RunTestGetListWithErrorAggregation(ctx context.Context, t *testing.T, store
 			}
 
 			// step 3: change the transformer so the marked objects appear corrupt
-			revertTransformer := store.UpdateTransformer(newErrInjectingModifier(corruptErr))
+			revertTransformer := store.UpdateTransformer(newErrInjectingModifier(test.inject))
 			defer revertTransformer()
 
 			// step 4: invoke GetList again, this time it should encounter the corrupt object(s)
@@ -3177,11 +3166,6 @@ func RunTestGetListWithoutErrorAggregation(ctx context.Context, t *testing.T, st
 			Name:      objNameFn(i),
 			Namespace: "ns",
 		}}
-		if i%2 == 0 {
-			obj.Annotations = map[string]string{
-				corruptErrKey: "",
-			}
-		}
 		testPropagateStore(ctx, t, store, obj)
 	}
 
@@ -3199,8 +3183,13 @@ func RunTestGetListWithoutErrorAggregation(ctx context.Context, t *testing.T, st
 		t.Fatalf("Expected length: %d, but got: %d", want, got)
 	}
 
-	// Step 3: corrupt the transformer so marked objects fail to decode
-	revertTransformer := store.UpdateTransformer(newErrInjectingModifier(corruptErr))
+	// Step 3: corrupt the transformer so even-numbered objects fail to decode
+	revertTransformer := store.UpdateTransformer(newErrInjectingModifier(func(key string) error {
+		if idOf(key)%2 == 0 {
+			return corruptErr
+		}
+		return nil
+	}))
 	defer revertTransformer()
 
 	// Step 4: list again, expect GetList to abort on the first corrupt object

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/store_tests.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/store_tests.go
@@ -2804,15 +2804,46 @@ func RunTestGetListRecursivePrefix(ctx context.Context, t *testing.T, store stor
 
 const (
 	// if the following annotation is present, the object is marked to become corrupt
-	CorruptErrKey = "testing.transformer.k8s.io/corrupt-error"
+	corruptErrKey = "testing.transformer.k8s.io/corrupt-error"
 
 	// if the following annotation is present, the object is marked
 	// to fail with an unexpected non-corrupt error
-	UnexpectedErrKey = "testing.transformer.k8s.io/unexpected-error"
+	unexpectedErrKey = "testing.transformer.k8s.io/unexpected-error"
 )
 
+// errInjectingTransformer wraps an existing transformer and injects errors
+// for objects whose raw data contains specific marker strings. This lets the
+// shared test code own both the markers (annotations on test objects) and the
+// transformer behavior (error injection), keeping the full test fixture in one place.
+type errInjectingTransformer struct {
+	value.Transformer
+	// corruptErr is the error returned for objects marked with corruptErrKey.
+	// The caller provides this because the concrete error type (e.g. corruptObjectError)
+	// may be unexported in the storage backend package.
+	corruptErr error
+}
+
+func (t *errInjectingTransformer) TransformFromStorage(ctx context.Context, data []byte, dataCtx value.Context) (out []byte, stale bool, err error) {
+	out, stale, err = t.Transformer.TransformFromStorage(ctx, data, dataCtx)
+	switch {
+	case err != nil:
+		return out, stale, err
+	case strings.Contains(string(data), corruptErrKey):
+		return out, stale, t.corruptErr
+	case strings.Contains(string(data), unexpectedErrKey):
+		return out, stale, fmt.Errorf("bits flipped")
+	}
+	return out, stale, err
+}
+
+func newErrInjectingModifier(corruptErr error) TransformerModifier {
+	return func(orig value.Transformer) value.Transformer {
+		return &errInjectingTransformer{Transformer: orig, corruptErr: corruptErr}
+	}
+}
+
 // RunTestGetListWithErrorAggregation tests aggregation of errors while the list operation is in progress
-func RunTestGetListWithErrorAggregation(ctx context.Context, t *testing.T, store InterfaceWithCorruptTransformer) {
+func RunTestGetListWithErrorAggregation(ctx context.Context, t *testing.T, store InterfaceWithTransformerOverride, corruptErr error) {
 	// the test creates n objects and assigns each object unique id i ie. 1 <= i <= n
 	objNameFn := func(id int) string {
 		// pad with leading zeros so that for i, j where i < j, object
@@ -2847,9 +2878,9 @@ func RunTestGetListWithErrorAggregation(ctx context.Context, t *testing.T, store
 			corrupter: func(i int) string {
 				switch {
 				case i == 2:
-					return UnexpectedErrKey
+					return unexpectedErrKey
 				case i%2 == 0:
-					return CorruptErrKey
+					return corruptErrKey
 				default:
 					return ""
 				}
@@ -2888,7 +2919,7 @@ func RunTestGetListWithErrorAggregation(ctx context.Context, t *testing.T, store
 			n: 7,
 			corrupter: func(i int) string {
 				if i%2 == 0 {
-					return CorruptErrKey
+					return corruptErrKey
 				}
 				return ""
 			},
@@ -2937,9 +2968,9 @@ func RunTestGetListWithErrorAggregation(ctx context.Context, t *testing.T, store
 			corrupter: func(i int) string {
 				switch {
 				case i == 4:
-					return UnexpectedErrKey
+					return unexpectedErrKey
 				case i%2 == 0:
-					return CorruptErrKey
+					return corruptErrKey
 				default:
 					return ""
 				}
@@ -2997,7 +3028,7 @@ func RunTestGetListWithErrorAggregation(ctx context.Context, t *testing.T, store
 			n: 210,
 			corrupter: func(i int) string {
 				if i%2 == 0 {
-					return CorruptErrKey
+					return corruptErrKey
 				}
 				return ""
 			},
@@ -3039,7 +3070,7 @@ func RunTestGetListWithErrorAggregation(ctx context.Context, t *testing.T, store
 			// - good: {}, all the objects are marked to become corrupt
 			// - corrupt: {1, 2, 3 ... 99, 100}, these objects are marked to become corrupt
 			n:         100,
-			corrupter: func(i int) string { return CorruptErrKey },
+			corrupter: func(i int) string { return corruptErrKey },
 			//  while listing the n objects, we expect the following:
 			//  a) GetList continues to aggregate the corruptObjErr errors
 			//  until it reaches the maximum limit, and then it immediately aborts
@@ -3110,7 +3141,7 @@ func RunTestGetListWithErrorAggregation(ctx context.Context, t *testing.T, store
 			}
 
 			// step 3: change the transformer so the marked objects appear corrupt
-			revertTransformer := store.CorruptTransformer()
+			revertTransformer := store.UpdateTransformer(newErrInjectingModifier(corruptErr))
 			defer revertTransformer()
 
 			// step 4: invoke GetList again, this time it should encounter the corrupt object(s)
@@ -3128,7 +3159,7 @@ func RunTestGetListWithErrorAggregation(ctx context.Context, t *testing.T, store
 
 // RunTestGetListWithoutErrorAggregation tests that when the AllowUnsafeMalformedObjectDeletion
 // feature is disabled, GetList maintains backward compatibility by aborting on the first error.
-func RunTestGetListWithoutErrorAggregation(ctx context.Context, t *testing.T, store InterfaceWithCorruptTransformer) {
+func RunTestGetListWithoutErrorAggregation(ctx context.Context, t *testing.T, store InterfaceWithTransformerOverride, corruptErr error) {
 	prefix := "/pods/ns/"
 	objNameFn := func(id int) string {
 		return fmt.Sprintf("foo-%06d", id)
@@ -3148,7 +3179,7 @@ func RunTestGetListWithoutErrorAggregation(ctx context.Context, t *testing.T, st
 		}}
 		if i%2 == 0 {
 			obj.Annotations = map[string]string{
-				CorruptErrKey: "",
+				corruptErrKey: "",
 			}
 		}
 		testPropagateStore(ctx, t, store, obj)
@@ -3169,7 +3200,7 @@ func RunTestGetListWithoutErrorAggregation(ctx context.Context, t *testing.T, st
 	}
 
 	// Step 3: corrupt the transformer so marked objects fail to decode
-	revertTransformer := store.CorruptTransformer()
+	revertTransformer := store.UpdateTransformer(newErrInjectingModifier(corruptErr))
 	defer revertTransformer()
 
 	// Step 4: list again, expect GetList to abort on the first corrupt object
@@ -3655,9 +3686,11 @@ type InterfaceWithPrefixTransformer interface {
 	UpdatePrefixTransformer(PrefixTransformerModifier) func()
 }
 
-type InterfaceWithCorruptTransformer interface {
+type TransformerModifier func(value.Transformer) value.Transformer
+
+type InterfaceWithTransformerOverride interface {
 	storage.Interface
-	CorruptTransformer() func()
+	UpdateTransformer(TransformerModifier) func()
 }
 
 func RunTestListResourceVersionMatch(ctx context.Context, t *testing.T, store InterfaceWithPrefixTransformer) {

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/watcher_tests.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/watcher_tests.go
@@ -414,7 +414,16 @@ func RunTestWatchError(ctx context.Context, t *testing.T, store InterfaceWithPre
 }
 
 func RunTestWatchWithUnsafeDelete(ctx context.Context, t *testing.T, store InterfaceWithCorruptTransformer) {
-	obj := &example.Pod{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "test-ns"}}
+	obj := &example.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "test-ns",
+			// this annotation marks the object to become corrupt
+			Annotations: map[string]string{
+				CorruptErrKey: "",
+			},
+		},
+	}
 	key := computePodKey(obj)
 
 	out := &example.Pod{}

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/watcher_tests.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/watcher_tests.go
@@ -418,10 +418,6 @@ func RunTestWatchWithUnsafeDelete(ctx context.Context, t *testing.T, store Inter
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "foo",
 			Namespace: "test-ns",
-			// this annotation marks the object to become corrupt
-			Annotations: map[string]string{
-				corruptErrKey: "",
-			},
 		},
 	}
 	key := computePodKey(obj)
@@ -442,8 +438,10 @@ func RunTestWatchWithUnsafeDelete(ctx context.Context, t *testing.T, store Inter
 		t.Errorf("Unexpected error: %v", err)
 	}
 
-	// Now trigger watch error by injecting failing transformer.
-	revertTransformer := store.UpdateTransformer(newErrInjectingModifier(corruptErr))
+	// Now trigger watch error by making the object fail to transform.
+	revertTransformer := store.UpdateTransformer(newErrInjectingModifier(func(string) error {
+		return corruptErr
+	}))
 	defer revertTransformer()
 
 	w, err := store.Watch(ctx, key, storage.ListOptions{ResourceVersion: list.ResourceVersion, Predicate: storage.Everything})

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/watcher_tests.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/watcher_tests.go
@@ -413,14 +413,14 @@ func RunTestWatchError(ctx context.Context, t *testing.T, store InterfaceWithPre
 	testCheckEventType(t, w, watch.Error)
 }
 
-func RunTestWatchWithUnsafeDelete(ctx context.Context, t *testing.T, store InterfaceWithCorruptTransformer) {
+func RunTestWatchWithUnsafeDelete(ctx context.Context, t *testing.T, store InterfaceWithTransformerOverride, corruptErr error) {
 	obj := &example.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "foo",
 			Namespace: "test-ns",
 			// this annotation marks the object to become corrupt
 			Annotations: map[string]string{
-				CorruptErrKey: "",
+				corruptErrKey: "",
 			},
 		},
 	}
@@ -443,7 +443,7 @@ func RunTestWatchWithUnsafeDelete(ctx context.Context, t *testing.T, store Inter
 	}
 
 	// Now trigger watch error by injecting failing transformer.
-	revertTransformer := store.CorruptTransformer()
+	revertTransformer := store.UpdateTransformer(newErrInjectingModifier(corruptErr))
 	defer revertTransformer()
 
 	w, err := store.Watch(ctx, key, storage.ListOptions{ResourceVersion: list.ResourceVersion, Predicate: storage.Everything})


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Behavior change: Previously the abort fired on the error after the aggregator was full, so a list with exactly 100 corrupt items completed the scan and returned 100 errors + `CauseTypeTooMany`. Now it aborts at the 100th, drops any items after it from the result, and reports CauseTypeTooMany. So the change limits the length of the error slice to 100. 

This PR adds a unit test for storage `GetList` to verify that list error aggregation works as expected

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
KEP: https://github.com/kubernetes/enhancements/pull/3927
```
