### PR TITLE
Fix grammar mistake in kubeadm config v1beta4

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/v1beta4/doc.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta4/doc.go
@@ -60,7 +60,7 @@ limitations under the License.
 //
 // # Basics
 //
-// The preferred way to configure kubeadm is to pass an YAML configuration file with the --config option. Some of the
+// The preferred way to configure kubeadm is to pass a YAML configuration file with the --config option. Some of the
 // configuration options defined in the kubeadm config file are also available as command line flags, but only
 // the most common/simple use case are supported with this approach.
 //


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/kind documentation

#### What this PR does / why we need it:
Fix grammar mistake in kubeadm configuration documentation - use "a YAML" instead of "an YAML" since YAML starts with a consonant sound.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
