### PR TITLE
kube-proxy: net.InterfaceAddrs may return error due to a race condition, causing the Nodeport Service to be inaccessible

### DIFF
--- a/pkg/proxy/ipvs/netlink_linux.go
+++ b/pkg/proxy/ipvs/netlink_linux.go
@@ -133,7 +133,10 @@ func (h *netlinkHandle) ListBindAddress(devName string) ([]string, error) {
 func (h *netlinkHandle) GetAllLocalAddresses() (sets.Set[string], error) {
 	addr, err := net.InterfaceAddrs()
 	if err != nil {
-		return nil, fmt.Errorf("Could not get addresses: %v", err)
+		err = proxyutil.GetInterfaceAddrsByInterfaces(&addr)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return proxyutil.AddressSet(h.isValidForSet, addr), nil
 }

--- a/pkg/proxy/util/network.go
+++ b/pkg/proxy/util/network.go
@@ -33,7 +33,14 @@ type RealNetwork struct{}
 
 // InterfaceAddrs wraps net.InterfaceAddrs(), it's a part of NetworkInterfacer interface.
 func (RealNetwork) InterfaceAddrs() ([]net.Addr, error) {
-	return net.InterfaceAddrs()
+	addr, err := net.InterfaceAddrs()
+	if err != nil {
+		err = GetInterfaceAddrsByInterfaces(&addr)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return addr, nil
 }
 
 var _ NetworkInterfacer = &RealNetwork{}


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:
1, syncProxyRules->GetNodeIPs->net.InterfaceAddrs()->interfaceAddrTable(which is in interface_linux.go for Linux)->syscall.NetlinkRIB(syscall.RTM_GETADDR, syscall.AF_UNSPEC) is called.
2. Then an interface is delete by CNI.
3. Then interfaceAddrTable(which is in interface_linux.go) call interfaceTable(which is in interface_linux.go)->syscall.NetlinkRIB(syscall.RTM_GETLINK, syscall.AF_UNSPEC)
The key point is that, RTM_GETADDR's return have the delete interface, but the RTM_GETLINK's return donot have the deleted interface.
4. Then in interfaceAddrTable->addrTable will return err.
5. Then the syncProxyRules will not write correct forward configuration because the GetNodeIPs's return donot have any ip.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #129146

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kube-proxy: net.InterfaceAddrs may return error due to a race condition, causing the Nodeport Service to be inaccessible
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
