### PR TITLE
e2e: don't panic asserting inside wait.Poll

### DIFF
--- a/test/e2e/network/dns_common.go
+++ b/test/e2e/network/dns_common.go
@@ -490,7 +490,7 @@ func assertFilesContain(ctx context.Context, fileNames []string, fileDir string,
 
 			if err != nil {
 				if ctx.Err() != nil {
-					framework.Failf("Unable to read %s from pod %s/%s: %v", fileName, pod.Namespace, pod.Name, err)
+					return false, fmt.Errorf("Unable to read %s from pod %s/%s: %v", fileName, pod.Namespace, pod.Name, err)
 				} else {
 					framework.Logf("Unable to read %s from pod %s/%s: %v", fileName, pod.Namespace, pod.Name, err)
 				}


### PR DESCRIPTION

/kind bug
/kind cleanup

```release-note
NONE
```

Seen in https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-kind-network-nftables/1865973883379650560

```
I1209 04:54:17.206099 71801 dns_common.go:514] Pod client logs for jessie-querier: 
E1209 04:54:22.123039   71801 core_dsl.go:427] "Observed a panic" panic=<
	�[1m�[38;5;9mYour Test Panicked�[0m
	�[38;5;243mk8s.io/kubernetes/test/e2e/network/dns_common.go:493�[0m
	  When you, or your assertion library, calls Ginkgo's Fail(),
	  Ginkgo panics to prevent subsequent assertions from running.
```