### PR TITLE
Promote raywainman and gjtempleton to HPA approvers

### DIFF
--- a/pkg/controller/podautoscaler/OWNERS
+++ b/pkg/controller/podautoscaler/OWNERS
@@ -2,13 +2,15 @@
 
 reviewers:
   - gjtempleton
-  - mwielgus
+  - raywainman
 approvers:
-  - mwielgus
+  - gjtempleton
+  - raywainman
 emeritus_approvers:
   - jszczepkowski
   - piosz
   - MaciekPytel
   - josephburnett
+  - mwielgus
 labels:
   - sig/autoscaling


### PR DESCRIPTION
Add raywainman and gjtempleton to HPA approvers to unblock work on HPA and ensure the community can continue to contribute to the project.

gjtempleton - Autoscaling SIG lead.
raywainman - already active owner in the VPA repository, technical lead of HPA within GKE.

/kind cleanup

#### Which issue(s) this PR fixes:

Fixes #

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
