### PR TITLE
Automated cherry pick of #128086: prevent unnecessary resolving of iscsi/fc devices to dm

### DIFF
--- a/pkg/volume/util/device_util_linux.go
+++ b/pkg/volume/util/device_util_linux.go
@@ -31,8 +31,13 @@ import (
 	"k8s.io/klog/v2"
 )
 
-// FindMultipathDeviceForDevice given a device name like /dev/sdx, find the devicemapper parent
+// FindMultipathDeviceForDevice given a device name like /dev/sdx, find the devicemapper parent. If called with a device
+// already resolved to devicemapper, do nothing.
 func (handler *deviceHandler) FindMultipathDeviceForDevice(device string) string {
+	if strings.HasPrefix(device, "/dev/dm-") {
+		return device
+	}
+
 	io := handler.getIo
 	disk, err := findDeviceForPath(device, io)
 	if err != nil {


### PR DESCRIPTION
Cherry pick of #128086 on release-1.28.

#128086: prevent unnecessary resolving of iscsi/fc devices to dm

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixed a storage bug around multipath. iSCSI and Fibre Channel devices attached to nodes via multipath now resolve correctly if partitioned.
```