### PR TITLE
Clean up v1alpha1 serving for authentication APIs

### DIFF
--- a/pkg/registry/authentication/rest/storage_authentication.go
+++ b/pkg/registry/authentication/rest/storage_authentication.go
@@ -18,7 +18,6 @@ package rest
 
 import (
 	authenticationv1 "k8s.io/api/authentication/v1"
-	authenticationv1alpha1 "k8s.io/api/authentication/v1alpha1"
 	authenticationv1beta1 "k8s.io/api/authentication/v1beta1"
 	"k8s.io/apiserver/pkg/authentication/authenticator"
 	"k8s.io/apiserver/pkg/registry/generic"
@@ -46,10 +45,6 @@ func (p RESTStorageProvider) NewRESTStorage(apiResourceConfigSource serverstorag
 	// If you add a version here, be sure to add an entry in `k8s.io/kubernetes/cmd/kube-apiserver/app/aggregator.go with specific priorities.
 	// TODO refactor the plumbing to provide the information in the APIGroupInfo
 
-	if storageMap := p.v1alpha1Storage(apiResourceConfigSource, restOptionsGetter); len(storageMap) > 0 {
-		apiGroupInfo.VersionedResourcesStorageMap[authenticationv1alpha1.SchemeGroupVersion.Version] = storageMap
-	}
-
 	if storageMap := p.v1beta1Storage(apiResourceConfigSource, restOptionsGetter); len(storageMap) > 0 {
 		apiGroupInfo.VersionedResourcesStorageMap[authenticationv1beta1.SchemeGroupVersion.Version] = storageMap
 	}
@@ -74,17 +69,6 @@ func (p RESTStorageProvider) v1Storage(apiResourceConfigSource serverstorage.API
 		storage[resource] = selfSRStorage
 	}
 
-	return storage
-}
-
-func (p RESTStorageProvider) v1alpha1Storage(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter) map[string]rest.Storage {
-	storage := map[string]rest.Storage{}
-
-	// selfsubjectreviews
-	if resource := "selfsubjectreviews"; apiResourceConfigSource.ResourceEnabled(authenticationv1alpha1.SchemeGroupVersion.WithResource(resource)) {
-		selfSRStorage := selfsubjectreview.NewREST()
-		storage[resource] = selfSRStorage
-	}
 	return storage
 }
 

--- a/test/integration/auth/selfsubjectreview_test.go
+++ b/test/integration/auth/selfsubjectreview_test.go
@@ -26,7 +26,6 @@ import (
 	"testing"
 
 	authenticationv1 "k8s.io/api/authentication/v1"
-	authenticationv1alpha1 "k8s.io/api/authentication/v1alpha1"
 	authenticationv1beta1 "k8s.io/api/authentication/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/authentication/authenticator"
@@ -39,7 +38,7 @@ import (
 
 func TestGetsSelfAttributes(t *testing.T) {
 	// KUBE_APISERVER_SERVE_REMOVED_APIS_FOR_ONE_RELEASE allows for APIs pending removal to not block tests
-	// TODO: Remove this line once authentication v1alpha1 types to be removed in 1.32 are fully removed
+	// TODO: Remove this line when oldest emulation version is 1.34, along with removal of v1beta1 SelfSubjectReview (unservable by default but still servable via this envvar in 1.33)
 	t.Setenv("KUBE_APISERVER_SERVE_REMOVED_APIS_FOR_ONE_RELEASE", "true")
 
 	tests := []struct {
@@ -98,7 +97,6 @@ func TestGetsSelfAttributes(t *testing.T) {
 
 	kubeClient, _, tearDownFn := framework.StartTestServer(tCtx, t, framework.TestServerSetup{
 		ModifyServerRunOptions: func(opts *options.ServerRunOptions) {
-			opts.APIEnablement.RuntimeConfig.Set("authentication.k8s.io/v1alpha1=true")
 			opts.APIEnablement.RuntimeConfig.Set("authentication.k8s.io/v1beta1=true")
 			opts.APIEnablement.RuntimeConfig.Set("authentication.k8s.io/v1=true")
 			opts.Authorization.Modes = []string{"AlwaysAllow"}
@@ -121,85 +119,58 @@ func TestGetsSelfAttributes(t *testing.T) {
 			response = tc.userInfo
 			respMu.Unlock()
 
-			res, err := kubeClient.AuthenticationV1alpha1().
-				SelfSubjectReviews().
-				Create(tCtx, &authenticationv1alpha1.SelfSubjectReview{}, metav1.CreateOptions{})
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-
-			if res == nil {
-				t.Fatalf("empty response")
-			}
-
-			if res.Status.UserInfo.Username != tc.expectedName {
-				t.Fatalf("unexpected username: wanted %s, got %s", tc.expectedName, res.Status.UserInfo.Username)
-			}
-
-			if res.Status.UserInfo.UID != tc.expectedUID {
-				t.Fatalf("unexpected uid: wanted %s, got %s", tc.expectedUID, res.Status.UserInfo.UID)
-			}
-
-			if !reflect.DeepEqual(res.Status.UserInfo.Groups, tc.expectedGroups) {
-				t.Fatalf("unexpected groups: wanted %v, got %v", tc.expectedGroups, res.Status.UserInfo.Groups)
-			}
-
-			if !reflect.DeepEqual(res.Status.UserInfo.Extra, tc.expectedExtra) {
-				t.Fatalf("unexpected extra: wanted %v, got %v", tc.expectedExtra, res.Status.UserInfo.Extra)
-			}
-
-			res2, err := kubeClient.AuthenticationV1beta1().
+			resBeta, err := kubeClient.AuthenticationV1beta1().
 				SelfSubjectReviews().
 				Create(tCtx, &authenticationv1beta1.SelfSubjectReview{}, metav1.CreateOptions{})
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
 
-			if res2 == nil {
+			if resBeta == nil {
 				t.Fatalf("empty response")
 			}
 
-			if res2.Status.UserInfo.Username != tc.expectedName {
-				t.Fatalf("unexpected username: wanted %s, got %s", tc.expectedName, res.Status.UserInfo.Username)
+			if resBeta.Status.UserInfo.Username != tc.expectedName {
+				t.Fatalf("unexpected username: wanted %s, got %s", tc.expectedName, resBeta.Status.UserInfo.Username)
 			}
 
-			if res2.Status.UserInfo.UID != tc.expectedUID {
-				t.Fatalf("unexpected uid: wanted %s, got %s", tc.expectedUID, res.Status.UserInfo.UID)
+			if resBeta.Status.UserInfo.UID != tc.expectedUID {
+				t.Fatalf("unexpected uid: wanted %s, got %s", tc.expectedUID, resBeta.Status.UserInfo.UID)
 			}
 
-			if !reflect.DeepEqual(res2.Status.UserInfo.Groups, tc.expectedGroups) {
-				t.Fatalf("unexpected groups: wanted %v, got %v", tc.expectedGroups, res.Status.UserInfo.Groups)
+			if !reflect.DeepEqual(resBeta.Status.UserInfo.Groups, tc.expectedGroups) {
+				t.Fatalf("unexpected groups: wanted %v, got %v", tc.expectedGroups, resBeta.Status.UserInfo.Groups)
 			}
 
-			if !reflect.DeepEqual(res2.Status.UserInfo.Extra, tc.expectedExtra) {
-				t.Fatalf("unexpected extra: wanted %v, got %v", tc.expectedExtra, res.Status.UserInfo.Extra)
+			if !reflect.DeepEqual(resBeta.Status.UserInfo.Extra, tc.expectedExtra) {
+				t.Fatalf("unexpected extra: wanted %v, got %v", tc.expectedExtra, resBeta.Status.UserInfo.Extra)
 			}
 
-			res3, err := kubeClient.AuthenticationV1().
+			resV1, err := kubeClient.AuthenticationV1().
 				SelfSubjectReviews().
 				Create(context.TODO(), &authenticationv1.SelfSubjectReview{}, metav1.CreateOptions{})
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
 
-			if res3 == nil {
+			if resV1 == nil {
 				t.Fatalf("empty response")
 			}
 
-			if res3.Status.UserInfo.Username != tc.expectedName {
-				t.Fatalf("unexpected username: wanted %s, got %s", tc.expectedName, res.Status.UserInfo.Username)
+			if resV1.Status.UserInfo.Username != tc.expectedName {
+				t.Fatalf("unexpected username: wanted %s, got %s", tc.expectedName, resV1.Status.UserInfo.Username)
 			}
 
-			if res3.Status.UserInfo.UID != tc.expectedUID {
-				t.Fatalf("unexpected uid: wanted %s, got %s", tc.expectedUID, res.Status.UserInfo.UID)
+			if resV1.Status.UserInfo.UID != tc.expectedUID {
+				t.Fatalf("unexpected uid: wanted %s, got %s", tc.expectedUID, resV1.Status.UserInfo.UID)
 			}
 
-			if !reflect.DeepEqual(res3.Status.UserInfo.Groups, tc.expectedGroups) {
-				t.Fatalf("unexpected groups: wanted %v, got %v", tc.expectedGroups, res.Status.UserInfo.Groups)
+			if !reflect.DeepEqual(resV1.Status.UserInfo.Groups, tc.expectedGroups) {
+				t.Fatalf("unexpected groups: wanted %v, got %v", tc.expectedGroups, resV1.Status.UserInfo.Groups)
 			}
 
-			if !reflect.DeepEqual(res3.Status.UserInfo.Extra, tc.expectedExtra) {
-				t.Fatalf("unexpected extra: wanted %v, got %v", tc.expectedExtra, res.Status.UserInfo.Extra)
+			if !reflect.DeepEqual(resV1.Status.UserInfo.Extra, tc.expectedExtra) {
+				t.Fatalf("unexpected extra: wanted %v, got %v", tc.expectedExtra, resV1.Status.UserInfo.Extra)
 			}
 		})
 	}
@@ -212,7 +183,6 @@ func TestGetsSelfAttributesError(t *testing.T) {
 	tCtx := ktesting.Init(t)
 	kubeClient, _, tearDownFn := framework.StartTestServer(tCtx, t, framework.TestServerSetup{
 		ModifyServerRunOptions: func(opts *options.ServerRunOptions) {
-			opts.APIEnablement.RuntimeConfig.Set("authentication.k8s.io/v1alpha1=true")
 			opts.APIEnablement.RuntimeConfig.Set("authentication.k8s.io/v1beta1=true")
 			opts.APIEnablement.RuntimeConfig.Set("authentication.k8s.io/v1=true")
 			opts.Authorization.Modes = []string{"AlwaysAllow"}
@@ -236,22 +206,6 @@ func TestGetsSelfAttributesError(t *testing.T) {
 	defer tearDownFn()
 
 	expected := fmt.Errorf("Unauthorized")
-
-	{ // v1alpha1
-		toggle.Store(!toggle.Load().(bool))
-
-		_, err := kubeClient.AuthenticationV1alpha1().
-			SelfSubjectReviews().
-			Create(tCtx, &authenticationv1alpha1.SelfSubjectReview{}, metav1.CreateOptions{})
-		if err == nil {
-			t.Fatalf("expected error: %v, got nil", err)
-		}
-
-		toggle.Store(!toggle.Load().(bool))
-		if expected.Error() != err.Error() {
-			t.Fatalf("expected error: %v, got %v", expected, err)
-		}
-	}
 
 	{ // v1beta1
 		toggle.Store(!toggle.Load().(bool))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kube-apiserver: inactive serving code is removed for authentication.k8s.io/v1alpha1 APIs
```

/sig auth
/kind cleanup