### PR TITLE
OWNERS: Update SIG Release aliases

### DIFF
--- a/CHANGELOG/OWNERS
+++ b/CHANGELOG/OWNERS
@@ -6,21 +6,12 @@ options:
 approvers:
   - release-engineering-approvers
   - release-managers
-  - AuraSinis # 1.24 Release Notes Lead
-  - cici37 # 1.23 Release Notes Lead
-  - csantanapr # 1.25 Release Notes Lead
-  - harshanarayana # 1.27 Release Notes Lead
-  - ramrodo # 1.26 Release Notes Lead
-  - sanchita-07 # 1.28 Release Notes Lead
-  - fsmunoz # 1.29 Release Notes Lead
-  - rashansmith # 1.30 Release Notes Lead
+  - release-team-subproject-leads
+  - satyampsoni # 1.32 Release Notes Lead
 reviewers:
   - release-managers
-  - fykaa # 1.30 Release Notes Shadow
-  - npolshakova # 1.30 Release Notes Shadow
-  - OrlinVasilev # 1.30 Release Notes Shadow
-  - rashansmith # 1.30 Release Notes Lead
-  - satyampsoni # 1.30 Release Notes Shadow
+  - release-team-subproject-leads
+  - satyampsoni # 1.32 Release Notes Lead
 labels:
   - sig/release
   - area/release-eng

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -94,6 +94,7 @@ aliases:
     - puerco # SIG Technical Lead / RelEng subproject owner / Release Manager
     - saschagrunert # SIG Chair / RelEng subproject owner / Release Manager
     - Verolop # SIG Technical Lead / RelEng subproject owner / Release Manager
+    - xmudrii # RelEng subproject lead / Release Manager
   release-managers:
     - cpanato
     - jeremyrickard
@@ -114,7 +115,7 @@ aliases:
     - puerco # SIG Technical Lead / RelEng subproject owner / Release Manager
     - saschagrunert # SIG Chair / RelEng subproject owner / Release Manager
     - Verolop # SIG Technical Lead / RelEng subproject owner / Release Manager
-    - xmudrii # Release Manager
+    - xmudrii # RelEng subproject lead / Release Manager
   build-image-reviewers:
     - BenTheElder
     - cblecker
@@ -126,7 +127,7 @@ aliases:
     - puerco # SIG Technical Lead / RelEng subproject owner / Release Manager
     - saschagrunert # SIG Chair / RelEng subproject owner / Release Manager
     - Verolop # SIG Technical Lead / RelEng subproject owner / Release Manager
-    - xmudrii # Release Manager
+    - xmudrii # RelEng subproject lead / Release Manager
   sig-storage-approvers:
     - gnufied
     - jsafrane

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -104,6 +104,9 @@ aliases:
     - saschagrunert
     - Verolop
     - xmudrii
+  release-team-subproject-leads:
+    - gracenng # Release Team subproject lead
+    - katcosgrove # Release Team subproject lead
   build-image-approvers:
     - BenTheElder
     - cblecker


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup documentation

#### What this PR does / why we need it:

- OWNERS(sig-release): Reflect Marko's position as RelEng subprj lead 
- OWNERS(sig-release): Add `release-team-subproject-leads` alias
- CHANGELOG: Reflect correct approvers/reviewers
  - Add `release-team-subproject-leads` alias to approvers/reviewers
  - Add 1.32 Release Notes Lead to approvers/reviewers
  - Prune previous Release Team entries

Signed-off-by: Stephen Augustus <foo@auggie.dev>

cc: @kubernetes/sig-release-leads @gracenng @katcosgrove @xmudrii 
ref: https://github.com/kubernetes/kubernetes/pull/129172, https://github.com/kubernetes/sig-release/issues/2695
xref: https://github.com/kubernetes/sig-release/issues/2516, https://github.com/kubernetes/sig-release/issues/2515

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
