### PR TITLE
TestSelectableFields flake: Shut down webhook after apiserver

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/fieldselector_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/fieldselector_test.go
@@ -200,23 +200,23 @@ func (sf selectableFieldTestCase) Name() string {
 }
 
 func TestSelectableFields(t *testing.T) {
+	// start a conversion webhook
+	handler := conversion.NewObjectConverterWebhookHandler(t, crdConverter)
+	upCh, handler := closeOnCall(handler)
+	whTearDown, webhookClientConfig, err := conversion.StartConversionWebhookServer(handler)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(whTearDown)
+
 	_, ctx := ktesting.NewTestContext(t)
 	tearDown, apiExtensionClient, dynamicClient, err := fixtures.StartDefaultServerWithClients(t)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer tearDown()
+	t.Cleanup(tearDown)
 
 	crd := selectableFieldFixture.DeepCopy()
-
-	// start a conversion webhook
-	handler := conversion.NewObjectConverterWebhookHandler(t, crdConverter)
-	upCh, handler := closeOnCall(handler)
-	tearDown, webhookClientConfig, err := conversion.StartConversionWebhookServer(handler)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer tearDown()
 
 	if webhookClientConfig != nil {
 		crd.Spec.Conversion = &apiextensionsv1.CustomResourceConversion{


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind flake


#### What this PR does / why we need it:

https://github.com/kubernetes/kubernetes/issues/128724 has only had a few failures in the last month.  A couple of them look like:

```
=== RUN   TestSelectableFields
    testserver.go:285: Resolved testserver package path to: "/home/prow/go/src/k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/testing"
    testserver.go:169: runtime-config=map[api/all:true]
    testserver.go:170: Starting apiextensions-apiserver on port 35393...
    testserver.go:196: Waiting for /healthz to be ok...
panic: conversion webhook for tests.example.com/v1, Kind=Shirt failed: Post "https://127.0.0.1:40859/convert?timeout=30s": EOF

goroutine 63139 [running]:
k8s.io/apiserver/pkg/storage/etcd3.decodeObj({0x300fff0?, 0xc001476a00?}, {0x30294c0, 0x489a200}, {0xc0017dc1e0?, 0x1da?, 0x1e0?}, 0x5a9b)
	/home/prow/go/src/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher.go:708 +0x1c6
k8s.io/apiserver/pkg/storage/etcd3.(*watchChan).prepareObjs(0xc0016b7a00, 0xc001604550)
	/home/prow/go/src/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher.go:676 +0xe5
k8s.io/apiserver/pkg/storage/etcd3.(*watchChan).transform(0xc0016b7a00, 0xc001604550)
	/home/prow/go/src/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher.go:565 +0x3b
k8s.io/apiserver/pkg/storage/etcd3.(*watchChan).serialProcessEvents(0xc0016b7a00, 0xc0005b9fb0?)
	/home/prow/go/src/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher.go:441 +0x11e
created by k8s.io/apiserver/pkg/storage/etcd3.(*watchChan).processEvents in goroutine 63057
	/home/prow/go/src/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher.go:433 +0xb3
```

This suggests the webhook is unavailable.   This PR changes the order of test cleanup to shut down the webhook AFTER the apiserver with the aim of preventing this particular error.

I'm not claiming this fixes the flakes, but it shouldn't hurt, it might help, and it should make future failures more clear.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
