### PR TITLE
Add watch permission to namespace-controller for WatchListClient feature

### DIFF
--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy.go
@@ -254,7 +254,7 @@ func buildControllerRoles() ([]rbacv1.ClusterRole, []rbacv1.ClusterRoleBinding) 
 		Rules: []rbacv1.PolicyRule{
 			rbacv1helpers.NewRule("get", "list", "watch", "delete").Groups(legacyGroup).Resources("namespaces").RuleOrDie(),
 			rbacv1helpers.NewRule("update").Groups(legacyGroup).Resources("namespaces/finalize", "namespaces/status").RuleOrDie(),
-			rbacv1helpers.NewRule("get", "list", "delete", "deletecollection").Groups("*").Resources("*").RuleOrDie(),
+			rbacv1helpers.NewRule("get", "list", "watch", "delete", "deletecollection").Groups("*").Resources("*").RuleOrDie(),
 		},
 	})
 	addControllerRole(&controllerRoles, &controllerRoleBindings, func() rbacv1.ClusterRole {

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/controller-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/controller-roles.yaml
@@ -875,6 +875,7 @@ items:
     - deletecollection
     - get
     - list
+    - watch
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRole
   metadata:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The WatchListClient feature is enabled for kube-controller-manager, but namespace-controller misses the necessary "watch" permission, which results in 30 error logs being generated every time a namespace is deleted and falling back to the standard LIST semantics.

The following is an example of errors when deleting a single namespace:
```
E1213 09:24:30.263981       1 metadata.go:231] "The watchlist request ended with an error, falling back to the standard LIST semantics" err="persistentvolumeclaims is forbidden: User \"system:serviceaccount:kube-system:namespace-controller\" cannot watch resource \"persistentvolumeclaims\" in API group \"\" in the namespace \"foo\"" logger="namespace-controller" resource="/v1, Resource=persistentvolumeclaims"
E1213 09:24:30.272435       1 metadata.go:231] "The watchlist request ended with an error, falling back to the standard LIST semantics" err="configmaps is forbidden: User \"system:serviceaccount:kube-system:namespace-controller\" cannot watch resource \"configmaps\" in API group \"\" in the namespace \"foo\"" logger="namespace-controller" resource="/v1, Resource=configmaps"
E1213 09:24:30.275915       1 metadata.go:231] "The watchlist request ended with an error, falling back to the standard LIST semantics" err="resourcequotas is forbidden: User \"system:serviceaccount:kube-system:namespace-controller\" cannot watch resource \"resourcequotas\" in API group \"\" in the namespace \"foo\"" logger="namespace-controller" resource="/v1, Resource=resourcequotas"
E1213 09:24:30.279189       1 metadata.go:231] "The watchlist request ended with an error, falling back to the standard LIST semantics" err="csistoragecapacities.storage.k8s.io is forbidden: User \"system:serviceaccount:kube-system:namespace-controller\" cannot watch resource \"csistoragecapacities\" in API group \"storage.k8s.io\" in the namespace \"foo\"" logger="namespace-controller" resource="storage.k8s.io/v1, Resource=csistoragecapacities"
W1213 09:24:30.281913       1 type.go:183] The watchlist request for pods ended with an error, falling back to the standard LIST semantics, err = pods is forbidden: User "system:serviceaccount:kube-system:namespace-controller" cannot watch resource "pods" in API group "" in the namespace "foo"
E1213 09:24:30.285904       1 metadata.go:231] "The watchlist request ended with an error, falling back to the standard LIST semantics" err="pods is forbidden: User \"system:serviceaccount:kube-system:namespace-controller\" cannot watch resource \"pods\" in API group \"\" in the namespace \"foo\"" logger="namespace-controller" resource="/v1, Resource=pods"
E1213 09:24:30.289490       1 metadata.go:231] "The watchlist request ended with an error, falling back to the standard LIST semantics" err="horizontalpodautoscalers.autoscaling is forbidden: User \"system:serviceaccount:kube-system:namespace-controller\" cannot watch resource \"horizontalpodautoscalers\" in API group \"autoscaling\" in the namespace \"foo\"" logger="namespace-controller" resource="autoscaling/v2, Resource=horizontalpodautoscalers"
E1213 09:24:30.298517       1 metadata.go:231] "The watchlist request ended with an error, falling back to the standard LIST semantics" err="jobs.batch is forbidden: User \"system:serviceaccount:kube-system:namespace-controller\" cannot watch resource \"jobs\" in API group \"batch\" in the namespace \"foo\"" logger="namespace-controller" resource="batch/v1, Resource=jobs"
E1213 09:24:30.397754       1 metadata.go:231] "The watchlist request ended with an error, falling back to the standard LIST semantics" err="endpointslices.discovery.k8s.io is forbidden: User \"system:serviceaccount:kube-system:namespace-controller\" cannot watch resource \"endpointslices\" in API group \"discovery.k8s.io\" in the namespace \"foo\"" logger="namespace-controller" resource="discovery.k8s.io/v1, Resource=endpointslices"
E1213 09:24:30.401047       1 metadata.go:231] "The watchlist request ended with an error, falling back to the standard LIST semantics" err="replicasets.apps is forbidden: User \"system:serviceaccount:kube-system:namespace-controller\" cannot watch resource \"replicasets\" in API group \"apps\" in the namespace \"foo\"" logger="namespace-controller" resource="apps/v1, Resource=replicasets"
E1213 09:24:30.404902       1 metadata.go:231] "The watchlist request ended with an error, falling back to the standard LIST semantics" err="poddisruptionbudgets.policy is forbidden: User \"system:serviceaccount:kube-system:namespace-controller\" cannot watch resource \"poddisruptionbudgets\" in API group \"policy\" in the namespace \"foo\"" logger="namespace-controller" resource="policy/v1, Resource=poddisruptionbudgets"
E1213 09:24:30.408699       1 metadata.go:231] "The watchlist request ended with an error, falling back to the standard LIST semantics" err="replicationcontrollers is forbidden: User \"system:serviceaccount:kube-system:namespace-controller\" cannot watch resource \"replicationcontrollers\" in API group \"\" in the namespace \"foo\"" logger="namespace-controller" resource="/v1, Resource=replicationcontrollers"
E1213 09:24:30.411726       1 metadata.go:231] "The watchlist request ended with an error, falling back to the standard LIST semantics" err="events.events.k8s.io is forbidden: User \"system:serviceaccount:kube-system:namespace-controller\" cannot watch resource \"events\" in API group \"events.k8s.io\" in the namespace \"foo\"" logger="namespace-controller" resource="events.k8s.io/v1, Resource=events"
E1213 09:24:30.415149       1 metadata.go:231] "The watchlist request ended with an error, falling back to the standard LIST semantics" err="ingresses.networking.k8s.io is forbidden: User \"system:serviceaccount:kube-system:namespace-controller\" cannot watch resource \"ingresses\" in API group \"networking.k8s.io\" in the namespace \"foo\"" logger="namespace-controller" resource="networking.k8s.io/v1, Resource=ingresses"
E1213 09:24:30.418918       1 metadata.go:231] "The watchlist request ended with an error, falling back to the standard LIST semantics" err="rolebindings.rbac.authorization.k8s.io is forbidden: User \"system:serviceaccount:kube-system:namespace-controller\" cannot watch resource \"rolebindings\" in API group \"rbac.authorization.k8s.io\" in the namespace \"foo\"" logger="namespace-controller" resource="rbac.authorization.k8s.io/v1, Resource=rolebindings"
E1213 09:24:30.422637       1 metadata.go:231] "The watchlist request ended with an error, falling back to the standard LIST semantics" err="services is forbidden: User \"system:serviceaccount:kube-system:namespace-controller\" cannot watch resource \"services\" in API group \"\" in the namespace \"foo\"" logger="namespace-controller" resource="/v1, Resource=services"
E1213 09:24:30.426500       1 metadata.go:231] "The watchlist request ended with an error, falling back to the standard LIST semantics" err="cronjobs.batch is forbidden: User \"system:serviceaccount:kube-system:namespace-controller\" cannot watch resource \"cronjobs\" in API group \"batch\" in the namespace \"foo\"" logger="namespace-controller" resource="batch/v1, Resource=cronjobs"
E1213 09:24:30.429908       1 metadata.go:231] "The watchlist request ended with an error, falling back to the standard LIST semantics" err="podtemplates is forbidden: User \"system:serviceaccount:kube-system:namespace-controller\" cannot watch resource \"podtemplates\" in API group \"\" in the namespace \"foo\"" logger="namespace-controller" resource="/v1, Resource=podtemplates"
E1213 09:24:30.433012       1 metadata.go:231] "The watchlist request ended with an error, falling back to the standard LIST semantics" err="secrets is forbidden: User \"system:serviceaccount:kube-system:namespace-controller\" cannot watch resource \"secrets\" in API group \"\" in the namespace \"foo\"" logger="namespace-controller" resource="/v1, Resource=secrets"
E1213 09:24:30.436147       1 metadata.go:231] "The watchlist request ended with an error, falling back to the standard LIST semantics" err="deployments.apps is forbidden: User \"system:serviceaccount:kube-system:namespace-controller\" cannot watch resource \"deployments\" in API group \"apps\" in the namespace \"foo\"" logger="namespace-controller" resource="apps/v1, Resource=deployments"
E1213 09:24:30.439421       1 metadata.go:231] "The watchlist request ended with an error, falling back to the standard LIST semantics" err="leases.coordination.k8s.io is forbidden: User \"system:serviceaccount:kube-system:namespace-controller\" cannot watch resource \"leases\" in API group \"coordination.k8s.io\" in the namespace \"foo\"" logger="namespace-controller" resource="coordination.k8s.io/v1, Resource=leases"
E1213 09:24:30.443297       1 metadata.go:231] "The watchlist request ended with an error, falling back to the standard LIST semantics" err="endpoints is forbidden: User \"system:serviceaccount:kube-system:namespace-controller\" cannot watch resource \"endpoints\" in API group \"\" in the namespace \"foo\"" logger="namespace-controller" resource="/v1, Resource=endpoints"
E1213 09:24:30.448932       1 metadata.go:231] "The watchlist request ended with an error, falling back to the standard LIST semantics" err="serviceaccounts is forbidden: User \"system:serviceaccount:kube-system:namespace-controller\" cannot watch resource \"serviceaccounts\" in API group \"\" in the namespace \"foo\"" logger="namespace-controller" resource="/v1, Resource=serviceaccounts"
E1213 09:24:30.452425       1 metadata.go:231] "The watchlist request ended with an error, falling back to the standard LIST semantics" err="limitranges is forbidden: User \"system:serviceaccount:kube-system:namespace-controller\" cannot watch resource \"limitranges\" in API group \"\" in the namespace \"foo\"" logger="namespace-controller" resource="/v1, Resource=limitranges"
E1213 09:24:30.455703       1 metadata.go:231] "The watchlist request ended with an error, falling back to the standard LIST semantics" err="controllerrevisions.apps is forbidden: User \"system:serviceaccount:kube-system:namespace-controller\" cannot watch resource \"controllerrevisions\" in API group \"apps\" in the namespace \"foo\"" logger="namespace-controller" resource="apps/v1, Resource=controllerrevisions"
E1213 09:24:30.458730       1 metadata.go:231] "The watchlist request ended with an error, falling back to the standard LIST semantics" err="events is forbidden: User \"system:serviceaccount:kube-system:namespace-controller\" cannot watch resource \"events\" in API group \"\" in the namespace \"foo\"" logger="namespace-controller" resource="/v1, Resource=events"
E1213 09:24:30.462453       1 metadata.go:231] "The watchlist request ended with an error, falling back to the standard LIST semantics" err="daemonsets.apps is forbidden: User \"system:serviceaccount:kube-system:namespace-controller\" cannot watch resource \"daemonsets\" in API group \"apps\" in the namespace \"foo\"" logger="namespace-controller" resource="apps/v1, Resource=daemonsets"
E1213 09:24:30.465144       1 metadata.go:231] "The watchlist request ended with an error, falling back to the standard LIST semantics" err="statefulsets.apps is forbidden: User \"system:serviceaccount:kube-system:namespace-controller\" cannot watch resource \"statefulsets\" in API group \"apps\" in the namespace \"foo\"" logger="namespace-controller" resource="apps/v1, Resource=statefulsets"
E1213 09:24:30.468699       1 metadata.go:231] "The watchlist request ended with an error, falling back to the standard LIST semantics" err="networkpolicies.networking.k8s.io is forbidden: User \"system:serviceaccount:kube-system:namespace-controller\" cannot watch resource \"networkpolicies\" in API group \"networking.k8s.io\" in the namespace \"foo\"" logger="namespace-controller" resource="networking.k8s.io/v1, Resource=networkpolicies"
E1213 09:24:30.473273       1 metadata.go:231] "The watchlist request ended with an error, falling back to the standard LIST semantics" err="roles.rbac.authorization.k8s.io is forbidden: User \"system:serviceaccount:kube-system:namespace-controller\" cannot watch resource \"roles\" in API group \"rbac.authorization.k8s.io\" in the namespace \"foo\"" logger="namespace-controller" resource="rbac.authorization.k8s.io/v1, Resource=roles"
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
