### PR TITLE
kubectl: add test coverage for cordon command

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/drain/cordon_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/drain/cordon_test.go
@@ -19,6 +19,7 @@ package drain
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -44,6 +45,10 @@ func TestNewCordonHelperFromRuntimeObject(t *testing.T) {
 			expectError: false,
 			expected: &CordonHelper{
 				node: &corev1.Node{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Node",
+						APIVersion: "v1",
+					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "test-node",
 					},
@@ -82,8 +87,8 @@ func TestNewCordonHelperFromRuntimeObject(t *testing.T) {
 				t.Error("Expected non-nil helper")
 			}
 			if tt.expected != nil && helper != nil {
-				if helper.node.Name != tt.expected.node.Name {
-					t.Errorf("Expected node name %s, got %s", tt.expected.node.Name, helper.node.Name)
+				if diff := cmp.Diff(tt.expected.node, helper.node); diff != "" {
+					t.Errorf("Node mismatch (-want +got):\n%s", diff)
 				}
 			}
 		})

--- a/staging/src/k8s.io/kubectl/pkg/drain/cordon_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/drain/cordon_test.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package drain
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+type newCordonHelperFromRuntimeObjectTestCase struct {
+	name        string
+	nodeObject  runtime.Object
+	expectError bool
+	expected    *CordonHelper
+}
+
+func TestNewCordonHelperFromRuntimeObject(t *testing.T) {
+	tests := []newCordonHelperFromRuntimeObjectTestCase{
+		{
+			name: "valid node object",
+			nodeObject: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+				},
+			},
+			expectError: false,
+			expected: &CordonHelper{
+				node: &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-node",
+					},
+				},
+			},
+		},
+		{
+			name: "invalid object type",
+			nodeObject: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pod",
+				},
+			},
+			expectError: true,
+			expected:    nil,
+		},
+	}
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	gvk := schema.GroupVersionKind{
+		Group:   "",
+		Version: "v1",
+		Kind:    "Node",
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			helper, err := NewCordonHelperFromRuntimeObject(tt.nodeObject, scheme, gvk)
+			if tt.expectError && err == nil {
+				t.Error("Expected error but got none")
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+			if !tt.expectError && helper == nil {
+				t.Error("Expected non-nil helper")
+			}
+			if tt.expected != nil && helper != nil {
+				if helper.node.Name != tt.expected.node.Name {
+					t.Errorf("Expected node name %s, got %s", tt.expected.node.Name, helper.node.Name)
+				}
+			}
+		})
+	}
+}
+
+type updateIfRequiredTestCase struct {
+	name          string
+	currentState  bool
+	desiredState  bool
+	expectUpdated bool
+}
+
+func TestUpdateIfRequired(t *testing.T) {
+	tests := []updateIfRequiredTestCase{
+		{
+			name:          "no change required",
+			currentState:  true,
+			desiredState:  true,
+			expectUpdated: false,
+		},
+		{
+			name:          "update required - cordon",
+			currentState:  false,
+			desiredState:  true,
+			expectUpdated: true,
+		},
+		{
+			name:          "update required - uncordon",
+			currentState:  true,
+			desiredState:  false,
+			expectUpdated: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+				},
+				Spec: corev1.NodeSpec{
+					Unschedulable: tt.currentState,
+				},
+			}
+
+			helper := NewCordonHelper(node)
+			updated := helper.UpdateIfRequired(tt.desiredState)
+			if updated != tt.expectUpdated {
+				t.Errorf("Expected UpdateIfRequired to return %v, got %v", tt.expectUpdated, updated)
+			}
+			if helper.desired != tt.desiredState {
+				t.Errorf("Expected desired state to be %v, got %v", tt.desiredState, helper.desired)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Added test coverage for the `kubectl cordon` command.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
