### PR TITLE
WIP: hack: detect incomplete embedding in e2e.test

### DIFF
--- a/cluster/log-dump/logdump.go
+++ b/cluster/log-dump/logdump.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logdump
+
+import _ "embed"
+
+// Script contains the self-contained log-dump.sh script.
+// It needs bash as shell.
+//
+//go:embed log-dump.sh
+var Script []byte

--- a/hack/ginkgo-e2e.sh
+++ b/hack/ginkgo-e2e.sh
@@ -264,7 +264,6 @@ case "${GINKGO_SHOW_COMMAND:-${CI:-no}}" in y|yes|true) set -x ;; esac
   --kube-master="${KUBE_MASTER:-}" \
   --cluster-tag="${CLUSTER_ID:-}" \
   --cloud-config-file="${CLOUD_CONFIG:-}" \
-  --repo-root="${KUBE_ROOT}" \
   --node-instance-group="${NODE_INSTANCE_GROUP:-}" \
   --prefix="${KUBE_GCE_INSTANCE_PREFIX:-e2e}" \
   --network="${KUBE_GCE_NETWORK:-${KUBE_GKE_NETWORK:-e2e}}" \

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -130,11 +130,13 @@ func TestMain(m *testing.M) {
 
 	framework.AfterReadingAllFlags(&framework.TestContext)
 
-	// TODO: Deprecating repo-root over time... instead just use gobindata_util.go , see #23987.
-	// Right now it is still needed, for example by
-	// test/e2e/framework/ingress/ingress_utils.go
-	// for providing the optional secret.yaml file and by
-	// test/e2e/framework/util.go for cluster/log-dump.
+	// TODO: Deprecating repo-root over time... instead just use go:embed , see #23987.
+	// Right now it is still needed by
+	// test/e2e/cloud/gcp/ha_master.go and test/e2e/framework/providers/gcp.go.
+	// Those tests must run in a job which explicitly sets -repo-root.
+	//
+	// CSI developers running the in-tree storage suites might also rely on it (to
+	// be checked with SIG Storage before the final removal).
 	if framework.TestContext.RepoRoot != "" {
 		testfiles.AddFileSource(testfiles.RootFileSource{Root: framework.TestContext.RepoRoot})
 	}

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -417,7 +417,7 @@ func RegisterClusterFlags(flags *flag.FlagSet) {
 	flags.StringVar(&TestContext.KubeletRootDir, "kubelet-root-dir", "/var/lib/kubelet", "The data directory of kubelet. Some tests (for example, CSI storage tests) deploy DaemonSets which need to know this value and cannot query it. Such tests only work in clusters where the data directory is the same on all nodes.")
 	flags.StringVar(&TestContext.KubeletRootDir, "volume-dir", "/var/lib/kubelet", "An alias for --kubelet-root-dir, kept for backwards compatibility.")
 	flags.StringVar(&TestContext.CertDir, "cert-dir", "", "Path to the directory containing the certs. Default is empty, which doesn't use certs.")
-	flags.StringVar(&TestContext.RepoRoot, "repo-root", "../../", "Root directory of kubernetes repository, for finding test files.")
+	flags.StringVar(&TestContext.RepoRoot, "repo-root", "", "Root directory for finding test files. Ignored if left empty, in which case all files must be embedded in the test binary.")
 	// NOTE: Node E2E tests have this flag defined as well, but true by default.
 	// If this becomes true as well, they should be refactored into RegisterCommonFlags.
 	flags.BoolVar(&TestContext.PrepullImages, "prepull-images", false, "If true, prepull images so image pull failures do not cause test failures.")


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The e2e.test binary is meant to be self-contained and must embed all files that it depends on. For example, it gets run outside of the Kubernetes source tree during conformance testing. The mechanism for loading files from the current directory (required for user-configurable files e.g. when running the storage tests against an out-of-tree CSI driver) can hide missing embedded files.

To detect missing embedding, the -repo-root parameter is left empty now and therefore loading of files from disk which should be embedded is disabled. This triggers the following error when a test runs:

    [FAILED] reading manifest file: Test file "test/e2e/testing-manifests/dra/dra-test-driver-proxy.yaml" was not found.
    The following files are embedded into the test executable:
       ...

#### Notes for reviewers

log-check.sh gets embedded and continues to work.
get-build.sh gets replaced by native Go code.

Some tests (test/e2e/cloud/gcp/ha_master.go, test/e2e/framework/providers/gcp.go) still depend on "test/cluster"
scripts. When running those tests, -repo-root must be set explicitly.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
