### PR TITLE
Expand emulated version range to 3 previous minor versions (with clamp)

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/options/server_run_options_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/server_run_options_test.go
@@ -34,8 +34,8 @@ import (
 func TestServerRunOptionsValidate(t *testing.T) {
 	testRegistry := featuregate.NewComponentGlobalsRegistry()
 	featureGate := utilfeature.DefaultFeatureGate.DeepCopy()
-	effectiveVersion := utilversion.NewEffectiveVersion("1.30")
-	effectiveVersion.SetEmulationVersion(version.MajorMinor(1, 32))
+	effectiveVersion := utilversion.NewEffectiveVersion("1.35")
+	effectiveVersion.SetEmulationVersion(version.MajorMinor(1, 31))
 	testComponent := "test"
 	utilruntime.Must(testRegistry.Register(testComponent, effectiveVersion, featureGate))
 
@@ -197,7 +197,7 @@ func TestServerRunOptionsValidate(t *testing.T) {
 				ComponentName:               testComponent,
 				ComponentGlobalsRegistry:    testRegistry,
 			},
-			expectErr: "emulation version 1.32 is not between [1.29, 1.30.0]",
+			expectErr: "emulation version 1.31 is not between [1.32, 1.35.0]",
 		},
 		{
 			name: "Test when ServerRunOptions is valid",

--- a/staging/src/k8s.io/component-base/version/version_test.go
+++ b/staging/src/k8s.io/component-base/version/version_test.go
@@ -43,9 +43,22 @@ func TestValidate(t *testing.T) {
 			minCompatibilityVersion: "v1.31.0",
 		},
 		{
-			name:                    "emulation version two minor lower than binary not ok",
+			name:                    "emulation version two minor lower than binary ok",
 			binaryVersion:           "v1.33.2",
 			emulationVersion:        "v1.31.0",
+			minCompatibilityVersion: "v1.31.0",
+			expectErrors:            false,
+		},
+		{
+			name:                    "emulation version three minor lower than binary ok",
+			binaryVersion:           "v1.35.0",
+			emulationVersion:        "v1.32.0",
+			minCompatibilityVersion: "v1.32.0",
+		},
+		{
+			name:                    "emulation version four minor lower than binary not ok",
+			binaryVersion:           "v1.36.0",
+			emulationVersion:        "v1.32.0",
 			minCompatibilityVersion: "v1.32.0",
 			expectErrors:            true,
 		},
@@ -64,19 +77,27 @@ func TestValidate(t *testing.T) {
 			expectErrors:            true,
 		},
 		{
-			name:                    "compatibility version same as binary not ok",
+			name:                    "compatibility version same as binary ok",
 			binaryVersion:           "v1.32.2",
 			emulationVersion:        "v1.32.0",
 			minCompatibilityVersion: "v1.32.0",
-			expectErrors:            true,
+			expectErrors:            false,
 		},
 		{
-			name:                    "compatibility version two minor lower than binary not ok",
-			binaryVersion:           "v1.32.2",
-			emulationVersion:        "v1.32.0",
-			minCompatibilityVersion: "v1.30.0",
-			expectErrors:            true,
+			name:                    "compatibility version two minor lower than binary ok",
+			binaryVersion:           "v1.33.2",
+			emulationVersion:        "v1.33.0",
+			minCompatibilityVersion: "v1.31.0",
+			expectErrors:            false,
 		},
+		{
+			name:                    "compatibility version three minor lower than binary ok",
+			binaryVersion:           "v1.34.2",
+			emulationVersion:        "v1.33.0",
+			minCompatibilityVersion: "v1.31.0",
+			expectErrors:            false,
+		},
+
 		{
 			name:                    "compatibility version one minor higher than binary not ok",
 			binaryVersion:           "v1.32.2",
@@ -101,6 +122,57 @@ func TestValidate(t *testing.T) {
 
 			if len(errs) == 0 && test.expectErrors {
 				t.Errorf("expected errors, no errors found")
+			}
+		})
+	}
+}
+
+func TestValidateKubeEffectiveVersion(t *testing.T) {
+	tests := []struct {
+		name                    string
+		emulationVersion        string
+		minCompatibilityVersion string
+		expectErr               bool
+	}{
+		{
+			name:                    "valid versions",
+			emulationVersion:        "v1.31.0",
+			minCompatibilityVersion: "v1.31.0",
+			expectErr:               false,
+		},
+		{
+			name:                    "emulationVersion too low",
+			emulationVersion:        "v1.30.0",
+			minCompatibilityVersion: "v1.31.0",
+			expectErr:               true,
+		},
+		{
+			name:                    "minCompatibilityVersion too low",
+			emulationVersion:        "v1.31.0",
+			minCompatibilityVersion: "v1.30.0",
+			expectErr:               true,
+		},
+		{
+			name:                    "both versions too low",
+			emulationVersion:        "v1.30.0",
+			minCompatibilityVersion: "v1.30.0",
+			expectErr:               true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+
+			effective := NewEffectiveVersion("1.32")
+			effective.SetEmulationVersion(version.MustParseGeneric(test.emulationVersion))
+			effective.SetMinCompatibilityVersion(version.MustParseGeneric(test.minCompatibilityVersion))
+
+			err := ValidateKubeEffectiveVersion(effective)
+			if test.expectErr && err == nil {
+				t.Error("expected error, but got nil")
+			}
+			if !test.expectErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/127514

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Extended legacy API emulation. API server components may now emulate a release up to 3 minor versions older, provided that the emulated minor version is v1.31 or newer.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
