### PR TITLE
Change default filestore permissions to 0700

### DIFF
--- a/pkg/kubelet/util/store/filestore.go
+++ b/pkg/kubelet/util/store/filestore.go
@@ -28,6 +28,9 @@ import (
 const (
 	// Name prefix for the temporary files.
 	tmpPrefix = "."
+
+	// The default permission bits to set on the filestore directory.
+	directoryPerm = 0700
 )
 
 // FileStore is an implementation of the Store interface which stores data in files.
@@ -41,7 +44,7 @@ type FileStore struct {
 
 // NewFileStore returns an instance of FileStore.
 func NewFileStore(path string, fs utilfs.Filesystem) (Store, error) {
-	if err := fs.MkdirAll(path, 0755); err != nil {
+	if err := fs.MkdirAll(path, directoryPerm); err != nil {
 		return nil, err
 	}
 	return &FileStore{directoryPath: path, filesystem: fs}, nil
@@ -52,7 +55,7 @@ func (f *FileStore) Write(key string, data []byte) error {
 	if err := ValidateKey(key); err != nil {
 		return err
 	}
-	if err := f.filesystem.MkdirAll(f.directoryPath, 0755); err != nil {
+	if err := f.filesystem.MkdirAll(f.directoryPath, directoryPerm); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Change the default directory permissions used by `pkg/kubelet/util/store/filestore.go` from `0755` to `0700`.  This utility is only used for storing Kubelet state, through either checkpoint_manager or usersns_manager, so there don't need to be any other readers.

This change is mainly to protect windows kubelets, which perform chmod on the target directory of `MkdirAll`, whether or not it's created (https://github.com/kubernetes/kubernetes/blob/ce31c0f7cbb6924b474537b8ac81c97401189281/pkg/util/filesystem/util_windows.go#L102). Since the root kubelet directory is used for some checkpoints, this caused the root kubelet directory permissions to change on windows (which led to in-place resize being rolled back). We should probably fix this issue on Windows, but changing the default filestore permissions is an easy short-term fix.

Fixes https://github.com/kubernetes/kubernetes/issues/128897

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/sig node
/priority important-soon
/milestone v1.33