### PR TITLE
accept GINKGO_FLAGS for test-e2e-node.sh

### DIFF
--- a/build/root/Makefile
+++ b/build/root/Makefile
@@ -221,7 +221,8 @@ define TEST_E2E_NODE_HELP_INFO
 # Args:
 #  FOCUS: Regexp that matches the tests to be run.  Defaults to "".
 #  SKIP: Regexp that matches the tests that needs to be skipped.
-#    Defaults to "\[Flaky\]|\[Slow\]|\[Serial\]".
+#    Defaults to "\[Flaky\]|\[Slow\]|\[Serial\]" unless LABEL_FILTER is set.
+#    If LABEL_FILTER is set, then no tests are skipped by default.
 #  LABEL_FILTER: Use Ginkgo labels query language to filter the tests to be run. May contain spaces and special characters (exclamation mark, vertical bar, etc.) but not quotation marks.
 #  TEST_ARGS: A space-separated list of arguments to pass to node e2e test.
 #    Defaults to "".

--- a/build/root/Makefile
+++ b/build/root/Makefile
@@ -222,7 +222,7 @@ define TEST_E2E_NODE_HELP_INFO
 #  FOCUS: Regexp that matches the tests to be run.  Defaults to "".
 #  SKIP: Regexp that matches the tests that needs to be skipped.
 #    Defaults to "\[Flaky\]|\[Slow\]|\[Serial\]".
-#  LABEL_FILTER: Use ginkgo labels query language to filter the tests to be run.
+#  LABEL_FILTER: Use Ginkgo labels query language to filter the tests to be run. May contain spaces and special characters (exclamation mark, vertical bar, etc.) but not quotation marks.
 #  TEST_ARGS: A space-separated list of arguments to pass to node e2e test.
 #    Defaults to "".
 #  RUN_UNTIL_FAILURE: If true, pass --until-it-fails=true to ginkgo so tests are run

--- a/build/root/Makefile
+++ b/build/root/Makefile
@@ -222,6 +222,7 @@ define TEST_E2E_NODE_HELP_INFO
 #  FOCUS: Regexp that matches the tests to be run.  Defaults to "".
 #  SKIP: Regexp that matches the tests that needs to be skipped.
 #    Defaults to "\[Flaky\]|\[Slow\]|\[Serial\]".
+#  LABEL_FILTER: Use ginkgo labels query language to filter the tests to be run.
 #  TEST_ARGS: A space-separated list of arguments to pass to node e2e test.
 #    Defaults to "".
 #  RUN_UNTIL_FAILURE: If true, pass --until-it-fails=true to ginkgo so tests are run

--- a/hack/make-rules/test-e2e-node.sh
+++ b/hack/make-rules/test-e2e-node.sh
@@ -30,6 +30,7 @@ export KUBE_PANIC_WATCH_DECODE_ERROR
 
 focus=${FOCUS:-""}
 skip=${SKIP-"\[Flaky\]|\[Slow\]|\[Serial\]"}
+label_filter=${LABEL_FILTER:=-""}
 # The number of tests that can run in parallel depends on what tests
 # are running and on the size of the node. Too many, and tests will
 # fail due to resource contention. 8 is a reasonable default for a
@@ -66,7 +67,7 @@ if [ "${remote}" = true ] && [ -n "${debug_tool}" ]; then
 fi
 
 # Parse the flags to pass to ginkgo
-ginkgoflags=${GINKGO_FLAGS:-"-timeout=24h"}
+ginkgoflags="-timeout=24h"
 if [[ ${parallelism} -gt 1 ]]; then
   ginkgoflags="${ginkgoflags} -nodes=${parallelism} "
 fi
@@ -77,6 +78,10 @@ fi
 
 if [[ ${skip} != "" ]]; then
   ginkgoflags="${ginkgoflags} -skip=\"${skip}\" "
+fi
+
+if [[ ${label_filter} != "" ]]; then
+  ginkgoflags="${ginkgoflags} --label-filter=\"${label_filter}\" "
 fi
 
 if [[ ${run_until_failure} == "true" ]]; then

--- a/hack/make-rules/test-e2e-node.sh
+++ b/hack/make-rules/test-e2e-node.sh
@@ -80,7 +80,7 @@ if [[ ${focus} != "" ]]; then
   ginkgoflags="${ginkgoflags} -focus=\"${focus}\" "
 fi
 
-if [[ ${skip} != "" && ${label_filter} == "" ]]; then
+if [[ ${skip} != "" ]]; then
   ginkgoflags="${ginkgoflags} -skip=\"${skip}\" "
 fi
 

--- a/hack/make-rules/test-e2e-node.sh
+++ b/hack/make-rules/test-e2e-node.sh
@@ -30,7 +30,7 @@ export KUBE_PANIC_WATCH_DECODE_ERROR
 
 focus=${FOCUS:-""}
 skip=${SKIP-"\[Flaky\]|\[Slow\]|\[Serial\]"}
-label_filter=${LABEL_FILTER:=-""}
+label_filter=${LABEL_FILTER:-""}
 # The number of tests that can run in parallel depends on what tests
 # are running and on the size of the node. Too many, and tests will
 # fail due to resource contention. 8 is a reasonable default for a

--- a/hack/make-rules/test-e2e-node.sh
+++ b/hack/make-rules/test-e2e-node.sh
@@ -76,7 +76,7 @@ if [[ ${parallelism} -gt 1 ]]; then
   ginkgoflags="${ginkgoflags} -nodes=${parallelism} "
 fi
 
-if [[ ${focus} != "" && ${label_filter} == "" ]]; then
+if [[ ${focus} != "" ]]; then
   ginkgoflags="${ginkgoflags} -focus=\"${focus}\" "
 fi
 

--- a/hack/make-rules/test-e2e-node.sh
+++ b/hack/make-rules/test-e2e-node.sh
@@ -29,8 +29,12 @@ KUBE_PANIC_WATCH_DECODE_ERROR="${KUBE_PANIC_WATCH_DECODE_ERROR:-true}"
 export KUBE_PANIC_WATCH_DECODE_ERROR
 
 focus=${FOCUS:-""}
-skip=${SKIP-"\[Flaky\]|\[Slow\]|\[Serial\]"}
 label_filter=${LABEL_FILTER:-""}
+if [ -n "${label_filter}" ]; then
+  skip=${SKIP:-""} # No default skip when LABEL_FILTER is set.
+else
+  skip=${SKIP-"\[Flaky\]|\[Slow\]|\[Serial\]"}
+fi
 # The number of tests that can run in parallel depends on what tests
 # are running and on the size of the node. Too many, and tests will
 # fail due to resource contention. 8 is a reasonable default for a

--- a/hack/make-rules/test-e2e-node.sh
+++ b/hack/make-rules/test-e2e-node.sh
@@ -66,7 +66,7 @@ if [ "${remote}" = true ] && [ -n "${debug_tool}" ]; then
 fi
 
 # Parse the flags to pass to ginkgo
-ginkgoflags="-timeout=24h"
+ginkgoflags=${GINKGO_FLAGS:-"-timeout=24h"}
 if [[ ${parallelism} -gt 1 ]]; then
   ginkgoflags="${ginkgoflags} -nodes=${parallelism} "
 fi

--- a/hack/make-rules/test-e2e-node.sh
+++ b/hack/make-rules/test-e2e-node.sh
@@ -72,11 +72,11 @@ if [[ ${parallelism} -gt 1 ]]; then
   ginkgoflags="${ginkgoflags} -nodes=${parallelism} "
 fi
 
-if [[ ${focus} != "" ]]; then
+if [[ ${focus} != "" && ${label_filter} == "" ]]; then
   ginkgoflags="${ginkgoflags} -focus=\"${focus}\" "
 fi
 
-if [[ ${skip} != "" ]]; then
+if [[ ${skip} != "" && ${label_filter} == "" ]]; then
   ginkgoflags="${ginkgoflags} -skip=\"${skip}\" "
 fi
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:
At the momment kubetest2 cant pass ginkgo `--label-filter`.

planing on add passing `LABEL_FILTER` so kubetest2 can pass `--label-filter` to run tests
at the momment we have broken tests, but the issue will affect any job that need to pass the flag to `ginkgo`:

https://testgrid.k8s.io/sig-node-cri-o#pr-node-kubelet-crio-cgrpv1-dra-kubetest2
https://testgrid.k8s.io/sig-node-cri-o#pr-node-kubelet-crio-cgrpv2-dra-kubetest2


#### Which issue(s) this PR fixes:
Relates to https://github.com/kubernetes-sigs/kubetest2/issues/285
part of this batch of work https://github.com/kubernetes/test-infra/issues/32567 

#### Does this PR introduce a user-facing change?
 ```release-note
 NONE
 ```