### PR TITLE
Revert "Change default filestore permissions to 0700"

### DIFF
--- a/pkg/kubelet/util/store/filestore.go
+++ b/pkg/kubelet/util/store/filestore.go
@@ -28,9 +28,6 @@ import (
 const (
 	// Name prefix for the temporary files.
 	tmpPrefix = "."
-
-	// The default permission bits to set on the filestore directory.
-	directoryPerm = 0700
 )
 
 // FileStore is an implementation of the Store interface which stores data in files.
@@ -44,7 +41,7 @@ type FileStore struct {
 
 // NewFileStore returns an instance of FileStore.
 func NewFileStore(path string, fs utilfs.Filesystem) (Store, error) {
-	if err := fs.MkdirAll(path, directoryPerm); err != nil {
+	if err := fs.MkdirAll(path, 0755); err != nil {
 		return nil, err
 	}
 	return &FileStore{directoryPath: path, filesystem: fs}, nil
@@ -55,7 +52,7 @@ func (f *FileStore) Write(key string, data []byte) error {
 	if err := ValidateKey(key); err != nil {
 		return err
 	}
-	if err := f.filesystem.MkdirAll(f.directoryPath, directoryPerm); err != nil {
+	if err := f.filesystem.MkdirAll(f.directoryPath, 0755); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Reverts kubernetes/kubernetes#129214

I missed a usage in my original analysis of this: the state file for the device manager uses the directory `/var/lib/kubelet/device-plugins/`, but this directory isn't explicitly created on Kubelet startup, so it may end up being initialized by the checkpoint manager. The intended directory permissions are `0750`.

```release-note
NONE
```

/sig node
/priority important-soon
/triage accepted
/milestone v1.33