### PR TITLE
Require canonicalization of NetworkDeviceData IPs

### DIFF
--- a/pkg/apis/resource/validation/validation_resourceclaim_test.go
+++ b/pkg/apis/resource/validation/validation_resourceclaim_test.go
@@ -1039,7 +1039,7 @@ func TestValidateClaimStatusUpdate(t *testing.T) {
 						NetworkData: &resource.NetworkDeviceData{
 							IPs: []string{
 								"2001:db8::1/64",
-								"2001:0db8::1/64",
+								"2001:db8::1/64",
 							},
 						},
 					},
@@ -1058,6 +1058,8 @@ func TestValidateClaimStatusUpdate(t *testing.T) {
 				field.TooLong(field.NewPath("status", "devices").Index(0).Child("networkData", "interfaceName"), "", interfaceNameMaxLength),
 				field.TooLong(field.NewPath("status", "devices").Index(0).Child("networkData", "hardwareAddress"), "", hardwareAddressMaxLength),
 				field.Invalid(field.NewPath("status", "devices").Index(0).Child("networkData", "ips").Index(0), "300.9.8.0/24", "must be a valid CIDR value, (e.g. 10.9.8.0/24 or 2001:db8::/64)"),
+				field.Invalid(field.NewPath("status", "devices").Index(0).Child("networkData", "ips").Index(1), "010.009.008.000/24", "must be in canonical form (10.9.8.0/24)"),
+				field.Invalid(field.NewPath("status", "devices").Index(0).Child("networkData", "ips").Index(2), "2001:0db8::1/64", "must be in canonical form (2001:db8::1/64)"),
 			},
 			oldClaim: func() *resource.ResourceClaim { return validAllocatedClaim }(),
 			update: func(claim *resource.ResourceClaim) *resource.ResourceClaim {
@@ -1071,6 +1073,8 @@ func TestValidateClaimStatusUpdate(t *testing.T) {
 							HardwareAddress: strings.Repeat("x", hardwareAddressMaxLength+1),
 							IPs: []string{
 								"300.9.8.0/24",
+								"010.009.008.000/24",
+								"2001:0db8::1/64",
 							},
 						},
 					},
@@ -1168,7 +1172,7 @@ func TestValidateClaimStatusUpdate(t *testing.T) {
 						NetworkData: &resource.NetworkDeviceData{
 							IPs: []string{
 								"2001:db8::1/64",
-								"2001:0db8::1/64",
+								"2001:db8::1/64",
 							},
 						},
 					},


### PR DESCRIPTION
#### What this PR does / why we need it:
Validates NetworkDeviceData more strictly. There's no reason to allow non-standard or non-canonical IP values in new APIs.

#### Which issue(s) this PR fixes:
None, but related to KEP-4858 (https://github.com/kubernetes/enhancements/pull/4899) and #128786

#### Does this PR introduce a user-facing change?
```release-note
When using the Alpha DRAResourceClaimDeviceStatus feature, IP address values
in the NetworkDeviceData are now validated more strictly.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/4858
```

/kind bug
/sig network
/cc @aojea
/assign @LionelJouin 