### PR TITLE
Add `github.com/golang/protobuf` to unwanted dependencies

### DIFF
--- a/hack/unwanted-dependencies.json
+++ b/hack/unwanted-dependencies.json
@@ -24,6 +24,7 @@
       "github.com/gogo/googleapis": "depends on unmaintained github.com/gogo/protobuf",
       "github.com/gogo/protobuf": "unmaintained",
       "github.com/golang/mock": "unmaintained, archive mode",
+      "github.com/golang/protobuf": "replace with google.golang.org/protobuf",
       "github.com/golang/groupcache": "unmaintained",
       "github.com/google/gofuzz": "unmaintained, archive mode",
       "github.com/google/s2a-go": "cloud dependency, unstable",
@@ -160,6 +161,28 @@
       "github.com/golang/groupcache": [
         "go.etcd.io/etcd/server/v3"
       ],
+      "github.com/golang/protobuf": [
+        "github.com/container-storage-interface/spec",
+        "github.com/containerd/containerd/api",
+        "github.com/containerd/errdefs",
+        "github.com/containerd/ttrpc",
+        "github.com/google/cadvisor",
+        "github.com/grpc-ecosystem/go-grpc-middleware",
+        "github.com/grpc-ecosystem/grpc-gateway",
+        "github.com/prometheus/client_golang",
+        "go.etcd.io/etcd/api/v3",
+        "go.etcd.io/etcd/client/v3",
+        "go.etcd.io/etcd/pkg/v3",
+        "go.etcd.io/etcd/raft/v3",
+        "go.etcd.io/etcd/server/v3",
+        "google.golang.org/genproto",
+        "google.golang.org/grpc",
+        "google.golang.org/protobuf",
+        "sigs.k8s.io/apiserver-network-proxy/konnectivity-client",
+        "sigs.k8s.io/kustomize/api",
+        "sigs.k8s.io/kustomize/kustomize/v5",
+        "sigs.k8s.io/kustomize/kyaml"
+      ],
       "github.com/google/gofuzz": [
         "github.com/json-iterator/go",
         "k8s.io/apiextensions-apiserver",
@@ -260,6 +283,7 @@
     "unwantedVendored": [
       "github.com/davecgh/go-spew",
       "github.com/gogo/protobuf",
+      "github.com/golang/protobuf",
       "github.com/google/gofuzz",
       "github.com/google/shlex",
       "github.com/gregjones/httpcache",


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
Follow-up on https://github.com/kubernetes/kubernetes/pull/128659 to avoid reintroducing the dependency again.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
None
#### Special notes for your reviewer:
cc @liggitt 
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
