### PR TITLE
Bump kubedns and nodelocaldns to 1.24.0 (fixed)

### DIFF
--- a/cluster/addons/dns/kube-dns/kube-dns.yaml.base
+++ b/cluster/addons/dns/kube-dns/kube-dns.yaml.base
@@ -114,7 +114,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: kubedns
-        image: registry.k8s.io/dns/k8s-dns-kube-dns:1.23.1
+        image: registry.k8s.io/dns/k8s-dns-kube-dns:1.24.0
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in
@@ -170,7 +170,7 @@ spec:
           runAsUser: 1001
           runAsGroup: 1001
       - name: dnsmasq
-        image: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny:1.23.1
+        image: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny:1.24.0
         livenessProbe:
           httpGet:
             path: /healthcheck/dnsmasq
@@ -182,7 +182,6 @@ spec:
           failureThreshold: 5
         args:
         - -v=2
-        - -logtostderr
         - -configDir=/etc/k8s/dns/dnsmasq-nanny
         - -restartDnsmasq=true
         - --
@@ -217,7 +216,7 @@ spec:
               - NET_BIND_SERVICE
               - SETGID
       - name: sidecar
-        image: registry.k8s.io/dns/k8s-dns-sidecar:1.23.1
+        image: registry.k8s.io/dns/k8s-dns-sidecar:1.24.0
         livenessProbe:
           httpGet:
             path: /metrics
@@ -229,7 +228,6 @@ spec:
           failureThreshold: 5
         args:
         - --v=2
-        - --logtostderr
         - --probe=kubedns,127.0.0.1:10053,kubernetes.default.svc.__DNS__DOMAIN__,5,SRV
         - --probe=dnsmasq,127.0.0.1:53,kubernetes.default.svc.__DNS__DOMAIN__,5,SRV
         ports:

--- a/cluster/addons/dns/kube-dns/kube-dns.yaml.in
+++ b/cluster/addons/dns/kube-dns/kube-dns.yaml.in
@@ -114,7 +114,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: kubedns
-        image: registry.k8s.io/dns/k8s-dns-kube-dns:1.23.1
+        image: registry.k8s.io/dns/k8s-dns-kube-dns:1.24.0
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in
@@ -170,7 +170,7 @@ spec:
           runAsUser: 1001
           runAsGroup: 1001
       - name: dnsmasq
-        image: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny:1.23.1
+        image: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny:1.24.0
         livenessProbe:
           httpGet:
             path: /healthcheck/dnsmasq
@@ -182,7 +182,6 @@ spec:
           failureThreshold: 5
         args:
         - -v=2
-        - -logtostderr
         - -configDir=/etc/k8s/dns/dnsmasq-nanny
         - -restartDnsmasq=true
         - --
@@ -217,7 +216,7 @@ spec:
               - NET_BIND_SERVICE
               - SETGID
       - name: sidecar
-        image: registry.k8s.io/dns/k8s-dns-sidecar:1.23.1
+        image: registry.k8s.io/dns/k8s-dns-sidecar:1.24.0
         livenessProbe:
           httpGet:
             path: /metrics
@@ -229,7 +228,6 @@ spec:
           failureThreshold: 5
         args:
         - --v=2
-        - --logtostderr
         - --probe=kubedns,127.0.0.1:10053,kubernetes.default.svc.dns_domain,5,SRV
         - --probe=dnsmasq,127.0.0.1:53,kubernetes.default.svc.dns_domain,5,SRV
         ports:

--- a/cluster/addons/dns/kube-dns/kube-dns.yaml.sed
+++ b/cluster/addons/dns/kube-dns/kube-dns.yaml.sed
@@ -114,7 +114,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: kubedns
-        image: registry.k8s.io/dns/k8s-dns-kube-dns:1.23.1
+        image: registry.k8s.io/dns/k8s-dns-kube-dns:1.24.0
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in
@@ -170,7 +170,7 @@ spec:
           runAsUser: 1001
           runAsGroup: 1001
       - name: dnsmasq
-        image: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny:1.23.1
+        image: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny:1.24.0
         livenessProbe:
           httpGet:
             path: /healthcheck/dnsmasq
@@ -182,7 +182,6 @@ spec:
           failureThreshold: 5
         args:
         - -v=2
-        - -logtostderr
         - -configDir=/etc/k8s/dns/dnsmasq-nanny
         - -restartDnsmasq=true
         - --
@@ -217,7 +216,7 @@ spec:
               - NET_BIND_SERVICE
               - SETGID
       - name: sidecar
-        image: registry.k8s.io/dns/k8s-dns-sidecar:1.23.1
+        image: registry.k8s.io/dns/k8s-dns-sidecar:1.24.0
         livenessProbe:
           httpGet:
             path: /metrics
@@ -229,7 +228,6 @@ spec:
           failureThreshold: 5
         args:
         - --v=2
-        - --logtostderr
         - --probe=kubedns,127.0.0.1:10053,kubernetes.default.svc.$DNS_DOMAIN,5,SRV
         - --probe=dnsmasq,127.0.0.1:53,kubernetes.default.svc.$DNS_DOMAIN,5,SRV
         ports:

--- a/cluster/addons/dns/nodelocaldns/nodelocaldns.yaml
+++ b/cluster/addons/dns/nodelocaldns/nodelocaldns.yaml
@@ -138,7 +138,7 @@ spec:
         operator: "Exists"
       containers:
       - name: node-cache
-        image: registry.k8s.io/dns/k8s-dns-node-cache:1.23.1
+        image: registry.k8s.io/dns/k8s-dns-node-cache:1.24.0
         resources:
           requests:
             cpu: 25m


### PR DESCRIPTION
In addition to the version bump (done in https://github.com/kubernetes/kubernetes/pull/129175 and reverted in https://github.com/kubernetes/kubernetes/pull/129231), this removes the usage of the flag `logtostderr` (see
https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/2845-deprecate-klog-specific-flags-in-k8s-components), which was causing errors https://github.com/kubernetes/kubernetes/issues/129230.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

The PR bumps kubedns and nodelocaldns. See e.g. https://github.com/kubernetes/dns/pull/649, https://github.com/kubernetes/dns/issues/656, and https://github.com/kubernetes/dns/discussions/654.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
(The following release note was already included in https://github.com/kubernetes/kubernetes/pull/129175, but since it was reverted, I'm repeating it here.)
```release-note
This renames some coredns metrics, see https://github.com/coredns/coredns/blob/v1.11.0/plugin/forward/README.md#metrics.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
