### PR TITLE
Automated cherry pick of #129085: Fix volume expansion offline e2e

### DIFF
--- a/test/e2e/storage/testsuites/volume_expand.go
+++ b/test/e2e/storage/testsuites/volume_expand.go
@@ -444,9 +444,11 @@ func WaitForPendingFSResizeCondition(ctx context.Context, pvc *v1.PersistentVolu
 		if len(inProgressConditions) == 0 {
 			return true, nil
 		}
-		conditionType := inProgressConditions[0].Type
-		if conditionType == v1.PersistentVolumeClaimFileSystemResizePending {
-			return true, nil
+		for _, condition := range inProgressConditions {
+			conditionType := condition.Type
+			if conditionType == v1.PersistentVolumeClaimFileSystemResizePending {
+				return true, nil
+			}
 		}
 		return false, nil
 	})


### PR DESCRIPTION
Cherry pick of #129085 on release-1.32.

#129085: Fix volume expansion offline e2e

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```