### PR TITLE
API-Machinery: Prevent panic with unsettable fields

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/converter.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/converter.go
@@ -527,6 +527,9 @@ func structFromUnstructured(sv, dv reflect.Value, ctx *fromUnstructuredContext) 
 	for i := 0; i < dt.NumField(); i++ {
 		fieldInfo := fieldInfoFromField(dt, i)
 		fv := dv.Field(i)
+		if !fv.CanSet() {
+			continue
+		}
 
 		if len(fieldInfo.name) == 0 {
 			// This field is inlined, recurse into fromUnstructured again

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/converter_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/converter_test.go
@@ -45,6 +45,9 @@ var simpleEquality = conversion.EqualitiesOrDie(
 	func(a, b time.Time) bool {
 		return a.UTC() == b.UTC()
 	},
+	func(a, b J) bool {
+		return a.A == b.A
+	},
 )
 
 // Define a number of test types.
@@ -111,6 +114,11 @@ type I struct {
 	H `json:",inline"`
 
 	UL1 UnknownLevel1 `json:"ul1"`
+}
+
+type J struct {
+	A int `json:"aa"`
+	b int `json:"-"` //lint:ignore U1000 This field is used for test.
 }
 
 type UnknownLevel1 struct {
@@ -996,5 +1004,16 @@ func TestCustomToUnstructuredTopLevel(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, expected, result)
 		})
+	}
+}
+
+func TestPrivateFields(t *testing.T) {
+	unstr := map[string]interface{}{"aa": 1}
+	var obj J
+	if err := runtime.NewTestUnstructuredConverter(simpleEquality).FromUnstructured(unstr, &obj); err != nil {
+		t.Errorf("Unexpected error in FromUnstructured: %v", err)
+	}
+	if obj.A != 1 {
+		t.Errorf("Incorrect conversion, diff: %v", cmp.Diff(obj, unstr))
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug


#### What this PR does / why we need it:

This PR prevents **panic** on unsettable fields.
Even if struct should not have private fields, apimachinery should not panic.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #124154

#### Special notes for your reviewer:

I don't know if it should silently ignore or return an error.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
