### PR TITLE
[windows] Don't chmod existing directory in MkdirAll

### DIFF
--- a/pkg/util/filesystem/util_windows.go
+++ b/pkg/util/filesystem/util_windows.go
@@ -94,14 +94,21 @@ func IsUnixDomainSocket(filePath string) (bool, error) {
 // permissions once the directory is created.
 func MkdirAll(path string, perm os.FileMode) error {
 	klog.V(6).InfoS("Function MkdirAll starts", "path", path, "perm", perm)
+	if _, err := os.Stat(path); err == nil {
+		// Path already exists: nothing to do.
+		return nil
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("error checking path %s: %w", path, err)
+	}
+
 	err := os.MkdirAll(path, perm)
 	if err != nil {
-		return fmt.Errorf("Error creating directory %s: %v", path, err)
+		return fmt.Errorf("error creating directory %s: %w", path, err)
 	}
 
 	err = Chmod(path, perm)
 	if err != nil {
-		return fmt.Errorf("Error setting permissions for directory %s: %v", path, err)
+		return fmt.Errorf("error setting permissions for directory %s: %w", path, err)
 	}
 
 	return nil


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

`os.MkdirAll` ignores the permission bits on Windows (https://github.com/golang/go/issues/65377), so Kubelet uses a utility method that changes the permissions on the directory after it's created. However, the previous implementation changed the permissions regardless of whether a new directory was created, which differs from the Linux behavior.

This change checks whether the directory exists before calling `os.MkdirAll`, and skips the `Chmod` call if it does.

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubernetes/issues/128897

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/sig windows node
/priority important-soon
/milestone v1.33
/triage accepted
/assign @marosset 