### PR TITLE
Fix WindowsGracefulNodeShutdown: shouldn't depend on GracefulNodeShutdown

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -256,6 +256,8 @@ const (
 	ExecProbeTimeout featuregate.Feature = "ExecProbeTimeout"
 
 	// owner: @bobbypage
+	// kep: https://kep.k8s.io/2000
+	//
 	// Adds support for kubelet to detect node shutdown and gracefully terminate pods prior to the node being shutdown.
 	GracefulNodeShutdown featuregate.Feature = "GracefulNodeShutdown"
 
@@ -390,6 +392,12 @@ const (
 	// Implement connection draining for terminating nodes for
 	// `externalTrafficPolicy: Cluster` services.
 	KubeProxyDrainingTerminatingNodes featuregate.Feature = "KubeProxyDrainingTerminatingNodes"
+
+	// owner: @bobbypage
+	// kep: https://kep.k8s.io/2000
+	//
+	// Enables support for graceful shutdown linux node.
+	LinuxGracefulNodeShutdown featuregate.Feature = "LinuxGracefulNodeShutdown"
 
 	// owner: @RobertKrawitz
 	//

--- a/pkg/features/versioned_kube_features.go
+++ b/pkg/features/versioned_kube_features.go
@@ -493,6 +493,10 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 		{Version: version.MustParse("1.31"), Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // GA in 1.31; remove in 1.33
 	},
 
+	LinuxGracefulNodeShutdown: {
+		{Version: version.MustParse("1.33"), Default: true, PreRelease: featuregate.Beta},
+	},
+
 	LoadBalancerIPMode: {
 		{Version: version.MustParse("1.29"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("1.30"), Default: true, PreRelease: featuregate.Beta},

--- a/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux.go
+++ b/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux.go
@@ -79,8 +79,9 @@ type managerImpl struct {
 
 // NewManager returns a new node shutdown manager.
 func NewManager(conf *Config) Manager {
-	if !utilfeature.DefaultFeatureGate.Enabled(features.GracefulNodeShutdown) {
+	if !utilfeature.DefaultFeatureGate.Enabled(features.GracefulNodeShutdown) || !utilfeature.DefaultFeatureGate.Enabled(features.LinuxGracefulNodeShutdown) {
 		m := managerStub{}
+		conf.Logger.Info("Node shutdown manager is disabled as the feature gate is not enabled", "featureGates", []string{"GracefulNodeShutdown", "LinuxGracefulNodeShutdown"})
 		return m
 	}
 

--- a/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux_test.go
+++ b/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux_test.go
@@ -334,6 +334,7 @@ func TestManager(t *testing.T) {
 				return fakeDbus, nil
 			}
 			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.GracefulNodeShutdown, true)
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.LinuxGracefulNodeShutdown, true)
 
 			proberManager := probetest.FakeManager{}
 			fakeRecorder := &record.FakeRecorder{}
@@ -440,6 +441,7 @@ func TestFeatureEnabled(t *testing.T) {
 				return nil
 			}
 			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.GracefulNodeShutdown, tc.featureGateEnabled)
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.LinuxGracefulNodeShutdown, tc.featureGateEnabled)
 
 			proberManager := probetest.FakeManager{}
 			fakeRecorder := &record.FakeRecorder{}

--- a/pkg/kubelet/nodeshutdown/nodeshutdown_manager_windows.go
+++ b/pkg/kubelet/nodeshutdown/nodeshutdown_manager_windows.go
@@ -71,9 +71,9 @@ type managerImpl struct {
 
 // NewManager returns a new node shutdown manager.
 func NewManager(conf *Config) Manager {
-	if !utilfeature.DefaultFeatureGate.Enabled(features.WindowsGracefulNodeShutdown) {
+	if !utilfeature.DefaultFeatureGate.Enabled(features.GracefulNodeShutdown) || !utilfeature.DefaultFeatureGate.Enabled(features.WindowsGracefulNodeShutdown) {
 		m := managerStub{}
-		conf.Logger.Info("Node shutdown manager is disabled as the feature gate is not enabled")
+		conf.Logger.Info("Node shutdown manager is disabled as the feature gate is not enabled", "featureGates", []string{"GracefulNodeShutdown", "WindowsGracefulNodeShutdown"})
 		return m
 	}
 

--- a/pkg/kubelet/nodeshutdown/nodeshutdown_manager_windows_test.go
+++ b/pkg/kubelet/nodeshutdown/nodeshutdown_manager_windows_test.go
@@ -80,6 +80,7 @@ func TestFeatureEnabled(t *testing.T) {
 			killPodsFunc := func(pod *v1.Pod, evict bool, gracePeriodOverride *int64, fn func(*v1.PodStatus)) error {
 				return nil
 			}
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.GracefulNodeShutdown, tc.featureGateEnabled)
 			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.WindowsGracefulNodeShutdown, tc.featureGateEnabled)
 
 			proberManager := probetest.FakeManager{}

--- a/test/e2e_node/node_shutdown_linux_test.go
+++ b/test/e2e_node/node_shutdown_linux_test.go
@@ -95,6 +95,7 @@ var _ = SIGDescribe("GracefulNodeShutdown", framework.WithSerial(), nodefeature.
 		tempSetCurrentKubeletConfig(f, func(ctx context.Context, initialConfig *kubeletconfig.KubeletConfiguration) {
 			initialConfig.FeatureGates = map[string]bool{
 				string(features.GracefulNodeShutdown):                   true,
+				string(features.LinuxGracefulNodeShutdown):              true,
 				string(features.GracefulNodeShutdownBasedOnPodPriority): false,
 			}
 			initialConfig.ShutdownGracePeriod = metav1.Duration{Duration: nodeShutdownGracePeriod}
@@ -197,6 +198,7 @@ var _ = SIGDescribe("GracefulNodeShutdown", framework.WithSerial(), nodefeature.
 		tempSetCurrentKubeletConfig(f, func(ctx context.Context, initialConfig *kubeletconfig.KubeletConfiguration) {
 			initialConfig.FeatureGates = map[string]bool{
 				string(features.GracefulNodeShutdown):                   true,
+				string(features.LinuxGracefulNodeShutdown):              true,
 				string(features.GracefulNodeShutdownBasedOnPodPriority): false,
 				string(features.PodReadyToStartContainersCondition):     true,
 			}
@@ -392,6 +394,7 @@ var _ = SIGDescribe("GracefulNodeShutdown", framework.WithSerial(), nodefeature.
 		tempSetCurrentKubeletConfig(f, func(ctx context.Context, initialConfig *kubeletconfig.KubeletConfiguration) {
 			initialConfig.FeatureGates = map[string]bool{
 				string(features.GracefulNodeShutdown):                   true,
+				string(features.LinuxGracefulNodeShutdown):              true,
 				string(features.GracefulNodeShutdownBasedOnPodPriority): true,
 			}
 			initialConfig.ShutdownGracePeriodByPodPriority = []kubeletconfig.ShutdownGracePeriodByPodPriority{

--- a/test/featuregates_linter/test_data/versioned_feature_list.yaml
+++ b/test/featuregates_linter/test_data/versioned_feature_list.yaml
@@ -708,6 +708,12 @@
     lockToDefault: true
     preRelease: GA
     version: "1.31"
+- name: LinuxGracefulNodeShutdown
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.33"
 - name: LoadBalancerIPMode
   versionedSpecs:
   - default: false
@@ -954,10 +960,10 @@
     version: "1.32"
 - name: PodLogsQuerySplitStreams
   versionedSpecs:
-    - default: false
-      lockToDefault: false
-      preRelease: Alpha
-      version: "1.32"
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.32"
 - name: PodReadyToStartContainersCondition
   versionedSpecs:
   - default: false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

See https://github.com/kubernetes/website/pull/48474#discussion_r1884679068

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Part of https://github.com/kubernetes/enhancements/issues/4802

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed a bug where the kubelet does not respect the feature-gate `WindowsGracefulNodeShutdown`. This bug causes the kubelet to not validate related configuration options and not to register related metrics when the feature-gate `GracefulNodeShutdown` is explicitly disabled.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
