### PR TITLE
devicemanager: add timeout for GetPreferredAllocation and Allocate RPC

### DIFF
--- a/pkg/kubelet/cm/devicemanager/endpoint.go
+++ b/pkg/kubelet/cm/devicemanager/endpoint.go
@@ -87,7 +87,9 @@ func (e *endpointImpl) getPreferredAllocation(available, mustInclude []string, s
 	if e.isStopped() {
 		return nil, fmt.Errorf(errEndpointStopped, e)
 	}
-	return e.api.GetPreferredAllocation(context.Background(), &pluginapi.PreferredAllocationRequest{
+	ctx, cancel := context.WithTimeout(context.Background(), pluginapi.KubeletGetPreferredAllocationRPCTimeoutInSecs*time.Second)
+	defer cancel()
+	return e.api.GetPreferredAllocation(ctx, &pluginapi.PreferredAllocationRequest{
 		ContainerRequests: []*pluginapi.ContainerPreferredAllocationRequest{
 			{
 				AvailableDeviceIDs:   available,
@@ -103,7 +105,9 @@ func (e *endpointImpl) allocate(devs []string) (*pluginapi.AllocateResponse, err
 	if e.isStopped() {
 		return nil, fmt.Errorf(errEndpointStopped, e)
 	}
-	return e.api.Allocate(context.Background(), &pluginapi.AllocateRequest{
+	ctx, cancel := context.WithTimeout(context.Background(), pluginapi.KubeletAllocateRPCTimeoutInSecs*time.Second)
+	defer cancel()
+	return e.api.Allocate(ctx, &pluginapi.AllocateRequest{
 		ContainerRequests: []*pluginapi.ContainerAllocateRequest{
 			{DevicesIDs: devs},
 		},

--- a/staging/src/k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1/constants.go
+++ b/staging/src/k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1/constants.go
@@ -39,6 +39,14 @@ const (
 	// KubeletSocketWindows is the path of the Kubelet registry socket on windows
 	KubeletSocketWindows = DevicePluginPathWindows + "kubelet.sock"
 
+	// KubeletGetPreferredAllocationRPCTimeoutInSecs is the timeout duration in secs for GetPreferredAllocation RPC
+	// Timeout duration in secs for GetPreferredAllocation RPC
+	KubeletGetPreferredAllocationRPCTimeoutInSecs = 30
+
+	// KubeletAllocateRPCTimeoutInSecs is the timeout duration in secs for Allocate RPC
+	// Timeout duration in secs for Allocate RPC
+	KubeletAllocateRPCTimeoutInSecs = 30
+
 	// KubeletPreStartContainerRPCTimeoutInSecs is the timeout duration in secs for PreStartContainer RPC
 	// Timeout duration in secs for PreStartContainer RPC
 	KubeletPreStartContainerRPCTimeoutInSecs = 30


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
For devicemanager, add timeout for `GetPreferredAllocation` and `Allocate` RPC, like `PreStartContainer` already does.

Make sure not stucking in those RPC, otherwise all new coming pods would be blocked on admitting.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #129249

#### Special notes for your reviewer:
Timeout for `GetPreferredAllocation` and `Allocate` RPC is consistent with `PreStartContainer`, which takes 30 seconds.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
