### PR TITLE
kubeadm: update owners for v1.33

### DIFF
--- a/cmd/kubeadm/OWNERS
+++ b/cmd/kubeadm/OWNERS
@@ -4,11 +4,13 @@ approvers:
   - neolit123
   - SataQiu
   - pacoxu
+  - carlory
 reviewers:
   - neolit123
   - SataQiu
   - pacoxu
   - carlory
+  - HirazawaUi
 emeritus_approvers:
   - fabriziopandini
   - luxas

--- a/test/e2e_kubeadm/OWNERS
+++ b/test/e2e_kubeadm/OWNERS
@@ -4,11 +4,13 @@ approvers:
   - neolit123
   - SataQiu
   - pacoxu
+  - carlory
 reviewers:
   - neolit123
   - SataQiu
   - pacoxu
   - carlory
+  - HirazawaUi
 emeritus_approvers:
   - fabriziopandini
   - luxas


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
additions / promotions:
- @carlory became a kubeadm for more than half a year, being active in both [review](https://github.com/kubernetes/kubernetes/pulls?q=is%3Apr+commenter%3Acarlory+label%3Aarea%2Fkubeadm+is%3Aclosed+) and fixing bugs. suggesting a promotion to approver.
- @HirazawaUi: who complete KEP-4656 and the implementation in v1.32 release cycle, suggesting a promotion to reviewer. I hope he can become more involved in the kubeadm project and drive the development of related features.

#### Which issue(s) this PR fixes:
Fixes None

#### Special notes for your reviewer:

/cc @neolit123 @SataQiu 

#### Does this PR introduce a user-facing change?

```release-note
None
```