### PR TITLE
Use OS-agnostic path separator in pod warnings check

### DIFF
--- a/pkg/api/pod/warnings.go
+++ b/pkg/api/pod/warnings.go
@@ -515,7 +515,7 @@ func checkVolumeMappingForOverlap(paths []pathAndSource) []string {
 }
 
 func checkForOverlap(haystack []pathAndSource, needle pathAndSource) []pathAndSource {
-	pathSeparator := string(os.PathSeparator)
+	pathSeparator := `/` // this check runs in the API server, use the OS-agnostic separator
 
 	if needle.path == "" {
 		return nil


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind failing-test

#### What this PR does / why we need it:

Fixes unit test errors on windows

xref https://github.com/kubernetes/kubernetes/issues/129084#issuecomment-2547687565

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/sig windows