### PR TITLE
Add missing godoc in apimachinery's `quantity_proto.go` file

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_proto.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_proto.go
@@ -26,6 +26,7 @@ import (
 
 var _ proto.Sizer = &Quantity{}
 
+// Marshal returns the Quantity encoded in Protobuf format.
 func (m *Quantity) Marshal() (data []byte, err error) {
 	size := m.Size()
 	data = make([]byte, size)
@@ -75,6 +76,7 @@ func encodeVarintGenerated(data []byte, offset int, v uint64) int {
 	return base
 }
 
+// Size returns the number of bytes required to marshal the Quantity to Protobuf.
 func (m *Quantity) Size() (n int) {
 	var l int
 	_ = l


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

This PR adds godoc for the `resource.Quantity.Size()` method in the `apimachinery` package, clarifying that it returns the bytes required to marshal the value to Protobuf, not the scalar quantity itself (which could be misleading based on the method's name without referring to the implementation).

While here, adds the missing godoc for the other `Marshal()` function in this file as well.

Thanks to @akutz for highlighting this issue and helping clarify the distinction.

#### Which issue(s) this PR fixes:

Fixes  N/A.

#### Special notes for your reviewer:

NONE

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
