### PR TITLE
Coerce null label and annotation values to empty string

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/helpers.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/helpers.go
@@ -188,7 +188,7 @@ func NestedSlice(obj map[string]interface{}, fields ...string) ([]interface{}, b
 // NestedStringMap returns a copy of map[string]string value of a nested field.
 // Returns false if value is not found and an error if not a map[string]interface{} or contains non-string values in the map.
 func NestedStringMap(obj map[string]interface{}, fields ...string) (map[string]string, bool, error) {
-	m, found, err := nestedMapNoCopy(obj, fields...)
+	m, found, err := nestedMapNoCopy(obj, false, fields...)
 	if !found || err != nil {
 		return nil, found, err
 	}
@@ -203,10 +203,32 @@ func NestedStringMap(obj map[string]interface{}, fields ...string) (map[string]s
 	return strMap, true, nil
 }
 
+// NestedNullCoercingStringMap returns a copy of map[string]string value of a nested field.
+// Returns `nil, true, nil` if the value exists and is explicitly null.
+// Returns `nil, false, err` if the value is not a map or a null value, or is a map and contains non-string non-null values.
+// Null values in the map are coerced to "" to match json decoding behavior.
+func NestedNullCoercingStringMap(obj map[string]interface{}, fields ...string) (map[string]string, bool, error) {
+	m, found, err := nestedMapNoCopy(obj, true, fields...)
+	if !found || err != nil || m == nil {
+		return nil, found, err
+	}
+	strMap := make(map[string]string, len(m))
+	for k, v := range m {
+		if str, ok := v.(string); ok {
+			strMap[k] = str
+		} else if v == nil {
+			strMap[k] = ""
+		} else {
+			return nil, false, fmt.Errorf("%v accessor error: contains non-string value in the map under key %q: %v is of the type %T, expected string", jsonPath(fields), k, v, v)
+		}
+	}
+	return strMap, true, nil
+}
+
 // NestedMap returns a deep copy of map[string]interface{} value of a nested field.
 // Returns false if value is not found and an error if not a map[string]interface{}.
 func NestedMap(obj map[string]interface{}, fields ...string) (map[string]interface{}, bool, error) {
-	m, found, err := nestedMapNoCopy(obj, fields...)
+	m, found, err := nestedMapNoCopy(obj, false, fields...)
 	if !found || err != nil {
 		return nil, found, err
 	}
@@ -215,10 +237,13 @@ func NestedMap(obj map[string]interface{}, fields ...string) (map[string]interfa
 
 // nestedMapNoCopy returns a map[string]interface{} value of a nested field.
 // Returns false if value is not found and an error if not a map[string]interface{}.
-func nestedMapNoCopy(obj map[string]interface{}, fields ...string) (map[string]interface{}, bool, error) {
+func nestedMapNoCopy(obj map[string]interface{}, tolerateNil bool, fields ...string) (map[string]interface{}, bool, error) {
 	val, found, err := NestedFieldNoCopy(obj, fields...)
 	if !found || err != nil {
 		return nil, found, err
+	}
+	if val == nil && tolerateNil {
+		return nil, true, nil
 	}
 	m, ok := val.(map[string]interface{})
 	if !ok {

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured.go
@@ -397,7 +397,7 @@ func (u *Unstructured) SetDeletionGracePeriodSeconds(deletionGracePeriodSeconds 
 }
 
 func (u *Unstructured) GetLabels() map[string]string {
-	m, _, _ := NestedStringMap(u.Object, "metadata", "labels")
+	m, _, _ := NestedNullCoercingStringMap(u.Object, "metadata", "labels")
 	return m
 }
 
@@ -410,7 +410,7 @@ func (u *Unstructured) SetLabels(labels map[string]string) {
 }
 
 func (u *Unstructured) GetAnnotations() map[string]string {
-	m, _, _ := NestedStringMap(u.Object, "metadata", "annotations")
+	m, _, _ := NestedNullCoercingStringMap(u.Object, "metadata", "annotations")
 	return m
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Adjusts unstructured label and annotation accessors to tolerate / coerce null values in the maps to empty string values.

This matches json decoding behavior and server-side behavior if those values were sent to the server.

/sig api-machinery

Fixes https://github.com/kubernetes/kubernetes/issues/129176

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
`kubectl apply` now coerces `null` values for labels and annotations in manifests to empty string values, consistent with typed JSON metadata decoding, rather than dropping all labels and annotations
```
