### PR TITLE
[WIP] introduce CheckedMilliValue and deprecate MilliValue

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/math.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/math.go
@@ -47,6 +47,9 @@ var (
 	// Compare with the return value of Quantity.Value() to
 	// see if it's safe to use Quantity.MilliValue().
 	MaxMilliValue = int64(((1 << 63) - 1) / 1000)
+	MinMilliValue = int64((-(1 << 63)) / 1000)
+
+	minMilliValueDec = inf.NewDec(MinMilliValue, inf.Scale(0))
 )
 
 const mostNegative = -(mostPositive + 1)

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
@@ -816,8 +816,26 @@ func (q *Quantity) Value() int64 {
 
 // MilliValue returns the value of ceil(q * 1000); this could overflow an int64;
 // if that's a concern, call Value() first to verify the number is small enough.
+//
+// Deprecated: Prefer CheckedMilliValue which will error on overflow instead of
+// silently overflowing.
 func (q *Quantity) MilliValue() int64 {
 	return q.ScaledValue(Milli)
+}
+
+var (
+	ErrOverflow = errors.New("cannot convert without overflow")
+)
+
+// CheckedMilliValue returns the value of ceil(q * 1000);
+// This may not fit in an int64 this could overflow an int64, in which case an error will be returned.
+// You can check errors.Is(err, ErrOverflow)
+func (q *Quantity) CheckedMilliValue() (int64, error) {
+	// TODO: check underflow?
+	if q.Value() > MaxMilliValue {
+		return 0, fmt.Errorf("value %v overflows MilliValue: %w", q.Value(), ErrOverflow)
+	}
+	return q.ScaledValue(Milli), nil
 }
 
 // ScaledValue returns the value of ceil(q / 10^scale).


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

Introduces a safer alternative to resource.Quantity.MilliValue() that checks for overflow.
Deprecates the easily misused resource.Quantity.MilliValue()

https://github.com/kubernetes/kubernetes/issues/128684

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
k8s.io/apimachinery/pkg/api/resource: introduce resource.CheckedMilliValue and deprecate resource.MilliValue
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

TODO:
- we probably want to do `ScaledValue` as well
- there are a lot of call sites to migrate (maybe I would do just some of them here for proof of concept and do the rest in follow-up, if the linter doesn't error on using a deprecated method ...)
- It looks like we internally disallow negative values already, but I need to confirm if we should be handling that here or not