### PR TITLE
[NodeLocalCRISocket]: remove kubeadm.alpha.kubernetes.io/cri-socket annotation when kubeadm upgrade

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/upgrade/apply/uploadconfig.go
+++ b/cmd/kubeadm/app/cmd/phases/upgrade/apply/uploadconfig.go
@@ -113,6 +113,10 @@ func runUploadKubeletConfig(c workflow.RunData) error {
 		if err := patchnodephase.AnnotateCRISocket(client, cfg.NodeRegistration.Name, cfg.NodeRegistration.CRISocket); err != nil {
 			return errors.Wrap(err, "error writing CRISocket for this node")
 		}
+	} else {
+		if err := patchnodephase.RemoveCRISocketAnnotation(client, cfg.NodeRegistration.Name); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/cmd/kubeadm/app/phases/patchnode/patchnode.go
+++ b/cmd/kubeadm/app/phases/patchnode/patchnode.go
@@ -17,6 +17,8 @@ limitations under the License.
 package patchnode
 
 import (
+	"github.com/pkg/errors"
+
 	"k8s.io/api/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
@@ -27,8 +29,7 @@ import (
 
 // AnnotateCRISocket annotates the node with the given crisocket
 func AnnotateCRISocket(client clientset.Interface, nodeName string, criSocket string) error {
-
-	klog.V(1).Infof("[patchnode] Uploading the CRI Socket information %q to the Node API object %q as an annotation\n", criSocket, nodeName)
+	klog.V(1).Infof("[patchnode] Uploading the CRI socket %q to Node %q as an annotation", criSocket, nodeName)
 
 	return apiclient.PatchNode(client, nodeName, func(n *v1.Node) {
 		annotateNodeWithCRISocket(n, criSocket)
@@ -40,4 +41,21 @@ func annotateNodeWithCRISocket(n *v1.Node, criSocket string) {
 		n.ObjectMeta.Annotations = make(map[string]string)
 	}
 	n.ObjectMeta.Annotations[constants.AnnotationKubeadmCRISocket] = criSocket
+}
+
+// RemoveCRISocketAnnotation removes the crisocket annotation from a node.
+func RemoveCRISocketAnnotation(client clientset.Interface, nodeName string) error {
+	klog.V(1).Infof("[patchnode] Removing the CRI socket annotation from Node %q", nodeName)
+
+	if err := apiclient.PatchNode(client, nodeName, removeNodeCRISocketAnnotation); err != nil {
+		return errors.Wrapf(err, "could not remove the CRI socket annotation from Node %q", nodeName)
+	}
+	return nil
+}
+
+func removeNodeCRISocketAnnotation(n *v1.Node) {
+	if n.ObjectMeta.Annotations == nil {
+		return
+	}
+	delete(n.ObjectMeta.Annotations, constants.AnnotationKubeadmCRISocket)
 }

--- a/cmd/kubeadm/app/util/apiclient/dryrun.go
+++ b/cmd/kubeadm/app/util/apiclient/dryrun.go
@@ -568,7 +568,7 @@ func getNode(name string) *corev1.Node {
 				"kubernetes.io/hostname": name,
 			},
 			Annotations: map[string]string{
-				"kubeadm.alpha.kubernetes.io/cri-socket": "dry-run-cri-socket",
+				constants.AnnotationKubeadmCRISocket: "dry-run-cri-socket",
 			},
 		},
 	}


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
If the `NodeLocalCRISocket` feature is enabled, the `kubeadm.alpha.kubernetes.io/cri-socket` annotation in the node object should be removed during the upgrade, We will get the `containerRuntimeEndpoint` field from `instance-config.yaml`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: if the `NodeLocalCRISocket` feature gate is enabled, remove the `kubeadm.alpha.kubernetes.io/cri-socket` annotation from a given node on `kubeadm upgrade`.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
https://github.com/kubernetes/enhancements/tree/master/keps/sig-cluster-lifecycle/kubeadm/4656-add-kubelet-instance-configuration
```
