### PR TITLE
Automated cherry pick of #129095: fetch cni plugins from GitHub releases

### DIFF
--- a/test/e2e_node/remote/utils.go
+++ b/test/e2e_node/remote/utils.go
@@ -80,7 +80,7 @@ func getCNIURL() string {
 	if builder.IsTargetArchArm64() {
 		cniArch = "arm64"
 	}
-	cniURL := fmt.Sprintf("https://storage.googleapis.com/k8s-artifacts-cni/release/%s/cni-plugins-linux-%s-%s.tgz", cniVersion, cniArch, cniVersion)
+	cniURL := fmt.Sprintf("https://github.com/containernetworking/plugins/releases/download/%s/cni-plugins-linux-%s-%s.tgz", cniVersion, cniArch, cniVersion)
 	return cniURL
 
 }


### PR DESCRIPTION
Cherry pick of #129095 on release-1.32.

#129095: fetch cni plugins from GitHub releases

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```