### PR TITLE
WIP: NOT IMPLEMENTED: mutatingadmissionpolicies: adding unit test for item deletion in list of list-type map

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/mutating/patch/smd_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/mutating/patch/smd_test.go
@@ -113,7 +113,7 @@ func TestApplyConfiguration(t *testing.T) {
 			}},
 		},
 		{
-			name: "apply configuration delete from listType=map",
+			name: "apply configuration delete from listType=map via filter",
 			expression: `Object{
 					spec: Object.spec{
 						template: Object.spec.template{
@@ -123,6 +123,37 @@ func TestApplyConfiguration(t *testing.T) {
 						}
 					}
 				}`,
+			gvr: deploymentGVR,
+			object: &appsv1.Deployment{Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Volumes: []corev1.Volume{{Name: "x"}, {Name: "y"}},
+					},
+				},
+			}},
+			expectedResult: &appsv1.Deployment{Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Volumes: []corev1.Volume{{Name: "x"}},
+					},
+				},
+			}},
+		},
+		{
+			name: "apply configuration delete from listType=map via optional.none()",
+			expression: `Object{
+					spec: Object.spec{
+						template: Object.spec.template{
+							spec: Object.spec.template.spec{
+								volumes: [Object.spec.template.spec.volumes{
+									name: "y",
+									_: optional.none()
+								}]
+							}
+						}
+					}
+				}`,
+			// gives:     smd_test.go:379: unexpected error: error applying patch: failed to convert patch object to typed object: .spec.template.spec.volumes[name="y"]._: field not declared in schema
 			gvr: deploymentGVR,
 			object: &appsv1.Deployment{Spec: appsv1.DeploymentSpec{
 				Template: corev1.PodTemplateSpec{

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/mutating/patch/smd_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/mutating/patch/smd_test.go
@@ -113,6 +113,33 @@ func TestApplyConfiguration(t *testing.T) {
 			}},
 		},
 		{
+			name: "apply configuration delete from listType=map",
+			expression: `Object{
+					spec: Object.spec{
+						template: Object.spec.template{
+							spec: Object.spec.template.spec{
+								volumes: object.spec.template.spec.volumes.filter(c, c.name != "y") 
+							}
+						}
+					}
+				}`,
+			gvr: deploymentGVR,
+			object: &appsv1.Deployment{Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Volumes: []corev1.Volume{{Name: "x"}, {Name: "y"}},
+					},
+				},
+			}},
+			expectedResult: &appsv1.Deployment{Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Volumes: []corev1.Volume{{Name: "x"}},
+					},
+				},
+			}},
+		},
+		{
 			name: "apply configuration with conditionals",
 			expression: `Object{
 					spec: Object.spec{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind regression
-->

#### What this PR does / why we need it:

The KEP for validating admission policies https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/3962-mutating-admission-policies#unsetting-values
suggests that one can use the `filter` method on a list of list-type map to remove elements. In practice in 1.32 though, it looks like that this has no effect, compare https://kubernetes.slack.com/archives/C02TTBG6LF4/p1734434494970379.

This PR adds a unit case for that very case, and it fails.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```