### PR TITLE
Add logs to print environment variable details when creating a container

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -388,6 +388,7 @@ func (m *kubeGenericRuntimeManager) generateContainerConfig(ctx context.Context,
 		}
 	}
 	config.Envs = envs
+	klog.V(4).Infof("Pod %s init env for container %s is: %v", format.Pod(pod), container.Name, config.Envs)
 
 	return config, cleanupAction, nil
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
Pod supports obtaining the Pod IP from the status and injecting it into the pod as an environment variable. In actual production environments, we occasionally encounter situations where the Pod IP environment variable fails to inject. When the business side asks us to identify the cause, we cannot effectively demonstrate whether the environment variable was injected into the pod as expected. Therefore, it is necessary to print out the specific content of the environment variables when creating the container to facilitate problem identification and troubleshooting.

#### Which issue(s) this PR fixes:
Fixes #  https://github.com/kubernetes/kubernetes/issues/129292
