### PR TITLE
Do not attempt to truncate revision history if revisionHistoryLimit is negative

### DIFF
--- a/pkg/controller/statefulset/stateful_set_control.go
+++ b/pkg/controller/statefulset/stateful_set_control.go
@@ -194,7 +194,7 @@ func (ssc *defaultStatefulSetControl) truncateHistory(
 	}
 	historyLen := len(history)
 	historyLimit := int(*set.Spec.RevisionHistoryLimit)
-	if historyLen <= historyLimit {
+	if historyLimit < 0 || historyLen <= historyLimit {
 		return nil
 	}
 	// delete any non-live history to maintain the revision limit.


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
This PR is spawn from https://github.com/kubernetes/kubernetes/pull/129017 based on the comment https://github.com/kubernetes/kubernetes/pull/129017#discussion_r1862451711 to fix the panic occurring in statefulset controller, when the revisionHistoryLimit is negative.

#### Which issue(s) this PR fixes:
Fixes partially https://github.com/kubernetes/kubernetes/issues/129018

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Fixes a panic in kube-controller-manager handling StatefulSet objects when revisionHistoryLimit is negative
```