### PR TITLE
kubeadm: fix idempotency retain, address deprecation

### DIFF
--- a/cmd/kubeadm/app/discovery/token/token_test.go
+++ b/cmd/kubeadm/app/discovery/token/token_test.go
@@ -303,7 +303,7 @@ type fakeConfigMap struct {
 }
 
 func (c *fakeConfigMap) createOrUpdate(client clientset.Interface) error {
-	return apiclient.CreateOrUpdateConfigMap(client, &v1.ConfigMap{
+	return apiclient.CreateOrUpdate(client.CoreV1().ConfigMaps(metav1.NamespacePublic), &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      c.name,
 			Namespace: metav1.NamespacePublic,

--- a/cmd/kubeadm/app/phases/addons/proxy/proxy.go
+++ b/cmd/kubeadm/app/phases/addons/proxy/proxy.go
@@ -133,19 +133,19 @@ func printOrCreateKubeProxyObjects(cmByte []byte, dsByte []byte, client clientse
 
 	// Create the objects if printManifest is false
 	if !printManifest {
-		if err := apiclient.CreateOrUpdateServiceAccount(client, sa); err != nil {
+		if err := apiclient.CreateOrUpdate(client.CoreV1().ServiceAccounts(sa.GetNamespace()), sa); err != nil {
 			return errors.Wrap(err, "error when creating kube-proxy service account")
 		}
 
-		if err := apiclient.CreateOrUpdateClusterRoleBinding(client, crb); err != nil {
+		if err := apiclient.CreateOrUpdate(client.RbacV1().ClusterRoleBindings(), crb); err != nil {
 			return err
 		}
 
-		if err := apiclient.CreateOrUpdateRole(client, role); err != nil {
+		if err := apiclient.CreateOrUpdate(client.RbacV1().Roles(role.GetNamespace()), role); err != nil {
 			return err
 		}
 
-		if err := apiclient.CreateOrUpdateRoleBinding(client, rb); err != nil {
+		if err := apiclient.CreateOrUpdate(client.RbacV1().RoleBindings(rb.GetNamespace()), rb); err != nil {
 			return err
 		}
 
@@ -243,7 +243,7 @@ func createKubeProxyConfigMap(cfg *kubeadmapi.ClusterConfiguration, localEndpoin
 	}
 
 	// Create the ConfigMap for kube-proxy or update it in case it already exists
-	return []byte(""), apiclient.CreateOrUpdateConfigMap(client, kubeproxyConfigMap)
+	return []byte(""), apiclient.CreateOrUpdate(client.CoreV1().ConfigMaps(kubeproxyConfigMap.GetNamespace()), kubeproxyConfigMap)
 }
 
 func createKubeProxyAddon(cfg *kubeadmapi.ClusterConfiguration, client clientset.Interface, printManifest bool) ([]byte, error) {
@@ -269,5 +269,5 @@ func createKubeProxyAddon(cfg *kubeadmapi.ClusterConfiguration, client clientset
 	*env = append(*env, kubeadmutil.MergeKubeadmEnvVars(kubeadmutil.GetProxyEnvVars(nil))...)
 
 	// Create the DaemonSet for kube-proxy or update it in case it already exists
-	return []byte(""), apiclient.CreateOrUpdateDaemonSet(client, kubeproxyDaemonSet)
+	return []byte(""), apiclient.CreateOrUpdate(client.AppsV1().DaemonSets(kubeproxyDaemonSet.GetNamespace()), kubeproxyDaemonSet)
 }

--- a/cmd/kubeadm/app/phases/bootstraptoken/clusterinfo/clusterinfo.go
+++ b/cmd/kubeadm/app/phases/bootstraptoken/clusterinfo/clusterinfo.go
@@ -69,7 +69,7 @@ func CreateBootstrapConfigMapIfNotExists(client clientset.Interface, kubeconfig 
 
 	// Create or update the ConfigMap in the kube-public namespace
 	klog.V(1).Infoln("[bootstrap-token] creating/updating ConfigMap in kube-public namespace")
-	return apiclient.CreateOrUpdateConfigMap(client, &v1.ConfigMap{
+	return apiclient.CreateOrUpdate(client.CoreV1().ConfigMaps(metav1.NamespacePublic), &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      bootstrapapi.ConfigMapClusterInfo,
 			Namespace: metav1.NamespacePublic,
@@ -83,7 +83,7 @@ func CreateBootstrapConfigMapIfNotExists(client clientset.Interface, kubeconfig 
 // CreateClusterInfoRBACRules creates the RBAC rules for exposing the cluster-info ConfigMap in the kube-public namespace to unauthenticated users
 func CreateClusterInfoRBACRules(client clientset.Interface) error {
 	klog.V(1).Infoln("creating the RBAC rules for exposing the cluster-info ConfigMap in the kube-public namespace")
-	err := apiclient.CreateOrUpdateRole(client, &rbac.Role{
+	err := apiclient.CreateOrUpdate(client.RbacV1().Roles(metav1.NamespacePublic), &rbac.Role{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      BootstrapSignerClusterRoleName,
 			Namespace: metav1.NamespacePublic,
@@ -101,7 +101,7 @@ func CreateClusterInfoRBACRules(client clientset.Interface) error {
 		return err
 	}
 
-	return apiclient.CreateOrUpdateRoleBinding(client, &rbac.RoleBinding{
+	return apiclient.CreateOrUpdate(client.RbacV1().RoleBindings(metav1.NamespacePublic), &rbac.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      BootstrapSignerClusterRoleName,
 			Namespace: metav1.NamespacePublic,

--- a/cmd/kubeadm/app/phases/bootstraptoken/node/tlsbootstrap.go
+++ b/cmd/kubeadm/app/phases/bootstraptoken/node/tlsbootstrap.go
@@ -31,7 +31,7 @@ import (
 func AllowBootstrapTokensToPostCSRs(client clientset.Interface) error {
 	fmt.Println("[bootstrap-token] Configured RBAC rules to allow Node Bootstrap tokens to post CSRs in order for nodes to get long term certificate credentials")
 
-	return apiclient.CreateOrUpdateClusterRoleBinding(client, &rbac.ClusterRoleBinding{
+	return apiclient.CreateOrUpdate(client.RbacV1().ClusterRoleBindings(), &rbac.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: constants.NodeKubeletBootstrap,
 		},
@@ -53,7 +53,7 @@ func AllowBootstrapTokensToPostCSRs(client clientset.Interface) error {
 func AllowBootstrapTokensToGetNodes(client clientset.Interface) error {
 	fmt.Println("[bootstrap-token] Configured RBAC rules to allow Node Bootstrap tokens to get nodes")
 
-	if err := apiclient.CreateOrUpdateClusterRole(client, &rbac.ClusterRole{
+	if err := apiclient.CreateOrUpdate(client.RbacV1().ClusterRoles(), &rbac.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: constants.GetNodesClusterRoleName,
 		},
@@ -68,7 +68,7 @@ func AllowBootstrapTokensToGetNodes(client clientset.Interface) error {
 		return err
 	}
 
-	return apiclient.CreateOrUpdateClusterRoleBinding(client, &rbac.ClusterRoleBinding{
+	return apiclient.CreateOrUpdate(client.RbacV1().ClusterRoleBindings(), &rbac.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: constants.GetNodesClusterRoleName,
 		},
@@ -91,7 +91,7 @@ func AutoApproveNodeBootstrapTokens(client clientset.Interface) error {
 	fmt.Println("[bootstrap-token] Configured RBAC rules to allow the csrapprover controller automatically approve CSRs from a Node Bootstrap Token")
 
 	// Always create this kubeadm-specific binding though
-	return apiclient.CreateOrUpdateClusterRoleBinding(client, &rbac.ClusterRoleBinding{
+	return apiclient.CreateOrUpdate(client.RbacV1().ClusterRoleBindings(), &rbac.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: constants.NodeAutoApproveBootstrapClusterRoleBinding,
 		},
@@ -113,7 +113,7 @@ func AutoApproveNodeBootstrapTokens(client clientset.Interface) error {
 func AutoApproveNodeCertificateRotation(client clientset.Interface) error {
 	fmt.Println("[bootstrap-token] Configured RBAC rules to allow certificate rotation for all node client certificates in the cluster")
 
-	return apiclient.CreateOrUpdateClusterRoleBinding(client, &rbac.ClusterRoleBinding{
+	return apiclient.CreateOrUpdate(client.RbacV1().ClusterRoleBindings(), &rbac.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: constants.NodeAutoApproveCertificateRotationClusterRoleBinding,
 		},

--- a/cmd/kubeadm/app/phases/bootstraptoken/node/token.go
+++ b/cmd/kubeadm/app/phases/bootstraptoken/node/token.go
@@ -40,10 +40,12 @@ func CreateNewTokens(client clientset.Interface, tokens []bootstraptokenv1.Boots
 // UpdateOrCreateTokens attempts to update a token with the given ID, or create if it does not already exist.
 func UpdateOrCreateTokens(client clientset.Interface, failIfExists bool, tokens []bootstraptokenv1.BootstrapToken) error {
 
+	secretsClient := client.CoreV1().Secrets(metav1.NamespaceSystem)
+
 	for _, token := range tokens {
 
 		secretName := bootstraputil.BootstrapTokenSecretName(token.Token.ID)
-		secret, err := client.CoreV1().Secrets(metav1.NamespaceSystem).Get(context.TODO(), secretName, metav1.GetOptions{})
+		secret, err := secretsClient.Get(context.Background(), secretName, metav1.GetOptions{})
 		if secret != nil && err == nil && failIfExists {
 			return errors.Errorf("a token with id %q already exists", token.Token.ID)
 		}
@@ -56,7 +58,7 @@ func UpdateOrCreateTokens(client clientset.Interface, failIfExists bool, tokens 
 			kubeadmconstants.KubernetesAPICallRetryInterval,
 			kubeadmapi.GetActiveTimeouts().KubernetesAPICall.Duration,
 			true, func(_ context.Context) (bool, error) {
-				if err := apiclient.CreateOrUpdateSecret(client, updatedOrNewSecret); err != nil {
+				if err := apiclient.CreateOrUpdate(secretsClient, updatedOrNewSecret); err != nil {
 					lastError = errors.Wrapf(err, "failed to create or update bootstrap token with name %s", secretName)
 					return false, nil
 				}

--- a/cmd/kubeadm/app/phases/copycerts/copycerts.go
+++ b/cmd/kubeadm/app/phases/copycerts/copycerts.go
@@ -106,7 +106,7 @@ func UploadCerts(client clientset.Interface, cfg *kubeadmapi.InitConfiguration, 
 		return err
 	}
 
-	err = apiclient.CreateOrUpdateSecret(client, &v1.Secret{
+	err = apiclient.CreateOrUpdate(client.CoreV1().Secrets(metav1.NamespaceSystem), &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            kubeadmconstants.KubeadmCertsSecret,
 			Namespace:       metav1.NamespaceSystem,
@@ -122,7 +122,7 @@ func UploadCerts(client clientset.Interface, cfg *kubeadmapi.InitConfiguration, 
 }
 
 func createRBAC(client clientset.Interface) error {
-	err := apiclient.CreateOrUpdateRole(client, &rbac.Role{
+	err := apiclient.CreateOrUpdate(client.RbacV1().Roles(metav1.NamespaceSystem), &rbac.Role{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      kubeadmconstants.KubeadmCertsClusterRoleName,
 			Namespace: metav1.NamespaceSystem,
@@ -140,7 +140,7 @@ func createRBAC(client clientset.Interface) error {
 		return err
 	}
 
-	return apiclient.CreateOrUpdateRoleBinding(client, &rbac.RoleBinding{
+	return apiclient.CreateOrUpdate(client.RbacV1().RoleBindings(metav1.NamespaceSystem), &rbac.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      kubeadmconstants.KubeadmCertsClusterRoleName,
 			Namespace: metav1.NamespaceSystem,

--- a/cmd/kubeadm/app/phases/kubelet/config.go
+++ b/cmd/kubeadm/app/phases/kubelet/config.go
@@ -151,7 +151,7 @@ func CreateConfigMap(cfg *kubeadmapi.ClusterConfiguration, client clientset.Inte
 		componentconfigs.SignConfigMap(configMap)
 	}
 
-	if err := apiclient.CreateOrUpdateConfigMap(client, configMap); err != nil {
+	if err := apiclient.CreateOrUpdate(client.CoreV1().ConfigMaps(configMap.GetNamespace()), configMap); err != nil {
 		return err
 	}
 
@@ -163,7 +163,7 @@ func CreateConfigMap(cfg *kubeadmapi.ClusterConfiguration, client clientset.Inte
 
 // createConfigMapRBACRules creates the RBAC rules for exposing the base kubelet ConfigMap in the kube-system namespace to unauthenticated users
 func createConfigMapRBACRules(client clientset.Interface) error {
-	if err := apiclient.CreateOrUpdateRole(client, &rbac.Role{
+	if err := apiclient.CreateOrUpdate(client.RbacV1().Roles(metav1.NamespaceSystem), &rbac.Role{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      kubeadmconstants.KubeletBaseConfigMapRole,
 			Namespace: metav1.NamespaceSystem,
@@ -180,7 +180,7 @@ func createConfigMapRBACRules(client clientset.Interface) error {
 		return err
 	}
 
-	return apiclient.CreateOrUpdateRoleBinding(client, &rbac.RoleBinding{
+	return apiclient.CreateOrUpdate(client.RbacV1().RoleBindings(metav1.NamespaceSystem), &rbac.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      kubeadmconstants.KubeletBaseConfigMapRole,
 			Namespace: metav1.NamespaceSystem,

--- a/cmd/kubeadm/app/phases/uploadconfig/uploadconfig.go
+++ b/cmd/kubeadm/app/phases/uploadconfig/uploadconfig.go
@@ -59,7 +59,7 @@ func UploadConfiguration(cfg *kubeadmapi.InitConfiguration, client clientset.Int
 		return err
 	}
 
-	err = apiclient.CreateOrMutateConfigMap(client, &v1.ConfigMap{
+	err = apiclient.CreateOrMutate(client.CoreV1().ConfigMaps(metav1.NamespaceSystem), &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      kubeadmconstants.KubeadmConfigConfigMap,
 			Namespace: metav1.NamespaceSystem,
@@ -78,7 +78,7 @@ func UploadConfiguration(cfg *kubeadmapi.InitConfiguration, client clientset.Int
 	}
 
 	// Ensure that the NodesKubeadmConfigClusterRoleName exists
-	err = apiclient.CreateOrUpdateRole(client, &rbac.Role{
+	err = apiclient.CreateOrUpdate(client.RbacV1().Roles(metav1.NamespaceSystem), &rbac.Role{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      NodesKubeadmConfigClusterRoleName,
 			Namespace: metav1.NamespaceSystem,
@@ -99,7 +99,7 @@ func UploadConfiguration(cfg *kubeadmapi.InitConfiguration, client clientset.Int
 	// Binds the NodesKubeadmConfigClusterRoleName to all the bootstrap tokens
 	// that are members of the system:bootstrappers:kubeadm:default-node-token group
 	// and to all nodes
-	return apiclient.CreateOrUpdateRoleBinding(client, &rbac.RoleBinding{
+	return apiclient.CreateOrUpdate(client.RbacV1().RoleBindings(metav1.NamespaceSystem), &rbac.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      NodesKubeadmConfigClusterRoleName,
 			Namespace: metav1.NamespaceSystem,

--- a/cmd/kubeadm/app/util/apiclient/idempotency_test.go
+++ b/cmd/kubeadm/app/util/apiclient/idempotency_test.go
@@ -112,7 +112,7 @@ func testCreateOrUpdate[T kubernetesObject](t *testing.T, resource, resources st
 		t.Run(fmt.Sprintf(tc.nameFormat, resource), func(t *testing.T) {
 			client := clientsetfake.NewSimpleClientset()
 			tc.setupClient(client, resources)
-			err := CreateOrUpdate(context.Background(), clientBuilder(client, empty), empty)
+			err := CreateOrUpdate(clientBuilder(client, empty), empty)
 			if (err != nil) != tc.expectedError {
 				t.Fatalf("expected error: %v, got %v, error: %v", tc.expectedError, err != nil, err)
 			}
@@ -205,7 +205,7 @@ func testCreateOrMutate[T kubernetesObject](t *testing.T, resource, resources st
 		t.Run(fmt.Sprintf(tc.nameFormat, resource), func(t *testing.T) {
 			client := clientsetfake.NewSimpleClientset()
 			tc.setupClient(client)
-			err := CreateOrMutate[T](context.Background(), clientBuilder(client, empty), empty, tc.mutator)
+			err := CreateOrMutate[T](clientBuilder(client, empty), empty, tc.mutator)
 			if (err != nil) != tc.expectedError {
 				t.Fatalf("expected error: %v, got %v, error: %v", tc.expectedError, err != nil, err)
 			}
@@ -274,7 +274,7 @@ func testCreateOrRetain[T kubernetesObject](t *testing.T, resource, resources st
 		t.Run(fmt.Sprintf(tc.nameFormat, resource), func(t *testing.T) {
 			client := clientsetfake.NewSimpleClientset()
 			tc.setupClient(client)
-			err := CreateOrRetain[T](context.Background(), clientBuilder(client, empty), empty)
+			err := CreateOrRetain[T](clientBuilder(client, empty), empty, resource)
 			if (err != nil) != tc.expectedError {
 				t.Fatalf("expected error: %v, got %v, error: %v", tc.expectedError, err != nil, err)
 			}

--- a/cmd/kubeadm/test/resources/configmap.go
+++ b/cmd/kubeadm/test/resources/configmap.go
@@ -32,7 +32,7 @@ type FakeConfigMap struct {
 
 // Create creates a fake configmap using the provided client
 func (c *FakeConfigMap) Create(client clientset.Interface) error {
-	return apiclient.CreateOrUpdateConfigMap(client, &v1.ConfigMap{
+	return apiclient.CreateOrUpdate(client.CoreV1().ConfigMaps(metav1.NamespaceSystem), &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      c.Name,
 			Namespace: metav1.NamespaceSystem,


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

CreateOrRetain is supposed to operate on an object name which isn't necessarily the given object's name (for use in migrations), this restores that feature.

Replace all uses of deprecated functions with their generic variants.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
