### PR TITLE
Add short names for long named resources

### DIFF
--- a/pkg/registry/admissionregistration/mutatingadmissionpolicy/storage/storage.go
+++ b/pkg/registry/admissionregistration/mutatingadmissionpolicy/storage/storage.go
@@ -71,3 +71,11 @@ var _ rest.CategoriesProvider = &REST{}
 func (r *REST) Categories() []string {
 	return []string{"api-extensions"}
 }
+
+// Implement ShortNamesProvider
+var _ rest.ShortNamesProvider = &REST{}
+
+// ShortNames implements the ShortNamesProvider interface. Returns a list of short names for a resource.
+func (r *REST) ShortNames() []string {
+	return []string{"map"}
+}

--- a/pkg/registry/admissionregistration/mutatingadmissionpolicybinding/storage/storage.go
+++ b/pkg/registry/admissionregistration/mutatingadmissionpolicybinding/storage/storage.go
@@ -75,6 +75,14 @@ func (r *REST) Categories() []string {
 	return []string{"api-extensions"}
 }
 
+// Implement ShortNamesProvider
+var _ rest.ShortNamesProvider = &REST{}
+
+// ShortNames implements the ShortNamesProvider interface. Returns a list of short names for a resource.
+func (r *REST) ShortNames() []string {
+	return []string{"mapb"}
+}
+
 type PolicyGetter interface {
 	// GetMutatingAdmissionPolicy returns a GetMutatingAdmissionPolicy
 	// by its name. There is no namespace because it is cluster-scoped.

--- a/pkg/registry/admissionregistration/mutatingwebhookconfiguration/storage/storage.go
+++ b/pkg/registry/admissionregistration/mutatingwebhookconfiguration/storage/storage.go
@@ -64,3 +64,11 @@ var _ rest.CategoriesProvider = &REST{}
 func (r *REST) Categories() []string {
 	return []string{"api-extensions"}
 }
+
+// Implement ShortNamesProvider
+var _ rest.ShortNamesProvider = &REST{}
+
+// ShortNames implements the ShortNamesProvider interface. Returns a list of short names for a resource.
+func (r *REST) ShortNames() []string {
+	return []string{"mwc"}
+}

--- a/pkg/registry/admissionregistration/validatingadmissionpolicy/storage/storage.go
+++ b/pkg/registry/admissionregistration/validatingadmissionpolicy/storage/storage.go
@@ -88,6 +88,14 @@ func (r *REST) Categories() []string {
 	return []string{"api-extensions"}
 }
 
+// Implement ShortNamesProvider
+var _ rest.ShortNamesProvider = &REST{}
+
+// ShortNames implements the ShortNamesProvider interface. Returns a list of short names for a resource.
+func (r *REST) ShortNames() []string {
+	return []string{"vap"}
+}
+
 // New generates a new ValidatingAdmissionPolicy object
 func (r *StatusREST) New() runtime.Object {
 	return &admissionregistration.ValidatingAdmissionPolicy{}

--- a/pkg/registry/admissionregistration/validatingadmissionpolicybinding/storage/storage.go
+++ b/pkg/registry/admissionregistration/validatingadmissionpolicybinding/storage/storage.go
@@ -75,6 +75,14 @@ func (r *REST) Categories() []string {
 	return []string{"api-extensions"}
 }
 
+// Implement ShortNamesProvider
+var _ rest.ShortNamesProvider = &REST{}
+
+// ShortNames implements the ShortNamesProvider interface. Returns a list of short names for a resource.
+func (r *REST) ShortNames() []string {
+	return []string{"vapb"}
+}
+
 type PolicyGetter interface {
 	// GetValidatingAdmissionPolicy returns a GetValidatingAdmissionPolicy
 	// by its name. There is no namespace because it is cluster-scoped.

--- a/pkg/registry/admissionregistration/validatingwebhookconfiguration/storage/storage.go
+++ b/pkg/registry/admissionregistration/validatingwebhookconfiguration/storage/storage.go
@@ -64,3 +64,11 @@ var _ rest.CategoriesProvider = &REST{}
 func (r *REST) Categories() []string {
 	return []string{"api-extensions"}
 }
+
+// Implement ShortNamesProvider
+var _ rest.ShortNamesProvider = &REST{}
+
+// ShortNames implements the ShortNamesProvider interface. Returns a list of short names for a resource.
+func (r *REST) ShortNames() []string {
+	return []string{"vwc"}
+}

--- a/pkg/registry/batch/job/storage/storage.go
+++ b/pkg/registry/batch/job/storage/storage.go
@@ -97,6 +97,14 @@ func (r *REST) Categories() []string {
 	return []string{"all"}
 }
 
+// Implement ShortNamesProvider
+var _ rest.ShortNamesProvider = &REST{}
+
+// ShortNames implements the ShortNamesProvider interface. Returns a list of short names for a resource.
+func (r *REST) ShortNames() []string {
+	return []string{"jo"}
+}
+
 func (r *REST) Delete(ctx context.Context, name string, deleteValidation rest.ValidateObjectFunc, options *metav1.DeleteOptions) (runtime.Object, bool, error) {
 	//nolint:staticcheck // SA1019 backwards compatibility
 	//nolint: staticcheck

--- a/pkg/registry/coordination/lease/storage/storage.go
+++ b/pkg/registry/coordination/lease/storage/storage.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/generic"
 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
+	"k8s.io/apiserver/pkg/registry/rest"
 	coordinationapi "k8s.io/kubernetes/pkg/apis/coordination"
 	"k8s.io/kubernetes/pkg/printers"
 	printersinternal "k8s.io/kubernetes/pkg/printers/internalversion"
@@ -52,4 +53,12 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, error) {
 	}
 
 	return &REST{store}, nil
+}
+
+// Implement ShortNamesProvider
+var _ rest.ShortNamesProvider = &REST{}
+
+// ShortNames implements the ShortNamesProvider interface. Returns a list of short names for a resource.
+func (r *REST) ShortNames() []string {
+	return []string{"le", "lea"}
 }

--- a/pkg/registry/core/podtemplate/storage/storage.go
+++ b/pkg/registry/core/podtemplate/storage/storage.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/generic"
 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
+	"k8s.io/apiserver/pkg/registry/rest"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/printers"
 	printersinternal "k8s.io/kubernetes/pkg/printers/internalversion"
@@ -53,4 +54,12 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, error) {
 		return nil, err
 	}
 	return &REST{store}, nil
+}
+
+// Implement ShortNamesProvider
+var _ rest.ShortNamesProvider = &REST{}
+
+// ShortNames implements the ShortNamesProvider interface. Returns a list of short names for a resource.
+func (r *REST) ShortNames() []string {
+	return []string{"pt", "ptpl"}
 }

--- a/pkg/registry/core/secret/storage/storage.go
+++ b/pkg/registry/core/secret/storage/storage.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/generic"
 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
+	"k8s.io/apiserver/pkg/registry/rest"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/printers"
 	printersinternal "k8s.io/kubernetes/pkg/printers/internalversion"
@@ -55,4 +56,12 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, error) {
 		return nil, err
 	}
 	return &REST{store}, nil
+}
+
+// Implement ShortNamesProvider
+var _ rest.ShortNamesProvider = &REST{}
+
+// ShortNames implements the ShortNamesProvider interface. Returns a list of short names for a resource.
+func (r *REST) ShortNames() []string {
+	return []string{"sec"}
 }

--- a/pkg/registry/discovery/endpointslice/storage/storage.go
+++ b/pkg/registry/discovery/endpointslice/storage/storage.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/generic"
 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
+	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/kubernetes/pkg/apis/discovery"
 	"k8s.io/kubernetes/pkg/printers"
 	printersinternal "k8s.io/kubernetes/pkg/printers/internalversion"
@@ -51,4 +52,12 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, error) {
 		return nil, err
 	}
 	return &REST{store}, nil
+}
+
+// Implement ShortNamesProvider
+var _ rest.ShortNamesProvider = &REST{}
+
+// ShortNames implements the ShortNamesProvider interface. Returns a list of short names for a resource.
+func (r *REST) ShortNames() []string {
+	return []string{"eps"}
 }

--- a/pkg/registry/flowcontrol/flowschema/storage/storage.go
+++ b/pkg/registry/flowcontrol/flowschema/storage/storage.go
@@ -72,6 +72,14 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST, error) {
 	return &REST{store}, &StatusREST{store: &statusStore}, nil
 }
 
+// Implement ShortNamesProvider
+var _ rest.ShortNamesProvider = &REST{}
+
+// ShortNames implements the ShortNamesProvider interface. Returns a list of short names for a resource.
+func (r *REST) ShortNames() []string {
+	return []string{"fs"}
+}
+
 // StatusREST implements the REST endpoint for changing the status of a flow schema.
 type StatusREST struct {
 	store *genericregistry.Store

--- a/pkg/registry/flowcontrol/prioritylevelconfiguration/storage/storage.go
+++ b/pkg/registry/flowcontrol/prioritylevelconfiguration/storage/storage.go
@@ -72,6 +72,14 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST, error) {
 	return &REST{store}, &StatusREST{store: &statusStore}, nil
 }
 
+// Implement ShortNamesProvider
+var _ rest.ShortNamesProvider = &REST{}
+
+// ShortNames implements the ShortNamesProvider interface. Returns a list of short names for a resource.
+func (r *REST) ShortNames() []string {
+	return []string{"plc"}
+}
+
 // StatusREST implements the REST endpoint for changing the status of a priority level configuration.
 type StatusREST struct {
 	store *genericregistry.Store

--- a/pkg/registry/networking/ingressclass/storage/storage.go
+++ b/pkg/registry/networking/ingressclass/storage/storage.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/generic"
 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
+	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/kubernetes/pkg/apis/networking"
 	"k8s.io/kubernetes/pkg/printers"
 	printersinternal "k8s.io/kubernetes/pkg/printers/internalversion"
@@ -52,4 +53,12 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, error) {
 	}
 
 	return &REST{store}, nil
+}
+
+// Implement ShortNamesProvider
+var _ rest.ShortNamesProvider = &REST{}
+
+// ShortNames implements the ShortNamesProvider interface. Returns a list of short names for a resource.
+func (r *REST) ShortNames() []string {
+	return []string{"ingc"}
 }

--- a/pkg/registry/rbac/clusterrole/storage/storage.go
+++ b/pkg/registry/rbac/clusterrole/storage/storage.go
@@ -52,3 +52,11 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, error) {
 
 	return &REST{store}, nil
 }
+
+// Implement ShortNamesProvider
+var _ rest.ShortNamesProvider = &REST{}
+
+// ShortNames implements the ShortNamesProvider interface. Returns a list of short names for a resource.
+func (r *REST) ShortNames() []string {
+	return []string{"cr", "crole"}
+}

--- a/pkg/registry/rbac/clusterrolebinding/storage/storage.go
+++ b/pkg/registry/rbac/clusterrolebinding/storage/storage.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/generic"
 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
+	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/kubernetes/pkg/apis/rbac"
 	"k8s.io/kubernetes/pkg/printers"
 	printersinternal "k8s.io/kubernetes/pkg/printers/internalversion"
@@ -52,4 +53,12 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, error) {
 	}
 
 	return &REST{store}, nil
+}
+
+// Implement ShortNamesProvider
+var _ rest.ShortNamesProvider = &REST{}
+
+// ShortNames implements the ShortNamesProvider interface. Returns a list of short names for a resource.
+func (r *REST) ShortNames() []string {
+	return []string{"crb"}
 }

--- a/pkg/registry/rbac/rolebinding/storage/storage.go
+++ b/pkg/registry/rbac/rolebinding/storage/storage.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/generic"
 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
+	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/kubernetes/pkg/apis/rbac"
 	"k8s.io/kubernetes/pkg/printers"
 	printersinternal "k8s.io/kubernetes/pkg/printers/internalversion"
@@ -52,4 +53,12 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, error) {
 	}
 
 	return &REST{store}, nil
+}
+
+// Implement ShortNamesProvider
+var _ rest.ShortNamesProvider = &REST{}
+
+// ShortNames implements the ShortNamesProvider interface. Returns a list of short names for a resource.
+func (r *REST) ShortNames() []string {
+	return []string{"rb"}
 }

--- a/pkg/registry/storage/csidriver/storage/storage.go
+++ b/pkg/registry/storage/csidriver/storage/storage.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/generic"
 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
+	"k8s.io/apiserver/pkg/registry/rest"
 	storageapi "k8s.io/kubernetes/pkg/apis/storage"
 	"k8s.io/kubernetes/pkg/printers"
 	printersinternal "k8s.io/kubernetes/pkg/printers/internalversion"
@@ -60,4 +61,12 @@ func NewStorage(optsGetter generic.RESTOptionsGetter) (*CSIDriverStorage, error)
 	return &CSIDriverStorage{
 		CSIDriver: &REST{store},
 	}, nil
+}
+
+// Implement ShortNamesProvider
+var _ rest.ShortNamesProvider = &REST{}
+
+// ShortNames implements the ShortNamesProvider interface. Returns a list of short names for a resource.
+func (r *REST) ShortNames() []string {
+	return []string{"csid"}
 }

--- a/pkg/registry/storage/csinode/storage/storage.go
+++ b/pkg/registry/storage/csinode/storage/storage.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/generic"
 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
+	"k8s.io/apiserver/pkg/registry/rest"
 	storageapi "k8s.io/kubernetes/pkg/apis/storage"
 	"k8s.io/kubernetes/pkg/printers"
 	printersinternal "k8s.io/kubernetes/pkg/printers/internalversion"
@@ -60,4 +61,12 @@ func NewStorage(optsGetter generic.RESTOptionsGetter) (*CSINodeStorage, error) {
 	return &CSINodeStorage{
 		CSINode: &REST{store},
 	}, nil
+}
+
+// Implement ShortNamesProvider
+var _ rest.ShortNamesProvider = &REST{}
+
+// ShortNames implements the ShortNamesProvider interface. Returns a list of short names for a resource.
+func (r *REST) ShortNames() []string {
+	return []string{"csin"}
 }

--- a/pkg/registry/storage/csistoragecapacity/storage/storage.go
+++ b/pkg/registry/storage/csistoragecapacity/storage/storage.go
@@ -58,3 +58,11 @@ func NewStorage(optsGetter generic.RESTOptionsGetter) (*CSIStorageCapacityStorag
 		CSIStorageCapacity: &REST{store},
 	}, nil
 }
+
+// Implement ShortNamesProvider
+var _ rest.ShortNamesProvider = &REST{}
+
+// ShortNames implements the ShortNamesProvider interface. Returns a list of short names for a resource.
+func (r *REST) ShortNames() []string {
+	return []string{"csc", "csisc"}
+}

--- a/pkg/registry/storage/volumeattachment/storage/storage.go
+++ b/pkg/registry/storage/volumeattachment/storage/storage.go
@@ -74,6 +74,14 @@ func NewStorage(optsGetter generic.RESTOptionsGetter) (*VolumeAttachmentStorage,
 	}, nil
 }
 
+// Implement ShortNamesProvider
+var _ rest.ShortNamesProvider = &REST{}
+
+// ShortNames implements the ShortNamesProvider interface. Returns a list of short names for a resource.
+func (r *REST) ShortNames() []string {
+	return []string{"va", "vattach"}
+}
+
 // StatusREST implements the REST endpoint for changing the status of a VolumeAttachment
 type StatusREST struct {
 	store *genericregistry.Store

--- a/staging/src/k8s.io/kube-aggregator/pkg/registry/apiservice/etcd/etcd.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/registry/apiservice/etcd/etcd.go
@@ -70,6 +70,14 @@ func (c *REST) Categories() []string {
 	return []string{"api-extensions"}
 }
 
+// Implement ShortNamesProvider
+var _ rest.ShortNamesProvider = &REST{}
+
+// ShortNames implements the ShortNamesProvider interface. Returns a list of short names for a resource.
+func (r *REST) ShortNames() []string {
+	return []string{"apis", "apisvc"}
+}
+
 var swaggerMetadataDescriptions = metav1.ObjectMeta{}.SwaggerDoc()
 
 // ConvertToTable implements the TableConvertor interface for REST.


### PR DESCRIPTION
#### What type of PR is this?
/kind documentation

#### What this PR does / why we need it:
Add short names for long named resources, to simplify `kubectl` commands.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
kubectl support more short names to get long named resources.
```