### PR TITLE
Add an interface that root apply configurations all implement

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/applyconfiguration/cr/v1/example.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/applyconfiguration/cr/v1/example.go
@@ -43,6 +43,9 @@ func Example(name, namespace string) *ExampleApplyConfiguration {
 	b.WithAPIVersion("cr.example.apiextensions.k8s.io/v1")
 	return b
 }
+func (b ExampleApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1/customresourcedefinition.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1/customresourcedefinition.go
@@ -42,6 +42,9 @@ func CustomResourceDefinition(name string) *CustomResourceDefinitionApplyConfigu
 	b.WithAPIVersion("apiextensions.k8s.io/v1")
 	return b
 }
+func (b CustomResourceDefinitionApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1beta1/customresourcedefinition.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1beta1/customresourcedefinition.go
@@ -42,6 +42,9 @@ func CustomResourceDefinition(name string) *CustomResourceDefinitionApplyConfigu
 	b.WithAPIVersion("apiextensions.k8s.io/v1beta1")
 	return b
 }
+func (b CustomResourceDefinitionApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/interfaces.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/interfaces.go
@@ -384,3 +384,9 @@ type Unstructured interface {
 	// If the items passed to fn are not retained, or are retained for the same duration, use EachListItem instead for memory efficiency.
 	EachListItemWithAlloc(func(Object) error) error
 }
+
+// ApplyConfiguration is an interface that root apply configuration types implement.
+type ApplyConfiguration interface {
+	// IsApplyConfiguration returns true if the object is the root of an apply configuration.
+	IsApplyConfiguration() bool
+}

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/mutatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/mutatingwebhookconfiguration.go
@@ -79,6 +79,9 @@ func extractMutatingWebhookConfiguration(mutatingWebhookConfiguration *admission
 	b.WithAPIVersion("admissionregistration.k8s.io/v1")
 	return b, nil
 }
+func (b MutatingWebhookConfigurationApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/validatingadmissionpolicy.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/validatingadmissionpolicy.go
@@ -80,6 +80,9 @@ func extractValidatingAdmissionPolicy(validatingAdmissionPolicy *admissionregist
 	b.WithAPIVersion("admissionregistration.k8s.io/v1")
 	return b, nil
 }
+func (b ValidatingAdmissionPolicyApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/validatingadmissionpolicybinding.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/validatingadmissionpolicybinding.go
@@ -79,6 +79,9 @@ func extractValidatingAdmissionPolicyBinding(validatingAdmissionPolicyBinding *a
 	b.WithAPIVersion("admissionregistration.k8s.io/v1")
 	return b, nil
 }
+func (b ValidatingAdmissionPolicyBindingApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/validatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/validatingwebhookconfiguration.go
@@ -79,6 +79,9 @@ func extractValidatingWebhookConfiguration(validatingWebhookConfiguration *admis
 	b.WithAPIVersion("admissionregistration.k8s.io/v1")
 	return b, nil
 }
+func (b ValidatingWebhookConfigurationApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/mutatingadmissionpolicy.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/mutatingadmissionpolicy.go
@@ -79,6 +79,9 @@ func extractMutatingAdmissionPolicy(mutatingAdmissionPolicy *admissionregistrati
 	b.WithAPIVersion("admissionregistration.k8s.io/v1alpha1")
 	return b, nil
 }
+func (b MutatingAdmissionPolicyApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/mutatingadmissionpolicybinding.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/mutatingadmissionpolicybinding.go
@@ -79,6 +79,9 @@ func extractMutatingAdmissionPolicyBinding(mutatingAdmissionPolicyBinding *admis
 	b.WithAPIVersion("admissionregistration.k8s.io/v1alpha1")
 	return b, nil
 }
+func (b MutatingAdmissionPolicyBindingApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/validatingadmissionpolicy.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/validatingadmissionpolicy.go
@@ -80,6 +80,9 @@ func extractValidatingAdmissionPolicy(validatingAdmissionPolicy *admissionregist
 	b.WithAPIVersion("admissionregistration.k8s.io/v1alpha1")
 	return b, nil
 }
+func (b ValidatingAdmissionPolicyApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/validatingadmissionpolicybinding.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/validatingadmissionpolicybinding.go
@@ -79,6 +79,9 @@ func extractValidatingAdmissionPolicyBinding(validatingAdmissionPolicyBinding *a
 	b.WithAPIVersion("admissionregistration.k8s.io/v1alpha1")
 	return b, nil
 }
+func (b ValidatingAdmissionPolicyBindingApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/mutatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/mutatingwebhookconfiguration.go
@@ -79,6 +79,9 @@ func extractMutatingWebhookConfiguration(mutatingWebhookConfiguration *admission
 	b.WithAPIVersion("admissionregistration.k8s.io/v1beta1")
 	return b, nil
 }
+func (b MutatingWebhookConfigurationApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/validatingadmissionpolicy.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/validatingadmissionpolicy.go
@@ -80,6 +80,9 @@ func extractValidatingAdmissionPolicy(validatingAdmissionPolicy *admissionregist
 	b.WithAPIVersion("admissionregistration.k8s.io/v1beta1")
 	return b, nil
 }
+func (b ValidatingAdmissionPolicyApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/validatingadmissionpolicybinding.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/validatingadmissionpolicybinding.go
@@ -79,6 +79,9 @@ func extractValidatingAdmissionPolicyBinding(validatingAdmissionPolicyBinding *a
 	b.WithAPIVersion("admissionregistration.k8s.io/v1beta1")
 	return b, nil
 }
+func (b ValidatingAdmissionPolicyBindingApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/validatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/validatingwebhookconfiguration.go
@@ -79,6 +79,9 @@ func extractValidatingWebhookConfiguration(validatingWebhookConfiguration *admis
 	b.WithAPIVersion("admissionregistration.k8s.io/v1beta1")
 	return b, nil
 }
+func (b ValidatingWebhookConfigurationApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apiserverinternal/v1alpha1/storageversion.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apiserverinternal/v1alpha1/storageversion.go
@@ -80,6 +80,9 @@ func extractStorageVersion(storageVersion *apiserverinternalv1alpha1.StorageVers
 	b.WithAPIVersion("internal.apiserver.k8s.io/v1alpha1")
 	return b, nil
 }
+func (b StorageVersionApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/controllerrevision.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/controllerrevision.go
@@ -83,6 +83,9 @@ func extractControllerRevision(controllerRevision *appsv1.ControllerRevision, fi
 	b.WithAPIVersion("apps/v1")
 	return b, nil
 }
+func (b ControllerRevisionApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/daemonset.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/daemonset.go
@@ -82,6 +82,9 @@ func extractDaemonSet(daemonSet *appsv1.DaemonSet, fieldManager string, subresou
 	b.WithAPIVersion("apps/v1")
 	return b, nil
 }
+func (b DaemonSetApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/deployment.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/deployment.go
@@ -82,6 +82,9 @@ func extractDeployment(deployment *appsv1.Deployment, fieldManager string, subre
 	b.WithAPIVersion("apps/v1")
 	return b, nil
 }
+func (b DeploymentApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/replicaset.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/replicaset.go
@@ -82,6 +82,9 @@ func extractReplicaSet(replicaSet *appsv1.ReplicaSet, fieldManager string, subre
 	b.WithAPIVersion("apps/v1")
 	return b, nil
 }
+func (b ReplicaSetApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/statefulset.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/statefulset.go
@@ -82,6 +82,9 @@ func extractStatefulSet(statefulSet *appsv1.StatefulSet, fieldManager string, su
 	b.WithAPIVersion("apps/v1")
 	return b, nil
 }
+func (b StatefulSetApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta1/controllerrevision.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta1/controllerrevision.go
@@ -83,6 +83,9 @@ func extractControllerRevision(controllerRevision *appsv1beta1.ControllerRevisio
 	b.WithAPIVersion("apps/v1beta1")
 	return b, nil
 }
+func (b ControllerRevisionApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta1/deployment.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta1/deployment.go
@@ -82,6 +82,9 @@ func extractDeployment(deployment *appsv1beta1.Deployment, fieldManager string, 
 	b.WithAPIVersion("apps/v1beta1")
 	return b, nil
 }
+func (b DeploymentApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta1/statefulset.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta1/statefulset.go
@@ -82,6 +82,9 @@ func extractStatefulSet(statefulSet *appsv1beta1.StatefulSet, fieldManager strin
 	b.WithAPIVersion("apps/v1beta1")
 	return b, nil
 }
+func (b StatefulSetApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/controllerrevision.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/controllerrevision.go
@@ -83,6 +83,9 @@ func extractControllerRevision(controllerRevision *appsv1beta2.ControllerRevisio
 	b.WithAPIVersion("apps/v1beta2")
 	return b, nil
 }
+func (b ControllerRevisionApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/daemonset.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/daemonset.go
@@ -82,6 +82,9 @@ func extractDaemonSet(daemonSet *appsv1beta2.DaemonSet, fieldManager string, sub
 	b.WithAPIVersion("apps/v1beta2")
 	return b, nil
 }
+func (b DaemonSetApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/deployment.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/deployment.go
@@ -82,6 +82,9 @@ func extractDeployment(deployment *appsv1beta2.Deployment, fieldManager string, 
 	b.WithAPIVersion("apps/v1beta2")
 	return b, nil
 }
+func (b DeploymentApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/replicaset.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/replicaset.go
@@ -82,6 +82,9 @@ func extractReplicaSet(replicaSet *appsv1beta2.ReplicaSet, fieldManager string, 
 	b.WithAPIVersion("apps/v1beta2")
 	return b, nil
 }
+func (b ReplicaSetApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/statefulset.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/statefulset.go
@@ -82,6 +82,9 @@ func extractStatefulSet(statefulSet *appsv1beta2.StatefulSet, fieldManager strin
 	b.WithAPIVersion("apps/v1beta2")
 	return b, nil
 }
+func (b StatefulSetApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v1/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v1/horizontalpodautoscaler.go
@@ -82,6 +82,9 @@ func extractHorizontalPodAutoscaler(horizontalPodAutoscaler *autoscalingv1.Horiz
 	b.WithAPIVersion("autoscaling/v1")
 	return b, nil
 }
+func (b HorizontalPodAutoscalerApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2/horizontalpodautoscaler.go
@@ -82,6 +82,9 @@ func extractHorizontalPodAutoscaler(horizontalPodAutoscaler *autoscalingv2.Horiz
 	b.WithAPIVersion("autoscaling/v2")
 	return b, nil
 }
+func (b HorizontalPodAutoscalerApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta1/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta1/horizontalpodautoscaler.go
@@ -82,6 +82,9 @@ func extractHorizontalPodAutoscaler(horizontalPodAutoscaler *autoscalingv2beta1.
 	b.WithAPIVersion("autoscaling/v2beta1")
 	return b, nil
 }
+func (b HorizontalPodAutoscalerApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta2/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta2/horizontalpodautoscaler.go
@@ -82,6 +82,9 @@ func extractHorizontalPodAutoscaler(horizontalPodAutoscaler *autoscalingv2beta2.
 	b.WithAPIVersion("autoscaling/v2beta2")
 	return b, nil
 }
+func (b HorizontalPodAutoscalerApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/batch/v1/cronjob.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/batch/v1/cronjob.go
@@ -82,6 +82,9 @@ func extractCronJob(cronJob *batchv1.CronJob, fieldManager string, subresource s
 	b.WithAPIVersion("batch/v1")
 	return b, nil
 }
+func (b CronJobApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/batch/v1/job.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/batch/v1/job.go
@@ -82,6 +82,9 @@ func extractJob(job *batchv1.Job, fieldManager string, subresource string) (*Job
 	b.WithAPIVersion("batch/v1")
 	return b, nil
 }
+func (b JobApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/batch/v1beta1/cronjob.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/batch/v1beta1/cronjob.go
@@ -82,6 +82,9 @@ func extractCronJob(cronJob *batchv1beta1.CronJob, fieldManager string, subresou
 	b.WithAPIVersion("batch/v1beta1")
 	return b, nil
 }
+func (b CronJobApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/certificates/v1/certificatesigningrequest.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/certificates/v1/certificatesigningrequest.go
@@ -80,6 +80,9 @@ func extractCertificateSigningRequest(certificateSigningRequest *certificatesv1.
 	b.WithAPIVersion("certificates.k8s.io/v1")
 	return b, nil
 }
+func (b CertificateSigningRequestApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/certificates/v1alpha1/clustertrustbundle.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/certificates/v1alpha1/clustertrustbundle.go
@@ -79,6 +79,9 @@ func extractClusterTrustBundle(clusterTrustBundle *certificatesv1alpha1.ClusterT
 	b.WithAPIVersion("certificates.k8s.io/v1alpha1")
 	return b, nil
 }
+func (b ClusterTrustBundleApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/certificates/v1beta1/certificatesigningrequest.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/certificates/v1beta1/certificatesigningrequest.go
@@ -80,6 +80,9 @@ func extractCertificateSigningRequest(certificateSigningRequest *certificatesv1b
 	b.WithAPIVersion("certificates.k8s.io/v1beta1")
 	return b, nil
 }
+func (b CertificateSigningRequestApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/coordination/v1/lease.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/coordination/v1/lease.go
@@ -81,6 +81,9 @@ func extractLease(lease *coordinationv1.Lease, fieldManager string, subresource 
 	b.WithAPIVersion("coordination.k8s.io/v1")
 	return b, nil
 }
+func (b LeaseApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/coordination/v1alpha2/leasecandidate.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/coordination/v1alpha2/leasecandidate.go
@@ -81,6 +81,9 @@ func extractLeaseCandidate(leaseCandidate *coordinationv1alpha2.LeaseCandidate, 
 	b.WithAPIVersion("coordination.k8s.io/v1alpha2")
 	return b, nil
 }
+func (b LeaseCandidateApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/coordination/v1beta1/lease.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/coordination/v1beta1/lease.go
@@ -81,6 +81,9 @@ func extractLease(lease *coordinationv1beta1.Lease, fieldManager string, subreso
 	b.WithAPIVersion("coordination.k8s.io/v1beta1")
 	return b, nil
 }
+func (b LeaseApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/componentstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/componentstatus.go
@@ -79,6 +79,9 @@ func extractComponentStatus(componentStatus *corev1.ComponentStatus, fieldManage
 	b.WithAPIVersion("v1")
 	return b, nil
 }
+func (b ComponentStatusApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/configmap.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/configmap.go
@@ -83,6 +83,9 @@ func extractConfigMap(configMap *corev1.ConfigMap, fieldManager string, subresou
 	b.WithAPIVersion("v1")
 	return b, nil
 }
+func (b ConfigMapApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/endpoints.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/endpoints.go
@@ -81,6 +81,9 @@ func extractEndpoints(endpoints *corev1.Endpoints, fieldManager string, subresou
 	b.WithAPIVersion("v1")
 	return b, nil
 }
+func (b EndpointsApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/event.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/event.go
@@ -94,6 +94,9 @@ func extractEvent(event *corev1.Event, fieldManager string, subresource string) 
 	b.WithAPIVersion("v1")
 	return b, nil
 }
+func (b EventApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/limitrange.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/limitrange.go
@@ -81,6 +81,9 @@ func extractLimitRange(limitRange *corev1.LimitRange, fieldManager string, subre
 	b.WithAPIVersion("v1")
 	return b, nil
 }
+func (b LimitRangeApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/namespace.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/namespace.go
@@ -80,6 +80,9 @@ func extractNamespace(namespace *corev1.Namespace, fieldManager string, subresou
 	b.WithAPIVersion("v1")
 	return b, nil
 }
+func (b NamespaceApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/node.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/node.go
@@ -80,6 +80,9 @@ func extractNode(node *corev1.Node, fieldManager string, subresource string) (*N
 	b.WithAPIVersion("v1")
 	return b, nil
 }
+func (b NodeApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/persistentvolume.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/persistentvolume.go
@@ -80,6 +80,9 @@ func extractPersistentVolume(persistentVolume *corev1.PersistentVolume, fieldMan
 	b.WithAPIVersion("v1")
 	return b, nil
 }
+func (b PersistentVolumeApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/persistentvolumeclaim.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/persistentvolumeclaim.go
@@ -82,6 +82,9 @@ func extractPersistentVolumeClaim(persistentVolumeClaim *corev1.PersistentVolume
 	b.WithAPIVersion("v1")
 	return b, nil
 }
+func (b PersistentVolumeClaimApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/pod.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/pod.go
@@ -82,6 +82,9 @@ func extractPod(pod *corev1.Pod, fieldManager string, subresource string) (*PodA
 	b.WithAPIVersion("v1")
 	return b, nil
 }
+func (b PodApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/podtemplate.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/podtemplate.go
@@ -81,6 +81,9 @@ func extractPodTemplate(podTemplate *corev1.PodTemplate, fieldManager string, su
 	b.WithAPIVersion("v1")
 	return b, nil
 }
+func (b PodTemplateApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/replicationcontroller.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/replicationcontroller.go
@@ -82,6 +82,9 @@ func extractReplicationController(replicationController *corev1.ReplicationContr
 	b.WithAPIVersion("v1")
 	return b, nil
 }
+func (b ReplicationControllerApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/resourcequota.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/resourcequota.go
@@ -82,6 +82,9 @@ func extractResourceQuota(resourceQuota *corev1.ResourceQuota, fieldManager stri
 	b.WithAPIVersion("v1")
 	return b, nil
 }
+func (b ResourceQuotaApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/secret.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/secret.go
@@ -84,6 +84,9 @@ func extractSecret(secret *corev1.Secret, fieldManager string, subresource strin
 	b.WithAPIVersion("v1")
 	return b, nil
 }
+func (b SecretApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/service.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/service.go
@@ -82,6 +82,9 @@ func extractService(service *corev1.Service, fieldManager string, subresource st
 	b.WithAPIVersion("v1")
 	return b, nil
 }
+func (b ServiceApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/serviceaccount.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/serviceaccount.go
@@ -83,6 +83,9 @@ func extractServiceAccount(serviceAccount *corev1.ServiceAccount, fieldManager s
 	b.WithAPIVersion("v1")
 	return b, nil
 }
+func (b ServiceAccountApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/discovery/v1/endpointslice.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/discovery/v1/endpointslice.go
@@ -83,6 +83,9 @@ func extractEndpointSlice(endpointSlice *discoveryv1.EndpointSlice, fieldManager
 	b.WithAPIVersion("discovery.k8s.io/v1")
 	return b, nil
 }
+func (b EndpointSliceApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/discovery/v1beta1/endpointslice.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/discovery/v1beta1/endpointslice.go
@@ -83,6 +83,9 @@ func extractEndpointSlice(endpointSlice *discoveryv1beta1.EndpointSlice, fieldMa
 	b.WithAPIVersion("discovery.k8s.io/v1beta1")
 	return b, nil
 }
+func (b EndpointSliceApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/events/v1/event.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/events/v1/event.go
@@ -95,6 +95,9 @@ func extractEvent(event *eventsv1.Event, fieldManager string, subresource string
 	b.WithAPIVersion("events.k8s.io/v1")
 	return b, nil
 }
+func (b EventApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/events/v1beta1/event.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/events/v1beta1/event.go
@@ -95,6 +95,9 @@ func extractEvent(event *eventsv1beta1.Event, fieldManager string, subresource s
 	b.WithAPIVersion("events.k8s.io/v1beta1")
 	return b, nil
 }
+func (b EventApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/daemonset.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/daemonset.go
@@ -82,6 +82,9 @@ func extractDaemonSet(daemonSet *extensionsv1beta1.DaemonSet, fieldManager strin
 	b.WithAPIVersion("extensions/v1beta1")
 	return b, nil
 }
+func (b DaemonSetApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/deployment.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/deployment.go
@@ -82,6 +82,9 @@ func extractDeployment(deployment *extensionsv1beta1.Deployment, fieldManager st
 	b.WithAPIVersion("extensions/v1beta1")
 	return b, nil
 }
+func (b DeploymentApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/ingress.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/ingress.go
@@ -82,6 +82,9 @@ func extractIngress(ingress *extensionsv1beta1.Ingress, fieldManager string, sub
 	b.WithAPIVersion("extensions/v1beta1")
 	return b, nil
 }
+func (b IngressApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/networkpolicy.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/networkpolicy.go
@@ -81,6 +81,9 @@ func extractNetworkPolicy(networkPolicy *extensionsv1beta1.NetworkPolicy, fieldM
 	b.WithAPIVersion("extensions/v1beta1")
 	return b, nil
 }
+func (b NetworkPolicyApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/replicaset.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/replicaset.go
@@ -82,6 +82,9 @@ func extractReplicaSet(replicaSet *extensionsv1beta1.ReplicaSet, fieldManager st
 	b.WithAPIVersion("extensions/v1beta1")
 	return b, nil
 }
+func (b ReplicaSetApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1/flowschema.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1/flowschema.go
@@ -80,6 +80,9 @@ func extractFlowSchema(flowSchema *flowcontrolv1.FlowSchema, fieldManager string
 	b.WithAPIVersion("flowcontrol.apiserver.k8s.io/v1")
 	return b, nil
 }
+func (b FlowSchemaApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1/prioritylevelconfiguration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1/prioritylevelconfiguration.go
@@ -80,6 +80,9 @@ func extractPriorityLevelConfiguration(priorityLevelConfiguration *flowcontrolv1
 	b.WithAPIVersion("flowcontrol.apiserver.k8s.io/v1")
 	return b, nil
 }
+func (b PriorityLevelConfigurationApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta1/flowschema.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta1/flowschema.go
@@ -80,6 +80,9 @@ func extractFlowSchema(flowSchema *flowcontrolv1beta1.FlowSchema, fieldManager s
 	b.WithAPIVersion("flowcontrol.apiserver.k8s.io/v1beta1")
 	return b, nil
 }
+func (b FlowSchemaApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta1/prioritylevelconfiguration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta1/prioritylevelconfiguration.go
@@ -80,6 +80,9 @@ func extractPriorityLevelConfiguration(priorityLevelConfiguration *flowcontrolv1
 	b.WithAPIVersion("flowcontrol.apiserver.k8s.io/v1beta1")
 	return b, nil
 }
+func (b PriorityLevelConfigurationApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta2/flowschema.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta2/flowschema.go
@@ -80,6 +80,9 @@ func extractFlowSchema(flowSchema *flowcontrolv1beta2.FlowSchema, fieldManager s
 	b.WithAPIVersion("flowcontrol.apiserver.k8s.io/v1beta2")
 	return b, nil
 }
+func (b FlowSchemaApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta2/prioritylevelconfiguration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta2/prioritylevelconfiguration.go
@@ -80,6 +80,9 @@ func extractPriorityLevelConfiguration(priorityLevelConfiguration *flowcontrolv1
 	b.WithAPIVersion("flowcontrol.apiserver.k8s.io/v1beta2")
 	return b, nil
 }
+func (b PriorityLevelConfigurationApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta3/flowschema.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta3/flowschema.go
@@ -80,6 +80,9 @@ func extractFlowSchema(flowSchema *flowcontrolv1beta3.FlowSchema, fieldManager s
 	b.WithAPIVersion("flowcontrol.apiserver.k8s.io/v1beta3")
 	return b, nil
 }
+func (b FlowSchemaApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta3/prioritylevelconfiguration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta3/prioritylevelconfiguration.go
@@ -80,6 +80,9 @@ func extractPriorityLevelConfiguration(priorityLevelConfiguration *flowcontrolv1
 	b.WithAPIVersion("flowcontrol.apiserver.k8s.io/v1beta3")
 	return b, nil
 }
+func (b PriorityLevelConfigurationApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/imagepolicy/v1alpha1/imagereview.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/imagepolicy/v1alpha1/imagereview.go
@@ -80,6 +80,9 @@ func extractImageReview(imageReview *imagepolicyv1alpha1.ImageReview, fieldManag
 	b.WithAPIVersion("imagepolicy.k8s.io/v1alpha1")
 	return b, nil
 }
+func (b ImageReviewApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/ingress.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/ingress.go
@@ -82,6 +82,9 @@ func extractIngress(ingress *networkingv1.Ingress, fieldManager string, subresou
 	b.WithAPIVersion("networking.k8s.io/v1")
 	return b, nil
 }
+func (b IngressApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/ingressclass.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/ingressclass.go
@@ -79,6 +79,9 @@ func extractIngressClass(ingressClass *networkingv1.IngressClass, fieldManager s
 	b.WithAPIVersion("networking.k8s.io/v1")
 	return b, nil
 }
+func (b IngressClassApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/networkpolicy.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/networkpolicy.go
@@ -81,6 +81,9 @@ func extractNetworkPolicy(networkPolicy *networkingv1.NetworkPolicy, fieldManage
 	b.WithAPIVersion("networking.k8s.io/v1")
 	return b, nil
 }
+func (b NetworkPolicyApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1alpha1/ipaddress.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1alpha1/ipaddress.go
@@ -79,6 +79,9 @@ func extractIPAddress(iPAddress *networkingv1alpha1.IPAddress, fieldManager stri
 	b.WithAPIVersion("networking.k8s.io/v1alpha1")
 	return b, nil
 }
+func (b IPAddressApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1alpha1/servicecidr.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1alpha1/servicecidr.go
@@ -80,6 +80,9 @@ func extractServiceCIDR(serviceCIDR *networkingv1alpha1.ServiceCIDR, fieldManage
 	b.WithAPIVersion("networking.k8s.io/v1alpha1")
 	return b, nil
 }
+func (b ServiceCIDRApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/ingress.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/ingress.go
@@ -82,6 +82,9 @@ func extractIngress(ingress *networkingv1beta1.Ingress, fieldManager string, sub
 	b.WithAPIVersion("networking.k8s.io/v1beta1")
 	return b, nil
 }
+func (b IngressApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/ingressclass.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/ingressclass.go
@@ -79,6 +79,9 @@ func extractIngressClass(ingressClass *networkingv1beta1.IngressClass, fieldMana
 	b.WithAPIVersion("networking.k8s.io/v1beta1")
 	return b, nil
 }
+func (b IngressClassApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/ipaddress.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/ipaddress.go
@@ -79,6 +79,9 @@ func extractIPAddress(iPAddress *networkingv1beta1.IPAddress, fieldManager strin
 	b.WithAPIVersion("networking.k8s.io/v1beta1")
 	return b, nil
 }
+func (b IPAddressApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/servicecidr.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/servicecidr.go
@@ -80,6 +80,9 @@ func extractServiceCIDR(serviceCIDR *networkingv1beta1.ServiceCIDR, fieldManager
 	b.WithAPIVersion("networking.k8s.io/v1beta1")
 	return b, nil
 }
+func (b ServiceCIDRApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/node/v1/runtimeclass.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/node/v1/runtimeclass.go
@@ -81,6 +81,9 @@ func extractRuntimeClass(runtimeClass *nodev1.RuntimeClass, fieldManager string,
 	b.WithAPIVersion("node.k8s.io/v1")
 	return b, nil
 }
+func (b RuntimeClassApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/node/v1alpha1/runtimeclass.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/node/v1alpha1/runtimeclass.go
@@ -79,6 +79,9 @@ func extractRuntimeClass(runtimeClass *nodev1alpha1.RuntimeClass, fieldManager s
 	b.WithAPIVersion("node.k8s.io/v1alpha1")
 	return b, nil
 }
+func (b RuntimeClassApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/node/v1beta1/runtimeclass.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/node/v1beta1/runtimeclass.go
@@ -81,6 +81,9 @@ func extractRuntimeClass(runtimeClass *nodev1beta1.RuntimeClass, fieldManager st
 	b.WithAPIVersion("node.k8s.io/v1beta1")
 	return b, nil
 }
+func (b RuntimeClassApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/policy/v1/eviction.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/policy/v1/eviction.go
@@ -81,6 +81,9 @@ func extractEviction(eviction *policyv1.Eviction, fieldManager string, subresour
 	b.WithAPIVersion("policy/v1")
 	return b, nil
 }
+func (b EvictionApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/policy/v1/poddisruptionbudget.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/policy/v1/poddisruptionbudget.go
@@ -82,6 +82,9 @@ func extractPodDisruptionBudget(podDisruptionBudget *policyv1.PodDisruptionBudge
 	b.WithAPIVersion("policy/v1")
 	return b, nil
 }
+func (b PodDisruptionBudgetApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/policy/v1beta1/eviction.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/policy/v1beta1/eviction.go
@@ -81,6 +81,9 @@ func extractEviction(eviction *policyv1beta1.Eviction, fieldManager string, subr
 	b.WithAPIVersion("policy/v1beta1")
 	return b, nil
 }
+func (b EvictionApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/policy/v1beta1/poddisruptionbudget.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/policy/v1beta1/poddisruptionbudget.go
@@ -82,6 +82,9 @@ func extractPodDisruptionBudget(podDisruptionBudget *policyv1beta1.PodDisruption
 	b.WithAPIVersion("policy/v1beta1")
 	return b, nil
 }
+func (b PodDisruptionBudgetApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1/clusterrole.go
@@ -80,6 +80,9 @@ func extractClusterRole(clusterRole *rbacv1.ClusterRole, fieldManager string, su
 	b.WithAPIVersion("rbac.authorization.k8s.io/v1")
 	return b, nil
 }
+func (b ClusterRoleApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1/clusterrolebinding.go
@@ -80,6 +80,9 @@ func extractClusterRoleBinding(clusterRoleBinding *rbacv1.ClusterRoleBinding, fi
 	b.WithAPIVersion("rbac.authorization.k8s.io/v1")
 	return b, nil
 }
+func (b ClusterRoleBindingApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1/role.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1/role.go
@@ -81,6 +81,9 @@ func extractRole(role *rbacv1.Role, fieldManager string, subresource string) (*R
 	b.WithAPIVersion("rbac.authorization.k8s.io/v1")
 	return b, nil
 }
+func (b RoleApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1/rolebinding.go
@@ -82,6 +82,9 @@ func extractRoleBinding(roleBinding *rbacv1.RoleBinding, fieldManager string, su
 	b.WithAPIVersion("rbac.authorization.k8s.io/v1")
 	return b, nil
 }
+func (b RoleBindingApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1alpha1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1alpha1/clusterrole.go
@@ -80,6 +80,9 @@ func extractClusterRole(clusterRole *rbacv1alpha1.ClusterRole, fieldManager stri
 	b.WithAPIVersion("rbac.authorization.k8s.io/v1alpha1")
 	return b, nil
 }
+func (b ClusterRoleApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1alpha1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1alpha1/clusterrolebinding.go
@@ -80,6 +80,9 @@ func extractClusterRoleBinding(clusterRoleBinding *rbacv1alpha1.ClusterRoleBindi
 	b.WithAPIVersion("rbac.authorization.k8s.io/v1alpha1")
 	return b, nil
 }
+func (b ClusterRoleBindingApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1alpha1/role.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1alpha1/role.go
@@ -81,6 +81,9 @@ func extractRole(role *rbacv1alpha1.Role, fieldManager string, subresource strin
 	b.WithAPIVersion("rbac.authorization.k8s.io/v1alpha1")
 	return b, nil
 }
+func (b RoleApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1alpha1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1alpha1/rolebinding.go
@@ -82,6 +82,9 @@ func extractRoleBinding(roleBinding *rbacv1alpha1.RoleBinding, fieldManager stri
 	b.WithAPIVersion("rbac.authorization.k8s.io/v1alpha1")
 	return b, nil
 }
+func (b RoleBindingApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1beta1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1beta1/clusterrole.go
@@ -80,6 +80,9 @@ func extractClusterRole(clusterRole *rbacv1beta1.ClusterRole, fieldManager strin
 	b.WithAPIVersion("rbac.authorization.k8s.io/v1beta1")
 	return b, nil
 }
+func (b ClusterRoleApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1beta1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1beta1/clusterrolebinding.go
@@ -80,6 +80,9 @@ func extractClusterRoleBinding(clusterRoleBinding *rbacv1beta1.ClusterRoleBindin
 	b.WithAPIVersion("rbac.authorization.k8s.io/v1beta1")
 	return b, nil
 }
+func (b ClusterRoleBindingApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1beta1/role.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1beta1/role.go
@@ -81,6 +81,9 @@ func extractRole(role *rbacv1beta1.Role, fieldManager string, subresource string
 	b.WithAPIVersion("rbac.authorization.k8s.io/v1beta1")
 	return b, nil
 }
+func (b RoleApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1beta1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1beta1/rolebinding.go
@@ -82,6 +82,9 @@ func extractRoleBinding(roleBinding *rbacv1beta1.RoleBinding, fieldManager strin
 	b.WithAPIVersion("rbac.authorization.k8s.io/v1beta1")
 	return b, nil
 }
+func (b RoleBindingApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1alpha3/deviceclass.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1alpha3/deviceclass.go
@@ -79,6 +79,9 @@ func extractDeviceClass(deviceClass *resourcev1alpha3.DeviceClass, fieldManager 
 	b.WithAPIVersion("resource.k8s.io/v1alpha3")
 	return b, nil
 }
+func (b DeviceClassApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1alpha3/resourceclaim.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1alpha3/resourceclaim.go
@@ -82,6 +82,9 @@ func extractResourceClaim(resourceClaim *resourcev1alpha3.ResourceClaim, fieldMa
 	b.WithAPIVersion("resource.k8s.io/v1alpha3")
 	return b, nil
 }
+func (b ResourceClaimApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1alpha3/resourceclaimtemplate.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1alpha3/resourceclaimtemplate.go
@@ -81,6 +81,9 @@ func extractResourceClaimTemplate(resourceClaimTemplate *resourcev1alpha3.Resour
 	b.WithAPIVersion("resource.k8s.io/v1alpha3")
 	return b, nil
 }
+func (b ResourceClaimTemplateApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1alpha3/resourceslice.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1alpha3/resourceslice.go
@@ -79,6 +79,9 @@ func extractResourceSlice(resourceSlice *resourcev1alpha3.ResourceSlice, fieldMa
 	b.WithAPIVersion("resource.k8s.io/v1alpha3")
 	return b, nil
 }
+func (b ResourceSliceApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/deviceclass.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/deviceclass.go
@@ -79,6 +79,9 @@ func extractDeviceClass(deviceClass *resourcev1beta1.DeviceClass, fieldManager s
 	b.WithAPIVersion("resource.k8s.io/v1beta1")
 	return b, nil
 }
+func (b DeviceClassApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/resourceclaim.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/resourceclaim.go
@@ -82,6 +82,9 @@ func extractResourceClaim(resourceClaim *resourcev1beta1.ResourceClaim, fieldMan
 	b.WithAPIVersion("resource.k8s.io/v1beta1")
 	return b, nil
 }
+func (b ResourceClaimApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/resourceclaimtemplate.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/resourceclaimtemplate.go
@@ -81,6 +81,9 @@ func extractResourceClaimTemplate(resourceClaimTemplate *resourcev1beta1.Resourc
 	b.WithAPIVersion("resource.k8s.io/v1beta1")
 	return b, nil
 }
+func (b ResourceClaimTemplateApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/resourceslice.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/resourceslice.go
@@ -79,6 +79,9 @@ func extractResourceSlice(resourceSlice *resourcev1beta1.ResourceSlice, fieldMan
 	b.WithAPIVersion("resource.k8s.io/v1beta1")
 	return b, nil
 }
+func (b ResourceSliceApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/scheduling/v1/priorityclass.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/scheduling/v1/priorityclass.go
@@ -83,6 +83,9 @@ func extractPriorityClass(priorityClass *schedulingv1.PriorityClass, fieldManage
 	b.WithAPIVersion("scheduling.k8s.io/v1")
 	return b, nil
 }
+func (b PriorityClassApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/scheduling/v1alpha1/priorityclass.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/scheduling/v1alpha1/priorityclass.go
@@ -83,6 +83,9 @@ func extractPriorityClass(priorityClass *schedulingv1alpha1.PriorityClass, field
 	b.WithAPIVersion("scheduling.k8s.io/v1alpha1")
 	return b, nil
 }
+func (b PriorityClassApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/scheduling/v1beta1/priorityclass.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/scheduling/v1beta1/priorityclass.go
@@ -83,6 +83,9 @@ func extractPriorityClass(priorityClass *schedulingv1beta1.PriorityClass, fieldM
 	b.WithAPIVersion("scheduling.k8s.io/v1beta1")
 	return b, nil
 }
+func (b PriorityClassApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/csidriver.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/csidriver.go
@@ -79,6 +79,9 @@ func extractCSIDriver(cSIDriver *storagev1.CSIDriver, fieldManager string, subre
 	b.WithAPIVersion("storage.k8s.io/v1")
 	return b, nil
 }
+func (b CSIDriverApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/csinode.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/csinode.go
@@ -79,6 +79,9 @@ func extractCSINode(cSINode *storagev1.CSINode, fieldManager string, subresource
 	b.WithAPIVersion("storage.k8s.io/v1")
 	return b, nil
 }
+func (b CSINodeApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/csistoragecapacity.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/csistoragecapacity.go
@@ -85,6 +85,9 @@ func extractCSIStorageCapacity(cSIStorageCapacity *storagev1.CSIStorageCapacity,
 	b.WithAPIVersion("storage.k8s.io/v1")
 	return b, nil
 }
+func (b CSIStorageCapacityApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/storageclass.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/storageclass.go
@@ -87,6 +87,9 @@ func extractStorageClass(storageClass *storagev1.StorageClass, fieldManager stri
 	b.WithAPIVersion("storage.k8s.io/v1")
 	return b, nil
 }
+func (b StorageClassApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/volumeattachment.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/volumeattachment.go
@@ -80,6 +80,9 @@ func extractVolumeAttachment(volumeAttachment *storagev1.VolumeAttachment, field
 	b.WithAPIVersion("storage.k8s.io/v1")
 	return b, nil
 }
+func (b VolumeAttachmentApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1alpha1/csistoragecapacity.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1alpha1/csistoragecapacity.go
@@ -85,6 +85,9 @@ func extractCSIStorageCapacity(cSIStorageCapacity *storagev1alpha1.CSIStorageCap
 	b.WithAPIVersion("storage.k8s.io/v1alpha1")
 	return b, nil
 }
+func (b CSIStorageCapacityApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1alpha1/volumeattachment.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1alpha1/volumeattachment.go
@@ -80,6 +80,9 @@ func extractVolumeAttachment(volumeAttachment *storagev1alpha1.VolumeAttachment,
 	b.WithAPIVersion("storage.k8s.io/v1alpha1")
 	return b, nil
 }
+func (b VolumeAttachmentApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1alpha1/volumeattributesclass.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1alpha1/volumeattributesclass.go
@@ -80,6 +80,9 @@ func extractVolumeAttributesClass(volumeAttributesClass *storagev1alpha1.VolumeA
 	b.WithAPIVersion("storage.k8s.io/v1alpha1")
 	return b, nil
 }
+func (b VolumeAttributesClassApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/csidriver.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/csidriver.go
@@ -79,6 +79,9 @@ func extractCSIDriver(cSIDriver *storagev1beta1.CSIDriver, fieldManager string, 
 	b.WithAPIVersion("storage.k8s.io/v1beta1")
 	return b, nil
 }
+func (b CSIDriverApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/csinode.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/csinode.go
@@ -79,6 +79,9 @@ func extractCSINode(cSINode *storagev1beta1.CSINode, fieldManager string, subres
 	b.WithAPIVersion("storage.k8s.io/v1beta1")
 	return b, nil
 }
+func (b CSINodeApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/csistoragecapacity.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/csistoragecapacity.go
@@ -85,6 +85,9 @@ func extractCSIStorageCapacity(cSIStorageCapacity *storagev1beta1.CSIStorageCapa
 	b.WithAPIVersion("storage.k8s.io/v1beta1")
 	return b, nil
 }
+func (b CSIStorageCapacityApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/storageclass.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/storageclass.go
@@ -87,6 +87,9 @@ func extractStorageClass(storageClass *storagev1beta1.StorageClass, fieldManager
 	b.WithAPIVersion("storage.k8s.io/v1beta1")
 	return b, nil
 }
+func (b StorageClassApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/volumeattachment.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/volumeattachment.go
@@ -80,6 +80,9 @@ func extractVolumeAttachment(volumeAttachment *storagev1beta1.VolumeAttachment, 
 	b.WithAPIVersion("storage.k8s.io/v1beta1")
 	return b, nil
 }
+func (b VolumeAttachmentApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/volumeattributesclass.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/volumeattributesclass.go
@@ -80,6 +80,9 @@ func extractVolumeAttributesClass(volumeAttributesClass *storagev1beta1.VolumeAt
 	b.WithAPIVersion("storage.k8s.io/v1beta1")
 	return b, nil
 }
+func (b VolumeAttributesClassApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/storagemigration/v1alpha1/storageversionmigration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storagemigration/v1alpha1/storageversionmigration.go
@@ -80,6 +80,9 @@ func extractStorageVersionMigration(storageVersionMigration *storagemigrationv1a
 	b.WithAPIVersion("storagemigration.k8s.io/v1alpha1")
 	return b, nil
 }
+func (b StorageVersionMigrationApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/code-generator/cmd/applyconfiguration-gen/generators/applyconfiguration.go
+++ b/staging/src/k8s.io/code-generator/cmd/applyconfiguration-gen/generators/applyconfiguration.go
@@ -108,6 +108,7 @@ func (g *applyConfigurationGenerator) GenerateType(c *generator.Context, t *type
 		if typeParams.OpenAPIType != nil {
 			g.generateClientgenExtract(sw, typeParams, !typeParams.Tags.NoStatus)
 		}
+		g.generateIsApplyConfiguration(typeParams.ApplyConfig.ApplyConfiguration, sw)
 	} else {
 		if hasTypeMetaField(t) {
 			sw.Do(constructorWithTypeMeta, typeParams)
@@ -268,6 +269,12 @@ func (g *applyConfigurationGenerator) generateStruct(sw *generator.SnippetWriter
 		}
 	}
 	sw.Do("}\n", typeParams)
+}
+
+func (g *applyConfigurationGenerator) generateIsApplyConfiguration(t *types.Type, sw *generator.SnippetWriter) {
+	sw.Do("func (b $.|public$) IsApplyConfiguration() bool {\n", t)
+	sw.Do("  return true\n", nil)
+	sw.Do("}\n", nil)
 }
 
 func deref(t *types.Type) *types.Type {

--- a/staging/src/k8s.io/code-generator/examples/HyphenGroup/applyconfiguration/example/v1/clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/examples/HyphenGroup/applyconfiguration/example/v1/clustertesttype.go
@@ -41,6 +41,9 @@ func ClusterTestType(name string) *ClusterTestTypeApplyConfiguration {
 	b.WithAPIVersion("example-group.hyphens.code-generator.k8s.io/v1")
 	return b
 }
+func (b ClusterTestTypeApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/code-generator/examples/HyphenGroup/applyconfiguration/example/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/HyphenGroup/applyconfiguration/example/v1/testtype.go
@@ -42,6 +42,9 @@ func TestType(name, namespace string) *TestTypeApplyConfiguration {
 	b.WithAPIVersion("example-group.hyphens.code-generator.k8s.io/v1")
 	return b
 }
+func (b TestTypeApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/code-generator/examples/MixedCase/applyconfiguration/example/v1/clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/examples/MixedCase/applyconfiguration/example/v1/clustertesttype.go
@@ -41,6 +41,9 @@ func ClusterTestType(name string) *ClusterTestTypeApplyConfiguration {
 	b.WithAPIVersion("example.crd.code-generator.k8s.io/v1")
 	return b
 }
+func (b ClusterTestTypeApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/code-generator/examples/MixedCase/applyconfiguration/example/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/MixedCase/applyconfiguration/example/v1/testtype.go
@@ -42,6 +42,9 @@ func TestType(name, namespace string) *TestTypeApplyConfiguration {
 	b.WithAPIVersion("example.crd.code-generator.k8s.io/v1")
 	return b
 }
+func (b TestTypeApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/code-generator/examples/crd/applyconfiguration/conflicting/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/applyconfiguration/conflicting/v1/testtype.go
@@ -43,6 +43,9 @@ func TestType(name, namespace string) *TestTypeApplyConfiguration {
 	b.WithAPIVersion("conflicting.test.crd.code-generator.k8s.io/v1")
 	return b
 }
+func (b TestTypeApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/code-generator/examples/crd/applyconfiguration/example/v1/clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/applyconfiguration/example/v1/clustertesttype.go
@@ -41,6 +41,9 @@ func ClusterTestType(name string) *ClusterTestTypeApplyConfiguration {
 	b.WithAPIVersion("example.crd.code-generator.k8s.io/v1")
 	return b
 }
+func (b ClusterTestTypeApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/code-generator/examples/crd/applyconfiguration/example/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/applyconfiguration/example/v1/testtype.go
@@ -42,6 +42,9 @@ func TestType(name, namespace string) *TestTypeApplyConfiguration {
 	b.WithAPIVersion("example.crd.code-generator.k8s.io/v1")
 	return b
 }
+func (b TestTypeApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/code-generator/examples/crd/applyconfiguration/example2/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/applyconfiguration/example2/v1/testtype.go
@@ -42,6 +42,9 @@ func TestType(name, namespace string) *TestTypeApplyConfiguration {
 	b.WithAPIVersion("example.test.crd.code-generator.k8s.io/v1")
 	return b
 }
+func (b TestTypeApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/code-generator/examples/crd/applyconfiguration/extensions/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/applyconfiguration/extensions/v1/testtype.go
@@ -42,6 +42,9 @@ func TestType(name, namespace string) *TestTypeApplyConfiguration {
 	b.WithAPIVersion("extensions.test.crd.code-generator.k8s.io/v1")
 	return b
 }
+func (b TestTypeApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/code-generator/examples/single/applyconfiguration/api/v1/clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/examples/single/applyconfiguration/api/v1/clustertesttype.go
@@ -41,6 +41,9 @@ func ClusterTestType(name string) *ClusterTestTypeApplyConfiguration {
 	b.WithAPIVersion("example.crd.code-generator.k8s.io/v1")
 	return b
 }
+func (b ClusterTestTypeApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/code-generator/examples/single/applyconfiguration/api/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/single/applyconfiguration/api/v1/testtype.go
@@ -42,6 +42,9 @@ func TestType(name, namespace string) *TestTypeApplyConfiguration {
 	b.WithAPIVersion("example.crd.code-generator.k8s.io/v1")
 	return b
 }
+func (b TestTypeApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/applyconfiguration/wardle/v1alpha1/fischer.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/applyconfiguration/wardle/v1alpha1/fischer.go
@@ -41,6 +41,9 @@ func Fischer(name string) *FischerApplyConfiguration {
 	b.WithAPIVersion("wardle.example.com/v1alpha1")
 	return b
 }
+func (b FischerApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/applyconfiguration/wardle/v1alpha1/flunder.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/applyconfiguration/wardle/v1alpha1/flunder.go
@@ -44,6 +44,9 @@ func Flunder(name, namespace string) *FlunderApplyConfiguration {
 	b.WithAPIVersion("wardle.example.com/v1alpha1")
 	return b
 }
+func (b FlunderApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/applyconfiguration/wardle/v1beta1/flunder.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/applyconfiguration/wardle/v1beta1/flunder.go
@@ -44,6 +44,9 @@ func Flunder(name, namespace string) *FlunderApplyConfiguration {
 	b.WithAPIVersion("wardle.example.com/v1beta1")
 	return b
 }
+func (b FlunderApplyConfiguration) IsApplyConfiguration() bool {
+	return true
+}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind feature

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

This was requested by the controller-runtime community.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Add a `runtime.ApplyConfiguration` interface that all generated root apply configurations types now implement.
```

