### PR TITLE
Fix `kubectl describe pod` probe host info

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/describe/describe.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe.go
@@ -2055,6 +2055,9 @@ func DescribeProbe(probe *corev1.Probe) string {
 		} else {
 			url.Host = probe.HTTPGet.Host
 		}
+		if url.Host == "" {
+			url.Host = "localhost"
+		}
 		url.Path = probe.HTTPGet.Path
 		return fmt.Sprintf("http-get %s %s", url.String(), attrs)
 	case probe.TCPSocket != nil:


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Using `kubectl describe po xxx` to show pod probe info, when the probe host is empty, there is no default value showed in the output, like below, so this PR add the default value.
```
    State:          Running
      Started:      Thu, 19 Dec 2024 15:25:42 +0800
    Ready:          False
    Restart Count:  0
    ...
    Liveness:       http-get http://:8080/healthz delay=0s timeout=5s period=10s #success=1 #failure=3
    ======== to below
    Liveness:       http-get http://localhost:8080/healthz delay=0s timeout=5s period=10s #success=1 #failure=3
```

#### Which issue(s) this PR fixes:
Fixes #129320

#### Does this PR introduce a user-facing change?
```release-note
NONE
```