### PR TITLE
Automated cherry pick of #129301: Do not attempt to truncate revision history if revisionHistoryLimit is negative

### DIFF
--- a/pkg/controller/statefulset/stateful_set_control.go
+++ b/pkg/controller/statefulset/stateful_set_control.go
@@ -194,7 +194,7 @@ func (ssc *defaultStatefulSetControl) truncateHistory(
 	}
 	historyLen := len(history)
 	historyLimit := int(*set.Spec.RevisionHistoryLimit)
-	if historyLen <= historyLimit {
+	if historyLimit < 0 || historyLen <= historyLimit {
 		return nil
 	}
 	// delete any non-live history to maintain the revision limit.


### PR DESCRIPTION
Cherry pick of #129301 on release-1.32.

#129301: Do not attempt to truncate revision history if revisionHistoryLimit is negative

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixes a panic in kube-controller-manager handling StatefulSet objects when revisionHistoryLimit is negative
```