### PR TITLE
Automated cherry pick of #129301: Do not attempt to truncate revision history if revisionHistoryLimit is negative

### DIFF
--- a/pkg/controller/statefulset/stateful_set_control.go
+++ b/pkg/controller/statefulset/stateful_set_control.go
@@ -194,7 +194,7 @@ func (ssc *defaultStatefulSetControl) truncateHistory(
 	}
 	historyLen := len(history)
 	historyLimit := int(*set.Spec.RevisionHistoryLimit)
-	if historyLen <= historyLimit {
+	if historyLimit < 0 || historyLen <= historyLimit {
 		return nil
 	}
 	// delete any non-live history to maintain the revision limit.

--- a/pkg/controller/statefulset/stateful_set_control_test.go
+++ b/pkg/controller/statefulset/stateful_set_control_test.go
@@ -51,6 +51,7 @@ import (
 	"k8s.io/kubernetes/pkg/controller"
 	"k8s.io/kubernetes/pkg/controller/history"
 	"k8s.io/kubernetes/pkg/features"
+	"k8s.io/utils/ptr"
 )
 
 type invariantFunc func(set *apps.StatefulSet, om *fakeObjectManager) error
@@ -2010,6 +2011,13 @@ func TestStatefulSetControlLimitsHistory(t *testing.T) {
 			if err != nil {
 				t.Fatalf("%s: %s", test.name, err)
 			}
+
+			if *set.Spec.RevisionHistoryLimit < 0 {
+				// If the revisionHistoryLimit is negative value, we don't truncate
+				// the revision history and it is incremental.
+				continue
+			}
+
 			if len(revisions) > int(*set.Spec.RevisionHistoryLimit)+2 {
 				t.Fatalf("%s: %d greater than limit %d", test.name, len(revisions), *set.Spec.RevisionHistoryLimit)
 			}
@@ -2029,6 +2037,33 @@ func TestStatefulSetControlLimitsHistory(t *testing.T) {
 			invariants: assertBurstInvariants,
 			initial: func() *apps.StatefulSet {
 				return burst(newStatefulSet(3))
+			},
+		},
+		{
+			name:       "zero revisionHistoryLimit",
+			invariants: assertMonotonicInvariants,
+			initial: func() *apps.StatefulSet {
+				sts := newStatefulSet(3)
+				sts.Spec.RevisionHistoryLimit = ptr.To(int32(0))
+				return sts
+			},
+		},
+		{
+			name:       "negative revisionHistoryLimit",
+			invariants: assertMonotonicInvariants,
+			initial: func() *apps.StatefulSet {
+				sts := newStatefulSet(3)
+				sts.Spec.RevisionHistoryLimit = ptr.To(int32(-2))
+				return sts
+			},
+		},
+		{
+			name:       "positive revisionHistoryLimit",
+			invariants: assertMonotonicInvariants,
+			initial: func() *apps.StatefulSet {
+				sts := newStatefulSet(3)
+				sts.Spec.RevisionHistoryLimit = ptr.To(int32(5))
+				return sts
 			},
 		},
 	}


### PR DESCRIPTION
Cherry pick of #129301 on release-1.30.

#129301: Do not attempt to truncate revision history if revisionHistoryLimit is negative

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixes a panic in kube-controller-manager handling StatefulSet objects when revisionHistoryLimit is negative
```