### PR TITLE
Automated cherry pick of #129142: fix(dra): support multiple resource in PublishResources

### DIFF
--- a/test/e2e/dra/test-driver/app/kubeletplugin.go
+++ b/test/e2e/dra/test-driver/app/kubeletplugin.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/dynamic-resource-allocation/kubeletplugin"
+	"k8s.io/dynamic-resource-allocation/resourceslice"
 	"k8s.io/klog/v2"
 	drapbv1alpha4 "k8s.io/kubelet/pkg/apis/dra/v1alpha4"
 	drapb "k8s.io/kubelet/pkg/apis/dra/v1beta1"
@@ -188,10 +189,16 @@ func StartPlugin(ctx context.Context, cdiDir, driverName string, kubeClient kube
 				Basic: &resourceapi.BasicDevice{},
 			}
 		}
-		resources := kubeletplugin.Resources{
-			Devices: devices,
+		driverResources := resourceslice.DriverResources{
+			Pools: map[string]resourceslice.Pool{
+				nodeName: {
+					Slices: []resourceslice.Slice{{
+						Devices: devices,
+					}},
+				},
+			},
 		}
-		if err := ex.d.PublishResources(ctx, resources); err != nil {
+		if err := ex.d.PublishResources(ctx, driverResources); err != nil {
 			return nil, fmt.Errorf("start kubelet plugin: publish resources: %w", err)
 		}
 	} else if len(ex.fileOps.Devices) > 0 {
@@ -202,10 +209,16 @@ func StartPlugin(ctx context.Context, cdiDir, driverName string, kubeClient kube
 				Basic: &resourceapi.BasicDevice{Attributes: ex.fileOps.Devices[deviceName]},
 			}
 		}
-		resources := kubeletplugin.Resources{
-			Devices: devices,
+		driverResources := resourceslice.DriverResources{
+			Pools: map[string]resourceslice.Pool{
+				nodeName: {
+					Slices: []resourceslice.Slice{{
+						Devices: devices,
+					}},
+				},
+			},
 		}
-		if err := ex.d.PublishResources(ctx, resources); err != nil {
+		if err := ex.d.PublishResources(ctx, driverResources); err != nil {
 			return nil, fmt.Errorf("start kubelet plugin: publish resources: %w", err)
 		}
 	}


### PR DESCRIPTION
Cherry pick of #129142 on release-1.32.

#129142: fix(dra): support multiple resource in PublishResources

Fixes: https://github.com/kubernetes/kubernetes/issues/129122

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
This PR changes the signature of the `PublishResources` to accept a `resourceslice.DriverResources` parameter instead of a `Resources` parameter.
```