### PR TITLE
client-go/transport: structured, contextual logging

### DIFF
--- a/staging/src/k8s.io/client-go/go.mod
+++ b/staging/src/k8s.io/client-go/go.mod
@@ -9,6 +9,7 @@ godebug default=go1.23
 godebug winsymlink=0
 
 require (
+	github.com/go-logr/logr v1.4.2
 	github.com/gogo/protobuf v1.3.2
 	github.com/google/gnostic-models v0.6.9
 	github.com/google/go-cmp v0.6.0
@@ -41,7 +42,6 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
-	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect

--- a/staging/src/k8s.io/client-go/transport/cert_rotation.go
+++ b/staging/src/k8s.io/client-go/transport/cert_rotation.go
@@ -19,7 +19,6 @@ package transport
 import (
 	"bytes"
 	"crypto/tls"
-	"fmt"
 	"reflect"
 	"sync"
 	"time"
@@ -40,6 +39,7 @@ var CertCallbackRefreshDuration = 5 * time.Minute
 type reloadFunc func(*tls.CertificateRequestInfo) (*tls.Certificate, error)
 
 type dynamicClientCert struct {
+	logger     klog.Logger
 	clientCert *tls.Certificate
 	certMtx    sync.RWMutex
 
@@ -50,8 +50,9 @@ type dynamicClientCert struct {
 	queue workqueue.TypedRateLimitingInterface[string]
 }
 
-func certRotatingDialer(reload reloadFunc, dial utilnet.DialFunc) *dynamicClientCert {
+func certRotatingDialer(logger klog.Logger, reload reloadFunc, dial utilnet.DialFunc) *dynamicClientCert {
 	d := &dynamicClientCert{
+		logger:     logger,
 		reload:     reload,
 		connDialer: connrotation.NewDialer(connrotation.DialFunc(dial)),
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
@@ -88,7 +89,7 @@ func (c *dynamicClientCert) loadClientCert() (*tls.Certificate, error) {
 		return cert, nil
 	}
 
-	klog.V(1).Infof("certificate rotation detected, shutting down client connections to start using new credentials")
+	c.logger.V(1).Info("Certificate rotation detected, shutting down client connections to start using new credentials")
 	c.connDialer.CloseAll()
 
 	return cert, nil
@@ -133,12 +134,12 @@ func byteMatrixEqual(left, right [][]byte) bool {
 }
 
 // run starts the controller and blocks until stopCh is closed.
-func (c *dynamicClientCert) Run(stopCh <-chan struct{}) {
-	defer utilruntime.HandleCrash()
+func (c *dynamicClientCert) run(stopCh <-chan struct{}) {
+	defer utilruntime.HandleCrashWithLogger(c.logger)
 	defer c.queue.ShutDown()
 
-	klog.V(3).Infof("Starting client certificate rotation controller")
-	defer klog.V(3).Infof("Shutting down client certificate rotation controller")
+	c.logger.V(3).Info("Starting client certificate rotation controller")
+	defer c.logger.V(3).Info("Shutting down client certificate rotation controller")
 
 	go wait.Until(c.runWorker, time.Second, stopCh)
 
@@ -168,7 +169,7 @@ func (c *dynamicClientCert) processNextWorkItem() bool {
 		return true
 	}
 
-	utilruntime.HandleError(fmt.Errorf("%v failed with : %v", dsKey, err))
+	utilruntime.HandleErrorWithLogger(c.logger, err, "Loading client cert failed", "key", dsKey)
 	c.queue.AddRateLimited(dsKey)
 
 	return true

--- a/staging/src/k8s.io/client-go/transport/token_source.go
+++ b/staging/src/k8s.io/client-go/transport/token_source.go
@@ -182,7 +182,10 @@ func (ts *cachingTokenSource) Token() (*oauth2.Token, error) {
 		if ts.tok == nil {
 			return nil, err
 		}
-		klog.Errorf("Unable to rotate token: %v", err)
+		// Not using a caller-provided logger isn't ideal, but impossible to fix
+		// without new APIs that go up all the way to HTTPWrappersForConfig.
+		// This is currently deemed not worth changing (too much effort, not enough benefit).
+		klog.TODO().Error(err, "Unable to rotate token")
 		return ts.tok, nil
 	}
 

--- a/staging/src/k8s.io/client-go/transport/transport.go
+++ b/staging/src/k8s.io/client-go/transport/transport.go
@@ -353,7 +353,7 @@ func tryCancelRequest(rt http.RoundTripper, req *http.Request) {
 	case utilnet.RoundTripperWrapper:
 		tryCancelRequest(rt.WrappedRoundTripper(), req)
 	default:
-		klog.Warningf("Unable to cancel request for %T", rt)
+		klog.FromContext(req.Context()).Info("Warning: unable to cancel request", "roundTripperType", fmt.Sprintf("%T", rt))
 	}
 }
 

--- a/test/cmd/get.sh
+++ b/test/cmd/get.sh
@@ -101,29 +101,29 @@ run_kubectl_get_tests() {
   ### Test kubectl get all
   output_message=$(kubectl --v=6 --namespace default get all --chunk-size=0 2>&1 "${kube_flags[@]}")
   # Post-condition: Check if we get 200 OK from all the url(s)
-  kube::test::if_has_string "${output_message}" "/api/v1/namespaces/default/pods 200 OK"
-  kube::test::if_has_string "${output_message}" "/api/v1/namespaces/default/replicationcontrollers 200 OK"
-  kube::test::if_has_string "${output_message}" "/api/v1/namespaces/default/services 200 OK"
-  kube::test::if_has_string "${output_message}" "/apis/apps/v1/namespaces/default/daemonsets 200 OK"
-  kube::test::if_has_string "${output_message}" "/apis/apps/v1/namespaces/default/deployments 200 OK"
-  kube::test::if_has_string "${output_message}" "/apis/apps/v1/namespaces/default/replicasets 200 OK"
-  kube::test::if_has_string "${output_message}" "/apis/apps/v1/namespaces/default/statefulsets 200 OK"
-  kube::test::if_has_string "${output_message}" "/apis/autoscaling/v2/namespaces/default/horizontalpodautoscalers 200"
-  kube::test::if_has_string "${output_message}" "/apis/batch/v1/namespaces/default/jobs 200 OK"
-  kube::test::if_has_not_string "${output_message}" "/apis/extensions/v1beta1/namespaces/default/daemonsets 200 OK"
-  kube::test::if_has_not_string "${output_message}" "/apis/extensions/v1beta1/namespaces/default/deployments 200 OK"
-  kube::test::if_has_not_string "${output_message}" "/apis/extensions/v1beta1/namespaces/default/replicasets 200 OK"
+  kube::test::if_has_string "${output_message}" '"Response" verb="GET" url=".*/api/v1/namespaces/default/pods" status="200 OK"'
+  kube::test::if_has_string "${output_message}" '"Response" verb="GET" url=".*/api/v1/namespaces/default/replicationcontrollers" status="200 OK"'
+  kube::test::if_has_string "${output_message}" '"Response" verb="GET" url=".*/api/v1/namespaces/default/services" status="200 OK"'
+  kube::test::if_has_string "${output_message}" '"Response" verb="GET" url=".*/apis/apps/v1/namespaces/default/daemonsets" status="200 OK"'
+  kube::test::if_has_string "${output_message}" '"Response" verb="GET" url=".*/apis/apps/v1/namespaces/default/deployments" status="200 OK"'
+  kube::test::if_has_string "${output_message}" '"Response" verb="GET" url=".*/apis/apps/v1/namespaces/default/replicasets" status="200 OK"'
+  kube::test::if_has_string "${output_message}" '"Response" verb="GET" url=".*/apis/apps/v1/namespaces/default/statefulsets" status="200 OK"'
+  kube::test::if_has_string "${output_message}" '"Response" verb="GET" url=".*/apis/autoscaling/v2/namespaces/default/horizontalpodautoscalers" status="200 OK"'
+  kube::test::if_has_string "${output_message}" '"Response" verb="GET" url=".*/apis/batch/v1/namespaces/default/jobs" status="200 OK"'
+  kube::test::if_has_not_string "${output_message}" '"Response" verb="GET" url=".*/apis/extensions/v1beta1/namespaces/default/daemonsets" status="200 OK"'
+  kube::test::if_has_not_string "${output_message}" '"Response" verb="GET" url=".*/apis/extensions/v1beta1/namespaces/default/deployments" status="200 OK"'
+  kube::test::if_has_not_string "${output_message}" '"Response" verb="GET" url=".*/apis/extensions/v1beta1/namespaces/default/replicasets" status="200 OK"'
 
   ### Test kubectl get chunk size
   output_message=$(kubectl --v=6 get clusterrole --chunk-size=10 2>&1 "${kube_flags[@]}")
   # Post-condition: Check if we get a limit and continue
-  kube::test::if_has_string "${output_message}" "/clusterroles?limit=10 200 OK"
-  kube::test::if_has_string "${output_message}" "/v1/clusterroles?continue="
+  kube::test::if_has_string "${output_message}" '"Response" verb="GET" url=".*/clusterroles?limit=10" status="200 OK"'
+  kube::test::if_has_string "${output_message}" '"Response" verb="GET" url=".*/v1/clusterroles?continue=.*'
 
   ### Test kubectl get chunk size defaults to 500
   output_message=$(kubectl --v=6 get clusterrole 2>&1 "${kube_flags[@]}")
   # Post-condition: Check if we get a limit and continue
-  kube::test::if_has_string "${output_message}" "/clusterroles?limit=500 200 OK"
+  kube::test::if_has_string "${output_message}" '"Response" verb="GET" url=".*/clusterroles?limit=500" status="200 OK"'
 
   ### Test kubectl get accumulates pages
   output_message=$(kubectl get namespaces --chunk-size=1 --no-headers "${kube_flags[@]}")

--- a/test/cmd/node-management.sh
+++ b/test/cmd/node-management.sh
@@ -177,9 +177,9 @@ run_cluster_management_tests() {
    # command - need to use force because pods are unmanaged, dry run (or skip-wait) because node is unready
    output_message=$(kubectl --v=6 drain --force --pod-selector type=test-pod --selector test=label --chunk-size=1 --dry-run=client 2>&1 "${kube_flags[@]}")
    # Post-condition: Check if we get a limit on node, and both limit and continue on pods
-   kube::test::if_has_string "${output_message}" "/v1/nodes?labelSelector=test%3Dlabel&limit=1 200 OK"
-   kube::test::if_has_string "${output_message}" "/v1/pods?fieldSelector=spec.nodeName%3D127.0.0.1&labelSelector=type%3Dtest-pod&limit=1 200 OK"
-   kube::test::if_has_string "${output_message}" "/v1/pods?continue=.*&fieldSelector=spec.nodeName%3D127.0.0.1&labelSelector=type%3Dtest-pod&limit=1 200 OK"
+   kube::test::if_has_string "${output_message}" '"Response" verb="GET" url=".*/v1/nodes?labelSelector=test%3Dlabel&limit=1" status="200 OK"'
+   kube::test::if_has_string "${output_message}" '"Response" verb="GET" url=".*/v1/pods?fieldSelector=spec.nodeName%3D127.0.0.1&labelSelector=type%3Dtest-pod&limit=1" status="200 OK"'
+   kube::test::if_has_string "${output_message}" '"Response" verb="GET" url=".*/v1/pods?continue=.*&fieldSelector=spec.nodeName%3D127.0.0.1&labelSelector=type%3Dtest-pod&limit=1" status="200 OK"'
    # Post-condition: Check we evict multiple pages worth of pods
    kube::test::if_has_string "${output_message}" "evicting pod .*/test-pod-1"
    kube::test::if_has_string "${output_message}" "evicting pod .*/test-pod-2"
@@ -190,8 +190,8 @@ run_cluster_management_tests() {
    ### Test kubectl drain chunk size defaults to 500
    output_message=$(kubectl --v=6 drain --force --selector test=label --dry-run=client 2>&1 "${kube_flags[@]}")
    # Post-condition: Check if we get a limit
-   kube::test::if_has_string "${output_message}" "/v1/nodes?labelSelector=test%3Dlabel&limit=500 200 OK"
-   kube::test::if_has_string "${output_message}" "/v1/pods?fieldSelector=spec.nodeName%3D127.0.0.1&limit=500 200 OK"
+   kube::test::if_has_string "${output_message}" '"Response" verb="GET" url=".*/v1/nodes?labelSelector=test%3Dlabel&limit=500" status="200 OK"'
+   kube::test::if_has_string "${output_message}" '"Response" verb="GET" url=".*/v1/pods?fieldSelector=spec.nodeName%3D127.0.0.1&limit=500" status="200 OK"'
 
   ### kubectl cordon command fails when no arguments are passed
   # Pre-condition: node exists

--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -651,13 +651,13 @@ metadata:
 				gomega.Expect(err).To(gomega.ContainSubstring("Using in-cluster namespace"))
 				gomega.Expect(err).To(gomega.ContainSubstring("Using in-cluster configuration"))
 
-				gomega.Expect(err).To(gomega.ContainSubstring(fmt.Sprintf("POST https://%s/api/v1/namespaces/configmap-namespace/configmaps", inClusterURL)))
+				gomega.Expect(err).To(gomega.ContainSubstring(fmt.Sprintf(`verb="POST" url="https://%s/api/v1/namespaces/configmap-namespace/configmaps`, inClusterURL)))
 
 				ginkgo.By("creating an object not containing a namespace with in-cluster config")
 				_, err = e2eoutput.RunHostCmd(ns, simplePodName, "/tmp/kubectl create -f /tmp/invalid-configmap-without-namespace.yaml --v=6 2>&1")
 				gomega.Expect(err).To(gomega.ContainSubstring("Using in-cluster namespace"))
 				gomega.Expect(err).To(gomega.ContainSubstring("Using in-cluster configuration"))
-				gomega.Expect(err).To(gomega.ContainSubstring(fmt.Sprintf("POST https://%s/api/v1/namespaces/%s/configmaps", inClusterURL, f.Namespace.Name)))
+				gomega.Expect(err).To(gomega.ContainSubstring(fmt.Sprintf(`verb="POST" url="https://%s/api/v1/namespaces/%s/configmaps`, inClusterURL, f.Namespace.Name)))
 
 				ginkgo.By("trying to use kubectl with invalid token")
 				_, err = e2eoutput.RunHostCmd(ns, simplePodName, "/tmp/kubectl get pods --token=invalid --v=7 2>&1")
@@ -665,27 +665,27 @@ metadata:
 				gomega.Expect(err).To(gomega.HaveOccurred())
 				gomega.Expect(err).To(gomega.ContainSubstring("Using in-cluster namespace"))
 				gomega.Expect(err).To(gomega.ContainSubstring("Using in-cluster configuration"))
-				gomega.Expect(err).To(gomega.ContainSubstring("Response Status: 401 Unauthorized"))
+				gomega.Expect(err).To(gomega.ContainSubstring(`"Response" status="401 Unauthorized"`))
 
 				ginkgo.By("trying to use kubectl with invalid server")
 				_, err = e2eoutput.RunHostCmd(ns, simplePodName, "/tmp/kubectl get pods --server=invalid --v=6 2>&1")
 				framework.Logf("got err %v", err)
 				gomega.Expect(err).To(gomega.HaveOccurred())
 				gomega.Expect(err).To(gomega.ContainSubstring("Unable to connect to the server"))
-				gomega.Expect(err).To(gomega.ContainSubstring("GET http://invalid/api"))
+				gomega.Expect(err).To(gomega.ContainSubstring(`verb="GET" url="http://invalid/api`))
 
 				ginkgo.By("trying to use kubectl with invalid namespace")
 				execOutput = e2eoutput.RunHostCmdOrDie(ns, simplePodName, "/tmp/kubectl get pods --namespace=invalid --v=6 2>&1")
 				gomega.Expect(execOutput).To(gomega.ContainSubstring("No resources found"))
 				gomega.Expect(execOutput).ToNot(gomega.ContainSubstring("Using in-cluster namespace"))
 				gomega.Expect(execOutput).To(gomega.ContainSubstring("Using in-cluster configuration"))
-				gomega.Expect(execOutput).To(gomega.MatchRegexp(fmt.Sprintf("GET http[s]?://[\\[]?%s[\\]]?:%s/api/v1/namespaces/invalid/pods", inClusterHost, inClusterPort)))
+				gomega.Expect(execOutput).To(gomega.MatchRegexp(fmt.Sprintf(`verb="GET" url="http[s]?://[\[]?%s[\]]?:%s/api/v1/namespaces/invalid/pods`, inClusterHost, inClusterPort)))
 
 				ginkgo.By("trying to use kubectl with kubeconfig")
 				execOutput = e2eoutput.RunHostCmdOrDie(ns, simplePodName, "/tmp/kubectl get pods --kubeconfig=/tmp/"+overrideKubeconfigName+" --v=6 2>&1")
 				gomega.Expect(execOutput).ToNot(gomega.ContainSubstring("Using in-cluster namespace"))
 				gomega.Expect(execOutput).ToNot(gomega.ContainSubstring("Using in-cluster configuration"))
-				gomega.Expect(execOutput).To(gomega.ContainSubstring("GET https://kubernetes.default.svc:443/api/v1/namespaces/default/pods"))
+				gomega.Expect(execOutput).To(gomega.ContainSubstring(`verb="GET" url="https://kubernetes.default.svc:443/api/v1/namespaces/default/pods`))
 			})
 		})
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The revised logging emits one log entry at the start of round-tripping ("Request") and another at the end ("Response"). This avoids the risk that related output gets interleaved by other output.

No API changes are necessary. A contextual logger is picked up from the context of the request that is being handled. The verbosity level of that logger is checked to determine what is supposed to be logged. This enables reducing log details on a by-request basis by storing a `logger.V(1)` in the context of the request.

#### Special notes for your reviewer:

##### request/response logging before/after

###### -v=5 before

```
<no output>
```

###### -v=5 after

```
<no logging>
```

###### -v=6 before

```
I0122 17:00:17.906990  346330 round_trippers.go:560] GET https://localhost:6444/apis/apps/v1/namespaces/default/daemonsets/my-daemonset 200 OK in 3 milliseconds
```

###### -v=6 after

```
I0122 17:09:32.381792  360675 round_trippers.go:630] "Response" verb="GET" url="https://localhost:6444/apis/apps/v1/namespaces/default/daemonsets/my-daemonset" status="200 OK" milliseconds=3
```

###### -v=7 before

```
I0122 17:00:18.081901  346351 round_trippers.go:470] GET https://localhost:6444/apis/apps/v1/namespaces/default/daemonsets/my-daemonset
I0122 17:00:18.081925  346351 round_trippers.go:476] Request Headers:
I0122 17:00:18.081942  346351 round_trippers.go:480]     Accept: application/json
I0122 17:00:18.081953  346351 round_trippers.go:480]     User-Agent: kubectl/v1.33.0 (linux/amd64) kubernetes/bd55d18
I0122 17:00:18.085132  346351 round_trippers.go:581] Response Status: 200 OK in 3 milliseconds
```

###### -v=7 after

```
I0122 17:09:32.570507  360704 round_trippers.go:525] "Request" verb="GET" url="https://localhost:6444/apis/apps/v1/namespaces/default/daemonsets/my-daemonset" headers=<
	Accept: application/json
	User-Agent: kubectl/v1.33.0 (linux/amd64) kubernetes/0de6992
 >
I0122 17:09:32.573856  360704 round_trippers.go:630] "Response" status="200 OK" milliseconds=3
```

###### -v=8 before

```
I0122 17:00:18.273097  346374 helper.go:105] "Request Body" body=""
I0122 17:00:18.273166  346374 round_trippers.go:470] GET https://localhost:6444/apis/apps/v1/namespaces/default/daemonsets/my-daemonset
I0122 17:00:18.273176  346374 round_trippers.go:476] Request Headers:
I0122 17:00:18.273192  346374 round_trippers.go:480]     Accept: application/json
I0122 17:00:18.273203  346374 round_trippers.go:480]     User-Agent: kubectl/v1.33.0 (linux/amd64) kubernetes/bd55d18
I0122 17:00:18.276270  346374 round_trippers.go:581] Response Status: 200 OK in 3 milliseconds
I0122 17:00:18.276295  346374 round_trippers.go:584] Response Headers:
I0122 17:00:18.276310  346374 round_trippers.go:587]     Content-Length: 2918
I0122 17:00:18.276322  346374 round_trippers.go:587]     Date: Wed, 22 Jan 2025 16:00:18 GMT
I0122 17:00:18.276329  346374 round_trippers.go:587]     Audit-Id: d01b8b74-2c39-4466-bb76-e28bf5cf1a99
I0122 17:00:18.276336  346374 round_trippers.go:587]     Cache-Control: no-cache, private
I0122 17:00:18.276341  346374 round_trippers.go:587]     Content-Type: application/json
I0122 17:00:18.276348  346374 round_trippers.go:587]     X-Kubernetes-Pf-Flowschema-Uid: fbe1061a-6a71-44e6-bf6e-8b7313b60122
I0122 17:00:18.276354  346374 round_trippers.go:587]     X-Kubernetes-Pf-Prioritylevel-Uid: c860c5bd-6097-4d6b-9a18-fb9099a6a480
I0122 17:00:18.276454  346374 helper.go:105] "Response Body" body="{\"kind\":\"DaemonSet\",... [truncated 1894 chars]"
```

###### -v=8 after

```
I0122 17:15:07.759356  368870 helper.go:105] "Request Body" body=""
I0122 17:15:07.759437  368870 round_trippers.go:527] "Request" verb="GET" url="https://localhost:6444/apis/apps/v1/namespaces/default/daemonsets/my-daemonset" headers=<
	Accept: application/json
	User-Agent: kubectl/v1.33.0 (linux/amd64) kubernetes/0de6992
 >
I0122 17:15:07.762713  368870 round_trippers.go:632] "Response" status="200 OK" headers=<
	Audit-Id: 85804509-da0e-4f4d-8edd-cf5c01dd9a02
	Cache-Control: no-cache, private
	Content-Length: 2918
	Content-Type: application/json
	Date: Wed, 22 Jan 2025 16:15:07 GMT
	X-Kubernetes-Pf-Flowschema-Uid: fbe1061a-6a71-44e6-bf6e-8b7313b60122
	X-Kubernetes-Pf-Prioritylevel-Uid: c860c5bd-6097-4d6b-9a18-fb9099a6a480
 > milliseconds=3
I0122 17:15:07.762848  368870 helper.go:105] "Response Body" body="{\"kind\":\"DaemonSet\",... [truncated 1894 chars]"
```

###### -v=9 before

```
I0122 17:00:18.460891  346396 helper.go:105] "Request Body" body=""
I0122 17:00:18.460975  346396 round_trippers.go:473] curl -v -XGET  -H "User-Agent: kubectl/v1.33.0 (linux/amd64) kubernetes/bd55d18" -H "Accept: application/json" 'https://localhost:6444/apis/apps/v1/namespaces/default/daemonsets/my-daemonset'
I0122 17:00:18.464151  346396 round_trippers.go:560] GET https://localhost:6444/apis/apps/v1/namespaces/default/daemonsets/my-daemonset 200 OK in 3 milliseconds
I0122 17:00:18.464178  346396 round_trippers.go:577] HTTP Statistics: GetConnection 0 ms ServerProcessing 2 ms Duration 3 ms
I0122 17:00:18.464193  346396 round_trippers.go:584] Response Headers:
I0122 17:00:18.464208  346396 round_trippers.go:587]     Audit-Id: 25fc0fc2-609b-42d1-8506-b92d5eeceb0a
I0122 17:00:18.464216  346396 round_trippers.go:587]     Cache-Control: no-cache, private
I0122 17:00:18.464222  346396 round_trippers.go:587]     Content-Type: application/json
I0122 17:00:18.464232  346396 round_trippers.go:587]     X-Kubernetes-Pf-Flowschema-Uid: fbe1061a-6a71-44e6-bf6e-8b7313b60122
I0122 17:00:18.464239  346396 round_trippers.go:587]     X-Kubernetes-Pf-Prioritylevel-Uid: c860c5bd-6097-4d6b-9a18-fb9099a6a480
I0122 17:00:18.464244  346396 round_trippers.go:587]     Content-Length: 2918
I0122 17:00:18.464251  346396 round_trippers.go:587]     Date: Wed, 22 Jan 2025 16:00:18 GMT
I0122 17:00:18.464318  346396 helper.go:105] "Response Body" body=<
	{"kind":"DaemonSet",...
 >
```

###### -v=9 after

```
I0122 17:15:07.955594  368893 helper.go:105] "Request Body" body=""
I0122 17:15:07.955683  368893 round_trippers.go:527] "Request" curlCommand=<
	curl -v -XGET  -H "Accept: application/json" -H "User-Agent: kubectl/v1.33.0 (linux/amd64) kubernetes/0de6992" 'https://localhost:6444/apis/apps/v1/namespaces/default/daemonsets/my-daemonset'
 >
I0122 17:15:07.959011  368893 round_trippers.go:632] "Response" verb="GET" url="https://localhost:6444/apis/apps/v1/namespaces/default/daemonsets/my-daemonset" status="200 OK" headers=<
	Audit-Id: 13081364-925f-4fe6-8e8f-d7b210dbe733
	Cache-Control: no-cache, private
	Content-Length: 2918
	Content-Type: application/json
	Date: Wed, 22 Jan 2025 16:15:07 GMT
	X-Kubernetes-Pf-Flowschema-Uid: fbe1061a-6a71-44e6-bf6e-8b7313b60122
	X-Kubernetes-Pf-Prioritylevel-Uid: c860c5bd-6097-4d6b-9a18-fb9099a6a480
 > milliseconds=3 getConnectionMilliseconds=0 serverProcessingMilliseconds=3
I0122 17:15:07.959095  368893 helper.go:105] "Response Body" body=<
	{"kind":"DaemonSet",...
 >
```


#### Does this PR introduce a user-facing change?
```release-note
NONE
```
