### PR TITLE
client-go command: structured, contextual logging

### DIFF
--- a/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
@@ -679,11 +679,13 @@ func (config *inClusterClientConfig) Possible() bool {
 // to the default config.
 func BuildConfigFromFlags(masterUrl, kubeconfigPath string) (*restclient.Config, error) {
 	if kubeconfigPath == "" && masterUrl == "" {
+		//nolint:logcheck // A helper function like this should not log. But this is probably part of the the established client-go API and not worth changing.
 		klog.Warning("Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.")
 		kubeconfig, err := restclient.InClusterConfig()
 		if err == nil {
 			return kubeconfig, nil
 		}
+		//nolint:logcheck // A helper function like this should not log. But this is probably part of the the established client-go API and not worth changing.
 		klog.Warning("error creating inClusterConfig, falling back to default config: ", err)
 	}
 	return NewNonInteractiveDeferredLoadingClientConfig(

--- a/staging/src/k8s.io/client-go/tools/clientcmd/config.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/config.go
@@ -492,6 +492,7 @@ func getConfigFromFile(filename string) (*clientcmdapi.Config, error) {
 func GetConfigFromFileOrDie(filename string) *clientcmdapi.Config {
 	config, err := getConfigFromFile(filename)
 	if err != nil {
+		//nolint:logcheck // A helper function like this should not log. But this is probably part of the the established client-go API and not worth changing.
 		klog.FatalDepth(1, err)
 	}
 

--- a/staging/src/k8s.io/client-go/tools/clientcmd/loader.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/loader.go
@@ -137,6 +137,7 @@ type WarningHandler func(error)
 
 func (handler WarningHandler) Warn(err error) {
 	if handler == nil {
+		//nolint:logcheck // This is the fallback when logging is not initialized. With nothing provided, using the global logger is the only option.
 		klog.V(1).Info(err)
 	} else {
 		handler(err)
@@ -402,6 +403,7 @@ func LoadFromFile(filename string) (*clientcmdapi.Config, error) {
 	if err != nil {
 		return nil, err
 	}
+	//nolint:logcheck // A helper function like this should not log. But this is probably part of the the established client-go API and not worth changing.
 	klog.V(6).Infoln("Config loaded from file: ", filename)
 
 	// set LocationOfOrigin on every Cluster, User, and Context

--- a/staging/src/k8s.io/client-go/tools/clientcmd/loader_test.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/loader_test.go
@@ -122,6 +122,7 @@ func TestNonExistentCommandLineFile(t *testing.T) {
 	}
 }
 
+//nolint:logcheck // Tests klog APIs.
 func TestToleratingMissingFiles(t *testing.T) {
 	envVarValue := "bogus"
 	loadingRules := ClientConfigLoadingRules{
@@ -146,6 +147,7 @@ func TestToleratingMissingFiles(t *testing.T) {
 	}
 }
 
+//nolint:logcheck // Tests klog APIs.
 func TestWarningMissingFiles(t *testing.T) {
 	envVarValue := "bogus"
 	t.Setenv(RecommendedConfigPathEnvVar, envVarValue)
@@ -171,6 +173,7 @@ func TestWarningMissingFiles(t *testing.T) {
 	}
 }
 
+//nolint:logcheck // Tests klog APIs.
 func TestNoWarningMissingFiles(t *testing.T) {
 	envVarValue := "bogus"
 	t.Setenv(RecommendedConfigPathEnvVar, envVarValue)

--- a/staging/src/k8s.io/client-go/tools/clientcmd/merged_client_builder.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/merged_client_builder.go
@@ -118,6 +118,7 @@ func (config *DeferredLoadingClientConfig) ClientConfig() (*restclient.Config, e
 
 	// check for in-cluster configuration and use it
 	if config.icc.Possible() {
+		//nolint:logcheck // A helper function like this should not log. But this is probably part of the the established client-go API and not worth changing.
 		klog.V(4).Infof("Using in-cluster configuration")
 		return config.icc.ClientConfig()
 	}
@@ -160,6 +161,7 @@ func (config *DeferredLoadingClientConfig) Namespace() (string, bool, error) {
 		}
 	}
 
+	//nolint:logcheck // A helper function like this should not log. But this is probably part of the the established client-go API and not worth changing.
 	klog.V(4).Infof("Using in-cluster namespace")
 
 	// allow the namespace from the service account token directory to be used.

--- a/staging/src/k8s.io/client-go/tools/remotecommand/errorstream.go
+++ b/staging/src/k8s.io/client-go/tools/remotecommand/errorstream.go
@@ -21,6 +21,7 @@ import (
 	"io"
 
 	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/klog/v2"
 )
 
 // errorStreamDecoder interprets the data on the error channel and creates a go error object from it.
@@ -32,11 +33,11 @@ type errorStreamDecoder interface {
 // decodes it with the given errorStreamDecoder, sends the decoded error (or nil if the remote
 // command exited successfully) to the returned error channel, and closes it.
 // This function returns immediately.
-func watchErrorStream(errorStream io.Reader, d errorStreamDecoder) chan error {
+func watchErrorStream(logger klog.Logger, errorStream io.Reader, d errorStreamDecoder) chan error {
 	errorChan := make(chan error)
 
 	go func() {
-		defer runtime.HandleCrash()
+		defer runtime.HandleCrashWithLogger(logger)
 
 		message, err := io.ReadAll(errorStream)
 		switch {

--- a/staging/src/k8s.io/client-go/tools/remotecommand/fallback.go
+++ b/staging/src/k8s.io/client-go/tools/remotecommand/fallback.go
@@ -53,7 +53,7 @@ func (f *FallbackExecutor) Stream(options StreamOptions) error {
 func (f *FallbackExecutor) StreamWithContext(ctx context.Context, options StreamOptions) error {
 	err := f.primary.StreamWithContext(ctx, options)
 	if err != nil && f.shouldFallback(err) {
-		klog.V(4).Infof("RemoteCommand fallback: %v", err)
+		klog.FromContext(ctx).V(4).Info("RemoteCommand fallback", "err", err)
 		return f.secondary.StreamWithContext(ctx, options)
 	}
 	return err

--- a/staging/src/k8s.io/client-go/tools/remotecommand/remotecommand.go
+++ b/staging/src/k8s.io/client-go/tools/remotecommand/remotecommand.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 
 	"k8s.io/apimachinery/pkg/util/httpstream"
+	"k8s.io/klog/v2"
 )
 
 // StreamOptions holds information pertaining to the current streaming session:
@@ -54,5 +55,5 @@ type streamCreator interface {
 }
 
 type streamProtocolHandler interface {
-	stream(conn streamCreator, ready chan<- struct{}) error
+	stream(logger klog.Logger, conn streamCreator, ready chan<- struct{}) error
 }

--- a/staging/src/k8s.io/client-go/tools/remotecommand/spdy.go
+++ b/staging/src/k8s.io/client-go/tools/remotecommand/spdy.go
@@ -121,6 +121,7 @@ func (e *spdyStreamExecutor) newConnectionAndStream(ctx context.Context, options
 
 	var streamer streamProtocolHandler
 
+	logger := klog.FromContext(ctx)
 	switch protocol {
 	case remotecommand.StreamProtocolV5Name:
 		streamer = newStreamProtocolV5(options)
@@ -131,7 +132,7 @@ func (e *spdyStreamExecutor) newConnectionAndStream(ctx context.Context, options
 	case remotecommand.StreamProtocolV2Name:
 		streamer = newStreamProtocolV2(options)
 	case "":
-		klog.V(4).Infof("The server did not negotiate a streaming protocol version. Falling back to %s", remotecommand.StreamProtocolV1Name)
+		logger.V(4).Info("The server did not negotiate a streaming protocol version, falling back", "protocol", remotecommand.StreamProtocolV1Name)
 		fallthrough
 	case remotecommand.StreamProtocolV1Name:
 		streamer = newStreamProtocolV1(options)
@@ -161,7 +162,7 @@ func (e *spdyStreamExecutor) StreamWithContext(ctx context.Context, options Stre
 		// The SPDY executor does not need to synchronize stream creation, so we pass a nil
 		// ready channel. The underlying spdystream library handles stream multiplexing
 		// without a race condition.
-		errorChan <- streamer.stream(conn, nil)
+		errorChan <- streamer.stream(klog.FromContext(ctx), conn, nil)
 	}()
 
 	select {

--- a/staging/src/k8s.io/client-go/tools/remotecommand/spdy_test.go
+++ b/staging/src/k8s.io/client-go/tools/remotecommand/spdy_test.go
@@ -38,6 +38,7 @@ import (
 	remotecommandconsts "k8s.io/apimachinery/pkg/util/remotecommand"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2/ktesting"
 )
 
 type AttachFunc func(in io.Reader, out, err io.WriteCloser, tty bool, resize <-chan TerminalSize) error
@@ -328,6 +329,7 @@ func (w *writeDetector) Write(p []byte) (n int, err error) {
 // and expects the deferred close of the connection leads to the exit of the goroutine on cancellation.
 // This test verifies that works.
 func TestStreamExitsAfterConnectionIsClosed(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	writeDetector := newWriterDetector(&fakeEmptyDataPty{})
 	options := StreamOptions{
 		Stdin:  &fakeEmptyDataPty{},
@@ -352,7 +354,7 @@ func TestStreamExitsAfterConnectionIsClosed(t *testing.T) {
 
 	errorChan := make(chan error)
 	go func() {
-		errorChan <- streamer.stream(conn, nil)
+		errorChan <- streamer.stream(logger, conn, nil)
 	}()
 
 	// Wait until stream goroutine starts.

--- a/staging/src/k8s.io/client-go/tools/remotecommand/v1.go
+++ b/staging/src/k8s.io/client-go/tools/remotecommand/v1.go
@@ -21,7 +21,7 @@ import (
 	"io"
 	"net/http"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/httpstream"
 	"k8s.io/klog/v2"
 )
@@ -47,15 +47,15 @@ func newStreamProtocolV1(options StreamOptions) streamProtocolHandler {
 	}
 }
 
-func (p *streamProtocolV1) stream(conn streamCreator, ready chan<- struct{}) error {
+func (p *streamProtocolV1) stream(logger klog.Logger, conn streamCreator, ready chan<- struct{}) error {
 	doneChan := make(chan struct{}, 2)
 	errorChan := make(chan error)
 
 	cp := func(s string, dst io.Writer, src io.Reader) {
-		klog.V(6).Infof("Copying %s", s)
-		defer klog.V(6).Infof("Done copying %s", s)
+		logger.V(6).Info("Copying", "data", s)
+		defer logger.V(6).Info("Done copying", "data", s)
 		if _, err := io.Copy(dst, src); err != nil && err != io.EOF {
-			klog.Errorf("Error copying %s: %v", s, err)
+			logger.Error(err, "Error copying", "data", s)
 		}
 		if s == v1.StreamTypeStdout || s == v1.StreamTypeStderr {
 			doneChan <- struct{}{}

--- a/staging/src/k8s.io/client-go/tools/remotecommand/v2.go
+++ b/staging/src/k8s.io/client-go/tools/remotecommand/v2.go
@@ -22,8 +22,9 @@ import (
 	"net/http"
 	"sync"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/klog/v2"
 )
 
 // streamProtocolV2 implements version 2 of the streaming protocol for attach
@@ -87,13 +88,13 @@ func (p *streamProtocolV2) createStreams(conn streamCreator) error {
 	return nil
 }
 
-func (p *streamProtocolV2) copyStdin() {
+func (p *streamProtocolV2) copyStdin(logger klog.Logger) {
 	if p.Stdin != nil {
 		var once sync.Once
 
 		// copy from client's stdin to container's stdin
 		go func() {
-			defer runtime.HandleCrash()
+			defer runtime.HandleCrashWithLogger(logger)
 
 			// if p.stdin is noninteractive, p.g. `echo abc | kubectl exec -i <pod> -- cat`, make sure
 			// we close remoteStdin as soon as the copy from p.stdin to remoteStdin finishes. Otherwise
@@ -101,7 +102,7 @@ func (p *streamProtocolV2) copyStdin() {
 			defer once.Do(func() { p.remoteStdin.Close() })
 
 			if _, err := io.Copy(p.remoteStdin, readerWrapper{p.Stdin}); err != nil {
-				runtime.HandleError(err)
+				runtime.HandleErrorWithLogger(logger, err, "Copying stdin failed")
 			}
 		}()
 
@@ -120,26 +121,26 @@ func (p *streamProtocolV2) copyStdin() {
 		// When that happens, we must Close() on our side of remoteStdin, to
 		// allow the copy in hijack to complete, and hijack to return.
 		go func() {
-			defer runtime.HandleCrash()
+			defer runtime.HandleCrashWithLogger(logger)
 			defer once.Do(func() { p.remoteStdin.Close() })
 
 			// this "copy" doesn't actually read anything - it's just here to wait for
 			// the server to close remoteStdin.
 			if _, err := io.Copy(io.Discard, p.remoteStdin); err != nil {
-				runtime.HandleError(err)
+				runtime.HandleErrorWithLogger(logger, err, "Waiting for server to close stdin failed")
 			}
 		}()
 	}
 }
 
-func (p *streamProtocolV2) copyStdout(wg *sync.WaitGroup) {
+func (p *streamProtocolV2) copyStdout(logger klog.Logger, wg *sync.WaitGroup) {
 	if p.Stdout == nil {
 		return
 	}
 
 	wg.Add(1)
 	go func() {
-		defer runtime.HandleCrash()
+		defer runtime.HandleCrashWithLogger(logger)
 		defer wg.Done()
 		// make sure, packet in queue can be consumed.
 		// block in queue may lead to deadlock in conn.server
@@ -147,29 +148,29 @@ func (p *streamProtocolV2) copyStdout(wg *sync.WaitGroup) {
 		defer io.Copy(io.Discard, p.remoteStdout)
 
 		if _, err := io.Copy(p.Stdout, p.remoteStdout); err != nil {
-			runtime.HandleError(err)
+			runtime.HandleErrorWithLogger(logger, err, "Copying stdout failed")
 		}
 	}()
 }
 
-func (p *streamProtocolV2) copyStderr(wg *sync.WaitGroup) {
+func (p *streamProtocolV2) copyStderr(logger klog.Logger, wg *sync.WaitGroup) {
 	if p.Stderr == nil || p.Tty {
 		return
 	}
 
 	wg.Add(1)
 	go func() {
-		defer runtime.HandleCrash()
+		defer runtime.HandleCrashWithLogger(logger)
 		defer wg.Done()
 		defer io.Copy(io.Discard, p.remoteStderr)
 
 		if _, err := io.Copy(p.Stderr, p.remoteStderr); err != nil {
-			runtime.HandleError(err)
+			runtime.HandleErrorWithLogger(logger, err, "Copying stderr failed")
 		}
 	}()
 }
 
-func (p *streamProtocolV2) stream(conn streamCreator, ready chan<- struct{}) error {
+func (p *streamProtocolV2) stream(logger klog.Logger, conn streamCreator, ready chan<- struct{}) error {
 	if err := p.createStreams(conn); err != nil {
 		return err
 	}
@@ -181,13 +182,13 @@ func (p *streamProtocolV2) stream(conn streamCreator, ready chan<- struct{}) err
 
 	// now that all the streams have been created, proceed with reading & copying
 
-	errorChan := watchErrorStream(p.errorStream, &errorDecoderV2{})
+	errorChan := watchErrorStream(logger, p.errorStream, &errorDecoderV2{})
 
-	p.copyStdin()
+	p.copyStdin(logger)
 
 	var wg sync.WaitGroup
-	p.copyStdout(&wg)
-	p.copyStderr(&wg)
+	p.copyStdout(logger, &wg)
+	p.copyStderr(logger, &wg)
 
 	// we're waiting for stdout/stderr to finish copying
 	wg.Wait()

--- a/staging/src/k8s.io/client-go/tools/remotecommand/v2_test.go
+++ b/staging/src/k8s.io/client-go/tools/remotecommand/v2_test.go
@@ -28,6 +28,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/httpstream"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2/ktesting"
 )
 
 type fakeReader struct {
@@ -179,6 +180,7 @@ func TestV2CreateStreams(t *testing.T) {
 }
 
 func TestV2ErrorStreamReading(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	tests := []struct {
 		name          string
 		stream        io.Reader
@@ -217,7 +219,7 @@ func TestV2ErrorStreamReading(t *testing.T) {
 		h := newStreamProtocolV2(StreamOptions{}).(*streamProtocolV2)
 		h.errorStream = test.stream
 
-		ch := watchErrorStream(h.errorStream, &errorDecoderV2{})
+		ch := watchErrorStream(logger, h.errorStream, &errorDecoderV2{})
 		if ch == nil {
 			t.Fatalf("%s: unexpected nil channel", test.name)
 		}

--- a/staging/src/k8s.io/client-go/tools/remotecommand/v3.go
+++ b/staging/src/k8s.io/client-go/tools/remotecommand/v3.go
@@ -22,8 +22,9 @@ import (
 	"net/http"
 	"sync"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/klog/v2"
 )
 
 // streamProtocolV3 implements version 3 of the streaming protocol for attach
@@ -62,12 +63,12 @@ func (p *streamProtocolV3) createStreams(conn streamCreator) error {
 	return nil
 }
 
-func (p *streamProtocolV3) handleResizes() {
+func (p *streamProtocolV3) handleResizes(logger klog.Logger) {
 	if p.resizeStream == nil || p.TerminalSizeQueue == nil {
 		return
 	}
 	go func() {
-		defer runtime.HandleCrash()
+		defer runtime.HandleCrashWithLogger(logger)
 
 		encoder := json.NewEncoder(p.resizeStream)
 		for {
@@ -76,13 +77,13 @@ func (p *streamProtocolV3) handleResizes() {
 				return
 			}
 			if err := encoder.Encode(&size); err != nil {
-				runtime.HandleError(err)
+				runtime.HandleErrorWithLogger(logger, err, "Encoding terminal size failed")
 			}
 		}
 	}()
 }
 
-func (p *streamProtocolV3) stream(conn streamCreator, ready chan<- struct{}) error {
+func (p *streamProtocolV3) stream(logger klog.Logger, conn streamCreator, ready chan<- struct{}) error {
 	if err := p.createStreams(conn); err != nil {
 		return err
 	}
@@ -94,15 +95,15 @@ func (p *streamProtocolV3) stream(conn streamCreator, ready chan<- struct{}) err
 
 	// now that all the streams have been created, proceed with reading & copying
 
-	errorChan := watchErrorStream(p.errorStream, &errorDecoderV3{})
+	errorChan := watchErrorStream(logger, p.errorStream, &errorDecoderV3{})
 
-	p.handleResizes()
+	p.handleResizes(logger)
 
-	p.copyStdin()
+	p.copyStdin(logger)
 
 	var wg sync.WaitGroup
-	p.copyStdout(&wg)
-	p.copyStderr(&wg)
+	p.copyStdout(logger, &wg)
+	p.copyStderr(logger, &wg)
 
 	// we're waiting for stdout/stderr to finish copying
 	wg.Wait()

--- a/staging/src/k8s.io/client-go/tools/remotecommand/v4.go
+++ b/staging/src/k8s.io/client-go/tools/remotecommand/v4.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/remotecommand"
 	"k8s.io/client-go/util/exec"
+	"k8s.io/klog/v2"
 )
 
 // streamProtocolV4 implements version 4 of the streaming protocol for attach
@@ -47,11 +48,11 @@ func (p *streamProtocolV4) createStreams(conn streamCreator) error {
 	return p.streamProtocolV3.createStreams(conn)
 }
 
-func (p *streamProtocolV4) handleResizes() {
-	p.streamProtocolV3.handleResizes()
+func (p *streamProtocolV4) handleResizes(logger klog.Logger) {
+	p.streamProtocolV3.handleResizes(logger)
 }
 
-func (p *streamProtocolV4) stream(conn streamCreator, ready chan<- struct{}) error {
+func (p *streamProtocolV4) stream(logger klog.Logger, conn streamCreator, ready chan<- struct{}) error {
 	if err := p.createStreams(conn); err != nil {
 		return err
 	}
@@ -63,15 +64,15 @@ func (p *streamProtocolV4) stream(conn streamCreator, ready chan<- struct{}) err
 
 	// now that all the streams have been created, proceed with reading & copying
 
-	errorChan := watchErrorStream(p.errorStream, &errorDecoderV4{})
+	errorChan := watchErrorStream(logger, p.errorStream, &errorDecoderV4{})
 
-	p.handleResizes()
+	p.handleResizes(logger)
 
-	p.copyStdin()
+	p.copyStdin(logger)
 
 	var wg sync.WaitGroup
-	p.copyStdout(&wg)
-	p.copyStderr(&wg)
+	p.copyStdout(logger, &wg)
+	p.copyStderr(logger, &wg)
 
 	// we're waiting for stdout/stderr to finish copying
 	wg.Wait()

--- a/staging/src/k8s.io/client-go/tools/remotecommand/v5.go
+++ b/staging/src/k8s.io/client-go/tools/remotecommand/v5.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package remotecommand
 
+import "k8s.io/klog/v2"
+
 // streamProtocolV5 add support for V5 of the remote command subprotocol.
 // For the streamProtocolHandler, this version is the same as V4.
 type streamProtocolV5 struct {
@@ -30,6 +32,6 @@ func newStreamProtocolV5(options StreamOptions) streamProtocolHandler {
 	}
 }
 
-func (p *streamProtocolV5) stream(conn streamCreator, ready chan<- struct{}) error {
-	return p.streamProtocolV4.stream(conn, ready)
+func (p *streamProtocolV5) stream(logger klog.Logger, conn streamCreator, ready chan<- struct{}) error {
+	return p.streamProtocolV4.stream(logger, conn, ready)
 }

--- a/staging/src/k8s.io/client-go/tools/remotecommand/websocket_test.go
+++ b/staging/src/k8s.io/client-go/tools/remotecommand/websocket_test.go
@@ -48,6 +48,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/rest"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/klog/v2/ktesting"
 )
 
 // TestWebSocketClient_LoopbackStdinToStdout returns random data sent on the STDIN channel
@@ -1049,6 +1050,7 @@ func TestWebSocketClient_ExecutorErrors(t *testing.T) {
 }
 
 func TestWebSocketClient_HeartbeatSucceeds(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	var upgrader = gwebsocket.Upgrader{
 		CheckOrigin: func(r *http.Request) bool {
 			return true // Accepting all requests
@@ -1081,7 +1083,7 @@ func TestWebSocketClient_HeartbeatSucceeds(t *testing.T) {
 	var expectedMsg = "test heartbeat message"
 	var period = 100 * time.Millisecond
 	var deadline = 200 * time.Millisecond
-	heartbeat := newHeartbeat(client, period, deadline)
+	heartbeat := newHeartbeat(logger, client, period, deadline)
 	heartbeat.setMessage(expectedMsg)
 	// Add a channel to the handler to retrieve the "pong" message.
 	pongMsgCh := make(chan string)
@@ -1121,7 +1123,8 @@ func TestWebSocketClient_HeartbeatSucceeds(t *testing.T) {
 }
 
 func TestLateStreamCreation(t *testing.T) {
-	c := newWSStreamCreator(nil)
+	logger, _ := ktesting.NewTestContext(t)
+	c := newWSStreamCreator(logger, nil)
 	c.closeAllStreamReaders(nil)
 	if err := c.setStream(0, nil); err == nil {
 		t.Fatal("expected error adding stream after closeAllStreamReaders")
@@ -1129,8 +1132,10 @@ func TestLateStreamCreation(t *testing.T) {
 }
 
 func TestWebSocketClient_StreamsAndExpectedErrors(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+
 	// Validate Stream functions.
-	c := newWSStreamCreator(nil)
+	c := newWSStreamCreator(logger, nil)
 	headers := http.Header{}
 	headers.Set(v1.StreamType, v1.StreamTypeStdin)
 	s, err := c.CreateStream(headers)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Nicer, context-aware log output.

#### Which issue(s) this PR fixes:

https://github.com/kubernetes/kubernetes/issues/119813

#### Special notes for your reviewer:

remotecommand:  the API for the package already had a context, so all that was missing was to extract and use the logger from that.

clientcmd: the only log output is for error messages which should normally not occur. It's also likely that users expect to see exactly those messages, so it's better to not touch them.

Part of https://github.com/kubernetes/kubernetes/pull/129125/

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
