### PR TITLE
Bump DefaultKubeBinaryVersion to 1.33 (minimal)

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/options/server_run_options_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/server_run_options_test.go
@@ -197,7 +197,7 @@ func TestServerRunOptionsValidate(t *testing.T) {
 				ComponentName:               testComponent,
 				ComponentGlobalsRegistry:    testRegistry,
 			},
-			expectErr: "emulation version 1.32 is not between [1.29, 1.30.0]",
+			expectErr: "emulation version 1.32 is not between [1.28, 1.30.0]",
 		},
 		{
 			name: "Test when ServerRunOptions is valid",

--- a/staging/src/k8s.io/component-base/version/base.go
+++ b/staging/src/k8s.io/component-base/version/base.go
@@ -66,5 +66,5 @@ const (
 	// DefaultKubeBinaryVersion is the hard coded k8 binary version based on the latest K8s release.
 	// It is supposed to be consistent with gitMajor and gitMinor, except for local tests, where gitMajor and gitMinor are "".
 	// Should update for each minor release!
-	DefaultKubeBinaryVersion = "1.32"
+	DefaultKubeBinaryVersion = "1.33"
 )

--- a/staging/src/k8s.io/component-base/version/version.go
+++ b/staging/src/k8s.io/component-base/version/version.go
@@ -136,13 +136,13 @@ func (m *effectiveVersion) Validate() []error {
 
 	// emulationVersion can only be 1.{binaryMinor-1}...1.{binaryMinor}.
 	maxEmuVer := binaryVersion
-	minEmuVer := binaryVersion.SubtractMinor(1)
+	minEmuVer := binaryVersion.SubtractMinor(2)
 	if emulationVersion.GreaterThan(maxEmuVer) || emulationVersion.LessThan(minEmuVer) {
 		errs = append(errs, fmt.Errorf("emulation version %s is not between [%s, %s]", emulationVersion.String(), minEmuVer.String(), maxEmuVer.String()))
 	}
 	// minCompatibilityVersion can only be 1.{binaryMinor-1} for alpha.
 	maxCompVer := binaryVersion.SubtractMinor(1)
-	minCompVer := binaryVersion.SubtractMinor(1)
+	minCompVer := binaryVersion.SubtractMinor(2)
 	if minCompatibilityVersion.GreaterThan(maxCompVer) || minCompatibilityVersion.LessThan(minCompVer) {
 		errs = append(errs, fmt.Errorf("minCompatibilityVersion version %s is not between [%s, %s]", minCompatibilityVersion.String(), minCompVer.String(), maxCompVer.String()))
 	}

--- a/staging/src/k8s.io/component-base/version/version_test.go
+++ b/staging/src/k8s.io/component-base/version/version_test.go
@@ -43,10 +43,17 @@ func TestValidate(t *testing.T) {
 			minCompatibilityVersion: "v1.31.0",
 		},
 		{
-			name:                    "emulation version two minor lower than binary not ok",
+			name:                    "emulation version two minor lower than binary ok",
 			binaryVersion:           "v1.33.2",
 			emulationVersion:        "v1.31.0",
-			minCompatibilityVersion: "v1.32.0",
+			minCompatibilityVersion: "v1.31.0",
+			expectErrors:            false,
+		},
+		{
+			name:                    "emulation version three lower than binary not ok",
+			binaryVersion:           "v1.33.0",
+			emulationVersion:        "v1.30.0",
+			minCompatibilityVersion: "v1.30.0",
 			expectErrors:            true,
 		},
 		{
@@ -71,10 +78,16 @@ func TestValidate(t *testing.T) {
 			expectErrors:            true,
 		},
 		{
-			name:                    "compatibility version two minor lower than binary not ok",
+			name:                    "compatibility version two minor lower than binary ok",
 			binaryVersion:           "v1.32.2",
 			emulationVersion:        "v1.32.0",
 			minCompatibilityVersion: "v1.30.0",
+		},
+		{
+			name:                    "compatibility version three minor lower than binary not ok",
+			binaryVersion:           "v1.32.2",
+			emulationVersion:        "v1.32.0",
+			minCompatibilityVersion: "v1.29.0",
 			expectErrors:            true,
 		},
 		{

--- a/test/integration/controlplane/transformation/kms_transformation_test.go
+++ b/test/integration/controlplane/transformation/kms_transformation_test.go
@@ -644,7 +644,7 @@ resources:
 		resources := etcd.GetResources(t, serverResources)
 		client := dynamic.NewForConfigOrDie(test.kubeAPIServer.ClientConfig)
 
-		etcdStorageData := etcd.GetEtcdStorageDataForNamespace(testNamespace)
+		etcdStorageData := etcd.GetServedEtcdStorageDataForNamespace(testNamespace)
 		restResourceSet := sets.New[schema.GroupVersionResource]()
 		stubResourceSet := sets.New[schema.GroupVersionResource]()
 		for _, resource := range resources {

--- a/test/integration/etcd/etcd_storage_path_test.go
+++ b/test/integration/etcd/etcd_storage_path_test.go
@@ -91,7 +91,7 @@ func TestEtcdStoragePath(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	etcdStorageData := GetEtcdStorageData()
+	etcdStorageData := GetServedEtcdStorageDataForNamespace("etcdstoragepathtestnamespace")
 
 	kindSeen := sets.NewString()
 	pathSeen := map[string][]schema.GroupVersionResource{}

--- a/test/integration/metrics/metrics_test.go
+++ b/test/integration/metrics/metrics_test.go
@@ -105,9 +105,6 @@ func TestAPIServerStorageMetrics(t *testing.T) {
 }
 
 func TestAPIServerMetrics(t *testing.T) {
-	// KUBE_APISERVER_SERVE_REMOVED_APIS_FOR_ONE_RELEASE allows for APIs pending removal to not block tests
-	t.Setenv("KUBE_APISERVER_SERVE_REMOVED_APIS_FOR_ONE_RELEASE", "true")
-
 	s := kubeapiservertesting.StartTestServerOrDie(t, nil, framework.DefaultTestServerFlags(), framework.SharedEtcd())
 	defer s.TearDownFn()
 
@@ -119,7 +116,7 @@ func TestAPIServerMetrics(t *testing.T) {
 	}
 
 	// Make a request to a deprecated API to ensure there's at least one data point
-	if _, err := client.FlowcontrolV1beta3().FlowSchemas().List(context.TODO(), metav1.ListOptions{}); err != nil {
+	if _, err := client.AdmissionregistrationV1beta1().ValidatingAdmissionPolicies().List(context.TODO(), metav1.ListOptions{}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Isolated from https://github.com/kubernetes/kubernetes/pull/128279, this PR consists of the minimum amount of changes to support the version bump to 1.33.

We've identified a couple of bugs with compatibility version that we'd like to address in followups. These include:

- Losing test coverage from removing APIs (flowcontrol/v1beta1)
- minCompatibilityVersion should be based on emulation version and not binary version
- Supporting n-3 with min version clamp
- Losing test coverage for GA API (ValidatingAdmissionPolicy) that cannot be emulated at 1.30 anymore

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
