### PR TITLE
client-go features: ignore contextual logging

### DIFF
--- a/staging/src/k8s.io/client-go/features/features.go
+++ b/staging/src/k8s.io/client-go/features/features.go
@@ -17,7 +17,7 @@ limitations under the License.
 package features
 
 import (
-	"errors"
+	"context"
 	"sync/atomic"
 
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -103,7 +103,9 @@ func AddFeaturesToExistingFeatureGates(registry Registry) error {
 //	clientgofeaturegate.ReplaceFeatureGates(utilfeature.DefaultMutableFeatureGate)
 func ReplaceFeatureGates(newFeatureGates Gates) {
 	if replaceFeatureGatesWithWarningIndicator(newFeatureGates) {
-		utilruntime.HandleError(errors.New("the default feature gates implementation has already been used and now it's being overwritten. This might lead to unexpected behaviour. Check your initialization order"))
+		// TODO (?): A new API would be needed where callers pass in a context or logger.
+		// Probably not worth it.
+		utilruntime.HandleErrorWithContext(context.TODO(), nil, "The default feature gates implementation has already been used and now it's being overwritten. This might lead to unexpected behaviour. Check your initialization order.")
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Part of https://github.com/kubernetes/kubernetes/pull/129125

https://github.com/kubernetes/kubernetes/issues/119813

#### Special notes for your reviewer:

The client-go feature gates implementation logs information about feature states at V(1). Changing that would imply changing the Enabled method, which is very intrusive because there are many callers which are not expected to log and thus don't have access to a contextual logger.

The code is not active in Kubernetes components, those use the clientAdapter to make client-go use the normal feature gate implementation, which doesn't log anything. Therefore the code doesn't get changed and only annotated so that logcheck won't complain.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/wg structured-logging
