### PR TITLE
client-go watch: context support

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/informers/externalversions/cr/v1/example.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/informers/externalversions/cr/v1/example.go
@@ -62,13 +62,25 @@ func NewFilteredExampleInformer(client versioned.Interface, namespace string, re
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CrV1().Examples(namespace).List(context.TODO(), options)
+				return client.CrV1().Examples(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CrV1().Examples(namespace).Watch(context.TODO(), options)
+				return client.CrV1().Examples(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.CrV1().Examples(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.CrV1().Examples(namespace).Watch(ctx, options)
 			},
 		},
 		&apiscrv1.Example{},

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1/customresourcedefinition.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1/customresourcedefinition.go
@@ -61,13 +61,25 @@ func NewFilteredCustomResourceDefinitionInformer(client clientset.Interface, res
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ApiextensionsV1().CustomResourceDefinitions().List(context.TODO(), options)
+				return client.ApiextensionsV1().CustomResourceDefinitions().List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ApiextensionsV1().CustomResourceDefinitions().Watch(context.TODO(), options)
+				return client.ApiextensionsV1().CustomResourceDefinitions().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.ApiextensionsV1().CustomResourceDefinitions().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.ApiextensionsV1().CustomResourceDefinitions().Watch(ctx, options)
 			},
 		},
 		&apisapiextensionsv1.CustomResourceDefinition{},

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1beta1/customresourcedefinition.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1beta1/customresourcedefinition.go
@@ -61,13 +61,25 @@ func NewFilteredCustomResourceDefinitionInformer(client clientset.Interface, res
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ApiextensionsV1beta1().CustomResourceDefinitions().List(context.TODO(), options)
+				return client.ApiextensionsV1beta1().CustomResourceDefinitions().List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ApiextensionsV1beta1().CustomResourceDefinitions().Watch(context.TODO(), options)
+				return client.ApiextensionsV1beta1().CustomResourceDefinitions().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.ApiextensionsV1beta1().CustomResourceDefinitions().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.ApiextensionsV1beta1().CustomResourceDefinitions().Watch(ctx, options)
 			},
 		},
 		&apisapiextensionsv1beta1.CustomResourceDefinition{},

--- a/staging/src/k8s.io/apimachinery/pkg/watch/streamwatcher_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/watch/streamwatcher_test.go
@@ -64,6 +64,7 @@ func TestStreamWatcher(t *testing.T) {
 	}
 
 	fd := fakeDecoder{items: make(chan Event, 5)}
+	//nolint:logcheck // Intentionally uses the old API.
 	sw := NewStreamWatcher(fd, nil)
 
 	for _, item := range table {
@@ -87,6 +88,7 @@ func TestStreamWatcher(t *testing.T) {
 func TestStreamWatcherError(t *testing.T) {
 	fd := fakeDecoder{err: fmt.Errorf("test error")}
 	fr := &fakeReporter{}
+	//nolint:logcheck // Intentionally uses the old API.
 	sw := NewStreamWatcher(fd, fr)
 	evt, ok := <-sw.ResultChan()
 	if !ok {
@@ -110,6 +112,7 @@ func TestStreamWatcherError(t *testing.T) {
 func TestStreamWatcherRace(t *testing.T) {
 	fd := fakeDecoder{err: fmt.Errorf("test error")}
 	fr := &fakeReporter{}
+	//nolint:logcheck // Intentionally uses the old API.
 	sw := NewStreamWatcher(fd, fr)
 	time.Sleep(10 * time.Millisecond)
 	sw.Stop()

--- a/staging/src/k8s.io/client-go/dynamic/dynamicinformer/informer.go
+++ b/staging/src/k8s.io/client-go/dynamic/dynamicinformer/informer.go
@@ -153,13 +153,25 @@ func NewFilteredDynamicInformer(client dynamic.Interface, gvr schema.GroupVersio
 					if tweakListOptions != nil {
 						tweakListOptions(&options)
 					}
-					return client.Resource(gvr).Namespace(namespace).List(context.TODO(), options)
+					return client.Resource(gvr).Namespace(namespace).List(context.Background(), options)
 				},
 				WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 					if tweakListOptions != nil {
 						tweakListOptions(&options)
 					}
-					return client.Resource(gvr).Namespace(namespace).Watch(context.TODO(), options)
+					return client.Resource(gvr).Namespace(namespace).Watch(context.Background(), options)
+				},
+				ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+					if tweakListOptions != nil {
+						tweakListOptions(&options)
+					}
+					return client.Resource(gvr).Namespace(namespace).List(ctx, options)
+				},
+				WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+					if tweakListOptions != nil {
+						tweakListOptions(&options)
+					}
+					return client.Resource(gvr).Namespace(namespace).Watch(ctx, options)
 				},
 			},
 			&unstructured.Unstructured{},

--- a/staging/src/k8s.io/client-go/informers/admissionregistration/v1/mutatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/informers/admissionregistration/v1/mutatingwebhookconfiguration.go
@@ -61,13 +61,25 @@ func NewFilteredMutatingWebhookConfigurationInformer(client kubernetes.Interface
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AdmissionregistrationV1().MutatingWebhookConfigurations().List(context.TODO(), options)
+				return client.AdmissionregistrationV1().MutatingWebhookConfigurations().List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AdmissionregistrationV1().MutatingWebhookConfigurations().Watch(context.TODO(), options)
+				return client.AdmissionregistrationV1().MutatingWebhookConfigurations().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.AdmissionregistrationV1().MutatingWebhookConfigurations().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.AdmissionregistrationV1().MutatingWebhookConfigurations().Watch(ctx, options)
 			},
 		},
 		&apiadmissionregistrationv1.MutatingWebhookConfiguration{},

--- a/staging/src/k8s.io/client-go/informers/admissionregistration/v1/validatingadmissionpolicy.go
+++ b/staging/src/k8s.io/client-go/informers/admissionregistration/v1/validatingadmissionpolicy.go
@@ -61,13 +61,25 @@ func NewFilteredValidatingAdmissionPolicyInformer(client kubernetes.Interface, r
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AdmissionregistrationV1().ValidatingAdmissionPolicies().List(context.TODO(), options)
+				return client.AdmissionregistrationV1().ValidatingAdmissionPolicies().List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AdmissionregistrationV1().ValidatingAdmissionPolicies().Watch(context.TODO(), options)
+				return client.AdmissionregistrationV1().ValidatingAdmissionPolicies().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.AdmissionregistrationV1().ValidatingAdmissionPolicies().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.AdmissionregistrationV1().ValidatingAdmissionPolicies().Watch(ctx, options)
 			},
 		},
 		&apiadmissionregistrationv1.ValidatingAdmissionPolicy{},

--- a/staging/src/k8s.io/client-go/informers/admissionregistration/v1/validatingadmissionpolicybinding.go
+++ b/staging/src/k8s.io/client-go/informers/admissionregistration/v1/validatingadmissionpolicybinding.go
@@ -61,13 +61,25 @@ func NewFilteredValidatingAdmissionPolicyBindingInformer(client kubernetes.Inter
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AdmissionregistrationV1().ValidatingAdmissionPolicyBindings().List(context.TODO(), options)
+				return client.AdmissionregistrationV1().ValidatingAdmissionPolicyBindings().List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AdmissionregistrationV1().ValidatingAdmissionPolicyBindings().Watch(context.TODO(), options)
+				return client.AdmissionregistrationV1().ValidatingAdmissionPolicyBindings().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.AdmissionregistrationV1().ValidatingAdmissionPolicyBindings().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.AdmissionregistrationV1().ValidatingAdmissionPolicyBindings().Watch(ctx, options)
 			},
 		},
 		&apiadmissionregistrationv1.ValidatingAdmissionPolicyBinding{},

--- a/staging/src/k8s.io/client-go/informers/admissionregistration/v1/validatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/informers/admissionregistration/v1/validatingwebhookconfiguration.go
@@ -61,13 +61,25 @@ func NewFilteredValidatingWebhookConfigurationInformer(client kubernetes.Interfa
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AdmissionregistrationV1().ValidatingWebhookConfigurations().List(context.TODO(), options)
+				return client.AdmissionregistrationV1().ValidatingWebhookConfigurations().List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AdmissionregistrationV1().ValidatingWebhookConfigurations().Watch(context.TODO(), options)
+				return client.AdmissionregistrationV1().ValidatingWebhookConfigurations().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.AdmissionregistrationV1().ValidatingWebhookConfigurations().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.AdmissionregistrationV1().ValidatingWebhookConfigurations().Watch(ctx, options)
 			},
 		},
 		&apiadmissionregistrationv1.ValidatingWebhookConfiguration{},

--- a/staging/src/k8s.io/client-go/informers/admissionregistration/v1alpha1/mutatingadmissionpolicy.go
+++ b/staging/src/k8s.io/client-go/informers/admissionregistration/v1alpha1/mutatingadmissionpolicy.go
@@ -61,13 +61,25 @@ func NewFilteredMutatingAdmissionPolicyInformer(client kubernetes.Interface, res
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AdmissionregistrationV1alpha1().MutatingAdmissionPolicies().List(context.TODO(), options)
+				return client.AdmissionregistrationV1alpha1().MutatingAdmissionPolicies().List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AdmissionregistrationV1alpha1().MutatingAdmissionPolicies().Watch(context.TODO(), options)
+				return client.AdmissionregistrationV1alpha1().MutatingAdmissionPolicies().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.AdmissionregistrationV1alpha1().MutatingAdmissionPolicies().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.AdmissionregistrationV1alpha1().MutatingAdmissionPolicies().Watch(ctx, options)
 			},
 		},
 		&apiadmissionregistrationv1alpha1.MutatingAdmissionPolicy{},

--- a/staging/src/k8s.io/client-go/informers/admissionregistration/v1alpha1/mutatingadmissionpolicybinding.go
+++ b/staging/src/k8s.io/client-go/informers/admissionregistration/v1alpha1/mutatingadmissionpolicybinding.go
@@ -61,13 +61,25 @@ func NewFilteredMutatingAdmissionPolicyBindingInformer(client kubernetes.Interfa
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AdmissionregistrationV1alpha1().MutatingAdmissionPolicyBindings().List(context.TODO(), options)
+				return client.AdmissionregistrationV1alpha1().MutatingAdmissionPolicyBindings().List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AdmissionregistrationV1alpha1().MutatingAdmissionPolicyBindings().Watch(context.TODO(), options)
+				return client.AdmissionregistrationV1alpha1().MutatingAdmissionPolicyBindings().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.AdmissionregistrationV1alpha1().MutatingAdmissionPolicyBindings().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.AdmissionregistrationV1alpha1().MutatingAdmissionPolicyBindings().Watch(ctx, options)
 			},
 		},
 		&apiadmissionregistrationv1alpha1.MutatingAdmissionPolicyBinding{},

--- a/staging/src/k8s.io/client-go/informers/admissionregistration/v1alpha1/validatingadmissionpolicy.go
+++ b/staging/src/k8s.io/client-go/informers/admissionregistration/v1alpha1/validatingadmissionpolicy.go
@@ -61,13 +61,25 @@ func NewFilteredValidatingAdmissionPolicyInformer(client kubernetes.Interface, r
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AdmissionregistrationV1alpha1().ValidatingAdmissionPolicies().List(context.TODO(), options)
+				return client.AdmissionregistrationV1alpha1().ValidatingAdmissionPolicies().List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AdmissionregistrationV1alpha1().ValidatingAdmissionPolicies().Watch(context.TODO(), options)
+				return client.AdmissionregistrationV1alpha1().ValidatingAdmissionPolicies().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.AdmissionregistrationV1alpha1().ValidatingAdmissionPolicies().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.AdmissionregistrationV1alpha1().ValidatingAdmissionPolicies().Watch(ctx, options)
 			},
 		},
 		&apiadmissionregistrationv1alpha1.ValidatingAdmissionPolicy{},

--- a/staging/src/k8s.io/client-go/informers/admissionregistration/v1alpha1/validatingadmissionpolicybinding.go
+++ b/staging/src/k8s.io/client-go/informers/admissionregistration/v1alpha1/validatingadmissionpolicybinding.go
@@ -61,13 +61,25 @@ func NewFilteredValidatingAdmissionPolicyBindingInformer(client kubernetes.Inter
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AdmissionregistrationV1alpha1().ValidatingAdmissionPolicyBindings().List(context.TODO(), options)
+				return client.AdmissionregistrationV1alpha1().ValidatingAdmissionPolicyBindings().List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AdmissionregistrationV1alpha1().ValidatingAdmissionPolicyBindings().Watch(context.TODO(), options)
+				return client.AdmissionregistrationV1alpha1().ValidatingAdmissionPolicyBindings().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.AdmissionregistrationV1alpha1().ValidatingAdmissionPolicyBindings().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.AdmissionregistrationV1alpha1().ValidatingAdmissionPolicyBindings().Watch(ctx, options)
 			},
 		},
 		&apiadmissionregistrationv1alpha1.ValidatingAdmissionPolicyBinding{},

--- a/staging/src/k8s.io/client-go/informers/admissionregistration/v1beta1/mutatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/informers/admissionregistration/v1beta1/mutatingwebhookconfiguration.go
@@ -61,13 +61,25 @@ func NewFilteredMutatingWebhookConfigurationInformer(client kubernetes.Interface
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().List(context.TODO(), options)
+				return client.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Watch(context.TODO(), options)
+				return client.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Watch(ctx, options)
 			},
 		},
 		&apiadmissionregistrationv1beta1.MutatingWebhookConfiguration{},

--- a/staging/src/k8s.io/client-go/informers/admissionregistration/v1beta1/validatingadmissionpolicy.go
+++ b/staging/src/k8s.io/client-go/informers/admissionregistration/v1beta1/validatingadmissionpolicy.go
@@ -61,13 +61,25 @@ func NewFilteredValidatingAdmissionPolicyInformer(client kubernetes.Interface, r
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AdmissionregistrationV1beta1().ValidatingAdmissionPolicies().List(context.TODO(), options)
+				return client.AdmissionregistrationV1beta1().ValidatingAdmissionPolicies().List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AdmissionregistrationV1beta1().ValidatingAdmissionPolicies().Watch(context.TODO(), options)
+				return client.AdmissionregistrationV1beta1().ValidatingAdmissionPolicies().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.AdmissionregistrationV1beta1().ValidatingAdmissionPolicies().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.AdmissionregistrationV1beta1().ValidatingAdmissionPolicies().Watch(ctx, options)
 			},
 		},
 		&apiadmissionregistrationv1beta1.ValidatingAdmissionPolicy{},

--- a/staging/src/k8s.io/client-go/informers/admissionregistration/v1beta1/validatingadmissionpolicybinding.go
+++ b/staging/src/k8s.io/client-go/informers/admissionregistration/v1beta1/validatingadmissionpolicybinding.go
@@ -61,13 +61,25 @@ func NewFilteredValidatingAdmissionPolicyBindingInformer(client kubernetes.Inter
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AdmissionregistrationV1beta1().ValidatingAdmissionPolicyBindings().List(context.TODO(), options)
+				return client.AdmissionregistrationV1beta1().ValidatingAdmissionPolicyBindings().List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AdmissionregistrationV1beta1().ValidatingAdmissionPolicyBindings().Watch(context.TODO(), options)
+				return client.AdmissionregistrationV1beta1().ValidatingAdmissionPolicyBindings().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.AdmissionregistrationV1beta1().ValidatingAdmissionPolicyBindings().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.AdmissionregistrationV1beta1().ValidatingAdmissionPolicyBindings().Watch(ctx, options)
 			},
 		},
 		&apiadmissionregistrationv1beta1.ValidatingAdmissionPolicyBinding{},

--- a/staging/src/k8s.io/client-go/informers/admissionregistration/v1beta1/validatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/informers/admissionregistration/v1beta1/validatingwebhookconfiguration.go
@@ -61,13 +61,25 @@ func NewFilteredValidatingWebhookConfigurationInformer(client kubernetes.Interfa
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().List(context.TODO(), options)
+				return client.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().Watch(context.TODO(), options)
+				return client.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().Watch(ctx, options)
 			},
 		},
 		&apiadmissionregistrationv1beta1.ValidatingWebhookConfiguration{},

--- a/staging/src/k8s.io/client-go/informers/apiserverinternal/v1alpha1/storageversion.go
+++ b/staging/src/k8s.io/client-go/informers/apiserverinternal/v1alpha1/storageversion.go
@@ -61,13 +61,25 @@ func NewFilteredStorageVersionInformer(client kubernetes.Interface, resyncPeriod
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.InternalV1alpha1().StorageVersions().List(context.TODO(), options)
+				return client.InternalV1alpha1().StorageVersions().List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.InternalV1alpha1().StorageVersions().Watch(context.TODO(), options)
+				return client.InternalV1alpha1().StorageVersions().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.InternalV1alpha1().StorageVersions().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.InternalV1alpha1().StorageVersions().Watch(ctx, options)
 			},
 		},
 		&apiapiserverinternalv1alpha1.StorageVersion{},

--- a/staging/src/k8s.io/client-go/informers/apps/v1/controllerrevision.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1/controllerrevision.go
@@ -62,13 +62,25 @@ func NewFilteredControllerRevisionInformer(client kubernetes.Interface, namespac
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AppsV1().ControllerRevisions(namespace).List(context.TODO(), options)
+				return client.AppsV1().ControllerRevisions(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AppsV1().ControllerRevisions(namespace).Watch(context.TODO(), options)
+				return client.AppsV1().ControllerRevisions(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.AppsV1().ControllerRevisions(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.AppsV1().ControllerRevisions(namespace).Watch(ctx, options)
 			},
 		},
 		&apiappsv1.ControllerRevision{},

--- a/staging/src/k8s.io/client-go/informers/apps/v1/daemonset.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1/daemonset.go
@@ -62,13 +62,25 @@ func NewFilteredDaemonSetInformer(client kubernetes.Interface, namespace string,
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AppsV1().DaemonSets(namespace).List(context.TODO(), options)
+				return client.AppsV1().DaemonSets(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AppsV1().DaemonSets(namespace).Watch(context.TODO(), options)
+				return client.AppsV1().DaemonSets(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.AppsV1().DaemonSets(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.AppsV1().DaemonSets(namespace).Watch(ctx, options)
 			},
 		},
 		&apiappsv1.DaemonSet{},

--- a/staging/src/k8s.io/client-go/informers/apps/v1/deployment.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1/deployment.go
@@ -62,13 +62,25 @@ func NewFilteredDeploymentInformer(client kubernetes.Interface, namespace string
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AppsV1().Deployments(namespace).List(context.TODO(), options)
+				return client.AppsV1().Deployments(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AppsV1().Deployments(namespace).Watch(context.TODO(), options)
+				return client.AppsV1().Deployments(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.AppsV1().Deployments(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.AppsV1().Deployments(namespace).Watch(ctx, options)
 			},
 		},
 		&apiappsv1.Deployment{},

--- a/staging/src/k8s.io/client-go/informers/apps/v1/replicaset.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1/replicaset.go
@@ -62,13 +62,25 @@ func NewFilteredReplicaSetInformer(client kubernetes.Interface, namespace string
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AppsV1().ReplicaSets(namespace).List(context.TODO(), options)
+				return client.AppsV1().ReplicaSets(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AppsV1().ReplicaSets(namespace).Watch(context.TODO(), options)
+				return client.AppsV1().ReplicaSets(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.AppsV1().ReplicaSets(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.AppsV1().ReplicaSets(namespace).Watch(ctx, options)
 			},
 		},
 		&apiappsv1.ReplicaSet{},

--- a/staging/src/k8s.io/client-go/informers/apps/v1/statefulset.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1/statefulset.go
@@ -62,13 +62,25 @@ func NewFilteredStatefulSetInformer(client kubernetes.Interface, namespace strin
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AppsV1().StatefulSets(namespace).List(context.TODO(), options)
+				return client.AppsV1().StatefulSets(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AppsV1().StatefulSets(namespace).Watch(context.TODO(), options)
+				return client.AppsV1().StatefulSets(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.AppsV1().StatefulSets(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.AppsV1().StatefulSets(namespace).Watch(ctx, options)
 			},
 		},
 		&apiappsv1.StatefulSet{},

--- a/staging/src/k8s.io/client-go/informers/apps/v1beta1/controllerrevision.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1beta1/controllerrevision.go
@@ -62,13 +62,25 @@ func NewFilteredControllerRevisionInformer(client kubernetes.Interface, namespac
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AppsV1beta1().ControllerRevisions(namespace).List(context.TODO(), options)
+				return client.AppsV1beta1().ControllerRevisions(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AppsV1beta1().ControllerRevisions(namespace).Watch(context.TODO(), options)
+				return client.AppsV1beta1().ControllerRevisions(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.AppsV1beta1().ControllerRevisions(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.AppsV1beta1().ControllerRevisions(namespace).Watch(ctx, options)
 			},
 		},
 		&apiappsv1beta1.ControllerRevision{},

--- a/staging/src/k8s.io/client-go/informers/apps/v1beta1/deployment.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1beta1/deployment.go
@@ -62,13 +62,25 @@ func NewFilteredDeploymentInformer(client kubernetes.Interface, namespace string
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AppsV1beta1().Deployments(namespace).List(context.TODO(), options)
+				return client.AppsV1beta1().Deployments(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AppsV1beta1().Deployments(namespace).Watch(context.TODO(), options)
+				return client.AppsV1beta1().Deployments(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.AppsV1beta1().Deployments(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.AppsV1beta1().Deployments(namespace).Watch(ctx, options)
 			},
 		},
 		&apiappsv1beta1.Deployment{},

--- a/staging/src/k8s.io/client-go/informers/apps/v1beta1/statefulset.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1beta1/statefulset.go
@@ -62,13 +62,25 @@ func NewFilteredStatefulSetInformer(client kubernetes.Interface, namespace strin
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AppsV1beta1().StatefulSets(namespace).List(context.TODO(), options)
+				return client.AppsV1beta1().StatefulSets(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AppsV1beta1().StatefulSets(namespace).Watch(context.TODO(), options)
+				return client.AppsV1beta1().StatefulSets(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.AppsV1beta1().StatefulSets(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.AppsV1beta1().StatefulSets(namespace).Watch(ctx, options)
 			},
 		},
 		&apiappsv1beta1.StatefulSet{},

--- a/staging/src/k8s.io/client-go/informers/apps/v1beta2/controllerrevision.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1beta2/controllerrevision.go
@@ -62,13 +62,25 @@ func NewFilteredControllerRevisionInformer(client kubernetes.Interface, namespac
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AppsV1beta2().ControllerRevisions(namespace).List(context.TODO(), options)
+				return client.AppsV1beta2().ControllerRevisions(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AppsV1beta2().ControllerRevisions(namespace).Watch(context.TODO(), options)
+				return client.AppsV1beta2().ControllerRevisions(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.AppsV1beta2().ControllerRevisions(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.AppsV1beta2().ControllerRevisions(namespace).Watch(ctx, options)
 			},
 		},
 		&apiappsv1beta2.ControllerRevision{},

--- a/staging/src/k8s.io/client-go/informers/apps/v1beta2/daemonset.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1beta2/daemonset.go
@@ -62,13 +62,25 @@ func NewFilteredDaemonSetInformer(client kubernetes.Interface, namespace string,
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AppsV1beta2().DaemonSets(namespace).List(context.TODO(), options)
+				return client.AppsV1beta2().DaemonSets(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AppsV1beta2().DaemonSets(namespace).Watch(context.TODO(), options)
+				return client.AppsV1beta2().DaemonSets(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.AppsV1beta2().DaemonSets(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.AppsV1beta2().DaemonSets(namespace).Watch(ctx, options)
 			},
 		},
 		&apiappsv1beta2.DaemonSet{},

--- a/staging/src/k8s.io/client-go/informers/apps/v1beta2/deployment.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1beta2/deployment.go
@@ -62,13 +62,25 @@ func NewFilteredDeploymentInformer(client kubernetes.Interface, namespace string
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AppsV1beta2().Deployments(namespace).List(context.TODO(), options)
+				return client.AppsV1beta2().Deployments(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AppsV1beta2().Deployments(namespace).Watch(context.TODO(), options)
+				return client.AppsV1beta2().Deployments(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.AppsV1beta2().Deployments(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.AppsV1beta2().Deployments(namespace).Watch(ctx, options)
 			},
 		},
 		&apiappsv1beta2.Deployment{},

--- a/staging/src/k8s.io/client-go/informers/apps/v1beta2/replicaset.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1beta2/replicaset.go
@@ -62,13 +62,25 @@ func NewFilteredReplicaSetInformer(client kubernetes.Interface, namespace string
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AppsV1beta2().ReplicaSets(namespace).List(context.TODO(), options)
+				return client.AppsV1beta2().ReplicaSets(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AppsV1beta2().ReplicaSets(namespace).Watch(context.TODO(), options)
+				return client.AppsV1beta2().ReplicaSets(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.AppsV1beta2().ReplicaSets(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.AppsV1beta2().ReplicaSets(namespace).Watch(ctx, options)
 			},
 		},
 		&apiappsv1beta2.ReplicaSet{},

--- a/staging/src/k8s.io/client-go/informers/apps/v1beta2/statefulset.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1beta2/statefulset.go
@@ -62,13 +62,25 @@ func NewFilteredStatefulSetInformer(client kubernetes.Interface, namespace strin
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AppsV1beta2().StatefulSets(namespace).List(context.TODO(), options)
+				return client.AppsV1beta2().StatefulSets(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AppsV1beta2().StatefulSets(namespace).Watch(context.TODO(), options)
+				return client.AppsV1beta2().StatefulSets(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.AppsV1beta2().StatefulSets(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.AppsV1beta2().StatefulSets(namespace).Watch(ctx, options)
 			},
 		},
 		&apiappsv1beta2.StatefulSet{},

--- a/staging/src/k8s.io/client-go/informers/autoscaling/v1/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/informers/autoscaling/v1/horizontalpodautoscaler.go
@@ -62,13 +62,25 @@ func NewFilteredHorizontalPodAutoscalerInformer(client kubernetes.Interface, nam
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AutoscalingV1().HorizontalPodAutoscalers(namespace).List(context.TODO(), options)
+				return client.AutoscalingV1().HorizontalPodAutoscalers(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AutoscalingV1().HorizontalPodAutoscalers(namespace).Watch(context.TODO(), options)
+				return client.AutoscalingV1().HorizontalPodAutoscalers(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.AutoscalingV1().HorizontalPodAutoscalers(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.AutoscalingV1().HorizontalPodAutoscalers(namespace).Watch(ctx, options)
 			},
 		},
 		&apiautoscalingv1.HorizontalPodAutoscaler{},

--- a/staging/src/k8s.io/client-go/informers/autoscaling/v2/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/informers/autoscaling/v2/horizontalpodautoscaler.go
@@ -62,13 +62,25 @@ func NewFilteredHorizontalPodAutoscalerInformer(client kubernetes.Interface, nam
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AutoscalingV2().HorizontalPodAutoscalers(namespace).List(context.TODO(), options)
+				return client.AutoscalingV2().HorizontalPodAutoscalers(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AutoscalingV2().HorizontalPodAutoscalers(namespace).Watch(context.TODO(), options)
+				return client.AutoscalingV2().HorizontalPodAutoscalers(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.AutoscalingV2().HorizontalPodAutoscalers(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.AutoscalingV2().HorizontalPodAutoscalers(namespace).Watch(ctx, options)
 			},
 		},
 		&apiautoscalingv2.HorizontalPodAutoscaler{},

--- a/staging/src/k8s.io/client-go/informers/autoscaling/v2beta1/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/informers/autoscaling/v2beta1/horizontalpodautoscaler.go
@@ -62,13 +62,25 @@ func NewFilteredHorizontalPodAutoscalerInformer(client kubernetes.Interface, nam
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AutoscalingV2beta1().HorizontalPodAutoscalers(namespace).List(context.TODO(), options)
+				return client.AutoscalingV2beta1().HorizontalPodAutoscalers(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AutoscalingV2beta1().HorizontalPodAutoscalers(namespace).Watch(context.TODO(), options)
+				return client.AutoscalingV2beta1().HorizontalPodAutoscalers(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.AutoscalingV2beta1().HorizontalPodAutoscalers(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.AutoscalingV2beta1().HorizontalPodAutoscalers(namespace).Watch(ctx, options)
 			},
 		},
 		&apiautoscalingv2beta1.HorizontalPodAutoscaler{},

--- a/staging/src/k8s.io/client-go/informers/autoscaling/v2beta2/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/informers/autoscaling/v2beta2/horizontalpodautoscaler.go
@@ -62,13 +62,25 @@ func NewFilteredHorizontalPodAutoscalerInformer(client kubernetes.Interface, nam
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AutoscalingV2beta2().HorizontalPodAutoscalers(namespace).List(context.TODO(), options)
+				return client.AutoscalingV2beta2().HorizontalPodAutoscalers(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AutoscalingV2beta2().HorizontalPodAutoscalers(namespace).Watch(context.TODO(), options)
+				return client.AutoscalingV2beta2().HorizontalPodAutoscalers(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.AutoscalingV2beta2().HorizontalPodAutoscalers(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.AutoscalingV2beta2().HorizontalPodAutoscalers(namespace).Watch(ctx, options)
 			},
 		},
 		&apiautoscalingv2beta2.HorizontalPodAutoscaler{},

--- a/staging/src/k8s.io/client-go/informers/batch/v1/cronjob.go
+++ b/staging/src/k8s.io/client-go/informers/batch/v1/cronjob.go
@@ -62,13 +62,25 @@ func NewFilteredCronJobInformer(client kubernetes.Interface, namespace string, r
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.BatchV1().CronJobs(namespace).List(context.TODO(), options)
+				return client.BatchV1().CronJobs(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.BatchV1().CronJobs(namespace).Watch(context.TODO(), options)
+				return client.BatchV1().CronJobs(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.BatchV1().CronJobs(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.BatchV1().CronJobs(namespace).Watch(ctx, options)
 			},
 		},
 		&apibatchv1.CronJob{},

--- a/staging/src/k8s.io/client-go/informers/batch/v1/job.go
+++ b/staging/src/k8s.io/client-go/informers/batch/v1/job.go
@@ -62,13 +62,25 @@ func NewFilteredJobInformer(client kubernetes.Interface, namespace string, resyn
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.BatchV1().Jobs(namespace).List(context.TODO(), options)
+				return client.BatchV1().Jobs(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.BatchV1().Jobs(namespace).Watch(context.TODO(), options)
+				return client.BatchV1().Jobs(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.BatchV1().Jobs(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.BatchV1().Jobs(namespace).Watch(ctx, options)
 			},
 		},
 		&apibatchv1.Job{},

--- a/staging/src/k8s.io/client-go/informers/batch/v1beta1/cronjob.go
+++ b/staging/src/k8s.io/client-go/informers/batch/v1beta1/cronjob.go
@@ -62,13 +62,25 @@ func NewFilteredCronJobInformer(client kubernetes.Interface, namespace string, r
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.BatchV1beta1().CronJobs(namespace).List(context.TODO(), options)
+				return client.BatchV1beta1().CronJobs(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.BatchV1beta1().CronJobs(namespace).Watch(context.TODO(), options)
+				return client.BatchV1beta1().CronJobs(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.BatchV1beta1().CronJobs(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.BatchV1beta1().CronJobs(namespace).Watch(ctx, options)
 			},
 		},
 		&apibatchv1beta1.CronJob{},

--- a/staging/src/k8s.io/client-go/informers/certificates/v1/certificatesigningrequest.go
+++ b/staging/src/k8s.io/client-go/informers/certificates/v1/certificatesigningrequest.go
@@ -61,13 +61,25 @@ func NewFilteredCertificateSigningRequestInformer(client kubernetes.Interface, r
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CertificatesV1().CertificateSigningRequests().List(context.TODO(), options)
+				return client.CertificatesV1().CertificateSigningRequests().List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CertificatesV1().CertificateSigningRequests().Watch(context.TODO(), options)
+				return client.CertificatesV1().CertificateSigningRequests().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.CertificatesV1().CertificateSigningRequests().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.CertificatesV1().CertificateSigningRequests().Watch(ctx, options)
 			},
 		},
 		&apicertificatesv1.CertificateSigningRequest{},

--- a/staging/src/k8s.io/client-go/informers/certificates/v1alpha1/clustertrustbundle.go
+++ b/staging/src/k8s.io/client-go/informers/certificates/v1alpha1/clustertrustbundle.go
@@ -61,13 +61,25 @@ func NewFilteredClusterTrustBundleInformer(client kubernetes.Interface, resyncPe
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CertificatesV1alpha1().ClusterTrustBundles().List(context.TODO(), options)
+				return client.CertificatesV1alpha1().ClusterTrustBundles().List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CertificatesV1alpha1().ClusterTrustBundles().Watch(context.TODO(), options)
+				return client.CertificatesV1alpha1().ClusterTrustBundles().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.CertificatesV1alpha1().ClusterTrustBundles().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.CertificatesV1alpha1().ClusterTrustBundles().Watch(ctx, options)
 			},
 		},
 		&apicertificatesv1alpha1.ClusterTrustBundle{},

--- a/staging/src/k8s.io/client-go/informers/certificates/v1beta1/certificatesigningrequest.go
+++ b/staging/src/k8s.io/client-go/informers/certificates/v1beta1/certificatesigningrequest.go
@@ -61,13 +61,25 @@ func NewFilteredCertificateSigningRequestInformer(client kubernetes.Interface, r
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CertificatesV1beta1().CertificateSigningRequests().List(context.TODO(), options)
+				return client.CertificatesV1beta1().CertificateSigningRequests().List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CertificatesV1beta1().CertificateSigningRequests().Watch(context.TODO(), options)
+				return client.CertificatesV1beta1().CertificateSigningRequests().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.CertificatesV1beta1().CertificateSigningRequests().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.CertificatesV1beta1().CertificateSigningRequests().Watch(ctx, options)
 			},
 		},
 		&apicertificatesv1beta1.CertificateSigningRequest{},

--- a/staging/src/k8s.io/client-go/informers/coordination/v1/lease.go
+++ b/staging/src/k8s.io/client-go/informers/coordination/v1/lease.go
@@ -62,13 +62,25 @@ func NewFilteredLeaseInformer(client kubernetes.Interface, namespace string, res
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CoordinationV1().Leases(namespace).List(context.TODO(), options)
+				return client.CoordinationV1().Leases(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CoordinationV1().Leases(namespace).Watch(context.TODO(), options)
+				return client.CoordinationV1().Leases(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.CoordinationV1().Leases(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.CoordinationV1().Leases(namespace).Watch(ctx, options)
 			},
 		},
 		&apicoordinationv1.Lease{},

--- a/staging/src/k8s.io/client-go/informers/coordination/v1alpha2/leasecandidate.go
+++ b/staging/src/k8s.io/client-go/informers/coordination/v1alpha2/leasecandidate.go
@@ -62,13 +62,25 @@ func NewFilteredLeaseCandidateInformer(client kubernetes.Interface, namespace st
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CoordinationV1alpha2().LeaseCandidates(namespace).List(context.TODO(), options)
+				return client.CoordinationV1alpha2().LeaseCandidates(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CoordinationV1alpha2().LeaseCandidates(namespace).Watch(context.TODO(), options)
+				return client.CoordinationV1alpha2().LeaseCandidates(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.CoordinationV1alpha2().LeaseCandidates(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.CoordinationV1alpha2().LeaseCandidates(namespace).Watch(ctx, options)
 			},
 		},
 		&apicoordinationv1alpha2.LeaseCandidate{},

--- a/staging/src/k8s.io/client-go/informers/coordination/v1beta1/lease.go
+++ b/staging/src/k8s.io/client-go/informers/coordination/v1beta1/lease.go
@@ -62,13 +62,25 @@ func NewFilteredLeaseInformer(client kubernetes.Interface, namespace string, res
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CoordinationV1beta1().Leases(namespace).List(context.TODO(), options)
+				return client.CoordinationV1beta1().Leases(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CoordinationV1beta1().Leases(namespace).Watch(context.TODO(), options)
+				return client.CoordinationV1beta1().Leases(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.CoordinationV1beta1().Leases(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.CoordinationV1beta1().Leases(namespace).Watch(ctx, options)
 			},
 		},
 		&apicoordinationv1beta1.Lease{},

--- a/staging/src/k8s.io/client-go/informers/core/v1/componentstatus.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/componentstatus.go
@@ -61,13 +61,25 @@ func NewFilteredComponentStatusInformer(client kubernetes.Interface, resyncPerio
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CoreV1().ComponentStatuses().List(context.TODO(), options)
+				return client.CoreV1().ComponentStatuses().List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CoreV1().ComponentStatuses().Watch(context.TODO(), options)
+				return client.CoreV1().ComponentStatuses().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.CoreV1().ComponentStatuses().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.CoreV1().ComponentStatuses().Watch(ctx, options)
 			},
 		},
 		&apicorev1.ComponentStatus{},

--- a/staging/src/k8s.io/client-go/informers/core/v1/configmap.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/configmap.go
@@ -62,13 +62,25 @@ func NewFilteredConfigMapInformer(client kubernetes.Interface, namespace string,
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CoreV1().ConfigMaps(namespace).List(context.TODO(), options)
+				return client.CoreV1().ConfigMaps(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CoreV1().ConfigMaps(namespace).Watch(context.TODO(), options)
+				return client.CoreV1().ConfigMaps(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.CoreV1().ConfigMaps(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.CoreV1().ConfigMaps(namespace).Watch(ctx, options)
 			},
 		},
 		&apicorev1.ConfigMap{},

--- a/staging/src/k8s.io/client-go/informers/core/v1/endpoints.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/endpoints.go
@@ -62,13 +62,25 @@ func NewFilteredEndpointsInformer(client kubernetes.Interface, namespace string,
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CoreV1().Endpoints(namespace).List(context.TODO(), options)
+				return client.CoreV1().Endpoints(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CoreV1().Endpoints(namespace).Watch(context.TODO(), options)
+				return client.CoreV1().Endpoints(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.CoreV1().Endpoints(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.CoreV1().Endpoints(namespace).Watch(ctx, options)
 			},
 		},
 		&apicorev1.Endpoints{},

--- a/staging/src/k8s.io/client-go/informers/core/v1/event.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/event.go
@@ -62,13 +62,25 @@ func NewFilteredEventInformer(client kubernetes.Interface, namespace string, res
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CoreV1().Events(namespace).List(context.TODO(), options)
+				return client.CoreV1().Events(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CoreV1().Events(namespace).Watch(context.TODO(), options)
+				return client.CoreV1().Events(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.CoreV1().Events(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.CoreV1().Events(namespace).Watch(ctx, options)
 			},
 		},
 		&apicorev1.Event{},

--- a/staging/src/k8s.io/client-go/informers/core/v1/limitrange.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/limitrange.go
@@ -62,13 +62,25 @@ func NewFilteredLimitRangeInformer(client kubernetes.Interface, namespace string
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CoreV1().LimitRanges(namespace).List(context.TODO(), options)
+				return client.CoreV1().LimitRanges(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CoreV1().LimitRanges(namespace).Watch(context.TODO(), options)
+				return client.CoreV1().LimitRanges(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.CoreV1().LimitRanges(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.CoreV1().LimitRanges(namespace).Watch(ctx, options)
 			},
 		},
 		&apicorev1.LimitRange{},

--- a/staging/src/k8s.io/client-go/informers/core/v1/namespace.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/namespace.go
@@ -61,13 +61,25 @@ func NewFilteredNamespaceInformer(client kubernetes.Interface, resyncPeriod time
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CoreV1().Namespaces().List(context.TODO(), options)
+				return client.CoreV1().Namespaces().List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CoreV1().Namespaces().Watch(context.TODO(), options)
+				return client.CoreV1().Namespaces().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.CoreV1().Namespaces().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.CoreV1().Namespaces().Watch(ctx, options)
 			},
 		},
 		&apicorev1.Namespace{},

--- a/staging/src/k8s.io/client-go/informers/core/v1/node.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/node.go
@@ -61,13 +61,25 @@ func NewFilteredNodeInformer(client kubernetes.Interface, resyncPeriod time.Dura
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CoreV1().Nodes().List(context.TODO(), options)
+				return client.CoreV1().Nodes().List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CoreV1().Nodes().Watch(context.TODO(), options)
+				return client.CoreV1().Nodes().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.CoreV1().Nodes().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.CoreV1().Nodes().Watch(ctx, options)
 			},
 		},
 		&apicorev1.Node{},

--- a/staging/src/k8s.io/client-go/informers/core/v1/persistentvolume.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/persistentvolume.go
@@ -61,13 +61,25 @@ func NewFilteredPersistentVolumeInformer(client kubernetes.Interface, resyncPeri
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CoreV1().PersistentVolumes().List(context.TODO(), options)
+				return client.CoreV1().PersistentVolumes().List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CoreV1().PersistentVolumes().Watch(context.TODO(), options)
+				return client.CoreV1().PersistentVolumes().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.CoreV1().PersistentVolumes().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.CoreV1().PersistentVolumes().Watch(ctx, options)
 			},
 		},
 		&apicorev1.PersistentVolume{},

--- a/staging/src/k8s.io/client-go/informers/core/v1/persistentvolumeclaim.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/persistentvolumeclaim.go
@@ -62,13 +62,25 @@ func NewFilteredPersistentVolumeClaimInformer(client kubernetes.Interface, names
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CoreV1().PersistentVolumeClaims(namespace).List(context.TODO(), options)
+				return client.CoreV1().PersistentVolumeClaims(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CoreV1().PersistentVolumeClaims(namespace).Watch(context.TODO(), options)
+				return client.CoreV1().PersistentVolumeClaims(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.CoreV1().PersistentVolumeClaims(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.CoreV1().PersistentVolumeClaims(namespace).Watch(ctx, options)
 			},
 		},
 		&apicorev1.PersistentVolumeClaim{},

--- a/staging/src/k8s.io/client-go/informers/core/v1/pod.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/pod.go
@@ -62,13 +62,25 @@ func NewFilteredPodInformer(client kubernetes.Interface, namespace string, resyn
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CoreV1().Pods(namespace).List(context.TODO(), options)
+				return client.CoreV1().Pods(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CoreV1().Pods(namespace).Watch(context.TODO(), options)
+				return client.CoreV1().Pods(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.CoreV1().Pods(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.CoreV1().Pods(namespace).Watch(ctx, options)
 			},
 		},
 		&apicorev1.Pod{},

--- a/staging/src/k8s.io/client-go/informers/core/v1/podtemplate.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/podtemplate.go
@@ -62,13 +62,25 @@ func NewFilteredPodTemplateInformer(client kubernetes.Interface, namespace strin
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CoreV1().PodTemplates(namespace).List(context.TODO(), options)
+				return client.CoreV1().PodTemplates(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CoreV1().PodTemplates(namespace).Watch(context.TODO(), options)
+				return client.CoreV1().PodTemplates(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.CoreV1().PodTemplates(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.CoreV1().PodTemplates(namespace).Watch(ctx, options)
 			},
 		},
 		&apicorev1.PodTemplate{},

--- a/staging/src/k8s.io/client-go/informers/core/v1/replicationcontroller.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/replicationcontroller.go
@@ -62,13 +62,25 @@ func NewFilteredReplicationControllerInformer(client kubernetes.Interface, names
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CoreV1().ReplicationControllers(namespace).List(context.TODO(), options)
+				return client.CoreV1().ReplicationControllers(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CoreV1().ReplicationControllers(namespace).Watch(context.TODO(), options)
+				return client.CoreV1().ReplicationControllers(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.CoreV1().ReplicationControllers(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.CoreV1().ReplicationControllers(namespace).Watch(ctx, options)
 			},
 		},
 		&apicorev1.ReplicationController{},

--- a/staging/src/k8s.io/client-go/informers/core/v1/resourcequota.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/resourcequota.go
@@ -62,13 +62,25 @@ func NewFilteredResourceQuotaInformer(client kubernetes.Interface, namespace str
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CoreV1().ResourceQuotas(namespace).List(context.TODO(), options)
+				return client.CoreV1().ResourceQuotas(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CoreV1().ResourceQuotas(namespace).Watch(context.TODO(), options)
+				return client.CoreV1().ResourceQuotas(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.CoreV1().ResourceQuotas(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.CoreV1().ResourceQuotas(namespace).Watch(ctx, options)
 			},
 		},
 		&apicorev1.ResourceQuota{},

--- a/staging/src/k8s.io/client-go/informers/core/v1/secret.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/secret.go
@@ -62,13 +62,25 @@ func NewFilteredSecretInformer(client kubernetes.Interface, namespace string, re
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CoreV1().Secrets(namespace).List(context.TODO(), options)
+				return client.CoreV1().Secrets(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CoreV1().Secrets(namespace).Watch(context.TODO(), options)
+				return client.CoreV1().Secrets(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.CoreV1().Secrets(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.CoreV1().Secrets(namespace).Watch(ctx, options)
 			},
 		},
 		&apicorev1.Secret{},

--- a/staging/src/k8s.io/client-go/informers/core/v1/service.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/service.go
@@ -62,13 +62,25 @@ func NewFilteredServiceInformer(client kubernetes.Interface, namespace string, r
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CoreV1().Services(namespace).List(context.TODO(), options)
+				return client.CoreV1().Services(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CoreV1().Services(namespace).Watch(context.TODO(), options)
+				return client.CoreV1().Services(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.CoreV1().Services(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.CoreV1().Services(namespace).Watch(ctx, options)
 			},
 		},
 		&apicorev1.Service{},

--- a/staging/src/k8s.io/client-go/informers/core/v1/serviceaccount.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/serviceaccount.go
@@ -62,13 +62,25 @@ func NewFilteredServiceAccountInformer(client kubernetes.Interface, namespace st
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CoreV1().ServiceAccounts(namespace).List(context.TODO(), options)
+				return client.CoreV1().ServiceAccounts(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CoreV1().ServiceAccounts(namespace).Watch(context.TODO(), options)
+				return client.CoreV1().ServiceAccounts(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.CoreV1().ServiceAccounts(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.CoreV1().ServiceAccounts(namespace).Watch(ctx, options)
 			},
 		},
 		&apicorev1.ServiceAccount{},

--- a/staging/src/k8s.io/client-go/informers/discovery/v1/endpointslice.go
+++ b/staging/src/k8s.io/client-go/informers/discovery/v1/endpointslice.go
@@ -62,13 +62,25 @@ func NewFilteredEndpointSliceInformer(client kubernetes.Interface, namespace str
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.DiscoveryV1().EndpointSlices(namespace).List(context.TODO(), options)
+				return client.DiscoveryV1().EndpointSlices(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.DiscoveryV1().EndpointSlices(namespace).Watch(context.TODO(), options)
+				return client.DiscoveryV1().EndpointSlices(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.DiscoveryV1().EndpointSlices(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.DiscoveryV1().EndpointSlices(namespace).Watch(ctx, options)
 			},
 		},
 		&apidiscoveryv1.EndpointSlice{},

--- a/staging/src/k8s.io/client-go/informers/discovery/v1beta1/endpointslice.go
+++ b/staging/src/k8s.io/client-go/informers/discovery/v1beta1/endpointslice.go
@@ -62,13 +62,25 @@ func NewFilteredEndpointSliceInformer(client kubernetes.Interface, namespace str
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.DiscoveryV1beta1().EndpointSlices(namespace).List(context.TODO(), options)
+				return client.DiscoveryV1beta1().EndpointSlices(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.DiscoveryV1beta1().EndpointSlices(namespace).Watch(context.TODO(), options)
+				return client.DiscoveryV1beta1().EndpointSlices(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.DiscoveryV1beta1().EndpointSlices(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.DiscoveryV1beta1().EndpointSlices(namespace).Watch(ctx, options)
 			},
 		},
 		&apidiscoveryv1beta1.EndpointSlice{},

--- a/staging/src/k8s.io/client-go/informers/events/v1/event.go
+++ b/staging/src/k8s.io/client-go/informers/events/v1/event.go
@@ -62,13 +62,25 @@ func NewFilteredEventInformer(client kubernetes.Interface, namespace string, res
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.EventsV1().Events(namespace).List(context.TODO(), options)
+				return client.EventsV1().Events(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.EventsV1().Events(namespace).Watch(context.TODO(), options)
+				return client.EventsV1().Events(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.EventsV1().Events(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.EventsV1().Events(namespace).Watch(ctx, options)
 			},
 		},
 		&apieventsv1.Event{},

--- a/staging/src/k8s.io/client-go/informers/events/v1beta1/event.go
+++ b/staging/src/k8s.io/client-go/informers/events/v1beta1/event.go
@@ -62,13 +62,25 @@ func NewFilteredEventInformer(client kubernetes.Interface, namespace string, res
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.EventsV1beta1().Events(namespace).List(context.TODO(), options)
+				return client.EventsV1beta1().Events(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.EventsV1beta1().Events(namespace).Watch(context.TODO(), options)
+				return client.EventsV1beta1().Events(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.EventsV1beta1().Events(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.EventsV1beta1().Events(namespace).Watch(ctx, options)
 			},
 		},
 		&apieventsv1beta1.Event{},

--- a/staging/src/k8s.io/client-go/informers/extensions/v1beta1/daemonset.go
+++ b/staging/src/k8s.io/client-go/informers/extensions/v1beta1/daemonset.go
@@ -62,13 +62,25 @@ func NewFilteredDaemonSetInformer(client kubernetes.Interface, namespace string,
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ExtensionsV1beta1().DaemonSets(namespace).List(context.TODO(), options)
+				return client.ExtensionsV1beta1().DaemonSets(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ExtensionsV1beta1().DaemonSets(namespace).Watch(context.TODO(), options)
+				return client.ExtensionsV1beta1().DaemonSets(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.ExtensionsV1beta1().DaemonSets(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.ExtensionsV1beta1().DaemonSets(namespace).Watch(ctx, options)
 			},
 		},
 		&apiextensionsv1beta1.DaemonSet{},

--- a/staging/src/k8s.io/client-go/informers/extensions/v1beta1/deployment.go
+++ b/staging/src/k8s.io/client-go/informers/extensions/v1beta1/deployment.go
@@ -62,13 +62,25 @@ func NewFilteredDeploymentInformer(client kubernetes.Interface, namespace string
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ExtensionsV1beta1().Deployments(namespace).List(context.TODO(), options)
+				return client.ExtensionsV1beta1().Deployments(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ExtensionsV1beta1().Deployments(namespace).Watch(context.TODO(), options)
+				return client.ExtensionsV1beta1().Deployments(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.ExtensionsV1beta1().Deployments(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.ExtensionsV1beta1().Deployments(namespace).Watch(ctx, options)
 			},
 		},
 		&apiextensionsv1beta1.Deployment{},

--- a/staging/src/k8s.io/client-go/informers/extensions/v1beta1/ingress.go
+++ b/staging/src/k8s.io/client-go/informers/extensions/v1beta1/ingress.go
@@ -62,13 +62,25 @@ func NewFilteredIngressInformer(client kubernetes.Interface, namespace string, r
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ExtensionsV1beta1().Ingresses(namespace).List(context.TODO(), options)
+				return client.ExtensionsV1beta1().Ingresses(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ExtensionsV1beta1().Ingresses(namespace).Watch(context.TODO(), options)
+				return client.ExtensionsV1beta1().Ingresses(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.ExtensionsV1beta1().Ingresses(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.ExtensionsV1beta1().Ingresses(namespace).Watch(ctx, options)
 			},
 		},
 		&apiextensionsv1beta1.Ingress{},

--- a/staging/src/k8s.io/client-go/informers/extensions/v1beta1/networkpolicy.go
+++ b/staging/src/k8s.io/client-go/informers/extensions/v1beta1/networkpolicy.go
@@ -62,13 +62,25 @@ func NewFilteredNetworkPolicyInformer(client kubernetes.Interface, namespace str
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ExtensionsV1beta1().NetworkPolicies(namespace).List(context.TODO(), options)
+				return client.ExtensionsV1beta1().NetworkPolicies(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ExtensionsV1beta1().NetworkPolicies(namespace).Watch(context.TODO(), options)
+				return client.ExtensionsV1beta1().NetworkPolicies(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.ExtensionsV1beta1().NetworkPolicies(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.ExtensionsV1beta1().NetworkPolicies(namespace).Watch(ctx, options)
 			},
 		},
 		&apiextensionsv1beta1.NetworkPolicy{},

--- a/staging/src/k8s.io/client-go/informers/extensions/v1beta1/replicaset.go
+++ b/staging/src/k8s.io/client-go/informers/extensions/v1beta1/replicaset.go
@@ -62,13 +62,25 @@ func NewFilteredReplicaSetInformer(client kubernetes.Interface, namespace string
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ExtensionsV1beta1().ReplicaSets(namespace).List(context.TODO(), options)
+				return client.ExtensionsV1beta1().ReplicaSets(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ExtensionsV1beta1().ReplicaSets(namespace).Watch(context.TODO(), options)
+				return client.ExtensionsV1beta1().ReplicaSets(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.ExtensionsV1beta1().ReplicaSets(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.ExtensionsV1beta1().ReplicaSets(namespace).Watch(ctx, options)
 			},
 		},
 		&apiextensionsv1beta1.ReplicaSet{},

--- a/staging/src/k8s.io/client-go/informers/flowcontrol/v1/flowschema.go
+++ b/staging/src/k8s.io/client-go/informers/flowcontrol/v1/flowschema.go
@@ -61,13 +61,25 @@ func NewFilteredFlowSchemaInformer(client kubernetes.Interface, resyncPeriod tim
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.FlowcontrolV1().FlowSchemas().List(context.TODO(), options)
+				return client.FlowcontrolV1().FlowSchemas().List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.FlowcontrolV1().FlowSchemas().Watch(context.TODO(), options)
+				return client.FlowcontrolV1().FlowSchemas().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.FlowcontrolV1().FlowSchemas().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.FlowcontrolV1().FlowSchemas().Watch(ctx, options)
 			},
 		},
 		&apiflowcontrolv1.FlowSchema{},

--- a/staging/src/k8s.io/client-go/informers/flowcontrol/v1/prioritylevelconfiguration.go
+++ b/staging/src/k8s.io/client-go/informers/flowcontrol/v1/prioritylevelconfiguration.go
@@ -61,13 +61,25 @@ func NewFilteredPriorityLevelConfigurationInformer(client kubernetes.Interface, 
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.FlowcontrolV1().PriorityLevelConfigurations().List(context.TODO(), options)
+				return client.FlowcontrolV1().PriorityLevelConfigurations().List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.FlowcontrolV1().PriorityLevelConfigurations().Watch(context.TODO(), options)
+				return client.FlowcontrolV1().PriorityLevelConfigurations().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.FlowcontrolV1().PriorityLevelConfigurations().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.FlowcontrolV1().PriorityLevelConfigurations().Watch(ctx, options)
 			},
 		},
 		&apiflowcontrolv1.PriorityLevelConfiguration{},

--- a/staging/src/k8s.io/client-go/informers/flowcontrol/v1beta1/flowschema.go
+++ b/staging/src/k8s.io/client-go/informers/flowcontrol/v1beta1/flowschema.go
@@ -61,13 +61,25 @@ func NewFilteredFlowSchemaInformer(client kubernetes.Interface, resyncPeriod tim
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.FlowcontrolV1beta1().FlowSchemas().List(context.TODO(), options)
+				return client.FlowcontrolV1beta1().FlowSchemas().List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.FlowcontrolV1beta1().FlowSchemas().Watch(context.TODO(), options)
+				return client.FlowcontrolV1beta1().FlowSchemas().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.FlowcontrolV1beta1().FlowSchemas().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.FlowcontrolV1beta1().FlowSchemas().Watch(ctx, options)
 			},
 		},
 		&apiflowcontrolv1beta1.FlowSchema{},

--- a/staging/src/k8s.io/client-go/informers/flowcontrol/v1beta1/prioritylevelconfiguration.go
+++ b/staging/src/k8s.io/client-go/informers/flowcontrol/v1beta1/prioritylevelconfiguration.go
@@ -61,13 +61,25 @@ func NewFilteredPriorityLevelConfigurationInformer(client kubernetes.Interface, 
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.FlowcontrolV1beta1().PriorityLevelConfigurations().List(context.TODO(), options)
+				return client.FlowcontrolV1beta1().PriorityLevelConfigurations().List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.FlowcontrolV1beta1().PriorityLevelConfigurations().Watch(context.TODO(), options)
+				return client.FlowcontrolV1beta1().PriorityLevelConfigurations().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.FlowcontrolV1beta1().PriorityLevelConfigurations().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.FlowcontrolV1beta1().PriorityLevelConfigurations().Watch(ctx, options)
 			},
 		},
 		&apiflowcontrolv1beta1.PriorityLevelConfiguration{},

--- a/staging/src/k8s.io/client-go/informers/flowcontrol/v1beta2/flowschema.go
+++ b/staging/src/k8s.io/client-go/informers/flowcontrol/v1beta2/flowschema.go
@@ -61,13 +61,25 @@ func NewFilteredFlowSchemaInformer(client kubernetes.Interface, resyncPeriod tim
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.FlowcontrolV1beta2().FlowSchemas().List(context.TODO(), options)
+				return client.FlowcontrolV1beta2().FlowSchemas().List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.FlowcontrolV1beta2().FlowSchemas().Watch(context.TODO(), options)
+				return client.FlowcontrolV1beta2().FlowSchemas().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.FlowcontrolV1beta2().FlowSchemas().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.FlowcontrolV1beta2().FlowSchemas().Watch(ctx, options)
 			},
 		},
 		&apiflowcontrolv1beta2.FlowSchema{},

--- a/staging/src/k8s.io/client-go/informers/flowcontrol/v1beta2/prioritylevelconfiguration.go
+++ b/staging/src/k8s.io/client-go/informers/flowcontrol/v1beta2/prioritylevelconfiguration.go
@@ -61,13 +61,25 @@ func NewFilteredPriorityLevelConfigurationInformer(client kubernetes.Interface, 
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.FlowcontrolV1beta2().PriorityLevelConfigurations().List(context.TODO(), options)
+				return client.FlowcontrolV1beta2().PriorityLevelConfigurations().List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.FlowcontrolV1beta2().PriorityLevelConfigurations().Watch(context.TODO(), options)
+				return client.FlowcontrolV1beta2().PriorityLevelConfigurations().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.FlowcontrolV1beta2().PriorityLevelConfigurations().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.FlowcontrolV1beta2().PriorityLevelConfigurations().Watch(ctx, options)
 			},
 		},
 		&apiflowcontrolv1beta2.PriorityLevelConfiguration{},

--- a/staging/src/k8s.io/client-go/informers/flowcontrol/v1beta3/flowschema.go
+++ b/staging/src/k8s.io/client-go/informers/flowcontrol/v1beta3/flowschema.go
@@ -61,13 +61,25 @@ func NewFilteredFlowSchemaInformer(client kubernetes.Interface, resyncPeriod tim
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.FlowcontrolV1beta3().FlowSchemas().List(context.TODO(), options)
+				return client.FlowcontrolV1beta3().FlowSchemas().List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.FlowcontrolV1beta3().FlowSchemas().Watch(context.TODO(), options)
+				return client.FlowcontrolV1beta3().FlowSchemas().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.FlowcontrolV1beta3().FlowSchemas().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.FlowcontrolV1beta3().FlowSchemas().Watch(ctx, options)
 			},
 		},
 		&apiflowcontrolv1beta3.FlowSchema{},

--- a/staging/src/k8s.io/client-go/informers/flowcontrol/v1beta3/prioritylevelconfiguration.go
+++ b/staging/src/k8s.io/client-go/informers/flowcontrol/v1beta3/prioritylevelconfiguration.go
@@ -61,13 +61,25 @@ func NewFilteredPriorityLevelConfigurationInformer(client kubernetes.Interface, 
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.FlowcontrolV1beta3().PriorityLevelConfigurations().List(context.TODO(), options)
+				return client.FlowcontrolV1beta3().PriorityLevelConfigurations().List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.FlowcontrolV1beta3().PriorityLevelConfigurations().Watch(context.TODO(), options)
+				return client.FlowcontrolV1beta3().PriorityLevelConfigurations().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.FlowcontrolV1beta3().PriorityLevelConfigurations().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.FlowcontrolV1beta3().PriorityLevelConfigurations().Watch(ctx, options)
 			},
 		},
 		&apiflowcontrolv1beta3.PriorityLevelConfiguration{},

--- a/staging/src/k8s.io/client-go/informers/networking/v1/ingress.go
+++ b/staging/src/k8s.io/client-go/informers/networking/v1/ingress.go
@@ -62,13 +62,25 @@ func NewFilteredIngressInformer(client kubernetes.Interface, namespace string, r
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.NetworkingV1().Ingresses(namespace).List(context.TODO(), options)
+				return client.NetworkingV1().Ingresses(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.NetworkingV1().Ingresses(namespace).Watch(context.TODO(), options)
+				return client.NetworkingV1().Ingresses(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.NetworkingV1().Ingresses(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.NetworkingV1().Ingresses(namespace).Watch(ctx, options)
 			},
 		},
 		&apinetworkingv1.Ingress{},

--- a/staging/src/k8s.io/client-go/informers/networking/v1/ingressclass.go
+++ b/staging/src/k8s.io/client-go/informers/networking/v1/ingressclass.go
@@ -61,13 +61,25 @@ func NewFilteredIngressClassInformer(client kubernetes.Interface, resyncPeriod t
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.NetworkingV1().IngressClasses().List(context.TODO(), options)
+				return client.NetworkingV1().IngressClasses().List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.NetworkingV1().IngressClasses().Watch(context.TODO(), options)
+				return client.NetworkingV1().IngressClasses().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.NetworkingV1().IngressClasses().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.NetworkingV1().IngressClasses().Watch(ctx, options)
 			},
 		},
 		&apinetworkingv1.IngressClass{},

--- a/staging/src/k8s.io/client-go/informers/networking/v1/ipaddress.go
+++ b/staging/src/k8s.io/client-go/informers/networking/v1/ipaddress.go
@@ -61,13 +61,25 @@ func NewFilteredIPAddressInformer(client kubernetes.Interface, resyncPeriod time
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.NetworkingV1().IPAddresses().List(context.TODO(), options)
+				return client.NetworkingV1().IPAddresses().List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.NetworkingV1().IPAddresses().Watch(context.TODO(), options)
+				return client.NetworkingV1().IPAddresses().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.NetworkingV1().IPAddresses().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.NetworkingV1().IPAddresses().Watch(ctx, options)
 			},
 		},
 		&apinetworkingv1.IPAddress{},

--- a/staging/src/k8s.io/client-go/informers/networking/v1/networkpolicy.go
+++ b/staging/src/k8s.io/client-go/informers/networking/v1/networkpolicy.go
@@ -62,13 +62,25 @@ func NewFilteredNetworkPolicyInformer(client kubernetes.Interface, namespace str
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.NetworkingV1().NetworkPolicies(namespace).List(context.TODO(), options)
+				return client.NetworkingV1().NetworkPolicies(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.NetworkingV1().NetworkPolicies(namespace).Watch(context.TODO(), options)
+				return client.NetworkingV1().NetworkPolicies(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.NetworkingV1().NetworkPolicies(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.NetworkingV1().NetworkPolicies(namespace).Watch(ctx, options)
 			},
 		},
 		&apinetworkingv1.NetworkPolicy{},

--- a/staging/src/k8s.io/client-go/informers/networking/v1/servicecidr.go
+++ b/staging/src/k8s.io/client-go/informers/networking/v1/servicecidr.go
@@ -61,13 +61,25 @@ func NewFilteredServiceCIDRInformer(client kubernetes.Interface, resyncPeriod ti
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.NetworkingV1().ServiceCIDRs().List(context.TODO(), options)
+				return client.NetworkingV1().ServiceCIDRs().List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.NetworkingV1().ServiceCIDRs().Watch(context.TODO(), options)
+				return client.NetworkingV1().ServiceCIDRs().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.NetworkingV1().ServiceCIDRs().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.NetworkingV1().ServiceCIDRs().Watch(ctx, options)
 			},
 		},
 		&apinetworkingv1.ServiceCIDR{},

--- a/staging/src/k8s.io/client-go/informers/networking/v1alpha1/ipaddress.go
+++ b/staging/src/k8s.io/client-go/informers/networking/v1alpha1/ipaddress.go
@@ -61,13 +61,25 @@ func NewFilteredIPAddressInformer(client kubernetes.Interface, resyncPeriod time
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.NetworkingV1alpha1().IPAddresses().List(context.TODO(), options)
+				return client.NetworkingV1alpha1().IPAddresses().List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.NetworkingV1alpha1().IPAddresses().Watch(context.TODO(), options)
+				return client.NetworkingV1alpha1().IPAddresses().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.NetworkingV1alpha1().IPAddresses().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.NetworkingV1alpha1().IPAddresses().Watch(ctx, options)
 			},
 		},
 		&apinetworkingv1alpha1.IPAddress{},

--- a/staging/src/k8s.io/client-go/informers/networking/v1alpha1/servicecidr.go
+++ b/staging/src/k8s.io/client-go/informers/networking/v1alpha1/servicecidr.go
@@ -61,13 +61,25 @@ func NewFilteredServiceCIDRInformer(client kubernetes.Interface, resyncPeriod ti
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.NetworkingV1alpha1().ServiceCIDRs().List(context.TODO(), options)
+				return client.NetworkingV1alpha1().ServiceCIDRs().List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.NetworkingV1alpha1().ServiceCIDRs().Watch(context.TODO(), options)
+				return client.NetworkingV1alpha1().ServiceCIDRs().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.NetworkingV1alpha1().ServiceCIDRs().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.NetworkingV1alpha1().ServiceCIDRs().Watch(ctx, options)
 			},
 		},
 		&apinetworkingv1alpha1.ServiceCIDR{},

--- a/staging/src/k8s.io/client-go/informers/networking/v1beta1/ingress.go
+++ b/staging/src/k8s.io/client-go/informers/networking/v1beta1/ingress.go
@@ -62,13 +62,25 @@ func NewFilteredIngressInformer(client kubernetes.Interface, namespace string, r
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.NetworkingV1beta1().Ingresses(namespace).List(context.TODO(), options)
+				return client.NetworkingV1beta1().Ingresses(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.NetworkingV1beta1().Ingresses(namespace).Watch(context.TODO(), options)
+				return client.NetworkingV1beta1().Ingresses(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.NetworkingV1beta1().Ingresses(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.NetworkingV1beta1().Ingresses(namespace).Watch(ctx, options)
 			},
 		},
 		&apinetworkingv1beta1.Ingress{},

--- a/staging/src/k8s.io/client-go/informers/networking/v1beta1/ingressclass.go
+++ b/staging/src/k8s.io/client-go/informers/networking/v1beta1/ingressclass.go
@@ -61,13 +61,25 @@ func NewFilteredIngressClassInformer(client kubernetes.Interface, resyncPeriod t
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.NetworkingV1beta1().IngressClasses().List(context.TODO(), options)
+				return client.NetworkingV1beta1().IngressClasses().List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.NetworkingV1beta1().IngressClasses().Watch(context.TODO(), options)
+				return client.NetworkingV1beta1().IngressClasses().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.NetworkingV1beta1().IngressClasses().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.NetworkingV1beta1().IngressClasses().Watch(ctx, options)
 			},
 		},
 		&apinetworkingv1beta1.IngressClass{},

--- a/staging/src/k8s.io/client-go/informers/networking/v1beta1/ipaddress.go
+++ b/staging/src/k8s.io/client-go/informers/networking/v1beta1/ipaddress.go
@@ -61,13 +61,25 @@ func NewFilteredIPAddressInformer(client kubernetes.Interface, resyncPeriod time
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.NetworkingV1beta1().IPAddresses().List(context.TODO(), options)
+				return client.NetworkingV1beta1().IPAddresses().List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.NetworkingV1beta1().IPAddresses().Watch(context.TODO(), options)
+				return client.NetworkingV1beta1().IPAddresses().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.NetworkingV1beta1().IPAddresses().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.NetworkingV1beta1().IPAddresses().Watch(ctx, options)
 			},
 		},
 		&apinetworkingv1beta1.IPAddress{},

--- a/staging/src/k8s.io/client-go/informers/networking/v1beta1/servicecidr.go
+++ b/staging/src/k8s.io/client-go/informers/networking/v1beta1/servicecidr.go
@@ -61,13 +61,25 @@ func NewFilteredServiceCIDRInformer(client kubernetes.Interface, resyncPeriod ti
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.NetworkingV1beta1().ServiceCIDRs().List(context.TODO(), options)
+				return client.NetworkingV1beta1().ServiceCIDRs().List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.NetworkingV1beta1().ServiceCIDRs().Watch(context.TODO(), options)
+				return client.NetworkingV1beta1().ServiceCIDRs().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.NetworkingV1beta1().ServiceCIDRs().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.NetworkingV1beta1().ServiceCIDRs().Watch(ctx, options)
 			},
 		},
 		&apinetworkingv1beta1.ServiceCIDR{},

--- a/staging/src/k8s.io/client-go/informers/node/v1/runtimeclass.go
+++ b/staging/src/k8s.io/client-go/informers/node/v1/runtimeclass.go
@@ -61,13 +61,25 @@ func NewFilteredRuntimeClassInformer(client kubernetes.Interface, resyncPeriod t
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.NodeV1().RuntimeClasses().List(context.TODO(), options)
+				return client.NodeV1().RuntimeClasses().List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.NodeV1().RuntimeClasses().Watch(context.TODO(), options)
+				return client.NodeV1().RuntimeClasses().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.NodeV1().RuntimeClasses().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.NodeV1().RuntimeClasses().Watch(ctx, options)
 			},
 		},
 		&apinodev1.RuntimeClass{},

--- a/staging/src/k8s.io/client-go/informers/node/v1alpha1/runtimeclass.go
+++ b/staging/src/k8s.io/client-go/informers/node/v1alpha1/runtimeclass.go
@@ -61,13 +61,25 @@ func NewFilteredRuntimeClassInformer(client kubernetes.Interface, resyncPeriod t
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.NodeV1alpha1().RuntimeClasses().List(context.TODO(), options)
+				return client.NodeV1alpha1().RuntimeClasses().List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.NodeV1alpha1().RuntimeClasses().Watch(context.TODO(), options)
+				return client.NodeV1alpha1().RuntimeClasses().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.NodeV1alpha1().RuntimeClasses().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.NodeV1alpha1().RuntimeClasses().Watch(ctx, options)
 			},
 		},
 		&apinodev1alpha1.RuntimeClass{},

--- a/staging/src/k8s.io/client-go/informers/node/v1beta1/runtimeclass.go
+++ b/staging/src/k8s.io/client-go/informers/node/v1beta1/runtimeclass.go
@@ -61,13 +61,25 @@ func NewFilteredRuntimeClassInformer(client kubernetes.Interface, resyncPeriod t
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.NodeV1beta1().RuntimeClasses().List(context.TODO(), options)
+				return client.NodeV1beta1().RuntimeClasses().List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.NodeV1beta1().RuntimeClasses().Watch(context.TODO(), options)
+				return client.NodeV1beta1().RuntimeClasses().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.NodeV1beta1().RuntimeClasses().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.NodeV1beta1().RuntimeClasses().Watch(ctx, options)
 			},
 		},
 		&apinodev1beta1.RuntimeClass{},

--- a/staging/src/k8s.io/client-go/informers/policy/v1/poddisruptionbudget.go
+++ b/staging/src/k8s.io/client-go/informers/policy/v1/poddisruptionbudget.go
@@ -62,13 +62,25 @@ func NewFilteredPodDisruptionBudgetInformer(client kubernetes.Interface, namespa
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.PolicyV1().PodDisruptionBudgets(namespace).List(context.TODO(), options)
+				return client.PolicyV1().PodDisruptionBudgets(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.PolicyV1().PodDisruptionBudgets(namespace).Watch(context.TODO(), options)
+				return client.PolicyV1().PodDisruptionBudgets(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.PolicyV1().PodDisruptionBudgets(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.PolicyV1().PodDisruptionBudgets(namespace).Watch(ctx, options)
 			},
 		},
 		&apipolicyv1.PodDisruptionBudget{},

--- a/staging/src/k8s.io/client-go/informers/policy/v1beta1/poddisruptionbudget.go
+++ b/staging/src/k8s.io/client-go/informers/policy/v1beta1/poddisruptionbudget.go
@@ -62,13 +62,25 @@ func NewFilteredPodDisruptionBudgetInformer(client kubernetes.Interface, namespa
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.PolicyV1beta1().PodDisruptionBudgets(namespace).List(context.TODO(), options)
+				return client.PolicyV1beta1().PodDisruptionBudgets(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.PolicyV1beta1().PodDisruptionBudgets(namespace).Watch(context.TODO(), options)
+				return client.PolicyV1beta1().PodDisruptionBudgets(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.PolicyV1beta1().PodDisruptionBudgets(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.PolicyV1beta1().PodDisruptionBudgets(namespace).Watch(ctx, options)
 			},
 		},
 		&apipolicyv1beta1.PodDisruptionBudget{},

--- a/staging/src/k8s.io/client-go/informers/rbac/v1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1/clusterrole.go
@@ -61,13 +61,25 @@ func NewFilteredClusterRoleInformer(client kubernetes.Interface, resyncPeriod ti
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.RbacV1().ClusterRoles().List(context.TODO(), options)
+				return client.RbacV1().ClusterRoles().List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.RbacV1().ClusterRoles().Watch(context.TODO(), options)
+				return client.RbacV1().ClusterRoles().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.RbacV1().ClusterRoles().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.RbacV1().ClusterRoles().Watch(ctx, options)
 			},
 		},
 		&apirbacv1.ClusterRole{},

--- a/staging/src/k8s.io/client-go/informers/rbac/v1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1/clusterrolebinding.go
@@ -61,13 +61,25 @@ func NewFilteredClusterRoleBindingInformer(client kubernetes.Interface, resyncPe
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.RbacV1().ClusterRoleBindings().List(context.TODO(), options)
+				return client.RbacV1().ClusterRoleBindings().List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.RbacV1().ClusterRoleBindings().Watch(context.TODO(), options)
+				return client.RbacV1().ClusterRoleBindings().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.RbacV1().ClusterRoleBindings().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.RbacV1().ClusterRoleBindings().Watch(ctx, options)
 			},
 		},
 		&apirbacv1.ClusterRoleBinding{},

--- a/staging/src/k8s.io/client-go/informers/rbac/v1/role.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1/role.go
@@ -62,13 +62,25 @@ func NewFilteredRoleInformer(client kubernetes.Interface, namespace string, resy
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.RbacV1().Roles(namespace).List(context.TODO(), options)
+				return client.RbacV1().Roles(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.RbacV1().Roles(namespace).Watch(context.TODO(), options)
+				return client.RbacV1().Roles(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.RbacV1().Roles(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.RbacV1().Roles(namespace).Watch(ctx, options)
 			},
 		},
 		&apirbacv1.Role{},

--- a/staging/src/k8s.io/client-go/informers/rbac/v1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1/rolebinding.go
@@ -62,13 +62,25 @@ func NewFilteredRoleBindingInformer(client kubernetes.Interface, namespace strin
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.RbacV1().RoleBindings(namespace).List(context.TODO(), options)
+				return client.RbacV1().RoleBindings(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.RbacV1().RoleBindings(namespace).Watch(context.TODO(), options)
+				return client.RbacV1().RoleBindings(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.RbacV1().RoleBindings(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.RbacV1().RoleBindings(namespace).Watch(ctx, options)
 			},
 		},
 		&apirbacv1.RoleBinding{},

--- a/staging/src/k8s.io/client-go/informers/rbac/v1alpha1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1alpha1/clusterrole.go
@@ -61,13 +61,25 @@ func NewFilteredClusterRoleInformer(client kubernetes.Interface, resyncPeriod ti
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.RbacV1alpha1().ClusterRoles().List(context.TODO(), options)
+				return client.RbacV1alpha1().ClusterRoles().List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.RbacV1alpha1().ClusterRoles().Watch(context.TODO(), options)
+				return client.RbacV1alpha1().ClusterRoles().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.RbacV1alpha1().ClusterRoles().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.RbacV1alpha1().ClusterRoles().Watch(ctx, options)
 			},
 		},
 		&apirbacv1alpha1.ClusterRole{},

--- a/staging/src/k8s.io/client-go/informers/rbac/v1alpha1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1alpha1/clusterrolebinding.go
@@ -61,13 +61,25 @@ func NewFilteredClusterRoleBindingInformer(client kubernetes.Interface, resyncPe
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.RbacV1alpha1().ClusterRoleBindings().List(context.TODO(), options)
+				return client.RbacV1alpha1().ClusterRoleBindings().List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.RbacV1alpha1().ClusterRoleBindings().Watch(context.TODO(), options)
+				return client.RbacV1alpha1().ClusterRoleBindings().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.RbacV1alpha1().ClusterRoleBindings().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.RbacV1alpha1().ClusterRoleBindings().Watch(ctx, options)
 			},
 		},
 		&apirbacv1alpha1.ClusterRoleBinding{},

--- a/staging/src/k8s.io/client-go/informers/rbac/v1alpha1/role.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1alpha1/role.go
@@ -62,13 +62,25 @@ func NewFilteredRoleInformer(client kubernetes.Interface, namespace string, resy
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.RbacV1alpha1().Roles(namespace).List(context.TODO(), options)
+				return client.RbacV1alpha1().Roles(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.RbacV1alpha1().Roles(namespace).Watch(context.TODO(), options)
+				return client.RbacV1alpha1().Roles(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.RbacV1alpha1().Roles(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.RbacV1alpha1().Roles(namespace).Watch(ctx, options)
 			},
 		},
 		&apirbacv1alpha1.Role{},

--- a/staging/src/k8s.io/client-go/informers/rbac/v1alpha1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1alpha1/rolebinding.go
@@ -62,13 +62,25 @@ func NewFilteredRoleBindingInformer(client kubernetes.Interface, namespace strin
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.RbacV1alpha1().RoleBindings(namespace).List(context.TODO(), options)
+				return client.RbacV1alpha1().RoleBindings(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.RbacV1alpha1().RoleBindings(namespace).Watch(context.TODO(), options)
+				return client.RbacV1alpha1().RoleBindings(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.RbacV1alpha1().RoleBindings(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.RbacV1alpha1().RoleBindings(namespace).Watch(ctx, options)
 			},
 		},
 		&apirbacv1alpha1.RoleBinding{},

--- a/staging/src/k8s.io/client-go/informers/rbac/v1beta1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1beta1/clusterrole.go
@@ -61,13 +61,25 @@ func NewFilteredClusterRoleInformer(client kubernetes.Interface, resyncPeriod ti
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.RbacV1beta1().ClusterRoles().List(context.TODO(), options)
+				return client.RbacV1beta1().ClusterRoles().List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.RbacV1beta1().ClusterRoles().Watch(context.TODO(), options)
+				return client.RbacV1beta1().ClusterRoles().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.RbacV1beta1().ClusterRoles().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.RbacV1beta1().ClusterRoles().Watch(ctx, options)
 			},
 		},
 		&apirbacv1beta1.ClusterRole{},

--- a/staging/src/k8s.io/client-go/informers/rbac/v1beta1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1beta1/clusterrolebinding.go
@@ -61,13 +61,25 @@ func NewFilteredClusterRoleBindingInformer(client kubernetes.Interface, resyncPe
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.RbacV1beta1().ClusterRoleBindings().List(context.TODO(), options)
+				return client.RbacV1beta1().ClusterRoleBindings().List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.RbacV1beta1().ClusterRoleBindings().Watch(context.TODO(), options)
+				return client.RbacV1beta1().ClusterRoleBindings().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.RbacV1beta1().ClusterRoleBindings().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.RbacV1beta1().ClusterRoleBindings().Watch(ctx, options)
 			},
 		},
 		&apirbacv1beta1.ClusterRoleBinding{},

--- a/staging/src/k8s.io/client-go/informers/rbac/v1beta1/role.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1beta1/role.go
@@ -62,13 +62,25 @@ func NewFilteredRoleInformer(client kubernetes.Interface, namespace string, resy
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.RbacV1beta1().Roles(namespace).List(context.TODO(), options)
+				return client.RbacV1beta1().Roles(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.RbacV1beta1().Roles(namespace).Watch(context.TODO(), options)
+				return client.RbacV1beta1().Roles(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.RbacV1beta1().Roles(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.RbacV1beta1().Roles(namespace).Watch(ctx, options)
 			},
 		},
 		&apirbacv1beta1.Role{},

--- a/staging/src/k8s.io/client-go/informers/rbac/v1beta1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1beta1/rolebinding.go
@@ -62,13 +62,25 @@ func NewFilteredRoleBindingInformer(client kubernetes.Interface, namespace strin
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.RbacV1beta1().RoleBindings(namespace).List(context.TODO(), options)
+				return client.RbacV1beta1().RoleBindings(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.RbacV1beta1().RoleBindings(namespace).Watch(context.TODO(), options)
+				return client.RbacV1beta1().RoleBindings(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.RbacV1beta1().RoleBindings(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.RbacV1beta1().RoleBindings(namespace).Watch(ctx, options)
 			},
 		},
 		&apirbacv1beta1.RoleBinding{},

--- a/staging/src/k8s.io/client-go/informers/resource/v1alpha3/deviceclass.go
+++ b/staging/src/k8s.io/client-go/informers/resource/v1alpha3/deviceclass.go
@@ -61,13 +61,25 @@ func NewFilteredDeviceClassInformer(client kubernetes.Interface, resyncPeriod ti
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ResourceV1alpha3().DeviceClasses().List(context.TODO(), options)
+				return client.ResourceV1alpha3().DeviceClasses().List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ResourceV1alpha3().DeviceClasses().Watch(context.TODO(), options)
+				return client.ResourceV1alpha3().DeviceClasses().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.ResourceV1alpha3().DeviceClasses().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.ResourceV1alpha3().DeviceClasses().Watch(ctx, options)
 			},
 		},
 		&apiresourcev1alpha3.DeviceClass{},

--- a/staging/src/k8s.io/client-go/informers/resource/v1alpha3/resourceclaim.go
+++ b/staging/src/k8s.io/client-go/informers/resource/v1alpha3/resourceclaim.go
@@ -62,13 +62,25 @@ func NewFilteredResourceClaimInformer(client kubernetes.Interface, namespace str
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ResourceV1alpha3().ResourceClaims(namespace).List(context.TODO(), options)
+				return client.ResourceV1alpha3().ResourceClaims(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ResourceV1alpha3().ResourceClaims(namespace).Watch(context.TODO(), options)
+				return client.ResourceV1alpha3().ResourceClaims(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.ResourceV1alpha3().ResourceClaims(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.ResourceV1alpha3().ResourceClaims(namespace).Watch(ctx, options)
 			},
 		},
 		&apiresourcev1alpha3.ResourceClaim{},

--- a/staging/src/k8s.io/client-go/informers/resource/v1alpha3/resourceclaimtemplate.go
+++ b/staging/src/k8s.io/client-go/informers/resource/v1alpha3/resourceclaimtemplate.go
@@ -62,13 +62,25 @@ func NewFilteredResourceClaimTemplateInformer(client kubernetes.Interface, names
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ResourceV1alpha3().ResourceClaimTemplates(namespace).List(context.TODO(), options)
+				return client.ResourceV1alpha3().ResourceClaimTemplates(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ResourceV1alpha3().ResourceClaimTemplates(namespace).Watch(context.TODO(), options)
+				return client.ResourceV1alpha3().ResourceClaimTemplates(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.ResourceV1alpha3().ResourceClaimTemplates(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.ResourceV1alpha3().ResourceClaimTemplates(namespace).Watch(ctx, options)
 			},
 		},
 		&apiresourcev1alpha3.ResourceClaimTemplate{},

--- a/staging/src/k8s.io/client-go/informers/resource/v1alpha3/resourceslice.go
+++ b/staging/src/k8s.io/client-go/informers/resource/v1alpha3/resourceslice.go
@@ -61,13 +61,25 @@ func NewFilteredResourceSliceInformer(client kubernetes.Interface, resyncPeriod 
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ResourceV1alpha3().ResourceSlices().List(context.TODO(), options)
+				return client.ResourceV1alpha3().ResourceSlices().List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ResourceV1alpha3().ResourceSlices().Watch(context.TODO(), options)
+				return client.ResourceV1alpha3().ResourceSlices().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.ResourceV1alpha3().ResourceSlices().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.ResourceV1alpha3().ResourceSlices().Watch(ctx, options)
 			},
 		},
 		&apiresourcev1alpha3.ResourceSlice{},

--- a/staging/src/k8s.io/client-go/informers/resource/v1beta1/deviceclass.go
+++ b/staging/src/k8s.io/client-go/informers/resource/v1beta1/deviceclass.go
@@ -61,13 +61,25 @@ func NewFilteredDeviceClassInformer(client kubernetes.Interface, resyncPeriod ti
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ResourceV1beta1().DeviceClasses().List(context.TODO(), options)
+				return client.ResourceV1beta1().DeviceClasses().List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ResourceV1beta1().DeviceClasses().Watch(context.TODO(), options)
+				return client.ResourceV1beta1().DeviceClasses().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.ResourceV1beta1().DeviceClasses().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.ResourceV1beta1().DeviceClasses().Watch(ctx, options)
 			},
 		},
 		&apiresourcev1beta1.DeviceClass{},

--- a/staging/src/k8s.io/client-go/informers/resource/v1beta1/resourceclaim.go
+++ b/staging/src/k8s.io/client-go/informers/resource/v1beta1/resourceclaim.go
@@ -62,13 +62,25 @@ func NewFilteredResourceClaimInformer(client kubernetes.Interface, namespace str
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ResourceV1beta1().ResourceClaims(namespace).List(context.TODO(), options)
+				return client.ResourceV1beta1().ResourceClaims(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ResourceV1beta1().ResourceClaims(namespace).Watch(context.TODO(), options)
+				return client.ResourceV1beta1().ResourceClaims(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.ResourceV1beta1().ResourceClaims(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.ResourceV1beta1().ResourceClaims(namespace).Watch(ctx, options)
 			},
 		},
 		&apiresourcev1beta1.ResourceClaim{},

--- a/staging/src/k8s.io/client-go/informers/resource/v1beta1/resourceclaimtemplate.go
+++ b/staging/src/k8s.io/client-go/informers/resource/v1beta1/resourceclaimtemplate.go
@@ -62,13 +62,25 @@ func NewFilteredResourceClaimTemplateInformer(client kubernetes.Interface, names
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ResourceV1beta1().ResourceClaimTemplates(namespace).List(context.TODO(), options)
+				return client.ResourceV1beta1().ResourceClaimTemplates(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ResourceV1beta1().ResourceClaimTemplates(namespace).Watch(context.TODO(), options)
+				return client.ResourceV1beta1().ResourceClaimTemplates(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.ResourceV1beta1().ResourceClaimTemplates(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.ResourceV1beta1().ResourceClaimTemplates(namespace).Watch(ctx, options)
 			},
 		},
 		&apiresourcev1beta1.ResourceClaimTemplate{},

--- a/staging/src/k8s.io/client-go/informers/resource/v1beta1/resourceslice.go
+++ b/staging/src/k8s.io/client-go/informers/resource/v1beta1/resourceslice.go
@@ -61,13 +61,25 @@ func NewFilteredResourceSliceInformer(client kubernetes.Interface, resyncPeriod 
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ResourceV1beta1().ResourceSlices().List(context.TODO(), options)
+				return client.ResourceV1beta1().ResourceSlices().List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ResourceV1beta1().ResourceSlices().Watch(context.TODO(), options)
+				return client.ResourceV1beta1().ResourceSlices().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.ResourceV1beta1().ResourceSlices().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.ResourceV1beta1().ResourceSlices().Watch(ctx, options)
 			},
 		},
 		&apiresourcev1beta1.ResourceSlice{},

--- a/staging/src/k8s.io/client-go/informers/scheduling/v1/priorityclass.go
+++ b/staging/src/k8s.io/client-go/informers/scheduling/v1/priorityclass.go
@@ -61,13 +61,25 @@ func NewFilteredPriorityClassInformer(client kubernetes.Interface, resyncPeriod 
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.SchedulingV1().PriorityClasses().List(context.TODO(), options)
+				return client.SchedulingV1().PriorityClasses().List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.SchedulingV1().PriorityClasses().Watch(context.TODO(), options)
+				return client.SchedulingV1().PriorityClasses().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.SchedulingV1().PriorityClasses().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.SchedulingV1().PriorityClasses().Watch(ctx, options)
 			},
 		},
 		&apischedulingv1.PriorityClass{},

--- a/staging/src/k8s.io/client-go/informers/scheduling/v1alpha1/priorityclass.go
+++ b/staging/src/k8s.io/client-go/informers/scheduling/v1alpha1/priorityclass.go
@@ -61,13 +61,25 @@ func NewFilteredPriorityClassInformer(client kubernetes.Interface, resyncPeriod 
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.SchedulingV1alpha1().PriorityClasses().List(context.TODO(), options)
+				return client.SchedulingV1alpha1().PriorityClasses().List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.SchedulingV1alpha1().PriorityClasses().Watch(context.TODO(), options)
+				return client.SchedulingV1alpha1().PriorityClasses().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.SchedulingV1alpha1().PriorityClasses().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.SchedulingV1alpha1().PriorityClasses().Watch(ctx, options)
 			},
 		},
 		&apischedulingv1alpha1.PriorityClass{},

--- a/staging/src/k8s.io/client-go/informers/scheduling/v1beta1/priorityclass.go
+++ b/staging/src/k8s.io/client-go/informers/scheduling/v1beta1/priorityclass.go
@@ -61,13 +61,25 @@ func NewFilteredPriorityClassInformer(client kubernetes.Interface, resyncPeriod 
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.SchedulingV1beta1().PriorityClasses().List(context.TODO(), options)
+				return client.SchedulingV1beta1().PriorityClasses().List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.SchedulingV1beta1().PriorityClasses().Watch(context.TODO(), options)
+				return client.SchedulingV1beta1().PriorityClasses().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.SchedulingV1beta1().PriorityClasses().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.SchedulingV1beta1().PriorityClasses().Watch(ctx, options)
 			},
 		},
 		&apischedulingv1beta1.PriorityClass{},

--- a/staging/src/k8s.io/client-go/informers/storage/v1/csidriver.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1/csidriver.go
@@ -61,13 +61,25 @@ func NewFilteredCSIDriverInformer(client kubernetes.Interface, resyncPeriod time
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.StorageV1().CSIDrivers().List(context.TODO(), options)
+				return client.StorageV1().CSIDrivers().List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.StorageV1().CSIDrivers().Watch(context.TODO(), options)
+				return client.StorageV1().CSIDrivers().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.StorageV1().CSIDrivers().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.StorageV1().CSIDrivers().Watch(ctx, options)
 			},
 		},
 		&apistoragev1.CSIDriver{},

--- a/staging/src/k8s.io/client-go/informers/storage/v1/csinode.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1/csinode.go
@@ -61,13 +61,25 @@ func NewFilteredCSINodeInformer(client kubernetes.Interface, resyncPeriod time.D
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.StorageV1().CSINodes().List(context.TODO(), options)
+				return client.StorageV1().CSINodes().List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.StorageV1().CSINodes().Watch(context.TODO(), options)
+				return client.StorageV1().CSINodes().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.StorageV1().CSINodes().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.StorageV1().CSINodes().Watch(ctx, options)
 			},
 		},
 		&apistoragev1.CSINode{},

--- a/staging/src/k8s.io/client-go/informers/storage/v1/csistoragecapacity.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1/csistoragecapacity.go
@@ -62,13 +62,25 @@ func NewFilteredCSIStorageCapacityInformer(client kubernetes.Interface, namespac
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.StorageV1().CSIStorageCapacities(namespace).List(context.TODO(), options)
+				return client.StorageV1().CSIStorageCapacities(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.StorageV1().CSIStorageCapacities(namespace).Watch(context.TODO(), options)
+				return client.StorageV1().CSIStorageCapacities(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.StorageV1().CSIStorageCapacities(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.StorageV1().CSIStorageCapacities(namespace).Watch(ctx, options)
 			},
 		},
 		&apistoragev1.CSIStorageCapacity{},

--- a/staging/src/k8s.io/client-go/informers/storage/v1/storageclass.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1/storageclass.go
@@ -61,13 +61,25 @@ func NewFilteredStorageClassInformer(client kubernetes.Interface, resyncPeriod t
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.StorageV1().StorageClasses().List(context.TODO(), options)
+				return client.StorageV1().StorageClasses().List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.StorageV1().StorageClasses().Watch(context.TODO(), options)
+				return client.StorageV1().StorageClasses().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.StorageV1().StorageClasses().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.StorageV1().StorageClasses().Watch(ctx, options)
 			},
 		},
 		&apistoragev1.StorageClass{},

--- a/staging/src/k8s.io/client-go/informers/storage/v1/volumeattachment.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1/volumeattachment.go
@@ -61,13 +61,25 @@ func NewFilteredVolumeAttachmentInformer(client kubernetes.Interface, resyncPeri
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.StorageV1().VolumeAttachments().List(context.TODO(), options)
+				return client.StorageV1().VolumeAttachments().List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.StorageV1().VolumeAttachments().Watch(context.TODO(), options)
+				return client.StorageV1().VolumeAttachments().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.StorageV1().VolumeAttachments().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.StorageV1().VolumeAttachments().Watch(ctx, options)
 			},
 		},
 		&apistoragev1.VolumeAttachment{},

--- a/staging/src/k8s.io/client-go/informers/storage/v1alpha1/csistoragecapacity.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1alpha1/csistoragecapacity.go
@@ -62,13 +62,25 @@ func NewFilteredCSIStorageCapacityInformer(client kubernetes.Interface, namespac
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.StorageV1alpha1().CSIStorageCapacities(namespace).List(context.TODO(), options)
+				return client.StorageV1alpha1().CSIStorageCapacities(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.StorageV1alpha1().CSIStorageCapacities(namespace).Watch(context.TODO(), options)
+				return client.StorageV1alpha1().CSIStorageCapacities(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.StorageV1alpha1().CSIStorageCapacities(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.StorageV1alpha1().CSIStorageCapacities(namespace).Watch(ctx, options)
 			},
 		},
 		&apistoragev1alpha1.CSIStorageCapacity{},

--- a/staging/src/k8s.io/client-go/informers/storage/v1alpha1/volumeattachment.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1alpha1/volumeattachment.go
@@ -61,13 +61,25 @@ func NewFilteredVolumeAttachmentInformer(client kubernetes.Interface, resyncPeri
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.StorageV1alpha1().VolumeAttachments().List(context.TODO(), options)
+				return client.StorageV1alpha1().VolumeAttachments().List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.StorageV1alpha1().VolumeAttachments().Watch(context.TODO(), options)
+				return client.StorageV1alpha1().VolumeAttachments().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.StorageV1alpha1().VolumeAttachments().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.StorageV1alpha1().VolumeAttachments().Watch(ctx, options)
 			},
 		},
 		&apistoragev1alpha1.VolumeAttachment{},

--- a/staging/src/k8s.io/client-go/informers/storage/v1alpha1/volumeattributesclass.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1alpha1/volumeattributesclass.go
@@ -61,13 +61,25 @@ func NewFilteredVolumeAttributesClassInformer(client kubernetes.Interface, resyn
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.StorageV1alpha1().VolumeAttributesClasses().List(context.TODO(), options)
+				return client.StorageV1alpha1().VolumeAttributesClasses().List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.StorageV1alpha1().VolumeAttributesClasses().Watch(context.TODO(), options)
+				return client.StorageV1alpha1().VolumeAttributesClasses().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.StorageV1alpha1().VolumeAttributesClasses().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.StorageV1alpha1().VolumeAttributesClasses().Watch(ctx, options)
 			},
 		},
 		&apistoragev1alpha1.VolumeAttributesClass{},

--- a/staging/src/k8s.io/client-go/informers/storage/v1beta1/csidriver.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1beta1/csidriver.go
@@ -61,13 +61,25 @@ func NewFilteredCSIDriverInformer(client kubernetes.Interface, resyncPeriod time
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.StorageV1beta1().CSIDrivers().List(context.TODO(), options)
+				return client.StorageV1beta1().CSIDrivers().List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.StorageV1beta1().CSIDrivers().Watch(context.TODO(), options)
+				return client.StorageV1beta1().CSIDrivers().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.StorageV1beta1().CSIDrivers().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.StorageV1beta1().CSIDrivers().Watch(ctx, options)
 			},
 		},
 		&apistoragev1beta1.CSIDriver{},

--- a/staging/src/k8s.io/client-go/informers/storage/v1beta1/csinode.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1beta1/csinode.go
@@ -61,13 +61,25 @@ func NewFilteredCSINodeInformer(client kubernetes.Interface, resyncPeriod time.D
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.StorageV1beta1().CSINodes().List(context.TODO(), options)
+				return client.StorageV1beta1().CSINodes().List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.StorageV1beta1().CSINodes().Watch(context.TODO(), options)
+				return client.StorageV1beta1().CSINodes().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.StorageV1beta1().CSINodes().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.StorageV1beta1().CSINodes().Watch(ctx, options)
 			},
 		},
 		&apistoragev1beta1.CSINode{},

--- a/staging/src/k8s.io/client-go/informers/storage/v1beta1/csistoragecapacity.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1beta1/csistoragecapacity.go
@@ -62,13 +62,25 @@ func NewFilteredCSIStorageCapacityInformer(client kubernetes.Interface, namespac
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.StorageV1beta1().CSIStorageCapacities(namespace).List(context.TODO(), options)
+				return client.StorageV1beta1().CSIStorageCapacities(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.StorageV1beta1().CSIStorageCapacities(namespace).Watch(context.TODO(), options)
+				return client.StorageV1beta1().CSIStorageCapacities(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.StorageV1beta1().CSIStorageCapacities(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.StorageV1beta1().CSIStorageCapacities(namespace).Watch(ctx, options)
 			},
 		},
 		&apistoragev1beta1.CSIStorageCapacity{},

--- a/staging/src/k8s.io/client-go/informers/storage/v1beta1/storageclass.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1beta1/storageclass.go
@@ -61,13 +61,25 @@ func NewFilteredStorageClassInformer(client kubernetes.Interface, resyncPeriod t
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.StorageV1beta1().StorageClasses().List(context.TODO(), options)
+				return client.StorageV1beta1().StorageClasses().List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.StorageV1beta1().StorageClasses().Watch(context.TODO(), options)
+				return client.StorageV1beta1().StorageClasses().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.StorageV1beta1().StorageClasses().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.StorageV1beta1().StorageClasses().Watch(ctx, options)
 			},
 		},
 		&apistoragev1beta1.StorageClass{},

--- a/staging/src/k8s.io/client-go/informers/storage/v1beta1/volumeattachment.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1beta1/volumeattachment.go
@@ -61,13 +61,25 @@ func NewFilteredVolumeAttachmentInformer(client kubernetes.Interface, resyncPeri
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.StorageV1beta1().VolumeAttachments().List(context.TODO(), options)
+				return client.StorageV1beta1().VolumeAttachments().List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.StorageV1beta1().VolumeAttachments().Watch(context.TODO(), options)
+				return client.StorageV1beta1().VolumeAttachments().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.StorageV1beta1().VolumeAttachments().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.StorageV1beta1().VolumeAttachments().Watch(ctx, options)
 			},
 		},
 		&apistoragev1beta1.VolumeAttachment{},

--- a/staging/src/k8s.io/client-go/informers/storage/v1beta1/volumeattributesclass.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1beta1/volumeattributesclass.go
@@ -61,13 +61,25 @@ func NewFilteredVolumeAttributesClassInformer(client kubernetes.Interface, resyn
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.StorageV1beta1().VolumeAttributesClasses().List(context.TODO(), options)
+				return client.StorageV1beta1().VolumeAttributesClasses().List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.StorageV1beta1().VolumeAttributesClasses().Watch(context.TODO(), options)
+				return client.StorageV1beta1().VolumeAttributesClasses().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.StorageV1beta1().VolumeAttributesClasses().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.StorageV1beta1().VolumeAttributesClasses().Watch(ctx, options)
 			},
 		},
 		&apistoragev1beta1.VolumeAttributesClass{},

--- a/staging/src/k8s.io/client-go/informers/storagemigration/v1alpha1/storageversionmigration.go
+++ b/staging/src/k8s.io/client-go/informers/storagemigration/v1alpha1/storageversionmigration.go
@@ -61,13 +61,25 @@ func NewFilteredStorageVersionMigrationInformer(client kubernetes.Interface, res
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.StoragemigrationV1alpha1().StorageVersionMigrations().List(context.TODO(), options)
+				return client.StoragemigrationV1alpha1().StorageVersionMigrations().List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.StoragemigrationV1alpha1().StorageVersionMigrations().Watch(context.TODO(), options)
+				return client.StoragemigrationV1alpha1().StorageVersionMigrations().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.StoragemigrationV1alpha1().StorageVersionMigrations().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.StoragemigrationV1alpha1().StorageVersionMigrations().Watch(ctx, options)
 			},
 		},
 		&apistoragemigrationv1alpha1.StorageVersionMigration{},

--- a/staging/src/k8s.io/client-go/metadata/metadatainformer/informer.go
+++ b/staging/src/k8s.io/client-go/metadata/metadatainformer/informer.go
@@ -183,13 +183,25 @@ func NewFilteredMetadataInformer(client metadata.Interface, gvr schema.GroupVers
 					if tweakListOptions != nil {
 						tweakListOptions(&options)
 					}
-					return client.Resource(gvr).Namespace(namespace).List(context.TODO(), options)
+					return client.Resource(gvr).Namespace(namespace).List(context.Background(), options)
 				},
 				WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 					if tweakListOptions != nil {
 						tweakListOptions(&options)
 					}
-					return client.Resource(gvr).Namespace(namespace).Watch(context.TODO(), options)
+					return client.Resource(gvr).Namespace(namespace).Watch(context.Background(), options)
+				},
+				ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+					if tweakListOptions != nil {
+						tweakListOptions(&options)
+					}
+					return client.Resource(gvr).Namespace(namespace).List(ctx, options)
+				},
+				WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+					if tweakListOptions != nil {
+						tweakListOptions(&options)
+					}
+					return client.Resource(gvr).Namespace(namespace).Watch(ctx, options)
 				},
 			},
 			&metav1.PartialObjectMetadata{},

--- a/staging/src/k8s.io/client-go/rest/request.go
+++ b/staging/src/k8s.io/client-go/rest/request.go
@@ -1008,7 +1008,8 @@ func (r *Request) newStreamWatcher(ctx context.Context, resp *http.Response) (wa
 	frameReader := framer.NewFrameReader(resp.Body)
 	watchEventDecoder := streaming.NewDecoder(frameReader, streamingSerializer)
 
-	return watch.NewStreamWatcher(
+	return watch.NewStreamWatcherWithLogger(
+		klog.FromContext(ctx),
 		restclientwatch.NewDecoder(watchEventDecoder, objectDecoder),
 		// use 500 to indicate that the cause of the error is unknown - other error codes
 		// are more specific to HTTP interactions, and set a reason

--- a/staging/src/k8s.io/client-go/tools/cache/controller_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/controller_test.go
@@ -367,7 +367,7 @@ func TestUpdate(t *testing.T) {
 	// everything we've added has been deleted.
 	watchCh := make(chan struct{})
 	_, controller := NewInformer(
-		&testLW{
+		&ListWatch{
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				watch, err := source.Watch(options)
 				close(watchCh)

--- a/staging/src/k8s.io/client-go/tools/cache/listwatch.go
+++ b/staging/src/k8s.io/client-go/tools/cache/listwatch.go
@@ -27,43 +27,152 @@ import (
 )
 
 // Lister is any object that knows how to perform an initial list.
+//
+// Ideally, all implementations of Lister should also implement ListerWithContext.
 type Lister interface {
 	// List should return a list type object; the Items field will be extracted, and the
 	// ResourceVersion field will be used to start the watch in the right place.
+	//
+	// Deprecated: use ListerWithContext.ListWithContext instead.
 	List(options metav1.ListOptions) (runtime.Object, error)
 }
 
+// ListerWithContext is any object that knows how to perform an initial list.
+type ListerWithContext interface {
+	// ListWithContext should return a list type object; the Items field will be extracted, and the
+	// ResourceVersion field will be used to start the watch in the right place.
+	ListWithContext(ctx context.Context, options metav1.ListOptions) (runtime.Object, error)
+}
+
+func ToListerWithContext(l Lister) ListerWithContext {
+	if l, ok := l.(ListerWithContext); ok {
+		return l
+	}
+	return listerWrapper{
+		parent: l,
+	}
+}
+
+type listerWrapper struct {
+	parent Lister
+}
+
+func (l listerWrapper) ListWithContext(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+	return l.parent.List(options)
+}
+
 // Watcher is any object that knows how to start a watch on a resource.
+//
+// Ideally, all implementations of Watcher should also implement WatcherWithContext.
 type Watcher interface {
 	// Watch should begin a watch at the specified version.
 	//
 	// If Watch returns an error, it should handle its own cleanup, including
 	// but not limited to calling Stop() on the watch, if one was constructed.
 	// This allows the caller to ignore the watch, if the error is non-nil.
+	//
+	// Deprecated: use WatcherWithContext.WatchWithContext instead.
 	Watch(options metav1.ListOptions) (watch.Interface, error)
 }
 
+// WatcherWithContext is any object that knows how to start a watch on a resource.
+type WatcherWithContext interface {
+	// WatchWithContext should begin a watch at the specified version.
+	//
+	// If Watch returns an error, it should handle its own cleanup, including
+	// but not limited to calling Stop() on the watch, if one was constructed.
+	// This allows the caller to ignore the watch, if the error is non-nil.
+	WatchWithContext(ctx context.Context, options metav1.ListOptions) (watch.Interface, error)
+}
+
+func ToWatcherWithContext(w Watcher) WatcherWithContext {
+	if w, ok := w.(WatcherWithContext); ok {
+		return w
+	}
+	return watcherWrapper{
+		parent: w,
+	}
+}
+
+type watcherWrapper struct {
+	parent Watcher
+}
+
+func (l watcherWrapper) WatchWithContext(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+	return l.parent.Watch(options)
+}
+
 // ListerWatcher is any object that knows how to perform an initial list and start a watch on a resource.
+//
+// Ideally, all implementations of ListerWatcher should also implement ListerWatcherWithContext.
 type ListerWatcher interface {
 	Lister
 	Watcher
 }
 
+// ListerWatcherWithContext is any object that knows how to perform an initial list and start a watch on a resource.
+type ListerWatcherWithContext interface {
+	ListerWithContext
+	WatcherWithContext
+}
+
+func ToListerWatcherWithContext(lw ListerWatcher) ListerWatcherWithContext {
+	if lw, ok := lw.(ListerWatcherWithContext); ok {
+		return lw
+	}
+	return listerWatcherWrapper{
+		ListerWithContext:  ToListerWithContext(lw),
+		WatcherWithContext: ToWatcherWithContext(lw),
+	}
+}
+
+type listerWatcherWrapper struct {
+	ListerWithContext
+	WatcherWithContext
+}
+
 // ListFunc knows how to list resources
+//
+// Deprecated: use ListWithContextFunc instead.
 type ListFunc func(options metav1.ListOptions) (runtime.Object, error)
 
+// ListWithContextFunc knows how to list resources
+type ListWithContextFunc func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error)
+
 // WatchFunc knows how to watch resources
+//
+// Deprecated: use WatchFuncWithContext instead.
 type WatchFunc func(options metav1.ListOptions) (watch.Interface, error)
 
-// ListWatch knows how to list and watch a set of apiserver resources.  It satisfies the ListerWatcher interface.
+// WatchFuncWithContext knows how to watch resources
+type WatchFuncWithContext func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error)
+
+// ListWatch knows how to list and watch a set of apiserver resources.
+// It satisfies the ListerWatcher and ListerWatcherWithContext interfaces.
 // It is a convenience function for users of NewReflector, etc.
-// ListFunc and WatchFunc must not be nil
+// ListFunc or ListWithContextFunc must be set. Same for WatchFunc and WatchFuncWithContext.
+// ListWithContextFunc and WatchFuncWithContext are preferred if
+// a context is available, otherwise ListFunc and WatchFunc.
+//
+// NewFilteredListWatchFromClient sets all of the functions to ensure that callers
+// which only know about ListFunc and WatchFunc continue to work.
 type ListWatch struct {
-	ListFunc  ListFunc
+	// Deprecated: use ListWithContext instead.
+	ListFunc ListFunc
+	// Deprecated: use WatchWithContext instead.
 	WatchFunc WatchFunc
+
+	ListWithContextFunc  ListWithContextFunc
+	WatchFuncWithContext WatchFuncWithContext
+
 	// DisableChunking requests no chunking for this list watcher.
 	DisableChunking bool
 }
+
+var (
+	_ ListerWatcher            = &ListWatch{}
+	_ ListerWatcherWithContext = &ListWatch{}
+)
 
 // Getter interface knows how to access Get method from RESTClient.
 type Getter interface {
@@ -71,6 +180,7 @@ type Getter interface {
 }
 
 // NewListWatchFromClient creates a new ListWatch from the specified client, resource, namespace and field selector.
+// For backward compatibility, all function fields are populated.
 func NewListWatchFromClient(c Getter, resource string, namespace string, fieldSelector fields.Selector) *ListWatch {
 	optionsModifier := func(options *metav1.ListOptions) {
 		options.FieldSelector = fieldSelector.String()
@@ -81,6 +191,7 @@ func NewListWatchFromClient(c Getter, resource string, namespace string, fieldSe
 // NewFilteredListWatchFromClient creates a new ListWatch from the specified client, resource, namespace, and option modifier.
 // Option modifier is a function takes a ListOptions and modifies the consumed ListOptions. Provide customized modifier function
 // to apply modification to ListOptions with a field selector, a label selector, or any other desired options.
+// For backward compatibility, all function fields are populated.
 func NewFilteredListWatchFromClient(c Getter, resource string, namespace string, optionsModifier func(options *metav1.ListOptions)) *ListWatch {
 	listFunc := func(options metav1.ListOptions) (runtime.Object, error) {
 		optionsModifier(&options)
@@ -88,7 +199,7 @@ func NewFilteredListWatchFromClient(c Getter, resource string, namespace string,
 			Namespace(namespace).
 			Resource(resource).
 			VersionedParams(&options, metav1.ParameterCodec).
-			Do(context.TODO()).
+			Do(context.Background()).
 			Get()
 	}
 	watchFunc := func(options metav1.ListOptions) (watch.Interface, error) {
@@ -98,19 +209,70 @@ func NewFilteredListWatchFromClient(c Getter, resource string, namespace string,
 			Namespace(namespace).
 			Resource(resource).
 			VersionedParams(&options, metav1.ParameterCodec).
-			Watch(context.TODO())
+			Watch(context.Background())
 	}
-	return &ListWatch{ListFunc: listFunc, WatchFunc: watchFunc}
+	listFuncWithContext := func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+		optionsModifier(&options)
+		return c.Get().
+			Namespace(namespace).
+			Resource(resource).
+			VersionedParams(&options, metav1.ParameterCodec).
+			Do(ctx).
+			Get()
+	}
+	watchFuncWithContext := func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+		options.Watch = true
+		optionsModifier(&options)
+		return c.Get().
+			Namespace(namespace).
+			Resource(resource).
+			VersionedParams(&options, metav1.ParameterCodec).
+			Watch(ctx)
+	}
+	return &ListWatch{
+		ListFunc:             listFunc,
+		WatchFunc:            watchFunc,
+		ListWithContextFunc:  listFuncWithContext,
+		WatchFuncWithContext: watchFuncWithContext,
+	}
 }
 
 // List a set of apiserver resources
+//
+// Deprecated: use ListWatchWithContext.ListWithContext instead.
 func (lw *ListWatch) List(options metav1.ListOptions) (runtime.Object, error) {
 	// ListWatch is used in Reflector, which already supports pagination.
 	// Don't paginate here to avoid duplication.
+	if lw.ListFunc != nil {
+		return lw.ListFunc(options)
+	}
+	return lw.ListWithContextFunc(context.Background(), options)
+}
+
+// List a set of apiserver resources
+func (lw *ListWatch) ListWithContext(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+	// ListWatch is used in Reflector, which already supports pagination.
+	// Don't paginate here to avoid duplication.
+	if lw.ListWithContextFunc != nil {
+		return lw.ListWithContextFunc(ctx, options)
+	}
 	return lw.ListFunc(options)
 }
 
 // Watch a set of apiserver resources
+//
+// Deprecated: use ListWatchWithContext.WatchWithContext instead.
 func (lw *ListWatch) Watch(options metav1.ListOptions) (watch.Interface, error) {
+	if lw.WatchFunc != nil {
+		return lw.WatchFunc(options)
+	}
+	return lw.WatchFuncWithContext(context.Background(), options)
+}
+
+// Watch a set of apiserver resources
+func (lw *ListWatch) WatchWithContext(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+	if lw.WatchFuncWithContext != nil {
+		return lw.WatchFuncWithContext(ctx, options)
+	}
 	return lw.WatchFunc(options)
 }

--- a/staging/src/k8s.io/client-go/tools/cache/mutation_detector_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/mutation_detector_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -29,7 +29,7 @@ import (
 
 func TestMutationDetector(t *testing.T) {
 	fakeWatch := watch.NewFake()
-	lw := &testLW{
+	lw := &ListWatch{
 		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 			return fakeWatch, nil
 		},

--- a/staging/src/k8s.io/client-go/tools/cache/reflector.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector.go
@@ -74,7 +74,7 @@ type Reflector struct {
 	// The destination to sync up with the watch source
 	store Store
 	// listerWatcher is used to perform lists and watches.
-	listerWatcher ListerWatcher
+	listerWatcher ListerWatcherWithContext
 	// backoff manages backoff of ListWatch
 	backoffManager wait.BackoffManager
 	resyncPeriod   time.Duration
@@ -248,7 +248,7 @@ func NewReflectorWithOptions(lw ListerWatcher, expectedType interface{}, store S
 		resyncPeriod:    options.ResyncPeriod,
 		minWatchTimeout: minWatchTimeout,
 		typeDescription: options.TypeDescription,
-		listerWatcher:   lw,
+		listerWatcher:   ToListerWatcherWithContext(lw),
 		store:           store,
 		// We used to make the call every 1sec (1 QPS), the goal here is to achieve ~98% traffic reduction when
 		// API server is not healthy. With these parameters, backoff will stop at [30,60) sec interval which is
@@ -490,7 +490,7 @@ func (r *Reflector) watch(ctx context.Context, w watch.Interface, resyncerrc cha
 				AllowWatchBookmarks: true,
 			}
 
-			w, err = r.listerWatcher.Watch(options)
+			w, err = r.listerWatcher.WatchWithContext(ctx, options)
 			if err != nil {
 				if canRetry := isWatchErrorRetriable(err); canRetry {
 					logger.V(4).Info("Watch failed - backing off", "reflector", r.name, "type", r.typeDescription, "err", err)
@@ -561,7 +561,7 @@ func (r *Reflector) list(ctx context.Context) error {
 		// Attempt to gather list in chunks, if supported by listerWatcher, if not, the first
 		// list request will return the full response.
 		pager := pager.New(pager.SimplePageFunc(func(opts metav1.ListOptions) (runtime.Object, error) {
-			return r.listerWatcher.List(opts)
+			return r.listerWatcher.ListWithContext(ctx, opts)
 		}))
 		switch {
 		case r.WatchListPageSize != 0:
@@ -717,7 +717,7 @@ func (r *Reflector) watchList(ctx context.Context) (watch.Interface, error) {
 		}
 		start := r.clock.Now()
 
-		w, err = r.listerWatcher.Watch(options)
+		w, err = r.listerWatcher.WatchWithContext(ctx, options)
 		if err != nil {
 			if isErrorRetriableWithSideEffectsFn(err) {
 				continue
@@ -749,7 +749,7 @@ func (r *Reflector) watchList(ctx context.Context) (watch.Interface, error) {
 	// we utilize the temporaryStore to ensure independence from the current store implementation.
 	// as of today, the store is implemented as a queue and will be drained by the higher-level
 	// component as soon as it finishes replacing the content.
-	checkWatchListDataConsistencyIfRequested(ctx, r.name, resourceVersion, wrapListFuncWithContext(r.listerWatcher.List), temporaryStore.List)
+	checkWatchListDataConsistencyIfRequested(ctx, r.name, resourceVersion, r.listerWatcher.ListWithContext, temporaryStore.List)
 
 	if err := r.store.Replace(temporaryStore.List(), resourceVersion); err != nil {
 		return nil, fmt.Errorf("unable to sync watch-list result: %w", err)
@@ -1033,13 +1033,6 @@ func isWatchErrorRetriable(err error) bool {
 		return true
 	}
 	return false
-}
-
-// wrapListFuncWithContext simply wraps ListFunction into another function that accepts a context and ignores it.
-func wrapListFuncWithContext(listFn ListFunc) func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
-	return func(_ context.Context, options metav1.ListOptions) (runtime.Object, error) {
-		return listFn(options)
-	}
 }
 
 // initialEventsEndBookmarkTicker a ticker that produces a warning if the bookmark event

--- a/staging/src/k8s.io/client-go/tools/watch/informerwatcher.go
+++ b/staging/src/k8s.io/client-go/tools/watch/informerwatcher.go
@@ -17,11 +17,14 @@ limitations under the License.
 package watch
 
 import (
+	"context"
 	"sync"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
 )
 
 func newEventProcessor(out chan<- watch.Event) *eventProcessor {
@@ -103,7 +106,19 @@ func (e *eventProcessor) stop() {
 // NewIndexerInformerWatcher will create an IndexerInformer and wrap it into watch.Interface
 // so you can use it anywhere where you'd have used a regular Watcher returned from Watch method.
 // it also returns a channel you can use to wait for the informers to fully shutdown.
+//
+// Contextual logging: NewIndexerInformerWatcherWithContext should be used instead of NewIndexerInformerWatcher in code which supports contextual logging.
 func NewIndexerInformerWatcher(lw cache.ListerWatcher, objType runtime.Object) (cache.Indexer, cache.Controller, watch.Interface, <-chan struct{}) {
+	return NewIndexerInformerWatcherWithContext(context.Background(), lw, objType)
+}
+
+// NewIndexerInformerWatcher will create an IndexerInformer and wrap it into watch.Interface
+// so you can use it anywhere where you'd have used a regular Watcher returned from Watch method.
+// it also returns a channel you can use to wait for the informers to fully shutdown.
+//
+// Cancellation of the context has the same effect as calling [watch.Interface.Stop]. One or
+// the other can be used.
+func NewIndexerInformerWatcherWithContext(ctx context.Context, lw cache.ListerWatcher, objType runtime.Object) (cache.Indexer, cache.Controller, watch.Interface, <-chan struct{}) {
 	ch := make(chan watch.Event)
 	w := watch.NewProxyWatcher(ch)
 	e := newEventProcessor(ch)
@@ -137,13 +152,30 @@ func NewIndexerInformerWatcher(lw cache.ListerWatcher, objType runtime.Object) (
 		},
 	}, cache.Indexers{})
 
+	// This will get stopped, but without waiting for it.
 	go e.run()
+
+	logger := klog.FromContext(ctx)
+	if ctx.Done() != nil {
+		go func() {
+			select {
+			case <-ctx.Done():
+				// Map cancellation to Stop. The informer below only waits for that.
+				w.Stop()
+			case <-w.StopChan():
+			}
+		}()
+	}
 
 	doneCh := make(chan struct{})
 	go func() {
 		defer close(doneCh)
 		defer e.stop()
-		informer.Run(w.StopChan())
+		// Waiting for w.StopChan() is the traditional behavior which gets
+		// preserved here. Context cancellation is handled above.
+		ctx := wait.ContextForChannel(w.StopChan())
+		ctx = klog.NewContext(ctx, logger)
+		informer.RunWithContext(ctx)
 	}()
 
 	return indexer, informer, w, doneCh

--- a/staging/src/k8s.io/client-go/tools/watch/informerwatcher_test.go
+++ b/staging/src/k8s.io/client-go/tools/watch/informerwatcher_test.go
@@ -18,7 +18,6 @@ package watch
 
 import (
 	"context"
-	"errors"
 	"reflect"
 	goruntime "runtime"
 	"sort"
@@ -40,8 +39,6 @@ import (
 	fakeclientset "k8s.io/client-go/kubernetes/fake"
 	testcore "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/klog/v2"
-	"k8s.io/klog/v2/ktesting"
 )
 
 // TestEventProcessorExit is expected to timeout if the event processor fails
@@ -466,30 +463,4 @@ func TestInformerWatcherDeletedFinalStateUnknown(t *testing.T) {
 	if watchCalls < 1 {
 		t.Fatalf("expected at least 1 watch call, got %d", watchCalls)
 	}
-}
-
-func TestInformerContext(t *testing.T) {
-	logger, ctx := ktesting.NewTestContext(t)
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	// Whatever gets called first will stop.
-	validateContext := func(ctx context.Context) error {
-		if reflect.TypeOf(logger.GetSink()) != reflect.TypeOf(klog.FromContext(ctx).GetSink()) {
-			t.Errorf("Expected logger %+v from context, got %+v", logger, klog.FromContext(ctx))
-		}
-		cancel()
-		return errors.New("not implemented by text")
-	}
-	lw := &cache.ListWatch{
-		ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
-			return nil, validateContext(ctx)
-		},
-		WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
-			return nil, validateContext(ctx)
-		},
-	}
-
-	_, _, _, done := NewIndexerInformerWatcherWithContext(ctx, lw, &corev1.Secret{})
-	<-done
 }

--- a/staging/src/k8s.io/client-go/tools/watch/retrywatcher.go
+++ b/staging/src/k8s.io/client-go/tools/watch/retrywatcher.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"sync"
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -48,23 +47,31 @@ type resourceVersionGetter interface {
 // Please note that this is not resilient to etcd cache not having the resource version anymore - you would need to
 // use Informers for that.
 type RetryWatcher struct {
+	cancel              func(error)
 	lastResourceVersion string
-	watcherClient       cache.Watcher
+	watcherClient       cache.WatcherWithContext
 	resultChan          chan watch.Event
-	stopChan            chan struct{}
 	doneChan            chan struct{}
 	minRestartDelay     time.Duration
-	stopChanLock        sync.Mutex
 }
 
 // NewRetryWatcher creates a new RetryWatcher.
 // It will make sure that watches gets restarted in case of recoverable errors.
 // The initialResourceVersion will be given to watch method when first called.
+//
+// Deprecated: use NewRetryWatcherWithContext instead.
 func NewRetryWatcher(initialResourceVersion string, watcherClient cache.Watcher) (*RetryWatcher, error) {
-	return newRetryWatcher(initialResourceVersion, watcherClient, 1*time.Second)
+	return NewRetryWatcherWithContext(context.Background(), initialResourceVersion, cache.ToWatcherWithContext(watcherClient))
 }
 
-func newRetryWatcher(initialResourceVersion string, watcherClient cache.Watcher, minRestartDelay time.Duration) (*RetryWatcher, error) {
+// NewRetryWatcherWithContext creates a new RetryWatcher.
+// It will make sure that watches gets restarted in case of recoverable errors.
+// The initialResourceVersion will be given to watch method when first called.
+func NewRetryWatcherWithContext(ctx context.Context, initialResourceVersion string, watcherClient cache.WatcherWithContext) (*RetryWatcher, error) {
+	return newRetryWatcher(ctx, initialResourceVersion, watcherClient, 1*time.Second)
+}
+
+func newRetryWatcher(ctx context.Context, initialResourceVersion string, watcherClient cache.WatcherWithContext, minRestartDelay time.Duration) (*RetryWatcher, error) {
 	switch initialResourceVersion {
 	case "", "0":
 		// TODO: revisit this if we ever get WATCH v2 where it means start "now"
@@ -74,34 +81,36 @@ func newRetryWatcher(initialResourceVersion string, watcherClient cache.Watcher,
 		break
 	}
 
+	ctx, cancel := context.WithCancelCause(ctx)
+
 	rw := &RetryWatcher{
+		cancel:              cancel,
 		lastResourceVersion: initialResourceVersion,
 		watcherClient:       watcherClient,
-		stopChan:            make(chan struct{}),
 		doneChan:            make(chan struct{}),
 		resultChan:          make(chan watch.Event, 0),
 		minRestartDelay:     minRestartDelay,
 	}
 
-	go rw.receive()
+	go rw.receive(ctx)
 	return rw, nil
 }
 
-func (rw *RetryWatcher) send(event watch.Event) bool {
+func (rw *RetryWatcher) send(ctx context.Context, event watch.Event) bool {
 	// Writing to an unbuffered channel is blocking operation
 	// and we need to check if stop wasn't requested while doing so.
 	select {
 	case rw.resultChan <- event:
 		return true
-	case <-rw.stopChan:
+	case <-ctx.Done():
 		return false
 	}
 }
 
 // doReceive returns true when it is done, false otherwise.
 // If it is not done the second return value holds the time to wait before calling it again.
-func (rw *RetryWatcher) doReceive() (bool, time.Duration) {
-	watcher, err := rw.watcherClient.Watch(metav1.ListOptions{
+func (rw *RetryWatcher) doReceive(ctx context.Context) (bool, time.Duration) {
+	watcher, err := rw.watcherClient.WatchWithContext(ctx, metav1.ListOptions{
 		ResourceVersion:     rw.lastResourceVersion,
 		AllowWatchBookmarks: true,
 	})
@@ -117,13 +126,13 @@ func (rw *RetryWatcher) doReceive() (bool, time.Duration) {
 		return false, 0
 
 	case io.ErrUnexpectedEOF:
-		klog.V(1).InfoS("Watch closed with unexpected EOF", "err", err)
+		klog.FromContext(ctx).V(1).Info("Watch closed with unexpected EOF", "err", err)
 		return false, 0
 
 	default:
 		msg := "Watch failed"
 		if net.IsProbableEOF(err) || net.IsTimeout(err) {
-			klog.V(5).InfoS(msg, "err", err)
+			klog.FromContext(ctx).V(5).Info(msg, "err", err)
 			// Retry
 			return false, 0
 		}
@@ -132,38 +141,38 @@ func (rw *RetryWatcher) doReceive() (bool, time.Duration) {
 		// being invalid (e.g. expired token).
 		if apierrors.IsForbidden(err) || apierrors.IsUnauthorized(err) {
 			// Add more detail since the forbidden message returned by the Kubernetes API is just "unknown".
-			klog.ErrorS(err, msg+": ensure the client has valid credentials and watch permissions on the resource")
+			klog.FromContext(ctx).Error(err, msg+": ensure the client has valid credentials and watch permissions on the resource")
 
 			if apiStatus, ok := err.(apierrors.APIStatus); ok {
 				statusErr := apiStatus.Status()
 
-				sent := rw.send(watch.Event{
+				sent := rw.send(ctx, watch.Event{
 					Type:   watch.Error,
 					Object: &statusErr,
 				})
 				if !sent {
 					// This likely means the RetryWatcher is stopping but return false so the caller to doReceive can
 					// verify this and potentially retry.
-					klog.Error("Failed to send the Unauthorized or Forbidden watch event")
+					klog.FromContext(ctx).Error(nil, "Failed to send the Unauthorized or Forbidden watch event")
 
 					return false, 0
 				}
 			} else {
 				// This should never happen since apierrors only handles apierrors.APIStatus. Still, this is an
 				// unrecoverable error, so still allow it to return true below.
-				klog.ErrorS(err, msg+": encountered an unexpected Unauthorized or Forbidden error type")
+				klog.FromContext(ctx).Error(err, msg+": encountered an unexpected Unauthorized or Forbidden error type")
 			}
 
 			return true, 0
 		}
 
-		klog.ErrorS(err, msg)
+		klog.FromContext(ctx).Error(err, msg)
 		// Retry
 		return false, 0
 	}
 
 	if watcher == nil {
-		klog.ErrorS(nil, "Watch returned nil watcher")
+		klog.FromContext(ctx).Error(nil, "Watch returned nil watcher")
 		// Retry
 		return false, 0
 	}
@@ -173,12 +182,12 @@ func (rw *RetryWatcher) doReceive() (bool, time.Duration) {
 
 	for {
 		select {
-		case <-rw.stopChan:
-			klog.V(4).InfoS("Stopping RetryWatcher.")
+		case <-ctx.Done():
+			klog.FromContext(ctx).V(4).Info("Stopping RetryWatcher")
 			return true, 0
 		case event, ok := <-ch:
 			if !ok {
-				klog.V(4).InfoS("Failed to get event! Re-creating the watcher.", "resourceVersion", rw.lastResourceVersion)
+				klog.FromContext(ctx).V(4).Info("Failed to get event - re-creating the watcher", "resourceVersion", rw.lastResourceVersion)
 				return false, 0
 			}
 
@@ -187,7 +196,7 @@ func (rw *RetryWatcher) doReceive() (bool, time.Duration) {
 			case watch.Added, watch.Modified, watch.Deleted, watch.Bookmark:
 				metaObject, ok := event.Object.(resourceVersionGetter)
 				if !ok {
-					_ = rw.send(watch.Event{
+					_ = rw.send(ctx, watch.Event{
 						Type:   watch.Error,
 						Object: &apierrors.NewInternalError(errors.New("retryWatcher: doesn't support resourceVersion")).ErrStatus,
 					})
@@ -197,7 +206,7 @@ func (rw *RetryWatcher) doReceive() (bool, time.Duration) {
 
 				resourceVersion := metaObject.GetResourceVersion()
 				if resourceVersion == "" {
-					_ = rw.send(watch.Event{
+					_ = rw.send(ctx, watch.Event{
 						Type:   watch.Error,
 						Object: &apierrors.NewInternalError(fmt.Errorf("retryWatcher: object %#v doesn't support resourceVersion", event.Object)).ErrStatus,
 					})
@@ -207,7 +216,7 @@ func (rw *RetryWatcher) doReceive() (bool, time.Duration) {
 
 				// All is fine; send the non-bookmark events and update resource version.
 				if event.Type != watch.Bookmark {
-					ok = rw.send(event)
+					ok = rw.send(ctx, event)
 					if !ok {
 						return true, 0
 					}
@@ -221,7 +230,7 @@ func (rw *RetryWatcher) doReceive() (bool, time.Duration) {
 				errObject := apierrors.FromObject(event.Object)
 				statusErr, ok := errObject.(*apierrors.StatusError)
 				if !ok {
-					klog.Error(fmt.Sprintf("Received an error which is not *metav1.Status but %s", dump.Pretty(event.Object)))
+					klog.FromContext(ctx).Error(nil, "Received an error which is not *metav1.Status", "errorObject", dump.Pretty(event.Object))
 					// Retry unknown errors
 					return false, 0
 				}
@@ -236,7 +245,7 @@ func (rw *RetryWatcher) doReceive() (bool, time.Duration) {
 				switch status.Code {
 				case http.StatusGone:
 					// Never retry RV too old errors
-					_ = rw.send(event)
+					_ = rw.send(ctx, event)
 					return true, 0
 
 				case http.StatusGatewayTimeout, http.StatusInternalServerError:
@@ -250,15 +259,15 @@ func (rw *RetryWatcher) doReceive() (bool, time.Duration) {
 
 					// Log here so we have a record of hitting the unexpected error
 					// and we can whitelist some error codes if we missed any that are expected.
-					klog.V(5).Info(fmt.Sprintf("Retrying after unexpected error: %s", dump.Pretty(event.Object)))
+					klog.FromContext(ctx).V(5).Info("Retrying after unexpected error", "errorObject", dump.Pretty(event.Object))
 
 					// Retry
 					return false, statusDelay
 				}
 
 			default:
-				klog.Errorf("Failed to recognize Event type %q", event.Type)
-				_ = rw.send(watch.Event{
+				klog.FromContext(ctx).Error(nil, "Failed to recognize event", "type", event.Type)
+				_ = rw.send(ctx, watch.Event{
 					Type:   watch.Error,
 					Object: &apierrors.NewInternalError(fmt.Errorf("retryWatcher failed to recognize Event type %q", event.Type)).ErrStatus,
 				})
@@ -270,29 +279,21 @@ func (rw *RetryWatcher) doReceive() (bool, time.Duration) {
 }
 
 // receive reads the result from a watcher, restarting it if necessary.
-func (rw *RetryWatcher) receive() {
+func (rw *RetryWatcher) receive(ctx context.Context) {
 	defer close(rw.doneChan)
 	defer close(rw.resultChan)
 
-	klog.V(4).Info("Starting RetryWatcher.")
-	defer klog.V(4).Info("Stopping RetryWatcher.")
+	logger := klog.FromContext(ctx)
+	logger.V(4).Info("Starting RetryWatcher")
+	defer logger.V(4).Info("Stopping RetryWatcher")
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	go func() {
-		select {
-		case <-rw.stopChan:
-			cancel()
-			return
-		case <-ctx.Done():
-			return
-		}
-	}()
 
 	// We use non sliding until so we don't introduce delays on happy path when WATCH call
 	// timeouts or gets closed and we need to reestablish it while also avoiding hot loops.
 	wait.NonSlidingUntilWithContext(ctx, func(ctx context.Context) {
-		done, retryAfter := rw.doReceive()
+		done, retryAfter := rw.doReceive(ctx)
 		if done {
 			cancel()
 			return
@@ -306,7 +307,7 @@ func (rw *RetryWatcher) receive() {
 		case <-timer.C:
 		}
 
-		klog.V(4).Infof("Restarting RetryWatcher at RV=%q", rw.lastResourceVersion)
+		logger.V(4).Info("Restarting RetryWatcher", "resourceVersion", rw.lastResourceVersion)
 	}, rw.minRestartDelay)
 }
 
@@ -317,15 +318,7 @@ func (rw *RetryWatcher) ResultChan() <-chan watch.Event {
 
 // Stop implements Interface.
 func (rw *RetryWatcher) Stop() {
-	rw.stopChanLock.Lock()
-	defer rw.stopChanLock.Unlock()
-
-	// Prevent closing an already closed channel to prevent a panic
-	select {
-	case <-rw.stopChan:
-	default:
-		close(rw.stopChan)
-	}
+	rw.cancel(errors.New("asked to stop"))
 }
 
 // Done allows the caller to be notified when Retry watcher stops.

--- a/staging/src/k8s.io/client-go/tools/watch/retrywatcher_test.go
+++ b/staging/src/k8s.io/client-go/tools/watch/retrywatcher_test.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
+	"k8s.io/klog/v2/ktesting"
 )
 
 func init() {
@@ -54,7 +55,7 @@ func (o testObject) GetObjectKind() schema.ObjectKind { return schema.EmptyObjec
 func (o testObject) DeepCopyObject() runtime.Object   { return o }
 func (o testObject) GetResourceVersion() string       { return o.resourceVersion }
 
-func withCounter(w cache.Watcher) (*uint32, cache.Watcher) {
+func withCounter(w cache.Watcher) (*uint32, cache.WatcherWithContext) {
 	var counter uint32
 	return &counter, &cache.ListWatch{
 		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
@@ -549,10 +550,11 @@ func TestRetryWatcher(t *testing.T) {
 	for _, tc := range tt {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			_, ctx := ktesting.NewTestContext(t)
 			t.Parallel()
 
 			atomicCounter, watchFunc := withCounter(tc.watchClient)
-			watcher, err := newRetryWatcher(tc.initialRV, watchFunc, time.Duration(0))
+			watcher, err := newRetryWatcher(ctx, tc.initialRV, watchFunc, time.Duration(0))
 			if err != nil {
 				t.Fatalf("failed to create a RetryWatcher: %v", err)
 			}

--- a/staging/src/k8s.io/client-go/tools/watch/until.go
+++ b/staging/src/k8s.io/client-go/tools/watch/until.go
@@ -126,7 +126,7 @@ func Until(ctx context.Context, initialResourceVersion string, watcherClient cac
 // The most frequent usage would be a command that needs to watch the "state of the world" and should't fail, like:
 // waiting for object reaching a state, "small" controllers, ...
 func UntilWithSync(ctx context.Context, lw cache.ListerWatcher, objType runtime.Object, precondition PreconditionFunc, conditions ...ConditionFunc) (*watch.Event, error) {
-	indexer, informer, watcher, done := NewIndexerInformerWatcherWithContext(ctx, lw, objType)
+	indexer, informer, watcher, done := NewIndexerInformerWatcherWithLogger(klog.FromContext(ctx), lw, objType)
 	// We need to wait for the internal informers to fully stop so it's easier to reason about
 	// and it works with non-thread safe clients.
 	defer func() { <-done }()

--- a/staging/src/k8s.io/client-go/tools/watch/until.go
+++ b/staging/src/k8s.io/client-go/tools/watch/until.go
@@ -105,7 +105,7 @@ func UntilWithoutRetry(ctx context.Context, watcher watch.Interface, conditions 
 //
 // The most frequent usage for Until would be a test where you want to verify exact order of events ("edges").
 func Until(ctx context.Context, initialResourceVersion string, watcherClient cache.Watcher, conditions ...ConditionFunc) (*watch.Event, error) {
-	w, err := NewRetryWatcher(initialResourceVersion, watcherClient)
+	w, err := NewRetryWatcherWithContext(ctx, initialResourceVersion, cache.ToWatcherWithContext(watcherClient))
 	if err != nil {
 		return nil, err
 	}
@@ -126,7 +126,7 @@ func Until(ctx context.Context, initialResourceVersion string, watcherClient cac
 // The most frequent usage would be a command that needs to watch the "state of the world" and should't fail, like:
 // waiting for object reaching a state, "small" controllers, ...
 func UntilWithSync(ctx context.Context, lw cache.ListerWatcher, objType runtime.Object, precondition PreconditionFunc, conditions ...ConditionFunc) (*watch.Event, error) {
-	indexer, informer, watcher, done := NewIndexerInformerWatcher(lw, objType)
+	indexer, informer, watcher, done := NewIndexerInformerWatcherWithContext(ctx, lw, objType)
 	// We need to wait for the internal informers to fully stop so it's easier to reason about
 	// and it works with non-thread safe clients.
 	defer func() { <-done }()
@@ -156,7 +156,7 @@ func UntilWithSync(ctx context.Context, lw cache.ListerWatcher, objType runtime.
 func ContextWithOptionalTimeout(parent context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
 	if timeout < 0 {
 		// This should be handled in validation
-		klog.Errorf("Timeout for context shall not be negative!")
+		klog.FromContext(parent).Error(nil, "Timeout for context shall not be negative")
 		timeout = 0
 	}
 

--- a/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/informer.go
+++ b/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/informer.go
@@ -86,7 +86,8 @@ func (g *informerGenerator) GenerateType(c *generator.Context, t *types.Type, w 
 		"cacheNewSharedIndexInformer":     c.Universe.Function(cacheNewSharedIndexInformer),
 		"cacheSharedIndexInformer":        c.Universe.Type(cacheSharedIndexInformer),
 		"clientSetInterface":              clientSetInterface,
-		"contextTODO":                     c.Universe.Type(contextTODOFunc),
+		"contextContext":                  c.Universe.Type(contextContext),
+		"contextBackground":               c.Universe.Function(contextBackgroundFunc),
 		"group":                           namer.IC(g.groupGoName),
 		"informerFor":                     informerFor,
 		"interfacesTweakListOptionsFunc":  c.Universe.Type(types.Name{Package: g.internalInterfacesPackage, Name: "TweakListOptionsFunc"}),
@@ -152,13 +153,25 @@ func NewFiltered$.type|public$Informer(client $.clientSetInterface|raw$$if .name
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.$.group$$.version$().$.type|publicPlural$($if .namespaced$namespace$end$).List($.contextTODO|raw$(), options)
+				return client.$.group$$.version$().$.type|publicPlural$($if .namespaced$namespace$end$).List($.contextBackground|raw$(), options)
 			},
 			WatchFunc: func(options $.v1ListOptions|raw$) ($.watchInterface|raw$, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.$.group$$.version$().$.type|publicPlural$($if .namespaced$namespace$end$).Watch($.contextTODO|raw$(), options)
+				return client.$.group$$.version$().$.type|publicPlural$($if .namespaced$namespace$end$).Watch($.contextBackground|raw$(), options)
+			},
+			ListWithContextFunc: func(ctx $.contextContext|raw$, options $.v1ListOptions|raw$) ($.runtimeObject|raw$, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.$.group$$.version$().$.type|publicPlural$($if .namespaced$namespace$end$).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx $.contextContext|raw$, options $.v1ListOptions|raw$) ($.watchInterface|raw$, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.$.group$$.version$().$.type|publicPlural$($if .namespaced$namespace$end$).Watch(ctx, options)
 			},
 		},
 		&$.type|raw${},

--- a/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/types.go
+++ b/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/types.go
@@ -29,7 +29,8 @@ var (
 	cacheNewSharedIndexInformer = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "NewSharedIndexInformer"}
 	cacheSharedIndexInformer    = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "SharedIndexInformer"}
 	cacheTransformFunc          = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "TransformFunc"}
-	contextTODOFunc             = types.Name{Package: "context", Name: "TODO"}
+	contextBackgroundFunc       = types.Name{Package: "context", Name: "Background"}
+	contextContext              = types.Name{Package: "context", Name: "Context"}
 	fmtErrorfFunc               = types.Name{Package: "fmt", Name: "Errorf"}
 	listOptions                 = types.Name{Package: "k8s.io/kubernetes/pkg/apis/core", Name: "ListOptions"}
 	reflectType                 = types.Name{Package: "reflect", Name: "Type"}

--- a/staging/src/k8s.io/code-generator/examples/HyphenGroup/informers/externalversions/example/v1/clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/examples/HyphenGroup/informers/externalversions/example/v1/clustertesttype.go
@@ -61,13 +61,25 @@ func NewFilteredClusterTestTypeInformer(client versioned.Interface, resyncPeriod
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ExampleGroupV1().ClusterTestTypes().List(context.TODO(), options)
+				return client.ExampleGroupV1().ClusterTestTypes().List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ExampleGroupV1().ClusterTestTypes().Watch(context.TODO(), options)
+				return client.ExampleGroupV1().ClusterTestTypes().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.ExampleGroupV1().ClusterTestTypes().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.ExampleGroupV1().ClusterTestTypes().Watch(ctx, options)
 			},
 		},
 		&apisexamplev1.ClusterTestType{},

--- a/staging/src/k8s.io/code-generator/examples/HyphenGroup/informers/externalversions/example/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/HyphenGroup/informers/externalversions/example/v1/testtype.go
@@ -62,13 +62,25 @@ func NewFilteredTestTypeInformer(client versioned.Interface, namespace string, r
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ExampleGroupV1().TestTypes(namespace).List(context.TODO(), options)
+				return client.ExampleGroupV1().TestTypes(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ExampleGroupV1().TestTypes(namespace).Watch(context.TODO(), options)
+				return client.ExampleGroupV1().TestTypes(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.ExampleGroupV1().TestTypes(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.ExampleGroupV1().TestTypes(namespace).Watch(ctx, options)
 			},
 		},
 		&apisexamplev1.TestType{},

--- a/staging/src/k8s.io/code-generator/examples/MixedCase/informers/externalversions/example/v1/clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/examples/MixedCase/informers/externalversions/example/v1/clustertesttype.go
@@ -61,13 +61,25 @@ func NewFilteredClusterTestTypeInformer(client versioned.Interface, resyncPeriod
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ExampleV1().ClusterTestTypes().List(context.TODO(), options)
+				return client.ExampleV1().ClusterTestTypes().List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ExampleV1().ClusterTestTypes().Watch(context.TODO(), options)
+				return client.ExampleV1().ClusterTestTypes().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.ExampleV1().ClusterTestTypes().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.ExampleV1().ClusterTestTypes().Watch(ctx, options)
 			},
 		},
 		&apisexamplev1.ClusterTestType{},

--- a/staging/src/k8s.io/code-generator/examples/MixedCase/informers/externalversions/example/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/MixedCase/informers/externalversions/example/v1/testtype.go
@@ -62,13 +62,25 @@ func NewFilteredTestTypeInformer(client versioned.Interface, namespace string, r
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ExampleV1().TestTypes(namespace).List(context.TODO(), options)
+				return client.ExampleV1().TestTypes(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ExampleV1().TestTypes(namespace).Watch(context.TODO(), options)
+				return client.ExampleV1().TestTypes(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.ExampleV1().TestTypes(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.ExampleV1().TestTypes(namespace).Watch(ctx, options)
 			},
 		},
 		&apisexamplev1.TestType{},

--- a/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/core/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/core/v1/testtype.go
@@ -62,13 +62,25 @@ func NewFilteredTestTypeInformer(client versioned.Interface, namespace string, r
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CoreV1().TestTypes(namespace).List(context.TODO(), options)
+				return client.CoreV1().TestTypes(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CoreV1().TestTypes(namespace).Watch(context.TODO(), options)
+				return client.CoreV1().TestTypes(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.CoreV1().TestTypes(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.CoreV1().TestTypes(namespace).Watch(ctx, options)
 			},
 		},
 		&apiscorev1.TestType{},

--- a/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/example/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/example/v1/testtype.go
@@ -62,13 +62,25 @@ func NewFilteredTestTypeInformer(client versioned.Interface, namespace string, r
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ExampleV1().TestTypes(namespace).List(context.TODO(), options)
+				return client.ExampleV1().TestTypes(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ExampleV1().TestTypes(namespace).Watch(context.TODO(), options)
+				return client.ExampleV1().TestTypes(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.ExampleV1().TestTypes(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.ExampleV1().TestTypes(namespace).Watch(ctx, options)
 			},
 		},
 		&apisexamplev1.TestType{},

--- a/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/example2/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/example2/v1/testtype.go
@@ -62,13 +62,25 @@ func NewFilteredTestTypeInformer(client versioned.Interface, namespace string, r
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.SecondExampleV1().TestTypes(namespace).List(context.TODO(), options)
+				return client.SecondExampleV1().TestTypes(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.SecondExampleV1().TestTypes(namespace).Watch(context.TODO(), options)
+				return client.SecondExampleV1().TestTypes(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.SecondExampleV1().TestTypes(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.SecondExampleV1().TestTypes(namespace).Watch(ctx, options)
 			},
 		},
 		&apisexample2v1.TestType{},

--- a/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/example3.io/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/example3.io/v1/testtype.go
@@ -62,13 +62,25 @@ func NewFilteredTestTypeInformer(client versioned.Interface, namespace string, r
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ThirdExampleV1().TestTypes(namespace).List(context.TODO(), options)
+				return client.ThirdExampleV1().TestTypes(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ThirdExampleV1().TestTypes(namespace).Watch(context.TODO(), options)
+				return client.ThirdExampleV1().TestTypes(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.ThirdExampleV1().TestTypes(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.ThirdExampleV1().TestTypes(namespace).Watch(ctx, options)
 			},
 		},
 		&apisexample3iov1.TestType{},

--- a/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/conflicting/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/conflicting/v1/testtype.go
@@ -62,13 +62,25 @@ func NewFilteredTestTypeInformer(client versioned.Interface, namespace string, r
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ConflictingExampleV1().TestTypes(namespace).List(context.TODO(), options)
+				return client.ConflictingExampleV1().TestTypes(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ConflictingExampleV1().TestTypes(namespace).Watch(context.TODO(), options)
+				return client.ConflictingExampleV1().TestTypes(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.ConflictingExampleV1().TestTypes(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.ConflictingExampleV1().TestTypes(namespace).Watch(ctx, options)
 			},
 		},
 		&apisconflictingv1.TestType{},

--- a/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/example/v1/clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/example/v1/clustertesttype.go
@@ -61,13 +61,25 @@ func NewFilteredClusterTestTypeInformer(client versioned.Interface, resyncPeriod
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ExampleV1().ClusterTestTypes().List(context.TODO(), options)
+				return client.ExampleV1().ClusterTestTypes().List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ExampleV1().ClusterTestTypes().Watch(context.TODO(), options)
+				return client.ExampleV1().ClusterTestTypes().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.ExampleV1().ClusterTestTypes().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.ExampleV1().ClusterTestTypes().Watch(ctx, options)
 			},
 		},
 		&apisexamplev1.ClusterTestType{},

--- a/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/example/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/example/v1/testtype.go
@@ -62,13 +62,25 @@ func NewFilteredTestTypeInformer(client versioned.Interface, namespace string, r
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ExampleV1().TestTypes(namespace).List(context.TODO(), options)
+				return client.ExampleV1().TestTypes(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ExampleV1().TestTypes(namespace).Watch(context.TODO(), options)
+				return client.ExampleV1().TestTypes(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.ExampleV1().TestTypes(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.ExampleV1().TestTypes(namespace).Watch(ctx, options)
 			},
 		},
 		&apisexamplev1.TestType{},

--- a/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/example2/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/example2/v1/testtype.go
@@ -62,13 +62,25 @@ func NewFilteredTestTypeInformer(client versioned.Interface, namespace string, r
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.SecondExampleV1().TestTypes(namespace).List(context.TODO(), options)
+				return client.SecondExampleV1().TestTypes(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.SecondExampleV1().TestTypes(namespace).Watch(context.TODO(), options)
+				return client.SecondExampleV1().TestTypes(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.SecondExampleV1().TestTypes(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.SecondExampleV1().TestTypes(namespace).Watch(ctx, options)
 			},
 		},
 		&apisexample2v1.TestType{},

--- a/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/extensions/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/extensions/v1/testtype.go
@@ -62,13 +62,25 @@ func NewFilteredTestTypeInformer(client versioned.Interface, namespace string, r
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ExtensionsExampleV1().TestTypes(namespace).List(context.TODO(), options)
+				return client.ExtensionsExampleV1().TestTypes(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ExtensionsExampleV1().TestTypes(namespace).Watch(context.TODO(), options)
+				return client.ExtensionsExampleV1().TestTypes(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.ExtensionsExampleV1().TestTypes(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.ExtensionsExampleV1().TestTypes(namespace).Watch(ctx, options)
 			},
 		},
 		&apisextensionsv1.TestType{},

--- a/staging/src/k8s.io/code-generator/examples/single/informers/externalversions/api/v1/clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/examples/single/informers/externalversions/api/v1/clustertesttype.go
@@ -61,13 +61,25 @@ func NewFilteredClusterTestTypeInformer(client versioned.Interface, resyncPeriod
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ExampleV1().ClusterTestTypes().List(context.TODO(), options)
+				return client.ExampleV1().ClusterTestTypes().List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ExampleV1().ClusterTestTypes().Watch(context.TODO(), options)
+				return client.ExampleV1().ClusterTestTypes().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.ExampleV1().ClusterTestTypes().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.ExampleV1().ClusterTestTypes().Watch(ctx, options)
 			},
 		},
 		&singleapiv1.ClusterTestType{},

--- a/staging/src/k8s.io/code-generator/examples/single/informers/externalversions/api/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/single/informers/externalversions/api/v1/testtype.go
@@ -62,13 +62,25 @@ func NewFilteredTestTypeInformer(client versioned.Interface, namespace string, r
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ExampleV1().TestTypes(namespace).List(context.TODO(), options)
+				return client.ExampleV1().TestTypes(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ExampleV1().TestTypes(namespace).Watch(context.TODO(), options)
+				return client.ExampleV1().TestTypes(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.ExampleV1().TestTypes(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.ExampleV1().TestTypes(namespace).Watch(ctx, options)
 			},
 		},
 		&singleapiv1.TestType{},

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/informers/externalversions/apiregistration/v1/apiservice.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/informers/externalversions/apiregistration/v1/apiservice.go
@@ -61,13 +61,25 @@ func NewFilteredAPIServiceInformer(client clientset.Interface, resyncPeriod time
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ApiregistrationV1().APIServices().List(context.TODO(), options)
+				return client.ApiregistrationV1().APIServices().List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ApiregistrationV1().APIServices().Watch(context.TODO(), options)
+				return client.ApiregistrationV1().APIServices().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.ApiregistrationV1().APIServices().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.ApiregistrationV1().APIServices().Watch(ctx, options)
 			},
 		},
 		&apisapiregistrationv1.APIService{},

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/informers/externalversions/apiregistration/v1beta1/apiservice.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/informers/externalversions/apiregistration/v1beta1/apiservice.go
@@ -61,13 +61,25 @@ func NewFilteredAPIServiceInformer(client clientset.Interface, resyncPeriod time
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ApiregistrationV1beta1().APIServices().List(context.TODO(), options)
+				return client.ApiregistrationV1beta1().APIServices().List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ApiregistrationV1beta1().APIServices().Watch(context.TODO(), options)
+				return client.ApiregistrationV1beta1().APIServices().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.ApiregistrationV1beta1().APIServices().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.ApiregistrationV1beta1().APIServices().Watch(ctx, options)
 			},
 		},
 		&apisapiregistrationv1beta1.APIService{},

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/informers/externalversions/wardle/v1alpha1/fischer.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/informers/externalversions/wardle/v1alpha1/fischer.go
@@ -61,13 +61,25 @@ func NewFilteredFischerInformer(client versioned.Interface, resyncPeriod time.Du
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.WardleV1alpha1().Fischers().List(context.TODO(), options)
+				return client.WardleV1alpha1().Fischers().List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.WardleV1alpha1().Fischers().Watch(context.TODO(), options)
+				return client.WardleV1alpha1().Fischers().Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.WardleV1alpha1().Fischers().List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.WardleV1alpha1().Fischers().Watch(ctx, options)
 			},
 		},
 		&apiswardlev1alpha1.Fischer{},

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/informers/externalversions/wardle/v1alpha1/flunder.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/informers/externalversions/wardle/v1alpha1/flunder.go
@@ -62,13 +62,25 @@ func NewFilteredFlunderInformer(client versioned.Interface, namespace string, re
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.WardleV1alpha1().Flunders(namespace).List(context.TODO(), options)
+				return client.WardleV1alpha1().Flunders(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.WardleV1alpha1().Flunders(namespace).Watch(context.TODO(), options)
+				return client.WardleV1alpha1().Flunders(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.WardleV1alpha1().Flunders(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.WardleV1alpha1().Flunders(namespace).Watch(ctx, options)
 			},
 		},
 		&apiswardlev1alpha1.Flunder{},

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/informers/externalversions/wardle/v1beta1/flunder.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/informers/externalversions/wardle/v1beta1/flunder.go
@@ -62,13 +62,25 @@ func NewFilteredFlunderInformer(client versioned.Interface, namespace string, re
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.WardleV1beta1().Flunders(namespace).List(context.TODO(), options)
+				return client.WardleV1beta1().Flunders(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.WardleV1beta1().Flunders(namespace).Watch(context.TODO(), options)
+				return client.WardleV1beta1().Flunders(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.WardleV1beta1().Flunders(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.WardleV1beta1().Flunders(namespace).Watch(ctx, options)
 			},
 		},
 		&apiswardlev1beta1.Flunder{},

--- a/staging/src/k8s.io/sample-controller/pkg/generated/informers/externalversions/samplecontroller/v1alpha1/foo.go
+++ b/staging/src/k8s.io/sample-controller/pkg/generated/informers/externalversions/samplecontroller/v1alpha1/foo.go
@@ -62,13 +62,25 @@ func NewFilteredFooInformer(client versioned.Interface, namespace string, resync
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.SamplecontrollerV1alpha1().Foos(namespace).List(context.TODO(), options)
+				return client.SamplecontrollerV1alpha1().Foos(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.SamplecontrollerV1alpha1().Foos(namespace).Watch(context.TODO(), options)
+				return client.SamplecontrollerV1alpha1().Foos(namespace).Watch(context.Background(), options)
+			},
+			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.SamplecontrollerV1alpha1().Foos(namespace).List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+				return client.SamplecontrollerV1alpha1().Foos(namespace).Watch(ctx, options)
 			},
 		},
 		&apissamplecontrollerv1alpha1.Foo{},


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The Lister and Watcher interfaces only supported methods without context, but
were typically implemented with client-go API calls which need a context. New
interfaces get added using the same approach as in
https://github.com/kubernetes/kubernetes/pull/129109.

For StreamWatcher and RaceFreeFakeWatcher it was easier to add `WithLogger`
configuration methods which override the default global logger. The downside of
this approach is that it cannot be enforced by logcheck. This is okay for
Kubernetes in this case because all existing usages of those two types are
local to client-go and get updated immediately.

#### Which issue(s) this PR fixes:

Part of https://github.com/kubernetes/kubernetes/pull/129125

#### Special notes for your reviewer:

Generated informers: for compatibility reasons, the old functions without the ctx parameter still
get generated, now with context.Background instead of context.TODO. In practice
that code won't be used by the client-go reflector code because it prefers
the *WithContext functions, but it cannot be ruled out that some other code
only supports the old fields.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

/wg structured-logging