### PR TITLE
client-go event: add WithContext expansion methods

### DIFF
--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/event_expansion.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/event_expansion.go
@@ -31,13 +31,29 @@ import (
 // The EventExpansion interface allows manually adding extra methods to the EventInterface.
 type EventExpansion interface {
 	// CreateWithEventNamespace is the same as a Create, except that it sends the request to the event.Namespace.
+	//
+	// Deprecated: use CreateWithEventNamespaceWithContext instead.
 	CreateWithEventNamespace(event *v1.Event) (*v1.Event, error)
 	// UpdateWithEventNamespace is the same as a Update, except that it sends the request to the event.Namespace.
+	//
+	// Deprecated: use UpdateWithEventNamespaceWithContext instead.
 	UpdateWithEventNamespace(event *v1.Event) (*v1.Event, error)
 	// PatchWithEventNamespace is the same as a Patch, except that it sends the request to the event.Namespace.
+	//
+	// Deprecated: use PatchWithEventNamespaceWithContext instead.
 	PatchWithEventNamespace(event *v1.Event, data []byte) (*v1.Event, error)
 	// Search finds events about the specified object
+	//
+	// Deprecated: use SearchWithContext instead.
 	Search(scheme *runtime.Scheme, objOrRef runtime.Object) (*v1.EventList, error)
+	// CreateWithEventNamespaceWithContext is the same as a Create, except that it sends the request to the event.Namespace.
+	CreateWithEventNamespaceWithContext(ctx context.Context, event *v1.Event) (*v1.Event, error)
+	// UpdateWithEventNamespaceWithContext is the same as a Update, except that it sends the request to the event.Namespace.
+	UpdateWithEventNamespaceWithContext(ctx context.Context, event *v1.Event) (*v1.Event, error)
+	// PatchWithEventNamespaceWithContext is the same as a Patch, except that it sends the request to the event.Namespace.
+	PatchWithEventNamespaceWithContext(ctx context.Context, event *v1.Event, data []byte) (*v1.Event, error)
+	// SearchWithContext finds events about the specified object
+	SearchWithContext(ctx context.Context, scheme *runtime.Scheme, objOrRef runtime.Object) (*v1.EventList, error)
 	// Returns the appropriate field selector based on the API version being used to communicate with the server.
 	// The returned field selector can be used with List and Watch to filter desired events.
 	GetFieldSelector(involvedObjectName, involvedObjectNamespace, involvedObjectKind, involvedObjectUID *string) fields.Selector
@@ -47,7 +63,17 @@ type EventExpansion interface {
 // or an error. The namespace to create the event within is deduced from the
 // event; it must either match this event client's namespace, or this event
 // client must have been created with the "" namespace.
+//
+// Deprecated: use CreateWithEventNamespaceWithContext instead.
 func (e *events) CreateWithEventNamespace(event *v1.Event) (*v1.Event, error) {
+	return e.CreateWithEventNamespaceWithContext(context.Background(), event)
+}
+
+// CreateWithEventNamespaceWithContext makes a new event. Returns the copy of the event the server returns,
+// or an error. The namespace to create the event within is deduced from the
+// event; it must either match this event client's namespace, or this event
+// client must have been created with the "" namespace.
+func (e *events) CreateWithEventNamespaceWithContext(ctx context.Context, event *v1.Event) (*v1.Event, error) {
 	if e.GetNamespace() != "" && event.Namespace != e.GetNamespace() {
 		return nil, fmt.Errorf("can't create an event with namespace '%v' in namespace '%v'", event.Namespace, e.GetNamespace())
 	}
@@ -56,7 +82,7 @@ func (e *events) CreateWithEventNamespace(event *v1.Event) (*v1.Event, error) {
 		NamespaceIfScoped(event.Namespace, len(event.Namespace) > 0).
 		Resource("events").
 		Body(event).
-		Do(context.TODO()).
+		Do(ctx).
 		Into(result)
 	return result, err
 }
@@ -66,7 +92,18 @@ func (e *events) CreateWithEventNamespace(event *v1.Event) (*v1.Event, error) {
 // namespace must either match this event client's namespace, or this event client must have been
 // created with the "" namespace. Update also requires the ResourceVersion to be set in the event
 // object.
+//
+// Deprecated: use UpdateWithEventNamespaceWithContext instead.
 func (e *events) UpdateWithEventNamespace(event *v1.Event) (*v1.Event, error) {
+	return e.UpdateWithEventNamespaceWithContext(context.Background(), event)
+}
+
+// UpdateWithEventNamespaceWithContext modifies an existing event. It returns the copy of the event that the server returns,
+// or an error. The namespace and key to update the event within is deduced from the event. The
+// namespace must either match this event client's namespace, or this event client must have been
+// created with the "" namespace. Update also requires the ResourceVersion to be set in the event
+// object.
+func (e *events) UpdateWithEventNamespaceWithContext(ctx context.Context, event *v1.Event) (*v1.Event, error) {
 	if e.GetNamespace() != "" && event.Namespace != e.GetNamespace() {
 		return nil, fmt.Errorf("can't update an event with namespace '%v' in namespace '%v'", event.Namespace, e.GetNamespace())
 	}
@@ -76,7 +113,7 @@ func (e *events) UpdateWithEventNamespace(event *v1.Event) (*v1.Event, error) {
 		Resource("events").
 		Name(event.Name).
 		Body(event).
-		Do(context.TODO()).
+		Do(ctx).
 		Into(result)
 	return result, err
 }
@@ -86,7 +123,18 @@ func (e *events) UpdateWithEventNamespace(event *v1.Event) (*v1.Event, error) {
 // target event is deduced from the incompleteEvent. The namespace must either
 // match this event client's namespace, or this event client must have been
 // created with the "" namespace.
+//
+// Deprecated: use PatchWithEventNamespaceWithContext instead.
 func (e *events) PatchWithEventNamespace(incompleteEvent *v1.Event, data []byte) (*v1.Event, error) {
+	return e.PatchWithEventNamespaceWithContext(context.Background(), incompleteEvent, data)
+}
+
+// PatchWithEventNamespaceWithContext modifies an existing event. It returns the copy of
+// the event that the server returns, or an error. The namespace and name of the
+// target event is deduced from the incompleteEvent. The namespace must either
+// match this event client's namespace, or this event client must have been
+// created with the "" namespace.
+func (e *events) PatchWithEventNamespaceWithContext(ctx context.Context, incompleteEvent *v1.Event, data []byte) (*v1.Event, error) {
 	if e.GetNamespace() != "" && incompleteEvent.Namespace != e.GetNamespace() {
 		return nil, fmt.Errorf("can't patch an event with namespace '%v' in namespace '%v'", incompleteEvent.Namespace, e.GetNamespace())
 	}
@@ -96,7 +144,7 @@ func (e *events) PatchWithEventNamespace(incompleteEvent *v1.Event, data []byte)
 		Resource("events").
 		Name(incompleteEvent.Name).
 		Body(data).
-		Do(context.TODO()).
+		Do(ctx).
 		Into(result)
 	return result, err
 }
@@ -104,7 +152,16 @@ func (e *events) PatchWithEventNamespace(incompleteEvent *v1.Event, data []byte)
 // Search finds events about the specified object. The namespace of the
 // object must match this event's client namespace unless the event client
 // was made with the "" namespace.
+//
+// Deprecated: use SearchWithContext instead.
 func (e *events) Search(scheme *runtime.Scheme, objOrRef runtime.Object) (*v1.EventList, error) {
+	return e.SearchWithContext(context.Background(), scheme, objOrRef)
+}
+
+// SearchWithContext finds events about the specified object. The namespace of the
+// object must match this event's client namespace unless the event client
+// was made with the "" namespace.
+func (e *events) SearchWithContext(ctx context.Context, scheme *runtime.Scheme, objOrRef runtime.Object) (*v1.EventList, error) {
 	ref, err := ref.GetReference(scheme, objOrRef)
 	if err != nil {
 		return nil, err
@@ -123,7 +180,7 @@ func (e *events) Search(scheme *runtime.Scheme, objOrRef runtime.Object) (*v1.Ev
 		refUID = &stringRefUID
 	}
 	fieldSelector := e.GetFieldSelector(&ref.Name, &ref.Namespace, refKind, refUID)
-	return e.List(context.TODO(), metav1.ListOptions{FieldSelector: fieldSelector.String()})
+	return e.List(ctx, metav1.ListOptions{FieldSelector: fieldSelector.String()})
 }
 
 // Returns the appropriate field selector based on the API version being used to communicate with the server.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_event_expansion.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_event_expansion.go
@@ -17,6 +17,8 @@ limitations under the License.
 package fake
 
 import (
+	"context"
+
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -25,7 +27,12 @@ import (
 	core "k8s.io/client-go/testing"
 )
 
+// Deprecated: use CreateWithEventNamespaceWithContext instead.
 func (c *fakeEvents) CreateWithEventNamespace(event *v1.Event) (*v1.Event, error) {
+	return c.CreateWithEventNamespaceWithContext(context.Background(), event)
+}
+
+func (c *fakeEvents) CreateWithEventNamespaceWithContext(_ context.Context, event *v1.Event) (*v1.Event, error) {
 	var action core.CreateActionImpl
 	if c.Namespace() != "" {
 		action = core.NewCreateAction(c.Resource(), c.Namespace(), event)
@@ -41,7 +48,14 @@ func (c *fakeEvents) CreateWithEventNamespace(event *v1.Event) (*v1.Event, error
 }
 
 // Update replaces an existing event. Returns the copy of the event the server returns, or an error.
+//
+// Deprecated: use UpdateWithEventNamespaceWithContext instead.
 func (c *fakeEvents) UpdateWithEventNamespace(event *v1.Event) (*v1.Event, error) {
+	return c.UpdateWithEventNamespaceWithContext(context.Background(), event)
+}
+
+// Update replaces an existing event. Returns the copy of the event the server returns, or an error.
+func (c *fakeEvents) UpdateWithEventNamespaceWithContext(_ context.Context, event *v1.Event) (*v1.Event, error) {
 	var action core.UpdateActionImpl
 	if c.Namespace() != "" {
 		action = core.NewUpdateAction(c.Resource(), c.Namespace(), event)
@@ -58,7 +72,15 @@ func (c *fakeEvents) UpdateWithEventNamespace(event *v1.Event) (*v1.Event, error
 
 // PatchWithEventNamespace patches an existing event. Returns the copy of the event the server returns, or an error.
 // TODO: Should take a PatchType as an argument probably.
+//
+// Deprecated: use PatchWithEventNamespaceWithContext instead.
 func (c *fakeEvents) PatchWithEventNamespace(event *v1.Event, data []byte) (*v1.Event, error) {
+	return c.PatchWithEventNamespaceWithContext(context.Background(), event, data)
+}
+
+// PatchWithEventNamespaceWithContext patches an existing event. Returns the copy of the event the server returns, or an error.
+// TODO: Should take a PatchType as an argument probably.
+func (c *fakeEvents) PatchWithEventNamespaceWithContext(_ context.Context, event *v1.Event, data []byte) (*v1.Event, error) {
 	// TODO: Should be configurable to support additional patch strategies.
 	pt := types.StrategicMergePatchType
 	var action core.PatchActionImpl
@@ -76,7 +98,14 @@ func (c *fakeEvents) PatchWithEventNamespace(event *v1.Event, data []byte) (*v1.
 }
 
 // Search returns a list of events matching the specified object.
+//
+// Deprecated: use SearchWithContext instead.
 func (c *fakeEvents) Search(scheme *runtime.Scheme, objOrRef runtime.Object) (*v1.EventList, error) {
+	return c.SearchWithContext(context.Background(), scheme, objOrRef)
+}
+
+// SearchWithContext returns a list of events matching the specified object.
+func (c *fakeEvents) SearchWithContext(_ context.Context, scheme *runtime.Scheme, objOrRef runtime.Object) (*v1.EventList, error) {
 	var action core.ListActionImpl
 	if c.Namespace() != "" {
 		action = core.NewListAction(c.Resource(), c.Kind(), c.Namespace(), metav1.ListOptions{})

--- a/staging/src/k8s.io/client-go/kubernetes/typed/events/v1beta1/event_expansion.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/events/v1beta1/event_expansion.go
@@ -52,7 +52,7 @@ func (e *events) CreateWithEventNamespace(event *v1beta1.Event) (*v1beta1.Event,
 		NamespaceIfScoped(event.Namespace, len(event.Namespace) > 0).
 		Resource("events").
 		Body(event).
-		Do(context.TODO()).
+		Do(context.Background() /* Nothing to do here, v1beta1 will be removed eventually. */).
 		Into(result)
 	return result, err
 }
@@ -73,7 +73,7 @@ func (e *events) UpdateWithEventNamespace(event *v1beta1.Event) (*v1beta1.Event,
 		Resource("events").
 		Name(event.Name).
 		Body(event).
-		Do(context.TODO()).
+		Do(context.Background() /* Nothing to do here, v1beta1 will be removed eventually. */).
 		Into(result)
 	return result, err
 }
@@ -93,7 +93,7 @@ func (e *events) PatchWithEventNamespace(event *v1beta1.Event, data []byte) (*v1
 		Resource("events").
 		Name(event.Name).
 		Body(data).
-		Do(context.TODO()).
+		Do(context.Background() /* Nothing to do here, v1beta1 will be removed eventually. */).
 		Into(result)
 	return result, err
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Remove `context.TODO`.

#### Special notes for your reviewer:

Only the v1 API should be in use. The v1beta1 API therefore doesn't get updated and doesn't need the context.TODO anymore.

Part of https://github.com/kubernetes/kubernetes/pull/129341

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
