### PR TITLE
apimachinery wait: support contextual logging

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/wait/loop.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/wait/loop.go
@@ -49,7 +49,7 @@ func loopConditionUntilContext(ctx context.Context, t Timer, immediate, sliding 
 	// if we haven't requested immediate execution, delay once
 	if immediate {
 		if ok, err := func() (bool, error) {
-			defer runtime.HandleCrash()
+			defer runtime.HandleCrashWithContext(ctx)
 			return condition(ctx)
 		}(); err != nil || ok {
 			return err
@@ -83,7 +83,7 @@ func loopConditionUntilContext(ctx context.Context, t Timer, immediate, sliding 
 			t.Next()
 		}
 		if ok, err := func() (bool, error) {
-			defer runtime.HandleCrash()
+			defer runtime.HandleCrashWithContext(ctx)
 			return condition(ctx)
 		}(); err != nil || ok {
 			return err

--- a/staging/src/k8s.io/apimachinery/pkg/util/wait/wait.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/wait/wait.go
@@ -141,6 +141,7 @@ func (c channelContext) Value(key any) any           { return nil }
 //
 // Deprecated: Will be removed when the legacy polling methods are removed.
 func runConditionWithCrashProtection(condition ConditionFunc) (bool, error) {
+	//nolint:logcheck // Already deprecated.
 	defer runtime.HandleCrash()
 	return condition()
 }
@@ -150,7 +151,7 @@ func runConditionWithCrashProtection(condition ConditionFunc) (bool, error) {
 //
 // Deprecated: Will be removed when the legacy polling methods are removed.
 func runConditionWithCrashProtectionWithContext(ctx context.Context, condition ConditionWithContextFunc) (bool, error) {
-	defer runtime.HandleCrash()
+	defer runtime.HandleCrashWithContext(ctx)
 	return condition(ctx)
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

By passing the context, if available, down into the actual wait loop it becomes possible to use contextual logging when handling a crash. That then logs more information about which component encountered the problem (WithName e.g. in kube-controller-manager) and what it was doing at the time (WithValues e.g. in kube-scheduler).

#### Special notes for your reviewer:

Part of https://github.com/kubernetes/kubernetes/pull/129341

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/wg structured-logging
