### PR TITLE
Remove duplicate PodCondition setting by api-server

### DIFF
--- a/pkg/registry/core/pod/storage/storage.go
+++ b/pkg/registry/core/pod/storage/storage.go
@@ -34,7 +34,6 @@ import (
 	storeerr "k8s.io/apiserver/pkg/storage/errors"
 	"k8s.io/apiserver/pkg/util/dryrun"
 	policyclient "k8s.io/client-go/kubernetes/typed/policy/v1"
-	podutil "k8s.io/kubernetes/pkg/api/pod"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/core/validation"
 	"k8s.io/kubernetes/pkg/kubelet/client"
@@ -245,10 +244,6 @@ func (r *BindingREST) setPodHostAndAnnotations(ctx context.Context, podUID types
 		for k, v := range annotations {
 			pod.Annotations[k] = v
 		}
-		podutil.UpdatePodCondition(&pod.Status, &api.PodCondition{
-			Type:   api.PodScheduled,
-			Status: api.ConditionTrue,
-		})
 		finalPod = pod
 		return pod, nil
 	}), dryRun, nil)


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
This PR fixes a bug where the PodScheduled condition was being created by kube-apiserver and Kubelet.
- Kube ApiServer sets the PodScheduled condition [here](https://github.com/kubernetes/kubernetes/blob/438bc5d44e5b72cad99d6eb521d2eb3572c5b034/pkg/registry/core/pod/storage/storage.go#L248). Also the registry codebase doesn't provide any client to update the status of the Pod so that kube apiserver becomes the field manager of it.
- Kubelet sets the PodScheduled condition [here](https://github.com/kubernetes/kubernetes/blob/v1.31.1/pkg/kubelet/status/status_manager.go#L639-L640). Later in the kubelet codebase `PatchPodStatus` is called which updates the status and thus field manager is updated to `kubelet`. 
- Before, there was no field manager because kube-apiserver was not updating the status and when kubelet tries to update the PodScheduled condition, it is already created by kube-apiserver and there is nothing to update and so kubelet doesn't touch the PodScheduled condition.


There are two places where this happens. Removing the kubeapiserver part of it since the issue says `kubelet` should be the status manager.

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubernetes/issues/127508

#### Does this PR introduce a user-facing change?
No

I am new contributor. Please suggest me the right solution if this is not the correct solution. 
