### PR TITLE
kubectl: use functions in component-helpers to calculate pod resources

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/util/resource/resource.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/resource/resource.go
@@ -25,6 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/sets"
+	resourcehelper "k8s.io/component-helpers/resource"
 )
 
 // PodRequestsAndLimits returns a dictionary of all defined resources summed up for all
@@ -35,154 +36,16 @@ func PodRequestsAndLimits(pod *corev1.Pod) (reqs, limits corev1.ResourceList) {
 	return podRequests(pod), podLimits(pod)
 }
 
-// podRequests is a simplified form of PodRequests from k8s.io/kubernetes/pkg/api/v1/resource that doesn't check
-// feature gate enablement and avoids adding a dependency on k8s.io/kubernetes/pkg/apis/core/v1 for kubectl.
 func podRequests(pod *corev1.Pod) corev1.ResourceList {
-	// attempt to reuse the maps if passed, or allocate otherwise
-	reqs := corev1.ResourceList{}
-
-	containerStatuses := map[string]*corev1.ContainerStatus{}
-	for i := range pod.Status.ContainerStatuses {
-		containerStatuses[pod.Status.ContainerStatuses[i].Name] = &pod.Status.ContainerStatuses[i]
-	}
-
-	for _, container := range pod.Spec.Containers {
-		containerReqs := container.Resources.Requests
-		cs, found := containerStatuses[container.Name]
-		if found && cs.Resources != nil {
-			if pod.Status.Resize == corev1.PodResizeStatusInfeasible {
-				containerReqs = cs.Resources.Requests.DeepCopy()
-			} else {
-				containerReqs = max(container.Resources.Requests, cs.Resources.Requests)
-			}
-		}
-		addResourceList(reqs, containerReqs)
-	}
-
-	restartableInitContainerReqs := corev1.ResourceList{}
-	initContainerReqs := corev1.ResourceList{}
-
-	for _, container := range pod.Spec.InitContainers {
-		containerReqs := container.Resources.Requests
-
-		if container.RestartPolicy != nil && *container.RestartPolicy == corev1.ContainerRestartPolicyAlways {
-			// and add them to the resulting cumulative container requests
-			addResourceList(reqs, containerReqs)
-
-			// track our cumulative restartable init container resources
-			addResourceList(restartableInitContainerReqs, containerReqs)
-			containerReqs = restartableInitContainerReqs
-		} else {
-			tmp := corev1.ResourceList{}
-			addResourceList(tmp, containerReqs)
-			addResourceList(tmp, restartableInitContainerReqs)
-			containerReqs = tmp
-		}
-		maxResourceList(initContainerReqs, containerReqs)
-	}
-
-	maxResourceList(reqs, initContainerReqs)
-
-	// Add overhead for running a pod to the sum of requests if requested:
-	if pod.Spec.Overhead != nil {
-		addResourceList(reqs, pod.Spec.Overhead)
-	}
-
+	reqs := resourcehelper.PodRequests(pod, resourcehelper.PodResourcesOptions{
+		UseStatusResources: true,
+	})
 	return reqs
 }
 
-// podLimits is a simplified form of PodLimits from k8s.io/kubernetes/pkg/api/v1/resource that doesn't check
-// feature gate enablement and avoids adding a dependency on k8s.io/kubernetes/pkg/apis/core/v1 for kubectl.
 func podLimits(pod *corev1.Pod) corev1.ResourceList {
-	limits := corev1.ResourceList{}
-
-	for _, container := range pod.Spec.Containers {
-		addResourceList(limits, container.Resources.Limits)
-	}
-
-	restartableInitContainerLimits := corev1.ResourceList{}
-	initContainerLimits := corev1.ResourceList{}
-
-	for _, container := range pod.Spec.InitContainers {
-		containerLimits := container.Resources.Limits
-		// Is the init container marked as a restartable init container?
-		if container.RestartPolicy != nil && *container.RestartPolicy == corev1.ContainerRestartPolicyAlways {
-			addResourceList(limits, containerLimits)
-
-			// track our cumulative restartable init container resources
-			addResourceList(restartableInitContainerLimits, containerLimits)
-			containerLimits = restartableInitContainerLimits
-		} else {
-			tmp := corev1.ResourceList{}
-			addResourceList(tmp, containerLimits)
-			addResourceList(tmp, restartableInitContainerLimits)
-			containerLimits = tmp
-		}
-
-		maxResourceList(initContainerLimits, containerLimits)
-	}
-
-	maxResourceList(limits, initContainerLimits)
-
-	// Add overhead to non-zero limits if requested:
-	if pod.Spec.Overhead != nil {
-		for name, quantity := range pod.Spec.Overhead {
-			if value, ok := limits[name]; ok && !value.IsZero() {
-				value.Add(quantity)
-				limits[name] = value
-			}
-		}
-	}
-
+	limits := resourcehelper.PodLimits(pod, resourcehelper.PodResourcesOptions{})
 	return limits
-}
-
-// max returns the result of max(a, b) for each named resource and is only used if we can't
-// accumulate into an existing resource list
-func max(a corev1.ResourceList, b corev1.ResourceList) corev1.ResourceList {
-	result := corev1.ResourceList{}
-	for key, value := range a {
-		if other, found := b[key]; found {
-			if value.Cmp(other) <= 0 {
-				result[key] = other.DeepCopy()
-				continue
-			}
-		}
-		result[key] = value.DeepCopy()
-	}
-	for key, value := range b {
-		if _, found := result[key]; !found {
-			result[key] = value.DeepCopy()
-		}
-	}
-	return result
-}
-
-// addResourceList adds the resources in newList to list
-func addResourceList(list, new corev1.ResourceList) {
-	for name, quantity := range new {
-		if value, ok := list[name]; !ok {
-			list[name] = quantity.DeepCopy()
-		} else {
-			value.Add(quantity)
-			list[name] = value
-		}
-	}
-}
-
-// maxResourceList sets list to the greater of list/newList for every resource
-// either list
-func maxResourceList(list, new corev1.ResourceList) {
-	for name, quantity := range new {
-		if value, ok := list[name]; !ok {
-			list[name] = quantity.DeepCopy()
-			continue
-		} else {
-			if quantity.Cmp(value) > 0 {
-				list[name] = quantity.DeepCopy()
-			}
-		}
-	}
 }
 
 // ExtractContainerResourceValue extracts the value of a resource


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind feature

#### What this PR does / why we need it:

Refactor the code to use library functions in component-helpers.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/kubernetes/kubectl/issues/1688

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
