### PR TITLE
e2e: deflake volume tests

### DIFF
--- a/test/e2e/storage/drivers/csi.go
+++ b/test/e2e/storage/drivers/csi.go
@@ -235,7 +235,6 @@ func (h *hostpathCSIDriver) PrepareTest(ctx context.Context, f *framework.Framew
 	// Create secondary namespace which will be used for creating driver
 	driverNamespace := utils.CreateDriverNamespace(ctx, f)
 	driverns := driverNamespace.Name
-	testns := f.Namespace.Name
 
 	ginkgo.By(fmt.Sprintf("deploying %s driver", h.driverInfo.Name))
 	cancelLogging := utils.StartPodLogs(ctx, f, driverNamespace)
@@ -328,7 +327,6 @@ func (h *hostpathCSIDriver) PrepareTest(ctx context.Context, f *framework.Framew
 	cleanupFunc := generateDriverCleanupFunc(
 		f,
 		h.driverInfo.Name,
-		testns,
 		driverns,
 		cancelLogging)
 	ginkgo.DeferCleanup(cleanupFunc)
@@ -600,7 +598,6 @@ func (m *mockCSIDriver) PrepareTest(ctx context.Context, f *framework.Framework)
 	// Create secondary namespace which will be used for creating driver
 	m.driverNamespace = utils.CreateDriverNamespace(ctx, f)
 	driverns := m.driverNamespace.Name
-	testns := f.Namespace.Name
 
 	if m.embedded {
 		ginkgo.By("deploying csi mock proxy")
@@ -762,7 +759,6 @@ func (m *mockCSIDriver) PrepareTest(ctx context.Context, f *framework.Framework)
 	driverCleanupFunc := generateDriverCleanupFunc(
 		f,
 		"mock",
-		testns,
 		driverns,
 		cancelLogging)
 
@@ -942,7 +938,6 @@ func (g *gcePDCSIDriver) GetSnapshotClass(ctx context.Context, config *storagefr
 }
 
 func (g *gcePDCSIDriver) PrepareTest(ctx context.Context, f *framework.Framework) *storageframework.PerTestConfig {
-	testns := f.Namespace.Name
 	cfg := &storageframework.PerTestConfig{
 		Driver:    g,
 		Prefix:    "gcepd",
@@ -1000,7 +995,6 @@ func (g *gcePDCSIDriver) PrepareTest(ctx context.Context, f *framework.Framework
 	cleanupFunc := generateDriverCleanupFunc(
 		f,
 		"gce-pd",
-		testns,
 		driverns,
 		cancelLogging)
 	ginkgo.DeferCleanup(cleanupFunc)
@@ -1073,17 +1067,12 @@ func tryFunc(f func()) error {
 
 func generateDriverCleanupFunc(
 	f *framework.Framework,
-	driverName, testns, driverns string,
+	driverName, driverns string,
 	cancelLogging func()) func(ctx context.Context) {
 
 	// Cleanup CSI driver and namespaces. This function needs to be idempotent and can be
 	// concurrently called from defer (or AfterEach) and AfterSuite action hooks.
 	cleanupFunc := func(ctx context.Context) {
-		ginkgo.By(fmt.Sprintf("deleting the test namespace: %s", testns))
-		// Delete the primary namespace but it's okay to fail here because this namespace will
-		// also be deleted by framework.Aftereach hook
-		_ = tryFunc(func() { f.DeleteNamespace(ctx, testns) })
-
 		ginkgo.By(fmt.Sprintf("uninstalling csi %s driver", driverName))
 		_ = tryFunc(cancelLogging)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

Failed Job: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/122016/pull-kubernetes-e2e-gce/1871036396114808832

![image](https://github.com/user-attachments/assets/59b21a48-1e0f-4a30-9ce3-703f2d5ad265)

audit.log: https://storage.googleapis.com/kubernetes-ci-logs/pr-logs/pull/122016/pull-kubernetes-e2e-gce/1871036396114808832/artifacts/e2e-c539298169-674b9-master/kube-apiserver-audit.log

```
{"kind":"Event","apiVersion":"audit.k8s.io/v1","level":"RequestResponse","auditID":"8872cae8-da58-48a9-9eaf-98bcc404299c","stage":"ResponseComplete","requestURI":"/apis/storage.k8s.io/v1/storageclasses","verb":"create","user":{"username":"kubecfg","groups":["system:masters","system:authenticated"],"extra":{"authentication.kubernetes.io/credential-id":["X509SHA256=51b211b47046b0c4c58738fcbce2004fdee8a7b473a852fb305add4c13a8ab47"]}},"sourceIPs":["35.222.117.50"],"userAgent":"e2e.test/v1.33.0 (linux/amd64) kubernetes/4a1d1c8 -- [sig-storage] CSI Mock volume fsgroup policies CSI FSGroupPolicy [LinuxOnly] should modify fsGroup if fsGroupPolicy=File","objectRef":{"resource":"storageclasses","name":"csi-mock-sc-csi-mock-volumes-fsgroup-policy-5610","apiGroup":"storage.k8s.io","apiVersion":"v1"},"responseStatus":{"metadata":{},"code":201},"requestObject":{"kind":"StorageClass","apiVersion":"storage.k8s.io/v1","metadata":{"name":"csi-mock-sc-csi-mock-volumes-fsgroup-policy-5610","creationTimestamp":null},"provisioner":"csi-mock-csi-mock-volumes-fsgroup-policy-5610","reclaimPolicy":"Delete","volumeBindingMode":"Immediate"},"responseObject":{"kind":"StorageClass","apiVersion":"storage.k8s.io/v1","metadata":{"name":"csi-mock-sc-csi-mock-volumes-fsgroup-policy-5610","uid":"7d51a2f0-fe79-4ddf-8bab-3480120c7f76","resourceVersion":"9335","creationTimestamp":"2024-12-23T04:01:01Z","managedFields":[{"manager":"e2e.test","operation":"Update","apiVersion":"storage.k8s.io/v1","time":"2024-12-23T04:01:01Z","fieldsType":"FieldsV1","fieldsV1":{"f:provisioner":{},"f:reclaimPolicy":{},"f:volumeBindingMode":{}}}]},"provisioner":"csi-mock-csi-mock-volumes-fsgroup-policy-5610","reclaimPolicy":"Delete","volumeBindingMode":"Immediate"},"requestReceivedTimestamp":"2024-12-23T04:01:01.519483Z","stageTimestamp":"2024-12-23T04:01:01.546747Z","annotations":{"authorization.k8s.io/decision":"allow","authorization.k8s.io/reason":""}}
{"kind":"Event","apiVersion":"audit.k8s.io/v1","level":"RequestResponse","auditID":"a939cc7c-5136-42b3-bfb4-bed1861afc22","stage":"ResponseComplete","requestURI":"/apis/storage.k8s.io/v1/storageclasses","verb":"create","user":{"username":"kubecfg","groups":["system:masters","system:authenticated"],"extra":{"authentication.kubernetes.io/credential-id":["X509SHA256=51b211b47046b0c4c58738fcbce2004fdee8a7b473a852fb305add4c13a8ab47"]}},"sourceIPs":["35.222.117.50"],"userAgent":"e2e.test/v1.33.0 (linux/amd64) kubernetes/4a1d1c8 -- [sig-storage] CSI Mock volume fsgroup policies CSI FSGroupPolicy Update [LinuxOnly] should update fsGroup if update from None to default","objectRef":{"resource":"storageclasses","name":"csi-mock-sc-csi-mock-volumes-fsgroup-policy-5610","apiGroup":"storage.k8s.io","apiVersion":"v1"},"responseStatus":{"metadata":{},"status":"Failure","message":"storageclasses.storage.k8s.io \"csi-mock-sc-csi-mock-volumes-fsgroup-policy-5610\" already exists","reason":"AlreadyExists","details":{"name":"csi-mock-sc-csi-mock-volumes-fsgroup-policy-5610","group":"storage.k8s.io","kind":"storageclasses"},"code":409},"requestObject":{"kind":"StorageClass","apiVersion":"storage.k8s.io/v1","metadata":{"name":"csi-mock-sc-csi-mock-volumes-fsgroup-policy-5610","creationTimestamp":null},"provisioner":"csi-mock-csi-mock-volumes-fsgroup-policy-5610","reclaimPolicy":"Delete","volumeBindingMode":"Immediate"},"responseObject":{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"storageclasses.storage.k8s.io \"csi-mock-sc-csi-mock-volumes-fsgroup-policy-5610\" already exists","reason":"AlreadyExists","details":{"name":"csi-mock-sc-csi-mock-volumes-fsgroup-policy-5610","group":"storage.k8s.io","kind":"storageclasses"},"code":409},"requestReceivedTimestamp":"2024-12-23T04:02:56.788518Z","stageTimestamp":"2024-12-23T04:02:56.797622Z","annotations":{"authorization.k8s.io/decision":"allow","authorization.k8s.io/reason":""}}
{"kind":"Event","apiVersion":"audit.k8s.io/v1","level":"RequestResponse","auditID":"1d518e9e-530e-4718-91ab-b5eaf1249c74","stage":"ResponseComplete","requestURI":"/apis/storage.k8s.io/v1/storageclasses/csi-mock-sc-csi-mock-volumes-fsgroup-policy-5610","verb":"delete","user":{"username":"kubecfg","groups":["system:masters","system:authenticated"],"extra":{"authentication.kubernetes.io/credential-id":["X509SHA256=51b211b47046b0c4c58738fcbce2004fdee8a7b473a852fb305add4c13a8ab47"]}},"sourceIPs":["35.222.117.50"],"userAgent":"e2e.test/v1.33.0 (linux/amd64) kubernetes/4a1d1c8 -- [sig-storage] CSI Mock volume fsgroup policies CSI FSGroupPolicy [LinuxOnly] should modify fsGroup if fsGroupPolicy=File","objectRef":{"resource":"storageclasses","name":"csi-mock-sc-csi-mock-volumes-fsgroup-policy-5610","apiGroup":"storage.k8s.io","apiVersion":"v1"},"responseStatus":{"metadata":{},"code":200},"requestObject":{"kind":"DeleteOptions","apiVersion":"meta.k8s.io/__internal"},"responseObject":{"kind":"StorageClass","apiVersion":"storage.k8s.io/v1","metadata":{"name":"csi-mock-sc-csi-mock-volumes-fsgroup-policy-5610","uid":"7d51a2f0-fe79-4ddf-8bab-3480120c7f76","resourceVersion":"14592","creationTimestamp":"2024-12-23T04:01:01Z","managedFields":[{"manager":"e2e.test","operation":"Update","apiVersion":"storage.k8s.io/v1","time":"2024-12-23T04:01:01Z","fieldsType":"FieldsV1","fieldsV1":{"f:provisioner":{},"f:reclaimPolicy":{},"f:volumeBindingMode":{}}}]},"provisioner":"csi-mock-csi-mock-volumes-fsgroup-policy-5610","reclaimPolicy":"Delete","volumeBindingMode":"Immediate"},"requestReceivedTimestamp":"2024-12-23T04:02:59.974752Z","stageTimestamp":"2024-12-23T04:02:59.990925Z","annotations":{"authorization.k8s.io/decision":"allow","authorization.k8s.io/reason":""}}
```
**Test 1**: "e2e.test/v1.33.0 (linux/amd64) kubernetes/4a1d1c8 -- [sig-storage] CSI Mock volume fsgroup policies CSI FSGroupPolicy [LinuxOnly] should modify fsGroup if fsGroupPolicy=File"

**Test 2**: "e2e.test/v1.33.0 (linux/amd64) kubernetes/4a1d1c8 -- [sig-storage] CSI Mock volume fsgroup policies CSI FSGroupPolicy Update [LinuxOnly] should update fsGroup if update from None to default"

2 tests create a storage class with the same name because the name is generated by the base name of the sc manifest file and the namespace from the framework while these tests have same base name and same namespace is created before the `It` container is executed.

**Timeline from the audit log**:

**Test 1**:

1. create sc:        "requestReceivedTimestamp":"2024-12-23T04:01:01.519483Z","stageTimestamp":"2024-12-23T04:01:01.546747Z"
1. delete namespace: "requestReceivedTimestamp": "2024-12-23T04:01:47.402392Z","stageTimestamp": "2024-12-23T04:01:47.447485Z",
1. delete sc:        "requestReceivedTimestamp":"2024-12-23T04:02:59.974752Z","stageTimestamp":"2024-12-23T04:02:59.990925Z"

**Test 2**:

1. create namespace: "requestReceivedTimestamp": "2024-12-23T04:02:54.243583Z","stageTimestamp": "2024-12-23T04:02:54.310733Z", (namespace is re-created)
1. create sc:        "requestReceivedTimestamp":"2024-12-23T04:02:56.788518Z","stageTimestamp":"2024-12-23T04:02:56.797622Z" (sc is re-created before the previous sc is deleted)


Defercleanup stack:

1. utils.CreateFromManifests https://github.com/carlory/kubernetes/blob/fix-118037-2/test/e2e/storage/utils/create.go#L161
2. generateDriverCleanupFunc https://github.com/carlory/kubernetes/blob/master/test/e2e/storage/drivers/csi.go#L1085

So the test namespace is deleted before the sc is deleted. It can explain the root cause of the question https://github.com/kubernetes/kubernetes/pull/119431#discussion_r1281730334

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/118037

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
