### PR TITLE
fix: adopt go1.23 behavior change in mount point parsing on Windows#2

### DIFF
--- a/pkg/util/filesystem/defaultfs.go
+++ b/pkg/util/filesystem/defaultfs.go
@@ -90,7 +90,7 @@ func MkdirAllWithPathCheck(path string, perm os.FileMode) error {
 		// 1. for Unix/Linux OS, check if the path is directory.
 		// 2. for windows NTFS, check if the path is symlink instead of directory.
 		if dir.IsDir() ||
-			(runtime.GOOS == "windows" && (dir.Mode()&os.ModeSymlink != 0)) {
+			(runtime.GOOS == "windows" && (dir.Mode()&os.ModeSymlink != 0 || dir.Mode()&os.ModeIrregular != 0)) {
 			return nil
 		}
 		return fmt.Errorf("path %v exists but is not a directory", path)

--- a/pkg/volume/util/fs/fs_windows.go
+++ b/pkg/volume/util/fs/fs_windows.go
@@ -85,6 +85,11 @@ func diskUsage(currPath string, info os.FileInfo) (int64, error) {
 		return size, nil
 	}
 
+	// go1.23 behavior change: https://github.com/golang/go/issues/63703#issuecomment-2535941458
+	if info.Mode()&os.ModeIrregular != 0 {
+		return size, nil
+	}
+
 	size += info.Size()
 
 	if !info.IsDir() {

--- a/pkg/volume/util/subpath/subpath_windows.go
+++ b/pkg/volume/util/subpath/subpath_windows.go
@@ -208,6 +208,12 @@ func lockAndCheckSubPathWithoutSymlink(volumePath, subPath string) ([]uintptr, e
 			break
 		}
 
+		// go1.23 behavior change: https://github.com/golang/go/issues/63703#issuecomment-2535941458
+		if stat.Mode()&os.ModeIrregular != 0 {
+			errorResult = fmt.Errorf("subpath %q is an unexpected irregular file after EvalSymlinks", currentFullPath)
+			break
+		}
+
 		if !mount.PathWithinBase(currentFullPath, volumePath) {
 			errorResult = fmt.Errorf("SubPath %q not within volume path %q", currentFullPath, volumePath)
 			break
@@ -341,6 +347,10 @@ func doSafeMakeDir(pathname string, base string, perm os.FileMode) error {
 		}
 		if stat.Mode()&os.ModeSymlink != 0 {
 			return fmt.Errorf("subpath %q is an unexpected symlink after Mkdir", currentPath)
+		}
+		// go1.23 behavior change: https://github.com/golang/go/issues/63703#issuecomment-2535941458
+		if stat.Mode()&os.ModeIrregular != 0 {
+			return fmt.Errorf("subpath %q is an unexpected irregular file after Mkdir", currentPath)
 		}
 	}
 

--- a/pkg/volume/util/volumepathhandler/volume_path_handler.go
+++ b/pkg/volume/util/volumepathhandler/volume_path_handler.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 
 	"k8s.io/klog/v2"
 	"k8s.io/mount-utils"
@@ -232,7 +233,7 @@ func (v VolumePathHandler) RemoveMapPath(mapPath string) error {
 	return nil
 }
 
-// IsSymlinkExist returns true if specified file exists and the type is symbolik link.
+// IsSymlinkExist returns true if specified file exists and the type is symbolik link or irregular file on Windows.
 // If file doesn't exist, or file exists but not symbolic link, return false with no error.
 // On other cases, return false with error from Lstat().
 func (v VolumePathHandler) IsSymlinkExist(mapPath string) (bool, error) {
@@ -247,6 +248,10 @@ func (v VolumePathHandler) IsSymlinkExist(mapPath string) (bool, error) {
 	}
 	// If file exits and it's symbolic link, return true and no error
 	if fi.Mode()&os.ModeSymlink == os.ModeSymlink {
+		return true, nil
+	}
+	// go1.23 behavior change: https://github.com/golang/go/issues/63703#issuecomment-2535941458
+	if (runtime.GOOS == "windows") && (fi.Mode()&os.ModeIrregular != 0) {
 		return true, nil
 	}
 	// If file exits but it's not symbolic link, return false and no error


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/priority important-soon
/sig storage
/sig windows
/triage accepted

#### What this PR does / why we need it:
fix: adopt go1.23 behavior change in mount point parsing on Windows, this PR is a proceeding fix of https://github.com/kubernetes/kubernetes/pull/129368

btw, `getAllParentLinks` func is not used anymore, so I cleaned it up in this PR also.

if a disk or smb file share is mounted to a path, from go 1.23, the path is not a ModeSymlink any more, it's ModeIrregular instead, check details here: https://github.com/golang/go/issues/63703#issuecomment-2535941458

I also tested by myself on Windows machine:

 - build following code with golang 1.23 (without any godebug symbol) and got following result:

```
	stat, err := os.Lstat(path)
	if err != nil {
		fmt.Printf("Error: %v", err)
		return
	}
	if stat.Mode()&os.ModeSymlink != 0 {
		fmt.Printf("%s is a symbolic link\n", path)
	}
	if stat.Mode()&os.ModeDir != 0 {
		fmt.Printf("%s is a directory\n", path)
	}
	if stat.Mode()&os.ModeIrregular != 0 {
		fmt.Printf("%s is a non-regular file\n", path)
	}
	if stat.Mode()&os.ModeDevice != 0 {
		fmt.Printf("%s is a device file\n", path)
	}

C:\>lstat.exe c:\var\lib\kubelet\plugins\kubernetes.io\csi\disk.csi.azure.com\05ee7e7cbf99f002f3c7b9a253a090cc282c52731210e29ec4a50e42e29a226a\globalmount
c:\var\lib\kubelet\plugins\kubernetes.io\csi\disk.csi.azure.com\05ee7e7cbf99f002f3c7b9a253a090cc282c52731210e29ec4a50e42e29a226a\globalmount is a non-regular file
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[ACTION REQUIRED] CSI drivers that calls IsLikelyNotMountPoint should not assume false means that the path is a mount point. Each CSI driver needs to make sure correct usage of return value of IsLikelyNotMountPoint because if the file is an irregular file but not a mount point is acceptable
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
[ACTION REQUIRED] CSI drivers that calls IsLikelyNotMountPoint should not assume false means that the path is a mount point. Each CSI driver needs to make sure correct usage of return value of IsLikelyNotMountPoint because if the file is an irregular file but not a mount point is acceptable
```
