### PR TITLE
fix: enable len rule from testifylint in module kubelet

### DIFF
--- a/staging/src/k8s.io/kubelet/pkg/cri/streaming/server_test.go
+++ b/staging/src/k8s.io/kubelet/pkg/cri/streaming/server_test.go
@@ -465,5 +465,5 @@ func readExpected(t *testing.T, streamName string, r io.Reader, expected string)
 func writeExpected(t *testing.T, streamName string, w io.Writer, data string) {
 	n, err := io.WriteString(w, data)
 	assert.NoError(t, err, "stream %s", streamName)
-	assert.Equal(t, len(data), n, "stream %s", streamName)
+	assert.Len(t, data, n, "stream %s", streamName)
 }


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/area test
/kind cleanup
/sig testing

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
This fixes [len](https://github.com/Antonboom/testifylint?tab=readme-ov-file#len) rule from [testifylint](https://github.com/Antonboom/testifylint) in module kubelet
 
