### PR TITLE
fix: API documentation incorrectly states that resizePolicy can be set to ephemeral containers

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -6982,7 +6982,7 @@
           "description": "Probes are not allowed for ephemeral containers."
         },
         "resizePolicy": {
-          "description": "Resources resize policy for the container.",
+          "description": "Resources resize policy for ephemeral containers are not allowed.",
           "items": {
             "$ref": "#/definitions/io.k8s.api.core.v1.ContainerResizePolicy"
           },

--- a/api/openapi-spec/v3/api__v1_openapi.json
+++ b/api/openapi-spec/v3/api__v1_openapi.json
@@ -2155,7 +2155,7 @@
             "description": "Probes are not allowed for ephemeral containers."
           },
           "resizePolicy": {
-            "description": "Resources resize policy for the container.",
+            "description": "Resources resize policy for ephemeral containers are not allowed.",
             "items": {
               "allOf": [
                 {

--- a/api/openapi-spec/v3/apis__apps__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__apps__v1_openapi.json
@@ -2313,7 +2313,7 @@
             "description": "Probes are not allowed for ephemeral containers."
           },
           "resizePolicy": {
-            "description": "Resources resize policy for the container.",
+            "description": "Resources resize policy for ephemeral containers are not allowed.",
             "items": {
               "allOf": [
                 {

--- a/api/openapi-spec/v3/apis__batch__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__batch__v1_openapi.json
@@ -1662,7 +1662,7 @@
             "description": "Probes are not allowed for ephemeral containers."
           },
           "resizePolicy": {
-            "description": "Resources resize policy for the container.",
+            "description": "Resources resize policy for ephemeral containers are not allowed.",
             "items": {
               "allOf": [
                 {

--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -4083,7 +4083,7 @@ type EphemeralContainerCommon struct {
 	// already allocated to the pod.
 	// +optional
 	Resources ResourceRequirements
-	// Resources resize policy for the container.
+	// Resources resize policy for ephemeral containers are not allowed.
 	// +featureGate=InPlacePodVerticalScaling
 	// +optional
 	ResizePolicy []ContainerResizePolicy

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -22488,7 +22488,7 @@ func schema_k8sio_api_core_v1_EphemeralContainer(ref common.ReferenceCallback) c
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "Resources resize policy for the container.",
+							Description: "Resources resize policy for ephemeral containers are not allowed.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -22796,7 +22796,7 @@ func schema_k8sio_api_core_v1_EphemeralContainerCommon(ref common.ReferenceCallb
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "Resources resize policy for the container.",
+							Description: "Resources resize policy for ephemeral containers are not allowed.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{

--- a/staging/src/k8s.io/api/core/v1/generated.proto
+++ b/staging/src/k8s.io/api/core/v1/generated.proto
@@ -1487,7 +1487,7 @@ message EphemeralContainerCommon {
   // +optional
   optional ResourceRequirements resources = 8;
 
-  // Resources resize policy for the container.
+  // Resources resize policy for ephemeral containers are not allowed.
   // +featureGate=InPlacePodVerticalScaling
   // +optional
   // +listType=atomic

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -4716,7 +4716,7 @@ type EphemeralContainerCommon struct {
 	// already allocated to the pod.
 	// +optional
 	Resources ResourceRequirements `json:"resources,omitempty" protobuf:"bytes,8,opt,name=resources"`
-	// Resources resize policy for the container.
+	// Resources resize policy for ephemeral containers are not allowed.
 	// +featureGate=InPlacePodVerticalScaling
 	// +optional
 	// +listType=atomic

--- a/staging/src/k8s.io/api/core/v1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/core/v1/types_swagger_doc_generated.go
@@ -648,7 +648,7 @@ var map_EphemeralContainerCommon = map[string]string{
 	"envFrom":                  "List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.",
 	"env":                      "List of environment variables to set in the container. Cannot be updated.",
 	"resources":                "Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources already allocated to the pod.",
-	"resizePolicy":             "Resources resize policy for the container.",
+	"resizePolicy":             "Resources resize policy for ephemeral containers are not allowed.",
 	"restartPolicy":            "Restart policy for the container to manage the restart behavior of each container within a pod. This may only be set for init containers. You cannot set this field on ephemeral containers.",
 	"volumeMounts":             "Pod volumes to mount into the container's filesystem. Subpath mounts are not allowed for ephemeral containers. Cannot be updated.",
 	"volumeDevices":            "volumeDevices is the list of block devices to be used by the container.",

--- a/staging/src/k8s.io/cli-runtime/artifacts/openapi/swagger-with-shared-parameters.json
+++ b/staging/src/k8s.io/cli-runtime/artifacts/openapi/swagger-with-shared-parameters.json
@@ -5771,7 +5771,7 @@
           "description": "Probes are not allowed for ephemeral containers."
         },
         "resizePolicy": {
-          "description": "Resources resize policy for the container.",
+          "description": "Resources resize policy for ephemeral containers are not allowed.",
           "items": {
             "$ref": "#/definitions/io.k8s.api.core.v1.ContainerResizePolicy"
           },

--- a/staging/src/k8s.io/kubectl/pkg/explain/v2/templates/batch.k8s.io_v1.json
+++ b/staging/src/k8s.io/kubectl/pkg/explain/v2/templates/batch.k8s.io_v1.json
@@ -5096,7 +5096,7 @@
             ]
           },
           "resizePolicy": {
-            "description": "Resources resize policy for the container.",
+            "description": "Resources resize policy for ephemeral containers are not allowed.",
             "type": "array",
             "items": {
               "default": {},

--- a/staging/src/k8s.io/kubectl/testdata/openapi/v3/apis/apps/v1.json
+++ b/staging/src/k8s.io/kubectl/testdata/openapi/v3/apis/apps/v1.json
@@ -2213,7 +2213,7 @@
             "description": "Probes are not allowed for ephemeral containers."
           },
           "resizePolicy": {
-            "description": "Resources resize policy for the container.",
+            "description": "Resources resize policy for ephemeral containers are not allowed.",
             "items": {
               "allOf": [
                 {


### PR DESCRIPTION
#### What type of PR is this?
/kind documentation

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
Fixes 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
