### PR TITLE
pkg/apis/autoscaling: Replace deprecated pointer package

### DIFF
--- a/pkg/apis/autoscaling/fuzzer/fuzzer.go
+++ b/pkg/apis/autoscaling/fuzzer/fuzzer.go
@@ -24,7 +24,7 @@ import (
 	runtimeserializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/kubernetes/pkg/apis/autoscaling"
 	api "k8s.io/kubernetes/pkg/apis/core"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 // Funcs returns the fuzzer functions for the autoscaling api group.
@@ -41,7 +41,7 @@ var Funcs = func(codecs runtimeserializer.CodecFactory) []interface{} {
 		},
 		func(s *autoscaling.HorizontalPodAutoscalerSpec, c fuzz.Continue) {
 			c.FuzzNoCustom(s) // fuzz self without calling this function again
-			s.MinReplicas = pointer.Int32(c.Rand.Int31())
+			s.MinReplicas = ptr.To(c.Rand.Int31())
 
 			randomQuantity := func() resource.Quantity {
 				var q resource.Quantity

--- a/pkg/apis/autoscaling/v1/conversion_test.go
+++ b/pkg/apis/autoscaling/v1/conversion_test.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/conversion"
 	"k8s.io/kubernetes/pkg/apis/autoscaling"
 	api "k8s.io/kubernetes/pkg/apis/core"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 // Test for #101370
@@ -46,7 +46,7 @@ func TestConvert_autoscaling_HorizontalPodAutoscalerSpec_To_v1_HorizontalPodAuto
 			"TestConversionWithCPUAverageValueAndUtilizationBoth1",
 			args{
 				in: &autoscaling.HorizontalPodAutoscalerSpec{
-					MinReplicas: utilpointer.Int32(1),
+					MinReplicas: ptr.To(int32(1)),
 					MaxReplicas: 3,
 					Metrics: []autoscaling.MetricSpec{
 						{
@@ -65,7 +65,7 @@ func TestConvert_autoscaling_HorizontalPodAutoscalerSpec_To_v1_HorizontalPodAuto
 								Name: api.ResourceCPU,
 								Target: autoscaling.MetricTarget{
 									Type:               autoscaling.UtilizationMetricType,
-									AverageUtilization: utilpointer.Int32(70),
+									AverageUtilization: ptr.To(int32(70)),
 								},
 							},
 						},
@@ -73,9 +73,9 @@ func TestConvert_autoscaling_HorizontalPodAutoscalerSpec_To_v1_HorizontalPodAuto
 				},
 				out: &autoscalingv1.HorizontalPodAutoscalerSpec{},
 				expectOut: &autoscalingv1.HorizontalPodAutoscalerSpec{
-					MinReplicas:                    utilpointer.Int32(1),
+					MinReplicas:                    ptr.To(int32(1)),
 					MaxReplicas:                    3,
-					TargetCPUUtilizationPercentage: utilpointer.Int32(70),
+					TargetCPUUtilizationPercentage: ptr.To(int32(70)),
 				},
 				s: nil,
 			},
@@ -85,7 +85,7 @@ func TestConvert_autoscaling_HorizontalPodAutoscalerSpec_To_v1_HorizontalPodAuto
 			"TestConversionWithCPUAverageValueAndUtilizationBoth2",
 			args{
 				in: &autoscaling.HorizontalPodAutoscalerSpec{
-					MinReplicas: utilpointer.Int32(1),
+					MinReplicas: ptr.To(int32(1)),
 					MaxReplicas: 3,
 					Metrics: []autoscaling.MetricSpec{
 						{
@@ -104,21 +104,21 @@ func TestConvert_autoscaling_HorizontalPodAutoscalerSpec_To_v1_HorizontalPodAuto
 								Name: api.ResourceCPU,
 								Target: autoscaling.MetricTarget{
 									Type:               autoscaling.UtilizationMetricType,
-									AverageUtilization: utilpointer.Int32(70),
+									AverageUtilization: ptr.To(int32(70)),
 								},
 							},
 						},
 					},
 				},
 				out: &autoscalingv1.HorizontalPodAutoscalerSpec{
-					MinReplicas:                    utilpointer.Int32(2),
+					MinReplicas:                    ptr.To(int32(2)),
 					MaxReplicas:                    4,
-					TargetCPUUtilizationPercentage: utilpointer.Int32(60),
+					TargetCPUUtilizationPercentage: ptr.To(int32(60)),
 				},
 				expectOut: &autoscalingv1.HorizontalPodAutoscalerSpec{
-					MinReplicas:                    utilpointer.Int32(1),
+					MinReplicas:                    ptr.To(int32(1)),
 					MaxReplicas:                    3,
-					TargetCPUUtilizationPercentage: utilpointer.Int32(70),
+					TargetCPUUtilizationPercentage: ptr.To(int32(70)),
 				},
 				s: nil,
 			},
@@ -128,19 +128,19 @@ func TestConvert_autoscaling_HorizontalPodAutoscalerSpec_To_v1_HorizontalPodAuto
 			"TestConversionWithoutMetrics",
 			args{
 				in: &autoscaling.HorizontalPodAutoscalerSpec{
-					MinReplicas: utilpointer.Int32(1),
+					MinReplicas: ptr.To(int32(1)),
 					MaxReplicas: 3,
 					Metrics:     []autoscaling.MetricSpec{},
 				},
 				out: &autoscalingv1.HorizontalPodAutoscalerSpec{
-					MinReplicas:                    utilpointer.Int32(1),
+					MinReplicas:                    ptr.To(int32(1)),
 					MaxReplicas:                    4,
-					TargetCPUUtilizationPercentage: utilpointer.Int32(60),
+					TargetCPUUtilizationPercentage: ptr.To(int32(60)),
 				},
 				expectOut: &autoscalingv1.HorizontalPodAutoscalerSpec{
-					MinReplicas:                    utilpointer.Int32(1),
+					MinReplicas:                    ptr.To(int32(1)),
 					MaxReplicas:                    3,
-					TargetCPUUtilizationPercentage: utilpointer.Int32(60),
+					TargetCPUUtilizationPercentage: ptr.To(int32(60)),
 				},
 				s: nil,
 			},
@@ -150,7 +150,7 @@ func TestConvert_autoscaling_HorizontalPodAutoscalerSpec_To_v1_HorizontalPodAuto
 			"TestConversionWithCPUUtilizationOnly",
 			args{
 				in: &autoscaling.HorizontalPodAutoscalerSpec{
-					MinReplicas: utilpointer.Int32(1),
+					MinReplicas: ptr.To(int32(1)),
 					MaxReplicas: 3,
 					Metrics: []autoscaling.MetricSpec{
 						{
@@ -159,7 +159,7 @@ func TestConvert_autoscaling_HorizontalPodAutoscalerSpec_To_v1_HorizontalPodAuto
 								Name: api.ResourceCPU,
 								Target: autoscaling.MetricTarget{
 									Type:               autoscaling.UtilizationMetricType,
-									AverageUtilization: utilpointer.Int32(60),
+									AverageUtilization: ptr.To(int32(60)),
 								},
 							},
 						},
@@ -167,9 +167,9 @@ func TestConvert_autoscaling_HorizontalPodAutoscalerSpec_To_v1_HorizontalPodAuto
 				},
 				out: &autoscalingv1.HorizontalPodAutoscalerSpec{},
 				expectOut: &autoscalingv1.HorizontalPodAutoscalerSpec{
-					MinReplicas:                    utilpointer.Int32(1),
+					MinReplicas:                    ptr.To(int32(1)),
 					MaxReplicas:                    3,
-					TargetCPUUtilizationPercentage: utilpointer.Int32(60),
+					TargetCPUUtilizationPercentage: ptr.To(int32(60)),
 				},
 				s: nil,
 			},

--- a/pkg/apis/autoscaling/v1/defaults.go
+++ b/pkg/apis/autoscaling/v1/defaults.go
@@ -19,7 +19,7 @@ package v1
 import (
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func addDefaultingFuncs(scheme *runtime.Scheme) error {
@@ -28,7 +28,7 @@ func addDefaultingFuncs(scheme *runtime.Scheme) error {
 
 func SetDefaults_HorizontalPodAutoscaler(obj *autoscalingv1.HorizontalPodAutoscaler) {
 	if obj.Spec.MinReplicas == nil {
-		obj.Spec.MinReplicas = pointer.Int32(1)
+		obj.Spec.MinReplicas = ptr.To(int32(1))
 	}
 
 	// NB: we apply a default for CPU utilization in conversion because

--- a/pkg/apis/autoscaling/v1/defaults_test.go
+++ b/pkg/apis/autoscaling/v1/defaults_test.go
@@ -29,7 +29,7 @@ import (
 	_ "k8s.io/kubernetes/pkg/apis/autoscaling/install"
 	. "k8s.io/kubernetes/pkg/apis/autoscaling/v1"
 	_ "k8s.io/kubernetes/pkg/apis/core/install"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestSetDefaultHPA(t *testing.T) {
@@ -46,7 +46,7 @@ func TestSetDefaultHPA(t *testing.T) {
 		{
 			hpa: autoscalingv1.HorizontalPodAutoscaler{
 				Spec: autoscalingv1.HorizontalPodAutoscalerSpec{
-					MinReplicas: utilpointer.Int32(3),
+					MinReplicas: ptr.To(int32(3)),
 				},
 			},
 			expectReplicas: 3,

--- a/pkg/apis/autoscaling/v2/defaults.go
+++ b/pkg/apis/autoscaling/v2/defaults.go
@@ -21,7 +21,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/kubernetes/pkg/apis/autoscaling"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 var (
@@ -70,7 +70,7 @@ func addDefaultingFuncs(scheme *runtime.Scheme) error {
 
 func SetDefaults_HorizontalPodAutoscaler(obj *autoscalingv2.HorizontalPodAutoscaler) {
 	if obj.Spec.MinReplicas == nil {
-		obj.Spec.MinReplicas = pointer.Int32(1)
+		obj.Spec.MinReplicas = ptr.To(int32(1))
 	}
 
 	if len(obj.Spec.Metrics) == 0 {

--- a/pkg/apis/autoscaling/v2/defaults_test.go
+++ b/pkg/apis/autoscaling/v2/defaults_test.go
@@ -31,7 +31,7 @@ import (
 	_ "k8s.io/kubernetes/pkg/apis/autoscaling/install"
 	. "k8s.io/kubernetes/pkg/apis/autoscaling/v2"
 	_ "k8s.io/kubernetes/pkg/apis/core/install"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestGenerateScaleDownRules(t *testing.T) {
@@ -65,13 +65,13 @@ func TestGenerateScaleDownRules(t *testing.T) {
 			rateDownPodsPeriodSeconds:    2,
 			rateDownPercent:              3,
 			rateDownPercentPeriodSeconds: 4,
-			stabilizationSeconds:         utilpointer.Int32(25),
+			stabilizationSeconds:         ptr.To(int32(25)),
 			selectPolicy:                 &maxPolicy,
 			expectedPolicies: []autoscalingv2.HPAScalingPolicy{
 				{Type: autoscalingv2.PodsScalingPolicy, Value: 1, PeriodSeconds: 2},
 				{Type: autoscalingv2.PercentScalingPolicy, Value: 3, PeriodSeconds: 4},
 			},
-			expectedStabilization: utilpointer.Int32(25),
+			expectedStabilization: ptr.To(int32(25)),
 			expectedSelectPolicy:  string(autoscalingv2.MaxChangePolicySelect),
 		},
 		{
@@ -147,7 +147,7 @@ func TestGenerateScaleUpRules(t *testing.T) {
 				{Type: autoscalingv2.PodsScalingPolicy, Value: 4, PeriodSeconds: 15},
 				{Type: autoscalingv2.PercentScalingPolicy, Value: 100, PeriodSeconds: 15},
 			},
-			expectedStabilization: utilpointer.Int32(0),
+			expectedStabilization: ptr.To(int32(0)),
 			expectedSelectPolicy:  string(autoscalingv2.MaxChangePolicySelect),
 		},
 		{
@@ -156,13 +156,13 @@ func TestGenerateScaleUpRules(t *testing.T) {
 			rateUpPodsPeriodSeconds:    2,
 			rateUpPercent:              3,
 			rateUpPercentPeriodSeconds: 4,
-			stabilizationSeconds:       utilpointer.Int32(25),
+			stabilizationSeconds:       ptr.To(int32(25)),
 			selectPolicy:               &maxPolicy,
 			expectedPolicies: []autoscalingv2.HPAScalingPolicy{
 				{Type: autoscalingv2.PodsScalingPolicy, Value: 1, PeriodSeconds: 2},
 				{Type: autoscalingv2.PercentScalingPolicy, Value: 3, PeriodSeconds: 4},
 			},
-			expectedStabilization: utilpointer.Int32(25),
+			expectedStabilization: ptr.To(int32(25)),
 			expectedSelectPolicy:  string(autoscalingv2.MaxChangePolicySelect),
 		},
 		{
@@ -173,7 +173,7 @@ func TestGenerateScaleUpRules(t *testing.T) {
 			expectedPolicies: []autoscalingv2.HPAScalingPolicy{
 				{Type: autoscalingv2.PodsScalingPolicy, Value: 1, PeriodSeconds: 2},
 			},
-			expectedStabilization: utilpointer.Int32(0),
+			expectedStabilization: ptr.To(int32(0)),
 			expectedSelectPolicy:  string(autoscalingv2.MinChangePolicySelect),
 		},
 		{
@@ -183,29 +183,29 @@ func TestGenerateScaleUpRules(t *testing.T) {
 			expectedPolicies: []autoscalingv2.HPAScalingPolicy{
 				{Type: autoscalingv2.PercentScalingPolicy, Value: 7, PeriodSeconds: 10},
 			},
-			expectedStabilization: utilpointer.Int32(0),
+			expectedStabilization: ptr.To(int32(0)),
 			expectedSelectPolicy:  string(autoscalingv2.MaxChangePolicySelect),
 		},
 		{
 			annotation:              "Pod policy and stabilization window are specified",
 			rateUpPodsPeriodSeconds: 2,
-			stabilizationSeconds:    utilpointer.Int32(25),
+			stabilizationSeconds:    ptr.To(int32(25)),
 			rateUpPods:              4,
 			expectedPolicies: []autoscalingv2.HPAScalingPolicy{
 				{Type: autoscalingv2.PodsScalingPolicy, Value: 4, PeriodSeconds: 2},
 			},
-			expectedStabilization: utilpointer.Int32(25),
+			expectedStabilization: ptr.To(int32(25)),
 			expectedSelectPolicy:  string(autoscalingv2.MaxChangePolicySelect),
 		},
 		{
 			annotation:                 "Percent policy and stabilization window are specified",
 			rateUpPercent:              7,
 			rateUpPercentPeriodSeconds: 60,
-			stabilizationSeconds:       utilpointer.Int32(25),
+			stabilizationSeconds:       ptr.To(int32(25)),
 			expectedPolicies: []autoscalingv2.HPAScalingPolicy{
 				{Type: autoscalingv2.PercentScalingPolicy, Value: 7, PeriodSeconds: 60},
 			},
-			expectedStabilization: utilpointer.Int32(25),
+			expectedStabilization: ptr.To(int32(25)),
 			expectedSelectPolicy:  string(autoscalingv2.MaxChangePolicySelect),
 		},
 	}

--- a/pkg/apis/autoscaling/v2beta1/defaults.go
+++ b/pkg/apis/autoscaling/v2beta1/defaults.go
@@ -18,10 +18,10 @@ package v2beta1
 
 import (
 	autoscalingv2beta1 "k8s.io/api/autoscaling/v2beta1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/kubernetes/pkg/apis/autoscaling"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func addDefaultingFuncs(scheme *runtime.Scheme) error {
@@ -30,7 +30,7 @@ func addDefaultingFuncs(scheme *runtime.Scheme) error {
 
 func SetDefaults_HorizontalPodAutoscaler(obj *autoscalingv2beta1.HorizontalPodAutoscaler) {
 	if obj.Spec.MinReplicas == nil {
-		obj.Spec.MinReplicas = pointer.Int32(1)
+		obj.Spec.MinReplicas = ptr.To(int32(1))
 	}
 
 	if len(obj.Spec.Metrics) == 0 {

--- a/pkg/apis/autoscaling/v2beta1/defaults_test.go
+++ b/pkg/apis/autoscaling/v2beta1/defaults_test.go
@@ -31,12 +31,12 @@ import (
 	_ "k8s.io/kubernetes/pkg/apis/autoscaling/install"
 	. "k8s.io/kubernetes/pkg/apis/autoscaling/v2beta1"
 	_ "k8s.io/kubernetes/pkg/apis/core/install"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestSetDefaultHPA(t *testing.T) {
 	utilizationDefaultVal := int32(autoscaling.DefaultCPUUtilization)
-	defaultReplicas := utilpointer.Int32(1)
+	defaultReplicas := ptr.To(int32(1))
 	defaultTemplate := []autoscalingv2beta1.MetricSpec{
 		{
 			Type: autoscalingv2beta1.ResourceMetricSourceType,
@@ -67,13 +67,13 @@ func TestSetDefaultHPA(t *testing.T) {
 		{ // MinReplicas update
 			original: &autoscalingv2beta1.HorizontalPodAutoscaler{
 				Spec: autoscalingv2beta1.HorizontalPodAutoscalerSpec{
-					MinReplicas: utilpointer.Int32(3),
+					MinReplicas: ptr.To(int32(3)),
 					Metrics:     defaultTemplate,
 				},
 			},
 			expected: &autoscalingv2beta1.HorizontalPodAutoscaler{
 				Spec: autoscalingv2beta1.HorizontalPodAutoscalerSpec{
-					MinReplicas: utilpointer.Int32(3),
+					MinReplicas: ptr.To(int32(3)),
 					Metrics:     defaultTemplate,
 				},
 			},

--- a/pkg/apis/autoscaling/v2beta2/defaults.go
+++ b/pkg/apis/autoscaling/v2beta2/defaults.go
@@ -21,7 +21,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/kubernetes/pkg/apis/autoscaling"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 var (
@@ -71,7 +71,7 @@ func addDefaultingFuncs(scheme *runtime.Scheme) error {
 
 func SetDefaults_HorizontalPodAutoscaler(obj *autoscalingv2beta2.HorizontalPodAutoscaler) {
 	if obj.Spec.MinReplicas == nil {
-		obj.Spec.MinReplicas = pointer.Int32(1)
+		obj.Spec.MinReplicas = ptr.To(int32(1))
 	}
 
 	if len(obj.Spec.Metrics) == 0 {

--- a/pkg/apis/autoscaling/v2beta2/defaults_test.go
+++ b/pkg/apis/autoscaling/v2beta2/defaults_test.go
@@ -31,7 +31,7 @@ import (
 	_ "k8s.io/kubernetes/pkg/apis/autoscaling/install"
 	. "k8s.io/kubernetes/pkg/apis/autoscaling/v2beta2"
 	_ "k8s.io/kubernetes/pkg/apis/core/install"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestGenerateScaleDownRules(t *testing.T) {
@@ -65,13 +65,13 @@ func TestGenerateScaleDownRules(t *testing.T) {
 			rateDownPodsPeriodSeconds:    2,
 			rateDownPercent:              3,
 			rateDownPercentPeriodSeconds: 4,
-			stabilizationSeconds:         utilpointer.Int32(25),
+			stabilizationSeconds:         ptr.To(int32(25)),
 			selectPolicy:                 &maxPolicy,
 			expectedPolicies: []autoscalingv2.HPAScalingPolicy{
 				{Type: autoscalingv2.PodsScalingPolicy, Value: 1, PeriodSeconds: 2},
 				{Type: autoscalingv2.PercentScalingPolicy, Value: 3, PeriodSeconds: 4},
 			},
-			expectedStabilization: utilpointer.Int32(25),
+			expectedStabilization: ptr.To(int32(25)),
 			expectedSelectPolicy:  string(autoscalingv2.MaxPolicySelect),
 		},
 		{
@@ -147,7 +147,7 @@ func TestGenerateScaleUpRules(t *testing.T) {
 				{Type: autoscalingv2.PodsScalingPolicy, Value: 4, PeriodSeconds: 15},
 				{Type: autoscalingv2.PercentScalingPolicy, Value: 100, PeriodSeconds: 15},
 			},
-			expectedStabilization: utilpointer.Int32(0),
+			expectedStabilization: ptr.To(int32(0)),
 			expectedSelectPolicy:  string(autoscalingv2.MaxPolicySelect),
 		},
 		{
@@ -156,13 +156,13 @@ func TestGenerateScaleUpRules(t *testing.T) {
 			rateUpPodsPeriodSeconds:    2,
 			rateUpPercent:              3,
 			rateUpPercentPeriodSeconds: 4,
-			stabilizationSeconds:       utilpointer.Int32(25),
+			stabilizationSeconds:       ptr.To(int32(25)),
 			selectPolicy:               &maxPolicy,
 			expectedPolicies: []autoscalingv2.HPAScalingPolicy{
 				{Type: autoscalingv2.PodsScalingPolicy, Value: 1, PeriodSeconds: 2},
 				{Type: autoscalingv2.PercentScalingPolicy, Value: 3, PeriodSeconds: 4},
 			},
-			expectedStabilization: utilpointer.Int32(25),
+			expectedStabilization: ptr.To(int32(25)),
 			expectedSelectPolicy:  string(autoscalingv2.MaxPolicySelect),
 		},
 		{
@@ -173,7 +173,7 @@ func TestGenerateScaleUpRules(t *testing.T) {
 			expectedPolicies: []autoscalingv2.HPAScalingPolicy{
 				{Type: autoscalingv2.PodsScalingPolicy, Value: 1, PeriodSeconds: 2},
 			},
-			expectedStabilization: utilpointer.Int32(0),
+			expectedStabilization: ptr.To(int32(0)),
 			expectedSelectPolicy:  string(autoscalingv2.MinPolicySelect),
 		},
 		{
@@ -183,29 +183,29 @@ func TestGenerateScaleUpRules(t *testing.T) {
 			expectedPolicies: []autoscalingv2.HPAScalingPolicy{
 				{Type: autoscalingv2.PercentScalingPolicy, Value: 7, PeriodSeconds: 10},
 			},
-			expectedStabilization: utilpointer.Int32(0),
+			expectedStabilization: ptr.To(int32(0)),
 			expectedSelectPolicy:  string(autoscalingv2.MaxPolicySelect),
 		},
 		{
 			annotation:              "Pod policy and stabilization window are specified",
 			rateUpPodsPeriodSeconds: 2,
-			stabilizationSeconds:    utilpointer.Int32(25),
+			stabilizationSeconds:    ptr.To(int32(25)),
 			rateUpPods:              4,
 			expectedPolicies: []autoscalingv2.HPAScalingPolicy{
 				{Type: autoscalingv2.PodsScalingPolicy, Value: 4, PeriodSeconds: 2},
 			},
-			expectedStabilization: utilpointer.Int32(25),
+			expectedStabilization: ptr.To(int32(25)),
 			expectedSelectPolicy:  string(autoscalingv2.MaxPolicySelect),
 		},
 		{
 			annotation:                 "Percent policy and stabilization window are specified",
 			rateUpPercent:              7,
 			rateUpPercentPeriodSeconds: 60,
-			stabilizationSeconds:       utilpointer.Int32(25),
+			stabilizationSeconds:       ptr.To(int32(25)),
 			expectedPolicies: []autoscalingv2.HPAScalingPolicy{
 				{Type: autoscalingv2.PercentScalingPolicy, Value: 7, PeriodSeconds: 60},
 			},
-			expectedStabilization: utilpointer.Int32(25),
+			expectedStabilization: ptr.To(int32(25)),
 			expectedSelectPolicy:  string(autoscalingv2.MaxPolicySelect),
 		},
 	}

--- a/pkg/apis/autoscaling/validation/validation_test.go
+++ b/pkg/apis/autoscaling/validation/validation_test.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/kubernetes/pkg/apis/autoscaling"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/features"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestValidateScale(t *testing.T) {
@@ -107,18 +107,18 @@ func TestValidateBehavior(t *testing.T) {
 		ScaleDown: nil,
 	}, {
 		ScaleUp: &autoscaling.HPAScalingRules{
-			StabilizationWindowSeconds: utilpointer.Int32(3600),
+			StabilizationWindowSeconds: ptr.To(int32(3600)),
 			SelectPolicy:               &minPolicy,
 			Policies:                   simplePoliciesList,
 		},
 		ScaleDown: &autoscaling.HPAScalingRules{
-			StabilizationWindowSeconds: utilpointer.Int32(0),
+			StabilizationWindowSeconds: ptr.To(int32(0)),
 			SelectPolicy:               &disabledPolicy,
 			Policies:                   simplePoliciesList,
 		},
 	}, {
 		ScaleUp: &autoscaling.HPAScalingRules{
-			StabilizationWindowSeconds: utilpointer.Int32(120),
+			StabilizationWindowSeconds: ptr.To(int32(120)),
 			SelectPolicy:               &maxPolicy,
 			Policies: []autoscaling.HPAScalingPolicy{{
 				Type:          autoscaling.PodsScalingPolicy,
@@ -139,7 +139,7 @@ func TestValidateBehavior(t *testing.T) {
 			}},
 		},
 		ScaleDown: &autoscaling.HPAScalingRules{
-			StabilizationWindowSeconds: utilpointer.Int32(120),
+			StabilizationWindowSeconds: ptr.To(int32(120)),
 			SelectPolicy:               &maxPolicy,
 			Policies: []autoscaling.HPAScalingPolicy{{
 				Type:          autoscaling.PodsScalingPolicy,
@@ -179,7 +179,7 @@ func TestValidateBehavior(t *testing.T) {
 	}, {
 		behavior: autoscaling.HorizontalPodAutoscalerBehavior{
 			ScaleUp: &autoscaling.HPAScalingRules{
-				StabilizationWindowSeconds: utilpointer.Int32(3601),
+				StabilizationWindowSeconds: ptr.To(int32(3601)),
 				SelectPolicy:               &minPolicy,
 				Policies:                   simplePoliciesList,
 			},
@@ -271,7 +271,7 @@ func TestValidateBehavior(t *testing.T) {
 	}, {
 		behavior: autoscaling.HorizontalPodAutoscalerBehavior{
 			ScaleDown: &autoscaling.HPAScalingRules{
-				StabilizationWindowSeconds: utilpointer.Int32(3601),
+				StabilizationWindowSeconds: ptr.To(int32(3601)),
 				SelectPolicy:               &minPolicy,
 				Policies:                   simplePoliciesList,
 			},
@@ -375,7 +375,7 @@ func prepareHPAWithBehavior(b autoscaling.HorizontalPodAutoscalerBehavior) autos
 				Kind: "ReplicationController",
 				Name: "myrc",
 			},
-			MinReplicas: utilpointer.Int32(1),
+			MinReplicas: ptr.To(int32(1)),
 			MaxReplicas: 5,
 			Metrics: []autoscaling.MetricSpec{{
 				Type: autoscaling.ResourceMetricSourceType,
@@ -383,7 +383,7 @@ func prepareHPAWithBehavior(b autoscaling.HorizontalPodAutoscalerBehavior) autos
 					Name: api.ResourceCPU,
 					Target: autoscaling.MetricTarget{
 						Type:               autoscaling.UtilizationMetricType,
-						AverageUtilization: utilpointer.Int32(70),
+						AverageUtilization: ptr.To(int32(70)),
 					},
 				},
 			}},
@@ -408,7 +408,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				Kind: "ReplicationController",
 				Name: "myrc",
 			},
-			MinReplicas: utilpointer.Int32(1),
+			MinReplicas: ptr.To(int32(1)),
 			MaxReplicas: 5,
 			Metrics: []autoscaling.MetricSpec{{
 				Type: autoscaling.ResourceMetricSourceType,
@@ -416,7 +416,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 					Name: api.ResourceCPU,
 					Target: autoscaling.MetricTarget{
 						Type:               autoscaling.UtilizationMetricType,
-						AverageUtilization: utilpointer.Int32(70),
+						AverageUtilization: ptr.To(int32(70)),
 					},
 				},
 			}},
@@ -431,7 +431,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				Kind: "ReplicationController",
 				Name: "myrc",
 			},
-			MinReplicas: utilpointer.Int32(1),
+			MinReplicas: ptr.To(int32(1)),
 			MaxReplicas: 5,
 		},
 	}, {
@@ -444,7 +444,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				Kind: "ReplicationController",
 				Name: "myrc",
 			},
-			MinReplicas: utilpointer.Int32(1),
+			MinReplicas: ptr.To(int32(1)),
 			MaxReplicas: 5,
 			Metrics: []autoscaling.MetricSpec{{
 				Type: autoscaling.ResourceMetricSourceType,
@@ -467,7 +467,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				Kind: "ReplicationController",
 				Name: "myrc",
 			},
-			MinReplicas: utilpointer.Int32(1),
+			MinReplicas: ptr.To(int32(1)),
 			MaxReplicas: 5,
 			Metrics: []autoscaling.MetricSpec{{
 				Type: autoscaling.PodsMetricSourceType,
@@ -492,7 +492,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				Kind: "ReplicationController",
 				Name: "myrc",
 			},
-			MinReplicas: utilpointer.Int32(1),
+			MinReplicas: ptr.To(int32(1)),
 			MaxReplicas: 5,
 			Metrics: []autoscaling.MetricSpec{{
 				Type: autoscaling.ContainerResourceMetricSourceType,
@@ -501,7 +501,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 					Container: "test-container",
 					Target: autoscaling.MetricTarget{
 						Type:               autoscaling.UtilizationMetricType,
-						AverageUtilization: utilpointer.Int32(70),
+						AverageUtilization: ptr.To(int32(70)),
 					},
 				},
 			}},
@@ -516,7 +516,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				Kind: "ReplicationController",
 				Name: "myrc",
 			},
-			MinReplicas: utilpointer.Int32(1),
+			MinReplicas: ptr.To(int32(1)),
 			MaxReplicas: 5,
 			Metrics: []autoscaling.MetricSpec{{
 				Type: autoscaling.ContainerResourceMetricSourceType,
@@ -540,7 +540,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				Kind: "ReplicationController",
 				Name: "myrc",
 			},
-			MinReplicas: utilpointer.Int32(1),
+			MinReplicas: ptr.To(int32(1)),
 			MaxReplicas: 5,
 			Metrics: []autoscaling.MetricSpec{{
 				Type: autoscaling.ObjectMetricSourceType,
@@ -569,7 +569,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				Kind: "ReplicationController",
 				Name: "myrc",
 			},
-			MinReplicas: utilpointer.Int32(1),
+			MinReplicas: ptr.To(int32(1)),
 			MaxReplicas: 5,
 			Metrics: []autoscaling.MetricSpec{{
 				Type: autoscaling.ExternalMetricSourceType,
@@ -595,7 +595,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				Kind: "ReplicationController",
 				Name: "myrc",
 			},
-			MinReplicas: utilpointer.Int32(1),
+			MinReplicas: ptr.To(int32(1)),
 			MaxReplicas: 5,
 			Metrics: []autoscaling.MetricSpec{{
 				Type: autoscaling.ExternalMetricSourceType,
@@ -626,7 +626,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 			Spec: autoscaling.HorizontalPodAutoscalerSpec{
 				ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc"},
-				MinReplicas:    utilpointer.Int32(1),
+				MinReplicas:    ptr.To(int32(1)),
 				MaxReplicas:    5,
 				Metrics: []autoscaling.MetricSpec{{
 					Type: autoscaling.ResourceMetricSourceType,
@@ -634,7 +634,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 						Name: api.ResourceCPU,
 						Target: autoscaling.MetricTarget{
 							Type:               autoscaling.UtilizationMetricType,
-							AverageUtilization: utilpointer.Int32(70),
+							AverageUtilization: ptr.To(int32(70)),
 						},
 					},
 				}},
@@ -646,7 +646,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 			Spec: autoscaling.HorizontalPodAutoscalerSpec{
 				ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc"},
-				MinReplicas:    utilpointer.Int32(1),
+				MinReplicas:    ptr.To(int32(1)),
 				MaxReplicas:    5,
 				Metrics: []autoscaling.MetricSpec{{
 					Type: autoscaling.ContainerResourceMetricSourceType,
@@ -655,7 +655,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 						Container: "test-application",
 						Target: autoscaling.MetricTarget{
 							Type:               autoscaling.UtilizationMetricType,
-							AverageUtilization: utilpointer.Int32(70),
+							AverageUtilization: ptr.To(int32(70)),
 						},
 					},
 				}},
@@ -667,7 +667,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 			Spec: autoscaling.HorizontalPodAutoscalerSpec{
 				ScaleTargetRef: autoscaling.CrossVersionObjectReference{Kind: "..", Name: "myrc"},
-				MinReplicas:    utilpointer.Int32(1),
+				MinReplicas:    ptr.To(int32(1)),
 				MaxReplicas:    5,
 				Metrics: []autoscaling.MetricSpec{{
 					Type: autoscaling.ResourceMetricSourceType,
@@ -675,7 +675,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 						Name: api.ResourceCPU,
 						Target: autoscaling.MetricTarget{
 							Type:               autoscaling.UtilizationMetricType,
-							AverageUtilization: utilpointer.Int32(70),
+							AverageUtilization: ptr.To(int32(70)),
 						},
 					},
 				}},
@@ -687,7 +687,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 			Spec: autoscaling.HorizontalPodAutoscalerSpec{
 				ScaleTargetRef: autoscaling.CrossVersionObjectReference{Kind: "..", Name: "myrc"},
-				MinReplicas:    utilpointer.Int32(1),
+				MinReplicas:    ptr.To(int32(1)),
 				MaxReplicas:    5,
 				Metrics: []autoscaling.MetricSpec{{
 					Type: autoscaling.ContainerResourceMetricSourceType,
@@ -696,7 +696,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 						Container: "test-application",
 						Target: autoscaling.MetricTarget{
 							Type:               autoscaling.UtilizationMetricType,
-							AverageUtilization: utilpointer.Int32(70),
+							AverageUtilization: ptr.To(int32(70)),
 						},
 					},
 				}},
@@ -708,7 +708,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 			Spec: autoscaling.HorizontalPodAutoscalerSpec{
 				ScaleTargetRef: autoscaling.CrossVersionObjectReference{Kind: "ReplicationController"},
-				MinReplicas:    utilpointer.Int32(1),
+				MinReplicas:    ptr.To(int32(1)),
 				MaxReplicas:    5,
 				Metrics: []autoscaling.MetricSpec{{
 					Type: autoscaling.ResourceMetricSourceType,
@@ -716,7 +716,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 						Name: api.ResourceCPU,
 						Target: autoscaling.MetricTarget{
 							Type:               autoscaling.UtilizationMetricType,
-							AverageUtilization: utilpointer.Int32(70),
+							AverageUtilization: ptr.To(int32(70)),
 						},
 					},
 				}},
@@ -728,7 +728,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 			Spec: autoscaling.HorizontalPodAutoscalerSpec{
 				ScaleTargetRef: autoscaling.CrossVersionObjectReference{Kind: "ReplicationController"},
-				MinReplicas:    utilpointer.Int32(1),
+				MinReplicas:    ptr.To(int32(1)),
 				MaxReplicas:    5,
 				Metrics: []autoscaling.MetricSpec{{
 					Type: autoscaling.ContainerResourceMetricSourceType,
@@ -737,7 +737,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 						Container: "test-application",
 						Target: autoscaling.MetricTarget{
 							Type:               autoscaling.UtilizationMetricType,
-							AverageUtilization: utilpointer.Int32(70),
+							AverageUtilization: ptr.To(int32(70)),
 						},
 					},
 				}},
@@ -749,7 +749,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 			Spec: autoscaling.HorizontalPodAutoscalerSpec{
 				ScaleTargetRef: autoscaling.CrossVersionObjectReference{Kind: "ReplicationController", Name: ".."},
-				MinReplicas:    utilpointer.Int32(1),
+				MinReplicas:    ptr.To(int32(1)),
 				MaxReplicas:    5,
 				Metrics: []autoscaling.MetricSpec{{
 					Type: autoscaling.ResourceMetricSourceType,
@@ -757,7 +757,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 						Name: api.ResourceCPU,
 						Target: autoscaling.MetricTarget{
 							Type:               autoscaling.UtilizationMetricType,
-							AverageUtilization: utilpointer.Int32(70),
+							AverageUtilization: ptr.To(int32(70)),
 						},
 					},
 				}},
@@ -769,7 +769,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 			Spec: autoscaling.HorizontalPodAutoscalerSpec{
 				ScaleTargetRef: autoscaling.CrossVersionObjectReference{Kind: "ReplicationController", Name: ".."},
-				MinReplicas:    utilpointer.Int32(1),
+				MinReplicas:    ptr.To(int32(1)),
 				MaxReplicas:    5,
 				Metrics: []autoscaling.MetricSpec{{
 					Type: autoscaling.ContainerResourceMetricSourceType,
@@ -778,7 +778,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 						Container: "test-application",
 						Target: autoscaling.MetricTarget{
 							Type:               autoscaling.UtilizationMetricType,
-							AverageUtilization: utilpointer.Int32(70),
+							AverageUtilization: ptr.To(int32(70)),
 						},
 					},
 				}},
@@ -793,7 +793,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 			},
 			Spec: autoscaling.HorizontalPodAutoscalerSpec{
 				ScaleTargetRef: autoscaling.CrossVersionObjectReference{},
-				MinReplicas:    utilpointer.Int32(-1),
+				MinReplicas:    ptr.To(int32(-1)),
 				MaxReplicas:    5,
 			},
 		},
@@ -806,7 +806,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 			},
 			Spec: autoscaling.HorizontalPodAutoscalerSpec{
 				ScaleTargetRef: autoscaling.CrossVersionObjectReference{},
-				MinReplicas:    utilpointer.Int32(7),
+				MinReplicas:    ptr.To(int32(7)),
 				MaxReplicas:    5,
 			},
 		},
@@ -819,7 +819,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 			},
 			Spec: autoscaling.HorizontalPodAutoscalerSpec{
 				ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-				MinReplicas:    utilpointer.Int32(1),
+				MinReplicas:    ptr.To(int32(1)),
 				MaxReplicas:    5,
 				Metrics: []autoscaling.MetricSpec{{
 					Type: autoscaling.ResourceMetricSourceType,
@@ -827,7 +827,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 						Name: api.ResourceCPU,
 						Target: autoscaling.MetricTarget{
 							Type:               autoscaling.UtilizationMetricType,
-							AverageUtilization: utilpointer.Int32(70),
+							AverageUtilization: ptr.To(int32(70)),
 							AverageValue:       resource.NewMilliQuantity(300, resource.DecimalSI),
 						},
 					},
@@ -843,7 +843,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 			},
 			Spec: autoscaling.HorizontalPodAutoscalerSpec{
 				ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-				MinReplicas:    utilpointer.Int32(1),
+				MinReplicas:    ptr.To(int32(1)),
 				MaxReplicas:    5,
 				Metrics: []autoscaling.MetricSpec{{
 					Type: autoscaling.ContainerResourceMetricSourceType,
@@ -852,7 +852,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 						Container: "test-application",
 						Target: autoscaling.MetricTarget{
 							Type:               autoscaling.UtilizationMetricType,
-							AverageUtilization: utilpointer.Int32(70),
+							AverageUtilization: ptr.To(int32(70)),
 							AverageValue:       resource.NewMilliQuantity(300, resource.DecimalSI),
 						},
 					},
@@ -865,14 +865,14 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 			Spec: autoscaling.HorizontalPodAutoscalerSpec{
 				ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-				MinReplicas:    utilpointer.Int32(1),
+				MinReplicas:    ptr.To(int32(1)),
 				MaxReplicas:    5,
 				Metrics: []autoscaling.MetricSpec{{
 					Type: autoscaling.ResourceMetricSourceType,
 					Resource: &autoscaling.ResourceMetricSource{
 						Target: autoscaling.MetricTarget{
 							Type:               autoscaling.UtilizationMetricType,
-							AverageUtilization: utilpointer.Int32(70),
+							AverageUtilization: ptr.To(int32(70)),
 						},
 					},
 				}},
@@ -884,7 +884,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 			Spec: autoscaling.HorizontalPodAutoscalerSpec{
 				ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-				MinReplicas:    utilpointer.Int32(1),
+				MinReplicas:    ptr.To(int32(1)),
 				MaxReplicas:    5,
 				Metrics: []autoscaling.MetricSpec{{
 					Type: autoscaling.ContainerResourceMetricSourceType,
@@ -892,7 +892,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 						Container: "test-application",
 						Target: autoscaling.MetricTarget{
 							Type:               autoscaling.UtilizationMetricType,
-							AverageUtilization: utilpointer.Int32(70),
+							AverageUtilization: ptr.To(int32(70)),
 						},
 					},
 				}},
@@ -904,7 +904,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 			Spec: autoscaling.HorizontalPodAutoscalerSpec{
 				ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-				MinReplicas:    utilpointer.Int32(1),
+				MinReplicas:    ptr.To(int32(1)),
 				MaxReplicas:    5,
 				Metrics: []autoscaling.MetricSpec{{
 					Type: autoscaling.ContainerResourceMetricSourceType,
@@ -913,7 +913,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 						Container: "test-application",
 						Target: autoscaling.MetricTarget{
 							Type:               autoscaling.UtilizationMetricType,
-							AverageUtilization: utilpointer.Int32(70),
+							AverageUtilization: ptr.To(int32(70)),
 						},
 					},
 				}},
@@ -925,7 +925,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 			Spec: autoscaling.HorizontalPodAutoscalerSpec{
 				ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-				MinReplicas:    utilpointer.Int32(1),
+				MinReplicas:    ptr.To(int32(1)),
 				MaxReplicas:    5,
 				Metrics: []autoscaling.MetricSpec{{
 					Type: autoscaling.ResourceMetricSourceType,
@@ -933,7 +933,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 						Name: api.ResourceCPU,
 						Target: autoscaling.MetricTarget{
 							Type:               autoscaling.UtilizationMetricType,
-							AverageUtilization: utilpointer.Int32(-10),
+							AverageUtilization: ptr.To(int32(-10)),
 						},
 					},
 				}},
@@ -945,7 +945,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 			Spec: autoscaling.HorizontalPodAutoscalerSpec{
 				ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-				MinReplicas:    utilpointer.Int32(1),
+				MinReplicas:    ptr.To(int32(1)),
 				MaxReplicas:    5,
 				Metrics: []autoscaling.MetricSpec{{
 					Type: autoscaling.ContainerResourceMetricSourceType,
@@ -954,7 +954,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 						Container: "test-application",
 						Target: autoscaling.MetricTarget{
 							Type:               autoscaling.UtilizationMetricType,
-							AverageUtilization: utilpointer.Int32(-10),
+							AverageUtilization: ptr.To(int32(-10)),
 						},
 					},
 				}},
@@ -966,7 +966,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 			Spec: autoscaling.HorizontalPodAutoscalerSpec{
 				ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-				MinReplicas:    utilpointer.Int32(1),
+				MinReplicas:    ptr.To(int32(1)),
 				MaxReplicas:    5,
 				Metrics: []autoscaling.MetricSpec{{
 					Type: autoscaling.ContainerResourceMetricSourceType,
@@ -974,7 +974,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 						Name: api.ResourceCPU,
 						Target: autoscaling.MetricTarget{
 							Type:               autoscaling.UtilizationMetricType,
-							AverageUtilization: utilpointer.Int32(-10),
+							AverageUtilization: ptr.To(int32(-10)),
 						},
 					},
 				}},
@@ -986,7 +986,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 			Spec: autoscaling.HorizontalPodAutoscalerSpec{
 				ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-				MinReplicas:    utilpointer.Int32(1),
+				MinReplicas:    ptr.To(int32(1)),
 				MaxReplicas:    5,
 				Metrics: []autoscaling.MetricSpec{{
 					Type: autoscaling.ContainerResourceMetricSourceType,
@@ -995,7 +995,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 						Container: "---***",
 						Target: autoscaling.MetricTarget{
 							Type:               autoscaling.UtilizationMetricType,
-							AverageUtilization: utilpointer.Int32(-10),
+							AverageUtilization: ptr.To(int32(-10)),
 						},
 					},
 				}},
@@ -1007,7 +1007,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 			Spec: autoscaling.HorizontalPodAutoscalerSpec{
 				ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-				MinReplicas:    utilpointer.Int32(1),
+				MinReplicas:    ptr.To(int32(1)),
 				MaxReplicas:    5,
 				Metrics: []autoscaling.MetricSpec{{
 					Type: autoscaling.ResourceMetricSourceType,
@@ -1026,7 +1026,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 			Spec: autoscaling.HorizontalPodAutoscalerSpec{
 				ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-				MinReplicas:    utilpointer.Int32(1),
+				MinReplicas:    ptr.To(int32(1)),
 				MaxReplicas:    5,
 				Metrics: []autoscaling.MetricSpec{{
 					Type: autoscaling.ContainerResourceMetricSourceType,
@@ -1046,7 +1046,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 			Spec: autoscaling.HorizontalPodAutoscalerSpec{
 				ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-				MinReplicas:    utilpointer.Int32(1),
+				MinReplicas:    ptr.To(int32(1)),
 				MaxReplicas:    5,
 				Metrics: []autoscaling.MetricSpec{{
 					Type: autoscaling.PodsMetricSourceType,
@@ -1066,7 +1066,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 			Spec: autoscaling.HorizontalPodAutoscalerSpec{
 				ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-				MinReplicas:    utilpointer.Int32(1),
+				MinReplicas:    ptr.To(int32(1)),
 				MaxReplicas:    5,
 				Metrics: []autoscaling.MetricSpec{{
 					Type: autoscaling.PodsMetricSourceType,
@@ -1087,7 +1087,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 			Spec: autoscaling.HorizontalPodAutoscalerSpec{
 				ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-				MinReplicas:    utilpointer.Int32(1),
+				MinReplicas:    ptr.To(int32(1)),
 				MaxReplicas:    5,
 				Metrics: []autoscaling.MetricSpec{{
 					Type: autoscaling.ObjectMetricSourceType,
@@ -1112,7 +1112,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 			Spec: autoscaling.HorizontalPodAutoscalerSpec{
 				ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-				MinReplicas:    utilpointer.Int32(1),
+				MinReplicas:    ptr.To(int32(1)),
 				MaxReplicas:    5,
 				Metrics: []autoscaling.MetricSpec{{
 					Type: autoscaling.ObjectMetricSourceType,
@@ -1137,7 +1137,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 			Spec: autoscaling.HorizontalPodAutoscalerSpec{
 				ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-				MinReplicas:    utilpointer.Int32(1),
+				MinReplicas:    ptr.To(int32(1)),
 				MaxReplicas:    5,
 				Metrics: []autoscaling.MetricSpec{{
 					Type: autoscaling.ObjectMetricSourceType,
@@ -1160,7 +1160,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 			Spec: autoscaling.HorizontalPodAutoscalerSpec{
 				ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-				MinReplicas:    utilpointer.Int32(1),
+				MinReplicas:    ptr.To(int32(1)),
 				MaxReplicas:    5,
 				Metrics: []autoscaling.MetricSpec{{
 					Type: autoscaling.ExternalMetricSourceType,
@@ -1182,7 +1182,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 			Spec: autoscaling.HorizontalPodAutoscalerSpec{
 				ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-				MinReplicas:    utilpointer.Int32(1),
+				MinReplicas:    ptr.To(int32(1)),
 				MaxReplicas:    5,
 				Metrics: []autoscaling.MetricSpec{{
 					Type: autoscaling.ExternalMetricSourceType,
@@ -1207,7 +1207,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 				Spec: autoscaling.HorizontalPodAutoscalerSpec{
 					ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-					MinReplicas:    utilpointer.Int32(1),
+					MinReplicas:    ptr.To(int32(1)),
 					MaxReplicas:    5,
 					Metrics: []autoscaling.MetricSpec{{
 						Type: autoscaling.ExternalMetricSourceType,
@@ -1229,7 +1229,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 				Spec: autoscaling.HorizontalPodAutoscalerSpec{
 					ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-					MinReplicas:    utilpointer.Int32(1),
+					MinReplicas:    ptr.To(int32(1)),
 					MaxReplicas:    5,
 					Metrics: []autoscaling.MetricSpec{{
 						Type: autoscaling.ExternalMetricSourceType,
@@ -1252,7 +1252,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 				Spec: autoscaling.HorizontalPodAutoscalerSpec{
 					ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-					MinReplicas:    utilpointer.Int32(1),
+					MinReplicas:    ptr.To(int32(1)),
 					MaxReplicas:    5,
 					Metrics: []autoscaling.MetricSpec{{
 						Type: autoscaling.ExternalMetricSourceType,
@@ -1275,7 +1275,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 				Spec: autoscaling.HorizontalPodAutoscalerSpec{
 					ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-					MinReplicas:    utilpointer.Int32(1),
+					MinReplicas:    ptr.To(int32(1)),
 					MaxReplicas:    5,
 					Metrics: []autoscaling.MetricSpec{{
 						Type: autoscaling.ExternalMetricSourceType,
@@ -1299,7 +1299,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 				Spec: autoscaling.HorizontalPodAutoscalerSpec{
 					ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-					MinReplicas:    utilpointer.Int32(1),
+					MinReplicas:    ptr.To(int32(1)),
 					MaxReplicas:    5,
 					Metrics: []autoscaling.MetricSpec{{
 						Type: autoscaling.ExternalMetricSourceType,
@@ -1322,7 +1322,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 				Spec: autoscaling.HorizontalPodAutoscalerSpec{
 					ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-					MinReplicas:    utilpointer.Int32(1),
+					MinReplicas:    ptr.To(int32(1)),
 					MaxReplicas:    5,
 					Metrics: []autoscaling.MetricSpec{{
 						Type: autoscaling.ExternalMetricSourceType,
@@ -1344,7 +1344,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 				Spec: autoscaling.HorizontalPodAutoscalerSpec{
 					ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-					MinReplicas:    utilpointer.Int32(1),
+					MinReplicas:    ptr.To(int32(1)),
 					MaxReplicas:    5,
 					Metrics: []autoscaling.MetricSpec{{
 						Type: autoscaling.ExternalMetricSourceType,
@@ -1363,7 +1363,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 				Spec: autoscaling.HorizontalPodAutoscalerSpec{
 					ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-					MinReplicas:    utilpointer.Int32(1),
+					MinReplicas:    ptr.To(int32(1)),
 					MaxReplicas:    5,
 					Metrics: []autoscaling.MetricSpec{
 						{},
@@ -1376,7 +1376,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 				Spec: autoscaling.HorizontalPodAutoscalerSpec{
 					ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-					MinReplicas:    utilpointer.Int32(1),
+					MinReplicas:    ptr.To(int32(1)),
 					MaxReplicas:    5,
 					Metrics: []autoscaling.MetricSpec{{
 						Type: autoscaling.MetricSourceType("InvalidType"),
@@ -1389,7 +1389,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 				Spec: autoscaling.HorizontalPodAutoscalerSpec{
 					ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-					MinReplicas:    utilpointer.Int32(1),
+					MinReplicas:    ptr.To(int32(1)),
 					MaxReplicas:    5,
 					Metrics: []autoscaling.MetricSpec{{
 						Type: autoscaling.ResourceMetricSourceType,
@@ -1485,7 +1485,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 				Spec: autoscaling.HorizontalPodAutoscalerSpec{
 					ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-					MinReplicas:    utilpointer.Int32(1),
+					MinReplicas:    ptr.To(int32(1)),
 					MaxReplicas:    5, Metrics: []autoscaling.MetricSpec{spec},
 				},
 			})
@@ -1517,7 +1517,7 @@ func prepareMinReplicasCases(t *testing.T, minReplicas int32) []autoscaling.Hori
 				Kind: "ReplicationController",
 				Name: "myrc",
 			},
-			MinReplicas: utilpointer.Int32(minReplicas),
+			MinReplicas: ptr.To(int32(minReplicas)),
 			MaxReplicas: 5,
 			Metrics: []autoscaling.MetricSpec{{
 				Type: autoscaling.ObjectMetricSourceType,
@@ -1547,7 +1547,7 @@ func prepareMinReplicasCases(t *testing.T, minReplicas int32) []autoscaling.Hori
 				Kind: "ReplicationController",
 				Name: "myrc",
 			},
-			MinReplicas: utilpointer.Int32(minReplicas),
+			MinReplicas: ptr.To(int32(minReplicas)),
 			MaxReplicas: 5,
 			Metrics: []autoscaling.MetricSpec{{
 				Type: autoscaling.ExternalMetricSourceType,
@@ -1598,7 +1598,7 @@ func TestValidateHorizontalPodAutoscalerScaleToZeroDisabled(t *testing.T) {
 	nonZeroMinReplicasCases := prepareMinReplicasCases(t, 1)
 
 	for _, successCase := range nonZeroMinReplicasCases {
-		successCase.Spec.MinReplicas = utilpointer.Int32(1)
+		successCase.Spec.MinReplicas = ptr.To(int32(1))
 		if errs := ValidateHorizontalPodAutoscaler(&successCase); len(errs) != 0 {
 			t.Errorf("expected success: %v", errs)
 		}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This commit will replace the deprecated k8s.io/utils/pointer functions with their ptr equivalent.
See https://github.com/kubernetes/utils/pull/283 for details.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
