### PR TITLE
kubeadm: add kernel version check for upgrade

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/upgrade/apply/preflight.go
+++ b/cmd/kubeadm/app/cmd/phases/upgrade/apply/preflight.go
@@ -72,6 +72,9 @@ func runPreflight(c workflow.RunData) error {
 	if err := preflight.RunRootCheckOnly(ignorePreflightErrors); err != nil {
 		return err
 	}
+	if err := preflight.RunUpgradeChecks(ignorePreflightErrors); err != nil {
+		return err
+	}
 
 	// Run CoreDNS migration check.
 	if err := upgrade.RunCoreDNSMigrationCheck(client, ignorePreflightErrors); err != nil {

--- a/cmd/kubeadm/app/cmd/phases/upgrade/node/preflight.go
+++ b/cmd/kubeadm/app/cmd/phases/upgrade/node/preflight.go
@@ -54,6 +54,9 @@ func runPreflight(c workflow.RunData) error {
 	if err := preflight.RunRootCheckOnly(data.IgnorePreflightErrors()); err != nil {
 		return err
 	}
+	if err := preflight.RunUpgradeChecks(data.IgnorePreflightErrors()); err != nil {
+		return err
+	}
 
 	// If this is a control-plane node, pull the basic images.
 	if data.IsControlPlaneNode() {

--- a/cmd/kubeadm/app/preflight/checks.go
+++ b/cmd/kubeadm/app/preflight/checks.go
@@ -1091,6 +1091,15 @@ func RunRootCheckOnly(ignorePreflightErrors sets.Set[string]) error {
 	return RunChecks(checks, os.Stderr, ignorePreflightErrors)
 }
 
+// RunUpgradeChecks initializes checks slice of structs and call RunChecks
+func RunUpgradeChecks(ignorePreflightErrors sets.Set[string]) error {
+	checks := []Checker{
+		SystemVerificationCheck{},
+	}
+
+	return RunChecks(checks, os.Stderr, ignorePreflightErrors)
+}
+
 // RunPullImagesCheck will pull images kubeadm needs if they are not found on the system
 func RunPullImagesCheck(execer utilsexec.Interface, cfg *kubeadmapi.InitConfiguration, ignorePreflightErrors sets.Set[string]) error {
 	containerRuntime := utilruntime.NewContainerRuntime(cfg.NodeRegistration.CRISocket)


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
kubeadm init checks kernel version, and the logic changed in v1.32.
- upgrade does not check kernel version

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/kubeadm/issues/3114

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
kubeadm: run kernel version and OS version preflight checks on `kubeadm upgrade`.
```