### PR TITLE
Add Prometheus Native Histogram defaults

### DIFF
--- a/staging/src/k8s.io/component-base/metrics/buckets.go
+++ b/staging/src/k8s.io/component-base/metrics/buckets.go
@@ -17,11 +17,33 @@ limitations under the License.
 package metrics
 
 import (
+	"time"
+
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 // DefBuckets is a wrapper for prometheus.DefBuckets
 var DefBuckets = prometheus.DefBuckets
+
+// DefNativeHistogramBucketFactor defines a sane default for the Prometheus
+// native histogram exponential bucket factor. The value of 1.1 means each
+// bucket is 10% wider than the previous bucket.
+//
+// For more information on Prometheus Native Histograms, see the upstream
+// client_golang documentation.
+//
+// https://pkg.go.dev/github.com/prometheus/client_golang/prometheus#HistogramOpts
+var DefNativeHistogramBucketFactor = 1.1
+
+// DefNativeHistogramMaxBucketNumber defines a sane default for the Prometheus
+// native histogram limit to the number of sparse buckets. This avoids
+// unbounded memory requirements for native histogram tracking.
+var DefNativeHistogramMaxBucketNumber = 160
+
+// DefNativeHistogramMinResetDuration defines a sane default for the Prometheus
+// native histogram minimum reset duration. This is used to reset the histogram
+// buckets in case the max bucket number value is reached.
+var DefNativeHistogramMinResetDuration = time.Hour
 
 // LinearBuckets is a wrapper for prometheus.LinearBuckets.
 func LinearBuckets(start, width float64, count int) []float64 {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Add some new default values to the metrics package for the Prometheus Native Histogram support.
* Use the upstream documented recommendation for a 10% bucket factor.
* Set an arbitrary limit of 160 buckets to avoid unbounded memory growth.
* Set a 1 hour minimum reset interval to avoid frequent resets which would affect efficiency of the 120 sample per hour Prometheus chunks given a 30s scrape interval.

#### Which issue(s) this PR fixes:

See: https://github.com/kubernetes/kubernetes/issues/128842

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
