### PR TITLE
kubeadm: skip disabled addons in clusterconfig on upgrade

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/upgrade/addons.go
+++ b/cmd/kubeadm/app/cmd/phases/upgrade/addons.go
@@ -83,13 +83,20 @@ func getInitData(c workflow.RunData) (*kubeadmapi.InitConfiguration, clientset.I
 
 // runCoreDNSAddon upgrades the CoreDNS addon.
 func runCoreDNSAddon(c workflow.RunData) error {
+	const skipMessagePrefix = "[upgrade/addon] Skipping the addon/coredns phase."
+
 	cfg, client, patchesDir, out, dryRun, isControlPlaneNode, err := getInitData(c)
 	if err != nil {
 		return err
 	}
 
 	if !isControlPlaneNode {
-		fmt.Println("[upgrade/addon] Skipping addon/coredns phase. Not a control plane node.")
+		fmt.Fprintf(out, "%s Not a control plane node.\n", skipMessagePrefix)
+		return nil
+	}
+
+	if cfg.ClusterConfiguration.DNS.Disabled {
+		fmt.Fprintf(out, "%s The addon is disabled.\n", skipMessagePrefix)
 		return nil
 	}
 
@@ -110,13 +117,20 @@ func runCoreDNSAddon(c workflow.RunData) error {
 
 // runKubeProxyAddon upgrades the kube-proxy addon.
 func runKubeProxyAddon(c workflow.RunData) error {
+	const skipMessagePrefix = "[upgrade/addon] Skipping the addon/kube-proxy phase."
+
 	cfg, client, _, out, dryRun, isControlPlaneNode, err := getInitData(c)
 	if err != nil {
 		return err
 	}
 
 	if !isControlPlaneNode {
-		fmt.Println("[upgrade/addon] Skipping addon/kube-proxy phase. Not a control plane node.")
+		fmt.Fprintf(out, "%s Not a control plane node.\n", skipMessagePrefix)
+		return nil
+	}
+
+	if cfg.ClusterConfiguration.Proxy.Disabled {
+		fmt.Fprintf(out, "%s The addon is disabled.\n", skipMessagePrefix)
 		return nil
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

If an addon is disabled in the ClusterConfiguration skip it on upgrade in the repsective subphase of 'addons'.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubeadm/issues/3137

#### Special notes for your reviewer:
NONE

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: if an addon is disabled in the ClusterConfiguration, skip it during upgrade.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
