### PR TITLE
Automated cherry pick of #129418 kubeadm: skip disabled addons in clusterconfig on upgrade

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/upgrade/addons.go
+++ b/cmd/kubeadm/app/cmd/phases/upgrade/addons.go
@@ -83,13 +83,20 @@ func getInitData(c workflow.RunData) (*kubeadmapi.InitConfiguration, clientset.I
 
 // runCoreDNSAddon upgrades the CoreDNS addon.
 func runCoreDNSAddon(c workflow.RunData) error {
+	const skipMessagePrefix = "[upgrade/addon] Skipping the addon/coredns phase."
+
 	cfg, client, patchesDir, out, dryRun, isControlPlaneNode, err := getInitData(c)
 	if err != nil {
 		return err
 	}
 
 	if !isControlPlaneNode {
-		fmt.Println("[upgrade/addon] Skipping addon/coredns phase. Not a control plane node.")
+		fmt.Fprintf(out, "%s Not a control plane node.\n", skipMessagePrefix)
+		return nil
+	}
+
+	if cfg.ClusterConfiguration.DNS.Disabled {
+		fmt.Fprintf(out, "%s The addon is disabled.\n", skipMessagePrefix)
 		return nil
 	}
 
@@ -110,13 +117,20 @@ func runCoreDNSAddon(c workflow.RunData) error {
 
 // runKubeProxyAddon upgrades the kube-proxy addon.
 func runKubeProxyAddon(c workflow.RunData) error {
+	const skipMessagePrefix = "[upgrade/addon] Skipping the addon/kube-proxy phase."
+
 	cfg, client, _, out, dryRun, isControlPlaneNode, err := getInitData(c)
 	if err != nil {
 		return err
 	}
 
 	if !isControlPlaneNode {
-		fmt.Println("[upgrade/addon] Skipping addon/kube-proxy phase. Not a control plane node.")
+		fmt.Fprintf(out, "%s Not a control plane node.\n", skipMessagePrefix)
+		return nil
+	}
+
+	if cfg.ClusterConfiguration.Proxy.Disabled {
+		fmt.Fprintf(out, "%s The addon is disabled.\n", skipMessagePrefix)
 		return nil
 	}
 


### PR DESCRIPTION
Cherry pick of #129418 on release-1.32.

kubeadm: skip disabled addons in clusterconfig on upgrade

xref 
- https://github.com/kubernetes/kubeadm/issues/3137

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```
kubeadm: if an addon is disabled in the ClusterConfiguration, skip it during upgrade.
```

