### PR TITLE
add etcd server overrides to etcd probe factory for healthz and readyz

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/config.go
@@ -125,38 +125,3 @@ func NewDefaultConfig(prefix string, codec runtime.Codec) *Config {
 		Transport:            TransportConfig{TracerProvider: noopoteltrace.NewTracerProvider()},
 	}
 }
-
-// DeepCopy returns a deep copy of the Config.
-func (config *Config) DeepCopy() *Config {
-	if config == nil {
-		return nil
-	}
-	// Deep copy the transport config
-	transport := config.Transport
-	transportCopy := TransportConfig{
-		ServerList:     make([]string, len(transport.ServerList)),
-		KeyFile:        transport.KeyFile,
-		CertFile:       transport.CertFile,
-		TrustedCAFile:  transport.TrustedCAFile,
-		EgressLookup:   transport.EgressLookup,
-		TracerProvider: transport.TracerProvider,
-	}
-	copy(transportCopy.ServerList, transport.ServerList)
-
-	return &Config{
-		Type:                      config.Type,
-		Prefix:                    config.Prefix,
-		Transport:                 transportCopy,
-		Codec:                     config.Codec,
-		EncodeVersioner:           config.EncodeVersioner,
-		Transformer:               config.Transformer,
-		CompactionInterval:        config.CompactionInterval,
-		CountMetricPollPeriod:     config.CountMetricPollPeriod,
-		DBMetricPollInterval:      config.DBMetricPollInterval,
-		EventsHistoryWindow:       config.EventsHistoryWindow,
-		HealthcheckTimeout:        config.HealthcheckTimeout,
-		ReadycheckTimeout:         config.ReadycheckTimeout,
-		LeaseManagerConfig:        config.LeaseManagerConfig,
-		StorageObjectCountTracker: config.StorageObjectCountTracker,
-	}
-}

--- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/config.go
@@ -125,3 +125,38 @@ func NewDefaultConfig(prefix string, codec runtime.Codec) *Config {
 		Transport:            TransportConfig{TracerProvider: noopoteltrace.NewTracerProvider()},
 	}
 }
+
+// DeepCopy returns a deep copy of the Config.
+func (config *Config) DeepCopy() *Config {
+	if config == nil {
+		return nil
+	}
+	// Deep copy the transport config
+	transport := config.Transport
+	transportCopy := TransportConfig{
+		ServerList:     make([]string, len(transport.ServerList)),
+		KeyFile:        transport.KeyFile,
+		CertFile:       transport.CertFile,
+		TrustedCAFile:  transport.TrustedCAFile,
+		EgressLookup:   transport.EgressLookup,
+		TracerProvider: transport.TracerProvider,
+	}
+	copy(transportCopy.ServerList, transport.ServerList)
+
+	return &Config{
+		Type:                      config.Type,
+		Prefix:                    config.Prefix,
+		Transport:                 transportCopy,
+		Codec:                     config.Codec,
+		EncodeVersioner:           config.EncodeVersioner,
+		Transformer:               config.Transformer,
+		CompactionInterval:        config.CompactionInterval,
+		CountMetricPollPeriod:     config.CountMetricPollPeriod,
+		DBMetricPollInterval:      config.DBMetricPollInterval,
+		EventsHistoryWindow:       config.EventsHistoryWindow,
+		HealthcheckTimeout:        config.HealthcheckTimeout,
+		ReadycheckTimeout:         config.ReadycheckTimeout,
+		LeaseManagerConfig:        config.LeaseManagerConfig,
+		StorageObjectCountTracker: config.StorageObjectCountTracker,
+	}
+}

--- a/test/integration/apiserver/health_handlers_test.go
+++ b/test/integration/apiserver/health_handlers_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiserver
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"k8s.io/kubernetes/test/utils/ktesting"
+)
+
+// TestHealthHandler tests /health?verbose with etcd overrides servers.
+func TestHealthHandler(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	// Setup multi etcd servers which is using `--etcd-servers-overrides`
+	c, closeFn := multiEtcdSetup(tCtx, t)
+	defer closeFn()
+
+	// Test /healthz
+	var statusCode int
+	req := c.CoreV1().RESTClient().Get().AbsPath("/healthz")
+	req.Param("verbose", "true")
+	result := req.Do(context.TODO())
+	result.StatusCode(&statusCode)
+	if statusCode == 200 {
+		t.Logf("Health check passed")
+	} else {
+		t.Errorf("Health check failed with status code: %d", statusCode)
+	}
+	raw, err := result.Raw()
+	if err != nil {
+		t.Errorf("Failed to get health check result: %v", err)
+	}
+	t.Logf("Health check result: %v", string(raw))
+	// assert the raw contains `[+]etcd-override ok`
+	if !strings.Contains(string(raw), "[+]etcd-override ok") {
+		t.Errorf("Health check result does not contain etcd-override ok")
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug feature

#### What this PR does / why we need it:

https://github.com/kubernetes/kubernetes/blob/6bb69444c72cfd6ee0a01c2fea29b705554bf645/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go#L277-L278

The monitor random one of the etcd to check.

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubernetes/issues/129417

#### Special notes for your reviewer:

Then the `healthz?verbose` is like below:
```
(base) ➜  ~ kubectl get --raw='/healthz?verbose'
[+]ping ok
[+]log ok
[+]etcd ok
[+]etcd-override-0 ok
```

```

(base) ➜  ~ kubectl get --raw='/readyz?verbose'
[+]ping ok
[+]log ok
[+]etcd ok
[+]etcd-readiness ok
[+]etcd-override-0 ok
[+]etcd-override-readiness-0 ok
[+]informer-sync ok
```

exclude by group
```
(base) ➜  ~ kubectl get --raw='/healthz?exclude=etcd&verbose'
[+]ping ok
[+]log ok
[+]etcd excluded: ok
[+]etcd-override-0 excluded with etcd: ok
...

(base) ➜  ~ kubectl get --raw='/healthz?exclude=etcd-override-0&verbose'
[+]ping ok
[+]log ok
[+]etcd ok
[+]etcd-override-0 excluded with etcd: ok
...
```

cc @mengqiy
/cc @liggitt 


#### Does this PR introduce a user-facing change?

```release-note
kube-apiserver: each unique set of etcd server overrides specified with `--etcd-servers-overrides` now surface health checks named `etcd-override-<index>` and `etcd-override-readiness-<index>`. These checks are still excluded by `?exclude=etcd` and `?exclude=etcd-readiness` directives.
```
