### PR TITLE
Extract list response struct to manage all the response fields

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
@@ -3079,7 +3079,7 @@ func TestListIndexer(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			pred := storagetesting.CreatePodPredicate(tt.fieldSelector, true, tt.indexFields)
-			_, _, usedIndex, err := cacher.listItems(ctx, 0, "/pods/"+tt.requestedNamespace, pred, tt.recursive)
+			_, usedIndex, err := cacher.listItems(ctx, 0, "/pods/"+tt.requestedNamespace, pred, tt.recursive)
 			if err != nil {
 				t.Errorf("Unexpected error: %v", err)
 			}


### PR DESCRIPTION
Refactor as part of https://github.com/kubernetes/kubernetes/pull/128951

/kind cleanup

```release-note
NONE
```

/sig api-machinery
/cc @wojtek-t @jpbetz @deads2k
