### PR TITLE
feature(scheduler): add more pod requeue case for dra plugin in integration test 

### DIFF
--- a/pkg/scheduler/testing/wrappers.go
+++ b/pkg/scheduler/testing/wrappers.go
@@ -1139,6 +1139,7 @@ func MakeResourceSlice(nodeName, driverName string) *ResourceSliceWrapper {
 	wrapper.Name = nodeName + "-" + driverName
 	wrapper.Spec.NodeName = nodeName
 	wrapper.Spec.Pool.Name = nodeName
+	wrapper.Spec.Pool.ResourceSliceCount = 1
 	wrapper.Spec.Driver = driverName
 	return wrapper
 }
@@ -1163,6 +1164,25 @@ func (wrapper *ResourceSliceWrapper) Devices(names ...string) *ResourceSliceWrap
 // Device sets the devices field of the inner object.
 func (wrapper *ResourceSliceWrapper) Device(name string, attrs map[resourceapi.QualifiedName]resourceapi.DeviceAttribute) *ResourceSliceWrapper {
 	wrapper.Spec.Devices = append(wrapper.Spec.Devices, resourceapi.Device{Name: name, Basic: &resourceapi.BasicDevice{Attributes: attrs}})
+	return wrapper
+}
+
+type DeviceClassWrapper struct {
+	resourceapi.DeviceClass
+}
+
+func MakeDeviceClass(name string) *DeviceClassWrapper {
+	wrapper := new(DeviceClassWrapper)
+	wrapper.Name = name
+	return wrapper
+}
+
+func (wrapper *DeviceClassWrapper) Obj() *resourceapi.DeviceClass {
+	return &wrapper.DeviceClass
+}
+
+func (wrapper *DeviceClassWrapper) Selectors(selector resourceapi.DeviceSelector) *DeviceClassWrapper {
+	wrapper.Spec.Selectors = append(wrapper.Spec.Selectors, selector)
 	return wrapper
 }
 

--- a/test/integration/scheduler/queueing/queueinghint/queue_test.go
+++ b/test/integration/scheduler/queueing/queueinghint/queue_test.go
@@ -37,6 +37,7 @@ func TestCoreResourceEnqueue(t *testing.T) {
 
 		t.Run(tt.Name, func(t *testing.T) {
 			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.SchedulerQueueingHints, true)
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.DynamicResourceAllocation, true)
 			queueing.RunTestCoreResourceEnqueue(t, tt)
 		})
 	}

--- a/test/integration/util/util.go
+++ b/test/integration/util/util.go
@@ -875,6 +875,22 @@ func CreatePausePodWithResource(cs clientset.Interface, podName string,
 	return CreatePausePod(cs, InitPausePod(&conf))
 }
 
+func CreateDeviceClass(cs clientset.Interface, deviceClass *resourceapi.DeviceClass) (*resourceapi.DeviceClass, error) {
+	return cs.ResourceV1beta1().DeviceClasses().Create(context.TODO(), deviceClass, metav1.CreateOptions{})
+}
+
+// CreateResourceClaim creates a ResourceClaim with the given config and
+// returns its pointer and error status.
+func CreateResourceClaim(cs clientset.Interface, resourceclaim *resourceapi.ResourceClaim) (*resourceapi.ResourceClaim, error) {
+	return cs.ResourceV1beta1().ResourceClaims(resourceclaim.Namespace).Create(context.TODO(), resourceclaim, metav1.CreateOptions{})
+}
+
+// CreateResourceSlice creates a ResourceClaim with the given config and
+// returns its pointer and error status.
+func CreateResourceSlice(cs clientset.Interface, resourceslice *resourceapi.ResourceSlice) (*resourceapi.ResourceSlice, error) {
+	return cs.ResourceV1beta1().ResourceSlices().Create(context.TODO(), resourceslice, metav1.CreateOptions{})
+}
+
 // CreatePVC creates a PersistentVolumeClaim with the given config and returns
 // its pointer and error status.
 func CreatePVC(cs clientset.Interface, pvc *v1.PersistentVolumeClaim) (*v1.PersistentVolumeClaim, error) {


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
- add more pod requeue case for dra plugin in integration test 
- base on comment: https://github.com/kubernetes/kubernetes/issues/122305#issuecomment-2420013243
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes  part of https://github.com/kubernetes/kubernetes/issues/122305

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
