### PR TITLE
apiextensions: simplify local error variable names

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/apiapproval_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/apiapproval_test.go
@@ -73,9 +73,9 @@ func TestAPIApproval(t *testing.T) {
 		t.Fatal(err)
 	}
 	err = wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 30*time.Second, true, func(ctx context.Context) (bool, error) {
-		approvedKubeAPI, getErr := apiExtensionClient.ApiextensionsV1().CustomResourceDefinitions().Get(ctx, approvedKubeAPI.Name, metav1.GetOptions{})
-		if getErr != nil {
-			return false, getErr
+		approvedKubeAPI, err = apiExtensionClient.ApiextensionsV1().CustomResourceDefinitions().Get(ctx, approvedKubeAPI.Name, metav1.GetOptions{})
+		if err != nil {
+			return false, err
 		}
 		if approvedKubeAPIApproved := findCRDCondition(approvedKubeAPI, apiextensionsv1.KubernetesAPIApprovalPolicyConformant); approvedKubeAPIApproved == nil || approvedKubeAPIApproved.Status != apiextensionsv1.ConditionTrue {
 			t.Log(approvedKubeAPIApproved)

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/apiapproval_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/apiapproval_test.go
@@ -73,6 +73,7 @@ func TestAPIApproval(t *testing.T) {
 		t.Fatal(err)
 	}
 	err = wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 30*time.Second, true, func(ctx context.Context) (bool, error) {
+		var err error
 		approvedKubeAPI, err = apiExtensionClient.ApiextensionsV1().CustomResourceDefinitions().Get(ctx, approvedKubeAPI.Name, metav1.GetOptions{})
 		if err != nil {
 			return false, err

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/conversion/conversion_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/conversion/conversion_test.go
@@ -220,6 +220,7 @@ func testWebhookConverter(t *testing.T, watchCache bool) {
 
 			// wait until new webhook is called the first time
 			if err := wait.PollUntilContextTimeout(context.Background(), time.Millisecond*100, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
+				var err error
 				_, err = ctc.versionedClient(marker.GetNamespace(), "v1alpha1").Get(ctx, marker.GetName(), metav1.GetOptions{})
 				select {
 				case <-upCh:

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/conversion/conversion_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/conversion/conversion_test.go
@@ -219,13 +219,13 @@ func testWebhookConverter(t *testing.T, watchCache bool) {
 			defer ctc.removeConversionWebhook(t)
 
 			// wait until new webhook is called the first time
-			if err := wait.PollUntilContextTimeout(context.Background(), time.Millisecond*100, wait.ForeverTestTimeout, true, func(ctx context.Context) (done bool, err error) {
-				_, getErr := ctc.versionedClient(marker.GetNamespace(), "v1alpha1").Get(ctx, marker.GetName(), metav1.GetOptions{})
+			if err := wait.PollUntilContextTimeout(context.Background(), time.Millisecond*100, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
+				_, err = ctc.versionedClient(marker.GetNamespace(), "v1alpha1").Get(ctx, marker.GetName(), metav1.GetOptions{})
 				select {
 				case <-upCh:
 					return true, nil
 				default:
-					t.Logf("Waiting for webhook to become effective, getting marker object: %v", getErr)
+					t.Logf("Waiting for webhook to become effective, getting marker object: %v", err)
 					return false, nil
 				}
 			}); err != nil {

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/conversion/conversion_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/conversion/conversion_test.go
@@ -220,8 +220,7 @@ func testWebhookConverter(t *testing.T, watchCache bool) {
 
 			// wait until new webhook is called the first time
 			if err := wait.PollUntilContextTimeout(context.Background(), time.Millisecond*100, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
-				var err error
-				_, err = ctc.versionedClient(marker.GetNamespace(), "v1alpha1").Get(ctx, marker.GetName(), metav1.GetOptions{})
+				_, err := ctc.versionedClient(marker.GetNamespace(), "v1alpha1").Get(ctx, marker.GetName(), metav1.GetOptions{})
 				select {
 				case <-upCh:
 					return true, nil

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/conversion/webhook.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/conversion/webhook.go
@@ -65,8 +65,7 @@ func StartConversionWebhookServer(handler http.Handler) (func(), *apiextensionsv
 
 	// StartTLS returns immediately, there is a small chance of a race to avoid.
 	if err := wait.PollUntilContextTimeout(context.Background(), time.Millisecond*100, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
-		var err error
-		_, err = webhookServer.Client().Get(webhookServer.URL) // even a 404 is fine
+		_, err := webhookServer.Client().Get(webhookServer.URL) // even a 404 is fine
 		return err == nil, nil
 	}); err != nil {
 		webhookServer.Close()

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/conversion/webhook.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/conversion/webhook.go
@@ -64,9 +64,9 @@ func StartConversionWebhookServer(handler http.Handler) (func(), *apiextensionsv
 	}
 
 	// StartTLS returns immediately, there is a small chance of a race to avoid.
-	if err := wait.PollUntilContextTimeout(context.Background(), time.Millisecond*100, wait.ForeverTestTimeout, true, func(ctx context.Context) (done bool, err error) {
-		_, getErr := webhookServer.Client().Get(webhookServer.URL) // even a 404 is fine
-		return getErr == nil, nil
+	if err := wait.PollUntilContextTimeout(context.Background(), time.Millisecond*100, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
+		_, err = webhookServer.Client().Get(webhookServer.URL) // even a 404 is fine
+		return err == nil, nil
 	}); err != nil {
 		webhookServer.Close()
 		return nil, nil, err

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/conversion/webhook.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/conversion/webhook.go
@@ -65,6 +65,7 @@ func StartConversionWebhookServer(handler http.Handler) (func(), *apiextensionsv
 
 	// StartTLS returns immediately, there is a small chance of a race to avoid.
 	if err := wait.PollUntilContextTimeout(context.Background(), time.Millisecond*100, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
+		var err error
 		_, err = webhookServer.Client().Get(webhookServer.URL) // even a 404 is fine
 		return err == nil, nil
 	}); err != nil {

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/listtype_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/listtype_test.go
@@ -210,15 +210,15 @@ func TestListTypes(t *testing.T) {
 
 	t.Logf("Updating again with invalid values, eventually successfully due to ratcheting logic")
 	err = wait.PollUntilContextTimeout(context.Background(), time.Millisecond*100, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
-		_, updateErr := fooClient.Update(ctx, modifiedInstance, metav1.UpdateOptions{})
-		if updateErr == nil {
+		_, err = fooClient.Update(ctx, modifiedInstance, metav1.UpdateOptions{})
+		if err == nil {
 			return true, nil
 		}
-		if errors.IsInvalid(updateErr) {
+		if errors.IsInvalid(err) {
 			// wait until modifiedInstance becomes valid again
 			return false, nil
 		}
-		return false, updateErr
+		return false, err
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/listtype_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/listtype_test.go
@@ -210,8 +210,7 @@ func TestListTypes(t *testing.T) {
 
 	t.Logf("Updating again with invalid values, eventually successfully due to ratcheting logic")
 	err = wait.PollUntilContextTimeout(context.Background(), time.Millisecond*100, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
-		var err error
-		_, err = fooClient.Update(ctx, modifiedInstance, metav1.UpdateOptions{})
+		_, err := fooClient.Update(ctx, modifiedInstance, metav1.UpdateOptions{})
 		if err == nil {
 			return true, nil
 		}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/listtype_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/listtype_test.go
@@ -210,6 +210,7 @@ func TestListTypes(t *testing.T) {
 
 	t.Logf("Updating again with invalid values, eventually successfully due to ratcheting logic")
 	err = wait.PollUntilContextTimeout(context.Background(), time.Millisecond*100, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
+		var err error
 		_, err = fooClient.Update(ctx, modifiedInstance, metav1.UpdateOptions{})
 		if err == nil {
 			return true, nil

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/validation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/validation_test.go
@@ -779,8 +779,7 @@ func TestCRValidationOnCRDUpdate(t *testing.T) {
 
 			// CR is now accepted
 			err = wait.PollUntilContextTimeout(context.Background(), 500*time.Millisecond, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
-				var err error
-				_, err = noxuResourceClient.Create(ctx, instanceToCreate, metav1.CreateOptions{})
+				_, err := noxuResourceClient.Create(ctx, instanceToCreate, metav1.CreateOptions{})
 				var statusErr *apierrors.StatusError
 				if errors.As(err, &statusErr) {
 					if apierrors.IsInvalid(err) {

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/validation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/validation_test.go
@@ -1531,7 +1531,7 @@ properties:
 			if len(tst.expectedViolations) == 0 {
 				// wait for condition to not appear
 				var cond *apiextensionsv1.CustomResourceDefinitionCondition
-				err = wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 5*time.Second, true, func(ctx context.Context) (bool, error) {
+				err := wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 5*time.Second, true, func(ctx context.Context) (bool, error) {
 					obj, err := apiExtensionClient.ApiextensionsV1().CustomResourceDefinitions().Get(ctx, betaCRD.Name, metav1.GetOptions{})
 					if err != nil {
 						return false, err

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/validation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/validation_test.go
@@ -1531,7 +1531,7 @@ properties:
 			if len(tst.expectedViolations) == 0 {
 				// wait for condition to not appear
 				var cond *apiextensionsv1.CustomResourceDefinitionCondition
-				err := wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 5*time.Second, true, func(ctx context.Context) (bool, error) {
+				err = wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 5*time.Second, true, func(ctx context.Context) (bool, error) {
 					obj, err := apiExtensionClient.ApiextensionsV1().CustomResourceDefinitions().Get(ctx, betaCRD.Name, metav1.GetOptions{})
 					if err != nil {
 						return false, err

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/validation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/validation_test.go
@@ -928,7 +928,6 @@ spec:
 	t.Log("Waiting for NonStructuralSchema condition")
 	var cond *apiextensionsv1.CustomResourceDefinitionCondition
 	err = wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 5*time.Second, true, func(ctx context.Context) (bool, error) {
-		var err error
 		obj, err := apiExtensionClient.ApiextensionsV1().CustomResourceDefinitions().Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
 			return false, err

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/validation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/validation_test.go
@@ -928,7 +928,7 @@ spec:
 	// wait for condition with violations
 	t.Log("Waiting for NonStructuralSchema condition")
 	var cond *apiextensionsv1.CustomResourceDefinitionCondition
-	err = wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 5*time.Second, true, func(ctx context.Context) (done bool, err error) {
+	err = wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 5*time.Second, true, func(ctx context.Context) (bool, error) {
 		var err error
 		obj, err := apiExtensionClient.ApiextensionsV1().CustomResourceDefinitions().Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
@@ -967,7 +967,8 @@ spec:
 
 	// wait for condition to go away
 	t.Log("Wait for condition to disappear")
-	err = wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 5*time.Second, true, func(ctx context.Context) (done bool, err error) {
+	err = wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 5*time.Second, true, func(ctx context.Context) (bool, error) {
+		var err error
 		obj, err := apiExtensionClient.ApiextensionsV1().CustomResourceDefinitions().Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
 			return false, err
@@ -1533,7 +1534,8 @@ properties:
 			if len(tst.expectedViolations) == 0 {
 				// wait for condition to not appear
 				var cond *apiextensionsv1.CustomResourceDefinitionCondition
-				err = wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 5*time.Second, true, func(ctx context.Context) (done bool, err error) {
+				err = wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 5*time.Second, true, func(ctx context.Context) (bool, error) {
+					var err error
 					obj, err := apiExtensionClient.ApiextensionsV1().CustomResourceDefinitions().Get(ctx, betaCRD.Name, metav1.GetOptions{})
 					if err != nil {
 						return false, err
@@ -1552,7 +1554,8 @@ properties:
 
 			// wait for condition to appear with the given violations
 			var cond *apiextensionsv1.CustomResourceDefinitionCondition
-			err = wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, wait.ForeverTestTimeout, true, func(ctx context.Context) (done bool, err error) {
+			err = wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
+				var err error
 				obj, err := apiExtensionClient.ApiextensionsV1().CustomResourceDefinitions().Get(ctx, betaCRD.Name, metav1.GetOptions{})
 				if err != nil {
 					return false, err

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/validation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/validation_test.go
@@ -1551,7 +1551,6 @@ properties:
 			// wait for condition to appear with the given violations
 			var cond *apiextensionsv1.CustomResourceDefinitionCondition
 			err = wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
-				var err error
 				obj, err := apiExtensionClient.ApiextensionsV1().CustomResourceDefinitions().Get(ctx, betaCRD.Name, metav1.GetOptions{})
 				if err != nil {
 					return false, err

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/validation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/validation_test.go
@@ -779,6 +779,7 @@ func TestCRValidationOnCRDUpdate(t *testing.T) {
 
 			// CR is now accepted
 			err = wait.PollUntilContextTimeout(context.Background(), 500*time.Millisecond, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
+				var err error
 				_, err = noxuResourceClient.Create(ctx, instanceToCreate, metav1.CreateOptions{})
 				var statusErr *apierrors.StatusError
 				if errors.As(err, &statusErr) {
@@ -928,6 +929,7 @@ spec:
 	t.Log("Waiting for NonStructuralSchema condition")
 	var cond *apiextensionsv1.CustomResourceDefinitionCondition
 	err = wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 5*time.Second, true, func(ctx context.Context) (done bool, err error) {
+		var err error
 		obj, err := apiExtensionClient.ApiextensionsV1().CustomResourceDefinitions().Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
 			return false, err

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/validation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/validation_test.go
@@ -778,16 +778,16 @@ func TestCRValidationOnCRDUpdate(t *testing.T) {
 			}
 
 			// CR is now accepted
-			err = wait.PollUntilContextTimeout(context.Background(), 500*time.Millisecond, wait.ForeverTestTimeout, true, func(ctx context.Context) (done bool, err error) {
-				_, createErr := noxuResourceClient.Create(ctx, instanceToCreate, metav1.CreateOptions{})
+			err = wait.PollUntilContextTimeout(context.Background(), 500*time.Millisecond, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
+				_, err = noxuResourceClient.Create(ctx, instanceToCreate, metav1.CreateOptions{})
 				var statusErr *apierrors.StatusError
-				if errors.As(createErr, &statusErr) {
-					if apierrors.IsInvalid(createErr) {
+				if errors.As(err, &statusErr) {
+					if apierrors.IsInvalid(err) {
 						return false, nil
 					}
 				}
-				if createErr != nil {
-					return false, createErr
+				if err != nil {
+					return false, err
 				}
 				return true, nil
 			})

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/validation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/validation_test.go
@@ -968,7 +968,6 @@ spec:
 	// wait for condition to go away
 	t.Log("Wait for condition to disappear")
 	err = wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 5*time.Second, true, func(ctx context.Context) (bool, error) {
-		var err error
 		obj, err := apiExtensionClient.ApiextensionsV1().CustomResourceDefinitions().Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
 			return false, err
@@ -1534,8 +1533,7 @@ properties:
 			if len(tst.expectedViolations) == 0 {
 				// wait for condition to not appear
 				var cond *apiextensionsv1.CustomResourceDefinitionCondition
-				err = wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 5*time.Second, true, func(ctx context.Context) (bool, error) {
-					var err error
+				err := wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 5*time.Second, true, func(ctx context.Context) (bool, error) {
 					obj, err := apiExtensionClient.ApiextensionsV1().CustomResourceDefinitions().Get(ctx, betaCRD.Name, metav1.GetOptions{})
 					if err != nil {
 						return false, err

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/versioning_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/versioning_test.go
@@ -90,19 +90,19 @@ func TestInternalVersionIsHandlerVersion(t *testing.T) {
 	{
 		t.Logf("patch of handler version v1beta1 (non-storage version) should succeed")
 		i := 0
-		err = wait.PollUntilContextTimeout(context.Background(), time.Millisecond*100, wait.ForeverTestTimeout, true, func(ctx context.Context) (done bool, err error) {
+		err = wait.PollUntilContextTimeout(context.Background(), time.Millisecond*100, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
 			patch := []byte(fmt.Sprintf(`{"i": %d}`, i))
 			i++
 
-			_, patchErr := noxuNamespacedResourceClientV1beta1.Patch(ctx, "foo", types.MergePatchType, patch, metav1.PatchOptions{})
-			if patchErr != nil {
+			_, err = noxuNamespacedResourceClientV1beta1.Patch(ctx, "foo", types.MergePatchType, patch, metav1.PatchOptions{})
+			if err != nil {
 				// work around "grpc: the client connection is closing" error
 				// TODO: fix the grpc error
 				var statusErr *errors.StatusError
-				if stderrors.As(patchErr, &statusErr) && statusErr.Status().Code == http.StatusInternalServerError {
+				if stderrors.As(err, &statusErr) && statusErr.Status().Code == http.StatusInternalServerError {
 					return false, nil
 				}
-				return false, patchErr
+				return false, err
 			}
 			return true, nil
 		})
@@ -114,21 +114,21 @@ func TestInternalVersionIsHandlerVersion(t *testing.T) {
 		t.Logf("patch of handler version v1beta2 (storage version) should fail")
 		i := 0
 		noxuNamespacedResourceClientV1beta2 := newNamespacedCustomResourceVersionedClient(ns, dynamicClient, noxuDefinition, "v1beta2") // use the storage version v1beta2
-		err = wait.PollUntilContextTimeout(context.Background(), time.Millisecond*100, wait.ForeverTestTimeout, true, func(ctx context.Context) (done bool, err error) {
+		err = wait.PollUntilContextTimeout(context.Background(), time.Millisecond*100, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
 			patch := []byte(fmt.Sprintf(`{"i": %d}`, i))
 			i++
 
-			_, patchErr := noxuNamespacedResourceClientV1beta2.Patch(ctx, "foo", types.MergePatchType, patch, metav1.PatchOptions{})
-			require.Error(t, patchErr)
+			_, err = noxuNamespacedResourceClientV1beta2.Patch(ctx, "foo", types.MergePatchType, patch, metav1.PatchOptions{})
+			require.Error(t, err)
 
 			// work around "grpc: the client connection is closing" error
 			// TODO: fix the grpc error
 			var statusErr *errors.StatusError
-			if stderrors.As(patchErr, &statusErr) && statusErr.Status().Code == http.StatusInternalServerError {
+			if stderrors.As(err, &statusErr) && statusErr.Status().Code == http.StatusInternalServerError {
 				return false, nil
 			}
 
-			assert.ErrorContains(t, patchErr, "apiVersion")
+			assert.ErrorContains(t, err, "apiVersion")
 			return true, nil
 		})
 		assert.NoError(t, err)

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/versioning_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/versioning_test.go
@@ -91,6 +91,7 @@ func TestInternalVersionIsHandlerVersion(t *testing.T) {
 		t.Logf("patch of handler version v1beta1 (non-storage version) should succeed")
 		i := 0
 		err = wait.PollUntilContextTimeout(context.Background(), time.Millisecond*100, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
+			var err error
 			patch := []byte(fmt.Sprintf(`{"i": %d}`, i))
 			i++
 
@@ -115,6 +116,7 @@ func TestInternalVersionIsHandlerVersion(t *testing.T) {
 		i := 0
 		noxuNamespacedResourceClientV1beta2 := newNamespacedCustomResourceVersionedClient(ns, dynamicClient, noxuDefinition, "v1beta2") // use the storage version v1beta2
 		err = wait.PollUntilContextTimeout(context.Background(), time.Millisecond*100, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
+			var err error
 			patch := []byte(fmt.Sprintf(`{"i": %d}`, i))
 			i++
 

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/versioning_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/versioning_test.go
@@ -91,11 +91,10 @@ func TestInternalVersionIsHandlerVersion(t *testing.T) {
 		t.Logf("patch of handler version v1beta1 (non-storage version) should succeed")
 		i := 0
 		err = wait.PollUntilContextTimeout(context.Background(), time.Millisecond*100, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
-			var err error
 			patch := []byte(fmt.Sprintf(`{"i": %d}`, i))
 			i++
 
-			_, err = noxuNamespacedResourceClientV1beta1.Patch(ctx, "foo", types.MergePatchType, patch, metav1.PatchOptions{})
+			_, err := noxuNamespacedResourceClientV1beta1.Patch(ctx, "foo", types.MergePatchType, patch, metav1.PatchOptions{})
 			if err != nil {
 				// work around "grpc: the client connection is closing" error
 				// TODO: fix the grpc error
@@ -116,11 +115,10 @@ func TestInternalVersionIsHandlerVersion(t *testing.T) {
 		i := 0
 		noxuNamespacedResourceClientV1beta2 := newNamespacedCustomResourceVersionedClient(ns, dynamicClient, noxuDefinition, "v1beta2") // use the storage version v1beta2
 		err = wait.PollUntilContextTimeout(context.Background(), time.Millisecond*100, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
-			var err error
 			patch := []byte(fmt.Sprintf(`{"i": %d}`, i))
 			i++
 
-			_, err = noxuNamespacedResourceClientV1beta2.Patch(ctx, "foo", types.MergePatchType, patch, metav1.PatchOptions{})
+			_, err := noxuNamespacedResourceClientV1beta2.Patch(ctx, "foo", types.MergePatchType, patch, metav1.PatchOptions{})
 			require.Error(t, err)
 
 			// work around "grpc: the client connection is closing" error


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Simplifies error variable naming in apiextensions-apiserver tests by using just err for locally-scoped errors instead of specific names like getErr, patchErr, etc. This follows Go conventions where dedicated error names are only needed when accessed non-locally. ( ref: https://github.com/kubernetes/kubernetes/pull/128759/files#r1886475456 )

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
