### PR TITLE
Automated cherry pick of #129452 kubeadm: fix a bug where the node.skipPhases in UpgradeNodeConfigurat…

### DIFF
--- a/cmd/kubeadm/app/cmd/upgrade/node.go
+++ b/cmd/kubeadm/app/cmd/upgrade/node.go
@@ -87,6 +87,13 @@ func newCmdNode(out io.Writer) *cobra.Command {
 				return err
 			}
 
+			data, err := nodeRunner.InitData(args)
+			if err != nil {
+				return err
+			}
+			if _, ok := data.(*nodeData); !ok {
+				return errors.New("invalid data struct")
+			}
 			if err := nodeRunner.Run(args); err != nil {
 				return err
 			}


### PR DESCRIPTION
Cherry pick of #129452 on release-1.32.

kubeadm: fix a bug where the 'node.skipPhases' in UpgradeConfiguration is not respected by 'kubeadm upgrade node' command

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```
kubeadm: fix a bug where the 'node.skipPhases' in UpgradeConfiguration is not respected by 'kubeadm upgrade node' command
```

