### PR TITLE
[kubectl] Enhance describe output for projected volume sources to indicate optional Secret/ConfigMap

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/describe/describe.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe.go
@@ -1080,18 +1080,21 @@ func printConfigMapVolumeSource(configMap *corev1.ConfigMapVolumeSource, w Prefi
 
 func printProjectedVolumeSource(projected *corev1.ProjectedVolumeSource, w PrefixWriter) {
 	w.Write(LEVEL_2, "Type:\tProjected (a volume that contains injected data from multiple sources)\n")
-	w.Write(LEVEL_2, "Sources:\n")
 	for _, source := range projected.Sources {
 		if source.Secret != nil {
 			optional := source.Secret.Optional != nil && *source.Secret.Optional
-			w.Write(LEVEL_3, "SecretName:\t%v (Optional:\t%v)\n", source.Secret.Name, optional)
+			w.Write(LEVEL_2, "SecretName:\t%v\n"+
+				"    Optional:\t%v\n",
+				source.Secret.Name, optional)
 		} else if source.DownwardAPI != nil {
-			w.Write(LEVEL_3, "DownwardAPI:\ttrue\n")
+			w.Write(LEVEL_2, "DownwardAPI:\ttrue\n")
 		} else if source.ConfigMap != nil {
 			optional := source.ConfigMap.Optional != nil && *source.ConfigMap.Optional
-			w.Write(LEVEL_3, "ConfigMapName:\t%v (Optional:\t%v)\n", source.ConfigMap.Name, optional)
+			w.Write(LEVEL_2, "ConfigMapName:\t%v\n"+
+				"    Optional:\t%v\n",
+				source.ConfigMap.Name, optional)
 		} else if source.ServiceAccountToken != nil {
-			w.Write(LEVEL_3, "TokenExpirationSeconds:\t%d\n",
+			w.Write(LEVEL_2, "TokenExpirationSeconds:\t%d\n",
 				*source.ServiceAccountToken.ExpirationSeconds)
 		}
 	}

--- a/staging/src/k8s.io/kubectl/pkg/describe/describe.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe.go
@@ -1080,19 +1080,18 @@ func printConfigMapVolumeSource(configMap *corev1.ConfigMapVolumeSource, w Prefi
 
 func printProjectedVolumeSource(projected *corev1.ProjectedVolumeSource, w PrefixWriter) {
 	w.Write(LEVEL_2, "Type:\tProjected (a volume that contains injected data from multiple sources)\n")
+	w.Write(LEVEL_2, "Sources:\n")
 	for _, source := range projected.Sources {
 		if source.Secret != nil {
-			w.Write(LEVEL_2, "SecretName:\t%v\n"+
-				"    SecretOptionalName:\t%v\n",
-				source.Secret.Name, source.Secret.Optional)
+			optional := source.Secret.Optional != nil && *source.Secret.Optional
+			w.Write(LEVEL_3, "SecretName:\t%v (Optional:\t%v)\n", source.Secret.Name, optional)
 		} else if source.DownwardAPI != nil {
-			w.Write(LEVEL_2, "DownwardAPI:\ttrue\n")
+			w.Write(LEVEL_3, "DownwardAPI:\ttrue\n")
 		} else if source.ConfigMap != nil {
-			w.Write(LEVEL_2, "ConfigMapName:\t%v\n"+
-				"    ConfigMapOptional:\t%v\n",
-				source.ConfigMap.Name, source.ConfigMap.Optional)
+			optional := source.ConfigMap.Optional != nil && *source.ConfigMap.Optional
+			w.Write(LEVEL_3, "ConfigMapName:\t%v (Optional:\t%v)\n", source.ConfigMap.Name, optional)
 		} else if source.ServiceAccountToken != nil {
-			w.Write(LEVEL_2, "TokenExpirationSeconds:\t%d\n",
+			w.Write(LEVEL_3, "TokenExpirationSeconds:\t%d\n",
 				*source.ServiceAccountToken.ExpirationSeconds)
 		}
 	}

--- a/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
@@ -6906,3 +6906,43 @@ func TestDescribeSeccompProfile(t *testing.T) {
 		})
 	}
 }
+
+func TestDescribeProjectedVolumesOptionalSecret(t *testing.T) {
+	fake := fake.NewSimpleClientset(&corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "bar",
+			Namespace: "foo",
+		},
+		Spec: corev1.PodSpec{
+			Volumes: []corev1.Volume{
+				{
+					Name: "optional-secret",
+					VolumeSource: corev1.VolumeSource{
+						Projected: &corev1.ProjectedVolumeSource{
+							Sources: []corev1.VolumeProjection{
+								{
+									Secret: &corev1.SecretProjection{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "optional-secret",
+										},
+										Optional: ptr.To(true),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+	c := &describeClient{T: t, Namespace: "foo", Interface: fake}
+	d := PodDescriber{c}
+	out, err := d.Describe("foo", "bar", DescriberSettings{ShowEvents: true})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	expectedOut := "SecretName:  optional-secret (Optional:  true)"
+	if !strings.Contains(out, expectedOut) {
+		t.Errorf("expected to find %q in output: %q", expectedOut, out)
+	}
+}

--- a/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
@@ -6941,7 +6941,7 @@ func TestDescribeProjectedVolumesOptionalSecret(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	expectedOut := "SecretName:  optional-secret (Optional:  true)"
+	expectedOut := "SecretName:  optional-secret\n    Optional:    true"
 	if !strings.Contains(out, expectedOut) {
 		t.Errorf("expected to find %q in output: %q", expectedOut, out)
 	}


### PR DESCRIPTION
…onal secrets

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
Fixes [#1694](https://github.com/kubernetes/kubectl/issues/1694)

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
Yes.

```release-note
[kubectl] Improved the describe output for projected volume sources to clearly indicate whether Secret and ConfigMap entries are optional.
```
