### PR TITLE
[KEP-2400] kubectl top: add a --show-swap option

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/top/top_node.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/top/top_node.go
@@ -201,12 +201,13 @@ func (o TopNodeOptions) RunTopNode() error {
 			availableResources[n.Name] = n.Status.Capacity
 		}
 
-		swapCapacity := int64(0)
 		if n.Status.NodeInfo.Swap != nil && n.Status.NodeInfo.Swap.Capacity != nil {
-			swapCapacity = *n.Status.NodeInfo.Swap.Capacity
+			swapCapacity := *n.Status.NodeInfo.Swap.Capacity
+			availableResources[n.Name]["swap"] = *resource.NewQuantity(swapCapacity, resource.BinarySI)
+		} else {
+			o.Printer.RegisterMissingResource(n.Name, metricsutil.ResourceSwap)
 		}
 
-		availableResources[n.Name]["swap"] = *resource.NewQuantity(swapCapacity, resource.BinarySI)
 	}
 
 	return o.Printer.PrintNodeMetrics(metrics.Items, availableResources, o.NoHeaders, o.SortBy)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/top/top_node.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/top/top_node.go
@@ -19,9 +19,9 @@ package top
 import (
 	"context"
 	"errors"
-
 	"github.com/spf13/cobra"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
@@ -45,6 +45,7 @@ type TopNodeOptions struct {
 	NoHeaders          bool
 	UseProtocolBuffers bool
 	ShowCapacity       bool
+	ShowSwap           bool
 
 	NodeClient      corev1client.CoreV1Interface
 	Printer         *metricsutil.TopCmdPrinter
@@ -95,6 +96,7 @@ func NewCmdTopNode(f cmdutil.Factory, o *TopNodeOptions, streams genericiooption
 	cmd.Flags().BoolVar(&o.NoHeaders, "no-headers", o.NoHeaders, "If present, print output without headers")
 	cmd.Flags().BoolVar(&o.UseProtocolBuffers, "use-protocol-buffers", o.UseProtocolBuffers, "Enables using protocol-buffers to access Metrics API.")
 	cmd.Flags().BoolVar(&o.ShowCapacity, "show-capacity", o.ShowCapacity, "Print node resources based on Capacity instead of Allocatable(default) of the nodes.")
+	cmd.Flags().BoolVar(&o.ShowSwap, "show-swap", o.ShowSwap, "Print node resources related to swap memory.")
 
 	return cmd
 }
@@ -127,7 +129,7 @@ func (o *TopNodeOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []
 
 	o.NodeClient = clientset.CoreV1()
 
-	o.Printer = metricsutil.NewTopCmdPrinter(o.Out)
+	o.Printer = metricsutil.NewTopCmdPrinter(o.Out, o.ShowSwap)
 	return nil
 }
 
@@ -198,6 +200,13 @@ func (o TopNodeOptions) RunTopNode() error {
 		} else {
 			availableResources[n.Name] = n.Status.Capacity
 		}
+
+		swapCapacity := int64(0)
+		if n.Status.NodeInfo.Swap != nil && n.Status.NodeInfo.Swap.Capacity != nil {
+			swapCapacity = *n.Status.NodeInfo.Swap.Capacity
+		}
+
+		availableResources[n.Name]["swap"] = *resource.NewQuantity(swapCapacity, resource.BinarySI)
 	}
 
 	return o.Printer.PrintNodeMetrics(metrics.Items, availableResources, o.NoHeaders, o.SortBy)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/top/top_node_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/top/top_node_test.go
@@ -426,73 +426,109 @@ func TestTopNodeWithSortByMemoryMetricsFrom(t *testing.T) {
 }
 
 func TestTopNodeWithSwap(t *testing.T) {
-	cmdtesting.InitTestErrorHandler(t)
-	expectedMetrics, nodes := testNodeV1beta1MetricsData()
-	expectedNodePath := fmt.Sprintf("/%s/%s/nodes", apiPrefix, apiVersion)
+	runTopCmd := func(expectedMetrics *metricsv1beta1api.NodeMetricsList, nodes *v1.NodeList) (result string) {
+		cmdtesting.InitTestErrorHandler(t)
+		expectedNodePath := fmt.Sprintf("/%s/%s/nodes", apiPrefix, apiVersion)
 
-	tf := cmdtesting.NewTestFactory().WithNamespace("test")
-	defer tf.Cleanup()
+		tf := cmdtesting.NewTestFactory().WithNamespace("test")
+		defer tf.Cleanup()
 
-	codec := scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
-	ns := scheme.Codecs.WithoutConversion()
+		codec := scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
+		ns := scheme.Codecs.WithoutConversion()
 
-	tf.Client = &fake.RESTClient{
-		NegotiatedSerializer: ns,
-		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
-			switch p, m := req.URL.Path, req.Method; {
-			case p == "/api":
-				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: io.NopCloser(bytes.NewReader([]byte(apibody)))}, nil
-			case p == "/apis":
-				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: io.NopCloser(bytes.NewReader([]byte(apisbodyWithMetrics)))}, nil
-			case p == expectedNodePath && m == "GET":
-				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, nodes)}, nil
-			default:
-				t.Fatalf("unexpected request: %#v\nGot URL: %#v\n", req, req.URL)
-				return nil, nil
+		tf.Client = &fake.RESTClient{
+			NegotiatedSerializer: ns,
+			Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+				switch p, m := req.URL.Path, req.Method; {
+				case p == "/api":
+					return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: io.NopCloser(bytes.NewReader([]byte(apibody)))}, nil
+				case p == "/apis":
+					return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: io.NopCloser(bytes.NewReader([]byte(apisbodyWithMetrics)))}, nil
+				case p == expectedNodePath && m == "GET":
+					return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, nodes)}, nil
+				default:
+					t.Fatalf("unexpected request: %#v\nGot URL: %#v\n", req, req.URL)
+					return nil, nil
+				}
+			}),
+		}
+		fakemetricsClientset := &metricsfake.Clientset{}
+		fakemetricsClientset.AddReactor("list", "nodes", func(action core.Action) (handled bool, ret runtime.Object, err error) {
+			return true, expectedMetrics, nil
+		})
+		tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
+		streams, _, buf, _ := genericiooptions.NewTestIOStreams()
+
+		cmd := NewCmdTopNode(tf, nil, streams)
+
+		// TODO in the long run, we want to test most of our commands like this. Wire the options struct with specific mocks
+		// TODO then check the particular Run functionality and harvest results from fake clients
+		cmdOptions := &TopNodeOptions{
+			IOStreams: streams,
+			ShowSwap:  true,
+		}
+		if err := cmdOptions.Complete(tf, cmd, []string{}); err != nil {
+			t.Fatal(err)
+		}
+		cmdOptions.MetricsClient = fakemetricsClientset
+		if err := cmdOptions.Validate(); err != nil {
+			t.Fatal(err)
+		}
+		if err := cmdOptions.RunTopNode(); err != nil {
+			t.Fatal(err)
+		}
+
+		return buf.String()
+	}
+
+	for _, tc := range []struct {
+		name                  string
+		isSwapDisabledOnNodes bool
+	}{
+		{
+			name:                  "nodes with swap",
+			isSwapDisabledOnNodes: false,
+		},
+		{
+			name:                  "nodes without swap",
+			isSwapDisabledOnNodes: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			expectedMetrics, nodes := testNodeV1beta1MetricsData()
+			if tc.isSwapDisabledOnNodes {
+				for i := range expectedMetrics.Items {
+					delete(expectedMetrics.Items[i].Usage, "swap")
+				}
+				for i := range nodes.Items {
+					nodes.Items[i].Status.NodeInfo.Swap = nil
+				}
 			}
-		}),
-	}
-	fakemetricsClientset := &metricsfake.Clientset{}
-	fakemetricsClientset.AddReactor("list", "nodes", func(action core.Action) (handled bool, ret runtime.Object, err error) {
-		return true, expectedMetrics, nil
-	})
-	tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
-	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 
-	cmd := NewCmdTopNode(tf, nil, streams)
+			result := runTopCmd(expectedMetrics, nodes)
+			fmt.Printf("%s\n", result)
 
-	// TODO in the long run, we want to test most of our commands like this. Wire the options struct with specific mocks
-	// TODO then check the particular Run functionality and harvest results from fake clients
-	cmdOptions := &TopNodeOptions{
-		IOStreams: streams,
-		ShowSwap:  true,
-	}
-	if err := cmdOptions.Complete(tf, cmd, []string{}); err != nil {
-		t.Fatal(err)
-	}
-	cmdOptions.MetricsClient = fakemetricsClientset
-	if err := cmdOptions.Validate(); err != nil {
-		t.Fatal(err)
-	}
-	if err := cmdOptions.RunTopNode(); err != nil {
-		t.Fatal(err)
-	}
+			if !strings.Contains(result, "SWAP(bytes)") {
+				t.Errorf("missing SWAP(bytes) header: \n%s", result)
+			}
+			if !strings.Contains(result, "SWAP(%)") {
+				t.Errorf("missing SWAP(%%) header: \n%s", result)
+			}
 
-	// Check the presence of node names in the output.
-	result := buf.String()
-	if !strings.Contains(result, "SWAP(bytes)") {
-		t.Errorf("missing SWAP(bytes) header: \n%s", result)
-	}
-	if !strings.Contains(result, "SWAP(%)") {
-		t.Errorf("missing SWAP(%%) header: \n%s", result)
-	}
+			if tc.isSwapDisabledOnNodes {
+				if !strings.Contains(result, "<unknown>") {
+					t.Errorf("expected swap to be <unknown>: \n%s", result)
+				}
+			}
 
-	for _, m := range expectedMetrics.Items {
-		if !strings.Contains(result, m.Name) {
-			t.Errorf("missing metrics for %s: \n%s", m.Name, result)
-		}
-		if _, foundSwapMetric := m.Usage["swap"]; !foundSwapMetric {
-			t.Errorf("missing swap metric for %s: \n%s", m.Name, result)
-		}
+			for _, m := range expectedMetrics.Items {
+				if !strings.Contains(result, m.Name) {
+					t.Errorf("missing metrics for %s: \n%s", m.Name, result)
+				}
+				if _, foundSwapMetric := m.Usage["swap"]; foundSwapMetric != !tc.isSwapDisabledOnNodes {
+					t.Errorf("missing swap metric for %s: \n%s", m.Name, result)
+				}
+			}
+		})
 	}
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod.go
@@ -53,6 +53,7 @@ type TopPodOptions struct {
 	NoHeaders          bool
 	UseProtocolBuffers bool
 	Sum                bool
+	ShowSwap           bool
 
 	PodClient       corev1client.PodsGetter
 	Printer         *metricsutil.TopCmdPrinter
@@ -117,6 +118,7 @@ func NewCmdTopPod(f cmdutil.Factory, o *TopPodOptions, streams genericiooptions.
 	cmd.Flags().BoolVar(&o.NoHeaders, "no-headers", o.NoHeaders, "If present, print output without headers.")
 	cmd.Flags().BoolVar(&o.UseProtocolBuffers, "use-protocol-buffers", o.UseProtocolBuffers, "Enables using protocol-buffers to access Metrics API.")
 	cmd.Flags().BoolVar(&o.Sum, "sum", o.Sum, "Print the sum of the resource usage")
+	cmd.Flags().BoolVar(&o.ShowSwap, "show-swap", o.ShowSwap, "Print pod resources related to swap memory.")
 	return cmd
 }
 
@@ -152,7 +154,7 @@ func (o *TopPodOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []s
 
 	o.PodClient = clientset.CoreV1()
 
-	o.Printer = metricsutil.NewTopCmdPrinter(o.Out, false)
+	o.Printer = metricsutil.NewTopCmdPrinter(o.Out, o.ShowSwap)
 	return nil
 }
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod.go
@@ -152,7 +152,7 @@ func (o *TopPodOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []s
 
 	o.PodClient = clientset.CoreV1()
 
-	o.Printer = metricsutil.NewTopCmdPrinter(o.Out)
+	o.Printer = metricsutil.NewTopCmdPrinter(o.Out, false)
 	return nil
 }
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/top/top_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/top/top_test.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
 	metricsv1beta1api "k8s.io/metrics/pkg/apis/metrics/v1beta1"
+	"k8s.io/utils/ptr"
 )
 
 func TestTopSubcommandsExist(t *testing.T) {
@@ -63,6 +64,7 @@ func testNodeV1beta1MetricsData() (*metricsv1beta1api.NodeMetricsList, *v1.NodeL
 				Window:     metav1.Duration{Duration: time.Minute},
 				Usage: v1.ResourceList{
 					v1.ResourceCPU:     *resource.NewMilliQuantity(1, resource.DecimalSI),
+					"swap":             *resource.NewQuantity(1*(1024*1024), resource.DecimalSI),
 					v1.ResourceMemory:  *resource.NewQuantity(2*(1024*1024), resource.DecimalSI),
 					v1.ResourceStorage: *resource.NewQuantity(3*(1024*1024), resource.DecimalSI),
 				},
@@ -72,6 +74,7 @@ func testNodeV1beta1MetricsData() (*metricsv1beta1api.NodeMetricsList, *v1.NodeL
 				Window:     metav1.Duration{Duration: time.Minute},
 				Usage: v1.ResourceList{
 					v1.ResourceCPU:     *resource.NewMilliQuantity(5, resource.DecimalSI),
+					"swap":             *resource.NewQuantity(2*(1024*1024), resource.DecimalSI),
 					v1.ResourceMemory:  *resource.NewQuantity(6*(1024*1024), resource.DecimalSI),
 					v1.ResourceStorage: *resource.NewQuantity(7*(1024*1024), resource.DecimalSI),
 				},
@@ -81,6 +84,7 @@ func testNodeV1beta1MetricsData() (*metricsv1beta1api.NodeMetricsList, *v1.NodeL
 				Window:     metav1.Duration{Duration: time.Minute},
 				Usage: v1.ResourceList{
 					v1.ResourceCPU:     *resource.NewMilliQuantity(3, resource.DecimalSI),
+					"swap":             *resource.NewQuantity(0, resource.DecimalSI),
 					v1.ResourceMemory:  *resource.NewQuantity(4*(1024*1024), resource.DecimalSI),
 					v1.ResourceStorage: *resource.NewQuantity(5*(1024*1024), resource.DecimalSI),
 				},
@@ -100,6 +104,11 @@ func testNodeV1beta1MetricsData() (*metricsv1beta1api.NodeMetricsList, *v1.NodeL
 						v1.ResourceMemory:  *resource.NewQuantity(20*(1024*1024), resource.DecimalSI),
 						v1.ResourceStorage: *resource.NewQuantity(30*(1024*1024), resource.DecimalSI),
 					},
+					NodeInfo: v1.NodeSystemInfo{
+						Swap: &v1.NodeSwapStatus{
+							Capacity: ptr.To(int64(10 * (1024 * 1024 * 1024))),
+						},
+					},
 				},
 			},
 			{
@@ -110,6 +119,11 @@ func testNodeV1beta1MetricsData() (*metricsv1beta1api.NodeMetricsList, *v1.NodeL
 						v1.ResourceMemory:  *resource.NewQuantity(60*(1024*1024), resource.DecimalSI),
 						v1.ResourceStorage: *resource.NewQuantity(70*(1024*1024), resource.DecimalSI),
 					},
+					NodeInfo: v1.NodeSystemInfo{
+						Swap: &v1.NodeSwapStatus{
+							Capacity: ptr.To(int64(20 * (1024 * 1024 * 1024))),
+						},
+					},
 				},
 			},
 			{
@@ -119,6 +133,11 @@ func testNodeV1beta1MetricsData() (*metricsv1beta1api.NodeMetricsList, *v1.NodeL
 						v1.ResourceCPU:     *resource.NewMilliQuantity(30, resource.DecimalSI),
 						v1.ResourceMemory:  *resource.NewQuantity(40*(1024*1024), resource.DecimalSI),
 						v1.ResourceStorage: *resource.NewQuantity(50*(1024*1024), resource.DecimalSI),
+					},
+					NodeInfo: v1.NodeSystemInfo{
+						Swap: &v1.NodeSwapStatus{
+							Capacity: ptr.To(int64(30 * (1024 * 1024 * 1024))),
+						},
 					},
 				},
 			},

--- a/staging/src/k8s.io/kubectl/pkg/metricsutil/metrics_printer.go
+++ b/staging/src/k8s.io/kubectl/pkg/metricsutil/metrics_printer.go
@@ -28,12 +28,6 @@ import (
 )
 
 var (
-	MeasuredResources = []v1.ResourceName{
-		v1.ResourceCPU,
-		v1.ResourceMemory,
-	}
-	NodeColumns     = []string{"NAME", "CPU(cores)", "CPU(%)", "MEMORY(bytes)", "MEMORY(%)"}
-	PodColumns      = []string{"NAME", "CPU(cores)", "MEMORY(bytes)"}
 	NamespaceColumn = "NAMESPACE"
 	PodColumn       = "POD"
 )
@@ -45,11 +39,24 @@ type ResourceMetricsInfo struct {
 }
 
 type TopCmdPrinter struct {
-	out io.Writer
+	out               io.Writer
+	measuredResources []v1.ResourceName
+	nodeColumns       []string
+	podColumns        []string
 }
 
 func NewTopCmdPrinter(out io.Writer) *TopCmdPrinter {
-	return &TopCmdPrinter{out: out}
+	printer := &TopCmdPrinter{
+		out: out,
+		measuredResources: []v1.ResourceName{
+			v1.ResourceCPU,
+			v1.ResourceMemory,
+		},
+		nodeColumns: []string{"NAME", "CPU(cores)", "CPU(%)", "MEMORY(bytes)", "MEMORY(%)"},
+		podColumns:  []string{"NAME", "CPU(cores)", "MEMORY(bytes)"},
+	}
+
+	return printer
 }
 
 func (printer *TopCmdPrinter) PrintNodeMetrics(metrics []metricsapi.NodeMetrics, availableResources map[string]v1.ResourceList, noHeaders bool, sortBy string) error {
@@ -59,25 +66,26 @@ func (printer *TopCmdPrinter) PrintNodeMetrics(metrics []metricsapi.NodeMetrics,
 	w := printers.GetNewTabWriter(printer.out)
 	defer w.Flush()
 
+	measuredResources := printer.measuredResources
 	sort.Sort(NewNodeMetricsSorter(metrics, sortBy))
 
 	if !noHeaders {
-		printColumnNames(w, NodeColumns)
+		printColumnNames(w, printer.nodeColumns)
 	}
 	var usage v1.ResourceList
 	for _, m := range metrics {
 		m.Usage.DeepCopyInto(&usage)
-		printMetricsLine(w, &ResourceMetricsInfo{
+		printer.printMetricsLine(w, &ResourceMetricsInfo{
 			Name:      m.Name,
 			Metrics:   usage,
 			Available: availableResources[m.Name],
-		})
+		}, measuredResources)
 		delete(availableResources, m.Name)
 	}
 
 	// print lines for nodes of which the metrics is unreachable.
 	for nodeName := range availableResources {
-		printMissingMetricsNodeLine(w, nodeName)
+		printer.printMissingMetricsNodeLine(w, nodeName, measuredResources)
 	}
 	return nil
 }
@@ -89,7 +97,7 @@ func (printer *TopCmdPrinter) PrintPodMetrics(metrics []metricsapi.PodMetrics, p
 	w := printers.GetNewTabWriter(printer.out)
 	defer w.Flush()
 
-	columnWidth := len(PodColumns)
+	columnWidth := len(printer.podColumns)
 	if !noHeaders {
 		if withNamespace {
 			printValue(w, NamespaceColumn)
@@ -99,27 +107,27 @@ func (printer *TopCmdPrinter) PrintPodMetrics(metrics []metricsapi.PodMetrics, p
 			printValue(w, PodColumn)
 			columnWidth++
 		}
-		printColumnNames(w, PodColumns)
+		printColumnNames(w, printer.podColumns)
 	}
 
-	sort.Sort(NewPodMetricsSorter(metrics, withNamespace, sortBy))
+	sort.Sort(NewPodMetricsSorter(metrics, withNamespace, sortBy, printer.measuredResources))
 
 	for _, m := range metrics {
 		if printContainers {
 			sort.Sort(NewContainerMetricsSorter(m.Containers, sortBy))
-			printSinglePodContainerMetrics(w, &m, withNamespace)
+			printer.printSinglePodContainerMetrics(w, &m, withNamespace, printer.measuredResources)
 		} else {
-			printSinglePodMetrics(w, &m, withNamespace)
+			printer.printSinglePodMetrics(w, &m, withNamespace, printer.measuredResources)
 		}
 
 	}
 
 	if sum {
-		adder := NewResourceAdder(MeasuredResources)
+		adder := NewResourceAdder(printer.measuredResources)
 		for _, m := range metrics {
 			adder.AddPodMetrics(&m)
 		}
-		printPodResourcesSum(w, adder.total, columnWidth)
+		printer.printPodResourcesSum(w, adder.total, columnWidth, printer.measuredResources)
 	}
 
 	return nil
@@ -132,40 +140,40 @@ func printColumnNames(out io.Writer, names []string) {
 	fmt.Fprint(out, "\n")
 }
 
-func printSinglePodMetrics(out io.Writer, m *metricsapi.PodMetrics, withNamespace bool) {
-	podMetrics := getPodMetrics(m)
+func (printer *TopCmdPrinter) printSinglePodMetrics(out io.Writer, m *metricsapi.PodMetrics, withNamespace bool, measuredResources []v1.ResourceName) {
+	podMetrics := getPodMetrics(m, measuredResources)
 	if withNamespace {
 		printValue(out, m.Namespace)
 	}
-	printMetricsLine(out, &ResourceMetricsInfo{
+	printer.printMetricsLine(out, &ResourceMetricsInfo{
 		Name:      m.Name,
 		Metrics:   podMetrics,
 		Available: v1.ResourceList{},
-	})
+	}, measuredResources)
 }
 
-func printSinglePodContainerMetrics(out io.Writer, m *metricsapi.PodMetrics, withNamespace bool) {
+func (printer *TopCmdPrinter) printSinglePodContainerMetrics(out io.Writer, m *metricsapi.PodMetrics, withNamespace bool, measuredResources []v1.ResourceName) {
 	for _, c := range m.Containers {
 		if withNamespace {
 			printValue(out, m.Namespace)
 		}
 		printValue(out, m.Name)
-		printMetricsLine(out, &ResourceMetricsInfo{
+		printer.printMetricsLine(out, &ResourceMetricsInfo{
 			Name:      c.Name,
 			Metrics:   c.Usage,
 			Available: v1.ResourceList{},
-		})
+		}, measuredResources)
 	}
 }
 
-func getPodMetrics(m *metricsapi.PodMetrics) v1.ResourceList {
+func getPodMetrics(m *metricsapi.PodMetrics, measuredResources []v1.ResourceName) v1.ResourceList {
 	podMetrics := make(v1.ResourceList)
-	for _, res := range MeasuredResources {
+	for _, res := range measuredResources {
 		podMetrics[res], _ = resource.ParseQuantity("0")
 	}
 
 	for _, c := range m.Containers {
-		for _, res := range MeasuredResources {
+		for _, res := range measuredResources {
 			quantity := podMetrics[res]
 			quantity.Add(c.Usage[res])
 			podMetrics[res] = quantity
@@ -174,16 +182,16 @@ func getPodMetrics(m *metricsapi.PodMetrics) v1.ResourceList {
 	return podMetrics
 }
 
-func printMetricsLine(out io.Writer, metrics *ResourceMetricsInfo) {
+func (printer *TopCmdPrinter) printMetricsLine(out io.Writer, metrics *ResourceMetricsInfo, measuredResources []v1.ResourceName) {
 	printValue(out, metrics.Name)
-	printAllResourceUsages(out, metrics)
+	printer.printAllResourceUsages(out, metrics, measuredResources)
 	fmt.Fprint(out, "\n")
 }
 
-func printMissingMetricsNodeLine(out io.Writer, nodeName string) {
+func (printer *TopCmdPrinter) printMissingMetricsNodeLine(out io.Writer, nodeName string, measuredResources []v1.ResourceName) {
 	printValue(out, nodeName)
 	unknownMetricsStatus := "<unknown>"
-	for i := 0; i < len(MeasuredResources); i++ {
+	for i := 0; i < len(measuredResources); i++ {
 		printValue(out, unknownMetricsStatus)
 		printValue(out, unknownMetricsStatus)
 	}
@@ -194,8 +202,8 @@ func printValue(out io.Writer, value interface{}) {
 	fmt.Fprintf(out, "%v\t", value)
 }
 
-func printAllResourceUsages(out io.Writer, metrics *ResourceMetricsInfo) {
-	for _, res := range MeasuredResources {
+func (printer *TopCmdPrinter) printAllResourceUsages(out io.Writer, metrics *ResourceMetricsInfo, measuredResources []v1.ResourceName) {
+	for _, res := range measuredResources {
 		quantity := metrics.Metrics[res]
 		printSingleResourceUsage(out, res, quantity)
 		fmt.Fprint(out, "\t")
@@ -217,7 +225,7 @@ func printSingleResourceUsage(out io.Writer, resourceType v1.ResourceName, quant
 	}
 }
 
-func printPodResourcesSum(out io.Writer, total v1.ResourceList, columnWidth int) {
+func (printer *TopCmdPrinter) printPodResourcesSum(out io.Writer, total v1.ResourceList, columnWidth int, measuredResources []v1.ResourceName) {
 	for i := 0; i < columnWidth-2; i++ {
 		printValue(out, "")
 	}
@@ -227,10 +235,10 @@ func printPodResourcesSum(out io.Writer, total v1.ResourceList, columnWidth int)
 	for i := 0; i < columnWidth-3; i++ {
 		printValue(out, "")
 	}
-	printMetricsLine(out, &ResourceMetricsInfo{
+	printer.printMetricsLine(out, &ResourceMetricsInfo{
 		Name:      "",
 		Metrics:   total,
 		Available: v1.ResourceList{},
-	})
+	}, measuredResources)
 
 }

--- a/staging/src/k8s.io/kubectl/pkg/metricsutil/metrics_printer.go
+++ b/staging/src/k8s.io/kubectl/pkg/metricsutil/metrics_printer.go
@@ -61,6 +61,7 @@ func NewTopCmdPrinter(out io.Writer, showSwap bool) *TopCmdPrinter {
 	if showSwap {
 		printer.measuredResources = append(printer.measuredResources, resourceSwap)
 		printer.nodeColumns = append(printer.nodeColumns, "SWAP(bytes)", "SWAP(%)")
+		printer.podColumns = append(printer.podColumns, "SWAP(bytes)")
 	}
 
 	return printer

--- a/staging/src/k8s.io/kubectl/pkg/metricsutil/metrics_printer_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/metricsutil/metrics_printer_test.go
@@ -130,7 +130,7 @@ node1   1000m        10%      1024Mi          10%
 			for _, n := range test.nodes {
 				availableResources[n.Name] = n.Status.Capacity
 			}
-			top := NewTopCmdPrinter(out)
+			top := NewTopCmdPrinter(out, false)
 			err := top.PrintNodeMetrics(test.nodeMetric, availableResources, test.noHeader, test.sortBy)
 			assert.Equal(t, test.expectedErr, err)
 			assert.Equal(t, test.expectedOutput, out.String())
@@ -374,7 +374,7 @@ test-1   400m         5120Mi
 			// Create a new TopCmdPrinter with a test writer.
 			_, _, out, _ := genericiooptions.NewTestIOStreams()
 
-			top := NewTopCmdPrinter(out)
+			top := NewTopCmdPrinter(out, false)
 			err := top.PrintPodMetrics(test.podMetric, test.printContainers,
 				test.withNamespace, test.noHeader, test.sortBy, test.sum)
 			assert.Equal(t, test.expectedErr, err)

--- a/staging/src/k8s.io/kubectl/pkg/metricsutil/metrics_sorter.go
+++ b/staging/src/k8s.io/kubectl/pkg/metricsutil/metrics_sorter.go
@@ -82,11 +82,11 @@ func (p *PodMetricsSorter) Less(i, j int) bool {
 	}
 }
 
-func NewPodMetricsSorter(metrics []metricsapi.PodMetrics, withNamespace bool, sortBy string) *PodMetricsSorter {
+func NewPodMetricsSorter(metrics []metricsapi.PodMetrics, withNamespace bool, sortBy string, measuredResources []v1.ResourceName) *PodMetricsSorter {
 	var podMetrics = make([]v1.ResourceList, len(metrics))
 	if len(sortBy) > 0 {
 		for i, v := range metrics {
-			podMetrics[i] = getPodMetrics(&v)
+			podMetrics[i] = getPodMetrics(&v, measuredResources)
 		}
 	}
 


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### Background
A while ago, swap stats were added to summary and metric APIs as part of https://github.com/kubernetes/kubernetes/pull/118865. Although these stats are extremely valuable, they're mostly designed to be consumed by programs (like HPAs or metrics solutions), not by humans. This raised the request for a better way of understanding which nodes have swap, the swap capacity and usage, which pods consume swap space and how much, etc.

I've tried to address this need in two past attempts.
In the first one, https://github.com/kubernetes/kubernetes/pull/123963, I've tried to add swap as another `ReasourceName`, hence to display it as part of `kubectl describe node`'s status. This attempt was eventually denied with the main concern being that adding swap as a `ResourceName` is confusing since it cannot be directly/explicitly consumed (since the swap limit is auto-calculated).

In the second one, https://github.com/kubernetes/kubernetes/pull/125278, I've tried to add a swap condition to nodes. This PR was also denied with the main concern being that a condition is not suited to report such data, and that a field is recommended in this case, although it wasn't easy thinking of a good field that will benefit the API.

Eventually we agreed to defer this to the future. However, while attempting to GA the swap feature there was a hard push-back against GA without addressing these needs.

Therefore, this is my third attempt to address it. My hope is that it will suffice the need of debugability and will pave the way for the upcoming GA.

#### What this PR does / why we need it:
This PR adds adds the `--show-swap` option to the `kubectl top` subcommands.

Behind the scenes, this purely relies on consuming the stats added in https://github.com/kubernetes/kubernetes/pull/118865, making them human-readable.

Example output:
```
    > kubectl top node --show-swap
    NAME     CPU(cores)   CPU(%)   MEMORY(bytes)   MEMORY(%)   SWAP(bytes)   SWAP(%)   SWAP CAPACITY(bytes)
    node01   500m         8%       2836Mi          60%         0Mi           0%        0Mi
    node02   260m         5%       2206Mi          47%         102Mi         10%       1023Mi
```
```
    > kubectl top pod -n kube-system --show-swap
    NAME                                      CPU(cores)   MEMORY(bytes)   SWAP(bytes)
    coredns-58d5bc5cdb-5nbk4                  2m           19Mi            0Mi
    coredns-58d5bc5cdb-jsh26                  3m           37Mi            0Mi
    etcd-node01                               51m          143Mi           0Mi
    kube-apiserver-node01                     98m          824Mi           0Mi
    kube-controller-manager-node01            20m          135Mi           0Mi
    kube-proxy-ffgs2                          1m           24Mi            0Mi
    kube-proxy-fhvwx                          1m           39Mi            0Mi
    kube-scheduler-node01                     13m          69Mi            0Mi
    metrics-server-8598789fdb-d2kcj           5m           26Mi            0Mi
```

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:
I recommend to review per-commit.

#### Does this PR introduce a user-facing change?
```release-note
Added a `--show-swap` option to `kubectl top` subcommands
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/2400-node-swap/README.md
```
