### PR TITLE
Automated cherry pick of #124223: Fix: EtcdOptions.StorageObjectCountTracker is nil, APF estimator got ObjectCountNotFoundErr

### DIFF
--- a/pkg/controlplane/apiserver/config.go
+++ b/pkg/controlplane/apiserver/config.go
@@ -138,6 +138,9 @@ func BuildGenericConfig(
 	if lastErr != nil {
 		return
 	}
+	// storageFactory.StorageConfig is copied from etcdOptions.StorageConfig,
+	// the StorageObjectCountTracker is still nil. Here we copy from genericConfig.
+	storageFactory.StorageConfig.StorageObjectCountTracker = genericConfig.StorageObjectCountTracker
 	if lastErr = s.Etcd.ApplyWithStorageFactoryTo(storageFactory, genericConfig); lastErr != nil {
 		return
 	}

--- a/pkg/controlplane/apiserver/config_test.go
+++ b/pkg/controlplane/apiserver/config_test.go
@@ -1,0 +1,58 @@
+package apiserver
+
+import (
+	extensionsapiserver "k8s.io/apiextensions-apiserver/pkg/apiserver"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	apiserveroptions "k8s.io/apiserver/pkg/server/options"
+	aggregatorscheme "k8s.io/kube-aggregator/pkg/apiserver/scheme"
+	"k8s.io/kubernetes/pkg/api/legacyscheme"
+	"k8s.io/kubernetes/pkg/controlplane/apiserver/options"
+	generatedopenapi "k8s.io/kubernetes/pkg/generated/openapi"
+	netutils "k8s.io/utils/net"
+	"net"
+	"testing"
+)
+
+func TestBuildGenericConfig(t *testing.T) {
+	opts := options.NewOptions()
+	s := (&apiserveroptions.SecureServingOptions{
+		BindAddress: netutils.ParseIPSloppy("127.0.0.1"),
+	}).WithLoopback()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen on 127.0.0.1:0")
+	}
+	defer ln.Close()
+	s.Listener = ln
+	s.BindPort = ln.Addr().(*net.TCPAddr).Port
+	opts.SecureServing = s
+
+	completedOptions, err := opts.Complete(nil, nil)
+	if err != nil {
+		t.Fatalf("Failed to complete apiserver options: %v", err)
+	}
+
+	genericConfig, _, storageFactory, err := BuildGenericConfig(
+		completedOptions,
+		[]*runtime.Scheme{legacyscheme.Scheme, extensionsapiserver.Scheme, aggregatorscheme.Scheme},
+		generatedopenapi.GetOpenAPIDefinitions,
+	)
+	if err != nil {
+		t.Fatalf("Failed to build generic config: %v", err)
+	}
+	if genericConfig.StorageObjectCountTracker == nil {
+		t.Errorf("genericConfig StorageObjectCountTracker is absent")
+	}
+	if genericConfig.StorageObjectCountTracker != storageFactory.StorageConfig.StorageObjectCountTracker {
+		t.Errorf("There are different StorageObjectCountTracker in genericConfig and storageFactory")
+	}
+
+	restOptions, err := genericConfig.RESTOptionsGetter.GetRESTOptions(schema.GroupResource{Group: "", Resource: ""})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if restOptions.StorageConfig.StorageObjectCountTracker != genericConfig.StorageObjectCountTracker {
+		t.Errorf("There are different StorageObjectCountTracker in restOptions and serverConfig")
+	}
+}

--- a/pkg/controlplane/apiserver/config_test.go
+++ b/pkg/controlplane/apiserver/config_test.go
@@ -1,6 +1,25 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package apiserver
 
 import (
+	"net"
+	"testing"
+
 	extensionsapiserver "k8s.io/apiextensions-apiserver/pkg/apiserver"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -10,8 +29,6 @@ import (
 	"k8s.io/kubernetes/pkg/controlplane/apiserver/options"
 	generatedopenapi "k8s.io/kubernetes/pkg/generated/openapi"
 	netutils "k8s.io/utils/net"
-	"net"
-	"testing"
 )
 
 func TestBuildGenericConfig(t *testing.T) {
@@ -23,7 +40,12 @@ func TestBuildGenericConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to listen on 127.0.0.1:0")
 	}
-	defer ln.Close()
+	defer func() {
+		err := ln.Close()
+		if err != nil {
+			t.Fatalf("Failed to close tcp listener: %v", err)
+		}
+	}()
 	s.Listener = ln
 	s.BindPort = ln.Addr().(*net.TCPAddr).Port
 	opts.SecureServing = s

--- a/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go
@@ -396,7 +396,11 @@ func (f *StorageFactoryRestOptionsFactory) GetRESTOptions(resource schema.GroupR
 		EnableGarbageCollection:   f.Options.EnableGarbageCollection,
 		ResourcePrefix:            f.StorageFactory.ResourcePrefix(resource),
 		CountMetricPollPeriod:     f.Options.StorageConfig.CountMetricPollPeriod,
-		StorageObjectCountTracker: storageConfig.StorageObjectCountTracker,
+		StorageObjectCountTracker: f.Options.StorageConfig.StorageObjectCountTracker,
+	}
+
+	if ret.StorageObjectCountTracker == nil {
+		ret.StorageObjectCountTracker = storageConfig.StorageObjectCountTracker
 	}
 
 	if f.Options.EnableWatchCache {

--- a/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go
@@ -396,7 +396,7 @@ func (f *StorageFactoryRestOptionsFactory) GetRESTOptions(resource schema.GroupR
 		EnableGarbageCollection:   f.Options.EnableGarbageCollection,
 		ResourcePrefix:            f.StorageFactory.ResourcePrefix(resource),
 		CountMetricPollPeriod:     f.Options.StorageConfig.CountMetricPollPeriod,
-		StorageObjectCountTracker: f.Options.StorageConfig.StorageObjectCountTracker,
+		StorageObjectCountTracker: storageConfig.StorageObjectCountTracker,
 	}
 
 	if f.Options.EnableWatchCache {

--- a/staging/src/k8s.io/apiserver/pkg/server/options/etcd_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/etcd_test.go
@@ -430,3 +430,18 @@ func healthChecksAreEqual(t *testing.T, want []string, healthChecks []healthz.He
 		t.Errorf("%s checks are not equal, missing=%q, extra=%q", checkerType, wantSet.Difference(gotSet).List(), gotSet.Difference(wantSet).List())
 	}
 }
+
+func TestRestOptionsStorageObjectCountTracker(t *testing.T) {
+	serverConfig := server.NewConfig(codecs)
+	etcdOptions := &EtcdOptions{}
+	if err := etcdOptions.ApplyTo(serverConfig); err != nil {
+		t.Fatalf("Failed to apply etcd options error: %v", err)
+	}
+	restOptions, err := serverConfig.RESTOptionsGetter.GetRESTOptions(schema.GroupResource{Group: "", Resource: ""})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if restOptions.StorageConfig.StorageObjectCountTracker != serverConfig.StorageObjectCountTracker {
+		t.Errorf("There are different StorageObjectCountTracker in restOptions and serverConfig")
+	}
+}


### PR DESCRIPTION
Cherry pick of #124223 on release-1.29.

#124223: Fix: EtcdOptions.StorageObjectCountTracker is nil, APF estimator got ObjectCountNotFoundErr

#124223 Got merged into 1.31 in April 2024 but cherrypick PR (#124432) for 1.29 is not merged.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```