### PR TITLE
Fix API server crash on concurrent map iteration and write

### DIFF
--- a/pkg/registry/core/serviceaccount/storage/storage_test.go
+++ b/pkg/registry/core/serviceaccount/storage/storage_test.go
@@ -144,7 +144,7 @@ func TestCreate_Token_SetsCredentialIDAuditAnnotation(t *testing.T) {
 	}
 
 	auditContext := audit.AuditContextFrom(ctx)
-	issuedCredentialID, ok := auditContext.Event.Annotations["authentication.kubernetes.io/issued-credential-id"]
+	issuedCredentialID, ok := auditContext.GetEventAnnotation("authentication.kubernetes.io/issued-credential-id")
 	if !ok || len(issuedCredentialID) == 0 {
 		t.Errorf("did not find issued-credential-id in audit event annotations")
 	}

--- a/staging/src/k8s.io/apiserver/pkg/admission/audit.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/audit.go
@@ -83,7 +83,7 @@ func ensureAnnotationGetter(a Attributes) error {
 }
 
 func (handler *auditHandler) logAnnotations(ctx context.Context, a Attributes) {
-	ae := audit.AuditEventFrom(ctx)
+	ae := audit.AuditContextFrom(ctx)
 	if ae == nil {
 		return
 	}
@@ -91,9 +91,9 @@ func (handler *auditHandler) logAnnotations(ctx context.Context, a Attributes) {
 	var annotations map[string]string
 	switch a := a.(type) {
 	case privateAnnotationsGetter:
-		annotations = a.getAnnotations(ae.Level)
+		annotations = a.getAnnotations(ae.GetEventLevel())
 	case AnnotationsGetter:
-		annotations = a.GetAnnotations(ae.Level)
+		annotations = a.GetAnnotations(ae.GetEventLevel())
 	default:
 		// this will never happen, because we have already checked it in ensureAnnotationGetter
 	}

--- a/staging/src/k8s.io/apiserver/pkg/admission/audit_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/audit_test.go
@@ -144,8 +144,7 @@ func TestWithAudit(t *testing.T) {
 		var handler Interface = fakeHandler{tc.admit, tc.admitAnnotations, tc.validate, tc.validateAnnotations, tc.handles}
 		ctx := audit.WithAuditContext(context.Background())
 		ac := audit.AuditContextFrom(ctx)
-		ae := &ac.Event
-		ae.Level = auditinternal.LevelMetadata
+		ac.SetEventLevel(auditinternal.LevelMetadata)
 		auditHandler := WithAudit(handler)
 		a := attributes()
 
@@ -171,9 +170,9 @@ func TestWithAudit(t *testing.T) {
 			annotations[k] = v
 		}
 		if len(annotations) == 0 {
-			assert.Nil(t, ae.Annotations, tcName+": unexptected annotations set in audit event")
+			assert.Nil(t, ac.GetEventAnnotations(), tcName+": unexptected annotations set in audit event")
 		} else {
-			assert.Equal(t, annotations, ae.Annotations, tcName+": unexptected annotations set in audit event")
+			assert.Equal(t, annotations, ac.GetEventAnnotations(), tcName+": unexptected annotations set in audit event")
 		}
 	}
 }
@@ -188,7 +187,7 @@ func TestWithAuditConcurrency(t *testing.T) {
 	var handler Interface = fakeHandler{admitAnnotations: admitAnnotations, handles: true}
 	ctx := audit.WithAuditContext(context.Background())
 	ac := audit.AuditContextFrom(ctx)
-	ac.Event.Level = auditinternal.LevelMetadata
+	ac.SetEventLevel(auditinternal.LevelMetadata)
 	auditHandler := WithAudit(handler)
 	a := attributes()
 

--- a/staging/src/k8s.io/apiserver/pkg/audit/context.go
+++ b/staging/src/k8s.io/apiserver/pkg/audit/context.go
@@ -18,10 +18,18 @@ package audit
 
 import (
 	"context"
+	"errors"
+	"maps"
 	"sync"
+	"sync/atomic"
+	"time"
 
+	authnv1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	auditinternal "k8s.io/apiserver/pkg/apis/audit"
+	"k8s.io/apiserver/pkg/authentication/user"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/klog/v2"
 )
@@ -35,22 +43,232 @@ const auditKey key = iota
 
 // AuditContext holds the information for constructing the audit events for the current request.
 type AuditContext struct {
-	// RequestAuditConfig is the audit configuration that applies to the request
-	RequestAuditConfig RequestAuditConfig
+	// initialized indicates whether requestAuditConfig and sink have been populated and are safe to read unguarded.
+	// This should only be set via Init().
+	initialized atomic.Bool
+	// initialize wraps setting requestAuditConfig and sink, and is only called via Init().
+	initialize sync.Once
+	// requestAuditConfig is the audit configuration that applies to the request.
+	// This should only be written via Init(RequestAuditConfig, Sink), and only read when initialized.Load() is true.
+	requestAuditConfig RequestAuditConfig
+	// sink is the sink to use when processing event stages.
+	// This should only be written via Init(RequestAuditConfig, Sink), and only read when initialized.Load() is true.
+	sink Sink
 
-	// Event is the audit Event object that is being captured to be written in
+	// lock guards event
+	lock sync.Mutex
+
+	// event is the audit Event object that is being captured to be written in
 	// the API audit log.
-	Event auditinternal.Event
+	event auditinternal.Event
 
-	// annotationMutex guards event.Annotations
-	annotationMutex sync.Mutex
+	// unguarded copy of auditID from the event
+	auditID atomic.Value
 }
 
 // Enabled checks whether auditing is enabled for this audit context.
 func (ac *AuditContext) Enabled() bool {
-	// Note: An unset Level should be considered Enabled, so that request data (e.g. annotations)
-	// can still be captured before the audit policy is evaluated.
-	return ac != nil && ac.RequestAuditConfig.Level != auditinternal.LevelNone
+	if ac == nil {
+		// protect against nil pointers
+		return false
+	}
+	if !ac.initialized.Load() {
+		// Note: An unset Level should be considered Enabled, so that request data (e.g. annotations)
+		// can still be captured before the audit policy is evaluated.
+		return true
+	}
+	return ac.requestAuditConfig.Level != auditinternal.LevelNone
+}
+
+func (ac *AuditContext) Init(requestAuditConfig RequestAuditConfig, sink Sink) error {
+	initialized := false
+	ac.initialize.Do(func() {
+		ac.requestAuditConfig = requestAuditConfig
+		ac.sink = sink
+		ac.initialized.Store(true)
+		initialized = true
+	})
+	if !initialized {
+		return errors.New("audit context was already initialized")
+	}
+	return nil
+}
+
+func (ac *AuditContext) AuditID() types.UID {
+	// return the unguarded copy of the auditID
+	id, _ := ac.auditID.Load().(types.UID)
+	return id
+}
+
+func (ac *AuditContext) visitEvent(f func(event *auditinternal.Event)) {
+	ac.lock.Lock()
+	defer ac.lock.Unlock()
+	f(&ac.event)
+}
+
+// ProcessEventStage returns true on success, false if there was an error processing the stage.
+func (ac *AuditContext) ProcessEventStage(ctx context.Context, stage auditinternal.Stage) bool {
+	if ac == nil || !ac.initialized.Load() {
+		return true
+	}
+	if ac.sink == nil {
+		return true
+	}
+	for _, omitStage := range ac.requestAuditConfig.OmitStages {
+		if stage == omitStage {
+			return true
+		}
+	}
+
+	processed := false
+	ac.visitEvent(func(event *auditinternal.Event) {
+		event.Stage = stage
+		if stage == auditinternal.StageRequestReceived {
+			event.StageTimestamp = event.RequestReceivedTimestamp
+		} else {
+			event.StageTimestamp = metav1.NewMicroTime(time.Now())
+		}
+
+		ObserveEvent(ctx)
+		processed = ac.sink.ProcessEvents(event)
+	})
+	return processed
+}
+
+func (ac *AuditContext) LogImpersonatedUser(user user.Info) {
+	ac.visitEvent(func(ev *auditinternal.Event) {
+		if ev == nil || ev.Level.Less(auditinternal.LevelMetadata) {
+			return
+		}
+		ev.ImpersonatedUser = &authnv1.UserInfo{
+			Username: user.GetName(),
+		}
+		ev.ImpersonatedUser.Groups = user.GetGroups()
+		ev.ImpersonatedUser.UID = user.GetUID()
+		ev.ImpersonatedUser.Extra = map[string]authnv1.ExtraValue{}
+		for k, v := range user.GetExtra() {
+			ev.ImpersonatedUser.Extra[k] = authnv1.ExtraValue(v)
+		}
+	})
+}
+
+func (ac *AuditContext) LogResponseObject(status *metav1.Status, obj *runtime.Unknown) {
+	ac.visitEvent(func(ae *auditinternal.Event) {
+		if status != nil {
+			// selectively copy the bounded fields.
+			ae.ResponseStatus = &metav1.Status{
+				Status:  status.Status,
+				Message: status.Message,
+				Reason:  status.Reason,
+				Details: status.Details,
+				Code:    status.Code,
+			}
+		}
+		if ae.Level.Less(auditinternal.LevelRequestResponse) {
+			return
+		}
+		ae.ResponseObject = obj
+	})
+}
+
+// LogRequestPatch fills in the given patch as the request object into an audit event.
+func (ac *AuditContext) LogRequestPatch(patch []byte) {
+	ac.visitEvent(func(ae *auditinternal.Event) {
+		ae.RequestObject = &runtime.Unknown{
+			Raw:         patch,
+			ContentType: runtime.ContentTypeJSON,
+		}
+	})
+}
+
+func (ac *AuditContext) GetEventAnnotation(key string) (string, bool) {
+	var val string
+	var ok bool
+	ac.visitEvent(func(event *auditinternal.Event) {
+		val, ok = event.Annotations[key]
+	})
+	return val, ok
+}
+
+func (ac *AuditContext) GetEventLevel() auditinternal.Level {
+	var level auditinternal.Level
+	ac.visitEvent(func(event *auditinternal.Event) {
+		level = event.Level
+	})
+	return level
+}
+
+func (ac *AuditContext) SetEventLevel(level auditinternal.Level) {
+	ac.visitEvent(func(event *auditinternal.Event) {
+		event.Level = level
+	})
+}
+
+func (ac *AuditContext) SetEventStage(stage auditinternal.Stage) {
+	ac.visitEvent(func(event *auditinternal.Event) {
+		event.Stage = stage
+	})
+}
+
+func (ac *AuditContext) GetEventStage() auditinternal.Stage {
+	var stage auditinternal.Stage
+	ac.visitEvent(func(event *auditinternal.Event) {
+		stage = event.Stage
+	})
+	return stage
+}
+
+func (ac *AuditContext) SetEventStageTimestamp(timestamp metav1.MicroTime) {
+	ac.visitEvent(func(event *auditinternal.Event) {
+		event.StageTimestamp = timestamp
+	})
+}
+
+func (ac *AuditContext) GetEventResponseStatus() *metav1.Status {
+	var status *metav1.Status
+	ac.visitEvent(func(event *auditinternal.Event) {
+		status = event.ResponseStatus
+	})
+	return status
+}
+
+func (ac *AuditContext) GetEventRequestReceivedTimestamp() metav1.MicroTime {
+	var timestamp metav1.MicroTime
+	ac.visitEvent(func(event *auditinternal.Event) {
+		timestamp = event.RequestReceivedTimestamp
+	})
+	return timestamp
+}
+
+func (ac *AuditContext) GetEventStageTimestamp() metav1.MicroTime {
+	var timestamp metav1.MicroTime
+	ac.visitEvent(func(event *auditinternal.Event) {
+		timestamp = event.StageTimestamp
+	})
+	return timestamp
+}
+
+func (ac *AuditContext) SetEventResponseStatus(status *metav1.Status) {
+	ac.visitEvent(func(event *auditinternal.Event) {
+		event.ResponseStatus = status
+	})
+}
+
+func (ac *AuditContext) SetEventResponseStatusCode(statusCode int32) {
+	ac.visitEvent(func(event *auditinternal.Event) {
+		if event.ResponseStatus == nil {
+			event.ResponseStatus = &metav1.Status{}
+		}
+		event.ResponseStatus.Code = statusCode
+	})
+}
+
+func (ac *AuditContext) GetEventAnnotations() map[string]string {
+	var annotations map[string]string
+	ac.visitEvent(func(event *auditinternal.Event) {
+		annotations = maps.Clone(event.Annotations)
+	})
+	return annotations
 }
 
 // AddAuditAnnotation sets the audit annotation for the given key, value pair.
@@ -66,8 +284,8 @@ func AddAuditAnnotation(ctx context.Context, key, value string) {
 		return
 	}
 
-	ac.annotationMutex.Lock()
-	defer ac.annotationMutex.Unlock()
+	ac.lock.Lock()
+	defer ac.lock.Unlock()
 
 	addAuditAnnotationLocked(ac, key, value)
 }
@@ -81,8 +299,8 @@ func AddAuditAnnotations(ctx context.Context, keysAndValues ...string) {
 		return
 	}
 
-	ac.annotationMutex.Lock()
-	defer ac.annotationMutex.Unlock()
+	ac.lock.Lock()
+	defer ac.lock.Unlock()
 
 	if len(keysAndValues)%2 != 0 {
 		klog.Errorf("Dropping mismatched audit annotation %q", keysAndValues[len(keysAndValues)-1])
@@ -100,8 +318,8 @@ func AddAuditAnnotationsMap(ctx context.Context, annotations map[string]string) 
 		return
 	}
 
-	ac.annotationMutex.Lock()
-	defer ac.annotationMutex.Unlock()
+	ac.lock.Lock()
+	defer ac.lock.Unlock()
 
 	for k, v := range annotations {
 		addAuditAnnotationLocked(ac, k, v)
@@ -110,8 +328,7 @@ func AddAuditAnnotationsMap(ctx context.Context, annotations map[string]string) 
 
 // addAuditAnnotationLocked records the audit annotation on the event.
 func addAuditAnnotationLocked(ac *AuditContext, key, value string) {
-	ae := &ac.Event
-
+	ae := &ac.event
 	if ae.Annotations == nil {
 		ae.Annotations = make(map[string]string)
 	}
@@ -128,15 +345,11 @@ func WithAuditContext(parent context.Context) context.Context {
 		return parent // Avoid double registering.
 	}
 
-	return genericapirequest.WithValue(parent, auditKey, &AuditContext{})
-}
-
-// AuditEventFrom returns the audit event struct on the ctx
-func AuditEventFrom(ctx context.Context) *auditinternal.Event {
-	if ac := AuditContextFrom(ctx); ac.Enabled() {
-		return &ac.Event
-	}
-	return nil
+	return genericapirequest.WithValue(parent, auditKey, &AuditContext{
+		event: auditinternal.Event{
+			Stage: auditinternal.StageResponseStarted,
+		},
+	})
 }
 
 // AuditContextFrom returns the pair of the audit configuration object
@@ -154,7 +367,10 @@ func WithAuditID(ctx context.Context, auditID types.UID) {
 		return
 	}
 	if ac := AuditContextFrom(ctx); ac != nil {
-		ac.Event.AuditID = auditID
+		ac.visitEvent(func(event *auditinternal.Event) {
+			ac.auditID.Store(auditID)
+			event.AuditID = auditID
+		})
 	}
 }
 
@@ -162,7 +378,8 @@ func WithAuditID(ctx context.Context, auditID types.UID) {
 // auditing is enabled.
 func AuditIDFrom(ctx context.Context) (types.UID, bool) {
 	if ac := AuditContextFrom(ctx); ac != nil {
-		return ac.Event.AuditID, true
+		id, _ := ac.auditID.Load().(types.UID)
+		return id, true
 	}
 	return "", false
 }

--- a/staging/src/k8s.io/apiserver/pkg/audit/request.go
+++ b/staging/src/k8s.io/apiserver/pkg/audit/request.go
@@ -45,105 +45,69 @@ func LogRequestMetadata(ctx context.Context, req *http.Request, requestReceivedT
 	if !ac.Enabled() {
 		return
 	}
-	ev := &ac.Event
 
-	ev.RequestReceivedTimestamp = metav1.NewMicroTime(requestReceivedTimestamp)
-	ev.Verb = attribs.GetVerb()
-	ev.RequestURI = req.URL.RequestURI()
-	ev.UserAgent = maybeTruncateUserAgent(req)
-	ev.Level = level
+	ac.visitEvent(func(ev *auditinternal.Event) {
+		ev.RequestReceivedTimestamp = metav1.NewMicroTime(requestReceivedTimestamp)
+		ev.Verb = attribs.GetVerb()
+		ev.RequestURI = req.URL.RequestURI()
+		ev.UserAgent = maybeTruncateUserAgent(req)
+		ev.Level = level
 
-	ips := utilnet.SourceIPs(req)
-	ev.SourceIPs = make([]string, len(ips))
-	for i := range ips {
-		ev.SourceIPs[i] = ips[i].String()
-	}
-
-	if user := attribs.GetUser(); user != nil {
-		ev.User.Username = user.GetName()
-		ev.User.Extra = map[string]authnv1.ExtraValue{}
-		for k, v := range user.GetExtra() {
-			ev.User.Extra[k] = authnv1.ExtraValue(v)
+		ips := utilnet.SourceIPs(req)
+		ev.SourceIPs = make([]string, len(ips))
+		for i := range ips {
+			ev.SourceIPs[i] = ips[i].String()
 		}
-		ev.User.Groups = user.GetGroups()
-		ev.User.UID = user.GetUID()
-	}
 
-	if attribs.IsResourceRequest() {
-		ev.ObjectRef = &auditinternal.ObjectReference{
-			Namespace:   attribs.GetNamespace(),
-			Name:        attribs.GetName(),
-			Resource:    attribs.GetResource(),
-			Subresource: attribs.GetSubresource(),
-			APIGroup:    attribs.GetAPIGroup(),
-			APIVersion:  attribs.GetAPIVersion(),
+		if user := attribs.GetUser(); user != nil {
+			ev.User.Username = user.GetName()
+			ev.User.Extra = map[string]authnv1.ExtraValue{}
+			for k, v := range user.GetExtra() {
+				ev.User.Extra[k] = authnv1.ExtraValue(v)
+			}
+			ev.User.Groups = user.GetGroups()
+			ev.User.UID = user.GetUID()
 		}
-	}
+
+		if attribs.IsResourceRequest() {
+			ev.ObjectRef = &auditinternal.ObjectReference{
+				Namespace:   attribs.GetNamespace(),
+				Name:        attribs.GetName(),
+				Resource:    attribs.GetResource(),
+				Subresource: attribs.GetSubresource(),
+				APIGroup:    attribs.GetAPIGroup(),
+				APIVersion:  attribs.GetAPIVersion(),
+			}
+		}
+	})
 }
 
 // LogImpersonatedUser fills in the impersonated user attributes into an audit event.
-func LogImpersonatedUser(ae *auditinternal.Event, user user.Info) {
-	if ae == nil || ae.Level.Less(auditinternal.LevelMetadata) {
+func LogImpersonatedUser(ctx context.Context, user user.Info) {
+	ac := AuditContextFrom(ctx)
+	if !ac.Enabled() {
 		return
 	}
-	ae.ImpersonatedUser = &authnv1.UserInfo{
-		Username: user.GetName(),
-	}
-	ae.ImpersonatedUser.Groups = user.GetGroups()
-	ae.ImpersonatedUser.UID = user.GetUID()
-	ae.ImpersonatedUser.Extra = map[string]authnv1.ExtraValue{}
-	for k, v := range user.GetExtra() {
-		ae.ImpersonatedUser.Extra[k] = authnv1.ExtraValue(v)
-	}
+	ac.LogImpersonatedUser(user)
 }
 
 // LogRequestObject fills in the request object into an audit event. The passed runtime.Object
 // will be converted to the given gv.
 func LogRequestObject(ctx context.Context, obj runtime.Object, objGV schema.GroupVersion, gvr schema.GroupVersionResource, subresource string, s runtime.NegotiatedSerializer) {
-	ae := AuditEventFrom(ctx)
-	if ae == nil || ae.Level.Less(auditinternal.LevelMetadata) {
+	ac := AuditContextFrom(ctx)
+	if !ac.Enabled() {
 		return
 	}
-
-	// complete ObjectRef
-	if ae.ObjectRef == nil {
-		ae.ObjectRef = &auditinternal.ObjectReference{}
+	if ac.GetEventLevel().Less(auditinternal.LevelMetadata) {
+		return
 	}
 
 	// meta.Accessor is more general than ObjectMetaAccessor, but if it fails, we can just skip setting these bits
-	if meta, err := meta.Accessor(obj); err == nil {
-		if len(ae.ObjectRef.Namespace) == 0 {
-			ae.ObjectRef.Namespace = meta.GetNamespace()
-		}
-		if len(ae.ObjectRef.Name) == 0 {
-			ae.ObjectRef.Name = meta.GetName()
-		}
-		if len(ae.ObjectRef.UID) == 0 {
-			ae.ObjectRef.UID = meta.GetUID()
-		}
-		if len(ae.ObjectRef.ResourceVersion) == 0 {
-			ae.ObjectRef.ResourceVersion = meta.GetResourceVersion()
-		}
-	}
-	if len(ae.ObjectRef.APIVersion) == 0 {
-		ae.ObjectRef.APIGroup = gvr.Group
-		ae.ObjectRef.APIVersion = gvr.Version
-	}
-	if len(ae.ObjectRef.Resource) == 0 {
-		ae.ObjectRef.Resource = gvr.Resource
-	}
-	if len(ae.ObjectRef.Subresource) == 0 {
-		ae.ObjectRef.Subresource = subresource
-	}
-
-	if ae.Level.Less(auditinternal.LevelRequest) {
-		return
-	}
-
-	if shouldOmitManagedFields(ctx) {
+	objMeta, _ := meta.Accessor(obj)
+	if shouldOmitManagedFields(ac) {
 		copy, ok, err := copyWithoutManagedFields(obj)
 		if err != nil {
-			klog.ErrorS(err, "Error while dropping managed fields from the request", "auditID", ae.AuditID)
+			klog.ErrorS(err, "Error while dropping managed fields from the request", "auditID", ac.AuditID())
 		}
 		if ok {
 			obj = copy
@@ -151,54 +115,73 @@ func LogRequestObject(ctx context.Context, obj runtime.Object, objGV schema.Grou
 	}
 
 	// TODO(audit): hook into the serializer to avoid double conversion
-	var err error
-	ae.RequestObject, err = encodeObject(obj, objGV, s)
+	requestObject, err := encodeObject(obj, objGV, s)
 	if err != nil {
 		// TODO(audit): add error slice to audit event struct
-		klog.ErrorS(err, "Encoding failed of request object", "auditID", ae.AuditID, "gvr", gvr.String(), "obj", obj)
+		klog.ErrorS(err, "Encoding failed of request object", "auditID", ac.AuditID(), "gvr", gvr.String(), "obj", obj)
 		return
 	}
+
+	ac.visitEvent(func(ae *auditinternal.Event) {
+		if ae.ObjectRef == nil {
+			ae.ObjectRef = &auditinternal.ObjectReference{}
+		}
+
+		if objMeta != nil {
+			if len(ae.ObjectRef.Namespace) == 0 {
+				ae.ObjectRef.Namespace = objMeta.GetNamespace()
+			}
+			if len(ae.ObjectRef.Name) == 0 {
+				ae.ObjectRef.Name = objMeta.GetName()
+			}
+			if len(ae.ObjectRef.UID) == 0 {
+				ae.ObjectRef.UID = objMeta.GetUID()
+			}
+			if len(ae.ObjectRef.ResourceVersion) == 0 {
+				ae.ObjectRef.ResourceVersion = objMeta.GetResourceVersion()
+			}
+		}
+		if len(ae.ObjectRef.APIVersion) == 0 {
+			ae.ObjectRef.APIGroup = gvr.Group
+			ae.ObjectRef.APIVersion = gvr.Version
+		}
+		if len(ae.ObjectRef.Resource) == 0 {
+			ae.ObjectRef.Resource = gvr.Resource
+		}
+		if len(ae.ObjectRef.Subresource) == 0 {
+			ae.ObjectRef.Subresource = subresource
+		}
+
+		if ae.Level.Less(auditinternal.LevelRequest) {
+			return
+		}
+		ae.RequestObject = requestObject
+	})
 }
 
 // LogRequestPatch fills in the given patch as the request object into an audit event.
 func LogRequestPatch(ctx context.Context, patch []byte) {
-	ae := AuditEventFrom(ctx)
-	if ae == nil || ae.Level.Less(auditinternal.LevelRequest) {
+	ac := AuditContextFrom(ctx)
+	if ac.GetEventLevel().Less(auditinternal.LevelRequest) {
 		return
 	}
-
-	ae.RequestObject = &runtime.Unknown{
-		Raw:         patch,
-		ContentType: runtime.ContentTypeJSON,
-	}
+	ac.LogRequestPatch(patch)
 }
 
 // LogResponseObject fills in the response object into an audit event. The passed runtime.Object
 // will be converted to the given gv.
 func LogResponseObject(ctx context.Context, obj runtime.Object, gv schema.GroupVersion, s runtime.NegotiatedSerializer) {
-	ae := AuditEventFrom(ctx)
-	if ae == nil || ae.Level.Less(auditinternal.LevelMetadata) {
-		return
-	}
-	if status, ok := obj.(*metav1.Status); ok {
-		// selectively copy the bounded fields.
-		ae.ResponseStatus = &metav1.Status{
-			Status:  status.Status,
-			Message: status.Message,
-			Reason:  status.Reason,
-			Details: status.Details,
-			Code:    status.Code,
-		}
-	}
-
-	if ae.Level.Less(auditinternal.LevelRequestResponse) {
+	ac := AuditContextFrom(WithAuditContext(ctx))
+	if ac.GetEventLevel().Less(auditinternal.LevelMetadata) {
 		return
 	}
 
-	if shouldOmitManagedFields(ctx) {
+	status, _ := obj.(*metav1.Status)
+
+	if shouldOmitManagedFields(ac) {
 		copy, ok, err := copyWithoutManagedFields(obj)
 		if err != nil {
-			klog.ErrorS(err, "Error while dropping managed fields from the response", "auditID", ae.AuditID)
+			klog.ErrorS(err, "Error while dropping managed fields from the response", "auditID", ac.AuditID())
 		}
 		if ok {
 			obj = copy
@@ -207,10 +190,11 @@ func LogResponseObject(ctx context.Context, obj runtime.Object, gv schema.GroupV
 
 	// TODO(audit): hook into the serializer to avoid double conversion
 	var err error
-	ae.ResponseObject, err = encodeObject(obj, gv, s)
+	responseObject, err := encodeObject(obj, gv, s)
 	if err != nil {
-		klog.ErrorS(err, "Encoding failed of response object", "auditID", ae.AuditID, "obj", obj)
+		klog.ErrorS(err, "Encoding failed of response object", "auditID", ac.AuditID(), "obj", obj)
 	}
+	ac.LogResponseObject(status, responseObject)
 }
 
 func encodeObject(obj runtime.Object, gv schema.GroupVersion, serializer runtime.NegotiatedSerializer) (*runtime.Unknown, error) {
@@ -301,9 +285,9 @@ func removeManagedFields(obj runtime.Object) error {
 	return nil
 }
 
-func shouldOmitManagedFields(ctx context.Context) bool {
-	if auditContext := AuditContextFrom(ctx); auditContext != nil {
-		return auditContext.RequestAuditConfig.OmitManagedFields
+func shouldOmitManagedFields(ac *AuditContext) bool {
+	if ac != nil && ac.initialized.Load() && ac.requestAuditConfig.OmitManagedFields {
+		return true
 	}
 
 	// If we can't decide, return false to maintain current behavior which is

--- a/staging/src/k8s.io/apiserver/pkg/authentication/token/cache/cached_token_authenticator.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/token/cache/cached_token_authenticator.go
@@ -201,10 +201,10 @@ func (a *cachedTokenAuthenticator) doAuthenticateToken(ctx context.Context, toke
 		ac := audit.AuditContextFrom(ctx)
 		// since this is shared work between multiple requests, we have no way of knowing if any
 		// particular request supports audit annotations.  thus we always attempt to record them.
-		ac.Event.Level = auditinternal.LevelMetadata
+		ac.SetEventLevel(auditinternal.LevelMetadata)
 
 		record.resp, record.ok, record.err = a.authenticator.AuthenticateToken(ctx, token)
-		record.annotations = ac.Event.Annotations
+		record.annotations = ac.GetEventAnnotations()
 		record.warnings = recorder.extractWarnings()
 
 		if !a.cacheErrs && record.err != nil {

--- a/staging/src/k8s.io/apiserver/pkg/authentication/token/cache/cached_token_authenticator_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/token/cache/cached_token_authenticator_test.go
@@ -306,7 +306,7 @@ func TestCachedAuditAnnotations(t *testing.T) {
 				ctx := withAudit(context.Background())
 				_, _, _ = a.AuthenticateToken(ctx, "token")
 
-				allAnnotations <- audit.AuditEventFrom(ctx).Annotations
+				allAnnotations <- audit.AuditContextFrom(ctx).GetEventAnnotations()
 			}()
 		}
 
@@ -343,7 +343,7 @@ func TestCachedAuditAnnotations(t *testing.T) {
 		for i := 0; i < cap(allAnnotations); i++ {
 			ctx := withAudit(context.Background())
 			_, _, _ = a.AuthenticateToken(ctx, "token")
-			allAnnotations = append(allAnnotations, audit.AuditEventFrom(ctx).Annotations)
+			allAnnotations = append(allAnnotations, audit.AuditContextFrom(ctx).GetEventAnnotations())
 		}
 
 		if len(allAnnotations) != cap(allAnnotations) {
@@ -370,14 +370,14 @@ func TestCachedAuditAnnotations(t *testing.T) {
 
 		ctx1 := withAudit(context.Background())
 		_, _, _ = a.AuthenticateToken(ctx1, "token1")
-		annotations1 := audit.AuditEventFrom(ctx1).Annotations
+		annotations1 := audit.AuditContextFrom(ctx1).GetEventAnnotations()
 
 		// guarantee different now times
 		time.Sleep(time.Second)
 
 		ctx2 := withAudit(context.Background())
 		_, _, _ = a.AuthenticateToken(ctx2, "token2")
-		annotations2 := audit.AuditEventFrom(ctx2).Annotations
+		annotations2 := audit.AuditContextFrom(ctx2).GetEventAnnotations()
 
 		if ok := len(annotations1) == 1 && len(annotations1["timestamp"]) > 0; !ok {
 			t.Errorf("invalid annotations 1: %v", annotations1)
@@ -547,7 +547,7 @@ func (s *singleBenchmark) bench(b *testing.B) {
 func withAudit(ctx context.Context) context.Context {
 	ctx = audit.WithAuditContext(ctx)
 	ac := audit.AuditContextFrom(ctx)
-	ac.Event.Level = auditinternal.LevelMetadata
+	ac.SetEventLevel(auditinternal.LevelMetadata)
 	return ctx
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit.go
@@ -44,7 +44,7 @@ func WithAudit(handler http.Handler, sink audit.Sink, policy audit.PolicyRuleEva
 		return handler
 	}
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		ac, err := evaluatePolicyAndCreateAuditEvent(req, policy)
+		ac, err := evaluatePolicyAndCreateAuditEvent(req, policy, sink)
 		if err != nil {
 			utilruntime.HandleError(fmt.Errorf("failed to create audit event: %v", err))
 			responsewriters.InternalError(w, req, errors.New("failed to create audit event"))
@@ -55,41 +55,37 @@ func WithAudit(handler http.Handler, sink audit.Sink, policy audit.PolicyRuleEva
 			handler.ServeHTTP(w, req)
 			return
 		}
-		ev := &ac.Event
 
 		ctx := req.Context()
-		omitStages := ac.RequestAuditConfig.OmitStages
 
-		ev.Stage = auditinternal.StageRequestReceived
-		if processed := processAuditEvent(ctx, sink, ev, omitStages); !processed {
+		if processed := ac.ProcessEventStage(ctx, auditinternal.StageRequestReceived); !processed {
 			audit.ApiserverAuditDroppedCounter.WithContext(ctx).Inc()
 			responsewriters.InternalError(w, req, errors.New("failed to store audit event"))
 			return
 		}
 
 		// intercept the status code
-		var longRunningSink audit.Sink
+		isLongRunning := false
 		if longRunningCheck != nil {
 			ri, _ := request.RequestInfoFrom(ctx)
 			if longRunningCheck(req, ri) {
-				longRunningSink = sink
+				isLongRunning = true
 			}
 		}
-		respWriter := decorateResponseWriter(ctx, w, ev, longRunningSink, omitStages)
+		respWriter := decorateResponseWriter(ctx, w, isLongRunning)
 
 		// send audit event when we leave this func, either via a panic or cleanly. In the case of long
 		// running requests, this will be the second audit event.
 		defer func() {
 			if r := recover(); r != nil {
 				defer panic(r)
-				ev.Stage = auditinternal.StagePanic
-				ev.ResponseStatus = &metav1.Status{
+				ac.SetEventResponseStatus(&metav1.Status{
 					Code:    http.StatusInternalServerError,
 					Status:  metav1.StatusFailure,
 					Reason:  metav1.StatusReasonInternalError,
 					Message: fmt.Sprintf("APIServer panic'd: %v", r),
-				}
-				processAuditEvent(ctx, sink, ev, omitStages)
+				})
+				ac.ProcessEventStage(ctx, auditinternal.StagePanic)
 				return
 			}
 
@@ -100,27 +96,25 @@ func WithAudit(handler http.Handler, sink audit.Sink, policy audit.PolicyRuleEva
 				Status:  metav1.StatusSuccess,
 				Message: "Connection closed early",
 			}
-			if ev.ResponseStatus == nil && longRunningSink != nil {
-				ev.ResponseStatus = fakedSuccessStatus
-				ev.Stage = auditinternal.StageResponseStarted
-				processAuditEvent(ctx, longRunningSink, ev, omitStages)
+			if ac.GetEventResponseStatus() == nil {
+				ac.SetEventResponseStatus(fakedSuccessStatus)
+				if isLongRunning {
+					// A nil ResponseStatus means the writer never processed the ResponseStarted stage, so do that now.
+					ac.ProcessEventStage(ctx, auditinternal.StageResponseStarted)
+				}
 			}
-
-			ev.Stage = auditinternal.StageResponseComplete
-			if ev.ResponseStatus == nil {
-				ev.ResponseStatus = fakedSuccessStatus
-			}
-			processAuditEvent(ctx, sink, ev, omitStages)
+			writeLatencyToAnnotation(ctx)
+			ac.ProcessEventStage(ctx, auditinternal.StageResponseComplete)
 		}()
 		handler.ServeHTTP(respWriter, req)
 	})
 }
 
 // evaluatePolicyAndCreateAuditEvent is responsible for evaluating the audit
-// policy configuration applicable to the request and create a new audit
-// event that will be written to the API audit log.
+// policy configuration applicable to the request and initializing the audit
+// context with the audit config for the request, the sink to write to, and the request metadata.
 // - error if anything bad happened
-func evaluatePolicyAndCreateAuditEvent(req *http.Request, policy audit.PolicyRuleEvaluator) (*audit.AuditContext, error) {
+func evaluatePolicyAndCreateAuditEvent(req *http.Request, policy audit.PolicyRuleEvaluator, sink audit.Sink) (*audit.AuditContext, error) {
 	ctx := req.Context()
 	ac := audit.AuditContextFrom(ctx)
 	if ac == nil {
@@ -135,7 +129,10 @@ func evaluatePolicyAndCreateAuditEvent(req *http.Request, policy audit.PolicyRul
 
 	rac := policy.EvaluatePolicyRule(attribs)
 	audit.ObservePolicyLevel(ctx, rac.Level)
-	ac.RequestAuditConfig = rac
+	err = ac.Init(rac, sink)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize audit context: %w", err)
+	}
 	if rac.Level == auditinternal.LevelNone {
 		// Don't audit.
 		return ac, nil
@@ -153,13 +150,14 @@ func evaluatePolicyAndCreateAuditEvent(req *http.Request, policy audit.PolicyRul
 // writeLatencyToAnnotation writes the latency incurred in different
 // layers of the apiserver to the annotations of the audit object.
 // it should be invoked after ev.StageTimestamp has been set appropriately.
-func writeLatencyToAnnotation(ctx context.Context, ev *auditinternal.Event) {
+func writeLatencyToAnnotation(ctx context.Context) {
+	ac := audit.AuditContextFrom(ctx)
 	// we will track latency in annotation only when the total latency
 	// of the given request exceeds 500ms, this is in keeping with the
 	// traces in rest/handlers for create, delete, update,
 	// get, list, and deletecollection.
 	const threshold = 500 * time.Millisecond
-	latency := ev.StageTimestamp.Time.Sub(ev.RequestReceivedTimestamp.Time)
+	latency := ac.GetEventStageTimestamp().Sub(ac.GetEventRequestReceivedTimestamp().Time)
 	if latency <= threshold {
 		return
 	}
@@ -177,34 +175,12 @@ func writeLatencyToAnnotation(ctx context.Context, ev *auditinternal.Event) {
 	audit.AddAuditAnnotationsMap(ctx, layerLatencies)
 }
 
-func processAuditEvent(ctx context.Context, sink audit.Sink, ev *auditinternal.Event, omitStages []auditinternal.Stage) bool {
-	for _, stage := range omitStages {
-		if ev.Stage == stage {
-			return true
-		}
-	}
-
-	switch {
-	case ev.Stage == auditinternal.StageRequestReceived:
-		ev.StageTimestamp = metav1.NewMicroTime(ev.RequestReceivedTimestamp.Time)
-	case ev.Stage == auditinternal.StageResponseComplete:
-		ev.StageTimestamp = metav1.NewMicroTime(time.Now())
-		writeLatencyToAnnotation(ctx, ev)
-	default:
-		ev.StageTimestamp = metav1.NewMicroTime(time.Now())
-	}
-
-	audit.ObserveEvent(ctx)
-	return sink.ProcessEvents(ev)
-}
-
-func decorateResponseWriter(ctx context.Context, responseWriter http.ResponseWriter, ev *auditinternal.Event, sink audit.Sink, omitStages []auditinternal.Stage) http.ResponseWriter {
+func decorateResponseWriter(ctx context.Context, responseWriter http.ResponseWriter, processResponseStartedStage bool) http.ResponseWriter {
 	delegate := &auditResponseWriter{
 		ctx:            ctx,
 		ResponseWriter: responseWriter,
-		event:          ev,
-		sink:           sink,
-		omitStages:     omitStages,
+
+		processResponseStartedStage: processResponseStartedStage,
 	}
 
 	return responsewriter.WrapForHTTP1Or2(delegate)
@@ -217,11 +193,10 @@ var _ responsewriter.UserProvidedDecorator = &auditResponseWriter{}
 // create immediately an event (for long running requests).
 type auditResponseWriter struct {
 	http.ResponseWriter
-	ctx        context.Context
-	event      *auditinternal.Event
-	once       sync.Once
-	sink       audit.Sink
-	omitStages []auditinternal.Stage
+	ctx  context.Context
+	once sync.Once
+
+	processResponseStartedStage bool
 }
 
 func (a *auditResponseWriter) Unwrap() http.ResponseWriter {
@@ -230,14 +205,10 @@ func (a *auditResponseWriter) Unwrap() http.ResponseWriter {
 
 func (a *auditResponseWriter) processCode(code int) {
 	a.once.Do(func() {
-		if a.event.ResponseStatus == nil {
-			a.event.ResponseStatus = &metav1.Status{}
-		}
-		a.event.ResponseStatus.Code = int32(code)
-		a.event.Stage = auditinternal.StageResponseStarted
-
-		if a.sink != nil {
-			processAuditEvent(a.ctx, a.sink, a.event, a.omitStages)
+		ac := audit.AuditContextFrom(a.ctx)
+		ac.SetEventResponseStatusCode(int32(code))
+		if a.processResponseStartedStage {
+			ac.ProcessEventStage(a.ctx, auditinternal.StageResponseStarted)
 		}
 	})
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit_test.go
@@ -18,24 +18,37 @@ package filters
 
 import (
 	"context"
+	"math/rand"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"reflect"
 	"sync"
 	"testing"
 	"time"
+	"unsafe"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	auditinternal "k8s.io/apiserver/pkg/apis/audit"
+	auditv1 "k8s.io/apiserver/pkg/apis/audit/v1"
 	"k8s.io/apiserver/pkg/audit"
 	"k8s.io/apiserver/pkg/audit/policy"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/endpoints/responsewriter"
+	"k8s.io/apiserver/plugin/pkg/audit/buffered"
+	"k8s.io/apiserver/plugin/pkg/audit/log"
+	"k8s.io/apiserver/plugin/pkg/audit/webhook"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/util/flowcontrol"
+	"k8s.io/client-go/util/retry"
 )
 
 type fakeAuditSink struct {
@@ -76,7 +89,7 @@ func (s *fakeAuditSink) Pop(timeout time.Duration) (*auditinternal.Event, error)
 
 func TestConstructResponseWriter(t *testing.T) {
 	inner := &responsewriter.FakeResponseWriter{}
-	actual := decorateResponseWriter(context.Background(), inner, nil, nil, nil)
+	actual := decorateResponseWriter(context.Background(), inner, false)
 	switch v := actual.(type) {
 	case *auditResponseWriter:
 	default:
@@ -86,7 +99,7 @@ func TestConstructResponseWriter(t *testing.T) {
 		t.Errorf("Expected the decorator to return the inner http.ResponseWriter object")
 	}
 
-	actual = decorateResponseWriter(context.Background(), &responsewriter.FakeResponseWriterFlusherCloseNotifier{}, nil, nil, nil)
+	actual = decorateResponseWriter(context.Background(), &responsewriter.FakeResponseWriterFlusherCloseNotifier{}, false)
 	//lint:file-ignore SA1019 Keep supporting deprecated http.CloseNotifier
 	if _, ok := actual.(http.CloseNotifier); !ok {
 		t.Errorf("Expected http.ResponseWriter to implement http.CloseNotifier")
@@ -98,7 +111,7 @@ func TestConstructResponseWriter(t *testing.T) {
 		t.Errorf("Expected http.ResponseWriter not to implement http.Hijacker")
 	}
 
-	actual = decorateResponseWriter(context.Background(), &responsewriter.FakeResponseWriterFlusherCloseNotifierHijacker{}, nil, nil, nil)
+	actual = decorateResponseWriter(context.Background(), &responsewriter.FakeResponseWriterFlusherCloseNotifierHijacker{}, false)
 	//lint:file-ignore SA1019 Keep supporting deprecated http.CloseNotifier
 	if _, ok := actual.(http.CloseNotifier); !ok {
 		t.Errorf("Expected http.ResponseWriter to implement http.CloseNotifier")
@@ -112,37 +125,43 @@ func TestConstructResponseWriter(t *testing.T) {
 }
 
 func TestDecorateResponseWriterWithoutChannel(t *testing.T) {
-	ev := &auditinternal.Event{}
-	actual := decorateResponseWriter(context.Background(), &responsewriter.FakeResponseWriter{}, ev, nil, nil)
+	ctx := audit.WithAuditContext(context.Background())
+	ac := audit.AuditContextFrom(ctx)
+	actual := decorateResponseWriter(ctx, &responsewriter.FakeResponseWriter{}, false)
 
 	// write status. This will not block because firstEventSentCh is nil
 	actual.WriteHeader(42)
-	if ev.ResponseStatus == nil {
+	if ac.GetEventResponseStatus() == nil {
 		t.Fatalf("Expected ResponseStatus to be non-nil")
 	}
-	if ev.ResponseStatus.Code != 42 {
-		t.Errorf("expected status code 42, got %d", ev.ResponseStatus.Code)
+	if ac.GetEventResponseStatus().Code != 42 {
+		t.Errorf("expected status code 42, got %d", ac.GetEventResponseStatus().Code)
 	}
 }
 
 func TestDecorateResponseWriterWithImplicitWrite(t *testing.T) {
-	ev := &auditinternal.Event{}
-	actual := decorateResponseWriter(context.Background(), &responsewriter.FakeResponseWriter{}, ev, nil, nil)
+	ctx := audit.WithAuditContext(context.Background())
+	ac := audit.AuditContextFrom(ctx)
+	actual := decorateResponseWriter(ctx, &responsewriter.FakeResponseWriter{}, false)
 
 	// write status. This will not block because firstEventSentCh is nil
 	actual.Write([]byte("foo"))
-	if ev.ResponseStatus == nil {
+	if ac.GetEventResponseStatus() == nil {
 		t.Fatalf("Expected ResponseStatus to be non-nil")
 	}
-	if ev.ResponseStatus.Code != 200 {
-		t.Errorf("expected status code 200, got %d", ev.ResponseStatus.Code)
+	if ac.GetEventResponseStatus().Code != 200 {
+		t.Errorf("expected status code 200, got %d", ac.GetEventResponseStatus().Code)
 	}
 }
 
 func TestDecorateResponseWriterChannel(t *testing.T) {
+	ctx := audit.WithAuditContext(context.Background())
 	sink := &fakeAuditSink{}
-	ev := &auditinternal.Event{}
-	actual := decorateResponseWriter(context.Background(), &responsewriter.FakeResponseWriter{}, ev, sink, nil)
+	auditContext := audit.AuditContextFrom(ctx)
+	if err := auditContext.Init(audit.RequestAuditConfig{}, sink); err != nil {
+		t.Fatal(err)
+	}
+	actual := decorateResponseWriter(ctx, &responsewriter.FakeResponseWriter{}, true)
 
 	done := make(chan struct{})
 	go func() {
@@ -164,8 +183,11 @@ func TestDecorateResponseWriterChannel(t *testing.T) {
 	}
 	t.Logf("Seen event with status %v", ev1.ResponseStatus)
 
-	if !reflect.DeepEqual(ev, ev1) {
-		t.Fatalf("ev1 and ev must be equal")
+	ev := getAuditContextEvent(auditContext)
+	if diff := cmp.Diff(ev, ev1, cmp.FilterPath(func(p cmp.Path) bool {
+		return p.String() == "StageTimestamp"
+	}, cmp.Ignore())); diff != "" {
+		t.Fatalf("ev1 and ev must be equal, diff: %s", diff)
 	}
 
 	<-done
@@ -176,6 +198,20 @@ func TestDecorateResponseWriterChannel(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
+}
+
+func getAuditContextEvent(ac *audit.AuditContext) *auditinternal.Event {
+	// Get the reflect.Value of the AuditContext
+	val := reflect.ValueOf(ac).Elem()
+
+	// Access the unexported `event` field
+	eventField := val.FieldByName("event")
+
+	// Use unsafe to get a pointer to the field
+	eventPtr := unsafe.Pointer(eventField.UnsafeAddr())
+
+	// Cast the pointer to the correct type
+	return (*auditinternal.Event)(eventPtr)
 }
 
 type fakeHTTPHandler struct{}
@@ -848,11 +884,130 @@ func withTestContext(req *http.Request, user user.Info, ae *auditinternal.Event)
 		ctx = request.WithUser(ctx, user)
 	}
 	if ae != nil {
-		ac := audit.AuditContextFrom(ctx)
-		ac.Event = *ae
+		ev := getAuditContextEvent(audit.AuditContextFrom(ctx))
+		*ev = *ae
 	}
 	if info, err := newTestRequestInfoResolver().NewRequestInfo(req); err == nil {
 		ctx = request.WithRequestInfo(ctx, info)
 	}
 	return req.WithContext(ctx)
+}
+
+type fakeAuditFile struct{}
+
+func (s fakeAuditFile) Write(p []byte) (n int, err error) {
+	time.Sleep(time.Duration(rand.Int63n(10000)))
+	return len(p), nil
+}
+
+type fakeAuditWebhookAuditBackend struct {
+}
+
+func (f fakeAuditWebhookAuditBackend) RoundTrip(r *http.Request) (*http.Response, error) {
+	time.Sleep(time.Duration(rand.Int63n(10000)))
+	return &http.Response{
+		StatusCode: http.StatusOK,
+	}, nil
+}
+
+// Test case for https://github.com/kubernetes/kubernetes/issues/120507
+// to test for race conditions in audit backends use the following command:
+// `go test ./ -race --run=TestAuditBackendRaceCondition -v`
+func TestAuditBackendRaceCondition(t *testing.T) {
+	defaultFakeLogBackend := log.NewBackend(fakeAuditFile{}, log.FormatJson, auditv1.SchemeGroupVersion)
+	testCases := []struct {
+		name           string
+		backendBuilder func() audit.Backend
+	}{
+		{
+			"log audit backend",
+			func() audit.Backend {
+				return defaultFakeLogBackend
+			},
+		},
+		{
+			"buffered audit backend",
+			func() audit.Backend {
+				backend := buffered.NewBackend(defaultFakeLogBackend, buffered.BatchConfig{
+					BufferSize:     10000,
+					MaxBatchSize:   1,
+					ThrottleEnable: false,
+					AsyncDelegate:  false,
+				})
+				err := backend.Run(wait.NeverStop)
+				if err != nil {
+					t.Fatal(err)
+				}
+				return backend
+			},
+		},
+		{
+			name: "webhook audit backend",
+			backendBuilder: func() audit.Backend {
+				codecFactory := audit.Codecs
+				codec := codecFactory.LegacyCodec(auditv1.SchemeGroupVersion)
+				negotiatedSerializer := serializer.NegotiatedSerializerWrapper(runtime.SerializerInfo{Serializer: codec})
+				client, err := rest.NewRESTClient(&url.URL{}, "/hello", rest.ClientContentConfig{
+					ContentType: "application/json",
+					Negotiator:  runtime.NewClientNegotiator(negotiatedSerializer, auditv1.SchemeGroupVersion),
+				}, flowcontrol.NewTokenBucketRateLimiter(100, 200), &http.Client{Transport: fakeAuditWebhookAuditBackend{}})
+				if err != nil {
+					t.Fatal(err)
+				}
+				return webhook.NewDynamicBackend(client, retry.DefaultBackoff)
+			},
+		},
+		{
+			"union audit backend",
+			func() audit.Backend {
+				return audit.Union(defaultFakeLogBackend, defaultFakeLogBackend)
+			},
+		},
+	}
+	fakeRuleEvaluator := policy.NewFakePolicyRuleEvaluator(auditinternal.LevelRequestResponse, nil)
+	longRunningCheck := func(r *http.Request, ri *request.RequestInfo) bool { return false }
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), wait.ForeverTestTimeout)
+			defer cancel()
+			for {
+				select {
+				case <-ctx.Done():
+					// finished the test
+					return
+				default:
+				}
+				serveStarted := make(chan struct{})
+				req, _ := http.NewRequest(http.MethodGet, "/api/v1/namespaces/default/pods/foo", nil)
+				req = withTestContext(req, &user.DefaultInfo{Name: "admin"}, nil)
+				backend := tc.backendBuilder()
+				go func() {
+					<-serveStarted
+					for {
+						select {
+						case <-ctx.Done():
+							// finished the test
+							backend.Shutdown()
+							return
+						default:
+						}
+						audit.AddAuditAnnotations(req.Context(), "a", "b")
+					}
+				}()
+				realHandler := http.HandlerFunc(func(writer http.ResponseWriter, r *http.Request) {
+					close(serveStarted)
+					// mock some business logic
+					time.Sleep(time.Millisecond)
+				})
+				handler := WithAudit(realHandler, backend, fakeRuleEvaluator, longRunningCheck)
+				handler = WithAuditInit(handler)
+				serveFinished := make(chan struct{})
+				go func() {
+					defer close(serveFinished)
+					handler.ServeHTTP(httptest.NewRecorder(), req)
+				}()
+				<-serveFinished
+			}
+		})
+	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authorization_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authorization_test.go
@@ -286,11 +286,21 @@ func TestAuditAnnotation(t *testing.T) {
 
 		req, _ := http.NewRequest("GET", "/api/v1/namespaces/default/pods", nil)
 		req = withTestContext(req, nil, &auditinternal.Event{Level: auditinternal.LevelMetadata})
-		ae := audit.AuditEventFrom(req.Context())
+		ae := audit.AuditContextFrom(req.Context())
 		req.RemoteAddr = "127.0.0.1"
 		handler.ServeHTTP(httptest.NewRecorder(), req)
-		assert.Equal(t, tc.decisionAnnotation, ae.Annotations[decisionAnnotationKey], k+": unexpected decision annotation")
-		assert.Equal(t, tc.reasonAnnotation, ae.Annotations[reasonAnnotationKey], k+": unexpected reason annotation")
+
+		var annotation string
+		var ok bool
+		if len(tc.decisionAnnotation) > 0 {
+			annotation, ok = ae.GetEventAnnotation(decisionAnnotationKey)
+			assert.True(t, ok, k+": decision annotation not found")
+			assert.Equal(t, tc.decisionAnnotation, annotation, k+": unexpected decision annotation")
+		}
+
+		annotation, ok = ae.GetEventAnnotation(reasonAnnotationKey)
+		assert.True(t, ok, k+": reason annotation not found")
+		assert.Equal(t, tc.reasonAnnotation, annotation, k+": unexpected reason annotation")
 	}
 
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/impersonation.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/impersonation.go
@@ -166,8 +166,7 @@ func WithImpersonation(handler http.Handler, a authorizer.Authorizer, s runtime.
 		oldUser, _ := request.UserFrom(ctx)
 		httplog.LogOf(req, w).Addf("%v is impersonating %v", userString(oldUser), userString(newUser))
 
-		ae := audit.AuditEventFrom(ctx)
-		audit.LogImpersonatedUser(ae, newUser)
+		audit.LogImpersonatedUser(audit.WithAuditContext(ctx), newUser)
 
 		// clear all the impersonation headers from the request
 		req.Header.Del(authenticationv1.ImpersonateUserHeader)

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/request_deadline.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/request_deadline.go
@@ -108,7 +108,7 @@ func withFailedRequestAudit(failedHandler http.Handler, statusErr *apierrors.Sta
 		return failedHandler
 	}
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		ac, err := evaluatePolicyAndCreateAuditEvent(req, policy)
+		ac, err := evaluatePolicyAndCreateAuditEvent(req, policy, sink)
 		if err != nil {
 			utilruntime.HandleError(fmt.Errorf("failed to create audit event: %v", err))
 			responsewriters.InternalError(w, req, errors.New("failed to create audit event"))
@@ -119,15 +119,15 @@ func withFailedRequestAudit(failedHandler http.Handler, statusErr *apierrors.Sta
 			failedHandler.ServeHTTP(w, req)
 			return
 		}
-		ev := &ac.Event
 
-		ev.ResponseStatus = &metav1.Status{}
-		ev.Stage = auditinternal.StageResponseStarted
+		respStatus := &metav1.Status{}
 		if statusErr != nil {
-			ev.ResponseStatus.Message = statusErr.Error()
+			respStatus.Message = statusErr.Error()
 		}
+		ac.SetEventResponseStatus(respStatus)
+		ac.SetEventStage(auditinternal.StageResponseStarted)
 
-		rw := decorateResponseWriter(req.Context(), w, ev, sink, ac.RequestAuditConfig.OmitStages)
+		rw := decorateResponseWriter(req.Context(), w, true)
 		failedHandler.ServeHTTP(rw, req)
 	})
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/request_deadline_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/request_deadline_test.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -408,21 +407,21 @@ func TestWithFailedRequestAudit(t *testing.T) {
 					t.Errorf("expected an http.ResponseWriter of type: %T but got: %T", &auditResponseWriter{}, rwGot)
 				}
 
-				auditEventGot := audit.AuditEventFrom(requestGot.Context())
-				if auditEventGot == nil {
+				auditContext := audit.AuditContextFrom(requestGot.Context())
+				if auditContext == nil {
 					t.Fatal("expected an audit event object but got nil")
 				}
-				if auditEventGot.Stage != auditinternal.StageResponseStarted {
-					t.Errorf("expected audit event Stage: %s, but got: %s", auditinternal.StageResponseStarted, auditEventGot.Stage)
+				if auditContext.GetEventStage() != auditinternal.StageResponseStarted {
+					t.Errorf("expected audit event Stage: %s, but got: %s", auditinternal.StageResponseStarted, auditContext.GetEventStage())
 				}
-				if auditEventGot.ResponseStatus == nil {
+				if auditContext.GetEventResponseStatus() == nil {
 					t.Fatal("expected a ResponseStatus field of the audit event object, but got nil")
 				}
-				if test.statusCodeExpected != int(auditEventGot.ResponseStatus.Code) {
-					t.Errorf("expected audit event ResponseStatus.Code: %d, but got: %d", test.statusCodeExpected, auditEventGot.ResponseStatus.Code)
+				if test.statusCodeExpected != int(auditContext.GetEventResponseStatus().Code) {
+					t.Errorf("expected audit event ResponseStatus.Code: %d, but got: %d", test.statusCodeExpected, auditContext.GetEventResponseStatus().Code)
 				}
-				if test.statusErr.Error() != auditEventGot.ResponseStatus.Message {
-					t.Errorf("expected audit event ResponseStatus.Message: %s, but got: %s", test.statusErr, auditEventGot.ResponseStatus.Message)
+				if test.statusErr.Error() != auditContext.GetEventResponseStatus().Message {
+					t.Errorf("expected audit event ResponseStatus.Message: %s, but got: %s", test.statusErr, auditContext.GetEventResponseStatus().Message)
 				}
 
 				// verify that the audit event from the request context is written to the audit sink.
@@ -430,8 +429,12 @@ func TestWithFailedRequestAudit(t *testing.T) {
 					t.Fatalf("expected audit sink to have 1 event, but got: %d", len(fakeSink.events))
 				}
 				auditEventFromSink := fakeSink.events[0]
-				if !reflect.DeepEqual(auditEventGot, auditEventFromSink) {
-					t.Errorf("expected the audit event from the request context to be written to the audit sink, but got diffs: %s", cmp.Diff(auditEventGot, auditEventFromSink))
+				eventFromAuditContext := getAuditContextEvent(auditContext)
+
+				if diff := cmp.Diff(eventFromAuditContext, auditEventFromSink, cmp.FilterPath(func(p cmp.Path) bool {
+					return p.String() == "StageTimestamp"
+				}, cmp.Ignore())); diff != "" {
+					t.Errorf("expected the audit event from the request context to be written to the audit sink, but got diffs: %s", diff)
 				}
 			}
 		})

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/delete_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/delete_test.go
@@ -74,7 +74,7 @@ func TestDeleteResourceAuditLogRequestObject(t *testing.T) {
 
 	ctx := audit.WithAuditContext(context.TODO())
 	ac := audit.AuditContextFrom(ctx)
-	ac.Event.Level = auditapis.LevelRequestResponse
+	ac.SetEventLevel(auditapis.LevelRequestResponse)
 
 	policy := metav1.DeletePropagationBackground
 	deleteOption := &metav1.DeleteOptions{

--- a/staging/src/k8s.io/apiserver/pkg/util/x509metrics/server_cert_deprecations_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/x509metrics/server_cert_deprecations_test.go
@@ -247,15 +247,15 @@ func TestCheckForHostnameError(t *testing.T) {
 			}
 			req = req.WithContext(audit.WithAuditContext(req.Context()))
 			auditCtx := audit.AuditContextFrom(req.Context())
-			auditCtx.Event.Level = auditapi.LevelMetadata
+			auditCtx.SetEventLevel(auditapi.LevelMetadata)
 
 			_, err = client.Transport.RoundTrip(req)
 
 			if sanChecker.CheckRoundTripError(err) {
 				sanChecker.IncreaseMetricsCounter(req)
-
-				if len(auditCtx.Event.Annotations["missing-san.invalid-cert.kubernetes.io/"+req.URL.Hostname()]) == 0 {
-					t.Errorf("expected audit annotations, got %#v", auditCtx.Event.Annotations)
+				annotations := auditCtx.GetEventAnnotations()
+				if len(annotations["missing-san.invalid-cert.kubernetes.io/"+req.URL.Hostname()]) == 0 {
+					t.Errorf("expected audit annotations, got %#v", annotations)
 				}
 			}
 
@@ -390,7 +390,7 @@ func TestCheckForInsecureAlgorithmError(t *testing.T) {
 			}
 			req = req.WithContext(audit.WithAuditContext(req.Context()))
 			auditCtx := audit.AuditContextFrom(req.Context())
-			auditCtx.Event.Level = auditapi.LevelMetadata
+			auditCtx.SetEventLevel(auditapi.LevelMetadata)
 
 			// can't use tlsServer.Client() as it contains the server certificate
 			// in tls.Config.Certificates. The signatures are, however, only checked
@@ -414,9 +414,9 @@ func TestCheckForInsecureAlgorithmError(t *testing.T) {
 
 			if sha1checker.CheckRoundTripError(err) {
 				sha1checker.IncreaseMetricsCounter(req)
-
-				if len(auditCtx.Event.Annotations["insecure-sha1.invalid-cert.kubernetes.io/"+req.URL.Hostname()]) == 0 {
-					t.Errorf("expected audit annotations, got %#v", auditCtx.Event.Annotations)
+				annotations := auditCtx.GetEventAnnotations()
+				if len(annotations["insecure-sha1.invalid-cert.kubernetes.io/"+req.URL.Hostname()]) == 0 {
+					t.Errorf("expected audit annotations, got %#v", annotations)
 				}
 			}
 


### PR DESCRIPTION
Improve audit context handling by encapsulating event data and operations behind a structured API. Make the Audit system more robust in concurrent environments by properly isolating mutable state. The cleaner API simplifies interaction with audit events, improving maintainability. Encapsulation reduces bugs by preventing direct manipulation of audit events.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

Newer version of earlier PR with the resurrected test case for race condition `TestAuditBackendRaceCondition`:
- https://github.com/kubernetes/kubernetes/pull/120692 

Related to issue: 
- https://github.com/kubernetes/kubernetes/issues/120507

Essentially does what was outlined in the checklist:
- https://github.com/kubernetes/kubernetes/pull/120692#discussion_r1331092403
- https://github.com/kubernetes/kubernetes/pull/120692#discussion_r1368618943

/kind bug

NOTE though, there is a minimal fix enumerated in the issue that may be enough as well:
- https://github.com/kubernetes/kubernetes/issues/120507#issuecomment-2568601851
- https://github.com/kubernetes/kubernetes/pull/130255

For the longer term that minimal fix may not be enough...

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
