### PR TITLE
[FG:InPlacePodVerticalScaling] Improve allocated resources checkpointing

### DIFF
--- a/pkg/kubelet/status/state/state.go
+++ b/pkg/kubelet/status/state/state.go
@@ -47,6 +47,7 @@ type Reader interface {
 
 type writer interface {
 	SetContainerResourceAllocation(podUID string, containerName string, alloc v1.ResourceRequirements) error
+	SetPodResourceAllocation(podUID string, alloc map[string]v1.ResourceRequirements) error
 	SetPodResizeStatus(podUID string, resizeStatus v1.PodResizeStatus)
 	Delete(podUID string, containerName string) error
 }

--- a/pkg/kubelet/status/state/state_checkpoint.go
+++ b/pkg/kubelet/status/state/state_checkpoint.go
@@ -127,6 +127,17 @@ func (sc *stateCheckpoint) SetContainerResourceAllocation(podUID string, contain
 	return sc.storeState()
 }
 
+// SetPodResourceAllocation sets pod resource allocation
+func (sc *stateCheckpoint) SetPodResourceAllocation(podUID string, alloc map[string]v1.ResourceRequirements) error {
+	sc.mux.Lock()
+	defer sc.mux.Unlock()
+	err := sc.cache.SetPodResourceAllocation(podUID, alloc)
+	if err != nil {
+		return err
+	}
+	return sc.storeState()
+}
+
 // SetPodResizeStatus sets the last resize decision for a pod
 func (sc *stateCheckpoint) SetPodResizeStatus(podUID string, resizeStatus v1.PodResizeStatus) {
 	sc.mux.Lock()
@@ -162,6 +173,10 @@ func (sc *noopStateCheckpoint) GetPodResizeStatus(_ string) v1.PodResizeStatus {
 }
 
 func (sc *noopStateCheckpoint) SetContainerResourceAllocation(_ string, _ string, _ v1.ResourceRequirements) error {
+	return nil
+}
+
+func (sc *noopStateCheckpoint) SetPodResourceAllocation(_ string, _ map[string]v1.ResourceRequirements) error {
 	return nil
 }
 

--- a/pkg/kubelet/status/state/state_checkpoint_test.go
+++ b/pkg/kubelet/status/state/state_checkpoint_test.go
@@ -110,11 +110,9 @@ func Test_stateCheckpoint_storeState(t *testing.T) {
 			originalSC, err := NewStateCheckpoint(testDir, testCheckpoint)
 			require.NoError(t, err)
 
-			for podUID, containerAlloc := range tt.args.podResourceAllocation {
-				for containerName, alloc := range containerAlloc {
-					err = originalSC.SetContainerResourceAllocation(podUID, containerName, alloc)
-					require.NoError(t, err)
-				}
+			for podUID, alloc := range tt.args.podResourceAllocation {
+				err = originalSC.SetPodResourceAllocation(podUID, alloc)
+				require.NoError(t, err)
 			}
 
 			actual := originalSC.GetPodResourceAllocation()

--- a/pkg/kubelet/status/state/state_mem.go
+++ b/pkg/kubelet/status/state/state_mem.go
@@ -77,6 +77,15 @@ func (s *stateMemory) SetContainerResourceAllocation(podUID string, containerNam
 	return nil
 }
 
+func (s *stateMemory) SetPodResourceAllocation(podUID string, alloc map[string]v1.ResourceRequirements) error {
+	s.Lock()
+	defer s.Unlock()
+
+	s.podAllocation[podUID] = alloc
+	klog.V(3).InfoS("Updated pod resource allocation", "podUID", podUID, "allocation", alloc)
+	return nil
+}
+
 func (s *stateMemory) SetPodResizeStatus(podUID string, resizeStatus v1.PodResizeStatus) {
 	s.Lock()
 	defer s.Unlock()


### PR DESCRIPTION
When the pod allocation is updated, the Kubelet always calls set allocation at the pod level, but the status manager sets it for _each container,_ calling through to the checkpoint state. This causes the checkpoint file to be written in quick succession for each container in the pod. It would be better to just update the checkpoint once per-pod.

Changed calls to set allocation from container level to _pod level_ on status manager.

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Fixes #128188

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/1287-in-place-update-pod-resources
```
