### PR TITLE
kubeadm: should not warn on non-detect sandbox image

### DIFF
--- a/cmd/kubeadm/app/util/runtime/runtime.go
+++ b/cmd/kubeadm/app/util/runtime/runtime.go
@@ -293,5 +293,9 @@ func (runtime *CRIRuntime) SandboxImage() (string, error) {
 		return "", errors.Wrap(err, "failed to unmarshal CRI info config")
 	}
 
+	if c.SandboxImage == "" {
+		return "", errors.New("no 'sandboxImage' field in CRI info config")
+	}
+
 	return c.SandboxImage, nil
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

xref kubernetes/kubeadm#3146

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```