### PR TITLE
test(network): replace jig.CreateRC with jig.CreateDeployment

### DIFF
--- a/test/e2e/apps/deployment.go
+++ b/test/e2e/apps/deployment.go
@@ -737,9 +737,10 @@ func testRollingUpdateDeployment(ctx context.Context, f *framework.Framework) {
 	ns := f.Namespace.Name
 	c := f.ClientSet
 	// Create webserver pods.
-	deploymentPodLabels := map[string]string{"name": "sample-pod"}
+	podName := "sample-pod"
+	deploymentPodLabels := map[string]string{"name": podName}
 	rsPodLabels := map[string]string{
-		"name": "sample-pod",
+		"name": podName,
 		"pod":  WebserverImageName,
 	}
 
@@ -754,7 +755,13 @@ func testRollingUpdateDeployment(ctx context.Context, f *framework.Framework) {
 	_, err := c.AppsV1().ReplicaSets(ns).Create(ctx, rs, metav1.CreateOptions{})
 	framework.ExpectNoError(err)
 	// Verify that the required pods have come up.
-	err = e2epod.VerifyPodsRunning(ctx, c, ns, "sample-pod", false, replicas)
+	err = e2epod.VerifyPodsRunning(ctx,
+		c,
+		ns,
+		podName,
+		labels.SelectorFromSet(map[string]string{"name": podName}),
+		false,
+		replicas)
 	framework.ExpectNoError(err, "error in waiting for pods to come up: %s", err)
 
 	// Create a deployment to delete webserver pods and instead bring up agnhost pods.
@@ -820,9 +827,10 @@ func testDeploymentCleanUpPolicy(ctx context.Context, f *framework.Framework) {
 	ns := f.Namespace.Name
 	c := f.ClientSet
 	// Create webserver pods.
-	deploymentPodLabels := map[string]string{"name": "cleanup-pod"}
+	podName := "cleanup-pod"
+	deploymentPodLabels := map[string]string{"name": podName}
 	rsPodLabels := map[string]string{
-		"name": "cleanup-pod",
+		"name": podName,
 		"pod":  WebserverImageName,
 	}
 	rsName := "test-cleanup-controller"
@@ -832,7 +840,13 @@ func testDeploymentCleanUpPolicy(ctx context.Context, f *framework.Framework) {
 	framework.ExpectNoError(err)
 
 	// Verify that the required pods have come up.
-	err = e2epod.VerifyPodsRunning(ctx, c, ns, "cleanup-pod", false, replicas)
+	err = e2epod.VerifyPodsRunning(ctx,
+		c,
+		ns,
+		podName,
+		labels.SelectorFromSet(map[string]string{"name": podName}),
+		false,
+		replicas)
 	framework.ExpectNoError(err, "error in waiting for pods to come up: %v", err)
 
 	// Create a deployment to delete webserver pods and instead bring up agnhost pods.
@@ -903,7 +917,13 @@ func testRolloverDeployment(ctx context.Context, f *framework.Framework) {
 	_, err := c.AppsV1().ReplicaSets(ns).Create(ctx, newRS(rsName, rsReplicas, rsPodLabels, WebserverImageName, WebserverImage, nil), metav1.CreateOptions{})
 	framework.ExpectNoError(err)
 	// Verify that the required pods have come up.
-	err = e2epod.VerifyPodsRunning(ctx, c, ns, podName, false, rsReplicas)
+	err = e2epod.VerifyPodsRunning(ctx,
+		c,
+		ns,
+		podName,
+		labels.SelectorFromSet(map[string]string{"name": podName}),
+		false,
+		rsReplicas)
 	framework.ExpectNoError(err, "error in waiting for pods to come up: %v", err)
 
 	// Wait for replica set to become ready before adopting it.
@@ -1202,7 +1222,7 @@ func testProportionalScalingDeployment(ctx context.Context, f *framework.Framewo
 
 	// Verify that the required pods have come up.
 	framework.Logf("Waiting for all required pods to come up")
-	err = e2epod.VerifyPodsRunning(ctx, c, ns, WebserverImageName, false, *(deployment.Spec.Replicas))
+	err = e2epod.VerifyPodsRunning(ctx, c, ns, WebserverImageName, labels.SelectorFromSet(podLabels), false, *(deployment.Spec.Replicas))
 	framework.ExpectNoError(err, "error in waiting for pods to come up: %v", err)
 
 	framework.Logf("Waiting for deployment %q to complete", deployment.Name)

--- a/test/e2e/apps/disruption.go
+++ b/test/e2e/apps/disruption.go
@@ -494,7 +494,7 @@ var _ = SIGDescribe("DisruptionController", func() {
 				waitForPdbToObserveHealthyPods(ctx, cs, ns, replicas, replicas-1)
 			} else {
 				ginkgo.By("Wait for pods to be running and not ready")
-				err := e2epod.VerifyPodsRunning(ctx, cs, ns, rsName, false, replicas)
+				err := e2epod.VerifyPodsRunning(ctx, cs, ns, rsName, labels.SelectorFromSet(rs.Labels), false, replicas)
 				framework.ExpectNoError(err)
 				waitForPdbToObserveHealthyPods(ctx, cs, ns, 0, replicas-1)
 			}

--- a/test/e2e/apps/rc.go
+++ b/test/e2e/apps/rc.go
@@ -28,6 +28,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	utilrand "k8s.io/apimachinery/pkg/util/rand"
@@ -485,6 +486,7 @@ func newRC(rsName string, replicas int32, rcPodLabels map[string]string, imageNa
 // The image serves its hostname which is checked for each replica.
 func TestReplicationControllerServeImageOrFail(ctx context.Context, f *framework.Framework, test string, image string) {
 	name := "my-hostname-" + test + "-" + string(uuid.NewUUID())
+	rcLabels := map[string]string{"name": name}
 	replicas := int32(1)
 
 	// Create a replication controller for a service
@@ -492,14 +494,14 @@ func TestReplicationControllerServeImageOrFail(ctx context.Context, f *framework
 	// The source for the Docker container kubernetes/serve_hostname is
 	// in contrib/for-demos/serve_hostname
 	ginkgo.By(fmt.Sprintf("Creating replication controller %s", name))
-	newRC := newRC(name, replicas, map[string]string{"name": name}, name, image, []string{"serve-hostname"})
+	newRC := newRC(name, replicas, rcLabels, name, image, []string{"serve-hostname"})
 	newRC.Spec.Template.Spec.Containers[0].Ports = []v1.ContainerPort{{ContainerPort: 9376}}
 	_, err := f.ClientSet.CoreV1().ReplicationControllers(f.Namespace.Name).Create(ctx, newRC, metav1.CreateOptions{})
 	framework.ExpectNoError(err)
 
 	// Check that pods for the new RC were created.
 	// TODO: Maybe switch PodsCreated to just check owner references.
-	pods, err := e2epod.PodsCreated(ctx, f.ClientSet, f.Namespace.Name, name, replicas)
+	pods, err := e2epod.PodsCreatedByLabel(ctx, f.ClientSet, f.Namespace.Name, name, replicas, labels.SelectorFromSet(rcLabels))
 	framework.ExpectNoError(err)
 
 	// Wait for the pods to enter the running state and are Ready. Waiting loops until the pods
@@ -529,7 +531,7 @@ func TestReplicationControllerServeImageOrFail(ctx context.Context, f *framework
 
 	// Verify that something is listening.
 	framework.Logf("Trying to dial the pod")
-	framework.ExpectNoError(e2epod.WaitForPodsResponding(ctx, f.ClientSet, f.Namespace.Name, name, true, 2*time.Minute, pods))
+	framework.ExpectNoError(e2epod.WaitForPodsResponding(ctx, f.ClientSet, f.Namespace.Name, name, labels.SelectorFromSet(rcLabels), true, 2*time.Minute, pods))
 }
 
 // 1. Create a quota restricting pods in the current namespace to 2.
@@ -666,15 +668,16 @@ func testRCAdoptMatchingOrphans(ctx context.Context, f *framework.Framework) {
 
 func testRCReleaseControlledNotMatching(ctx context.Context, f *framework.Framework) {
 	name := "pod-release"
+	rcLabels := map[string]string{"name": name}
 	ginkgo.By("Given a ReplicationController is created")
 	replicas := int32(1)
-	rcSt := newRC(name, replicas, map[string]string{"name": name}, name, WebserverImage, nil)
-	rcSt.Spec.Selector = map[string]string{"name": name}
+	rcSt := newRC(name, replicas, rcLabels, name, WebserverImage, nil)
+	rcSt.Spec.Selector = rcLabels
 	rc, err := f.ClientSet.CoreV1().ReplicationControllers(f.Namespace.Name).Create(ctx, rcSt, metav1.CreateOptions{})
 	framework.ExpectNoError(err)
 
 	ginkgo.By("When the matched label of one of its pods change")
-	pods, err := e2epod.PodsCreated(ctx, f.ClientSet, f.Namespace.Name, rc.Name, replicas)
+	pods, err := e2epod.PodsCreatedByLabel(ctx, f.ClientSet, f.Namespace.Name, rc.Name, replicas, labels.SelectorFromSet(rcLabels))
 	framework.ExpectNoError(err)
 
 	p := pods.Items[0]

--- a/test/e2e/cloud/gcp/resize_nodes.go
+++ b/test/e2e/cloud/gcp/resize_nodes.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/common"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -97,11 +98,14 @@ var _ = SIGDescribe("Nodes", framework.WithDisruptive(), func() {
 			// Create a replication controller for a service that serves its hostname.
 			// The source for the Docker container kubernetes/serve_hostname is in contrib/for-demos/serve_hostname
 			name := "my-hostname-delete-node"
+			rcLabels := map[string]string{"name": name}
 			numNodes, err := e2enode.TotalRegistered(ctx, c)
 			framework.ExpectNoError(err)
 			originalNodeCount = int32(numNodes)
-			common.NewRCByName(c, ns, name, originalNodeCount, nil, nil)
-			err = e2epod.VerifyPods(ctx, c, ns, name, true, originalNodeCount)
+			_, err = common.NewRCByName(c, ns, name, originalNodeCount, nil, nil, rcLabels)
+			framework.ExpectNoError(err)
+
+			err = e2epod.VerifyPods(ctx, c, ns, name, labels.SelectorFromSet(rcLabels), true, originalNodeCount)
 			framework.ExpectNoError(err)
 
 			targetNumNodes := int32(framework.TestContext.CloudConfig.NumNodes - 1)
@@ -118,7 +122,7 @@ var _ = SIGDescribe("Nodes", framework.WithDisruptive(), func() {
 			time.Sleep(f.Timeouts.PodStartShort)
 
 			ginkgo.By("verifying whether the pods from the removed node are recreated")
-			err = e2epod.VerifyPods(ctx, c, ns, name, true, originalNodeCount)
+			err = e2epod.VerifyPods(ctx, c, ns, name, labels.SelectorFromSet(rcLabels), true, originalNodeCount)
 			framework.ExpectNoError(err)
 		})
 
@@ -127,12 +131,17 @@ var _ = SIGDescribe("Nodes", framework.WithDisruptive(), func() {
 			// Create a replication controller for a service that serves its hostname.
 			// The source for the Docker container kubernetes/serve_hostname is in contrib/for-demos/serve_hostname
 			name := "my-hostname-add-node"
-			common.NewSVCByName(c, ns, name)
+			rcLabels := map[string]string{"name": name}
+			err := common.NewSVCByName(c, ns, name, rcLabels)
+			framework.ExpectNoError(err)
+
 			numNodes, err := e2enode.TotalRegistered(ctx, c)
 			framework.ExpectNoError(err)
 			originalNodeCount = int32(numNodes)
-			common.NewRCByName(c, ns, name, originalNodeCount, nil, nil)
-			err = e2epod.VerifyPods(ctx, c, ns, name, true, originalNodeCount)
+			_, err = common.NewRCByName(c, ns, name, originalNodeCount, nil, nil, rcLabels)
+			framework.ExpectNoError(err)
+
+			err = e2epod.VerifyPods(ctx, c, ns, name, labels.SelectorFromSet(rcLabels), true, originalNodeCount)
 			framework.ExpectNoError(err)
 
 			targetNumNodes := int32(framework.TestContext.CloudConfig.NumNodes + 1)
@@ -147,7 +156,7 @@ var _ = SIGDescribe("Nodes", framework.WithDisruptive(), func() {
 			ginkgo.By(fmt.Sprintf("increasing size of the replication controller to %d and verifying all pods are running", originalNodeCount+1))
 			err = resizeRC(ctx, c, ns, name, originalNodeCount+1)
 			framework.ExpectNoError(err)
-			err = e2epod.VerifyPods(ctx, c, ns, name, true, originalNodeCount+1)
+			err = e2epod.VerifyPods(ctx, c, ns, name, labels.SelectorFromSet(rcLabels), true, originalNodeCount+1)
 			framework.ExpectNoError(err)
 		})
 	})

--- a/test/e2e/framework/pod/resource.go
+++ b/test/e2e/framework/pod/resource.go
@@ -59,12 +59,6 @@ func expectNoErrorWithOffset(offset int, err error, explain ...interface{}) {
 	gomega.ExpectWithOffset(1+offset, err).NotTo(gomega.HaveOccurred(), explain...)
 }
 
-// PodsCreated returns a pod list matched by the given name.
-func PodsCreated(ctx context.Context, c clientset.Interface, ns, name string, replicas int32) (*v1.PodList, error) {
-	label := labels.SelectorFromSet(labels.Set(map[string]string{"name": name}))
-	return PodsCreatedByLabel(ctx, c, ns, name, replicas, label)
-}
-
 // PodsCreatedByLabel returns a created pod list matched by the given label.
 func PodsCreatedByLabel(ctx context.Context, c clientset.Interface, ns, name string, replicas int32, label labels.Selector) (*v1.PodList, error) {
 	timeout := 2 * time.Minute
@@ -95,26 +89,32 @@ func PodsCreatedByLabel(ctx context.Context, c clientset.Interface, ns, name str
 }
 
 // VerifyPods checks if the specified pod is responding.
-func VerifyPods(ctx context.Context, c clientset.Interface, ns, name string, wantName bool, replicas int32) error {
-	return podRunningMaybeResponding(ctx, c, ns, name, wantName, replicas, true)
-}
-
-// VerifyPodsRunning checks if the specified pod is running.
-func VerifyPodsRunning(ctx context.Context, c clientset.Interface, ns, name string, wantName bool, replicas int32) error {
-	return podRunningMaybeResponding(ctx, c, ns, name, wantName, replicas, false)
-}
-
-func podRunningMaybeResponding(ctx context.Context, c clientset.Interface, ns, name string, wantName bool, replicas int32, checkResponding bool) error {
-	pods, err := PodsCreated(ctx, c, ns, name, replicas)
+func VerifyPods(ctx context.Context, c clientset.Interface, ns, name string, selector labels.Selector, wantName bool, replicas int32) error {
+	pods, err := PodsCreatedByLabel(ctx, c, ns, name, replicas, selector)
 	if err != nil {
 		return err
 	}
+
+	return podsRunningMaybeResponding(ctx, c, ns, name, selector, pods, wantName, true)
+}
+
+// VerifyPodsRunning checks if the specified pod is running.
+func VerifyPodsRunning(ctx context.Context, c clientset.Interface, ns, name string, selector labels.Selector, wantName bool, replicas int32) error {
+	pods, err := PodsCreatedByLabel(ctx, c, ns, name, replicas, selector)
+	if err != nil {
+		return err
+	}
+
+	return podsRunningMaybeResponding(ctx, c, ns, name, selector, pods, wantName, false)
+}
+
+func podsRunningMaybeResponding(ctx context.Context, c clientset.Interface, ns string, name string, selector labels.Selector, pods *v1.PodList, wantName bool, checkResponding bool) error {
 	e := podsRunning(ctx, c, pods)
 	if len(e) > 0 {
 		return fmt.Errorf("failed to wait for pods running: %v", e)
 	}
 	if checkResponding {
-		return WaitForPodsResponding(ctx, c, ns, name, wantName, podRespondingTimeout, pods)
+		return WaitForPodsResponding(ctx, c, ns, name, selector, wantName, podRespondingTimeout, pods)
 	}
 	return nil
 }

--- a/test/e2e/framework/pod/wait.go
+++ b/test/e2e/framework/pod/wait.go
@@ -604,13 +604,12 @@ func WaitForPodNotFoundInNamespace(ctx context.Context, c clientset.Interface, p
 }
 
 // WaitForPodsResponding waits for the pods to response.
-func WaitForPodsResponding(ctx context.Context, c clientset.Interface, ns string, controllerName string, wantName bool, timeout time.Duration, pods *v1.PodList) error {
+func WaitForPodsResponding(ctx context.Context, c clientset.Interface, ns string, controllerName string, selector labels.Selector, wantName bool, timeout time.Duration, pods *v1.PodList) error {
 	if timeout == 0 {
 		timeout = podRespondingTimeout
 	}
 	ginkgo.By("trying to dial each unique pod")
-	label := labels.SelectorFromSet(labels.Set(map[string]string{"name": controllerName}))
-	options := metav1.ListOptions{LabelSelector: label.String()}
+	options := metav1.ListOptions{LabelSelector: selector.String()}
 
 	type response struct {
 		podName  string

--- a/test/e2e/framework/rc/rc_utils.go
+++ b/test/e2e/framework/rc/rc_utils.go
@@ -40,8 +40,6 @@ func ByNameContainer(name string, replicas int32, labels map[string]string, c v1
 
 	zeroGracePeriod := int64(0)
 
-	// Add "name": name to the labels, overwriting if it exists.
-	labels["name"] = name
 	if gracePeriod == nil {
 		gracePeriod = &zeroGracePeriod
 	}
@@ -55,9 +53,7 @@ func ByNameContainer(name string, replicas int32, labels map[string]string, c v1
 		},
 		Spec: v1.ReplicationControllerSpec{
 			Replicas: pointer.Int32(replicas),
-			Selector: map[string]string{
-				"name": name,
-			},
+			Selector: labels,
 			Template: &v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: labels,

--- a/test/e2e/network/fixture.go
+++ b/test/e2e/network/fixture.go
@@ -18,8 +18,8 @@ package network
 
 import (
 	"context"
-	appsv1 "k8s.io/api/apps/v1"
 
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/test/e2e/network/fixture.go
+++ b/test/e2e/network/fixture.go
@@ -18,6 +18,7 @@ package network
 
 import (
 	"context"
+	appsv1 "k8s.io/api/apps/v1"
 
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -25,7 +26,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	clientset "k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/util/retry"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 
 	"github.com/onsi/ginkgo/v2"
@@ -40,10 +40,10 @@ type TestFixture struct {
 	TestID string
 	Labels map[string]string
 
-	rcs      map[string]bool
-	services map[string]bool
-	Name     string
-	Image    string
+	deployments map[string]bool
+	services    map[string]bool
+	Name        string
+	Image       string
 }
 
 // NewServerTest creates a new TestFixture for the tests.
@@ -57,7 +57,7 @@ func NewServerTest(client clientset.Interface, namespace string, serviceName str
 		"testid": t.TestID,
 	}
 
-	t.rcs = make(map[string]bool)
+	t.deployments = make(map[string]bool)
 	t.services = make(map[string]bool)
 
 	t.Name = "webserver"
@@ -84,13 +84,12 @@ func (t *TestFixture) BuildServiceSpec() *v1.Service {
 	return service
 }
 
-// CreateRC creates a replication controller and records it for cleanup.
-func (t *TestFixture) CreateRC(rc *v1.ReplicationController) (*v1.ReplicationController, error) {
-	rc, err := t.Client.CoreV1().ReplicationControllers(t.Namespace).Create(context.TODO(), rc, metav1.CreateOptions{})
+func (t *TestFixture) CreateDeployment(deployment *appsv1.Deployment) (*appsv1.Deployment, error) {
+	deployment, err := t.Client.AppsV1().Deployments(t.Namespace).Create(context.TODO(), deployment, metav1.CreateOptions{})
 	if err == nil {
-		t.rcs[rc.Name] = true
+		t.deployments[deployment.Name] = true
 	}
-	return rc, err
+	return deployment, err
 }
 
 // CreateService creates a service, and record it for cleanup
@@ -114,33 +113,10 @@ func (t *TestFixture) DeleteService(serviceName string) error {
 // Cleanup cleans all ReplicationControllers and Services which this object holds.
 func (t *TestFixture) Cleanup() []error {
 	var errs []error
-	for rcName := range t.rcs {
-		ginkgo.By("stopping RC " + rcName + " in namespace " + t.Namespace)
-		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-			// First, resize the RC to 0.
-			old, err := t.Client.CoreV1().ReplicationControllers(t.Namespace).Get(context.TODO(), rcName, metav1.GetOptions{})
-			if err != nil {
-				if apierrors.IsNotFound(err) {
-					return nil
-				}
-				return err
-			}
-			x := int32(0)
-			old.Spec.Replicas = &x
-			if _, err := t.Client.CoreV1().ReplicationControllers(t.Namespace).Update(context.TODO(), old, metav1.UpdateOptions{}); err != nil {
-				if apierrors.IsNotFound(err) {
-					return nil
-				}
-				return err
-			}
-			return nil
-		})
+	for deploymentName := range t.deployments {
+		ginkgo.By("deleting deployment " + deploymentName + " in namespace " + t.Namespace)
+		err := t.Client.AppsV1().Deployments(t.Namespace).Delete(context.TODO(), deploymentName, metav1.DeleteOptions{})
 		if err != nil {
-			errs = append(errs, err)
-		}
-		// TODO(mikedanese): Wait.
-		// Then, delete the RC altogether.
-		if err := t.Client.CoreV1().ReplicationControllers(t.Namespace).Delete(context.TODO(), rcName, metav1.DeleteOptions{}); err != nil {
 			if !apierrors.IsNotFound(err) {
 				errs = append(errs, err)
 			}

--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -1823,7 +1823,7 @@ var _ = common.SIGDescribe("Services", func() {
 		framework.ExpectNoError(err)
 
 		ginkgo.By("Verifying pods for Deployment " + t.Name)
-		framework.ExpectNoError(e2epod.VerifyPods(ctx, t.Client, t.Namespace, t.Name, false, 1))
+		framework.ExpectNoError(e2epod.VerifyPods(ctx, t.Client, t.Namespace, t.Name, labels.SelectorFromSet(t.Labels), false, 1))
 
 		svcName := fmt.Sprintf("%v.%v.svc.%v", serviceName, f.Namespace.Name, framework.TestContext.ClusterDNSDomain)
 		ginkgo.By("Waiting for endpoints of Service with DNS name " + svcName)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup
/sig network

#### What this PR does / why we need it:
This change rewrites some of the network-related e2e tests to use Deployments instead of ReplicationControllers when setting up the test environment. The test code has been made more clear using direct API calls where possible, and the advantages Deployments offer over RCs will make live debugging of e2e tests easier.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Partially fixes #119021

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
