### PR TITLE
[go1.24][1.31] webhook: alter regex to account for x509sha1 GODEBUG removal

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/webhook/webhook_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/webhook/webhook_test.go
@@ -406,14 +406,14 @@ func TestTLSConfig(t *testing.T) {
 			test:       "server cert with SHA1 signature",
 			clientCA:   caCert,
 			serverCert: append(append(sha1ServerCertInter, byte('\n')), caCertInter...), serverKey: serverKey,
-			errRegex:                         "x509: cannot verify signature: insecure algorithm SHA1-RSA \\(temporarily override with GODEBUG=x509sha1=1\\)",
+			errRegex:                         "x509: cannot verify signature: insecure algorithm SHA1-RSA",
 			increaseSHA1SignatureWarnCounter: true,
 		},
 		{
 			test:       "server cert signed by an intermediate CA with SHA1 signature",
 			clientCA:   caCert,
 			serverCert: append(append(serverCertInterSHA1, byte('\n')), caCertInterSHA1...), serverKey: serverKey,
-			errRegex:                         "x509: cannot verify signature: insecure algorithm SHA1-RSA \\(temporarily override with GODEBUG=x509sha1=1\\)",
+			errRegex:                         "x509: cannot verify signature: insecure algorithm SHA1-RSA",
 			increaseSHA1SignatureWarnCounter: true,
 		},
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Cherry-pick of https://github.com/kubernetes/kubernetes/pull/129430 

go1.24 removes the x509sha1 GODEBUG variable, and with it the support for SHA-1 signed certs. This commit alters the regex in unit tests to account for that and prep for go1.24.

See https://github.com/kubernetes/kubernetes/pull/129224 and https://github.com/kubernetes/kubernetes/issues/125689

#### Which issue(s) this PR fixes:

NA

#### Special notes for your reviewer:

NA

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/assign @dims @liggitt 