### PR TITLE
Fix service's nodePort already allocated

### DIFF
--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -1703,7 +1703,7 @@ var _ = common.SIGDescribe("Services", func() {
 				}
 				break
 			}
-			if apierrors.IsConflict(err) {
+			if apierrors.IsInvalid(err) {
 				framework.Logf("node port %d is already allocated to other service, retrying ... : %v", port, err)
 				continue
 			}
@@ -3979,7 +3979,7 @@ var _ = common.SIGDescribe("Services", func() {
 				}
 				break
 			}
-			if apierrors.IsConflict(err) {
+			if apierrors.IsInvalid(err) {
 				framework.Logf("node port %d is already allocated to other service, retrying ... : %v", port, err)
 				continue
 			}
@@ -3987,7 +3987,12 @@ var _ = common.SIGDescribe("Services", func() {
 
 		}
 
-		defer e2eservice.ReleaseStaticNodePort(svc.Spec.HealthCheckNodePort)
+		ginkgo.DeferCleanup(func(ctx context.Context) {
+			err := cs.CoreV1().Services(namespace).Delete(ctx, serviceName, metav1.DeleteOptions{})
+			framework.ExpectNoError(err, "failed to delete service: %s in namespace: %s", serviceName, namespace)
+			e2eservice.ReleaseStaticNodePort(svc.Spec.HealthCheckNodePort)
+		})
+
 		nodePortStr := fmt.Sprintf("%d", svc.Spec.Ports[0].NodePort)
 		hcNodePortStr := fmt.Sprintf("%d", svc.Spec.HealthCheckNodePort)
 		framework.Logf("NodePort is %s, HealthCheckNodePort is %s", nodePortStr, hcNodePortStr)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

Timeline:

```
{"kind":"Event","apiVersion":"audit.k8s.io/v1","level":"RequestResponse","auditID":"2e905ebc-fb24-4156-81b6-e07b03ff57ee","stage":"ResponseComplete","requestURI":"/api/v1/namespaces/services-2476/services","verb":"create","user":{"username":"kubecfg","groups":["system:masters","system:authenticated"],"extra":{"authentication.kubernetes.io/credential-id":["X509SHA256=2351e8a8273095e751c0d1824e7ce7fb937590191a06e73b92246edbaa1830b7"]}},"sourceIPs":["34.71.99.93"],"userAgent":"e2e.test/v1.33.0 (linux/amd64) kubernetes/c3f3fdc -- [sig-network] Services should implement NodePort and HealthCheckNodePort correctly when ExternalTrafficPolicy changes","objectRef":{"resource":"services","namespace":"services-2476","name":"external-local-update","apiVersion":"v1"},"responseStatus":{"metadata":{},"code":201},"requestObject":{"kind":"Service","apiVersion":"v1","metadata":{"name":"external-local-update","namespace":"services-2476","creationTimestamp":null,"labels":{"testid":"external-local-update-c8f7af80-cc9c-43bb-ac7a-bcbcb47d178e"}},"spec":{"ports":[{"protocol":"TCP","port":80,"targetPort":80}],"selector":{"testid":"external-local-update-c8f7af80-cc9c-43bb-ac7a-bcbcb47d178e"},"type":"LoadBalancer","sessionAffinity":"None","externalTrafficPolicy":"Local","healthCheckNodePort":30018,"allocateLoadBalancerNodePorts":true,"internalTrafficPolicy":"Cluster"},"status":{"loadBalancer":{}}},"responseObject":{"kind":"Service","apiVersion":"v1","metadata":{"name":"external-local-update","namespace":"services-2476","uid":"89d2ab63-2f9d-4d9b-9594-04831177ac13","resourceVersion":"14522","creationTimestamp":"2025-01-07T00:26:51Z","labels":{"testid":"external-local-update-c8f7af80-cc9c-43bb-ac7a-bcbcb47d178e"},"managedFields":[{"manager":"e2e.test","operation":"Update","apiVersion":"v1","time":"2025-01-07T00:26:51Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:labels":{".":{},"f:testid":{}}},"f:spec":{"f:allocateLoadBalancerNodePorts":{},"f:externalTrafficPolicy":{},"f:healthCheckNodePort":{},"f:internalTrafficPolicy":{},"f:ports":{".":{},"k:{\"port\":80,\"protocol\":\"TCP\"}":{".":{},"f:port":{},"f:protocol":{},"f:targetPort":{}}},"f:selector":{},"f:sessionAffinity":{},"f:type":{}}}}]},"spec":{"ports":[{"protocol":"TCP","port":80,"targetPort":80,"nodePort":32742}],"selector":{"testid":"external-local-update-c8f7af80-cc9c-43bb-ac7a-bcbcb47d178e"},"clusterIP":"10.0.137.164","clusterIPs":["10.0.137.164"],"type":"LoadBalancer","sessionAffinity":"None","externalTrafficPolicy":"Local","healthCheckNodePort":30018,"ipFamilies":["IPv4"],"ipFamilyPolicy":"SingleStack","allocateLoadBalancerNodePorts":true,"internalTrafficPolicy":"Cluster"},"status":{"loadBalancer":{}}},"requestReceivedTimestamp":"2025-01-07T00:26:51.220816Z","stageTimestamp":"2025-01-07T00:26:51.242530Z","annotations":{"authorization.k8s.io/decision":"allow","authorization.k8s.io/reason":""}}
{"kind":"Event","apiVersion":"audit.k8s.io/v1","level":"RequestResponse","auditID":"d084d52c-3acb-4e32-919c-6ed733eba2ad","stage":"ResponseComplete","requestURI":"/api/v1/namespaces/services-604/services","verb":"create","user":{"username":"kubecfg","groups":["system:masters","system:authenticated"],"extra":{"authentication.kubernetes.io/credential-id":["X509SHA256=2351e8a8273095e751c0d1824e7ce7fb937590191a06e73b92246edbaa1830b7"]}},"sourceIPs":["34.71.99.93"],"userAgent":"e2e.test/v1.33.0 (linux/amd64) kubernetes/c3f3fdc -- [sig-network] Services should release NodePorts on delete","objectRef":{"resource":"services","namespace":"services-604","name":"nodeport-reuse","apiVersion":"v1"},"responseStatus":{"metadata":{},"status":"Failure","message":"Service \"nodeport-reuse\" is invalid: spec.ports[0].nodePort: Invalid value: 30018: provided port is already allocated","reason":"Invalid","details":{"name":"nodeport-reuse","kind":"Service","causes":[{"reason":"FieldValueInvalid","message":"Invalid value: 30018: provided port is already allocated","field":"spec.ports[0].nodePort"}]},"code":422},"requestObject":{"kind":"Service","apiVersion":"v1","metadata":{"name":"nodeport-reuse","namespace":"services-604","creationTimestamp":null},"spec":{"ports":[{"protocol":"TCP","port":80,"targetPort":80,"nodePort":30018}],"selector":{"testid":"nodeport-reuse-b0587e61-835c-47b8-93b0-4d1ea3070aed"},"type":"NodePort","sessionAffinity":"None","externalTrafficPolicy":"Cluster","internalTrafficPolicy":"Cluster"},"status":{"loadBalancer":{}}},"responseObject":{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"Service \"nodeport-reuse\" is invalid: spec.ports[0].nodePort: Invalid value: 30018: provided port is already allocated","reason":"Invalid","details":{"name":"nodeport-reuse","kind":"Service","causes":[{"reason":"FieldValueInvalid","message":"Invalid value: 30018: provided port is already allocated","field":"spec.ports[0].nodePort"}]},"code":422},"requestReceivedTimestamp":"2025-01-07T00:27:30.326919Z","stageTimestamp":"2025-01-07T00:27:30.470664Z","annotations":{"authorization.k8s.io/decision":"allow","authorization.k8s.io/reason":""}}
```

Test Services `should implement NodePort and HealthCheckNodePort correctly when ExternalTrafficPolicy changes ` runs and allocates NodePorts 30018 and 32742 for "resource":"services","namespace":"services-2476","name":"external-local-update","apiVersion":"v1"},

Test `[sig-network] Services should release NodePorts on delete"`, runs in parallel and tries to allocate a NodePort already allocated

`{"resource":"services","namespace":"services-604","name":"nodeport-reuse","apiVersion":"v1"},"responseStatus":{"metadata":{},"status":"Failure","message":"Service \"nodeport-reuse\" is invalid: spec.ports[0].nodePort: Invalid value: 30018: provided port is already` 
the test fails, since we can not control the e2e test order to avoid two test asking for the same nodeport, a static nodeport allocator was added in https://github.com/kubernetes/kubernetes/pull/127153

The release of the nodeport on the e2e allocator should be done only after the Service has been deleted to avoid the chance of a new Service using it and failing like in this case

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #129520

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
