### PR TITLE
update publishing rules to use go1.22.10 for some active release branches

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -7,25 +7,25 @@ rules:
       dirs:
       - staging/src/k8s.io/apimachinery
   - name: release-1.28
-    go: 1.22.9
+    go: 1.22.10
     source:
       branch: release-1.28
       dirs:
       - staging/src/k8s.io/apimachinery
   - name: release-1.29
-    go: 1.22.9
+    go: 1.22.10
     source:
       branch: release-1.29
       dirs:
       - staging/src/k8s.io/apimachinery
   - name: release-1.30
-    go: 1.22.9
+    go: 1.22.10
     source:
       branch: release-1.30
       dirs:
       - staging/src/k8s.io/apimachinery
   - name: release-1.31
-    go: 1.22.9
+    go: 1.22.10
     source:
       branch: release-1.31
       dirs:
@@ -47,7 +47,7 @@ rules:
       dirs:
       - staging/src/k8s.io/api
   - name: release-1.28
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -56,7 +56,7 @@ rules:
       dirs:
       - staging/src/k8s.io/api
   - name: release-1.29
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -65,7 +65,7 @@ rules:
       dirs:
       - staging/src/k8s.io/api
   - name: release-1.30
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -74,7 +74,7 @@ rules:
       dirs:
       - staging/src/k8s.io/api
   - name: release-1.31
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -108,7 +108,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.28
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -123,7 +123,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.29
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -138,7 +138,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.30
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -153,7 +153,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.31
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -193,19 +193,19 @@ rules:
       dirs:
       - staging/src/k8s.io/code-generator
   - name: release-1.28
-    go: 1.22.9
+    go: 1.22.10
     source:
       branch: release-1.28
       dirs:
       - staging/src/k8s.io/code-generator
   - name: release-1.29
-    go: 1.22.9
+    go: 1.22.10
     source:
       branch: release-1.29
       dirs:
       - staging/src/k8s.io/code-generator
   - name: release-1.30
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -214,7 +214,7 @@ rules:
       dirs:
       - staging/src/k8s.io/code-generator
   - name: release-1.31
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -245,7 +245,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-base
   - name: release-1.28
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -258,7 +258,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-base
   - name: release-1.29
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -271,7 +271,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-base
   - name: release-1.30
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -284,7 +284,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-base
   - name: release-1.31
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -324,7 +324,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-helpers
   - name: release-1.28
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -337,7 +337,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-helpers
   - name: release-1.29
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -350,7 +350,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-helpers
   - name: release-1.30
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -363,7 +363,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-helpers
   - name: release-1.31
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -399,7 +399,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kms
   - name: release-1.28
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -412,7 +412,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kms
   - name: release-1.29
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -421,7 +421,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kms
   - name: release-1.30
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -430,7 +430,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kms
   - name: release-1.31
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -466,7 +466,7 @@ rules:
       dirs:
       - staging/src/k8s.io/apiserver
   - name: release-1.28
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -483,7 +483,7 @@ rules:
       dirs:
       - staging/src/k8s.io/apiserver
   - name: release-1.29
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -500,7 +500,7 @@ rules:
       dirs:
       - staging/src/k8s.io/apiserver
   - name: release-1.30
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -517,7 +517,7 @@ rules:
       dirs:
       - staging/src/k8s.io/apiserver
   - name: release-1.31
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -573,7 +573,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-aggregator
   - name: release-1.28
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -594,7 +594,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-aggregator
   - name: release-1.29
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -615,7 +615,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-aggregator
   - name: release-1.30
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -636,7 +636,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-aggregator
   - name: release-1.31
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -704,7 +704,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.28
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -730,7 +730,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.29
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -756,7 +756,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.30
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -782,7 +782,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.31
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -854,7 +854,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.28
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -874,7 +874,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.29
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -894,7 +894,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.30
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -914,7 +914,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.31
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -977,7 +977,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.28
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -1000,7 +1000,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.29
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -1023,7 +1023,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.30
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -1046,7 +1046,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.31
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -1107,7 +1107,7 @@ rules:
       dirs:
       - staging/src/k8s.io/metrics
   - name: release-1.28
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -1122,7 +1122,7 @@ rules:
       dirs:
       - staging/src/k8s.io/metrics
   - name: release-1.29
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -1137,7 +1137,7 @@ rules:
       dirs:
       - staging/src/k8s.io/metrics
   - name: release-1.30
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -1152,7 +1152,7 @@ rules:
       dirs:
       - staging/src/k8s.io/metrics
   - name: release-1.31
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -1196,7 +1196,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cli-runtime
   - name: release-1.28
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: api
       branch: release-1.28
@@ -1209,7 +1209,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cli-runtime
   - name: release-1.29
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: api
       branch: release-1.29
@@ -1222,7 +1222,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cli-runtime
   - name: release-1.30
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: api
       branch: release-1.30
@@ -1235,7 +1235,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cli-runtime
   - name: release-1.31
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: api
       branch: release-1.31
@@ -1277,7 +1277,7 @@ rules:
       dirs:
       - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.28
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: api
       branch: release-1.28
@@ -1292,7 +1292,7 @@ rules:
       dirs:
       - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.29
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: api
       branch: release-1.29
@@ -1307,7 +1307,7 @@ rules:
       dirs:
       - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.30
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: api
       branch: release-1.30
@@ -1322,7 +1322,7 @@ rules:
       dirs:
       - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.31
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: api
       branch: release-1.31
@@ -1367,7 +1367,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-proxy
   - name: release-1.28
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -1382,7 +1382,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-proxy
   - name: release-1.29
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -1397,7 +1397,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-proxy
   - name: release-1.30
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -1412,7 +1412,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-proxy
   - name: release-1.31
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -1449,25 +1449,25 @@ rules:
       dirs:
       - staging/src/k8s.io/cri-api
   - name: release-1.28
-    go: 1.22.9
+    go: 1.22.10
     source:
       branch: release-1.28
       dirs:
       - staging/src/k8s.io/cri-api
   - name: release-1.29
-    go: 1.22.9
+    go: 1.22.10
     source:
       branch: release-1.29
       dirs:
       - staging/src/k8s.io/cri-api
   - name: release-1.30
-    go: 1.22.9
+    go: 1.22.10
     source:
       branch: release-1.30
       dirs:
       - staging/src/k8s.io/cri-api
   - name: release-1.31
-    go: 1.22.9
+    go: 1.22.10
     source:
       branch: release-1.31
       dirs:
@@ -1497,7 +1497,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cri-client
   - name: release-1.31
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: api
       branch: release-1.31
@@ -1553,7 +1553,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubelet
   - name: release-1.28
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -1574,7 +1574,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubelet
   - name: release-1.29
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -1595,7 +1595,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubelet
   - name: release-1.30
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -1616,7 +1616,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubelet
   - name: release-1.31
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -1674,7 +1674,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-scheduler
   - name: release-1.28
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -1689,7 +1689,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-scheduler
   - name: release-1.29
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -1704,7 +1704,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-scheduler
   - name: release-1.30
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -1719,7 +1719,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-scheduler
   - name: release-1.31
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -1769,7 +1769,7 @@ rules:
       dirs:
       - staging/src/k8s.io/controller-manager
   - name: release-1.28
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: api
       branch: release-1.28
@@ -1788,7 +1788,7 @@ rules:
       dirs:
       - staging/src/k8s.io/controller-manager
   - name: release-1.29
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: api
       branch: release-1.29
@@ -1807,7 +1807,7 @@ rules:
       dirs:
       - staging/src/k8s.io/controller-manager
   - name: release-1.30
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: api
       branch: release-1.30
@@ -1826,7 +1826,7 @@ rules:
       dirs:
       - staging/src/k8s.io/controller-manager
   - name: release-1.31
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: api
       branch: release-1.31
@@ -1888,7 +1888,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cloud-provider
   - name: release-1.28
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: api
       branch: release-1.28
@@ -1911,7 +1911,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cloud-provider
   - name: release-1.29
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: api
       branch: release-1.29
@@ -1934,7 +1934,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cloud-provider
   - name: release-1.30
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: api
       branch: release-1.30
@@ -1957,7 +1957,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cloud-provider
   - name: release-1.31
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: api
       branch: release-1.31
@@ -2029,7 +2029,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-controller-manager
   - name: release-1.28
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -2054,7 +2054,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-controller-manager
   - name: release-1.29
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -2079,7 +2079,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-controller-manager
   - name: release-1.30
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -2104,7 +2104,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-controller-manager
   - name: release-1.31
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -2166,7 +2166,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.28
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -2177,7 +2177,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.29
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -2188,7 +2188,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.30
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -2199,7 +2199,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.31
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -2233,7 +2233,7 @@ rules:
       dirs:
       - staging/src/k8s.io/csi-translation-lib
   - name: release-1.28
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: api
       branch: release-1.28
@@ -2244,7 +2244,7 @@ rules:
       dirs:
       - staging/src/k8s.io/csi-translation-lib
   - name: release-1.29
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: api
       branch: release-1.29
@@ -2255,7 +2255,7 @@ rules:
       dirs:
       - staging/src/k8s.io/csi-translation-lib
   - name: release-1.30
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: api
       branch: release-1.30
@@ -2266,7 +2266,7 @@ rules:
       dirs:
       - staging/src/k8s.io/csi-translation-lib
   - name: release-1.31
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: api
       branch: release-1.31
@@ -2295,25 +2295,25 @@ rules:
       dirs:
       - staging/src/k8s.io/mount-utils
   - name: release-1.28
-    go: 1.22.9
+    go: 1.22.10
     source:
       branch: release-1.28
       dirs:
       - staging/src/k8s.io/mount-utils
   - name: release-1.29
-    go: 1.22.9
+    go: 1.22.10
     source:
       branch: release-1.29
       dirs:
       - staging/src/k8s.io/mount-utils
   - name: release-1.30
-    go: 1.22.9
+    go: 1.22.10
     source:
       branch: release-1.30
       dirs:
       - staging/src/k8s.io/mount-utils
   - name: release-1.31
-    go: 1.22.9
+    go: 1.22.10
     source:
       branch: release-1.31
       dirs:
@@ -2327,7 +2327,7 @@ rules:
 - destination: legacy-cloud-providers
   branches:
   - name: release-1.28
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: api
       branch: release-1.28
@@ -2352,7 +2352,7 @@ rules:
       dirs:
       - staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.29
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: api
       branch: release-1.29
@@ -2377,7 +2377,7 @@ rules:
       dirs:
       - staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.30
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: api
       branch: release-1.30
@@ -2427,7 +2427,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubectl
   - name: release-1.28
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: api
       branch: release-1.28
@@ -2450,7 +2450,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubectl
   - name: release-1.29
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: api
       branch: release-1.29
@@ -2473,7 +2473,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubectl
   - name: release-1.30
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: api
       branch: release-1.30
@@ -2496,7 +2496,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubectl
   - name: release-1.31
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: api
       branch: release-1.31
@@ -2562,7 +2562,7 @@ rules:
       dirs:
       - staging/src/k8s.io/pod-security-admission
   - name: release-1.28
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: api
       branch: release-1.28
@@ -2581,7 +2581,7 @@ rules:
       dirs:
       - staging/src/k8s.io/pod-security-admission
   - name: release-1.29
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: api
       branch: release-1.29
@@ -2600,7 +2600,7 @@ rules:
       dirs:
       - staging/src/k8s.io/pod-security-admission
   - name: release-1.30
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: api
       branch: release-1.30
@@ -2619,7 +2619,7 @@ rules:
       dirs:
       - staging/src/k8s.io/pod-security-admission
   - name: release-1.31
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: api
       branch: release-1.31
@@ -2683,7 +2683,7 @@ rules:
       dirs:
       - staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.28
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -2704,7 +2704,7 @@ rules:
       dirs:
       - staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.29
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -2725,7 +2725,7 @@ rules:
       dirs:
       - staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.30
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -2748,7 +2748,7 @@ rules:
       dirs:
       - staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.31
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -2813,7 +2813,7 @@ rules:
       dirs:
       - staging/src/k8s.io/endpointslice
   - name: release-1.28
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: api
       branch: release-1.28
@@ -2828,7 +2828,7 @@ rules:
       dirs:
       - staging/src/k8s.io/endpointslice
   - name: release-1.29
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: api
       branch: release-1.29
@@ -2843,7 +2843,7 @@ rules:
       dirs:
       - staging/src/k8s.io/endpointslice
   - name: release-1.30
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: api
       branch: release-1.30
@@ -2858,7 +2858,7 @@ rules:
       dirs:
       - staging/src/k8s.io/endpointslice
   - name: release-1.31
-    go: 1.22.9
+    go: 1.22.10
     dependencies:
     - repository: api
       branch: release-1.31


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:

- Update publishing-bot rules to Go 1.22.10 for the active release branches

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
xref: https://github.com/kubernetes/release/issues/3848


/assign @dims @xmudrii @Verolop  
cc @kubernetes/release-managers 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
