### PR TITLE
fix dra test lint

### DIFF
--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
@@ -59,7 +59,6 @@ var (
 	resourceName  = "my-resource"
 	resourceName2 = resourceName + "-2"
 	claimName     = podName + "-" + resourceName
-	claimName2    = podName + "-" + resourceName + "-2"
 	className     = "my-resource-class"
 	namespace     = "default"
 	attrName      = resourceapi.QualifiedName("healthy") // device attribute only available on non-default node
@@ -88,11 +87,6 @@ var (
 		}
 		return pod
 	}()
-	podWithTwoClaimNames = st.MakePod().Name(podName).Namespace(namespace).
-				UID(podUID).
-				PodResourceClaims(v1.PodResourceClaim{Name: resourceName, ResourceClaimName: &claimName}).
-				PodResourceClaims(v1.PodResourceClaim{Name: resourceName2, ResourceClaimName: &claimName2}).
-				Obj()
 	podWithTwoClaimTemplates = st.MakePod().Name(podName).Namespace(namespace).
 					UID(podUID).
 					PodResourceClaims(v1.PodResourceClaim{Name: resourceName, ResourceClaimTemplateName: &claimName}).
@@ -123,14 +117,8 @@ var (
 		Namespace(namespace).
 		Request(className).
 		Obj()
-	deleteClaim = st.FromResourceClaim(claim).
-			OwnerReference(podName, podUID, podKind).
-			Deleting(metav1.Now()).Obj()
 	pendingClaim = st.FromResourceClaim(claim).
 			OwnerReference(podName, podUID, podKind).
-			Obj()
-	pendingClaim2 = st.FromResourceClaim(pendingClaim).
-			Name(claimName2).
 			Obj()
 	allocationResult = &resourceapi.AllocationResult{
 		Devices: resourceapi.DeviceAllocationResult{
@@ -167,9 +155,6 @@ var (
 	otherAllocatedClaim = st.FromResourceClaim(otherClaim).
 				Allocation(allocationResult).
 				Obj()
-
-	resourceSlice        = st.MakeResourceSlice(nodeName, driver).Device("instance-1", nil).Obj()
-	resourceSliceUpdated = st.FromResourceSlice(resourceSlice).Device("instance-1", map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{attrName: {BoolValue: ptr.To(true)}}).Obj()
 )
 
 func reserve(claim *resourceapi.ResourceClaim, pod *v1.Pod) *resourceapi.ResourceClaim {


### PR DESCRIPTION
#### What type of PR is this?
/kind failing-test

#### What this PR does / why we need it:

See https://testgrid.k8s.io/sig-release-master-blocking#verify-master 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
ref https://github.com/kubernetes/kubernetes/pull/129517

#### Special notes for your reviewer:
https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-verify-master/1877142243328921600

> { ScriptError  pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go:62:2: var `claimName2` is unused (unused) 	claimName2    = podName + "-" + resourceName + "-2" 	
> pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go:91:2: var `podWithTwoClaimNames` is unused (unused) 	podWithTwoClaimNames = st.MakePod().Name(podName).Namespace(namespace). 	^ 
> pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go:126:2: var `deleteClaim` is unused (unused) 	deleteClaim = st.FromResourceClaim(claim). 	^ 
> pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go:132:2: var `pendingClaim2` is unused (unused) 	pendingClaim2 = st.FromResourceClaim(pendingClaim). 	^ 
> pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go:171:2: var `resourceSlice` is unused (unused) 	resourceSlice        = st.MakeResourceSlice(nodeName, driver).Device("instance-1", nil).Obj() 	^ 
> pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go:172:2: var `resourceSliceUpdated` is unused (unused) 	resourceSliceUpdated = st.FromResourceSlice(resourceSlice).Device("instance-1", map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{attrName: {BoolValue: ptr.To(true)}}).Obj() 	^ }



#### Does this PR introduce a user-facing change?

```release-note
None
```
