### PR TITLE
bump corefile/migration to v1.0.25 to support coredns v1.11.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5
 	github.com/blang/semver/v4 v4.0.0
 	github.com/container-storage-interface/spec v1.9.0
-	github.com/coredns/corefile-migration v1.0.24
+	github.com/coredns/corefile-migration v1.0.25
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/cpuguy83/go-md2man/v2 v2.0.4

--- a/go.sum
+++ b/go.sum
@@ -193,8 +193,8 @@ github.com/containerd/typeurl/v2 v2.2.0 h1:6NBDbQzr7I5LHgp34xAXYF5DOTQDn05X58lsP
 github.com/containerd/typeurl/v2 v2.2.0/go.mod h1:8XOOxnyatxSWuG8OfsZXVnAF4iZfedjS/8UHSPJnX4g=
 github.com/coredns/caddy v1.1.1 h1:2eYKZT7i6yxIfGP3qLJoJ7HAsDJqYB+X68g4NYjSrE0=
 github.com/coredns/caddy v1.1.1/go.mod h1:A6ntJQlAWuQfFlsd9hvigKbo2WS0VUs2l1e2F+BawD4=
-github.com/coredns/corefile-migration v1.0.24 h1:NL/zRKijhJZLYlNnMr891DRv5jXgfd3Noons1M6oTpc=
-github.com/coredns/corefile-migration v1.0.24/go.mod h1:56DPqONc3njpVPsdilEnfijCwNGC3/kTJLl7i7SPavY=
+github.com/coredns/corefile-migration v1.0.25 h1:/XexFhM8FFlFLTS/zKNEWgIZ8Gl5GaWrHsMarGj/PRQ=
+github.com/coredns/corefile-migration v1.0.25/go.mod h1:56DPqONc3njpVPsdilEnfijCwNGC3/kTJLl7i7SPavY=
 github.com/coreos/go-oidc v2.2.1+incompatible h1:mh48q/BqXqgjVHpy2ZY7WnWAbenxRjsz9N1i1YxjHAk=
 github.com/coreos/go-oidc v2.2.1+incompatible/go.mod h1:CgnwVTmzoESiwO9qyAFEMiHoZ1nMCKZlZ9V6mm3/LKc=
 github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr4=

--- a/vendor/github.com/coredns/corefile-migration/migration/plugins.go
+++ b/vendor/github.com/coredns/corefile-migration/migration/plugins.go
@@ -311,12 +311,12 @@ var plugins = map[string]map[string]plugin{
 		},
 		"v3": plugin{
 			namedOptions: map[string]option{
-				"type":        {},
-				"class":       {},
-				"name":        {},
-				"answer name": {},
-				"edns0":       {},
-				"ttl":         {}, 
+				"type":         {},
+				"class":        {},
+				"name":         {},
+				"answer name":  {},
+				"edns0":        {},
+				"ttl":          {},
 				"cname_target": {}, // new option
 			},
 		},
@@ -351,7 +351,19 @@ var plugins = map[string]map[string]plugin{
 				"success":     {},
 				"denial":      {},
 				"prefetch":    {},
-				"serve_stale": {}, 
+				"serve_stale": {},
+				"disable":     {}, // v1.9.4 new option
+				"servfail":    {}, // v1.9.4 new option
+			},
+		},
+		"v4": plugin{
+			namedOptions: map[string]option{
+				"success":     {},
+				"denial":      {},
+				"prefetch":    {},
+				"serve_stale": {},
+				"disable":     {},
+				"servfail":    {},
 				"keepttl":     {}, // new option
 			},
 		},
@@ -417,6 +429,21 @@ var plugins = map[string]map[string]plugin{
 				},
 			},
 		},
+		"v4": plugin{
+			namedOptions: map[string]option{
+				"except":         {},
+				"force_tcp":      {},
+				"prefer_udp":     {},
+				"expire":         {},
+				"max_fails":      {},
+				"tls":            {},
+				"tls_servername": {},
+				"policy":         {},
+				"health_check":   {},
+				"max_concurrent": {},
+				"next":           {}, // new option
+			},
+		},
 	},
 
 	"k8s_external": {
@@ -428,8 +455,8 @@ var plugins = map[string]map[string]plugin{
 		},
 		"v2": plugin{
 			namedOptions: map[string]option{
-				"apex": {},
-				"ttl":  {},
+				"apex":        {},
+				"ttl":         {},
 				"fallthrough": {}, // new option
 			},
 		},

--- a/vendor/github.com/coredns/corefile-migration/migration/versions.go
+++ b/vendor/github.com/coredns/corefile-migration/migration/versions.go
@@ -30,22 +30,34 @@ type release struct {
 
 // Versions holds a map of plugin/option migrations per CoreDNS release (since 1.1.4)
 var Versions = map[string]release{
+	"1.12.0": {
+		priorVersion:   "1.11.4",
+		dockerImageSHA: "40384aa1f5ea6bfdc77997d243aec73da05f27aed0c5e9d65bfa98933c519d97",
+		plugins:        plugins_1_11_4,
+	},
+	"1.11.4": {
+		nextVersion:    "1.12.0",
+		priorVersion:   "1.11.3",
+		dockerImageSHA: "4190b960ea90e017631e3e1a38eea28e98e057ab60d57d47b3db6e5cf77436f7",
+		plugins:        plugins_1_11_4,
+	},
 	"1.11.3": {
+		nextVersion:    "1.11.4",
 		priorVersion:   "1.11.1",
 		dockerImageSHA: "9caabbf6238b189a65d0d6e6ac138de60d6a1c419e5a341fbbb7c78382559c6e",
-		plugins: 		plugins_1_11_0,
+		plugins:        plugins_1_11_0,
 	},
 	"1.11.1": {
 		nextVersion:    "1.11.3",
 		priorVersion:   "1.11.0",
 		dockerImageSHA: "1eeb4c7316bacb1d4c8ead65571cd92dd21e27359f0d4917f1a5822a73b75db1",
-		plugins: 		plugins_1_11_0,
+		plugins:        plugins_1_11_0,
 	},
 	"1.11.0": {
 		nextVersion:    "1.11.1",
 		priorVersion:   "1.10.1",
 		dockerImageSHA: "cc3ebb05fbdba439d2d69813f162aa204b027098c8244fb3156e6e7c0f31c548",
-		plugins: 		plugins_1_11_0,
+		plugins:        plugins_1_11_0,
 	},
 	"1.10.1": {
 		nextVersion:    "1.11.0",
@@ -57,13 +69,13 @@ var Versions = map[string]release{
 		nextVersion:    "1.10.1",
 		priorVersion:   "1.9.4",
 		dockerImageSHA: "017727efcfeb7d053af68e51436ce8e65edbc6ca573720afb4f79c8594036955",
-		plugins:        plugins_1_9_3,
+		plugins:        plugins_1_9_4,
 	},
 	"1.9.4": {
 		nextVersion:    "1.10.0",
 		priorVersion:   "1.9.3",
 		dockerImageSHA: "b82e294de6be763f73ae71266c8f5466e7e03c69f3a1de96efd570284d35bb18",
-		plugins:        plugins_1_9_3,
+		plugins:        plugins_1_9_4,
 	},
 	"1.9.3": {
 		nextVersion:    "1.9.4",
@@ -763,6 +775,25 @@ var Versions = map[string]release{
 }`},
 }
 
+var plugins_1_11_4 = map[string]plugin{
+	"errors":       plugins["errors"]["v3"],
+	"log":          plugins["log"]["v1"],
+	"health":       plugins["health"]["v1"],
+	"ready":        {},
+	"autopath":     {},
+	"kubernetes":   plugins["kubernetes"]["v8"],
+	"k8s_external": plugins["k8s_external"]["v2"],
+	"prometheus":   {},
+	"forward":      plugins["forward"]["v4"], // add next option
+	"cache":        plugins["cache"]["v4"],
+	"loop":         {},
+	"reload":       {},
+	"loadbalance":  {},
+	"hosts":        plugins["hosts"]["v1"],
+	"rewrite":      plugins["rewrite"]["v3"],
+	"transfer":     plugins["transfer"]["v1"],
+}
+
 var plugins_1_11_0 = map[string]plugin{
 	"errors":       plugins["errors"]["v3"],
 	"log":          plugins["log"]["v1"],
@@ -773,7 +804,7 @@ var plugins_1_11_0 = map[string]plugin{
 	"k8s_external": plugins["k8s_external"]["v2"], //add fallthrough option
 	"prometheus":   {},
 	"forward":      plugins["forward"]["v3"],
-	"cache":        plugins["cache"]["v2"],
+	"cache":        plugins["cache"]["v4"],
 	"loop":         {},
 	"reload":       {},
 	"loadbalance":  {},
@@ -792,7 +823,26 @@ var plugins_1_10_1 = map[string]plugin{
 	"k8s_external": plugins["k8s_external"]["v1"],
 	"prometheus":   {},
 	"forward":      plugins["forward"]["v3"],
-	"cache":        plugins["cache"]["v2"], // add keepttl option
+	"cache":        plugins["cache"]["v4"], // add keepttl option
+	"loop":         {},
+	"reload":       {},
+	"loadbalance":  {},
+	"hosts":        plugins["hosts"]["v1"],
+	"rewrite":      plugins["rewrite"]["v2"],
+	"transfer":     plugins["transfer"]["v1"],
+}
+
+var plugins_1_9_4 = map[string]plugin{
+	"errors":       plugins["errors"]["v3"], // stacktrace option added
+	"log":          plugins["log"]["v1"],
+	"health":       plugins["health"]["v1"],
+	"ready":        {},
+	"autopath":     {},
+	"kubernetes":   plugins["kubernetes"]["v8"],
+	"k8s_external": plugins["k8s_external"]["v1"],
+	"prometheus":   {},
+	"forward":      plugins["forward"]["v3"],
+	"cache":        plugins["cache"]["v3"], // add disable and servfail options
 	"loop":         {},
 	"reload":       {},
 	"loadbalance":  {},

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -86,7 +86,7 @@ github.com/containerd/ttrpc
 # github.com/coredns/caddy v1.1.1
 ## explicit; go 1.13
 github.com/coredns/caddy/caddyfile
-# github.com/coredns/corefile-migration v1.0.24
+# github.com/coredns/corefile-migration v1.0.25
 ## explicit; go 1.14
 github.com/coredns/corefile-migration/migration
 github.com/coredns/corefile-migration/migration/corefile


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup


#### What this PR does / why we need it:
https://github.com/kubernetes/kubernetes/pull/128795 is pending on this.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```
