### PR TITLE
[FG:InPlacePodVerticalScaling] Add debug log, when drop pod update message and only old update is processed

### DIFF
--- a/pkg/kubelet/pod_workers.go
+++ b/pkg/kubelet/pod_workers.go
@@ -964,6 +964,7 @@ func (p *podWorkers) UpdatePod(options UpdatePodOptions) {
 	select {
 	case podUpdates <- struct{}{}:
 	default:
+		klog.V(4).InfoS("Pending update already queued", "pod", klog.KRef(ns, name), "podUID", uid, "updateType", options.UpdateType)
 	}
 
 	if (becameTerminating || wasGracePeriodShortened) && status.cancelFn != nil {


### PR DESCRIPTION
 #### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Add debug log, help user get the information, when kubelet drop pod update message.

#### Which issue(s) this PR fixes:
Fixes #129518

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

