### PR TITLE
hack/ginkgo-e2e.sh: forward TERM/INT to Ginkgo

### DIFF
--- a/hack/ginkgo-e2e.sh
+++ b/hack/ginkgo-e2e.sh
@@ -204,6 +204,49 @@ fi
 # is not used.
 suite_args+=(--report-complete-ginkgo --report-complete-junit)
 
+# When SIGTERM doesn't reach the E2E test suite binaries, ginkgo will exit
+# without collecting information from about the currently running and
+# potentially stuck tests. This seems to happen when Prow shuts down a test
+# job because of a timeout.
+#
+# It's useful to print one final progress report in that case,
+# so GINKGO_PROGRESS_REPORT_ON_SIGTERM (enabled by default when CI=true)
+# catches SIGTERM and forwards it to all processes spawned by ginkgo.
+#
+# Manual invocations can trigger a similar report with `killall -USR1 e2e.test`
+# without having to kill the test run.
+GINKGO_CLI_PID=
+signal_handler() {
+  if [ -n "${GINKGO_CLI_PID}" ]; then
+    cat <<EOF
+
+*** $0: received $1 signal -> asking Ginkgo to stop.
+***
+*** Beware that a timeout may have been caused by some earlier test,
+*** not necessarily the one which gets interrupted now.
+*** See the "Spec runtime" for information about how long the
+*** interrupted test was running.
+
+EOF
+    # This goes to the process group, which is important because we
+    # need to reach the e2e.test processes forked by the Ginkgo CLI.
+    kill -TERM "-${GINKGO_CLI_PID}" || true
+
+    echo "Waiting for Ginkgo with pid ${GINKGO_CLI_PID}..."
+    wait "{$GINKGO_CLI_PID}"
+    echo "Ginkgo terminated."
+  fi
+}
+case "${GINKGO_PROGRESS_REPORT_ON_SIGTERM:-${CI:-no}}" in
+  y|yes|true)
+    kube::util::trap_add "signal_handler INT" INT
+    kube::util::trap_add "signal_handler TERM" TERM
+    # Job control is needed to make the Ginkgo CLI and all workers run
+    # in their own process group.
+    set -m
+    ;;
+esac
+
 # The following invocation is fairly complex. Let's dump it to simplify
 # determining what the final options are. Enabled by default in CI
 # environments like Prow.
@@ -236,4 +279,8 @@ case "${GINKGO_SHOW_COMMAND:-${CI:-no}}" in y|yes|true) set -x ;; esac
   ${E2E_REPORT_DIR:+"--report-dir=${E2E_REPORT_DIR}"} \
   ${E2E_REPORT_PREFIX:+"--report-prefix=${E2E_REPORT_PREFIX}"} \
   "${suite_args[@]:+${suite_args[@]}}" \
-  "${@}"
+  "${@}" &
+
+set +x
+GINKGO_CLI_PID=$!
+wait "${GINKGO_CLI_PID}"


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

What happens at the moment in e.g. pull-kubernetes-e2e-kind in case of a
timeout is that ginkgo-e2e.sh gets killed with SIGTERM. This is not propagated
to the E2E test suite processes, therefore there is no "Interrupted by User"
report and no JUnit file, depending on timing during the process shutdown.
    
Running the Ginkgo CLI with job control enabled creates a new process group,
which then can be used to kill the Ginko CLI and the E2E test suite
processes. With these changes, more information is produced and Ginkgo has
time to write a JUnit file.

#### Special notes for your reviewer:

Earlier in this PR, I was experimenting with intentionally causing tests to time out.

Jobs which timed out **without** the `ginkgo-e2e.sh` changes:
- https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/129545/pull-kubernetes-e2e-kind/1879850204451049472

```
...
+ /home/prow/go/src/k8s.io/kubernetes/_output/bin/ginkgo --nodes=25 --poll-progress-after=60m --poll-progress-interval=5m --source-root=/home/prow/go/src/k8s.io/kubernetes/cluster/.. --timeout=24h --silence-skips --force-newlines --no-color /home/prow/go/src/k8s.io/kubernetes/_output/bin/e2e.test -- --kubeconfig=/root/.kube/kind-test-config --host=https://127.0.0.1:43881 --provider=skeleton --gce-project= --gce-zone= --gce-region= --gce-multizone=false --gke-cluster= --kube-master= --cluster-tag= --cloud-config-file= --repo-root=/home/prow/go/src/k8s.io/kubernetes/cluster/.. --node-instance-group= --prefix=e2e --network=e2e --node-tag= --master-tag= --docker-config-file= --dns-domain=cluster.local --prepull-images=false --report-complete-ginkgo --report-complete-junit --provider=skeleton --num-nodes=2 --ginkgo.focus=. '--ginkgo.skip=\[Serial\]|\[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PodSecurityPolicy|LoadBalancer|load.balancer|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing|NFS|nfs|inline.execution.and.attach|should.be.rejected.when.no.endpoints.exist' --ginkgo.label-filter= --report-dir=/logs/artifacts --disable-log-dump=true
Running Suite: Kubernetes e2e suite - /home/prow/go/src/k8s.io/kubernetes/_output/bin
=====================================================================================
Random Seed: 1737026902 - will randomize all specs

Will run 2025 of 6644 specs
Running in parallel across 25 processes
•
...
•
{"component":"entrypoint","file":"sigs.k8s.io/prow/pkg/entrypoint/run.go:169","func":"sigs.k8s.io/prow/pkg/entrypoint.Options.ExecuteProcess","level":"error","msg":"Process did not finish before 1h0m0s timeout","severity":"error","time":"2025-01-16T12:17:50Z"}
wrapper.sh] [EARLY EXIT] Interrupted, entering handler ...
...
+ signal_handler
+ [ -n 69647 ]
+ kill -TERM 69647
+ cleanup
+ [ false = true ]
+ [ true = true ]
+ kind export logs /logs/artifacts
...
wrapper.sh] [EARLY EXIT] Completed handler ...
  ------------------------------
  Progress Report for Ginkgo Process #2
  Automatically polling progress:
    [sig-cli] Kubectl client Kubectl cluster-info dump should check if cluster-info dump succeeds (Spec Runtime: 1h0m0.082s)
      k8s.io/kubernetes/test/e2e/kubectl/kubectl.go:1376
      In [It] (Node Runtime: 1h0m0s)
        k8s.io/kubernetes/test/e2e/kubectl/kubectl.go:1376

      Begin Captured GinkgoWriter Output >>
        I0116 11:29:39.530877 69841 util.go:502] >>> kubeConfig: /root/.kube/kind-test-config
      << End Captured GinkgoWriter Output

      Spec Goroutine
      goroutine 7161 [select]
        github.com/onsi/gomega/internal.(*AsyncAssertion).match(0xc002b1a700, {0x53308c8, 0xc000c48ed0}, 0x1, {0x0, 0x0, 0x0})
          github.com/onsi/gomega@v1.35.1/internal/async_assertion.go:546
        github.com/onsi/gomega/internal.(*AsyncAssertion).Should(0xc002b1a700, {0x53308c8, 0xc000c48ed0}, {0x0, 0x0, 0x0})
          github.com/onsi/gomega@v1.35.1/internal/async_assertion.go:145
      > k8s.io/kubernetes/test/e2e/kubectl.init.func5.19.1({0x7f29e05fbe50?, 0xc002b104e0})
          k8s.io/kubernetes/test/e2e/kubectl/kubectl.go:1380
        github.com/onsi/ginkgo/v2/internal.extractBodyFunction.func2({0x5357590?, 0xc002b104e0?})
          github.com/onsi/ginkgo/v2@v2.21.0/internal/node.go:465
        github.com/onsi/ginkgo/v2/internal.(*Suite).runNode.func3()
          github.com/onsi/ginkgo/v2@v2.21.0/internal/suite.go:894
        github.com/onsi/ginkgo/v2/internal.(*Suite).runNode in goroutine 6404
          github.com/onsi/ginkgo/v2@v2.21.0/internal/suite.go:881

      Begin Additional Progress Reports >>
        fake error to block test
      << End Additional Progress Reports
  ------------------------------
{"component":"entrypoint","file":"sigs.k8s.io/prow/pkg/entrypoint/run.go:267","func":"sigs.k8s.io/prow/pkg/entrypoint.gracefullyTerminate","level":"error","msg":"Process did not exit before 15m0s grace period","severity":"error","time":"2025-01-16T12:32:50Z"}
{"component":"entrypoint","error":"os: process already finished","file":"sigs.k8s.io/prow/pkg/entrypoint/run.go:269","func":"sigs.k8s.io/prow/pkg/entrypoint.gracefullyTerminate","level":"error","msg":"Could not kill process after grace period","severity":"error","time":"2025-01-16T12:32:50Z"}
```

The progress report comes from `--poll-progress-after=60m`.

No JUnit file!

- https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/129545/pull-kubernetes-kind-dra-canary/1879850204388134912

Again, no JUnit file and no progress report because the job wasn't configured to trigger it early enough.

Jobs which timed out **with** the `ginkgo-e2e.sh` changes:
- https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/129545/pull-kubernetes-e2e-kind/1879918882622279680
- https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/129545/pull-kubernetes-kind-dra-canary/1879918882500644864

Both contain a JUnit file *and* that file describes why the tests timed out. The failure reason is empty. This is something that could be improved in Ginkgo, but for now that seems sufficient and is better than before.
