### PR TITLE
Only set worker to nil when the key exists.

### DIFF
--- a/pkg/controller/tainteviction/timed_workers.go
+++ b/pkg/controller/tainteviction/timed_workers.go
@@ -105,13 +105,7 @@ func (q *TimedWorkerQueue) getWrappedWorkerFunc(key string) func(ctx context.Con
 		err := q.workFunc(ctx, fireAt, args)
 		q.Lock()
 		defer q.Unlock()
-		if err == nil {
-			// To avoid duplicated calls we keep the key in the queue, to prevent
-			// subsequent additions.
-			q.workers[key] = nil
-		} else {
-			delete(q.workers, key)
-		}
+		delete(q.workers, key)
 		return err
 	}
 }

--- a/pkg/controller/tainteviction/timed_workers_test.go
+++ b/pkg/controller/tainteviction/timed_workers_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 func TestExecute(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
 	testVal := int32(0)
 	wg := sync.WaitGroup{}
 	wg.Add(5)
@@ -37,17 +38,11 @@ func TestExecute(t *testing.T) {
 		return nil
 	})
 	now := time.Now()
-	queue.AddWork(context.TODO(), NewWorkArgs("1", "1"), now, now)
-	queue.AddWork(context.TODO(), NewWorkArgs("2", "2"), now, now)
-	queue.AddWork(context.TODO(), NewWorkArgs("3", "3"), now, now)
-	queue.AddWork(context.TODO(), NewWorkArgs("4", "4"), now, now)
-	queue.AddWork(context.TODO(), NewWorkArgs("5", "5"), now, now)
-	// Adding the same thing second time should be no-op
-	queue.AddWork(context.TODO(), NewWorkArgs("1", "1"), now, now)
-	queue.AddWork(context.TODO(), NewWorkArgs("2", "2"), now, now)
-	queue.AddWork(context.TODO(), NewWorkArgs("3", "3"), now, now)
-	queue.AddWork(context.TODO(), NewWorkArgs("4", "4"), now, now)
-	queue.AddWork(context.TODO(), NewWorkArgs("5", "5"), now, now)
+	queue.AddWork(ctx, NewWorkArgs("1", "1"), now, now)
+	queue.AddWork(ctx, NewWorkArgs("2", "2"), now, now)
+	queue.AddWork(ctx, NewWorkArgs("3", "3"), now, now)
+	queue.AddWork(ctx, NewWorkArgs("4", "4"), now, now)
+	queue.AddWork(ctx, NewWorkArgs("5", "5"), now, now)
 	wg.Wait()
 	lastVal := atomic.LoadInt32(&testVal)
 	if lastVal != 5 {
@@ -56,6 +51,7 @@ func TestExecute(t *testing.T) {
 }
 
 func TestExecuteDelayed(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
 	testVal := int32(0)
 	wg := sync.WaitGroup{}
 	wg.Add(5)
@@ -68,16 +64,16 @@ func TestExecuteDelayed(t *testing.T) {
 	then := now.Add(10 * time.Second)
 	fakeClock := testingclock.NewFakeClock(now)
 	queue.clock = fakeClock
-	queue.AddWork(context.TODO(), NewWorkArgs("1", "1"), now, then)
-	queue.AddWork(context.TODO(), NewWorkArgs("2", "2"), now, then)
-	queue.AddWork(context.TODO(), NewWorkArgs("3", "3"), now, then)
-	queue.AddWork(context.TODO(), NewWorkArgs("4", "4"), now, then)
-	queue.AddWork(context.TODO(), NewWorkArgs("5", "5"), now, then)
-	queue.AddWork(context.TODO(), NewWorkArgs("1", "1"), now, then)
-	queue.AddWork(context.TODO(), NewWorkArgs("2", "2"), now, then)
-	queue.AddWork(context.TODO(), NewWorkArgs("3", "3"), now, then)
-	queue.AddWork(context.TODO(), NewWorkArgs("4", "4"), now, then)
-	queue.AddWork(context.TODO(), NewWorkArgs("5", "5"), now, then)
+	queue.AddWork(ctx, NewWorkArgs("1", "1"), now, then)
+	queue.AddWork(ctx, NewWorkArgs("2", "2"), now, then)
+	queue.AddWork(ctx, NewWorkArgs("3", "3"), now, then)
+	queue.AddWork(ctx, NewWorkArgs("4", "4"), now, then)
+	queue.AddWork(ctx, NewWorkArgs("5", "5"), now, then)
+	queue.AddWork(ctx, NewWorkArgs("1", "1"), now, then)
+	queue.AddWork(ctx, NewWorkArgs("2", "2"), now, then)
+	queue.AddWork(ctx, NewWorkArgs("3", "3"), now, then)
+	queue.AddWork(ctx, NewWorkArgs("4", "4"), now, then)
+	queue.AddWork(ctx, NewWorkArgs("5", "5"), now, then)
 	fakeClock.Step(11 * time.Second)
 	wg.Wait()
 	lastVal := atomic.LoadInt32(&testVal)
@@ -87,6 +83,7 @@ func TestExecuteDelayed(t *testing.T) {
 }
 
 func TestCancel(t *testing.T) {
+	logger, ctx := ktesting.NewTestContext(t)
 	testVal := int32(0)
 	wg := sync.WaitGroup{}
 	wg.Add(3)
@@ -99,17 +96,16 @@ func TestCancel(t *testing.T) {
 	then := now.Add(10 * time.Second)
 	fakeClock := testingclock.NewFakeClock(now)
 	queue.clock = fakeClock
-	queue.AddWork(context.TODO(), NewWorkArgs("1", "1"), now, then)
-	queue.AddWork(context.TODO(), NewWorkArgs("2", "2"), now, then)
-	queue.AddWork(context.TODO(), NewWorkArgs("3", "3"), now, then)
-	queue.AddWork(context.TODO(), NewWorkArgs("4", "4"), now, then)
-	queue.AddWork(context.TODO(), NewWorkArgs("5", "5"), now, then)
-	queue.AddWork(context.TODO(), NewWorkArgs("1", "1"), now, then)
-	queue.AddWork(context.TODO(), NewWorkArgs("2", "2"), now, then)
-	queue.AddWork(context.TODO(), NewWorkArgs("3", "3"), now, then)
-	queue.AddWork(context.TODO(), NewWorkArgs("4", "4"), now, then)
-	queue.AddWork(context.TODO(), NewWorkArgs("5", "5"), now, then)
-	logger, _ := ktesting.NewTestContext(t)
+	queue.AddWork(ctx, NewWorkArgs("1", "1"), now, then)
+	queue.AddWork(ctx, NewWorkArgs("2", "2"), now, then)
+	queue.AddWork(ctx, NewWorkArgs("3", "3"), now, then)
+	queue.AddWork(ctx, NewWorkArgs("4", "4"), now, then)
+	queue.AddWork(ctx, NewWorkArgs("5", "5"), now, then)
+	queue.AddWork(ctx, NewWorkArgs("1", "1"), now, then)
+	queue.AddWork(ctx, NewWorkArgs("2", "2"), now, then)
+	queue.AddWork(ctx, NewWorkArgs("3", "3"), now, then)
+	queue.AddWork(ctx, NewWorkArgs("4", "4"), now, then)
+	queue.AddWork(ctx, NewWorkArgs("5", "5"), now, then)
 	queue.CancelWork(logger, NewWorkArgs("2", "2").KeyFromWorkArgs())
 	queue.CancelWork(logger, NewWorkArgs("4", "4").KeyFromWorkArgs())
 	fakeClock.Step(11 * time.Second)
@@ -121,6 +117,7 @@ func TestCancel(t *testing.T) {
 }
 
 func TestCancelAndReadd(t *testing.T) {
+	logger, ctx := ktesting.NewTestContext(t)
 	testVal := int32(0)
 	wg := sync.WaitGroup{}
 	wg.Add(4)
@@ -133,20 +130,19 @@ func TestCancelAndReadd(t *testing.T) {
 	then := now.Add(10 * time.Second)
 	fakeClock := testingclock.NewFakeClock(now)
 	queue.clock = fakeClock
-	queue.AddWork(context.TODO(), NewWorkArgs("1", "1"), now, then)
-	queue.AddWork(context.TODO(), NewWorkArgs("2", "2"), now, then)
-	queue.AddWork(context.TODO(), NewWorkArgs("3", "3"), now, then)
-	queue.AddWork(context.TODO(), NewWorkArgs("4", "4"), now, then)
-	queue.AddWork(context.TODO(), NewWorkArgs("5", "5"), now, then)
-	queue.AddWork(context.TODO(), NewWorkArgs("1", "1"), now, then)
-	queue.AddWork(context.TODO(), NewWorkArgs("2", "2"), now, then)
-	queue.AddWork(context.TODO(), NewWorkArgs("3", "3"), now, then)
-	queue.AddWork(context.TODO(), NewWorkArgs("4", "4"), now, then)
-	queue.AddWork(context.TODO(), NewWorkArgs("5", "5"), now, then)
-	logger, _ := ktesting.NewTestContext(t)
+	queue.AddWork(ctx, NewWorkArgs("1", "1"), now, then)
+	queue.AddWork(ctx, NewWorkArgs("2", "2"), now, then)
+	queue.AddWork(ctx, NewWorkArgs("3", "3"), now, then)
+	queue.AddWork(ctx, NewWorkArgs("4", "4"), now, then)
+	queue.AddWork(ctx, NewWorkArgs("5", "5"), now, then)
+	queue.AddWork(ctx, NewWorkArgs("1", "1"), now, then)
+	queue.AddWork(ctx, NewWorkArgs("2", "2"), now, then)
+	queue.AddWork(ctx, NewWorkArgs("3", "3"), now, then)
+	queue.AddWork(ctx, NewWorkArgs("4", "4"), now, then)
+	queue.AddWork(ctx, NewWorkArgs("5", "5"), now, then)
 	queue.CancelWork(logger, NewWorkArgs("2", "2").KeyFromWorkArgs())
 	queue.CancelWork(logger, NewWorkArgs("4", "4").KeyFromWorkArgs())
-	queue.AddWork(context.TODO(), NewWorkArgs("2", "2"), now, then)
+	queue.AddWork(ctx, NewWorkArgs("2", "2"), now, then)
 	fakeClock.Step(11 * time.Second)
 	wg.Wait()
 	lastVal := atomic.LoadInt32(&testVal)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
The TimedWorkerQueue is controlled by a mutex lock. Other go-routines that acquire the lock will remove the corresponding key from the map after the worker completes its task. If the lock is acquired here again right after the key has been deleted, the deleted key will be re-added to the queue with a value of nil. In special cases, this can lead to erroneous judgments.


The code to acquire a lock and delete a key is as follows:

https://github.com/kubernetes/kubernetes/blob/d8093cc40394b8e25a864576fe6a38306730d3cb/pkg/controller/tainteviction/timed_workers.go#L136C1-L150C2


```
func (q *TimedWorkerQueue) CancelWork(logger klog.Logger, key string) bool {
	q.Lock()
	defer q.Unlock()
	worker, found := q.workers[key]
	result := false
	if found {
		logger.V(4).Info("Cancelling TimedWorkerQueue item", "item", key, "time", time.Now())
		if worker != nil {
			result = true
			worker.Cancel()
		}
		delete(q.workers, key)
	}
	return result
}
```


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #125332


#### Special notes for your reviewer:
Sorry, as a new contributor, I might not be very familiar with the community rules. If there are any issues with my actions, please guide me. Thank you.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
