### PR TITLE
[KEP-2400]: Swap-aware memory eviction (with no additional APIs)

### DIFF
--- a/pkg/kubelet/eviction/eviction_manager.go
+++ b/pkg/kubelet/eviction/eviction_manager.go
@@ -327,7 +327,7 @@ func (m *managerImpl) synchronize(diskInfoProvider DiskInfoProvider, podFunc Act
 			klog.ErrorS(err, "eviction manager: found conflicting containerfs eviction. Ignoring.")
 		}
 		m.splitContainerImageFs = &splitContainerImageFs
-		m.signalToRankFunc = buildSignalToRankFunc(hasImageFs, splitContainerImageFs)
+		m.signalToRankFunc = buildSignalToRankFunc(hasImageFs, splitContainerImageFs, swapLimitCalculator)
 		m.signalToNodeReclaimFuncs = buildSignalToNodeReclaimFuncs(m.imageGC, m.containerGC, hasImageFs, splitContainerImageFs)
 	}
 

--- a/pkg/kubelet/eviction/eviction_manager_test.go
+++ b/pkg/kubelet/eviction/eviction_manager_test.go
@@ -189,6 +189,10 @@ func makeMemoryStats(nodeAvailableBytes string, podStats map[*v1.Pod]statsapi.Po
 				AvailableBytes:  &availableBytes,
 				WorkingSetBytes: &WorkingSetBytes,
 			},
+			Swap: &statsapi.SwapStats{
+				SwapAvailableBytes: ptr.To(uint64(0)),
+				SwapUsageBytes:     ptr.To(uint64(0)),
+			},
 			SystemContainers: []statsapi.ContainerStats{
 				// Used for memory signal observations on linux
 				{

--- a/pkg/kubelet/eviction/helpers_others.go
+++ b/pkg/kubelet/eviction/helpers_others.go
@@ -24,11 +24,11 @@ import (
 	statsapi "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
 )
 
-func makeMemoryAvailableSignalObservation(summary *statsapi.Summary) *signalObservation {
+func makeMemoryAvailableSignalObservation(summary *statsapi.Summary, accessibleSwap, swapUsageBytes uint64) *signalObservation {
 	if memory := summary.Node.Memory; memory != nil && memory.AvailableBytes != nil && memory.WorkingSetBytes != nil {
 		return &signalObservation{
-			available: resource.NewQuantity(int64(*memory.AvailableBytes), resource.BinarySI),
-			capacity:  resource.NewQuantity(int64(*memory.AvailableBytes+*memory.WorkingSetBytes), resource.BinarySI),
+			available: resource.NewQuantity(int64(*memory.AvailableBytes)+int64(accessibleSwap)-int64(swapUsageBytes), resource.BinarySI),
+			capacity:  resource.NewQuantity(int64(*memory.AvailableBytes+*memory.WorkingSetBytes)+int64(accessibleSwap), resource.BinarySI),
 			time:      memory.Time,
 		}
 	}

--- a/pkg/kubelet/eviction/helpers_windows.go
+++ b/pkg/kubelet/eviction/helpers_windows.go
@@ -26,7 +26,7 @@ import (
 	evictionapi "k8s.io/kubernetes/pkg/kubelet/eviction/api"
 )
 
-func makeMemoryAvailableSignalObservation(summary *statsapi.Summary) *signalObservation {
+func makeMemoryAvailableSignalObservation(summary *statsapi.Summary, _, _ uint64) *signalObservation {
 	klog.V(4).InfoS("Eviction manager: building memory signal observations for windows")
 	sysContainer, err := getSysContainer(summary.Node.SystemContainers, statsapi.SystemContainerWindowsGlobalCommitMemory)
 	if err != nil {

--- a/pkg/kubelet/eviction/types.go
+++ b/pkg/kubelet/eviction/types.go
@@ -19,6 +19,7 @@ package eviction
 
 import (
 	"context"
+	"k8s.io/kubernetes/pkg/kubelet/apis/config"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -54,6 +55,8 @@ type Config struct {
 	KernelMemcgNotification bool
 	// PodCgroupRoot is the cgroup which contains all pods.
 	PodCgroupRoot string
+	// SwapConfig is the configuration for swap.
+	SwapConfig config.MemorySwapConfiguration
 }
 
 // Manager evaluates when an eviction threshold for node stability has been met on the node.

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -530,6 +530,7 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 		Thresholds:               thresholds,
 		KernelMemcgNotification:  kernelMemcgNotification,
 		PodCgroupRoot:            kubeDeps.ContainerManager.GetPodCgroupRoot(),
+		SwapConfig:               kubeCfg.MemorySwap,
 	}
 
 	var serviceLister corelisters.ServiceLister

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go
@@ -422,7 +422,7 @@ type swapConfigurationHelper struct {
 }
 
 func newSwapConfigurationHelper(machineInfo cadvisorv1.MachineInfo, swapBehavior string) (*swapConfigurationHelper, error) {
-	limitCalculator, err := swap.NewLimitCalculator(int64(machineInfo.MemoryCapacity), int64(machineInfo.SwapCapacity), !isCgroup2UnifiedMode(), swapBehavior)
+	limitCalculator, err := swap.NewLimitCalculator(machineInfo.MemoryCapacity, machineInfo.SwapCapacity, !isCgroup2UnifiedMode(), swapBehavior)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create swap limit calculator: %w", err)
 	}

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_linux_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_linux_test.go
@@ -1243,7 +1243,7 @@ func TestGenerateLinuxContainerResourcesWithSwap(t *testing.T) {
 				return
 			}
 
-			swapLimitCalculator, err := swap.NewLimitCalculator(int64(m.machineInfo.MemoryCapacity), int64(m.machineInfo.SwapCapacity), tc.cgroupVersion == cgroupV1, tc.swapBehavior)
+			swapLimitCalculator, err := swap.NewLimitCalculator(m.machineInfo.MemoryCapacity, m.machineInfo.SwapCapacity, tc.cgroupVersion == cgroupV1, tc.swapBehavior)
 			require.NoError(t, err)
 			c1ExpectedSwap, err := swapLimitCalculator.CalcContainerSwapLimit(*pod, pod.Spec.Containers[0])
 			require.NoError(t, err)

--- a/pkg/kubelet/util/swap/limit_calculator.go
+++ b/pkg/kubelet/util/swap/limit_calculator.go
@@ -1,0 +1,197 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package swap
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/pkg/apis/core/v1/helper/qos"
+	"k8s.io/kubernetes/pkg/kubelet/types"
+)
+
+func NewLimitCalculator(nodeMemoryCapacity, nodeSwapCapacity uint64, isCgroupV1 bool, swapBehavior string) (LimitCalculator, error) {
+	switch swapBehavior {
+	case types.LimitedSwap:
+		return NewLimitedSwapCalculator(nodeMemoryCapacity, nodeSwapCapacity, isCgroupV1)
+	case types.NoSwap:
+		return NewNoSwapCalculator(), nil
+	default:
+		return nil, fmt.Errorf("unknown swap behavior %s", swapBehavior)
+	}
+}
+
+type LimitCalculator interface {
+	IsContainerEligibleForSwap(pod corev1.Pod, container corev1.Container) (bool, error)
+	IsPodEligibleForSwap(pod corev1.Pod) (bool, error)
+	CalcContainerSwapLimit(pod corev1.Pod, container corev1.Container) (int64, error)
+	CalcPodSwapLimit(pod corev1.Pod) (int64, error)
+}
+
+// To ensure that LimitedSwapCalculator and NoSwapCalculator implement LimitCalculator at compilation time.
+var (
+	_ LimitCalculator = &LimitedSwapCalculator{}
+	_ LimitCalculator = &NoSwapCalculator{}
+)
+
+func calcPodSwapLimit(limitCalculator LimitCalculator, pod corev1.Pod) (int64, error) {
+	swapLimit := int64(0)
+	for _, container := range pod.Spec.Containers {
+		limit, err := limitCalculator.CalcContainerSwapLimit(pod, container)
+		if err != nil {
+			return 0, err
+		}
+
+		swapLimit += limit
+	}
+
+	return swapLimit, nil
+}
+
+func atLeastOneContainerEligibleForSwap(limitCalculator LimitCalculator, pod corev1.Pod) (bool, error) {
+	for _, container := range pod.Spec.Containers {
+		eligible, err := limitCalculator.IsContainerEligibleForSwap(pod, container)
+		if err != nil {
+			return false, err
+		}
+
+		if eligible {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+type LimitedSwapCalculator struct {
+	nodeMemoryCapacity uint64
+	nodeSwapCapacity   uint64
+	isCgroupV1         bool
+}
+
+func NewLimitedSwapCalculator(nodeMemoryCapacity, nodeSwapCapacity uint64, isCgroupV1 bool) (*LimitedSwapCalculator, error) {
+	if nodeMemoryCapacity <= 0 {
+		return nil, fmt.Errorf("total node memory is 0")
+	}
+
+	if nodeSwapCapacity <= 0 {
+		klog.InfoS("LimitedSwapCalculator is initialized with total node swap is 0, swap limit will always be set to zero")
+	}
+
+	return &LimitedSwapCalculator{
+		nodeMemoryCapacity: nodeMemoryCapacity,
+		nodeSwapCapacity:   nodeSwapCapacity,
+		isCgroupV1:         isCgroupV1,
+	}, nil
+}
+
+func (l *LimitedSwapCalculator) isPodRuledOutForSwap(pod corev1.Pod) bool {
+	if qos.GetPodQOS(&pod) != corev1.PodQOSBurstable {
+		return true
+	}
+	if types.IsCriticalPod(&pod) {
+		return true
+	}
+	if l.nodeSwapCapacity <= 0 {
+		return true
+	}
+
+	return false
+}
+
+func (l *LimitedSwapCalculator) IsContainerEligibleForSwap(pod corev1.Pod, container corev1.Container) (bool, error) {
+	if l.isPodRuledOutForSwap(pod) {
+		return false, nil
+	}
+	if container.Resources.Requests == nil || container.Resources.Requests.Memory() == nil {
+		return false, nil
+	}
+
+	containerDoesNotRequestMemory := container.Resources.Requests.Memory().IsZero() && container.Resources.Limits.Memory().IsZero()
+	memoryRequestEqualsToLimit := container.Resources.Requests.Memory().Cmp(*container.Resources.Limits.Memory()) == 0
+
+	if containerDoesNotRequestMemory || l.isCgroupV1 || memoryRequestEqualsToLimit {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func (l *LimitedSwapCalculator) IsPodEligibleForSwap(pod corev1.Pod) (bool, error) {
+	if l.isPodRuledOutForSwap(pod) {
+		return false, nil
+	}
+
+	hasContainerEligibleForSwap, err := atLeastOneContainerEligibleForSwap(l, pod)
+	if err != nil {
+		return false, err
+	}
+
+	return hasContainerEligibleForSwap, nil
+}
+
+func (l *LimitedSwapCalculator) CalcContainerSwapLimit(pod corev1.Pod, container corev1.Container) (int64, error) {
+	containerEligibleForSwap, err := l.IsContainerEligibleForSwap(pod, container)
+	if err != nil {
+		return 0, err
+	}
+
+	if !containerEligibleForSwap {
+		return 0, nil
+	}
+
+	containerMemoryRequest := container.Resources.Requests.Memory().Value()
+	if containerMemoryRequest > int64(l.nodeMemoryCapacity) {
+		return 0, fmt.Errorf("container request %d is larger than total node memory %d", containerMemoryRequest, l.nodeMemoryCapacity)
+	}
+
+	containerMemoryProportion := float64(containerMemoryRequest) / float64(l.nodeMemoryCapacity)
+	swapAllocation := containerMemoryProportion * float64(l.nodeSwapCapacity)
+
+	return int64(swapAllocation), nil
+}
+
+func (l *LimitedSwapCalculator) CalcPodSwapLimit(pod corev1.Pod) (int64, error) {
+	if !l.isPodRuledOutForSwap(pod) {
+		return 0, nil
+	}
+
+	return calcPodSwapLimit(l, pod)
+}
+
+type NoSwapCalculator struct{}
+
+func NewNoSwapCalculator() *NoSwapCalculator {
+	return &NoSwapCalculator{}
+}
+
+func (n NoSwapCalculator) IsContainerEligibleForSwap(_ corev1.Pod, _ corev1.Container) (bool, error) {
+	return false, nil
+}
+
+func (n NoSwapCalculator) IsPodEligibleForSwap(pod corev1.Pod) (bool, error) {
+	return false, nil
+}
+
+func (n NoSwapCalculator) CalcContainerSwapLimit(_ corev1.Pod, _ corev1.Container) (int64, error) {
+	return 0, nil
+}
+
+func (n NoSwapCalculator) CalcPodSwapLimit(pod corev1.Pod) (int64, error) {
+	return 0, nil
+}

--- a/pkg/kubelet/util/swap/limit_calculator_test.go
+++ b/pkg/kubelet/util/swap/limit_calculator_test.go
@@ -1,0 +1,397 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package swap_test
+
+import (
+	"fmt"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/kubernetes/pkg/apis/scheduling"
+	"k8s.io/kubernetes/pkg/kubelet/util/swap"
+	"k8s.io/utils/ptr"
+)
+
+const gb = 1024 * 1024 * 1024
+
+func getTestPod(memoryRequest int64, toSetLimit bool) v1.Pod {
+	pod := v1.Pod{Spec: v1.PodSpec{Containers: []v1.Container{{Resources: v1.ResourceRequirements{}}}}}
+
+	if memoryRequest > 0 {
+		pod.Spec.Containers[0].Resources.Requests = v1.ResourceList{v1.ResourceMemory: resource.MustParse(fmt.Sprintf("%d", memoryRequest))}
+
+		if toSetLimit {
+			pod.Spec.Containers[0].Resources.Limits = v1.ResourceList{v1.ResourceMemory: resource.MustParse(fmt.Sprintf("%d", memoryRequest))}
+		}
+	}
+
+	return pod
+}
+
+type nodeResources struct {
+	nodeMemoryCapacity uint64
+	nodeSwapCapacity   uint64
+}
+
+var nodeWithSwap = nodeResources{
+	nodeMemoryCapacity: 512 * gb,
+	nodeSwapCapacity:   8 * gb,
+}
+
+var nodeWithNoSwap = nodeResources{
+	nodeMemoryCapacity: 512 * gb,
+	nodeSwapCapacity:   0,
+}
+
+func TestLimitedSwapCalculator_IsContainerEligibleForSwap(t *testing.T) {
+	tests := []struct {
+		name       string
+		resources  nodeResources
+		isCgroupV1 bool
+		// pod calculated is the first container in the pod's spec
+		pod                   v1.Pod
+		expectEligibleForSwap bool
+	}{
+		{
+			name:                  "container with no request, expected not to be eligible for swap",
+			resources:             nodeWithSwap,
+			pod:                   getTestPod(0, false),
+			expectEligibleForSwap: false,
+		},
+		{
+			name:                  "container with memory request equal to limit, expected not to be eligible for swap",
+			resources:             nodeWithSwap,
+			pod:                   getTestPod(1234, true),
+			expectEligibleForSwap: false,
+		},
+		{
+			name:                  "with cgroup v1, expected not to be eligible for swap",
+			resources:             nodeWithSwap,
+			isCgroupV1:            true,
+			pod:                   getTestPod(1234, false),
+			expectEligibleForSwap: false,
+		},
+		{
+			name:                  "a container with no memory limit, expected to be eligible for swap",
+			resources:             nodeWithSwap,
+			pod:                   getTestPod(1234, false),
+			expectEligibleForSwap: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l, err := swap.NewLimitedSwapCalculator(tt.resources.nodeMemoryCapacity, tt.resources.nodeSwapCapacity, tt.isCgroupV1)
+			if err != nil {
+				t.Errorf("NewLimitedSwapCalculator() error = %v", err)
+			}
+			eligibleForSwap, err := l.IsContainerEligibleForSwap(tt.pod, tt.pod.Spec.Containers[0])
+			if err != nil {
+				t.Errorf("NewLimitedSwapCalculator() error = %v", err)
+			}
+
+			if eligibleForSwap != tt.expectEligibleForSwap {
+				t.Errorf("IsContainerEligibleForSwap() eligibleForSwap = %v, expectEligibleForSwap %v", eligibleForSwap, tt.expectEligibleForSwap)
+			}
+		})
+	}
+}
+
+func TestLimitedSwapCalculator_IsPodEligibleForSwap(t *testing.T) {
+	tests := []struct {
+		name       string
+		resources  nodeResources
+		isCgroupV1 bool
+		// pod calculated is the first container in the pod's spec
+		pod                   v1.Pod
+		expectEligibleForSwap bool
+	}{
+		{
+			name:                  "best-effort QoS pod, expected not to be eligible for swap",
+			resources:             nodeWithSwap,
+			pod:                   getTestPod(0, false),
+			expectEligibleForSwap: false,
+		},
+		{
+			name:                  "guaranteed QoS pod, expected not to be eligible for swap",
+			resources:             nodeWithSwap,
+			pod:                   getTestPod(1234, true),
+			expectEligibleForSwap: false,
+		},
+		{
+			name:      "critical pod, expected not to be eligible for swap",
+			resources: nodeWithSwap,
+			pod: func() v1.Pod {
+				pod := getTestPod(1234, false)
+				pod.Spec.Priority = ptr.To(scheduling.SystemCriticalPriority)
+				return pod
+			}(),
+			expectEligibleForSwap: false,
+		},
+		{
+			name:                  "node with no swap, expected not to be eligible for swap",
+			resources:             nodeWithNoSwap,
+			pod:                   getTestPod(1234, false),
+			expectEligibleForSwap: false,
+		},
+		{
+			name:                  "a pod that should be eligible for swap",
+			resources:             nodeWithSwap,
+			pod:                   getTestPod(1234, false),
+			expectEligibleForSwap: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l, err := swap.NewLimitedSwapCalculator(tt.resources.nodeMemoryCapacity, tt.resources.nodeSwapCapacity, tt.isCgroupV1)
+			if err != nil {
+				t.Errorf("NewLimitedSwapCalculator() error = %v", err)
+			}
+			eligibleForSwap, err := l.IsPodEligibleForSwap(tt.pod)
+			if err != nil {
+				t.Errorf("IsPodEligibleForSwap() error = %v", err)
+				return
+			}
+
+			if eligibleForSwap != tt.expectEligibleForSwap {
+				t.Errorf("IsPodEligibleForSwap() eligibleForSwap = %v, expectEligibleForSwap %v", eligibleForSwap, tt.expectEligibleForSwap)
+			}
+		})
+	}
+}
+
+func TestLimitedSwapCalculator_CalcContainerSwapLimit(t *testing.T) {
+	tests := []struct {
+		name       string
+		resources  nodeResources
+		isCgroupV1 bool
+		// pod calculated is the first container in the pod's spec
+		pod             v1.Pod
+		expectSwapLimit int64
+	}{
+		{
+			name:            "container with no request, expected not to be eligible for swap",
+			resources:       nodeWithSwap,
+			pod:             getTestPod(0, false),
+			expectSwapLimit: 0,
+		},
+		{
+			name:            "expect zero limit on nodes with no swap",
+			resources:       nodeWithNoSwap,
+			pod:             getTestPod(123, false),
+			expectSwapLimit: 0,
+		},
+		{
+			name:            "container eligible for swap, ensure correct calculation",
+			resources:       nodeWithSwap,
+			pod:             getTestPod(5*gb, false),
+			expectSwapLimit: int64((float64(5*gb) / float64(nodeWithSwap.nodeMemoryCapacity)) * float64(nodeWithSwap.nodeSwapCapacity)),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l, err := swap.NewLimitedSwapCalculator(tt.resources.nodeMemoryCapacity, tt.resources.nodeSwapCapacity, tt.isCgroupV1)
+			if err != nil {
+				t.Errorf("NewLimitedSwapCalculator() error = %v", err)
+			}
+			swapLimit, err := l.CalcContainerSwapLimit(tt.pod, tt.pod.Spec.Containers[0])
+			if err != nil {
+				t.Errorf("NewLimitedSwapCalculator() error = %v", err)
+			}
+
+			if swapLimit != tt.expectSwapLimit {
+				t.Errorf("IsContainerEligibleForSwap() swapLimit = %v, expectSwapLimit %v", swapLimit, tt.expectSwapLimit)
+			}
+		})
+	}
+}
+
+func TestLimitedSwapCalculator_CalcPodSwapLimit(t *testing.T) {
+	tests := []struct {
+		name       string
+		resources  nodeResources
+		isCgroupV1 bool
+		// pod calculated is the first container in the pod's spec
+		pod             v1.Pod
+		expectSwapLimit int64
+	}{
+		{
+			name:            "container with no request, expected not to be eligible for swap",
+			resources:       nodeWithSwap,
+			pod:             getTestPod(0, false),
+			expectSwapLimit: 0,
+		},
+		{
+			name:            "container eligible for swap, ensure correct calculation",
+			resources:       nodeWithSwap,
+			pod:             getTestPod(5*gb, false),
+			expectSwapLimit: int64((float64(5*gb) / float64(nodeWithSwap.nodeMemoryCapacity)) * float64(nodeWithSwap.nodeSwapCapacity)),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l, err := swap.NewLimitedSwapCalculator(tt.resources.nodeMemoryCapacity, tt.resources.nodeSwapCapacity, tt.isCgroupV1)
+			if err != nil {
+				t.Errorf("NewLimitedSwapCalculator() error = %v", err)
+			}
+			swapLimit, err := l.CalcContainerSwapLimit(tt.pod, tt.pod.Spec.Containers[0])
+			if err != nil {
+				t.Errorf("NewLimitedSwapCalculator() error = %v", err)
+			}
+
+			if swapLimit != tt.expectSwapLimit {
+				t.Errorf("IsContainerEligibleForSwap() swapLimit = %v, expectSwapLimit %v", swapLimit, tt.expectSwapLimit)
+			}
+		})
+	}
+}
+
+func TestNoSwapCalculator_IsContainerEligibleForSwap(t *testing.T) {
+	const expectEligibleForSwap = false
+
+	tests := []struct {
+		name string
+		// pod calculated is the first container in the pod's spec
+		pod v1.Pod
+	}{
+		{
+			name: "container with no request, expected not to be eligible for swap",
+			pod:  getTestPod(0, false),
+		},
+		{
+			name: "container with memory request equal to limit, expected not to be eligible for swap",
+			pod:  getTestPod(1234, true),
+		},
+		{
+			name: "with cgroup v1, expected not to be eligible for swap",
+			pod:  getTestPod(1234, false),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l := swap.NewNoSwapCalculator()
+			eligibleForSwap, err := l.IsContainerEligibleForSwap(tt.pod, tt.pod.Spec.Containers[0])
+			if err != nil {
+				t.Errorf("NewNoSwapCalculator() error = %v", err)
+			}
+
+			if eligibleForSwap != expectEligibleForSwap {
+				t.Errorf("IsContainerEligibleForSwap() eligibleForSwap = %v, expectEligibleForSwap %v", eligibleForSwap, expectEligibleForSwap)
+			}
+		})
+	}
+}
+
+func TestNoSwapCalculator_IsPodEligibleForSwap(t *testing.T) {
+	const expectEligibleForSwap = false
+
+	tests := []struct {
+		name string
+		// pod calculated is the first container in the pod's spec
+		pod v1.Pod
+	}{
+		{
+			name: "container with no request, expected not to be eligible for swap",
+			pod: func() v1.Pod {
+				pod := getTestPod(1234, false)
+				pod.Spec.Containers = append(pod.Spec.Containers, v1.Container{Resources: v1.ResourceRequirements{Requests: v1.ResourceList{}}})
+				return pod
+			}(),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l := swap.NewNoSwapCalculator()
+			eligibleForSwap, err := l.IsPodEligibleForSwap(tt.pod)
+			if err != nil {
+				t.Errorf("NewNoSwapCalculator() error = %v", err)
+			}
+
+			if eligibleForSwap != expectEligibleForSwap {
+				t.Errorf("IsContainerEligibleForSwap() eligibleForSwap = %v, expectEligibleForSwap %v", eligibleForSwap, expectEligibleForSwap)
+			}
+		})
+	}
+}
+
+func TestNoSwapCalculator_CalcContainerSwapLimit(t *testing.T) {
+	const expectSwapLimit = int64(0)
+
+	tests := []struct {
+		name string
+		// pod calculated is the first container in the pod's spec
+		pod v1.Pod
+	}{
+		{
+			name: "container with no request, expected not to be eligible for swap",
+			pod:  getTestPod(0, false),
+		},
+		{
+			name: "container eligible for swap, ensure correct calculation",
+			pod:  getTestPod(5*gb, false),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l := swap.NewNoSwapCalculator()
+			swapLimit, err := l.CalcContainerSwapLimit(tt.pod, tt.pod.Spec.Containers[0])
+			if err != nil {
+				t.Errorf("NewNoSwapCalculator() error = %v", err)
+			}
+
+			if swapLimit != expectSwapLimit {
+				t.Errorf("IsContainerEligibleForSwap() swapLimit = %v, expectSwapLimit %v", swapLimit, expectSwapLimit)
+			}
+		})
+	}
+}
+
+func TestNoSwapCalculator_CalcPodSwapLimit(t *testing.T) {
+	const expectSwapLimit = int64(0)
+
+	tests := []struct {
+		name       string
+		resources  nodeResources
+		isCgroupV1 bool
+		// pod calculated is the first container in the pod's spec
+		pod v1.Pod
+	}{
+		{
+			name:      "container with no request, expected not to be eligible for swap",
+			resources: nodeWithSwap,
+			pod:       getTestPod(0, false),
+		},
+		{
+			name:      "container eligible for swap, ensure correct calculation",
+			resources: nodeWithSwap,
+			pod:       getTestPod(5*gb, false),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l := swap.NewNoSwapCalculator()
+			swapLimit, err := l.CalcContainerSwapLimit(tt.pod, tt.pod.Spec.Containers[0])
+			if err != nil {
+				t.Errorf("NewNoSwapCalculator() error = %v", err)
+			}
+
+			if swapLimit != expectSwapLimit {
+				t.Errorf("IsContainerEligibleForSwap() swapLimit = %v, expectSwapLimit %v", swapLimit, expectSwapLimit)
+			}
+		})
+	}
+}

--- a/test/e2e_node/eviction_test.go
+++ b/test/e2e_node/eviction_test.go
@@ -570,6 +570,11 @@ type podEvictSpec struct {
 
 	evictionMaxPodGracePeriod int
 	evictionSoftGracePeriod   int
+
+	// Can be used in order to alter pod using runtime data
+	prePodCreationMofificationFunc func(pod *v1.Pod)
+	// Can be used in order to perform validation on the given pod right after a pressure condition is met.
+	postPressureValidationFunc func(pod *v1.Pod)
 }
 
 // runEvictionTest sets up a testing environment given the provided pods, and checks a few things:
@@ -592,7 +597,11 @@ func runEvictionTest(f *framework.Framework, pressureTimeout time.Duration, expe
 			ginkgo.By("setting up pods to be used by tests")
 			pods := []*v1.Pod{}
 			for _, spec := range testSpecs {
-				pods = append(pods, spec.pod)
+				p := spec.pod.DeepCopy()
+				if spec.prePodCreationMofificationFunc != nil {
+					spec.prePodCreationMofificationFunc(p)
+				}
+				pods = append(pods, p)
 			}
 			e2epod.NewPodClient(f).CreateBatch(ctx, pods)
 		})
@@ -628,6 +637,13 @@ func runEvictionTest(f *framework.Framework, pressureTimeout time.Duration, expe
 
 			ginkgo.By("checking for the expected pod conditions for evicted pods")
 			verifyPodConditions(ctx, f, testSpecs)
+
+			for _, spec := range testSpecs {
+				if spec.postPressureValidationFunc != nil {
+					ginkgo.By("running a post-validation function for pod " + spec.pod.Name)
+					spec.postPressureValidationFunc(spec.pod.DeepCopy())
+				}
+			}
 
 			// We observe pressure from the API server.  The eviction manager observes pressure from the kubelet internal stats.
 			// This means the eviction manager will observe pressure before we will, creating a delay between when the eviction manager
@@ -941,14 +957,12 @@ func logDiskMetrics(ctx context.Context) {
 	}
 }
 
-func logMemoryMetrics(ctx context.Context) {
-	summary, err := getNodeSummary(ctx)
-	if err != nil {
-		framework.Logf("Error getting summary: %v", err)
-		return
-	}
+func logMemoryMetricsWithSummary(ctx context.Context, summary *kubeletstatsv1alpha1.Summary) {
 	if summary.Node.Memory != nil && summary.Node.Memory.WorkingSetBytes != nil && summary.Node.Memory.AvailableBytes != nil {
 		framework.Logf("Node.Memory.WorkingSetBytes: %d, Node.Memory.AvailableBytes: %d", *summary.Node.Memory.WorkingSetBytes, *summary.Node.Memory.AvailableBytes)
+	}
+	if summary.Node.Swap != nil && summary.Node.Swap.SwapUsageBytes != nil && summary.Node.Swap.SwapAvailableBytes != nil {
+		framework.Logf("summary.Node.Swap.SwapUsageBytes: %d, summary.Node.Swap.SwapAvailableBytes: %d", *summary.Node.Swap.SwapUsageBytes, *summary.Node.Swap.SwapAvailableBytes)
 	}
 	for _, sysContainer := range summary.Node.SystemContainers {
 		if sysContainer.Name == kubeletstatsv1alpha1.SystemContainerPods && sysContainer.Memory != nil && sysContainer.Memory.WorkingSetBytes != nil && sysContainer.Memory.AvailableBytes != nil {
@@ -960,9 +974,29 @@ func logMemoryMetrics(ctx context.Context) {
 		for _, container := range pod.Containers {
 			if container.Memory != nil && container.Memory.WorkingSetBytes != nil {
 				framework.Logf("--- summary Container: %s WorkingSetBytes: %d", container.Name, *container.Memory.WorkingSetBytes)
+				if container.Memory.UsageBytes != nil {
+					framework.Logf("--- summary Container: %s UsageBytes: %d", container.Name, *container.Memory.UsageBytes)
+				}
+			}
+			if container.Swap != nil {
+				if container.Swap.SwapUsageBytes != nil {
+					framework.Logf("--- summary Container: %s SwapUsageBytes: %d", container.Name, *container.Swap.SwapUsageBytes)
+				}
+				if container.Swap.SwapAvailableBytes != nil {
+					framework.Logf("--- summary Container: %s SwapAvailableBytes: %d", container.Name, *container.Swap.SwapAvailableBytes)
+				}
 			}
 		}
 	}
+}
+
+func logMemoryMetrics(ctx context.Context) {
+	summary, err := getNodeSummary(ctx)
+	if err != nil {
+		framework.Logf("Error getting summary: %v", err)
+		return
+	}
+	logMemoryMetricsWithSummary(ctx, summary)
 }
 
 func logPidMetrics(ctx context.Context) {

--- a/test/e2e_node/swap_test.go
+++ b/test/e2e_node/swap_test.go
@@ -46,6 +46,7 @@ import (
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	testutils "k8s.io/kubernetes/test/utils"
 	admissionapi "k8s.io/pod-security-admission/api"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -237,8 +238,7 @@ var _ = SIGDescribe("Swap", "[LinuxOnly]", ginkgo.Ordered, feature.Swap, framewo
 					}, 5*time.Minute, 1*time.Second).Should(gomega.Succeed(), "swap usage is above zero: %s", swapUsage.String())
 
 					// Better to delete the stress pod ASAP to avoid node failures
-					err := podClient.Delete(context.Background(), stressPod.Name, metav1.DeleteOptions{})
-					framework.ExpectNoError(err)
+					_ = podClient.Delete(context.Background(), stressPod.Name, metav1.DeleteOptions{GracePeriodSeconds: ptr.To(int64(0))})
 				})
 
 				ginkgo.It("should be able to use more memory than memory limits", func() {
@@ -287,8 +287,7 @@ var _ = SIGDescribe("Swap", "[LinuxOnly]", ginkgo.Ordered, feature.Swap, framewo
 					}, 5*time.Minute, 1*time.Second).Should(gomega.Succeed())
 
 					// Better to delete the stress pod ASAP to avoid node failures
-					err := podClient.Delete(context.Background(), stressPod.Name, metav1.DeleteOptions{})
-					framework.ExpectNoError(err)
+					_ = podClient.Delete(context.Background(), stressPod.Name, metav1.DeleteOptions{GracePeriodSeconds: ptr.To(int64(0))})
 				})
 
 				ginkgo.It("ensure summary API properly reports swap", func() {


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/sig node

#### Problem and background
Prior to this PR, kubelet's eviction manager completely overlooked swap memory, leading to several issues:
* **Inaccessible Swap**: The memory eviction threshold is configured in such a way that swap is never triggered during node-level pressure, as eviction occurs before the node starts swapping memory.
* **Unfairness & Instability**: The eviction manager may evict the "wrong" or innocent pods, failing to address the actual memory pressure.
* **Unexpected Behavior**: Pods that exceed their memory limits (with regular and swap memory) are not evicted first, even though they would immediately get killed if swap were not used.

In addition, this PR serves as an alternative to https://github.com/kubernetes/kubernetes/pull/128137. In that PR, swap is presented as a standalone signal alongside memory. However, I believe this approach is problematic, as it attempts to completely separate memory and swap memory. In reality, the two are inherently connected and should be addressed as a single issue. As a small example for how the two are inherently connected, swap is never used until the memory is full.

#### What this PR does / why we need it:

This PR addresses the above issues by making the eviction manager swap-aware. The proposed logic is fully backward compatible and requires no additional configuration, making it completely transparent to the user.

#### The main idea
Let `accessible swap` be the amount of swap that is accessible by pods according to the LimitedSwap swap behavior [[1](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/2400-node-swap/README.md#steps-to-calculate-swap-limit)]. Note that the amount of accessible swap changes in time according to the pods running on the node.

**Triggering evictions**: The eviction manager considers `accessible swap` as additional memory capacity.
**Eviction ordering**: The [eviction order](https://kubernetes.io/docs/concepts/scheduling-eviction/node-pressure-eviction/#pod-selection-for-kubelet-eviction) will be defined as follows (for more info, see discussion [here](https://github.com/kubernetes/enhancements/pull/4701#discussion_r1944859336)):
```
The kubelet uses the following parameters to determine the pod eviction order:
1. Whether the pod's resource usage (memory usage + swap usage) exceeds requests (memory requests + swap requests)
2. [Pod Priority](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/)
3. The pod's resource usage (memory usage + swap usage) relative to requests (memory requests + swap requests)
```


<!--
Older version:

- Eviction manager considers `accessible swap` as additional memory capacity.
- In the context of ranking pods for evictions, swap memory is considered as additional "regular" memory. This is relevant for checking whether memory requests are exceeded [[2](https://github.com/kubernetes/kubernetes/blob/d8093cc40394b8e25a864576fe6a38306730d3cb/pkg/kubelet/eviction/helpers.go#L684)] or for identifying which pods uses more memory [[3](https://github.com/kubernetes/kubernetes/blob/d8093cc40394b8e25a864576fe6a38306730d3cb/pkg/kubelet/eviction/helpers.go#L703)].
- When the memory eviction threshold is reached, pods that use more memory and swap than their memory limits are being killed first. Note that while there is no memory pressure using more than the pods limits is perfectly ok.
-->
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #120800

#### Special notes for your reviewer:
- I recommend reviewing this PR per commit.
- ~Please don't mind the last commit. It cherry picks the fix from https://github.com/kubernetes/kubernetes/pull/129486 and will be removed after this PR is merged.~ the PR is now merged and rebase on top of this one.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Make eviction mechanism swap-aware
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/2400-node-swap/README.md
```
