### PR TITLE
e2e services: avoid panic on service creation retry

### DIFF
--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -1680,16 +1680,17 @@ var _ = common.SIGDescribe("Services", func() {
 			}
 		}()
 
-		service := t.BuildServiceSpec()
-		service.Spec.Type = v1.ServiceTypeNodePort
+		var service *v1.Service
+		baseService := t.BuildServiceSpec()
+		baseService.Spec.Type = v1.ServiceTypeNodePort
 		numberOfRetries := 5
 		ginkgo.By("creating service " + serviceName + " with type NodePort in namespace " + ns)
 		var err error
 		for i := 0; i < numberOfRetries; i++ {
 			port, err := e2eservice.GetUnusedStaticNodePort()
 			framework.ExpectNoError(err, "Static node port allocator was not able to find a free nodeport.")
-			service.Spec.Ports[0].NodePort = port
-			service, err = t.CreateService(service)
+			baseService.Spec.Ports[0].NodePort = port
+			service, err = t.CreateService(baseService)
 			// We will later delete this service and then recreate it with same nodeport. We need to ensure that
 			// another e2e test doesn't start listening on our old nodeport and conflicts re-creation of service
 			// hence we use ReserveStaticNodePort.


### PR DESCRIPTION
The test was reusing the same variable for the service on each iteration, the problem is that when the service creation fails, it clears out the variable and in the next iteration it panics because is trying to use a field on that same variable.


/kind flake
```release-note
NONE
```


Seen in https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-e2e-gci-gce-nftables/1878625027453095936

```
> Enter [It] should release NodePorts on delete - k8s.io/kubernetes/test/e2e/network/service.go:1669 @ 01/13/25 02:17:05.783
STEP: creating service nodeport-reuse with type NodePort in namespace services-1182 - k8s.io/kubernetes/test/e2e/network/service.go:1686 @ 01/13/25 02:17:05.783
I0113 02:17:05.957719 8797 service.go:1707] node port 30021 is already allocated to other service, retrying ... : Service "nodeport-reuse" is invalid: spec.ports[0].nodePort: Invalid value: 30021: provided port is already allocated
[PANICKED] Test Panicked
In [It] at: runtime/panic.go:115 @ 01/13/25 02:17:05.957

runtime error: index out of range [0] with length 0

Full Stack Trace
  k8s.io/kubernetes/test/e2e/network.init.func23.21({0x7fb11844bfb8, 0xc0020997a0})
  	k8s.io/kubernetes/test/e2e/network/service.go:1691 +0xca6
< Exit [It] should release NodePorts on delete - k8s.io/kubernetes/test/e2e/network/service.go:1669 @ 01/13/25 02:17:05.957 (174ms)
> Enter [DeferCleanup (Each)] [sig-network] Services - k8s.io/kubernetes/test/e2e/framework/metrics/init/init.go:35 @ 01/13/25 02:17:05.958
< Exit [DeferCleanup (Each)] [sig-network] Services - k8s.io/kubernetes/test/e2e/framework/metrics/init/init.go:35 @ 01/13/25 02:17:05.958 (0s)
> Enter [DeferCleanup (Each)] [sig-network] Services - k8s.io/kubernetes/test/e2e/framework/node/init/init.go:34 @ 01/13/25 02:17:05.958
I0113 02:17:05.958328 8797 helper.go:125] Waiting up to 7m0s for all (but 0) nodes to be ready
< Exit [DeferCleanup (Each)] [sig-network] Services - k8s.io/kubernetes/test/e2e/framework/node/init/init.go:34 @ 01/13/25 02:17:06.042 (85ms)
> Enter [DeferCleanup (Each)] [sig-network] Services - dump namespaces | framework.go:218 @ 01/13/25 02:17:06.043
```