### PR TITLE
fix container status remains ready state

### DIFF
--- a/pkg/kubelet/kuberuntime/fake_kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/fake_kuberuntime_manager.go
@@ -23,6 +23,7 @@ import (
 
 	cadvisorapi "github.com/google/cadvisor/info/v1"
 	"go.opentelemetry.io/otel/trace"
+
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -111,6 +112,7 @@ func newFakeKubeRuntimeManager(runtimeService internalapi.RuntimeService, imageS
 		containerManager:       cm.NewFakeContainerManager(),
 		runtimeHelper:          runtimeHelper,
 		runtimeService:         runtimeService,
+		readinessManager:       proberesults.NewManager(),
 		imageService:           imageService,
 		keyring:                keyring,
 		seccompProfileRoot:     fakeSeccompProfileRoot,

--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -851,6 +851,10 @@ func (m *kubeGenericRuntimeManager) killContainersWithSyncResult(ctx context.Con
 				klog.ErrorS(err, "Kill container failed", "pod", klog.KRef(runningPod.Namespace, runningPod.Name), "podUID", runningPod.ID,
 					"containerName", container.Name, "containerID", container.ID)
 			}
+			// if the container is killed, the container must not be ready for readiness. #129552
+			if gracePeriodOverride != nil {
+				m.readinessManager.Set(container.ID, proberesults.Failure, pod)
+			}
 			containerResults <- killContainerResult
 		}(container)
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
set container ready as failure after kill container

#### Which issue(s) this PR fixes:
Fixes #129552

#### Special notes for your reviewer:
@bobbypage @aojea 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix container status remains ready state when pod has terminationGracePeriodSeconds
```
