### PR TITLE
Fix flaking test in k8s.io/client-go/tools/cache (#129352)

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/controller_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/controller_test.go
@@ -249,6 +249,8 @@ func TestHammerController(t *testing.T) {
 
 	wg := sync.WaitGroup{}
 	const threads = 3
+	const opsPerThread = 100
+	const totalOps = threads * opsPerThread
 	wg.Add(threads)
 	for i := 0; i < threads; i++ {
 		go func() {
@@ -257,7 +259,7 @@ func TestHammerController(t *testing.T) {
 			currentNames := sets.String{}
 			rs := rand.NewSource(rand.Int63())
 			f := fuzz.New().NilChance(.5).NumElements(0, 2).RandSource(rs)
-			for i := 0; i < 100; i++ {
+			for i := 0; i < opsPerThread; i++ {
 				var name string
 				var isNew bool
 				if currentNames.Len() == 0 || rand.Intn(3) == 1 {
@@ -295,7 +297,21 @@ func TestHammerController(t *testing.T) {
 
 	// Let's wait for the controller to finish processing the things we just added.
 	// TODO: look in the queue to see how many items need to be processed.
-	time.Sleep(100 * time.Millisecond)
+	err := wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
+		outputSetLock.Lock()
+		defer outputSetLock.Unlock()
+
+		// Count total operations across all keys
+		var processedOps uint64
+		for _, ops := range outputSet {
+			processedOps += uint64(len(ops))
+		}
+
+		return processedOps == totalOps, nil
+	})
+	if err != nil {
+		t.Errorf("Error during PollUntilContextTimeout: %v", err)
+	}
 	cancel()
 
 	// Before we permanently lock this mutex, we have to be sure

--- a/staging/src/k8s.io/client-go/tools/cache/controller_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/controller_test.go
@@ -302,8 +302,6 @@ func TestHammerController(t *testing.T) {
 	// At this point, all goroutines should have stopped, and
 	// leak checking is done by TestMain.
 	controllerWG.Wait()
-
-	t.Logf("got: %#v", outputSet)
 }
 
 func TestUpdate(t *testing.T) {


### PR DESCRIPTION
Use wait.PollWithContext to ensure all queued operations are processed before concluding the test, preventing intermittent failures caused by early test completion under heavy concurrency.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind flake

#### What this PR does / why we need it:
This PR fixes a flaking test in `k8s.io/client-go/tools/cache/controller_test.go`. It uses `wait.PollWithContext` to wait for all queued operations to be processed before concluding the test, ensuring the test doesn’t end prematurely under heavy concurrency.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #129352

#### Special notes for your reviewer:
Ran stress test with race detection for 5+ minutes with no failures:
```
go test ./pkg/kubelet/config -race -c
stress ./config.test -test.run staging/src/k8s.io/client-go/tools/cache/controller_test.go
5m15s: 2852 runs so far, 0 failures, 10 active
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
