### PR TITLE
Automated cherry pick of #129594: kubeadm: remove misplaced error during image pull

### DIFF
--- a/cmd/kubeadm/app/preflight/checks.go
+++ b/cmd/kubeadm/app/preflight/checks.go
@@ -863,9 +863,6 @@ func (ipc ImagePullCheck) Check() (warnings, errorList []error) {
 				klog.V(1).Infof("image exists: %s", image)
 				continue
 			}
-			if err != nil {
-				errorList = append(errorList, errors.Wrapf(err, "failed to check if image %s exists", image))
-			}
 			fallthrough // Proceed with pulling the image if it does not exist
 		case v1.PullAlways:
 			klog.V(1).Infof("pulling: %s", image)


### PR DESCRIPTION
Cherry pick of #129594 on release-1.32.

#129594: kubeadm: remove misplaced error during image pull

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
kubeadm: fixed a bug where an image is not pulled if there is an error with the sandbox image from CRI.
```