### PR TITLE
Move some exec helper functions from framework/volume to framework/pod

### DIFF
--- a/test/e2e/node/kubelet.go
+++ b/test/e2e/node/kubelet.go
@@ -421,7 +421,7 @@ var _ = SIGDescribe("kubelet", func() {
 					pod = createPodUsingNfs(ctx, f, c, ns, nfsIP, t.podCmd)
 
 					ginkgo.By("Stop the NFS server")
-					e2evolume.StopNFSServer(f, nfsServerPod)
+					e2evolume.StopNFSServer(ctx, f, nfsServerPod)
 
 					ginkgo.By("Delete the pod mounted to the NFS volume -- expect failure")
 					err := e2epod.DeletePodWithWait(ctx, c, pod)
@@ -432,7 +432,7 @@ var _ = SIGDescribe("kubelet", func() {
 					checkPodCleanup(ctx, c, pod, false)
 
 					ginkgo.By("Restart the nfs server")
-					e2evolume.RestartNFSServer(f, nfsServerPod)
+					e2evolume.RestartNFSServer(ctx, f, nfsServerPod)
 
 					ginkgo.By("Verify that the deleted client pod is now cleaned up")
 					checkPodCleanup(ctx, c, pod, true)

--- a/test/e2e/storage/host_path_type.go
+++ b/test/e2e/storage/host_path_type.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2eevents "k8s.io/kubernetes/test/e2e/framework/events"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
-	e2evolume "k8s.io/kubernetes/test/e2e/framework/volume"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 	admissionapi "k8s.io/pod-security-admission/api"
@@ -270,7 +269,7 @@ var _ = utils.SIGDescribe("HostPathType Character Device", framework.WithSlow(),
 		targetCharDev = path.Join(hostBaseDir, "achardev")
 		ginkgo.By("Create a character device for further testing")
 		cmd := fmt.Sprintf("mknod %s c 89 1", path.Join(mountBaseDir, "achardev"))
-		stdout, stderr, err := e2evolume.PodExec(f, basePod, cmd)
+		stdout, stderr, err := e2epod.ExecShellInPodWithFullOutput(ctx, f, basePod.Name, cmd)
 		framework.ExpectNoError(err, "command: %q, stdout: %s\nstderr: %s", cmd, stdout, stderr)
 	})
 
@@ -340,7 +339,7 @@ var _ = utils.SIGDescribe("HostPathType Block Device", framework.WithSlow(), fun
 		targetBlockDev = path.Join(hostBaseDir, "ablkdev")
 		ginkgo.By("Create a block device for further testing")
 		cmd := fmt.Sprintf("mknod %s b 89 1", path.Join(mountBaseDir, "ablkdev"))
-		stdout, stderr, err := e2evolume.PodExec(f, basePod, cmd)
+		stdout, stderr, err := e2epod.ExecShellInPodWithFullOutput(ctx, f, basePod.Name, cmd)
 		framework.ExpectNoError(err, "command %q: stdout: %s\nstderr: %s", cmd, stdout, stderr)
 	})
 

--- a/test/e2e/storage/testsuites/ephemeral.go
+++ b/test/e2e/storage/testsuites/ephemeral.go
@@ -194,7 +194,7 @@ func (p *ephemeralTestSuite) DefineTests(driver storageframework.TestDriver, pat
 				// attempt to create a dummy file and expect for it not to be created
 				command = "ls /mnt/test* && (touch /mnt/test-0/hello-world || true) && [ ! -f /mnt/test-0/hello-world ]"
 			}
-			e2evolume.VerifyExecInPodSucceed(f, pod, command)
+			e2epod.VerifyExecInPodSucceed(ctx, f, pod, command)
 			return nil
 		}
 		l.testCase.TestEphemeral(ctx)
@@ -214,7 +214,7 @@ func (p *ephemeralTestSuite) DefineTests(driver storageframework.TestDriver, pat
 			if pattern.VolMode == v1.PersistentVolumeBlock {
 				command = "if ! [ -b /mnt/test-0 ]; then echo /mnt/test-0 is not a block device; exit 1; fi"
 			}
-			e2evolume.VerifyExecInPodSucceed(f, pod, command)
+			e2epod.VerifyExecInPodSucceed(ctx, f, pod, command)
 			return nil
 		}
 		l.testCase.TestEphemeral(ctx)
@@ -308,8 +308,8 @@ func (p *ephemeralTestSuite) DefineTests(driver storageframework.TestDriver, pat
 			// visible in the other.
 			if pattern.VolMode != v1.PersistentVolumeBlock && !readOnly && !shared {
 				ginkgo.By("writing data in one pod and checking the second does not see it (it should get its own volume)")
-				e2evolume.VerifyExecInPodSucceed(f, pod, "touch /mnt/test-0/hello-world")
-				e2evolume.VerifyExecInPodSucceed(f, pod2, "[ ! -f /mnt/test-0/hello-world ]")
+				e2epod.VerifyExecInPodSucceed(ctx, f, pod, "touch /mnt/test-0/hello-world")
+				e2epod.VerifyExecInPodSucceed(ctx, f, pod2, "[ ! -f /mnt/test-0/hello-world ]")
 			}
 
 			// TestEphemeral expects the pod to be fully deleted

--- a/test/e2e/storage/testsuites/ephemeral.go
+++ b/test/e2e/storage/testsuites/ephemeral.go
@@ -194,7 +194,8 @@ func (p *ephemeralTestSuite) DefineTests(driver storageframework.TestDriver, pat
 				// attempt to create a dummy file and expect for it not to be created
 				command = "ls /mnt/test* && (touch /mnt/test-0/hello-world || true) && [ ! -f /mnt/test-0/hello-world ]"
 			}
-			e2epod.VerifyExecInPodSucceed(ctx, f, pod, command)
+			err := e2epod.VerifyExecInPodSucceed(ctx, f, pod, command)
+			framework.ExpectNoError(err, "while checking read-only mount")
 			return nil
 		}
 		l.testCase.TestEphemeral(ctx)
@@ -214,7 +215,8 @@ func (p *ephemeralTestSuite) DefineTests(driver storageframework.TestDriver, pat
 			if pattern.VolMode == v1.PersistentVolumeBlock {
 				command = "if ! [ -b /mnt/test-0 ]; then echo /mnt/test-0 is not a block device; exit 1; fi"
 			}
-			e2epod.VerifyExecInPodSucceed(ctx, f, pod, command)
+			err := e2epod.VerifyExecInPodSucceed(ctx, f, pod, command)
+			framework.ExpectNoError(err, "while checking read/write mount")
 			return nil
 		}
 		l.testCase.TestEphemeral(ctx)
@@ -308,8 +310,10 @@ func (p *ephemeralTestSuite) DefineTests(driver storageframework.TestDriver, pat
 			// visible in the other.
 			if pattern.VolMode != v1.PersistentVolumeBlock && !readOnly && !shared {
 				ginkgo.By("writing data in one pod and checking the second does not see it (it should get its own volume)")
-				e2epod.VerifyExecInPodSucceed(ctx, f, pod, "touch /mnt/test-0/hello-world")
-				e2epod.VerifyExecInPodSucceed(ctx, f, pod2, "[ ! -f /mnt/test-0/hello-world ]")
+				err := e2epod.VerifyExecInPodSucceed(ctx, f, pod, "touch /mnt/test-0/hello-world")
+				framework.ExpectNoError(err, "while writing data in first pod")
+				err = e2epod.VerifyExecInPodSucceed(ctx, f, pod2, "[ ! -f /mnt/test-0/hello-world ]")
+				framework.ExpectNoError(err, "while checking data in second pod")
 			}
 
 			// TestEphemeral expects the pod to be fully deleted

--- a/test/e2e/storage/testsuites/fsgroupchangepolicy.go
+++ b/test/e2e/storage/testsuites/fsgroupchangepolicy.go
@@ -250,12 +250,12 @@ func (s *fsGroupChangePolicyTestSuite) DefineTests(driver storageframework.TestD
 			// Change the ownership of files in the initial pod.
 			if test.changedRootDirFileOwnership != 0 {
 				ginkgo.By(fmt.Sprintf("Changing the root directory file ownership to %s", strconv.Itoa(test.changedRootDirFileOwnership)))
-				storageutils.ChangeFilePathGidInPod(f, rootDirFilePath, strconv.Itoa(test.changedRootDirFileOwnership), pod)
+				storageutils.ChangeFilePathGidInPod(ctx, f, rootDirFilePath, strconv.Itoa(test.changedRootDirFileOwnership), pod)
 			}
 
 			if test.changedSubDirFileOwnership != 0 {
 				ginkgo.By(fmt.Sprintf("Changing the sub-directory file ownership to %s", strconv.Itoa(test.changedSubDirFileOwnership)))
-				storageutils.ChangeFilePathGidInPod(f, subDirFilePath, strconv.Itoa(test.changedSubDirFileOwnership), pod)
+				storageutils.ChangeFilePathGidInPod(ctx, f, subDirFilePath, strconv.Itoa(test.changedSubDirFileOwnership), pod)
 			}
 
 			ginkgo.By(fmt.Sprintf("Deleting Pod %s/%s", pod.Namespace, pod.Name))
@@ -281,24 +281,24 @@ func createPodAndVerifyContentGid(ctx context.Context, f *framework.Framework, p
 		ginkgo.By(fmt.Sprintf("Creating a sub-directory and file, and verifying their ownership is %s", podFsGroup))
 		cmd := fmt.Sprintf("touch %s", rootDirFilePath)
 		var err error
-		_, _, err = e2evolume.PodExec(f, pod, cmd)
+		_, _, err = e2epod.ExecShellInPodWithFullOutput(ctx, f, pod.Name, cmd)
 		framework.ExpectNoError(err)
-		storageutils.VerifyFilePathGidInPod(f, rootDirFilePath, podFsGroup, pod)
+		storageutils.VerifyFilePathGidInPod(ctx, f, rootDirFilePath, podFsGroup, pod)
 
 		cmd = fmt.Sprintf("mkdir %s", subdir)
-		_, _, err = e2evolume.PodExec(f, pod, cmd)
+		_, _, err = e2epod.ExecShellInPodWithFullOutput(ctx, f, pod.Name, cmd)
 		framework.ExpectNoError(err)
 		cmd = fmt.Sprintf("touch %s", subDirFilePath)
-		_, _, err = e2evolume.PodExec(f, pod, cmd)
+		_, _, err = e2epod.ExecShellInPodWithFullOutput(ctx, f, pod.Name, cmd)
 		framework.ExpectNoError(err)
-		storageutils.VerifyFilePathGidInPod(f, subDirFilePath, podFsGroup, pod)
+		storageutils.VerifyFilePathGidInPod(ctx, f, subDirFilePath, podFsGroup, pod)
 		return pod
 	}
 
 	// Verify existing contents of the volume
 	ginkgo.By(fmt.Sprintf("Verifying the ownership of root directory file is %s", expectedRootDirFileOwnership))
-	storageutils.VerifyFilePathGidInPod(f, rootDirFilePath, expectedRootDirFileOwnership, pod)
+	storageutils.VerifyFilePathGidInPod(ctx, f, rootDirFilePath, expectedRootDirFileOwnership, pod)
 	ginkgo.By(fmt.Sprintf("Verifying the ownership of sub directory file is %s", expectedSubDirFileOwnership))
-	storageutils.VerifyFilePathGidInPod(f, subDirFilePath, expectedSubDirFileOwnership, pod)
+	storageutils.VerifyFilePathGidInPod(ctx, f, subDirFilePath, expectedSubDirFileOwnership, pod)
 	return pod
 }

--- a/test/e2e/storage/testsuites/fsgroupchangepolicy.go
+++ b/test/e2e/storage/testsuites/fsgroupchangepolicy.go
@@ -250,12 +250,12 @@ func (s *fsGroupChangePolicyTestSuite) DefineTests(driver storageframework.TestD
 			// Change the ownership of files in the initial pod.
 			if test.changedRootDirFileOwnership != 0 {
 				ginkgo.By(fmt.Sprintf("Changing the root directory file ownership to %s", strconv.Itoa(test.changedRootDirFileOwnership)))
-				storageutils.ChangeFilePathGidInPod(ctx, f, rootDirFilePath, strconv.Itoa(test.changedRootDirFileOwnership), pod)
+				storageutils.ChangeFilePathGIDInPod(ctx, f, rootDirFilePath, strconv.Itoa(test.changedRootDirFileOwnership), pod)
 			}
 
 			if test.changedSubDirFileOwnership != 0 {
 				ginkgo.By(fmt.Sprintf("Changing the sub-directory file ownership to %s", strconv.Itoa(test.changedSubDirFileOwnership)))
-				storageutils.ChangeFilePathGidInPod(ctx, f, subDirFilePath, strconv.Itoa(test.changedSubDirFileOwnership), pod)
+				storageutils.ChangeFilePathGIDInPod(ctx, f, subDirFilePath, strconv.Itoa(test.changedSubDirFileOwnership), pod)
 			}
 
 			ginkgo.By(fmt.Sprintf("Deleting Pod %s/%s", pod.Namespace, pod.Name))
@@ -283,7 +283,7 @@ func createPodAndVerifyContentGid(ctx context.Context, f *framework.Framework, p
 		var err error
 		_, _, err = e2epod.ExecShellInPodWithFullOutput(ctx, f, pod.Name, cmd)
 		framework.ExpectNoError(err)
-		storageutils.VerifyFilePathGidInPod(ctx, f, rootDirFilePath, podFsGroup, pod)
+		storageutils.VerifyFilePathGIDInPod(ctx, f, rootDirFilePath, podFsGroup, pod)
 
 		cmd = fmt.Sprintf("mkdir %s", subdir)
 		_, _, err = e2epod.ExecShellInPodWithFullOutput(ctx, f, pod.Name, cmd)
@@ -291,14 +291,14 @@ func createPodAndVerifyContentGid(ctx context.Context, f *framework.Framework, p
 		cmd = fmt.Sprintf("touch %s", subDirFilePath)
 		_, _, err = e2epod.ExecShellInPodWithFullOutput(ctx, f, pod.Name, cmd)
 		framework.ExpectNoError(err)
-		storageutils.VerifyFilePathGidInPod(ctx, f, subDirFilePath, podFsGroup, pod)
+		storageutils.VerifyFilePathGIDInPod(ctx, f, subDirFilePath, podFsGroup, pod)
 		return pod
 	}
 
 	// Verify existing contents of the volume
 	ginkgo.By(fmt.Sprintf("Verifying the ownership of root directory file is %s", expectedRootDirFileOwnership))
-	storageutils.VerifyFilePathGidInPod(ctx, f, rootDirFilePath, expectedRootDirFileOwnership, pod)
+	storageutils.VerifyFilePathGIDInPod(ctx, f, rootDirFilePath, expectedRootDirFileOwnership, pod)
 	ginkgo.By(fmt.Sprintf("Verifying the ownership of sub directory file is %s", expectedSubDirFileOwnership))
-	storageutils.VerifyFilePathGidInPod(ctx, f, subDirFilePath, expectedSubDirFileOwnership, pod)
+	storageutils.VerifyFilePathGIDInPod(ctx, f, subDirFilePath, expectedSubDirFileOwnership, pod)
 	return pod
 }

--- a/test/e2e/storage/testsuites/multivolume.go
+++ b/test/e2e/storage/testsuites/multivolume.go
@@ -499,7 +499,8 @@ func testAccessMultipleVolumes(ctx context.Context, f *framework.Framework, cs c
 		index := i + 1
 		path := fmt.Sprintf("/mnt/volume%d", index)
 		ginkgo.By(fmt.Sprintf("Checking if the volume%d exists as expected volume mode (%s)", index, *pvc.Spec.VolumeMode))
-		e2evolume.CheckVolumeModeOfPath(ctx, f, pod, *pvc.Spec.VolumeMode, path)
+		err = e2evolume.CheckVolumeModeOfPath(ctx, f, pod, *pvc.Spec.VolumeMode, path)
+		framework.ExpectNoError(err)
 
 		if readSeedBase > 0 {
 			ginkgo.By(fmt.Sprintf("Checking if read from the volume%d works properly", index))
@@ -607,7 +608,8 @@ func TestConcurrentAccessToSingleVolume(ctx context.Context, f *framework.Framew
 	for i, pod := range pods {
 		index := i + 1
 		ginkgo.By(fmt.Sprintf("Checking if the volume in pod%d exists as expected volume mode (%s)", index, *pvc.Spec.VolumeMode))
-		e2evolume.CheckVolumeModeOfPath(ctx, f, pod, *pvc.Spec.VolumeMode, path)
+		err := e2evolume.CheckVolumeModeOfPath(ctx, f, pod, *pvc.Spec.VolumeMode, path)
+		framework.ExpectNoError(err)
 
 		if readOnly {
 			ginkgo.By("Skipping volume content checks, volume is read-only")
@@ -643,7 +645,8 @@ func TestConcurrentAccessToSingleVolume(ctx context.Context, f *framework.Framew
 		index := i + 1
 		// index of pod and index of pvc match, because pods are created above way
 		ginkgo.By(fmt.Sprintf("Rechecking if the volume in pod%d exists as expected volume mode (%s)", index, *pvc.Spec.VolumeMode))
-		e2evolume.CheckVolumeModeOfPath(ctx, f, pod, *pvc.Spec.VolumeMode, "/mnt/volume1")
+		err := e2evolume.CheckVolumeModeOfPath(ctx, f, pod, *pvc.Spec.VolumeMode, "/mnt/volume1")
+		framework.ExpectNoError(err)
 
 		if readOnly {
 			ginkgo.By("Skipping volume content checks, volume is read-only")

--- a/test/e2e/storage/utils/utils.go
+++ b/test/e2e/storage/utils/utils.go
@@ -722,23 +722,23 @@ func WaitForGVRFinalizer(ctx context.Context, c dynamic.Interface, gvr schema.Gr
 	return err
 }
 
-// VerifyFilePathGidInPod verfies expected GID of the target filepath
-func VerifyFilePathGidInPod(ctx context.Context, f *framework.Framework, filePath, expectedGid string, pod *v1.Pod) {
+// VerifyFilePathGIDInPod verfies expected GID of the target filepath
+func VerifyFilePathGIDInPod(ctx context.Context, f *framework.Framework, filePath, expectedGID string, pod *v1.Pod) {
 	cmd := fmt.Sprintf("ls -l %s", filePath)
 	stdout, stderr, err := e2epod.ExecShellInPodWithFullOutput(ctx, f, pod.Name, cmd)
 	framework.ExpectNoError(err)
 	framework.Logf("pod %s/%s exec for cmd %s, stdout: %s, stderr: %s", pod.Namespace, pod.Name, cmd, stdout, stderr)
 	ll := strings.Fields(stdout)
-	framework.Logf("stdout split: %v, expected gid: %v", ll, expectedGid)
-	gomega.Expect(ll[3]).To(gomega.Equal(expectedGid))
+	framework.Logf("stdout split: %v, expected gid: %v", ll, expectedGID)
+	gomega.Expect(ll[3]).To(gomega.Equal(expectedGID))
 }
 
-// ChangeFilePathGidInPod changes the GID of the target filepath.
-func ChangeFilePathGidInPod(ctx context.Context, f *framework.Framework, filePath, targetGid string, pod *v1.Pod) {
-	cmd := fmt.Sprintf("chgrp %s %s", targetGid, filePath)
+// ChangeFilePathGIDInPod changes the GID of the target filepath.
+func ChangeFilePathGIDInPod(ctx context.Context, f *framework.Framework, filePath, targetGID string, pod *v1.Pod) {
+	cmd := fmt.Sprintf("chgrp %s %s", targetGID, filePath)
 	_, _, err := e2epod.ExecShellInPodWithFullOutput(ctx, f, pod.Name, cmd)
 	framework.ExpectNoError(err)
-	VerifyFilePathGidInPod(ctx, f, filePath, targetGid, pod)
+	VerifyFilePathGIDInPod(ctx, f, filePath, targetGID, pod)
 }
 
 // DeleteStorageClass deletes the passed in StorageClass and catches errors other than "Not Found"

--- a/test/e2e/upgrades/storage/volume_mode.go
+++ b/test/e2e/upgrades/storage/volume_mode.go
@@ -105,7 +105,8 @@ func (t *VolumeModeDowngradeTest) Setup(ctx context.Context, f *framework.Framew
 	framework.ExpectNoError(err)
 
 	ginkgo.By("Checking if PV exists as expected volume mode")
-	e2evolume.CheckVolumeModeOfPath(ctx, f, t.pod, block, devicePath)
+	err = e2evolume.CheckVolumeModeOfPath(ctx, f, t.pod, block, devicePath)
+	framework.ExpectNoError(err)
 
 	ginkgo.By("Checking if read/write to PV works properly")
 	storageutils.CheckReadWriteToPath(ctx, f, t.pod, block, devicePath)
@@ -118,7 +119,8 @@ func (t *VolumeModeDowngradeTest) Test(ctx context.Context, f *framework.Framewo
 	<-done
 
 	ginkgo.By("Verifying that nothing exists at the device path in the pod")
-	e2epod.VerifyExecInPodFail(ctx, f, t.pod, fmt.Sprintf("test -e %s", devicePath), 1)
+	err := e2epod.VerifyExecInPodFail(ctx, f, t.pod, fmt.Sprintf("test -e %s", devicePath), 1)
+	framework.ExpectNoError(err)
 }
 
 // Teardown cleans up any remaining resources.

--- a/test/e2e/upgrades/storage/volume_mode.go
+++ b/test/e2e/upgrades/storage/volume_mode.go
@@ -105,10 +105,10 @@ func (t *VolumeModeDowngradeTest) Setup(ctx context.Context, f *framework.Framew
 	framework.ExpectNoError(err)
 
 	ginkgo.By("Checking if PV exists as expected volume mode")
-	e2evolume.CheckVolumeModeOfPath(f, t.pod, block, devicePath)
+	e2evolume.CheckVolumeModeOfPath(ctx, f, t.pod, block, devicePath)
 
 	ginkgo.By("Checking if read/write to PV works properly")
-	storageutils.CheckReadWriteToPath(f, t.pod, block, devicePath)
+	storageutils.CheckReadWriteToPath(ctx, f, t.pod, block, devicePath)
 }
 
 // Test waits for the downgrade to complete, and then verifies that a pod can no
@@ -118,7 +118,7 @@ func (t *VolumeModeDowngradeTest) Test(ctx context.Context, f *framework.Framewo
 	<-done
 
 	ginkgo.By("Verifying that nothing exists at the device path in the pod")
-	e2evolume.VerifyExecInPodFail(f, t.pod, fmt.Sprintf("test -e %s", devicePath), 1)
+	e2epod.VerifyExecInPodFail(ctx, f, t.pod, fmt.Sprintf("test -e %s", devicePath), 1)
 }
 
 // Teardown cleans up any remaining resources.

--- a/test/e2e_node/mirror_pod_test.go
+++ b/test/e2e_node/mirror_pod_test.go
@@ -231,7 +231,7 @@ var _ = SIGDescribe("MirrorPod", func() {
 			}
 
 			ginkgo.By("Stopping the NFS server")
-			e2evolume.StopNFSServer(f, nfsServerPod)
+			e2evolume.StopNFSServer(ctx, f, nfsServerPod)
 
 			ginkgo.By(fmt.Sprintf("Deleting the static nfs test pod: %s", staticPodName))
 			err = deleteStaticPod(podPath, staticPodName, ns)
@@ -243,7 +243,7 @@ var _ = SIGDescribe("MirrorPod", func() {
 			}, 5*time.Minute, 10*time.Second).Should(gomega.BeTrueBecause("pod volume should exist while nfs server is stopped"))
 
 			ginkgo.By("Start the NFS server")
-			e2evolume.RestartNFSServer(f, nfsServerPod)
+			e2evolume.RestartNFSServer(ctx, f, nfsServerPod)
 
 			ginkgo.By("Waiting for the pod volume to deleted after the NFS server is started")
 			gomega.Eventually(func() bool {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

A follow-up of https://github.com/kubernetes/kubernetes/pull/112043

```
// PodExec runs f.ExecCommandInContainerWithFullOutput to execute a shell cmd in target pod
// TODO: put this under e2epod once https://github.com/kubernetes/kubernetes/issues/81245
// is resolved. Otherwise there will be dependency issue.

// VerifyExecInPodSucceed verifies shell cmd in target pod succeed
// TODO: put this under e2epod once https://github.com/kubernetes/kubernetes/issues/81245
// is resolved. Otherwise there will be dependency issue.

// VerifyExecInPodFail verifies shell cmd in target pod fail with certain exit code
// TODO: put this under e2epod once https://github.com/kubernetes/kubernetes/issues/81245
// is resolved. Otherwise there will be dependency issue.
```

PodExec is  removed in favor of ExecShellInPodWithFullOutput

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
