### PR TITLE
Add field error properties to blocking error for CEL validation

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/strategy.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/strategy.go
@@ -405,7 +405,9 @@ func (a customResourceStrategy) MatchCustomResourceDefinitionStorage(label label
 func hasBlockingErr(errs field.ErrorList) (bool, *field.Error) {
 	for _, err := range errs {
 		if err.Type == field.ErrorTypeNotSupported || err.Type == field.ErrorTypeRequired || err.Type == field.ErrorTypeTooLong || err.Type == field.ErrorTypeTooMany || err.Type == field.ErrorTypeTypeInvalid {
-			return true, field.Invalid(nil, nil, "some validation rules were not checked because the object was invalid; correct the existing errors to complete validation")
+			berr := *err
+			berr.Detail = "some validation rules were not checked because the object was invalid; correct the existing errors to complete validation"
+			return true, &berr
 		}
 	}
 	return false, nil

--- a/test/integration/apiserver/crd_validation_expressions_test.go
+++ b/test/integration/apiserver/crd_validation_expressions_test.go
@@ -516,8 +516,8 @@ func TestCustomResourceValidatorsWithBlockingErrors(t *testing.T) {
 			}}
 
 			_, err := crClient.Create(context.TODO(), cr, metav1.CreateOptions{})
-			if err == nil || !strings.Contains(err.Error(), "some validation rules were not checked because the object was invalid; correct the existing errors to complete validation") {
-				t.Fatalf("expect error to contain \"some validation rules were not checked because the object was invalid; correct the existing errors to complete validation\" but get: %v", err)
+			if err == nil || !strings.Contains(err.Error(), "spec.extra: Too long: some validation rules were not checked because the object was invalid; correct the existing errors to complete validation") {
+				t.Fatalf("expect error to contain \"spec.extra: Too long: some validation rules were not checked because the object was invalid; correct the existing errors to complete validation\" but get: %v", err)
 			}
 		})
 		t.Run("custom resource create and update MUST NOT allow data if there is blocking error of MaxItems", func(t *testing.T) {
@@ -550,8 +550,8 @@ func TestCustomResourceValidatorsWithBlockingErrors(t *testing.T) {
 			cr.Object["spec"].(map[string]interface{})["assocList"] = assocList
 
 			_, err = crClient.Create(context.TODO(), cr, metav1.CreateOptions{})
-			if err == nil || !strings.Contains(err.Error(), "some validation rules were not checked because the object was invalid; correct the existing errors to complete validation") {
-				t.Fatalf("expect error to contain \"some validation rules were not checked because the object was invalid; correct the existing errors to complete validation\" but get: %v", err)
+			if err == nil || !strings.Contains(err.Error(), "spec.assocList: Too many: 101: some validation rules were not checked because the object was invalid; correct the existing errors to complete validation") {
+				t.Fatalf("expect error to contain \"spec.assocList: Too many: 101: some validation rules were not checked because the object was invalid; correct the existing errors to complete validation\" but get: %v", err)
 			}
 		})
 		t.Run("custom resource create and update MUST NOT allow data if there is blocking error of MaxProperties", func(t *testing.T) {
@@ -582,8 +582,8 @@ func TestCustomResourceValidatorsWithBlockingErrors(t *testing.T) {
 			}
 
 			_, err = crClient.Create(context.TODO(), cr, metav1.CreateOptions{})
-			if err == nil || !strings.Contains(err.Error(), "some validation rules were not checked because the object was invalid; correct the existing errors to complete validation") {
-				t.Fatalf("expect error to contain \"some validation rules were not checked because the object was invalid; correct the existing errors to complete validation\" but get: %v", err)
+			if err == nil || !strings.Contains(err.Error(), "spec.floatMap: Too many: 101: some validation rules were not checked because the object was invalid; correct the existing errors to complete validation") {
+				t.Fatalf("expect error to contain \"spec.floatMap: Too many: 101: some validation rules were not checked because the object was invalid; correct the existing errors to complete validation\" but get: %v", err)
 			}
 		})
 		t.Run("custom resource create and update MUST NOT allow data if there is blocking error of missing required field", func(t *testing.T) {
@@ -612,8 +612,8 @@ func TestCustomResourceValidatorsWithBlockingErrors(t *testing.T) {
 			}}
 
 			_, err = crClient.Create(context.TODO(), cr, metav1.CreateOptions{})
-			if err == nil || !strings.Contains(err.Error(), "some validation rules were not checked because the object was invalid; correct the existing errors to complete validation") {
-				t.Fatalf("expect error to contain \"some validation rules were not checked because the object was invalid; correct the existing errors to complete validation\" but get: %v", err)
+			if err == nil || !strings.Contains(err.Error(), "spec.assocList[0].v: Required value: some validation rules were not checked because the object was invalid; correct the existing errors to complete validation") {
+				t.Fatalf("expect error to contain \"spec.assocList[0].v: Required value: some validation rules were not checked because the object was invalid; correct the existing errors to complete validation\" but get: %v", err)
 			}
 		})
 		t.Run("custom resource create and update MUST NOT allow data if there is blocking error of type", func(t *testing.T) {
@@ -643,8 +643,8 @@ func TestCustomResourceValidatorsWithBlockingErrors(t *testing.T) {
 			}}
 
 			_, err = crClient.Create(context.TODO(), cr, metav1.CreateOptions{})
-			if err == nil || !strings.Contains(err.Error(), "some validation rules were not checked because the object was invalid; correct the existing errors to complete validation") {
-				t.Fatalf("expect error to contain \"some validation rules were not checked because the object was invalid; correct the existing errors to complete validation\" but get: %v", err)
+			if err == nil || !strings.Contains(err.Error(), "Invalid value: \"boolean\": some validation rules were not checked because the object was invalid; correct the existing errors to complete validation") {
+				t.Fatalf("expect error to contain \"Invalid value: \"boolean\": some validation rules were not checked because the object was invalid; correct the existing errors to complete validation\" but get: %v", err)
 			}
 		})
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Enhance blocking error message with field error details (type, path, value) to clarify why CEL validation was skipped.

Follow up on #108859, see https://github.com/kubernetes/kubernetes/pull/108859#discussion_r1914543607:

> Hello, using nil field name and value as a placeholder produces confusing message, e.g.:
> ```
> The FooType "foo" is invalid:
> * spec.bar: Too long: may not be longer than 63
> * <nil>: Invalid value: "null": some validation rules were not checked because the object was invalid; correct the existing errors to complete validation
> ```
> 
> 
> Would it be OK if we change this to reuse field path and type from the `err` that error message looks like:
> ```
> The FooType "foo" is invalid:
> * spec.bar: Too long: may not be longer than 63
> * spec.bar: Too long: may not be longer than 63: some validation rules were not checked because the object was invalid; correct the existing errors to complete validation
> ```
>
> Ideally this should be not a field error but object error but that is not supported afaict.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Enhance blocking error message to clarify why CEL validation was skipped.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
