### PR TITLE
client-go/tools/cache: fix TestAddWhileActive

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/shared_informer_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/shared_informer_test.go
@@ -1077,7 +1077,6 @@ func TestAddWhileActive(t *testing.T) {
 		wg.Wait()
 	}()
 
-	go informer.Run(stop)
 	source.Add(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1"}})
 
 	if !listener1.ok() {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test
/kind flake
/priority important-soon

#### What this PR does / why we need it:

4638ba971661497b147906b8977ae206c9dd6e44 added tracking of the goroutine which executes informer.Run. In the TestAddWhileActive the original `go informer.Run()` was left in place, causing a data race between the two `informer.Run` instances:

```

==================
WARNING: DATA RACE
Read at 0x00c000262398 by goroutine 5302:
  k8s.io/client-go/tools/cache.(*controller).RunWithContext()
      /home/prow/go/src/k8s.io/kubernetes/staging/src/k8s.io/client-go/tools/cache/controller.go:162 +0x1ad
  k8s.io/client-go/tools/cache.(*sharedIndexInformer).RunWithContext()
      /home/prow/go/src/k8s.io/kubernetes/staging/src/k8s.io/client-go/tools/cache/shared_informer.go:584 +0x6c5
  k8s.io/client-go/tools/cache.(*sharedIndexInformer).Run()
      /home/prow/go/src/k8s.io/kubernetes/staging/src/k8s.io/client-go/tools/cache/shared_informer.go:527 +0x48
  k8s.io/client-go/tools/cache.TestAddWhileActive.gowrap1()
      /home/prow/go/src/k8s.io/kubernetes/staging/src/k8s.io/client-go/tools/cache/shared_informer_test.go:1080 +0x17

Previous write at 0x00c000262398 by goroutine 5301:
  k8s.io/client-go/tools/cache.New()
      /home/prow/go/src/k8s.io/kubernetes/staging/src/k8s.io/client-go/tools/cache/controller.go:142 +0x9de
  k8s.io/client-go/tools/cache.(*sharedIndexInformer).RunWithContext.func1()
      /home/prow/go/src/k8s.io/kubernetes/staging/src/k8s.io/client-go/tools/cache/shared_informer.go:562 +0xa78
  k8s.io/client-go/tools/cache.(*sharedIndexInformer).RunWithContext()
      /home/prow/go/src/k8s.io/kubernetes/staging/src/k8s.io/client-go/tools/cache/shared_informer.go:565 +0x119
  k8s.io/client-go/tools/cache.(*sharedIndexInformer).Run()
      /home/prow/go/src/k8s.io/kubernetes/staging/src/k8s.io/client-go/tools/cache/shared_informer.go:527 +0x44
  k8s.io/client-go/tools/cache.(*sharedIndexInformer).Run-fm()
      <autogenerated>:1 +0x17
  k8s.io/client-go/tools/cache.TestAddWhileActive.(*Group).StartWithChannel.func2()
      /home/prow/go/src/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/wait/wait.go:55 +0x38
  k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
      /home/prow/go/src/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/wait/wait.go:72 +0x86

Goroutine 5302 (running) created at:
  k8s.io/client-go/tools/cache.TestAddWhileActive()
      /home/prow/go/src/k8s.io/kubernetes/staging/src/k8s.io/client-go/tools/cache/shared_informer_test.go:1080 +0x93e
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1690 +0x226
  testing.(*T).Run.gowrap1()
      /usr/local/go/src/testing/testing.go:1743 +0x44

Goroutine 5301 (running) created at:
  k8s.io/apimachinery/pkg/util/wait.(*Group).Start()
      /home/prow/go/src/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/wait/wait.go:70 +0xe4
  k8s.io/apimachinery/pkg/util/wait.(*Group).StartWithChannel()
      /home/prow/go/src/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/wait/wait.go:54 +0x7e6
  k8s.io/client-go/tools/cache.TestAddWhileActive()
      /home/prow/go/src/k8s.io/kubernetes/staging/src/k8s.io/client-go/tools/cache/shared_informer_test.go:1074 +0x6a1
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1690 +0x226
  testing.(*T).Run.gowrap1()
      /usr/local/go/src/testing/testing.go:1743 +0x44
==================

```

#### Which issue(s) this PR fixes:

Fixes https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/129341/pull-kubernetes-unit/1879133011962761216

#### Special notes for your reviewer:

In a coincidence of cosmic justice, this particular flake only occurs in my own PRs?!

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
