### PR TITLE
Self-nominating ffromani as approver for sig-node container and resource managers

### DIFF
--- a/pkg/kubelet/cm/OWNERS
+++ b/pkg/kubelet/cm/OWNERS
@@ -6,6 +6,7 @@ approvers:
   - derekwaynecarr
   - yujuhong
   - klueska
+  - ffromani
 reviewers:
   - sig-node-reviewers
 emeritus_approvers:

--- a/test/e2e/node/OWNERS
+++ b/test/e2e/node/OWNERS
@@ -10,6 +10,7 @@ approvers:
   - mrunalp
   - SergeyKanzhelev
   - endocrimes
+  - ffromani
 emeritus_approvers:
   - vishh
   - dchen1107

--- a/test/e2e_node/OWNERS
+++ b/test/e2e_node/OWNERS
@@ -8,6 +8,7 @@ approvers:
   - mrunalp
   - SergeyKanzhelev
   - endocrimes
+  - ffromani
 emeritus_approvers:
   - balajismaniam
   - Random-Liu


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:
I'm self-nominating for the role of approver for the subtree `k/k/pkg/kubelet/cm` which includes
1. all the resource managers (cpu, memory, device, topology manager) - main focus of mine
2. some cgroup related utilities - did some work
3. the pod, node, container and qos manager code, which is about the lifecycle of the containers - secondary focus of mine, did less work
4. the dra subtree - see below
5. the e2e node tests

This layout almost completely fit my area of work in the past years (see references below) but I'd be fine removing the `dra` part. I have interest, but not expertise. I'd be fine narrowing down 3 further, but that would require adding more `OWNERS` files, and/or changing the code layout.
This change I'm proposing has the benefit of being the simplest.

References:
- active in the SIG since 2020
- org member since 2021: https://github.com/kubernetes/org/issues/2560
- formal reviewer since April 2024: https://github.com/kubernetes/kubernetes/pull/123757
- authored KEPs: https://github.com/kubernetes/enhancements/pulls?q=is%3Apr+author%3Affromani+is%3Aclosed+is%3Amerged
- reviewed KEPs:  https://github.com/kubernetes/enhancements/pulls?q=is%3Apr+is%3Amerged+assignee%3Affromani+ (noteworthy: 3695, 4176, 4188, 1769, 4540, 4622, 4680, 4800, 4885)
- authored PRs: (~50) https://github.com/kubernetes/kubernetes/pulls?q=is%3Apr+is%3Amerged+author%3Affromani+
- reviewed PRs: (~110) https://github.com/kubernetes/kubernetes/pulls?q=is%3Apr+is%3Amerged+assignee%3Affromani+

#### Which issue(s) this PR fixes:
Fixes N/A

#### Special notes for your reviewer:
happy to provide more qualifications

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
