### PR TITLE
kubeadm: graduate WaitForAllControlPlaneComponents to Beta

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/join/waitcontrolplane.go
+++ b/cmd/kubeadm/app/cmd/phases/join/waitcontrolplane.go
@@ -26,9 +26,11 @@ import (
 	"k8s.io/klog/v2"
 
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow"
+	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/features"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
 	dryrunutil "k8s.io/kubernetes/cmd/kubeadm/app/util/dryrun"
+	staticpodutil "k8s.io/kubernetes/cmd/kubeadm/app/util/staticpod"
 )
 
 // NewWaitControlPlanePhase is a hidden phase that runs after the control-plane and etcd phases
@@ -71,7 +73,12 @@ func runWaitControlPlanePhase(c workflow.RunData) error {
 	}
 
 	waiter.SetTimeout(data.Cfg().Timeouts.ControlPlaneComponentHealthCheck.Duration)
-	if err := waiter.WaitForControlPlaneComponents(&initCfg.ClusterConfiguration,
+	pods, err := staticpodutil.ReadMultipleStaticPodsFromDisk(data.ManifestDir(),
+		constants.ControlPlaneComponents...)
+	if err != nil {
+		return err
+	}
+	if err = waiter.WaitForControlPlaneComponents(pods,
 		data.Cfg().ControlPlane.LocalAPIEndpoint.AdvertiseAddress); err != nil {
 		return err
 	}

--- a/cmd/kubeadm/app/features/features.go
+++ b/cmd/kubeadm/app/features/features.go
@@ -53,7 +53,7 @@ var InitFeatureGates = FeatureList{
 		DeprecationMessage: "Deprecated in favor of the core kubelet feature UserNamespacesSupport which is beta since 1.30." +
 			" Once UserNamespacesSupport graduates to GA, kubeadm will start using it and RootlessControlPlane will be removed.",
 	},
-	WaitForAllControlPlaneComponents: {FeatureSpec: featuregate.FeatureSpec{Default: false, PreRelease: featuregate.Alpha}},
+	WaitForAllControlPlaneComponents: {FeatureSpec: featuregate.FeatureSpec{Default: true, PreRelease: featuregate.Beta}},
 	ControlPlaneKubeletLocalMode:     {FeatureSpec: featuregate.FeatureSpec{Default: false, PreRelease: featuregate.Alpha}},
 	NodeLocalCRISocket:               {FeatureSpec: featuregate.FeatureSpec{Default: false, PreRelease: featuregate.Alpha}},
 }

--- a/cmd/kubeadm/app/phases/upgrade/staticpods_test.go
+++ b/cmd/kubeadm/app/phases/upgrade/staticpods_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pkg/errors"
 	"go.etcd.io/etcd/client/pkg/v3/transport"
 
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/clientcmd"
 	certutil "k8s.io/client-go/util/cert"
 
@@ -99,7 +100,7 @@ func NewFakeStaticPodWaiter(errsToReturn map[string]error) apiclient.Waiter {
 }
 
 // WaitForControlPlaneComponents just returns a dummy nil, to indicate that the program should just proceed
-func (w *fakeWaiter) WaitForControlPlaneComponents(cfg *kubeadmapi.ClusterConfiguration, apiServerAddress string) error {
+func (w *fakeWaiter) WaitForControlPlaneComponents(podsMap map[string]*v1.Pod, apiServerAddress string) error {
 	return nil
 }
 

--- a/cmd/kubeadm/app/util/apiclient/wait_test.go
+++ b/cmd/kubeadm/app/util/apiclient/wait_test.go
@@ -21,38 +21,56 @@ import (
 	"reflect"
 	"testing"
 
-	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	v1 "k8s.io/api/core/v1"
+
+	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 )
 
 func TestGetControlPlaneComponents(t *testing.T) {
-	testcases := []struct {
-		name     string
-		cfg      *kubeadmapi.ClusterConfiguration
-		expected []controlPlaneComponent
+	getTestPod := func(command []string) *v1.Pod {
+		pod := &v1.Pod{
+			Spec: v1.PodSpec{},
+		}
+		if command != nil {
+			pod.Spec.Containers = []v1.Container{{}}
+			if len(command) > 0 {
+				pod.Spec.Containers[0].Command = command
+			}
+		}
+		return pod
+	}
+	testCases := []struct {
+		name          string
+		setup         func() map[string]*v1.Pod
+		expected      []controlPlaneComponent
+		expectedError string
 	}{
 		{
-			name: "port and addresses from config",
-			cfg: &kubeadmapi.ClusterConfiguration{
-				APIServer: kubeadmapi.APIServer{
-					ControlPlaneComponent: kubeadmapi.ControlPlaneComponent{
-						ExtraArgs: []kubeadmapi.Arg{
-							{Name: "secure-port", Value: "1111"},
-							{Name: "advertise-address", Value: "fd00:1::"},
-						},
-					},
-				},
-				ControllerManager: kubeadmapi.ControlPlaneComponent{
-					ExtraArgs: []kubeadmapi.Arg{
-						{Name: "secure-port", Value: "2222"},
-						{Name: "bind-address", Value: "127.0.0.1"},
-					},
-				},
-				Scheduler: kubeadmapi.ControlPlaneComponent{
-					ExtraArgs: []kubeadmapi.Arg{
-						{Name: "secure-port", Value: "3333"},
-						{Name: "bind-address", Value: "127.0.0.1"},
-					},
-				},
+			name: "valid: all port and addresses from config",
+			setup: func() map[string]*v1.Pod {
+				var (
+					pod    *v1.Pod
+					podMap = map[string]*v1.Pod{}
+				)
+				pod = getTestPod([]string{
+					constants.KubeAPIServer,
+					fmt.Sprintf("--%s=%s", argAdvertiseAddress, "fd00:1::"),
+					fmt.Sprintf("--%s=%s", argPort, "1111"),
+				})
+				podMap[constants.KubeAPIServer] = pod
+				pod = getTestPod([]string{
+					constants.KubeControllerManager,
+					fmt.Sprintf("--%s=%s", argBindAddress, "127.0.0.1"),
+					fmt.Sprintf("--%s=%s", argPort, "2222"),
+				})
+				podMap[constants.KubeControllerManager] = pod
+				pod = getTestPod([]string{
+					constants.KubeScheduler,
+					fmt.Sprintf("--%s=%s", argBindAddress, "127.0.0.1"),
+					fmt.Sprintf("--%s=%s", argPort, "3333"),
+				})
+				podMap[constants.KubeScheduler] = pod
+				return podMap
 			},
 			expected: []controlPlaneComponent{
 				{name: "kube-apiserver", url: fmt.Sprintf("https://[fd00:1::]:1111/%s", endpointLivez)},
@@ -61,19 +79,115 @@ func TestGetControlPlaneComponents(t *testing.T) {
 			},
 		},
 		{
-			name: "default ports and addresses",
-			cfg:  &kubeadmapi.ClusterConfiguration{},
+			name: "valid: all port and addresses from config (alt. formatting)",
+			setup: func() map[string]*v1.Pod {
+				var (
+					pod    *v1.Pod
+					podMap = map[string]*v1.Pod{}
+				)
+				pod = getTestPod([]string{
+					constants.KubeAPIServer,
+					fmt.Sprintf("-%s=%s", argAdvertiseAddress, "fd00:1::"),
+					fmt.Sprintf("-%s=%s", argPort, "1111"),
+				})
+				podMap[constants.KubeAPIServer] = pod
+				pod = getTestPod([]string{
+					constants.KubeControllerManager,
+					fmt.Sprintf("-%s %s", argBindAddress, "127.0.0.1"),
+					fmt.Sprintf("-%s %s", argPort, "2222"),
+				})
+				podMap[constants.KubeControllerManager] = pod
+				pod = getTestPod([]string{
+					constants.KubeScheduler,
+					fmt.Sprintf("-%s %s", argBindAddress, "127.0.0.1"),
+					fmt.Sprintf("-%s %s", argPort, "3333"),
+				})
+				podMap[constants.KubeScheduler] = pod
+				return podMap
+			},
+			expected: []controlPlaneComponent{
+				{name: "kube-apiserver", url: fmt.Sprintf("https://[fd00:1::]:1111/%s", endpointLivez)},
+				{name: "kube-controller-manager", url: fmt.Sprintf("https://127.0.0.1:2222/%s", endpointHealthz)},
+				{name: "kube-scheduler", url: fmt.Sprintf("https://127.0.0.1:3333/%s", endpointLivez)},
+			},
+		},
+		{
+			name: "valid: default ports and addresses",
+			setup: func() map[string]*v1.Pod {
+				var (
+					pod    *v1.Pod
+					podMap = map[string]*v1.Pod{}
+				)
+				pod = getTestPod([]string{
+					constants.KubeAPIServer,
+				})
+				podMap[constants.KubeAPIServer] = pod
+				pod = getTestPod([]string{
+					constants.KubeControllerManager,
+				})
+				podMap[constants.KubeControllerManager] = pod
+				pod = getTestPod([]string{
+					constants.KubeScheduler,
+				})
+				podMap[constants.KubeScheduler] = pod
+				return podMap
+			},
 			expected: []controlPlaneComponent{
 				{name: "kube-apiserver", url: fmt.Sprintf("https://192.168.0.1:6443/%s", endpointLivez)},
 				{name: "kube-controller-manager", url: fmt.Sprintf("https://127.0.0.1:10257/%s", endpointHealthz)},
 				{name: "kube-scheduler", url: fmt.Sprintf("https://127.0.0.1:10259/%s", endpointLivez)},
 			},
 		},
+		{
+			name: "invalid: nil Pods in map",
+			setup: func() map[string]*v1.Pod {
+				return map[string]*v1.Pod{}
+			},
+			expectedError: `[got nil Pod for component "kube-apiserver", ` +
+				`got nil Pod for component "kube-controller-manager", ` +
+				`got nil Pod for component "kube-scheduler"]`,
+		},
+		{
+			name: "invalid: empty commands in containers",
+			setup: func() map[string]*v1.Pod {
+				podMap := map[string]*v1.Pod{}
+				podMap[constants.KubeAPIServer] = getTestPod([]string{})
+				podMap[constants.KubeControllerManager] = getTestPod([]string{})
+				podMap[constants.KubeScheduler] = getTestPod([]string{})
+				return podMap
+			},
+			expectedError: `[the Pod has no container command starting with "kube-apiserver", ` +
+				`the Pod has no container command starting with "kube-controller-manager", ` +
+				`the Pod has no container command starting with "kube-scheduler"]`,
+		},
+		{
+			name: "invalid: missing commands in containers",
+			setup: func() map[string]*v1.Pod {
+				var (
+					pod    = getTestPod([]string{""})
+					podMap = map[string]*v1.Pod{}
+				)
+				podMap[constants.KubeAPIServer] = pod
+				podMap[constants.KubeControllerManager] = pod
+				podMap[constants.KubeScheduler] = pod
+				return podMap
+			},
+			expectedError: `[the Pod has no container command starting with "kube-apiserver", ` +
+				`the Pod has no container command starting with "kube-controller-manager", ` +
+				`the Pod has no container command starting with "kube-scheduler"]`,
+		},
 	}
 
-	for _, tc := range testcases {
+	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actual := getControlPlaneComponents(tc.cfg, "192.168.0.1")
+			m := tc.setup()
+			actual, err := getControlPlaneComponents(m, "192.168.0.1")
+			if err != nil {
+				if err.Error() != tc.expectedError {
+					t.Fatalf("expected error:\n%v\ngot:\n%v",
+						tc.expectedError, err)
+				}
+			}
 			if !reflect.DeepEqual(tc.expected, actual) {
 				t.Fatalf("expected result: %+v, got: %+v", tc.expected, actual)
 			}

--- a/cmd/kubeadm/app/util/dryrun/dryrun.go
+++ b/cmd/kubeadm/app/util/dryrun/dryrun.go
@@ -23,10 +23,10 @@ import (
 	"path/filepath"
 	"time"
 
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	errorsutil "k8s.io/apimachinery/pkg/util/errors"
 
-	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
 )
@@ -90,7 +90,7 @@ func NewWaiter() apiclient.Waiter {
 }
 
 // WaitForControlPlaneComponents just returns a dummy nil, to indicate that the program should just proceed
-func (w *Waiter) WaitForControlPlaneComponents(cfg *kubeadmapi.ClusterConfiguration, apiServerAddress string) error {
+func (w *Waiter) WaitForControlPlaneComponents(podsMap map[string]*v1.Pod, apiServerAddress string) error {
 	return nil
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?


/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

- Set the feature gate to Beta and enabled by default.
- Make sure that the source of truth for which address/port to use for a component health check comes from the respective component static Pod manifest. That is done to comply with any user --patches that are applied on top
of the ClusterConfiguration.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
xref
- https://github.com/kubernetes/kubeadm/issues/2907

#### Special notes for your reviewer:

~first commit fixes circular dependency problems. check the commit message.~

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: graduated the WaitForAllControlPlaneComponents feature gate to Beta. When checking the health status of a control plane component, make sure that the address and port defined as arguments in the respective component's static Pod manifest are used.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
