### PR TITLE
Add introduced and removed version information in etcd fixtures

### DIFF
--- a/test/integration/etcd/etcd_storage_path_test.go
+++ b/test/integration/etcd/etcd_storage_path_test.go
@@ -94,8 +94,8 @@ func testEtcdStoragePathWithVersion(t *testing.T, v string) {
 		// Only test for beta and GA APIs with emulated version.
 		featuregatetesting.SetFeatureGateEmulationVersionDuringTest(t, feature.DefaultFeatureGate, version.MustParse(v))
 		featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, "AllBeta", true)
-		registerEffectiveEmulationVersion(t)
 	}
+	registerEffectiveEmulationVersion(t)
 
 	apiServer := StartRealAPIServerOrDie(t, func(opts *options.ServerRunOptions) {
 		// Disable alphas when emulating previous versions.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/129491

#### Special notes for your reviewer:

The data for prerelease was obtained from adding a test to `roundtrip_test.go` to get all the prerelease information, a very fuzzy gvk -> gvr replace, and matching the prerelease information to the corresponding gvr in `test/integration/etcd/data.go`. Here is the [raw data](https://gist.github.com/Jefftree/24c9ad2f9757d62fb91d18bf839f62ee)

```
func TestGenFixtureData(t *testing.T) {
	scheme := runtime.NewScheme()
	for _, builder := range groups {
		if err := builder.AddToScheme(scheme); err != nil {
			t.Fatalf("unexpected error adding to scheme: %v", err)
		}
	}
	for gvk, _ := range scheme.AllKnownTypes() {
		o, err := scheme.New(gvk)
		if err != nil {
			panic(err)
		}
		oWithIntroduced, ok := o.(introducedInterface)
		if !ok {
			continue
		}
		major, minor := oWithIntroduced.APILifecycleIntroduced()
		t.Logf("%s.%s.%s, Introduced: %d.%d\n", gvk.Group, gvk.Version, strings.ToLower(gvk.Kind)+"s", major, minor)

		oWithRemoved, ok := o.(removedInterface)
		if !ok {
			continue
		}
		major, minor = oWithRemoved.APILifecycleRemoved()
		t.Logf("%s.%s.%s, Removed: %d.%d\n", gvk.Group, gvk.Version, strings.ToLower(gvk.Kind)+"s", major, minor)

	}
}

type introducedInterface interface {
	APILifecycleIntroduced() (major, minor int)
}
type removedInterface interface {
	APILifecycleRemoved() (major, minor int)
}
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/triage accepted