### PR TITLE
Fix Portworx plugin's CSI translation to copy secret name & namespace

### DIFF
--- a/staging/src/k8s.io/csi-translation-lib/plugins/portworx.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/portworx.go
@@ -18,6 +18,7 @@ package plugins
 
 import (
 	"fmt"
+	"strings"
 
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
@@ -28,6 +29,29 @@ import (
 const (
 	PortworxVolumePluginName = "kubernetes.io/portworx-volume"
 	PortworxDriverName       = "pxd.portworx.com"
+
+	OpenStorageAuthSecretNameKey      = "openstorage.io/auth-secret-name"
+	OpenStorageAuthSecretNamespaceKey = "openstorage.io/auth-secret-namespace"
+
+	csiParameterPrefix = "csi.storage.k8s.io/"
+
+	prefixedProvisionerSecretNameKey      = csiParameterPrefix + "provisioner-secret-name"
+	prefixedProvisionerSecretNamespaceKey = csiParameterPrefix + "provisioner-secret-namespace"
+
+	prefixedControllerPublishSecretNameKey      = csiParameterPrefix + "controller-publish-secret-name"
+	prefixedControllerPublishSecretNamespaceKey = csiParameterPrefix + "controller-publish-secret-namespace"
+
+	prefixedNodeStageSecretNameKey      = csiParameterPrefix + "node-stage-secret-name"
+	prefixedNodeStageSecretNamespaceKey = csiParameterPrefix + "node-stage-secret-namespace"
+
+	prefixedNodePublishSecretNameKey      = csiParameterPrefix + "node-publish-secret-name"
+	prefixedNodePublishSecretNamespaceKey = csiParameterPrefix + "node-publish-secret-namespace"
+
+	prefixedControllerExpandSecretNameKey      = csiParameterPrefix + "controller-expand-secret-name"
+	prefixedControllerExpandSecretNamespaceKey = csiParameterPrefix + "controller-expand-secret-namespace"
+
+	prefixedNodeExpandSecretNameKey      = csiParameterPrefix + "node-expand-secret-name"
+	prefixedNodeExpandSecretNamespaceKey = csiParameterPrefix + "node-expand-secret-namespace"
 )
 
 var _ InTreePlugin = &portworxCSITranslator{}
@@ -44,7 +68,34 @@ func (p portworxCSITranslator) TranslateInTreeStorageClassToCSI(logger klog.Logg
 	if sc == nil {
 		return nil, fmt.Errorf("sc is nil")
 	}
+
+	var params = map[string]string{}
+	for k, v := range sc.Parameters {
+		switch strings.ToLower(k) {
+		case OpenStorageAuthSecretNameKey:
+			params[prefixedProvisionerSecretNameKey] = v
+			params[prefixedControllerPublishSecretNameKey] = v
+			params[prefixedNodePublishSecretNameKey] = v
+			params[prefixedNodeStageSecretNameKey] = v
+			params[prefixedControllerExpandSecretNameKey] = v
+			params[prefixedNodeExpandSecretNameKey] = v
+		case OpenStorageAuthSecretNamespaceKey:
+			params[prefixedProvisionerSecretNamespaceKey] = v
+			params[prefixedControllerPublishSecretNamespaceKey] = v
+			params[prefixedNodePublishSecretNamespaceKey] = v
+			params[prefixedNodeStageSecretNamespaceKey] = v
+			params[prefixedControllerExpandSecretNamespaceKey] = v
+			params[prefixedNodeExpandSecretNamespaceKey] = v
+		default:
+			// All other parameters can be copied as is
+			params[k] = v
+		}
+	}
+	if len(params) > 0 {
+		sc.Parameters = params
+	}
 	sc.Provisioner = PortworxDriverName
+
 	return sc, nil
 }
 
@@ -87,11 +138,26 @@ func (p portworxCSITranslator) TranslateInTreePVToCSI(logger klog.Logger, pv *v1
 	if pv == nil || pv.Spec.PortworxVolume == nil {
 		return nil, fmt.Errorf("pv is nil or PortworxVolume not defined on pv")
 	}
+	var secretRef *v1.SecretReference
+
+	if metav1.HasAnnotation(pv.ObjectMeta, OpenStorageAuthSecretNameKey) &&
+		metav1.HasAnnotation(pv.ObjectMeta, OpenStorageAuthSecretNamespaceKey) {
+		secretRef = &v1.SecretReference{
+			Name:      pv.Annotations[OpenStorageAuthSecretNameKey],
+			Namespace: pv.Annotations[OpenStorageAuthSecretNamespaceKey],
+		}
+	}
+
 	csiSource := &v1.CSIPersistentVolumeSource{
-		Driver:           PortworxDriverName,
-		VolumeHandle:     pv.Spec.PortworxVolume.VolumeID,
-		FSType:           pv.Spec.PortworxVolume.FSType,
-		VolumeAttributes: make(map[string]string), // copy access mode
+		Driver:                     PortworxDriverName,
+		VolumeHandle:               pv.Spec.PortworxVolume.VolumeID,
+		FSType:                     pv.Spec.PortworxVolume.FSType,
+		VolumeAttributes:           make(map[string]string), // copy access mode
+		ControllerPublishSecretRef: secretRef,
+		NodeStageSecretRef:         secretRef,
+		NodePublishSecretRef:       secretRef,
+		ControllerExpandSecretRef:  secretRef,
+		NodeExpandSecretRef:        secretRef,
 	}
 	pv.Spec.PortworxVolume = nil
 	pv.Spec.CSI = csiSource

--- a/staging/src/k8s.io/csi-translation-lib/plugins/portworx_test.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/portworx_test.go
@@ -72,6 +72,35 @@ func TestTranslatePortworxInTreeStorageClassToCSI(t *testing.T) {
 			},
 			errorExp: false,
 		},
+		{
+			name: "with secret params",
+			inTreeSC: &storage.StorageClass{
+				Parameters: map[string]string{
+					"repl":                                 "1",
+					"openstorage.io/auth-secret-name":      "test-secret",
+					"openstorage.io/auth-secret-namespace": "test-namespace",
+				},
+			},
+			csiSC: &storage.StorageClass{
+				Parameters: map[string]string{
+					"repl": "1",
+					"csi.storage.k8s.io/provisioner-secret-name":             "test-secret",
+					"csi.storage.k8s.io/provisioner-secret-namespace":        "test-namespace",
+					"csi.storage.k8s.io/controller-publish-secret-name":      "test-secret",
+					"csi.storage.k8s.io/controller-publish-secret-namespace": "test-namespace",
+					"csi.storage.k8s.io/node-stage-secret-name":              "test-secret",
+					"csi.storage.k8s.io/node-stage-secret-namespace":         "test-namespace",
+					"csi.storage.k8s.io/node-publish-secret-name":            "test-secret",
+					"csi.storage.k8s.io/node-publish-secret-namespace":       "test-namespace",
+					"csi.storage.k8s.io/controller-expand-secret-name":       "test-secret",
+					"csi.storage.k8s.io/controller-expand-secret-namespace":  "test-namespace",
+					"csi.storage.k8s.io/node-expand-secret-name":             "test-secret",
+					"csi.storage.k8s.io/node-expand-secret-namespace":        "test-namespace",
+				},
+				Provisioner: PortworxDriverName,
+			},
+			errorExp: false,
+		},
 	}
 	for _, tc := range testCases {
 		t.Logf("Testing %v", tc.name)
@@ -225,6 +254,81 @@ func TestTranslatePortworxInTreePVToCSI(t *testing.T) {
 							VolumeHandle:     "ID1111",
 							FSType:           "type",
 							VolumeAttributes: make(map[string]string),
+						},
+					},
+				},
+			},
+			errExpected: false,
+		},
+		{
+			name: "with secret annotations",
+			inTree: &v1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pxd.portworx.com",
+					Annotations: map[string]string{
+						"openstorage.io/auth-secret-name":      "test-secret",
+						"openstorage.io/auth-secret-namespace": "test-namespace",
+					},
+				},
+				Spec: v1.PersistentVolumeSpec{
+					AccessModes: []v1.PersistentVolumeAccessMode{
+						v1.ReadWriteOnce,
+					},
+					ClaimRef: &v1.ObjectReference{
+						Name:      "test-pvc",
+						Namespace: "default",
+					},
+					PersistentVolumeSource: v1.PersistentVolumeSource{
+						PortworxVolume: &v1.PortworxVolumeSource{
+							VolumeID: "ID1111",
+							FSType:   "type",
+							ReadOnly: false,
+						},
+					},
+				},
+			},
+			csi: &v1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pxd.portworx.com",
+					Annotations: map[string]string{
+						"openstorage.io/auth-secret-name":      "test-secret",
+						"openstorage.io/auth-secret-namespace": "test-namespace",
+					},
+				},
+				Spec: v1.PersistentVolumeSpec{
+					AccessModes: []v1.PersistentVolumeAccessMode{
+						v1.ReadWriteOnce,
+					},
+					ClaimRef: &v1.ObjectReference{
+						Name:      "test-pvc",
+						Namespace: "default",
+					},
+					PersistentVolumeSource: v1.PersistentVolumeSource{
+						CSI: &v1.CSIPersistentVolumeSource{
+							Driver:           PortworxDriverName,
+							VolumeHandle:     "ID1111",
+							FSType:           "type",
+							VolumeAttributes: make(map[string]string),
+							ControllerPublishSecretRef: &v1.SecretReference{
+								Name:      "test-secret",
+								Namespace: "test-namespace",
+							},
+							NodeStageSecretRef: &v1.SecretReference{
+								Name:      "test-secret",
+								Namespace: "test-namespace",
+							},
+							NodePublishSecretRef: &v1.SecretReference{
+								Name:      "test-secret",
+								Namespace: "test-namespace",
+							},
+							ControllerExpandSecretRef: &v1.SecretReference{
+								Name:      "test-secret",
+								Namespace: "test-namespace",
+							},
+							NodeExpandSecretRef: &v1.SecretReference{
+								Name:      "test-secret",
+								Namespace: "test-namespace",
+							},
 						},
 					},
 				},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
1. The in-tree Portworx driver required user to specify below params in StorageClass for secret name & namespace.
```
apiVersion: storage.k8s.io/v1
kind: StorageClass
.
.
provisioner: kubernetes.io/portworx-volume
parameters:
    openstorage.io/auth-secret-name: <token-secret-name>                 <<<<----------
    openstorage.io/auth-secret-namespace: <token-secret-namespace>       <<<<----------
.
.
```

For in-tree to CSI migration, these parameters are not converted to [StorageClass Secrets](https://kubernetes-csi.github.io/docs/secrets-and-credentials-storage-class.html#storageclass-secrets) that external-provisioner handles.

2. Similarly, in-tree PVs that gets created by in-tree Portworx driver currently doesn't have any info about the StorageClass secrets. So during in-tree to CSI migration for such PVs, the kubelet/sidecars will not pass any `Secrets` to CSI driver.
The absence of `Secrets` in CSI API requests breaks one of the deployment modes for Portworx CSI driver.

To fix this, firstly we will have a system to patch such PVs to have secret name & namespace as annotations.
Then whenever the sidecar/kubelet invokes `TranslateInTreePVToCSI`, the method will copy secret name/namespace from annotation to several secret references in CSI source. This ensures that `Secrets` correctly get passed in CSI API requests.

Please note Portworx CSI driver uses the data from the same secret for all CSI operations.

#### Testing done
Tested this on a cluster with Kubernetes v1.31 and Portworx security feature enabled.

1. Before the fix, if a PVC is created using the StorageClass which used to work with in-tree Portworx plugin, the volume creation was failing with error emanating from Portworx CSI driver -  `Access denied without authentication token`

External-provisioner logs:
```
I1219 02:24:41.873826       1 controller.go:560] translating storage class for in-tree plugin kubernetes.io/portworx-volume to CSI
.
.
I1219 02:24:41.886494       1 controller.go:1075] Final error received, removing PVC af88637e-372b-4b17-9f8b-d9085255e43e from claims in progress
W1219 02:24:41.886566       1 controller.go:934] Retrying syncing claim "af88637e-372b-4b17-9f8b-d9085255e43e", failure 0
I1219 02:24:41.886578       1 event.go:298] Event(v1.ObjectReference{Kind:"PersistentVolumeClaim", Namespace:"elasticsearch-applicationscaleupdown-0-12-19-02h24m11s", Name:"elasticsearch-storage-elasticsearch-0", UID:"af88637e-372b-4b17-9f8b-d9085255e43e", APIVersion:"v1", ResourceVersion:"6002", FieldPath:""}): type: 'Warning' reason: 'ProvisioningFailed' failed to provision volume with StorageClass "elasticsearch-sc": rpc error: code = PermissionDenied desc = Access denied without authentication token
E1219 02:24:41.886659       1 controller.go:957] error syncing claim "af88637e-372b-4b17-9f8b-d9085255e43e": failed to provision volume with StorageClass "elasticsearch-sc": rpc error: code = PermissionDenied desc = Access denied without authentication token
```

Fix tested - Made changes in csi-translation-lib vendored in external-provisioner, deployed external-provisioner with the changes and then PVC provisioning happened successfully.

2. Similarly if an in-tree PV issued a `NodePublishVolume` invocation upon a pod creation, the mount was failing from Portworx CSI driver with error - `Access denied without authentication token`.

Kubelet logs:
```
Jan 13 05:31:22  kubelet[14897]: I0113 05:31:22.879760   14897 reconciler_common.go:218] "operationExecutor.MountVolume started for volume \"pvc-193e3fb0-2375-4d7d-8730-fda195d5edea\" (UniqueName: \"kubernetes.io/csi/pxd.portworx.com^39647901999249734\") pod \"vanilla-block-pod-intree-sc\" (UID: \"2650111e-62a7-4a9a-b253-f15dbfeb9b4d\") " pod="default/vanilla-block-pod-intree-sc"

Jan 13 05:31:22 kubelet[14897]: E0113 05:31:22.886936   14897 nestedpendingoperations.go:348] Operation for "{volumeName:kubernetes.io/csi/pxd.portworx.com^39647901999249734 podName: nodeName:}" failed. No retries permitted until 2025-01-13 05:31:30.886918003 +0000 UTC m=+355327.215278987 (durationBeforeRetry 8s). Error: MountVolume.SetUp failed for volume "pvc-193e3fb0-2375-4d7d-8730-fda195d5edea" (UniqueName: "kubernetes.io/csi/pxd.portworx.com^39647901999249734") pod "vanilla-block-pod-intree-sc" (UID: "2650111e-62a7-4a9a-b253-f15dbfeb9b4d") : rpc error: code = PermissionDenied desc = Access denied without authentication token
```

Fix tested - Made changes in csi-translation-lib in staging directory in k/k, built kubelet following the [doc](https://github.com/kubernetes/kubernetes/blob/master/build/README.md) and replaced kubelet in all worker nodes. After this, correct Secret data was getting passed in `NodePublishVolumeRequest` and mount was succeeding.

```
Jan 15 00:40:56 kubelet[1819142]: I0115 00:40:56.464295 1819142 reconciler_common.go:224] "operationExecutor.MountVolume started for volume \"pvc-193e3fb0-2375-4d7d-8730-fda195d5edea\" (UniqueName: \"kubernetes.io/csi/pxd.portworx.com^39647901999249734\") pod \"vanilla-block-pod-intree-sc\" (UID: \"2650111e-62a7-4a9a-b253-f15dbfeb9b4d\") " pod="default/vanilla-block-pod-intree-sc"

Jan 15 00:40:56  kubelet[1819142]: I0115 00:40:56.466710 1819142 operation_generator.go:557] "MountVolume.MountDevice succeeded for volume \"pvc-193e3fb0-2375-4d7d-8730-fda195d5edea\" (UniqueName: \"kubernetes.io/csi/pxd.portworx.com^39647901999249734\") pod \"vanilla-block-pod-intree-sc\" (UID: \"2650111e-62a7-4a9a-b253-f15dbfeb9b4d\") device mount path \"/var/lib/kubelet/plugins/kubernetes.io/csi/pxd.portworx.com/679f1f2565f1af0351b028045819ffaecb7dd0727af2e765d5e118fa3de91667/globalmount\"" pod="default/vanilla-block-pod-intree-sc"
```



#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
Built sidecar(external-provisioner in our case) & kubelet with this change and ensured that `Secrets` are being passed in CSI requests.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed in-tree to CSI migration for Portworx volumes, in clusters where Portworx security feature is enabled (it's a Portworx feature, not Kubernetes feature). It required secret data from the secret mentioned in-tree SC, to be passed in CSI requests which was not happening before this fix.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```
- [KEP]: https://github.com/kubernetes/enhancements/issues/2589
```
