### PR TITLE
Prevent alpha feature gates from being enabled by default

### DIFF
--- a/pkg/features/kube_features_test.go
+++ b/pkg/features/kube_features_test.go
@@ -73,3 +73,27 @@ func TestAllRegisteredFeaturesExpected(t *testing.T) {
 		}
 	}
 }
+func TestEnsureAlphaGatesAreNotSwitchedOnByDefault(t *testing.T) {
+	checkAlphaGates := func(feature featuregate.Feature, spec featuregate.FeatureSpec) {
+		// FIXME(dims): remove this check when WindowsHostNetwork is fixed up or removed
+		// entirely. Please do NOT add more entries here.
+		if feature == "WindowsHostNetwork" {
+			return
+		}
+		if spec.PreRelease == featuregate.Alpha && spec.Default {
+			t.Errorf("The alpha feature gate %q is switched on by default", feature)
+		}
+		if spec.PreRelease == featuregate.Alpha && spec.LockToDefault {
+			t.Errorf("The alpha feature gate %q is locked to default", feature)
+		}
+	}
+
+	for feature, spec := range defaultKubernetesFeatureGates {
+		checkAlphaGates(feature, spec)
+	}
+	for feature, specs := range defaultVersionedKubernetesFeatureGates {
+		for _, spec := range specs {
+			checkAlphaGates(feature, spec)
+		}
+	}
+}


### PR DESCRIPTION
Adding tests to ensure we do not enable Alpha features by default and we do not lock them to defaults either!

xref: https://github.com/kubernetes/kubernetes/issues/129636

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
