### PR TITLE
KEP-3866 nftables kube-proxy to GA

### DIFF
--- a/cmd/kube-proxy/app/server_linux.go
+++ b/cmd/kube-proxy/app/server_linux.go
@@ -36,13 +36,11 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 	toolswatch "k8s.io/client-go/tools/watch"
 	utilsysctl "k8s.io/component-helpers/node/util/sysctl"
 	"k8s.io/klog/v2"
-	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/proxy"
 	proxyconfigapi "k8s.io/kubernetes/pkg/proxy/apis/config"
 	"k8s.io/kubernetes/pkg/proxy/iptables"
@@ -527,11 +525,9 @@ func platformCleanup(ctx context.Context, mode proxyconfigapi.ProxyMode, cleanup
 		}
 	}
 
-	if utilfeature.DefaultFeatureGate.Enabled(features.NFTablesProxyMode) {
-		// Clean up nftables rules when switching to iptables or ipvs, or if cleanupAndExit
-		if isIPTablesBased(mode) || cleanupAndExit {
-			encounteredError = nftables.CleanupLeftovers(ctx) || encounteredError
-		}
+	// Clean up nftables rules when switching to iptables or ipvs, or if cleanupAndExit
+	if isIPTablesBased(mode) || cleanupAndExit {
+		encounteredError = nftables.CleanupLeftovers(ctx) || encounteredError
 	}
 
 	if encounteredError {

--- a/pkg/features/versioned_kube_features.go
+++ b/pkg/features/versioned_kube_features.go
@@ -542,6 +542,7 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 	NFTablesProxyMode: {
 		{Version: version.MustParse("1.29"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("1.31"), Default: true, PreRelease: featuregate.Beta},
+		{Version: version.MustParse("1.33"), Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	},
 
 	NodeInclusionPolicyInPodTopologySpread: {

--- a/pkg/proxy/apis/config/validation/validation.go
+++ b/pkg/proxy/apis/config/validation/validation.go
@@ -30,7 +30,6 @@ import (
 	logsapi "k8s.io/component-base/logs/api/v1"
 	"k8s.io/component-base/metrics"
 	apivalidation "k8s.io/kubernetes/pkg/apis/core/validation"
-	"k8s.io/kubernetes/pkg/features"
 	kubeproxyconfig "k8s.io/kubernetes/pkg/proxy/apis/config"
 	netutils "k8s.io/utils/net"
 )
@@ -173,11 +172,8 @@ func validateProxyModeLinux(mode kubeproxyconfig.ProxyMode, fldPath *field.Path)
 	validModes := sets.New[string](
 		string(kubeproxyconfig.ProxyModeIPTables),
 		string(kubeproxyconfig.ProxyModeIPVS),
+		string(kubeproxyconfig.ProxyModeNFTables),
 	)
-
-	if utilfeature.DefaultFeatureGate.Enabled(features.NFTablesProxyMode) {
-		validModes.Insert(string(kubeproxyconfig.ProxyModeNFTables))
-	}
 
 	if mode == "" || validModes.Has(string(mode)) {
 		return nil

--- a/test/featuregates_linter/test_data/versioned_feature_list.yaml
+++ b/test/featuregates_linter/test_data/versioned_feature_list.yaml
@@ -842,6 +842,10 @@
     lockToDefault: false
     preRelease: Beta
     version: "1.31"
+  - default: true
+    lockToDefault: true
+    preRelease: GA
+    version: "1.33"
 - name: NodeInclusionPolicyInPodTopologySpread
   versionedSpecs:
   - default: false


### PR DESCRIPTION
#### What this PR does / why we need it:
Bump `NFTablesProxyMode` to GA. (Also, add in a bit of documentation that we said we'd add before going to GA.)

#### Does this PR introduce a user-facing change?
```release-note
The nftables mode of kube-proxy is now GA. (The iptables mode remains the
default; you can select the nftables mode by passing `--proxy-mode nftables`
or using a config file with `mode: nftables`. See the kube-proxy documentation
for more details.)
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/3866-nftables-proxy/README.md
```

/kind documentation
/kind feature
/priority important-soon
/triage accepted