### PR TITLE
storage/cacher/ready: dynamically calculate the retryAfterSeconds

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/util.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/util.go
@@ -17,7 +17,9 @@ limitations under the License.
 package cacher
 
 import (
+	"math"
 	"strings"
+	"time"
 )
 
 // hasPathPrefix returns true if the string matches pathPrefix exactly, or if is prefixed with pathPrefix at a path segment boundary
@@ -43,4 +45,12 @@ func hasPathPrefix(s, pathPrefix string) bool {
 		return true
 	}
 	return false
+}
+
+// calculateRetryAfterForUnreadyCache calculates the retry duration based on the cache downtime.
+func calculateRetryAfterForUnreadyCache(downtime time.Duration) int {
+	factor := 0.06
+	result := math.Exp(factor * downtime.Seconds())
+	result = math.Min(30, math.Max(1, result))
+	return int(result)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

Ref https://github.com/kubernetes/enhancements/issues/4568

```release-note
NONE
```
