### PR TITLE
Adding support for providing version for functions in kube_codegen.sh

### DIFF
--- a/staging/src/k8s.io/code-generator/kube_codegen.sh
+++ b/staging/src/k8s.io/code-generator/kube_codegen.sh
@@ -65,6 +65,7 @@ function kube::codegen::internal::grep() {
 function kube::codegen::gen_helpers() {
     local in_dir=""
     local boilerplate="${KUBE_CODEGEN_ROOT}/hack/boilerplate.go.txt"
+    local version="latest"
     local v="${KUBE_VERBOSE:-0}"
     local extra_peers=()
 
@@ -76,6 +77,10 @@ function kube::codegen::gen_helpers() {
                 ;;
             "--extra-peer-dir")
                 extra_peers+=("$2")
+                shift 2
+                ;;
+            "--version")
+                version="$2"
                 shift 2
                 ;;
             *)
@@ -103,9 +108,9 @@ function kube::codegen::gen_helpers() {
         # and then install with forced module mode on and fully qualified name.
         cd "${KUBE_CODEGEN_ROOT}"
         BINS=(
-            conversion-gen
-            deepcopy-gen
-            defaulter-gen
+            conversion-gen@${version}
+            deepcopy-gen@${version}
+            defaulter-gen@${version}
         )
         # shellcheck disable=2046 # printf word-splitting is intentional
         GO111MODULE=on go install $(printf "k8s.io/code-generator/cmd/%s " "${BINS[@]}")
@@ -257,6 +262,7 @@ function kube::codegen::gen_openapi() {
     local report="/dev/null"
     local update_report=""
     local boilerplate="${KUBE_CODEGEN_ROOT}/hack/boilerplate.go.txt"
+    local version="latest"
     local v="${KUBE_VERBOSE:-0}"
 
     while [ "$#" -gt 0 ]; do
@@ -283,6 +289,10 @@ function kube::codegen::gen_openapi() {
                 ;;
             "--boilerplate")
                 boilerplate="$2"
+                shift 2
+                ;;
+            "--version")
+                version="$2"
                 shift 2
                 ;;
             *)
@@ -324,7 +334,7 @@ function kube::codegen::gen_openapi() {
         # and then install with forced module mode on and fully qualified name.
         cd "${KUBE_CODEGEN_ROOT}"
         BINS=(
-            openapi-gen
+            openapi-gen@${version}
         )
         # shellcheck disable=2046 # printf word-splitting is intentional
         GO111MODULE=on go install $(printf "k8s.io/kube-openapi/cmd/%s " "${BINS[@]}")
@@ -433,9 +443,6 @@ function kube::codegen::gen_openapi() {
 #   --plural-exceptions <string = "">
 #     An optional list of comma separated plural exception definitions in Type:PluralizedType form.
 #
-#   --prefers-protobuf
-#     Enables generation of clientsets that use protobuf for API requests.
-#
 function kube::codegen::gen_client() {
     local in_dir=""
     local one_input_api=""
@@ -452,6 +459,7 @@ function kube::codegen::gen_client() {
     local informers_subdir="informers"
     local boilerplate="${KUBE_CODEGEN_ROOT}/hack/boilerplate.go.txt"
     local plural_exceptions=""
+    local version="latest"
     local v="${KUBE_VERBOSE:-0}"
     local prefers_protobuf="false"
 
@@ -513,9 +521,13 @@ function kube::codegen::gen_client() {
                 plural_exceptions="$2"
                 shift 2
                 ;;
-            "--prefers-protobuf")
+              "--prefers-protobuf")
                 prefers_protobuf="true"
                 shift
+                ;;
+            "--version")
+                version="$2"
+                shift 2
                 ;;
             *)
                 if [[ "$1" =~ ^-- ]]; then
@@ -551,10 +563,10 @@ function kube::codegen::gen_client() {
         # and then install with forced module mode on and fully qualified name.
         cd "${KUBE_CODEGEN_ROOT}"
         BINS=(
-            applyconfiguration-gen
-            client-gen
-            informer-gen
-            lister-gen
+            applyconfiguration-gen@${version}
+            client-gen@${version}
+            informer-gen@${version}
+            lister-gen@${version}
         )
         # shellcheck disable=2046 # printf word-splitting is intentional
         GO111MODULE=on go install $(printf "k8s.io/code-generator/cmd/%s " "${BINS[@]}")
@@ -693,12 +705,17 @@ function kube::codegen::gen_client() {
 function kube::codegen::gen_register() {
     local in_dir=""
     local boilerplate="${KUBE_CODEGEN_ROOT}/hack/boilerplate.go.txt"
+    local version="latest"
     local v="${KUBE_VERBOSE:-0}"
 
     while [ "$#" -gt 0 ]; do
         case "$1" in
             "--boilerplate")
                 boilerplate="$2"
+                shift 2
+                ;;
+            "--version")
+                version="$2"
                 shift 2
                 ;;
             *)
@@ -726,7 +743,7 @@ function kube::codegen::gen_register() {
         # and then install with forced module mode on and fully qualified name.
         cd "${KUBE_CODEGEN_ROOT}"
         BINS=(
-            register-gen
+            register-gen@${version}
         )
         # shellcheck disable=2046 # printf word-splitting is intentional
         GO111MODULE=on go install $(printf "k8s.io/code-generator/cmd/%s " "${BINS[@]}")

--- a/staging/src/k8s.io/code-generator/kube_codegen.sh
+++ b/staging/src/k8s.io/code-generator/kube_codegen.sh
@@ -27,8 +27,9 @@ set -o pipefail
 
 KUBE_CODEGEN_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 
-# Callers which want a specific tag of the k8s.io/code-generator repo should set the KUBE_CODEGEN_TAG to the
-# tag name, e.g. KUBE_CODEGEN_TAG="release-1.32" before sourcing this file.
+# Callers which want a specific tag of the k8s.io/code-generator repo should
+# set the KUBE_CODEGEN_TAG to the tag name, e.g. KUBE_CODEGEN_TAG="release-1.32"
+# before sourcing this file.
 CODEGEN_VERSION_SPEC="${KUBE_CODEGEN_TAG:+"@${KUBE_CODEGEN_TAG}"}"
 
 function kube::codegen::internal::findz() {
@@ -517,7 +518,7 @@ function kube::codegen::gen_client() {
                 plural_exceptions="$2"
                 shift 2
                 ;;
-              "--prefers-protobuf")
+            "--prefers-protobuf")
                 prefers_protobuf="true"
                 shift
                 ;;
@@ -697,7 +698,6 @@ function kube::codegen::gen_client() {
 function kube::codegen::gen_register() {
     local in_dir=""
     local boilerplate="${KUBE_CODEGEN_ROOT}/hack/boilerplate.go.txt"
-    local version="latest"
     local v="${KUBE_VERBOSE:-0}"
 
     while [ "$#" -gt 0 ]; do


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
code-generator/kube_codegen.sh makes it mandatory to import k8s.io/code-generator. This is only required to get the version while invoking `go install`. This PR adds an option to specify `--version` for every function in kube_codegen.sh.
This allows consumers to directly specify the version while invoking the functions in this script.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/code-generator/issues/184

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Provides an additional function argument to directly specify the version for the tools that the consumers wishes to use
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
