### PR TITLE
Put the target plugin names in the Qhint integration test cases

### DIFF
--- a/test/integration/scheduler/queueing/former/queue_test.go
+++ b/test/integration/scheduler/queueing/former/queue_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package queueing
 
 import (
+	"strings"
 	"testing"
 
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -35,7 +36,7 @@ func TestCoreResourceEnqueueWithQueueingHints(t *testing.T) {
 		}
 		// Note: if EnableSchedulingQueueHint is nil, we assume the test should be run both with/without the feature gate.
 
-		t.Run(tt.Name, func(t *testing.T) {
+		t.Run(strings.Join(append(tt.EnablePlugins, tt.Name), "/"), func(t *testing.T) {
 			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.SchedulerQueueingHints, false)
 			queueing.RunTestCoreResourceEnqueue(t, tt)
 		})

--- a/test/integration/scheduler/queueing/queueinghint/queue_test.go
+++ b/test/integration/scheduler/queueing/queueinghint/queue_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package queueing
 
 import (
+	"strings"
 	"testing"
 
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -34,8 +35,7 @@ func TestCoreResourceEnqueue(t *testing.T) {
 			continue
 		}
 		// Note: if EnableSchedulingQueueHint is nil, we assume the test should be run both with/without the feature gate.
-
-		t.Run(tt.Name, func(t *testing.T) {
+		t.Run(strings.Join(append(tt.EnablePlugins, tt.Name), "/"), func(t *testing.T) {
 			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.SchedulerQueueingHints, true)
 			queueing.RunTestCoreResourceEnqueue(t, tt)
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:

I'm trying to add `EnablePlugins` to all test cases[^1] in `CoreResourceEnqueueTestCases`. However, since there are too many test cases and it takes a long time to run entirely, I'm using the below command to debug.
https://github.com/kubernetes/kubernetes/blob/2d0a4f75560154454682b193b42813159b20f284/test/integration/scheduler/queueing/queue.go#L99
```console
$ go test -timeout 300s -run ^TestCoreResourceEnqueue/Pod_rejected_with_node_by_the_ k8s.io/kubernetes/test/integration/scheduler/queueing/queueinghint
```
[^1]: https://github.com/kubernetes/kubernetes/pull/129360#pullrequestreview-2520305953

However, it'd be better to specify each plugin, like
```console
go test -v -timeout 300s -run ^TestCoreResourceEnqueue/VolumeBinding$ k8s.io/kubernetes/test/integration/scheduler/queueing/queueinghint
``` 

I considered using `[]` or `(),` but they have special means in Golang regex. Thus, I avoided them.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/129641

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
