### PR TITLE
KubeletSeparateDiskGC was promoted to beta in v1.31

### DIFF
--- a/pkg/features/versioned_kube_features.go
+++ b/pkg/features/versioned_kube_features.go
@@ -403,7 +403,7 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 
 	ImageMaximumGCAge: {
 		{Version: version.MustParse("1.29"), Default: false, PreRelease: featuregate.Alpha},
-		{Version: version.MustParse("1.30"), Default: true, PreRelease: featuregate.Beta},
+		{Version: version.MustParse("1.31"), Default: true, PreRelease: featuregate.Beta},
 	},
 
 	ImageVolume: {


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
See https://github.com/kubernetes/kubernetes/pull/126205 which is in v1.31.

#### Which issue(s) this PR fixes:

ref https://github.com/kubernetes/enhancements/pull/4684
https://github.com/kubernetes/enhancements/issues/4191

#### Special notes for your reviewer:
/cc @kannon92 @kwilczynski 
/assign @mrunalp 
/sig node 

#### Does this PR introduce a user-facing change?

```release-note
None
```
