### PR TITLE
tests: include stdout of failed commands in JUnit

### DIFF
--- a/third_party/forked/shell2junit/sh2ju.sh
+++ b/third_party/forked/shell2junit/sh2ju.sh
@@ -20,7 +20,7 @@
 ###             -ierror="RegExp" : same as -error but case insensitive
 ###             -fail="RegExp"   : Any line from stderr which contains this pattern becomes part of
 ###                                the failure messsage, without the text matching that pattern.
-###                                Example: -failure="^ERROR: "
+###                                Example: -fail="^ERROR: "
 ###                                Default is to use the entire stderr as failure message.
 ###             -output="Path"   : path to output directory, defaults to "./results"
 ###     - Junit reports are left in the folder 'result' under the directory where the script is executed.
@@ -129,6 +129,7 @@ function juLog() {
       [[ -n "${H}" ]] && err=1
   fi
   [[ ${err} -ne 0 ]] && echo "+++ error: ${err}"         | tee -a ${outf}
+  outMsg=$(cat ${outf})
   rm -f ${outf}
 
   errMsg=$(cat ${errf})
@@ -163,6 +164,7 @@ ${failureMsg}
     <testcase assertions=\"1\" name=\"${name}\" time=\"${time}\" classname=\"${class}\">
     ${failure}
     <system-err><![CDATA[${errMsg}]]></system-err>
+    <system-out><![CDATA[${outMsg}]]></system-out>
     </testcase>
   "
   ## testsuite block


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

All of the shell commands used by `make test-cmd` log success and failures to stdout, e.g.:
   get.sh -> if_has_string ->
   https://github.com/kubernetes/kubernetes/blob/2c9153576ec0eef9dfb4acac591874a71ff72cbb/hack/lib/test.sh#L340-L360

juLog captured stdout in addition to forwarding it to the overall test stdout, but then only used it to check for text that indicates a problem. The result was that after a test failure, the only thing visible in Spyglass was a fairly useless "script error" generated by juLog for its own call chain. One had to know that the entire build log contained more information and where to look for it.

Now the stdout text is included in the JUnit file and thus visible when looking at just one failed test. The output itself is still hard to read (contains one line saying "FAIL!" and one has to know that the text below that line explains the failure), but that is a different story.

#### Special notes for your reviewer:

I ran into this in https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/129125/pull-kubernetes-integration/1879257822013689856. Changing log output broke some kubectl testcases which checked that output.

I don't know if this ever worked differently.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
