### PR TITLE
e2e: expand error conditions when test-ing port-forward

### DIFF
--- a/test/e2e/kubectl/portforward.go
+++ b/test/e2e/kubectl/portforward.go
@@ -617,7 +617,7 @@ var _ = SIGDescribe("Kubectl Port forwarding", func() {
 				// this error indicates timeout when POST-ing data
 				gomega.ContainSubstring("context deadline exceeded"),
 				// this will happen when trying to write to a closed connection
-				gomega.ContainSubstring("write: broken pipe")))
+				gomega.ContainSubstring("write: broken pipe"), gomega.ContainSubstring("closed network connection")))
 
 			ginkgo.By("Check kubectl port-forward exit code")
 			gomega.Expect(cmd.cmd.ProcessState.ExitCode()).To(gomega.BeNumerically("<", 0), "kubectl port-forward should finish with non-zero exit code")


### PR DESCRIPTION
#### What type of PR is this?
/kind flake

#### What this PR does / why we need it:
Reported on [slack](https://kubernetes.slack.com/archives/C2GL57FJ4/p1737374167556889) the [problem is](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-e2e-kind-beta-features/1881257635315978240):
```
{ failed [FAILED] Expected
    <string>: Post "http://localhost:35309/header": readfrom tcp [::1]:35510->[::1]:35309: write tcp [::1]:35510->[::1]:35309: use of closed network connection
To satisfy at least one of these matchers: [%!s(*matchers.ContainSubstringMatcher=&{connection reset by peer []}) %!s(*matchers.ContainSubstringMatcher=&{EOF []}) %!s(*matchers.ContainSubstringMatcher=&{context deadline exceeded []}) %!s(*matchers.ContainSubstringMatcher=&{write: broken pipe []})]
In [It] at: k8s.io/kubernetes/test/e2e/kubectl/portforward.go:614 @ 01/20/25 08:48:25.736
}
```
this PR expands the error check with `closed network connection` string check. 

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
/assign @ardaguclu @wendy-ha18 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
