### PR TITLE
[WIP][FG:InPlacePodVerticalScaling] Fix InPlacePodVerticalScaling does not meet the requirement of qosClass being equal to Guaranteed after shrinking the memory

### DIFF
--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -2181,6 +2181,11 @@ func (kl *Kubelet) convertToAPIContainerStatuses(pod *v1.Pod, podStatus *kubecon
 				preserveOldResourcesValue(v1.ResourceCPU, oldStatus.Resources.Requests, resources.Requests)
 			}
 		}
+		if resources.Requests != nil && resources.Limits != nil && v1qos.GetPodQOS(pod) == v1.PodQOSGuaranteed && utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {
+			if cStatus.Resources != nil && cStatus.Resources.MemoryLimit != nil {
+				resources.Requests[v1.ResourceMemory] = cStatus.Resources.MemoryLimit.DeepCopy()
+			}
+		}
 
 		return &resources
 	}


### PR DESCRIPTION
What type of PR is this?

/kind bug

What this PR does / why we need it:

InPlacePodVerticalScaling does not meet the requirement of qosClass being equal to Guaranteed after shrinking the memory. Not clear if this is an issue or not https://github.com/kubernetes/kubernetes/pull/128710#issuecomment-2469629935 , re-opening [the corresponding old PR](https://github.com/kubernetes/kubernetes/pull/128710) with this PR to continue discussion here.

When we attempt to set pod memory limit less than current memory usage, as it is now it will remain InProgress for Guaranteed Qos Pod. Requests parameter is modified but limit is kept with previous value. 

Background , discussion , demonstrating problem please check https://github.com/kubernetes/kubernetes/issues/124786#issuecomment-2465656911

Which issue(s) this PR fixes:

Attempt to fix https://github.com/kubernetes/kubernetes/issues/124786

#### Special notes for your reviewer:

Please see files changes for more details.

This PR replace #128756 , needed due to company transfer.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```