### PR TITLE
promote CustomCPUCFSQuotaPeriod to beta

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -1066,6 +1066,7 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 
 	CPUCFSQuotaPeriod: {
 		{Version: version.MustParse("1.12"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.34"), Default: true, PreRelease: featuregate.Beta},
 	},
 
 	CPUManagerPolicyAlphaOptions: {

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -273,6 +273,10 @@
     lockToDefault: false
     preRelease: Alpha
     version: "1.12"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.34"
 - name: CPUManagerPolicyAlphaOptions
   versionedSpecs:
   - default: false


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
CustomCPUCFSQuotaPeriod: Enable nodes to change cpuCFSQuotaPeriod in [kubelet config](https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/).
- The feature gate was added in v1.12 https://github.com/kubernetes/kubernetes/pull/63437
- In 1.20, a validation check was updated https://github.com/kubernetes/kubernetes/pull/94687.


#### Which issue(s) this PR fixes:

Fixes None

#### Special notes for your reviewer:

To change cpuCFSQuotaPeriod, you need to specify `cpuCFSQuotaPeriod` and enable this feature gate. 
- `cpuCFSQuotaPeriod` is the CPU CFS quota period value, cpu.cfs_period_us. The value must be between 1 ms and 1 second, inclusive. Requires the CustomCPUCFSQuotaPeriod feature gate to be enabled. Default: "100ms"

**The feature gate is only a gate for a custom configuration. It seems that there is no risk to promote this feature gate to beta.**


#### Does this PR introduce a user-facing change?

```release-note
Promote CustomCPUCFSQuotaPeriod to beta
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: No-KEP 
```
