### PR TITLE
E2E framework: Add conditional cleanup helper

### DIFF
--- a/test/e2e/framework/ginkgowrapper.go
+++ b/test/e2e/framework/ginkgowrapper.go
@@ -598,3 +598,46 @@ func TagsEqual(a, b interface{}) bool {
 	}
 	return slices.Equal(al.parts, bl.parts)
 }
+
+// DeferCleanup is an alias for ginkgo.DeferCleanup.
+var DeferCleanup = ginkgo.DeferCleanup
+
+// IsFailed is an alias for ginkgo.GinkgoT().Failed.
+var IsFailed = ginkgo.GinkgoT().Failed
+
+// DeferConditionalCleanup wraps ginkgo.DeferCleanup, allowing conditional execution of cleanup actions.
+// The function accepts a cleanup function as the first argument, followed by any arguments to be passed to that function.
+// The cleanup function will only be executed if TestContext.CleanupOnFailure is true or the current test has not failed.
+func DeferConditionalCleanup(args ...interface{}) {
+	if len(args) == 0 {
+		Fail("DeferConditionalCleanup called with no arguments")
+		return
+	}
+
+	cleanupFunc := args[0]
+	cleanupArgs := args[1:]
+
+	funcVal := reflect.ValueOf(cleanupFunc)
+	funcType := reflect.TypeOf(cleanupFunc)
+
+	if reflect.ValueOf(cleanupFunc).Kind() != reflect.Func {
+		Fail("The first argument to DeferConditionalCleanup should be a function")
+		return
+	}
+
+	wrappedCleanupFunc := reflect.MakeFunc(funcType, func(in []reflect.Value) []reflect.Value {
+		var out []reflect.Value
+		if TestContext.CleanupOnFailure || !IsFailed() {
+			out = funcVal.Call(in)
+		} else {
+			// Create zero values for the function's return types to skip execution
+			out = make([]reflect.Value, funcType.NumOut())
+			for i := 0; i < funcType.NumOut(); i++ {
+				out[i] = reflect.Zero(funcType.Out(i))
+			}
+		}
+		return out
+	}).Interface()
+
+	DeferCleanup(append([]interface{}{wrappedCleanupFunc}, cleanupArgs...)...)
+}

--- a/test/e2e/framework/ginkgowrapper_test.go
+++ b/test/e2e/framework/ginkgowrapper_test.go
@@ -14,12 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package framework
+package framework_test
 
 import (
 	"fmt"
 	"testing"
 
+	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/framework/internal/unittests/features"
 )
 
@@ -30,22 +31,195 @@ func TestTagsEqual(t *testing.T) {
 	}{
 		{1, 2, false},
 		{2, 2, false},
-		{WithSlow(), 2, false},
-		{WithSlow(), WithSerial(), false},
-		{WithSerial(), WithSlow(), false},
-		{WithSlow(), WithSlow(), true},
-		{WithSerial(), WithSerial(), true},
-		{WithLabel("hello"), WithLabel("world"), false},
-		{WithLabel("hello"), WithLabel("hello"), true},
-		{WithFeatureGate(features.Test), WithLabel("Test"), false},
-		{WithFeatureGate(features.Test), WithFeatureGate(features.Test), true},
+		{framework.WithSlow(), 2, false},
+		{framework.WithSlow(), framework.WithSerial(), false},
+		{framework.WithSerial(), framework.WithSlow(), false},
+		{framework.WithSlow(), framework.WithSlow(), true},
+		{framework.WithSerial(), framework.WithSerial(), true},
+		{framework.WithLabel("hello"), framework.WithLabel("world"), false},
+		{framework.WithLabel("hello"), framework.WithLabel("hello"), true},
+		{framework.WithFeatureGate(features.Test), framework.WithLabel("Test"), false},
+		{framework.WithFeatureGate(features.Test), framework.WithFeatureGate(features.Test), true},
 	}
 
 	for _, tc := range testcases {
 		t.Run(fmt.Sprintf("%v=%v", tc.a, tc.b), func(t *testing.T) {
-			actualEqual := TagsEqual(tc.a, tc.b)
+			actualEqual := framework.TagsEqual(tc.a, tc.b)
 			if actualEqual != tc.expectEqual {
 				t.Errorf("expected %v, got %v", tc.expectEqual, actualEqual)
+			}
+		})
+	}
+}
+
+var (
+	failCalled               bool
+	failMessage              string
+	deferCleanupCalled       bool
+	originalFail             = framework.Fail
+	originalDeferCleanup     = framework.DeferCleanup
+	originalIsFailed         = framework.IsFailed
+	originalCleanupOnFailure bool
+)
+
+// mockFail replaces framework.Fail to prevent ginkgo panic.
+func mockFail(message string, _ ...int) {
+	failCalled = true
+	failMessage = message
+}
+
+// mockDeferCleanupAlways replaces framework.DeferCleanup to prevent ginkgo cleanup usage outside of ginkgo context.
+// It always calls passed cleanup function.
+func mockDeferCleanupAlways(args ...interface{}) {
+	deferCleanupCalled = true
+	if len(args) > 0 {
+		if fn, ok := args[0].(func()); ok {
+			fn()
+		}
+	}
+}
+
+// mockDeferCleanupAlways replaces framework.DeferCleanup to prevent ginkgo cleanup usage outside of ginkgo context.
+// It follows the logic expected in framework.DeferConditionalCleanup.
+func mockDeferCleanupOnFailure(args ...interface{}) {
+	if framework.TestContext.CleanupOnFailure || !framework.IsFailed() {
+		deferCleanupCalled = true
+		if len(args) > 0 {
+			if fn, ok := args[0].(func()); ok {
+				fn()
+			}
+		}
+	}
+}
+
+// mockIsFailedAlways replaces framework.IsFailed to prevent ginkgo usage outside of ginkgo context.
+// It always returns true.
+func mockIsFailedAlways() bool {
+	return true
+}
+
+func resetFrameworkState() {
+	failCalled = false
+	failMessage = ""
+	deferCleanupCalled = false
+	framework.Fail = originalFail
+	framework.DeferCleanup = originalDeferCleanup
+	framework.TestContext.CleanupOnFailure = originalCleanupOnFailure
+	framework.IsFailed = originalIsFailed
+}
+
+func TestDeferConditionalCleanup(t *testing.T) {
+	originalCleanupOnFailure = framework.TestContext.CleanupOnFailure
+	framework.Fail = mockFail
+	framework.DeferCleanup = mockDeferCleanupAlways
+	defer resetFrameworkState()
+
+	tests := []struct {
+		name          string
+		args          []interface{}
+		setup         func()
+		expectFail    bool
+		expectMessage string
+		expectCleanup bool
+	}{
+		{
+			name:          "calls Fail when no arguments provided",
+			args:          nil,
+			expectFail:    true,
+			expectMessage: "DeferConditionalCleanup called with no arguments",
+		},
+		{
+			name:          "calls Fail when first argument is not a function",
+			args:          []interface{}{"not-a-function"},
+			expectFail:    true,
+			expectMessage: "The first argument to DeferConditionalCleanup should be a function",
+		},
+		{
+			name: "executes cleanup function with arguments",
+			args: []interface{}{
+				func(arg string) {
+					t.Logf("arg is %q", arg)
+				},
+				"test-arg",
+			},
+			expectCleanup: true,
+		},
+		{
+			name: "executes cleanup function without arguments",
+			args: []interface{}{
+				func() {
+					t.Log("called without arguments")
+				},
+			},
+			expectCleanup: true,
+		},
+		{
+			name: "executes cleanup when it's wrapped into a function with different count of arguments",
+			args: []interface{}{
+				framework.IgnoreNotFound(func(arg1 string, arg2 int) {
+					t.Logf("arg1 is %q and arg2 is %d", arg1, arg2)
+				}),
+				"test-arg1", 42,
+			},
+			expectCleanup: true,
+		},
+		{
+			name: "skips cleanup when test fails and CleanupOnFailure is false",
+			args: []interface{}{
+				func() {
+					t.Error("cleanup should not run")
+				},
+			},
+			setup: func() {
+				framework.TestContext.CleanupOnFailure = false
+				framework.IsFailed = mockIsFailedAlways
+				framework.DeferCleanup = mockDeferCleanupOnFailure
+			},
+			expectCleanup: false,
+		},
+		{
+			name: "runs cleanup when test fails and CleanupOnFailure is true",
+			args: []interface{}{
+				func() {
+					t.Log("cleanup ran successfully")
+				},
+			},
+			setup: func() {
+				framework.TestContext.CleanupOnFailure = true
+				framework.IsFailed = mockIsFailedAlways
+			},
+			expectCleanup: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			failCalled = false
+			failMessage = ""
+			deferCleanupCalled = false
+			if tt.setup != nil {
+				tt.setup()
+			}
+
+			framework.DeferConditionalCleanup(tt.args...)
+
+			if tt.expectFail {
+				if !failCalled {
+					t.Errorf("expected Fail to be called, but it wasn't")
+				}
+				if failMessage != tt.expectMessage {
+					t.Errorf("expected Fail message %q, but got %q", tt.expectMessage, failMessage)
+				}
+			} else if failCalled {
+				t.Errorf("didn't expect Fail to be called, but it was with message: %q", failMessage)
+			}
+
+			if tt.expectCleanup {
+				if !deferCleanupCalled {
+					t.Errorf("expected DeferCleanup to be called, but it wasn't")
+				}
+			} else if deferCleanupCalled {
+				t.Errorf("expected DeferCleanup to be skipped, but it was called")
 			}
 		})
 	}

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -157,6 +157,7 @@ type TestContextType struct {
 	VerifyServiceAccount     bool
 	DeleteNamespace          bool
 	DeleteNamespaceOnFailure bool
+	CleanupOnFailure         bool
 	AllowedNotReadyNodes     int
 	CleanStart               bool
 	// If set to 'true' or 'all' framework will start a goroutine monitoring resource usage of system add-ons.
@@ -362,6 +363,7 @@ func RegisterCommonFlags(flags *flag.FlagSet) {
 	flags.StringVar(&TestContext.LogexporterGCSPath, "logexporter-gcs-path", "", "Path to the GCS artifacts directory to dump logs from nodes. Logexporter gets enabled if this is non-empty.")
 	flags.BoolVar(&TestContext.DeleteNamespace, "delete-namespace", true, "If true tests will delete namespace after completion. It is only designed to make debugging easier, DO NOT turn it off by default.")
 	flags.BoolVar(&TestContext.DeleteNamespaceOnFailure, "delete-namespace-on-failure", true, "If true, framework will delete test namespace on failure. Used only during test debugging.")
+	flags.BoolVar(&TestContext.CleanupOnFailure, "cleanup-on-failure", true, "If true, framework will cleanup resources created by tests, after test failure. Used only during test debugging.")
 	flags.IntVar(&TestContext.AllowedNotReadyNodes, "allowed-not-ready-nodes", 0, "If greater than zero, framework will allow for that many non-ready nodes when checking for all ready nodes. If -1, no waiting will be performed for ready nodes or daemonset pods.")
 
 	flags.StringVar(&TestContext.Host, "host", "", fmt.Sprintf("The host, or apiserver, to connect to. Will default to %s if this argument and --kubeconfig are not set.", defaultHost))


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR adds a wrapper to use in e2e tests that allows to optionally skip execution of cleanup actions in case of test failure. 
New option `--cleanup-on-failure=bool` is also added to test framework (`true` by default).
Note that all (or at least conformance) e2e tests should use this wrapper instead of calling `ginkgo.DeferCleanup` (or cleaning up inside `ginkgo.AfterEach`) directly, but it should be done separately, only if this change is accepted.

#### Which issue(s) this PR fixes:

Not fixes completely, but it's for #129728

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

