### PR TITLE
Remove this comment since the tests are running in parallel

### DIFF
--- a/test/e2e/autoscaling/horizontal_pod_autoscaling.go
+++ b/test/e2e/autoscaling/horizontal_pod_autoscaling.go
@@ -42,7 +42,6 @@ const (
 	memResource             = v1.ResourceMemory
 )
 
-// These tests don't seem to be running properly in parallel: issue: #20338.
 var _ = SIGDescribe(feature.HPA, "Horizontal pod autoscaling (scale resource: CPU)", func() {
 	f := framework.NewDefaultFramework("horizontal-pod-autoscaling")
 	f.NamespacePodSecurityLevel = api.LevelBaseline


### PR DESCRIPTION
/kind cleanup

These e2e tests were ran sequentially due to the bug mentioned in the comment but now we dont pass WithSerial() to the main test definition.