### PR TITLE
Fix resizePolicy documentation for ephemeral containers

### DIFF
--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -4821,22 +4821,27 @@ var _ = Container(EphemeralContainerCommon{})
 // To add an ephemeral container, use the ephemeralcontainers subresource of an existing
 // Pod. Ephemeral containers may not be removed or restarted.
 type EphemeralContainer struct {
-	// Ephemeral containers have all of the fields of Container, plus additional fields
-	// specific to ephemeral containers. Fields in common with Container are in the
-	// following inlined struct so than an EphemeralContainer may easily be converted
-	// to a Container.
-	EphemeralContainerCommon `json:",inline" protobuf:"bytes,1,req"`
+        // Ephemeral containers have all of the fields of Container, plus additional fields
+        // specific to ephemeral containers. Fields in common with Container are in the
+        // following inlined struct so that an EphemeralContainer may easily be converted
+        // to a Container.
+        EphemeralContainerCommon `json:",inline" protobuf:"bytes,1,req"`
 
-	// If set, the name of the container from PodSpec that this ephemeral container targets.
-	// The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container.
-	// If not set then the ephemeral container uses the namespaces configured in the Pod spec.
-	//
-	// The container runtime must implement support for this feature. If the runtime does not
-	// support namespace targeting then the result of setting this field is undefined.
-	// +optional
-	TargetContainerName string `json:"targetContainerName,omitempty" protobuf:"bytes,2,opt,name=targetContainerName"`
+        // If set, the name of the container from PodSpec that this ephemeral container targets.
+        // The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container.
+        // If not set then the ephemeral container uses the namespaces configured in the Pod spec.
+        //
+        // The container runtime must implement support for this feature. If the runtime does not
+        // support namespace targeting then the result of setting this field is undefined.
+        // +optional
+        TargetContainerName string `json:"targetContainerName,omitempty" protobuf:"bytes,2,opt,name=targetContainerName"`
+
+        // ResizePolicy defines how the resources of a container can be resized.
+        // This field is not supported for ephemeral containers as they do not support
+        // resource requests or limits.
+        // +optional
+        ResizePolicy []ContainerResizePolicy `json:"resizePolicy,omitempty" protobuf:"bytes,14,rep,name=resizePolicy"`
 }
-
 // PodStatus represents information about the status of a pod. Status may trail the actual
 // state of a system, especially if the node that hosts the pod cannot contact the control
 // plane.


### PR DESCRIPTION
What type of PR is this?
/kind documentation

What this PR does / why we need it:
This PR fixes the incorrect API documentation for the resizePolicy field in the EphemeralContainer struct. It clarifies that the resizePolicy field does not apply to ephemeral containers because they do not support resource requests or limits. These changes ensure accuracy and reduce confusion for Kubernetes users.

Which issue(s) this PR fixes:
Fixes #128384

Special notes for your reviewer:
Changes were made to the staging/src/k8s.io/api/core/v1/types.go file.
Comments were added to clarify the limitations of the resizePolicy field for ephemeral containers.
Does this PR introduce a user-facing change?

NONE
Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

NONE
