### PR TITLE
Automated cherry pick of #129629: Fix: touch /dev/null permission denied on macos

### DIFF
--- a/staging/src/k8s.io/code-generator/kube_codegen.sh
+++ b/staging/src/k8s.io/code-generator/kube_codegen.sh
@@ -368,7 +368,10 @@ function kube::codegen::gen_openapi() {
             "${input_pkgs[@]}"
     fi
 
-    touch "${report}" # in case it doesn't exist yet
+    if [ ! -e "${report}" ]; then
+        touch "${report}" # in case it doesn't exist yet
+    fi
+
     if ! diff -u "${report}" "${new_report}"; then
         echo -e "ERROR:"
         echo -e "\tAPI rule check failed for ${report}: new reported violations"


### PR DESCRIPTION
Cherry pick of #129629 on release-1.31.

#129629: Fix: touch /dev/null permission denied on macos

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```