### PR TITLE
DRA:  CEL cost estimate during validation

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/cel/cache.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/cel/cache.go
@@ -43,6 +43,8 @@ func NewCache(maxCacheEntries int) *Cache {
 // GetOrCompile checks whether the cache already has a compilation result
 // and returns that if available. Otherwise it compiles, stores successful
 // results and returns the new result.
+//
+// Cost estimation is disabled.
 func (c *Cache) GetOrCompile(expression string) CompilationResult {
 	// Compiling a CEL expression is expensive enough that it is cheaper
 	// to lock a mutex than doing it several times in parallel.
@@ -55,7 +57,7 @@ func (c *Cache) GetOrCompile(expression string) CompilationResult {
 		return *cached
 	}
 
-	expr := GetCompiler().CompileCELExpression(expression, Options{})
+	expr := GetCompiler().CompileCELExpression(expression, Options{DisableCostEstimation: true})
 	if expr.Error == nil {
 		c.add(expression, &expr)
 	}

--- a/staging/src/k8s.io/dynamic-resource-allocation/cel/cache_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/cel/cache_test.go
@@ -18,6 +18,7 @@ package cel
 
 import (
 	"fmt"
+	"math"
 	"sync"
 	"testing"
 
@@ -72,6 +73,11 @@ func TestCacheSemantic(t *testing.T) {
 	resultFalseAgain = cache.GetOrCompile("false")
 	if resultFalse == resultFalseAgain {
 		t.Fatal("result of compiling `false` should have been evicted from the cache")
+	}
+
+	// Cost estimation must be off (not needed by scheduler).
+	if resultFalseAgain.MaxCost != math.MaxUint64 {
+		t.Error("cost estimation should have been disabled, was enabled")
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Compiling a CEL expression used to do the cost estimation, whether the caller needed the result or not. Now callers can disable it and that is done by the code which runs in the scheduler.

The main advantage is that failures in the estimator (like panics) are limited to the apiserver. Performance in the scheduler is not expected to benefit much because compilation results are cached.

#### Which issue(s) this PR fixes:

Related-to: https://github.com/kubernetes/kubernetes/pull/129690#issuecomment-2605607954

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/4381
```
