### PR TITLE
Fix dual stack tests after moving the e2e test to use Endpoint Slices

### DIFF
--- a/test/e2e/framework/network/utils.go
+++ b/test/e2e/framework/network/utils.go
@@ -863,10 +863,14 @@ func (config *NetworkingTestConfig) setup(ctx context.Context, selector map[stri
 	}
 
 	ginkgo.By("Waiting for NodePort service to expose endpoint")
-	err = framework.WaitForServiceEndpointsNum(ctx, config.f.ClientSet, config.Namespace, nodePortServiceName, len(config.EndpointPods), time.Second, wait.ForeverTestTimeout)
+	numEndpoints := len(config.EndpointPods)
+	if config.DualStackEnabled {
+		numEndpoints = 2 * len(config.EndpointPods)
+	}
+	err = framework.WaitForServiceEndpointsNum(ctx, config.f.ClientSet, config.Namespace, nodePortServiceName, numEndpoints, time.Second, wait.ForeverTestTimeout)
 	framework.ExpectNoError(err, "failed to validate endpoints for service %s in namespace: %s", nodePortServiceName, config.Namespace)
 	ginkgo.By("Waiting for Session Affinity service to expose endpoint")
-	err = framework.WaitForServiceEndpointsNum(ctx, config.f.ClientSet, config.Namespace, sessionAffinityServiceName, len(config.EndpointPods), time.Second, wait.ForeverTestTimeout)
+	err = framework.WaitForServiceEndpointsNum(ctx, config.f.ClientSet, config.Namespace, sessionAffinityServiceName, numEndpoints, time.Second, wait.ForeverTestTimeout)
 	framework.ExpectNoError(err, "failed to validate endpoints for service %s in namespace: %s", sessionAffinityServiceName, config.Namespace)
 }
 
@@ -916,7 +920,11 @@ func (config *NetworkingTestConfig) DeleteNetProxyPod(ctx context.Context) {
 		framework.Failf("Failed to delete %s pod: %v", pod.Name, err)
 	}
 	// wait for endpoint being removed.
-	err = framework.WaitForServiceEndpointsNum(ctx, config.f.ClientSet, config.Namespace, nodePortServiceName, len(config.EndpointPods), time.Second, wait.ForeverTestTimeout)
+	numEndpoints := len(config.EndpointPods)
+	if config.DualStackEnabled {
+		numEndpoints = 2 * len(config.EndpointPods)
+	}
+	err = framework.WaitForServiceEndpointsNum(ctx, config.f.ClientSet, config.Namespace, nodePortServiceName, numEndpoints, time.Second, wait.ForeverTestTimeout)
 	if err != nil {
 		framework.Failf("Failed to remove endpoint from service: %s", nodePortServiceName)
 	}


### PR DESCRIPTION

/kind failing-test
```release-note
NONE
```

When removing the references to v1.Endpoints in the e2e tests the `WaitForServiceEndpointsNum` functionality was changed to count the total number of endpoints, since EndpointSlices have both IP families, but v1.Endpoints are restricted to one IP family.


https://github.com/kubernetes/kubernetes/pull/128896/files#r1925059249

We need to adapt the test that depended on this detail

Fixes: https://github.com/kubernetes/kubernetes/issues/129753
