### PR TITLE
Add dom4ha to SIG Scheduling reviewers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -174,6 +174,7 @@ aliases:
     - AxeZhan
     - damemi
     - denkensk
+    - dom4ha
     - macsko
     - sanposhiho
     - kerthcet


### PR DESCRIPTION


#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Hi everyone, I would like to self-nominate to become a SIG Scheduling reviewer:

- I'm a member from Oct 16
- Reviewed [21 PRs (4 are open)](https://github.com/kubernetes/kubernetes/pulls?q=is%3Apr+-author%3Adom4ha+reviewed-by%3Adom4ha)
- Contributed with [11 PRs (1 is open)](https://github.com/kubernetes/kubernetes/pulls?q=is%3Apr+author%3Adom4ha+)

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
