### PR TITLE
Drop declaration of IP/CDIR type CEL variables

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/cel/library/cidr.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/library/cidr.go
@@ -160,9 +160,7 @@ var cidrLibraryDecls = map[string][]cel.FunctionOpt{
 }
 
 func (*cidrs) CompileOptions() []cel.EnvOption {
-	options := []cel.EnvOption{cel.Types(apiservercel.CIDRType),
-		cel.Variable(apiservercel.CIDRType.TypeName(), types.NewTypeTypeWithParam(apiservercel.CIDRType)),
-	}
+	options := []cel.EnvOption{cel.Types(apiservercel.CIDRType)}
 	for name, overloads := range cidrLibraryDecls {
 		options = append(options, cel.Function(name, overloads...))
 	}

--- a/staging/src/k8s.io/apiserver/pkg/cel/library/ip.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/library/ip.go
@@ -187,9 +187,7 @@ var ipLibraryDecls = map[string][]cel.FunctionOpt{
 }
 
 func (*ip) CompileOptions() []cel.EnvOption {
-	options := []cel.EnvOption{cel.Types(apiservercel.IPType),
-		cel.Variable(apiservercel.IPType.TypeName(), types.NewTypeTypeWithParam(apiservercel.IPType)),
-	}
+	options := []cel.EnvOption{cel.Types(apiservercel.IPType)}
 	for name, overloads := range ipLibraryDecls {
 		options = append(options, cel.Function(name, overloads...))
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Drop the declaration of net.IP and net.CIDR variables in the CEL environment.

These were added as [a workaround](https://github.com/kubernetes/kubernetes/pull/121912#discussion_r1421238943) until a [fix in the upstream cel-go library](https://github.com/google/cel-go/commit/d45f67fee20b8ecd7eacf1747bd60e0d8f4c4835) was merged.

The fix was released in cel-go v0.19.0, and we bumped from v0.17.8 straight to v0.20.1 in https://github.com/kubernetes/kubernetes/pull/124328

Release-1.30 is still on the older dep, so removing the declarations there causes existing tests to fail, but on the release-1.31 and newer branches, this removal does not affect the existing tests.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
