### PR TITLE
when pod scheduling faild, patch pod in parallel.

### DIFF
--- a/pkg/scheduler/schedule_one_test.go
+++ b/pkg/scheduler/schedule_one_test.go
@@ -1487,9 +1487,8 @@ func TestUpdatePod(t *testing.T) {
 			_, ctx := ktesting.NewTestContext(t)
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
-			if err := updatePod(ctx, cs, pod, test.newPodCondition, test.newNominatingInfo); err != nil {
-				t.Fatalf("Error calling update: %v", err)
-			}
+			updatePodParallel(ctx, cs, pod, test.newPodCondition, test.newNominatingInfo)
+			time.Sleep(time.Millisecond * 100)
 
 			if actualPatchRequests != test.expectedPatchRequests {
 				t.Fatalf("Actual patch requests (%d) does not equal expected patch requests (%d), actual patch data: %v", actualPatchRequests, test.expectedPatchRequests, actualPatchData)


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
when pod scheduling faild, patch pod in parallel.

#### What this PR does / why we need it:
when pod scheduling faild, patch pod in parallel. used to improve the scheduling speed of the scheduler.

This change has been running for 9 to 10 months across over 200 internal clusters without any issues, and it can effectively improve scheduling speed under specific conditions.
