### PR TITLE
cluster ip allocator should check first on the legacy allocators

### DIFF
--- a/pkg/registry/core/service/ipallocator/cidrallocator_test.go
+++ b/pkg/registry/core/service/ipallocator/cidrallocator_test.go
@@ -484,9 +484,6 @@ func TestCIDRAllocateDualWrite(t *testing.T) {
 	if f := r.Free(); f != 0 {
 		t.Errorf("free: %d", f)
 	}
-	if _, err := r.AllocateNext(); err == nil {
-		t.Error(err)
-	}
 
 	cidr := newServiceCIDR("test", "192.168.0.0/28")
 	_, err = r.client.ServiceCIDRs().Create(context.Background(), cidr, metav1.CreateOptions{})
@@ -553,9 +550,6 @@ func TestCIDRAllocateDualWriteCollision(t *testing.T) {
 
 	if f := r.Free(); f != 0 {
 		t.Errorf("free: %d", f)
-	}
-	if _, err := r.AllocateNext(); err == nil {
-		t.Error(err)
 	}
 
 	cidr := newServiceCIDR("test", "192.168.0.0/28")

--- a/test/integration/dualstack/dualstack_test.go
+++ b/test/integration/dualstack/dualstack_test.go
@@ -298,7 +298,7 @@ func TestCreateServiceSingleStackIPv6(t *testing.T) {
 					apiServerOptions,
 					[]string{
 						fmt.Sprintf("--runtime-config=networking.k8s.io/v1beta1=%v", enableMultiServiceCIDR),
-						"--service-cluster-ip-range=2001:db8:1::/112",
+						"--service-cluster-ip-range=2001:db8:1::/108",
 						"--advertise-address=2001:db8::10",
 						"--disable-admission-plugins=ServiceAccount",
 						fmt.Sprintf("--feature-gates=%s=%v,%s=%v", features.MultiCIDRServiceAllocator, enableMultiServiceCIDR, features.DisableAllocatorDualWrite, disableAllocatorDualWrite),
@@ -529,7 +529,7 @@ func TestCreateServiceDualStackIPv4IPv6(t *testing.T) {
 					apiServerOptions,
 					[]string{
 						fmt.Sprintf("--runtime-config=networking.k8s.io/v1beta1=%v", enableMultiServiceCIDR),
-						"--service-cluster-ip-range=10.0.0.0/16,2001:db8:1::/112",
+						"--service-cluster-ip-range=10.0.0.0/16,2001:db8:1::/108",
 						"--advertise-address=10.0.0.1",
 						"--disable-admission-plugins=ServiceAccount",
 						fmt.Sprintf("--feature-gates=%s=%v,%s=%v", features.MultiCIDRServiceAllocator, enableMultiServiceCIDR, features.DisableAllocatorDualWrite, disableAllocatorDualWrite),
@@ -808,7 +808,7 @@ func TestCreateServiceDualStackIPv6IPv4(t *testing.T) {
 					apiServerOptions,
 					[]string{
 						fmt.Sprintf("--runtime-config=networking.k8s.io/v1beta1=%v", enableMultiServiceCIDR),
-						"--service-cluster-ip-range=2001:db8:1::/112,10.0.0.0/16",
+						"--service-cluster-ip-range=2001:db8:1::/108,10.0.0.0/16",
 						"--advertise-address=2001:db8::10",
 						"--disable-admission-plugins=ServiceAccount",
 						fmt.Sprintf("--feature-gates=%s=%v,%s=%v", features.MultiCIDRServiceAllocator, enableMultiServiceCIDR, features.DisableAllocatorDualWrite, disableAllocatorDualWrite),
@@ -1038,7 +1038,7 @@ func TestUpgradeDowngrade(t *testing.T) {
 	s := kubeapiservertesting.StartTestServerOrDie(t,
 		apiServerOptions,
 		[]string{
-			"--service-cluster-ip-range=10.0.0.0/16,2001:db8:1::/112",
+			"--service-cluster-ip-range=10.0.0.0/16,2001:db8:1::/108",
 			"--advertise-address=10.0.0.1",
 			"--disable-admission-plugins=ServiceAccount",
 		},
@@ -1149,7 +1149,7 @@ func TestConvertToFromExternalName(t *testing.T) {
 	s := kubeapiservertesting.StartTestServerOrDie(t,
 		apiServerOptions,
 		[]string{
-			"--service-cluster-ip-range=10.0.0.0/16,2001:db8:1::/112",
+			"--service-cluster-ip-range=10.0.0.0/16,2001:db8:1::/108",
 			"--advertise-address=10.0.0.1",
 			"--disable-admission-plugins=ServiceAccount",
 		},
@@ -1238,7 +1238,7 @@ func TestPreferDualStack(t *testing.T) {
 	s := kubeapiservertesting.StartTestServerOrDie(t,
 		apiServerOptions,
 		[]string{
-			"--service-cluster-ip-range=10.0.0.0/16,2001:db8:1::/112",
+			"--service-cluster-ip-range=10.0.0.0/16,2001:db8:1::/108",
 			"--advertise-address=10.0.0.1",
 			"--disable-admission-plugins=ServiceAccount",
 		},
@@ -1552,7 +1552,7 @@ func TestUpgradeServicePreferToDualStack(t *testing.T) {
 	s = kubeapiservertesting.StartTestServerOrDie(t,
 		apiServerOptions,
 		[]string{
-			"--service-cluster-ip-range=192.168.0.0/24,2001:db8:1::/112",
+			"--service-cluster-ip-range=192.168.0.0/24,2001:db8:1::/108",
 			"--disable-admission-plugins=ServiceAccount",
 		},
 		sharedEtcd)
@@ -1593,7 +1593,7 @@ func TestDowngradeServicePreferToDualStack(t *testing.T) {
 	s := kubeapiservertesting.StartTestServerOrDie(t,
 		apiServerOptions,
 		[]string{
-			"--service-cluster-ip-range=192.168.0.0/24,2001:db8:1::/112",
+			"--service-cluster-ip-range=192.168.0.0/24,2001:db8:1::/108",
 			"--advertise-address=10.0.0.1",
 			"--disable-admission-plugins=ServiceAccount",
 		},


### PR DESCRIPTION
Kubernetes clusters allow to define an IPv6 range of /108 for IPv6 despite the old allocators will only use the first /112 of that range.

The new allocators does not have this limitation, so they can allocate IPs on the whole space, the problem happens on upgrades from clusters that were already using this size, since the new allocators can allocate addresses that may not work for both new and old allocators.

The new allocators, when configured to keep compatibility with the old allocators, must try first to allocate an IP that is compatible with the old allocators and only fall back to the new behavior if it is not possible.


/kind bug
Fixes #129797

```release-note
NONE
```

/sig network