### PR TITLE
kubelet: monitor plugin connections with application-level pings

### DIFF
--- a/pkg/kubelet/pluginmanager/cache/actual_state_of_world.go
+++ b/pkg/kubelet/pluginmanager/cache/actual_state_of_world.go
@@ -88,12 +88,20 @@ var _ ActualStateOfWorld = &actualStateOfWorld{}
 
 // PluginInfo holds information of a plugin
 type PluginInfo struct {
+	// SocketPath is a path to a Unix domain socket that the plugin is listening on
+	// to handle kubelet gRPC registration requests.
+	// The plugin may also provide other services via the same socket.
+	// SocketPath and Endpoint may be identical.
 	SocketPath string
 	Timestamp  time.Time
 	UUID       types.UID
 	Handler    PluginHandler
 	Name       string
-	Endpoint   string
+	// Endpoint is the endpoint of the plugin provided by the plugin in the GetInfo response.
+	// If endpoint is not provided it will be set to the socket path by the operation generator
+	// when it processes GetInfo response.
+	Endpoint          string
+	SupportedVersions []string
 }
 
 func (asw *actualStateOfWorld) AddPlugin(pluginInfo PluginInfo) error {

--- a/pkg/kubelet/pluginmanager/cache/actual_state_of_world.go
+++ b/pkg/kubelet/pluginmanager/cache/actual_state_of_world.go
@@ -63,6 +63,10 @@ type ActualStateOfWorld interface {
 	// PluginExistsWithCorrectUUID checks if the given plugin exists in the current actual
 	// state of world cache with the correct UUID
 	PluginExistsWithCorrectUUID(pluginInfo PluginInfo) bool
+
+	// PluginExists checks if the given socket path exists in the current actual
+	// state of world cache
+	PluginExists(socketPath string) bool
 }
 
 // NewActualStateOfWorld returns a new instance of ActualStateOfWorld
@@ -132,6 +136,14 @@ func (asw *actualStateOfWorld) PluginExistsWithCorrectTimestamp(pluginInfo Plugi
 	// matches the given plugin (from the desired state cache) timestamp
 	actualStatePlugin, exists := asw.socketFileToInfo[pluginInfo.SocketPath]
 	return exists && (actualStatePlugin.Timestamp == pluginInfo.Timestamp)
+}
+
+func (asw *actualStateOfWorld) PluginExists(socketPath string) bool {
+	asw.RLock()
+	defer asw.RUnlock()
+
+	_, exists := asw.socketFileToInfo[socketPath]
+	return exists
 }
 
 func (asw *actualStateOfWorld) PluginExistsWithCorrectUUID(pluginInfo PluginInfo) bool {

--- a/pkg/kubelet/pluginmanager/cache/actual_state_of_world_test.go
+++ b/pkg/kubelet/pluginmanager/cache/actual_state_of_world_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cache
 
 import (
+	"reflect"
 	goruntime "runtime"
 	"testing"
 	"time"
@@ -49,8 +50,8 @@ func Test_ASW_AddPlugin_Positive_NewPlugin(t *testing.T) {
 	if len(aswPlugins) != 1 {
 		t.Fatalf("Actual state of world length should be one but it's %d", len(aswPlugins))
 	}
-	if aswPlugins[0] != pluginInfo {
-		t.Fatalf("Expected\n%v\nin actual state of world, but got\n%v\n", pluginInfo, aswPlugins[0])
+	if !reflect.DeepEqual(aswPlugins[0], pluginInfo) {
+		t.Fatalf("Expected\n%#v\nin actual state of world, but got\n%#v\n", pluginInfo, aswPlugins[0])
 	}
 
 	// Check PluginExistsWithCorrectUUID returns true

--- a/pkg/kubelet/pluginmanager/operationexecutor/operation_generator.go
+++ b/pkg/kubelet/pluginmanager/operationexecutor/operation_generator.go
@@ -114,11 +114,12 @@ func (og *operationGenerator) GenerateRegisterPluginFunc(
 		// We add the plugin to the actual state of world cache before calling a plugin consumer's Register handle
 		// so that if we receive a delete event during Register Plugin, we can process it as a DeRegister call.
 		err = actualStateOfWorldUpdater.AddPlugin(cache.PluginInfo{
-			SocketPath: socketPath,
-			UUID:       pluginUUID,
-			Handler:    handler,
-			Name:       infoResp.Name,
-			Endpoint:   infoResp.Endpoint,
+			SocketPath:        socketPath,
+			UUID:              pluginUUID,
+			Handler:           handler,
+			Name:              infoResp.Name,
+			Endpoint:          infoResp.Endpoint,
+			SupportedVersions: infoResp.SupportedVersions,
 		})
 		if err != nil {
 			klog.ErrorS(err, "RegisterPlugin error -- failed to add plugin", "path", socketPath)

--- a/pkg/kubelet/pluginmanager/plugin_manager.go
+++ b/pkg/kubelet/pluginmanager/plugin_manager.go
@@ -71,6 +71,7 @@ func NewPluginManager(
 		desiredStateOfWorldPopulator: pluginwatcher.NewWatcher(
 			sockDir,
 			dsw,
+			asw,
 		),
 		reconciler:          reconciler,
 		desiredStateOfWorld: dsw,

--- a/pkg/kubelet/pluginmanager/plugin_manager.go
+++ b/pkg/kubelet/pluginmanager/plugin_manager.go
@@ -109,7 +109,7 @@ var _ PluginManager = &pluginManager{}
 func (pm *pluginManager) Run(sourcesReady config.SourcesReady, stopCh <-chan struct{}) {
 	defer runtime.HandleCrash()
 
-	if err := pm.desiredStateOfWorldPopulator.Start(stopCh); err != nil {
+	if err := pm.desiredStateOfWorldPopulator.Start(stopCh, pluginwatcher.DefaultMaxFailures); err != nil {
 		klog.ErrorS(err, "The desired_state_of_world populator (plugin watcher) starts failed!")
 		return
 	}

--- a/pkg/kubelet/pluginmanager/pluginwatcher/README.md
+++ b/pkg/kubelet/pluginmanager/pluginwatcher/README.md
@@ -1,9 +1,10 @@
 # Plugin Registration Service
 
 This folder contains a utility, pluginwatcher, for Kubelet to register
-different types of node-level plugins such as device plugins or CSI plugins.
-It discovers plugins by monitoring inotify events under the directory returned by
-kubelet.getPluginsDir(). We will refer to this directory as PluginsDir.
+different types of node-level plugins such as Device plugins, DRA plugins or
+CSI plugins. It discovers plugins by monitoring inotify events under the
+directory returned by kubelet.getPluginsDir(). We will refer to this directory
+as PluginsDir.
 
 Plugins are expected to implement the gRPC registration service specified in
 pkg/kubelet/apis/pluginregistration/v*/api.proto.
@@ -121,6 +122,10 @@ During plugin initialization phase, Kubelet will issue Plugin specific calls
 Once Kubelet determines that it is ready to use your plugin it will issue a
 Registration.NotifyRegistrationStatus gRPC call.
 
+After a plugin is registered, the pluginwatcher periodically sends
+Registration.GetInfo requests to it to check its functionality. If it stops
+responding to these requests, it is automatically unregistered.
+
 If the plugin removes its socket from the PluginDir this will be interpreted
 as a plugin Deregistration. If any of the following steps in deregistration fails,
 on retry deregistration will start from scratch:
@@ -135,7 +140,7 @@ Here are the general rules that Kubelet plugin developers should follow:
   directory, requires plugin process to be running as 'root'.
 
 - The plugin name sent during Registration.GetInfo grpc should be unique
-  for the given plugin type (CSIPlugin or DevicePlugin).
+  for the given plugin type (DRAPlugin, CSIPlugin or DevicePlugin).
 
 - The socket path needs to be unique within one directory, in normal case,
   each plugin type has its own sub directory, but the design does support socket file

--- a/pkg/kubelet/pluginmanager/pluginwatcher/README.md
+++ b/pkg/kubelet/pluginmanager/pluginwatcher/README.md
@@ -6,6 +6,9 @@ CSI plugins. It discovers plugins by monitoring inotify events under the
 directory returned by kubelet.getPluginsDir(). We will refer to this directory
 as PluginsDir.
 
+Additionally, it periodically sends Registration.GetInfo gRPC requests to the
+Unix sockets found in this directory to monitor plugin health.
+
 Plugins are expected to implement the gRPC registration service specified in
 pkg/kubelet/apis/pluginregistration/v*/api.proto.
 
@@ -125,6 +128,11 @@ Registration.NotifyRegistrationStatus gRPC call.
 After a plugin is registered, the pluginwatcher periodically sends
 Registration.GetInfo requests to it to check its functionality. If it stops
 responding to these requests, it is automatically unregistered.
+
+The pluginwatcher also attempts to connect and send Registration.GetInfo
+requests to sockets in the PluginsDir that do not belong to registered
+plugins. If a plugin responds to the requests it will be automatically
+re-registered.
 
 If the plugin removes its socket from the PluginDir this will be interpreted
 as a plugin Deregistration. If any of the following steps in deregistration fails,

--- a/pkg/kubelet/pluginmanager/pluginwatcher/example_plugin.go
+++ b/pkg/kubelet/pluginmanager/pluginwatcher/example_plugin.go
@@ -44,6 +44,7 @@ type examplePlugin struct {
 	pluginType         string
 	versions           []string
 	unlinkSocket       bool
+	getInfoLock        sync.Mutex
 }
 
 type pluginServiceV1Beta1 struct {
@@ -98,6 +99,8 @@ func GetPluginInfo(plugin *examplePlugin) cache.PluginInfo {
 
 // GetInfo is the RPC invoked by plugin watcher
 func (e *examplePlugin) GetInfo(ctx context.Context, req *registerapi.InfoRequest) (*registerapi.PluginInfo, error) {
+	e.getInfoLock.Lock()
+	defer e.getInfoLock.Unlock()
 	return &registerapi.PluginInfo{
 		Type:              e.pluginType,
 		Name:              e.pluginName,
@@ -191,4 +194,14 @@ func (e *examplePlugin) Stop() error {
 
 func (e *examplePlugin) SetUnlinkSocket(unlinkSocket bool) {
 	e.unlinkSocket = unlinkSocket
+}
+
+// StuckGetInfo locks getInfoLock to simulate a stuck GetInfo call.
+func (e *examplePlugin) StuckGetInfo() {
+	e.getInfoLock.Lock()
+}
+
+// UnstuckGetInfo unlocks getInfoLock to unstuck GetInfo call.
+func (e *examplePlugin) UnstuckGetInfo() {
+	e.getInfoLock.Unlock()
 }

--- a/pkg/kubelet/pluginmanager/pluginwatcher/example_plugin.go
+++ b/pkg/kubelet/pluginmanager/pluginwatcher/example_plugin.go
@@ -43,6 +43,7 @@ type examplePlugin struct {
 	pluginName         string
 	pluginType         string
 	versions           []string
+	unlinkSocket       bool
 }
 
 type pluginServiceV1Beta1 struct {
@@ -84,6 +85,7 @@ func NewTestExamplePlugin(pluginName string, pluginType string, endpoint string,
 		endpoint:           endpoint,
 		versions:           advertisedVersions,
 		registrationStatus: make(chan registerapi.RegistrationStatus),
+		unlinkSocket:       true, // delete unix socket file on close
 	}
 }
 
@@ -121,6 +123,8 @@ func (e *examplePlugin) Serve(services ...string) error {
 	if err != nil {
 		return err
 	}
+
+	lis.(*net.UnixListener).SetUnlinkOnClose(e.unlinkSocket)
 
 	klog.InfoS("Example server started", "endpoint", e.endpoint)
 	e.grpcServer = grpc.NewServer()
@@ -171,9 +175,20 @@ func (e *examplePlugin) Stop() error {
 		return errors.New("timed out on waiting for stop completion")
 	}
 
-	if err := os.Remove(e.endpoint); err != nil && !os.IsNotExist(err) {
-		return err
+	if e.unlinkSocket {
+		// NOTE: Unix socket gets unlinked by the net.UnixListener.close()
+		// so this is not necessary, but we do it anyway to be explicit.
+		if err := os.Remove(e.endpoint); err != nil && !os.IsNotExist(err) {
+			klog.ErrorS(err, "Failed to remove endpoint", "endpoint", e.endpoint)
+			return err
+		}
 	}
 
+	klog.InfoS("Example server stopped", "endpoint", e.endpoint)
+
 	return nil
+}
+
+func (e *examplePlugin) SetUnlinkSocket(unlinkSocket bool) {
+	e.unlinkSocket = unlinkSocket
 }

--- a/pkg/kubelet/pluginmanager/pluginwatcher/monitor.go
+++ b/pkg/kubelet/pluginmanager/pluginwatcher/monitor.go
@@ -1,0 +1,220 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pluginwatcher
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"google.golang.org/grpc"
+	"k8s.io/klog/v2"
+	registerapi "k8s.io/kubelet/pkg/apis/pluginregistration/v1"
+	"k8s.io/kubernetes/pkg/kubelet/pluginmanager/cache"
+)
+
+const (
+	// defaultDialTimeout is the default timeout duration for dialing a plugin socket.
+	defaultDialTimeout time.Duration = 20 * time.Second
+
+	// defaultGetInfoTimeout is the default timeout duration for GetInfo call.
+	defaultGetInfoTimeout time.Duration = 10 * time.Second
+
+	// defaultPluginListInterval is the default duration between getting list of registered plugins from ASW.
+	defaultPluginListInterval time.Duration = 10 * time.Second
+
+	// defaultConnectionCheckInterval is the default interval duration between connection checks.
+	defaultConnectionCheckInterval time.Duration = 10 * time.Second
+
+	// DefaultMaxFailures is the default maximum number of allowed connection monitor failures.
+	// If the number of consecutive failures exceeds this value, the connection is considered dead.
+	DefaultMaxFailures uint = 2
+
+	// UndefinedPluginName is the name of the plugin that is the not registered yet.
+	// It is used to monitor sockets that are not belong to registered plugins.
+	// As soon as the plugin becomes registered, the name is updated with the actual plugin name.
+	UndefinedPluginName = "Undefined"
+)
+
+// pluginConnectionMonitor is a struct to monitor GRPC connections between Kubelet and plugins
+type pluginConnectionMonitor struct {
+	// A sync.Map to store monitored connections
+	connMap sync.Map
+
+	// A channel to stop the monitor
+	stopCh chan struct{}
+	once   sync.Once
+
+	// dialTimeout is the timeout duration for dialing a plugin socket.
+	dialTimeout time.Duration
+
+	// getInfoTimeout is the timeout duration for GetInfo call.
+	getInfoTimeout time.Duration
+
+	// pluginListInterval is the duration between getting list of registered plugins from ASW.
+	pluginListInterval time.Duration
+
+	// connectionCheckInterval is the interval duration between connection checks.
+	connectionCheckInterval time.Duration
+
+	// maxFailures is the maximum number of allowed connection monitor failures.
+	// If the number of consecutive failures exceeds this value, the connection is considered dead.
+	maxFailures uint
+
+	dsw cache.DesiredStateOfWorld
+	asw cache.ActualStateOfWorld
+}
+
+// newPluginConnectionMonitor creates a new plugin connection monitor.
+func newPluginConnectionMonitor(sockDir string, dsw cache.DesiredStateOfWorld, asw cache.ActualStateOfWorld) *pluginConnectionMonitor {
+	return &pluginConnectionMonitor{
+		sockDir:                 sockDir,
+		connMap:                 sync.Map{},
+		stopCh:                  make(chan struct{}),
+		dialTimeout:             defaultDialTimeout,
+		getInfoTimeout:          defaultGetInfoTimeout,
+		pluginListInterval:      defaultPluginListInterval,
+		connectionCheckInterval: defaultConnectionCheckInterval,
+		maxFailures:             DefaultMaxFailures,
+		dsw:                     dsw,
+		asw:                     asw,
+	}
+}
+
+// configure sets the configuration parameters for the plugin connection monitor.
+// It's used only for testing purposes.
+func (m *pluginConnectionMonitor) configure(dialTimeout, getInfoTimeout, pluginListInterval, connectionCheckInterval time.Duration, maxFailures uint) {
+	m.dialTimeout = dialTimeout
+	m.getInfoTimeout = getInfoTimeout
+	m.pluginListInterval = pluginListInterval
+	m.connectionCheckInterval = connectionCheckInterval
+	m.maxFailures = maxFailures
+}
+
+// start starts the plugin connection monitor.
+func (m *pluginConnectionMonitor) start() {
+	go func() {
+		for {
+			select {
+			case <-m.stopCh:
+				klog.InfoS("Stopping plugin connection monitor")
+				return
+			case <-time.After(m.pluginListInterval):
+				for _, plugin := range m.asw.GetRegisteredPlugins() {
+					if m.dsw.PluginExists(plugin.SocketPath) {
+						if _, exists := m.connMap.Load(plugin.SocketPath); !exists {
+							m.connMap.Store(plugin.SocketPath, nil)
+							go m.monitorPluginConnection(plugin)
+						}
+					}
+				}
+			}
+		}
+	}()
+}
+
+// monitorPluginConnection monitors GRPC connection to the plugin
+// by periodically sending GetInfo RPC to the plugin.
+func (m *pluginConnectionMonitor) monitorPluginConnection(plugin cache.PluginInfo) {
+	socket := plugin.SocketPath
+	klog.InfoS("Start monitoring plugin connection", "plugin", plugin.Name, "socket", socket)
+
+	var client registerapi.RegistrationClient
+	var conn *grpc.ClientConn
+	var err error
+
+	defer func() {
+		if conn != nil {
+			if err := conn.Close(); err != nil {
+				klog.ErrorS(err, "Failed to close connection", "plugin", plugin.Name, "socket", socket)
+			}
+		}
+	}()
+
+	consecutiveFailures := uint(0)
+	for {
+		select {
+		case <-m.stopCh:
+			klog.InfoS("Stop monitoring plugin connection", "plugin", plugin.Name, "socket", socket)
+			return
+		case <-time.After(m.connectionCheckInterval):
+			client, conn, err = getOrEstablishConnection(client, conn, plugin, m.dialTimeout)
+			if err == nil {
+				m.connMap.Store(socket, conn)
+				if err = checkConnection(client, &plugin, m.getInfoTimeout); err == nil {
+					consecutiveFailures = 0
+					continue
+				}
+			}
+
+			// Exit after reaching the failure threshold
+			consecutiveFailures++
+			if consecutiveFailures >= m.maxFailures {
+				klog.ErrorS(err, "Failure threshold reached, remove plugin from dsw and stop monitoring", "plugin", plugin.Name, "socket", socket)
+				m.connMap.Delete(socket)
+				m.dsw.RemovePlugin(socket)
+				return
+			}
+
+		}
+	}
+}
+
+// getOrEstablishConnection ensures a connection is established and returns the client and connection.
+func getOrEstablishConnection(
+	client registerapi.RegistrationClient,
+	conn *grpc.ClientConn,
+	plugin cache.PluginInfo,
+	dialTimeout time.Duration,
+) (registerapi.RegistrationClient, *grpc.ClientConn, error) {
+	// If connection is already established, return it
+	if conn != nil {
+		return client, conn, nil
+	}
+
+	socket := plugin.SocketPath
+	newClient, newConn, err := dial(socket, dialTimeout)
+	if err != nil {
+		klog.ErrorS(err, "Failed to establish connection", "plugin", plugin.Name, "socket", socket)
+		return nil, nil, err
+	}
+
+	klog.InfoS("Connection established successfully", "plugin", plugin.Name, "socket", socket)
+	return newClient, newConn, nil
+}
+
+// checkConnection checks the connection to the plugin by sending GetInfo RPC.
+func checkConnection(client registerapi.RegistrationClient, plugin *cache.PluginInfo, getInfoTimeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(context.Background(), getInfoTimeout)
+	defer cancel()
+
+	_, err := client.GetInfo(ctx, &registerapi.InfoRequest{})
+	if err != nil {
+		klog.ErrorS(err, "Failed to get plugin info", "plugin", plugin.Name, "socket", plugin.SocketPath)
+		return err
+	}
+	return nil
+}
+
+// stop closes the stop channel, which results in
+// stoping the plugin connection monitor and all running
+// monitorPluginConnection goroutines created by it.
+func (m *pluginConnectionMonitor) stop() {
+	m.once.Do(func() {
+		close(m.stopCh)
+	})
+}

--- a/pkg/kubelet/pluginmanager/pluginwatcher/plugin_watcher.go
+++ b/pkg/kubelet/pluginmanager/pluginwatcher/plugin_watcher.go
@@ -35,14 +35,16 @@ type Watcher struct {
 	fs                  utilfs.Filesystem
 	fsWatcher           *fsnotify.Watcher
 	desiredStateOfWorld cache.DesiredStateOfWorld
+	actualStateOfWorld  cache.ActualStateOfWorld
 }
 
 // NewWatcher provides a new watcher for socket registration
-func NewWatcher(sockDir string, desiredStateOfWorld cache.DesiredStateOfWorld) *Watcher {
+func NewWatcher(sockDir string, desiredStateOfWorld cache.DesiredStateOfWorld, actualStateOfWorld cache.ActualStateOfWorld) *Watcher {
 	return &Watcher{
 		path:                sockDir,
 		fs:                  &utilfs.DefaultFs{},
 		desiredStateOfWorld: desiredStateOfWorld,
+		actualStateOfWorld:  actualStateOfWorld,
 	}
 }
 

--- a/pkg/kubelet/pluginmanager/pluginwatcher/plugin_watcher.go
+++ b/pkg/kubelet/pluginmanager/pluginwatcher/plugin_watcher.go
@@ -36,6 +36,7 @@ type Watcher struct {
 	fsWatcher           *fsnotify.Watcher
 	desiredStateOfWorld cache.DesiredStateOfWorld
 	actualStateOfWorld  cache.ActualStateOfWorld
+	monitor             *pluginConnectionMonitor
 }
 
 // NewWatcher provides a new watcher for socket registration
@@ -45,11 +46,12 @@ func NewWatcher(sockDir string, desiredStateOfWorld cache.DesiredStateOfWorld, a
 		fs:                  &utilfs.DefaultFs{},
 		desiredStateOfWorld: desiredStateOfWorld,
 		actualStateOfWorld:  actualStateOfWorld,
+		monitor:             newPluginConnectionMonitor(sockDir, desiredStateOfWorld, actualStateOfWorld),
 	}
 }
 
 // Start watches for the creation and deletion of plugin sockets at the path
-func (w *Watcher) Start(stopCh <-chan struct{}) error {
+func (w *Watcher) Start(stopCh <-chan struct{}, maxFailures uint) error {
 	klog.V(2).InfoS("Plugin Watcher Start", "path", w.path)
 
 	// Creating the directory to be watched if it doesn't exist yet,
@@ -68,6 +70,8 @@ func (w *Watcher) Start(stopCh <-chan struct{}) error {
 	if err := w.traversePluginDir(w.path); err != nil {
 		klog.ErrorS(err, "Failed to traverse plugin socket path", "path", w.path)
 	}
+
+	w.monitor.start()
 
 	go func(fsWatcher *fsnotify.Watcher) {
 		for {
@@ -90,6 +94,7 @@ func (w *Watcher) Start(stopCh <-chan struct{}) error {
 				continue
 			case <-stopCh:
 				w.fsWatcher.Close()
+				w.monitor.stop()
 				return
 			}
 		}

--- a/pkg/kubelet/pluginmanager/pluginwatcher/plugin_watcher_test.go
+++ b/pkg/kubelet/pluginmanager/pluginwatcher/plugin_watcher_test.go
@@ -108,7 +108,8 @@ func TestPluginRegistration(t *testing.T) {
 	defer os.RemoveAll(socketDir)
 
 	dsw := cache.NewDesiredStateOfWorld()
-	newWatcher(t, socketDir, dsw, wait.NeverStop)
+	asw := cache.NewActualStateOfWorld()
+	newWatcher(t, socketDir, dsw, asw, wait.NeverStop)
 
 	for i := 0; i < 10; i++ {
 		socketPath := filepath.Join(socketDir, fmt.Sprintf("plugin-%d.sock", i))
@@ -142,7 +143,8 @@ func TestPluginRegistrationSameName(t *testing.T) {
 	defer os.RemoveAll(socketDir)
 
 	dsw := cache.NewDesiredStateOfWorld()
-	newWatcher(t, socketDir, dsw, wait.NeverStop)
+	asw := cache.NewActualStateOfWorld()
+	newWatcher(t, socketDir, dsw, asw, wait.NeverStop)
 
 	// Make 10 plugins with the same name and same type but different socket path;
 	// all 10 should be in desired state of world cache
@@ -168,7 +170,8 @@ func TestPluginReRegistration(t *testing.T) {
 	defer os.RemoveAll(socketDir)
 
 	dsw := cache.NewDesiredStateOfWorld()
-	newWatcher(t, socketDir, dsw, wait.NeverStop)
+	asw := cache.NewActualStateOfWorld()
+	newWatcher(t, socketDir, dsw, asw, wait.NeverStop)
 
 	// Create a plugin first, we are then going to remove the plugin, update the plugin with a different name
 	// and recreate it.
@@ -226,7 +229,8 @@ func TestPluginRegistrationAtKubeletStart(t *testing.T) {
 	}
 
 	dsw := cache.NewDesiredStateOfWorld()
-	newWatcher(t, socketDir, dsw, wait.NeverStop)
+	asw := cache.NewActualStateOfWorld()
+	newWatcher(t, socketDir, dsw, asw, wait.NeverStop)
 
 	var wg sync.WaitGroup
 	for i := 0; i < len(plugins); i++ {
@@ -254,8 +258,8 @@ func TestPluginRegistrationAtKubeletStart(t *testing.T) {
 	}
 }
 
-func newWatcher(t *testing.T, socketDir string, desiredStateOfWorldCache cache.DesiredStateOfWorld, stopCh <-chan struct{}) *Watcher {
-	w := NewWatcher(socketDir, desiredStateOfWorldCache)
+func newWatcher(t *testing.T, socketDir string, desiredStateOfWorldCache cache.DesiredStateOfWorld, actualStateOfWorldCache cache.ActualStateOfWorld, stopCh <-chan struct{}) *Watcher {
+	w := NewWatcher(socketDir, desiredStateOfWorldCache, actualStateOfWorldCache)
 	require.NoError(t, w.Start(stopCh))
 
 	return w

--- a/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/noderegistrar.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/noderegistrar.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/stats"
 	"k8s.io/klog/v2"
 	registerapi "k8s.io/kubelet/pkg/apis/pluginregistration/v1"
 )
@@ -30,7 +31,7 @@ type nodeRegistrar struct {
 }
 
 // startRegistrar returns a running instance.
-func startRegistrar(logger klog.Logger, grpcVerbosity int, interceptors []grpc.UnaryServerInterceptor, streamInterceptors []grpc.StreamServerInterceptor, driverName string, supportedServices []string, socketpath string, pluginRegistrationEndpoint endpoint) (*nodeRegistrar, error) {
+func startRegistrar(logger klog.Logger, grpcVerbosity int, interceptors []grpc.UnaryServerInterceptor, streamInterceptors []grpc.StreamServerInterceptor, statsHandlers []stats.Handler, driverName string, supportedServices []string, socketpath string, pluginRegistrationEndpoint endpoint) (*nodeRegistrar, error) {
 	n := &nodeRegistrar{
 		registrationServer: registrationServer{
 			driverName:        driverName,
@@ -38,7 +39,7 @@ func startRegistrar(logger klog.Logger, grpcVerbosity int, interceptors []grpc.U
 			supportedVersions: supportedServices, // DRA uses this field to describe provided services (e.g. "v1beta1.DRAPlugin").
 		},
 	}
-	s, err := startGRPCServer(logger, grpcVerbosity, interceptors, streamInterceptors, pluginRegistrationEndpoint, func(grpcServer *grpc.Server) {
+	s, err := startGRPCServer(logger, grpcVerbosity, interceptors, streamInterceptors, statsHandlers, pluginRegistrationEndpoint, func(grpcServer *grpc.Server) {
 		registerapi.RegisterRegistrationServer(grpcServer, n)
 	})
 	if err != nil {

--- a/test/e2e/dra/test-driver/app/kubeletplugin.go
+++ b/test/e2e/dra/test-driver/app/kubeletplugin.go
@@ -241,6 +241,13 @@ func (ex *ExamplePlugin) IsRegistered() bool {
 	return status.PluginRegistered
 }
 
+func (ex *ExamplePlugin) ResetRegistrationStatus() {
+	status := ex.d.RegistrationStatus()
+	if status != nil {
+		status.Reset()
+	}
+}
+
 // BlockGetInfo locks blockGetInfoMutex and returns unlocking function for it
 func (ex *ExamplePlugin) BlockGetInfo() func() {
 	ex.blockGetInfoMutex.Lock()


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/king feature

#### What this PR does / why we need it:

This PR implements a connection monitor for the Kubelet plugin watcher. The connection monitor periodically sends GetInfo requests to all registered plugins. If plugin stops responding to these requests it's automatically unregistered.
This implementation is used for Dynamic Resource Allocation (DRA), Container Storage Interface (CSI), and Device plugins.

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/kubernetes/issues/128696
Ref https://github.com/kubernetes/kubernetes/issues/127457

#### Does this PR introduce a user-facing change?

```release-note
Implemented a connection monitor for the Kubelet plugins. The connection monitor periodically sends GetInfo requests to all registered plugins. If a plugin stops responding to these requests, it is automatically unregistered. This implementation is used for Dynamic Resource Allocation (DRA), Container Storage Interface (CSI), and Device plugins.
```