### PR TITLE
Bump kubedns and nodelocaldns to 1.25.0

### DIFF
--- a/cluster/addons/dns/kube-dns/kube-dns.yaml.base
+++ b/cluster/addons/dns/kube-dns/kube-dns.yaml.base
@@ -114,7 +114,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: kubedns
-        image: registry.k8s.io/dns/k8s-dns-kube-dns:1.24.0
+        image: registry.k8s.io/dns/k8s-dns-kube-dns:1.25.0
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in
@@ -170,7 +170,7 @@ spec:
           runAsUser: 1001
           runAsGroup: 1001
       - name: dnsmasq
-        image: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny:1.24.0
+        image: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny:1.25.0
         livenessProbe:
           httpGet:
             path: /healthcheck/dnsmasq
@@ -216,7 +216,7 @@ spec:
               - NET_BIND_SERVICE
               - SETGID
       - name: sidecar
-        image: registry.k8s.io/dns/k8s-dns-sidecar:1.24.0
+        image: registry.k8s.io/dns/k8s-dns-sidecar:1.25.0
         livenessProbe:
           httpGet:
             path: /metrics

--- a/cluster/addons/dns/kube-dns/kube-dns.yaml.in
+++ b/cluster/addons/dns/kube-dns/kube-dns.yaml.in
@@ -114,7 +114,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: kubedns
-        image: registry.k8s.io/dns/k8s-dns-kube-dns:1.24.0
+        image: registry.k8s.io/dns/k8s-dns-kube-dns:1.25.0
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in
@@ -170,7 +170,7 @@ spec:
           runAsUser: 1001
           runAsGroup: 1001
       - name: dnsmasq
-        image: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny:1.24.0
+        image: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny:1.25.0
         livenessProbe:
           httpGet:
             path: /healthcheck/dnsmasq
@@ -216,7 +216,7 @@ spec:
               - NET_BIND_SERVICE
               - SETGID
       - name: sidecar
-        image: registry.k8s.io/dns/k8s-dns-sidecar:1.24.0
+        image: registry.k8s.io/dns/k8s-dns-sidecar:1.25.0
         livenessProbe:
           httpGet:
             path: /metrics

--- a/cluster/addons/dns/kube-dns/kube-dns.yaml.sed
+++ b/cluster/addons/dns/kube-dns/kube-dns.yaml.sed
@@ -114,7 +114,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: kubedns
-        image: registry.k8s.io/dns/k8s-dns-kube-dns:1.24.0
+        image: registry.k8s.io/dns/k8s-dns-kube-dns:1.25.0
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in
@@ -170,7 +170,7 @@ spec:
           runAsUser: 1001
           runAsGroup: 1001
       - name: dnsmasq
-        image: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny:1.24.0
+        image: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny:1.25.0
         livenessProbe:
           httpGet:
             path: /healthcheck/dnsmasq
@@ -216,7 +216,7 @@ spec:
               - NET_BIND_SERVICE
               - SETGID
       - name: sidecar
-        image: registry.k8s.io/dns/k8s-dns-sidecar:1.24.0
+        image: registry.k8s.io/dns/k8s-dns-sidecar:1.25.0
         livenessProbe:
           httpGet:
             path: /metrics

--- a/cluster/addons/dns/nodelocaldns/nodelocaldns.yaml
+++ b/cluster/addons/dns/nodelocaldns/nodelocaldns.yaml
@@ -138,7 +138,7 @@ spec:
         operator: "Exists"
       containers:
       - name: node-cache
-        image: registry.k8s.io/dns/k8s-dns-node-cache:1.24.0
+        image: registry.k8s.io/dns/k8s-dns-node-cache:1.25.0
         resources:
           requests:
             cpu: 25m


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

The PR bumps kubedns and nodelocaldns to make use of https://github.com/kubernetes/dns/releases/tag/1.25.0, which fixes some vulnerabilities present in `1.24.0`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

I've checked that the images have already been promoted
```
$ for i in "k8s-dns-dnsmasq-nanny" "k8s-dns-kube-dns" "k8s-dns-sidecar" "k8s-dns-node-cache"; do docker pull registry.k8s.io/dns/$i:1.25.0 | grep "Pulling\|sha"; done
1.25.0: Pulling from dns/k8s-dns-dnsmasq-nanny
Digest: sha256:26fd9709bc2757624060ad2fbbef611faf5ff1467bb12eedfe1d3c072714b68a
1.25.0: Pulling from dns/k8s-dns-kube-dns
Digest: sha256:69e37e6407b8a4e9b04c29207edb01877c8e6e9fc1682d8bfc80af075a4e562e
1.25.0: Pulling from dns/k8s-dns-sidecar
Digest: sha256:c1c529cafbd38cde0e141831ecc0c9e827dcaea975b690c549f346db3ce12ec6
1.25.0: Pulling from dns/k8s-dns-node-cache
Digest: sha256:c10362235fc2a5c4cd8f2c4cd4b79221026ba4f69005b1c640a6ba48410f7fa4
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
