### PR TITLE
e2e: bump port-forward timeout

### DIFF
--- a/test/e2e/kubectl/portforward.go
+++ b/test/e2e/kubectl/portforward.go
@@ -640,7 +640,7 @@ var _ = SIGDescribe("Kubectl Port forwarding", func() {
 
 			ginkgo.By("Send a http request to verify port-forward working")
 			client := http.Client{
-				Timeout: 10 * time.Second,
+				Timeout: 15 * time.Second,
 			}
 			resp, err := client.Get(fmt.Sprintf("http://127.0.0.1:%d/", cmd.port))
 			framework.ExpectNoError(err, "couldn't get http response from port-forward")


### PR DESCRIPTION
#### What type of PR is this?
/sig cli
/kind flake

#### What this PR does / why we need it:
We've [decided](https://github.com/kubernetes/kubernetes/pull/128319#discussion_r1821013576) with @aojea that 10s should be enough, looking at the failures from https://github.com/kubernetes/kubernetes/issues/129803 it's clear that the we need to bump that timeout slightly higher, since all of the failures are GCE based, only. 

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubernetes/issues/129803

#### Special notes for your reviewer:
/assign @ardaguclu @aojea 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```