### PR TITLE
Improve SA max token expiry with external signer logic, and plumb extended expiry duration.

### DIFF
--- a/pkg/controlplane/apiserver/apis.go
+++ b/pkg/controlplane/apiserver/apis.go
@@ -52,8 +52,8 @@ func (c *CompletedConfig) NewCoreGenericConfig() *corerest.GenericConfig {
 		LoopbackClientConfig:        c.Generic.LoopbackClientConfig,
 		ServiceAccountIssuer:        c.Extra.ServiceAccountIssuer,
 		ExtendExpiration:            c.Extra.ExtendExpiration,
-		IsTokenSignerExternal:       c.Extra.IsTokenSignerExternal,
 		ServiceAccountMaxExpiration: c.Extra.ServiceAccountMaxExpiration,
+		MaxExtendedExpiration:       c.Extra.ServiceAccountExtendedMaxExpiration,
 		APIAudiences:                c.Generic.Authentication.APIAudiences,
 		Informers:                   c.Extra.VersionedInformers,
 	}

--- a/pkg/controlplane/apiserver/config.go
+++ b/pkg/controlplane/apiserver/config.go
@@ -89,10 +89,10 @@ type Extra struct {
 	// version skew. If unset, AdvertiseAddress/BindAddress will be used.
 	PeerAdvertiseAddress peerreconcilers.PeerAdvertiseAddress
 
-	ServiceAccountIssuer        serviceaccount.TokenGenerator
-	ServiceAccountMaxExpiration time.Duration
-	ExtendExpiration            bool
-	IsTokenSignerExternal       bool
+	ServiceAccountIssuer                serviceaccount.TokenGenerator
+	ServiceAccountMaxExpiration         time.Duration
+	ServiceAccountExtendedMaxExpiration time.Duration
+	ExtendExpiration                    bool
 
 	// ServiceAccountIssuerDiscovery
 	ServiceAccountIssuerURL        string
@@ -299,10 +299,10 @@ func CreateConfig(
 			ProxyTransport:          proxyTransport,
 			SystemNamespaces:        opts.SystemNamespaces,
 
-			ServiceAccountIssuer:        opts.ServiceAccountIssuer,
-			ServiceAccountMaxExpiration: opts.ServiceAccountTokenMaxExpiration,
-			ExtendExpiration:            opts.Authentication.ServiceAccounts.ExtendExpiration,
-			IsTokenSignerExternal:       opts.Authentication.ServiceAccounts.IsTokenSignerExternal,
+			ServiceAccountIssuer:                opts.ServiceAccountIssuer,
+			ServiceAccountMaxExpiration:         opts.ServiceAccountTokenMaxExpiration,
+			ServiceAccountExtendedMaxExpiration: opts.Authentication.ServiceAccounts.MaxExtendedExpiration,
+			ExtendExpiration:                    opts.Authentication.ServiceAccounts.ExtendExpiration,
 
 			VersionedInformers: versionedInformers,
 		},

--- a/pkg/kubeapiserver/options/authentication.go
+++ b/pkg/kubeapiserver/options/authentication.go
@@ -131,9 +131,9 @@ type ServiceAccountAuthenticationOptions struct {
 	Lookup                bool
 	Issuers               []string
 	JWKSURI               string
-	MaxExpiration         time.Duration
 	ExtendExpiration      bool
-	IsTokenSignerExternal bool
+	MaxExpiration         time.Duration
+	MaxExtendedExpiration time.Duration
 	// OptionalTokenGetter is a function that returns a service account token getter.
 	// If not set, the default token getter will be used.
 	OptionalTokenGetter func(factory informers.SharedInformerFactory) serviceaccount.ServiceAccountTokenGetter
@@ -224,6 +224,7 @@ func (o *BuiltInAuthenticationOptions) WithServiceAccounts() *BuiltInAuthenticat
 	}
 	o.ServiceAccounts.Lookup = true
 	o.ServiceAccounts.ExtendExpiration = true
+	o.ServiceAccounts.MaxExtendedExpiration = serviceaccount.ExpirationExtensionSeconds * time.Second
 	return o
 }
 

--- a/pkg/kubeapiserver/options/authentication_test.go
+++ b/pkg/kubeapiserver/options/authentication_test.go
@@ -437,11 +437,12 @@ func TestBuiltInAuthenticationOptionsAddFlags(t *testing.T) {
 			AllowedNames:    []string{"kube-aggregator"},
 		},
 		ServiceAccounts: &ServiceAccountAuthenticationOptions{
-			KeyFiles:         []string{"cert", "key"},
-			Lookup:           true,
-			Issuers:          []string{"http://foo.bar.com"},
-			JWKSURI:          "https://qux.com",
-			ExtendExpiration: true,
+			KeyFiles:              []string{"cert", "key"},
+			Lookup:                true,
+			Issuers:               []string{"http://foo.bar.com"},
+			JWKSURI:               "https://qux.com",
+			ExtendExpiration:      true,
+			MaxExtendedExpiration: serviceaccount.ExpirationExtensionSeconds * time.Second,
 		},
 		TokenFile: &TokenFileAuthenticationOptions{
 			TokenFile: "tokenfile",

--- a/pkg/registry/core/rest/storage_core.go
+++ b/pkg/registry/core/rest/storage_core.go
@@ -223,7 +223,7 @@ func (p *legacyProvider) NewRESTStorage(apiResourceConfigSource serverstorage.AP
 			utilfeature.DefaultFeatureGate.Enabled(features.ServiceAccountTokenPodNodeInfo) {
 			nodeGetter = nodeStorage.Node.Store
 		}
-		serviceAccountStorage, err = serviceaccountstore.NewREST(restOptionsGetter, p.ServiceAccountIssuer, p.APIAudiences, p.ServiceAccountMaxExpiration, podStorage.Pod.Store, storage["secrets"].(rest.Getter), nodeGetter, p.ExtendExpiration, p.IsTokenSignerExternal)
+		serviceAccountStorage, err = serviceaccountstore.NewREST(restOptionsGetter, p.ServiceAccountIssuer, p.APIAudiences, p.ServiceAccountMaxExpiration, podStorage.Pod.Store, storage["secrets"].(rest.Getter), nodeGetter, p.ExtendExpiration, p.MaxExtendedExpiration)
 		if err != nil {
 			return genericapiserver.APIGroupInfo{}, err
 		}

--- a/pkg/registry/core/rest/storage_core_generic.go
+++ b/pkg/registry/core/rest/storage_core_generic.go
@@ -57,7 +57,7 @@ type GenericConfig struct {
 	ServiceAccountIssuer        serviceaccount.TokenGenerator
 	ServiceAccountMaxExpiration time.Duration
 	ExtendExpiration            bool
-	IsTokenSignerExternal       bool
+	MaxExtendedExpiration       time.Duration
 
 	APIAudiences authenticator.Audiences
 
@@ -103,9 +103,9 @@ func (c *GenericConfig) NewRESTStorage(apiResourceConfigSource serverstorage.API
 
 	var serviceAccountStorage *serviceaccountstore.REST
 	if c.ServiceAccountIssuer != nil {
-		serviceAccountStorage, err = serviceaccountstore.NewREST(restOptionsGetter, c.ServiceAccountIssuer, c.APIAudiences, c.ServiceAccountMaxExpiration, newNotFoundGetter(schema.GroupResource{Resource: "pods"}), secretStorage.Store, newNotFoundGetter(schema.GroupResource{Resource: "nodes"}), c.ExtendExpiration, c.IsTokenSignerExternal)
+		serviceAccountStorage, err = serviceaccountstore.NewREST(restOptionsGetter, c.ServiceAccountIssuer, c.APIAudiences, c.ServiceAccountMaxExpiration, newNotFoundGetter(schema.GroupResource{Resource: "pods"}), secretStorage.Store, newNotFoundGetter(schema.GroupResource{Resource: "nodes"}), c.ExtendExpiration, c.MaxExtendedExpiration)
 	} else {
-		serviceAccountStorage, err = serviceaccountstore.NewREST(restOptionsGetter, nil, nil, 0, newNotFoundGetter(schema.GroupResource{Resource: "pods"}), newNotFoundGetter(schema.GroupResource{Resource: "secrets"}), newNotFoundGetter(schema.GroupResource{Resource: "nodes"}), false, c.IsTokenSignerExternal)
+		serviceAccountStorage, err = serviceaccountstore.NewREST(restOptionsGetter, nil, nil, 0, newNotFoundGetter(schema.GroupResource{Resource: "pods"}), newNotFoundGetter(schema.GroupResource{Resource: "secrets"}), newNotFoundGetter(schema.GroupResource{Resource: "nodes"}), false, c.MaxExtendedExpiration)
 	}
 	if err != nil {
 		return genericapiserver.APIGroupInfo{}, err

--- a/pkg/registry/core/serviceaccount/storage/storage.go
+++ b/pkg/registry/core/serviceaccount/storage/storage.go
@@ -39,7 +39,7 @@ type REST struct {
 }
 
 // NewREST returns a RESTStorage object that will work against service accounts.
-func NewREST(optsGetter generic.RESTOptionsGetter, issuer token.TokenGenerator, auds authenticator.Audiences, max time.Duration, podStorage, secretStorage, nodeStorage rest.Getter, extendExpiration bool, isTokenSignerExternal bool) (*REST, error) {
+func NewREST(optsGetter generic.RESTOptionsGetter, issuer token.TokenGenerator, auds authenticator.Audiences, max time.Duration, podStorage, secretStorage, nodeStorage rest.Getter, extendExpiration bool, maxExtendedExpiration time.Duration) (*REST, error) {
 	store := &genericregistry.Store{
 		NewFunc:                   func() runtime.Object { return &api.ServiceAccount{} },
 		NewListFunc:               func() runtime.Object { return &api.ServiceAccountList{} },
@@ -61,16 +61,16 @@ func NewREST(optsGetter generic.RESTOptionsGetter, issuer token.TokenGenerator, 
 	var trest *TokenREST
 	if issuer != nil && podStorage != nil && secretStorage != nil {
 		trest = &TokenREST{
-			svcaccts:              store,
-			pods:                  podStorage,
-			secrets:               secretStorage,
-			nodes:                 nodeStorage,
-			issuer:                issuer,
-			auds:                  auds,
-			audsSet:               sets.NewString(auds...),
-			maxExpirationSeconds:  int64(max.Seconds()),
-			extendExpiration:      extendExpiration,
-			isTokenSignerExternal: isTokenSignerExternal,
+			svcaccts:                     store,
+			pods:                         podStorage,
+			secrets:                      secretStorage,
+			nodes:                        nodeStorage,
+			issuer:                       issuer,
+			auds:                         auds,
+			audsSet:                      sets.NewString(auds...),
+			maxExpirationSeconds:         int64(max.Seconds()),
+			maxExtendedExpirationSeconds: int64(maxExtendedExpiration.Seconds()),
+			extendExpiration:             extendExpiration,
 		}
 	}
 

--- a/pkg/registry/core/serviceaccount/storage/storage_test.go
+++ b/pkg/registry/core/serviceaccount/storage/storage_test.go
@@ -19,6 +19,7 @@ package storage
 import (
 	"context"
 	"testing"
+	"time"
 
 	"gopkg.in/go-jose/go-jose.v2/jwt"
 
@@ -55,7 +56,7 @@ func newTokenStorage(t *testing.T, issuer token.TokenGenerator, auds authenticat
 		ResourcePrefix:          "serviceaccounts",
 	}
 	// set issuer, podStore and secretStore to allow the token endpoint to be initialised
-	rest, err := NewREST(restOptions, issuer, auds, 0, podStorage, secretStorage, nodeStorage, false, false)
+	rest, err := NewREST(restOptions, issuer, auds, 0, podStorage, secretStorage, nodeStorage, false, time.Hour*9999)
 	if err != nil {
 		t.Fatalf("unexpected error from REST storage: %v", err)
 	}


### PR DESCRIPTION
Allow setting `--service-account-max-token-expiry` when using an external signer, so long as the duration is less than what the external signer supports.  Also replaced "IsExternalSigner" plumbing with a simple 2nd duration that is only used for extended SA tokens.

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
Improves functionality of `--service-account-max-token-expiration` when using external signer with `--service-account-signing-endpoint`. Also centralizes the `ExtendedSigningDuration` logic to the apiserver options and plumbs that around instead of `IsExternalSigner` bool and depend on several systems to make decisions on extended token duration.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kube-apiserver: --service-account-max-token-expiration can now be used in combination with an external token signer --service-account-signing-endpoint, as long as the --service-account-max-token-expiration is not longer than the external token signer's max expiration.
```
