### PR TITLE
fix up iptables construction, kubelet iptables startup messages

### DIFF
--- a/cmd/kube-proxy/app/server_linux.go
+++ b/cmd/kube-proxy/app/server_linux.go
@@ -109,12 +109,10 @@ func isIPTablesBased(mode proxyconfigapi.ProxyMode) bool {
 // is not v1.IPFamilyUnknown then it will also separately return the interface for just
 // that family.
 func getIPTables(primaryFamily v1.IPFamily) ([2]utiliptables.Interface, utiliptables.Interface) {
-	execer := exec.New()
-
 	// Create iptables handlers for both families. Always ordered as IPv4, IPv6
 	ipt := [2]utiliptables.Interface{
-		utiliptables.New(execer, utiliptables.ProtocolIPv4),
-		utiliptables.New(execer, utiliptables.ProtocolIPv6),
+		utiliptables.New(utiliptables.ProtocolIPv4),
+		utiliptables.New(utiliptables.ProtocolIPv6),
 	}
 
 	var iptInterface utiliptables.Interface

--- a/pkg/kubelet/kubelet_network_linux.go
+++ b/pkg/kubelet/kubelet_network_linux.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 	utiliptables "k8s.io/kubernetes/pkg/util/iptables"
-	utilexec "k8s.io/utils/exec"
 )
 
 const (
@@ -38,10 +37,9 @@ const (
 )
 
 func (kl *Kubelet) initNetworkUtil() {
-	exec := utilexec.New()
 	iptClients := []utiliptables.Interface{
-		utiliptables.New(exec, utiliptables.ProtocolIPv4),
-		utiliptables.New(exec, utiliptables.ProtocolIPv6),
+		utiliptables.New(utiliptables.ProtocolIPv4),
+		utiliptables.New(utiliptables.ProtocolIPv6),
 	}
 
 	for i := range iptClients {

--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -94,7 +94,7 @@ const sysctlNFConntrackTCPBeLiberal = "net/netfilter/nf_conntrack_tcp_be_liberal
 // NewDualStackProxier creates a MetaProxier instance, with IPv4 and IPv6 proxies.
 func NewDualStackProxier(
 	ctx context.Context,
-	ipt [2]utiliptables.Interface,
+	ipts map[v1.IPFamily]utiliptables.Interface,
 	sysctl utilsysctl.Interface,
 	syncPeriod time.Duration,
 	minSyncPeriod time.Duration,
@@ -110,7 +110,7 @@ func NewDualStackProxier(
 	initOnly bool,
 ) (proxy.Provider, error) {
 	// Create an ipv4 instance of the single-stack proxier
-	ipv4Proxier, err := NewProxier(ctx, v1.IPv4Protocol, ipt[0], sysctl,
+	ipv4Proxier, err := NewProxier(ctx, v1.IPv4Protocol, ipts[v1.IPv4Protocol], sysctl,
 		syncPeriod, minSyncPeriod, masqueradeAll, localhostNodePorts, masqueradeBit,
 		localDetectors[v1.IPv4Protocol], hostname, nodeIPs[v1.IPv4Protocol],
 		recorder, healthzServer, nodePortAddresses, initOnly)
@@ -118,7 +118,7 @@ func NewDualStackProxier(
 		return nil, fmt.Errorf("unable to create ipv4 proxier: %v", err)
 	}
 
-	ipv6Proxier, err := NewProxier(ctx, v1.IPv6Protocol, ipt[1], sysctl,
+	ipv6Proxier, err := NewProxier(ctx, v1.IPv6Protocol, ipts[v1.IPv6Protocol], sysctl,
 		syncPeriod, minSyncPeriod, masqueradeAll, false, masqueradeBit,
 		localDetectors[v1.IPv6Protocol], hostname, nodeIPs[v1.IPv6Protocol],
 		recorder, healthzServer, nodePortAddresses, initOnly)

--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -110,7 +110,7 @@ const (
 // NewDualStackProxier returns a new Proxier for dual-stack operation
 func NewDualStackProxier(
 	ctx context.Context,
-	ipt [2]utiliptables.Interface,
+	ipts map[v1.IPFamily]utiliptables.Interface,
 	ipvs utilipvs.Interface,
 	ipset utilipset.Interface,
 	sysctl utilsysctl.Interface,
@@ -133,7 +133,7 @@ func NewDualStackProxier(
 	initOnly bool,
 ) (proxy.Provider, error) {
 	// Create an ipv4 instance of the single-stack proxier
-	ipv4Proxier, err := NewProxier(ctx, v1.IPv4Protocol, ipt[0], ipvs, ipset, sysctl,
+	ipv4Proxier, err := NewProxier(ctx, v1.IPv4Protocol, ipts[v1.IPv4Protocol], ipvs, ipset, sysctl,
 		syncPeriod, minSyncPeriod, filterCIDRs(false, excludeCIDRs), strictARP,
 		tcpTimeout, tcpFinTimeout, udpTimeout, masqueradeAll, masqueradeBit,
 		localDetectors[v1.IPv4Protocol], hostname, nodeIPs[v1.IPv4Protocol], recorder,
@@ -142,7 +142,7 @@ func NewDualStackProxier(
 		return nil, fmt.Errorf("unable to create ipv4 proxier: %v", err)
 	}
 
-	ipv6Proxier, err := NewProxier(ctx, v1.IPv6Protocol, ipt[1], ipvs, ipset, sysctl,
+	ipv6Proxier, err := NewProxier(ctx, v1.IPv6Protocol, ipts[v1.IPv6Protocol], ipvs, ipset, sysctl,
 		syncPeriod, minSyncPeriod, filterCIDRs(true, excludeCIDRs), strictARP,
 		tcpTimeout, tcpFinTimeout, udpTimeout, masqueradeAll, masqueradeBit,
 		localDetectors[v1.IPv6Protocol], hostname, nodeIPs[v1.IPv6Protocol], recorder,

--- a/pkg/util/iptables/iptables.go
+++ b/pkg/util/iptables/iptables.go
@@ -246,8 +246,8 @@ func newInternal(exec utilexec.Interface, protocol Protocol, lockfilePath14x, lo
 }
 
 // New returns a new Interface which will exec iptables.
-func New(exec utilexec.Interface, protocol Protocol) Interface {
-	return newInternal(exec, protocol, "", "")
+func New(protocol Protocol) Interface {
+	return newInternal(utilexec.New(), protocol, "", "")
 }
 
 // EnsureChain is part of Interface.

--- a/pkg/util/iptables/iptables_test.go
+++ b/pkg/util/iptables/iptables_test.go
@@ -61,7 +61,7 @@ func testIPTablesVersionCmds(t *testing.T, protocol Protocol) {
 			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
 		},
 	}
-	_ = New(fexec, protocol)
+	_ = newInternal(fexec, protocol, "", "")
 
 	// Check that proper iptables version command was used during runner instantiation
 	if !sets.New(fcmd.CombinedOutputLog[0]...).HasAll(iptablesCmd, "--version") {
@@ -103,7 +103,7 @@ func testEnsureChain(t *testing.T, protocol Protocol) {
 			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
 		},
 	}
-	runner := New(fexec, protocol)
+	runner := newInternal(fexec, protocol, "", "")
 	// Success.
 	exists, err := runner.EnsureChain(TableNAT, Chain("FOOBAR"))
 	if err != nil {
@@ -160,7 +160,7 @@ func TestFlushChain(t *testing.T) {
 			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
 		},
 	}
-	runner := New(fexec, ProtocolIPv4)
+	runner := newInternal(fexec, ProtocolIPv4, "", "")
 	// Success.
 	err := runner.FlushChain(TableNAT, Chain("FOOBAR"))
 	if err != nil {
@@ -197,7 +197,7 @@ func TestDeleteChain(t *testing.T) {
 			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
 		},
 	}
-	runner := New(fexec, ProtocolIPv4)
+	runner := newInternal(fexec, ProtocolIPv4, "", "")
 	// Success.
 	err := runner.DeleteChain(TableNAT, Chain("FOOBAR"))
 	if err != nil {
@@ -233,7 +233,7 @@ func TestEnsureRuleAlreadyExists(t *testing.T) {
 			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
 		},
 	}
-	runner := New(fexec, ProtocolIPv4)
+	runner := newInternal(fexec, ProtocolIPv4, "", "")
 	exists, err := runner.EnsureRule(Append, TableNAT, ChainOutput, "abc", "123")
 	if err != nil {
 		t.Errorf("expected success, got %v", err)
@@ -269,7 +269,7 @@ func TestEnsureRuleNew(t *testing.T) {
 			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
 		},
 	}
-	runner := New(fexec, ProtocolIPv4)
+	runner := newInternal(fexec, ProtocolIPv4, "", "")
 	exists, err := runner.EnsureRule(Append, TableNAT, ChainOutput, "abc", "123")
 	if err != nil {
 		t.Errorf("expected success, got %v", err)
@@ -302,7 +302,7 @@ func TestEnsureRuleErrorChecking(t *testing.T) {
 			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
 		},
 	}
-	runner := New(fexec, ProtocolIPv4)
+	runner := newInternal(fexec, ProtocolIPv4, "", "")
 	_, err := runner.EnsureRule(Append, TableNAT, ChainOutput, "abc", "123")
 	if err == nil {
 		t.Errorf("expected failure")
@@ -332,7 +332,7 @@ func TestEnsureRuleErrorCreating(t *testing.T) {
 			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
 		},
 	}
-	runner := New(fexec, ProtocolIPv4)
+	runner := newInternal(fexec, ProtocolIPv4, "", "")
 	_, err := runner.EnsureRule(Append, TableNAT, ChainOutput, "abc", "123")
 	if err == nil {
 		t.Errorf("expected failure")
@@ -359,7 +359,7 @@ func TestDeleteRuleDoesNotExist(t *testing.T) {
 			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
 		},
 	}
-	runner := New(fexec, ProtocolIPv4)
+	runner := newInternal(fexec, ProtocolIPv4, "", "")
 	err := runner.DeleteRule(TableNAT, ChainOutput, "abc", "123")
 	if err != nil {
 		t.Errorf("expected success, got %v", err)
@@ -392,7 +392,7 @@ func TestDeleteRuleExists(t *testing.T) {
 			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
 		},
 	}
-	runner := New(fexec, ProtocolIPv4)
+	runner := newInternal(fexec, ProtocolIPv4, "", "")
 	err := runner.DeleteRule(TableNAT, ChainOutput, "abc", "123")
 	if err != nil {
 		t.Errorf("expected success, got %v", err)
@@ -422,7 +422,7 @@ func TestDeleteRuleErrorChecking(t *testing.T) {
 			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
 		},
 	}
-	runner := New(fexec, ProtocolIPv4)
+	runner := newInternal(fexec, ProtocolIPv4, "", "")
 	err := runner.DeleteRule(TableNAT, ChainOutput, "abc", "123")
 	if err == nil {
 		t.Errorf("expected failure")
@@ -452,7 +452,7 @@ func TestDeleteRuleErrorDeleting(t *testing.T) {
 			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
 		},
 	}
-	runner := New(fexec, ProtocolIPv4)
+	runner := newInternal(fexec, ProtocolIPv4, "", "")
 	err := runner.DeleteRule(TableNAT, ChainOutput, "abc", "123")
 	if err == nil {
 		t.Errorf("expected failure")
@@ -487,7 +487,7 @@ func TestGetIPTablesHasCheckCommand(t *testing.T) {
 				func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
 			},
 		}
-		ipt := New(fexec, ProtocolIPv4)
+		ipt := newInternal(fexec, ProtocolIPv4, "", "")
 		runner := ipt.(*runner)
 		if testCase.Expected != runner.hasCheck {
 			t.Errorf("Expected result: %v, Got result: %v", testCase.Expected, runner.hasCheck)
@@ -648,7 +648,7 @@ func TestWaitFlagUnavailable(t *testing.T) {
 			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
 		},
 	}
-	runner := New(fexec, ProtocolIPv4)
+	runner := newInternal(fexec, ProtocolIPv4, "", "")
 	err := runner.DeleteChain(TableNAT, Chain("FOOBAR"))
 	if err != nil {
 		t.Errorf("expected success, got %v", err)
@@ -679,7 +679,7 @@ func TestWaitFlagOld(t *testing.T) {
 			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
 		},
 	}
-	runner := New(fexec, ProtocolIPv4)
+	runner := newInternal(fexec, ProtocolIPv4, "", "")
 	err := runner.DeleteChain(TableNAT, Chain("FOOBAR"))
 	if err != nil {
 		t.Errorf("expected success, got %v", err)
@@ -713,7 +713,7 @@ func TestWaitFlagNew(t *testing.T) {
 			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
 		},
 	}
-	runner := New(fexec, ProtocolIPv4)
+	runner := newInternal(fexec, ProtocolIPv4, "", "")
 	err := runner.DeleteChain(TableNAT, Chain("FOOBAR"))
 	if err != nil {
 		t.Errorf("expected success, got %v", err)
@@ -744,7 +744,7 @@ func TestWaitIntervalFlagNew(t *testing.T) {
 			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
 		},
 	}
-	runner := New(fexec, ProtocolIPv4)
+	runner := newInternal(fexec, ProtocolIPv4, "", "")
 	err := runner.DeleteChain(TableNAT, Chain("FOOBAR"))
 	if err != nil {
 		t.Errorf("expected success, got %v", err)
@@ -789,7 +789,7 @@ COMMIT
 			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
 		},
 	}
-	runner := New(fexec, protocol)
+	runner := newInternal(fexec, protocol, "", "")
 	buffer := bytes.NewBuffer(nil)
 
 	// Success.
@@ -857,7 +857,7 @@ func testRestore(t *testing.T, protocol Protocol) {
 			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
 		},
 	}
-	runner := New(fexec, protocol)
+	runner := newInternal(fexec, protocol, "", "")
 
 	// both flags true
 	err := runner.Restore(TableNAT, []byte{}, FlushTables, RestoreCounters)

--- a/pkg/util/iptables/iptables_test.go
+++ b/pkg/util/iptables/iptables_test.go
@@ -177,13 +177,9 @@ func TestNew(t *testing.T) {
 					command: "iptables --version",
 					action:  func() ([]byte, []byte, error) { return nil, nil, fmt.Errorf("no such file or directory") },
 				},
-				{
-					command: "iptables-restore --version",
-					action:  func() ([]byte, []byte, error) { return nil, nil, fmt.Errorf("no such file or directory") },
-				},
 			},
 			expected: &runner{
-				hasCheck:        true,
+				hasCheck:        false,
 				hasRandomFully:  false,
 				waitFlag:        nil,
 				restoreWaitFlag: nil,
@@ -601,7 +597,7 @@ func TestGetIPTablesHasCheckCommand(t *testing.T) {
 		{"iptables v1.4.11", true},
 		{"iptables v1.4.19.1", true},
 		{"iptables v2.0.0", true},
-		{"total junk", true},
+		{"total junk", false},
 	}
 
 	for _, testCase := range testCases {

--- a/pkg/util/iptables/monitor_test.go
+++ b/pkg/util/iptables/monitor_test.go
@@ -191,7 +191,7 @@ func (mfc *monitorFakeCmd) Stop() {
 
 func TestIPTablesMonitor(t *testing.T) {
 	mfe := newMonitorFakeExec()
-	ipt := New(mfe, ProtocolIPv4)
+	ipt := newInternal(mfe, ProtocolIPv4, "", "")
 
 	var reloads uint32
 	stopCh := make(chan struct{})


### PR DESCRIPTION
#### What this PR does / why we need it:
1. If you run kubelet on a system with no IPTables binaries, it will currently log multiple errors:

        iptables.go:225] "Error checking iptables version, assuming version at least" version=1.4.11 err=< executable file not found in $PATH >
        iptables.go:225] "Error checking iptables version, assuming version at least" version=1.4.11 err=< executable file not found in $PATH >
        kubelet_network_linux.go:69] "Failed to ensure that iptables hint chain exists" err=< error creating chain "KUBE-IPTABLES-HINT": executable file not found in $PATH >
        kubelet_network_linux.go:58] "Failed to initialize iptables rules; some functionality may be missing." protocol=IPv4
        kubelet_network_linux.go:69] "Failed to ensure that iptables hint chain exists" err=< error creating chain "KUBE-IPTABLES-HINT": executable file not found in $PATH >
        kubelet_network_linux.go:58] "Failed to initialize iptables rules; some functionality may be missing." protocol=IPv6

    This cuts it down to just

        kubelet_network_linux.go:42] "No iptables support on this system; not creating the KUBE-IPTABLES-HINT chain"

2. some general cleanup / simplification

#### Special notes for your reviewer:
sig-node approval needed just for the change to `pkg/kubelet/kubelet_network_linux.go`. The rest is all sig-network.

#### Does this PR introduce a user-facing change?
```release-note
kubelet no longer logs multiple errors when running on a system with no iptables binaries installed.
```

/kind cleanup
/sig network
/sig node
/triage accepted
