### PR TITLE
client-go transport: always wrap transport with debug transport

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/proxy/streamtranslator_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/proxy/streamtranslator_test.go
@@ -948,7 +948,7 @@ func v4WriteStatusFunc(stream io.Writer) func(status *apierrors.StatusError) err
 	}
 }
 
-func fakeTransport() (*http.Transport, error) {
+func fakeTransport() (http.RoundTripper, error) {
 	cfg := &transport.Config{
 		TLS: transport.TLSConfig{
 			Insecure: true,
@@ -959,9 +959,5 @@ func fakeTransport() (*http.Transport, error) {
 	if err != nil {
 		return nil, err
 	}
-	t, ok := rt.(*http.Transport)
-	if !ok {
-		return nil, fmt.Errorf("unknown transport type: %T", rt)
-	}
-	return t, nil
+	return rt, nil
 }

--- a/staging/src/k8s.io/client-go/rest/connection_test.go
+++ b/staging/src/k8s.io/client-go/rest/connection_test.go
@@ -364,7 +364,24 @@ func TestRestClientTimeout(t *testing.T) {
 	if err == nil {
 		t.Fatalf("timeout error expected")
 	}
-	if !strings.Contains(err.Error(), "deadline exceeded") {
+	// Two errors are possible:
+	//
+	// error(*net/url.Error) *{
+	//   Op: "Get",
+	//   URL: "http://127.0.0.1:34051/?timeout=1s",
+	//   Err: error(context.deadlineExceededError) {},
+	// }
+	//
+	// If CancelRequest is active (see https://cs.opensource.google/go/go/+/master:src/net/http/client.go;l=358-367),
+	// then we can also get:
+	// error(*net/url.Error) *{
+	//   Op: "Get",
+	//   URL: "http://127.0.0.1:36249/?timeout=1s",
+	//   Err: error(*net/http.timeoutError) *{
+	//     err: "net/http: request canceled (Client.Timeout exceeded while awaiting headers)",
+	// }}
+	if !strings.Contains(err.Error(), "deadline exceeded") &&
+		!strings.Contains(err.Error(), "request canceled") {
 		t.Fatalf("timeout error expected, received %v", err)
 	}
 }

--- a/staging/src/k8s.io/client-go/transport/transport_test.go
+++ b/staging/src/k8s.io/client-go/transport/transport_test.go
@@ -367,15 +367,16 @@ func TestNew(t *testing.T) {
 				return
 			}
 
+			delegateRT := rt.(*debuggingRoundTripper).delegatedRoundTripper
 			switch {
-			case testCase.Default && rt != http.DefaultTransport:
+			case testCase.Default && delegateRT != http.DefaultTransport:
 				t.Fatalf("got %#v, expected the default transport", rt)
-			case !testCase.Default && rt == http.DefaultTransport:
+			case !testCase.Default && delegateRT == http.DefaultTransport:
 				t.Fatalf("got %#v, expected non-default transport", rt)
 			}
 
 			// We only know how to check TLSConfig on http.Transports
-			transport := rt.(*http.Transport)
+			transport := rt.(*debuggingRoundTripper).delegatedRoundTripper.(*http.Transport)
 			switch {
 			case testCase.TLS && transport.TLSClientConfig == nil:
 				t.Fatalf("got %#v, expected TLSClientConfig", transport)


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Originally, wrapping the roundtripper was avoided at log levels < 6.
This behavior was faithfully reproduced during the [initial conversion](https://github.com/kubernetes/kubernetes/pull/129330) to
contextual logging. It had the drawback that a per-context logger which is
configured differently than the global logger would never even get asked
whether logging is enabled if the global logging is using levels < 6.
    
Now the roundtrip wrapper is used unconditionally and always checks the current
context. As before, nothing gets logged if the context logger isn't enabled for
at least level 6. This adds some additional overhead, but that should be low
compared to the costs of roundtripping a request.

The main drawback is that this wrapping is externally visible:
- Consumers might make assumptions about the transport (see unit tests).
- The standard library "detects" its own transports and handles cancellation differently for them (https://github.com/kubernetes/kubernetes/pull/129330#issuecomment-2609977702).

#### Which issue(s) this PR fixes:

Related-to:
- https://github.com/kubernetes/kubernetes/pull/129330#discussion_r1923986652
- https://github.com/kubernetes/kubernetes/pull/129330#issuecomment-2609977702

#### Special notes for your reviewer:

This is currently a draft to discuss whether it's worth it.

#### Does this PR introduce a user-facing change?

```release-note
client-go: transports are always wrapped to inject logging which checks the context of the request to determine what should be logged. Previously, this wrapping was only done if the global log verbosity was >= 6, so it was impossible to run a binary with low verbosity and then debug individual requests with higher verbosity.
```

/wg structured-logging