### PR TITLE
Cleanup running dmesg process in `local-up-cluster.sh`

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -156,6 +156,9 @@ KUBE_CONTROLLERS="${KUBE_CONTROLLERS:-"*"}"
 # Audit policy
 AUDIT_POLICY_FILE=${AUDIT_POLICY_FILE:-""}
 
+# dmesg command PID for cleanup
+DMESG_PID=${DMESG_PID:-""}
+
 # Stop right away if the build fails
 set -e
 
@@ -410,6 +413,9 @@ cleanup()
   if [[ "${PRESERVE_ETCD}" == "false" ]]; then
     [[ -n "${ETCD_DIR-}" ]] && kube::etcd::clean_etcd_dir
   fi
+
+  # Cleanup dmesg running in the background
+  [[ -n "${DMESG_PID-}" ]] && kill "$DMESG_PID"
 
   exit 0
 }
@@ -812,6 +818,7 @@ function wait_coredns_available(){
     # loop through and grab all things in dmesg
     dmesg > "${LOG_DIR}/dmesg.log"
     dmesg -w --human >> "${LOG_DIR}/dmesg.log" &
+    DMESG_PID=$!
   fi
 }
 


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
We have to cleanup the background job after the script otherwise we will end up having them hanging around.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
