### PR TITLE
initialize ContainerStatus.Started based on kubecontainer.Status

### DIFF
--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -71,6 +71,7 @@ import (
 	volumevalidation "k8s.io/kubernetes/pkg/volume/validation"
 	"k8s.io/kubernetes/third_party/forked/golang/expansion"
 	utilnet "k8s.io/utils/net"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -2055,7 +2056,7 @@ func (kl *Kubelet) convertStatusToAPIStatus(pod *v1.Pod, podStatus *kubecontaine
 // convertToAPIContainerStatuses converts the given internal container
 // statuses into API container statuses.
 func (kl *Kubelet) convertToAPIContainerStatuses(pod *v1.Pod, podStatus *kubecontainer.PodStatus, previousStatus []v1.ContainerStatus, containers []v1.Container, hasInitContainers, isInitContainer bool) []v1.ContainerStatus {
-	convertContainerStatus := func(cs *kubecontainer.Status, oldStatus *v1.ContainerStatus) *v1.ContainerStatus {
+	convertContainerStatus := func(cs *kubecontainer.Status, oldStatus *v1.ContainerStatus, hasStartupProbe bool) *v1.ContainerStatus {
 		cid := cs.ID.String()
 		status := &v1.ContainerStatus{
 			Name:         cs.Name,
@@ -2070,6 +2071,9 @@ func (kl *Kubelet) convertToAPIContainerStatuses(pod *v1.Pod, podStatus *kubecon
 		if oldStatus != nil {
 			status.VolumeMounts = oldStatus.VolumeMounts // immutable
 		}
+		// without a startup probe, mark this container started during the time it is running
+		// otherwise set the started field depending on the probe result
+		status.Started = ptr.To(!cs.StartedAt.IsZero() && cs.FinishedAt.IsZero() && !hasStartupProbe)
 		switch {
 		case cs.State == kubecontainer.ContainerStateRunning:
 			status.State.Running = &v1.ContainerStateRunning{StartedAt: metav1.NewTime(cs.StartedAt)}
@@ -2217,7 +2221,11 @@ func (kl *Kubelet) convertToAPIContainerStatuses(pod *v1.Pod, podStatus *kubecon
 
 	supportsRRO := kl.runtimeClassSupportsRecursiveReadOnlyMounts(pod)
 
+	containersWithStartupProbe := sets.Set[string]{}
 	for _, container := range containers {
+		if container.StartupProbe != nil {
+			containersWithStartupProbe.Insert(container.Name)
+		}
 		status := &v1.ContainerStatus{
 			Name:  container.Name,
 			Image: container.Image,
@@ -2349,7 +2357,7 @@ func (kl *Kubelet) convertToAPIContainerStatuses(pod *v1.Pod, podStatus *kubecon
 		if oldStatus, ok := oldStatuses[cName]; ok {
 			oldStatusPtr = &oldStatus
 		}
-		status := convertContainerStatus(cStatus, oldStatusPtr)
+		status := convertContainerStatus(cStatus, oldStatusPtr, containersWithStartupProbe.Has(cName))
 		if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {
 			status.Resources = convertContainerStatusResources(cName, status, cStatus, oldStatuses)
 

--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -2116,6 +2116,7 @@ func runningStateWithStartedAt(cName string, startedAt time.Time) v1.ContainerSt
 		State: v1.ContainerState{
 			Running: &v1.ContainerStateRunning{StartedAt: metav1.Time{Time: startedAt}},
 		},
+		Started: ptr.To(true),
 	}
 }
 func stoppedState(cName string) v1.ContainerStatus {
@@ -3730,6 +3731,8 @@ func Test_generateAPIPodStatus(t *testing.T) {
 					ready(waitingStateWithReason("containerA", "ContainerCreating")),
 					ready(withID(runningStateWithStartedAt("containerB", time.Unix(1, 0).UTC()), "://foo")),
 				},
+				EphemeralContainerStatuses: []v1.ContainerStatus{},
+				InitContainerStatuses:      []v1.ContainerStatus{},
 			},
 			expectedPodReadyToStartContainersCondition: v1.PodCondition{
 				Type:   v1.PodReadyToStartContainers,
@@ -3789,6 +3792,8 @@ func Test_generateAPIPodStatus(t *testing.T) {
 					ready(withID(runningStateWithStartedAt("containerA", time.Unix(1, 0).UTC()), "://c1")),
 					ready(withID(runningStateWithStartedAt("containerB", time.Unix(2, 0).UTC()), "://c2")),
 				},
+				EphemeralContainerStatuses: []v1.ContainerStatus{},
+				InitContainerStatuses:      []v1.ContainerStatus{},
 			},
 			expectedPodReadyToStartContainersCondition: v1.PodCondition{
 				Type:   v1.PodReadyToStartContainers,
@@ -4745,6 +4750,7 @@ func TestConvertToAPIContainerStatusesForResources(t *testing.T) {
 				State:              v1.ContainerState{Running: &v1.ContainerStateRunning{StartedAt: metav1.NewTime(nowTime)}},
 				AllocatedResources: CPU1AndMem1G,
 				Resources:          &v1.ResourceRequirements{Limits: CPU1AndMem1G, Requests: CPU1AndMem1G},
+				Started:            ptr.To(true),
 			},
 		},
 		"BurstableQoSPod with CPU and memory CRI status": {
@@ -4764,6 +4770,7 @@ func TestConvertToAPIContainerStatusesForResources(t *testing.T) {
 				State:              v1.ContainerState{Running: &v1.ContainerStateRunning{StartedAt: metav1.NewTime(nowTime)}},
 				AllocatedResources: CPU1AndMem1G,
 				Resources:          &v1.ResourceRequirements{Limits: CPU1AndMem1G, Requests: CPU1AndMem1G},
+				Started:            ptr.To(true),
 			},
 		},
 		"BurstableQoSPod without CPU": {
@@ -4794,6 +4801,7 @@ func TestConvertToAPIContainerStatusesForResources(t *testing.T) {
 				Resources: &v1.ResourceRequirements{Requests: v1.ResourceList{
 					v1.ResourceMemory: resource.MustParse("100M"),
 				}},
+				Started: ptr.To(true),
 			},
 		},
 		"BurstableQoSPod with below min CPU": {
@@ -4844,6 +4852,7 @@ func TestConvertToAPIContainerStatusesForResources(t *testing.T) {
 						v1.ResourceCPU: resource.MustParse("5m"),
 					},
 				},
+				Started: ptr.To(true),
 			},
 		},
 		"GuaranteedQoSPod with CPU and memory CRI status, with ephemeral storage": {
@@ -4863,6 +4872,7 @@ func TestConvertToAPIContainerStatusesForResources(t *testing.T) {
 				State:              v1.ContainerState{Running: &v1.ContainerStateRunning{StartedAt: metav1.NewTime(nowTime)}},
 				AllocatedResources: CPU1AndMem1GAndStorage2G,
 				Resources:          &v1.ResourceRequirements{Limits: CPU1AndMem1GAndStorage2G, Requests: CPU1AndMem1GAndStorage2G},
+				Started:            ptr.To(true),
 			},
 		},
 		"BurstableQoSPod with CPU and memory CRI status, with ephemeral storage": {
@@ -4882,6 +4892,7 @@ func TestConvertToAPIContainerStatusesForResources(t *testing.T) {
 				State:              v1.ContainerState{Running: &v1.ContainerStateRunning{StartedAt: metav1.NewTime(nowTime)}},
 				AllocatedResources: CPU1AndMem1GAndStorage2G,
 				Resources:          &v1.ResourceRequirements{Limits: CPU1AndMem1GAndStorage2G, Requests: CPU1AndMem1GAndStorage2G},
+				Started:            ptr.To(true),
 			},
 		},
 		"BurstableQoSPod with CPU and memory CRI status, with ephemeral storage, nil resources in OldStatus": {
@@ -4900,6 +4911,7 @@ func TestConvertToAPIContainerStatusesForResources(t *testing.T) {
 				State:              v1.ContainerState{Running: &v1.ContainerStateRunning{StartedAt: metav1.NewTime(nowTime)}},
 				AllocatedResources: CPU1AndMem1GAndStorage2G,
 				Resources:          &v1.ResourceRequirements{Limits: CPU1AndMem1GAndStorage2G, Requests: CPU1AndMem1GAndStorage2G},
+				Started:            ptr.To(true),
 			},
 		},
 		"BestEffortQoSPod": {
@@ -4917,6 +4929,7 @@ func TestConvertToAPIContainerStatusesForResources(t *testing.T) {
 				ImageID:     "img1234",
 				State:       v1.ContainerState{Running: &v1.ContainerStateRunning{StartedAt: metav1.NewTime(nowTime)}},
 				Resources:   &v1.ResourceRequirements{},
+				Started:     ptr.To(true),
 			},
 		},
 		"BestEffort QoSPod with extended resources": {
@@ -4936,6 +4949,7 @@ func TestConvertToAPIContainerStatusesForResources(t *testing.T) {
 				State:              v1.ContainerState{Running: &v1.ContainerStateRunning{StartedAt: metav1.NewTime(nowTime)}},
 				AllocatedResources: addExtendedResource(v1.ResourceList{}),
 				Resources:          &v1.ResourceRequirements{Requests: addExtendedResource(v1.ResourceList{})},
+				Started:            ptr.To(true),
 			},
 		},
 		"BurstableQoSPod with extended resources": {
@@ -4955,6 +4969,7 @@ func TestConvertToAPIContainerStatusesForResources(t *testing.T) {
 				State:              v1.ContainerState{Running: &v1.ContainerStateRunning{StartedAt: metav1.NewTime(nowTime)}},
 				AllocatedResources: addExtendedResource(CPU1AndMem1G),
 				Resources:          &v1.ResourceRequirements{Requests: addExtendedResource(CPU1AndMem1G)},
+				Started:            ptr.To(true),
 			},
 		},
 		"BurstableQoSPod with storage, ephemeral storage and extended resources": {
@@ -4974,6 +4989,7 @@ func TestConvertToAPIContainerStatusesForResources(t *testing.T) {
 				State:              v1.ContainerState{Running: &v1.ContainerStateRunning{StartedAt: metav1.NewTime(nowTime)}},
 				AllocatedResources: addExtendedResource(CPU1AndMem1GAndStorage2G),
 				Resources:          &v1.ResourceRequirements{Requests: addExtendedResource(CPU1AndMem1GAndStorage2G)},
+				Started:            ptr.To(true),
 			},
 		},
 		"GuaranteedQoSPod with extended resources": {
@@ -4993,6 +5009,7 @@ func TestConvertToAPIContainerStatusesForResources(t *testing.T) {
 				State:              v1.ContainerState{Running: &v1.ContainerStateRunning{StartedAt: metav1.NewTime(nowTime)}},
 				AllocatedResources: addExtendedResource(CPU1AndMem1G),
 				Resources:          &v1.ResourceRequirements{Requests: addExtendedResource(CPU1AndMem1G), Limits: addExtendedResource(CPU1AndMem1G)},
+				Started:            ptr.To(true),
 			},
 		},
 		"newly created Pod": {
@@ -5007,6 +5024,7 @@ func TestConvertToAPIContainerStatusesForResources(t *testing.T) {
 				State:              v1.ContainerState{Waiting: &v1.ContainerStateWaiting{}},
 				AllocatedResources: CPU1AndMem1GAndStorage2G,
 				Resources:          &v1.ResourceRequirements{Limits: CPU1AndMem1GAndStorage2G, Requests: CPU1AndMem1GAndStorage2G},
+				Started:            ptr.To(false),
 			},
 		},
 		"newly running Pod": {
@@ -5025,6 +5043,7 @@ func TestConvertToAPIContainerStatusesForResources(t *testing.T) {
 				State:              v1.ContainerState{Running: &v1.ContainerStateRunning{StartedAt: metav1.NewTime(nowTime)}},
 				AllocatedResources: CPU1AndMem1GAndStorage2G,
 				Resources:          &v1.ResourceRequirements{Limits: CPU1AndMem1GAndStorage2G, Requests: CPU1AndMem1GAndStorage2G},
+				Started:            ptr.To(true),
 			},
 		},
 		"newly terminated Pod": {
@@ -5051,6 +5070,7 @@ func TestConvertToAPIContainerStatusesForResources(t *testing.T) {
 				}},
 				AllocatedResources: CPU2AndMem2GAndStorage2G,
 				Resources:          &v1.ResourceRequirements{Limits: CPU2AndMem2GAndStorage2G, Requests: CPU2AndMem2GAndStorage2G},
+				Started:            ptr.To(false),
 			},
 		},
 		"resizing Pod": {
@@ -5071,6 +5091,7 @@ func TestConvertToAPIContainerStatusesForResources(t *testing.T) {
 				State:              v1.ContainerState{Running: &v1.ContainerStateRunning{StartedAt: metav1.NewTime(nowTime)}},
 				AllocatedResources: CPU2AndMem2GAndStorage2G,
 				Resources:          &v1.ResourceRequirements{Limits: CPU1AndMem1GAndStorage2G, Requests: CPU1AndMem2GAndStorage2G},
+				Started:            ptr.To(true),
 			},
 		},
 	} {
@@ -5164,6 +5185,7 @@ func TestConvertToAPIContainerStatusesForUser(t *testing.T) {
 				Image:       "img",
 				State:       v1.ContainerState{Running: &v1.ContainerStateRunning{StartedAt: metav1.NewTime(nowTime)}},
 				User:        user,
+				Started:     ptr.To(true),
 			},
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Initialize `ContainerStatus.Started` at the moment when `ContainerStatus` is created, to avoid discrepancies with `StartedAt` (more details in https://github.com/kubernetes/kubernetes/issues/115553).

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #115553

#### Special notes for your reviewer:
3rd time the charm?

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
