### PR TITLE
Updated the stats provider to check the storage of dead containers as…

### DIFF
--- a/pkg/kubelet/stats/cadvisor_stats_provider.go
+++ b/pkg/kubelet/stats/cadvisor_stats_provider.go
@@ -108,9 +108,7 @@ func (p *cadvisorStatsProvider) ListPodStats(ctx context.Context) ([]statsapi.Po
 	// Ensure pods that only have terminated containers are also included
 	for podRef, terminatedPodStats := range podTerminatedContainersToStats {
 		if _, found := podToStats[podRef]; !found {
-			podToStats[podRef] = &statsapi.PodStats{
-				PodRef: terminatedPodStats.PodRef,
-			}
+			podToStats[podRef] = terminatedPodStats
 		}
 	}
 

--- a/pkg/kubelet/stats/cadvisor_stats_provider.go
+++ b/pkg/kubelet/stats/cadvisor_stats_provider.go
@@ -138,11 +138,18 @@ func (p *cadvisorStatsProvider) ListPodStats(ctx context.Context) ([]statsapi.Po
 		status, found := p.statusProvider.GetPodStatus(podUID)
 		if found && status.StartTime != nil && !status.StartTime.IsZero() {
 			podStats.StartTime = *status.StartTime
-			// only append stats if we were able to get the start time of the pod
+		} else if podStats.StartTime.IsZero() {
+			for _, c := range podStats.Containers {
+				if !c.StartTime.IsZero() {
+					podStats.StartTime = c.StartTime
+					break
+				}
+			}
+		}
+		if len(podStats.Containers) > 0 {
 			result = append(result, *podStats)
 		}
 	}
-
 	return result, nil
 }
 

--- a/pkg/kubelet/stats/cadvisor_stats_provider.go
+++ b/pkg/kubelet/stats/cadvisor_stats_provider.go
@@ -99,59 +99,20 @@ func (p *cadvisorStatsProvider) ListPodStats(ctx context.Context) ([]statsapi.Po
 	if err != nil {
 		return nil, fmt.Errorf("failed to get container info from cadvisor: %v", err)
 	}
-	filteredInfos, allInfos := filterTerminatedContainerInfoAndAssembleByPodCgroupKey(logger, infos)
+
+	filteredInfos, terminatedInfos, allInfos := filterTerminatedContainerInfoAndAssembleByPodCgroupKey(logger, infos)
 	// Map each container to a pod and update the PodStats with container data.
-	podToStats := map[statsapi.PodReference]*statsapi.PodStats{}
-	for key, cinfo := range filteredInfos {
-		// On systemd using devicemapper each mount into the container has an
-		// associated cgroup. We ignore them to ensure we do not get duplicate
-		// entries in our summary. For details on .mount units:
-		// http://man7.org/linux/man-pages/man5/systemd.mount.5.html
-		if strings.HasSuffix(key, ".mount") {
-			continue
-		}
-		// Build the Pod key if this container is managed by a Pod
-		if !isPodManagedContainer(logger, &cinfo) {
-			continue
-		}
-		ref := buildPodRef(cinfo.Spec.Labels)
-
-		// Lookup the PodStats for the pod using the PodRef. If none exists,
-		// initialize a new entry.
-		podStats, found := podToStats[ref]
-		if !found {
-			podStats = &statsapi.PodStats{PodRef: ref}
-			podToStats[ref] = podStats
-		}
-
-		// Update the PodStats entry with the stats from the container by
-		// adding it to podStats.Containers.
-		containerName := kubetypes.GetContainerName(cinfo.Spec.Labels)
-		if containerName == kubetypes.PodInfraContainerName {
-			// Special case for infrastructure container which is hidden from
-			// the user and has network stats.
-			podStats.Network = cadvisorInfoToNetworkStats(&cinfo)
-		} else {
-			containerStat := cadvisorInfoToContainerStats(logger, containerName, &cinfo, &rootFsInfo, &imageFsInfo)
-			// NOTE: This doesn't support the old pod log path, `/var/log/pods/UID`. For containers
-			// using old log path, they will be populated by cadvisorInfoToContainerStats.
-			podUID := types.UID(podStats.PodRef.UID)
-			logs, err := p.hostStatsProvider.getPodContainerLogStats(podStats.PodRef.Namespace, podStats.PodRef.Name, podUID, containerName, &rootFsInfo)
-			if err != nil {
-				logger.Error(err, "Unable to fetch container log stats", "containerName", containerName)
-			} else {
-				containerStat.Logs = logs
-			}
-			podStats.Containers = append(podStats.Containers, *containerStat)
-		}
-		// Either way, collect process stats
-		podStats.ProcessStats = mergeProcessStats(podStats.ProcessStats, cadvisorInfoToProcessStats(&cinfo))
-	}
+	podToStats := p.containerInfosToPodStats(logger, filteredInfos, rootFsInfo, imageFsInfo)
+	podTerminatedContainersToStats := p.containerInfosToPodStats(logger, terminatedInfos, rootFsInfo, imageFsInfo)
 
 	// Add each PodStats to the result.
 	result := make([]statsapi.PodStats, 0, len(podToStats))
-	for _, podStats := range podToStats {
-		makePodStorageStats(logger, podStats, &rootFsInfo, p.resourceAnalyzer, p.hostStatsProvider, false)
+	for podRef, podStats := range podToStats {
+		var podTerminatedContainerStats []statsapi.ContainerStats
+		if terminatedContainers, found := podTerminatedContainersToStats[podRef]; found {
+			podTerminatedContainerStats = terminatedContainers.Containers
+		}
+		makePodStorageStats(logger, podStats, podTerminatedContainerStats, &rootFsInfo, p.resourceAnalyzer, p.hostStatsProvider, false)
 
 		podUID := types.UID(podStats.PodRef.UID)
 		// Lookup the pod-level cgroup's CPU and memory stats
@@ -230,7 +191,7 @@ func (p *cadvisorStatsProvider) ListPodCPUAndMemoryStats(ctx context.Context) ([
 	if err != nil {
 		return nil, fmt.Errorf("failed to get container info from cadvisor: %v", err)
 	}
-	filteredInfos, allInfos := filterTerminatedContainerInfoAndAssembleByPodCgroupKey(logger, infos)
+	filteredInfos, _, allInfos := filterTerminatedContainerInfoAndAssembleByPodCgroupKey(logger, infos)
 	// Map each container to a pod and update the PodStats with container data.
 	podToStats := map[statsapi.PodReference]*statsapi.PodStats{}
 	for key, cinfo := range filteredInfos {
@@ -430,11 +391,13 @@ func getCadvisorPodInfoFromPodUID(podUID types.UID, infos map[string]cadvisorapi
 
 // filterTerminatedContainerInfoAndAssembleByPodCgroupKey returns the specified containerInfo but with
 // the stats of the terminated containers removed and all containerInfos assembled by pod cgroup key.
-// the first return map is container cgroup name <-> ContainerInfo and
-// the second return map is pod cgroup key <-> ContainerInfo.
+// the first return map is container cgroup name <-> ContainerInfo
+// the second return map is terminated container cgroup name <-> ContainerInfo
+// the third return map is pod cgroup key <-> ContainerInfo.
 // A ContainerInfo is considered to be of a terminated container if it has an
 // older CreationTime and zero CPU instantaneous and memory RSS usage.
-func filterTerminatedContainerInfoAndAssembleByPodCgroupKey(logger klog.Logger, containerInfo map[string]cadvisorapi.ContainerInfo) (map[string]cadvisorapi.ContainerInfo, map[string]cadvisorapi.ContainerInfo) {
+
+func filterTerminatedContainerInfoAndAssembleByPodCgroupKey(logger klog.Logger, containerInfo map[string]cadvisorapi.ContainerInfo) (map[string]cadvisorapi.ContainerInfo, map[string]cadvisorapi.ContainerInfo, map[string]cadvisorapiv2.ContainerInfo) {
 	cinfoMap := make(map[containerID][]containerInfoWithCgroup)
 	cinfosByPodCgroupKey := make(map[string]cadvisorapi.ContainerInfo)
 	for key, cinfo := range containerInfo {
@@ -460,13 +423,17 @@ func filterTerminatedContainerInfoAndAssembleByPodCgroupKey(logger klog.Logger, 
 			cgroup: key,
 		})
 	}
+
 	result := make(map[string]cadvisorapi.ContainerInfo)
+	terminated := make(map[string]cadvisorapi.ContainerInfo)
 	for _, refs := range cinfoMap {
 		if len(refs) == 1 {
 			// ContainerInfo with no CPU/memory/network usage for uncleaned cgroups of
 			// already terminated containers, which should not be shown in the results.
 			if !isContainerTerminated(&refs[0].cinfo) {
 				result[refs[0].cgroup] = refs[0].cinfo
+			} else {
+				terminated[refs[0].cgroup] = refs[0].cinfo
 			}
 			continue
 		}
@@ -478,7 +445,57 @@ func filterTerminatedContainerInfoAndAssembleByPodCgroupKey(logger klog.Logger, 
 			}
 		}
 	}
-	return result, cinfosByPodCgroupKey
+	return result, terminated, cinfosByPodCgroupKey
+}
+
+func (p *cadvisorStatsProvider) containerInfosToPodStats(logger klog.Logger, containerInfos map[string]cadvisorapiv2.ContainerInfo, rootFsInfo, imageFsInfo cadvisorapiv2.FsInfo) map[statsapi.PodReference]*statsapi.PodStats {
+	podToStats := map[statsapi.PodReference]*statsapi.PodStats{}
+	for key, cinfo := range containerInfos {
+		// On systemd using devicemapper each mount into the container has an
+		// associated cgroup. We ignore them to ensure we do not get duplicate
+		// entries in our summary. For details on .mount units:
+		// http://man7.org/linux/man-pages/man5/systemd.mount.5.html
+		if strings.HasSuffix(key, ".mount") {
+			continue
+		}
+		// Build the Pod key if this container is managed by a Pod
+		if !isPodManagedContainer(logger, &cinfo) {
+			continue
+		}
+		ref := buildPodRef(cinfo.Spec.Labels)
+
+		// Lookup the PodStats for the pod using the PodRef. If none exists,
+		// initialize a new entry.
+		podStats, found := podToStats[ref]
+		if !found {
+			podStats = &statsapi.PodStats{PodRef: ref}
+			podToStats[ref] = podStats
+		}
+
+		// Update the PodStats entry with the stats from the container by
+		// adding it to podStats.Containers.
+		containerName := kubetypes.GetContainerName(cinfo.Spec.Labels)
+		if containerName == kubetypes.PodInfraContainerName {
+			// Special case for infrastructure container which is hidden from
+			// the user and has network stats.
+			podStats.Network = cadvisorInfoToNetworkStats(&cinfo)
+		} else {
+			containerStat := cadvisorInfoToContainerStats(logger, containerName, &cinfo, &rootFsInfo, &imageFsInfo)
+			// NOTE: This doesn't support the old pod log path, `/var/log/pods/UID`. For containers
+			// using old log path, they will be populated by cadvisorInfoToContainerStats.
+			podUID := types.UID(podStats.PodRef.UID)
+			logs, err := p.hostStatsProvider.getPodContainerLogStats(podStats.PodRef.Namespace, podStats.PodRef.Name, podUID, containerName, &rootFsInfo)
+			if err != nil {
+				klog.ErrorS(err, "Unable to fetch container log stats", "containerName", containerName)
+			} else {
+				containerStat.Logs = logs
+			}
+			podStats.Containers = append(podStats.Containers, *containerStat)
+		}
+		// Either way, collect process stats
+		podStats.ProcessStats = mergeProcessStats(podStats.ProcessStats, cadvisorInfoToProcessStats(&cinfo))
+	}
+	return podToStats
 }
 
 // ByCreationTime implements sort.Interface for []containerInfoWithCgroup based

--- a/pkg/kubelet/stats/cadvisor_stats_provider.go
+++ b/pkg/kubelet/stats/cadvisor_stats_provider.go
@@ -494,7 +494,7 @@ func (p *cadvisorStatsProvider) containerInfosToPodStats(logger klog.Logger, con
 			podUID := types.UID(podStats.PodRef.UID)
 			logs, err := p.hostStatsProvider.getPodContainerLogStats(podStats.PodRef.Namespace, podStats.PodRef.Name, podUID, containerName, &rootFsInfo)
 			if err != nil {
-				klog.FromContext(ctx).Error(err, "Unable to fetch container log stats", "containerName", containerName)
+				logger.Error(err, "Unable to fetch container log stats", "containerName", containerName)
 			} else {
 				containerStat.Logs = logs
 			}

--- a/pkg/kubelet/stats/cadvisor_stats_provider.go
+++ b/pkg/kubelet/stats/cadvisor_stats_provider.go
@@ -494,7 +494,7 @@ func (p *cadvisorStatsProvider) containerInfosToPodStats(logger klog.Logger, con
 			podUID := types.UID(podStats.PodRef.UID)
 			logs, err := p.hostStatsProvider.getPodContainerLogStats(podStats.PodRef.Namespace, podStats.PodRef.Name, podUID, containerName, &rootFsInfo)
 			if err != nil {
-				klog.ErrorS(err, "Unable to fetch container log stats", "containerName", containerName)
+				klog.FromContext(ctx).Error(err, "Unable to fetch container log stats", "containerName", containerName)
 			} else {
 				containerStat.Logs = logs
 			}

--- a/pkg/kubelet/stats/cadvisor_stats_provider.go
+++ b/pkg/kubelet/stats/cadvisor_stats_provider.go
@@ -411,7 +411,7 @@ func getCadvisorPodInfoFromPodUID(podUID types.UID, infos map[string]cadvisorapi
 // A ContainerInfo is considered to be of a terminated container if it has an
 // older CreationTime and zero CPU instantaneous and memory RSS usage.
 
-func filterTerminatedContainerInfoAndAssembleByPodCgroupKey(logger klog.Logger, containerInfo map[string]cadvisorapi.ContainerInfo) (map[string]cadvisorapi.ContainerInfo, map[string]cadvisorapi.ContainerInfo, map[string]cadvisorapiv2.ContainerInfo) {
+func filterTerminatedContainerInfoAndAssembleByPodCgroupKey(logger klog.Logger, containerInfo map[string]cadvisorapi.ContainerInfo) (map[string]cadvisorapi.ContainerInfo, map[string]cadvisorapi.ContainerInfo, map[string]cadvisorapi.ContainerInfo) {
 	cinfoMap := make(map[containerID][]containerInfoWithCgroup)
 	cinfosByPodCgroupKey := make(map[string]cadvisorapi.ContainerInfo)
 	for key, cinfo := range containerInfo {
@@ -470,7 +470,7 @@ func filterTerminatedContainerInfoAndAssembleByPodCgroupKey(logger klog.Logger, 
 	return result, terminated, cinfosByPodCgroupKey
 }
 
-func (p *cadvisorStatsProvider) containerInfosToPodStats(logger klog.Logger, containerInfos map[string]cadvisorapiv2.ContainerInfo, rootFsInfo, imageFsInfo cadvisorapiv2.FsInfo) map[statsapi.PodReference]*statsapi.PodStats {
+func (p *cadvisorStatsProvider) containerInfosToPodStats(logger klog.Logger, containerInfos map[string]cadvisorapi.ContainerInfo, rootFsInfo, imageFsInfo cadvisorapi.FsInfo) map[statsapi.PodReference]*statsapi.PodStats {
 	podToStats := map[statsapi.PodReference]*statsapi.PodStats{}
 	for key, cinfo := range containerInfos {
 		// On systemd using devicemapper each mount into the container has an

--- a/pkg/kubelet/stats/cadvisor_stats_provider.go
+++ b/pkg/kubelet/stats/cadvisor_stats_provider.go
@@ -438,6 +438,14 @@ func filterTerminatedContainerInfoAndAssembleByPodCgroupKey(logger klog.Logger, 
 			continue
 		}
 		sort.Sort(ByCreationTime(refs))
+
+		// collect terminated containers
+		for _, ref := range refs {
+			if isContainerTerminated(&ref.cinfo) {
+				terminated[ref.cgroup] = ref.cinfo
+			}
+		}
+
 		for i := len(refs) - 1; i >= 0; i-- {
 			if hasMemoryAndCPUInstUsage(&refs[i].cinfo) {
 				result[refs[i].cgroup] = refs[i].cinfo

--- a/pkg/kubelet/stats/cadvisor_stats_provider_test.go
+++ b/pkg/kubelet/stats/cadvisor_stats_provider_test.go
@@ -129,7 +129,7 @@ func TestFilterTerminatedContainerInfo_ReturnsAllTerminatedInstances(t *testing.
 		container = "c0"
 	)
 
-	infos := map[string]cadvisorapiv2.ContainerInfo{
+	infos := map[string]cadvisorapi.ContainerInfo{
 		// Old terminated container
 		"/pod0-c0-terminated-1": getTerminatedContainerInfo(
 			seedPastPodInfra, podName, namespace, container,

--- a/pkg/kubelet/stats/cadvisor_stats_provider_test.go
+++ b/pkg/kubelet/stats/cadvisor_stats_provider_test.go
@@ -116,6 +116,60 @@ func TestFilterTerminatedContainerInfoAndAssembleByPodCgroupKey(t *testing.T) {
 	}
 }
 
+func TestFilterTerminatedContainerInfo_ReturnsAllTerminatedInstances(t *testing.T) {
+	const (
+		seedPastPodInfra = 1000
+		seedPodInfra     = 2000
+		seedPodContainer = 3000
+	)
+
+	const (
+		namespace = "test"
+		podName   = "pod0"
+		container = "c0"
+	)
+
+	infos := map[string]cadvisorapiv2.ContainerInfo{
+		// Old terminated container
+		"/pod0-c0-terminated-1": getTerminatedContainerInfo(
+			seedPastPodInfra, podName, namespace, container,
+		),
+
+		// Mid terminated container
+		"/pod0-c0-terminated-2": getTerminatedContainerInfo(
+			seedPodInfra, podName, namespace, container,
+		),
+
+		// Latest running container
+		"/pod0-c0": getTestContainerInfo(
+			seedPodContainer, podName, namespace, container,
+		),
+	}
+
+	logger, _ := ktesting.NewTestContext(t)
+
+	filteredInfos, terminatedInfos, allInfos :=
+		filterTerminatedContainerInfoAndAssembleByPodCgroupKey(logger, infos)
+
+	assert.Len(t, allInfos, 3)
+	assert.Len(t, filteredInfos, 1)
+	if _, found := filteredInfos["/pod0-c0"]; !found {
+		t.Errorf("expected running container to be present in filteredInfos")
+	}
+
+	// terminated containers should be returned
+	assert.Len(t, terminatedInfos, 2)
+
+	for _, cgroup := range []string{
+		"/pod0-c0-terminated-1",
+		"/pod0-c0-terminated-2",
+	} {
+		if _, found := terminatedInfos[cgroup]; !found {
+			t.Errorf("expected terminated container %q to be present", cgroup)
+		}
+	}
+}
+
 func TestCadvisorListPodStats(t *testing.T) {
 	ctx := ktesting.Init(t).Context
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.KubeletPSI, true)

--- a/pkg/kubelet/stats/cadvisor_stats_provider_test.go
+++ b/pkg/kubelet/stats/cadvisor_stats_provider_test.go
@@ -92,7 +92,7 @@ func TestFilterTerminatedContainerInfoAndAssembleByPodCgroupKey(t *testing.T) {
 		"/pod2-c222-zerocpumem-1": getContainerInfoWithZeroCPUMem(seedPastPod0Container0, pName2, namespace, cName222),
 	}
 	logger, _ := ktesting.NewTestContext(t)
-	filteredInfos, allInfos := filterTerminatedContainerInfoAndAssembleByPodCgroupKey(logger, infos)
+	filteredInfos, _, allInfos := filterTerminatedContainerInfoAndAssembleByPodCgroupKey(logger, infos)
 	assert.Len(t, filteredInfos, 5)
 	assert.Len(t, allInfos, 11)
 	for _, c := range []string{"/pod0-i", "/pod0-c0"} {

--- a/pkg/kubelet/stats/cri_stats_provider.go
+++ b/pkg/kubelet/stats/cri_stats_provider.go
@@ -189,7 +189,7 @@ func (p *criStatsProvider) listPodStatsPartiallyFromCRI(ctx context.Context, upd
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch cadvisor stats: %v", err)
 	}
-	caInfos, allInfos := getCRICadvisorStats(logger, allInfos)
+	caInfos, _, allInfos := getCRICadvisorStats(logger, allInfos)
 
 	// get network stats for containers.
 	// This is only used on Windows. For other platforms, (nil, nil) should be returned.
@@ -245,7 +245,7 @@ func (p *criStatsProvider) listPodStatsPartiallyFromCRI(ctx context.Context, upd
 
 	result := make([]statsapi.PodStats, 0, len(sandboxIDToPodStats))
 	for _, s := range sandboxIDToPodStats {
-		makePodStorageStats(logger, s, rootFsInfo, p.resourceAnalyzer, p.hostStatsProvider, true)
+		makePodStorageStats(logger, s, nil, rootFsInfo, p.resourceAnalyzer, p.hostStatsProvider, true)
 		result = append(result, *s)
 	}
 	return result, nil
@@ -278,7 +278,8 @@ func (p *criStatsProvider) listPodStatsStrictlyFromCRI(ctx context.Context, upda
 		addCRIPodMemoryStats(ps, criSandboxStat)
 		addCRIPodProcessStats(ps, criSandboxStat)
 		addCRIPodIOStats(ps, criSandboxStat)
-		makePodStorageStats(logger, ps, rootFsInfo, p.resourceAnalyzer, p.hostStatsProvider, true)
+
+		makePodStorageStats(logger, ps, nil, rootFsInfo, p.resourceAnalyzer, p.hostStatsProvider, true)
 		summarySandboxStats = append(summarySandboxStats, *ps)
 	}
 	return summarySandboxStats, nil
@@ -428,7 +429,8 @@ func (p *criStatsProvider) ListPodCPUAndMemoryStats(ctx context.Context) ([]stat
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch cadvisor stats: %v", err)
 	}
-	caInfos, allInfos := getCRICadvisorStats(logger, allInfos)
+
+	caInfos, _, allInfos := getCRICadvisorStats(logger, allInfos)
 
 	for _, stats := range resp {
 		containerID := stats.Attributes.Id
@@ -1202,9 +1204,11 @@ func (p *criStatsProvider) addCadvisorContainerCPUAndMemoryStats(
 	}
 }
 
-func getCRICadvisorStats(logger klog.Logger, infos map[string]cadvisorapi.ContainerInfo) (map[string]cadvisorapi.ContainerInfo, map[string]cadvisorapi.ContainerInfo) {
+
+func getCRICadvisorStats(logger klog.Logger, infos map[string]cadvisorapi.ContainerInfo) (map[string]cadvisorapi.ContainerInfo, map[string]cadvisorapi.ContainerInfo, map[string]cadvisorapi.ContainerInfo) {
 	stats := make(map[string]cadvisorapi.ContainerInfo)
-	filteredInfos, cinfosByPodCgroupKey := filterTerminatedContainerInfoAndAssembleByPodCgroupKey(logger, infos)
+	terminatedStats := make(map[string]cadvisorapi.ContainerInfo)
+	filteredInfos, terminatedInfos, cinfosByPodCgroupKey := filterTerminatedContainerInfoAndAssembleByPodCgroupKey(logger, infos)
 	for key, info := range filteredInfos {
 		// On systemd using devicemapper each mount into the container has an
 		// associated cgroup. We ignore them to ensure we do not get duplicate
@@ -1219,7 +1223,16 @@ func getCRICadvisorStats(logger klog.Logger, infos map[string]cadvisorapi.Contai
 		}
 		stats[extractIDFromCgroupPath(key)] = info
 	}
-	return stats, cinfosByPodCgroupKey
+	for key, info := range terminatedInfos {
+		if strings.HasSuffix(key, ".mount") {
+			continue
+		}
+		if !isPodManagedContainer(logger, &info) {
+			continue
+		}
+		terminatedStats[extractIDFromCgroupPath(key)] = info
+	}
+	return stats, terminatedStats, cinfosByPodCgroupKey
 }
 
 func extractIDFromCgroupPath(cgroupPath string) string {

--- a/pkg/kubelet/stats/helper.go
+++ b/pkg/kubelet/stats/helper.go
@@ -494,7 +494,7 @@ func addUsage(first, second *uint64) *uint64 {
 	return &total
 }
 
-func makePodStorageStats(logger klog.Logger, s *statsapi.PodStats, rootFsInfo *cadvisorapi.FsInfo, resourceAnalyzer stats.ResourceAnalyzer, hostStatsProvider HostStatsProvider, isCRIStatsProvider bool) {
+func makePodStorageStats(logger klog.Logger, s *statsapi.PodStats, terminatedContainerStats []statsapi.ContainerStats, rootFsInfo *cadvisorapi.FsInfo, resourceAnalyzer stats.ResourceAnalyzer, hostStatsProvider HostStatsProvider, isCRIStatsProvider bool) {
 	podNs := s.PodRef.Namespace
 	podName := s.PodRef.Name
 	podUID := types.UID(s.PodRef.UID)
@@ -517,7 +517,11 @@ func makePodStorageStats(logger klog.Logger, s *statsapi.PodStats, rootFsInfo *c
 	if err != nil {
 		logger.V(6).Info("Unable to fetch pod etc hosts stats", "pod", klog.KRef(podNs, podName), "err", err)
 	}
-	s.EphemeralStorage = calcEphemeralStorage(s.Containers, ephemeralStats, rootFsInfo, logStats, etcHostsStats, isCRIStatsProvider)
+	containers := s.Containers
+	if terminatedContainerStats != nil {
+		containers = append(containers, terminatedContainerStats...)
+	}
+	s.EphemeralStorage = calcEphemeralStorage(containers, ephemeralStats, rootFsInfo, logStats, etcHostsStats, isCRIStatsProvider)
 }
 
 func cadvisorPSIToStatsPSI(psi *cadvisorapi.PSIStats) *statsapi.PSIStats {

--- a/test/e2e_node/summary_test.go
+++ b/test/e2e_node/summary_test.go
@@ -409,7 +409,7 @@ var _ = SIGDescribe("Summary API", framework.WithNodeConformance(), func() {
 
 				for _, ps := range summary.Pods {
 					if ps.PodRef.Name == podName && ps.PodRef.Namespace == f.Namespace.Name {
-						for _, cs:=	range ps.Containers {
+						for _, cs := range ps.Containers {
 							if cs.Rootfs != nil && cs.Rootfs.UsedBytes != nil {
 								return true
 							}

--- a/test/e2e_node/summary_test.go
+++ b/test/e2e_node/summary_test.go
@@ -409,16 +409,16 @@ var _ = SIGDescribe("Summary API", framework.WithNodeConformance(), func() {
 
 				for _, ps := range summary.Pods {
 					if ps.PodRef.Name == podName && ps.PodRef.Namespace == f.Namespace.Name {
-						for _, cs := range ps.Containers {
-							if cs.Rootfs != nil && cs.Rootfs.UsedBytes != nil {
-								return true
-							}
-						}
+						return ps.EphemeralStorage != nil &&
+							ps.EphemeralStorage.UsedBytes != nil
 					}
 				}
 				return false
-			}, 2*time.Minute, 10*time.Second).Should(gomega.BeTrue())
-
+			}, 2*time.Minute, 10*time.Second).Should(
+				gomega.BeTrueBecause(
+					"terminated pod should report ephemeral storage usage in /stats/summary",
+				),
+			)
 			summary, err := getNodeSummary(ctx)
 			framework.ExpectNoError(err)
 

--- a/test/e2e_node/summary_test.go
+++ b/test/e2e_node/summary_test.go
@@ -366,73 +366,73 @@ var _ = SIGDescribe("Summary API", framework.WithNodeConformance(), func() {
 			gomega.Consistently(ctx, getNodeSummary, 30*time.Second, 15*time.Second).Should(matchExpectations)
 		})
 		ginkgo.It("should include terminated container storage stats in pod summary", func(ctx context.Context) {
-    		const podName = "terminated-container-pod"
+			const podName = "terminated-container-pod"
 
-    		pod := &v1.Pod{
-        		ObjectMeta: metav1.ObjectMeta{
-            		Name: podName,
-        		},
-        		Spec: v1.PodSpec{
-            		RestartPolicy: v1.RestartPolicyNever,
-            		Containers: []v1.Container{
-                		{
-                    		Name:    "writer",
-                    		Image:   busyboxImage,
-                    		Command: []string{"sh", "-c", "echo hello > /tmp/logfile"},
-                		},
-            		},
-        		},
-    		}
+			pod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: podName,
+				},
+				Spec: v1.PodSpec{
+					RestartPolicy: v1.RestartPolicyNever,
+					Containers: []v1.Container{
+						{
+							Name:    "writer",
+							Image:   busyboxImage,
+							Command: []string{"sh", "-c", "echo hello > /tmp/logfile"},
+						},
+					},
+				},
+			}
 
-    		ginkgo.By("Creating a pod with a short-lived container")
-    		e2epod.NewPodClient(f).Create(ctx, pod)
+			ginkgo.By("Creating a pod with a short-lived container")
+			e2epod.NewPodClient(f).Create(ctx, pod)
 
-    		ginkgo.By("Waiting for the pod to complete")
-    		framework.ExpectNoError(
-        		e2epod.WaitForPodCondition(
-        			ctx,
-        			f.ClientSet,
-        			f.Namespace.Name,
-        			pod.Name,
-        			"pod reached Succeeded phase",
-        			framework.PodStartTimeout,
-        			func(p *v1.Pod) (bool, error) {
-            			return p.Status.Phase == v1.PodSucceeded, nil
-        			},
-    			),
-    		)
+			ginkgo.By("Waiting for the pod to complete")
+			framework.ExpectNoError(
+				e2epod.WaitForPodCondition(
+					ctx,
+					f.ClientSet,
+					f.Namespace.Name,
+					pod.Name,
+					"pod reached Succeeded phase",
+					framework.PodStartTimeout,
+					func(p *v1.Pod) (bool, error) {
+						return p.Status.Phase == v1.PodSucceeded, nil
+					},
+				),
+			)
 
-    		ginkgo.By("Validating terminated container storage stats appear in summary")
-    		gomega.Eventually(ctx, func() *kubeletstatsv1alpha1.PodStats {
-        		summary, err := getNodeSummary(ctx)
-        		framework.ExpectNoError(err)
+			ginkgo.By("Validating terminated container storage stats appear in summary")
+			gomega.Eventually(ctx, func() *kubeletstatsv1alpha1.PodStats {
+				summary, err := getNodeSummary(ctx)
+				framework.ExpectNoError(err)
 
-        		for _, ps := range summary.Pods {
-            		if ps.PodRef.Name == podName && ps.PodRef.Namespace == f.Namespace.Name {
-                		return &ps
-            		}
-        		}
-        		return nil
-    		}, 2*time.Minute, 10*time.Second).ShouldNot(gomega.BeNil())
+				for _, ps := range summary.Pods {
+					if ps.PodRef.Name == podName && ps.PodRef.Namespace == f.Namespace.Name {
+						return &ps
+					}
+				}
+				return nil
+			}, 2*time.Minute, 10*time.Second).ShouldNot(gomega.BeNil())
 
-    		summary, err := getNodeSummary(ctx)
-    		framework.ExpectNoError(err)
+			summary, err := getNodeSummary(ctx)
+			framework.ExpectNoError(err)
 
-    		var podStats *kubeletstatsv1alpha1.PodStats
-    		for _, ps := range summary.Pods {
-        		if ps.PodRef.Name == podName && ps.PodRef.Namespace == f.Namespace.Name {
-            		podStats = &ps
-            		break
-        		}
-    		}
+			var podStats *kubeletstatsv1alpha1.PodStats
+			for _, ps := range summary.Pods {
+				if ps.PodRef.Name == podName && ps.PodRef.Namespace == f.Namespace.Name {
+					podStats = &ps
+					break
+				}
+			}
 
-    		gomega.Expect(podStats).NotTo(gomega.BeNil())
-    		gomega.Expect(podStats.Containers).NotTo(gomega.BeEmpty())
+			gomega.Expect(podStats).NotTo(gomega.BeNil())
+			gomega.Expect(podStats.Containers).NotTo(gomega.BeEmpty())
 
-    		container := podStats.Containers[0]
+			container := podStats.Containers[0]
 
-    		gomega.Expect(container.Logs).NotTo(gomega.BeNil())
-    		gomega.Expect(container.Logs.UsedBytes).NotTo(gomega.BeZero())
+			gomega.Expect(container.Logs).NotTo(gomega.BeNil())
+			gomega.Expect(container.Logs.UsedBytes).NotTo(gomega.BeZero())
 		})
 	})
 

--- a/test/e2e_node/summary_test.go
+++ b/test/e2e_node/summary_test.go
@@ -389,7 +389,7 @@ var _ = SIGDescribe("Summary API", framework.WithNodeConformance(), func() {
 
     		ginkgo.By("Waiting for the pod to complete")
     		framework.ExpectNoError(
-        		e2epod.WaitForPodSuccess(ctx, f.ClientSet, pod.Name, f.Namespace.Name),
+        		e2epod.WaitForPodNameSucceededInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name),
     		)
 
     		ginkgo.By("Validating terminated container storage stats appear in summary")

--- a/test/e2e_node/summary_test.go
+++ b/test/e2e_node/summary_test.go
@@ -389,7 +389,17 @@ var _ = SIGDescribe("Summary API", framework.WithNodeConformance(), func() {
 
     		ginkgo.By("Waiting for the pod to complete")
     		framework.ExpectNoError(
-        		e2epod.WaitForPodNameSucceededInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name),
+        		e2epod.WaitForPodCondition(
+        			ctx,
+        			f.ClientSet,
+        			f.Namespace.Name,
+        			pod.Name,
+        			"pod reached Succeeded phase",
+        			framework.PodStartTimeout,
+        			func(p *v1.Pod) (bool, error) {
+            			return p.Status.Phase == v1.PodSucceeded, nil
+        			},
+    			),
     		)
 
     		ginkgo.By("Validating terminated container storage stats appear in summary")


### PR DESCRIPTION
… well

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:

/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Currently, when the disk pressure occurs then the disk usage of dead containers is not taken into account while calculating the eviction rank and hence the pod with less disk space is evicted first. The PR updates the process of collecting stats from cadvisor and CRI stats provider. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref #115201 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Pod-level ephemeral storage reported via Summary API and used for eviction ranking now includes storage usage from terminated containers
```

