### PR TITLE
Add a test ensuring all /scale sub-resources return table

### DIFF
--- a/pkg/registry/apps/deployment/storage/storage.go
+++ b/pkg/registry/apps/deployment/storage/storage.go
@@ -306,7 +306,7 @@ func (r *ScaleREST) Destroy() {
 func (r *ScaleREST) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
 	obj, err := r.store.Get(ctx, name, options)
 	if err != nil {
-		return nil, errors.NewNotFound(apps.Resource("deployments/scale"), name)
+		return nil, err
 	}
 	deployment := obj.(*apps.Deployment)
 	scale, err := scaleFromDeployment(deployment)

--- a/pkg/registry/apps/replicaset/storage/storage.go
+++ b/pkg/registry/apps/replicaset/storage/storage.go
@@ -202,7 +202,7 @@ func (r *ScaleREST) Destroy() {
 func (r *ScaleREST) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
 	obj, err := r.store.Get(ctx, name, options)
 	if err != nil {
-		return nil, errors.NewNotFound(apps.Resource("replicasets/scale"), name)
+		return nil, err
 	}
 	rs := obj.(*apps.ReplicaSet)
 	scale, err := scaleFromReplicaSet(rs)

--- a/pkg/registry/core/replicationcontroller/storage/storage.go
+++ b/pkg/registry/core/replicationcontroller/storage/storage.go
@@ -190,7 +190,7 @@ func (r *ScaleREST) Destroy() {
 func (r *ScaleREST) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
 	obj, err := r.store.Get(ctx, name, options)
 	if err != nil {
-		return nil, errors.NewNotFound(autoscaling.Resource("replicationcontrollers/scale"), name)
+		return nil, err
 	}
 	rc := obj.(*api.ReplicationController)
 	return scaleFromRC(rc), nil

--- a/test/integration/apiserver/apiserver_test.go
+++ b/test/integration/apiserver/apiserver_test.go
@@ -80,6 +80,7 @@ import (
 	"k8s.io/kubernetes/test/integration/etcd"
 	"k8s.io/kubernetes/test/integration/framework"
 	"k8s.io/kubernetes/test/utils/ktesting"
+	"k8s.io/utils/ptr"
 )
 
 func setup(t *testing.T, groupVersions ...schema.GroupVersion) (context.Context, clientset.Interface, *restclient.Config, framework.TearDownFunc) {
@@ -1674,6 +1675,203 @@ func TestGetSubresourcesAsTables(t *testing.T) {
 				t.Fatalf("Expected Kind 'Table', got '%v'", actualKind)
 			}
 		})
+	}
+}
+
+func TestGetScaleSubresourceAsTableForAllBuiltins(t *testing.T) {
+	// KUBE_APISERVER_SERVE_REMOVED_APIS_FOR_ONE_RELEASE allows for APIs pending removal to not block tests
+	t.Setenv("KUBE_APISERVER_SERVE_REMOVED_APIS_FOR_ONE_RELEASE", "true")
+
+	// Enable all features for testing
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, "AllAlpha", true)
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, "AllBeta", true)
+
+	testNamespace := "test-scale"
+	server := kubeapiservertesting.StartTestServerOrDie(t, nil, framework.DefaultTestServerFlags(), framework.SharedEtcd())
+	defer server.TearDownFn()
+
+	clientset := clientset.NewForConfigOrDie(server.ClientConfig)
+
+	ns := framework.CreateNamespaceOrDie(clientset, testNamespace, t)
+	defer framework.DeleteNamespaceOrDie(clientset, ns, t)
+
+	scaleResources := map[string]runtime.Object{
+		"deployments.apps/v1": &apps.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "dummy",
+			},
+			Spec: apps.DeploymentSpec{
+				Replicas: ptr.To[int32](1),
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"app": "dummy",
+					},
+				},
+				Template: v1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							"app": "dummy",
+						},
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name:  "dummy-container",
+								Image: "nginx:latest",
+							},
+						},
+					},
+				},
+			},
+		},
+		"replicasets.apps/v1": &apps.ReplicaSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "dummy",
+			},
+			Spec: apps.ReplicaSetSpec{
+				Replicas: ptr.To[int32](1),
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"app": "dummy",
+					},
+				},
+				Template: v1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							"app": "dummy",
+						},
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name:  "dummy-container",
+								Image: "nginx:latest",
+							},
+						},
+					},
+				},
+			},
+		},
+		"statefulsets.apps/v1": &apps.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "dummy",
+			},
+			Spec: apps.StatefulSetSpec{
+				ServiceName: "dummy",
+				Replicas:    ptr.To[int32](1),
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"app": "dummy",
+					},
+				},
+				Template: v1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							"app": "dummy",
+						},
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name:  "dummy-container",
+								Image: "nginx:latest",
+							},
+						},
+					},
+				},
+			},
+		},
+		"replicationcontrollers.v1": &v1.ReplicationController{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "dummy",
+			},
+			Spec: v1.ReplicationControllerSpec{
+				Replicas: ptr.To[int32](1),
+				Selector: map[string]string{
+					"app": "dummy",
+				},
+				Template: &v1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							"app": "dummy",
+						},
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name:  "dummy-container",
+								Image: "nginx:latest",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	_, serverResources, err := clientset.Discovery().ServerGroupsAndResources()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, resourceList := range serverResources {
+		for _, resource := range resourceList.APIResources {
+			if !strings.Contains(resource.Name, "/scale") {
+				continue
+			}
+			resourceName := strings.Split(resource.Name, "/")[0]
+			// we can safely skip error here, since the group version is coming from the server
+			groupVersion, _ := schema.ParseGroupVersion(resourceList.GroupVersion)
+
+			t.Run(resourceName, func(t *testing.T) {
+				_, ctx := ktesting.NewTestContext(t)
+				scaleResourceObjName := fmt.Sprintf("%s.%s", resourceName, resourceList.GroupVersion)
+				obj, ok := scaleResources[scaleResourceObjName]
+				if !ok {
+					t.Fatalf("sample resource for %s not found in scaleResources", scaleResourceObjName)
+				}
+
+				cfg := dynamic.ConfigFor(server.ClientConfig)
+				if len(groupVersion.Group) == 0 {
+					cfg = dynamic.ConfigFor(server.ClientConfig)
+					cfg.APIPath = "/api"
+				} else {
+					cfg.APIPath = "/apis"
+				}
+				cfg.GroupVersion = &groupVersion
+				client, err := restclient.RESTClientFor(cfg)
+				if err != nil {
+					t.Fatalf("failed to create RESTClient: %v", err)
+				}
+
+				err = client.Post().
+					NamespaceIfScoped(testNamespace, resource.Namespaced).Resource(resourceName).
+					VersionedParams(&metav1.CreateOptions{}, metav1.ParameterCodec).
+					Body(obj).Do(ctx).Error()
+				if err != nil {
+					t.Fatalf("failed to create object: %v", err)
+				}
+
+				metaAccessor, err := meta.Accessor(obj)
+				if err != nil {
+					t.Fatalf("failed to get metadata accessor: %v", err)
+				}
+				res := client.Get().
+					NamespaceIfScoped(testNamespace, resource.Namespaced).Resource(resourceName).
+					SetHeader("Accept", "application/json;as=Table;g=meta.k8s.io;v=v1").
+					Name(metaAccessor.GetName()).
+					SubResource("scale").
+					Do(ctx)
+				resObj, err := res.Get()
+				if err != nil {
+					t.Fatalf("failed to retrieve object from response: %v", err)
+				}
+				actualKind := resObj.GetObjectKind().GroupVersionKind().Kind
+				if actualKind != "Table" {
+					t.Fatalf("Expected Kind 'Table', got '%v'", actualKind)
+				}
+			})
+		}
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/sig cli
/sig api-machinery

#### What this PR does / why we need it:
This PR adds a test requested in https://github.com/kubernetes/enhancements/pull/4468/files#r1480169620, which is currently being pursuit in https://github.com/kubernetes/enhancements/pull/5079 as part of graduation https://github.com/kubernetes/enhancements/issues/2590 to GA.

Additionally, while testing I've noticed we have inconsistencies how we return error from get in the scale resource. I don't have any strong preference about the exact output, but I decided to just go with the default, which just prints `<resource-type> "<name>" not found`, for example `deployments.apps "dummy" not found`. I believe that's sufficient information. 

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
/assign @enj 
since you were the one asking for that test in the original PR
/assign @nikhita @MadhavJivrajani 
since you two were the original authors behind the feature

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/2590
```
