### PR TITLE
Fix HPA controller assuming terminated pods have a 100% utilization

### DIFF
--- a/pkg/controller/podautoscaler/replica_calculator.go
+++ b/pkg/controller/podautoscaler/replica_calculator.go
@@ -380,7 +380,8 @@ func groupPods(pods []*v1.Pod, metrics metricsclient.PodMetricsInfo, resource v1
 	unreadyPods = sets.New[string]()
 	ignoredPods = sets.New[string]()
 	for _, pod := range pods {
-		if pod.DeletionTimestamp != nil || pod.Status.Phase == v1.PodFailed {
+		podTerminated := pod.Status.Phase == v1.PodFailed || pod.Status.Phase == v1.PodSucceeded
+		if pod.DeletionTimestamp != nil || podTerminated {
 			ignoredPods.Insert(pod.Name)
 			continue
 		}

--- a/pkg/controller/podautoscaler/replica_calculator_test.go
+++ b/pkg/controller/podautoscaler/replica_calculator_test.go
@@ -573,12 +573,12 @@ func TestReplicaCalcScaleHotCpuNoScale(t *testing.T) {
 	tc.runTest(t)
 }
 
-func TestReplicaCalcScaleUpIgnoresFailedPods(t *testing.T) {
+func TestReplicaCalcScaleUpIgnoresTerminatedPods(t *testing.T) {
 	tc := replicaCalcTestCase{
 		currentReplicas:  2,
 		expectedReplicas: 4,
 		podReadiness:     []v1.ConditionStatus{v1.ConditionTrue, v1.ConditionTrue, v1.ConditionFalse, v1.ConditionFalse},
-		podPhase:         []v1.PodPhase{v1.PodRunning, v1.PodRunning, v1.PodFailed, v1.PodFailed},
+		podPhase:         []v1.PodPhase{v1.PodRunning, v1.PodRunning, v1.PodFailed, v1.PodSucceeded},
 		resource: &resourceInfo{
 			name:     v1.ResourceCPU,
 			requests: []resource.Quantity{resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0")},


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR ensures that terminated pods are ignored by the HPA logic. Currently only pods that terminated on failures are handled, this PR ensures that pods that terminated normally also are.

#### Which issue(s) this PR fixes:

Fixes #129866