### PR TITLE
chore: use NewNotFound error for missing components

### DIFF
--- a/pkg/registry/core/componentstatus/rest.go
+++ b/pkg/registry/core/componentstatus/rest.go
@@ -18,7 +18,6 @@ package componentstatus
 
 import (
 	"context"
-	"fmt"
 	"sync"
 
 	"k8s.io/apimachinery/pkg/fields"
@@ -26,6 +25,7 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic"
 	"k8s.io/apiserver/pkg/storage"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -136,7 +136,7 @@ func (rs *REST) Get(ctx context.Context, name string, options *metav1.GetOptions
 	servers := rs.GetServersToValidate()
 
 	if server, ok := servers[name]; !ok {
-		return nil, fmt.Errorf("Component not found: %s", name)
+		return nil, apierrors.NewNotFound(api.Resource("componentstatus"), name)
 	} else {
 		return rs.getComponentStatus(name, server), nil
 	}

--- a/pkg/registry/core/componentstatus/rest_test.go
+++ b/pkg/registry/core/componentstatus/rest_test.go
@@ -177,7 +177,7 @@ func TestGet_BadName(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Expected error, but did not get one")
 	}
-	if !strings.Contains(err.Error(), "Component not found: invalidname") {
+	if !strings.Contains(err.Error(), `componentstatus "invalidname" not found`) {
 		t.Fatalf("Got unexpected error: %v", err)
 	}
 }


### PR DESCRIPTION
In this way, the return status could be 404 instead of 500

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:
This PR fixes part of https://github.com/kubernetes/kubernetes/issues/113939
It returns an api errors with status code as 404 so that it would returns the 404 instead of 500 when resource not found.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
Tested in kind
```
~ kubectl get --raw='/api/v1/componentstatuses/xx' -v6                                                                                          
I0128 15:17:52.773202 1760020 loader.go:395] Config loaded from file:  /usr/local/google/home/yongrlin/.kube/config
I0128 15:17:52.780213 1760020 round_trippers.go:553] GET https://127.0.0.1:34973/api/v1/componentstatuses/xx 404 Not Found in 6 milliseconds
Warning: v1 ComponentStatus is deprecated in v1.19+
I0128 15:17:52.780586 1760020 helpers.go:246] server response object: [{
  "metadata": {},
  "status": "Failure",
  "message": "componentstatus \"xx\" not found",
  "reason": "NotFound",
  "details": {
    "name": "xx",
    "kind": "componentstatus"
  },
  "code": 404
}]
Error from server (NotFound): componentstatus "xx" not found
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
