### PR TITLE
[FG:InPlacePodVerticalScaling] Stop storing pod resize status in the Kubelet

### DIFF
--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -3808,7 +3808,7 @@ func Test_generateAPIPodStatus(t *testing.T) {
 					kl.readinessManager.Set(kubecontainer.BuildContainerID("", findContainerStatusByName(test.expected, name).ContainerID), results.Failure, test.pod)
 				}
 				expected := test.expected.DeepCopy()
-				actual := kl.generateAPIPodStatus(test.pod, test.currentStatus, test.isPodTerminal)
+				actual := kl.generateAPIPodStatus(test.pod, test.currentStatus, "", test.isPodTerminal)
 				if enablePodReadyToStartContainersCondition {
 					expected.Conditions = append([]v1.PodCondition{test.expectedPodReadyToStartContainersCondition}, expected.Conditions...)
 				}
@@ -3926,7 +3926,7 @@ func Test_generateAPIPodStatusForInPlaceVPAEnabled(t *testing.T) {
 			oldStatus := test.pod.Status
 			kl.statusManager = status.NewFakeManager()
 			kl.statusManager.SetPodStatus(test.pod, oldStatus)
-			actual := kl.generateAPIPodStatus(test.pod, &testKubecontainerPodStatus /* criStatus */, false /* test.isPodTerminal */)
+			actual := kl.generateAPIPodStatus(test.pod, &testKubecontainerPodStatus /* criStatus */, "" /* resizeStatus */, false /* test.isPodTerminal */)
 
 			if actual.Resize != "" {
 				t.Fatalf("Unexpected Resize status: %s", actual.Resize)
@@ -4242,7 +4242,7 @@ func TestGenerateAPIPodStatusHostNetworkPodIPs(t *testing.T) {
 				IPs:       tc.criPodIPs,
 			}
 
-			status := kl.generateAPIPodStatus(pod, criStatus, false)
+			status := kl.generateAPIPodStatus(pod, criStatus, "", false)
 			if !reflect.DeepEqual(status.PodIPs, tc.podIPs) {
 				t.Fatalf("Expected PodIPs %#v, got %#v", tc.podIPs, status.PodIPs)
 			}
@@ -4366,7 +4366,7 @@ func TestNodeAddressUpdatesGenerateAPIPodStatusHostNetworkPodIPs(t *testing.T) {
 			}
 			podStatus.IPs = tc.nodeIPs
 
-			status := kl.generateAPIPodStatus(pod, podStatus, false)
+			status := kl.generateAPIPodStatus(pod, podStatus, "", false)
 			if !reflect.DeepEqual(status.PodIPs, tc.expectedPodIPs) {
 				t.Fatalf("Expected PodIPs %#v, got %#v", tc.expectedPodIPs, status.PodIPs)
 			}
@@ -4499,7 +4499,7 @@ func TestGenerateAPIPodStatusPodIPs(t *testing.T) {
 				IPs:       tc.criPodIPs,
 			}
 
-			status := kl.generateAPIPodStatus(pod, criStatus, false)
+			status := kl.generateAPIPodStatus(pod, criStatus, "", false)
 			if !reflect.DeepEqual(status.PodIPs, tc.podIPs) {
 				t.Fatalf("Expected PodIPs %#v, got %#v", tc.podIPs, status.PodIPs)
 			}

--- a/pkg/kubelet/status/fake_status_manager.go
+++ b/pkg/kubelet/status/fake_status_manager.go
@@ -68,10 +68,6 @@ func (m *fakeManager) GetContainerResourceAllocation(podUID string, containerNam
 	return m.state.GetContainerResourceAllocation(podUID, containerName)
 }
 
-func (m *fakeManager) GetPodResizeStatus(podUID types.UID) v1.PodResizeStatus {
-	return m.state.GetPodResizeStatus(string(podUID))
-}
-
 func (m *fakeManager) UpdatePodFromAllocation(pod *v1.Pod) (*v1.Pod, bool) {
 	allocs := m.state.GetPodResourceAllocation()
 	return updatePodFromAllocation(pod, allocs)
@@ -84,10 +80,6 @@ func (m *fakeManager) SetPodAllocation(pod *v1.Pod) error {
 		m.state.SetContainerResourceAllocation(string(pod.UID), container.Name, alloc)
 	}
 	return nil
-}
-
-func (m *fakeManager) SetPodResizeStatus(podUID types.UID, resizeStatus v1.PodResizeStatus) {
-	m.state.SetPodResizeStatus(string(podUID), resizeStatus)
 }
 
 // NewFakeManager creates empty/fake memory manager

--- a/pkg/kubelet/status/state/state.go
+++ b/pkg/kubelet/status/state/state.go
@@ -23,9 +23,6 @@ import (
 // PodResourceAllocation type is used in tracking resources allocated to pod's containers
 type PodResourceAllocation map[string]map[string]v1.ResourceRequirements
 
-// PodResizeStatus type is used in tracking the last resize decision for pod
-type PodResizeStatus map[string]v1.PodResizeStatus
-
 // Clone returns a copy of PodResourceAllocation
 func (pr PodResourceAllocation) Clone() PodResourceAllocation {
 	prCopy := make(PodResourceAllocation)
@@ -42,12 +39,10 @@ func (pr PodResourceAllocation) Clone() PodResourceAllocation {
 type Reader interface {
 	GetContainerResourceAllocation(podUID string, containerName string) (v1.ResourceRequirements, bool)
 	GetPodResourceAllocation() PodResourceAllocation
-	GetPodResizeStatus(podUID string) v1.PodResizeStatus
 }
 
 type writer interface {
 	SetContainerResourceAllocation(podUID string, containerName string, alloc v1.ResourceRequirements) error
-	SetPodResizeStatus(podUID string, resizeStatus v1.PodResizeStatus)
 	Delete(podUID string, containerName string) error
 }
 

--- a/pkg/kubelet/status/state/state_checkpoint.go
+++ b/pkg/kubelet/status/state/state_checkpoint.go
@@ -112,26 +112,12 @@ func (sc *stateCheckpoint) GetPodResourceAllocation() PodResourceAllocation {
 	return sc.cache.GetPodResourceAllocation()
 }
 
-// GetPodResizeStatus returns the last resize decision for a pod
-func (sc *stateCheckpoint) GetPodResizeStatus(podUID string) v1.PodResizeStatus {
-	sc.mux.RLock()
-	defer sc.mux.RUnlock()
-	return sc.cache.GetPodResizeStatus(podUID)
-}
-
 // SetContainerResourceAllocation sets resources allocated to a pod's container
 func (sc *stateCheckpoint) SetContainerResourceAllocation(podUID string, containerName string, alloc v1.ResourceRequirements) error {
 	sc.mux.Lock()
 	defer sc.mux.Unlock()
 	sc.cache.SetContainerResourceAllocation(podUID, containerName, alloc)
 	return sc.storeState()
-}
-
-// SetPodResizeStatus sets the last resize decision for a pod
-func (sc *stateCheckpoint) SetPodResizeStatus(podUID string, resizeStatus v1.PodResizeStatus) {
-	sc.mux.Lock()
-	defer sc.mux.Unlock()
-	sc.cache.SetPodResizeStatus(podUID, resizeStatus)
 }
 
 // Delete deletes allocations for specified pod
@@ -157,15 +143,9 @@ func (sc *noopStateCheckpoint) GetPodResourceAllocation() PodResourceAllocation 
 	return nil
 }
 
-func (sc *noopStateCheckpoint) GetPodResizeStatus(_ string) v1.PodResizeStatus {
-	return ""
-}
-
 func (sc *noopStateCheckpoint) SetContainerResourceAllocation(_ string, _ string, _ v1.ResourceRequirements) error {
 	return nil
 }
-
-func (sc *noopStateCheckpoint) SetPodResizeStatus(_ string, _ v1.PodResizeStatus) {}
 
 func (sc *noopStateCheckpoint) Delete(_ string, _ string) error {
 	return nil

--- a/pkg/kubelet/status/state/state_mem.go
+++ b/pkg/kubelet/status/state/state_mem.go
@@ -25,8 +25,7 @@ import (
 
 type stateMemory struct {
 	sync.RWMutex
-	podAllocation   PodResourceAllocation
-	podResizeStatus PodResizeStatus
+	podAllocation PodResourceAllocation
 }
 
 var _ State = &stateMemory{}
@@ -38,8 +37,7 @@ func NewStateMemory(alloc PodResourceAllocation) State {
 	}
 	klog.V(2).InfoS("Initialized new in-memory state store for pod resource allocation tracking")
 	return &stateMemory{
-		podAllocation:   alloc,
-		podResizeStatus: PodResizeStatus{},
+		podAllocation: alloc,
 	}
 }
 
@@ -57,13 +55,6 @@ func (s *stateMemory) GetPodResourceAllocation() PodResourceAllocation {
 	return s.podAllocation.Clone()
 }
 
-func (s *stateMemory) GetPodResizeStatus(podUID string) v1.PodResizeStatus {
-	s.RLock()
-	defer s.RUnlock()
-
-	return s.podResizeStatus[podUID]
-}
-
 func (s *stateMemory) SetContainerResourceAllocation(podUID string, containerName string, alloc v1.ResourceRequirements) error {
 	s.Lock()
 	defer s.Unlock()
@@ -77,23 +68,10 @@ func (s *stateMemory) SetContainerResourceAllocation(podUID string, containerNam
 	return nil
 }
 
-func (s *stateMemory) SetPodResizeStatus(podUID string, resizeStatus v1.PodResizeStatus) {
-	s.Lock()
-	defer s.Unlock()
-
-	if resizeStatus != "" {
-		s.podResizeStatus[podUID] = resizeStatus
-	} else {
-		delete(s.podResizeStatus, podUID)
-	}
-	klog.V(3).InfoS("Updated pod resize state", "podUID", podUID, "resizeStatus", resizeStatus)
-}
-
 func (s *stateMemory) deleteContainer(podUID string, containerName string) {
 	delete(s.podAllocation[podUID], containerName)
 	if len(s.podAllocation[podUID]) == 0 {
 		delete(s.podAllocation, podUID)
-		delete(s.podResizeStatus, podUID)
 	}
 	klog.V(3).InfoS("Deleted pod resource allocation", "podUID", podUID, "containerName", containerName)
 }
@@ -103,7 +81,6 @@ func (s *stateMemory) Delete(podUID string, containerName string) error {
 	defer s.Unlock()
 	if len(containerName) == 0 {
 		delete(s.podAllocation, podUID)
-		delete(s.podResizeStatus, podUID)
 		klog.V(3).InfoS("Deleted pod resource allocation and resize state", "podUID", podUID)
 		return nil
 	}

--- a/pkg/kubelet/status/status_manager.go
+++ b/pkg/kubelet/status/status_manager.go
@@ -143,12 +143,6 @@ type Manager interface {
 	// the provided podUIDs.
 	RemoveOrphanedStatuses(podUIDs map[types.UID]bool)
 
-	// GetPodResizeStatus returns cached PodStatus.Resize value
-	GetPodResizeStatus(podUID types.UID) v1.PodResizeStatus
-
-	// SetPodResizeStatus caches the last resizing decision for the pod.
-	SetPodResizeStatus(podUID types.UID, resize v1.PodResizeStatus)
-
 	allocationManager
 }
 
@@ -285,13 +279,6 @@ func updatePodFromAllocation(pod *v1.Pod, allocs state.PodResourceAllocation) (*
 	return pod, updated
 }
 
-// GetPodResizeStatus returns the last cached ResizeStatus value.
-func (m *manager) GetPodResizeStatus(podUID types.UID) v1.PodResizeStatus {
-	m.podStatusesLock.RLock()
-	defer m.podStatusesLock.RUnlock()
-	return m.state.GetPodResizeStatus(string(podUID))
-}
-
 // SetPodAllocation checkpoints the resources allocated to a pod's containers
 func (m *manager) SetPodAllocation(pod *v1.Pod) error {
 	m.podStatusesLock.RLock()
@@ -304,14 +291,6 @@ func (m *manager) SetPodAllocation(pod *v1.Pod) error {
 	}
 	return nil
 }
-
-// SetPodResizeStatus checkpoints the last resizing decision for the pod.
-func (m *manager) SetPodResizeStatus(podUID types.UID, resizeStatus v1.PodResizeStatus) {
-	m.podStatusesLock.RLock()
-	defer m.podStatusesLock.RUnlock()
-	m.state.SetPodResizeStatus(string(podUID), resizeStatus)
-}
-
 func (m *manager) GetPodStatus(uid types.UID) (v1.PodStatus, bool) {
 	m.podStatusesLock.RLock()
 	defer m.podStatusesLock.RUnlock()


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

Pod ResizeStatus is recomputed with each pod sync loop and then written to the pod status. Plumbing the resize status through is simple enough, so there's no reason to store it in the status manager.

#### Which issue(s) this PR fixes:
Preparatory refactoring for switching to edge-triggered resizing.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/sig node
/milestone v1.33
/priority important-soon