### PR TITLE
Fix kubelet_authz_test.go

### DIFF
--- a/test/e2e/node/kubelet_authz.go
+++ b/test/e2e/node/kubelet_authz.go
@@ -14,17 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package e2enode
+package node
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
-	"net/http"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
-	authenticationv1 "k8s.io/api/authentication/v1"
 	authorizationv1 "k8s.io/api/authorization/v1"
 	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -34,34 +31,39 @@ import (
 	"k8s.io/kubernetes/test/e2e/feature"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2eauth "k8s.io/kubernetes/test/e2e/framework/auth"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	e2eoutput "k8s.io/kubernetes/test/e2e/framework/pod/output"
+	admissionapi "k8s.io/pod-security-admission/api"
 )
 
-var _ = SIGDescribe("Kubelet Authz", feature.KubeletFineGrainedAuthz, func() {
+var _ = SIGDescribe(feature.KubeletFineGrainedAuthz, func() {
 	f := framework.NewDefaultFramework("kubelet-authz-test")
+	f.NamespacePodSecurityLevel = admissionapi.LevelBaseline
+
 	ginkgo.Context("when calling kubelet API", func() {
 		ginkgo.It("check /healthz enpoint is accessible via nodes/healthz RBAC", func(ctx context.Context) {
 			sc := runKubeletAuthzTest(ctx, f, "healthz", "healthz")
-			gomega.Expect(sc).To(gomega.Equal(http.StatusOK))
+			gomega.Expect(sc).To(gomega.Equal("200"))
 		})
 		ginkgo.It("check /healthz enpoint is accessible via nodes/proxy RBAC", func(ctx context.Context) {
 			sc := runKubeletAuthzTest(ctx, f, "healthz", "proxy")
-			gomega.Expect(sc).To(gomega.Equal(http.StatusOK))
+			gomega.Expect(sc).To(gomega.Equal("200"))
 		})
 		ginkgo.It("check /healthz enpoint is not accessible via nodes/configz RBAC", func(ctx context.Context) {
 			sc := runKubeletAuthzTest(ctx, f, "healthz", "configz")
-			gomega.Expect(sc).To(gomega.Equal(http.StatusUnauthorized))
+			gomega.Expect(sc).To(gomega.Equal("403"))
 		})
 	})
 })
 
-func runKubeletAuthzTest(ctx context.Context, f *framework.Framework, endpoint, authzSubresource string) int {
+func runKubeletAuthzTest(ctx context.Context, f *framework.Framework, endpoint, authzSubresource string) string {
 	ns := f.Namespace.Name
 	saName := authzSubresource
 	crName := authzSubresource
 	verb := "get"
 	resource := "nodes"
 
-	ginkgo.By(fmt.Sprintf("Creating Service Account:%s/%s", ns, saName))
+	ginkgo.By(fmt.Sprintf("Creating Service Account %s/%s", ns, saName))
 
 	_, err := f.ClientSet.CoreV1().ServiceAccounts(ns).Create(ctx, &v1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
@@ -112,27 +114,41 @@ func runKubeletAuthzTest(ctx context.Context, f *framework.Framework, endpoint, 
 	)
 	framework.ExpectNoError(err)
 
-	ginkgo.By(fmt.Sprintf("Getting token for ServiceAccount %s/%s.", ns, saName))
-
-	tr, err := f.ClientSet.CoreV1().ServiceAccounts(ns).CreateToken(ctx, saName, &authenticationv1.TokenRequest{}, metav1.CreateOptions{})
-	framework.ExpectNoError(err)
-
-	resp, err := healthCheck(fmt.Sprintf("https://127.0.0.1:%d/%s", ports.KubeletPort, endpoint), tr.Status.Token)
-	framework.ExpectNoError(err)
-	return resp.StatusCode
-}
-
-func healthCheck(url, token string) (*http.Response, error) {
-	insecureTransport := http.DefaultTransport.(*http.Transport).Clone()
-	insecureTransport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
-	insecureHTTPClient := &http.Client{
-		Transport: insecureTransport,
+	pod := e2epod.NewAgnhostPod(ns, fmt.Sprintf("agnhost-pod-%s", authzSubresource), nil, nil, nil)
+	pod.Spec.ServiceAccountName = saName
+	pod.Spec.Containers[0].Env = []v1.EnvVar{
+		{
+			Name: "NODE_IP",
+			ValueFrom: &v1.EnvVarSource{
+				FieldRef: &v1.ObjectFieldSelector{
+					FieldPath: "status.hostIP",
+				},
+			},
+		},
 	}
 
-	req, err := http.NewRequest(http.MethodGet, url, nil)
-	if err != nil {
-		return nil, err
+	ginkgo.By(fmt.Sprintf("Creating Pod %s in namespace %s with serviceaccount %s", pod.Name, pod.Namespace, pod.Spec.ServiceAccountName))
+
+	_ = e2epod.NewPodClient(f).CreateSync(ctx, pod)
+
+	ginkgo.By("Running command in Pod")
+
+	var hostWarpStart, hostWarpEnd string
+	// IPv6 host must be wrapped within [] if you specify a port.
+	if framework.TestContext.ClusterIsIPv6() {
+		hostWarpStart = "["
+		hostWarpEnd = "]"
 	}
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
-	return insecureHTTPClient.Do(req)
+
+	result := e2eoutput.RunHostCmdOrDie(ns,
+		pod.Name,
+		fmt.Sprintf("curl -XGET -sIk -o /dev/null -w '%s' --header \"Authorization: Bearer `%s`\" https://%s$NODE_IP%s:%d/%s",
+			"%{http_code}",
+			"cat /var/run/secrets/kubernetes.io/serviceaccount/token",
+			hostWarpStart,
+			hostWarpEnd,
+			ports.KubeletPort,
+			endpoint))
+
+	return result
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind failing-test


#### What this PR does / why we need it: Fix failing node_e2e  kubelet_auth_test.go

We were missing the APIGroup in the ClusterRole that we were creating.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #129896

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
