### PR TITLE
Fix the error message of duplicate keys existing in both matchLabelKeys and labelSelector

### DIFF
--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -8197,7 +8197,7 @@ func ValidateMatchLabelKeysAndMismatchLabelKeys(fldPath *field.Path, matchLabelK
 				// Before validateLabelKeysWithSelector is called, the labelSelector has already got the selector created from matchLabelKeys.
 				// Here, we found the duplicate key in labelSelector and the key is specified in labelKeys.
 				// Meaning that the same key is specified in both labelSelector and matchLabelKeys/mismatchLabelKeys.
-				allErrs = append(allErrs, field.Invalid(fldPath.Index(i), key, "exists in both matchLabelKeys and labelSelector").WithOrigin("duplicatedLabelKeys"))
+				allErrs = append(allErrs, field.Invalid(fldPath.Child("matchLabelKeys").Index(i), key, "exists in both matchLabelKeys and labelSelector").WithOrigin("duplicatedLabelKeys"))
 			}
 
 			labelSelectorKeys.Insert(key)

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -11638,7 +11638,7 @@ func TestValidatePod(t *testing.T) {
 			),
 		},
 		"invalid soft pod affinity, key exists in both matchLabelKeys and labelSelector": {
-			expectedError: "exists in both matchLabelKeys and labelSelector",
+			expectedError: "spec.affinity.podAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.matchLabelKeys[0]: Invalid value: \"key\": exists in both matchLabelKeys and labelSelector",
 			spec: *podtest.MakePod("123",
 				podtest.SetAffinity(&core.Affinity{
 					PodAffinity: &core.PodAffinity{
@@ -11671,7 +11671,7 @@ func TestValidatePod(t *testing.T) {
 			),
 		},
 		"invalid hard pod affinity, key exists in both matchLabelKeys and labelSelector": {
-			expectedError: "exists in both matchLabelKeys and labelSelector",
+			expectedError: "spec.affinity.podAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].matchLabelKeys[0]: Invalid value: \"key\": exists in both matchLabelKeys and labelSelector",
 			spec: *podtest.MakePod("123",
 				podtest.SetLabels(map[string]string{"key": "value1"}),
 				podtest.SetAffinity(&core.Affinity{
@@ -11702,7 +11702,7 @@ func TestValidatePod(t *testing.T) {
 			),
 		},
 		"invalid soft pod anti-affinity, key exists in both matchLabelKeys and labelSelector": {
-			expectedError: "exists in both matchLabelKeys and labelSelector",
+			expectedError: "spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.matchLabelKeys[0]: Invalid value: \"key\": exists in both matchLabelKeys and labelSelector",
 			spec: *podtest.MakePod("123",
 				podtest.SetLabels(map[string]string{"key": "value1"}),
 				podtest.SetAffinity(&core.Affinity{
@@ -11736,7 +11736,7 @@ func TestValidatePod(t *testing.T) {
 			),
 		},
 		"invalid hard pod anti-affinity, key exists in both matchLabelKeys and labelSelector": {
-			expectedError: "exists in both matchLabelKeys and labelSelector",
+			expectedError: "spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].matchLabelKeys[0]: Invalid value: \"key\": exists in both matchLabelKeys and labelSelector",
 			spec: *podtest.MakePod("123",
 				podtest.SetLabels(map[string]string{"key": "value1"}),
 				podtest.SetAffinity(&core.Affinity{
@@ -23540,8 +23540,7 @@ func TestValidateTopologySpreadConstraints(t *testing.T) {
 				},
 			},
 		}},
-		// TODO: This expected message is not perfect, and will be fixed in #129900.
-		wantFieldErrors: field.ErrorList{field.Invalid(subFldPath0.Index(0), nil, "").WithOrigin("duplicatedLabelKeys")},
+		wantFieldErrors: field.ErrorList{field.Invalid(fieldPathMatchLabelKeys.Index(0), nil, "").WithOrigin("duplicatedLabelKeys")},
 		opts: PodValidationOptions{
 			AllowMatchLabelKeysInPodTopologySpread:              true,
 			AllowMatchLabelKeysInPodTopologySpreadSelectorMerge: true,
@@ -23670,8 +23669,7 @@ func TestValidateTopologySpreadConstraints(t *testing.T) {
 				},
 			},
 		}},
-		// TODO: This expected message is not perfect, and will be fixed in #129900.
-		wantFieldErrors: field.ErrorList{field.Invalid(subFldPath0.Index(0), nil, "").WithOrigin("duplicatedLabelKeys")},
+		wantFieldErrors: field.ErrorList{field.Invalid(fieldPathMatchLabelKeys.Index(0), nil, "").WithOrigin("duplicatedLabelKeys")},
 		opts: PodValidationOptions{
 			AllowMatchLabelKeysInPodTopologySpread:              true,
 			AllowMatchLabelKeysInPodTopologySpreadSelectorMerge: true,


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/sig scheduling

#### What this PR does / why we need it:
Fix the error message of duplicate keys existing in both `matchLabelKeys` and `labelSelector` in PodAffinity.

Current error message is as below(`requiredDuringSchedulingIgnoredDuringExecution[0][0]` seems odd):

```console
The Pod "sample-affinity-matchlabelkeys" is invalid: spec.affinity.podAffinity.requiredDuringSchedulingIgnoredDuringExecution[0][0]: Invalid value: "app": exists in both matchLabelKeys and labelSelector
```

This PR fixes as below:

```console
The Pod "sample-affinity-matchlabelkeys" is invalid: spec.affinity.podAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].matchLabelKeys[0]: Invalid value: "app": exists in both matchLabelKeys and labelSelector
```

#### Which issue(s) this PR fixes:


#### Special notes for your reviewer:

Related: https://github.com/kubernetes/kubernetes/pull/129874#discussion_r1933473698

#### Does this PR introduce a user-facing change?

```release-note
Fix the error message of duplicate keys existing in both `matchLabelKeys` and `labelSelector` in PodAffinity.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
