### PR TITLE
Decouple namespace matcher from ns lister/client

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/plugin.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/plugin.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/admission/initializer"
 	"k8s.io/apiserver/pkg/admission/plugin/policy/matching"
+	"k8s.io/apiserver/pkg/admission/plugin/webhook/predicates/namespace"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/informers"
@@ -164,7 +165,11 @@ func (c *Plugin[H]) ValidateInitialization() error {
 
 	// Use default matcher
 	namespaceInformer := c.informerFactory.Core().V1().Namespaces()
-	c.matcher = matching.NewMatcher(namespaceInformer.Lister(), c.client)
+	namespaceProvider := namespace.Provider{
+		NamespaceLister: namespaceInformer.Lister(),
+		Client:          c.client,
+	}
+	c.matcher = matching.NewMatcher(&namespaceProvider)
 
 	if err := c.matcher.ValidateInitialization(); err != nil {
 		return err

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/matching/matching.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/matching/matching.go
@@ -23,8 +23,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/admission"
-	"k8s.io/client-go/kubernetes"
-	listersv1 "k8s.io/client-go/listers/core/v1"
 
 	"k8s.io/apiserver/pkg/admission/plugin/webhook/predicates/namespace"
 	"k8s.io/apiserver/pkg/admission/plugin/webhook/predicates/object"
@@ -50,13 +48,11 @@ func (m *Matcher) GetNamespace(name string) (*corev1.Namespace, error) {
 
 // NewMatcher initialize the matcher with dependencies requires
 func NewMatcher(
-	namespaceLister listersv1.NamespaceLister,
-	client kubernetes.Interface,
+	namespaceProvider namespace.NamespaceProvider,
 ) *Matcher {
 	return &Matcher{
 		namespaceMatcher: &namespace.Matcher{
-			NamespaceLister: namespaceLister,
-			Client:          client,
+			NamespaceProvider: namespaceProvider,
 		},
 		objectMatcher: &object.Matcher{},
 	}

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/matching/matching_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/matching/matching_test.go
@@ -664,7 +664,8 @@ func BenchmarkMatcher(b *testing.B) {
 	criteria := &fakeCriteria{matchResources: mr}
 	attrs := admission.NewAttributesRecord(nil, nil, gvk("autoscaling", "v1", "Scale"), "ns", "name", gvr("apps", "v1", "deployments"), "scale", admission.Create, &metav1.CreateOptions{}, false, nil)
 	interfaces := &admission.RuntimeObjectInterfaces{EquivalentResourceMapper: mapper}
-	matcher := &Matcher{namespaceMatcher: &namespace.Matcher{NamespaceLister: namespaceLister}, objectMatcher: &object.Matcher{}}
+	namespaceProvider := &namespace.Provider{NamespaceLister: namespaceLister}
+	matcher := &Matcher{namespaceMatcher: &namespace.Matcher{NamespaceProvider: namespaceProvider}, objectMatcher: &object.Matcher{}}
 
 	for i := 0; i < b.N; i++ {
 		matcher.Matches(attrs, interfaces, criteria)
@@ -734,7 +735,8 @@ func BenchmarkShouldCallHookWithComplexRule(b *testing.B) {
 	criteria := &fakeCriteria{matchResources: mr}
 	attrs := admission.NewAttributesRecord(nil, nil, gvk("autoscaling", "v1", "Scale"), "ns", "name", gvr("apps", "v1", "deployments"), "scale", admission.Create, &metav1.CreateOptions{}, false, nil)
 	interfaces := &admission.RuntimeObjectInterfaces{EquivalentResourceMapper: mapper}
-	matcher := &Matcher{namespaceMatcher: &namespace.Matcher{NamespaceLister: namespaceLister}, objectMatcher: &object.Matcher{}}
+	namespaceProvider := &namespace.Provider{NamespaceLister: namespaceLister}
+	matcher := &Matcher{namespaceMatcher: &namespace.Matcher{NamespaceProvider: namespaceProvider}, objectMatcher: &object.Matcher{}}
 
 	for i := 0; i < b.N; i++ {
 		matcher.Matches(attrs, interfaces, criteria)
@@ -809,7 +811,8 @@ func BenchmarkShouldCallHookWithComplexSelectorAndRule(b *testing.B) {
 	criteria := &fakeCriteria{matchResources: mr}
 	attrs := admission.NewAttributesRecord(nil, nil, gvk("autoscaling", "v1", "Scale"), "ns", "name", gvr("apps", "v1", "deployments"), "scale", admission.Create, &metav1.CreateOptions{}, false, nil)
 	interfaces := &admission.RuntimeObjectInterfaces{EquivalentResourceMapper: mapper}
-	matcher := &Matcher{namespaceMatcher: &namespace.Matcher{NamespaceLister: namespaceLister}, objectMatcher: &object.Matcher{}}
+	namespaceProvider := &namespace.Provider{NamespaceLister: namespaceLister}
+	matcher := &Matcher{namespaceMatcher: &namespace.Matcher{NamespaceProvider: namespaceProvider}, objectMatcher: &object.Matcher{}}
 
 	for i := 0; i < b.N; i++ {
 		matcher.Matches(attrs, interfaces, criteria)

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/mutating/dispatcher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/mutating/dispatcher_test.go
@@ -18,10 +18,10 @@ package mutating
 
 import (
 	"context"
-	"github.com/google/go-cmp/cmp"
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	"k8s.io/api/admissionregistration/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -36,6 +36,7 @@ import (
 	"k8s.io/apiserver/pkg/admission/plugin/policy/generic"
 	"k8s.io/apiserver/pkg/admission/plugin/policy/matching"
 	"k8s.io/apiserver/pkg/admission/plugin/policy/mutating/patch"
+	"k8s.io/apiserver/pkg/admission/plugin/webhook/predicates/namespace"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/openapi/openapitest"
@@ -651,7 +652,11 @@ func TestDispatcher(t *testing.T) {
 			}
 
 			informerFactory := informers.NewSharedInformerFactory(client, 0)
-			matcher := matching.NewMatcher(informerFactory.Core().V1().Namespaces().Lister(), client)
+			namespaceProvider := namespace.Provider{
+				NamespaceLister: informerFactory.Core().V1().Namespaces().Lister(),
+				Client:          client,
+			}
+			matcher := matching.NewMatcher(&namespaceProvider)
 			paramInformer, err := informerFactory.ForResource(schema.GroupVersionResource{Version: "v1", Resource: "configmaps"})
 			if err != nil {
 				t.Fatal(err)

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/generic/webhook_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/generic/webhook_test.go
@@ -561,7 +561,8 @@ func BenchmarkShouldCallHookWithComplexSelector(b *testing.B) {
 	}
 	attrs := admission.NewAttributesRecord(nil, nil, gvk("autoscaling", "v1", "Scale"), "ns", "name", gvr("apps", "v1", "deployments"), "scale", admission.Create, &metav1.CreateOptions{}, false, nil)
 	interfaces := &admission.RuntimeObjectInterfaces{EquivalentResourceMapper: mapper}
-	a := &Webhook{namespaceMatcher: &namespace.Matcher{NamespaceLister: namespaceLister}, objectMatcher: &object.Matcher{}}
+	namespaceProvider := &namespace.Provider{NamespaceLister: namespaceLister}
+	a := &Webhook{namespaceMatcher: &namespace.Matcher{NamespaceProvider: namespaceProvider}, objectMatcher: &object.Matcher{}}
 
 	for i := 0; i < b.N; i++ {
 		a.ShouldCallHook(context.TODO(), wbAccessor, attrs, interfaces, nil)
@@ -632,7 +633,8 @@ func BenchmarkShouldCallHookWithComplexRule(b *testing.B) {
 	}
 	attrs := admission.NewAttributesRecord(nil, nil, gvk("autoscaling", "v1", "Scale"), "ns", "name", gvr("apps", "v1", "deployments"), "scale", admission.Create, &metav1.CreateOptions{}, false, nil)
 	interfaces := &admission.RuntimeObjectInterfaces{EquivalentResourceMapper: mapper}
-	a := &Webhook{namespaceMatcher: &namespace.Matcher{NamespaceLister: namespaceLister}, objectMatcher: &object.Matcher{}}
+	namespaceProvider := &namespace.Provider{NamespaceLister: namespaceLister}
+	a := &Webhook{namespaceMatcher: &namespace.Matcher{NamespaceProvider: namespaceProvider}, objectMatcher: &object.Matcher{}}
 
 	for i := 0; i < b.N; i++ {
 		a.ShouldCallHook(context.TODO(), wbAccessor, attrs, interfaces, &fakeVersionedAttributeAccessor{})
@@ -708,7 +710,8 @@ func BenchmarkShouldCallHookWithComplexSelectorAndRule(b *testing.B) {
 	}
 	attrs := admission.NewAttributesRecord(nil, nil, gvk("autoscaling", "v1", "Scale"), "ns", "name", gvr("apps", "v1", "deployments"), "scale", admission.Create, &metav1.CreateOptions{}, false, nil)
 	interfaces := &admission.RuntimeObjectInterfaces{EquivalentResourceMapper: mapper}
-	a := &Webhook{namespaceMatcher: &namespace.Matcher{NamespaceLister: namespaceLister}, objectMatcher: &object.Matcher{}}
+	namespaceProvider := &namespace.Provider{NamespaceLister: namespaceLister}
+	a := &Webhook{namespaceMatcher: &namespace.Matcher{NamespaceProvider: namespaceProvider}, objectMatcher: &object.Matcher{}}
 
 	for i := 0; i < b.N; i++ {
 		a.ShouldCallHook(context.TODO(), wbAccessor, attrs, interfaces, nil)

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/predicates/namespace/matcher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/predicates/namespace/matcher_test.go
@@ -102,7 +102,9 @@ func TestGetNamespaceLabels(t *testing.T) {
 		},
 	}
 	matcher := namespace.Matcher{
-		NamespaceLister: namespaceLister,
+		NamespaceProvider: &namespace.Provider{
+			NamespaceLister: namespaceLister,
+		},
 	}
 	for _, tt := range tests {
 		actualLabels, err := matcher.GetNamespaceLabels(tt.attr)


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Decouple namespace matcher from the namespace lister/client.
The namespace matcher doesn't need to know about the namespace lister and client implementation details, all it needs is to lookup a namespace from a given name.

This PR introduces an abstraction between the matcher and the actual lister/client based implementation.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
