### PR TITLE
e2e: expand error conditions when test-ing port-forward

### DIFF
--- a/test/e2e/kubectl/portforward.go
+++ b/test/e2e/kubectl/portforward.go
@@ -617,7 +617,8 @@ var _ = SIGDescribe("Kubectl Port forwarding", func() {
 				// this error indicates timeout when POST-ing data
 				gomega.ContainSubstring("context deadline exceeded"),
 				// this will happen when trying to write to a closed connection
-				gomega.ContainSubstring("write: broken pipe"), gomega.ContainSubstring("closed network connection")))
+				gomega.ContainSubstring("write: broken pipe"), gomega.ContainSubstring("closed network connection"),
+				gomega.ContainSubstring("connect: connection refused")))
 
 			ginkgo.By("Check kubectl port-forward exit code")
 			gomega.Expect(cmd.cmd.ProcessState.ExitCode()).To(gomega.BeNumerically("<", 0), "kubectl port-forward should finish with non-zero exit code")


### PR DESCRIPTION
#### What type of PR is this?
/kind flake

#### What this PR does / why we need it:
Continuation of the problem reported in https://github.com/kubernetes/kubernetes/issues/129706:
```
{ failed [FAILED] Expected
    <string>: Post "http://localhost:41921/header": dial tcp [::1]:41921: connect: connection refused
To satisfy at least one of these matchers: [%!s(*matchers.ContainSubstringMatcher=&{connection reset by peer []}) %!s(*matchers.ContainSubstringMatcher=&{EOF []}) %!s(*matchers.ContainSubstringMatcher=&{context deadline exceeded []}) %!s(*matchers.ContainSubstringMatcher=&{write: broken pipe []}) %!s(*matchers.ContainSubstringMatcher=&{closed network connection []})]
In [It] at: k8s.io/kubernetes/test/e2e/kubectl/portforward.go:614 @ 01/30/25 06:14:37.529
}
```
this PR expands the error check with `connect: connection refused` string check. 

Although, after adding yet another condition I'm starting to look into how to rewrite this into something more manageable. 

#### Which issue(s) this PR fixes:
https://github.com/kubernetes/kubernetes/issues/129706

#### Special notes for your reviewer:
/assign @ardaguclu @wendy-ha18 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
