### PR TITLE
Custom dialers for streaming connections, comments and errors.

### DIFF
--- a/staging/src/k8s.io/client-go/rest/config.go
+++ b/staging/src/k8s.io/client-go/rest/config.go
@@ -149,7 +149,8 @@ type Config struct {
 	// The maximum length of time to wait before giving up on a server request. A value of zero means no timeout.
 	Timeout time.Duration
 
-	// Dial specifies the dial function for creating unencrypted TCP connections.
+	// Dial function is only used for the connection to the apiserver; streaming
+	// connections like SPDY or websockets will ignore this dialer.
 	Dial func(ctx context.Context, network, address string) (net.Conn, error)
 
 	// Proxy is the proxy func to be used for all requests made by this

--- a/staging/src/k8s.io/client-go/transport/spdy/spdy.go
+++ b/staging/src/k8s.io/client-go/transport/spdy/spdy.go
@@ -35,6 +35,11 @@ type Upgrader interface {
 
 // RoundTripperFor returns a round tripper and upgrader to use with SPDY.
 func RoundTripperFor(config *restclient.Config) (http.RoundTripper, Upgrader, error) {
+	// Custom dialers not currently supported for streaming connections:
+	//   https://github.com/kubernetes/kubernetes/issues/129915
+	if config.Dial != nil {
+		return nil, nil, fmt.Errorf("custom dial function not supported for streaming connections")
+	}
 	tlsConfig, err := restclient.TLSConfigFor(config)
 	if err != nil {
 		return nil, nil, err

--- a/staging/src/k8s.io/client-go/transport/spdy/spdy_test.go
+++ b/staging/src/k8s.io/client-go/transport/spdy/spdy_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spdy
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	restclient "k8s.io/client-go/rest"
+)
+
+func TestWebSocketRoundTripper_CustomDialerError(t *testing.T) {
+	// Validate config without custom dialer set does *not* return an error.
+	rt, upgradeRT, err := RoundTripperFor(&restclient.Config{Host: "fakehost"})
+	require.NoError(t, err)
+	require.NotNil(t, rt, "roundtripper should be non-nil")
+	require.NotNil(t, upgradeRT, "upgrade roundtripper should be non-nil")
+	// Validate that custom dialer returns error.
+	rt, upgradeRT, err = RoundTripperFor(&restclient.Config{
+		Host: "fakehost",
+		Dial: func(context.Context, string, string) (net.Conn, error) {
+			return nil, fmt.Errorf("not used")
+		},
+	})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "custom dial function not supported for streaming connections")
+	require.Nil(t, rt, "invalid rest config should cause roundtripper to be nil, got (%v)", rt)
+	require.Nil(t, upgradeRT, "invalid rest config should cause upgrade roundtripper to be nil, got (%v)", upgradeRT)
+}

--- a/staging/src/k8s.io/client-go/transport/websocket/roundtripper.go
+++ b/staging/src/k8s.io/client-go/transport/websocket/roundtripper.go
@@ -181,6 +181,11 @@ func (rt *RoundTripper) RoundTrip(request *http.Request) (retResp *http.Response
 // websocket connection after RoundTrip() on the wrapper. Returns an error if there is
 // a problem creating the round trippers.
 func RoundTripperFor(config *restclient.Config) (http.RoundTripper, ConnectionHolder, error) {
+	// Custom dialers not currently supported for streaming connections:
+	//   https://github.com/kubernetes/kubernetes/issues/129915
+	if config.Dial != nil {
+		return nil, nil, fmt.Errorf("custom dial function not supported for streaming connections")
+	}
 	transportCfg, err := config.TransportConfig()
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
* Adds comment that custom dialer within `rest.Config` is currently ignored for streaming connections.
* Adds errors (and tests) when a custom `Dial` function is added to `rest.Config` for streaming connections, since these custom dialers are currently not supported.

/kind cleanup

Associated with issue: https://github.com/kubernetes/kubernetes/issues/129915

```release-note
NONE
```
