### PR TITLE
scheduler_perf: add thresholds to DRA test cases

### DIFF
--- a/test/integration/scheduler_perf/dra/performance-config.yaml
+++ b/test/integration/scheduler_perf/dra/performance-config.yaml
@@ -93,6 +93,8 @@
     featureGates:
       SchedulerQueueingHints: false
     labels: [performance]
+    # https://perf-dash.k8s.io/#/?jobname=scheduler-perf-benchmark&metriccategoryname=Scheduler&metricname=BenchmarkPerfScheduling&Metric=SchedulingThroughput&Name=BenchmarkPerfScheduling%2FSchedulingWithResourceClaimTemplate%2F5000pods_500nodes%2Ftest&event=not%20applicable&extension_point=not%20applicable&plugin=not%20applicable&result=not%20applicable
+    threshold: 40 # typically above 51
     params:
       nodesWithDRA: 500
       nodesWithoutDRA: 0
@@ -103,6 +105,8 @@
     featureGates:
       SchedulerQueueingHints: true
     labels: [performance]
+    # https://perf-dash.k8s.io/#/?jobname=scheduler-perf-benchmark&metriccategoryname=Scheduler&metricname=BenchmarkPerfScheduling&Metric=SchedulingThroughput&Name=BenchmarkPerfScheduling%2FSchedulingWithResourceClaimTemplate%2F5000pods_500nodes_QueueingHintsEnabled%2Ftest&event=not%20applicable&extension_point=not%20applicable&plugin=not%20applicable&result=not%20applicable
+    threshold: 56 # typically above 70
     params:
       nodesWithDRA: 500
       nodesWithoutDRA: 0
@@ -191,6 +195,8 @@
     featureGates:
       SchedulerQueueingHints: false
     labels: [performance]
+    # https://perf-dash.k8s.io/#/?jobname=scheduler-perf-benchmark&metriccategoryname=Scheduler&metricname=BenchmarkPerfScheduling&Metric=SchedulingThroughput&Name=BenchmarkPerfScheduling%2FSteadyStateClusterResourceClaimTemplate%2Fempty_500nodes%2Ftest&event=not%20applicable&extension_point=not%20applicable&plugin=not%20applicable&result=not%20applicable
+    threshold: 64 # typically above 81
     params:
       nodesWithDRA: 500
       nodesWithoutDRA: 0
@@ -201,6 +207,8 @@
     featureGates:
       SchedulerQueueingHints: true
     labels: [performance]
+    # https://perf-dash.k8s.io/#/?jobname=scheduler-perf-benchmark&metriccategoryname=Scheduler&metricname=BenchmarkPerfScheduling&Metric=SchedulingThroughput&Name=BenchmarkPerfScheduling%2FSteadyStateClusterResourceClaimTemplate%2Fempty_500nodes_QueueingHintsEnabled%2Ftest&event=not%20applicable&extension_point=not%20applicable&plugin=not%20applicable&result=not%20applicable
+    threshold: 64 # typically above 81
     params:
       nodesWithDRA: 500
       nodesWithoutDRA: 0
@@ -226,6 +234,8 @@
     featureGates:
       SchedulerQueueingHints: false
     labels: [performance]
+    # https://perf-dash.k8s.io/#/?jobname=scheduler-perf-benchmark&metriccategoryname=Scheduler&metricname=BenchmarkPerfScheduling&Metric=SchedulingThroughput&Name=BenchmarkPerfScheduling%2FSteadyStateClusterResourceClaimTemplate%2Fhalf_500nodes%2Ftest&event=not%20applicable&extension_point=not%20applicable&plugin=not%20applicable&result=not%20applicable
+    threshold: 70 # typically over 78
     params:
       nodesWithDRA: 500
       nodesWithoutDRA: 0
@@ -236,6 +246,8 @@
     featureGates:
       SchedulerQueueingHints: true
     labels: [performance]
+    # https://perf-dash.k8s.io/#/?jobname=scheduler-perf-benchmark&metriccategoryname=Scheduler&metricname=BenchmarkPerfScheduling&Metric=SchedulingThroughput&Name=BenchmarkPerfScheduling%2FSteadyStateClusterResourceClaimTemplate%2Fhalf_500nodes_QueueingHintsEnabled%2Ftest&event=not%20applicable&extension_point=not%20applicable&plugin=not%20applicable&result=not%20applicable
+    threshold: 60 # typically over 75
     params:
       nodesWithDRA: 500
       nodesWithoutDRA: 0
@@ -261,6 +273,8 @@
     featureGates:
       SchedulerQueueingHints: false
     labels: [performance]
+    # https://perf-dash.k8s.io/#/?jobname=scheduler-perf-benchmark&metriccategoryname=Scheduler&metricname=BenchmarkPerfScheduling&Metric=SchedulingThroughput&Name=BenchmarkPerfScheduling%2FSteadyStateClusterResourceClaimTemplate%2Ffull_500nodes%2Ftest&event=not%20applicable&extension_point=not%20applicable&plugin=not%20applicable&result=not%20applicable
+    threshold: 60 # typically over 75
     params:
       nodesWithDRA: 500
       nodesWithoutDRA: 0
@@ -271,6 +285,8 @@
     featureGates:
       SchedulerQueueingHints: true
     labels: [performance]
+    # https://perf-dash.k8s.io/#/?jobname=scheduler-perf-benchmark&metriccategoryname=Scheduler&metricname=BenchmarkPerfScheduling&Metric=SchedulingThroughput&Name=BenchmarkPerfScheduling%2FSteadyStateClusterResourceClaimTemplate%2Ffull_500nodes_QueueingHintsEnabled%2Ftest&event=not%20applicable&extension_point=not%20applicable&plugin=not%20applicable&result=not%20applicable
+    threshold: 60 # typically over 75
     params:
       nodesWithDRA: 500
       nodesWithoutDRA: 0


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Detect regressions in DRA scheduling performance.

#### Special notes for your reviewer:

They were enabled yesterday and executed seven times, with results that (so far) seem to be fairly stable with just one run that was slower across the board.

The links in the YAML can be used to navigate to each test case quickly. The thresholds were chose with a 20% security margin below what seems to be a common result.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @macsko 
/cc @byako 