### PR TITLE
perf: Use WalkDir to reduce stat call.

### DIFF
--- a/cmd/kubeadm/app/util/patches/patches.go
+++ b/cmd/kubeadm/app/util/patches/patches.go
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -322,17 +323,17 @@ func getPatchSetsFromPath(targetPath string, knownTargets []string, output io.Wr
 		goto return_path_error
 	}
 
-	err = filepath.Walk(targetPath, func(path string, info os.FileInfo, err error) error {
+	err = filepath.WalkDir(targetPath, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 
 		// Sub-directories and "." are ignored.
-		if info.IsDir() {
+		if d.IsDir() {
 			return nil
 		}
 
-		baseName := info.Name()
+		baseName := d.Name()
 
 		// Parse the filename and retrieve the target and patch type
 		targetName, patchType, warn, err := parseFilename(baseName, knownTargets)

--- a/cmd/kubelet/app/server_bootstrap_test.go
+++ b/cmd/kubelet/app/server_bootstrap_test.go
@@ -24,7 +24,9 @@ import (
 	"crypto/x509/pkix"
 	"encoding/json"
 	"encoding/pem"
+	"fmt"
 	"io"
+	"io/fs"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
@@ -194,14 +196,17 @@ func Test_buildClientCertificateManager_populateCertDir(t *testing.T) {
 
 }
 
-func getFileInfo(dir string) map[string]os.FileInfo {
-	fi := make(map[string]os.FileInfo)
-	filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+func getFileInfo(dir string) map[string]fs.DirEntry {
+	fi := make(map[string]fs.DirEntry)
+	filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
 		if path == dir {
 			return nil
 		}
-		fi[path] = info
-		if !info.IsDir() {
+		fi[path] = d
+		if !d.IsDir() {
 			os.Remove(path)
 		}
 		return nil

--- a/cmd/preferredimports/preferredimports.go
+++ b/cmd/preferredimports/preferredimports.go
@@ -27,6 +27,7 @@ import (
 	"go/format"
 	"go/parser"
 	"go/token"
+	"io/fs"
 	"log"
 	"os"
 	"path/filepath"
@@ -193,11 +194,11 @@ type collector struct {
 // handlePath walks the filesystem recursively, collecting directories,
 // ignoring some unneeded directories (hidden/vendored) that are handled
 // specially later.
-func (c *collector) handlePath(path string, info os.FileInfo, err error) error {
+func (c *collector) handlePath(path string, d fs.DirEntry, err error) error {
 	if err != nil {
 		return err
 	}
-	if info.IsDir() {
+	if d.IsDir() {
 		// Ignore hidden directories (.git, .cache, etc)
 		if len(path) > 1 && path[0] == '.' ||
 			// OS-specific vendor code tends to be imported by OS-specific
@@ -233,7 +234,7 @@ func main() {
 	}
 	c := collector{regex: regex}
 	for _, arg := range args {
-		err := filepath.Walk(arg, c.handlePath)
+		err := filepath.WalkDir(arg, c.handlePath)
 		if err != nil {
 			log.Fatalf("Error walking: %v", err)
 		}

--- a/pkg/kubelet/cm/cgroup_manager_linux.go
+++ b/pkg/kubelet/cm/cgroup_manager_linux.go
@@ -18,6 +18,7 @@ package cm
 
 import (
 	"fmt"
+	"io/fs"
 	"os"
 	"path"
 	"path/filepath"
@@ -433,12 +434,12 @@ func (m *cgroupCommon) Pids(name CgroupName) []int {
 		pidsToKill.Insert(pids...)
 
 		// WalkFunc which is called for each file and directory in the pod cgroup dir
-		visitor := func(path string, info os.FileInfo, err error) error {
+		visitor := func(path string, d fs.DirEntry, err error) error {
 			if err != nil {
 				klog.V(4).InfoS("Cgroup manager encountered error scanning cgroup path", "path", path, "err", err)
 				return filepath.SkipDir
 			}
-			if !info.IsDir() {
+			if !d.IsDir() {
 				return nil
 			}
 			pids, err = getCgroupProcs(path)
@@ -452,7 +453,7 @@ func (m *cgroupCommon) Pids(name CgroupName) []int {
 		// Walk through the pod cgroup directory to check if
 		// container cgroups haven't been GCed yet. Get attached processes to
 		// all such unwanted containers under the pod cgroup
-		if err = filepath.Walk(dir, visitor); err != nil {
+		if err = filepath.WalkDir(dir, visitor); err != nil {
 			klog.V(4).InfoS("Cgroup manager encountered error scanning pids for directory", "path", dir, "err", err)
 		}
 	}

--- a/pkg/volume/util/atomic_writer.go
+++ b/pkg/volume/util/atomic_writer.go
@@ -19,6 +19,7 @@ package util
 import (
 	"bytes"
 	"fmt"
+	"io/fs"
 	"os"
 	"path"
 	"path/filepath"
@@ -357,7 +358,7 @@ func shouldWriteFile(path string, content []byte) (bool, error) {
 // written to the target directory.
 func (w *AtomicWriter) pathsToRemove(payload map[string]FileProjection, oldTSDir string) (sets.Set[string], error) {
 	paths := sets.New[string]()
-	visitor := func(path string, info os.FileInfo, err error) error {
+	visitor := func(path string, d fs.DirEntry, err error) error {
 		relativePath := strings.TrimPrefix(path, oldTSDir)
 		relativePath = strings.TrimPrefix(relativePath, string(os.PathSeparator))
 		if relativePath == "" {
@@ -368,7 +369,7 @@ func (w *AtomicWriter) pathsToRemove(payload map[string]FileProjection, oldTSDir
 		return nil
 	}
 
-	err := filepath.Walk(oldTSDir, visitor)
+	err := filepath.WalkDir(oldTSDir, visitor)
 	if os.IsNotExist(err) {
 		return nil, nil
 	} else if err != nil {

--- a/pkg/volume/util/subpath/subpath_linux_test.go
+++ b/pkg/volume/util/subpath/subpath_linux_test.go
@@ -21,6 +21,7 @@ package subpath
 
 import (
 	"fmt"
+	"io/fs"
 	"io/ioutil"
 	"net"
 	"os"
@@ -588,7 +589,7 @@ func TestCleanSubPaths(t *testing.T) {
 				return mounts, nil
 			},
 			unmount: func(mountpath string) error {
-				err := filepath.Walk(mountpath, func(path string, info os.FileInfo, _ error) error {
+				err := filepath.WalkDir(mountpath, func(path string, d fs.DirEntry, _ error) error {
 					if path == mountpath {
 						// Skip top level directory
 						return nil

--- a/test/featuregates_linter/cmd/feature_gates.go
+++ b/test/featuregates_linter/cmd/feature_gates.go
@@ -21,6 +21,7 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -229,7 +230,7 @@ func searchPathForFeatures(path string, versioned bool) ([]featureInfo, error) {
 	allFeatures := []featureInfo{}
 	// Create a FileSet to work with
 	fset := token.NewFileSet()
-	err := filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
+	err := filepath.WalkDir(path, func(path string, d fs.DirEntry, err error) error {
 		if strings.HasPrefix(path, "vendor") || strings.HasPrefix(path, "_") {
 			return filepath.SkipDir
 		}

--- a/test/instrumentation/main.go
+++ b/test/instrumentation/main.go
@@ -24,6 +24,7 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -125,7 +126,7 @@ func main() {
 func searchPathForStableMetrics(path string) ([]metric, []error) {
 	metrics := []metric{}
 	errors := []error{}
-	err := filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
+	err := filepath.WalkDir(path, func(path string, d fs.DirEntry, err error) error {
 		if strings.HasPrefix(path, "vendor") {
 			return filepath.SkipDir
 		}

--- a/test/integration/logs/benchmark/benchmark_test.go
+++ b/test/integration/logs/benchmark/benchmark_test.go
@@ -44,7 +44,7 @@ func BenchmarkEncoding(b *testing.B) {
 	// Each "data/(v[0-9]/)?*.log" file is expected to contain JSON log
 	// messages. We generate one sub-benchmark for each file where logging
 	// is tested with the log level from the directory.
-	if err := filepath.Walk("data", func(path string, info fs.FileInfo, err error) error {
+	if err := filepath.WalkDir("data", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}

--- a/test/list/main.go
+++ b/test/list/main.go
@@ -24,8 +24,8 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"io/fs"
 	"log"
-	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -229,7 +229,7 @@ type testList struct {
 // handlePath walks the filesystem recursively, collecting tests
 // from files with paths *e2e*.go and *_test.go, ignoring third_party
 // and staging directories.
-func (t *testList) handlePath(path string, info os.FileInfo, err error) error {
+func (t *testList) handlePath(path string, d fs.DirEntry, err error) error {
 	if err != nil {
 		return err
 	}
@@ -254,7 +254,7 @@ func main() {
 	}
 	tests := testList{}
 	for _, arg := range args {
-		err := filepath.Walk(arg, tests.handlePath)
+		err := filepath.WalkDir(arg, tests.handlePath)
 		if err != nil {
 			log.Fatalf("Error walking: %v", err)
 		}


### PR DESCRIPTION
filepath.Walk calls os.Lstat for every file or directory to retrieve os.FileInfo. filepath.WalkDir provides fs.DirEntry without requiring stat call.

#### What type of PR is this?
Performance improvement

<!--
Add one of the following kinds:
/kind perf\

#### What this PR does / why we need it:
Performance improvement by reducing stat call

#### Does this PR introduce a user-facing change?
No




