### PR TITLE
Fix/Perf: Remove redundant Stat calls and enhance relative path handling 

### DIFF
--- a/cmd/kubeadm/app/util/patches/patches.go
+++ b/cmd/kubeadm/app/util/patches/patches.go
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -316,17 +317,17 @@ func getPatchSetsFromPath(targetPath string, knownTargets []string, output io.Wr
 		goto return_path_error
 	}
 
-	err = filepath.Walk(targetPath, func(path string, info os.FileInfo, err error) error {
+	err = filepath.WalkDir(targetPath, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 
 		// Sub-directories and "." are ignored.
-		if info.IsDir() {
+		if d.IsDir() {
 			return nil
 		}
 
-		baseName := info.Name()
+		baseName := d.Name()
 
 		// Parse the filename and retrieve the target and patch type
 		targetName, patchType, warn, err := parseFilename(baseName, knownTargets)

--- a/cmd/preferredimports/preferredimports.go
+++ b/cmd/preferredimports/preferredimports.go
@@ -27,6 +27,7 @@ import (
 	"go/format"
 	"go/parser"
 	"go/token"
+	"io/fs"
 	"log"
 	"os"
 	"path/filepath"
@@ -193,11 +194,11 @@ type collector struct {
 // handlePath walks the filesystem recursively, collecting directories,
 // ignoring some unneeded directories (hidden/vendored) that are handled
 // specially later.
-func (c *collector) handlePath(path string, info os.FileInfo, err error) error {
+func (c *collector) handlePath(path string, d fs.DirEntry, err error) error {
 	if err != nil {
 		return err
 	}
-	if info.IsDir() {
+	if d.IsDir() {
 		// Ignore hidden directories (.git, .cache, etc)
 		if len(path) > 1 && path[0] == '.' ||
 			// OS-specific vendor code tends to be imported by OS-specific
@@ -233,7 +234,7 @@ func main() {
 	}
 	c := collector{regex: regex}
 	for _, arg := range args {
-		err := filepath.Walk(arg, c.handlePath)
+		err := filepath.WalkDir(arg, c.handlePath)
 		if err != nil {
 			log.Fatalf("Error walking: %v", err)
 		}

--- a/pkg/volume/util/atomic_writer.go
+++ b/pkg/volume/util/atomic_writer.go
@@ -19,6 +19,7 @@ package util
 import (
 	"bytes"
 	"fmt"
+	"io/fs"
 	"os"
 	"path"
 	"path/filepath"
@@ -357,7 +358,7 @@ func shouldWriteFile(path string, content []byte) (bool, error) {
 // written to the target directory.
 func (w *AtomicWriter) pathsToRemove(payload map[string]FileProjection, oldTSDir string) (sets.Set[string], error) {
 	paths := sets.New[string]()
-	visitor := func(path string, info os.FileInfo, err error) error {
+	visitor := func(path string, d fs.DirEntry, err error) error {
 		relativePath := strings.TrimPrefix(path, oldTSDir)
 		relativePath = strings.TrimPrefix(relativePath, string(os.PathSeparator))
 		if relativePath == "" {
@@ -368,7 +369,7 @@ func (w *AtomicWriter) pathsToRemove(payload map[string]FileProjection, oldTSDir
 		return nil
 	}
 
-	err := filepath.Walk(oldTSDir, visitor)
+	err := filepath.WalkDir(oldTSDir, visitor)
 	if os.IsNotExist(err) {
 		return nil, nil
 	} else if err != nil {

--- a/pkg/volume/util/atomic_writer_test.go
+++ b/pkg/volume/util/atomic_writer_test.go
@@ -759,8 +759,10 @@ func checkVolumeContents(targetDir, tcName string, payload map[string]FileProjec
 			return nil
 		}
 
-		relativePath := strings.TrimPrefix(path, dataDirPath)
-		relativePath = strings.TrimPrefix(relativePath, "/")
+		relativePath, err := filepath.Rel(dataDirPath, path)
+		if err != nil {
+			return fmt.Errorf("failed to get relative path: %w", err)
+		}
 		if strings.HasPrefix(relativePath, "..") {
 			return nil
 		}
@@ -769,11 +771,8 @@ func checkVolumeContents(targetDir, tcName string, payload map[string]FileProjec
 		if err != nil {
 			return err
 		}
-		fileInfo, err := os.Stat(path)
-		if err != nil {
-			return err
-		}
-		mode := int32(fileInfo.Mode())
+
+		mode := int32(info.Mode())
 
 		observedPayload[relativePath] = FileProjection{Data: content, Mode: mode}
 

--- a/pkg/volume/util/subpath/subpath_linux_test.go
+++ b/pkg/volume/util/subpath/subpath_linux_test.go
@@ -21,6 +21,7 @@ package subpath
 
 import (
 	"fmt"
+	"io/fs"
 	"io/ioutil"
 	"net"
 	"os"
@@ -588,7 +589,7 @@ func TestCleanSubPaths(t *testing.T) {
 				return mounts, nil
 			},
 			unmount: func(mountpath string) error {
-				err := filepath.Walk(mountpath, func(path string, info os.FileInfo, _ error) error {
+				err := filepath.WalkDir(mountpath, func(path string, d fs.DirEntry, _ error) error {
 					if path == mountpath {
 						// Skip top level directory
 						return nil

--- a/test/compatibility_lifecycle/cmd/feature_gates.go
+++ b/test/compatibility_lifecycle/cmd/feature_gates.go
@@ -21,6 +21,7 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -281,7 +282,7 @@ func searchPathForFeatures(path string) ([]featureInfo, error) {
 	allFeatures := []featureInfo{}
 	// Create a FileSet to work with
 	fset := token.NewFileSet()
-	err := filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
+	err := filepath.WalkDir(path, func(path string, d fs.DirEntry, err error) error {
 		if strings.HasPrefix(path, "vendor") || strings.HasPrefix(path, "_") {
 			return filepath.SkipDir
 		}

--- a/test/instrumentation/main.go
+++ b/test/instrumentation/main.go
@@ -24,6 +24,7 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -125,7 +126,7 @@ func main() {
 func searchPathForStableMetrics(path string) ([]metric, []error) {
 	metrics := []metric{}
 	errors := []error{}
-	err := filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
+	err := filepath.WalkDir(path, func(path string, d fs.DirEntry, err error) error {
 		if strings.HasPrefix(path, "vendor") {
 			return filepath.SkipDir
 		}

--- a/test/integration/logs/benchmark/benchmark_test.go
+++ b/test/integration/logs/benchmark/benchmark_test.go
@@ -44,7 +44,7 @@ func BenchmarkEncoding(b *testing.B) {
 	// Each "data/(v[0-9]/)?*.log" file is expected to contain JSON log
 	// messages. We generate one sub-benchmark for each file where logging
 	// is tested with the log level from the directory.
-	if err := filepath.Walk("data", func(path string, info fs.FileInfo, err error) error {
+	if err := filepath.WalkDir("data", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}

--- a/test/list/main.go
+++ b/test/list/main.go
@@ -24,8 +24,8 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"io/fs"
 	"log"
-	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -229,7 +229,7 @@ type testList struct {
 // handlePath walks the filesystem recursively, collecting tests
 // from files with paths *e2e*.go and *_test.go, ignoring third_party
 // and staging directories.
-func (t *testList) handlePath(path string, info os.FileInfo, err error) error {
+func (t *testList) handlePath(path string, d fs.DirEntry, err error) error {
 	if err != nil {
 		return err
 	}
@@ -254,7 +254,7 @@ func main() {
 	}
 	tests := testList{}
 	for _, arg := range args {
-		err := filepath.Walk(arg, tests.handlePath)
+		err := filepath.WalkDir(arg, tests.handlePath)
 		if err != nil {
 			log.Fatalf("Error walking: %v", err)
 		}


### PR DESCRIPTION
Use os.FileInfo directly from Walk, which provides Mod(), removing the need for an extra os.Stat call.

Use WalkDir instead of Walk to avoid unnecessary os.Lstat calls during every traversal. 
https://pkg.go.dev/path/filepath#Walk

Use filepath.Rel instead of strings.TrimPrefix to determine relative paths, ensuring better OS compatibility.

#### What type of PR is this?
This PR improves filesystem traversal performance by reducing redundant system calls and improving cross-platform compatibility.

Add one of the following kinds:
/kind cleanup
/kind performance


#### Does this PR introduce a user-facing change?
None
