### PR TITLE
kubeadm: Promote ControlPlaneKubeletLocalMode feature gate to beta - second attempt

### DIFF
--- a/cmd/kubeadm/app/cmd/join.go
+++ b/cmd/kubeadm/app/cmd/join.go
@@ -609,7 +609,9 @@ func (j *joinData) Client() (clientset.Interface, error) {
 			AppendReactor(dryRun.GetKubeadmConfigReactor()).
 			AppendReactor(dryRun.GetKubeadmCertsReactor()).
 			AppendReactor(dryRun.GetKubeProxyConfigReactor()).
-			AppendReactor(dryRun.GetKubeletConfigReactor())
+			AppendReactor(dryRun.GetKubeletConfigReactor()).
+			AppendReactor(dryRun.GetNodeReactor()).
+			AppendReactor(dryRun.PatchNodeReactor())
 
 		j.client = dryRun.FakeClient()
 		return j.client, nil

--- a/cmd/kubeadm/app/cmd/phases/upgrade/apply/kubeconfig.go
+++ b/cmd/kubeadm/app/cmd/phases/upgrade/apply/kubeconfig.go
@@ -24,7 +24,6 @@ import (
 
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow"
-	"k8s.io/kubernetes/cmd/kubeadm/app/features"
 	"k8s.io/kubernetes/cmd/kubeadm/app/phases/upgrade"
 )
 
@@ -53,13 +52,11 @@ func runKubeconfig() func(c workflow.RunData) error {
 
 		cfg := data.InitCfg()
 
-		if features.Enabled(cfg.FeatureGates, features.ControlPlaneKubeletLocalMode) {
-			if err := upgrade.UpdateKubeletLocalMode(cfg, data.DryRun()); err != nil {
-				return errors.Wrap(err, "failed to update kubelet local mode")
-			}
+		if err := upgrade.UpdateKubeletKubeconfigServer(cfg, data.DryRun()); err != nil {
+			return errors.Wrap(err, "failed to update kubelet local mode")
 		}
 
-		fmt.Println("[upgrad/kubeconfig] The kubeconfig files for this node were successfully upgraded!")
+		fmt.Println("[upgrade/kubeconfig] The kubeconfig files for this node were successfully upgraded!")
 
 		return nil
 	}

--- a/cmd/kubeadm/app/cmd/phases/upgrade/node/kubeconfig.go
+++ b/cmd/kubeadm/app/cmd/phases/upgrade/node/kubeconfig.go
@@ -24,7 +24,6 @@ import (
 
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow"
-	"k8s.io/kubernetes/cmd/kubeadm/app/features"
 	"k8s.io/kubernetes/cmd/kubeadm/app/phases/upgrade"
 )
 
@@ -60,10 +59,8 @@ func runKubeconfig() func(c workflow.RunData) error {
 		// Otherwise, retrieve all the info required for kubeconfig upgrade.
 		cfg := data.InitCfg()
 
-		if features.Enabled(cfg.FeatureGates, features.ControlPlaneKubeletLocalMode) {
-			if err := upgrade.UpdateKubeletLocalMode(cfg, data.DryRun()); err != nil {
-				return errors.Wrap(err, "failed to update kubelet local mode")
-			}
+		if err := upgrade.UpdateKubeletKubeconfigServer(cfg, data.DryRun()); err != nil {
+			return errors.Wrap(err, "failed to update kubelet local mode")
 		}
 
 		fmt.Println("[upgrade/kubeconfig] The kubeconfig files for this node were successfully upgraded!")

--- a/cmd/kubeadm/app/features/features.go
+++ b/cmd/kubeadm/app/features/features.go
@@ -36,7 +36,7 @@ const (
 	RootlessControlPlane = "RootlessControlPlane"
 	// WaitForAllControlPlaneComponents is expected to be alpha in v1.30
 	WaitForAllControlPlaneComponents = "WaitForAllControlPlaneComponents"
-	// ControlPlaneKubeletLocalMode is expected to be in alpha in v1.31, beta in v1.32
+	// ControlPlaneKubeletLocalMode is expected to be in alpha in v1.31, beta in v1.33
 	ControlPlaneKubeletLocalMode = "ControlPlaneKubeletLocalMode"
 	// NodeLocalCRISocket is expected to be in alpha in v1.32, beta in v1.33, ga in v1.35
 	NodeLocalCRISocket = "NodeLocalCRISocket"
@@ -54,7 +54,7 @@ var InitFeatureGates = FeatureList{
 			" Once UserNamespacesSupport graduates to GA, kubeadm will start using it and RootlessControlPlane will be removed.",
 	},
 	WaitForAllControlPlaneComponents: {FeatureSpec: featuregate.FeatureSpec{Default: true, PreRelease: featuregate.Beta}},
-	ControlPlaneKubeletLocalMode:     {FeatureSpec: featuregate.FeatureSpec{Default: false, PreRelease: featuregate.Alpha}},
+	ControlPlaneKubeletLocalMode:     {FeatureSpec: featuregate.FeatureSpec{Default: true, PreRelease: featuregate.Beta}},
 	NodeLocalCRISocket:               {FeatureSpec: featuregate.FeatureSpec{Default: false, PreRelease: featuregate.Alpha}},
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR promotes kubeadm's ControlPlaneKubeletLocalMode feature gate to beta and unhides the related phases in kubeadm.

Also adds two fixes:
* Fixes kubeadm's `kubelet-wait-bootstrap` phase introduced for the ControlPlaneKubeletLocalMode feature-gate when using dry-run.
* Fixes kubeadm's upgrade to be able to rollback the ControlPlaneKubeletLocalMode to false

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

Part of: https://github.com/kubernetes/kubeadm/issues/3154

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: promoted the feature gate `ControlPlaneKubeletLocalMode` to Beta. Kubeadm will per default use the local kube-apiserver endpoint for the kubelet when creating a cluster with "kubeadm init" or when joining control plane nodes with "kubeadm join". Enabling the feature gate also affects the `kubeadm init phase kubeconfig kubelet` phase, where the flag `--control-plane-endpoint` no longer affects the generated kubeconfig `Server` field, but the flag `--apiserver-advertise-address` can now be used for the same purpose.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/bcd6c468b88903b49d1784a9364516142a8e83f9/keps/sig-cluster-lifecycle/kubeadm/4471-cp-join-kubelet-local-apiserver/README.md
```
