### PR TITLE
Add ResourceVersion="0" to ResourceQuota and LimitRanger LIST calls

### DIFF
--- a/plugin/pkg/admission/limitranger/admission.go
+++ b/plugin/pkg/admission/limitranger/admission.go
@@ -170,7 +170,7 @@ func (l *LimitRanger) GetLimitRanges(a admission.Attributes) ([]*corev1.LimitRan
 			// Fixed: #22422
 			// use singleflight to alleviate simultaneous calls to
 			lruItemObj, err, _ = l.group.Do(a.GetNamespace(), func() (interface{}, error) {
-				liveList, err := l.client.CoreV1().LimitRanges(a.GetNamespace()).List(context.TODO(), metav1.ListOptions{})
+				liveList, err := l.client.CoreV1().LimitRanges(a.GetNamespace()).List(context.TODO(), metav1.ListOptions{ResourceVersion: "0"})
 				if err != nil {
 					return nil, admission.NewForbidden(a, err)
 				}

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/resourcequota/resource_access.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/resourcequota/resource_access.go
@@ -119,7 +119,7 @@ func (e *quotaAccessor) GetQuotas(namespace string) ([]corev1.ResourceQuota, err
 			// use singleflight.Group to avoid flooding the apiserver with repeated
 			// requests. See #22422 for details.
 			lruItemObj, err, _ = e.group.Do(namespace, func() (interface{}, error) {
-				liveList, err := e.client.CoreV1().ResourceQuotas(namespace).List(context.TODO(), metav1.ListOptions{})
+				liveList, err := e.client.CoreV1().ResourceQuotas(namespace).List(context.TODO(), metav1.ListOptions{ResourceVersion: "0"})
 				if err != nil {
 					return nil, err
 				}


### PR DESCRIPTION
/kind bug
/kind regression

#### What this PR does / why we need it:

This PR mitigates the problem of high latency caused by consistent reads made in Admission/Validation of ResourceQuota/LimitRange. LISTs will be served by cache "immediately" instead of waiting 100ms watch poll time. More details are available in the linked bug report.

#### Which issue(s) this PR fixes:

Issue #129931 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

/cc @jpbetz @serathius 
