### PR TITLE
fix(kubelet-windows): Typo in structured log user display name fixed

### DIFF
--- a/cmd/kubelet/app/server_windows.go
+++ b/cmd/kubelet/app/server_windows.go
@@ -38,7 +38,7 @@ func checkPermissions(ctx context.Context) error {
 
 	// For Windows user.UserName contains the login name and user.Name contains
 	// the user's display name - https://pkg.go.dev/os/user#User
-	logger.Info("Kubelet is running as", "login name", u.Username, "dispaly name", u.Name)
+	logger.Info("Kubelet is running as", "login name", u.Username, "display name", u.Name)
 
 	if !windows.GetCurrentProcessToken().IsElevated() {
 		return errors.New("kubelet needs to run with elevated permissions!")


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

/sig windows

#### What this PR does / why we need it:
It fixes a structured log entry on level info, which is emitted only on windows kubelets during startup. The key is changed from `dispaly name` to `display name`.

This log field only exists on the windows kubelet build and is still readable by a human. The typo only slightly distracts the user when reading or grepping it, for example in structured log aggregation systems.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
N/A