### PR TITLE
Add feature-gated audit id handler that validates audit ids

### DIFF
--- a/pkg/features/versioned_kube_features.go
+++ b/pkg/features/versioned_kube_features.go
@@ -262,6 +262,10 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 		{Version: version.MustParse("1.30"), Default: false, PreRelease: featuregate.Alpha},
 	},
 
+	genericfeatures.AuditIDValidation: {
+		{Version: version.MustParse("1.33"), Default: true, PreRelease: featuregate.GA},
+	},
+
 	genericfeatures.AuthorizeWithSelectors: {
 		{Version: version.MustParse("1.31"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("1.32"), Default: true, PreRelease: featuregate.Beta},

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit_init.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit_init.go
@@ -18,10 +18,15 @@ package filters
 
 import (
 	"net/http"
+	"regexp"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	auditinternal "k8s.io/apiserver/pkg/apis/audit"
 	"k8s.io/apiserver/pkg/audit"
+	"k8s.io/apiserver/pkg/endpoints/handlers/responsewriters"
 
 	"github.com/google/uuid"
 )
@@ -31,12 +36,41 @@ import (
 // a. If the caller does not specify a value for Audit-ID in the request header, we generate a new audit ID
 // b. We echo the Audit-ID value to the caller via the response Header 'Audit-ID'.
 func WithAuditInit(handler http.Handler) http.Handler {
-	return withAuditInit(handler, func() string {
-		return uuid.New().String()
-	})
+	return withAuditInit(handler, defaultNewAuditID, nil, nil)
 }
 
-func withAuditInit(handler http.Handler, newAuditIDFunc func() string) http.Handler {
+// WithValidatingAuditInit initializes the audit context and attaches the Audit-ID associated
+// with a request, validating that a client provided Audit-ID satisfies the following:
+// - No longer than 64 characters
+// - Only contains alphanumeric characters, separable with a hyphen (-)
+//
+// If the caller does not specify a value for Audit-ID in the request header, we generate a new audit ID.
+// Audit-ID values are echoed to the caller via the response header 'Audit-ID'.
+func WithValidatingAuditInit(handler http.Handler, serializer runtime.NegotiatedSerializer) http.Handler {
+	return withAuditInit(handler, defaultNewAuditID, validateAuditID, invalidAuditID(serializer))
+}
+
+func defaultNewAuditID() string {
+	return uuid.New().String()
+}
+
+var auditIDPatternRegex = regexp.MustCompile("^([A-Za-z0-9][A-Za-z0-9-]*[A-Za-z0-9]+)$")
+
+const maxAuditIDLength = 64
+
+func validateAuditID(id string) bool {
+	if len(id) > maxAuditIDLength {
+		return false
+	}
+
+	if !auditIDPatternRegex.MatchString(id) {
+		return false
+	}
+
+	return true
+}
+
+func withAuditInit(handler http.Handler, newAuditIDFunc func() string, auditIDValidationFunc func(string) bool, validationFailed http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := audit.WithAuditContext(r.Context())
 		r = r.WithContext(ctx)
@@ -60,6 +94,21 @@ func withAuditInit(handler http.Handler, newAuditIDFunc func() string) http.Hand
 			w.Header().Set(auditinternal.HeaderAuditID, auditID)
 		}
 
+		if auditIDValidationFunc != nil {
+			valid := auditIDValidationFunc(auditID)
+			if !valid {
+				validationFailed.ServeHTTP(w, r)
+				return
+			}
+		}
+
 		handler.ServeHTTP(w, r)
+	})
+}
+
+func invalidAuditID(serializer runtime.NegotiatedSerializer) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gv := schema.GroupVersion{}
+		responsewriters.ErrorNegotiated(apierrors.NewBadRequest("provided Audit-ID is invalid. Must be less than 64 characters in length and only contain alphanumeric characters separated by hyphens (-)."), serializer, gv, w, r)
 	})
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit_init_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit_init_test.go
@@ -23,6 +23,8 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apiserver/pkg/audit"
 )
 
@@ -80,7 +82,7 @@ func TestWithAuditID(t *testing.T) {
 
 			wrapped := WithAuditInit(handler)
 			if test.newAuditIDFunc != nil {
-				wrapped = withAuditInit(handler, test.newAuditIDFunc)
+				wrapped = withAuditInit(handler, test.newAuditIDFunc, nil, nil)
 			}
 
 			testRequest, err := http.NewRequest(http.MethodGet, "/api/v1/namespaces", nil)
@@ -109,5 +111,134 @@ func TestWithAuditID(t *testing.T) {
 				t.Errorf("WithAuditID: expected Audit-ID response header: %q, but got: %q", test.auditIDExpected, auditIDEchoed)
 			}
 		})
+	}
+}
+
+func TestWithValidatingAuditID(t *testing.T) {
+	largeAuditID := fmt.Sprintf("%s-%s", uuid.New().String(), uuid.New().String())
+	tests := []struct {
+		name                 string
+		newAuditIDFunc       func() string
+		auditIDSpecified     string
+		auditIDExpected      string
+		innerHandlerExpected bool
+	}{
+		{
+			name:                 "user specifies a value for Audit-ID in the request header",
+			auditIDSpecified:     "foo-bar-baz",
+			auditIDExpected:      "foo-bar-baz",
+			innerHandlerExpected: true,
+		},
+		{
+			name: "user does not specify a value for Audit-ID in the request header",
+			newAuditIDFunc: func() string {
+				return "foo-bar-baz"
+			},
+			auditIDExpected:      "foo-bar-baz",
+			innerHandlerExpected: true,
+		},
+		{
+			name: "the generated Audit-ID is too large, should fail validation",
+			newAuditIDFunc: func() string {
+				return largeAuditID
+			},
+			auditIDExpected:      largeAuditID,
+			innerHandlerExpected: false,
+		},
+		{
+			name: "the generated Audit-ID has invalid characters, should fail validation",
+			newAuditIDFunc: func() string {
+				return "foo-$%!@#-baz"
+			},
+			auditIDExpected:      "foo-$%!@#-baz",
+			innerHandlerExpected: false,
+		},
+		{
+			name:                 "the value in Audit-ID request header is too large, should return bad request",
+			auditIDSpecified:     largeAuditID,
+			auditIDExpected:      largeAuditID,
+			innerHandlerExpected: false,
+		},
+		{
+			name:                 "user specifies Audit-ID with invalid characters, should return bad request",
+			auditIDSpecified:     "foo-$%!@#-baz",
+			auditIDExpected:      "foo-$%!@#-baz",
+			innerHandlerExpected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			const auditKey = "Audit-ID"
+			var (
+				innerHandlerCallCount int
+				auditIDGot            string
+				found                 bool
+			)
+			handler := http.HandlerFunc(func(_ http.ResponseWriter, req *http.Request) {
+				innerHandlerCallCount++
+
+				// does the inner handler see the audit ID?
+				v, ok := audit.AuditIDFrom(req.Context())
+
+				found = ok
+				auditIDGot = string(v)
+			})
+
+			negotiatedSerializer := serializer.NewCodecFactory(runtime.NewScheme())
+			wrapped := WithValidatingAuditInit(handler, negotiatedSerializer)
+			if test.newAuditIDFunc != nil {
+				wrapped = withAuditInit(handler, test.newAuditIDFunc, validateAuditID, invalidAuditID(negotiatedSerializer))
+			}
+
+			testRequest, err := http.NewRequest(http.MethodGet, "/api/v1/namespaces", nil)
+			if err != nil {
+				t.Fatalf("failed to create new http request - %v", err)
+			}
+			if len(test.auditIDSpecified) > 0 {
+				testRequest.Header.Set(auditKey, test.auditIDSpecified)
+			}
+
+			w := httptest.NewRecorder()
+			wrapped.ServeHTTP(w, testRequest)
+
+			// Only run these validations on the test case if the inner handler is expected to be called.
+			if test.innerHandlerExpected {
+				if innerHandlerCallCount != 1 {
+					t.Errorf("WithValidatingAuditID: expected the inner handler to be invoked one time, but was invoked %d times", innerHandlerCallCount)
+				}
+				if !found {
+					t.Error("WithValidatingAuditID: expected request.AuditIDFrom to return true, but got false")
+				}
+				if test.auditIDExpected != auditIDGot {
+					t.Errorf("WithValidatingAuditID: expected the request context to have: %q, but got=%q", test.auditIDExpected, auditIDGot)
+				}
+			} else {
+				// if we are running a validating audit-id init test
+				// and the inner handler isn't expected to have run, we
+				// are testing an invalid audit-id scenario. In that case,
+				// ensure the status code returned is representative of
+				// a bad request (400).
+				if w.Code != http.StatusBadRequest {
+					t.Errorf("WithValidatingAuditID: expected status code %v but got %v", http.StatusBadRequest, w.Code)
+				}
+			}
+
+			auditIDEchoed := w.Header().Get(auditKey)
+			if test.auditIDExpected != auditIDEchoed {
+				t.Errorf("WithValidatingAuditID: expected Audit-ID response header: %q, but got: %q", test.auditIDExpected, auditIDEchoed)
+			}
+		})
+	}
+}
+
+func TestDefaultNewAuditIDAlwaysValid(t *testing.T) {
+	// try 1000 generated audit id's to build reasonable confidence that the
+	// defaultNewAuditID function always returns a valid audit id.
+	for range 1000 {
+		generatedAuditID := defaultNewAuditID()
+		if !validateAuditID(generatedAuditID) {
+			t.Errorf("defaultNewAuditID: generated audit id %q is not valid. length: %d, matches regex?: %v", generatedAuditID, len(generatedAuditID), auditIDPatternRegex.MatchString(generatedAuditID))
+		}
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
@@ -88,6 +88,12 @@ const (
 	// Enables serving watch requests in separate goroutines.
 	APIServingWithRoutine featuregate.Feature = "APIServingWithRoutine"
 
+	// owner: @everettraven
+	//
+	// Enables validation of client provided audit-id values.
+	// See https://github.com/kubernetes/kubernetes/issues/127801
+	AuditIDValidation = "AuditIDValidation"
+
 	// owner: @deads2k
 	// kep: https://kep.k8s.io/4601
 	//
@@ -301,14 +307,18 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 		{Version: version.MustParse("1.30"), Default: false, PreRelease: featuregate.Alpha},
 	},
 
-	BtreeWatchCache: {
-		{Version: version.MustParse("1.32"), Default: true, PreRelease: featuregate.Beta},
-		{Version: version.MustParse("1.33"), Default: true, PreRelease: featuregate.GA, LockToDefault: true},
+	AuditIDValidation: {
+		{Version: version.MustParse("1.33"), Default: true, PreRelease: featuregate.GA},
 	},
 
 	AuthorizeWithSelectors: {
 		{Version: version.MustParse("1.31"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("1.32"), Default: true, PreRelease: featuregate.Beta},
+	},
+
+	BtreeWatchCache: {
+		{Version: version.MustParse("1.32"), Default: true, PreRelease: featuregate.Beta},
+		{Version: version.MustParse("1.33"), Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	},
 
 	CBORServingAndStorage: {

--- a/test/featuregates_linter/test_data/versioned_feature_list.yaml
+++ b/test/featuregates_linter/test_data/versioned_feature_list.yaml
@@ -158,6 +158,12 @@
     lockToDefault: true
     preRelease: GA
     version: "1.31"
+- name: AuditIDValidation
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: GA
+    version: "1.33"
 - name: AuthorizeNodeWithSelectors
   versionedSpecs:
   - default: false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:
Outlined in https://github.com/kubernetes/kubernetes/issues/127801, there is no validation performed on audit ids leading to potential security risks as injecting a malicious string may result in vulnerabilities for systems that do some processing on audit ids.

This PR addresses this issue by:
- Adding a new feature gate, `AuditIDValidation`, that is enabled by default
- Updates the `filters.withAuditInit()` function with logic to validate audit ids, adding 2 new input parameters to the function signature:
    - A function for validating an audit id
    - A `http.Handler` to call `ServeHTTP()` on if the audit id is invalid
- Adds a new `filters.WithValidatingAuditInit()` function that calls `filters.withAuditInit()` providing inputs for the new parameters added to `filters.withAuditInit()`
- Updates the apiserver default handler chain to use `filters.WithValidatingAuditInit()` when the `AuditIDValidation` feature gate is enabled and `filters.WithAuditInit()` when it is disabled.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #127801 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added validation to audit ids specified in the 'Audit-ID' request header. Audit IDs must be less than 64 characters in length and only contain alphanumeric characters separated by hyphens ('-'). Audit ID validation can be disabled by disabling the `AuditIDValidation` feature gate.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
