### PR TITLE
E2E node: fix --timeout default

### DIFF
--- a/test/e2e_node/remote/remote.go
+++ b/test/e2e_node/remote/remote.go
@@ -154,7 +154,7 @@ func RunRemote(cfg RunRemoteConfig) (string, bool, error) {
 	}
 
 	allGinkgoFlags := cfg.GinkgoArgs
-	if !strings.Contains(allGinkgoFlags, "--timeout") {
+	if !strings.Contains(allGinkgoFlags, "-timeout") {
 		klog.Warningf("ginkgo flags are missing explicit --timeout (ginkgo defaults to 60 minutes)")
 		// see https://github.com/onsi/ginkgo/blob/master/docs/index.md#:~:text=ginkgo%20%2D%2Dtimeout%3Dduration
 		// ginkgo suite timeout should be more than the default but less than the


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

For unknown reasons, hack/make-rules/test-e2e-node.sh adds -timeout instead of --timeout. Therefore the fallback code in test/e2e_node/remote/remote.go didn't find it and added its own --timeout=60m after it. This effectively limits E2E node test runs to 60 minutes, regardless of what is specified in the job:

    W0206 09:53:51.425532    7151 remote.go:158] ginkgo flags are missing explicit --timeout (ginkgo defaults to 60 minutes)
    I0206 09:53:51.425565    7151 remote.go:165] updated ginkgo flags: -timeout=24h --label-filter="Feature: containsAny DynamicResourceAllocation && Feature: isSubsetOf { Beta, DynamicResourceAllocation } && !Flaky && !Slow"  --no-color -v --timeout=60m
    ...
    I0206 09:53:57.767096    7151 ssh.go:146] Running the command ssh, with args: ... timeout -k 30s 3600.000000s ./ginkgo -timeout=24h --label-filter="Feature: containsAny DynamicResourceAllocation && Feature: isSubsetOf { Beta, DynamicResourceAllocation } && !Flaky && !Slow"  --no-color -v --timeout=60m ...

Note that the timeout for the test was 60m in this case (hence the "timeout -k 30s 3600.000000s") but it could also be something larger.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @bart0sh 