### PR TITLE
Disable ServiceAccountNodeAudienceRestriction feature gate by default in v1.32

### DIFF
--- a/pkg/features/versioned_kube_features.go
+++ b/pkg/features/versioned_kube_features.go
@@ -690,7 +690,7 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 	},
 
 	ServiceAccountNodeAudienceRestriction: {
-		{Version: version.MustParse("1.32"), Default: true, PreRelease: featuregate.Beta},
+		{Version: version.MustParse("1.32"), Default: false, PreRelease: featuregate.Beta},
 	},
 
 	ServiceAccountTokenJTI: {

--- a/test/featuregates_linter/test_data/versioned_feature_list.yaml
+++ b/test/featuregates_linter/test_data/versioned_feature_list.yaml
@@ -1162,7 +1162,7 @@
     version: "1.29"
 - name: ServiceAccountNodeAudienceRestriction
   versionedSpecs:
-  - default: true
+  - default: false
     lockToDefault: false
     preRelease: Beta
     version: "1.32"


### PR DESCRIPTION
```release-note
Fixes a 1.32 regression in with the ServiceAccountNodeAudienceRestriction feature where `azureFile` volumes encounter "failed to get service accoount token attributes" errors. Reverts the `ServiceAccountNodeAudienceRestriction` feature to disabled in v1.32. Refer to https://github.com/kubernetes/kubernetes/issues/129935 for more details. If you're using in-tree inline volumes or in-tree persistent volumes whose CSI drivers depend on service account tokens, do not enable this feature in the 1.32 release.
```

/kind regression
/sig auth
/triage accepted
/priority important-soon