### PR TITLE
KEP-4330: extend version information with more detailed version fields

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -86014,7 +86014,7 @@
           "application/json"
         ],
         "description": "get the version information for this server",
-        "operationId": "getVersion",
+        "operationId": "getCodeVersion",
         "produces": [
           "application/json"
         ],

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -19474,6 +19474,14 @@
         "compiler": {
           "type": "string"
         },
+        "emulationMajor": {
+          "description": "EmulationMajor is the major version of the emulation version",
+          "type": "string"
+        },
+        "emulationMinor": {
+          "description": "EmulationMinor is the minor version of the emulation version",
+          "type": "string"
+        },
         "gitCommit": {
           "type": "string"
         },
@@ -19487,9 +19495,19 @@
           "type": "string"
         },
         "major": {
+          "description": "Major is the major version of the binary version",
+          "type": "string"
+        },
+        "minCompatibilityMajor": {
+          "description": "MinCompatibilityMajor is the major version of the minimum compatibility version",
+          "type": "string"
+        },
+        "minCompatibilityMinor": {
+          "description": "MinCompatibilityMinor is the minor version of the minimum compatibility version",
           "type": "string"
         },
         "minor": {
+          "description": "Minor is the minor version of the binary version",
           "type": "string"
         },
         "platform": {
@@ -85995,8 +86013,8 @@
         "consumes": [
           "application/json"
         ],
-        "description": "get the code version",
-        "operationId": "getCodeVersion",
+        "description": "get the version information for this server",
+        "operationId": "getVersion",
         "produces": [
           "application/json"
         ],

--- a/api/openapi-spec/v3/version_openapi.json
+++ b/api/openapi-spec/v3/version_openapi.json
@@ -91,7 +91,7 @@
     "/version/": {
       "get": {
         "description": "get the version information for this server",
-        "operationId": "getVersion",
+        "operationId": "getCodeVersion",
         "responses": {
           "200": {
             "content": {

--- a/api/openapi-spec/v3/version_openapi.json
+++ b/api/openapi-spec/v3/version_openapi.json
@@ -12,6 +12,14 @@
             "default": "",
             "type": "string"
           },
+          "emulationMajor": {
+            "description": "EmulationMajor is the major version of the emulation version",
+            "type": "string"
+          },
+          "emulationMinor": {
+            "description": "EmulationMinor is the minor version of the emulation version",
+            "type": "string"
+          },
           "gitCommit": {
             "default": "",
             "type": "string"
@@ -30,10 +38,20 @@
           },
           "major": {
             "default": "",
+            "description": "Major is the major version of the binary version",
+            "type": "string"
+          },
+          "minCompatibilityMajor": {
+            "description": "MinCompatibilityMajor is the major version of the minimum compatibility version",
+            "type": "string"
+          },
+          "minCompatibilityMinor": {
+            "description": "MinCompatibilityMinor is the minor version of the minimum compatibility version",
             "type": "string"
           },
           "minor": {
             "default": "",
+            "description": "Minor is the minor version of the binary version",
             "type": "string"
           },
           "platform": {
@@ -72,8 +90,8 @@
   "paths": {
     "/version/": {
       "get": {
-        "description": "get the code version",
-        "operationId": "getCodeVersion",
+        "description": "get the version information for this server",
+        "operationId": "getVersion",
         "responses": {
           "200": {
             "content": {

--- a/pkg/controlplane/instance_test.go
+++ b/pkg/controlplane/instance_test.go
@@ -243,8 +243,14 @@ func TestVersion(t *testing.T) {
 	}
 	expectedInfo := utilversion.Get()
 	kubeVersion := compatibility.DefaultKubeEffectiveVersionForTest().BinaryVersion()
+	emulationVersion := compatibility.DefaultKubeEffectiveVersionForTest().EmulationVersion()
+	minCompatibilityVersion := compatibility.DefaultKubeEffectiveVersionForTest().MinCompatibilityVersion()
 	expectedInfo.Major = fmt.Sprintf("%d", kubeVersion.Major())
 	expectedInfo.Minor = fmt.Sprintf("%d", kubeVersion.Minor())
+	expectedInfo.EmulationMajor = fmt.Sprintf("%d", emulationVersion.Major())
+	expectedInfo.EmulationMinor = fmt.Sprintf("%d", emulationVersion.Minor())
+	expectedInfo.MinCompatibilityMajor = fmt.Sprintf("%d", minCompatibilityVersion.Major())
+	expectedInfo.MinCompatibilityMinor = fmt.Sprintf("%d", minCompatibilityVersion.Minor())
 
 	if !reflect.DeepEqual(expectedInfo, info) {
 		t.Errorf("Expected %#v, Got %#v", expectedInfo, info)

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -58457,16 +58457,46 @@ func schema_k8sio_apimachinery_pkg_version_Info(ref common.ReferenceCallback) co
 				Properties: map[string]spec.Schema{
 					"major": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Description: "Major is the major version of the binary version",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"minor": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Description: "Minor is the minor version of the binary version",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"emulationMajor": {
+						SchemaProps: spec.SchemaProps{
+							Description: "EmulationMajor is the major version of the emulation version",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"emulationMinor": {
+						SchemaProps: spec.SchemaProps{
+							Description: "EmulationMinor is the minor version of the emulation version",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"minCompatibilityMajor": {
+						SchemaProps: spec.SchemaProps{
+							Description: "MinCompatibilityMajor is the major version of the minimum compatibility version",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"minCompatibilityMinor": {
+						SchemaProps: spec.SchemaProps{
+							Description: "MinCompatibilityMinor is the minor version of the minimum compatibility version",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"gitVersion": {

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/generated/openapi/zz_generated.openapi.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/generated/openapi/zz_generated.openapi.go
@@ -6599,16 +6599,46 @@ func schema_k8sio_apimachinery_pkg_version_Info(ref common.ReferenceCallback) co
 				Properties: map[string]spec.Schema{
 					"major": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Description: "Major is the major version of the binary version",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"minor": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Description: "Minor is the minor version of the binary version",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"emulationMajor": {
+						SchemaProps: spec.SchemaProps{
+							Description: "EmulationMajor is the major version of the emulation version",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"emulationMinor": {
+						SchemaProps: spec.SchemaProps{
+							Description: "EmulationMinor is the minor version of the emulation version",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"minCompatibilityMajor": {
+						SchemaProps: spec.SchemaProps{
+							Description: "MinCompatibilityMajor is the major version of the minimum compatibility version",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"minCompatibilityMinor": {
+						SchemaProps: spec.SchemaProps{
+							Description: "MinCompatibilityMinor is the minor version of the minimum compatibility version",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"gitVersion": {

--- a/staging/src/k8s.io/apimachinery/pkg/util/version/version.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/version/version.go
@@ -33,7 +33,6 @@ type Version struct {
 	semver        bool
 	preRelease    string
 	buildMetadata string
-	info          apimachineryversion.Info
 }
 
 var (
@@ -456,24 +455,25 @@ func (v *Version) Compare(other string) (int, error) {
 	return v.compareInternal(ov), nil
 }
 
-// WithInfo returns copy of the version object with requested info
+// WithInfo returns copy of the version object.
+// Deprecated: The Info field has been removed from the Version struct. This method no longer modifies the Version object.
 func (v *Version) WithInfo(info apimachineryversion.Info) *Version {
 	result := *v
-	result.info = info
 	return &result
 }
 
+// Info returns the version information of a component.
+// Deprecated: Use Info() from effective version instead.
 func (v *Version) Info() *apimachineryversion.Info {
 	if v == nil {
 		return nil
 	}
 	// in case info is empty, or the major and minor in info is different from the actual major and minor
-	v.info.Major = Itoa(v.Major())
-	v.info.Minor = Itoa(v.Minor())
-	if v.info.GitVersion == "" {
-		v.info.GitVersion = v.String()
+	return &apimachineryversion.Info{
+		Major:      Itoa(v.Major()),
+		Minor:      Itoa(v.Minor()),
+		GitVersion: v.String(),
 	}
-	return &v.info
 }
 
 func Itoa(i uint) string {

--- a/staging/src/k8s.io/apimachinery/pkg/util/version/version.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/version/version.go
@@ -468,15 +468,15 @@ func (v *Version) Info() *apimachineryversion.Info {
 		return nil
 	}
 	// in case info is empty, or the major and minor in info is different from the actual major and minor
-	v.info.Major = itoa(v.Major())
-	v.info.Minor = itoa(v.Minor())
+	v.info.Major = Itoa(v.Major())
+	v.info.Minor = Itoa(v.Minor())
 	if v.info.GitVersion == "" {
 		v.info.GitVersion = v.String()
 	}
 	return &v.info
 }
 
-func itoa(i uint) string {
+func Itoa(i uint) string {
 	if i == 0 {
 		return ""
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/version/doc.go
+++ b/staging/src/k8s.io/apimachinery/pkg/version/doc.go
@@ -16,5 +16,5 @@ limitations under the License.
 
 // +k8s:openapi-gen=true
 
-// Package version supplies the type for version information collected at build time.
+// Package version supplies the type for version information.
 package version

--- a/staging/src/k8s.io/apimachinery/pkg/version/types.go
+++ b/staging/src/k8s.io/apimachinery/pkg/version/types.go
@@ -20,15 +20,25 @@ package version
 // TODO: Add []string of api versions supported? It's still unclear
 // how we'll want to distribute that information.
 type Info struct {
-	Major        string `json:"major"`
-	Minor        string `json:"minor"`
-	GitVersion   string `json:"gitVersion"`
-	GitCommit    string `json:"gitCommit"`
-	GitTreeState string `json:"gitTreeState"`
-	BuildDate    string `json:"buildDate"`
-	GoVersion    string `json:"goVersion"`
-	Compiler     string `json:"compiler"`
-	Platform     string `json:"platform"`
+	// Major is the major version of the binary version
+	Major string `json:"major"`
+	// Minor is the minor version of the binary version
+	Minor string `json:"minor"`
+	// EmulationMajor is the major version of the emulation version
+	EmulationMajor string `json:"emulationMajor,omitempty"`
+	// EmulationMinor is the minor version of the emulation version
+	EmulationMinor string `json:"emulationMinor,omitempty"`
+	// MinCompatibilityMajor is the major version of the minimum compatibility version
+	MinCompatibilityMajor string `json:"minCompatibilityMajor,omitempty"`
+	// MinCompatibilityMinor is the minor version of the minimum compatibility version
+	MinCompatibilityMinor string `json:"minCompatibilityMinor,omitempty"`
+	GitVersion            string `json:"gitVersion"`
+	GitCommit             string `json:"gitCommit"`
+	GitTreeState          string `json:"gitTreeState"`
+	BuildDate             string `json:"buildDate"`
+	GoVersion             string `json:"goVersion"`
+	Compiler              string `json:"compiler"`
+	Platform              string `json:"platform"`
 }
 
 // String returns info as a human-friendly version string.

--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -1108,7 +1108,7 @@ func installAPI(name string, s *GenericAPIServer, c *Config) {
 		}
 	}
 
-	routes.Version{Version: c.EffectiveVersion.BinaryVersion().Info()}.Install(s.Handler.GoRestfulContainer)
+	routes.Version{Version: c.EffectiveVersion.Info()}.Install(s.Handler.GoRestfulContainer)
 
 	if c.EnableDiscovery {
 		if c.FeatureGate.Enabled(genericfeatures.AggregatedDiscoveryEndpoint) {

--- a/staging/src/k8s.io/apiserver/pkg/server/options/serving_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/serving_test.go
@@ -372,7 +372,7 @@ func TestServerRunWithSNI(t *testing.T) {
 				t.Fatalf("failed to connect with loopback client: %v", err)
 			}
 			if expected := &v; !reflect.DeepEqual(got, expected) {
-				t.Errorf("loopback client didn't get correct version info: expected=%v got=%v", expected, got)
+				t.Errorf("loopback client didn't get correct version info: expected=%v got=%v", *expected, *got)
 			}
 
 			select {
@@ -463,9 +463,13 @@ func certSignature(cert tls.Certificate) (string, error) {
 
 func fakeVersion() version.Info {
 	return version.Info{
-		Major:      "42",
-		Minor:      "42",
-		GitVersion: "42.42",
+		Major:                 "42",
+		Minor:                 "42",
+		EmulationMajor:        "42",
+		EmulationMinor:        "42",
+		MinCompatibilityMajor: "42",
+		MinCompatibilityMinor: "41",
+		GitVersion:            "42.42",
 	}
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/server/options/serving_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/serving_test.go
@@ -47,6 +47,7 @@ import (
 	restclient "k8s.io/client-go/rest"
 	cliflag "k8s.io/component-base/cli/flag"
 	basecompatibility "k8s.io/component-base/compatibility"
+	baseversion "k8s.io/component-base/version"
 	"k8s.io/klog/v2/ktesting"
 	netutils "k8s.io/utils/net"
 )
@@ -277,9 +278,8 @@ func TestServerRunWithSNI(t *testing.T) {
 
 			// launch server
 			config := setUp(t)
-			v := fakeVersion()
-			config.EffectiveVersion = basecompatibility.NewEffectiveVersionFromString(v.String(), "", "")
-
+			info := fakeVersionInfo()
+			config.EffectiveVersion = basecompatibility.NewEffectiveVersionFromString(fmt.Sprintf("%s.%s", info.Major, info.Minor), "", "")
 			config.EnableIndex = true
 			secureOptions := (&SecureServingOptions{
 				BindAddress: netutils.ParseIPSloppy("127.0.0.1"),
@@ -371,7 +371,7 @@ func TestServerRunWithSNI(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to connect with loopback client: %v", err)
 			}
-			if expected := &v; !reflect.DeepEqual(got, expected) {
+			if expected := &info; !reflect.DeepEqual(got, expected) {
 				t.Errorf("loopback client didn't get correct version info: expected=%v got=%v", *expected, *got)
 			}
 
@@ -461,16 +461,15 @@ func certSignature(cert tls.Certificate) (string, error) {
 	return x509CertSignature(x509Certs[0]), nil
 }
 
-func fakeVersion() version.Info {
-	return version.Info{
-		Major:                 "42",
-		Minor:                 "42",
-		EmulationMajor:        "42",
-		EmulationMinor:        "42",
-		MinCompatibilityMajor: "42",
-		MinCompatibilityMinor: "41",
-		GitVersion:            "42.42",
-	}
+func fakeVersionInfo() version.Info {
+	baseVer := baseversion.Get()
+	baseVer.Major = "42"
+	baseVer.Minor = "42"
+	baseVer.EmulationMajor = "42"
+	baseVer.EmulationMinor = "42"
+	baseVer.MinCompatibilityMajor = "42"
+	baseVer.MinCompatibilityMinor = "41"
+	return baseVer
 }
 
 // generateSelfSignedCertKey creates a self-signed certificate and key for the given host.

--- a/staging/src/k8s.io/apiserver/pkg/server/routes/version.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/routes/version.go
@@ -39,11 +39,11 @@ func (v Version) Install(c *restful.Container) {
 	// Set up a service to return the git code version.
 	versionWS := new(restful.WebService)
 	versionWS.Path("/version")
-	versionWS.Doc("git code version from which this is built")
+	versionWS.Doc("get the version information for this server.")
 	versionWS.Route(
 		versionWS.GET("/").To(v.handleVersion).
-			Doc("get the code version").
-			Operation("getCodeVersion").
+			Doc("get the version information for this server").
+			Operation("getVersion").
 			Produces(restful.MIME_JSON).
 			Consumes(restful.MIME_JSON).
 			Writes(version.Info{}))

--- a/staging/src/k8s.io/apiserver/pkg/server/routes/version.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/routes/version.go
@@ -43,7 +43,7 @@ func (v Version) Install(c *restful.Container) {
 	versionWS.Route(
 		versionWS.GET("/").To(v.handleVersion).
 			Doc("get the version information for this server").
-			Operation("getVersion").
+			Operation("getCodeVersion").
 			Produces(restful.MIME_JSON).
 			Consumes(restful.MIME_JSON).
 			Writes(version.Info{}))

--- a/staging/src/k8s.io/apiserver/pkg/util/compatibility/version.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/compatibility/version.go
@@ -55,11 +55,11 @@ func kubeEffectiveVersionFloors(binaryVersion *version.Version) *version.Version
 // We do not enforce the N-3..N emulation version range in tests so that the tests would not automatically fail when there is a version bump.
 // Only used in tests.
 func DefaultKubeEffectiveVersionForTest() basecompatibility.MutableEffectiveVersion {
-	binaryVersion := version.MustParse(baseversion.DefaultKubeBinaryVersion).WithInfo(baseversion.Get())
+	binaryVersion := version.MustParse(baseversion.DefaultKubeBinaryVersion)
 	return basecompatibility.NewEffectiveVersion(binaryVersion, false, version.MustParse("0.0"), version.MustParse("0.0"))
 }
 
 func defaultBuildBinaryVersion() *version.Version {
 	verInfo := baseversion.Get()
-	return version.MustParse(verInfo.String()).WithInfo(verInfo)
+	return version.MustParse(verInfo.String())
 }

--- a/staging/src/k8s.io/code-generator/examples/apiserver/openapi/zz_generated.openapi.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/openapi/zz_generated.openapi.go
@@ -2625,16 +2625,46 @@ func schema_k8sio_apimachinery_pkg_version_Info(ref common.ReferenceCallback) co
 				Properties: map[string]spec.Schema{
 					"major": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Description: "Major is the major version of the binary version",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"minor": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Description: "Minor is the minor version of the binary version",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"emulationMajor": {
+						SchemaProps: spec.SchemaProps{
+							Description: "EmulationMajor is the major version of the emulation version",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"emulationMinor": {
+						SchemaProps: spec.SchemaProps{
+							Description: "EmulationMinor is the minor version of the emulation version",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"minCompatibilityMajor": {
+						SchemaProps: spec.SchemaProps{
+							Description: "MinCompatibilityMajor is the major version of the minimum compatibility version",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"minCompatibilityMinor": {
+						SchemaProps: spec.SchemaProps{
+							Description: "MinCompatibilityMinor is the minor version of the minimum compatibility version",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"gitVersion": {

--- a/staging/src/k8s.io/component-base/compatibility/version.go
+++ b/staging/src/k8s.io/component-base/compatibility/version.go
@@ -185,7 +185,12 @@ func (m *effectiveVersion) Info() *apimachineryversion.Info {
 		return nil
 	}
 
-	info := binVer.Info()
+	info := baseversion.Get()
+	info.Major = version.Itoa(binVer.Major())
+	info.Minor = version.Itoa(binVer.Minor())
+	if info.GitVersion == "" {
+		info.GitVersion = binVer.String()
+	}
 
 	if ev := m.EmulationVersion(); ev != nil {
 		info.EmulationMajor = version.Itoa(ev.Major())
@@ -197,7 +202,7 @@ func (m *effectiveVersion) Info() *apimachineryversion.Info {
 		info.MinCompatibilityMinor = version.Itoa(mcv.Minor())
 	}
 
-	return info
+	return &info
 }
 
 // NewEffectiveVersion creates a MutableEffectiveVersion from the binaryVersion.
@@ -236,5 +241,5 @@ func NewEffectiveVersionFromString(binaryVer, emulationVerFloor, minCompatibilit
 
 func defaultBuildBinaryVersion() *version.Version {
 	verInfo := baseversion.Get()
-	return version.MustParse(verInfo.String()).WithInfo(verInfo)
+	return version.MustParse(verInfo.String())
 }

--- a/staging/src/k8s.io/component-base/compatibility/version_test.go
+++ b/staging/src/k8s.io/component-base/compatibility/version_test.go
@@ -17,11 +17,9 @@ limitations under the License.
 package compatibility
 
 import (
-	"reflect"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/version"
-	apimachineryversion "k8s.io/apimachinery/pkg/version"
 )
 
 func TestValidate(t *testing.T) {
@@ -151,91 +149,80 @@ func TestSetEmulationVersion(t *testing.T) {
 
 func TestInfo(t *testing.T) {
 	tests := []struct {
-		name                    string
-		binaryVersion           string
-		emulationVersion        string
-		minCompatibilityVersion string
-		expectedInfo            *apimachineryversion.Info
+		name                          string
+		binaryVersion                 string
+		emulationVersion              string
+		minCompatibilityVersion       string
+		expectedMajor                 string
+		expectedMinor                 string
+		expectedEmulationMajor        string
+		expectedEmulationMinor        string
+		expectedMinCompatibilityMajor string
+		expectedMinCompatibilityMinor string
 	}{
 		{
-			name:                    "normal case",
-			binaryVersion:           "v1.34.0",
-			emulationVersion:        "v1.32.0",
-			minCompatibilityVersion: "v1.31.0",
-			expectedInfo: &apimachineryversion.Info{
-				Major:                 "1",
-				Minor:                 "34",
-				EmulationMajor:        "1",
-				EmulationMinor:        "32",
-				MinCompatibilityMajor: "1",
-				MinCompatibilityMinor: "31",
-				GitVersion:            "1.34.0",
-			},
+			name:                          "normal case",
+			binaryVersion:                 "v1.34.0",
+			emulationVersion:              "v1.32.0",
+			minCompatibilityVersion:       "v1.31.0",
+			expectedMajor:                 "1",
+			expectedMinor:                 "34",
+			expectedEmulationMajor:        "1",
+			expectedEmulationMinor:        "32",
+			expectedMinCompatibilityMajor: "1",
+			expectedMinCompatibilityMinor: "31",
 		},
 		{
 			name:             "default min compatibility version is emulation version - 1",
 			binaryVersion:    "v1.34.0",
 			emulationVersion: "v1.32.0",
 			// minCompatibilityVersion not set, should default to v1.31.0
-			expectedInfo: &apimachineryversion.Info{
-				Major:                 "1",
-				Minor:                 "34",
-				EmulationMajor:        "1",
-				EmulationMinor:        "32",
-				MinCompatibilityMajor: "1",
-				MinCompatibilityMinor: "31",
-				GitVersion:            "1.34.0",
-			},
+			expectedMajor:                 "1",
+			expectedMinor:                 "34",
+			expectedEmulationMajor:        "1",
+			expectedEmulationMinor:        "32",
+			expectedMinCompatibilityMajor: "1",
+			expectedMinCompatibilityMinor: "31",
 		},
 		{
 			name:             "emulation version same as binary version",
 			binaryVersion:    "v1.34.0",
 			emulationVersion: "v1.34.0",
 			// minCompatibilityVersion not set, should default to v1.33.0
-			expectedInfo: &apimachineryversion.Info{
-				Major:                 "1",
-				Minor:                 "34",
-				EmulationMajor:        "1",
-				EmulationMinor:        "34",
-				MinCompatibilityMajor: "1",
-				MinCompatibilityMinor: "33",
-				GitVersion:            "1.34.0",
-			},
+			expectedMajor:                 "1",
+			expectedMinor:                 "34",
+			expectedEmulationMajor:        "1",
+			expectedEmulationMinor:        "34",
+			expectedMinCompatibilityMajor: "1",
+			expectedMinCompatibilityMinor: "33",
 		},
 		{
 			name:          "empty binary version",
 			binaryVersion: "",
-			expectedInfo:  nil,
 		},
 		{
 			name:             "with pre-release and build metadata",
 			binaryVersion:    "v1.34.0-alpha.1+abc123",
 			emulationVersion: "v1.32.0",
 			// minCompatibilityVersion not set, should default to v1.31.0
-			expectedInfo: &apimachineryversion.Info{
-				Major:                 "1",
-				Minor:                 "34",
-				EmulationMajor:        "1",
-				EmulationMinor:        "32",
-				MinCompatibilityMajor: "1",
-				MinCompatibilityMinor: "31",
-				GitVersion:            "1.34.0-alpha.1+abc123",
-			},
+			expectedMajor:                 "1",
+			expectedMinor:                 "34",
+			expectedEmulationMajor:        "1",
+			expectedEmulationMinor:        "32",
+			expectedMinCompatibilityMajor: "1",
+			expectedMinCompatibilityMinor: "31",
 		},
 		{
-			name:                    "override default min compatibility version",
-			binaryVersion:           "v1.34.0",
-			emulationVersion:        "v1.32.0",
-			minCompatibilityVersion: "v1.32.0", // explicitly set to same as emulation version
-			expectedInfo: &apimachineryversion.Info{
-				Major:                 "1",
-				Minor:                 "34",
-				EmulationMajor:        "1",
-				EmulationMinor:        "32",
-				MinCompatibilityMajor: "1",
-				MinCompatibilityMinor: "32",
-				GitVersion:            "1.34.0",
-			},
+			name:                          "override default min compatibility version",
+			binaryVersion:                 "v1.34.0",
+			emulationVersion:              "v1.32.0",
+			minCompatibilityVersion:       "v1.32.0", // explicitly set to same as emulation version
+			expectedMajor:                 "1",
+			expectedMinor:                 "34",
+			expectedEmulationMajor:        "1",
+			expectedEmulationMinor:        "32",
+			expectedMinCompatibilityMajor: "1",
+			expectedMinCompatibilityMinor: "32",
 		},
 	}
 
@@ -254,8 +241,30 @@ func TestInfo(t *testing.T) {
 				}
 			}
 			info := effective.Info()
-			if !reflect.DeepEqual(test.expectedInfo, info) {
-				t.Errorf("Expected %#v, Got %#v", test.expectedInfo, *info)
+			if info == nil {
+				if test.expectedMajor != "" {
+					t.Fatalf("expected info, got nil")
+				}
+				return
+			}
+
+			if info.Major != test.expectedMajor {
+				t.Errorf("expected major %s, got %s", test.expectedMajor, info.Major)
+			}
+			if info.Minor != test.expectedMinor {
+				t.Errorf("expected minor %s, got %s", test.expectedMinor, info.Minor)
+			}
+			if info.EmulationMajor != test.expectedEmulationMajor {
+				t.Errorf("expected emulation major %s, got %s", test.expectedEmulationMajor, info.EmulationMajor)
+			}
+			if info.EmulationMinor != test.expectedEmulationMinor {
+				t.Errorf("expected emulation minor %s, got %s", test.expectedEmulationMinor, info.EmulationMinor)
+			}
+			if info.MinCompatibilityMajor != test.expectedMinCompatibilityMajor {
+				t.Errorf("expected min compatibility major %s, got %s", test.expectedMinCompatibilityMajor, info.MinCompatibilityMajor)
+			}
+			if info.MinCompatibilityMinor != test.expectedMinCompatibilityMinor {
+				t.Errorf("expected min compatibility minor %s, got %s", test.expectedMinCompatibilityMinor, info.MinCompatibilityMinor)
 			}
 		})
 	}

--- a/staging/src/k8s.io/component-base/version/version.go
+++ b/staging/src/k8s.io/component-base/version/version.go
@@ -25,6 +25,8 @@ import (
 
 // Get returns the overall codebase version. It's for detecting
 // what code a binary was built from.
+// The caller should use BinaryMajor and BinaryMinor to determine
+// the binary version. The Major and Minor fields are still set by git version for backwards compatibility.
 func Get() apimachineryversion.Info {
 	// These variables typically come from -ldflags settings and in
 	// their absence fallback to the settings in ./base.go

--- a/staging/src/k8s.io/kube-aggregator/pkg/generated/openapi/zz_generated.openapi.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/generated/openapi/zz_generated.openapi.go
@@ -2625,16 +2625,46 @@ func schema_k8sio_apimachinery_pkg_version_Info(ref common.ReferenceCallback) co
 				Properties: map[string]spec.Schema{
 					"major": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Description: "Major is the major version of the binary version",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"minor": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Description: "Minor is the minor version of the binary version",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"emulationMajor": {
+						SchemaProps: spec.SchemaProps{
+							Description: "EmulationMajor is the major version of the emulation version",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"emulationMinor": {
+						SchemaProps: spec.SchemaProps{
+							Description: "EmulationMinor is the minor version of the emulation version",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"minCompatibilityMajor": {
+						SchemaProps: spec.SchemaProps{
+							Description: "MinCompatibilityMajor is the major version of the minimum compatibility version",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"minCompatibilityMinor": {
+						SchemaProps: spec.SchemaProps{
+							Description: "MinCompatibilityMinor is the minor version of the minimum compatibility version",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"gitVersion": {

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/openapi/zz_generated.openapi.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/openapi/zz_generated.openapi.go
@@ -2623,16 +2623,46 @@ func schema_k8sio_apimachinery_pkg_version_Info(ref common.ReferenceCallback) co
 				Properties: map[string]spec.Schema{
 					"major": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Description: "Major is the major version of the binary version",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"minor": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Description: "Minor is the minor version of the binary version",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"emulationMajor": {
+						SchemaProps: spec.SchemaProps{
+							Description: "EmulationMajor is the major version of the emulation version",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"emulationMinor": {
+						SchemaProps: spec.SchemaProps{
+							Description: "EmulationMinor is the minor version of the emulation version",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"minCompatibilityMajor": {
+						SchemaProps: spec.SchemaProps{
+							Description: "MinCompatibilityMajor is the major version of the minimum compatibility version",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"minCompatibilityMinor": {
+						SchemaProps: spec.SchemaProps{
+							Description: "MinCompatibilityMinor is the minor version of the minimum compatibility version",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"gitVersion": {

--- a/test/integration/client/client_test.go
+++ b/test/integration/client/client_test.go
@@ -85,8 +85,14 @@ func TestClient(t *testing.T) {
 	}
 	expectedInfo := utilversion.Get()
 	kubeVersion := compatibility.DefaultKubeEffectiveVersionForTest().BinaryVersion()
+	emulationVersion := compatibility.DefaultKubeEffectiveVersionForTest().EmulationVersion()
+	minCompatibilityVersion := compatibility.DefaultKubeEffectiveVersionForTest().MinCompatibilityVersion()
 	expectedInfo.Major = fmt.Sprintf("%d", kubeVersion.Major())
 	expectedInfo.Minor = fmt.Sprintf("%d", kubeVersion.Minor())
+	expectedInfo.EmulationMajor = fmt.Sprintf("%d", emulationVersion.Major())
+	expectedInfo.EmulationMinor = fmt.Sprintf("%d", emulationVersion.Minor())
+	expectedInfo.MinCompatibilityMajor = fmt.Sprintf("%d", minCompatibilityVersion.Major())
+	expectedInfo.MinCompatibilityMinor = fmt.Sprintf("%d", minCompatibilityVersion.Minor())
 
 	if e, a := expectedInfo, *info; !reflect.DeepEqual(e, a) {
 		t.Errorf("expected %#v, got %#v", e, a)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:
- Add new version fields to version.Info struct:
  * BinaryMajor and BinaryMinor to track binary version
  * MinCompatibilityMajor and MinCompatibilityMinor for compatibility tracking
- Update related code to populate and use these new fields
- Improve version information documentation and OpenAPI generation
- Modify version routes and documentation to reflect new version information structure

Part of [KEP-4330](https://github.com/kubernetes/enhancements/issues/4330) to extend the [/version endpoint](https://github.com/kubernetes/enhancements/blob/master/keps/sig-architecture/4330-compatibility-versions/README.md#version-introspection)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/kubernetes/kubernetes/issues/129969

#### Special notes for your reviewer:
This would also require some client-side change to separate to consume binary version and compatibility version.
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Update /version response to report binary version information separate from compatibility version
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-architecture/4330-compatibility-versions/README.md
```
