### PR TITLE
mark QOSReserved as beta and enable by default

### DIFF
--- a/pkg/features/versioned_kube_features.go
+++ b/pkg/features/versioned_kube_features.go
@@ -613,6 +613,7 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 
 	QOSReserved: {
 		{Version: version.MustParse("1.11"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.33"), Default: true, PreRelease: featuregate.Beta},
 	},
 
 	RecoverVolumeExpansionFailure: {

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -1039,6 +1039,10 @@
     lockToDefault: false
     preRelease: Alpha
     version: "1.11"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.33"
 - name: RecoverVolumeExpansionFailure
   versionedSpecs:
   - default: false


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
deprecate the FG as it is alpha since v1.11.

When the FG is enabled, kubelet will respect `qosReserved` setting. So I just deprecate the FG and respect the `qosReserved`.

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/enhancements/issues/5046

#### Special notes for your reviewer:
I think there are two choices

1. deprecated it: remove the qosReserved setting.
1. deprecated it: respect the qosReserved setting.
1. promote it to beta and then GA: respect the qosReserved setting   **[This PR now]**
1. remove the fg: keep the qosReserved setting 
1. remove the fg: remove the qosReserved setting

**I think 2\3\4 are OK. I prefer 2 > 4 > 3.**  I am also OK for 3.

Currently, I prefer to the second choice since this FG is merely a gate and you need to additionally specify the qosReserved to use this feature.

https://github.com/kubernetes/kubernetes/blob/d36322f8d76c8e2a456e381bcc6bb43e4bbe602c/pkg/kubelet/cm/qos_container_manager_linux.go#L348-L377

#### Does this PR introduce a user-facing change?

```release-note
Promote feature gate QOSReserved to beta and enable by default 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/5046
```
