### PR TITLE
kubeadm: add --etcd-upgrade flag to kubeadm upgrade plan

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/fuzzer/fuzzer.go
+++ b/cmd/kubeadm/app/apis/kubeadm/fuzzer/fuzzer.go
@@ -169,5 +169,7 @@ func fuzzUpgradeConfiguration(obj *kubeadm.UpgradeConfiguration, c fuzz.Continue
 	obj.Apply.ImagePullPolicy = corev1.PullIfNotPresent
 	obj.Apply.ImagePullSerial = ptr.To(true)
 
+	obj.Plan.EtcdUpgrade = ptr.To(true)
+
 	kubeadm.SetDefaultTimeouts(&obj.Timeouts)
 }

--- a/cmd/kubeadm/app/apis/kubeadm/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/types.go
@@ -657,6 +657,9 @@ type UpgradePlanConfiguration struct {
 	// DryRun tells if the dry run mode is enabled, don't apply any change if it is and just output what would be done.
 	DryRun *bool
 
+	// EtcdUpgrade instructs kubeadm to execute etcd upgrade during upgrades.
+	EtcdUpgrade *bool
+
 	// IgnorePreflightErrors provides a slice of pre-flight errors to be ignored during the upgrade process, e.g. 'IsPrivilegedUser,Swap'.
 	// Value 'all' ignores errors from all checks.
 	IgnorePreflightErrors []string

--- a/cmd/kubeadm/app/apis/kubeadm/v1beta4/defaults.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta4/defaults.go
@@ -299,6 +299,10 @@ func SetDefaults_UpgradeConfiguration(obj *UpgradeConfiguration) {
 		obj.Apply.ImagePullSerial = ptr.To(true)
 	}
 
+	if obj.Plan.EtcdUpgrade == nil {
+		obj.Plan.EtcdUpgrade = ptr.To(true)
+	}
+
 	if obj.Timeouts == nil {
 		obj.Timeouts = &Timeouts{}
 	}

--- a/cmd/kubeadm/app/apis/kubeadm/v1beta4/doc.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta4/doc.go
@@ -24,6 +24,11 @@ limitations under the License.
 //
 // A list of changes since v1beta3:
 //
+// v1.33:
+//   - Add an `EtcdUpgrade` field into `UpgradeConfiguration.Plan` that can be used to control whether the etcd upgrade plan
+//     should be displayed.
+//
+// v1.31:
 //   - Support custom environment variables in control plane components under `ClusterConfiguration`.
 //     Use `APIServer.ExtraEnvs`, `ControllerManager.ExtraEnvs`, `Scheduler.ExtraEnvs`, `Etcd.Local.ExtraEnvs`.
 //   - The `ResetConfiguration` API type is now supported in v1beta4. Users are able to reset a node by passing

--- a/cmd/kubeadm/app/apis/kubeadm/v1beta4/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta4/types.go
@@ -749,6 +749,11 @@ type UpgradePlanConfiguration struct {
 	// +optional
 	DryRun *bool `json:"dryRun,omitempty"`
 
+	// EtcdUpgrade instructs kubeadm to execute etcd upgrade during upgrades.
+	// Defaults to true.
+	// +optional
+	EtcdUpgrade *bool `json:"etcdUpgrade,omitempty"`
+
 	// IgnorePreflightErrors provides a slice of pre-flight errors to be ignored during the upgrade process, e.g. 'IsPrivilegedUser,Swap'.
 	// Value 'all' ignores errors from all checks.
 	// +optional

--- a/cmd/kubeadm/app/apis/kubeadm/v1beta4/zz_generated.conversion.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta4/zz_generated.conversion.go
@@ -1141,6 +1141,7 @@ func autoConvert_v1beta4_UpgradePlanConfiguration_To_kubeadm_UpgradePlanConfigur
 	out.AllowExperimentalUpgrades = (*bool)(unsafe.Pointer(in.AllowExperimentalUpgrades))
 	out.AllowRCUpgrades = (*bool)(unsafe.Pointer(in.AllowRCUpgrades))
 	out.DryRun = (*bool)(unsafe.Pointer(in.DryRun))
+	out.EtcdUpgrade = (*bool)(unsafe.Pointer(in.EtcdUpgrade))
 	out.IgnorePreflightErrors = *(*[]string)(unsafe.Pointer(&in.IgnorePreflightErrors))
 	out.PrintConfig = (*bool)(unsafe.Pointer(in.PrintConfig))
 	return nil
@@ -1156,6 +1157,7 @@ func autoConvert_kubeadm_UpgradePlanConfiguration_To_v1beta4_UpgradePlanConfigur
 	out.AllowExperimentalUpgrades = (*bool)(unsafe.Pointer(in.AllowExperimentalUpgrades))
 	out.AllowRCUpgrades = (*bool)(unsafe.Pointer(in.AllowRCUpgrades))
 	out.DryRun = (*bool)(unsafe.Pointer(in.DryRun))
+	out.EtcdUpgrade = (*bool)(unsafe.Pointer(in.EtcdUpgrade))
 	out.IgnorePreflightErrors = *(*[]string)(unsafe.Pointer(&in.IgnorePreflightErrors))
 	out.PrintConfig = (*bool)(unsafe.Pointer(in.PrintConfig))
 	return nil

--- a/cmd/kubeadm/app/apis/kubeadm/v1beta4/zz_generated.deepcopy.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta4/zz_generated.deepcopy.go
@@ -864,6 +864,11 @@ func (in *UpgradePlanConfiguration) DeepCopyInto(out *UpgradePlanConfiguration) 
 		*out = new(bool)
 		**out = **in
 	}
+	if in.EtcdUpgrade != nil {
+		in, out := &in.EtcdUpgrade, &out.EtcdUpgrade
+		*out = new(bool)
+		**out = **in
+	}
 	if in.IgnorePreflightErrors != nil {
 		in, out := &in.IgnorePreflightErrors, &out.IgnorePreflightErrors
 		*out = make([]string, len(*in))

--- a/cmd/kubeadm/app/apis/kubeadm/zz_generated.deepcopy.go
+++ b/cmd/kubeadm/app/apis/kubeadm/zz_generated.deepcopy.go
@@ -904,6 +904,11 @@ func (in *UpgradePlanConfiguration) DeepCopyInto(out *UpgradePlanConfiguration) 
 		*out = new(bool)
 		**out = **in
 	}
+	if in.EtcdUpgrade != nil {
+		in, out := &in.EtcdUpgrade, &out.EtcdUpgrade
+		*out = new(bool)
+		**out = **in
+	}
 	if in.IgnorePreflightErrors != nil {
 		in, out := &in.IgnorePreflightErrors, &out.IgnorePreflightErrors
 		*out = make([]string, len(*in))

--- a/cmd/kubeadm/app/cmd/upgrade/apply.go
+++ b/cmd/kubeadm/app/cmd/upgrade/apply.go
@@ -50,7 +50,6 @@ type applyFlags struct {
 	nonInteractiveMode bool
 	force              bool
 	dryRun             bool
-	etcdUpgrade        bool
 	renewCerts         bool
 	patchesDir         string
 }
@@ -81,7 +80,6 @@ type applyData struct {
 func newCmdApply(apf *applyPlanFlags) *cobra.Command {
 	flags := &applyFlags{
 		applyPlanFlags: apf,
-		etcdUpgrade:    true,
 		renewCerts:     true,
 	}
 
@@ -126,7 +124,6 @@ func newCmdApply(apf *applyPlanFlags) *cobra.Command {
 	cmd.Flags().BoolVarP(&flags.nonInteractiveMode, "yes", "y", flags.nonInteractiveMode, "Perform the upgrade and do not prompt for confirmation (non-interactive mode).")
 	cmd.Flags().BoolVarP(&flags.force, options.Force, "f", flags.force, "Force upgrading although some requirements might not be met. This also implies non-interactive mode.")
 	cmd.Flags().BoolVar(&flags.dryRun, options.DryRun, flags.dryRun, "Do not change any state, just output what actions would be performed.")
-	cmd.Flags().BoolVar(&flags.etcdUpgrade, options.EtcdUpgrade, flags.etcdUpgrade, "Perform the upgrade of etcd.")
 	cmd.Flags().BoolVar(&flags.renewCerts, options.CertificateRenewal, flags.renewCerts, "Perform the renewal of certificates used by component changed during upgrades.")
 	options.AddPatchesFlag(cmd.Flags(), &flags.patchesDir)
 

--- a/cmd/kubeadm/app/cmd/upgrade/apply_test.go
+++ b/cmd/kubeadm/app/cmd/upgrade/apply_test.go
@@ -120,6 +120,7 @@ func TestNewApplyData(t *testing.T) {
 				allowExperimentalUpgrades: false,
 				allowRCUpgrades:           false,
 				printConfig:               false,
+				etcdUpgrade:               true,
 				out:                       os.Stdout,
 			}
 
@@ -132,7 +133,6 @@ func TestNewApplyData(t *testing.T) {
 
 			flags := &applyFlags{
 				applyPlanFlags: apf,
-				etcdUpgrade:    true,
 				renewCerts:     true,
 			}
 

--- a/cmd/kubeadm/app/cmd/upgrade/plan.go
+++ b/cmd/kubeadm/app/cmd/upgrade/plan.go
@@ -139,15 +139,19 @@ func runPlan(flagSet *pflag.FlagSet, flags *planFlags, args []string, printer ou
 	}
 
 	// Generate and print the upgrade plan
-	plan := genUpgradePlan(availUpgrades, configVersionStates)
+	etcdUpgrade, ok := cmdutil.ValueFromFlagsOrConfig(flagSet, options.EtcdUpgrade, upgradeCfg.Plan.EtcdUpgrade, &flags.etcdUpgrade).(*bool)
+	if !ok {
+		return cmdutil.TypeMismatchErr("etcdUpgrade", "bool")
+	}
+	plan := genUpgradePlan(availUpgrades, configVersionStates, *etcdUpgrade)
 	return printer.PrintObj(plan, os.Stdout)
 }
 
 // genUpgradePlan generates upgrade plan from available upgrades and component config version states
-func genUpgradePlan(availUpgrades []upgrade.Upgrade, configVersions []outputapiv1alpha3.ComponentConfigVersionState) *outputapiv1alpha3.UpgradePlan {
+func genUpgradePlan(availUpgrades []upgrade.Upgrade, configVersions []outputapiv1alpha3.ComponentConfigVersionState, etcdUpgrade bool) *outputapiv1alpha3.UpgradePlan {
 	plan := &outputapiv1alpha3.UpgradePlan{ConfigVersions: configVersions}
 	for _, up := range availUpgrades {
-		plan.AvailableUpgrades = append(plan.AvailableUpgrades, genAvailableUpgrade(&up))
+		plan.AvailableUpgrades = append(plan.AvailableUpgrades, genAvailableUpgrade(&up, etcdUpgrade))
 	}
 	return plan
 }
@@ -176,7 +180,7 @@ func appendKubeadmComponent(components []outputapiv1alpha3.ComponentUpgradePlan,
 }
 
 // genAvailableUpgrade generates available upgrade from upgrade object.
-func genAvailableUpgrade(up *upgrade.Upgrade) outputapiv1alpha3.AvailableUpgrade {
+func genAvailableUpgrade(up *upgrade.Upgrade, etcdUpgrade bool) outputapiv1alpha3.AvailableUpgrade {
 	components := []outputapiv1alpha3.ComponentUpgradePlan{}
 
 	if up.CanUpgradeKubelets() {
@@ -216,10 +220,12 @@ func genAvailableUpgrade(up *upgrade.Upgrade) outputapiv1alpha3.AvailableUpgrade
 	components = appendKubeadmComponent(components, up, constants.Kubeadm)
 
 	// If etcd is not external, we should include it in the upgrade plan
-	for _, oldVersion := range sortedSliceFromStringStringArrayMap(up.Before.EtcdVersions) {
-		nodeNames := up.Before.EtcdVersions[oldVersion]
-		for _, nodeName := range nodeNames {
-			components = append(components, newComponentUpgradePlan(constants.Etcd, oldVersion, up.After.EtcdVersion, nodeName))
+	if etcdUpgrade {
+		for _, oldVersion := range sortedSliceFromStringStringArrayMap(up.Before.EtcdVersions) {
+			nodeNames := up.Before.EtcdVersions[oldVersion]
+			for _, nodeName := range nodeNames {
+				components = append(components, newComponentUpgradePlan(constants.Etcd, oldVersion, up.After.EtcdVersion, nodeName))
+			}
 		}
 	}
 

--- a/cmd/kubeadm/app/cmd/upgrade/plan_test.go
+++ b/cmd/kubeadm/app/cmd/upgrade/plan_test.go
@@ -570,7 +570,7 @@ _____________________________________________________________________
 				t.Errorf("failed ToPrinter, err: %+v", err)
 			}
 
-			plan := genUpgradePlan(rt.upgrades, rt.versionStates)
+			plan := genUpgradePlan(rt.upgrades, rt.versionStates, true)
 			if err := printer.PrintObj(plan, rt.buf); err != nil {
 				t.Errorf("unexpected error when print object: %v", err)
 			}
@@ -814,7 +814,7 @@ _____________________________________________________________________
 				t.Errorf("failed ToPrinter, err: %+v", err)
 			}
 
-			plan := genUpgradePlan(upgrades, versionStates)
+			plan := genUpgradePlan(upgrades, versionStates, true)
 			if err := printer.PrintObj(plan, rt.buf); err != nil {
 				t.Errorf("unexpected error when print object: %v", err)
 			}

--- a/cmd/kubeadm/app/cmd/upgrade/upgrade.go
+++ b/cmd/kubeadm/app/cmd/upgrade/upgrade.go
@@ -35,6 +35,7 @@ type applyPlanFlags struct {
 	allowExperimentalUpgrades bool
 	allowRCUpgrades           bool
 	printConfig               bool
+	etcdUpgrade               bool
 	ignorePreflightErrors     []string
 	out                       io.Writer
 }
@@ -48,6 +49,7 @@ func NewCmdUpgrade(out io.Writer) *cobra.Command {
 		allowExperimentalUpgrades: false,
 		allowRCUpgrades:           false,
 		printConfig:               false,
+		etcdUpgrade:               true,
 		out:                       out,
 	}
 
@@ -71,5 +73,6 @@ func addApplyPlanFlags(fs *pflag.FlagSet, flags *applyPlanFlags) {
 	fs.BoolVar(&flags.allowExperimentalUpgrades, "allow-experimental-upgrades", flags.allowExperimentalUpgrades, "Show unstable versions of Kubernetes as an upgrade alternative and allow upgrading to an alpha/beta/release candidate versions of Kubernetes.")
 	fs.BoolVar(&flags.allowRCUpgrades, "allow-release-candidate-upgrades", flags.allowRCUpgrades, "Show release candidate versions of Kubernetes as an upgrade alternative and allow upgrading to a release candidate versions of Kubernetes.")
 	fs.BoolVar(&flags.printConfig, "print-config", flags.printConfig, "Specifies whether the configuration file that will be used in the upgrade should be printed or not.")
+	fs.BoolVar(&flags.etcdUpgrade, options.EtcdUpgrade, flags.etcdUpgrade, "Perform the upgrade of etcd.")
 	options.AddIgnorePreflightErrorsFlag(fs, &flags.ignorePreflightErrors)
 }

--- a/cmd/kubeadm/app/util/config/upgradeconfiguration_test.go
+++ b/cmd/kubeadm/app/util/config/upgradeconfiguration_test.go
@@ -63,6 +63,9 @@ func TestDocMapToUpgradeConfiguration(t *testing.T) {
 					ImagePullPolicy:    v1.PullIfNotPresent,
 					ImagePullSerial:    ptr.To(true),
 				},
+				Plan: kubeadmapi.UpgradePlanConfiguration{
+					EtcdUpgrade: ptr.To(true),
+				},
 			},
 		},
 		{
@@ -72,6 +75,9 @@ func TestDocMapToUpgradeConfiguration(t *testing.T) {
 					CertificateRenewal: ptr.To(false),
 				},
 				Node: kubeadmapiv1.UpgradeNodeConfiguration{
+					EtcdUpgrade: ptr.To(false),
+				},
+				Plan: kubeadmapiv1.UpgradePlanConfiguration{
 					EtcdUpgrade: ptr.To(false),
 				},
 				TypeMeta: metav1.TypeMeta{
@@ -91,6 +97,9 @@ func TestDocMapToUpgradeConfiguration(t *testing.T) {
 					EtcdUpgrade:        ptr.To(false),
 					ImagePullPolicy:    v1.PullIfNotPresent,
 					ImagePullSerial:    ptr.To(true),
+				},
+				Plan: kubeadmapi.UpgradePlanConfiguration{
+					EtcdUpgrade: ptr.To(false),
 				},
 			},
 		},
@@ -180,6 +189,9 @@ func TestLoadUpgradeConfigurationFromFile(t *testing.T) {
 					ImagePullPolicy:    v1.PullIfNotPresent,
 					ImagePullSerial:    ptr.To(true),
 				},
+				Plan: kubeadmapi.UpgradePlanConfiguration{
+					EtcdUpgrade: ptr.To(true),
+				},
 			},
 			wantErr: false,
 		},
@@ -236,6 +248,9 @@ func TestDefaultedUpgradeConfiguration(t *testing.T) {
 					ImagePullPolicy:    v1.PullIfNotPresent,
 					ImagePullSerial:    ptr.To(true),
 				},
+				Plan: kubeadmapi.UpgradePlanConfiguration{
+					EtcdUpgrade: ptr.To(true),
+				},
 			},
 		},
 		{
@@ -250,6 +265,9 @@ func TestDefaultedUpgradeConfiguration(t *testing.T) {
 					EtcdUpgrade:     ptr.To(false),
 					ImagePullPolicy: v1.PullAlways,
 					ImagePullSerial: ptr.To(false),
+				},
+				Plan: kubeadmapiv1.UpgradePlanConfiguration{
+					EtcdUpgrade: ptr.To(false),
 				},
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: kubeadmapiv1.SchemeGroupVersion.String(),
@@ -268,6 +286,9 @@ func TestDefaultedUpgradeConfiguration(t *testing.T) {
 					EtcdUpgrade:        ptr.To(false),
 					ImagePullPolicy:    v1.PullAlways,
 					ImagePullSerial:    ptr.To(false),
+				},
+				Plan: kubeadmapi.UpgradePlanConfiguration{
+					EtcdUpgrade: ptr.To(false),
 				},
 			},
 		},
@@ -312,6 +333,9 @@ func TestLoadOrDefaultUpgradeConfiguration(t *testing.T) {
 				Node: kubeadmapiv1.UpgradeNodeConfiguration{
 					EtcdUpgrade: ptr.To(false),
 				},
+				Plan: kubeadmapiv1.UpgradePlanConfiguration{
+					EtcdUpgrade: ptr.To(false),
+				},
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: kubeadmapiv1.SchemeGroupVersion.String(),
 					Kind:       constants.UpgradeConfigurationKind,
@@ -329,6 +353,9 @@ func TestLoadOrDefaultUpgradeConfiguration(t *testing.T) {
 					EtcdUpgrade:        ptr.To(false),
 					ImagePullPolicy:    v1.PullIfNotPresent,
 					ImagePullSerial:    ptr.To(true),
+				},
+				Plan: kubeadmapi.UpgradePlanConfiguration{
+					EtcdUpgrade: ptr.To(false),
 				},
 			},
 		},
@@ -348,6 +375,9 @@ func TestLoadOrDefaultUpgradeConfiguration(t *testing.T) {
 					ImagePullPolicy:    v1.PullNever,
 					ImagePullSerial:    ptr.To(false),
 				},
+				Plan: kubeadmapiv1.UpgradePlanConfiguration{
+					EtcdUpgrade: ptr.To(false),
+				},
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: kubeadmapiv1.SchemeGroupVersion.String(),
 					Kind:       constants.UpgradeConfigurationKind,
@@ -365,6 +395,9 @@ func TestLoadOrDefaultUpgradeConfiguration(t *testing.T) {
 					EtcdUpgrade:        ptr.To(false),
 					ImagePullPolicy:    v1.PullNever,
 					ImagePullSerial:    ptr.To(false),
+				},
+				Plan: kubeadmapi.UpgradePlanConfiguration{
+					EtcdUpgrade: ptr.To(false),
 				},
 			},
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
kubeadm: add --etcd-upgrade flag to kubeadm upgrade plan

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes kubernetes/kubeadm#3155

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: 'kubeadm upgrade plan' now supports '--etcd-upgrade' flag to control whether the etcd upgrade plan should be displayed. Add an `EtcdUpgrade` field into `UpgradeConfiguration.Plan` for v1beta4.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
