### PR TITLE
fake/clientset: improve TestNewSimpleClientset

### DIFF
--- a/staging/src/k8s.io/client-go/kubernetes/fake/clientset_generated_test.go
+++ b/staging/src/k8s.io/client-go/kubernetes/fake/clientset_generated_test.go
@@ -18,8 +18,10 @@ package fake
 
 import (
 	"context"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
 
 	v1 "k8s.io/api/core/v1"
 	policy "k8s.io/api/policy/v1"
@@ -29,35 +31,36 @@ import (
 
 func TestNewSimpleClientset(t *testing.T) {
 	client := NewSimpleClientset()
-	client.CoreV1().Pods("default").Create(context.Background(), &v1.Pod{
+	expectedPods := []*v1.Pod{}
+
+	pod, err := client.CoreV1().Pods("default").Create(context.Background(), &v1.Pod{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "pod-1",
 			Namespace: "default",
 		},
 	}, meta_v1.CreateOptions{})
-	client.CoreV1().Pods("default").Create(context.Background(), &v1.Pod{
+	require.NoError(t, err)
+	expectedPods = append(expectedPods, pod)
+
+	pod, err = client.CoreV1().Pods("default").Create(context.Background(), &v1.Pod{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "pod-2",
 			Namespace: "default",
 		},
 	}, meta_v1.CreateOptions{})
-	err := client.CoreV1().Pods("default").EvictV1(context.Background(), &policy.Eviction{
+	require.NoError(t, err)
+	expectedPods = append(expectedPods, pod)
+
+	err = client.CoreV1().Pods("default").EvictV1(context.Background(), &policy.Eviction{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name: "pod-2",
 		},
 	})
-
-	if err != nil {
-		t.Errorf("TestNewSimpleClientset() res = %v", err.Error())
-	}
+	require.NoError(t, err)
 
 	pods, err := client.CoreV1().Pods("default").List(context.Background(), meta_v1.ListOptions{})
-	// err: item[0]: can't assign or convert v1beta1.Eviction into v1.Pod
-	if err != nil {
-		t.Errorf("TestNewSimpleClientset() res = %v", err.Error())
-	} else {
-		t.Logf("TestNewSimpleClientset() res = %v", pods)
-	}
+	require.NoError(t, err)
+	cmp.Equal(expectedPods, pods.Items)
 }
 
 func TestManagedFieldClientset(t *testing.T) {
@@ -69,58 +72,47 @@ func TestManagedFieldClientset(t *testing.T) {
 			ObjectMeta: meta_v1.ObjectMeta{Name: name, Namespace: namespace},
 			Data:       map[string]string{"k0": "v0"},
 		}, meta_v1.CreateOptions{FieldManager: "test-manager-0"})
-	if err != nil {
-		t.Errorf("Failed to create pod: %v", err)
-	}
-	assert.Equal(t, map[string]string{"k0": "v0"}, cm.Data)
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{"k0": "v0"}, cm.Data)
 
 	// Apply with test-manager-1
 	// Expect data to be shared with initial create
 	cm, err = client.CoreV1().ConfigMaps("default").Apply(context.Background(),
 		v1ac.ConfigMap(name, namespace).WithData(map[string]string{"k1": "v1"}),
 		meta_v1.ApplyOptions{FieldManager: "test-manager-1"})
-	if err != nil {
-		t.Errorf("Failed to create pod: %v", err)
-	}
-	assert.Equal(t, map[string]string{"k0": "v0", "k1": "v1"}, cm.Data)
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{"k0": "v0", "k1": "v1"}, cm.Data)
 
 	// Apply conflicting with test-manager-2, expect apply to fail
 	_, err = client.CoreV1().ConfigMaps("default").Apply(context.Background(),
 		v1ac.ConfigMap(name, namespace).WithData(map[string]string{"k1": "xyz"}),
 		meta_v1.ApplyOptions{FieldManager: "test-manager-2"})
-	if assert.Error(t, err) {
-		assert.Equal(t, "Apply failed with 1 conflict: conflict with \"test-manager-1\": .data.k1", err.Error())
-	}
+	require.Error(t, err)
+	require.Equal(t, "Apply failed with 1 conflict: conflict with \"test-manager-1\": .data.k1", err.Error())
 
 	// Apply with test-manager-2
 	// Expect data to be shared with initial create and test-manager-1
 	cm, err = client.CoreV1().ConfigMaps("default").Apply(context.Background(),
 		v1ac.ConfigMap(name, namespace).WithData(map[string]string{"k2": "v2"}),
 		meta_v1.ApplyOptions{FieldManager: "test-manager-2"})
-	if err != nil {
-		t.Errorf("Failed to create pod: %v", err)
-	}
-	assert.Equal(t, map[string]string{"k0": "v0", "k1": "v1", "k2": "v2"}, cm.Data)
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{"k0": "v0", "k1": "v1", "k2": "v2"}, cm.Data)
 
 	// Apply with test-manager-1
 	// Expect owned data to be updated
 	cm, err = client.CoreV1().ConfigMaps("default").Apply(context.Background(),
 		v1ac.ConfigMap(name, namespace).WithData(map[string]string{"k1": "v101"}),
 		meta_v1.ApplyOptions{FieldManager: "test-manager-1"})
-	if err != nil {
-		t.Errorf("Failed to create pod: %v", err)
-	}
-	assert.Equal(t, map[string]string{"k0": "v0", "k1": "v101", "k2": "v2"}, cm.Data)
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{"k0": "v0", "k1": "v101", "k2": "v2"}, cm.Data)
 
 	// Force apply with test-manager-2
 	// Expect data owned by test-manager-1 to be updated, expect data already owned but not in apply configuration to be removed
 	cm, err = client.CoreV1().ConfigMaps("default").Apply(context.Background(),
 		v1ac.ConfigMap(name, namespace).WithData(map[string]string{"k1": "v202"}),
 		meta_v1.ApplyOptions{FieldManager: "test-manager-2", Force: true})
-	if err != nil {
-		t.Errorf("Failed to create pod: %v", err)
-	}
-	assert.Equal(t, map[string]string{"k0": "v0", "k1": "v202"}, cm.Data)
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{"k0": "v0", "k1": "v202"}, cm.Data)
 
 	// Update with test-manager-1 to perform a force update of the entire resource
 	cm, err = client.CoreV1().ConfigMaps("default").Update(context.Background(),
@@ -137,8 +129,6 @@ func TestManagedFieldClientset(t *testing.T) {
 				"k99": "v99",
 			},
 		}, meta_v1.UpdateOptions{FieldManager: "test-manager-0"})
-	if err != nil {
-		t.Errorf("Failed to update pod: %v", err)
-	}
-	assert.Equal(t, map[string]string{"k99": "v99"}, cm.Data)
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{"k99": "v99"}, cm.Data)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR improves `TestNewSimpleClientset` by:
- checking the error returned from the pod creation calls
- checking the output from the List call

This PR also improves `TestManagedFieldClientset` by:
- using `require.NoError` instead of the if statement followed by `t.Error`
- using `require.Equal` instead of `assert.Equal` which doesn't stop the test on errors.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
