### PR TITLE
kubeadm: update preflight check

### DIFF
--- a/cmd/kubeadm/app/preflight/checks_darwin.go
+++ b/cmd/kubeadm/app/preflight/checks_darwin.go
@@ -19,10 +19,18 @@ limitations under the License.
 
 package preflight
 
+import utilsexec "k8s.io/utils/exec"
+
 // This is a MacOS stub
 
 // Check number of memory required by kubeadm
 // No-op for Darwin (MacOS).
 func (mc MemCheck) Check() (warnings, errorList []error) {
 	return nil, nil
+}
+
+// addExecChecks adds checks that verify if certain binaries are in PATH
+// No-op for Darwin (MacOS).
+func addExecChecks(checks []Checker, _ utilsexec.Interface, _ string) []Checker {
+	return checks
 }

--- a/cmd/kubeadm/app/preflight/checks_linux.go
+++ b/cmd/kubeadm/app/preflight/checks_linux.go
@@ -88,5 +88,8 @@ func addExecChecks(checks []Checker, execer utilsexec.Interface, k8sVersion stri
 
 	// kubelet requires mount to be present in PATH for in-tree volume plugins.
 	checks = append(checks, InPathCheck{executable: "mount", mandatory: true, exec: execer})
+
+	// kubeadm requires cp to be present in PATH for copying etcd directories.
+	checks = append(checks, InPathCheck{executable: "cp", mandatory: true, exec: execer})
 	return checks
 }

--- a/cmd/kubeadm/app/preflight/checks_other.go
+++ b/cmd/kubeadm/app/preflight/checks_other.go
@@ -21,7 +21,6 @@ package preflight
 
 import (
 	system "k8s.io/system-validators/validators"
-	utilsexec "k8s.io/utils/exec"
 )
 
 // addOSValidator adds a new OSValidator
@@ -45,11 +44,5 @@ func addIPv4Checks(checks []Checker) []Checker {
 // addSwapCheck adds a swap check
 // No-op for Darwin (MacOS), Windows.
 func addSwapCheck(checks []Checker) []Checker {
-	return checks
-}
-
-// addExecChecks adds checks that verify if certain binaries are in PATH
-// No-op for Darwin (MacOS), Windows.
-func addExecChecks(checks []Checker, _ utilsexec.Interface, _ string) []Checker {
 	return checks
 }

--- a/cmd/kubeadm/app/preflight/checks_windows.go
+++ b/cmd/kubeadm/app/preflight/checks_windows.go
@@ -22,6 +22,7 @@ package preflight
 import (
 	"github.com/pkg/errors"
 	"golang.org/x/sys/windows"
+	utilsexec "k8s.io/utils/exec"
 )
 
 // Check validates if a user has elevated (administrator) privileges.
@@ -37,4 +38,11 @@ func (ipuc IsPrivilegedUserCheck) Check() (warnings, errorList []error) {
 // No-op for Windows.
 func (mc MemCheck) Check() (warnings, errorList []error) {
 	return nil, nil
+}
+
+// addExecChecks adds checks that verify if certain binaries are in PATH.
+func addExecChecks(checks []Checker, execer utilsexec.Interface, _ string) []Checker {
+	// kubeadm requires xcopy to be present in PATH for copying etcd directories.
+	checks = append(checks, InPathCheck{executable: "xcopy", mandatory: true, exec: execer})
+	return checks
 }

--- a/cmd/kubeadm/app/util/initsystem/initsystem_unix.go
+++ b/cmd/kubeadm/app/util/initsystem/initsystem_unix.go
@@ -160,6 +160,13 @@ func GetInitSystem() (InitSystem, error) {
 	}
 	_, err = exec.LookPath("openrc")
 	if err == nil {
+		binaries := []string{"rc-service", "rc-update"}
+		for _, binary := range binaries {
+			_, err = exec.LookPath(binary)
+			if err != nil {
+				return nil, errors.Wrapf(err, "openrc detected, but missing required binary: %s", binary)
+			}
+		}
 		return &OpenRCInitSystem{}, nil
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

These binaries are required for kubeadm to work properly.

![image](https://github.com/user-attachments/assets/1929b2bf-30a7-4039-baba-b5fcfbf1652c)


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: added preflight check for `cp` on Linux nodes and `xcopy` on Windows nodes. These binaries are required for kubeadm to work properly.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
