### PR TITLE
[KEP-2400] [failing-test] resource metrics e2e tests: expect swap node and container level stats

### DIFF
--- a/test/e2e_node/resource_metrics_test.go
+++ b/test/e2e_node/resource_metrics_test.go
@@ -87,6 +87,8 @@ var _ = SIGDescribe("ResourceMetricsAPI", feature.ResourceMetrics, func() {
 				keys = append(keys, "container_cpu_usage_seconds_total", "container_memory_working_set_bytes", "container_start_time_seconds")
 			}
 
+			zeroSampe := boundedSample(0, 0)
+
 			matchResourceMetrics := gomega.And(gstruct.MatchKeys(gstruct.IgnoreMissing, gstruct.Keys{
 				"resource_scrape_error": gstruct.Ignore(),
 				"node_cpu_usage_seconds_total": gstruct.MatchAllElements(nodeID, gstruct.Elements{
@@ -94,6 +96,10 @@ var _ = SIGDescribe("ResourceMetricsAPI", feature.ResourceMetrics, func() {
 				}),
 				"node_memory_working_set_bytes": gstruct.MatchAllElements(nodeID, gstruct.Elements{
 					"": boundedSample(10*e2evolume.Mb, memoryLimit),
+				}),
+
+				"node_swap_usage_bytes": gstruct.MatchElements(nodeID, gstruct.IgnoreExtras, gstruct.Elements{
+					"": zeroSampe,
 				}),
 
 				"container_cpu_usage_seconds_total": gstruct.MatchElements(containerID, gstruct.IgnoreExtras, gstruct.Elements{
@@ -109,6 +115,11 @@ var _ = SIGDescribe("ResourceMetricsAPI", feature.ResourceMetrics, func() {
 				"container_start_time_seconds": gstruct.MatchElements(containerID, gstruct.IgnoreExtras, gstruct.Elements{
 					fmt.Sprintf("%s::%s::%s", f.Namespace.Name, pod0, "busybox-container"): boundedSample(time.Now().Add(-maxStatsAge).Unix(), time.Now().Add(2*time.Minute).Unix()),
 					fmt.Sprintf("%s::%s::%s", f.Namespace.Name, pod1, "busybox-container"): boundedSample(time.Now().Add(-maxStatsAge).Unix(), time.Now().Add(2*time.Minute).Unix()),
+				}),
+
+				"container_swap_usage_bytes": gstruct.MatchElements(containerID, gstruct.IgnoreExtras, gstruct.Elements{
+					fmt.Sprintf("%s::%s::%s", f.Namespace.Name, pod0, "busybox-container"): zeroSampe,
+					fmt.Sprintf("%s::%s::%s", f.Namespace.Name, pod1, "busybox-container"): zeroSampe,
 				}),
 
 				"pod_cpu_usage_seconds_total": gstruct.MatchElements(podID, gstruct.IgnoreExtras, gstruct.Elements{


### PR DESCRIPTION
/kind failing-test

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Fixing failing test reported by https://github.com/kubernetes/kubernetes/issues/129991 by expecting swap node and container level stats.

#### Which issue(s) this PR fixes:
Fixes #129991

Testgrid link:
https://testgrid.k8s.io/sig-node-presubmits#pr-crio-cgrpv1-evented-pleg-gce-e2e-kubetest2

Failure:
```
Expected
    <string>: KubeletMetrics
to match keys: {
."node_swap_usage_bytes":
	unexpected key node_swap_usage_bytes: map[container_cpu_usage_seconds_total:[container_cpu_usage_seconds_total{container="busybox-container", namespace="resource-metrics-5450", pod="stats-busybox-0"} => 0.191321 @[1738767713.808] container_cpu_usage_seconds_total{container="busybox-container", namespace="resource-metrics-5450", pod="stats-busybox-1"} => 0.169314 @[1738767705.332] container_cpu_usage_seconds_total{container="busybox-scheduling-a43f2c17-bd84-4648-b51c-fa6a77ebb10e", namespace="kubelet-test-5805", pod="busybox-scheduling-a43f2c17-bd84-4648-b51c-fa6a77ebb10e"} => 0.015503 @[1738767710.62] container_cpu_usage_seconds_total{container="main", namespace="container-probe-2990", pod="test-liveness-sidecar-8f2e7533-5e29-4058-878e-9fd43d8a3b13"} => 0.052462 @[1738767703.24] container_cpu_usage_seconds_total{container="regular-1", namespace="containers-lifecycle-test-5036", pod="restartable-init-container-exit-0-continuously"} => 0.050144 @[1738767715.33] container_cpu_usage_seconds_total{container="restartable-init-2", namespace="containers-lifecycle-test-5059", pod="restartable-init-container-failed-liveness-imgupdate-always"} => 0.035203 @[1738767716.439] container_cpu_usage_seconds_total{container="sidecar", namespace="container-probe-2990", pod="test-liveness-sidecar-8f2e7533-5e29-4058-878e-9fd43d8a3b13"} => 0.055067 @[1738767700.405] container_cpu_usage_seconds_total{container="sidecar", namespace="container-probe-9632", pod="startup-sidecar-eeba75db-141e-4f6a-be8d-71979e843558"} => 0.016363 @[1738767712.248]] container_memory_working_set_bytes:[container_memory_working_set_bytes{container="busybox-container", namespace="resource-metrics-5450", pod="stats-busybox-0"} => 352256 @[1738767713.808] container_memory_working_set_bytes{container="busybox-container", namespace="resource-metrics-5450", pod="stats-busybox-1"} => 356352 @[1738767705.332] container_memory_working_set_bytes{container="busybox-scheduling-a43f2c17-bd84-4648-b51c-fa6a77ebb10e", namespace="kubelet-test-5805", pod="busybox-scheduling-a43f2c17-bd84-4648-b51c-fa6a77ebb10e"} => 352256 @[1738767710.62] container_memory_working_set_bytes{container="main", namespace="container-probe-2990", pod="test-liveness-sidecar-8f2e7533-5e29-4058-878e-9fd43d8a3b13"} => 5931008 @[1738767703.24] container_memory_working_set_bytes{container="regular-1", namespace="containers-lifecycle-test-5036", pod="restartable-init-container-exit-0-continuously"} => 581632 @[1738767715.33] container_memory_working_set_bytes{container="restartable-init-2", namespace="containers-lifecycle-test-5059", pod="restartable-init-container-failed-liveness-imgupdate-always"} => 413696 @[1738767716.439] container_memory_working_set_bytes{container="sidecar", namespace="container-probe-2990", pod="test-liveness-sidecar-8f2e7533-5e29-4058-878e-9fd43d8a3b13"} => 5951488 @[1738767700.405] container_memory_working_set_bytes{container="sidecar", namespace="container-probe-9632", pod="startup-sidecar-eeba75db-141e-4f6a-be8d-71979e843558"} => 339968 @[1738767712.248]] container_start_time_seconds:[container_start_time_seconds{container="busybox-container", namespace="resource-metrics-5450", pod="stats-busybox-0"} => 1738767647.58987 @[0] container_start_time_seconds{container="busybox-container", namespace="resource-metrics-5450", pod="stats-busybox-1"} => 1738767650.09542 @[0] container_start_time_seconds{container="busybox-scheduling-a43f2c17-bd84-4648-b51c-fa6a77ebb10e", namespace="kubelet-test-5805", pod="busybox-scheduling-a43f2c17-bd84-4648-b51c-fa6a77ebb10e"} => 1738767686.2433274 @[0] container_start_time_seconds{container="main", namespace="container-probe-2990", pod="test-liveness-sidecar-8f2e7533-5e29-4058-878e-9fd43d8a3b13"} => 1738767590.153934 @[0] container_start_time_seconds{container="regular-1", namespace="containers-lifecycle-test-5036", pod="restartable-init-container-exit-0-continuously"} => 1738767685.4388096 @[0] container_start_time_seconds{container="restartable-init-2", namespace="containers-lifecycle-test-5059", pod="restartable-init-container-failed-liveness-imgupdate-always"} => 1738767705.1093965 @[0] container_start_time_seconds{container="sidecar", namespace="container-probe-2990", pod="test-liveness-sidecar-8f2e7533-5e29-4058-878e-9fd43d8a3b13"} => 1738767586.9450195 @[0] container_start_time_seconds{container="sidecar", namespace="container-probe-9632", pod="startup-sidecar-eeba75db-141e-4f6a-be8d-71979e843558"} => 1738767701.5413375 @[0]] container_swap_usage_bytes:[container_swap_usage_bytes{container="busybox-container", namespace="resource-metrics-5450", pod="stats-busybox-0"} => 0 @[1738767713.808] container_swap_usage_bytes{container="busybox-container", namespace="resource-metrics-5450", pod="stats-busybox-1"} => 0 @[1738767705.332] container_swap_usage_bytes{container="busybox-scheduling-a43f2c17-bd84-4648-b51c-fa6a77ebb10e", namespace="kubelet-test-5805", pod="busybox-scheduling-a43f2c17-bd84-4648-b51c-fa6a77ebb10e"} => 0 @[1738767710.62] container_swap_usage_bytes{container="main", namespace="container-probe-2990", pod="test-liveness-sidecar-8f2e7533-5e29-4058-878e-9fd43d8a3b13"} => 0 @[1738767703.24] container_swap_usage_bytes{container="regular-1", namespace="containers-lifecycle-test-5036", pod="restartable-init-container-exit-0-continuously"} => 0 @[1738767715.33] container_swap_usage_bytes{container="restartable-init-2", namespace="containers-lifecycle-test-5059", pod="restartable-init-container-failed-liveness-imgupdate-always"} => 0 @[1738767716.439] container_swap_usage_bytes{container="sidecar", namespace="container-probe-2990", pod="test-liveness-sidecar-8f2e7533-5e29-4058-878e-9fd43d8a3b13"} => 0 @[1738767700.405] container_swap_usage_bytes{container="sidecar", namespace="container-probe-9632", pod="startup-sidecar-eeba75db-141e-4f6a-be8d-71979e843558"} => 0 @[1738767712.248]] node_cpu_usage_seconds_total:[node_cpu_usage_seconds_total => 531.060042 @[1738767712.185]] node_memory_working_set_bytes:[node_memory_working_set_bytes => 1450782720 @[1738767712.185]] node_swap_usage_bytes:[node_swap_usage_bytes => 0 @[1738767712.185]] pod_cpu_usage_seconds_total:[pod_cpu_usage_seconds_total{namespace="container-probe-2990", pod="test-liveness-sidecar-8f2e7533-5e29-4058-878e-9fd43d8a3b13"} => 0.151997 @[1738767702.892] pod_cpu_usage_seconds_total{namespace="container-probe-7953", pod="busybox-119854c3-757e-44c1-b3aa-2ed63d7d145d"} => 0.069656 @[1738767713.706] pod_cpu_usage_seconds_total{namespace="container-probe-9632", pod="startup-sidecar-eeba75db-141e-4f6a-be8d-71979e843558"} => 0 @[1738767701.16] pod_cpu_usage_seconds_total{namespace="containers-lifecycle-test-5036", pod="restartable-init-container-exit-0-continuously"} => 0.293861 @[1738767708.367] pod_cpu_usage_seconds_total{namespace="containers-lifecycle-test-5059", pod="restartable-init-container-failed-liveness-imgupdate-always"} => 0 @[1738767702.273] pod_cpu_usage_seconds_total{namespace="kubelet-test-5805", pod="busybox-scheduling-a43f2c17-bd84-4648-b51c-fa6a77ebb10e"} => 0.061539 @[1738767709.597] pod_cpu_usage_seconds_total{namespace="resource-metrics-5450", pod="stats-busybox-0"} => 0.275492 @[1738767715.552] pod_cpu_usage_seconds_total{namespace="resource-metrics-5450", pod="stats-busybox-1"} => 0.242798 @[1738767704.087]] pod_memory_working_set_bytes:[pod_memory_working_set_bytes{namespace="container-probe-2990", pod="test-liveness-sidecar-8f2e7533-5e29-4058-878e-9fd43d8a3b13"} => 12107776 @[1738767702.892] pod_memory_working_set_bytes{namespace="container-probe-7953", pod="busybox-119854c3-757e-44c1-b3aa-2ed63d7d145d"} => 557056 @[1738767713.706] pod_memory_working_set_bytes{namespace="container-probe-9632", pod="startup-sidecar-eeba75db-141e-4f6a-be8d-71979e843558"} => 0 @[1738767701.16] pod_memory_working_set_bytes{namespace="containers-lifecycle-test-5036", pod="restartable-init-container-exit-0-continuously"} => 921600 @[1738767708.367] pod_memory_working_set_bytes{namespace="containers-lifecycle-test-5059", pod="restartable-init-container-failed-liveness-imgupdate-always"} => 0 @[1738767702.273] pod_memory_working_set_bytes{namespace="kubelet-test-5805", pod="busybox-scheduling-a43f2c17-bd84-4648-b51c-fa6a77ebb10e"} => 577536 @[1738767709.597] pod_memory_working_set_bytes{namespace="resource-metrics-5450", pod="stats-busybox-0"} => 610304 @[1738767715.552] pod_memory_working_set_bytes{namespace="resource-metrics-5450", pod="stats-busybox-1"} => 618496 @[1738767704.087]] pod_swap_usage_bytes:[pod_swap_usage_bytes{namespace="container-probe-2990", pod="test-liveness-sidecar-8f2e7533-5e29-4058-878e-9fd43d8a3b13"} => 0 @[1738767702.892] pod_swap_usage_bytes{namespace="container-probe-7953", pod="busybox-119854c3-757e-44c1-b3aa-2ed63d7d145d"} => 0 @[1738767713.706] pod_swap_usage_bytes{namespace="container-probe-9632", pod="startup-sidecar-eeba75db-141e-4f6a-be8d-71979e843558"} => 0 @[1738767701.16] pod_swap_usage_bytes{namespace="containers-lifecycle-test-5036", pod="restartable-init-container-exit-0-continuously"} => 0 @[1738767708.367] pod_swap_usage_bytes{namespace="containers-lifecycle-test-5059", pod="restartable-init-container-failed-liveness-imgupdate-always"} => 0 @[1738767702.273] pod_swap_usage_bytes{namespace="kubelet-test-5805", pod="busybox-scheduling-a43f2c17-bd84-4648-b51c-fa6a77ebb10e"} => 0 @[1738767709.597] pod_swap_usage_bytes{namespace="resource-metrics-5450", pod="stats-busybox-0"} => 0 @[1738767715.552] pod_swap_usage_bytes{namespace="resource-metrics-5450", pod="stats-busybox-1"} => 0 @[1738767704.087]] resource_scrape_error:[resource_scrape_error => 0 @[0]]]
."container_swap_usage_bytes":
	unexpected key container_swap_usage_bytes: map[container_cpu_usage_seconds_total:[container_cpu_usage_seconds_total{container="busybox-container", namespace="resource-metrics-5450", pod="stats-busybox-0"} => 0.191321 @[1738767713.808] container_cpu_usage_seconds_total{container="busybox-container", namespace="resource-metrics-5450", pod="stats-busybox-1"} => 0.169314 @[1738767705.332] container_cpu_usage_seconds_total{container="busybox-scheduling-a43f2c17-bd84-4648-b51c-fa6a77ebb10e", namespace="kubelet-test-5805", pod="busybox-scheduling-a43f2c17-bd84-4648-b51c-fa6a77ebb10e"} => 0.015503 @[1738767710.62] container_cpu_usage_seconds_total{container="main", namespace="container-probe-2990", pod="test-liveness-sidecar-8f2e7533-5e29-4058-878e-9fd43d8a3b13"} => 0.052462 @[1738767703.24] container_cpu_usage_seconds_total{container="regular-1", namespace="containers-lifecycle-test-5036", pod="restartable-init-container-exit-0-continuously"} => 0.050144 @[1738767715.33] container_cpu_usage_seconds_total{container="restartable-init-2", namespace="containers-lifecycle-test-5059", pod="restartable-init-container-failed-liveness-imgupdate-always"} => 0.035203 @[1738767716.439] container_cpu_usage_seconds_total{container="sidecar", namespace="container-probe-2990", pod="test-liveness-sidecar-8f2e7533-5e29-4058-878e-9fd43d8a3b13"} => 0.055067 @[1738767700.405] container_cpu_usage_seconds_total{container="sidecar", namespace="container-probe-9632", pod="startup-sidecar-eeba75db-141e-4f6a-be8d-71979e843558"} => 0.016363 @[1738767712.248]] container_memory_working_set_bytes:[container_memory_working_set_bytes{container="busybox-container", namespace="resource-metrics-5450", pod="stats-busybox-0"} => 352256 @[1738767713.808] container_memory_working_set_bytes{container="busybox-container", namespace="resource-metrics-5450", pod="stats-busybox-1"} => 356352 @[1738767705.332] container_memory_working_set_bytes{container="busybox-scheduling-a43f2c17-bd84-4648-b51c-fa6a77ebb10e", namespace="kubelet-test-5805", pod="busybox-scheduling-a43f2c17-bd84-4648-b51c-fa6a77ebb10e"} => 352256 @[1738767710.62] container_memory_working_set_bytes{container="main", namespace="container-probe-2990", pod="test-liveness-sidecar-8f2e7533-5e29-4058-878e-9fd43d8a3b13"} => 5931008 @[1738767703.24] container_memory_working_set_bytes{container="regular-1", namespace="containers-lifecycle-test-5036", pod="restartable-init-container-exit-0-continuously"} => 581632 @[1738767715.33] container_memory_working_set_bytes{container="restartable-init-2", namespace="containers-lifecycle-test-5059", pod="restartable-init-container-failed-liveness-imgupdate-always"} => 413696 @[1738767716.439] container_memory_working_set_bytes{container="sidecar", namespace="container-probe-2990", pod="test-liveness-sidecar-8f2e7533-5e29-4058-878e-9fd43d8a3b13"} => 5951488 @[1738767700.405] container_memory_working_set_bytes{container="sidecar", namespace="container-probe-9632", pod="startup-sidecar-eeba75db-141e-4f6a-be8d-71979e843558"} => 339968 @[1738767712.248]] container_start_time_seconds:[container_start_time_seconds{container="busybox-container", namespace="resource-metrics-5450", pod="stats-busybox-0"} => 1738767647.58987 @[0] container_start_time_seconds{container="busybox-container", namespace="resource-metrics-5450", pod="stats-busybox-1"} => 1738767650.09542 @[0] container_start_time_seconds{container="busybox-scheduling-a43f2c17-bd84-4648-b51c-fa6a77ebb10e", namespace="kubelet-test-5805", pod="busybox-scheduling-a43f2c17-bd84-4648-b51c-fa6a77ebb10e"} => 1738767686.2433274 @[0] container_start_time_seconds{container="main", namespace="container-probe-2990", pod="test-liveness-sidecar-8f2e7533-5e29-4058-878e-9fd43d8a3b13"} => 1738767590.153934 @[0] container_start_time_seconds{container="regular-1", namespace="containers-lifecycle-test-5036", pod="restartable-init-container-exit-0-continuously"} => 1738767685.4388096 @[0] container_start_time_seconds{container="restartable-init-2", namespace="containers-lifecycle-test-5059", pod="restartable-init-container-failed-liveness-imgupdate-always"} => 1738767705.1093965 @[0] container_start_time_seconds{container="sidecar", namespace="container-probe-2990", pod="test-liveness-sidecar-8f2e7533-5e29-4058-878e-9fd43d8a3b13"} => 1738767586.9450195 @[0] container_start_time_seconds{container="sidecar", namespace="container-probe-9632", pod="startup-sidecar-eeba75db-141e-4f6a-be8d-71979e843558"} => 1738767701.5413375 @[0]] container_swap_usage_bytes:[container_swap_usage_bytes{container="busybox-container", namespace="resource-metrics-5450", pod="stats-busybox-0"} => 0 @[1738767713.808] container_swap_usage_bytes{container="busybox-container", namespace="resource-metrics-5450", pod="stats-busybox-1"} => 0 @[1738767705.332] container_swap_usage_bytes{container="busybox-scheduling-a43f2c17-bd84-4648-b51c-fa6a77ebb10e", namespace="kubelet-test-5805", pod="busybox-scheduling-a43f2c17-bd84-4648-b51c-fa6a77ebb10e"} => 0 @[1738767710.62] container_swap_usage_bytes{container="main", namespace="container-probe-2990", pod="test-liveness-sidecar-8f2e7533-5e29-4058-878e-9fd43d8a3b13"} => 0 @[1738767703.24] container_swap_usage_bytes{container="regular-1", namespace="containers-lifecycle-test-5036", pod="restartable-init-container-exit-0-continuously"} => 0 @[1738767715.33] container_swap_usage_bytes{container="restartable-init-2", namespace="containers-lifecycle-test-5059", pod="restartable-init-container-failed-liveness-imgupdate-always"} => 0 @[1738767716.439] container_swap_usage_bytes{container="sidecar", namespace="container-probe-2990", pod="test-liveness-sidecar-8f2e7533-5e29-4058-878e-9fd43d8a3b13"} => 0 @[1738767700.405] container_swap_usage_bytes{container="sidecar", namespace="container-probe-9632", pod="startup-sidecar-eeba75db-141e-4f6a-be8d-71979e843558"} => 0 @[1738767712.248]] node_cpu_usage_seconds_total:[node_cpu_usage_seconds_total => 531.060042 @[1738767712.185]] node_memory_working_set_bytes:[node_memory_working_set_bytes => 1450782720 @[1738767712.185]] node_swap_usage_bytes:[node_swap_usage_bytes => 0 @[1738767712.185]] pod_cpu_usage_seconds_total:[pod_cpu_usage_seconds_total{namespace="container-probe-2990", pod="test-liveness-sidecar-8f2e7533-5e29-4058-878e-9fd43d8a3b13"} => 0.151997 @[1738767702.892] pod_cpu_usage_seconds_total{namespace="container-probe-7953", pod="busybox-119854c3-757e-44c1-b3aa-2ed63d7d145d"} => 0.069656 @[1738767713.706] pod_cpu_usage_seconds_total{namespace="container-probe-9632", pod="startup-sidecar-eeba75db-141e-4f6a-be8d-71979e843558"} => 0 @[1738767701.16] pod_cpu_usage_seconds_total{namespace="containers-lifecycle-test-5036", pod="restartable-init-container-exit-0-continuously"} => 0.293861 @[1738767708.367] pod_cpu_usage_seconds_total{namespace="containers-lifecycle-test-5059", pod="restartable-init-container-failed-liveness-imgupdate-always"} => 0 @[1738767702.273] pod_cpu_usage_seconds_total{namespace="kubelet-test-5805", pod="busybox-scheduling-a43f2c17-bd84-4648-b51c-fa6a77ebb10e"} => 0.061539 @[1738767709.597] pod_cpu_usage_seconds_total{namespace="resource-metrics-5450", pod="stats-busybox-0"} => 0.275492 @[1738767715.552] pod_cpu_usage_seconds_total{namespace="resource-metrics-5450", pod="stats-busybox-1"} => 0.242798 @[1738767704.087]] pod_memory_working_set_bytes:[pod_memory_working_set_bytes{namespace="container-probe-2990", pod="test-liveness-sidecar-8f2e7533-5e29-4058-878e-9fd43d8a3b13"} => 12107776 @[1738767702.892] pod_memory_working_set_bytes{namespace="container-probe-7953", pod="busybox-119854c3-757e-44c1-b3aa-2ed63d7d145d"} => 557056 @[1738767713.706] pod_memory_working_set_bytes{namespace="container-probe-9632", pod="startup-sidecar-eeba75db-141e-4f6a-be8d-71979e843558"} => 0 @[1738767701.16] pod_memory_working_set_bytes{namespace="containers-lifecycle-test-5036", pod="restartable-init-container-exit-0-continuously"} => 921600 @[1738767708.367] pod_memory_working_set_bytes{namespace="containers-lifecycle-test-5059", pod="restartable-init-container-failed-liveness-imgupdate-always"} => 0 @[1738767702.273] pod_memory_working_set_bytes{namespace="kubelet-test-5805", pod="busybox-scheduling-a43f2c17-bd84-4648-b51c-fa6a77ebb10e"} => 577536 @[1738767709.597] pod_memory_working_set_bytes{namespace="resource-metrics-5450", pod="stats-busybox-0"} => 610304 @[1738767715.552] pod_memory_working_set_bytes{namespace="resource-metrics-5450", pod="stats-busybox-1"} => 618496 @[1738767704.087]] pod_swap_usage_bytes:[pod_swap_usage_bytes{namespace="container-probe-2990", pod="test-liveness-sidecar-8f2e7533-5e29-4058-878e-9fd43d8a3b13"} => 0 @[1738767702.892] pod_swap_usage_bytes{namespace="container-probe-7953", pod="busybox-119854c3-757e-44c1-b3aa-2ed63d7d145d"} => 0 @[1738767713.706] pod_swap_usage_bytes{namespace="container-probe-9632", pod="startup-sidecar-eeba75db-141e-4f6a-be8d-71979e843558"} => 0 @[1738767701.16] pod_swap_usage_bytes{namespace="containers-lifecycle-test-5036", pod="restartable-init-container-exit-0-continuously"} => 0 @[1738767708.367] pod_swap_usage_bytes{namespace="containers-lifecycle-test-5059", pod="restartable-init-container-failed-liveness-imgupdate-always"} => 0 @[1738767702.273] pod_swap_usage_bytes{namespace="kubelet-test-5805", pod="busybox-scheduling-a43f2c17-bd84-4648-b51c-fa6a77ebb10e"} => 0 @[1738767709.597] pod_swap_usage_bytes{namespace="resource-metrics-5450", pod="stats-busybox-0"} => 0 @[1738767715.552] pod_swap_usage_bytes{namespace="resource-metrics-5450", pod="stats-busybox-1"} => 0 @[1738767704.087]] resource_scrape_error:[resource_scrape_error => 0 @[0]]]
```

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/2400-node-swap/README.md
```
