### PR TITLE
WIP:DNM: Idea - validation error "origins"

### DIFF
--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -9183,7 +9183,7 @@ func TestValidateContainers(t *testing.T) {
 				t.Fatal("expected error but received none")
 			}
 
-			if diff := cmp.Diff(tc.expectedErrors, errs, cmpopts.IgnoreFields(field.Error{}, "BadValue", "Detail")); diff != "" {
+			if diff := cmp.Diff(tc.expectedErrors, errs, cmpopts.IgnoreFields(field.Error{}, "BadValue", "Detail", "Origin")); diff != "" {
 				t.Errorf("unexpected diff in errors (-want, +got):\n%s", diff)
 				t.Errorf("INFO: all errors:\n%s", prettyErrorList(errs))
 			}
@@ -20674,7 +20674,7 @@ func TestValidateEndpointsCreate(t *testing.T) {
 	errorCases := map[string]struct {
 		endpoints   core.Endpoints
 		errorType   field.ErrorType
-		errorDetail string
+		errorOrigin string
 	}{
 		"missing namespace": {
 			endpoints: core.Endpoints{ObjectMeta: metav1.ObjectMeta{Name: "mysvc"}},
@@ -20685,14 +20685,12 @@ func TestValidateEndpointsCreate(t *testing.T) {
 			errorType: "FieldValueRequired",
 		},
 		"invalid namespace": {
-			endpoints:   core.Endpoints{ObjectMeta: metav1.ObjectMeta{Name: "mysvc", Namespace: "no@#invalid.;chars\"allowed"}},
-			errorType:   "FieldValueInvalid",
-			errorDetail: dnsLabelErrMsg,
+			endpoints: core.Endpoints{ObjectMeta: metav1.ObjectMeta{Name: "mysvc", Namespace: "no@#invalid.;chars\"allowed"}},
+			errorType: "FieldValueInvalid",
 		},
 		"invalid name": {
-			endpoints:   core.Endpoints{ObjectMeta: metav1.ObjectMeta{Name: "-_Invliad^&Characters", Namespace: "namespace"}},
-			errorType:   "FieldValueInvalid",
-			errorDetail: dnsSubdomainLabelErrMsg,
+			endpoints: core.Endpoints{ObjectMeta: metav1.ObjectMeta{Name: "-_Invliad^&Characters", Namespace: "namespace"}},
+			errorType: "FieldValueInvalid",
 		},
 		"empty addresses": {
 			endpoints: core.Endpoints{
@@ -20712,7 +20710,7 @@ func TestValidateEndpointsCreate(t *testing.T) {
 				}},
 			},
 			errorType:   "FieldValueInvalid",
-			errorDetail: "must be a valid IP address",
+			errorOrigin: "IP",
 		},
 		"Multiple ports, one without name": {
 			endpoints: core.Endpoints{
@@ -20733,7 +20731,7 @@ func TestValidateEndpointsCreate(t *testing.T) {
 				}},
 			},
 			errorType:   "FieldValueInvalid",
-			errorDetail: "between",
+			errorOrigin: "PortNum",
 		},
 		"Invalid protocol": {
 			endpoints: core.Endpoints{
@@ -20754,7 +20752,7 @@ func TestValidateEndpointsCreate(t *testing.T) {
 				}},
 			},
 			errorType:   "FieldValueInvalid",
-			errorDetail: "must be a valid IP address",
+			errorOrigin: "IP",
 		},
 		"Port missing number": {
 			endpoints: core.Endpoints{
@@ -20765,7 +20763,7 @@ func TestValidateEndpointsCreate(t *testing.T) {
 				}},
 			},
 			errorType:   "FieldValueInvalid",
-			errorDetail: "between",
+			errorOrigin: "PortNum",
 		},
 		"Port missing protocol": {
 			endpoints: core.Endpoints{
@@ -20786,7 +20784,7 @@ func TestValidateEndpointsCreate(t *testing.T) {
 				}},
 			},
 			errorType:   "FieldValueInvalid",
-			errorDetail: "loopback",
+			errorOrigin: "NonSpecialIP",
 		},
 		"Address is link-local": {
 			endpoints: core.Endpoints{
@@ -20797,7 +20795,7 @@ func TestValidateEndpointsCreate(t *testing.T) {
 				}},
 			},
 			errorType:   "FieldValueInvalid",
-			errorDetail: "link-local",
+			errorOrigin: "NonSpecialIP",
 		},
 		"Address is link-local multicast": {
 			endpoints: core.Endpoints{
@@ -20808,7 +20806,7 @@ func TestValidateEndpointsCreate(t *testing.T) {
 				}},
 			},
 			errorType:   "FieldValueInvalid",
-			errorDetail: "link-local multicast",
+			errorOrigin: "NonSpecialIP",
 		},
 		"Invalid AppProtocol": {
 			endpoints: core.Endpoints{
@@ -20819,14 +20817,14 @@ func TestValidateEndpointsCreate(t *testing.T) {
 				}},
 			},
 			errorType:   "FieldValueInvalid",
-			errorDetail: "name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character",
+			errorOrigin: "QualifiedName",
 		},
 	}
 
 	for k, v := range errorCases {
 		t.Run(k, func(t *testing.T) {
-			if errs := ValidateEndpointsCreate(&v.endpoints); len(errs) == 0 || errs[0].Type != v.errorType || !strings.Contains(errs[0].Detail, v.errorDetail) {
-				t.Errorf("Expected error type %s with detail %q, got %v", v.errorType, v.errorDetail, errs)
+			if errs := ValidateEndpointsCreate(&v.endpoints); len(errs) == 0 || errs[0].Type != v.errorType || errs[0].Origin != v.errorOrigin {
+				t.Errorf("Expected error type %s with origin %q, got %#v", v.errorType, v.errorOrigin, errs[0])
 			}
 		})
 	}
@@ -21190,7 +21188,7 @@ func TestValidateSchedulingGates(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			errs := validateSchedulingGates(tt.schedulingGates, fieldPath)
-			if diff := cmp.Diff(tt.wantFieldErrors, errs); diff != "" {
+			if diff := cmp.Diff(tt.wantFieldErrors, errs, cmpopts.IgnoreFields(field.Error{}, "Detail", "Origin")); diff != "" {
 				t.Errorf("unexpected field errors (-want, +got):\n%s", diff)
 			}
 		})

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go
@@ -373,7 +373,7 @@ func IsValidPortName(port string) []string {
 func IsValidIP(fldPath *field.Path, value string) field.ErrorList {
 	var allErrors field.ErrorList
 	if netutils.ParseIPSloppy(value) == nil {
-		allErrors = append(allErrors, field.Invalid(fldPath, value, "must be a valid IP address, (e.g. 10.9.8.7 or 2001:db8::ffff)"))
+		allErrors.AppendWithOrigin("IP", field.Invalid(fldPath, value, "must be a valid IP address, (e.g. 10.9.8.7 or 2001:db8::ffff)"))
 	}
 	return allErrors
 }


### PR DESCRIPTION
This is a test to see how bad the explosions really are.

Problem statement: API validation tests are SUPER brittle.  Many of them depend the the specific `Detail` string, to the extent that making the error message clearer or fixing a typo breaks hundreds of test cases.

This introduces a new field, `Origin`, into type `field.Error`, which tracks the "meaning" of an error without encoding the human-oriented detail string.  This really matters when a field might get multiple errors of the same type (e.g. "Invalid") but different meaning.  It makes some test cases more precise (those that were not looking at `Detail` or did very loose substring matching), and some less precise (e.g. in this PR, some cases used to differentiate "link-local" from "multicast" but now just look for "NonSpecialIP").  I think that's PROBABLY ok?

I converted one validation, `ValidateEndpointsCreate()`, because it was simple enough to do all at once but complex enough to to show the idea.

I added a few different ways of setting origin, to see which pattern(s) feel most natural and obvious.  I was trying to avoid touching thousands of call-sites, but I can if we decide that is simplest (e.g. changing `field.Invalid()` to take another arg)

The goal is to enable this incrementally, as needed.  If we find an approach we do not hate, we can also introduce a "compare" function which uses or ignores particular fields, or just use the `cmpopts.IgnoreFields()` approach more consistently.

I fully expect this PR (and if we stick with it, all subsequent ones) to have some collateral damage - many tests just do an direct compare of `Error`s, which will fail with this new field.

I'm very open to ideas on how to minimize collateral damage and make this as low-impact as possible.

/cc @jpbetz 
/cc @yongruilin 
/cc @aaron-prindle 

```release-note
NONE
```
