### PR TITLE
Fix labelValues for scheduler-perf

### DIFF
--- a/test/integration/scheduler_perf/scheduler_perf.go
+++ b/test/integration/scheduler_perf/scheduler_perf.go
@@ -140,25 +140,25 @@ var (
 		Metrics: map[string][]*labelValues{
 			"scheduler_framework_extension_point_duration_seconds": {
 				{
-					label:  extensionPointsLabelName,
-					values: metrics.ExtentionPoints,
+					Label:  extensionPointsLabelName,
+					Values: metrics.ExtentionPoints,
 				},
 			},
 			"scheduler_scheduling_attempt_duration_seconds": {
 				{
-					label:  resultLabelName,
-					values: []string{metrics.ScheduledResult, metrics.UnschedulableResult, metrics.ErrorResult},
+					Label:  resultLabelName,
+					Values: []string{metrics.ScheduledResult, metrics.UnschedulableResult, metrics.ErrorResult},
 				},
 			},
 			"scheduler_pod_scheduling_duration_seconds": nil,
 			"scheduler_plugin_execution_duration_seconds": {
 				{
-					label:  pluginLabelName,
-					values: PluginNames,
+					Label:  pluginLabelName,
+					Values: PluginNames,
 				},
 				{
-					label:  extensionPointsLabelName,
-					values: metrics.ExtentionPoints,
+					Label:  extensionPointsLabelName,
+					Values: metrics.ExtentionPoints,
 				},
 			},
 		},
@@ -167,18 +167,18 @@ var (
 	qHintMetrics = map[string][]*labelValues{
 		"scheduler_queueing_hint_execution_duration_seconds": {
 			{
-				label:  pluginLabelName,
-				values: PluginNames,
+				Label:  pluginLabelName,
+				Values: PluginNames,
 			},
 			{
-				label:  eventLabelName,
-				values: schedframework.AllClusterEventLabels(),
+				Label:  eventLabelName,
+				Values: schedframework.AllClusterEventLabels(),
 			},
 		},
 		"scheduler_event_handling_duration_seconds": {
 			{
-				label:  eventLabelName,
-				values: schedframework.AllClusterEventLabels(),
+				Label:  eventLabelName,
+				Values: schedframework.AllClusterEventLabels(),
 			},
 		},
 	}

--- a/test/integration/scheduler_perf/util.go
+++ b/test/integration/scheduler_perf/util.go
@@ -303,8 +303,8 @@ func dataFilename(destFile string) (string, error) {
 }
 
 type labelValues struct {
-	label  string
-	values []string
+	Label  string
+	Values []string
 }
 
 // metricsCollectorConfig is the config to be marshalled to YAML config file.
@@ -380,13 +380,13 @@ func uniqueLVCombos(lvs []*labelValues) []map[string]string {
 	results := make([]map[string]string, 0)
 
 	current := lvs[0]
-	for _, value := range current.values {
+	for _, value := range current.Values {
 		for _, combo := range remainingCombos {
 			newCombo := make(map[string]string, len(combo)+1)
 			for k, v := range combo {
 				newCombo[k] = v
 			}
-			newCombo[current.label] = value
+			newCombo[current.Label] = value
 			results = append(results, newCombo)
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

When running the test in scheduler_perf with the following metricsCollectorConfig definition in performance-config.yaml(e.g., test/integration/scheduler_perf/volumes/performance-config.yaml), the following error occurs:

### **Error:**
```
 scheduler_perf.go:1153: parsing test cases error: error unmarshaling JSON: while decoding JSON: json: unknown field "label"
```

### **performance-config.yaml**
```yaml
- name: SchedulingSecrets
  defaultPodTemplatePath: ../templates/pod-with-secret-volume.yaml
  metricsCollectorConfig:
    metrics:
      scheduler_framework_extension_point_duration_seconds:
        - label: extension_point
          values:
            - PreFilter
            - Filter
            - PostFilter
            - PreScore
            - Score
            - Reserve
            - Permit
            - PreBind
            - Bind
            - PostBind
      scheduler_scheduling_attempt_duration_seconds: null
      scheduler_pod_scheduling_duration_seconds: null 
  workloadTemplate:
  - opcode: createNodes
    countParam: $initNodes
  - opcode: createPods
    countParam: $initPods
...
```

The error occurs because the fields of the `labelValues` struct are private, making it impossible to unmarshal the YAML data.
This issue is addressed in this PR, which modifies the struct to allow unmarshaling.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
None

#### Special notes for your reviewer:

related: 
https://github.com/kubernetes-sigs/kube-scheduler-wasm-extension/pull/135

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
