### PR TITLE
Clean(pkg/apis) use generic sets rather than deprecated sets struct and method

### DIFF
--- a/pkg/apis/core/helper/qos/qos.go
+++ b/pkg/apis/core/helper/qos/qos.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/kubernetes/pkg/features"
 )
 
-var supportedQoSComputeResources = sets.NewString(string(core.ResourceCPU), string(core.ResourceMemory))
+var supportedQoSComputeResources = sets.New(string(core.ResourceCPU), string(core.ResourceMemory))
 
 func isSupportedQoSComputeResource(name core.ResourceName) bool {
 	return supportedQoSComputeResources.Has(string(name))
@@ -128,7 +128,7 @@ func ComputePodQOS(pod *core.Pod) core.PodQOSClass {
 				}
 			}
 			// process limits
-			qosLimitsFound := sets.NewString()
+			qosLimitsFound := sets.New[string]()
 			for name, quantity := range container.Resources.Limits {
 				if !isSupportedQoSComputeResource(name) {
 					continue

--- a/pkg/apis/core/v1/helper/qos/qos.go
+++ b/pkg/apis/core/v1/helper/qos/qos.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/kubernetes/pkg/features"
 )
 
-var supportedQoSComputeResources = sets.NewString(string(core.ResourceCPU), string(core.ResourceMemory))
+var supportedQoSComputeResources = sets.New(string(core.ResourceCPU), string(core.ResourceMemory))
 
 // QOSList is a set of (resource name, QoS class) pairs.
 type QOSList map[v1.ResourceName]v1.PodQOSClass
@@ -131,7 +131,7 @@ func ComputePodQOS(pod *v1.Pod) v1.PodQOSClass {
 				}
 			}
 			// process limits
-			qosLimitsFound := sets.NewString()
+			qosLimitsFound := sets.New[string]()
 			for name, quantity := range container.Resources.Limits {
 				if !isSupportedQoSComputeResource(name) {
 					continue

--- a/pkg/apis/core/v1/validation/validation.go
+++ b/pkg/apis/core/v1/validation/validation.go
@@ -163,7 +163,7 @@ func ValidatePodLogOptions(opts *v1.PodLogOptions) field.ErrorList {
 
 // AccumulateUniqueHostPorts checks all the containers for duplicates ports. Any
 // duplicate port will be returned in the ErrorList.
-func AccumulateUniqueHostPorts(containers []v1.Container, accumulator *sets.String, fldPath *field.Path) field.ErrorList {
+func AccumulateUniqueHostPorts(containers []v1.Container, accumulator *sets.Set[string], fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	for ci, ctr := range containers {

--- a/pkg/apis/core/v1/validation/validation_test.go
+++ b/pkg/apis/core/v1/validation/validation_test.go
@@ -347,7 +347,7 @@ func TestAccumulateUniqueHostPorts(t *testing.T) {
 	successCase := []struct {
 		name        string
 		containers  []v1.Container
-		accumulator *sets.String
+		accumulator *sets.Set[string]
 		fldPath     *field.Path
 	}{{
 		name: "HostPort is not allocated while containers use the same port with different protocol",
@@ -362,7 +362,7 @@ func TestAccumulateUniqueHostPorts(t *testing.T) {
 				Protocol: v1.ProtocolTCP,
 			}},
 		}},
-		accumulator: &sets.String{},
+		accumulator: &sets.Set[string]{},
 		fldPath:     field.NewPath("spec", "containers"),
 	}, {
 		name: "HostPort is not allocated while containers use different ports",
@@ -377,7 +377,7 @@ func TestAccumulateUniqueHostPorts(t *testing.T) {
 				Protocol: v1.ProtocolUDP,
 			}},
 		}},
-		accumulator: &sets.String{},
+		accumulator: &sets.Set[string]{},
 		fldPath:     field.NewPath("spec", "containers"),
 	}}
 	for _, tc := range successCase {
@@ -390,7 +390,7 @@ func TestAccumulateUniqueHostPorts(t *testing.T) {
 	errorCase := []struct {
 		name        string
 		containers  []v1.Container
-		accumulator *sets.String
+		accumulator *sets.Set[string]
 		fldPath     *field.Path
 	}{{
 		name: "HostPort is already allocated while containers use the same port with UDP",
@@ -405,7 +405,7 @@ func TestAccumulateUniqueHostPorts(t *testing.T) {
 				Protocol: v1.ProtocolUDP,
 			}},
 		}},
-		accumulator: &sets.String{},
+		accumulator: &sets.Set[string]{},
 		fldPath:     field.NewPath("spec", "containers"),
 	}, {
 		name: "HostPort is already allocated",
@@ -420,7 +420,7 @@ func TestAccumulateUniqueHostPorts(t *testing.T) {
 				Protocol: v1.ProtocolUDP,
 			}},
 		}},
-		accumulator: &sets.String{"8080/UDP": sets.Empty{}},
+		accumulator: &sets.Set[string]{"8080/UDP": sets.Empty{}},
 		fldPath:     field.NewPath("spec", "containers"),
 	}}
 	for _, tc := range errorCase {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
`sets.String` was deprecated, use generic sets

```
sets.String{}  => sets.Set[string]{}
sets.NewString() => sets.New[String]()
sets.String{}.List() => sets.List()
``` 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
