### PR TITLE
[compatibility version] Avoid resetting config when adding flags

### DIFF
--- a/staging/src/k8s.io/component-base/compatibility/registry_test.go
+++ b/staging/src/k8s.io/component-base/compatibility/registry_test.go
@@ -150,6 +150,7 @@ func TestVersionedFeatureGateFlags(t *testing.T) {
 func TestFlags(t *testing.T) {
 	tests := []struct {
 		name                         string
+		setupRegistry                func(r *componentGlobalsRegistry) error
 		flags                        []string
 		parseError                   string
 		expectedKubeEmulationVersion string
@@ -272,14 +273,46 @@ func TestFlags(t *testing.T) {
 			},
 			parseError: "component not registered: test3",
 		},
+		{
+			name: "feature gates config should accumulate across multiple flag sets",
+			setupRegistry: func(r *componentGlobalsRegistry) error {
+				fs := pflag.NewFlagSet("setupTestflag", pflag.ContinueOnError)
+				r.AddFlags(fs)
+				return fs.Parse([]string{"--feature-gates=test:commonC=true"})
+			},
+			flags: []string{
+				"--feature-gates=test:testA=true",
+			},
+			expectedTestFeatureValues: map[featuregate.Feature]bool{"testA": true, "commonC": true},
+		},
+		{
+			name: "feature gates config should be overridden when set multiple times one the same feature",
+			setupRegistry: func(r *componentGlobalsRegistry) error {
+				fs := pflag.NewFlagSet("setupTestflag", pflag.ContinueOnError)
+				r.AddFlags(fs)
+				return fs.Parse([]string{"--feature-gates=test:testA=false"})
+			},
+			flags: []string{
+				"--feature-gates=test:testA=true",
+			},
+			expectedTestFeatureValues: map[featuregate.Feature]bool{"testA": true},
+		},
 	}
 	for i, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			fs := pflag.NewFlagSet("testflag", pflag.ContinueOnError)
 			r := testRegistry(t)
+			if test.setupRegistry != nil {
+				if err := test.setupRegistry(r); err != nil {
+					t.Fatalf("failed to setup registry: %v", err)
+				}
+			}
 			r.AddFlags(fs)
 			err := fs.Parse(test.flags)
 			if err == nil {
+				// AddFlags again to check whether there is no resetting on the config.
+				fs = pflag.NewFlagSet("testflag2", pflag.ContinueOnError)
+				r.AddFlags(fs)
 				err = r.Set()
 			}
 			if test.parseError != "" {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:

Avoid resetting config of emulation verison and featuregates when adding flags
    This change introduces improvements to the component compatibility registry:

- Modify the kube-scheduler test server to create a separate ComponentGlobalsRegistry
- Update the compatibility registry to handle multiple flag configurations
- Enhance test cases to support emulation version mapping between components

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/129994

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-architecture/4330-compatibility-versions/README.md
```
