### PR TITLE
test(network): replace RCs with Deployments in util function StartServeHostnameService

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -1865,9 +1865,9 @@
   description: 'Create a service of type "NodePort" and provide service port and protocol.
     Service''s sessionAffinity is set to "ClientIP". Service creation MUST be successful
     by assigning a "ClusterIP" to the service and allocating NodePort on all the nodes.
-    Create a Replication Controller to ensure that 3 pods are running and are targeted
-    by the service to serve hostname of the pod when requests are sent to the service.
-    Create another pod to make requests to the service. Update the service''s sessionAffinity
+    Create a Deployment to ensure that 3 pods are running and are targeted by the
+    service to serve hostname of the pod when requests are sent to the service. Create
+    another pod to make requests to the service. Update the service''s sessionAffinity
     to "None". Service update MUST be successful. When a requests are made to the
     service on node''s IP and NodePort, service MUST be able serve the hostname from
     any pod of the replica. When service''s sessionAffinily is updated back to "ClientIP",
@@ -1882,15 +1882,15 @@
     service with type clusterIP [LinuxOnly] [Conformance]'
   description: 'Create a service of type "ClusterIP". Service''s sessionAffinity is
     set to "ClientIP". Service creation MUST be successful by assigning "ClusterIP"
-    to the service. Create a Replication Controller to ensure that 3 pods are running
-    and are targeted by the service to serve hostname of the pod when requests are
-    sent to the service. Create another pod to make requests to the service. Update
-    the service''s sessionAffinity to "None". Service update MUST be successful. When
-    a requests are made to the service, it MUST be able serve the hostname from any
-    pod of the replica. When service''s sessionAffinily is updated back to "ClientIP",
-    service MUST serve the hostname from the same pod of the replica for all consecutive
-    requests. Service MUST be reachable over serviceName and the ClusterIP on servicePort.
-    [LinuxOnly]: Windows does not support session affinity.'
+    to the service. Create a Deployment to ensure that 3 pods are running and are
+    targeted by the service to serve hostname of the pod when requests are sent to
+    the service. Create another pod to make requests to the service. Update the service''s
+    sessionAffinity to "None". Service update MUST be successful. When a requests
+    are made to the service, it MUST be able serve the hostname from any pod of the
+    replica. When service''s sessionAffinily is updated back to "ClientIP", service
+    MUST serve the hostname from the same pod of the replica for all consecutive requests.
+    Service MUST be reachable over serviceName and the ClusterIP on servicePort. [LinuxOnly]:
+    Windows does not support session affinity.'
   release: v1.19
   file: test/e2e/network/service.go
 - testname: Service, complete ServiceStatus lifecycle
@@ -1922,13 +1922,13 @@
   description: 'Create a service of type "NodePort" and provide service port and protocol.
     Service''s sessionAffinity is set to "ClientIP". Service creation MUST be successful
     by assigning a "ClusterIP" to service and allocating NodePort on all nodes. Create
-    a Replication Controller to ensure that 3 pods are running and are targeted by
-    the service to serve hostname of the pod when a requests are sent to the service.
-    Create another pod to make requests to the service on node''s IP and NodePort.
-    Service MUST serve the hostname from the same pod of the replica for all consecutive
-    requests. Service MUST be reachable over serviceName and the ClusterIP on servicePort.
-    Service MUST also be reachable over node''s IP on NodePort. [LinuxOnly]: Windows
-    does not support session affinity.'
+    a Deployment to ensure that 3 pods are running and are targeted by the service
+    to serve hostname of the pod when a requests are sent to the service. Create another
+    pod to make requests to the service on node''s IP and NodePort. Service MUST serve
+    the hostname from the same pod of the replica for all consecutive requests. Service
+    MUST be reachable over serviceName and the ClusterIP on servicePort. Service MUST
+    also be reachable over node''s IP on NodePort. [LinuxOnly]: Windows does not support
+    session affinity.'
   release: v1.19
   file: test/e2e/network/service.go
 - testname: Service, ClusterIP type, session affinity to ClientIP
@@ -1936,10 +1936,10 @@
     with type clusterIP [LinuxOnly] [Conformance]'
   description: 'Create a service of type "ClusterIP". Service''s sessionAffinity is
     set to "ClientIP". Service creation MUST be successful by assigning "ClusterIP"
-    to the service. Create a Replication Controller to ensure that 3 pods are running
-    and are targeted by the service to serve hostname of the pod when requests are
-    sent to the service. Create another pod to make requests to the service. Service
-    MUST serve the hostname from the same pod of the replica for all consecutive requests.
+    to the service. Create a Deployment to ensure that 3 pods are running and are
+    targeted by the service to serve hostname of the pod when requests are sent to
+    the service. Create another pod to make requests to the service. Service MUST
+    serve the hostname from the same pod of the replica for all consecutive requests.
     Service MUST be reachable over serviceName and the ClusterIP on servicePort. [LinuxOnly]:
     Windows does not support session affinity.'
   release: v1.19


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup
/sig network

#### What this PR does / why we need it:
This change rewrites some of the network-related e2e tests to use Deployments instead of ReplicationControllers when setting up the test environment. The test code has been made more clear using direct API calls where possible, and the advantages Deployments offer over RCs will make live debugging of e2e tests easier.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Partially fixes #119021

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
