### PR TITLE
test(network): replace calls to e2erc.RunRC with Deployments in SIG Network tests

### DIFF
--- a/test/e2e/network/proxy.go
+++ b/test/e2e/network/proxy.go
@@ -29,6 +29,7 @@ import (
 	"sync"
 	"time"
 
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -38,11 +39,10 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/transport"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2edeployment "k8s.io/kubernetes/test/e2e/framework/deployment"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
-	e2erc "k8s.io/kubernetes/test/e2e/framework/rc"
 	"k8s.io/kubernetes/test/e2e/network/common"
-	testutils "k8s.io/kubernetes/test/utils"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 	admissionapi "k8s.io/pod-security-admission/api"
 
@@ -133,52 +133,95 @@ var _ = common.SIGDescribe("Proxy", func() {
 			}, metav1.CreateOptions{})
 			framework.ExpectNoError(err)
 
-			// Make an RC with a single pod. The 'porter' image is
+			// Make a deployment with a single pod. The 'porter' image is
 			// a simple server which serves the values of the
 			// environmental variables below.
 			ginkgo.By("starting an echo server on multiple ports")
-			pods := []*v1.Pod{}
-			cfg := testutils.RCConfig{
-				Client:       f.ClientSet,
-				Image:        imageutils.GetE2EImage(imageutils.Agnhost),
-				Command:      []string{"/agnhost", "porter"},
-				Name:         service.Name,
-				Namespace:    f.Namespace.Name,
-				Replicas:     1,
-				PollInterval: time.Second,
-				Env: map[string]string{
-					"SERVE_PORT_80":   `<a href="/rewriteme">test</a>`,
-					"SERVE_PORT_1080": `<a href="/rewriteme">test</a>`,
-					"SERVE_PORT_160":  "foo",
-					"SERVE_PORT_162":  "bar",
 
-					"SERVE_TLS_PORT_443": `<a href="/tlsrewriteme">test</a>`,
-					"SERVE_TLS_PORT_460": `tls baz`,
-					"SERVE_TLS_PORT_462": `tls qux`,
+			deploymentConfig := e2edeployment.NewDeployment(service.Name,
+				1,
+				labels,
+				service.Name,
+				imageutils.GetE2EImage(imageutils.Agnhost),
+				appsv1.RecreateDeploymentStrategyType)
+			deploymentConfig.Spec.Template.Spec.Containers[0].Command = []string{"/agnhost", "porter"}
+			deploymentConfig.Spec.Template.Spec.Containers[0].Env = []v1.EnvVar{
+				{
+					Name:  "SERVE_PORT_80",
+					Value: `<a href="/rewriteme">test</a>`,
 				},
-				Ports: map[string]int{
-					"dest1": 160,
-					"dest2": 162,
-
-					"tlsdest1": 460,
-					"tlsdest2": 462,
+				{
+					Name:  "SERVE_PORT_1080",
+					Value: `<a href="/rewriteme">test</a>`,
 				},
-				ReadinessProbe: &v1.Probe{
-					ProbeHandler: v1.ProbeHandler{
-						HTTPGet: &v1.HTTPGetAction{
-							Port: intstr.FromInt32(80),
-						},
-					},
-					InitialDelaySeconds: 1,
-					TimeoutSeconds:      5,
-					PeriodSeconds:       10,
+				{
+					Name:  "SERVE_PORT_160",
+					Value: "foo",
 				},
-				Labels:      labels,
-				CreatedPods: &pods,
+				{
+					Name:  "SERVE_PORT_162",
+					Value: "bar",
+				},
+				{
+					Name:  "SERVE_TLS_PORT_443",
+					Value: `<a href="/tlsrewriteme">test</a>`,
+				},
+				{
+					Name:  "SERVE_TLS_PORT_460",
+					Value: "tls baz",
+				},
+				{
+					Name:  "SERVE_TLS_PORT_462",
+					Value: "tls qux",
+				},
 			}
-			err = e2erc.RunRC(ctx, cfg)
+			deploymentConfig.Spec.Template.Spec.Containers[0].Ports = []v1.ContainerPort{
+				{
+					ContainerPort: 80,
+				},
+				{
+					Name:          "dest1",
+					ContainerPort: 160,
+				},
+				{
+					Name:          "dest2",
+					ContainerPort: 162,
+				},
+				{
+					Name:          "tlsdest1",
+					ContainerPort: 460,
+				},
+				{
+					Name:          "tlsdest2",
+					ContainerPort: 462,
+				},
+			}
+			deploymentConfig.Spec.Template.Spec.Containers[0].ReadinessProbe = &v1.Probe{
+				ProbeHandler: v1.ProbeHandler{
+					HTTPGet: &v1.HTTPGetAction{
+						Port: intstr.FromInt32(80),
+					},
+				},
+				InitialDelaySeconds: 1,
+				TimeoutSeconds:      5,
+				PeriodSeconds:       10,
+			}
+
+			deployment, err := f.ClientSet.AppsV1().Deployments(f.Namespace.Name).Create(ctx,
+				deploymentConfig,
+				metav1.CreateOptions{})
 			framework.ExpectNoError(err)
-			ginkgo.DeferCleanup(e2erc.DeleteRCAndWaitForGC, f.ClientSet, f.Namespace.Name, cfg.Name)
+
+			ginkgo.DeferCleanup(func(ctx context.Context, name string) error {
+				return f.ClientSet.AppsV1().Deployments(f.Namespace.Name).Delete(ctx, name, metav1.DeleteOptions{})
+			}, deployment.Name)
+
+			err = e2edeployment.WaitForDeploymentComplete(f.ClientSet, deployment)
+			framework.ExpectNoError(err)
+
+			podList, err := e2edeployment.GetPodsForDeployment(ctx, f.ClientSet, deployment)
+			framework.ExpectNoError(err)
+			pods := podList.Items
 
 			err = waitForEndpoint(ctx, f.ClientSet, f.Namespace.Name, service.Name)
 			framework.ExpectNoError(err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup
/sig network

#### What this PR does / why we need it:
This change rewrites some of the network-related e2e tests to use Deployments instead of ReplicationControllers when setting up the test environment. The test code has been made more clear using direct API calls where possible, and the advantages Deployments offer over RCs will make live debugging of e2e tests easier.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Partially fixes #119021

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
