### PR TITLE
Modify how to check the status in PodRejectionStatus test

### DIFF
--- a/test/e2e/node/pod_admission.go
+++ b/test/e2e/node/pod_admission.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/gstruct"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -97,14 +98,24 @@ var _ = SIGDescribe("PodRejectionStatus", func() {
 
 			// This detects if there are any new fields in Status that were dropped by the pod rejection.
 			// These new fields either should be kept by kubelet's admission or added explicitly in the list of fields that are having a different value or must be cleared.
-			expectedStatus := pod.Status.DeepCopy()
-			expectedStatus.Phase = gotPod.Status.Phase
-			expectedStatus.Conditions = nil
-			expectedStatus.Message = gotPod.Status.Message
-			expectedStatus.Reason = gotPod.Status.Reason
-			expectedStatus.StartTime = gotPod.Status.StartTime
-			// expectedStatus.QOSClass keep it as is
-			gomega.Expect(gotPod.Status).To(gomega.Equal(*expectedStatus))
+			gomega.Expect(gotPod.Status).To(gstruct.MatchAllFields(gstruct.Fields{
+				"Phase":                      gstruct.Ignore(),
+				"Conditions":                 gstruct.Ignore(),
+				"Message":                    gstruct.Ignore(),
+				"Reason":                     gstruct.Ignore(),
+				"NominatedNodeName":          gstruct.Ignore(),
+				"HostIP":                     gstruct.Ignore(),
+				"HostIPs":                    gstruct.Ignore(),
+				"PodIP":                      gstruct.Ignore(),
+				"PodIPs":                     gstruct.Ignore(),
+				"StartTime":                  gstruct.Ignore(),
+				"InitContainerStatuses":      gstruct.Ignore(),
+				"ContainerStatuses":          gstruct.Ignore(),
+				"QOSClass":                   gomega.Equal(pod.Status.QOSClass), // QOSClass should be kept
+				"EphemeralContainerStatuses": gstruct.Ignore(),
+				"Resize":                     gstruct.Ignore(),
+				"ResourceClaimStatuses":      gstruct.Ignore(),
+			}))
 		})
 	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Currently the PodRejectionStatus test assumes that most fields are the same as the previous status except for a few certain fields. However this assumption is sometimes wrong in case that there's an operator which modifies the pod when it is bound to a node.
Operator with this behaviour is not rare, for example [ovn-kubernetes](https://github.com/openshift/ovn-kubernetes) behaves like that, and in that environment, the test always fails.
(cf. failure in openshift org https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_kubernetes/2189/pull-ci-openshift-kubernetes-release-4.19-k8s-e2e-gcp-ovn/1884690562456489984)

This PR changes the way to compare and make the restriction more relaxed so that e2e test in those environment should success.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #129056

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
