### PR TITLE
Remove OIDCAuthenticationOptions.areFlagsConfigured and AnonymousAuthenticationOptions.areFlagsSet to make AddFlags() a non-mutating function

### DIFF
--- a/cmd/kube-apiserver/app/options/options_test.go
+++ b/cmd/kube-apiserver/app/options/options_test.go
@@ -18,7 +18,6 @@ package options
 
 import (
 	"net"
-	"reflect"
 	"testing"
 	"time"
 
@@ -347,9 +346,14 @@ func TestAddFlags(t *testing.T) {
 	// setting the method to nil since methods can't be compared with reflect.DeepEqual
 	s.Authorization.AreLegacyFlagsSet = nil
 
-	if !reflect.DeepEqual(expected, s) {
-		t.Errorf("Got different run options than expected.\nDifference detected on:\n%s", cmp.Diff(expected, s, cmpopts.IgnoreFields(apiserveroptions.ServerRunOptions{}, "ComponentGlobalsRegistry"), cmpopts.IgnoreUnexported(admission.Plugins{}, kubeoptions.OIDCAuthenticationOptions{}, kubeoptions.AnonymousAuthenticationOptions{})))
+	if diff := cmp.Diff(expected, s,
+		cmpopts.IgnoreFields(apiserveroptions.ServerRunOptions{}, "ComponentGlobalsRegistry"),
+		cmpopts.IgnoreUnexported(admission.Plugins{}, kubeoptions.BuiltInAuthenticationOptions{}),
+		cmpopts.IgnoreFields(apiserveroptions.AdmissionOptions{}, "Decorators"),
+	); diff != "" {
+		t.Errorf("Got different run options than expected.\nDifference detected on:\n%s", diff)
 	}
+
 	testEffectiveVersion := s.GenericServerRunOptions.ComponentGlobalsRegistry.EffectiveVersionFor("test")
 	if testEffectiveVersion.EmulationVersion().String() != "1.31" {
 		t.Errorf("Got emulation version %s, wanted %s", testEffectiveVersion.EmulationVersion().String(), "1.31")

--- a/pkg/controlplane/apiserver/options/options_test.go
+++ b/pkg/controlplane/apiserver/options/options_test.go
@@ -24,7 +24,6 @@ import (
 	"encoding/pem"
 	"fmt"
 	"os"
-	"reflect"
 	"testing"
 	"time"
 
@@ -307,8 +306,12 @@ func TestAddFlags(t *testing.T) {
 	// setting the method to nil since methods can't be compared with reflect.DeepEqual
 	s.Authorization.AreLegacyFlagsSet = nil
 
-	if !reflect.DeepEqual(expected, s) {
-		t.Errorf("Got different run options than expected.\nDifference detected on:\n%s", cmp.Diff(expected, s, cmpopts.IgnoreFields(apiserveroptions.ServerRunOptions{}, "ComponentGlobalsRegistry"), cmpopts.IgnoreUnexported(admission.Plugins{}, kubeoptions.OIDCAuthenticationOptions{}, kubeoptions.AnonymousAuthenticationOptions{})))
+	if diff := cmp.Diff(expected, s,
+		cmpopts.IgnoreFields(apiserveroptions.ServerRunOptions{}, "ComponentGlobalsRegistry"),
+		cmpopts.IgnoreUnexported(admission.Plugins{}, kubeoptions.BuiltInAuthenticationOptions{}),
+		cmpopts.IgnoreFields(apiserveroptions.AdmissionOptions{}, "Decorators"),
+	); diff != "" {
+		t.Errorf("Got different run options than expected.\nDifference detected on:\n%s", diff)
 	}
 
 	testEffectiveVersion := s.GenericServerRunOptions.ComponentGlobalsRegistry.EffectiveVersionFor("test")

--- a/pkg/kubeapiserver/options/authentication_test.go
+++ b/pkg/kubeapiserver/options/authentication_test.go
@@ -57,6 +57,8 @@ import (
 func TestAuthenticationValidate(t *testing.T) {
 	testCases := []struct {
 		name                              string
+		areOIDCFlagsConfigured            bool
+		areAnonymousFlagsConfigured       bool
 		testAnonymous                     *AnonymousAuthenticationOptions
 		testOIDC                          *OIDCAuthenticationOptions
 		testSA                            *ServiceAccountAuthenticationOptions
@@ -69,26 +71,25 @@ func TestAuthenticationValidate(t *testing.T) {
 			name: "test when OIDC and ServiceAccounts are nil",
 		},
 		{
-			name: "test when OIDC and ServiceAccounts are valid",
+			name:                   "test when OIDC and ServiceAccounts are valid",
+			areOIDCFlagsConfigured: true,
 			testOIDC: &OIDCAuthenticationOptions{
-				UsernameClaim:      "sub",
-				SigningAlgs:        []string{"RS256"},
-				IssuerURL:          "https://testIssuerURL",
-				ClientID:           "testClientID",
-				areFlagsConfigured: func() bool { return true },
+				UsernameClaim: "sub",
+				SigningAlgs:   []string{"RS256"},
+				IssuerURL:     "https://testIssuerURL",
+				ClientID:      "testClientID",
 			},
 			testSA: &ServiceAccountAuthenticationOptions{
 				Issuers:  []string{"http://foo.bar.com"},
 				KeyFiles: []string{"testkeyfile1", "testkeyfile2"},
 			},
-		},
-		{
-			name: "test when OIDC is invalid",
+		}, {
+			name:                   "test when OIDC is invalid",
+			areOIDCFlagsConfigured: true,
 			testOIDC: &OIDCAuthenticationOptions{
-				UsernameClaim:      "sub",
-				SigningAlgs:        []string{"RS256"},
-				IssuerURL:          "https://testIssuerURL",
-				areFlagsConfigured: func() bool { return true },
+				UsernameClaim: "sub",
+				SigningAlgs:   []string{"RS256"},
+				IssuerURL:     "https://testIssuerURL",
 			},
 			testSA: &ServiceAccountAuthenticationOptions{
 				Issuers:  []string{"http://foo.bar.com"},
@@ -97,13 +98,13 @@ func TestAuthenticationValidate(t *testing.T) {
 			expectErr: "oidc-issuer-url and oidc-client-id must be specified together when any oidc-* flags are set",
 		},
 		{
-			name: "test when ServiceAccounts doesn't have key file",
+			name:                   "test when ServiceAccounts doesn't have key file",
+			areOIDCFlagsConfigured: true,
 			testOIDC: &OIDCAuthenticationOptions{
-				UsernameClaim:      "sub",
-				SigningAlgs:        []string{"RS256"},
-				IssuerURL:          "https://testIssuerURL",
-				ClientID:           "testClientID",
-				areFlagsConfigured: func() bool { return true },
+				UsernameClaim: "sub",
+				SigningAlgs:   []string{"RS256"},
+				IssuerURL:     "https://testIssuerURL",
+				ClientID:      "testClientID",
 			},
 			testSA: &ServiceAccountAuthenticationOptions{
 				Issuers: []string{"http://foo.bar.com"},
@@ -111,13 +112,13 @@ func TestAuthenticationValidate(t *testing.T) {
 			expectErr: "either `--service-account-key-file` or `--service-account-signing-endpoint` must be set",
 		},
 		{
-			name: "test when ServiceAccounts doesn't have issuer",
+			name:                   "test when ServiceAccounts doesn't have issuer",
+			areOIDCFlagsConfigured: true,
 			testOIDC: &OIDCAuthenticationOptions{
-				UsernameClaim:      "sub",
-				SigningAlgs:        []string{"RS256"},
-				IssuerURL:          "https://testIssuerURL",
-				ClientID:           "testClientID",
-				areFlagsConfigured: func() bool { return true },
+				UsernameClaim: "sub",
+				SigningAlgs:   []string{"RS256"},
+				IssuerURL:     "https://testIssuerURL",
+				ClientID:      "testClientID",
 			},
 			testSA: &ServiceAccountAuthenticationOptions{
 				Issuers: []string{},
@@ -125,13 +126,13 @@ func TestAuthenticationValidate(t *testing.T) {
 			expectErr: "service-account-issuer is a required flag",
 		},
 		{
-			name: "test when ServiceAccounts has empty string as issuer",
+			name:                   "test when ServiceAccounts has empty string as issuer",
+			areOIDCFlagsConfigured: true,
 			testOIDC: &OIDCAuthenticationOptions{
-				UsernameClaim:      "sub",
-				SigningAlgs:        []string{"RS256"},
-				IssuerURL:          "https://testIssuerURL",
-				ClientID:           "testClientID",
-				areFlagsConfigured: func() bool { return true },
+				UsernameClaim: "sub",
+				SigningAlgs:   []string{"RS256"},
+				IssuerURL:     "https://testIssuerURL",
+				ClientID:      "testClientID",
 			},
 			testSA: &ServiceAccountAuthenticationOptions{
 				Issuers: []string{""},
@@ -139,13 +140,13 @@ func TestAuthenticationValidate(t *testing.T) {
 			expectErr: "service-account-issuer should not be an empty string",
 		},
 		{
-			name: "test when ServiceAccounts has duplicate issuers",
+			name:                   "test when ServiceAccounts has duplicate issuers",
+			areOIDCFlagsConfigured: true,
 			testOIDC: &OIDCAuthenticationOptions{
-				UsernameClaim:      "sub",
-				SigningAlgs:        []string{"RS256"},
-				IssuerURL:          "https://testIssuerURL",
-				ClientID:           "testClientID",
-				areFlagsConfigured: func() bool { return true },
+				UsernameClaim: "sub",
+				SigningAlgs:   []string{"RS256"},
+				IssuerURL:     "https://testIssuerURL",
+				ClientID:      "testClientID",
 			},
 			testSA: &ServiceAccountAuthenticationOptions{
 				Issuers: []string{"http://foo.bar.com", "http://foo.bar.com"},
@@ -153,13 +154,13 @@ func TestAuthenticationValidate(t *testing.T) {
 			expectErr: "service-account-issuer \"http://foo.bar.com\" is already specified",
 		},
 		{
-			name: "test when ServiceAccount has bad issuer",
+			name:                   "test when ServiceAccount has bad issuer",
+			areOIDCFlagsConfigured: true,
 			testOIDC: &OIDCAuthenticationOptions{
-				UsernameClaim:      "sub",
-				SigningAlgs:        []string{"RS256"},
-				IssuerURL:          "https://testIssuerURL",
-				ClientID:           "testClientID",
-				areFlagsConfigured: func() bool { return true },
+				UsernameClaim: "sub",
+				SigningAlgs:   []string{"RS256"},
+				IssuerURL:     "https://testIssuerURL",
+				ClientID:      "testClientID",
 			},
 			testSA: &ServiceAccountAuthenticationOptions{
 				Issuers: []string{"http://[::1]:namedport"},
@@ -167,13 +168,13 @@ func TestAuthenticationValidate(t *testing.T) {
 			expectErr: "service-account-issuer \"http://[::1]:namedport\" contained a ':' but was not a valid URL",
 		},
 		{
-			name: "test when ServiceAccounts has invalid JWKSURI",
+			name:                   "test when ServiceAccounts has invalid JWKSURI",
+			areOIDCFlagsConfigured: true,
 			testOIDC: &OIDCAuthenticationOptions{
-				UsernameClaim:      "sub",
-				SigningAlgs:        []string{"RS256"},
-				IssuerURL:          "https://testIssuerURL",
-				ClientID:           "testClientID",
-				areFlagsConfigured: func() bool { return true },
+				UsernameClaim: "sub",
+				SigningAlgs:   []string{"RS256"},
+				IssuerURL:     "https://testIssuerURL",
+				ClientID:      "testClientID",
 			},
 			testSA: &ServiceAccountAuthenticationOptions{
 				KeyFiles: []string{"cert", "key"},
@@ -183,13 +184,13 @@ func TestAuthenticationValidate(t *testing.T) {
 			expectErr: "service-account-jwks-uri must be a valid URL: parse \"https://host:port\": invalid port \":port\" after host",
 		},
 		{
-			name: "test when ServiceAccounts has invalid JWKSURI (not https scheme)",
+			name:                   "test when ServiceAccounts has invalid JWKSURI (not https scheme)",
+			areOIDCFlagsConfigured: true,
 			testOIDC: &OIDCAuthenticationOptions{
-				UsernameClaim:      "sub",
-				SigningAlgs:        []string{"RS256"},
-				IssuerURL:          "https://testIssuerURL",
-				ClientID:           "testClientID",
-				areFlagsConfigured: func() bool { return true },
+				UsernameClaim: "sub",
+				SigningAlgs:   []string{"RS256"},
+				IssuerURL:     "https://testIssuerURL",
+				ClientID:      "testClientID",
 			},
 			testSA: &ServiceAccountAuthenticationOptions{
 				KeyFiles: []string{"cert", "key"},
@@ -199,13 +200,13 @@ func TestAuthenticationValidate(t *testing.T) {
 			expectErr: "service-account-jwks-uri requires https scheme, parsed as: http://baz.com",
 		},
 		{
-			name: "test when WebHook has invalid retry attempts",
+			name:                   "test when WebHook has invalid retry attempts",
+			areOIDCFlagsConfigured: true,
 			testOIDC: &OIDCAuthenticationOptions{
-				UsernameClaim:      "sub",
-				SigningAlgs:        []string{"RS256"},
-				IssuerURL:          "https://testIssuerURL",
-				ClientID:           "testClientID",
-				areFlagsConfigured: func() bool { return true },
+				UsernameClaim: "sub",
+				SigningAlgs:   []string{"RS256"},
+				IssuerURL:     "https://testIssuerURL",
+				ClientID:      "testClientID",
 			},
 			testSA: &ServiceAccountAuthenticationOptions{
 				KeyFiles: []string{"cert", "key"},
@@ -232,23 +233,23 @@ func TestAuthenticationValidate(t *testing.T) {
 		},
 		{
 			name:                         "test when authentication config file and oidc-* flags are set",
+			areOIDCFlagsConfigured:       true,
 			testAuthenticationConfigFile: "configfile",
 			testOIDC: &OIDCAuthenticationOptions{
-				UsernameClaim:      "sub",
-				SigningAlgs:        []string{"RS256"},
-				IssuerURL:          "https://testIssuerURL",
-				ClientID:           "testClientID",
-				areFlagsConfigured: func() bool { return true },
+				UsernameClaim: "sub",
+				SigningAlgs:   []string{"RS256"},
+				IssuerURL:     "https://testIssuerURL",
+				ClientID:      "testClientID",
 			},
 			expectErr: "authentication-config file and oidc-* flags are mutually exclusive",
 		},
 		{
 			name:                         "test when authentication config file and anonymous-auth flags are set AnonymousAuthConfigurableEndpoints disabled",
+			areAnonymousFlagsConfigured:  true,
 			disabledFeatures:             []featuregate.Feature{features.AnonymousAuthConfigurableEndpoints},
 			testAuthenticationConfigFile: "configfile",
 			testAnonymous: &AnonymousAuthenticationOptions{
-				Allow:       true,
-				areFlagsSet: func() bool { return true },
+				Allow: true,
 			},
 		},
 	}
@@ -261,6 +262,15 @@ func TestAuthenticationValidate(t *testing.T) {
 			options.ServiceAccounts = testcase.testSA
 			options.WebHook = testcase.testWebHook
 			options.AuthenticationConfigFile = testcase.testAuthenticationConfigFile
+			pf, err := configureFlagSet(options, testcase.areOIDCFlagsConfigured, testcase.areAnonymousFlagsConfigured, testcase.testOIDC)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if pf != nil {
+				if err := pf.Parse([]string{}); err != nil {
+					t.Fatal(err)
+				}
+			}
 			for _, f := range testcase.enabledFeatures {
 				featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, f, true)
 			}
@@ -465,23 +475,19 @@ func TestBuiltInAuthenticationOptionsAddFlags(t *testing.T) {
 	opts := NewBuiltInAuthenticationOptions().WithAll()
 	pf := pflag.NewFlagSet("test-builtin-authentication-opts", pflag.ContinueOnError)
 	opts.AddFlags(pf)
+	expected.flagSet = pf
 
 	if err := pf.Parse(args); err != nil {
 		t.Fatal(err)
 	}
 
-	if !opts.OIDC.areFlagsConfigured() {
+	if !opts.OIDC.areFlagsConfigured(pf) {
 		t.Fatal("OIDC flags should be configured")
 	}
-	// nil these out because you cannot compare functions
-	opts.OIDC.areFlagsConfigured = nil
 
-	if !opts.Anonymous.areFlagsSet() {
+	if !opts.Anonymous.areFlagsSet(pf) {
 		t.Fatalf("Anonymous flags should be configured")
 	}
-
-	// nil these out because you cannot compare functions
-	opts.Anonymous.areFlagsSet = nil
 
 	if !reflect.DeepEqual(opts, expected) {
 		t.Error(cmp.Diff(opts, expected, cmp.AllowUnexported(OIDCAuthenticationOptions{}, AnonymousAuthenticationOptions{})))
@@ -1685,4 +1691,33 @@ func (d *dummyPublicKeyGetter) GetCacheAgeMaxSeconds() int {
 
 func (d *dummyPublicKeyGetter) GetPublicKeys(ctx context.Context, keyIDHint string) []serviceaccount.PublicKey {
 	return []serviceaccount.PublicKey{}
+}
+
+func configureFlagSet(options *BuiltInAuthenticationOptions, areOIDCFlagsConfigured, areAnonymousFlagsConfigured bool, testOIDC *OIDCAuthenticationOptions) (*pflag.FlagSet, error) {
+	if !areOIDCFlagsConfigured && !areAnonymousFlagsConfigured {
+		return nil, nil
+	}
+
+	pf := pflag.NewFlagSet("test-builtin-authentication-opts", pflag.ContinueOnError)
+	options.AddFlags(pf)
+
+	if areOIDCFlagsConfigured {
+		usernameClaim := "sub"
+		if testOIDC != nil && testOIDC.UsernameClaim != "" {
+			usernameClaim = testOIDC.UsernameClaim
+		}
+		err := pf.Set(oidcUsernameClaimFlag, usernameClaim)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if areAnonymousFlagsConfigured {
+		err := pf.Set(anonymousAuthFlag, "true")
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return pf, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:
Modifies OIDC flags to not mutate [OIDCAuthenticationOptions.areFlagsConfigured](https://github.com/kubernetes/kubernetes/blob/release-1.32/pkg/kubeapiserver/options/authentication.go#L125) everytime [AddFlags()](https://github.com/kubernetes/kubernetes/blob/release-1.32/pkg/kubeapiserver/options/authentication.go#L396-L407) is called


Follow up on [this](https://github.com/kubernetes/kubernetes/pull/128674#issuecomment-2463176541) comment
