### PR TITLE
Canonicalize IPs written out by controllers

### DIFF
--- a/pkg/controller/endpoint/endpoints_controller.go
+++ b/pkg/controller/endpoint/endpoints_controller.go
@@ -214,38 +214,12 @@ func (e *Controller) addPod(obj interface{}) {
 
 func podToEndpointAddressForService(svc *v1.Service, pod *v1.Pod) (*v1.EndpointAddress, error) {
 	var endpointIP string
-	ipFamily := v1.IPv4Protocol
 
-	if len(svc.Spec.IPFamilies) > 0 {
-		// controller is connected to an api-server that correctly sets IPFamilies
-		ipFamily = svc.Spec.IPFamilies[0] // this works for headful and headless
-	} else {
-		// controller is connected to an api server that does not correctly
-		// set IPFamilies (e.g. old api-server during an upgrade)
-		// TODO (khenidak): remove by when the possibility of upgrading
-		// from a cluster that does not support dual stack is nil
-		if len(svc.Spec.ClusterIP) > 0 && svc.Spec.ClusterIP != v1.ClusterIPNone {
-			// headful service. detect via service clusterIP
-			if utilnet.IsIPv6String(svc.Spec.ClusterIP) {
-				ipFamily = v1.IPv6Protocol
-			}
-		} else {
-			// Since this is a headless service we use podIP to identify the family.
-			// This assumes that status.PodIP is assigned correctly (follows pod cidr and
-			// pod cidr list order is same as service cidr list order). The expectation is
-			// this is *most probably* the case.
-
-			// if the family was incorrectly identified then this will be corrected once the
-			// upgrade is completed (controller connects to api-server that correctly defaults services)
-			if utilnet.IsIPv6String(pod.Status.PodIP) {
-				ipFamily = v1.IPv6Protocol
-			}
-		}
-	}
+	wantIPv6 := svc.Spec.IPFamilies[0] == v1.IPv6Protocol
 
 	// find an ip that matches the family
 	for _, podIP := range pod.Status.PodIPs {
-		if (ipFamily == v1.IPv6Protocol) == utilnet.IsIPv6String(podIP.IP) {
+		if wantIPv6 == utilnet.IsIPv6String(podIP.IP) {
 			endpointIP = podIP.IP
 			break
 		}

--- a/pkg/controller/endpoint/endpoints_controller.go
+++ b/pkg/controller/endpoint/endpoints_controller.go
@@ -217,10 +217,12 @@ func podToEndpointAddressForService(svc *v1.Service, pod *v1.Pod) (*v1.EndpointA
 
 	wantIPv6 := svc.Spec.IPFamilies[0] == v1.IPv6Protocol
 
-	// find an ip that matches the family
+	// Find an IP that matches the family. We parse and restringify the IP in case the
+	// value on the Pod is in an irregular format.
 	for _, podIP := range pod.Status.PodIPs {
-		if wantIPv6 == utilnet.IsIPv6String(podIP.IP) {
-			endpointIP = podIP.IP
+		ip := utilnet.ParseIPSloppy(podIP.IP)
+		if wantIPv6 == utilnet.IsIPv6(ip) {
+			endpointIP = ip.String()
 			break
 		}
 	}

--- a/pkg/controller/endpoint/endpoints_controller_test.go
+++ b/pkg/controller/endpoint/endpoints_controller_test.go
@@ -387,8 +387,9 @@ func TestSyncEndpointsWithPodResourceVersionUpdateOnly(t *testing.T) {
 	endpoints.serviceStore.Add(&v1.Service{
 		ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: ns},
 		Spec: v1.ServiceSpec{
-			Selector: map[string]string{"foo": "bar"},
-			Ports:    []v1.ServicePort{{Port: 80, Protocol: "TCP", TargetPort: intstr.FromInt32(8080)}},
+			Selector:   map[string]string{"foo": "bar"},
+			Ports:      []v1.ServicePort{{Port: 80, Protocol: "TCP", TargetPort: intstr.FromInt32(8080)}},
+			IPFamilies: []v1.IPFamily{v1.IPv4Protocol},
 		},
 	})
 	pod0.ResourceVersion = "3"
@@ -472,8 +473,9 @@ func TestSyncEndpointsProtocolTCP(t *testing.T) {
 	endpoints.serviceStore.Add(&v1.Service{
 		ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: ns},
 		Spec: v1.ServiceSpec{
-			Selector: map[string]string{},
-			Ports:    []v1.ServicePort{{Port: 80, TargetPort: intstr.FromInt32(8080), Protocol: "TCP"}},
+			Selector:   map[string]string{},
+			Ports:      []v1.ServicePort{{Port: 80, TargetPort: intstr.FromInt32(8080), Protocol: "TCP"}},
+			IPFamilies: []v1.IPFamily{v1.IPv4Protocol},
 		},
 	})
 	err := endpoints.syncService(tCtx, ns+"/foo")
@@ -622,8 +624,9 @@ func TestSyncEndpointsProtocolUDP(t *testing.T) {
 	endpoints.serviceStore.Add(&v1.Service{
 		ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: ns},
 		Spec: v1.ServiceSpec{
-			Selector: map[string]string{},
-			Ports:    []v1.ServicePort{{Port: 80, TargetPort: intstr.FromInt32(8080), Protocol: "UDP"}},
+			Selector:   map[string]string{},
+			Ports:      []v1.ServicePort{{Port: 80, TargetPort: intstr.FromInt32(8080), Protocol: "UDP"}},
+			IPFamilies: []v1.IPFamily{v1.IPv4Protocol},
 		},
 	})
 	err := endpoints.syncService(tCtx, ns+"/foo")
@@ -670,8 +673,9 @@ func TestSyncEndpointsProtocolSCTP(t *testing.T) {
 	endpoints.serviceStore.Add(&v1.Service{
 		ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: ns},
 		Spec: v1.ServiceSpec{
-			Selector: map[string]string{},
-			Ports:    []v1.ServicePort{{Port: 80, TargetPort: intstr.FromInt32(8080), Protocol: "SCTP"}},
+			Selector:   map[string]string{},
+			Ports:      []v1.ServicePort{{Port: 80, TargetPort: intstr.FromInt32(8080), Protocol: "SCTP"}},
+			IPFamilies: []v1.IPFamily{v1.IPv4Protocol},
 		},
 	})
 	err := endpoints.syncService(tCtx, ns+"/foo")
@@ -715,8 +719,9 @@ func TestSyncEndpointsItemsEmptySelectorSelectsAll(t *testing.T) {
 	endpoints.serviceStore.Add(&v1.Service{
 		ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: ns},
 		Spec: v1.ServiceSpec{
-			Selector: map[string]string{},
-			Ports:    []v1.ServicePort{{Port: 80, Protocol: "TCP", TargetPort: intstr.FromInt32(8080)}},
+			Selector:   map[string]string{},
+			Ports:      []v1.ServicePort{{Port: 80, Protocol: "TCP", TargetPort: intstr.FromInt32(8080)}},
+			IPFamilies: []v1.IPFamily{v1.IPv4Protocol},
 		},
 	})
 	err := endpoints.syncService(tCtx, ns+"/foo")
@@ -760,8 +765,9 @@ func TestSyncEndpointsItemsEmptySelectorSelectsAllNotReady(t *testing.T) {
 	endpoints.serviceStore.Add(&v1.Service{
 		ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: ns},
 		Spec: v1.ServiceSpec{
-			Selector: map[string]string{},
-			Ports:    []v1.ServicePort{{Port: 80, Protocol: "TCP", TargetPort: intstr.FromInt32(8080)}},
+			Selector:   map[string]string{},
+			Ports:      []v1.ServicePort{{Port: 80, Protocol: "TCP", TargetPort: intstr.FromInt32(8080)}},
+			IPFamilies: []v1.IPFamily{v1.IPv4Protocol},
 		},
 	})
 	err := endpoints.syncService(tCtx, ns+"/foo")
@@ -805,8 +811,9 @@ func TestSyncEndpointsItemsEmptySelectorSelectsAllMixed(t *testing.T) {
 	endpoints.serviceStore.Add(&v1.Service{
 		ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: ns},
 		Spec: v1.ServiceSpec{
-			Selector: map[string]string{},
-			Ports:    []v1.ServicePort{{Port: 80, Protocol: "TCP", TargetPort: intstr.FromInt32(8080)}},
+			Selector:   map[string]string{},
+			Ports:      []v1.ServicePort{{Port: 80, Protocol: "TCP", TargetPort: intstr.FromInt32(8080)}},
+			IPFamilies: []v1.IPFamily{v1.IPv4Protocol},
 		},
 	})
 	err := endpoints.syncService(tCtx, ns+"/foo")
@@ -853,8 +860,9 @@ func TestSyncEndpointsItemsPreexisting(t *testing.T) {
 	endpoints.serviceStore.Add(&v1.Service{
 		ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: ns},
 		Spec: v1.ServiceSpec{
-			Selector: map[string]string{"foo": "bar"},
-			Ports:    []v1.ServicePort{{Port: 80, Protocol: "TCP", TargetPort: intstr.FromInt32(8080)}},
+			Selector:   map[string]string{"foo": "bar"},
+			Ports:      []v1.ServicePort{{Port: 80, Protocol: "TCP", TargetPort: intstr.FromInt32(8080)}},
+			IPFamilies: []v1.IPFamily{v1.IPv4Protocol},
 		},
 	})
 	err := endpoints.syncService(tCtx, ns+"/foo")
@@ -900,8 +908,9 @@ func TestSyncEndpointsItemsPreexistingIdentical(t *testing.T) {
 	endpoints.serviceStore.Add(&v1.Service{
 		ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: metav1.NamespaceDefault},
 		Spec: v1.ServiceSpec{
-			Selector: map[string]string{"foo": "bar"},
-			Ports:    []v1.ServicePort{{Port: 80, Protocol: "TCP", TargetPort: intstr.FromInt32(8080)}},
+			Selector:   map[string]string{"foo": "bar"},
+			Ports:      []v1.ServicePort{{Port: 80, Protocol: "TCP", TargetPort: intstr.FromInt32(8080)}},
+			IPFamilies: []v1.IPFamily{v1.IPv4Protocol},
 		},
 	})
 	err := endpoints.syncService(tCtx, ns+"/foo")
@@ -928,6 +937,7 @@ func TestSyncEndpointsItems(t *testing.T) {
 				{Name: "port0", Port: 80, Protocol: "TCP", TargetPort: intstr.FromInt32(8080)},
 				{Name: "port1", Port: 88, Protocol: "TCP", TargetPort: intstr.FromInt32(8088)},
 			},
+			IPFamilies: []v1.IPFamily{v1.IPv4Protocol},
 		},
 	})
 	err := endpoints.syncService(tCtx, "other/foo")
@@ -980,6 +990,7 @@ func TestSyncEndpointsItemsWithLabels(t *testing.T) {
 				{Name: "port0", Port: 80, Protocol: "TCP", TargetPort: intstr.FromInt32(8080)},
 				{Name: "port1", Port: 88, Protocol: "TCP", TargetPort: intstr.FromInt32(8088)},
 			},
+			IPFamilies: []v1.IPFamily{v1.IPv4Protocol},
 		},
 	})
 	err := endpoints.syncService(tCtx, ns+"/foo")
@@ -1041,8 +1052,9 @@ func TestSyncEndpointsItemsPreexistingLabelsChange(t *testing.T) {
 			Labels:    serviceLabels,
 		},
 		Spec: v1.ServiceSpec{
-			Selector: map[string]string{"foo": "bar"},
-			Ports:    []v1.ServicePort{{Port: 80, Protocol: "TCP", TargetPort: intstr.FromInt32(8080)}},
+			Selector:   map[string]string{"foo": "bar"},
+			Ports:      []v1.ServicePort{{Port: 80, Protocol: "TCP", TargetPort: intstr.FromInt32(8080)}},
+			IPFamilies: []v1.IPFamily{v1.IPv4Protocol},
 		},
 	})
 	err := endpoints.syncService(tCtx, ns+"/foo")
@@ -1091,8 +1103,9 @@ func TestWaitsForAllInformersToBeSynced2(t *testing.T) {
 			service := &v1.Service{
 				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: ns},
 				Spec: v1.ServiceSpec{
-					Selector: map[string]string{},
-					Ports:    []v1.ServicePort{{Port: 80, TargetPort: intstr.FromInt32(8080), Protocol: "TCP"}},
+					Selector:   map[string]string{},
+					Ports:      []v1.ServicePort{{Port: 80, TargetPort: intstr.FromInt32(8080), Protocol: "TCP"}},
+					IPFamilies: []v1.IPFamily{v1.IPv4Protocol},
 				},
 			}
 			endpoints.serviceStore.Add(service)
@@ -1141,9 +1154,10 @@ func TestSyncEndpointsHeadlessService(t *testing.T) {
 	service := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: ns, Labels: map[string]string{"a": "b"}},
 		Spec: v1.ServiceSpec{
-			Selector:  map[string]string{},
-			ClusterIP: api.ClusterIPNone,
-			Ports:     []v1.ServicePort{},
+			Selector:   map[string]string{},
+			ClusterIP:  api.ClusterIPNone,
+			Ports:      []v1.ServicePort{},
+			IPFamilies: []v1.IPFamily{v1.IPv4Protocol},
 		},
 	}
 	originalService := service.DeepCopy()
@@ -1196,8 +1210,9 @@ func TestSyncEndpointsItemsExcludeNotReadyPodsWithRestartPolicyNeverAndPhaseFail
 	endpoints.serviceStore.Add(&v1.Service{
 		ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: ns},
 		Spec: v1.ServiceSpec{
-			Selector: map[string]string{"foo": "bar"},
-			Ports:    []v1.ServicePort{{Port: 80, Protocol: "TCP", TargetPort: intstr.FromInt32(8080)}},
+			Selector:   map[string]string{"foo": "bar"},
+			Ports:      []v1.ServicePort{{Port: 80, Protocol: "TCP", TargetPort: intstr.FromInt32(8080)}},
+			IPFamilies: []v1.IPFamily{v1.IPv4Protocol},
 		},
 	})
 	err := endpoints.syncService(tCtx, ns+"/foo")
@@ -1240,8 +1255,9 @@ func TestSyncEndpointsItemsExcludeNotReadyPodsWithRestartPolicyNeverAndPhaseSucc
 	endpoints.serviceStore.Add(&v1.Service{
 		ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: ns},
 		Spec: v1.ServiceSpec{
-			Selector: map[string]string{"foo": "bar"},
-			Ports:    []v1.ServicePort{{Port: 80, Protocol: "TCP", TargetPort: intstr.FromInt32(8080)}},
+			Selector:   map[string]string{"foo": "bar"},
+			Ports:      []v1.ServicePort{{Port: 80, Protocol: "TCP", TargetPort: intstr.FromInt32(8080)}},
+			IPFamilies: []v1.IPFamily{v1.IPv4Protocol},
 		},
 	})
 	err := endpoints.syncService(tCtx, ns+"/foo")
@@ -1284,8 +1300,9 @@ func TestSyncEndpointsItemsExcludeNotReadyPodsWithRestartPolicyOnFailureAndPhase
 	endpoints.serviceStore.Add(&v1.Service{
 		ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: ns},
 		Spec: v1.ServiceSpec{
-			Selector: map[string]string{"foo": "bar"},
-			Ports:    []v1.ServicePort{{Port: 80, Protocol: "TCP", TargetPort: intstr.FromInt32(8080)}},
+			Selector:   map[string]string{"foo": "bar"},
+			Ports:      []v1.ServicePort{{Port: 80, Protocol: "TCP", TargetPort: intstr.FromInt32(8080)}},
+			IPFamilies: []v1.IPFamily{v1.IPv4Protocol},
 		},
 	})
 	err := endpoints.syncService(tCtx, ns+"/foo")
@@ -1316,9 +1333,10 @@ func TestSyncEndpointsHeadlessWithoutPort(t *testing.T) {
 	endpoints.serviceStore.Add(&v1.Service{
 		ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: ns},
 		Spec: v1.ServiceSpec{
-			Selector:  map[string]string{"foo": "bar"},
-			ClusterIP: "None",
-			Ports:     nil,
+			Selector:   map[string]string{"foo": "bar"},
+			ClusterIP:  "None",
+			Ports:      nil,
+			IPFamilies: []v1.IPFamily{v1.IPv4Protocol},
 		},
 	})
 	addPods(endpoints.podStore, ns, 1, 1, 0, ipv4only)
@@ -1359,7 +1377,8 @@ func TestPodToEndpointAddressForService(t *testing.T) {
 			ipFamilies: ipv4only,
 			service: v1.Service{
 				Spec: v1.ServiceSpec{
-					ClusterIP: "10.0.0.1",
+					ClusterIP:  "10.0.0.1",
+					IPFamilies: []v1.IPFamily{v1.IPv4Protocol},
 				},
 			},
 			expectedEndpointFamily: ipv4,
@@ -1369,7 +1388,8 @@ func TestPodToEndpointAddressForService(t *testing.T) {
 			ipFamilies: ipv4ipv6,
 			service: v1.Service{
 				Spec: v1.ServiceSpec{
-					ClusterIP: "10.0.0.1",
+					ClusterIP:  "10.0.0.1",
+					IPFamilies: []v1.IPFamily{v1.IPv4Protocol},
 				},
 			},
 			expectedEndpointFamily: ipv4,
@@ -1379,7 +1399,8 @@ func TestPodToEndpointAddressForService(t *testing.T) {
 			ipFamilies: ipv6ipv4,
 			service: v1.Service{
 				Spec: v1.ServiceSpec{
-					ClusterIP: "10.0.0.1",
+					ClusterIP:  "10.0.0.1",
+					IPFamilies: []v1.IPFamily{v1.IPv4Protocol},
 				},
 			},
 			expectedEndpointFamily: ipv4,
@@ -1389,7 +1410,8 @@ func TestPodToEndpointAddressForService(t *testing.T) {
 			ipFamilies: ipv4only,
 			service: v1.Service{
 				Spec: v1.ServiceSpec{
-					ClusterIP: v1.ClusterIPNone,
+					ClusterIP:  v1.ClusterIPNone,
+					IPFamilies: []v1.IPFamily{v1.IPv4Protocol},
 				},
 			},
 			expectedEndpointFamily: ipv4,
@@ -1406,31 +1428,12 @@ func TestPodToEndpointAddressForService(t *testing.T) {
 			expectedEndpointFamily: ipv4,
 		},
 		{
-			name:       "v4 legacy headless service, in a dual stack cluster",
-			ipFamilies: ipv4ipv6,
-			service: v1.Service{
-				Spec: v1.ServiceSpec{
-					ClusterIP: v1.ClusterIPNone,
-				},
-			},
-			expectedEndpointFamily: ipv4,
-		},
-		{
-			name:       "v4 legacy headless service, in a dual stack ipv6-primary cluster",
-			ipFamilies: ipv6ipv4,
-			service: v1.Service{
-				Spec: v1.ServiceSpec{
-					ClusterIP: v1.ClusterIPNone,
-				},
-			},
-			expectedEndpointFamily: ipv6,
-		},
-		{
 			name:       "v6 service, in a dual stack cluster",
 			ipFamilies: ipv4ipv6,
 			service: v1.Service{
 				Spec: v1.ServiceSpec{
-					ClusterIP: "3000::1",
+					ClusterIP:  "3000::1",
+					IPFamilies: []v1.IPFamily{v1.IPv6Protocol},
 				},
 			},
 			expectedEndpointFamily: ipv6,
@@ -1440,13 +1443,14 @@ func TestPodToEndpointAddressForService(t *testing.T) {
 			ipFamilies: ipv6only,
 			service: v1.Service{
 				Spec: v1.ServiceSpec{
-					ClusterIP: v1.ClusterIPNone,
+					ClusterIP:  v1.ClusterIPNone,
+					IPFamilies: []v1.IPFamily{v1.IPv6Protocol},
 				},
 			},
 			expectedEndpointFamily: ipv6,
 		},
 		{
-			name:       "v6 headless service, in a dual stack cluster (connected to a new api-server)",
+			name:       "v6 headless service, in a dual stack cluster",
 			ipFamilies: ipv4ipv6,
 			service: v1.Service{
 				Spec: v1.ServiceSpec{
@@ -1457,38 +1461,12 @@ func TestPodToEndpointAddressForService(t *testing.T) {
 			expectedEndpointFamily: ipv6,
 		},
 		{
-			name:       "v6 legacy headless service, in a dual stack cluster  (connected to a old api-server)",
-			ipFamilies: ipv4ipv6,
-			service: v1.Service{
-				Spec: v1.ServiceSpec{
-					ClusterIP: v1.ClusterIPNone, // <- families are not set by api-server
-				},
-			},
-			expectedEndpointFamily: ipv4,
-		},
-		// in reality this is a misconfigured cluster
-		// i.e user is not using dual stack and have PodIP == v4 and ServiceIP==v6
-		// previously controller could assign wrong ip to endpoint address
-		// with gate removed. this is no longer the case. this is *not* behavior change
-		// because previously things would have failed in kube-proxy anyway (due to editing wrong iptables).
-		{
-			name:       "v6 service, in a v4 only cluster.",
-			ipFamilies: ipv4only,
-			service: v1.Service{
-				Spec: v1.ServiceSpec{
-					ClusterIP: "3000::1",
-				},
-			},
-			expectError:            true,
-			expectedEndpointFamily: ipv4,
-		},
-		// but this will actually give an error
-		{
 			name:       "v6 service, in a v4 only cluster",
 			ipFamilies: ipv4only,
 			service: v1.Service{
 				Spec: v1.ServiceSpec{
-					ClusterIP: "3000::1",
+					ClusterIP:  "3000::1",
+					IPFamilies: []v1.IPFamily{v1.IPv6Protocol},
 				},
 			},
 			expectError: true,
@@ -1566,8 +1544,9 @@ func TestLastTriggerChangeTimeAnnotation(t *testing.T) {
 	endpoints.serviceStore.Add(&v1.Service{
 		ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: ns, CreationTimestamp: metav1.NewTime(triggerTime)},
 		Spec: v1.ServiceSpec{
-			Selector: map[string]string{},
-			Ports:    []v1.ServicePort{{Port: 80, TargetPort: intstr.FromInt32(8080), Protocol: "TCP"}},
+			Selector:   map[string]string{},
+			Ports:      []v1.ServicePort{{Port: 80, TargetPort: intstr.FromInt32(8080), Protocol: "TCP"}},
+			IPFamilies: []v1.IPFamily{v1.IPv4Protocol},
 		},
 	})
 	err := endpoints.syncService(tCtx, ns+"/foo")
@@ -1621,8 +1600,9 @@ func TestLastTriggerChangeTimeAnnotation_AnnotationOverridden(t *testing.T) {
 	endpoints.serviceStore.Add(&v1.Service{
 		ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: ns, CreationTimestamp: metav1.NewTime(triggerTime)},
 		Spec: v1.ServiceSpec{
-			Selector: map[string]string{},
-			Ports:    []v1.ServicePort{{Port: 80, TargetPort: intstr.FromInt32(8080), Protocol: "TCP"}},
+			Selector:   map[string]string{},
+			Ports:      []v1.ServicePort{{Port: 80, TargetPort: intstr.FromInt32(8080), Protocol: "TCP"}},
+			IPFamilies: []v1.IPFamily{v1.IPv4Protocol},
 		},
 	})
 	err := endpoints.syncService(tCtx, ns+"/foo")
@@ -1677,8 +1657,9 @@ func TestLastTriggerChangeTimeAnnotation_AnnotationCleared(t *testing.T) {
 	endpoints.serviceStore.Add(&v1.Service{
 		ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: ns},
 		Spec: v1.ServiceSpec{
-			Selector: map[string]string{},
-			Ports:    []v1.ServicePort{{Port: 80, TargetPort: intstr.FromInt32(8080), Protocol: "TCP"}},
+			Selector:   map[string]string{},
+			Ports:      []v1.ServicePort{{Port: 80, TargetPort: intstr.FromInt32(8080), Protocol: "TCP"}},
+			IPFamilies: []v1.IPFamily{v1.IPv4Protocol},
 		},
 	})
 	err := endpoints.syncService(tCtx, ns+"/foo")
@@ -1820,8 +1801,9 @@ func TestPodUpdatesBatching(t *testing.T) {
 			endpoints.serviceStore.Add(&v1.Service{
 				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: ns},
 				Spec: v1.ServiceSpec{
-					Selector: map[string]string{"foo": "bar"},
-					Ports:    []v1.ServicePort{{Port: 80}},
+					Selector:   map[string]string{"foo": "bar"},
+					Ports:      []v1.ServicePort{{Port: 80}},
+					IPFamilies: []v1.IPFamily{v1.IPv4Protocol},
 				},
 			})
 
@@ -1941,8 +1923,9 @@ func TestPodAddsBatching(t *testing.T) {
 			endpoints.serviceStore.Add(&v1.Service{
 				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: ns},
 				Spec: v1.ServiceSpec{
-					Selector: map[string]string{"foo": "bar"},
-					Ports:    []v1.ServicePort{{Port: 80}},
+					Selector:   map[string]string{"foo": "bar"},
+					Ports:      []v1.ServicePort{{Port: 80}},
+					IPFamilies: []v1.IPFamily{v1.IPv4Protocol},
 				},
 			})
 
@@ -2065,8 +2048,9 @@ func TestPodDeleteBatching(t *testing.T) {
 			endpoints.serviceStore.Add(&v1.Service{
 				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: ns},
 				Spec: v1.ServiceSpec{
-					Selector: map[string]string{"foo": "bar"},
-					Ports:    []v1.ServicePort{{Port: 80}},
+					Selector:   map[string]string{"foo": "bar"},
+					Ports:      []v1.ServicePort{{Port: 80}},
+					IPFamilies: []v1.IPFamily{v1.IPv4Protocol},
 				},
 			})
 
@@ -2207,8 +2191,9 @@ func TestSyncServiceOverCapacity(t *testing.T) {
 			svc := &v1.Service{
 				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: ns},
 				Spec: v1.ServiceSpec{
-					Selector: map[string]string{"foo": "bar"},
-					Ports:    []v1.ServicePort{{Port: 80}},
+					Selector:   map[string]string{"foo": "bar"},
+					Ports:      []v1.ServicePort{{Port: 80}},
+					IPFamilies: []v1.IPFamily{v1.IPv4Protocol},
 				},
 			}
 			c.serviceStore.Add(svc)
@@ -2405,9 +2390,10 @@ func TestMultipleServiceChanges(t *testing.T) {
 	svc := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: ns},
 		Spec: v1.ServiceSpec{
-			Selector:  map[string]string{"foo": "bar"},
-			ClusterIP: "None",
-			Ports:     nil,
+			Selector:   map[string]string{"foo": "bar"},
+			ClusterIP:  "None",
+			Ports:      nil,
+			IPFamilies: []v1.IPFamily{v1.IPv4Protocol},
 		},
 	}
 
@@ -2477,9 +2463,10 @@ func TestMultiplePodChanges(t *testing.T) {
 	_ = controller.serviceStore.Add(&v1.Service{
 		ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: ns},
 		Spec: v1.ServiceSpec{
-			Selector:  map[string]string{"foo": "bar"},
-			ClusterIP: "10.0.0.1",
-			Ports:     []v1.ServicePort{{Port: 80, Protocol: "TCP", TargetPort: intstr.FromInt32(8080)}},
+			Selector:   map[string]string{"foo": "bar"},
+			ClusterIP:  "10.0.0.1",
+			Ports:      []v1.ServicePort{{Port: 80, Protocol: "TCP", TargetPort: intstr.FromInt32(8080)}},
+			IPFamilies: []v1.IPFamily{v1.IPv4Protocol},
 		},
 	})
 
@@ -2525,6 +2512,7 @@ func TestSyncServiceAddresses(t *testing.T) {
 				Type:                     v1.ServiceTypeClusterIP,
 				ClusterIP:                "1.1.1.1",
 				Ports:                    []v1.ServicePort{{Port: 80}},
+				IPFamilies:               []v1.IPFamily{v1.IPv4Protocol},
 			},
 		}
 	}

--- a/pkg/controller/endpointslice/endpointslice_controller_test.go
+++ b/pkg/controller/endpointslice/endpointslice_controller_test.go
@@ -782,7 +782,7 @@ func TestSyncService(t *testing.T) {
 						Serving:     ptr.To(true),
 						Terminating: ptr.To(false),
 					},
-					Addresses: []string{"fd08::5678:0000:0000:9abc:def0"},
+					Addresses: []string{"fd08::5678:0:0:9abc:def0"},
 					TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "default", Name: "pod1"},
 					NodeName:  ptr.To("node-1"),
 				},

--- a/pkg/controller/endpointslicemirroring/reconciler_helpers.go
+++ b/pkg/controller/endpointslicemirroring/reconciler_helpers.go
@@ -87,8 +87,7 @@ func (d *desiredCalc) initPorts(subsetPorts []v1.EndpointPort) multiAddrTypePort
 // addAddress adds an EndpointAddress to the desired state if it is valid. It
 // returns false if the address was invalid.
 func (d *desiredCalc) addAddress(address v1.EndpointAddress, multiKey multiAddrTypePortMapKey, ready bool) bool {
-	endpoint := addressToEndpoint(address, ready)
-	addrType := getAddressType(address.IP)
+	endpoint, addrType := addressToEndpoint(address, ready)
 	if addrType == nil {
 		return false
 	}

--- a/pkg/controller/endpointslicemirroring/reconciler_test.go
+++ b/pkg/controller/endpointslicemirroring/reconciler_test.go
@@ -1245,7 +1245,7 @@ func expectMatchingAddresses(t *testing.T, epSubset corev1.EndpointSubset, esEnd
 	expectedEndpoints := map[string]addressInfo{}
 
 	for _, address := range epSubset.Addresses {
-		at := getAddressType(address.IP)
+		_, at := addressToEndpoint(address, true)
 		if at != nil && *at == addrType && len(expectedEndpoints) < maxEndpointsPerSubset {
 			expectedEndpoints[address.IP] = addressInfo{
 				ready:     true,
@@ -1255,7 +1255,7 @@ func expectMatchingAddresses(t *testing.T, epSubset corev1.EndpointSubset, esEnd
 	}
 
 	for _, address := range epSubset.NotReadyAddresses {
-		at := getAddressType(address.IP)
+		_, at := addressToEndpoint(address, true)
 		if at != nil && *at == addrType && len(expectedEndpoints) < maxEndpointsPerSubset {
 			expectedEndpoints[address.IP] = addressInfo{
 				ready:     false,

--- a/pkg/controller/endpointslicemirroring/utils.go
+++ b/pkg/controller/endpointslicemirroring/utils.go
@@ -49,18 +49,6 @@ func (pk addrTypePortMapKey) addressType() discovery.AddressType {
 	return discovery.AddressTypeIPv4
 }
 
-func getAddressType(address string) *discovery.AddressType {
-	ip := netutils.ParseIPSloppy(address)
-	if ip == nil {
-		return nil
-	}
-	addressType := discovery.AddressTypeIPv4
-	if ip.To4() == nil {
-		addressType = discovery.AddressTypeIPv6
-	}
-	return &addressType
-}
-
 // newEndpointSlice returns an EndpointSlice generated from an Endpoints
 // resource, ports, and address type.
 func newEndpointSlice(endpoints *corev1.Endpoints, ports []discovery.EndpointPort, addrType discovery.AddressType, sliceName string) *discovery.EndpointSlice {
@@ -115,10 +103,20 @@ func getEndpointSlicePrefix(serviceName string) string {
 }
 
 // addressToEndpoint converts an address from an Endpoints resource to an
-// EndpointSlice endpoint.
-func addressToEndpoint(address corev1.EndpointAddress, ready bool) *discovery.Endpoint {
+// EndpointSlice endpoint and AddressType.
+func addressToEndpoint(address corev1.EndpointAddress, ready bool) (*discovery.Endpoint, *discovery.AddressType) {
+	ip := netutils.ParseIPSloppy(address.IP)
+	if ip == nil {
+		return nil, nil
+	}
+	addressType := discovery.AddressTypeIPv4
+	if ip.To4() == nil {
+		addressType = discovery.AddressTypeIPv6
+	}
+
 	endpoint := &discovery.Endpoint{
-		Addresses: []string{address.IP},
+		// We parse and restringify the Endpoints IP in case it is in an irregular format.
+		Addresses: []string{ip.String()},
 		Conditions: discovery.EndpointConditions{
 			Ready: &ready,
 		},
@@ -132,7 +130,7 @@ func addressToEndpoint(address corev1.EndpointAddress, ready bool) *discovery.En
 		endpoint.Hostname = &address.Hostname
 	}
 
-	return endpoint
+	return endpoint, &addressType
 }
 
 // epPortsToEpsPorts converts ports from an Endpoints resource to ports for an

--- a/pkg/controller/endpointslicemirroring/utils_test.go
+++ b/pkg/controller/endpointslicemirroring/utils_test.go
@@ -217,8 +217,9 @@ func TestAddressToEndpoint(t *testing.T) {
 		NodeName: pointer.String("node-abc"),
 	}
 
-	ep := addressToEndpoint(epAddress, ready)
+	ep, addrType := addressToEndpoint(epAddress, ready)
 	assert.EqualValues(t, expectedEndpoint, *ep)
+	assert.EqualValues(t, discovery.AddressTypeIPv4, *addrType)
 }
 
 // Test helpers

--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -4580,6 +4580,12 @@ func TestSortPodIPs(t *testing.T) {
 			podIPs:      []string{"10.0.0.1", "10.0.0.2", "fd01::1234", "10.0.0.3", "fd01::5678"},
 			expectedIPs: []string{"10.0.0.1", "fd01::1234"},
 		},
+		{
+			name:        "Badly-formatted IPs from CRI",
+			nodeIP:      "",
+			podIPs:      []string{"010.000.000.001", "fd01:0:0:0:0:0:0:1234"},
+			expectedIPs: []string{"10.0.0.1", "fd01::1234"},
+		},
 	}
 
 	for _, tc := range testcases {

--- a/staging/src/k8s.io/endpointslice/reconciler_test.go
+++ b/staging/src/k8s.io/endpointslice/reconciler_test.go
@@ -370,7 +370,7 @@ func TestReconcile1Pod(t *testing.T) {
 			expectedEndpointPerSlice: map[discovery.AddressType][]discovery.Endpoint{
 				discovery.AddressTypeIPv6: {
 					{
-						Addresses: []string{"1234::5678:0000:0000:9abc:def0"},
+						Addresses: []string{"1234::5678:0:0:9abc:def0"},
 						Conditions: discovery.EndpointConditions{
 							Ready:       pointer.Bool(true),
 							Serving:     pointer.Bool(true),
@@ -398,7 +398,7 @@ func TestReconcile1Pod(t *testing.T) {
 			expectedEndpointPerSlice: map[discovery.AddressType][]discovery.Endpoint{
 				discovery.AddressTypeIPv6: {
 					{
-						Addresses: []string{"1234::5678:0000:0000:9abc:def0"},
+						Addresses: []string{"1234::5678:0:0:9abc:def0"},
 						Conditions: discovery.EndpointConditions{
 							Ready:       pointer.Bool(true),
 							Serving:     pointer.Bool(true),
@@ -425,7 +425,7 @@ func TestReconcile1Pod(t *testing.T) {
 			expectedEndpointPerSlice: map[discovery.AddressType][]discovery.Endpoint{
 				discovery.AddressTypeIPv6: {
 					{
-						Addresses: []string{"1234::5678:0000:0000:9abc:def0"},
+						Addresses: []string{"1234::5678:0:0:9abc:def0"},
 						Conditions: discovery.EndpointConditions{
 							Ready:       pointer.Bool(true),
 							Serving:     pointer.Bool(true),

--- a/staging/src/k8s.io/endpointslice/utils.go
+++ b/staging/src/k8s.io/endpointslice/utils.go
@@ -109,13 +109,15 @@ func getEndpointAddresses(podStatus v1.PodStatus, service *v1.Service, addressTy
 	addresses := []string{}
 
 	for _, podIP := range podStatus.PodIPs {
-		isIPv6PodIP := utilnet.IsIPv6String(podIP.IP)
+		// We parse and restringify the pod IP in case it is in an irregular format.
+		ip := utilnet.ParseIPSloppy(podIP.IP)
+		isIPv6PodIP := utilnet.IsIPv6(ip)
 		if isIPv6PodIP && addressType == discovery.AddressTypeIPv6 {
-			addresses = append(addresses, podIP.IP)
+			addresses = append(addresses, ip.String())
 		}
 
 		if !isIPv6PodIP && addressType == discovery.AddressTypeIPv4 {
-			addresses = append(addresses, podIP.IP)
+			addresses = append(addresses, ip.String())
 		}
 	}
 


### PR DESCRIPTION
#### What this PR does / why we need it:
Part of KEP-4858 IP/CIDR validation improvements.

This fixes the Endpoints controller, EndpointSlice controller, EndpointSlice mirroring controller, and kubelet to always write out canonicalized IPs even if they receive IPs in invalid-but-parseable formats from their sources (Pods, Pods, Endpoints, and CRI, respectively).

[The KEP called for updating](https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/4858-ip-cidr-validation/README.md#canonicalization-of-kubernetes-controlled-values):

>  - Set by the Endpoints Controller
>    - `endpoints.subsets[].addresses[].ip`
>    - `endpoints.subsets[].notReadyAddresses[].ip`
>
>  - Set by the EndpointSlice and EndpointSlice Mirroring controllers:
>    - `endpointslice.endpoints[].addresses[]`
>
>  - Set by kubelet:
>    - `pod.status.podIP`
>    - `pod.status.podIPs[].ip`

These are all done by this PR.

>  - Set by the NodeIPAM controller:
>    - `node.spec.podCIDR`
>    - `node.spec.podCIDRs[]`
>
>  - Set by kubelet:
>    - `pod.status.hostIP`
>    - `pod.status.hostIPs[].ip`
>
>  - Set by kube-apiserver:
>    - `service.spec.clusterIP`
>    - `service.spec.clusterIPs[]`

These are already guaranteed canonical. (They are set by calling `.String()` on a `net.IP` or `*net.IPNet` value.)

>  - Set by the cloud-provider framework code:
>    - `service.status.loadBalancer.ingress[].ip`

This I was confused about; it's not set by the framework code in `k8s.io/cloud-provider`, it's set by each individual cloud provider in its own private code. (So that becomes a Non-Goal for us.)

#### Does this PR introduce a user-facing change?
```release-note
Various controllers that write out IP address or CIDR values to API objects now
ensure that they always write out the values in canonical form.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/4858
```

/kind cleanup
/kind feature
/sig network
/priority important-soon
/triage accepted