### PR TITLE
Update websocket logging levels for better debuggability

### DIFF
--- a/staging/src/k8s.io/client-go/tools/remotecommand/websocket.go
+++ b/staging/src/k8s.io/client-go/tools/remotecommand/websocket.go
@@ -248,6 +248,7 @@ func (c *wsStreamCreator) readDemuxLoop(bufferSize int, period time.Duration, de
 	// Initialize and start the ping/pong heartbeat.
 	h := newHeartbeat(c.conn, period, deadline)
 	// Set initial timeout for websocket connection reading.
+	klog.V(5).Infof("Websocket initial read deadline: %s", deadline)
 	if err := c.conn.SetReadDeadline(time.Now().Add(deadline)); err != nil {
 		klog.Errorf("Websocket initial setting read deadline failed %v", err)
 		return
@@ -354,8 +355,8 @@ func (s *stream) Read(p []byte) (n int, err error) {
 
 // Write writes directly to the underlying WebSocket connection.
 func (s *stream) Write(p []byte) (n int, err error) {
-	klog.V(4).Infof("Write() on stream %d", s.id)
-	defer klog.V(4).Infof("Write() done on stream %d", s.id)
+	klog.V(8).Infof("Write() on stream %d", s.id)
+	defer klog.V(8).Infof("Write() done on stream %d", s.id)
 	s.connWriteLock.Lock()
 	defer s.connWriteLock.Unlock()
 	if s.conn == nil {
@@ -363,7 +364,7 @@ func (s *stream) Write(p []byte) (n int, err error) {
 	}
 	err = s.conn.SetWriteDeadline(time.Now().Add(writeDeadline))
 	if err != nil {
-		klog.V(7).Infof("Websocket setting write deadline failed %v", err)
+		klog.V(4).Infof("Websocket setting write deadline failed %v", err)
 		return 0, err
 	}
 	// Message writer buffers the message data, so we don't need to do that ourselves.
@@ -392,8 +393,8 @@ func (s *stream) Write(p []byte) (n int, err error) {
 
 // Close half-closes the stream, indicating this side is finished with the stream.
 func (s *stream) Close() error {
-	klog.V(4).Infof("Close() on stream %d", s.id)
-	defer klog.V(4).Infof("Close() done on stream %d", s.id)
+	klog.V(6).Infof("Close() on stream %d", s.id)
+	defer klog.V(6).Infof("Close() done on stream %d", s.id)
 	s.connWriteLock.Lock()
 	defer s.connWriteLock.Unlock()
 	if s.conn == nil {
@@ -452,7 +453,7 @@ func newHeartbeat(conn *gwebsocket.Conn, period time.Duration, deadline time.Dur
 	// be empty.
 	h.conn.SetPongHandler(func(msg string) error {
 		// Push the read deadline into the future.
-		klog.V(8).Infof("Pong message received (%s)--resetting read deadline", msg)
+		klog.V(6).Infof("Pong message received (%s)--resetting read deadline", msg)
 		err := h.conn.SetReadDeadline(time.Now().Add(deadline))
 		if err != nil {
 			klog.Errorf("Websocket setting read deadline failed %v", err)
@@ -487,14 +488,14 @@ func (h *heartbeat) start() {
 	for {
 		select {
 		case <-h.closer:
-			klog.V(8).Infof("closed channel--returning")
+			klog.V(5).Infof("closed channel--returning")
 			return
 		case <-t.C:
 			// "WriteControl" does not need to be protected by a mutex. According to
 			// gorilla/websockets library docs: "The Close and WriteControl methods can
 			// be called concurrently with all other methods."
 			if err := h.conn.WriteControl(gwebsocket.PingMessage, h.message, time.Now().Add(pingReadDeadline)); err == nil {
-				klog.V(8).Infof("Websocket Ping succeeeded")
+				klog.V(6).Infof("Websocket Ping succeeeded")
 			} else {
 				klog.Errorf("Websocket Ping failed: %v", err)
 				if errors.Is(err, gwebsocket.ErrCloseSent) {


### PR DESCRIPTION
* Updates the logging levels for WebSocket functionality to make debugging easier.
  * Increases log level for `Write`, since this is common and can pollute the screen.
  * Decreases log level for the heartbeat, to make this more viewable.
  * Decreases log level for channel closing, to make it more viewable.

Debugging using `-v=6` is readable now. It looks like:
```
$ ./kubectl cp -v=6 /tmp/kube-exec-large-file/random-1gb.img nginx:/tmp
I0211 19:32:13.665561 1293607 loader.go:402] Config loaded from file:  /usr/local/google/home/seans/.kube/config
I0211 19:32:13.665918 1293607 envvar.go:172] "Feature gate default state" feature="ClientsAllowCBOR" enabled=false
I0211 19:32:13.665937 1293607 envvar.go:172] "Feature gate default state" feature="ClientsPreferCBOR" enabled=false
I0211 19:32:13.665944 1293607 envvar.go:172] "Feature gate default state" feature="InformerResourceVersion" enabled=false
I0211 19:32:13.665952 1293607 envvar.go:172] "Feature gate default state" feature="InOrderInformers" enabled=true
I0211 19:32:13.665956 1293607 envvar.go:172] "Feature gate default state" feature="WatchListClient" enabled=false
I0211 19:32:13.756138 1293607 round_trippers.go:632] "Response" verb="GET" url="https://34.145.59.72/api/v1/namespaces/default/pods/nginx" status="200 OK" milliseconds=89
I0211 19:32:13.756392 1293607 podcmd.go:88] Defaulting container name to nginx
I0211 19:32:13.861744 1293607 round_trippers.go:632] "Response" verb="GET" url="https://34.145.59.72/api/v1/namespaces/default/pods/nginx/exec?command=test&command=-d&command=%2Ftmp&container=nginx&stderr=true&stdout=true" status="101 Switching Protocols" milliseconds=105
I0211 19:32:13.861778 1293607 websocket.go:133] The subprotocol is v5.channel.k8s.io
I0211 19:32:13.861903 1293607 websocket.go:251] Websocket initial read deadline: 1m1s
I0211 19:32:13.935263 1293607 websocket.go:491] closed channel--returning
I0211 19:32:13.968005 1293607 round_trippers.go:632] "Response" verb="GET" url="https://34.145.59.72/api/v1/namespaces/default/pods/nginx" status="200 OK" milliseconds=32
I0211 19:32:13.968213 1293607 podcmd.go:88] Defaulting container name to nginx
I0211 19:32:14.054877 1293607 round_trippers.go:632] "Response" verb="GET" url="https://34.145.59.72/api/v1/namespaces/default/pods/nginx/exec?command=tar&command=-xmf&command=-&command=-C&command=%2Ftmp&container=nginx&stderr=true&stdin=true&stdout=true" status="101 Switching Protocols" milliseconds=86
I0211 19:32:14.054917 1293607 websocket.go:133] The subprotocol is v5.channel.k8s.io
I0211 19:32:14.055050 1293607 websocket.go:251] Websocket initial read deadline: 1m1s
I0211 19:32:19.087854 1293607 websocket.go:498] Websocket Ping succeeeded
I0211 19:32:19.381691 1293607 websocket.go:456] Pong message received ()--resetting read deadline
I0211 19:32:24.065602 1293607 websocket.go:498] Websocket Ping succeeeded
I0211 19:32:24.304212 1293607 websocket.go:456] Pong message received ()--resetting read deadline
I0211 19:32:29.248043 1293607 websocket.go:498] Websocket Ping succeeeded
I0211 19:32:29.508800 1293607 websocket.go:456] Pong message received ()--resetting read deadline
I0211 19:32:34.143211 1293607 websocket.go:498] Websocket Ping succeeeded
I0211 19:32:34.357104 1293607 websocket.go:456] Pong message received ()--resetting read deadline
I0211 19:32:39.088498 1293607 websocket.go:498] Websocket Ping succeeeded
I0211 19:32:39.249323 1293607 websocket.go:456] Pong message received ()--resetting read deadline
I0211 19:32:44.062364 1293607 websocket.go:498] Websocket Ping succeeeded
I0211 19:32:44.490230 1293607 websocket.go:456] Pong message received ()--resetting read deadline
I0211 19:32:49.123856 1293607 websocket.go:498] Websocket Ping succeeeded
I0211 19:32:49.701136 1293607 websocket.go:456] Pong message received ()--resetting read deadline
I0211 19:32:54.192979 1293607 websocket.go:498] Websocket Ping succeeeded
I0211 19:32:54.431316 1293607 websocket.go:456] Pong message received ()--resetting read deadline
I0211 19:32:59.059603 1293607 websocket.go:498] Websocket Ping succeeeded
I0211 19:32:59.255037 1293607 websocket.go:456] Pong message received ()--resetting read deadline
I0211 19:33:03.474894 1293607 websocket.go:396] Close() on stream 0
I0211 19:33:03.474921 1293607 websocket.go:406] Close() done on stream 0
I0211 19:33:03.902945 1293607 websocket.go:491] closed channel--returning
```

/kind cleanup

```release-note
NONE
```
