### PR TITLE
fix getPodMatches should call /runningpods endpoint

### DIFF
--- a/test/e2e/node/kubelet.go
+++ b/test/e2e/node/kubelet.go
@@ -67,7 +67,7 @@ const (
 func getPodMatches(ctx context.Context, c clientset.Interface, nodeName string, podNamePrefix string, namespace string) sets.String {
 	matches := sets.NewString()
 	framework.Logf("Checking pods on node %v via /runningpods endpoint", nodeName)
-	runningPods, err := e2ekubelet.GetKubeletPods(ctx, c, nodeName)
+	runningPods, err := e2ekubelet.GetKubeletRunningPods(ctx, c, nodeName)
 	if err != nil {
 		framework.Logf("Error checking running pods on %v: %v", nodeName, err)
 		return matches


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

`GetKubeletPods` was added in https://github.com/kubernetes/kubernetes/commit/a10a6a296e4efa90483febce5f6147b620e84e7b. It is used to fetch pods on a node via `/runningpods` endpoint. It was changed in https://github.com/kubernetes/kubernetes/commit/f8e1404f871cff0f7c0f0c88cc4d11d008252e1c and introduced a new function `GetKubeletRunningPods` but the author forgot to update the existing callers of `GetKubeletPods` to use the new function.

I find this issue from the following [failing test](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/129997/pull-kubernetes-e2e-kind/1889510315645734912):

```
I0212 03:21:41.220094   72098 runners.go:193] cleanup20-8fbe308f-5dac-48a8-9823-83c168c11f2b Pods: 21 out of 20 created, 0 running, 20 pending, 0 waiting, 1 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
I0212 03:21:51.221227   72098 runners.go:193] cleanup20-8fbe308f-5dac-48a8-9823-83c168c11f2b Pods: 21 out of 20 created, 9 running, 11 pending, 0 waiting, 1 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
I0212 03:22:01.222188   72098 runners.go:193] cleanup20-8fbe308f-5dac-48a8-9823-83c168c11f2b Pods: 21 out of 20 created, 20 running, 0 pending, 0 waiting, 1 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
I0212 03:22:02.222894 72098 kubelet.go:69] Checking pods on node kind-worker2 via /runningpods endpoint
I0212 03:22:02.223182 72098 kubelet.go:69] Checking pods on node kind-worker via /runningpods endpoint
I0212 03:22:02.300658 72098 kubelet.go:109] Waiting for 20 pods to be running on the node; 21 are currently running;

I0212 03:22:31.223439 72098 kubelet.go:346] Unexpected error: 
    <context.deadlineExceededError>: 
    context deadline exceeded
    
        {}
[FAILED] context deadline exceeded
In [It] at: k8s.io/kubernetes/test/e2e/node/kubelet.go:346 @ 02/12/25 03:22:31.223
< Exit [It] kubelet should be able to delete 10 pods per node in 1m0s. - k8s.io/kubernetes/test/e2e/node/kubelet.go:326 @ 02/12/25 03:22:31.223 (1m0.143s)
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
![image](https://github.com/user-attachments/assets/09ac14c5-eccd-488f-800f-c8d1a903c848)

https://storage.googleapis.com/k8s-triage/index.html?pr=1&test=%20kubelet%20should%20be%20able%20to%20delete%2010%20pods%20per%20node%20in%201m0s

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
