### PR TITLE
Fix intermittent failure in TestDispatcher test

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/mutating/dispatcher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/mutating/dispatcher_test.go
@@ -656,8 +656,8 @@ func TestDispatcher(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			informerFactory.WaitForCacheSync(ctx.Done())
 			informerFactory.Start(ctx.Done())
+			informerFactory.WaitForCacheSync(ctx.Done())
 			for i, h := range tc.policyHooks {
 				tc.policyHooks[i].ParamInformer = paramInformer
 				tc.policyHooks[i].ParamScope = testParamScope{}


### PR DESCRIPTION
Start the informerFactory before WaitForCacheSync

#### What type of PR is this?

/kind bug
/kind flake

#### What this PR does / why we need it:

When running the kubernetes unit tests locally, I am seeing intermittent timing errors
```
=== RUN   TestDispatcher
E0210 16:24:37.091715 6843015 typeconverter.go:152] "Unhandled Error" err="no schema for apps/v1, Kind=Deployment" logger="UnhandledError"
=== RUN   TestDispatcher/simple_patch
    dispatcher_test.go:690: error dispatching policy hooks: namespaces "default" not found
=== RUN   TestDispatcher/with_param
=== RUN   TestDispatcher/both_policies_reinvoked
    dispatcher_test.go:690: error dispatching policy hooks: namespaces "default" not found
=== RUN   TestDispatcher/1st_policy_sets_match_condition_that_2nd_policy_matches
=== RUN   TestDispatcher/1st_policy_still_does_not_match_after_2nd_policy_sets_match_condition
--- FAIL: TestDispatcher (0.41s)
    --- FAIL: TestDispatcher/simple_patch (0.11s)
    --- PASS: TestDispatcher/with_param (0.11s)
    --- FAIL: TestDispatcher/both_policies_reinvoked (0.02s)
    --- PASS: TestDispatcher/1st_policy_sets_match_condition_that_2nd_policy_matches (0.03s)
    --- PASS: TestDispatcher/1st_policy_still_does_not_match_after_2nd_policy_sets_match_condition (0.02s)
```

I believe the reason for this is the following two lines of code in the test 
```
			informerFactory.WaitForCacheSync(ctx.Done())
			informerFactory.Start(ctx.Done())
```

From looking at the implementations of these two functions, I see that `WaitForCacheSync` is only waiting for started informers, so it doesn't wait.  It then does the `Start` and continues with the test, leaving a race between the cache syncing and being used.  By swapping the order of these two lines, the informers are started and then we wait for them to sync. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
