### PR TITLE
node: cpumgr: metrics: add uncore cache alignment metrics

### DIFF
--- a/pkg/kubelet/cm/cpumanager/policy_static_test.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static_test.go
@@ -667,7 +667,7 @@ func runStaticPolicyTestCase(t *testing.T, testCase staticPolicyTest) {
 				testCase.description, container.Name, st.assignments)
 		}
 
-		if !reflect.DeepEqual(cset, testCase.expCSet) {
+		if !cset.Equals(testCase.expCSet) {
 			t.Errorf("StaticPolicy Allocate() error (%v). expected cpuset %v but got %v",
 				testCase.description, testCase.expCSet, cset)
 		}
@@ -732,7 +732,7 @@ func TestStaticPolicyReuseCPUs(t *testing.T) {
 		for _, container := range append(pod.Spec.InitContainers, pod.Spec.Containers...) {
 			policy.Allocate(st, pod, &container)
 		}
-		if !reflect.DeepEqual(st.defaultCPUSet, testCase.expCSetAfterAlloc) {
+		if !st.defaultCPUSet.Equals(testCase.expCSetAfterAlloc) {
 			t.Errorf("StaticPolicy Allocate() error (%v). expected default cpuset %v but got %v",
 				testCase.description, testCase.expCSetAfterAlloc, st.defaultCPUSet)
 		}
@@ -740,7 +740,7 @@ func TestStaticPolicyReuseCPUs(t *testing.T) {
 		// remove
 		policy.RemoveContainer(st, string(pod.UID), testCase.containerName)
 
-		if !reflect.DeepEqual(st.defaultCPUSet, testCase.expCSetAfterRemove) {
+		if !st.defaultCPUSet.Equals(testCase.expCSetAfterRemove) {
 			t.Errorf("StaticPolicy RemoveContainer() error (%v). expected default cpuset %v but got %v",
 				testCase.description, testCase.expCSetAfterRemove, st.defaultCPUSet)
 		}
@@ -792,7 +792,7 @@ func TestStaticPolicyDoNotReuseCPUs(t *testing.T) {
 					testCase.description, err)
 			}
 		}
-		if !reflect.DeepEqual(st.defaultCPUSet, testCase.expCSetAfterAlloc) {
+		if !st.defaultCPUSet.Equals(testCase.expCSetAfterAlloc) {
 			t.Errorf("StaticPolicy Allocate() error (%v). expected default cpuset %v but got %v",
 				testCase.description, testCase.expCSetAfterAlloc, st.defaultCPUSet)
 		}
@@ -870,7 +870,7 @@ func TestStaticPolicyRemove(t *testing.T) {
 
 		policy.RemoveContainer(st, testCase.podUID, testCase.containerName)
 
-		if !reflect.DeepEqual(st.defaultCPUSet, testCase.expCSet) {
+		if !st.defaultCPUSet.Equals(testCase.expCSet) {
 			t.Errorf("StaticPolicy RemoveContainer() error (%v). expected default cpuset %v but got %v",
 				testCase.description, testCase.expCSet, st.defaultCPUSet)
 		}
@@ -973,7 +973,7 @@ func TestTopologyAwareAllocateCPUs(t *testing.T) {
 			continue
 		}
 
-		if !reflect.DeepEqual(tc.expCSet, cset) {
+		if !tc.expCSet.Equals(cset) {
 			t.Errorf("StaticPolicy allocateCPUs() error (%v). expected CPUSet %v but got %v",
 				tc.description, tc.expCSet, cset)
 		}
@@ -1152,7 +1152,7 @@ func TestStaticPolicyAddWithResvList(t *testing.T) {
 					testCase.description, container.Name, st.assignments)
 			}
 
-			if !reflect.DeepEqual(cset, testCase.expCSet) {
+			if !cset.Equals(testCase.expCSet) {
 				t.Errorf("StaticPolicy Allocate() error (%v). expected cpuset %v but got %v",
 					testCase.description, testCase.expCSet, cset)
 			}

--- a/pkg/kubelet/cm/cpumanager/policy_static_test.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static_test.go
@@ -70,7 +70,10 @@ func (spt staticPolicyTest) PseudoClone() staticPolicyTest {
 }
 
 func TestStaticPolicyName(t *testing.T) {
-	policy, _ := NewStaticPolicy(topoSingleSocketHT, 1, cpuset.New(), topologymanager.NewFakeManager(), nil)
+	policy, err := NewStaticPolicy(topoSingleSocketHT, 1, cpuset.New(), topologymanager.NewFakeManager(), nil)
+	if err != nil {
+		t.Fatalf("NewStaticPolicy() failed: %v", err)
+	}
 
 	policyName := policy.Name()
 	if policyName != "static" {
@@ -168,13 +171,16 @@ func TestStaticPolicyStart(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.description, func(t *testing.T) {
 			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.CPUManagerPolicyAlphaOptions, true)
-			p, _ := NewStaticPolicy(testCase.topo, testCase.numReservedCPUs, cpuset.New(), topologymanager.NewFakeManager(), testCase.options)
+			p, err := NewStaticPolicy(testCase.topo, testCase.numReservedCPUs, cpuset.New(), topologymanager.NewFakeManager(), testCase.options)
+			if err != nil {
+				t.Fatalf("NewStaticPolicy() failed: %v", err)
+			}
 			policy := p.(*staticPolicy)
 			st := &mockState{
 				assignments:   testCase.stAssignments,
 				defaultCPUSet: testCase.stDefaultCPUSet,
 			}
-			err := policy.Start(st)
+			err = policy.Start(st)
 			if !reflect.DeepEqual(err, testCase.expErr) {
 				t.Errorf("StaticPolicy Start() error (%v). expected error: %v but got: %v",
 					testCase.description, testCase.expErr, err)
@@ -637,7 +643,10 @@ func runStaticPolicyTestCase(t *testing.T, testCase staticPolicyTest) {
 	if testCase.reservedCPUs != nil {
 		cpus = testCase.reservedCPUs.Clone()
 	}
-	policy, _ := NewStaticPolicy(testCase.topo, testCase.numReservedCPUs, cpus, tm, testCase.options)
+	policy, err := NewStaticPolicy(testCase.topo, testCase.numReservedCPUs, cpus, tm, testCase.options)
+	if err != nil {
+		t.Fatalf("NewStaticPolicy() failed: %v", err)
+	}
 
 	st := &mockState{
 		assignments:   testCase.stAssignments,
@@ -645,7 +654,7 @@ func runStaticPolicyTestCase(t *testing.T, testCase staticPolicyTest) {
 	}
 
 	container := &testCase.pod.Spec.Containers[0]
-	err := policy.Allocate(st, testCase.pod, container)
+	err = policy.Allocate(st, testCase.pod, container)
 	if !reflect.DeepEqual(err, testCase.expErr) {
 		t.Errorf("StaticPolicy Allocate() error (%v). expected add error: %q but got: %q",
 			testCase.description, testCase.expErr, err)
@@ -708,7 +717,10 @@ func TestStaticPolicyReuseCPUs(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		policy, _ := NewStaticPolicy(testCase.topo, testCase.numReservedCPUs, cpuset.New(), topologymanager.NewFakeManager(), nil)
+		policy, err := NewStaticPolicy(testCase.topo, testCase.numReservedCPUs, cpuset.New(), topologymanager.NewFakeManager(), nil)
+		if err != nil {
+			t.Fatalf("NewStaticPolicy() failed: %v", err)
+		}
 
 		st := &mockState{
 			assignments:   testCase.stAssignments,
@@ -761,7 +773,10 @@ func TestStaticPolicyDoNotReuseCPUs(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		policy, _ := NewStaticPolicy(testCase.topo, testCase.numReservedCPUs, cpuset.New(), topologymanager.NewFakeManager(), nil)
+		policy, err := NewStaticPolicy(testCase.topo, testCase.numReservedCPUs, cpuset.New(), topologymanager.NewFakeManager(), nil)
+		if err != nil {
+			t.Fatalf("NewStaticPolicy() failed: %v", err)
+		}
 
 		st := &mockState{
 			assignments:   testCase.stAssignments,
@@ -843,7 +858,10 @@ func TestStaticPolicyRemove(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		policy, _ := NewStaticPolicy(testCase.topo, testCase.numReservedCPUs, cpuset.New(), topologymanager.NewFakeManager(), nil)
+		policy, err := NewStaticPolicy(testCase.topo, testCase.numReservedCPUs, cpuset.New(), topologymanager.NewFakeManager(), nil)
+		if err != nil {
+			t.Fatalf("NewStaticPolicy() failed: %v", err)
+		}
 
 		st := &mockState{
 			assignments:   testCase.stAssignments,
@@ -933,13 +951,16 @@ func TestTopologyAwareAllocateCPUs(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		p, _ := NewStaticPolicy(tc.topo, 0, cpuset.New(), topologymanager.NewFakeManager(), nil)
+		p, err := NewStaticPolicy(tc.topo, 0, cpuset.New(), topologymanager.NewFakeManager(), nil)
+		if err != nil {
+			t.Fatalf("NewStaticPolicy() failed: %v", err)
+		}
 		policy := p.(*staticPolicy)
 		st := &mockState{
 			assignments:   tc.stAssignments,
 			defaultCPUSet: tc.stDefaultCPUSet,
 		}
-		err := policy.Start(st)
+		err = policy.Start(st)
 		if err != nil {
 			t.Errorf("StaticPolicy Start() error (%v)", err)
 			continue
@@ -1107,7 +1128,10 @@ func TestStaticPolicyAddWithResvList(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		policy, _ := NewStaticPolicy(testCase.topo, testCase.numReservedCPUs, testCase.reserved, topologymanager.NewFakeManager(), nil)
+		policy, err := NewStaticPolicy(testCase.topo, testCase.numReservedCPUs, testCase.reserved, topologymanager.NewFakeManager(), nil)
+		if err != nil {
+			t.Fatalf("NewStaticPolicy() failed: %v", err)
+		}
 
 		st := &mockState{
 			assignments:   testCase.stAssignments,
@@ -1115,7 +1139,7 @@ func TestStaticPolicyAddWithResvList(t *testing.T) {
 		}
 
 		container := &testCase.pod.Spec.Containers[0]
-		err := policy.Allocate(st, testCase.pod, container)
+		err = policy.Allocate(st, testCase.pod, container)
 		if !reflect.DeepEqual(err, testCase.expErr) {
 			t.Errorf("StaticPolicy Allocate() error (%v). expected add error: %v but got: %v",
 				testCase.description, testCase.expErr, err)

--- a/pkg/kubelet/cm/cpumanager/policy_static_test.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static_test.go
@@ -668,12 +668,12 @@ func runStaticPolicyTestCase(t *testing.T, testCase staticPolicyTest) {
 		}
 
 		if !cset.Equals(testCase.expCSet) {
-			t.Errorf("StaticPolicy Allocate() error (%v). expected cpuset %v but got %v",
+			t.Errorf("StaticPolicy Allocate() error (%v). expected cpuset %s but got %s",
 				testCase.description, testCase.expCSet, cset)
 		}
 
 		if !cset.Intersection(st.defaultCPUSet).IsEmpty() {
-			t.Errorf("StaticPolicy Allocate() error (%v). expected cpuset %v to be disoint from the shared cpuset %v",
+			t.Errorf("StaticPolicy Allocate() error (%v). expected cpuset %s to be disoint from the shared cpuset %s",
 				testCase.description, cset, st.defaultCPUSet)
 		}
 	}
@@ -733,7 +733,7 @@ func TestStaticPolicyReuseCPUs(t *testing.T) {
 			policy.Allocate(st, pod, &container)
 		}
 		if !st.defaultCPUSet.Equals(testCase.expCSetAfterAlloc) {
-			t.Errorf("StaticPolicy Allocate() error (%v). expected default cpuset %v but got %v",
+			t.Errorf("StaticPolicy Allocate() error (%v). expected default cpuset %s but got %s",
 				testCase.description, testCase.expCSetAfterAlloc, st.defaultCPUSet)
 		}
 
@@ -741,7 +741,7 @@ func TestStaticPolicyReuseCPUs(t *testing.T) {
 		policy.RemoveContainer(st, string(pod.UID), testCase.containerName)
 
 		if !st.defaultCPUSet.Equals(testCase.expCSetAfterRemove) {
-			t.Errorf("StaticPolicy RemoveContainer() error (%v). expected default cpuset %v but got %v",
+			t.Errorf("StaticPolicy RemoveContainer() error (%v). expected default cpuset %sv but got %s",
 				testCase.description, testCase.expCSetAfterRemove, st.defaultCPUSet)
 		}
 		if _, found := st.assignments[string(pod.UID)][testCase.containerName]; found {
@@ -793,7 +793,7 @@ func TestStaticPolicyDoNotReuseCPUs(t *testing.T) {
 			}
 		}
 		if !st.defaultCPUSet.Equals(testCase.expCSetAfterAlloc) {
-			t.Errorf("StaticPolicy Allocate() error (%v). expected default cpuset %v but got %v",
+			t.Errorf("StaticPolicy Allocate() error (%v). expected default cpuset %s but got %s",
 				testCase.description, testCase.expCSetAfterAlloc, st.defaultCPUSet)
 		}
 	}
@@ -871,7 +871,7 @@ func TestStaticPolicyRemove(t *testing.T) {
 		policy.RemoveContainer(st, testCase.podUID, testCase.containerName)
 
 		if !st.defaultCPUSet.Equals(testCase.expCSet) {
-			t.Errorf("StaticPolicy RemoveContainer() error (%v). expected default cpuset %v but got %v",
+			t.Errorf("StaticPolicy RemoveContainer() error (%v). expected default cpuset %s but got %s",
 				testCase.description, testCase.expCSet, st.defaultCPUSet)
 		}
 
@@ -1153,12 +1153,12 @@ func TestStaticPolicyAddWithResvList(t *testing.T) {
 			}
 
 			if !cset.Equals(testCase.expCSet) {
-				t.Errorf("StaticPolicy Allocate() error (%v). expected cpuset %v but got %v",
+				t.Errorf("StaticPolicy Allocate() error (%v). expected cpuset %s but got %s",
 					testCase.description, testCase.expCSet, cset)
 			}
 
 			if !cset.Intersection(st.defaultCPUSet).IsEmpty() {
-				t.Errorf("StaticPolicy Allocate() error (%v). expected cpuset %v to be disoint from the shared cpuset %v",
+				t.Errorf("StaticPolicy Allocate() error (%v). expected cpuset %s to be disoint from the shared cpuset %s",
 					testCase.description, cset, st.defaultCPUSet)
 			}
 		}

--- a/pkg/kubelet/cm/cpumanager/policy_static_test.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static_test.go
@@ -966,16 +966,16 @@ func TestTopologyAwareAllocateCPUs(t *testing.T) {
 			continue
 		}
 
-		cset, err := policy.allocateCPUs(st, tc.numRequested, tc.socketMask, cpuset.New())
+		cpuAlloc, err := policy.allocateCPUs(st, tc.numRequested, tc.socketMask, cpuset.New())
 		if err != nil {
 			t.Errorf("StaticPolicy allocateCPUs() error (%v). expected CPUSet %v not error %v",
 				tc.description, tc.expCSet, err)
 			continue
 		}
 
-		if !tc.expCSet.Equals(cset) {
+		if !tc.expCSet.Equals(cpuAlloc.CPUs) {
 			t.Errorf("StaticPolicy allocateCPUs() error (%v). expected CPUSet %v but got %v",
-				tc.description, tc.expCSet, cset)
+				tc.description, tc.expCSet, cpuAlloc.CPUs)
 		}
 	}
 }

--- a/pkg/kubelet/cm/cpumanager/topology/alignment.go
+++ b/pkg/kubelet/cm/cpumanager/topology/alignment.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package topology
+
+import (
+	"fmt"
+
+	"k8s.io/utils/cpuset"
+)
+
+// Alignment is metadata about a cpuset allocation
+type Alignment struct {
+	// UncoreCache is true if all the CPUs are uncore-cache aligned,
+	// IOW if they all share the same Uncore cache block.
+	// If the allocated CPU count is greater than a Uncore Group size,
+	// CPUs can't be uncore-aligned; otherwise, they are.
+	// This flag tracks alignment, not interference or lack thereof.
+	UncoreCache bool
+}
+
+func (ca Alignment) String() string {
+	return fmt.Sprintf("aligned=<uncore:%v>", ca.UncoreCache)
+}
+
+// Allocation represents a CPU set plus alignment metadata
+type Allocation struct {
+	CPUs    cpuset.CPUSet
+	Aligned Alignment
+}
+
+func (ca Allocation) String() string {
+	return ca.CPUs.String() + " " + ca.Aligned.String()
+}
+
+// EmptyAllocation returns a new zero-valued CPU allocation. Please note that
+// a empty cpuset is aligned according to every possible way we can consider
+func EmptyAllocation() Allocation {
+	return Allocation{
+		CPUs: cpuset.New(),
+		Aligned: Alignment{
+			UncoreCache: true,
+		},
+	}
+}
+
+func isAlignedAtUncoreCache(topo *CPUTopology, cpuList ...int) bool {
+	if len(cpuList) <= 1 {
+		return true
+	}
+	reference, ok := topo.CPUDetails[cpuList[0]]
+	if !ok {
+		return false
+	}
+	for _, cpu := range cpuList[1:] {
+		info, ok := topo.CPUDetails[cpu]
+		if !ok {
+			return false
+		}
+		if info.UncoreCacheID != reference.UncoreCacheID {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/kubelet/cm/cpumanager/topology/alignment_test.go
+++ b/pkg/kubelet/cm/cpumanager/topology/alignment_test.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package topology
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/utils/cpuset"
+)
+
+func TestNewAlignment(t *testing.T) {
+	topo := &CPUTopology{
+		NumCPUs:        32,
+		NumSockets:     1,
+		NumCores:       32,
+		NumNUMANodes:   1,
+		NumUncoreCache: 8,
+		CPUDetails: map[int]CPUInfo{
+			0:  {CoreID: 0, SocketID: 0, NUMANodeID: 0, UncoreCacheID: 0},
+			1:  {CoreID: 1, SocketID: 0, NUMANodeID: 0, UncoreCacheID: 0},
+			2:  {CoreID: 2, SocketID: 0, NUMANodeID: 0, UncoreCacheID: 0},
+			3:  {CoreID: 3, SocketID: 0, NUMANodeID: 0, UncoreCacheID: 0},
+			4:  {CoreID: 4, SocketID: 0, NUMANodeID: 0, UncoreCacheID: 1},
+			5:  {CoreID: 5, SocketID: 0, NUMANodeID: 0, UncoreCacheID: 1},
+			6:  {CoreID: 6, SocketID: 0, NUMANodeID: 0, UncoreCacheID: 1},
+			7:  {CoreID: 7, SocketID: 0, NUMANodeID: 0, UncoreCacheID: 1},
+			8:  {CoreID: 8, SocketID: 0, NUMANodeID: 0, UncoreCacheID: 2},
+			9:  {CoreID: 9, SocketID: 0, NUMANodeID: 0, UncoreCacheID: 2},
+			10: {CoreID: 10, SocketID: 0, NUMANodeID: 0, UncoreCacheID: 2},
+			11: {CoreID: 11, SocketID: 0, NUMANodeID: 0, UncoreCacheID: 2},
+			12: {CoreID: 12, SocketID: 0, NUMANodeID: 0, UncoreCacheID: 3},
+			13: {CoreID: 13, SocketID: 0, NUMANodeID: 0, UncoreCacheID: 3},
+			14: {CoreID: 14, SocketID: 0, NUMANodeID: 0, UncoreCacheID: 3},
+			15: {CoreID: 15, SocketID: 0, NUMANodeID: 0, UncoreCacheID: 3},
+			16: {CoreID: 16, SocketID: 0, NUMANodeID: 0, UncoreCacheID: 4},
+			17: {CoreID: 17, SocketID: 0, NUMANodeID: 0, UncoreCacheID: 4},
+			18: {CoreID: 18, SocketID: 0, NUMANodeID: 0, UncoreCacheID: 4},
+			19: {CoreID: 19, SocketID: 0, NUMANodeID: 0, UncoreCacheID: 4},
+			20: {CoreID: 20, SocketID: 0, NUMANodeID: 0, UncoreCacheID: 5},
+			21: {CoreID: 21, SocketID: 0, NUMANodeID: 0, UncoreCacheID: 5},
+			22: {CoreID: 22, SocketID: 0, NUMANodeID: 0, UncoreCacheID: 5},
+			23: {CoreID: 23, SocketID: 0, NUMANodeID: 0, UncoreCacheID: 5},
+			24: {CoreID: 24, SocketID: 0, NUMANodeID: 0, UncoreCacheID: 6},
+			25: {CoreID: 25, SocketID: 0, NUMANodeID: 0, UncoreCacheID: 6},
+			26: {CoreID: 26, SocketID: 0, NUMANodeID: 0, UncoreCacheID: 6},
+			27: {CoreID: 27, SocketID: 0, NUMANodeID: 0, UncoreCacheID: 6},
+			28: {CoreID: 28, SocketID: 0, NUMANodeID: 0, UncoreCacheID: 7},
+			29: {CoreID: 29, SocketID: 0, NUMANodeID: 0, UncoreCacheID: 7},
+			30: {CoreID: 30, SocketID: 0, NUMANodeID: 0, UncoreCacheID: 7},
+			31: {CoreID: 31, SocketID: 0, NUMANodeID: 0, UncoreCacheID: 7},
+		},
+	}
+
+	tests := []struct {
+		name string
+		topo *CPUTopology
+		cpus cpuset.CPUSet
+		want Alignment
+	}{{
+		name: "empty cpuset",
+		topo: topo,
+		cpus: cpuset.New(),
+		want: Alignment{
+			UncoreCache: true,
+		},
+	}, {
+		name: "single random CPU",
+		topo: topo,
+		cpus: cpuset.New(11), // any single id is fine, no special meaning
+		want: Alignment{
+			UncoreCache: true,
+		},
+	}, {
+		name: "less CPUs than a uncore cache group",
+		topo: topo,
+		cpus: cpuset.New(29, 30, 31), // random cpus as long as they belong to the same uncore cache
+		want: Alignment{
+			UncoreCache: true,
+		},
+	}, {
+		name: "enough CPUs to fill a uncore cache group",
+		topo: topo,
+		cpus: cpuset.New(8, 9, 10, 11), // random cpus as long as they belong to the same uncore cache
+		want: Alignment{
+			UncoreCache: true,
+		},
+	}, {
+		name: "more CPUs than a full a uncore cache group",
+		topo: topo,
+		cpus: cpuset.New(9, 10, 11, 23), // random cpus as long as they belong to the same uncore cache
+		want: Alignment{
+			UncoreCache: false,
+		},
+	}, {
+		name: "enough CPUs to exactly fill multiple uncore cache groups",
+		topo: topo,
+		cpus: cpuset.New(8, 9, 10, 11, 16, 17, 18, 19), // random cpus as long as they belong to the same uncore cache
+		want: Alignment{
+			UncoreCache: false,
+		},
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.topo.CheckAlignment(tt.cpus)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("AlignmentFromCPUSet() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/kubelet/cm/cpumanager/topology/topology.go
+++ b/pkg/kubelet/cm/cpumanager/topology/topology.go
@@ -101,6 +101,15 @@ func (topo *CPUTopology) CPUNUMANodeID(cpu int) (int, error) {
 	return info.NUMANodeID, nil
 }
 
+// CheckAlignment returns alignment information for the given cpuset in
+// the context of the current CPU topology
+func (topo *CPUTopology) CheckAlignment(cpus cpuset.CPUSet) Alignment {
+	cpuList := cpus.UnsortedList()
+	return Alignment{
+		UncoreCache: isAlignedAtUncoreCache(topo, cpuList...),
+	}
+}
+
 // CPUInfo contains the NUMA, socket, UncoreCache and core IDs associated with a CPU.
 type CPUInfo struct {
 	NUMANodeID    int

--- a/pkg/kubelet/metrics/metrics.go
+++ b/pkg/kubelet/metrics/metrics.go
@@ -150,6 +150,7 @@ const (
 
 	AlignedPhysicalCPU = "physical_cpu"
 	AlignedNUMANode    = "numa_node"
+	AlignedUncoreCache = "uncore_cache"
 
 	// Metrics to track kubelet admission rejections.
 	AdmissionRejectionsTotalKey = "admission_rejections_total"

--- a/test/e2e_node/cpu_manager_metrics_test.go
+++ b/test/e2e_node/cpu_manager_metrics_test.go
@@ -177,7 +177,7 @@ var _ = SIGDescribe("CPU Manager Metrics", framework.WithSerial(), feature.CPUMa
 			gomega.Consistently(ctx, getKubeletMetrics, 1*time.Minute, 15*time.Second).Should(matchResourceMetrics)
 		})
 
-		ginkgo.It("should return updated alignment counters when pod successfully run", func(ctx context.Context) {
+		ginkgo.It("should return updated SMT alignment counters when pod successfully run", func(ctx context.Context) {
 			ginkgo.By("Creating the test pod")
 			testPod = e2epod.NewPodClient(f).Create(ctx, makeGuaranteedCPUExclusiveSleeperPod("count-align-smt-ok", smtLevel))
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
Add alignment metrics for uncore (aka last-level) cache (KEP-4800)

#### Which issue(s) this PR fixes:
Part of the work needed for KEP 4800: https://github.com/kubernetes/enhancements/issues/4800

#### Special notes for your reviewer:
continuation of #100145 29529

#### Does this PR introduce a user-facing change?
```release-note
Add metrics to track allocation of Uncore (aka last-level aka L3) Cache blocks
```


