### PR TITLE
[e2e] [sig-cli] skip "should handle in-cluster config" e2e test for GCE provider

### DIFF
--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -557,6 +557,11 @@ var _ = SIGDescribe("Kubectl client", func() {
 			})
 
 			ginkgo.It("should handle in-cluster config", func(ctx context.Context) {
+				// This test does not work for dynamically linked kubectl binaries; only statically linked ones. The
+				// problem happens when the kubectl binary is copied to a pod in the cluster. For dynamically linked
+				// binaries, the necessary libraries are not also copied. For this reason, the test can not be
+				// guaranteed to work with GKE, which sometimes run tests using a dynamically linked kubectl.
+				e2eskipper.SkipIfProviderIs("gce")
 				// TODO: Find a way to download and copy the appropriate kubectl binary, or maybe a multi-arch kubectl image
 				// for now this only works on amd64
 				e2eskipper.SkipUnlessNodeOSArchIs("amd64")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind failing-test

#### What this PR does / why we need it:
In #124519, we dropped support for GKE as a provider type for e2e tests. In #129687, we removed mentions of GKE as a provider in the e2e tests. However, this is causing [this test](https://github.com/kubernetes/kubernetes/blob/master/test/e2e/kubectl/kubectl.go#L559) to fail on GKE. This was a known issue that was documented [before](https://github.com/kubernetes/kubernetes/blob/b51d6308a737df2e61746913008ab9a8095e59f5/test/e2e/kubectl/kubectl.go#L563) and the test was skipped on GKE as a consequence, but the provider check for this test was removed in #129687. To resolve this, we need to add back the skip command but using `gce` as a provider instead of `gke`. 
#### Which issue(s) this PR fixes:
Skips failing test `should handle in-cluster config` in `test/e2e/kubectl/kubectl.go` on GKE.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
