### PR TITLE
features: Enable user namespaces by default

### DIFF
--- a/pkg/features/versioned_kube_features.go
+++ b/pkg/features/versioned_kube_features.go
@@ -797,6 +797,7 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 	UserNamespacesSupport: {
 		{Version: version.MustParse("1.25"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("1.30"), Default: false, PreRelease: featuregate.Beta},
+		{Version: version.MustParse("1.33"), Default: true, PreRelease: featuregate.Beta},
 	},
 
 	VolumeAttributesClass: {

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -95,6 +95,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/sysctl"
 	"k8s.io/kubernetes/pkg/kubelet/token"
 	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
+	"k8s.io/kubernetes/pkg/kubelet/userns"
 	kubeletutil "k8s.io/kubernetes/pkg/kubelet/util"
 	"k8s.io/kubernetes/pkg/kubelet/util/queue"
 	kubeletvolume "k8s.io/kubernetes/pkg/kubelet/volumemanager"
@@ -368,6 +369,10 @@ func newTestKubeletWithImageList(
 		ShutdownGracePeriodCriticalPods: 0,
 	})
 	kubelet.shutdownManager = shutdownManager
+	kubelet.usernsManager, err = userns.MakeUserNsManager(kubelet)
+	if err != nil {
+		t.Fatalf("Failed to create UserNsManager: %v", err)
+	}
 	kubelet.admitHandlers.AddPodAdmitHandler(shutdownManager)
 
 	// Add this as cleanup predicate pod admitter

--- a/test/e2e_node/proc_mount_test.go
+++ b/test/e2e_node/proc_mount_test.go
@@ -41,7 +41,7 @@ var _ = SIGDescribe("DefaultProcMount [LinuxOnly]", framework.WithNodeConformanc
 	f.NamespacePodSecurityLevel = admissionapi.LevelBaseline
 
 	ginkgo.It("will mask proc mounts by default", func(ctx context.Context) {
-		testProcMount(ctx, f, v1.DefaultProcMount, gomega.BeNumerically(">", 1), gomega.BeNumerically(">", 0))
+		testProcMount(ctx, f, v1.DefaultProcMount, true, gomega.BeNumerically(">", 1), gomega.BeNumerically(">", 0))
 	})
 })
 
@@ -85,11 +85,11 @@ var _ = SIGDescribe("ProcMount [LinuxOnly]", feature.ProcMountType, feature.User
 		if !supportsUserNS(ctx, f) {
 			e2eskipper.Skipf("runtime does not support user namespaces")
 		}
-		testProcMount(ctx, f, v1.UnmaskedProcMount, gomega.Equal(1), gomega.BeZero())
+		testProcMount(ctx, f, v1.UnmaskedProcMount, false, gomega.Equal(1), gomega.BeZero())
 	})
 })
 
-func testProcMount(ctx context.Context, f *framework.Framework, pmt v1.ProcMountType, expectedLines gomegatypes.GomegaMatcher, expectedReadOnly gomegatypes.GomegaMatcher) {
+func testProcMount(ctx context.Context, f *framework.Framework, pmt v1.ProcMountType, hostUsers bool, expectedLines gomegatypes.GomegaMatcher, expectedReadOnly gomegatypes.GomegaMatcher) {
 	ginkgo.By("creating a target pod")
 	podClient := e2epod.NewPodClient(f)
 	pod := podClient.CreateSync(ctx, &v1.Pod{
@@ -106,7 +106,7 @@ func testProcMount(ctx context.Context, f *framework.Framework, pmt v1.ProcMount
 					},
 				},
 			},
-			HostUsers: &falseVar,
+			HostUsers: &hostUsers,
 		},
 	})
 

--- a/test/featuregates_linter/test_data/versioned_feature_list.yaml
+++ b/test/featuregates_linter/test_data/versioned_feature_list.yaml
@@ -1486,6 +1486,10 @@
     lockToDefault: false
     preRelease: Beta
     version: "1.30"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.33"
 - name: VolumeAttributesClass
   versionedSpecs:
   - default: false


### PR DESCRIPTION
The feature gate UserNamespacesSupport is enabled by default now (KEP 127): https://github.com/kubernetes/enhancements/pull/5118.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it: Enable user namespaces by default (beta).

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer: Please see each commit message for details.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
User namespaces support (feature gate UserNamespacesSupport) is enabled by default. If you want to use it, please check the documentation for the node requirements.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
The KEP change was done in this PR: https://github.com/kubernetes/enhancements/pull/5118

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/2e2f53025277c2725976eb30076a6834049afa40/keps/sig-node/127-user-namespaces/README.md
- [Usage]: https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/
- [Other doc]: https://kubernetes.io/docs/tasks/configure-pod-container/user-namespaces/
```
