### PR TITLE
Use `sudo` for dmesg in hack/local-up-cluster.sh

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -411,7 +411,7 @@ cleanup()
   fi
 
   # Cleanup dmesg running in the background
-  [[ -n "${DMESG_PID-}" ]] && kill "$DMESG_PID"
+  [[ -n "${DMESG_PID-}" ]] && sudo kill "$DMESG_PID" 2>/dev/null
 
   exit 0
 }
@@ -812,8 +812,10 @@ function wait_coredns_available(){
     echo "6" | sudo tee /proc/sys/kernel/printk
 
     # loop through and grab all things in dmesg
-    dmesg > "${LOG_DIR}/dmesg.log"
-    dmesg -w --human >> "${LOG_DIR}/dmesg.log" &
+    # shellcheck disable=SC2024
+    sudo dmesg > "${LOG_DIR}/dmesg.log"
+    # shellcheck disable=SC2024
+    sudo dmesg -w --human >> "${LOG_DIR}/dmesg.log" &
     DMESG_PID=$!
   fi
 }


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
Kernels may have `kernel.dmesg_restrict = 1` set which requires root access to see dmesg. We're now using `sudo` to mitigate that.

#### Which issue(s) this PR fixes:
None
#### Special notes for your reviewer:
cc @dims 
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
