### PR TITLE
Add fs to options.Authentication.Validate() and ToAuthenticationConfig()

### DIFF
--- a/cmd/kube-apiserver/app/options/options_test.go
+++ b/cmd/kube-apiserver/app/options/options_test.go
@@ -135,6 +135,7 @@ func TestAddFlags(t *testing.T) {
 	// This is a snapshot of expected options parsed by args.
 	expected := &ServerRunOptions{
 		Options: &controlplaneapiserver.Options{
+			ParsedFlags: s.ParsedFlags,
 			GenericServerRunOptions: &apiserveroptions.ServerRunOptions{
 				AdvertiseAddress:             netutils.ParseIPSloppy("192.168.10.10"),
 				CorsAllowedOriginList:        []string{"10.10.10.100", "10.10.10.200"},

--- a/pkg/controlplane/apiserver/config.go
+++ b/pkg/controlplane/apiserver/config.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/spf13/pflag"
 	noopoteltrace "go.opentelemetry.io/otel/trace/noop"
 
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -206,7 +207,12 @@ func BuildGenericConfig(
 	ctx := wait.ContextForChannel(genericConfig.DrainedNotify())
 
 	// Authentication.ApplyTo requires already applied OpenAPIConfig and EgressSelector if present
-	if lastErr = s.Authentication.ApplyTo(ctx, &genericConfig.Authentication, genericConfig.SecureServing, genericConfig.EgressSelector, genericConfig.OpenAPIConfig, genericConfig.OpenAPIV3Config, clientgoExternalClient, versionedInformers, genericConfig.APIServerID); lastErr != nil {
+	var fs *pflag.FlagSet
+	if s.ParsedFlags != nil {
+		fs = s.ParsedFlags.FlagSet("authentication")
+	}
+
+	if lastErr = s.Authentication.ApplyTo(ctx, fs, &genericConfig.Authentication, genericConfig.SecureServing, genericConfig.EgressSelector, genericConfig.OpenAPIConfig, genericConfig.OpenAPIV3Config, clientgoExternalClient, versionedInformers, genericConfig.APIServerID); lastErr != nil {
 		return
 	}
 

--- a/pkg/controlplane/apiserver/options/options.go
+++ b/pkg/controlplane/apiserver/options/options.go
@@ -48,6 +48,7 @@ import (
 // Options define the flags and validation for a generic controlplane. If the
 // structs are nil, the options are not added to the command line and not validated.
 type Options struct {
+	ParsedFlags             *cliflag.NamedFlagSets
 	Flagz                   flagz.Reader
 	GenericServerRunOptions *genericoptions.ServerRunOptions
 	Etcd                    *genericoptions.EtcdOptions
@@ -201,6 +202,8 @@ func (s *Options) AddFlags(fss *cliflag.NamedFlagSets) {
 
 	fs.StringVar(&s.ServiceAccountSigningEndpoint, "service-account-signing-endpoint", s.ServiceAccountSigningEndpoint, ""+
 		"Path to socket where a external JWT signer is listening. This flag is mutually exclusive with --service-account-signing-key-file and --service-account-key-file. Requires enabling feature gate (ExternalServiceAccountTokenSigner)")
+
+	s.ParsedFlags = fss
 }
 
 func (o *Options) Complete(ctx context.Context, alternateDNS []string, alternateIPs []net.IP) (CompletedOptions, error) {

--- a/pkg/controlplane/apiserver/options/options_test.go
+++ b/pkg/controlplane/apiserver/options/options_test.go
@@ -129,6 +129,7 @@ func TestAddFlags(t *testing.T) {
 
 	// This is a snapshot of expected options parsed by args.
 	expected := &Options{
+		ParsedFlags: s.ParsedFlags,
 		GenericServerRunOptions: &apiserveroptions.ServerRunOptions{
 			AdvertiseAddress:             netutils.ParseIPSloppy("192.168.10.10"),
 			CorsAllowedOriginList:        []string{"10.10.10.100", "10.10.10.200"},

--- a/pkg/controlplane/apiserver/options/validation.go
+++ b/pkg/controlplane/apiserver/options/validation.go
@@ -127,6 +127,14 @@ func validateServiceAccountTokenSigningConfig(options *Options) []error {
 	return errors
 }
 
+func validateAuthentication(s *Options) []error {
+	if s.ParsedFlags != nil {
+		return s.Authentication.Validate(s.ParsedFlags.FlagSet("authentication"))
+	}
+
+	return nil
+}
+
 // Validate checks Options and return a slice of found errs.
 func (s *Options) Validate() []error {
 	var errs []error
@@ -135,7 +143,7 @@ func (s *Options) Validate() []error {
 	errs = append(errs, s.Etcd.Validate()...)
 	errs = append(errs, validateAPIPriorityAndFairness(s)...)
 	errs = append(errs, s.SecureServing.Validate()...)
-	errs = append(errs, s.Authentication.Validate()...)
+	errs = append(errs, validateAuthentication(s)...)
 	errs = append(errs, s.Authorization.Validate()...)
 	errs = append(errs, s.Audit.Validate()...)
 	errs = append(errs, s.Admission.Validate()...)

--- a/pkg/kubeapiserver/options/authentication.go
+++ b/pkg/kubeapiserver/options/authentication.go
@@ -100,8 +100,7 @@ type BuiltInAuthenticationOptions struct {
 
 // AnonymousAuthenticationOptions contains anonymous authentication options for API Server
 type AnonymousAuthenticationOptions struct {
-	Allow       bool
-	areFlagsSet func() bool
+	Allow bool
 }
 
 // BootstrapTokenAuthenticationOptions contains bootstrap token authentication options for API Server
@@ -120,9 +119,6 @@ type OIDCAuthenticationOptions struct {
 	GroupsPrefix   string
 	SigningAlgs    []string
 	RequiredClaims map[string]string
-
-	// areFlagsConfigured is a function that returns true if any of the oidc-* flags are configured.
-	areFlagsConfigured func() bool
 }
 
 // ServiceAccountAuthenticationOptions contains service account authentication options for API Server
@@ -183,8 +179,7 @@ func (o *BuiltInAuthenticationOptions) WithAll() *BuiltInAuthenticationOptions {
 // WithAnonymous set default value for anonymous authentication
 func (o *BuiltInAuthenticationOptions) WithAnonymous() *BuiltInAuthenticationOptions {
 	o.Anonymous = &AnonymousAuthenticationOptions{
-		Allow:       true,
-		areFlagsSet: func() bool { return false },
+		Allow: true,
 	}
 	return o
 }
@@ -204,9 +199,8 @@ func (o *BuiltInAuthenticationOptions) WithClientCert() *BuiltInAuthenticationOp
 // WithOIDC set default value for OIDC authentication
 func (o *BuiltInAuthenticationOptions) WithOIDC() *BuiltInAuthenticationOptions {
 	o.OIDC = &OIDCAuthenticationOptions{
-		areFlagsConfigured: func() bool { return false },
-		UsernameClaim:      "sub",
-		SigningAlgs:        []string{"RS256"},
+		UsernameClaim: "sub",
+		SigningAlgs:   []string{"RS256"},
 	}
 	return o
 }
@@ -245,14 +239,14 @@ func (o *BuiltInAuthenticationOptions) WithWebHook() *BuiltInAuthenticationOptio
 }
 
 // Validate checks invalid config combination
-func (o *BuiltInAuthenticationOptions) Validate() []error {
+func (o *BuiltInAuthenticationOptions) Validate(fs *pflag.FlagSet) []error {
 	if o == nil {
 		return nil
 	}
 
 	var allErrors []error
 
-	allErrors = append(allErrors, o.validateOIDCOptions()...)
+	allErrors = append(allErrors, o.validateOIDCOptions(fs)...)
 
 	if o.ServiceAccounts != nil && len(o.ServiceAccounts.Issuers) > 0 {
 		seen := make(map[string]bool)
@@ -337,10 +331,6 @@ func (o *BuiltInAuthenticationOptions) AddFlags(fs *pflag.FlagSet) {
 			"Enables anonymous requests to the secure port of the API server. "+
 			"Requests that are not rejected by another authentication method are treated as anonymous requests. "+
 			"Anonymous requests have a username of system:anonymous, and a group name of system:unauthenticated.")
-
-		o.Anonymous.areFlagsSet = func() bool {
-			return fs.Changed("anonymous-auth")
-		}
 	}
 
 	if o.BootstrapToken != nil {
@@ -393,18 +383,6 @@ func (o *BuiltInAuthenticationOptions) AddFlags(fs *pflag.FlagSet) {
 			"A key=value pair that describes a required claim in the ID Token. "+
 			"If set, the claim is verified to be present in the ID Token with a matching value. "+
 			"Repeat this flag to specify multiple claims.")
-
-		o.OIDC.areFlagsConfigured = func() bool {
-			return fs.Changed(oidcIssuerURLFlag) ||
-				fs.Changed(oidcClientIDFlag) ||
-				fs.Changed(oidcCAFileFlag) ||
-				fs.Changed(oidcUsernameClaimFlag) ||
-				fs.Changed(oidcUsernamePrefixFlag) ||
-				fs.Changed(oidcGroupsClaimFlag) ||
-				fs.Changed(oidcGroupsPrefixFlag) ||
-				fs.Changed(oidcSigningAlgsFlag) ||
-				fs.Changed(oidcRequiredClaimFlag)
-		}
 	}
 
 	if o.RequestHeader != nil {
@@ -472,7 +450,7 @@ func (o *BuiltInAuthenticationOptions) AddFlags(fs *pflag.FlagSet) {
 
 // ToAuthenticationConfig convert BuiltInAuthenticationOptions to kubeauthenticator.Config. Returns
 // an empty config if o is nil.
-func (o *BuiltInAuthenticationOptions) ToAuthenticationConfig() (kubeauthenticator.Config, error) {
+func (o *BuiltInAuthenticationOptions) ToAuthenticationConfig(fs *pflag.FlagSet) (kubeauthenticator.Config, error) {
 	if o == nil {
 		return kubeauthenticator.Config{}, nil
 	}
@@ -572,7 +550,7 @@ func (o *BuiltInAuthenticationOptions) ToAuthenticationConfig() (kubeauthenticat
 	// Set up anonymous authenticator from config file or flags
 	if o.Anonymous != nil {
 		switch {
-		case ret.AuthenticationConfig.Anonymous != nil && o.Anonymous.areFlagsSet():
+		case ret.AuthenticationConfig.Anonymous != nil && o.Anonymous.areFlagsSet(fs):
 			// Flags and config file are mutually exclusive
 			return kubeauthenticator.Config{}, field.Forbidden(field.NewPath("anonymous"), "--anonynous-auth flag cannot be set when anonymous field is configured in authentication configuration file")
 		case ret.AuthenticationConfig.Anonymous != nil:
@@ -654,6 +632,7 @@ func (o *BuiltInAuthenticationOptions) ToAuthenticationConfig() (kubeauthenticat
 // The input context controls the lifecycle of background goroutines started to reload the authentication config file.
 func (o *BuiltInAuthenticationOptions) ApplyTo(
 	ctx context.Context,
+	fs *pflag.FlagSet,
 	authInfo *genericapiserver.AuthenticationInfo,
 	secureServing *genericapiserver.SecureServingInfo,
 	egressSelector *egressselector.EgressSelector,
@@ -670,7 +649,7 @@ func (o *BuiltInAuthenticationOptions) ApplyTo(
 		return errors.New("uninitialized OpenAPIConfig")
 	}
 
-	authenticatorConfig, err := o.ToAuthenticationConfig()
+	authenticatorConfig, err := o.ToAuthenticationConfig(fs)
 	if err != nil {
 		return err
 	}
@@ -823,12 +802,12 @@ func (o *BuiltInAuthenticationOptions) ApplyAuthorization(authorization *BuiltIn
 	}
 }
 
-func (o *BuiltInAuthenticationOptions) validateOIDCOptions() []error {
+func (o *BuiltInAuthenticationOptions) validateOIDCOptions(fs *pflag.FlagSet) []error {
 	var allErrors []error
 
 	// Existing validation when jwt authenticator is configured with oidc-* flags
 	if len(o.AuthenticationConfigFile) == 0 {
-		if o.OIDC != nil && o.OIDC.areFlagsConfigured() && (len(o.OIDC.IssuerURL) == 0 || len(o.OIDC.ClientID) == 0) {
+		if o.OIDC != nil && o.OIDC.areFlagsConfigured(fs) && (len(o.OIDC.IssuerURL) == 0 || len(o.OIDC.ClientID) == 0) {
 			allErrors = append(allErrors, fmt.Errorf("oidc-issuer-url and oidc-client-id must be specified together when any oidc-* flags are set"))
 		}
 
@@ -843,7 +822,7 @@ func (o *BuiltInAuthenticationOptions) validateOIDCOptions() []error {
 	}
 
 	// Authentication config file and oidc-* flags are mutually exclusive
-	if o.OIDC != nil && o.OIDC.areFlagsConfigured() {
+	if o.OIDC != nil && o.OIDC.areFlagsConfigured(fs) {
 		allErrors = append(allErrors, fmt.Errorf("authentication-config file and oidc-* flags are mutually exclusive"))
 	}
 
@@ -892,4 +871,20 @@ func loadAuthenticationConfigFromData(data []byte) (*apiserver.AuthenticationCon
 	}
 
 	return configuration, nil
+}
+
+func (o *OIDCAuthenticationOptions) areFlagsConfigured(fs *pflag.FlagSet) bool {
+	return fs != nil && (fs.Changed(oidcIssuerURLFlag) ||
+		fs.Changed(oidcClientIDFlag) ||
+		fs.Changed(oidcCAFileFlag) ||
+		fs.Changed(oidcUsernameClaimFlag) ||
+		fs.Changed(oidcUsernamePrefixFlag) ||
+		fs.Changed(oidcGroupsClaimFlag) ||
+		fs.Changed(oidcGroupsPrefixFlag) ||
+		fs.Changed(oidcSigningAlgsFlag) ||
+		fs.Changed(oidcRequiredClaimFlag))
+}
+
+func (o *AnonymousAuthenticationOptions) areFlagsSet(fs *pflag.FlagSet) bool {
+	return fs != nil && fs.Changed("anonymous-auth")
 }

--- a/pkg/kubeapiserver/options/authentication_test.go
+++ b/pkg/kubeapiserver/options/authentication_test.go
@@ -57,6 +57,8 @@ import (
 func TestAuthenticationValidate(t *testing.T) {
 	testCases := []struct {
 		name                              string
+		areOIDCFlagsConfigured            bool
+		areAnonymousFlagsConfigured       bool
 		testAnonymous                     *AnonymousAuthenticationOptions
 		testOIDC                          *OIDCAuthenticationOptions
 		testSA                            *ServiceAccountAuthenticationOptions
@@ -69,26 +71,25 @@ func TestAuthenticationValidate(t *testing.T) {
 			name: "test when OIDC and ServiceAccounts are nil",
 		},
 		{
-			name: "test when OIDC and ServiceAccounts are valid",
+			name:                   "test when OIDC and ServiceAccounts are valid",
+			areOIDCFlagsConfigured: true,
 			testOIDC: &OIDCAuthenticationOptions{
-				UsernameClaim:      "sub",
-				SigningAlgs:        []string{"RS256"},
-				IssuerURL:          "https://testIssuerURL",
-				ClientID:           "testClientID",
-				areFlagsConfigured: func() bool { return true },
+				UsernameClaim: "sub",
+				SigningAlgs:   []string{"RS256"},
+				IssuerURL:     "https://testIssuerURL",
+				ClientID:      "testClientID",
 			},
 			testSA: &ServiceAccountAuthenticationOptions{
 				Issuers:  []string{"http://foo.bar.com"},
 				KeyFiles: []string{"testkeyfile1", "testkeyfile2"},
 			},
-		},
-		{
-			name: "test when OIDC is invalid",
+		}, {
+			name:                   "test when OIDC is invalid",
+			areOIDCFlagsConfigured: true,
 			testOIDC: &OIDCAuthenticationOptions{
-				UsernameClaim:      "sub",
-				SigningAlgs:        []string{"RS256"},
-				IssuerURL:          "https://testIssuerURL",
-				areFlagsConfigured: func() bool { return true },
+				UsernameClaim: "sub",
+				SigningAlgs:   []string{"RS256"},
+				IssuerURL:     "https://testIssuerURL",
 			},
 			testSA: &ServiceAccountAuthenticationOptions{
 				Issuers:  []string{"http://foo.bar.com"},
@@ -97,13 +98,13 @@ func TestAuthenticationValidate(t *testing.T) {
 			expectErr: "oidc-issuer-url and oidc-client-id must be specified together when any oidc-* flags are set",
 		},
 		{
-			name: "test when ServiceAccounts doesn't have key file",
+			name:                   "test when ServiceAccounts doesn't have key file",
+			areOIDCFlagsConfigured: true,
 			testOIDC: &OIDCAuthenticationOptions{
-				UsernameClaim:      "sub",
-				SigningAlgs:        []string{"RS256"},
-				IssuerURL:          "https://testIssuerURL",
-				ClientID:           "testClientID",
-				areFlagsConfigured: func() bool { return true },
+				UsernameClaim: "sub",
+				SigningAlgs:   []string{"RS256"},
+				IssuerURL:     "https://testIssuerURL",
+				ClientID:      "testClientID",
 			},
 			testSA: &ServiceAccountAuthenticationOptions{
 				Issuers: []string{"http://foo.bar.com"},
@@ -111,13 +112,13 @@ func TestAuthenticationValidate(t *testing.T) {
 			expectErr: "either `--service-account-key-file` or `--service-account-signing-endpoint` must be set",
 		},
 		{
-			name: "test when ServiceAccounts doesn't have issuer",
+			name:                   "test when ServiceAccounts doesn't have issuer",
+			areOIDCFlagsConfigured: true,
 			testOIDC: &OIDCAuthenticationOptions{
-				UsernameClaim:      "sub",
-				SigningAlgs:        []string{"RS256"},
-				IssuerURL:          "https://testIssuerURL",
-				ClientID:           "testClientID",
-				areFlagsConfigured: func() bool { return true },
+				UsernameClaim: "sub",
+				SigningAlgs:   []string{"RS256"},
+				IssuerURL:     "https://testIssuerURL",
+				ClientID:      "testClientID",
 			},
 			testSA: &ServiceAccountAuthenticationOptions{
 				Issuers: []string{},
@@ -125,13 +126,13 @@ func TestAuthenticationValidate(t *testing.T) {
 			expectErr: "service-account-issuer is a required flag",
 		},
 		{
-			name: "test when ServiceAccounts has empty string as issuer",
+			name:                   "test when ServiceAccounts has empty string as issuer",
+			areOIDCFlagsConfigured: true,
 			testOIDC: &OIDCAuthenticationOptions{
-				UsernameClaim:      "sub",
-				SigningAlgs:        []string{"RS256"},
-				IssuerURL:          "https://testIssuerURL",
-				ClientID:           "testClientID",
-				areFlagsConfigured: func() bool { return true },
+				UsernameClaim: "sub",
+				SigningAlgs:   []string{"RS256"},
+				IssuerURL:     "https://testIssuerURL",
+				ClientID:      "testClientID",
 			},
 			testSA: &ServiceAccountAuthenticationOptions{
 				Issuers: []string{""},
@@ -139,13 +140,13 @@ func TestAuthenticationValidate(t *testing.T) {
 			expectErr: "service-account-issuer should not be an empty string",
 		},
 		{
-			name: "test when ServiceAccounts has duplicate issuers",
+			name:                   "test when ServiceAccounts has duplicate issuers",
+			areOIDCFlagsConfigured: true,
 			testOIDC: &OIDCAuthenticationOptions{
-				UsernameClaim:      "sub",
-				SigningAlgs:        []string{"RS256"},
-				IssuerURL:          "https://testIssuerURL",
-				ClientID:           "testClientID",
-				areFlagsConfigured: func() bool { return true },
+				UsernameClaim: "sub",
+				SigningAlgs:   []string{"RS256"},
+				IssuerURL:     "https://testIssuerURL",
+				ClientID:      "testClientID",
 			},
 			testSA: &ServiceAccountAuthenticationOptions{
 				Issuers: []string{"http://foo.bar.com", "http://foo.bar.com"},
@@ -153,13 +154,13 @@ func TestAuthenticationValidate(t *testing.T) {
 			expectErr: "service-account-issuer \"http://foo.bar.com\" is already specified",
 		},
 		{
-			name: "test when ServiceAccount has bad issuer",
+			name:                   "test when ServiceAccount has bad issuer",
+			areOIDCFlagsConfigured: true,
 			testOIDC: &OIDCAuthenticationOptions{
-				UsernameClaim:      "sub",
-				SigningAlgs:        []string{"RS256"},
-				IssuerURL:          "https://testIssuerURL",
-				ClientID:           "testClientID",
-				areFlagsConfigured: func() bool { return true },
+				UsernameClaim: "sub",
+				SigningAlgs:   []string{"RS256"},
+				IssuerURL:     "https://testIssuerURL",
+				ClientID:      "testClientID",
 			},
 			testSA: &ServiceAccountAuthenticationOptions{
 				Issuers: []string{"http://[::1]:namedport"},
@@ -167,13 +168,13 @@ func TestAuthenticationValidate(t *testing.T) {
 			expectErr: "service-account-issuer \"http://[::1]:namedport\" contained a ':' but was not a valid URL",
 		},
 		{
-			name: "test when ServiceAccounts has invalid JWKSURI",
+			name:                   "test when ServiceAccounts has invalid JWKSURI",
+			areOIDCFlagsConfigured: true,
 			testOIDC: &OIDCAuthenticationOptions{
-				UsernameClaim:      "sub",
-				SigningAlgs:        []string{"RS256"},
-				IssuerURL:          "https://testIssuerURL",
-				ClientID:           "testClientID",
-				areFlagsConfigured: func() bool { return true },
+				UsernameClaim: "sub",
+				SigningAlgs:   []string{"RS256"},
+				IssuerURL:     "https://testIssuerURL",
+				ClientID:      "testClientID",
 			},
 			testSA: &ServiceAccountAuthenticationOptions{
 				KeyFiles: []string{"cert", "key"},
@@ -183,13 +184,13 @@ func TestAuthenticationValidate(t *testing.T) {
 			expectErr: "service-account-jwks-uri must be a valid URL: parse \"https://host:port\": invalid port \":port\" after host",
 		},
 		{
-			name: "test when ServiceAccounts has invalid JWKSURI (not https scheme)",
+			name:                   "test when ServiceAccounts has invalid JWKSURI (not https scheme)",
+			areOIDCFlagsConfigured: true,
 			testOIDC: &OIDCAuthenticationOptions{
-				UsernameClaim:      "sub",
-				SigningAlgs:        []string{"RS256"},
-				IssuerURL:          "https://testIssuerURL",
-				ClientID:           "testClientID",
-				areFlagsConfigured: func() bool { return true },
+				UsernameClaim: "sub",
+				SigningAlgs:   []string{"RS256"},
+				IssuerURL:     "https://testIssuerURL",
+				ClientID:      "testClientID",
 			},
 			testSA: &ServiceAccountAuthenticationOptions{
 				KeyFiles: []string{"cert", "key"},
@@ -199,13 +200,13 @@ func TestAuthenticationValidate(t *testing.T) {
 			expectErr: "service-account-jwks-uri requires https scheme, parsed as: http://baz.com",
 		},
 		{
-			name: "test when WebHook has invalid retry attempts",
+			name:                   "test when WebHook has invalid retry attempts",
+			areOIDCFlagsConfigured: true,
 			testOIDC: &OIDCAuthenticationOptions{
-				UsernameClaim:      "sub",
-				SigningAlgs:        []string{"RS256"},
-				IssuerURL:          "https://testIssuerURL",
-				ClientID:           "testClientID",
-				areFlagsConfigured: func() bool { return true },
+				UsernameClaim: "sub",
+				SigningAlgs:   []string{"RS256"},
+				IssuerURL:     "https://testIssuerURL",
+				ClientID:      "testClientID",
 			},
 			testSA: &ServiceAccountAuthenticationOptions{
 				KeyFiles: []string{"cert", "key"},
@@ -232,23 +233,23 @@ func TestAuthenticationValidate(t *testing.T) {
 		},
 		{
 			name:                         "test when authentication config file and oidc-* flags are set",
+			areOIDCFlagsConfigured:       true,
 			testAuthenticationConfigFile: "configfile",
 			testOIDC: &OIDCAuthenticationOptions{
-				UsernameClaim:      "sub",
-				SigningAlgs:        []string{"RS256"},
-				IssuerURL:          "https://testIssuerURL",
-				ClientID:           "testClientID",
-				areFlagsConfigured: func() bool { return true },
+				UsernameClaim: "sub",
+				SigningAlgs:   []string{"RS256"},
+				IssuerURL:     "https://testIssuerURL",
+				ClientID:      "testClientID",
 			},
 			expectErr: "authentication-config file and oidc-* flags are mutually exclusive",
 		},
 		{
 			name:                         "test when authentication config file and anonymous-auth flags are set AnonymousAuthConfigurableEndpoints disabled",
+			areAnonymousFlagsConfigured:  true,
 			disabledFeatures:             []featuregate.Feature{features.AnonymousAuthConfigurableEndpoints},
 			testAuthenticationConfigFile: "configfile",
 			testAnonymous: &AnonymousAuthenticationOptions{
-				Allow:       true,
-				areFlagsSet: func() bool { return true },
+				Allow: true,
 			},
 		},
 	}
@@ -261,13 +262,22 @@ func TestAuthenticationValidate(t *testing.T) {
 			options.ServiceAccounts = testcase.testSA
 			options.WebHook = testcase.testWebHook
 			options.AuthenticationConfigFile = testcase.testAuthenticationConfigFile
+			pf, err := configureFlagSet(options, testcase.areOIDCFlagsConfigured, testcase.areAnonymousFlagsConfigured, testcase.testOIDC)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if pf != nil {
+				if err := pf.Parse([]string{}); err != nil {
+					t.Fatal(err)
+				}
+			}
 			for _, f := range testcase.enabledFeatures {
 				featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, f, true)
 			}
 			for _, f := range testcase.disabledFeatures {
 				featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, f, false)
 			}
-			errs := options.Validate()
+			errs := options.Validate(pf)
 			if len(errs) > 0 && (!strings.Contains(utilerrors.NewAggregate(errs).Error(), testcase.expectErr) || testcase.expectErr == "") {
 				t.Errorf("Got err: %v, Expected err: %s", errs, testcase.expectErr)
 			}
@@ -366,7 +376,7 @@ func TestToAuthenticationConfig(t *testing.T) {
 	}
 	expectConfig.AuthenticationConfig.JWT[0].Issuer.CertificateAuthority = string(fileBytes)
 
-	resultConfig, err := testOptions.ToAuthenticationConfig()
+	resultConfig, err := testOptions.ToAuthenticationConfig(pflag.NewFlagSet("test-builtin-authentication-opts", pflag.ContinueOnError))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -470,18 +480,13 @@ func TestBuiltInAuthenticationOptionsAddFlags(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !opts.OIDC.areFlagsConfigured() {
+	if !opts.OIDC.areFlagsConfigured(pf) {
 		t.Fatal("OIDC flags should be configured")
 	}
-	// nil these out because you cannot compare functions
-	opts.OIDC.areFlagsConfigured = nil
 
-	if !opts.Anonymous.areFlagsSet() {
+	if !opts.Anonymous.areFlagsSet(pf) {
 		t.Fatalf("Anonymous flags should be configured")
 	}
-
-	// nil these out because you cannot compare functions
-	opts.Anonymous.areFlagsSet = nil
 
 	if !reflect.DeepEqual(opts, expected) {
 		t.Error(cmp.Diff(opts, expected, cmp.AllowUnexported(OIDCAuthenticationOptions{}, AnonymousAuthenticationOptions{})))
@@ -499,7 +504,7 @@ func TestWithTokenGetterFunction(t *testing.T) {
 		}
 		opts := NewBuiltInAuthenticationOptions().WithServiceAccounts()
 		opts.ServiceAccounts.OptionalTokenGetter = f
-		err := opts.ApplyTo(context.Background(), &genericapiserver.AuthenticationInfo{}, nil, nil, &openapicommon.Config{}, nil, fakeClientset, versionedInformer, "")
+		err := opts.ApplyTo(context.Background(), nil, &genericapiserver.AuthenticationInfo{}, nil, nil, &openapicommon.Config{}, nil, fakeClientset, versionedInformer, "")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -510,7 +515,7 @@ func TestWithTokenGetterFunction(t *testing.T) {
 	}
 	{
 		opts := NewBuiltInAuthenticationOptions().WithServiceAccounts()
-		err := opts.ApplyTo(context.Background(), &genericapiserver.AuthenticationInfo{}, nil, nil, &openapicommon.Config{}, nil, fakeClientset, versionedInformer, "")
+		err := opts.ApplyTo(context.Background(), nil, &genericapiserver.AuthenticationInfo{}, nil, nil, &openapicommon.Config{}, nil, fakeClientset, versionedInformer, "")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -767,7 +772,7 @@ jwt:
 				t.Fatal(err)
 			}
 
-			resultConfig, err := opts.ToAuthenticationConfig()
+			resultConfig, err := opts.ToAuthenticationConfig(pf)
 
 			if testcase.expectErr != "" {
 				if err == nil {
@@ -1050,7 +1055,7 @@ jwt:
 				t.Fatal(err)
 			}
 
-			resultConfig, err := opts.ToAuthenticationConfig()
+			resultConfig, err := opts.ToAuthenticationConfig(pf)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1216,7 +1221,7 @@ func TestValidateOIDCOptions(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			errs := opts.Validate()
+			errs := opts.Validate(pf)
 			if len(errs) > 0 && (!strings.Contains(utilerrors.NewAggregate(errs).Error(), tt.expectErr) || tt.expectErr == "") {
 				t.Errorf("Got err: %v, Expected err: %s", errs, tt.expectErr)
 			}
@@ -1639,7 +1644,7 @@ func TestToAuthenticationConfigForServiceAccount(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		resultConfig, err := tc.options.ToAuthenticationConfig()
+		resultConfig, err := tc.options.ToAuthenticationConfig(nil)
 		if tc.expectedErr != nil {
 			if err == nil || tc.expectedErr.Error() != err.Error() {
 				t.Fatalf("Expected error: %v and got: %v", tc.expectedErr, err)
@@ -1685,4 +1690,33 @@ func (d *dummyPublicKeyGetter) GetCacheAgeMaxSeconds() int {
 
 func (d *dummyPublicKeyGetter) GetPublicKeys(ctx context.Context, keyIDHint string) []serviceaccount.PublicKey {
 	return []serviceaccount.PublicKey{}
+}
+
+func configureFlagSet(options *BuiltInAuthenticationOptions, areOIDCFlagsConfigured, areAnonymousFlagsConfigured bool, testOIDC *OIDCAuthenticationOptions) (*pflag.FlagSet, error) {
+	if !areOIDCFlagsConfigured && !areAnonymousFlagsConfigured {
+		return nil, nil
+	}
+
+	pf := pflag.NewFlagSet("test-builtin-authentication-opts", pflag.ContinueOnError)
+	options.AddFlags(pf)
+
+	if areOIDCFlagsConfigured {
+		usernameClaim := "sub"
+		if testOIDC != nil && testOIDC.UsernameClaim != "" {
+			usernameClaim = testOIDC.UsernameClaim
+		}
+		err := pf.Set(oidcUsernameClaimFlag, usernameClaim)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if areAnonymousFlagsConfigured {
+		err := pf.Set("anonymous-auth", "true")
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return pf, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:
Modifies Anonymous and OIDC flags to not mutate [OIDCAuthenticationOptions.areFlagsConfigured](https://github.com/kubernetes/kubernetes/blob/release-1.32/pkg/kubeapiserver/options/authentication.go#L125) everytime [AddFlags()](https://github.com/kubernetes/kubernetes/blob/release-1.32/pkg/kubeapiserver/options/authentication.go#L396-L407) is called

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #130318
