### PR TITLE
test: Generalize unit test for ValidatePodTemplateSpec()

### DIFF
--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -23425,7 +23425,7 @@ func TestValidateSeccompAnnotationsAndFieldsMatch(t *testing.T) {
 	}
 }
 
-func TestValidatePodTemplateSpecSeccomp(t *testing.T) {
+func TestValidatePodTemplateSpec(t *testing.T) {
 	rootFld := field.NewPath("template")
 	tests := []struct {
 		description string
@@ -23506,7 +23506,7 @@ func TestValidatePodTemplateSpecSeccomp(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		err := ValidatePodTemplateSpec(test.spec, rootFld, PodValidationOptions{})
+		err := ValidatePodTemplateSpec(test.spec, test.fldPath, PodValidationOptions{})
 		assert.Equal(t, test.expectedErr, err, "TestCase[%d]: %s", i, test.description)
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area test
/sig testing
/sig api-machinery

#### What this PR does / why we need it:
In `TestValidatePodTemplateSpecSeccomp()`, `ValidatePodTemplateSpec()` is invoked for each test case containing `PodTemplateSpec`, but `ValidatePodTemplateSpec()` is not only for seccomp validation.
Therefore I think the name `TestValidatePodTemplateSpecSeccomp()` should be more general like `TestValidatePodTemplateSpec()`.
In addition, `fldPath` in each test case is not used because the constant path `rootFld` is used as second arg of `ValidatePodTemplateSpec()`.
It seems to be overlooked.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:
New test cases for validation of `PodTemplateSpec` containing `affinity` might be added here relating to https://github.com/kubernetes/kubernetes/issues/130063.
I think it's redundant to add a new test function like `TestValidatePodTemplateSpecAffinity()` which invokes the same `ValidatePodTemplateSpec()`.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

