### PR TITLE
when a pod fails to allocate partial resources, leading to UnexpectedAdmissionError

### DIFF
--- a/pkg/kubelet/cm/devicemanager/manager.go
+++ b/pkg/kubelet/cm/devicemanager/manager.go
@@ -866,6 +866,9 @@ func (m *ManagerImpl) allocateContainerResources(ctx context.Context, pod *v1.Po
 		}
 		allocDevices, err := m.devicesToAllocate(ctx, podUID, contName, resource, needed, devicesToReuse[resource])
 		if err != nil {
+			m.mutex.Lock()
+			m.allocatedDevices = m.podDevices.devices()
+			m.mutex.Unlock()
 			return err
 		}
 		if allocDevices == nil || len(allocDevices) <= 0 {

--- a/pkg/kubelet/cm/devicemanager/manager.go
+++ b/pkg/kubelet/cm/devicemanager/manager.go
@@ -842,6 +842,7 @@ func (m *ManagerImpl) allocateContainerResources(ctx context.Context, pod *v1.Po
 	contName := container.Name
 	allocatedDevicesUpdated := false
 	needsUpdateCheckpoint := false
+
 	// Extended resources are not allowed to be overcommitted.
 	// Since device plugin advertises extended resources,
 	// therefore Requests must be equal to Limits and iterating
@@ -858,17 +859,17 @@ func (m *ManagerImpl) allocateContainerResources(ctx context.Context, pod *v1.Po
 		if !m.isDevicePluginResource(resource) {
 			continue
 		}
+
 		// Updates allocatedDevices to garbage collect any stranded resources
 		// before doing the device plugin allocation.
 		if !allocatedDevicesUpdated {
 			m.UpdateAllocatedDevices()
 			allocatedDevicesUpdated = true
 		}
+
 		allocDevices, err := m.devicesToAllocate(ctx, podUID, contName, resource, needed, devicesToReuse[resource])
 		if err != nil {
-			m.mutex.Lock()
-			m.allocatedDevices = m.podDevices.devices()
-			m.mutex.Unlock()
+			m.restoreAllocatedDevices()
 			return err
 		}
 		if allocDevices == nil || len(allocDevices) <= 0 {
@@ -890,14 +891,10 @@ func (m *ManagerImpl) allocateContainerResources(ctx context.Context, pod *v1.Po
 		// in real use as the result of this. Should also consider to parallelize device
 		// plugin Allocate grpc calls if it becomes common that a container may require
 		// resources from multiple device plugins.
-		m.mutex.Lock()
-		eI, ok := m.endpoints[resource]
-		m.mutex.Unlock()
-		if !ok {
-			m.mutex.Lock()
-			m.allocatedDevices = m.podDevices.devices()
-			m.mutex.Unlock()
-			return fmt.Errorf("unknown Device Plugin %s", resource)
+		eI, err := m.getEndpointInfo(resource)
+		if err != nil {
+			m.restoreAllocatedDevices()
+			return err
 		}
 
 		devs := allocDevices.UnsortedList()
@@ -909,9 +906,7 @@ func (m *ManagerImpl) allocateContainerResources(ctx context.Context, pod *v1.Po
 		if err != nil {
 			// In case of allocation failure, we want to restore m.allocatedDevices
 			// to the actual allocated state from m.podDevices.
-			m.mutex.Lock()
-			m.allocatedDevices = m.podDevices.devices()
-			m.mutex.Unlock()
+			m.restoreAllocatedDevices()
 			return err
 		}
 
@@ -919,27 +914,55 @@ func (m *ManagerImpl) allocateContainerResources(ctx context.Context, pod *v1.Po
 			return fmt.Errorf("no containers return in allocation response %v", resp)
 		}
 
-		allocDevicesWithNUMA := checkpoint.NewDevicesPerNUMA()
-		// Update internal cached podDevices state.
-		m.mutex.Lock()
-		for dev := range allocDevices {
-			if m.allDevices[resource][dev].Topology == nil || len(m.allDevices[resource][dev].Topology.Nodes) == 0 {
-				allocDevicesWithNUMA[nodeWithoutTopology] = append(allocDevicesWithNUMA[nodeWithoutTopology], dev)
-				continue
-			}
-			for idx := range m.allDevices[resource][dev].Topology.Nodes {
-				node := m.allDevices[resource][dev].Topology.Nodes[idx]
-				allocDevicesWithNUMA[node.ID] = append(allocDevicesWithNUMA[node.ID], dev)
-			}
+		if err := m.updatePodDevices(podUID, contName, resource, allocDevices, resp.ContainerResponses[0]); err != nil {
+			return err
 		}
-		m.mutex.Unlock()
-		m.podDevices.insert(podUID, contName, resource, allocDevicesWithNUMA, resp.ContainerResponses[0])
 	}
 
 	if needsUpdateCheckpoint {
 		return m.writeCheckpoint(logger)
 	}
 
+	return nil
+}
+
+// getEndpointInfo safely retrieves endpoint information for a resource
+func (m *ManagerImpl) getEndpointInfo(resource string) (endpointInfo, error) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	eI, ok := m.endpoints[resource]
+	if !ok {
+		return endpointInfo{}, fmt.Errorf("unknown Device Plugin %s", resource)
+	}
+	return eI, nil
+}
+
+// restoreAllocatedDevices restores allocated devices to the actual allocated state from podDevices
+func (m *ManagerImpl) restoreAllocatedDevices() {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.allocatedDevices = m.podDevices.devices()
+}
+
+// updatePodDevices updates the internal cached podDevices state
+func (m *ManagerImpl) updatePodDevices(podUID, contName, resource string, allocDevices sets.Set[string], containerResp *pluginapi.ContainerAllocateResponse) error {
+	allocDevicesWithNUMA := checkpoint.NewDevicesPerNUMA()
+
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	for dev := range allocDevices {
+		if m.allDevices[resource][dev].Topology == nil || len(m.allDevices[resource][dev].Topology.Nodes) == 0 {
+			allocDevicesWithNUMA[nodeWithoutTopology] = append(allocDevicesWithNUMA[nodeWithoutTopology], dev)
+			continue
+		}
+		for idx := range m.allDevices[resource][dev].Topology.Nodes {
+			node := m.allDevices[resource][dev].Topology.Nodes[idx]
+			allocDevicesWithNUMA[node.ID] = append(allocDevicesWithNUMA[node.ID], dev)
+		}
+	}
+
+	m.podDevices.insert(podUID, contName, resource, allocDevicesWithNUMA, containerResp)
 	return nil
 }
 

--- a/pkg/kubelet/cm/devicemanager/manager_test.go
+++ b/pkg/kubelet/cm/devicemanager/manager_test.go
@@ -18,6 +18,7 @@ package devicemanager
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -1441,6 +1442,133 @@ func TestInitContainerDeviceAllocation(t *testing.T) {
 	as.True(initCont2Devices.IsSuperset(normalCont1Devices))
 	as.True(initCont2Devices.IsSuperset(normalCont2Devices))
 	as.Equal(0, normalCont1Devices.Intersection(normalCont2Devices).Len())
+}
+
+func TestPodPartialDeviceAllocationFailed(t *testing.T) {
+	// This test case constructs a scenario where partial resource allocation fails
+	// The node has three healthy devices: dev1, dev2, dev3
+	// Pod1 first attempts to allocate all three devices:
+	// - dev1 and dev2 are successfully allocated and recorded
+	// - Allocation of dev3 fails due to m.callGetPreferredAllocationIfAvailable failure
+	// After the first failure, Pod2 attempts to allocate dev1 and dev2 again:
+	// - Fails initially due to dirty data
+	// - Succeeds after data cleanup/repair
+	resourceName := "domain1.com/resource3"
+	res1 := TestResource{
+		resourceName:     resourceName,
+		resourceQuantity: *resource.NewQuantity(int64(3), resource.DecimalSI),
+		devs:             checkpoint.DevicesPerNUMA{0: []string{"dev1", "dev2", "dev3"}},
+	}
+	res2 := TestResource{
+		resourceName:     resourceName,
+		resourceQuantity: *resource.NewQuantity(int64(2), resource.DecimalSI),
+		devs:             checkpoint.DevicesPerNUMA{0: []string{"dev1", "dev2"}},
+	}
+
+	testResources := make([]TestResource, 0)
+	testResources = append(testResources, res2, res1)
+	as := require.New(t)
+	tmpDir := t.TempDir()
+
+	allDevices := ResourceDeviceInstances{
+		resourceName: map[string]*pluginapi.Device{
+			"dev1": {
+				ID: "dev1",
+				Topology: &pluginapi.TopologyInfo{
+					Nodes: []*pluginapi.NUMANode{
+						{ID: 1},
+					},
+				},
+			},
+			"dev2": {
+				ID: "dev2",
+				Topology: &pluginapi.TopologyInfo{
+					Nodes: []*pluginapi.NUMANode{
+						{ID: 1},
+						{ID: 2},
+					},
+				},
+			},
+			"dev3": {
+				ID: "dev3",
+				Topology: &pluginapi.TopologyInfo{
+					Nodes: []*pluginapi.NUMANode{
+						{ID: 2},
+					},
+				},
+			},
+		},
+	}
+	fakeAffinity, _ := bitmask.NewBitMask(2)
+	fakeHint := topologymanager.TopologyHint{
+		NUMANodeAffinity: fakeAffinity,
+		Preferred:        true,
+	}
+	testManager, err := getTestManager(tmpDir, func() []*v1.Pod { return []*v1.Pod{} }, testResources)
+	as.NoError(err)
+	testManager.topologyAffinityStore = topologymanager.NewFakeManagerWithHint(&fakeHint)
+	testManager.allDevices = allDevices
+	testManager.endpoints[resourceName] = endpointInfo{
+		e: &MockEndpoint{
+			allocateFunc: allocateStubFunc(),
+			getPreferredAllocationFunc: func(available, mustInclude []string, size int) (*pluginapi.PreferredAllocationResponse, error) {
+				// inject a fault only when pod1 allocates dev3.
+				if size == 3 {
+					return nil, errors.New("fake error")
+				}
+				return nil, nil
+			}},
+		opts: &pluginapi.DevicePluginOptions{
+			GetPreferredAllocationAvailable: true,
+		},
+	}
+	pod1 := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID: uuid.NewUUID(),
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name: string(uuid.NewUUID()),
+					Resources: v1.ResourceRequirements{
+						Limits: v1.ResourceList{
+							v1.ResourceName(resourceName): res1.resourceQuantity,
+						},
+					},
+				},
+			},
+		},
+	}
+	pod2 := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID: uuid.NewUUID(),
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name: string(uuid.NewUUID()),
+					Resources: v1.ResourceRequirements{
+						Limits: v1.ResourceList{
+							v1.ResourceName(resourceName): res2.resourceQuantity,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	err = testManager.Allocate(pod1, &pod1.Spec.Containers[0])
+	as.Error(err)
+	t.Logf("allocate failed for podid %s, error %s", pod1.UID, err)
+
+	err = testManager.Allocate(pod2, &pod2.Spec.Containers[0])
+	as.NoError(err)
+	podUID := string(pod2.UID)
+	normalCont1 := pod2.Spec.Containers[0].Name
+	normalCont1Devices := testManager.podDevices.containerDevices(podUID, normalCont1, res1.resourceName)
+	as.Equal(2, normalCont1Devices.Len())
+	as.True(normalCont1Devices.Has("dev2"))
+	as.True(normalCont1Devices.Has("dev3"))
 }
 
 func TestRestartableInitContainerDeviceAllocation(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/sig node
<!--
Add one of the following kinds:

/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
When `m.devicesToAllocate` fails, it is necessary to reset `m.allocatedDevices` to avoid generating stale data.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #130145

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed a bug where failures during multiple device allocation makess partial device allocation to be wrongly retained, which in turn cause UnexpectedAdmissionError in subsequent pod admission attempts.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
