### PR TITLE
[release-1.31][go1.23] Honor KUBE_HACK_TOOLS_GOTOOLCHAIN

### DIFF
--- a/hack/jenkins/benchmark-dockerized.sh
+++ b/hack/jenkins/benchmark-dockerized.sh
@@ -48,8 +48,12 @@ export PATH=${GOPATH}/bin:${PWD}/third_party/etcd:/usr/local/go/bin:${PATH}
 export GO111MODULE=off
 
 # Install tools we need
-GO111MODULE=on go -C "${KUBE_ROOT}/hack/tools" install github.com/cespare/prettybench
-GO111MODULE=on go -C "${KUBE_ROOT}/hack/tools" install gotest.tools/gotestsum
+hack_tools_gotoolchain="${GOTOOLCHAIN:-}"
+if [ -n "${KUBE_HACK_TOOLS_GOTOOLCHAIN:-}" ]; then
+  hack_tools_gotoolchain="${KUBE_HACK_TOOLS_GOTOOLCHAIN}";
+fi
+GOTOOLCHAIN="${hack_tools_gotoolchain}" GO111MODULE=on go -C "${KUBE_ROOT}/hack/tools" install github.com/cespare/prettybench
+GOTOOLCHAIN="${hack_tools_gotoolchain}" GO111MODULE=on go -C "${KUBE_ROOT}/hack/tools" install gotest.tools/gotestsum
 
 # Disable the Go race detector.
 export KUBE_RACE=" "

--- a/hack/jenkins/test-dockerized.sh
+++ b/hack/jenkins/test-dockerized.sh
@@ -32,7 +32,11 @@ export PATH=${GOPATH}/bin:${PWD}/third_party/etcd:/usr/local/go/bin:${PATH}
 export GO111MODULE=off
 
 # Install tools we need
-GO111MODULE=on go -C "./hack/tools" install gotest.tools/gotestsum
+hack_tools_gotoolchain="${GOTOOLCHAIN:-}"
+if [ -n "${KUBE_HACK_TOOLS_GOTOOLCHAIN:-}" ]; then
+  hack_tools_gotoolchain="${KUBE_HACK_TOOLS_GOTOOLCHAIN}";
+fi
+GOTOOLCHAIN="${hack_tools_gotoolchain}" GO111MODULE=on go -C "./hack/tools" install gotest.tools/gotestsum
 
 # Disable coverage report
 export KUBE_COVER="n"

--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -594,12 +594,26 @@ kube::golang::setup_env() {
   kube::golang::internal::verify_go_version
 }
 
+# kube::golang::hack_tools_gotoolchain outputs the value to use for $GOTOOLCHAIN,
+# using $KUBE_HACK_TOOLS_GOTOOLCHAIN if set, falling back to $GOTOOLCHAIN if set,
+# or outputting the empty string.
+#
+# Use this when installing / building tools specified in the hack/tools module:
+# GOTOOLCHAIN="$(kube::golang::hack_tools_gotoolchain)" go install ...
+kube::golang::hack_tools_gotoolchain() {
+  local hack_tools_gotoolchain="${GOTOOLCHAIN:-}"
+  if [ -n "${KUBE_HACK_TOOLS_GOTOOLCHAIN:-}" ]; then
+     hack_tools_gotoolchain="${KUBE_HACK_TOOLS_GOTOOLCHAIN}";
+  fi
+  echo -n "${hack_tools_gotoolchain}"
+}
+
 kube::golang::setup_gomaxprocs() {
   # GOMAXPROCS by default does not reflect the number of cpu(s) available
   # when running in a container, please see https://github.com/golang/go/issues/33803
   if [[ -z "${GOMAXPROCS:-}" ]]; then
     if ! command -v ncpu >/dev/null 2>&1; then
-      go -C "${KUBE_ROOT}/hack/tools" install ./ncpu || echo "Will not automatically set GOMAXPROCS"
+      GOTOOLCHAIN="$(kube::golang::hack_tools_gotoolchain)" go -C "${KUBE_ROOT}/hack/tools" install ./ncpu || echo "Will not automatically set GOMAXPROCS"
     fi
     if command -v ncpu >/dev/null 2>&1; then
       GOMAXPROCS=$(ncpu)

--- a/hack/make-rules/test.sh
+++ b/hack/make-rules/test.sh
@@ -191,7 +191,7 @@ produceJUnitXMLReport() {
 
   if ! command -v gotestsum >/dev/null 2>&1; then
     kube::log::status "gotestsum not found; installing from ./hack/tools"
-    go -C "${KUBE_ROOT}/hack/tools" install gotest.tools/gotestsum
+    GOTOOLCHAIN="$(kube::golang::hack_tools_gotoolchain)" go -C "${KUBE_ROOT}/hack/tools" install gotest.tools/gotestsum
   fi
   gotestsum --junitfile "${junit_xml_filename}" --raw-command cat "${junit_filename_prefix}"*.stdout
   if [[ ! ${KUBE_KEEP_VERBOSE_TEST_OUTPUT} =~ ^[yY]$ ]]; then

--- a/hack/update-mocks.sh
+++ b/hack/update-mocks.sh
@@ -27,7 +27,7 @@ source "${KUBE_ROOT}/hack/lib/init.sh"
 kube::golang::setup_env
 
 echo 'installing mockery'
-go -C "${KUBE_ROOT}/hack/tools" install github.com/vektra/mockery/v2
+GOTOOLCHAIN="$(kube::golang::hack_tools_gotoolchain)" go -C "${KUBE_ROOT}/hack/tools" install github.com/vektra/mockery/v2
 
 function git_grep() {
   git grep --untracked --exclude-standard \

--- a/hack/update-netparse-cve.sh
+++ b/hack/update-netparse-cve.sh
@@ -36,7 +36,7 @@ PATH="${GOBIN}:${PATH}"
 
 # Install golangci-lint
 echo 'installing net parser converter'
-go -C "${KUBE_ROOT}/hack/tools" install github.com/aojea/sloppy-netparser
+GOTOOLCHAIN="$(kube::golang::hack_tools_gotoolchain)" go -C "${KUBE_ROOT}/hack/tools" install github.com/aojea/sloppy-netparser
 
 cd "${KUBE_ROOT}"
 

--- a/hack/update-vanity-imports.sh
+++ b/hack/update-vanity-imports.sh
@@ -26,7 +26,7 @@ source "${KUBE_ROOT}/hack/lib/init.sh"
 
 kube::golang::verify_go_version
 
-go -C "${KUBE_ROOT}/hack/tools" install github.com/jcchavezs/porto/cmd/porto
+GOTOOLCHAIN="$(kube::golang::hack_tools_gotoolchain)" go -C "${KUBE_ROOT}/hack/tools" install github.com/jcchavezs/porto/cmd/porto
 
 porto --restrict-to-dirs="staging" --restrict-to-files="doc\\.go$" -w "${KUBE_ROOT}"
 

--- a/hack/verify-golangci-lint.sh
+++ b/hack/verify-golangci-lint.sh
@@ -127,12 +127,12 @@ done
 
 # Install golangci-lint
 echo "installing golangci-lint and logcheck plugin from hack/tools into ${GOBIN}"
-go -C "${KUBE_ROOT}/hack/tools" install github.com/golangci/golangci-lint/cmd/golangci-lint
+GOTOOLCHAIN="$(kube::golang::hack_tools_gotoolchain)" go -C "${KUBE_ROOT}/hack/tools" install github.com/golangci/golangci-lint/cmd/golangci-lint
 if [ "${golangci_config}" ]; then
   # This cannot be used without a config.
   # This uses `go build` because `go install -buildmode=plugin` doesn't work
   # (on purpose: https://github.com/golang/go/issues/64964).
-  go -C "${KUBE_ROOT}/hack/tools" build -o "${GOBIN}/logcheck.so" -buildmode=plugin sigs.k8s.io/logtools/logcheck/plugin
+  GOTOOLCHAIN="$(kube::golang::hack_tools_gotoolchain)" go -C "${KUBE_ROOT}/hack/tools" build -o "${GOBIN}/logcheck.so" -buildmode=plugin sigs.k8s.io/logtools/logcheck/plugin
 fi
 
 if [ "${golangci_config}" ]; then

--- a/hack/verify-spelling.sh
+++ b/hack/verify-spelling.sh
@@ -32,7 +32,7 @@ export GOBIN="${KUBE_OUTPUT_BIN}"
 PATH="${GOBIN}:${PATH}"
 
 # Install tools we need
-go -C "${KUBE_ROOT}/hack/tools" install github.com/client9/misspell/cmd/misspell
+GOTOOLCHAIN="$(kube::golang::hack_tools_gotoolchain)" go -C "${KUBE_ROOT}/hack/tools" install github.com/client9/misspell/cmd/misspell
 
 # Spell checking
 # All the skipping files are defined in hack/.spelling_failures


### PR DESCRIPTION
Allows overriding the go toolchain specifically for install hack/tools.

Needed to allow independent bumping of go version required for CI / verify tools on release branches while still running unit / integration tests on original release branch go versions.

Cherry-pick of https://github.com/kubernetes/kubernetes/pull/130176

```release-note
NONE
```