### PR TITLE
Honor KUBE_HACK_TOOLS_GOTOOLCHAIN

### DIFF
--- a/hack/jenkins/benchmark-dockerized.sh
+++ b/hack/jenkins/benchmark-dockerized.sh
@@ -43,8 +43,12 @@ export KUBE_ROOT
 export PATH=${GOPATH}/bin:${PWD}/third_party/etcd:/usr/local/go/bin:${PATH}
 
 # Install tools we need
-go -C "${KUBE_ROOT}/hack/tools" install github.com/cespare/prettybench
-go -C "${KUBE_ROOT}/hack/tools" install gotest.tools/gotestsum
+hack_tools_gotoolchain="${GOTOOLCHAIN:-}"
+if [ -n "${KUBE_HACK_TOOLS_GOTOOLCHAIN:-}" ]; then
+  hack_tools_gotoolchain="${KUBE_HACK_TOOLS_GOTOOLCHAIN}";
+fi
+GOTOOLCHAIN="${hack_tools_gotoolchain}" go -C "${KUBE_ROOT}/hack/tools" install github.com/cespare/prettybench
+GOTOOLCHAIN="${hack_tools_gotoolchain}" go -C "${KUBE_ROOT}/hack/tools" install gotest.tools/gotestsum
 
 # Disable the Go race detector.
 export KUBE_RACE=" "

--- a/hack/jenkins/test-dockerized.sh
+++ b/hack/jenkins/test-dockerized.sh
@@ -27,7 +27,11 @@ set -o xtrace
 export PATH=${GOPATH}/bin:${PWD}/third_party/etcd:/usr/local/go/bin:${PATH}
 
 # Install tools we need
-go -C "./hack/tools" install gotest.tools/gotestsum
+hack_tools_gotoolchain="${GOTOOLCHAIN:-}"
+if [ -n "${KUBE_HACK_TOOLS_GOTOOLCHAIN:-}" ]; then
+  hack_tools_gotoolchain="${KUBE_HACK_TOOLS_GOTOOLCHAIN}";
+fi
+GOTOOLCHAIN="${hack_tools_gotoolchain}" go -C "./hack/tools" install gotest.tools/gotestsum
 
 # Disable coverage report
 export KUBE_COVER="n"

--- a/hack/make-rules/test.sh
+++ b/hack/make-rules/test.sh
@@ -182,7 +182,7 @@ junitFilenamePrefix() {
 installTools() {
   if ! command -v gotestsum >/dev/null 2>&1; then
     kube::log::status "gotestsum not found; installing from ./hack/tools"
-    go -C "${KUBE_ROOT}/hack/tools" install gotest.tools/gotestsum
+    GOTOOLCHAIN="$(kube::golang::hack_tools_gotoolchain)" go -C "${KUBE_ROOT}/hack/tools" install gotest.tools/gotestsum
   fi
 
   if ! command -v prune-junit-xml >/dev/null 2>&1; then

--- a/hack/update-mocks.sh
+++ b/hack/update-mocks.sh
@@ -27,7 +27,7 @@ source "${KUBE_ROOT}/hack/lib/init.sh"
 kube::golang::setup_env
 
 echo 'installing mockery'
-go -C "${KUBE_ROOT}/hack/tools" install github.com/vektra/mockery/v2
+GOTOOLCHAIN="$(kube::golang::hack_tools_gotoolchain)" go -C "${KUBE_ROOT}/hack/tools" install github.com/vektra/mockery/v2
 
 function git_grep() {
   git grep --untracked --exclude-standard \

--- a/hack/update-netparse-cve.sh
+++ b/hack/update-netparse-cve.sh
@@ -36,7 +36,7 @@ PATH="${GOBIN}:${PATH}"
 
 # Install golangci-lint
 echo 'installing net parser converter'
-go -C "${KUBE_ROOT}/hack/tools" install github.com/aojea/sloppy-netparser
+GOTOOLCHAIN="$(kube::golang::hack_tools_gotoolchain)" go -C "${KUBE_ROOT}/hack/tools" install github.com/aojea/sloppy-netparser
 
 cd "${KUBE_ROOT}"
 

--- a/hack/verify-golangci-lint.sh
+++ b/hack/verify-golangci-lint.sh
@@ -127,12 +127,12 @@ done
 
 # Install golangci-lint
 echo "installing golangci-lint and logcheck plugin from hack/tools into ${GOBIN}"
-go -C "${KUBE_ROOT}/hack/tools" install github.com/golangci/golangci-lint/cmd/golangci-lint
+GOTOOLCHAIN="$(kube::golang::hack_tools_gotoolchain)" go -C "${KUBE_ROOT}/hack/tools" install github.com/golangci/golangci-lint/cmd/golangci-lint
 if [ "${golangci_config}" ]; then
   # This cannot be used without a config.
   # This uses `go build` because `go install -buildmode=plugin` doesn't work
   # (on purpose: https://github.com/golang/go/issues/64964).
-  go -C "${KUBE_ROOT}/hack/tools" build -o "${GOBIN}/logcheck.so" -buildmode=plugin sigs.k8s.io/logtools/logcheck/plugin
+  GOTOOLCHAIN="$(kube::golang::hack_tools_gotoolchain)" go -C "${KUBE_ROOT}/hack/tools" build -o "${GOBIN}/logcheck.so" -buildmode=plugin sigs.k8s.io/logtools/logcheck/plugin
 fi
 
 if [ "${golangci_config}" ]; then

--- a/hack/verify-publishing-bot.sh
+++ b/hack/verify-publishing-bot.sh
@@ -27,6 +27,6 @@ source "${KUBE_ROOT}/hack/lib/init.sh"
 
 kube::golang::setup_env
 
-go -C "${KUBE_ROOT}/hack/tools" install ./publishing-verifier
+GOTOOLCHAIN="$(kube::golang::hack_tools_gotoolchain)" go -C "${KUBE_ROOT}/hack/tools" install ./publishing-verifier
 
 publishing-verifier "${KUBE_ROOT}"

--- a/hack/verify-spelling.sh
+++ b/hack/verify-spelling.sh
@@ -32,7 +32,7 @@ export GOBIN="${KUBE_OUTPUT_BIN}"
 PATH="${GOBIN}:${PATH}"
 
 # Install tools we need
-go -C "${KUBE_ROOT}/hack/tools" install github.com/client9/misspell/cmd/misspell
+GOTOOLCHAIN="$(kube::golang::hack_tools_gotoolchain)" go -C "${KUBE_ROOT}/hack/tools" install github.com/client9/misspell/cmd/misspell
 
 # Spell checking
 # All the skipping files are defined in hack/.spelling_failures


### PR DESCRIPTION
Allows overriding the go toolchain specifically for install hack/tools.

Needed to allow independent bumping of go version required for CI / verify tools on release branches while still running unit / integration tests on original release branch go versions.

* 1.32: https://github.com/kubernetes/kubernetes/pull/130175
* 1.31: https://github.com/kubernetes/kubernetes/pull/130174
* 1.30: https://github.com/kubernetes/kubernetes/pull/130173
* 1.29: https://github.com/kubernetes/kubernetes/pull/130171

```release-note
NONE
```