### PR TITLE
e2e: fix node conformance flake

### DIFF
--- a/test/e2e/common/node/pods.go
+++ b/test/e2e/common/node/pods.go
@@ -638,7 +638,11 @@ var _ = SIGDescribe("Pods", func() {
 		})
 
 		ginkgo.By("submitting the pod to kubernetes")
-		podClient.CreateSync(ctx, pod)
+		pod = podClient.CreateSync(ctx, pod)
+
+		ginkgo.By("waiting for the container to be running")
+		err = e2epod.WaitForContainerRunning(ctx, f.ClientSet, pod.Namespace, pod.Name, pod.Spec.Containers[0].Name, framework.PodStartShortTimeout)
+		framework.ExpectNoError(err, "failed to wait for container to be running")
 
 		req := f.ClientSet.CoreV1().RESTClient().Get().
 			Namespace(f.Namespace.Name).


### PR DESCRIPTION
#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

The test `Pods should support retriving logs from the container over websockets` flakes as it doesn't always wait until container is running and is able to produce expected output. Waiting for pod to be in the `Running` state is not enough as it doesn't always mean that [container is running](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase), it could also mean that the container is still starting.

This PR ensures that the container under test is running before trying to retrieve its logs.

#### Which issue(s) this PR fixes:

Fixes #129955

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

/sig node

