### PR TITLE
[FG:PodObservedGenerationTracking] start setting pod metadata.generation

### DIFF
--- a/pkg/api/pod/testing/make.go
+++ b/pkg/api/pod/testing/make.go
@@ -202,6 +202,12 @@ func SetLabels(annos map[string]string) Tweak {
 	}
 }
 
+func SetGeneration(gen int64) Tweak {
+	return func(pod *api.Pod) {
+		pod.Generation = gen
+	}
+}
+
 func SetSchedulingGates(gates ...api.PodSchedulingGate) Tweak {
 	return func(pod *api.Pod) {
 		pod.Spec.SchedulingGates = gates

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -5581,7 +5581,7 @@ func ValidatePodEphemeralContainersUpdate(newPod, oldPod *core.Pod, opts PodVali
 func ValidatePodResize(newPod, oldPod *core.Pod, opts PodValidationOptions) field.ErrorList {
 	// Part 1: Validate newPod's spec and updates to metadata
 	fldPath := field.NewPath("metadata")
-	allErrs := ValidateImmutableField(&newPod.ObjectMeta, &oldPod.ObjectMeta, fldPath)
+	allErrs := ValidateObjectMetaUpdate(&newPod.ObjectMeta, &oldPod.ObjectMeta, fldPath)
 	allErrs = append(allErrs, validatePodMetadataAndSpec(newPod, opts)...)
 
 	// pods with pod-level resources cannot be resized

--- a/pkg/registry/core/pod/strategy_test.go
+++ b/pkg/registry/core/pod/strategy_test.go
@@ -942,6 +942,7 @@ func TestEphemeralContainerStrategyValidateUpdate(t *testing.T) {
 			name: "add ephemeral container to regular pod and expect success",
 			oldPod: podtest.MakePod("test-pod",
 				podtest.SetResourceVersion("1"),
+				podtest.SetGeneration(1),
 			),
 			newPod: podtest.MakePod("test-pod",
 				podtest.SetResourceVersion("1"),
@@ -953,6 +954,7 @@ func TestEphemeralContainerStrategyValidateUpdate(t *testing.T) {
 						TerminationMessagePolicy: "File",
 					},
 				}),
+				podtest.SetGeneration(2),
 			),
 		},
 	}
@@ -1338,7 +1340,7 @@ func TestNodeInclusionPolicyEnablementInCreating(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.NodeInclusionPolicyInPodTopologySpread, tc.enableNodeInclusionPolicy)
 
-			pod := podtest.MakePod("foo")
+			pod := podtest.MakePod("foo", podtest.SetGeneration(1))
 			wantPod := pod.DeepCopy()
 			pod.Spec.TopologySpreadConstraints = append(pod.Spec.TopologySpreadConstraints, tc.topologySpreadConstraints...)
 
@@ -2470,6 +2472,7 @@ func TestPodResizePrepareForUpdate(t *testing.T) {
 						},
 					}),
 				)),
+				podtest.SetGeneration(1),
 				podtest.SetStatus(podtest.MakePodStatus(
 					podtest.SetContainerStatuses(podtest.MakeContainerStatus("container1",
 						api.ResourceList{
@@ -2489,6 +2492,7 @@ func TestPodResizePrepareForUpdate(t *testing.T) {
 						},
 					}),
 				)),
+				podtest.SetGeneration(1),
 				podtest.SetStatus(podtest.MakePodStatus(
 					podtest.SetContainerStatuses(podtest.MakeContainerStatus("container1",
 						api.ResourceList{
@@ -2508,6 +2512,7 @@ func TestPodResizePrepareForUpdate(t *testing.T) {
 						},
 					}),
 				)),
+				podtest.SetGeneration(1),
 				podtest.SetStatus(podtest.MakePodStatus(
 					podtest.SetContainerStatuses(podtest.MakeContainerStatus("container1",
 						api.ResourceList{
@@ -2530,6 +2535,7 @@ func TestPodResizePrepareForUpdate(t *testing.T) {
 						},
 					}),
 				)),
+				podtest.SetGeneration(1),
 				podtest.SetStatus(podtest.MakePodStatus(
 					podtest.SetContainerStatuses(podtest.MakeContainerStatus("container1",
 						api.ResourceList{
@@ -2552,6 +2558,7 @@ func TestPodResizePrepareForUpdate(t *testing.T) {
 						api.ContainerResizePolicy{ResourceName: "memory", RestartPolicy: "RestartContainer"},
 					),
 				)),
+				podtest.SetGeneration(1),
 				podtest.SetStatus(podtest.MakePodStatus(
 					podtest.SetContainerStatuses(podtest.MakeContainerStatus("container1",
 						api.ResourceList{
@@ -2574,6 +2581,7 @@ func TestPodResizePrepareForUpdate(t *testing.T) {
 						api.ContainerResizePolicy{ResourceName: "memory", RestartPolicy: "RestartContainer"},
 					),
 				)),
+				podtest.SetGeneration(2),
 				podtest.SetStatus(podtest.MakePodStatus(
 					podtest.SetContainerStatuses(podtest.MakeContainerStatus("container1",
 						api.ResourceList{
@@ -2595,6 +2603,7 @@ func TestPodResizePrepareForUpdate(t *testing.T) {
 						},
 					}),
 				)),
+				podtest.SetGeneration(1),
 				podtest.SetStatus(podtest.MakePodStatus(
 					podtest.SetContainerStatuses(podtest.MakeContainerStatus("container1",
 						api.ResourceList{
@@ -2623,6 +2632,7 @@ func TestPodResizePrepareForUpdate(t *testing.T) {
 						}),
 					),
 				),
+				podtest.SetGeneration(1),
 				podtest.SetStatus(podtest.MakePodStatus(
 					podtest.SetContainerStatuses(podtest.MakeContainerStatus("container1",
 						api.ResourceList{
@@ -2641,6 +2651,7 @@ func TestPodResizePrepareForUpdate(t *testing.T) {
 						},
 					}),
 				)),
+				podtest.SetGeneration(1),
 				podtest.SetStatus(podtest.MakePodStatus(
 					podtest.SetContainerStatuses(podtest.MakeContainerStatus("container1",
 						api.ResourceList{
@@ -2662,6 +2673,7 @@ func TestPodResizePrepareForUpdate(t *testing.T) {
 						},
 					}),
 				)),
+				podtest.SetGeneration(1),
 				podtest.SetStatus(podtest.MakePodStatus(
 					podtest.SetContainerStatuses(podtest.MakeContainerStatus("container1",
 						api.ResourceList{
@@ -2690,6 +2702,7 @@ func TestPodResizePrepareForUpdate(t *testing.T) {
 						}),
 					),
 				),
+				podtest.SetGeneration(1),
 				podtest.SetStatus(podtest.MakePodStatus(
 					podtest.SetContainerStatuses(podtest.MakeContainerStatus("container1",
 						api.ResourceList{
@@ -2708,6 +2721,7 @@ func TestPodResizePrepareForUpdate(t *testing.T) {
 						},
 					}),
 				)),
+				podtest.SetGeneration(2),
 				podtest.SetStatus(podtest.MakePodStatus(
 					podtest.SetResizeStatus(api.PodResizeStatusProposed), // Resize status set
 					podtest.SetContainerStatuses(podtest.MakeContainerStatus("container1",
@@ -2740,6 +2754,7 @@ func TestPodResizePrepareForUpdate(t *testing.T) {
 						}),
 					),
 				),
+				podtest.SetGeneration(1),
 				podtest.SetStatus(podtest.MakePodStatus(
 					podtest.SetContainerStatuses(
 						podtest.MakeContainerStatus("container1",
@@ -2775,6 +2790,7 @@ func TestPodResizePrepareForUpdate(t *testing.T) {
 						}),
 					),
 				),
+				podtest.SetGeneration(1),
 				podtest.SetStatus(podtest.MakePodStatus(
 					podtest.SetContainerStatuses(
 						podtest.MakeContainerStatus("container1",
@@ -2810,6 +2826,7 @@ func TestPodResizePrepareForUpdate(t *testing.T) {
 						}),
 					),
 				),
+				podtest.SetGeneration(2),
 				podtest.SetStatus(podtest.MakePodStatus(
 					podtest.SetResizeStatus(api.PodResizeStatusProposed), // Resize status set
 					podtest.SetContainerStatuses(
@@ -2842,6 +2859,7 @@ func TestPodResizePrepareForUpdate(t *testing.T) {
 						}),
 					),
 				),
+				podtest.SetGeneration(1),
 				podtest.SetStatus(podtest.MakePodStatus(
 					podtest.SetContainerStatuses(
 						podtest.MakeContainerStatus("container1",
@@ -2865,6 +2883,7 @@ func TestPodResizePrepareForUpdate(t *testing.T) {
 						}),
 					),
 				),
+				podtest.SetGeneration(1),
 				podtest.SetStatus(podtest.MakePodStatus(
 					podtest.SetContainerStatuses(
 						podtest.MakeContainerStatus("container1",
@@ -2888,6 +2907,7 @@ func TestPodResizePrepareForUpdate(t *testing.T) {
 						}),
 					),
 				),
+				podtest.SetGeneration(1),
 				podtest.SetStatus(podtest.MakePodStatus(
 					podtest.SetContainerStatuses(
 						podtest.MakeContainerStatus("container1",
@@ -2914,6 +2934,7 @@ func TestPodResizePrepareForUpdate(t *testing.T) {
 						}),
 					),
 				),
+				podtest.SetGeneration(1),
 				podtest.SetStatus(podtest.MakePodStatus(
 					podtest.SetContainerStatuses(
 						podtest.MakeContainerStatus("init-container1",
@@ -2937,6 +2958,7 @@ func TestPodResizePrepareForUpdate(t *testing.T) {
 						}),
 					),
 				),
+				podtest.SetGeneration(1),
 				podtest.SetStatus(podtest.MakePodStatus(
 					podtest.SetContainerStatuses(
 						podtest.MakeContainerStatus("init-container1",
@@ -2960,6 +2982,7 @@ func TestPodResizePrepareForUpdate(t *testing.T) {
 						}),
 					),
 				),
+				podtest.SetGeneration(2),
 				podtest.SetStatus(podtest.MakePodStatus(
 					podtest.SetResizeStatus(api.PodResizeStatusProposed), // Resize status set
 					podtest.SetContainerStatuses(
@@ -3030,6 +3053,7 @@ func TestPodResizePrepareForUpdate(t *testing.T) {
 						}),
 					),
 				),
+				podtest.SetGeneration(1),
 				podtest.SetStatus(podtest.MakePodStatus(
 					podtest.SetResizeStatus(""), // Resize status not set
 					podtest.SetContainerStatuses(
@@ -3053,6 +3077,232 @@ func TestPodResizePrepareForUpdate(t *testing.T) {
 			ResizeStrategy.PrepareForUpdate(ctx, tc.newPod, tc.oldPod)
 			if !cmp.Equal(tc.expected, tc.newPod) {
 				t.Errorf("ResizeStrategy.PrepareForUpdate() diff = %v", cmp.Diff(tc.expected, tc.newPod))
+			}
+		})
+	}
+}
+
+func TestPodGenerationPrepareForCreate(t *testing.T) {
+	testCases := []struct {
+		pod                *api.Pod
+		expectedGeneration int64
+	}{
+		{
+			pod: &api.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "gen-not-set",
+				},
+			},
+			expectedGeneration: 1,
+		},
+		{
+			pod: &api.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "gen-custom-set",
+					Generation: 5,
+				},
+			},
+			expectedGeneration: 1,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.pod.Name, func(t *testing.T) {
+			Strategy.PrepareForCreate(genericapirequest.NewContext(), tc.pod)
+			actual := tc.pod.Generation
+			if actual != tc.expectedGeneration {
+				t.Errorf("invalid generation for pod %s, expected: %d, actual: %d", tc.pod.Name, tc.expectedGeneration, actual)
+			}
+		})
+	}
+}
+
+func TestPodGenerationPrepareForUpdate(t *testing.T) {
+	testCases := []struct {
+		description        string
+		oldPod             *api.Pod
+		newPod             *api.Pod
+		expectedGeneration int64
+	}{
+		{
+			description: "pod not updated",
+			oldPod: &api.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "pod-not-updated",
+					Generation: 1,
+				},
+				Spec: api.PodSpec{
+					Containers: []api.Container{newContainer("container", getResourceList("100m", "100Mi"), getResourceList("100m", "100Mi"))},
+				},
+			},
+			newPod: &api.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "pod-not-updated",
+					Generation: 1,
+				},
+				Spec: api.PodSpec{
+					Containers: []api.Container{newContainer("container", getResourceList("100m", "100Mi"), getResourceList("100m", "100Mi"))},
+				},
+			},
+			expectedGeneration: 1,
+		},
+		{
+			description: "only metadata change",
+			oldPod: &api.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "only-metadata-change",
+					Generation:  1,
+					Annotations: map[string]string{"foo": "bar"},
+				},
+				Spec: api.PodSpec{
+					Containers: []api.Container{newContainer("container", getResourceList("100m", "100Mi"), getResourceList("100m", "100Mi"))},
+				},
+			},
+			newPod: &api.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "only-metadata-change",
+					Generation:  1,
+					Annotations: map[string]string{"foo": "baz"},
+				},
+				Spec: api.PodSpec{
+					Containers: []api.Container{newContainer("container", getResourceList("100m", "100Mi"), getResourceList("100m", "100Mi"))},
+				},
+			},
+			expectedGeneration: 1,
+		},
+		{
+			description: "spec semantically equal",
+			oldPod: &api.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "spec-semantically-equal",
+					Generation: 1,
+				},
+				Spec: api.PodSpec{
+					Tolerations: []api.Toleration{},
+				},
+			},
+			newPod: &api.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "spec-semantically-equal",
+					Generation: 1,
+				},
+				Spec: api.PodSpec{
+					Containers: []api.Container{},
+				},
+			},
+			expectedGeneration: 1,
+		},
+		{
+			description: "tolerations updated",
+			oldPod: &api.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "tolerations-updated",
+					Generation: 1,
+				},
+				Spec: api.PodSpec{},
+			},
+			newPod: &api.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "tolerations-updated",
+					Generation: 1,
+				},
+				Spec: api.PodSpec{
+					Tolerations: []api.Toleration{{
+						Key:   "toleration-key",
+						Value: "toleration-value",
+					}},
+				},
+			},
+			expectedGeneration: 2,
+		},
+		{
+			description: "generation not set",
+			oldPod: &api.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "gen-not-set",
+				},
+				Spec: api.PodSpec{},
+			},
+			newPod: &api.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "gen-not-set",
+				},
+				Spec: api.PodSpec{},
+			},
+			expectedGeneration: 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			Strategy.PrepareForUpdate(genericapirequest.NewContext(), tc.newPod, tc.oldPod)
+			actual := tc.newPod.Generation
+			if actual != tc.expectedGeneration {
+				t.Errorf("invalid generation for pod %s, expected: %d, actual: %d", tc.oldPod.Name, tc.expectedGeneration, actual)
+			}
+		})
+	}
+}
+
+func TestEphemeralContainersPrepareForUpdate(t *testing.T) {
+	testCases := []struct {
+		description        string
+		oldPod             *api.Pod
+		newPod             *api.Pod
+		expectedGeneration int64
+	}{
+		{
+			description: "pod not updated",
+			oldPod: &api.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "pod-not-updated",
+					Generation: 1,
+				},
+				Spec: api.PodSpec{
+					Containers: []api.Container{newContainer("container", getResourceList("100m", "100Mi"), getResourceList("100m", "100Mi"))},
+				},
+			},
+			newPod: &api.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "pod-not-updated",
+					Generation: 1,
+				},
+				Spec: api.PodSpec{
+					Containers: []api.Container{newContainer("container", getResourceList("100m", "100Mi"), getResourceList("100m", "100Mi"))},
+				},
+			},
+			expectedGeneration: 1,
+		},
+		{
+			description: "ephemeral containers updated",
+			oldPod: &api.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "ephemeral-containers-updated",
+					Generation: 1,
+				},
+				Spec: api.PodSpec{},
+			},
+			newPod: &api.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "ephemeral-containers-updated",
+					Generation: 1,
+				},
+				Spec: api.PodSpec{
+					EphemeralContainers: []api.EphemeralContainer{{
+						EphemeralContainerCommon: api.EphemeralContainerCommon{Name: "ephemeral-container"},
+					}},
+				},
+			},
+			expectedGeneration: 2,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			EphemeralContainersStrategy.PrepareForUpdate(genericapirequest.NewContext(), tc.newPod, tc.oldPod)
+			actual := tc.newPod.Generation
+			if actual != tc.expectedGeneration {
+				t.Errorf("invalid generation for pod %s, expected: %d, actual: %d", tc.oldPod.Name, tc.expectedGeneration, actual)
 			}
 		})
 	}

--- a/test/e2e/common/node/ephemeral_containers.go
+++ b/test/e2e/common/node/ephemeral_containers.go
@@ -63,6 +63,7 @@ var _ = SIGDescribe("Ephemeral Containers", framework.WithNodeConformance(), fun
 				},
 			},
 		})
+		gomega.Expect(pod.Generation).To(gomega.BeEquivalentTo(1))
 
 		ginkgo.By("adding an ephemeral container")
 		ecName := "debugger"
@@ -77,6 +78,11 @@ var _ = SIGDescribe("Ephemeral Containers", framework.WithNodeConformance(), fun
 		}
 		err := podClient.AddEphemeralContainerSync(ctx, pod, ec, time.Minute)
 		framework.ExpectNoError(err, "Failed to patch ephemeral containers in pod %q", e2epod.FormatPod(pod))
+
+		ginkgo.By("verifying the pod's generation is 2")
+		pod, err = podClient.Get(ctx, pod.Name, metav1.GetOptions{})
+		framework.ExpectNoError(err, "failed to query for pod")
+		gomega.Expect(pod.Generation).To(gomega.BeEquivalentTo(2))
 
 		ginkgo.By("checking pod container endpoints")
 		// Can't use anything depending on kubectl here because it's not available in the node test environment
@@ -110,6 +116,7 @@ var _ = SIGDescribe("Ephemeral Containers", framework.WithNodeConformance(), fun
 				},
 			},
 		})
+		gomega.Expect(pod.Generation).To(gomega.BeEquivalentTo(1))
 
 		ginkgo.By("adding an ephemeral container")
 		ecName := "debugger"
@@ -124,6 +131,11 @@ var _ = SIGDescribe("Ephemeral Containers", framework.WithNodeConformance(), fun
 		}
 		err := podClient.AddEphemeralContainerSync(ctx, pod, ec, time.Minute)
 		framework.ExpectNoError(err, "Failed to patch ephemeral containers in pod %q", e2epod.FormatPod(pod))
+
+		ginkgo.By("verifying the pod's generation is 2")
+		pod, err = podClient.Get(ctx, pod.Name, metav1.GetOptions{})
+		framework.ExpectNoError(err, "failed to query for pod")
+		gomega.Expect(pod.Generation).To(gomega.BeEquivalentTo(2))
 
 		ginkgo.By("checking pod container endpoints")
 		// Can't use anything depending on kubectl here because it's not available in the node test environment

--- a/test/e2e/node/pod_resize.go
+++ b/test/e2e/node/pod_resize.go
@@ -275,17 +275,20 @@ func doPodResizeSchedulerTests(f *framework.Framework) {
 		ginkgo.By(fmt.Sprintf("TEST1: Create pod '%s' that fits the node '%s'", testPod1.Name, node.Name))
 		testPod1 = podClient.CreateSync(ctx, testPod1)
 		gomega.Expect(testPod1.Status.Phase).To(gomega.Equal(v1.PodRunning))
+		gomega.Expect(testPod1.Generation).To(gomega.BeEquivalentTo(1))
 
 		ginkgo.By(fmt.Sprintf("TEST1: Create pod '%s' that won't fit node '%s' with pod '%s' on it", testPod2.Name, node.Name, testPod1.Name))
 		testPod2 = podClient.Create(ctx, testPod2)
 		err = e2epod.WaitForPodNameUnschedulableInNamespace(ctx, f.ClientSet, testPod2.Name, testPod2.Namespace)
 		framework.ExpectNoError(err)
 		gomega.Expect(testPod2.Status.Phase).To(gomega.Equal(v1.PodPending))
+		gomega.Expect(testPod2.Generation).To(gomega.BeEquivalentTo(1))
 
 		ginkgo.By(fmt.Sprintf("TEST1: Resize pod '%s' to fit in node '%s'", testPod2.Name, node.Name))
 		testPod2, pErr := f.ClientSet.CoreV1().Pods(testPod2.Namespace).Patch(ctx,
 			testPod2.Name, types.StrategicMergePatchType, []byte(patchTestpod2ToFitNode), metav1.PatchOptions{}, "resize")
 		framework.ExpectNoError(pErr, "failed to patch pod for resize")
+		gomega.Expect(testPod2.Generation).To(gomega.BeEquivalentTo(2))
 
 		ginkgo.By(fmt.Sprintf("TEST1: Verify that pod '%s' is running after resize", testPod2.Name))
 		framework.ExpectNoError(e2epod.WaitForPodRunningInNamespace(ctx, f.ClientSet, testPod2))
@@ -329,11 +332,13 @@ func doPodResizeSchedulerTests(f *framework.Framework) {
 		p3Err := e2epod.WaitForPodNameUnschedulableInNamespace(ctx, f.ClientSet, testPod3.Name, testPod3.Namespace)
 		framework.ExpectNoError(p3Err, "failed to create pod3 or pod3 did not become pending!")
 		gomega.Expect(testPod3.Status.Phase).To(gomega.Equal(v1.PodPending))
+		gomega.Expect(testPod3.Generation).To(gomega.BeEquivalentTo(1))
 
 		ginkgo.By(fmt.Sprintf("TEST2: Resize pod '%s' to make enough space for pod '%s'", testPod1.Name, testPod3.Name))
 		testPod1, p1Err := f.ClientSet.CoreV1().Pods(testPod1.Namespace).Patch(ctx,
 			testPod1.Name, types.StrategicMergePatchType, []byte(patchTestpod1ToMakeSpaceForPod3), metav1.PatchOptions{}, "resize")
 		framework.ExpectNoError(p1Err, "failed to patch pod for resize")
+		gomega.Expect(testPod1.Generation).To(gomega.BeEquivalentTo(2))
 
 		ginkgo.By(fmt.Sprintf("TEST2: Verify pod '%s' is running after successfully resizing pod '%s'", testPod3.Name, testPod1.Name))
 		framework.Logf("TEST2: Pod '%s' CPU requests '%dm'", testPod1.Name, testPod1.Spec.Containers[0].Resources.Requests.Cpu().MilliValue())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

Start populating `metadata.generation` on pods.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of the pod generation KEP: https://github.com/kubernetes/enhancements/issues/5067

#### Special notes for your reviewer:
Changes to add `observedGeneration` per the KEP are coming in a later PR. 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Changed metadata management for Pods to populate `.metadata.generation` on writes. New pods will have a `metadata.generation` of 1; updates to mutable fields in the Pod `.spec` will result in `metadata.generation` being incremented by 1.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/d85f53a0a668c07aed41b532e65c4c7ba508f28d/keps/sig-node/5067-pod-generation/README.md
```
