### PR TITLE
Fixing k8s.io/kubernetes/pkg/scheduler/metrics unit tests when run on…

### DIFF
--- a/pkg/scheduler/metrics/metric_recorder_test.go
+++ b/pkg/scheduler/metrics/metric_recorder_test.go
@@ -128,7 +128,8 @@ func TestInFlightEventAsync(t *testing.T) {
 		t.Errorf("unexpected aggregatedInflightEventMetric: %s", d)
 	}
 
-	r.aggregatedInflightEventMetricLastFlushTime = time.Now().Add(-time.Hour) // to test flush
+	// The extra 15 milliseconds are added to compensate for a lower time.Now() resolution on some platforms.
+	r.aggregatedInflightEventMetricLastFlushTime = time.Now().Add(-time.Hour).Add(-time.Millisecond * 15) // to test flush
 
 	// It adds -4 and flushes the metric to the channel.
 	r.ObserveInFlightEventsAsync(podAddLabel, -4, false)


### PR DESCRIPTION
… Windows

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind failing-test

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation

/kind flake
/kind regression
-->

#### What this PR does / why we need it:

`TestInFlightEventAsync` is failing consistently on Windows Server 2022 machines with the following error:

>{Failed  === RUN   TestInFlightEventAsync
    metric_recorder_test.go:136: aggregatedInflightEventMetric should be cleared, but got: map[{inflight_events Pod/Add}:5 {inflight_events PodPopped}:1]
    metric_recorder_test.go:166: unexpected metrics are sent to aggregatedInflightEventMetricBufferCh:   []metrics.gaugeVecMetric{
        + 	{labelValues: []string{"Pod/Add"}, valueToAdd: 5},
        + 	{labelValues: []string{"PodPopped"}, valueToAdd: 1},
          }
--- FAIL: TestInFlightEventAsync (0.00s)
}

It looks like this is happening because the resolution of time.Now() is lower on Windows vs other platforms and the flush is not actually happening.

Adding a delay of 10-15 milliseconds in is enough to consistently simulate the flush and stabilize the unit test when run on windows.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of https://github.com/kubernetes/kubernetes/issues/130149

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
