### PR TITLE
[FG:InPlacePodVerticalScaling] Deprecate 'NotRequired' resize restart policy in favor of 'PreferNoRestart'

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -6521,7 +6521,7 @@
           "type": "string"
         },
         "restartPolicy": {
-          "description": "Restart policy to apply when specified resource is resized. If not specified, it defaults to NotRequired.",
+          "description": "Restart policy to apply when specified resource is resized. If not specified, the implicit default is NotRequired.",
           "type": "string"
         }
       },

--- a/api/openapi-spec/v3/api__v1_openapi.json
+++ b/api/openapi-spec/v3/api__v1_openapi.json
@@ -1399,7 +1399,7 @@
           },
           "restartPolicy": {
             "default": "",
-            "description": "Restart policy to apply when specified resource is resized. If not specified, it defaults to NotRequired.",
+            "description": "Restart policy to apply when specified resource is resized. If not specified, the implicit default is NotRequired.",
             "type": "string"
           }
         },

--- a/api/openapi-spec/v3/apis__apps__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__apps__v1_openapi.json
@@ -2018,7 +2018,7 @@
           },
           "restartPolicy": {
             "default": "",
-            "description": "Restart policy to apply when specified resource is resized. If not specified, it defaults to NotRequired.",
+            "description": "Restart policy to apply when specified resource is resized. If not specified, the implicit default is NotRequired.",
             "type": "string"
           }
         },

--- a/api/openapi-spec/v3/apis__batch__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__batch__v1_openapi.json
@@ -1357,7 +1357,7 @@
           },
           "restartPolicy": {
             "default": "",
-            "description": "Restart policy to apply when specified resource is resized. If not specified, it defaults to NotRequired.",
+            "description": "Restart policy to apply when specified resource is resized. If not specified, the implicit default is NotRequired.",
             "type": "string"
           }
         },

--- a/pkg/api/pod/util_test.go
+++ b/pkg/api/pod/util_test.go
@@ -2569,8 +2569,8 @@ func TestDropInPlacePodVerticalScaling(t *testing.T) {
 							Limits:   api.ResourceList{api.ResourceCPU: resource.MustParse("200m")},
 						},
 						ResizePolicy: []api.ContainerResizePolicy{
-							{ResourceName: api.ResourceCPU, RestartPolicy: api.NotRequired},
-							{ResourceName: api.ResourceMemory, RestartPolicy: api.RestartContainer},
+							{ResourceName: api.ResourceCPU, RestartPolicy: api.ResizeRestartPolicyNotRequired},
+							{ResourceName: api.ResourceMemory, RestartPolicy: api.ResizeRestartPolicyRestartContainer},
 						},
 					},
 				},
@@ -4457,7 +4457,7 @@ func TestValidateAllowSidecarResizePolicy(t *testing.T) {
 						Name:  "c1-init",
 						Image: "image",
 						ResizePolicy: []api.ContainerResizePolicy{
-							{ResourceName: api.ResourceCPU, RestartPolicy: api.NotRequired},
+							{ResourceName: api.ResourceCPU, RestartPolicy: api.ResizeRestartPolicyNotRequired},
 						},
 					},
 				},
@@ -4473,7 +4473,7 @@ func TestValidateAllowSidecarResizePolicy(t *testing.T) {
 						Image:         "image",
 						RestartPolicy: &restartPolicyAlways,
 						ResizePolicy: []api.ContainerResizePolicy{
-							{ResourceName: api.ResourceCPU, RestartPolicy: api.NotRequired},
+							{ResourceName: api.ResourceCPU, RestartPolicy: api.ResizeRestartPolicyNotRequired},
 						},
 					},
 					{
@@ -4493,14 +4493,14 @@ func TestValidateAllowSidecarResizePolicy(t *testing.T) {
 						Image:         "image",
 						RestartPolicy: &restartPolicyAlways,
 						ResizePolicy: []api.ContainerResizePolicy{
-							{ResourceName: api.ResourceCPU, RestartPolicy: api.NotRequired},
+							{ResourceName: api.ResourceCPU, RestartPolicy: api.ResizeRestartPolicyNotRequired},
 						},
 					},
 					{
 						Name:  "c1-init",
 						Image: "image",
 						ResizePolicy: []api.ContainerResizePolicy{
-							{ResourceName: api.ResourceCPU, RestartPolicy: api.NotRequired},
+							{ResourceName: api.ResourceCPU, RestartPolicy: api.ResizeRestartPolicyNotRequired},
 						},
 					},
 				},
@@ -4516,7 +4516,7 @@ func TestValidateAllowSidecarResizePolicy(t *testing.T) {
 						Image:         "image",
 						RestartPolicy: &restartPolicyAlways,
 						ResizePolicy: []api.ContainerResizePolicy{
-							{ResourceName: api.ResourceCPU, RestartPolicy: api.NotRequired},
+							{ResourceName: api.ResourceCPU, RestartPolicy: api.ResizeRestartPolicyNotRequired},
 						},
 					},
 					{
@@ -4536,14 +4536,14 @@ func TestValidateAllowSidecarResizePolicy(t *testing.T) {
 						Name:  "c1-init",
 						Image: "image",
 						ResizePolicy: []api.ContainerResizePolicy{
-							{ResourceName: api.ResourceCPU, RestartPolicy: api.NotRequired},
+							{ResourceName: api.ResourceCPU, RestartPolicy: api.ResizeRestartPolicyNotRequired},
 						},
 					},
 					{
 						Name:  "c2-init",
 						Image: "image",
 						ResizePolicy: []api.ContainerResizePolicy{
-							{ResourceName: api.ResourceCPU, RestartPolicy: api.NotRequired},
+							{ResourceName: api.ResourceCPU, RestartPolicy: api.ResizeRestartPolicyNotRequired},
 						},
 					},
 				},
@@ -4558,14 +4558,14 @@ func TestValidateAllowSidecarResizePolicy(t *testing.T) {
 						Name:  "c1",
 						Image: "image",
 						ResizePolicy: []api.ContainerResizePolicy{
-							{ResourceName: api.ResourceCPU, RestartPolicy: api.NotRequired},
+							{ResourceName: api.ResourceCPU, RestartPolicy: api.ResizeRestartPolicyNotRequired},
 						},
 					},
 					{
 						Name:  "c2",
 						Image: "image",
 						ResizePolicy: []api.ContainerResizePolicy{
-							{ResourceName: api.ResourceCPU, RestartPolicy: api.NotRequired},
+							{ResourceName: api.ResourceCPU, RestartPolicy: api.ResizeRestartPolicyNotRequired},
 						},
 					},
 				},

--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -2416,10 +2416,18 @@ type ResourceResizeRestartPolicy string
 
 // These are the valid resource resize restart policy values:
 const (
+	// ResizeRestartPolicyPreferNoRestart means Kubernetes will try to resize the container without
+	// restarting it, if possible. This option does not guarantee that the container won't be
+	// restarted during the resize.
+	// This option is semantically equivalent to "NotRequired", and will replace that as the default in a future release.
+	// This option is currently in alpha.
+	// +featureGate=InPlacePodVerticalScalingPreferNoRestart
+	ResizeRestartPolicyPreferNoRestart ResourceResizeRestartPolicy = "PreferNoRestart"
 	// ResizeRestartPolicyNotRequired means Kubernetes will try to resize the container
 	// without restarting it, if possible. Kubernetes may however choose to
 	// restart the container if it is unable to actuate resize without a
 	// restart. For e.g. the runtime doesn't support restart-free resizing.
+	// This is the implicit default when no resource resize policy is specified.
 	ResizeRestartPolicyNotRequired ResourceResizeRestartPolicy = "NotRequired"
 	// ResizeRestartPolicyRestartContainer means Kubernetes will resize the container in-place
 	// by stopping and starting the container when new resources are applied.
@@ -2434,7 +2442,7 @@ type ContainerResizePolicy struct {
 	// Supported values: cpu, memory.
 	ResourceName ResourceName
 	// Restart policy to apply when specified resource is resized.
-	// If not specified, it defaults to NotRequired.
+	// If not specified, the implicit default is NotRequired.
 	RestartPolicy ResourceResizeRestartPolicy
 }
 

--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -2416,16 +2416,16 @@ type ResourceResizeRestartPolicy string
 
 // These are the valid resource resize restart policy values:
 const (
-	// 'NotRequired' means Kubernetes will try to resize the container
+	// ResizeRestartPolicyNotRequired means Kubernetes will try to resize the container
 	// without restarting it, if possible. Kubernetes may however choose to
 	// restart the container if it is unable to actuate resize without a
 	// restart. For e.g. the runtime doesn't support restart-free resizing.
-	NotRequired ResourceResizeRestartPolicy = "NotRequired"
-	// 'RestartContainer' means Kubernetes will resize the container in-place
+	ResizeRestartPolicyNotRequired ResourceResizeRestartPolicy = "NotRequired"
+	// ResizeRestartPolicyRestartContainer means Kubernetes will resize the container in-place
 	// by stopping and starting the container when new resources are applied.
 	// This is needed for legacy applications. For e.g. java apps using the
 	// -xmxN flag which are unable to use resized memory without restarting.
-	RestartContainer ResourceResizeRestartPolicy = "RestartContainer"
+	ResizeRestartPolicyRestartContainer ResourceResizeRestartPolicy = "RestartContainer"
 )
 
 // ContainerResizePolicy represents resource resize policy for the container.

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -7699,7 +7699,7 @@ func TestValidatePullPolicy(t *testing.T) {
 func TestValidateResizePolicy(t *testing.T) {
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScaling, true)
 	tSupportedResizeResources := sets.NewString(string(core.ResourceCPU), string(core.ResourceMemory))
-	tSupportedResizePolicies := sets.NewString(string(core.NotRequired), string(core.RestartContainer))
+	tSupportedResizePolicies := sets.NewString(string(core.ResizeRestartPolicyNotRequired), string(core.ResizeRestartPolicyRestartContainer))
 	type T struct {
 		PolicyList       []core.ContainerResizePolicy
 		ExpectError      bool
@@ -25861,13 +25861,13 @@ func TestValidatePodResize(t *testing.T) {
 			err:  "memory limits cannot be decreased",
 		}, {
 			test: "restart NotRequired: memory limit decrease",
-			old:  mkPod(core.ResourceList{}, getResources("100m", "200Mi", "", ""), resizePolicy("memory", core.NotRequired)),
-			new:  mkPod(core.ResourceList{}, getResources("100m", "100Mi", "", ""), resizePolicy("memory", core.NotRequired)),
+			old:  mkPod(core.ResourceList{}, getResources("100m", "200Mi", "", ""), resizePolicy("memory", core.ResizeRestartPolicyNotRequired)),
+			new:  mkPod(core.ResourceList{}, getResources("100m", "100Mi", "", ""), resizePolicy("memory", core.ResizeRestartPolicyNotRequired)),
 			err:  "memory limits cannot be decreased",
 		}, {
 			test: "RestartContainer: memory limit decrease",
-			old:  mkPod(core.ResourceList{}, getResources("100m", "200Mi", "", ""), resizePolicy("memory", core.RestartContainer)),
-			new:  mkPod(core.ResourceList{}, getResources("100m", "100Mi", "", ""), resizePolicy("memory", core.RestartContainer)),
+			old:  mkPod(core.ResourceList{}, getResources("100m", "200Mi", "", ""), resizePolicy("memory", core.ResizeRestartPolicyRestartContainer)),
+			new:  mkPod(core.ResourceList{}, getResources("100m", "100Mi", "", ""), resizePolicy("memory", core.ResizeRestartPolicyRestartContainer)),
 			err:  "",
 		}, {
 			test: "storage limit change",
@@ -26088,13 +26088,13 @@ func TestValidatePodResize(t *testing.T) {
 			err:  "memory limits cannot be decreased",
 		}, {
 			test: "memory limit decrease for sidecar containers, resize policy NotRequired",
-			old:  mkPodWithInitContainers(core.ResourceList{}, getResources("100m", "200Mi", "", ""), core.ContainerRestartPolicyAlways, resizePolicy(core.ResourceMemory, core.NotRequired)),
-			new:  mkPodWithInitContainers(core.ResourceList{}, getResources("100m", "100Mi", "", ""), core.ContainerRestartPolicyAlways, resizePolicy(core.ResourceMemory, core.NotRequired)),
+			old:  mkPodWithInitContainers(core.ResourceList{}, getResources("100m", "200Mi", "", ""), core.ContainerRestartPolicyAlways, resizePolicy(core.ResourceMemory, core.ResizeRestartPolicyNotRequired)),
+			new:  mkPodWithInitContainers(core.ResourceList{}, getResources("100m", "100Mi", "", ""), core.ContainerRestartPolicyAlways, resizePolicy(core.ResourceMemory, core.ResizeRestartPolicyNotRequired)),
 			err:  "memory limits cannot be decreased",
 		}, {
 			test: "memory limit decrease for sidecar containers, resize policy RestartContainer",
-			old:  mkPodWithInitContainers(core.ResourceList{}, getResources("100m", "200Mi", "", ""), core.ContainerRestartPolicyAlways, resizePolicy(core.ResourceMemory, core.RestartContainer)),
-			new:  mkPodWithInitContainers(core.ResourceList{}, getResources("100m", "100Mi", "", ""), core.ContainerRestartPolicyAlways, resizePolicy(core.ResourceMemory, core.RestartContainer)),
+			old:  mkPodWithInitContainers(core.ResourceList{}, getResources("100m", "200Mi", "", ""), core.ContainerRestartPolicyAlways, resizePolicy(core.ResourceMemory, core.ResizeRestartPolicyRestartContainer)),
+			new:  mkPodWithInitContainers(core.ResourceList{}, getResources("100m", "100Mi", "", ""), core.ContainerRestartPolicyAlways, resizePolicy(core.ResourceMemory, core.ResizeRestartPolicyRestartContainer)),
 			err:  "",
 		}, {
 			test: "storage limit change for sidecar containers",
@@ -26118,13 +26118,13 @@ func TestValidatePodResize(t *testing.T) {
 			err:  "spec: Forbidden: only cpu and memory resources for sidecar containers are mutable",
 		}, {
 			test: "change resize restart policy",
-			old:  mkPod(getResources("100m", "0", "1Gi", ""), core.ResourceList{}, resizePolicy(core.ResourceCPU, core.NotRequired)),
-			new:  mkPod(getResources("100m", "0", "2Gi", ""), core.ResourceList{}, resizePolicy(core.ResourceCPU, core.RestartContainer)),
+			old:  mkPod(getResources("100m", "0", "1Gi", ""), core.ResourceList{}, resizePolicy(core.ResourceCPU, core.ResizeRestartPolicyNotRequired)),
+			new:  mkPod(getResources("100m", "0", "2Gi", ""), core.ResourceList{}, resizePolicy(core.ResourceCPU, core.ResizeRestartPolicyRestartContainer)),
 			err:  "spec: Forbidden: only cpu and memory resources are mutable",
 		}, {
 			test: "change sidecar container resize restart policy",
-			old:  mkPodWithInitContainers(getResources("100m", "0", "1Gi", ""), core.ResourceList{}, core.ContainerRestartPolicyAlways, resizePolicy(core.ResourceMemory, core.RestartContainer)),
-			new:  mkPodWithInitContainers(getResources("100m", "0", "2Gi", ""), core.ResourceList{}, core.ContainerRestartPolicyAlways, resizePolicy(core.ResourceMemory, core.NotRequired)),
+			old:  mkPodWithInitContainers(getResources("100m", "0", "1Gi", ""), core.ResourceList{}, core.ContainerRestartPolicyAlways, resizePolicy(core.ResourceMemory, core.ResizeRestartPolicyRestartContainer)),
+			new:  mkPodWithInitContainers(getResources("100m", "0", "2Gi", ""), core.ResourceList{}, core.ContainerRestartPolicyAlways, resizePolicy(core.ResourceMemory, core.ResizeRestartPolicyNotRequired)),
 			err:  "spec: Forbidden: only cpu and memory resources are mutable",
 		},
 	}

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -277,6 +277,12 @@ const (
 	// CPU Manager Static Policy option set.
 	InPlacePodVerticalScalingExclusiveCPUs featuregate.Feature = "InPlacePodVerticalScalingExclusiveCPUs"
 
+	// owner: @tallclair
+	// kep: http://kep.k8s.io/1287
+	//
+	// Enables the "PreferNoRestart" resize restart policy and deprecates the "NotRequired" policy.
+	InPlacePodVerticalScalingPreferNoRestart featuregate.Feature = "InPlacePodVerticalScalingPreferNoRestart"
+
 	// owner: @trierra
 	//
 	// Disables the Portworx in-tree driver.

--- a/pkg/features/versioned_kube_features.go
+++ b/pkg/features/versioned_kube_features.go
@@ -408,6 +408,10 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 		{Version: version.MustParse("1.32"), Default: false, PreRelease: featuregate.Alpha},
 	},
 
+	InPlacePodVerticalScalingPreferNoRestart: {
+		{Version: version.MustParse("1.33"), Default: false, PreRelease: featuregate.Alpha},
+	},
+
 	InTreePluginPortworxUnregister: {
 		{Version: version.MustParse("1.23"), Default: false, PreRelease: featuregate.Alpha}, // remove it along with CSIMigrationPortworx in 1.36
 	},

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -21648,7 +21648,7 @@ func schema_k8sio_api_core_v1_ContainerResizePolicy(ref common.ReferenceCallback
 					},
 					"restartPolicy": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Restart policy to apply when specified resource is resized. If not specified, it defaults to NotRequired.",
+							Description: "Restart policy to apply when specified resource is resized. If not specified, the implicit default is NotRequired.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",

--- a/pkg/kubelet/container/helpers_test.go
+++ b/pkg/kubelet/container/helpers_test.go
@@ -915,10 +915,10 @@ func TestHashContainerWithoutResources(t *testing.T) {
 	cpu200m := resource.MustParse("200m")
 	mem100M := resource.MustParse("100Mi")
 	mem200M := resource.MustParse("200Mi")
-	cpuPolicyRestartNotRequired := v1.ContainerResizePolicy{ResourceName: v1.ResourceCPU, RestartPolicy: v1.NotRequired}
-	memPolicyRestartNotRequired := v1.ContainerResizePolicy{ResourceName: v1.ResourceMemory, RestartPolicy: v1.NotRequired}
-	cpuPolicyRestartRequired := v1.ContainerResizePolicy{ResourceName: v1.ResourceCPU, RestartPolicy: v1.RestartContainer}
-	memPolicyRestartRequired := v1.ContainerResizePolicy{ResourceName: v1.ResourceMemory, RestartPolicy: v1.RestartContainer}
+	cpuPolicyRestartNotRequired := v1.ContainerResizePolicy{ResourceName: v1.ResourceCPU, RestartPolicy: v1.ResizeRestartPolicyNotRequired}
+	memPolicyRestartNotRequired := v1.ContainerResizePolicy{ResourceName: v1.ResourceMemory, RestartPolicy: v1.ResizeRestartPolicyNotRequired}
+	cpuPolicyRestartRequired := v1.ContainerResizePolicy{ResourceName: v1.ResourceCPU, RestartPolicy: v1.ResizeRestartPolicyRestartContainer}
+	memPolicyRestartRequired := v1.ContainerResizePolicy{ResourceName: v1.ResourceMemory, RestartPolicy: v1.ResizeRestartPolicyRestartContainer}
 
 	type testCase struct {
 		name         string

--- a/pkg/kubelet/container/helpers_test.go
+++ b/pkg/kubelet/container/helpers_test.go
@@ -915,8 +915,8 @@ func TestHashContainerWithoutResources(t *testing.T) {
 	cpu200m := resource.MustParse("200m")
 	mem100M := resource.MustParse("100Mi")
 	mem200M := resource.MustParse("200Mi")
-	cpuPolicyRestartNotRequired := v1.ContainerResizePolicy{ResourceName: v1.ResourceCPU, RestartPolicy: v1.ResizeRestartPolicyNotRequired}
-	memPolicyRestartNotRequired := v1.ContainerResizePolicy{ResourceName: v1.ResourceMemory, RestartPolicy: v1.ResizeRestartPolicyNotRequired}
+	cpuPolicyRestartNotRequired := v1.ContainerResizePolicy{ResourceName: v1.ResourceCPU, RestartPolicy: v1.ResizeRestartPolicyPreferNoRestart}
+	memPolicyRestartNotRequired := v1.ContainerResizePolicy{ResourceName: v1.ResourceMemory, RestartPolicy: v1.ResizeRestartPolicyPreferNoRestart}
 	cpuPolicyRestartRequired := v1.ContainerResizePolicy{ResourceName: v1.ResourceCPU, RestartPolicy: v1.ResizeRestartPolicyRestartContainer}
 	memPolicyRestartRequired := v1.ContainerResizePolicy{ResourceName: v1.ResourceMemory, RestartPolicy: v1.ResizeRestartPolicyRestartContainer}
 

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -631,7 +631,7 @@ func (m *kubeGenericRuntimeManager) computePodResizeAction(pod *v1.Pod, containe
 		}
 		for _, policy := range container.ResizePolicy {
 			if policy.ResourceName == rName {
-				return true, policy.RestartPolicy == v1.RestartContainer
+				return true, policy.RestartPolicy == v1.ResizeRestartPolicyRestartContainer
 			}
 		}
 		// If a resource policy isn't set, the implicit default is NotRequired.

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -2565,8 +2565,8 @@ func TestComputePodActionsForPodResize(t *testing.T) {
 	cpu200m := resource.MustParse("200m")
 	mem100M := resource.MustParse("100Mi")
 	mem200M := resource.MustParse("200Mi")
-	cpuPolicyRestartNotRequired := v1.ContainerResizePolicy{ResourceName: v1.ResourceCPU, RestartPolicy: v1.ResizeRestartPolicyNotRequired}
-	memPolicyRestartNotRequired := v1.ContainerResizePolicy{ResourceName: v1.ResourceMemory, RestartPolicy: v1.ResizeRestartPolicyNotRequired}
+	cpuPolicyRestartNotRequired := v1.ContainerResizePolicy{ResourceName: v1.ResourceCPU, RestartPolicy: v1.ResizeRestartPolicyPreferNoRestart}
+	memPolicyRestartNotRequired := v1.ContainerResizePolicy{ResourceName: v1.ResourceMemory, RestartPolicy: v1.ResizeRestartPolicyPreferNoRestart}
 	cpuPolicyRestartRequired := v1.ContainerResizePolicy{ResourceName: v1.ResourceCPU, RestartPolicy: v1.ResizeRestartPolicyRestartContainer}
 	memPolicyRestartRequired := v1.ContainerResizePolicy{ResourceName: v1.ResourceMemory, RestartPolicy: v1.ResizeRestartPolicyRestartContainer}
 

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -2565,10 +2565,10 @@ func TestComputePodActionsForPodResize(t *testing.T) {
 	cpu200m := resource.MustParse("200m")
 	mem100M := resource.MustParse("100Mi")
 	mem200M := resource.MustParse("200Mi")
-	cpuPolicyRestartNotRequired := v1.ContainerResizePolicy{ResourceName: v1.ResourceCPU, RestartPolicy: v1.NotRequired}
-	memPolicyRestartNotRequired := v1.ContainerResizePolicy{ResourceName: v1.ResourceMemory, RestartPolicy: v1.NotRequired}
-	cpuPolicyRestartRequired := v1.ContainerResizePolicy{ResourceName: v1.ResourceCPU, RestartPolicy: v1.RestartContainer}
-	memPolicyRestartRequired := v1.ContainerResizePolicy{ResourceName: v1.ResourceMemory, RestartPolicy: v1.RestartContainer}
+	cpuPolicyRestartNotRequired := v1.ContainerResizePolicy{ResourceName: v1.ResourceCPU, RestartPolicy: v1.ResizeRestartPolicyNotRequired}
+	memPolicyRestartNotRequired := v1.ContainerResizePolicy{ResourceName: v1.ResourceMemory, RestartPolicy: v1.ResizeRestartPolicyNotRequired}
+	cpuPolicyRestartRequired := v1.ContainerResizePolicy{ResourceName: v1.ResourceCPU, RestartPolicy: v1.ResizeRestartPolicyRestartContainer}
+	memPolicyRestartRequired := v1.ContainerResizePolicy{ResourceName: v1.ResourceMemory, RestartPolicy: v1.ResizeRestartPolicyRestartContainer}
 
 	for desc, test := range map[string]struct {
 		setupFn                 func(*v1.Pod, *kubecontainer.PodStatus)

--- a/staging/src/k8s.io/api/core/v1/generated.proto
+++ b/staging/src/k8s.io/api/core/v1/generated.proto
@@ -938,7 +938,7 @@ message ContainerResizePolicy {
   optional string resourceName = 1;
 
   // Restart policy to apply when specified resource is resized.
-  // If not specified, it defaults to NotRequired.
+  // If not specified, the implicit default is NotRequired.
   optional string restartPolicy = 2;
 }
 

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -2620,10 +2620,18 @@ type ResourceResizeRestartPolicy string
 
 // These are the valid resource resize restart policy values:
 const (
+	// ResizeRestartPolicyPreferNoRestart means Kubernetes will try to resize the container without
+	// restarting it, if possible. This option does not guarantee that the container won't be
+	// restarted during the resize.
+	// This option is semantically equivalent to "NotRequired", and will replace that as the default in a future release.
+	// This option is currently in alpha.
+	// +featureGate=InPlacePodVerticalScalingPreferNoRestart
+	ResizeRestartPolicyPreferNoRestart ResourceResizeRestartPolicy = "PreferNoRestart"
 	// ResizeRestartPolicyNotRequired means Kubernetes will try to resize the container
 	// without restarting it, if possible. Kubernetes may however choose to
 	// restart the container if it is unable to actuate resize without a
 	// restart. For e.g. the runtime doesn't support restart-free resizing.
+	// This is the implicit default when no resource resize policy is specified.
 	ResizeRestartPolicyNotRequired ResourceResizeRestartPolicy = "NotRequired"
 	// ResizeRestartPolicyRestartContainer means Kubernetes will resize the container in-place
 	// by stopping and starting the container when new resources are applied.
@@ -2638,7 +2646,7 @@ type ContainerResizePolicy struct {
 	// Supported values: cpu, memory.
 	ResourceName ResourceName `json:"resourceName" protobuf:"bytes,1,opt,name=resourceName,casttype=ResourceName"`
 	// Restart policy to apply when specified resource is resized.
-	// If not specified, it defaults to NotRequired.
+	// If not specified, the implicit default is NotRequired.
 	RestartPolicy ResourceResizeRestartPolicy `json:"restartPolicy" protobuf:"bytes,2,opt,name=restartPolicy,casttype=ResourceResizeRestartPolicy"`
 }
 

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -2620,16 +2620,16 @@ type ResourceResizeRestartPolicy string
 
 // These are the valid resource resize restart policy values:
 const (
-	// 'NotRequired' means Kubernetes will try to resize the container
+	// ResizeRestartPolicyNotRequired means Kubernetes will try to resize the container
 	// without restarting it, if possible. Kubernetes may however choose to
 	// restart the container if it is unable to actuate resize without a
 	// restart. For e.g. the runtime doesn't support restart-free resizing.
-	NotRequired ResourceResizeRestartPolicy = "NotRequired"
-	// 'RestartContainer' means Kubernetes will resize the container in-place
+	ResizeRestartPolicyNotRequired ResourceResizeRestartPolicy = "NotRequired"
+	// ResizeRestartPolicyRestartContainer means Kubernetes will resize the container in-place
 	// by stopping and starting the container when new resources are applied.
 	// This is needed for legacy applications. For e.g. java apps using the
 	// -xmxN flag which are unable to use resized memory without restarting.
-	RestartContainer ResourceResizeRestartPolicy = "RestartContainer"
+	ResizeRestartPolicyRestartContainer ResourceResizeRestartPolicy = "RestartContainer"
 )
 
 // ContainerResizePolicy represents resource resize policy for the container.

--- a/staging/src/k8s.io/api/core/v1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/core/v1/types_swagger_doc_generated.go
@@ -406,7 +406,7 @@ func (ContainerPort) SwaggerDoc() map[string]string {
 var map_ContainerResizePolicy = map[string]string{
 	"":              "ContainerResizePolicy represents resource resize policy for the container.",
 	"resourceName":  "Name of the resource to which this resource resize policy applies. Supported values: cpu, memory.",
-	"restartPolicy": "Restart policy to apply when specified resource is resized. If not specified, it defaults to NotRequired.",
+	"restartPolicy": "Restart policy to apply when specified resource is resized. If not specified, the implicit default is NotRequired.",
 }
 
 func (ContainerResizePolicy) SwaggerDoc() map[string]string {

--- a/test/e2e/common/node/pod_resize.go
+++ b/test/e2e/common/node/pod_resize.go
@@ -79,8 +79,8 @@ func doPodResizeTests() {
 		testRollback bool
 	}
 
-	noRestart := v1.NotRequired
-	doRestart := v1.RestartContainer
+	noRestart := v1.ResizeRestartPolicyNotRequired
+	doRestart := v1.ResizeRestartPolicyRestartContainer
 	tests := []testCase{
 		{
 			name: "Guaranteed QoS pod, one container - increase CPU & memory",

--- a/test/e2e/common/node/pod_resize.go
+++ b/test/e2e/common/node/pod_resize.go
@@ -79,6 +79,7 @@ func doPodResizeTests() {
 		testRollback bool
 	}
 
+	// TODO(tallclair): Change to PreferNoRestart once InPlacePodVerticalScalingPreferNoRestart graduates to beta.j
 	noRestart := v1.ResizeRestartPolicyNotRequired
 	doRestart := v1.ResizeRestartPolicyRestartContainer
 	tests := []testCase{

--- a/test/featuregates_linter/test_data/versioned_feature_list.yaml
+++ b/test/featuregates_linter/test_data/versioned_feature_list.yaml
@@ -544,6 +544,12 @@
     lockToDefault: false
     preRelease: Alpha
     version: "1.32"
+- name: InPlacePodVerticalScalingPreferNoRestart
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.33"
 - name: InTreePluginPortworxUnregister
   versionedSpecs:
   - default: false


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/kind api-change

#### What this PR does / why we need it:

Rename the resize restart policy `NotRequired` to `PreferNoRestart`. `NotRequired` is kept as a deprecated value (not strictly required since the feature is still alpha).

#### Does this PR introduce a user-facing change?
```release-note
InPlacePodVerticalScaling: the resize restart policy "NotRequired" is deprecated in favor of "PreferNoRestart".
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
- [KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/1287-in-place-update-pod-resources/README.md#container-resize-policy

/sig node
/priority important-soon
/milestone v1.33
