### PR TITLE
Move PodResizeStatus cache out of allocated state

### DIFF
--- a/pkg/kubelet/status/fake_status_manager.go
+++ b/pkg/kubelet/status/fake_status_manager.go
@@ -28,7 +28,8 @@ import (
 )
 
 type fakeManager struct {
-	state state.State
+	state             state.State
+	podResizeStatuses map[types.UID]v1.PodResizeStatus
 }
 
 func (m *fakeManager) Start() {
@@ -72,7 +73,7 @@ func (m *fakeManager) GetContainerResourceAllocation(podUID string, containerNam
 }
 
 func (m *fakeManager) GetPodResizeStatus(podUID types.UID) v1.PodResizeStatus {
-	return m.state.GetPodResizeStatus(string(podUID))
+	return m.podResizeStatuses[podUID]
 }
 
 func (m *fakeManager) UpdatePodFromAllocation(pod *v1.Pod) (*v1.Pod, bool) {
@@ -102,12 +103,13 @@ func (m *fakeManager) SetPodAllocation(pod *v1.Pod) error {
 }
 
 func (m *fakeManager) SetPodResizeStatus(podUID types.UID, resizeStatus v1.PodResizeStatus) {
-	m.state.SetPodResizeStatus(string(podUID), resizeStatus)
+	m.podResizeStatuses[podUID] = resizeStatus
 }
 
 // NewFakeManager creates empty/fake memory manager
 func NewFakeManager() Manager {
 	return &fakeManager{
-		state: state.NewStateMemory(state.PodResourceAllocation{}),
+		state:             state.NewStateMemory(state.PodResourceAllocation{}),
+		podResizeStatuses: make(map[types.UID]v1.PodResizeStatus),
 	}
 }

--- a/pkg/kubelet/status/state/state.go
+++ b/pkg/kubelet/status/state/state.go
@@ -42,13 +42,11 @@ func (pr PodResourceAllocation) Clone() PodResourceAllocation {
 type Reader interface {
 	GetContainerResourceAllocation(podUID string, containerName string) (v1.ResourceRequirements, bool)
 	GetPodResourceAllocation() PodResourceAllocation
-	GetPodResizeStatus(podUID string) v1.PodResizeStatus
 }
 
 type writer interface {
 	SetContainerResourceAllocation(podUID string, containerName string, alloc v1.ResourceRequirements) error
 	SetPodResourceAllocation(podUID string, alloc map[string]v1.ResourceRequirements) error
-	SetPodResizeStatus(podUID string, resizeStatus v1.PodResizeStatus)
 	Delete(podUID string, containerName string) error
 }
 

--- a/pkg/kubelet/status/state/state_checkpoint.go
+++ b/pkg/kubelet/status/state/state_checkpoint.go
@@ -112,13 +112,6 @@ func (sc *stateCheckpoint) GetPodResourceAllocation() PodResourceAllocation {
 	return sc.cache.GetPodResourceAllocation()
 }
 
-// GetPodResizeStatus returns the last resize decision for a pod
-func (sc *stateCheckpoint) GetPodResizeStatus(podUID string) v1.PodResizeStatus {
-	sc.mux.RLock()
-	defer sc.mux.RUnlock()
-	return sc.cache.GetPodResizeStatus(podUID)
-}
-
 // SetContainerResourceAllocation sets resources allocated to a pod's container
 func (sc *stateCheckpoint) SetContainerResourceAllocation(podUID string, containerName string, alloc v1.ResourceRequirements) error {
 	sc.mux.Lock()
@@ -136,13 +129,6 @@ func (sc *stateCheckpoint) SetPodResourceAllocation(podUID string, alloc map[str
 		return err
 	}
 	return sc.storeState()
-}
-
-// SetPodResizeStatus sets the last resize decision for a pod
-func (sc *stateCheckpoint) SetPodResizeStatus(podUID string, resizeStatus v1.PodResizeStatus) {
-	sc.mux.Lock()
-	defer sc.mux.Unlock()
-	sc.cache.SetPodResizeStatus(podUID, resizeStatus)
 }
 
 // Delete deletes allocations for specified pod
@@ -168,10 +154,6 @@ func (sc *noopStateCheckpoint) GetPodResourceAllocation() PodResourceAllocation 
 	return nil
 }
 
-func (sc *noopStateCheckpoint) GetPodResizeStatus(_ string) v1.PodResizeStatus {
-	return ""
-}
-
 func (sc *noopStateCheckpoint) SetContainerResourceAllocation(_ string, _ string, _ v1.ResourceRequirements) error {
 	return nil
 }
@@ -179,8 +161,6 @@ func (sc *noopStateCheckpoint) SetContainerResourceAllocation(_ string, _ string
 func (sc *noopStateCheckpoint) SetPodResourceAllocation(_ string, _ map[string]v1.ResourceRequirements) error {
 	return nil
 }
-
-func (sc *noopStateCheckpoint) SetPodResizeStatus(_ string, _ v1.PodResizeStatus) {}
 
 func (sc *noopStateCheckpoint) Delete(_ string, _ string) error {
 	return nil


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Refactor the pod resize status cache out of the allocation state. This is in preparation to separate the allocation manager from the status manager (but leaving pod resize status tracking in status manager).

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/sig node
/priority important-soon