### PR TITLE
WIP: Add "kyaml" support to kubectl

### DIFF
--- a/staging/src/k8s.io/cli-runtime/go.mod
+++ b/staging/src/k8s.io/cli-runtime/go.mod
@@ -26,6 +26,7 @@ require (
 	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738
 	sigs.k8s.io/kustomize/api v0.19.0
 	sigs.k8s.io/kustomize/kyaml v0.19.0
+	sigs.k8s.io/randfill v1.0.0
 	sigs.k8s.io/yaml v1.4.0
 )
 
@@ -66,7 +67,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 // indirect
-	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.6.0 // indirect
 )
 

--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/json_yaml_flags.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/json_yaml_flags.go
@@ -29,7 +29,7 @@ func (f *JSONYamlPrintFlags) AllowedFormats() []string {
 	if f == nil {
 		return []string{}
 	}
-	return []string{"json", "yaml"}
+	return []string{"json", "yaml", "kyaml"}
 }
 
 // JSONYamlPrintFlags provides default flags necessary for json/yaml printing.
@@ -52,6 +52,8 @@ func (f *JSONYamlPrintFlags) ToPrinter(outputFormat string) (printers.ResourcePr
 		printer = &printers.JSONPrinter{}
 	case "yaml":
 		printer = &printers.YAMLPrinter{}
+	case "kyaml":
+		printer = &printers.KYAMLPrinter{}
 	default:
 		return nil, NoCompatiblePrinterError{OutputFormat: &outputFormat, AllowedFormats: f.AllowedFormats()}
 	}

--- a/staging/src/k8s.io/cli-runtime/pkg/printers/json_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/printers/json_test.go
@@ -105,8 +105,9 @@ func TestPrintersSuccess(t *testing.T) {
 	om := func(name string) metav1.ObjectMeta { return metav1.ObjectMeta{Name: name} }
 
 	genericPrinters := map[string]ResourcePrinter{
-		"json": NewTypeSetter(scheme.Scheme).ToPrinter(&JSONPrinter{}),
-		"yaml": NewTypeSetter(scheme.Scheme).ToPrinter(&YAMLPrinter{}),
+		"json":  NewTypeSetter(scheme.Scheme).ToPrinter(&JSONPrinter{}),
+		"yaml":  NewTypeSetter(scheme.Scheme).ToPrinter(&YAMLPrinter{}),
+		"kyaml": NewTypeSetter(scheme.Scheme).ToPrinter(&KYAMLPrinter{}),
 	}
 	objects := map[string]runtime.Object{
 		"pod":             &v1.Pod{ObjectMeta: om("pod")},

--- a/staging/src/k8s.io/cli-runtime/pkg/printers/kyaml.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/printers/kyaml.go
@@ -1,0 +1,463 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package printers
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"time"
+	"unicode"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utiljson "k8s.io/apimachinery/pkg/util/json"
+)
+
+// KYAMLPrinter is an implementation of ResourcePrinter which formats data into
+// a specific dialect of YAML, known as KYAML. KYAML is halfway between YAML
+// and JSON, but is a strict subset of YAML, and so it should should be
+// readable by any YAML parser. It is designed to be explicit and unambiguous,
+// and eschews significant whitespace.
+//
+// Any type that implements json.Marshaler will be marshaled to JSON and then
+// to YAML.
+type KYAMLPrinter struct {
+	printCount int64
+}
+
+// PrintObj prints the data as KYAML to the specified writer.
+func (p *KYAMLPrinter) PrintObj(obj runtime.Object, w io.Writer) error {
+	// We use reflect.Indirect here in order to obtain the actual value from a pointer.
+	// We need an actual value in order to retrieve the package path for an object.
+	// Using reflect.Indirect indiscriminately is valid here, as all runtime.Objects are supposed to be pointers.
+	if InternalObjectPreventer.IsForbidden(reflect.Indirect(reflect.ValueOf(obj)).Type().PkgPath()) {
+		return errors.New(InternalObjectPrinterErr)
+	}
+
+	// Print a comment shebang to indicate that this is a YAML document.
+	count := atomic.AddInt64(&p.printCount, 1)
+	if count == 1 {
+		if _, err := fmt.Fprintln(w, "#!yaml"); err != nil {
+			return fmt.Errorf("error writing to output: %w", err)
+		}
+	}
+
+	// Always emit a document separator, which helps disambiguate between YAML
+	// and JSON.
+	if _, err := fmt.Fprintln(w, "---"); err != nil {
+		return fmt.Errorf("error writing to output: %w", err)
+	}
+
+	switch obj := obj.(type) {
+	case *metav1.WatchEvent:
+		if InternalObjectPreventer.IsForbidden(reflect.Indirect(reflect.ValueOf(obj.Object.Object)).Type().PkgPath()) {
+			return errors.New(InternalObjectPrinterErr)
+		}
+	case *runtime.Unknown:
+		return p.fromJSON(obj.Raw, w)
+	}
+
+	if obj.GetObjectKind().GroupVersionKind().Empty() {
+		return fmt.Errorf("missing apiVersion or kind; try GetObjectKind().SetGroupVersionKind() if you know the type")
+	}
+
+	return p.fromAny(obj, w)
+}
+
+func (p *KYAMLPrinter) fromJSON(jsonBytes []byte, w io.Writer) error {
+	jsonObj, err := p.unmarshalJSON(jsonBytes)
+	if err != nil {
+		return err
+	}
+	return p.fromAny(jsonObj, w)
+}
+
+func (p *KYAMLPrinter) unmarshalJSON(jsonBytes []byte) (interface{}, error) {
+	// We are using our own JSON here(instead of json.Unmarshal) because the
+	// Go JSON library doesn't try to pick the right number type (int, float,
+	// etc.) when unmarshalling to interface{}, it just picks float64
+	// universally.
+	var jsonObj interface{}
+	if err := utiljson.Unmarshal(jsonBytes, &jsonObj); err != nil {
+		return nil, fmt.Errorf("error unmarshaling from JSON: %w", err)
+	}
+	return jsonObj, nil
+}
+
+func (p *KYAMLPrinter) fromAny(obj any, w io.Writer) error {
+	buf := &strings.Builder{}
+	if err := p.formatValue(reflect.ValueOf(obj), 0, flagDefault, buf); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "%s\n", buf.String()); err != nil {
+		return fmt.Errorf("error writing to output: %w", err)
+	}
+	return nil
+}
+
+type flagMask uint64
+
+const (
+	flagDefault   flagMask = 0
+	flagLazyQuote flagMask = 1 << iota
+)
+
+func (p *KYAMLPrinter) formatValue(v reflect.Value, indent int, flags flagMask, buf *strings.Builder) error {
+	if !v.IsValid() {
+		buf.WriteString("null")
+		return nil
+	}
+
+	// Handle things that implement json.Marshaler through that interface.
+	if v.CanInterface() {
+		if m, ok := v.Interface().(json.Marshaler); ok {
+			jsonBytes, err := m.MarshalJSON()
+			if err != nil {
+				return fmt.Errorf("error marshaling to JSON: %w", err)
+			}
+			jsonObj, err := p.unmarshalJSON(jsonBytes)
+			if err != nil {
+				return err
+			}
+			// If something chose to marshal as "null", we should respect that.
+			// Any nil-pointer will work.
+			if jsonObj == nil {
+				jsonObj = (*int)(nil)
+			}
+			v = reflect.ValueOf(jsonObj)
+		}
+	}
+
+	switch v.Kind() {
+	case reflect.String:
+		val := v.String()
+		if (flags&flagLazyQuote != 0) && !needsQuotes(val) {
+			fmt.Fprintf(buf, "%s", val)
+		} else {
+			fmt.Fprintf(buf, "%q", val)
+		}
+		return nil
+
+	case reflect.Bool:
+		val := v.Bool()
+		fmt.Fprintf(buf, "%v", val)
+		return nil
+
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		val := v.Int()
+		fmt.Fprintf(buf, "%d", val)
+		return nil
+
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		val := v.Uint()
+		fmt.Fprintf(buf, "%d", val)
+		return nil
+
+	case reflect.Float32, reflect.Float64:
+		val := v.Float()
+		fmt.Fprintf(buf, "%g", val)
+		return nil
+
+	case reflect.Interface, reflect.Ptr:
+		if v.IsNil() {
+			buf.WriteString("null")
+			return nil
+		}
+		// Note: retain flags here.
+		return p.formatValue(v.Elem(), indent, flags, buf)
+
+	case reflect.Struct:
+		buf.WriteString("{\n")
+		if err := p.writeStructFields(v, indent, buf); err != nil {
+			return err
+		}
+		p.writeIndent(indent, buf)
+		buf.WriteString("}")
+		return nil
+
+	case reflect.Map:
+		if v.Len() == 0 {
+			buf.WriteString("{}")
+			return nil
+		}
+		buf.WriteString("{\n")
+
+		mapKeys := v.MapKeys()
+		sort.Slice(mapKeys, func(i, j int) bool {
+			return mapKeys[i].String() < mapKeys[j].String()
+		})
+		for _, key := range mapKeys {
+			p.writeIndent(indent+1, buf)
+			if err := p.formatValue(key, indent+1, flagLazyQuote, buf); err != nil {
+				return err
+			}
+			buf.WriteString(": ")
+			if err := p.formatValue(v.MapIndex(key), indent+1, flagDefault, buf); err != nil {
+				return err
+			}
+			buf.WriteString(",\n")
+		}
+		p.writeIndent(indent, buf)
+		buf.WriteString("}")
+		return nil
+
+	case reflect.Array, reflect.Slice:
+		if v.Len() == 0 {
+			buf.WriteString("[]")
+			return nil
+		}
+
+		// Check if elements are structs or maps
+		elemKind := v.Index(0).Kind()
+		if elemKind == reflect.Interface || elemKind == reflect.Ptr {
+			elemKind = v.Index(0).Elem().Kind()
+		}
+		isCuddledType := elemKind == reflect.Struct || elemKind == reflect.Map || elemKind == reflect.Array || elemKind == reflect.Slice
+
+		buf.WriteString("[")
+		if !isCuddledType {
+			buf.WriteByte('\n')
+		}
+
+		for i := 0; i < v.Len(); i++ {
+			if i > 0 {
+				if !isCuddledType {
+					buf.WriteByte('\n')
+				} else {
+					buf.WriteByte(' ')
+				}
+			}
+			if !isCuddledType {
+				// Indent beyond the opening bracket.
+				p.writeIndent(indent+1, buf)
+			}
+			// Indent is not +1 here because it's only used for cuddled types,
+			// which will increment it internally, so the final closing brace
+			// lines up with the current key.
+			if err := p.formatValue(v.Index(i), indent, flagDefault, buf); err != nil {
+				return err
+			}
+			if !isCuddledType || i != v.Len()-1 {
+				buf.WriteByte(',')
+			}
+		}
+
+		if !isCuddledType {
+			buf.WriteString("\n")
+			p.writeIndent(indent, buf)
+		}
+		buf.WriteByte(']')
+		return nil
+
+	default:
+		return fmt.Errorf("KYAML: unsupported type: %v (kind %v)", v.Type(), v.Kind())
+	}
+}
+
+func (p *KYAMLPrinter) writeStructFields(v reflect.Value, indent int, buf *strings.Builder) error {
+	fbuf := &strings.Builder{}
+
+	t := v.Type()
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		if field.PkgPath != "" { // Skip unexported fields
+			continue
+		}
+
+		fieldName := ""
+		fieldValue := v.Field(i)
+		omitempty := false
+
+		if jsonTag, found := field.Tag.Lookup("json"); found {
+			parts := strings.Split(jsonTag, ",")
+			if parts[0] == "-" {
+				continue
+			}
+			if parts[0] != "" {
+				fieldName = parts[0]
+			}
+			for _, opt := range parts[1:] {
+				if opt == "omitempty" {
+					omitempty = true
+					break
+				}
+			}
+		}
+
+		// Check for empty value when omitempty is set
+		if omitempty && isEmptyValue(fieldValue) {
+			continue
+		}
+
+		// Handle embedded structs
+		if field.Anonymous && fieldName == "" {
+			if err := p.writeStructFields(fieldValue, indent, fbuf); err != nil {
+				return err
+			}
+			continue
+		}
+		if fieldName == "" {
+			// Do this AFTER handling embedded.
+			fieldName = field.Name
+		}
+
+		p.writeIndent(indent+1, fbuf)
+		fbuf.WriteString(fieldName)
+		fbuf.WriteString(": ")
+		if err := p.formatValue(fieldValue, indent+1, flagDefault, fbuf); err != nil {
+			return err
+		}
+		fbuf.WriteString(",\n")
+	}
+
+	if str := fbuf.String(); len(str) > 0 {
+		buf.WriteString(str)
+	}
+	return nil
+}
+
+func (p *KYAMLPrinter) writeIndent(level int, buf *strings.Builder) {
+	for i := 0; i < level*2; i++ {
+		buf.WriteByte(' ')
+	}
+}
+
+func isEmptyValue(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
+		return v.Len() == 0
+	case reflect.Bool:
+		return !v.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return v.Int() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return v.Uint() == 0
+	case reflect.Float32, reflect.Float64:
+		return v.Float() == 0
+	case reflect.Interface, reflect.Ptr:
+		return v.IsNil()
+	}
+	return false
+}
+
+func needsQuotes(s string) bool {
+	if s == "" {
+		return true
+	}
+	if yamlGuessesWrong(s) {
+		return true
+	}
+	for _, r := range s {
+		if !unicode.IsLetter(r) && !unicode.IsNumber(r) && r != '_' && r != '-' {
+			return true
+		}
+	}
+	return false
+}
+
+func yamlGuessesWrong(s string) bool {
+	// Null-like strings
+	switch s {
+	case "null", "Null", "NULL", "~":
+		return true
+	}
+
+	// Boolean-like strings
+	if _, err := strconv.ParseBool(s); err == nil {
+		return true
+	}
+	switch strings.ToLower(s) {
+	case "true", "y", "yes", "on", "false", "n", "no", "off":
+		return true
+	}
+
+	// Number-like strings (the stripping of underscores is gross)
+	if _, err := strconv.ParseInt(strings.ReplaceAll(s, "_", ""), 0, 64); err == nil && !isSyntaxError(err) {
+		return true
+	}
+	if _, err := strconv.ParseFloat(s, 64); err == nil && !isSyntaxError(err) {
+		return true
+	}
+
+	// Infinity and NaN
+	switch strings.ToLower(s) {
+	case ".inf", "-.inf", "+.inf", ".nan":
+		return true
+	}
+
+	// Time-like strings
+	if _, matches := parseTimestamp(s); matches {
+		return true
+	}
+
+	return false
+}
+
+func isSyntaxError(err error) bool {
+	var numerr *strconv.NumError
+	if ok := errors.As(err, &numerr); ok {
+		return errors.Is(numerr.Err, strconv.ErrSyntax)
+	}
+	return false
+}
+
+// This is a subset of the formats allowed by the regular expression
+// defined at http://yaml.org/type/timestamp.html.
+//
+// NOTE: This was copied from sigs.k8s.io/yaml/goyaml.v2
+var allowedTimestampFormats = []string{
+	"2006-1-2T15:4:5.999999999Z07:00", // RCF3339Nano with short date fields.
+	"2006-1-2t15:4:5.999999999Z07:00", // RFC3339Nano with short date fields and lower-case "t".
+	"2006-1-2 15:4:5.999999999",       // space separated with no time zone
+	"2006-1-2",                        // date only
+	// Notable exception: time.Parse cannot handle: "2001-12-14 21:59:43.10 -5"
+	// from the set of examples.
+}
+
+// parseTimestamp parses s as a timestamp string and
+// returns the timestamp and reports whether it succeeded.
+// Timestamp formats are defined at http://yaml.org/type/timestamp.html
+//
+// NOTE: This was copied from sigs.k8s.io/yaml/goyaml.v2
+func parseTimestamp(s string) (time.Time, bool) {
+	// TODO write code to check all the formats supported by
+	// http://yaml.org/type/timestamp.html instead of using time.Parse.
+
+	// Quick check: all date formats start with YYYY-.
+	i := 0
+	for ; i < len(s); i++ {
+		if c := s[i]; c < '0' || c > '9' {
+			break
+		}
+	}
+	if i != 4 || i == len(s) || s[i] != '-' {
+		return time.Time{}, false
+	}
+	for _, format := range allowedTimestampFormats {
+		if t, err := time.Parse(format, s); err == nil {
+			return t, true
+		}
+	}
+	return time.Time{}, false
+}

--- a/staging/src/k8s.io/cli-runtime/pkg/printers/kyaml_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/printers/kyaml_test.go
@@ -1,0 +1,303 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package printers
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/randfill"
+	"sigs.k8s.io/yaml"
+)
+
+type AllTypesStruct struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	// Basic types
+	String  string      `json:"string,omitempty"`
+	Bool    bool        `json:"bool,omitempty"`
+	Int     int         `json:"int,omitempty"`
+	Int8    int8        `json:"int8,omitempty"`
+	Int16   int16       `json:"int16,omitempty"`
+	Int32   int32       `json:"int32,omitempty"`
+	Int64   int64       `json:"int64,omitempty"`
+	Uint    uint        `json:"uint,omitempty"`
+	Uint8   uint8       `json:"uint8,omitempty"`
+	Uint16  uint16      `json:"uint16,omitempty"`
+	Uint32  uint32      `json:"uint32,omitempty"`
+	Uint64  uint64      `json:"uint64,omitempty"`
+	Float32 float32     `json:"float32,omitempty"`
+	Float64 float64     `json:"float64,omitempty"`
+	Time    metav1.Time `json:"time,omitempty"`
+	Bytes   []byte      `json:"bytes,omitempty"`
+
+	// Pointers to basic types
+	StringPtr  *string      `json:"stringPtr,omitempty"`
+	BoolPtr    *bool        `json:"boolPtr,omitempty"`
+	IntPtr     *int         `json:"intPtr,omitempty"`
+	Int8Ptr    *int8        `json:"int8Ptr,omitempty"`
+	Int16Ptr   *int16       `json:"int16Ptr,omitempty"`
+	Int32Ptr   *int32       `json:"int32Ptr,omitempty"`
+	Int64Ptr   *int64       `json:"int64Ptr,omitempty"`
+	UintPtr    *uint        `json:"uintPtr,omitempty"`
+	Uint8Ptr   *uint8       `json:"uint8Ptr,omitempty"`
+	Uint16Ptr  *uint16      `json:"uint16Ptr,omitempty"`
+	Uint32Ptr  *uint32      `json:"uint32Ptr,omitempty"`
+	Uint64Ptr  *uint64      `json:"uint64Ptr,omitempty"`
+	Float32Ptr *float32     `json:"float32Ptr,omitempty"`
+	Float64Ptr *float64     `json:"float64Ptr,omitempty"`
+	TimePtr    *metav1.Time `json:"timePtr,omitempty"`
+
+	// Slices of basic types
+	StringSlice  []string      `json:"stringSlice,omitempty"`
+	BoolSlice    []bool        `json:"boolSlice,omitempty"`
+	IntSlice     []int         `json:"intSlice,omitempty"`
+	Int8Slice    []int8        `json:"int8Slice,omitempty"`
+	Int16Slice   []int16       `json:"int16Slice,omitempty"`
+	Int32Slice   []int32       `json:"int32Slice,omitempty"`
+	Int64Slice   []int64       `json:"int64Slice,omitempty"`
+	UintSlice    []uint        `json:"uintSlice,omitempty"`
+	Uint8Slice   []uint8       `json:"uint8Slice,omitempty"`
+	Uint16Slice  []uint16      `json:"uint16Slice,omitempty"`
+	Uint32Slice  []uint32      `json:"uint32Slice,omitempty"`
+	Uint64Slice  []uint64      `json:"uint64Slice,omitempty"`
+	Float32Slice []float32     `json:"float32Slice,omitempty"`
+	Float64Slice []float64     `json:"float64Slice,omitempty"`
+	TimeSlice    []metav1.Time `json:"timeSlice,omitempty"`
+
+	// Maps of string to basic types
+	StringMap  map[string]string      `json:"stringMap,omitempty"`
+	BoolMap    map[string]bool        `json:"boolMap,omitempty"`
+	IntMap     map[string]int         `json:"intMap,omitempty"`
+	Int8Map    map[string]int8        `json:"int8Map,omitempty"`
+	Int16Map   map[string]int16       `json:"int16Map,omitempty"`
+	Int32Map   map[string]int32       `json:"int32Map,omitempty"`
+	Int64Map   map[string]int64       `json:"int64Map,omitempty"`
+	UintMap    map[string]uint        `json:"uintMap,omitempty"`
+	Uint8Map   map[string]uint8       `json:"uint8Map,omitempty"`
+	Uint16Map  map[string]uint16      `json:"uint16Map,omitempty"`
+	Uint32Map  map[string]uint32      `json:"uint32Map,omitempty"`
+	Uint64Map  map[string]uint64      `json:"uint64Map,omitempty"`
+	Float32Map map[string]float32     `json:"float32Map,omitempty"`
+	Float64Map map[string]float64     `json:"float64Map,omitempty"`
+	TimeMap    map[string]metav1.Time `json:"timeMap,omitempty"`
+
+	// Slice of slices
+	StringSliceSlice  [][]string      `json:"stringSliceSlice,omitempty"`
+	BoolSliceSlice    [][]bool        `json:"boolSliceSlice,omitempty"`
+	IntSliceSlice     [][]int         `json:"intSliceSlice,omitempty"`
+	Int8SliceSlice    [][]int8        `json:"int8SliceSlice,omitempty"`
+	Int16SliceSlice   [][]int16       `json:"int16SliceSlice,omitempty"`
+	Int32SliceSlice   [][]int32       `json:"int32SliceSlice,omitempty"`
+	Int64SliceSlice   [][]int64       `json:"int64SliceSlice,omitempty"`
+	UintSliceSlice    [][]uint        `json:"uintSliceSlice,omitempty"`
+	Uint8SliceSlice   [][]uint8       `json:"uint8SliceSlice,omitempty"`
+	Uint16SliceSlice  [][]uint16      `json:"uint16SliceSlice,omitempty"`
+	Uint32SliceSlice  [][]uint32      `json:"uint32SliceSlice,omitempty"`
+	Uint64SliceSlice  [][]uint64      `json:"uint64SliceSlice,omitempty"`
+	Float32SliceSlice [][]float32     `json:"float32SliceSlice,omitempty"`
+	Float64SliceSlice [][]float64     `json:"float64SliceSlice,omitempty"`
+	TimeSliceSlice    [][]metav1.Time `json:"timeSliceSlice,omitempty"`
+
+	// Slice of maps
+	StringSliceMap  []map[string]string      `json:"stringSliceMap,omitempty"`
+	BoolSliceMap    []map[string]bool        `json:"boolSliceMap,omitempty"`
+	IntSliceMap     []map[string]int         `json:"intSliceMap,omitempty"`
+	Int8SliceMap    []map[string]int8        `json:"int8SliceMap,omitempty"`
+	Int16SliceMap   []map[string]int16       `json:"int16SliceMap,omitempty"`
+	Int32SliceMap   []map[string]int32       `json:"int32SliceMap,omitempty"`
+	Int64SliceMap   []map[string]int64       `json:"int64SliceMap,omitempty"`
+	UintSliceMap    []map[string]uint        `json:"uintSliceMap,omitempty"`
+	Uint8SliceMap   []map[string]uint8       `json:"uint8SliceMap,omitempty"`
+	Uint16SliceMap  []map[string]uint16      `json:"uint16SliceMap,omitempty"`
+	Uint32SliceMap  []map[string]uint32      `json:"uint32SliceMap,omitempty"`
+	Uint64SliceMap  []map[string]uint64      `json:"uint64SliceMap,omitempty"`
+	Float32SliceMap []map[string]float32     `json:"float32SliceMap,omitempty"`
+	Float64SliceMap []map[string]float64     `json:"float64SliceMap,omitempty"`
+	TimeSliceMap    []map[string]metav1.Time `json:"timeSliceMap,omitempty"`
+
+	// Map of string to slices
+	StringMapSlice  map[string][]string      `json:"stringMapSlice,omitempty"`
+	BoolMapSlice    map[string][]bool        `json:"boolMapSlice,omitempty"`
+	IntMapSlice     map[string][]int         `json:"intMapSlice,omitempty"`
+	Int8MapSlice    map[string][]int8        `json:"int8MapSlice,omitempty"`
+	Int16MapSlice   map[string][]int16       `json:"int16MapSlice,omitempty"`
+	Int32MapSlice   map[string][]int32       `json:"int32MapSlice,omitempty"`
+	Int64MapSlice   map[string][]int64       `json:"int64MapSlice,omitempty"`
+	UintMapSlice    map[string][]uint        `json:"uintMapSlice,omitempty"`
+	Uint8MapSlice   map[string][]uint8       `json:"uint8MapSlice,omitempty"`
+	Uint16MapSlice  map[string][]uint16      `json:"uint16MapSlice,omitempty"`
+	Uint32MapSlice  map[string][]uint32      `json:"uint32MapSlice,omitempty"`
+	Uint64MapSlice  map[string][]uint64      `json:"uint64MapSlice,omitempty"`
+	Float32MapSlice map[string][]float32     `json:"float32MapSlice,omitempty"`
+	Float64MapSlice map[string][]float64     `json:"float64MapSlice,omitempty"`
+	TimeMapSlice    map[string][]metav1.Time `json:"timeMapSlice,omitempty"`
+
+	// Map of string to maps
+	StringMapMap  map[string]map[string]string      `json:"stringMapMap,omitempty"`
+	BoolMapMap    map[string]map[string]bool        `json:"boolMapMap,omitempty"`
+	IntMapMap     map[string]map[string]int         `json:"intMapMap,omitempty"`
+	Int8MapMap    map[string]map[string]int8        `json:"int8MapMap,omitempty"`
+	Int16MapMap   map[string]map[string]int16       `json:"int16MapMap,omitempty"`
+	Int32MapMap   map[string]map[string]int32       `json:"int32MapMap,omitempty"`
+	Int64MapMap   map[string]map[string]int64       `json:"int64MapMap,omitempty"`
+	UintMapMap    map[string]map[string]uint        `json:"uintMapMap,omitempty"`
+	Uint8MapMap   map[string]map[string]uint8       `json:"uint8MapMap,omitempty"`
+	Uint16MapMap  map[string]map[string]uint16      `json:"uint16MapMap,omitempty"`
+	Uint32MapMap  map[string]map[string]uint32      `json:"uint32MapMap,omitempty"`
+	Uint64MapMap  map[string]map[string]uint64      `json:"uint64MapMap,omitempty"`
+	Float32MapMap map[string]map[string]float32     `json:"float32MapMap,omitempty"`
+	Float64MapMap map[string]map[string]float64     `json:"float64MapMap,omitempty"`
+	TimeMapMap    map[string]map[string]metav1.Time `json:"timeMapMap,omitempty"`
+
+	// Recursive types
+	Self           *AllTypesStruct                       `json:"self,omitempty"`
+	SelfSlice      []*AllTypesStruct                     `json:"selfSlice,omitempty"`
+	SelfMap        map[string]*AllTypesStruct            `json:"selfMap,omitempty"`
+	SelfSliceSlice [][](*AllTypesStruct)                 `json:"selfSliceSlice,omitempty"`
+	SelfSliceMap   []map[string]*AllTypesStruct          `json:"selfSliceMap,omitempty"`
+	SelfMapSlice   map[string][]*AllTypesStruct          `json:"selfMapSlice,omitempty"`
+	SelfMapMap     map[string]map[string]*AllTypesStruct `json:"selfMapMap,omitempty"`
+}
+
+func TestKYAMLPrinterRoundTrip(t *testing.T) {
+	for i := 0; i < 1000; i++ {
+		// Create and fill an instance.
+		original := &AllTypesStruct{}
+		f := randfill.New().NilChance(0.5).NumElements(1, 5).MaxDepth(3)
+		f.Fill(original)
+
+		// Render to YAML.
+		var buf bytes.Buffer
+		printer := &KYAMLPrinter{}
+		if err := printer.fromAny(original, &buf); err != nil {
+			t.Fatalf("iteration %d: failed to render KYAML: %v", i, err)
+		}
+
+		// Parse back from YAML with the standard parser.
+		parsed := &AllTypesStruct{}
+		if err := yaml.Unmarshal(buf.Bytes(), parsed); err != nil {
+			t.Fatalf("iteration %d: failed to parse KYAML: %v\nKYAML:\n%s", i, err, buf.String())
+		}
+
+		// Compare.
+		if diff := cmp.Diff(original, parsed, cmpopts.EquateEmpty()); diff != "" {
+			t.Fatalf("iteration %d: objects differ after round trip (-original +parsed):\n%s\nKYAML:\n%s", i, diff, buf.String())
+		}
+	}
+}
+
+type SelfMarshalStruct struct {
+	String string `json:"string,omitempty"`
+}
+
+func (s SelfMarshalStruct) MarshalJSON() ([]byte, error) {
+	return []byte(`{"key":"value"}`), nil
+}
+
+func TestKYAMLSelfMarshal(t *testing.T) {
+	original := &SelfMarshalStruct{String: "string"}
+	var buf bytes.Buffer
+	printer := &KYAMLPrinter{}
+	if err := printer.fromAny(original, &buf); err != nil {
+		t.Fatalf("failed to render KYAML: %v", err)
+	}
+	expected := "{\n  key: \"value\",\n}\n"
+	if buf.String() != expected {
+		t.Fatalf("wrong result:\nexpected: %q\n     got: %q", expected, buf.String())
+	}
+}
+
+func TestYamlGuessesWrong(t *testing.T) {
+	type testCase struct {
+		name     string
+		input    string
+		expected bool
+	}
+
+	tests := []testCase{
+		// Regular strings that should not need quotes
+		{"regular string", "regular", false},
+		{"alphanumeric", "abc123", false},
+		{"underscore", "hello_world", false},
+		{"hyphen", "hello-world", false},
+
+		// Boolean-like strings
+		{"yes", "yes", true},
+		{"YES", "YES", true},
+		{"y", "y", true},
+		{"Y", "Y", true},
+		{"no", "no", true},
+		{"NO", "NO", true},
+		{"n", "n", true},
+		{"N", "N", true},
+		{"on", "on", true},
+		{"ON", "ON", true},
+		{"off", "off", true},
+		{"OFF", "OFF", true},
+
+		// Numbers should stay strings
+		{"decimal", "1234", true},
+		{"underscores", "_1_2_3_4_", true},
+		{"leading zero", "0123", true},
+		{"plus sign", "+123", true},
+		{"negative sign", "-123", true},
+		{"large decimal", "123456789012345678901234567890", true},
+		{"octal 0", "0777", true},
+		{"octal 0o", "0o777", true},
+		{"hex lowercase", "0xff", true},
+		{"hex uppercase", "0xFF", true},
+
+		// Infinity and NaN
+		{"infinity", ".inf", true},
+		{"negative infinity", "-.inf", true},
+		{"positive infinity", "+.inf", true},
+		{"not a number", ".nan", true},
+		{"uppercase infinity", ".INF", true},
+		{"uppercase nan", ".NAN", true},
+
+		// Scientific notation
+		{"scientific", "1e10", true},
+		{"scientific uppercase", "1E10", true},
+
+		// Timestamp-like strings
+		{"year", "2006", true},
+		{"date", "2006-1-2", true},
+		{"RCF3339Nano with short date", "2006-1-2T15:4:5.999999999-08:00", true},
+		{"RCF3339Nano with lowercase t", "2006-1-2t15:4:5.999999999-08:00", true},
+		{"space separated", "2006-1-2 14:4:5.999999999", true},
+
+		// Null-like strings
+		{"null lowercase", "null", true},
+		{"null mixed", "Null", true},
+		{"null uppercase", "NULL", true},
+		{"tilde", "~", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := yamlGuessesWrong(tt.input)
+			if result != tt.expected {
+				t.Errorf("yamlGuessesWrong(%q) = %v, want %v", tt.input, result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
KYAML is a strict subset of YAML, which is sort of halfway between YAML and JSON.  It has the following properties:
* Does not depend on whitespace (easier to text-patch and template).
* Always quotes value strings (no ambiguity aroud things like "no").
* Allows quoted keys, but does not require them, and only quotes them if they are not obviously safe (e.g. "no" would always be quoted).
* Always uses {} for structs and maps (no more obscure errors about mapping values).
* Always uses [] for lists (no more trying to figure out if a dash changes the meaning).
* When printing, it includes a header which makes it clear this is YAML and not ill-formed JSON.
* Allows trailing commas
* Allows comments,
* Tries to economize on vertical space by "cuddling" some kinds of brackets together.

Output from `kubectl get -okyaml` can be fed back into `kubectl`.

I'd like to argue that this would be a better format to use in examples and documentation.  @sftim 

Examples:

A struct:

```yaml
metadata: {
  creationTimestamp: "2024-12-11T00:10:11Z",
  labels: {
    app: "hostnames",
  },
  name: "hostnames",
  namespace: "default",
  resourceVersion: "15231643",
  uid: "f64dbcba-9c58-40b0-bbe7-70495efb5202",
},
```

A list of primitves:

```yaml
ipFamilies: [
  "IPv4",
  "IPv6",
],
```

A list of structs:

```yaml
ports: [{
  port: 80,
  protocol: "TCP",
  targetPort: 80,
}, {
  port: 443,
  protocol: "TCP",
  targetPort: 443,
}],
```

A multi-document stream:

```yaml
#!yaml
---
{
  foo: "bar",
}
---
{
  qux: "zrb",
}
```


/kind feature
/sig cli
/sig api-machinery

/cc @sftim 
/cc @deads2k (since I mentioned it)
/cc @benluddy (FYI, this is what I was doing)

```release-note
Added support for a new kubectl output format, `kyaml`. KYAML is a strict subset of YAML and should be accepted by any YAML processor. The formatting of KYAML is halfway between JSON and YAML.  Because it is more explicit than the default YAML style, it should be less error-prone.
```