### PR TITLE
kube-proxy: metric to track conntrack reconciliation latency

### DIFF
--- a/pkg/proxy/conntrack/cleanup.go
+++ b/pkg/proxy/conntrack/cleanup.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/proxy"
+	"k8s.io/kubernetes/pkg/proxy/metrics"
 	netutils "k8s.io/utils/net"
 )
 
@@ -120,6 +121,7 @@ func CleanStaleEntries(ct Interface, ipFamily v1.IPFamily,
 	} else {
 		klog.V(4).InfoS("Finished reconciling conntrack entries", "ipFamily", ipFamily, "entriesDeleted", n, "took", time.Since(start))
 	}
+	metrics.ReconcileConntrackFlowsLatency.WithLabelValues(string(ipFamily)).Observe(metrics.SinceInSeconds(start))
 }
 
 // ipFamilyMap maps v1.IPFamily to the corresponding unix constant.

--- a/pkg/proxy/metrics/metrics.go
+++ b/pkg/proxy/metrics/metrics.go
@@ -283,6 +283,18 @@ var (
 		"Number of packets accepted on nodeports of loopback interface",
 		nil, nil, metrics.ALPHA, "")
 	LocalhostNodePortAcceptedNFAcctCounter = "localhost_nps_accepted_pkts"
+
+	// ReconcileConntrackFlowsLatency is the latency of one round of kube-proxy conntrack flows reconciliation.
+	ReconcileConntrackFlowsLatency = metrics.NewHistogramVec(
+		&metrics.HistogramOpts{
+			Subsystem:      kubeProxySubsystem,
+			Name:           "conntrack_reconciler_sync_duration_seconds",
+			Help:           "ReconcileConntrackFlowsLatency latency in seconds",
+			Buckets:        metrics.ExponentialBuckets(0.001, 2, 15),
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"ip_family"},
+	)
 )
 
 var registerMetricsOnce sync.Once
@@ -321,15 +333,18 @@ func RegisterMetrics(mode kubeproxyconfig.ProxyMode) {
 			legacyregistry.MustRegister(IPTablesPartialRestoreFailuresTotal)
 			legacyregistry.MustRegister(IPTablesRulesTotal)
 			legacyregistry.MustRegister(IPTablesRulesLastSync)
+			legacyregistry.MustRegister(ReconcileConntrackFlowsLatency)
 
 		case kubeproxyconfig.ProxyModeIPVS:
 			legacyregistry.MustRegister(IPTablesRestoreFailuresTotal)
+			legacyregistry.MustRegister(ReconcileConntrackFlowsLatency)
 
 		case kubeproxyconfig.ProxyModeNFTables:
 			legacyregistry.MustRegister(SyncFullProxyRulesLatency)
 			legacyregistry.MustRegister(SyncPartialProxyRulesLatency)
 			legacyregistry.MustRegister(NFTablesSyncFailuresTotal)
 			legacyregistry.MustRegister(NFTablesCleanupFailuresTotal)
+			legacyregistry.MustRegister(ReconcileConntrackFlowsLatency)
 
 		case kubeproxyconfig.ProxyModeKernelspace:
 			// currently no winkernel-specific metrics


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR introduces "kubeproxy_conntrack_reconciler_sync_duration_seconds" metric for tracking time spent by conntrack reconciler on cleaning up stale conntrack flows.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
```
root@kind-worker:/# curl --silent localhost:10249/metrics | grep kubeproxy_conntrack_reconciler_sync_duration_seconds
# HELP kubeproxy_conntrack_reconciler_sync_duration_seconds [ALPHA] ReconcileConntrackFlowsLatency latency in seconds
# TYPE kubeproxy_conntrack_reconciler_sync_duration_seconds histogram
kubeproxy_conntrack_reconciler_sync_duration_seconds_bucket{ip_family="IPv4",le="0.001"} 0
kubeproxy_conntrack_reconciler_sync_duration_seconds_bucket{ip_family="IPv4",le="0.002"} 0
kubeproxy_conntrack_reconciler_sync_duration_seconds_bucket{ip_family="IPv4",le="0.004"} 0
kubeproxy_conntrack_reconciler_sync_duration_seconds_bucket{ip_family="IPv4",le="0.008"} 0
kubeproxy_conntrack_reconciler_sync_duration_seconds_bucket{ip_family="IPv4",le="0.016"} 1
kubeproxy_conntrack_reconciler_sync_duration_seconds_bucket{ip_family="IPv4",le="0.032"} 1
kubeproxy_conntrack_reconciler_sync_duration_seconds_bucket{ip_family="IPv4",le="0.064"} 1
kubeproxy_conntrack_reconciler_sync_duration_seconds_bucket{ip_family="IPv4",le="0.128"} 2
kubeproxy_conntrack_reconciler_sync_duration_seconds_bucket{ip_family="IPv4",le="0.256"} 7
kubeproxy_conntrack_reconciler_sync_duration_seconds_bucket{ip_family="IPv4",le="0.512"} 10
kubeproxy_conntrack_reconciler_sync_duration_seconds_bucket{ip_family="IPv4",le="1.024"} 12
kubeproxy_conntrack_reconciler_sync_duration_seconds_bucket{ip_family="IPv4",le="2.048"} 13
kubeproxy_conntrack_reconciler_sync_duration_seconds_bucket{ip_family="IPv4",le="4.096"} 13
kubeproxy_conntrack_reconciler_sync_duration_seconds_bucket{ip_family="IPv4",le="8.192"} 13
kubeproxy_conntrack_reconciler_sync_duration_seconds_bucket{ip_family="IPv4",le="16.384"} 13
kubeproxy_conntrack_reconciler_sync_duration_seconds_bucket{ip_family="IPv4",le="+Inf"} 14
kubeproxy_conntrack_reconciler_sync_duration_seconds_sum{ip_family="IPv4"} 76.68063526899999
kubeproxy_conntrack_reconciler_sync_duration_seconds_count{ip_family="IPv4"} 14
root@kind-worker:/# 
```
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
`kubeproxy_conntrack_reconciler_sync_duration_seconds` metric can be used to track conntrack reconciliation latency
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
