### PR TITLE
kube-proxy: metric to track entries deleted in conntrack reconciliation

### DIFF
--- a/pkg/proxy/conntrack/cleanup.go
+++ b/pkg/proxy/conntrack/cleanup.go
@@ -116,12 +116,14 @@ func CleanStaleEntries(ct Interface, ipFamily v1.IPFamily,
 		}
 	}
 
-	if n, err := ct.ClearEntries(ipFamilyMap[ipFamily], filters...); err != nil {
+	var n int
+	if n, err = ct.ClearEntries(ipFamilyMap[ipFamily], filters...); err != nil {
 		klog.ErrorS(err, "Failed to clear all conntrack entries", "ipFamily", ipFamily, "entriesDeleted", n, "took", time.Since(start))
 	} else {
 		klog.V(4).InfoS("Finished reconciling conntrack entries", "ipFamily", ipFamily, "entriesDeleted", n, "took", time.Since(start))
 	}
 	metrics.ReconcileConntrackFlowsLatency.WithLabelValues(string(ipFamily)).Observe(metrics.SinceInSeconds(start))
+	metrics.ReconcileConntrackFlowsDeletedEntriesTotal.WithLabelValues(string(ipFamily)).Add(float64(n))
 }
 
 // ipFamilyMap maps v1.IPFamily to the corresponding unix constant.

--- a/pkg/proxy/metrics/metrics.go
+++ b/pkg/proxy/metrics/metrics.go
@@ -295,6 +295,17 @@ var (
 		},
 		[]string{"ip_family"},
 	)
+
+	// ReconcileConntrackFlowsDeletedEntriesTotal is the number of entries deleted by conntrack reconciler.
+	ReconcileConntrackFlowsDeletedEntriesTotal = metrics.NewCounterVec(
+		&metrics.CounterOpts{
+			Subsystem:      kubeProxySubsystem,
+			Name:           "conntrack_reconciler_deleted_entries_total",
+			Help:           "Cumulative conntrack flows deleted by conntrack reconciler",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"ip_family"},
+	)
 )
 
 var registerMetricsOnce sync.Once
@@ -334,10 +345,12 @@ func RegisterMetrics(mode kubeproxyconfig.ProxyMode) {
 			legacyregistry.MustRegister(IPTablesRulesTotal)
 			legacyregistry.MustRegister(IPTablesRulesLastSync)
 			legacyregistry.MustRegister(ReconcileConntrackFlowsLatency)
+			legacyregistry.MustRegister(ReconcileConntrackFlowsDeletedEntriesTotal)
 
 		case kubeproxyconfig.ProxyModeIPVS:
 			legacyregistry.MustRegister(IPTablesRestoreFailuresTotal)
 			legacyregistry.MustRegister(ReconcileConntrackFlowsLatency)
+			legacyregistry.MustRegister(ReconcileConntrackFlowsDeletedEntriesTotal)
 
 		case kubeproxyconfig.ProxyModeNFTables:
 			legacyregistry.MustRegister(SyncFullProxyRulesLatency)
@@ -345,6 +358,7 @@ func RegisterMetrics(mode kubeproxyconfig.ProxyMode) {
 			legacyregistry.MustRegister(NFTablesSyncFailuresTotal)
 			legacyregistry.MustRegister(NFTablesCleanupFailuresTotal)
 			legacyregistry.MustRegister(ReconcileConntrackFlowsLatency)
+			legacyregistry.MustRegister(ReconcileConntrackFlowsDeletedEntriesTotal)
 
 		case kubeproxyconfig.ProxyModeKernelspace:
 			// currently no winkernel-specific metrics


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR introduces a metric to track conntrack flows deleted by conntrack reconciler.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
```
root@kind-worker:/# conntrack -L -p udp | wc
conntrack v1.4.7 (conntrack-tools): 34 flow entries have been shown.
     34     442    4514
root@kind-worker:/# curl --silent localhost:10249/metrics | grep kubeproxy_conntrack_reconciler_deleted_entries_total
# HELP kubeproxy_conntrack_reconciler_deleted_entries_total [ALPHA] Cumulative conntrack flows deleted by conntrack reconciler
# TYPE kubeproxy_conntrack_reconciler_deleted_entries_total counter
kubeproxy_conntrack_reconciler_deleted_entries_total{ip_family="IPv4"} 0
root@kind-worker:/#

// trigger a proxy/reconciler sync

root@kind-worker:/#
root@kind-worker:/# curl --silent localhost:10249/metrics | grep kubeproxy_conntrack_reconciler_deleted_entries_total
# HELP kubeproxy_conntrack_reconciler_deleted_entries_total [ALPHA] Cumulative conntrack flows deleted by conntrack reconciler
# TYPE kubeproxy_conntrack_reconciler_deleted_entries_total counter
kubeproxy_conntrack_reconciler_deleted_entries_total{ip_family="IPv4"} 18
root@kind-worker:/# 
```
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
`kubeproxy_conntrack_reconciler_deleted_entries_total` metric can be used to track cumulative sum of conntrack flows cleared by reconciler
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
