### PR TITLE
KEP-3619: Promote SupplementalGroupsPolicy feature to Beta

### DIFF
--- a/pkg/api/pod/testing/make.go
+++ b/pkg/api/pod/testing/make.go
@@ -327,6 +327,18 @@ func SetContainerStatuses(containerStatuses ...api.ContainerStatus) TweakPodStat
 	}
 }
 
+func SetInitContainerStatuses(containerStatuses ...api.ContainerStatus) TweakPodStatus {
+	return func(podstatus *api.PodStatus) {
+		podstatus.InitContainerStatuses = containerStatuses
+	}
+}
+
+func SetEphemeralContainerStatuses(containerStatuses ...api.ContainerStatus) TweakPodStatus {
+	return func(podstatus *api.PodStatus) {
+		podstatus.EphemeralContainerStatuses = containerStatuses
+	}
+}
+
 func MakeContainerStatus(name string, allocatedResources api.ResourceList) api.ContainerStatus {
 	cs := api.ContainerStatus{
 		Name:               name,

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -8624,10 +8624,10 @@ func validateContainerStatusUsers(containerStatuses []core.ContainerStatus, fldP
 		switch osName {
 		case core.Windows:
 			if containerUser.Linux != nil {
-				allErrors = append(allErrors, field.Forbidden(fldPath.Index(i).Child("linux"), "cannot be set for a windows pod"))
+				allErrors = append(allErrors, field.Forbidden(fldPath.Index(i).Child("user").Child("linux"), "cannot be set for a windows pod"))
 			}
 		case core.Linux:
-			allErrors = append(allErrors, validateLinuxContainerUser(containerUser.Linux, fldPath.Index(i).Child("linux"))...)
+			allErrors = append(allErrors, validateLinuxContainerUser(containerUser.Linux, fldPath.Index(i).Child("user").Child("linux"))...)
 		}
 	}
 	return allErrors

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -25707,9 +25707,9 @@ func TestValidatePodStatusUpdateWithSupplementalGroupsPolicy(t *testing.T) {
 				},
 			}},
 			wantFieldErrors: field.ErrorList{
-				field.Invalid(field.NewPath("[0].linux.uid"), badUID, "must be between 0 and 2147483647, inclusive"),
-				field.Invalid(field.NewPath("[0].linux.gid"), badGID, "must be between 0 and 2147483647, inclusive"),
-				field.Invalid(field.NewPath("[0].linux.supplementalGroups[0]"), badGID, "must be between 0 and 2147483647, inclusive"),
+				field.Invalid(field.NewPath("[0].user.linux.uid"), badUID, "must be between 0 and 2147483647, inclusive"),
+				field.Invalid(field.NewPath("[0].user.linux.gid"), badGID, "must be between 0 and 2147483647, inclusive"),
+				field.Invalid(field.NewPath("[0].user.linux.supplementalGroups[0]"), badGID, "must be between 0 and 2147483647, inclusive"),
 			},
 		},
 		"user.linux must not be set in windows": {
@@ -25720,7 +25720,7 @@ func TestValidatePodStatusUpdateWithSupplementalGroupsPolicy(t *testing.T) {
 				},
 			}},
 			wantFieldErrors: field.ErrorList{
-				field.Forbidden(field.NewPath("[0].linux"), "cannot be set for a windows pod"),
+				field.Forbidden(field.NewPath("[0].user.linux"), "cannot be set for a windows pod"),
 			},
 		},
 	}

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -1747,6 +1747,7 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 
 	SupplementalGroupsPolicy: {
 		{Version: version.MustParse("1.31"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.33"), Default: true, PreRelease: featuregate.Beta},
 	},
 
 	SystemdWatchdog: {

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -245,6 +245,7 @@ var (
 		lifecycle.PodOSNotSupported,
 		lifecycle.InvalidNodeInfo,
 		lifecycle.InitContainerRestartPolicyForbidden,
+		lifecycle.SupplementalGroupsPolicyNotSupported,
 		lifecycle.UnexpectedAdmissionError,
 		lifecycle.UnknownReason,
 		lifecycle.UnexpectedPredicateFailureType,

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -3660,6 +3660,15 @@ func TestRecordAdmissionRejection(t *testing.T) {
             `,
 		},
 		{
+			name:   "SupplementalGroupsPolicyNotSupported",
+			reason: lifecycle.SupplementalGroupsPolicyNotSupported,
+			wants: `
+                # HELP kubelet_admission_rejections_total [ALPHA] Cumulative number pod admission rejections by the Kubelet.
+                # TYPE kubelet_admission_rejections_total counter
+                kubelet_admission_rejections_total{reason="SupplementalGroupsPolicyNotSupported"} 1
+            `,
+		},
+		{
 			name:   "UnexpectedAdmissionError",
 			reason: lifecycle.UnexpectedAdmissionError,
 			wants: `

--- a/pkg/kubelet/lifecycle/predicate_test.go
+++ b/pkg/kubelet/lifecycle/predicate_test.go
@@ -437,7 +437,7 @@ func TestRejectPodAdmissionBasedOnOSField(t *testing.T) {
 }
 
 func TestPodAdmissionBasedOnSupplementalGroupsPolicy(t *testing.T) {
-	nodeSupportedTheFeature := &v1.Node{
+	nodeWithFeature := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{Name: "test"},
 		Status: v1.NodeStatus{
 			Features: &v1.NodeFeatures{
@@ -445,11 +445,11 @@ func TestPodAdmissionBasedOnSupplementalGroupsPolicy(t *testing.T) {
 			},
 		},
 	}
-	nodeNotSupportedTheFeature := &v1.Node{
+	nodeWithoutFeature := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{Name: "test"},
 	}
-	podNotUsedTheFeature := &v1.Pod{}
-	podUsedTheFeature := &v1.Pod{Spec: v1.PodSpec{
+	podNotUsingFeature := &v1.Pod{}
+	podUsingFeature := &v1.Pod{Spec: v1.PodSpec{
 		SecurityContext: &v1.PodSecurityContext{
 			SupplementalGroupsPolicy: ptr.To(v1.SupplementalGroupsPolicyStrict),
 		},
@@ -465,29 +465,29 @@ func TestPodAdmissionBasedOnSupplementalGroupsPolicy(t *testing.T) {
 		{
 			name:             "feature=Beta, node=feature not supported, pod=in use: it should REJECT",
 			emulationVersion: utilversion.MustParse("1.33"),
-			node:             nodeNotSupportedTheFeature,
-			pod:              podUsedTheFeature,
+			node:             nodeWithoutFeature,
+			pod:              podUsingFeature,
 			expectRejection:  true,
 		},
 		{
 			name:             "feature=Beta, node=feature supported, pod=in use: it should ADMIT",
 			emulationVersion: utilversion.MustParse("1.33"),
-			node:             nodeSupportedTheFeature,
-			pod:              podUsedTheFeature,
+			node:             nodeWithFeature,
+			pod:              podUsingFeature,
 			expectRejection:  false,
 		},
 		{
 			name:             "feature=Beta, node=feature not supported, pod=not in use: it should ADMIT",
 			emulationVersion: utilversion.MustParse("1.33"),
-			node:             nodeNotSupportedTheFeature,
-			pod:              podNotUsedTheFeature,
+			node:             nodeWithoutFeature,
+			pod:              podNotUsingFeature,
 			expectRejection:  false,
 		},
 		{
 			name:             "feature=Beta, node=feature supported, pod=not in use: it should ADMIT",
 			emulationVersion: utilversion.MustParse("1.33"),
-			node:             nodeSupportedTheFeature,
-			pod:              podNotUsedTheFeature,
+			node:             nodeWithFeature,
+			pod:              podNotUsingFeature,
 			expectRejection:  false,
 		},
 		// The feature is Alpha(v1.31, v1.32) in emulated version
@@ -495,29 +495,29 @@ func TestPodAdmissionBasedOnSupplementalGroupsPolicy(t *testing.T) {
 		{
 			name:             "feature=Alpha, node=feature not supported, pod=feature used: it should ADMIT",
 			emulationVersion: utilversion.MustParse("1.32"),
-			node:             nodeNotSupportedTheFeature,
-			pod:              podUsedTheFeature,
+			node:             nodeWithoutFeature,
+			pod:              podUsingFeature,
 			expectRejection:  false,
 		},
 		{
 			name:             "feature=Alpha, node=feature not supported, pod=feature not used: it should ADMIT",
 			emulationVersion: utilversion.MustParse("1.32"),
-			node:             nodeNotSupportedTheFeature,
-			pod:              podNotUsedTheFeature,
+			node:             nodeWithoutFeature,
+			pod:              podNotUsingFeature,
 			expectRejection:  false,
 		},
 		{
 			name:             "feature=Alpha, node=feature supported, pod=feature used: it should ADMIT",
 			emulationVersion: utilversion.MustParse("1.32"),
-			node:             nodeSupportedTheFeature,
-			pod:              podUsedTheFeature,
+			node:             nodeWithFeature,
+			pod:              podUsingFeature,
 			expectRejection:  false,
 		},
 		{
 			name:             "feature=Alpha, node=feature supported, pod=feature not used: it should ADMIT",
 			emulationVersion: utilversion.MustParse("1.32"),
-			node:             nodeSupportedTheFeature,
-			pod:              podNotUsedTheFeature,
+			node:             nodeWithFeature,
+			pod:              podNotUsingFeature,
 			expectRejection:  false,
 		},
 		// The feature is not yet released (< v1.31) in emulated version (this can happen when only kubelet downgraded).
@@ -525,15 +525,15 @@ func TestPodAdmissionBasedOnSupplementalGroupsPolicy(t *testing.T) {
 		{
 			name:             "feature=NotReleased, node=feature not supported, pod=feature used: it should ADMIT",
 			emulationVersion: utilversion.MustParse("1.30"),
-			node:             nodeNotSupportedTheFeature,
-			pod:              podUsedTheFeature,
+			node:             nodeWithoutFeature,
+			pod:              podUsingFeature,
 			expectRejection:  false,
 		},
 		{
 			name:             "feature=NotReleased, node=feature not supported, pod=feature not used: it should ADMIT",
 			emulationVersion: utilversion.MustParse("1.30"),
-			node:             nodeNotSupportedTheFeature,
-			pod:              podNotUsedTheFeature,
+			node:             nodeWithoutFeature,
+			pod:              podNotUsingFeature,
 			expectRejection:  false,
 		},
 	}

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -1521,6 +1521,10 @@
     lockToDefault: false
     preRelease: Alpha
     version: "1.31"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.33"
 - name: SystemdWatchdog
   versionedSpecs:
   - default: true

--- a/test/e2e/common/node/security_context.go
+++ b/test/e2e/common/node/security_context.go
@@ -20,14 +20,19 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
+	"reflect"
 	"strconv"
 	"strings"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/kubernetes/pkg/apis/core"
+	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/events"
+	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
 	"k8s.io/kubernetes/test/e2e/feature"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
@@ -40,6 +45,7 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/gcustom"
 )
 
 var (
@@ -705,6 +711,249 @@ var _ = SIGDescribe("Security Context", func() {
 			if err := createAndMatchOutput(ctx, podName, "Effective uid: 0", &apeTrue, nonRootTestUserID); err != nil {
 				framework.Failf("Match output for pod %q failed: %v", podName, err)
 			}
+		})
+	})
+
+	f.Context("SupplementalGroupsPolicy [LinuxOnly]", feature.SupplementalGroupsPolicy, framework.WithFeatureGate(features.SupplementalGroupsPolicy), func() {
+		timeout := 1 * time.Minute
+
+		agnhostImage := imageutils.GetE2EImage(imageutils.Agnhost)
+		uidInImage := int64(1000)
+		gidDefinedInImage := int64(50000)
+		supplementalGroup := int64(60000)
+
+		mkPod := func(policy *v1.SupplementalGroupsPolicy) *v1.Pod {
+			// In specified image(agnhost E2E image),
+			// - user-defined-in-image(uid=1000) is defined
+			// - user-defined-in-image belongs to group-defined-in-image(gid=50000)
+			// thus, resultant supplementary group of the container processes should be
+			// - 1000 : self
+			// - 50000: pre-defined groups defined in the container image(/etc/group) of self(uid=1000)
+			// - 60000: specified in SupplementalGroups
+			// $ id -G
+			// 1000 50000 60000 (if SupplementalGroupsPolicy=Merge or not set)
+			// 1000 60000       (if SupplementalGroupsPolicy=Strict)
+			podName := "sppl-grp-plcy-" + string(uuid.NewUUID())
+			return &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        podName,
+					Labels:      map[string]string{"name": podName},
+					Annotations: map[string]string{},
+				},
+				Spec: v1.PodSpec{
+					SecurityContext: &v1.PodSecurityContext{
+						RunAsUser:                &uidInImage,
+						SupplementalGroups:       []int64{supplementalGroup},
+						SupplementalGroupsPolicy: policy,
+					},
+					Containers: []v1.Container{
+						{
+							Name:    "test-container",
+							Image:   agnhostImage,
+							Command: []string{"sh", "-c", "id -G; while :; do sleep 1; done"},
+						},
+					},
+					RestartPolicy: v1.RestartPolicyNever,
+				},
+			}
+		}
+
+		nodeSupportsSupplementalGroupsPolicy := func(ctx context.Context, f *framework.Framework, nodeName string) bool {
+			node, err := f.ClientSet.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+			framework.ExpectNoError(err)
+			gomega.Expect(node).NotTo(gomega.BeNil())
+			if node.Status.Features != nil {
+				supportsSupplementalGroupsPolicy := node.Status.Features.SupplementalGroupsPolicy
+				if supportsSupplementalGroupsPolicy != nil && *supportsSupplementalGroupsPolicy {
+					return true
+				}
+			}
+			return false
+		}
+		waitForContainerUser := func(ctx context.Context, f *framework.Framework, podName string, containerName string, expectedContainerUser *v1.ContainerUser) error {
+			return framework.Gomega().Eventually(ctx,
+				framework.RetryNotFound(framework.GetObject(f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get, podName, metav1.GetOptions{}))).
+				WithTimeout(timeout).
+				Should(gcustom.MakeMatcher(func(p *v1.Pod) (bool, error) {
+					for _, s := range p.Status.ContainerStatuses {
+						if s.Name == containerName {
+							return reflect.DeepEqual(s.User, expectedContainerUser), nil
+						}
+					}
+					return false, nil
+				}))
+		}
+		waitForPodLogs := func(ctx context.Context, f *framework.Framework, podName string, containerName string, expectedLog string) error {
+			return framework.Gomega().Eventually(ctx,
+				framework.RetryNotFound(framework.GetObject(f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get, podName, metav1.GetOptions{}))).
+				WithTimeout(timeout).
+				Should(gcustom.MakeMatcher(func(p *v1.Pod) (bool, error) {
+					podLogs, err := e2epod.GetPodLogs(ctx, f.ClientSet, p.Namespace, p.Name, containerName)
+					if err != nil {
+						return false, err
+					}
+					return podLogs == expectedLog, nil
+				}))
+		}
+		expectMergePolicyInEffect := func(ctx context.Context, f *framework.Framework, podName string, containerName string, featureSupportedOnNode bool) {
+			expectedOutput := fmt.Sprintf("%d %d %d", uidInImage, gidDefinedInImage, supplementalGroup)
+			expectedContainerUser := &v1.ContainerUser{
+				Linux: &v1.LinuxContainerUser{
+					UID:                uidInImage,
+					GID:                uidInImage,
+					SupplementalGroups: []int64{uidInImage, gidDefinedInImage, supplementalGroup},
+				},
+			}
+
+			if featureSupportedOnNode {
+				framework.ExpectNoError(waitForContainerUser(ctx, f, podName, containerName, expectedContainerUser))
+			}
+			framework.ExpectNoError(waitForPodLogs(ctx, f, podName, containerName, expectedOutput+"\n"))
+
+			stdout := e2epod.ExecCommandInContainer(f, podName, containerName, "id", "-G")
+			gomega.Expect(stdout).To(gomega.Equal(expectedOutput))
+		}
+		expectStrictPolicyInEffect := func(ctx context.Context, f *framework.Framework, podName string, containerName string, featureSupportedOnNode bool) {
+			expectedOutput := fmt.Sprintf("%d %d", uidInImage, supplementalGroup)
+			expectedContainerUser := &v1.ContainerUser{
+				Linux: &v1.LinuxContainerUser{
+					UID:                uidInImage,
+					GID:                uidInImage,
+					SupplementalGroups: []int64{uidInImage, supplementalGroup},
+				},
+			}
+
+			if featureSupportedOnNode {
+				framework.ExpectNoError(waitForContainerUser(ctx, f, podName, containerName, expectedContainerUser))
+			}
+			framework.ExpectNoError(waitForPodLogs(ctx, f, podName, containerName, expectedOutput+"\n"))
+
+			stdout := e2epod.ExecCommandInContainer(f, podName, containerName, "id", "-G")
+			gomega.Expect(stdout).To(gomega.Equal(expectedOutput))
+		}
+		expectRejectionEventIssued := func(ctx context.Context, f *framework.Framework, pod *v1.Pod) {
+			framework.ExpectNoError(
+				framework.Gomega().Eventually(ctx,
+					framework.HandleRetry(framework.ListObjects(
+						f.ClientSet.CoreV1().Events(pod.Namespace).List,
+						metav1.ListOptions{
+							FieldSelector: fields.Set{
+								"type":                      core.EventTypeWarning,
+								"reason":                    lifecycle.SupplementalGroupsPolicyNotSupported,
+								"involvedObject.kind":       "Pod",
+								"involvedObject.apiVersion": v1.SchemeGroupVersion.String(),
+								"involvedObject.name":       pod.Name,
+								"involvedObject.uid":        string(pod.UID),
+							}.AsSelector().String(),
+						},
+					))).
+					WithTimeout(timeout).
+					Should(gcustom.MakeMatcher(func(eventList *v1.EventList) (bool, error) {
+						return len(eventList.Items) == 1, nil
+					})),
+			)
+		}
+
+		ginkgo.When("SupplementalGroupsPolicy nil in SecurityContext", func() {
+			ginkgo.When("if the container's primary UID belongs to some groups in the image", func() {
+				var pod *v1.Pod
+				ginkgo.BeforeEach(func(ctx context.Context) {
+					ginkgo.By("creating a pod", func() {
+						pod = e2epod.NewPodClient(f).CreateSync(ctx, mkPod(ptr.To(v1.SupplementalGroupsPolicyMerge)))
+					})
+				})
+				ginkgo.When("scheduled node does not support SupplementalGroupsPolicy", func() {
+					ginkgo.BeforeEach(func(ctx context.Context) {
+						// ensure the scheduled node does not support SupplementalGroupsPolicy
+						if nodeSupportsSupplementalGroupsPolicy(ctx, f, pod.Spec.NodeName) {
+							e2eskipper.Skipf("scheduled node does support SupplementalGroupsPolicy")
+						}
+					})
+					ginkgo.It("it should add SupplementalGroups to them [LinuxOnly]", func(ctx context.Context) {
+						expectMergePolicyInEffect(ctx, f, pod.Name, pod.Spec.Containers[0].Name, false)
+					})
+				})
+				ginkgo.When("scheduled node supports SupplementalGroupsPolicy", func() {
+					ginkgo.BeforeEach(func(ctx context.Context) {
+						// ensure the scheduled node does support SupplementalGroupsPolicy
+						if !nodeSupportsSupplementalGroupsPolicy(ctx, f, pod.Spec.NodeName) {
+							e2eskipper.Skipf("scheduled node does not support SupplementalGroupsPolicy")
+						}
+					})
+					ginkgo.It("it should add SupplementalGroups to them [LinuxOnly]", func(ctx context.Context) {
+						expectMergePolicyInEffect(ctx, f, pod.Name, pod.Spec.Containers[0].Name, true)
+					})
+				})
+			})
+		})
+		ginkgo.When("SupplementalGroupsPolicy was set to Merge in PodSpec", func() {
+			ginkgo.When("the container's primary UID belongs to some groups in the image", func() {
+				var pod *v1.Pod
+				ginkgo.BeforeEach(func(ctx context.Context) {
+					ginkgo.By("creating a pod", func() {
+						pod = e2epod.NewPodClient(f).CreateSync(ctx, mkPod(nil))
+					})
+				})
+				ginkgo.When("scheduled node does not support SupplementalGroupsPolicy", func() {
+					ginkgo.BeforeEach(func(ctx context.Context) {
+						// ensure the scheduled node does not support SupplementalGroupsPolicy
+						if nodeSupportsSupplementalGroupsPolicy(ctx, f, pod.Spec.NodeName) {
+							e2eskipper.Skipf("scheduled node does support SupplementalGroupsPolicy")
+						}
+					})
+					ginkgo.It("it should add SupplementalGroups to them [LinuxOnly]", func(ctx context.Context) {
+						expectMergePolicyInEffect(ctx, f, pod.Name, pod.Spec.Containers[0].Name, false)
+					})
+				})
+				ginkgo.When("scheduled node supports SupplementalGroupsPolicy", func() {
+					ginkgo.BeforeEach(func(ctx context.Context) {
+						// ensure the scheduled node does support SupplementalGroupsPolicy
+						if !nodeSupportsSupplementalGroupsPolicy(ctx, f, pod.Spec.NodeName) {
+							e2eskipper.Skipf("scheduled node does not support SupplementalGroupsPolicy")
+						}
+					})
+					ginkgo.It("it should add SupplementalGroups to them [LinuxOnly]", func(ctx context.Context) {
+						expectMergePolicyInEffect(ctx, f, pod.Name, pod.Spec.Containers[0].Name, true)
+					})
+				})
+			})
+		})
+		ginkgo.When("SupplementalGroupsPolicy was set to Strict in PodSpec", func() {
+			ginkgo.When("the container's primary UID belongs to some groups in the image", func() {
+				var pod *v1.Pod
+				ginkgo.BeforeEach(func(ctx context.Context) {
+					ginkgo.By("creating a pod", func() {
+						pod = e2epod.NewPodClient(f).Create(ctx, mkPod(ptr.To(v1.SupplementalGroupsPolicyStrict)))
+						framework.ExpectNoError(e2epod.WaitForPodScheduled(ctx, f.ClientSet, pod.Namespace, pod.Name))
+						var err error
+						pod, err = e2epod.NewPodClient(f).Get(ctx, pod.Name, metav1.GetOptions{})
+						framework.ExpectNoError(err)
+					})
+				})
+				ginkgo.When("scheduled node does not support SupplementalGroupsPolicy", func() {
+					ginkgo.BeforeEach(func(ctx context.Context) {
+						// ensure the scheduled node does not support SupplementalGroupsPolicy
+						if nodeSupportsSupplementalGroupsPolicy(ctx, f, pod.Spec.NodeName) {
+							e2eskipper.Skipf("scheduled node does support SupplementalGroupsPolicy")
+						}
+					})
+					ginkgo.It("it should reject the pod [LinuxOnly]", func(ctx context.Context) {
+						expectRejectionEventIssued(ctx, f, pod)
+					})
+				})
+				ginkgo.When("scheduled node supports SupplementalGroupsPolicy", func() {
+					ginkgo.BeforeEach(func(ctx context.Context) {
+						// ensure the scheduled node does support SupplementalGroupsPolicy
+						if !nodeSupportsSupplementalGroupsPolicy(ctx, f, pod.Spec.NodeName) {
+							e2eskipper.Skipf("scheduled node does not support SupplementalGroupsPolicy")
+						}
+						framework.ExpectNoError(e2epod.WaitForPodRunningInNamespace(ctx, f.ClientSet, pod))
+					})
+					ginkgo.It("it should NOT add SupplementalGroups to them [LinuxOnly]", func(ctx context.Context) {
+						expectStrictPolicyInEffect(ctx, f, pod.Name, pod.Spec.Containers[0].Name, true)
+					})
+				})
+			})
 		})
 	})
 })

--- a/test/e2e/node/security_context.go
+++ b/test/e2e/node/security_context.go
@@ -25,29 +25,19 @@ package node
 import (
 	"context"
 	"fmt"
-	"reflect"
-	"time"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/util/uuid"
-	"k8s.io/kubernetes/pkg/apis/core"
-	"k8s.io/kubernetes/pkg/features"
-	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
-	"k8s.io/kubernetes/test/e2e/feature"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2ekubectl "k8s.io/kubernetes/test/e2e/framework/kubectl"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2eoutput "k8s.io/kubernetes/test/e2e/framework/pod/output"
-	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 	admissionapi "k8s.io/pod-security-admission/api"
-	ptr "k8s.io/utils/ptr"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
-	"github.com/onsi/gomega/gcustom"
 )
 
 // SeccompProcStatusField is the field of /proc/$PID/status referencing the seccomp filter type.
@@ -121,234 +111,6 @@ var _ = SIGDescribe("Security Context", func() {
 				pod, 0,
 				[]string{fmt.Sprintf("%d %d %d", uidInImage, gidDefinedInImage, supplementalGroup)},
 			)
-		})
-	})
-
-	SIGDescribe("SupplementalGroupsPolicy", feature.SupplementalGroupsPolicy, framework.WithFeatureGate(features.SupplementalGroupsPolicy), func() {
-		timeout := 1 * time.Minute
-
-		agnhostImage := imageutils.GetE2EImage(imageutils.Agnhost)
-		uidInImage := int64(1000)
-		gidDefinedInImage := int64(50000)
-		supplementalGroup := int64(60000)
-
-		supportsSupplementalGroupsPolicy := func(ctx context.Context, f *framework.Framework, nodeName string) bool {
-			node, err := f.ClientSet.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
-			framework.ExpectNoError(err)
-			gomega.Expect(node).NotTo(gomega.BeNil())
-			if node.Status.Features != nil {
-				supportsSupplementalGroupsPolicy := node.Status.Features.SupplementalGroupsPolicy
-				if supportsSupplementalGroupsPolicy != nil && *supportsSupplementalGroupsPolicy {
-					return true
-				}
-			}
-			return false
-		}
-		mkPod := func(policy *v1.SupplementalGroupsPolicy) *v1.Pod {
-			pod := scTestPod(false, false)
-
-			// In specified image(agnhost E2E image),
-			// - user-defined-in-image(uid=1000) is defined
-			// - user-defined-in-image belongs to group-defined-in-image(gid=50000)
-			// thus, resultant supplementary group of the container processes should be
-			// - 1000 : self
-			// - 50000: pre-defined groups defined in the container image(/etc/group) of self(uid=1000)
-			// - 60000: specified in SupplementalGroups
-			// $ id -G
-			// 1000 50000 60000 (if SupplementalGroupsPolicy=Merge or not set)
-			// 1000 60000       (if SupplementalGroupsPolicy=Strict)
-			pod.Spec.SecurityContext.RunAsUser = &uidInImage
-			pod.Spec.SecurityContext.SupplementalGroupsPolicy = policy
-			pod.Spec.SecurityContext.SupplementalGroups = []int64{supplementalGroup}
-			pod.Spec.Containers[0].Image = agnhostImage
-			pod.Spec.Containers[0].Command = []string{"sh", "-c", "id -G; while :; do sleep 1; done"}
-
-			return pod
-		}
-		waitForContainerUser := func(ctx context.Context, f *framework.Framework, podName string, containerName string, expectedContainerUser *v1.ContainerUser) error {
-			return framework.Gomega().Eventually(ctx,
-				framework.RetryNotFound(framework.GetObject(f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get, podName, metav1.GetOptions{}))).
-				WithTimeout(timeout).
-				Should(gcustom.MakeMatcher(func(p *v1.Pod) (bool, error) {
-					for _, s := range p.Status.ContainerStatuses {
-						if s.Name == containerName {
-							return reflect.DeepEqual(s.User, expectedContainerUser), nil
-						}
-					}
-					return false, nil
-				}))
-		}
-		waitForPodLogs := func(ctx context.Context, f *framework.Framework, podName string, containerName string, expectedLog string) error {
-			return framework.Gomega().Eventually(ctx,
-				framework.RetryNotFound(framework.GetObject(f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get, podName, metav1.GetOptions{}))).
-				WithTimeout(timeout).
-				Should(gcustom.MakeMatcher(func(p *v1.Pod) (bool, error) {
-					podLogs, err := e2epod.GetPodLogs(ctx, f.ClientSet, p.Namespace, p.Name, containerName)
-					if err != nil {
-						return false, err
-					}
-					return podLogs == expectedLog, nil
-				}))
-		}
-		expectMergePolicyInEffect := func(ctx context.Context, f *framework.Framework, podName string, containerName string, featureSupportedOnNode bool) {
-			expectedOutput := fmt.Sprintf("%d %d %d", uidInImage, gidDefinedInImage, supplementalGroup)
-			expectedContainerUser := &v1.ContainerUser{
-				Linux: &v1.LinuxContainerUser{
-					UID:                uidInImage,
-					GID:                uidInImage,
-					SupplementalGroups: []int64{uidInImage, gidDefinedInImage, supplementalGroup},
-				},
-			}
-
-			if featureSupportedOnNode {
-				framework.ExpectNoError(waitForContainerUser(ctx, f, podName, containerName, expectedContainerUser))
-			}
-			framework.ExpectNoError(waitForPodLogs(ctx, f, podName, containerName, expectedOutput+"\n"))
-
-			stdout := e2epod.ExecCommandInContainer(f, podName, containerName, "id", "-G")
-			gomega.Expect(stdout).To(gomega.Equal(expectedOutput))
-		}
-		expectStrictPolicyInEffect := func(ctx context.Context, f *framework.Framework, podName string, containerName string, featureSupportedOnNode bool) {
-			expectedOutput := fmt.Sprintf("%d %d", uidInImage, supplementalGroup)
-			expectedContainerUser := &v1.ContainerUser{
-				Linux: &v1.LinuxContainerUser{
-					UID:                uidInImage,
-					GID:                uidInImage,
-					SupplementalGroups: []int64{uidInImage, supplementalGroup},
-				},
-			}
-
-			if featureSupportedOnNode {
-				framework.ExpectNoError(waitForContainerUser(ctx, f, podName, containerName, expectedContainerUser))
-			}
-			framework.ExpectNoError(waitForPodLogs(ctx, f, podName, containerName, expectedOutput+"\n"))
-
-			stdout := e2epod.ExecCommandInContainer(f, podName, containerName, "id", "-G")
-			gomega.Expect(stdout).To(gomega.Equal(expectedOutput))
-		}
-		expectRejectionEventIssued := func(ctx context.Context, f *framework.Framework, pod *v1.Pod) {
-			framework.ExpectNoError(
-				framework.Gomega().Eventually(ctx,
-					framework.HandleRetry(framework.ListObjects(
-						f.ClientSet.CoreV1().Events(pod.Namespace).List,
-						metav1.ListOptions{
-							FieldSelector: fields.Set{
-								"type":                      core.EventTypeWarning,
-								"reason":                    lifecycle.SupplementalGroupsPolicyNotSupported,
-								"involvedObject.kind":       "Pod",
-								"involvedObject.apiVersion": v1.SchemeGroupVersion.String(),
-								"involvedObject.name":       pod.Name,
-								"involvedObject.uid":        string(pod.UID),
-							}.AsSelector().String(),
-						},
-					))).
-					WithTimeout(timeout).
-					Should(gcustom.MakeMatcher(func(eventList *v1.EventList) (bool, error) {
-						return len(eventList.Items) == 1, nil
-					})),
-			)
-		}
-
-		ginkgo.When("SupplementalGroupsPolicy was not set in PodSpec", func() {
-			ginkgo.When("if the container's primary UID belongs to some groups in the image", func() {
-				var pod *v1.Pod
-				ginkgo.BeforeEach(func(ctx context.Context) {
-					ginkgo.By("creating a pod", func() {
-						pod = e2epod.NewPodClient(f).CreateSync(ctx, mkPod(ptr.To(v1.SupplementalGroupsPolicyMerge)))
-					})
-				})
-				ginkgo.When("scheduled node does not support SupplementalGroupsPolicy", func() {
-					ginkgo.BeforeEach(func(ctx context.Context) {
-						// ensure the scheduled node does not support SupplementalGroupsPolicy
-						if supportsSupplementalGroupsPolicy(ctx, f, pod.Spec.NodeName) {
-							e2eskipper.Skipf("node does support SupplementalGroupsPolicy")
-						}
-					})
-					ginkgo.It("it should add SupplementalGroups to them [LinuxOnly]", func(ctx context.Context) {
-						expectMergePolicyInEffect(ctx, f, pod.Name, pod.Spec.Containers[0].Name, false)
-					})
-				})
-				ginkgo.When("scheduled node supports SupplementalGroupsPolicy", func() {
-					ginkgo.BeforeEach(func(ctx context.Context) {
-						// ensure the scheduled node does support SupplementalGroupsPolicy
-						if !supportsSupplementalGroupsPolicy(ctx, f, pod.Spec.NodeName) {
-							e2eskipper.Skipf("node does not support SupplementalGroupsPolicy")
-						}
-					})
-					ginkgo.It("it should add SupplementalGroups to them [LinuxOnly]", func(ctx context.Context) {
-						expectMergePolicyInEffect(ctx, f, pod.Name, pod.Spec.Containers[0].Name, true)
-					})
-				})
-			})
-		})
-		ginkgo.When("SupplementalGroupsPolicy was set to Merge in PodSpec", func() {
-			ginkgo.When("the container's primary UID belongs to some groups in the image", func() {
-				var pod *v1.Pod
-				ginkgo.BeforeEach(func(ctx context.Context) {
-					ginkgo.By("creating a pod", func() {
-						pod = e2epod.NewPodClient(f).CreateSync(ctx, mkPod(nil))
-					})
-				})
-				ginkgo.When("scheduled node does not support SupplementalGroupsPolicy", func() {
-					ginkgo.BeforeEach(func(ctx context.Context) {
-						// ensure the scheduled node does not support SupplementalGroupsPolicy
-						if supportsSupplementalGroupsPolicy(ctx, f, pod.Spec.NodeName) {
-							e2eskipper.Skipf("node does support SupplementalGroupsPolicy")
-						}
-					})
-					ginkgo.It("it should add SupplementalGroups to them [LinuxOnly]", func(ctx context.Context) {
-						expectMergePolicyInEffect(ctx, f, pod.Name, pod.Spec.Containers[0].Name, false)
-					})
-				})
-				ginkgo.When("scheduled node supports SupplementalGroupsPolicy", func() {
-					ginkgo.BeforeEach(func(ctx context.Context) {
-						// ensure the scheduled node does support SupplementalGroupsPolicy
-						if !supportsSupplementalGroupsPolicy(ctx, f, pod.Spec.NodeName) {
-							e2eskipper.Skipf("node does not support SupplementalGroupsPolicy")
-						}
-					})
-					ginkgo.It("it should add SupplementalGroups to them [LinuxOnly]", func(ctx context.Context) {
-						expectMergePolicyInEffect(ctx, f, pod.Name, pod.Spec.Containers[0].Name, true)
-					})
-				})
-			})
-		})
-		ginkgo.When("SupplementalGroupsPolicy was set to Strict in PodSpec", func() {
-			ginkgo.When("the container's primary UID belongs to some groups in the image", func() {
-				var pod *v1.Pod
-				ginkgo.BeforeEach(func(ctx context.Context) {
-					ginkgo.By("creating a pod", func() {
-						pod = e2epod.NewPodClient(f).Create(ctx, mkPod(ptr.To(v1.SupplementalGroupsPolicyStrict)))
-						framework.ExpectNoError(e2epod.WaitForPodScheduled(ctx, f.ClientSet, pod.Namespace, pod.Name))
-						var err error
-						pod, err = e2epod.NewPodClient(f).Get(ctx, pod.Name, metav1.GetOptions{})
-						framework.ExpectNoError(err)
-					})
-				})
-				ginkgo.When("scheduled node does not support SupplementalGroupsPolicy", func() {
-					ginkgo.BeforeEach(func(ctx context.Context) {
-						// ensure the scheduled node does not support SupplementalGroupsPolicy
-						if supportsSupplementalGroupsPolicy(ctx, f, pod.Spec.NodeName) {
-							e2eskipper.Skipf("node does support SupplementalGroupsPolicy")
-						}
-					})
-					ginkgo.It("it reject the pod [LinuxOnly]", func(ctx context.Context) {
-						expectRejectionEventIssued(ctx, f, pod)
-					})
-				})
-				ginkgo.When("scheduled node supports SupplementalGroupsPolicy", func() {
-					ginkgo.BeforeEach(func(ctx context.Context) {
-						// ensure the scheduled node does support SupplementalGroupsPolicy
-						if !supportsSupplementalGroupsPolicy(ctx, f, pod.Spec.NodeName) {
-							e2eskipper.Skipf("node does not support SupplementalGroupsPolicy")
-						}
-						framework.ExpectNoError(e2epod.WaitForPodRunningInNamespace(ctx, f.ClientSet, pod))
-					})
-					ginkgo.It("it should Not add SupplementalGroups to them [LinuxOnly]", func(ctx context.Context) {
-						expectStrictPolicyInEffect(ctx, f, pod.Name, pod.Spec.Containers[0].Name, true)
-					})
-				})
-			})
 		})
 	})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Promote https://github.com/kubernetes/enhancements/issues/3619 to Beta

- Beta feature gate was added to versioned feature gates.
- From Beta release, kubelet now rejects the pods with `SupplementalGroupsPolicy=Strict` when the scheduled node does not support the feature(by detecting `Node.Status.Features.SupplementalGroupsPolicy`), implemented in `predicateAdmitHandler` (ref: [KEP-3619 - Version Skew Strategy](https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/3619-supplemental-groups-policy#version-skew-strategy)).
- E2E was updated to check the admission rejection event issued when a pod with `SupplementalGroupsPolicy=Strict` is scheduled to a node that does not support the feature. (and the tests are moved from `/test/e2e/node/security_context.go` to `/test/e2e/common/node/security_context.go` because [`/test/e2e/node` discourages to add new tests anymore](https://github.com/kubernetes/kubernetes/blob/master/test/e2e/node/README.md).

#### Special notes for your reviewer:

This feature depends on CRI runtime support. Thus, this PR performs optional E2E tests on both CRI runtimes that supports/does not support the feature.

- SupplementalGroupsPolicy supported:
  - [pull-kubernetes-node-e2e-containerd-features](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/130210/pull-kubernetes-node-e2e-containerd-features/1900451670593114112) (containerd main)
  - _In the test result page, please open passed test cases(accordion) and search with '[Feature:SupplementalGroupsPolicy]'_
  - (invoked manually [here](https://github.com/kubernetes/kubernetes/pull/130210#issuecomment-2723874992) because [pull-kubernetes-e2e-kind-alpha-beta-features](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/130210/pull-kubernetes-e2e-kind-alpha-beta-features/1900451622757076992) does skip my test cases currently)
- SupplementalGroupsPolicy not supported:
  - No such job has been paved yet. So, I ran E2E locally manually with containerd v1.7. [Here is the result](https://gist.github.com/everpeace/3683f0c8cf6726a4c98f257ad0a27a46#file-e2e-test-on-containerd-v1-7-md)



#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
KEP-3619: fined-grained supplemental groups policy is graduated to Beta. Note that kubelet now rejects pods with `.spec.securityContext.supplementalGroupsPolicy: Strict` when scheduled to the node that does not support the feature (`.status.features.supplementalGroupsPolicy: false`).
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/3619-supplemental-groups-policy
```
