### PR TITLE
Add more logs in the certificate manager

### DIFF
--- a/staging/src/k8s.io/client-go/util/certificate/certificate_manager.go
+++ b/staging/src/k8s.io/client-go/util/certificate/certificate_manager.go
@@ -448,6 +448,7 @@ func (m *manager) run() {
 
 		// Don't enter rotateCerts and trigger backoff if we don't even have a template to request yet
 		if m.getTemplate() == nil {
+			logger.V(4).Info("No certificate template available")
 			return
 		}
 
@@ -470,6 +471,7 @@ func (m *manager) run() {
 	}()
 
 	if m.dynamicTemplate {
+		logger.V(4).Info("Using dynamic template")
 		template := func(ctx context.Context) {
 			// check if the current template matches what we last requested
 			lastRequestCancel, lastRequestTemplate := m.getLastRequest()
@@ -478,6 +480,7 @@ func (m *manager) run() {
 				// if the template is different, queue up an interrupt of the rotation deadline loop.
 				// if we've requested a CSR that matches the new template by the time the interrupt is handled, the interrupt is disregarded.
 				if lastRequestCancel != nil {
+					logger.V(2).Info("Canceling old CSR that no longer matches the template")
 					// if we're currently waiting on a submitted request that no longer matches what we want, stop waiting
 					lastRequestCancel()
 				}
@@ -617,6 +620,7 @@ func (m *manager) rotateCerts(ctx context.Context) (bool, error) {
 		return false, nil
 	}
 
+	logger.V(4).Info("Storing the new cert/key pair")
 	cert, err := m.certStore.Update(crtPEM, keyPEM)
 	if err != nil {
 		utilruntime.HandleErrorWithContext(ctx, err, "Unable to store the new cert/key pair")

--- a/staging/src/k8s.io/client-go/util/certificate/csr/csr.go
+++ b/staging/src/k8s.io/client-go/util/certificate/csr/csr.go
@@ -78,13 +78,14 @@ func RequestCertificateWithContext(ctx context.Context, client clientset.Interfa
 		csr.Spec.ExpirationSeconds = DurationToExpirationSeconds(*requestedDuration)
 	}
 
+	logger := klog.FromContext(ctx)
+	logger.V(4).Info("creating csr")
 	reqName, reqUID, err = create(ctx, client, csr)
 	switch {
 	case err == nil:
 		return reqName, reqUID, err
 
 	case apierrors.IsAlreadyExists(err) && len(name) > 0:
-		logger := klog.FromContext(ctx)
 		logger.Info("csr for this node already exists, reusing")
 		req, err := get(ctx, client, name)
 		if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This is to make it easier to debug issues with CSRs and certificate management in general.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
Related to https://github.com/kubernetes/kubernetes/issues/130001

#### Special notes for your reviewer:

Note that the certificate manager defaults to [V(2) verbosity](https://github.com/kubernetes/kubernetes/blob/87fcae2bc765e4f752bcf7dfbd0c57f75ec751a3/staging/src/k8s.io/client-go/util/certificate/certificate_manager.go#L356) so these logs would not show up with the default kubelet verbosity == 0.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
