### PR TITLE
Add more log information to help debug flake #129779

### DIFF
--- a/test/e2e/apps/deployment.go
+++ b/test/e2e/apps/deployment.go
@@ -419,7 +419,7 @@ var _ = SIGDescribe("Deployment", func() {
 					return found, nil
 				}
 			default:
-				framework.Logf("observed event type %v", event.Type)
+				framework.Logf("observed event type %#v", event)
 			}
 			return false, nil
 		})

--- a/test/e2e/apps/replica_set.go
+++ b/test/e2e/apps/replica_set.go
@@ -547,6 +547,8 @@ func testRSLifeCycle(ctx context.Context, f *framework.Framework) {
 				framework.Logf("observed Replicaset %v in namespace %v with ReadyReplicas %v found %v", rset.ObjectMeta.Name, rset.ObjectMeta.Namespace, rset.Status.ReadyReplicas, found)
 			}
 			return found, nil
+		} else {
+			framework.Logf("observed event type %#v", event)
 		}
 		return false, nil
 	})


### PR DESCRIPTION
#### What type of PR is this?
/kind flake
/sig apps
/sig testing

#### What this PR does / why we need it:
I'm seeing frequent problems where watch fails before starting, like so:
```
STEP: patching the ReplicaSet - k8s.io/kubernetes/test/e2e/apps/replica_set.go:509 @ 02/11/25 17:45:46.07
I0211 17:45:46.208432 11179 replica_set.go:552] Unexpected error: failed to see replicas of test-rs in namespace replicaset-9691 scale to requested amount of 3: 
    <*errors.errorString | 0x723cc30>: 
    watch closed before UntilWithoutRetry timeout
    {
        s: "watch closed before UntilWithoutRetry timeout",
    }
[FAILED] failed to see replicas of test-rs in namespace replicaset-9691 scale to requested amount of 3: watch closed before UntilWithoutRetry timeout
```
this is while investigating https://github.com/kubernetes/kubernetes/issues/129779 but I've noticed that this is also happening in [the deployment test](https://storage.googleapis.com/k8s-triage/index.html?text=watch%20closed%20before%20UntilWithoutRetry%20timeout). So I'm adding a bit more info about the watch event, which hopefully allow me to dig through to the root cause. 

#### Which issue(s) this PR fixes:
Related to https://github.com/kubernetes/kubernetes/issues/129779

#### Special notes for your reviewer:
/assign @aojea 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

