### PR TITLE
kubectl debug: truncate node debugger pod name to avoid length limit

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go
@@ -678,7 +678,13 @@ func (o *DebugOptions) generateNodeDebugPod(node *corev1.Node) (*corev1.Pod, err
 	// The name of the debugging pod is based on the target node, and it's not configurable to
 	// limit the number of command line flags. There may be a collision on the name, but this
 	// should be rare enough that it's not worth the API round trip to check.
-	pn := fmt.Sprintf("node-debugger-%s-%s", node.Name, nameSuffixFunc(5))
+	// The node name is truncated to 43 characters to avoid exceeding the 63 character limit for pod names.
+	const maxNodeNameLength = 43
+	nodeName := node.Name
+	if len(nodeName) > maxNodeNameLength {
+		nodeName = nodeName[:maxNodeNameLength]
+	}
+	pn := fmt.Sprintf("node-debugger-%s-%s", nodeName, nameSuffixFunc(5))
 	if !o.Quiet {
 		fmt.Fprintf(o.Out, "Creating debugging pod %s with container %s on node %s.\n", pn, cn, node.Name)
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug_test.go
@@ -1457,7 +1457,7 @@ func TestGenerateNodeDebugPod(t *testing.T) {
 			name: "minimum options",
 			node: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "node-XXX",
+					Name: "node-name-max-length-is-44-characters-the-rest-will-be-truncated",
 				},
 			},
 			opts: &DebugOptions{
@@ -1467,7 +1467,7 @@ func TestGenerateNodeDebugPod(t *testing.T) {
 			},
 			expected: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "node-debugger-node-XXX-1",
+					Name: "node-debugger-node-name-max-length-is-44-characters-the-r-1",
 				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
@@ -1487,7 +1487,7 @@ func TestGenerateNodeDebugPod(t *testing.T) {
 					HostIPC:       true,
 					HostNetwork:   true,
 					HostPID:       true,
-					NodeName:      "node-XXX",
+					NodeName:      "node-name-max-length-is-44-characters-the-rest-will-be-truncated",
 					RestartPolicy: corev1.RestartPolicyNever,
 					Volumes: []corev1.Volume{
 						{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:

The node debugger pod name is constructed as "node-debugger-{nodename}-{suffix}".
When the node name is too long, the final pod name may exceed the 63-character
limit imposed by Kubernetes naming conventions.

Add a 44-character limit to the node name portion to ensure the full pod name
stays within the limit:
- "node-debugger-" prefix: 14 chars
- node name: max 43 chars
- "-{suffix}": 6 chars (including the hyphen)
Total: 63 chars maximum

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
N/A
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
N/A
```
