### PR TITLE
Update kubectl subresource to stable

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
@@ -539,7 +539,7 @@ func AddPruningFlags(cmd *cobra.Command, prune *bool, pruneAllowlist *[]string, 
 }
 
 func AddSubresourceFlags(cmd *cobra.Command, subresource *string, usage string) {
-	cmd.Flags().StringVar(subresource, "subresource", "", fmt.Sprintf("%s This flag is beta and may change in the future.", usage))
+	cmd.Flags().StringVar(subresource, "subresource", "", usage)
 	CheckErr(cmd.RegisterFlagCompletionFunc("subresource", func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
 		var commonSubresources = []string{"status", "scale", "resize"}
 		return commonSubresources, cobra.ShellCompDirectiveNoFileComp


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/sig cli

#### What this PR does / why we need it:
Promotes `--subresource` flag to stable. 

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
/assign @ardaguclu 

#### Does this PR introduce a user-facing change?
```release-note
Promotes kubectl --subresource flag to stable.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/2590

```
