### PR TITLE
Revert userns kernel check

### DIFF
--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -138,8 +138,9 @@ func (kl *Kubelet) getKubeletMappings() (uint32, uint32, error) {
 				features.UserNamespacesSupport, err)
 		}
 		if kernelVersion != nil && !kernelVersion.AtLeast(version.MustParseGeneric(utilkernel.UserNamespacesSupportKernelVersion)) {
-			klog.InfoS("WARNING: the kernel version is incompatible with the feature gate, which needs as a minimum kernel version",
-				"kernelVersion", kernelVersion, "feature", features.UserNamespacesSupport, "minKernelVersion", utilkernel.UserNamespacesSupportKernelVersion)
+			return 0, 0, fmt.Errorf(
+				"the kernel version (%s) is incompatible with the %s feature gate, which needs %s as a minimum kernel version",
+				kernelVersion, features.UserNamespacesSupport, utilkernel.UserNamespacesSupportKernelVersion)
 		}
 	}
 

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -40,7 +40,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	utilvalidation "k8s.io/apimachinery/pkg/util/validation"
-	"k8s.io/apimachinery/pkg/util/version"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/klog/v2"
@@ -62,7 +61,6 @@ import (
 	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
 	"k8s.io/kubernetes/pkg/kubelet/util/format"
 	utilfs "k8s.io/kubernetes/pkg/util/filesystem"
-	utilkernel "k8s.io/kubernetes/pkg/util/kernel"
 	utilpod "k8s.io/kubernetes/pkg/util/pod"
 	volumeutil "k8s.io/kubernetes/pkg/volume/util"
 	"k8s.io/kubernetes/pkg/volume/util/hostutil"
@@ -131,17 +129,6 @@ func (kl *Kubelet) getKubeletMappings() (uint32, uint32, error) {
 
 	if !utilfeature.DefaultFeatureGate.Enabled(features.UserNamespacesSupport) {
 		return defaultFirstID, defaultLen, nil
-	} else {
-		kernelVersion, err := utilkernel.GetVersion()
-		if err != nil {
-			return 0, 0, fmt.Errorf("failed to get kernel version, unable to determine if feature %s can be supported : %w",
-				features.UserNamespacesSupport, err)
-		}
-		if kernelVersion != nil && !kernelVersion.AtLeast(version.MustParseGeneric(utilkernel.UserNamespacesSupportKernelVersion)) {
-			return 0, 0, fmt.Errorf(
-				"the kernel version (%s) is incompatible with the %s feature gate, which needs %s as a minimum kernel version",
-				kernelVersion, features.UserNamespacesSupport, utilkernel.UserNamespacesSupportKernelVersion)
-		}
 	}
 
 	_, err := user.Lookup(kubeletUser)

--- a/pkg/util/kernel/constants.go
+++ b/pkg/util/kernel/constants.go
@@ -44,10 +44,6 @@ const TCPFinTimeoutNamespacedKernelVersion = "4.6"
 // (ref: https://github.com/torvalds/linux/commit/35dfb013149f74c2be1ff9c78f14e6a3cd1539d1)
 const IPVSConnReuseModeFixedKernelVersion = "5.9"
 
-// UserNamespacesSupportKernelVersion is the kernel version where idmap for tmpfs support was added
-// (ref: https://github.com/torvalds/linux/commit/05e6295f7b5e05f09e369a3eb2882ec5b40fff20)
-const UserNamespacesSupportKernelVersion = "6.3"
-
 const TmpfsNoswapSupportKernelVersion = "6.4"
 
 // NFTablesKubeProxyKernelVersion is the lowest kernel version kube-proxy supports using


### PR DESCRIPTION
Here is the commit description of the second commit in this PR, that explains why I want to revert.

@dims let me know if I'm missing something, if there was a clear bug that motivated your PR or some context that I might be lacking. As I say here and in the PR you did adding the kernel check, we are _already_ returning a clear error to users when they want to use the feature and the kernel lacks the support we need to do it.

cc @giuseppe @haircommander @mrunalp 

---

This reverts commit 8597b343fa49dcb491282eaa5e5887221a985905.
    
I wrote in the Kubernetes documentation:
    
In practice this means you need at least Linux 6.3, as tmpfs started
supporting idmap mounts in that version. This is usually needed as
several Kubernetes features use tmpfs (the service account token that is
mounted by default uses a tmpfs, Secrets use a tmpfs, etc.)
    
The check is wrong for several reasons:
  * Pods can use userns before 6.3, they will just need to be
     careful to not use a tmpfs (like a serviceaccount). MOST users
     will probably need 6.3, but it is possible to use earlier kernel
     versions. 5.19 probably works fine and with improvements in
     the runtime 5.12 can probably be supported too.
  * Several distros backport changes and the recommended way is
     usually to try the syscall instead of testing kernel versions.
     I expect support for simple fs like tmpfs will be backported
     in several distros, but with this check it can generate confusion.
  * Today a clear error is shown when the pod is created, so it's
     unlikely a user will not understand why it fails.
   * Returning an error if utilkernel fails to understand what
      kernel version is running is also too strict (as we are
      logging a warning even if it is not the expected version)
   * We are switching to enabled by default, which will log a
      warning on every user that runs on an older than 6.3 kernel,
      adding noise to the logs.
    
For there reasons, let's just remove the hardcoded kernel version check.



<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it: This reverts this PR https://github.com/kubernetes/kubernetes/pull/124731 and https://github.com/kubernetes/kubernetes/pull/124835. Those checks are wrong and now that we are switching userns to be enabled by default, they will add confusing logs to the kubelet. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer: I'm reverting those two PRs because they seem wrong. I don't know if they tried to solve a real problem, but if they did, I think we have the means in place to return better errors when the action occurs. I don't see this improving the experience of users.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixes a regression in 1.31, removing a warning around Linux user namespaces and kernel version. If the feature gate `UserNamespacesSupport` was enabled, the kubelet previously warned when detecting a Linux kernel version earlier than 6.3.0. User namespace support on Linux typically does still need kernel 6.3 or newer, but it can work in older kernels too.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/127-user-namespaces/README.md
- [Usage]: https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/. Here I explained already why 6.3 _might_ be what most users need, but it is definitely not a requirement and older kernels can work just fine.
```
