### PR TITLE
Fix concurrent map iteration and write panic

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/audit/context.go
+++ b/staging/src/k8s.io/apiserver/pkg/audit/context.go
@@ -186,3 +186,10 @@ func GetAuditIDTruncated(ctx context.Context) string {
 
 	return string(auditID)
 }
+
+func DeepcopyAuditContextEvent(ac *AuditContext) *auditinternal.Event {
+	ac.annotationMutex.Lock()
+	defer ac.annotationMutex.Unlock()
+
+	return ac.Event.DeepCopy()
+}


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

It's a minimal fix for concurrent map iteration and write panic. 

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/kubernetes/issues/120507

#### Special notes for your reviewer:
**The General Idea**:
- Based on the apiserver panic logs, a data race is occurring at audit/log.(*backend).logEvent, with other goroutines modifying the audit event annotations. Instead of identifying the exact source of the data race (which could be difficult and involve multiple points), I focused on isolating logEvent to minimize its scope and prevent data races with other goroutines.

This PR can be used as a reference for simple fix until there are more detailed fixes and merges in the upstream.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
Trace[279947743]: [14.535217631s] [14.535217631s] END
fatal error: concurrent map iteration and map write
goroutine 13083278 [running]:
runtime.throw({0x4bef5ff?, 0x80?})
	/usr/local/go/src/runtime/panic.go:992 +0x71 fp=0xc6ae9f2ae8 sp=0xc6ae9f2ab8 pc=0x4362d1
runtime.mapiternext(0x40d847?)
	/usr/local/go/src/runtime/map.go:871 +0x4eb fp=0xc6ae9f2b58 sp=0xc6ae9f2ae8 pc=0x40ff6b
runtime.mapiterinit(0xc6ae9f2bc0?, 0x4d6849?, 0x0?)
	/usr/local/go/src/runtime/map.go:861 +0x228 fp=0xc6ae9f2b78 sp=0xc6ae9f2b58 pc=0x40fa28
reflect.mapiterinit(0x195?, 0x200?, 0x41ab300?)
	/usr/local/go/src/runtime/map.go:1373 +0x19 fp=0xc6ae9f2ba0 sp=0xc6ae9f2b78 pc=0x462c99
reflect.(*MapIter).Next(0x41ab300?)
	/usr/local/go/src/reflect/value.go:1782 +0x65 fp=0xc6ae9f2bd0 sp=0xc6ae9f2ba0 pc=0x4d6625
encoding/json.mapEncoder.encode({0xc6ae9f2dc0?}, 0xcad5300c00, {0x41ab300?, 0xc90f168270?, 0xc90f1681b0?}, {0xe?, 0x0?})
	/usr/local/go/src/encoding/json/encode.go:799 +0x2d4 fp=0xc6ae9f2d90 sp=0xc6ae9f2bd0 pc=0x6dddb4
encoding/json.mapEncoder.encode-fm(0x41ab300?, {0x41ab300?, 0xc90f168270?, 0x5?}, {0x72?, 0xa6?})
	/usr/local/go/src/encoding/json/encode.go:779 +0x45 fp=0xc6ae9f2dd0 sp=0xc6ae9f2d90 pc=0x6e8765
encoding/json.structEncoder.encode({{{0xc01eb07900?, 0x4041f4?, 0xc6ae9f31e0?}, 0xc088753dd0?}}, 0xcad5300c00, {0x4a81aa0?, 0xc90f168140?, 0xc?}, {0x0, 0x1})
	/usr/local/go/src/encoding/json/encode.go:761 +0x1f4 fp=0xc6ae9f2e80 sp=0xc6ae9f2dd0 pc=0x6dd834
encoding/json.structEncoder.encode-fm(0x4a2a480?, {0x4a81aa0?, 0xc90f168140?, 0xc6ae9f2f60?}, {0xf7?, 0x19?})
	/usr/local/go/src/encoding/json/encode.go:732 +0x69 fp=0xc6ae9f2ed8 sp=0xc6ae9f2e80 pc=0x6e86a9
encoding/json.ptrEncoder.encode({0x4a81aa0?}, 0xcad5300c00, {0x4a2a480?, 0xc90f168140?, 0x4a2a480?}, {0x0?, 0x0?})
	/usr/local/go/src/encoding/json/encode.go:945 +0x25e fp=0xc6ae9f2fa8 sp=0xc6ae9f2ed8 pc=0x6df4be
encoding/json.ptrEncoder.encode-fm(0x4a2a480?, {0x4a2a480?, 0xc90f168140?, 0xc841656630?}, {0x16?, 0x0?})
	/usr/local/go/src/encoding/json/encode.go:930 +0x45 fp=0xc6ae9f2fe8 sp=0xc6ae9f2fa8 pc=0x6e8c45
encoding/json.(*encodeState).reflectValue(0xc6ae9f3080?, {0x4a2a480?, 0xc90f168140?, 0x6db4ec?}, {0x40?, 0x46?})
	/usr/local/go/src/encoding/json/encode.go:360 +0x78 fp=0xc6ae9f3048 sp=0xc6ae9f2fe8 pc=0x6db3b8
encoding/json.(*encodeState).marshal(0x4b7a672?, {0x4a2a480?, 0xc90f168140?}, {0x2?, 0x0?})
	/usr/local/go/src/encoding/json/encode.go:332 +0xfa fp=0xc6ae9f30c0 sp=0xc6ae9f3048 pc=0x6daffa
encoding/json.(*Encoder).Encode(0xc6ae9f3170, {0x4a2a480, 0xc90f168140})
	/usr/local/go/src/encoding/json/stream.go:206 +0x7e fp=0xc6ae9f3140 sp=0xc6ae9f30c0 pc=0x6e705e
k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/runtime/serializer/json.(*Serializer).doEncode(0x3aee9fb?, {0x53cf4e8?, 0xc90f168140?}, {0x53b8e60, 0xc911145290})
	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/runtime/serializer/json/json.go:233 +0x19a fp=0xc6ae9f31d0 sp=0xc6ae9f3140 pc=0xdbbefa
k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/runtime/serializer/json.(*Serializer).Encode(0xc000324870, {0x53cf4e8, 0xc90f168140}, {0x53b8e60, 0xc911145290})
	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/runtime/serializer/json/json.go:207 +0xfc fp=0xc6ae9f3230 sp=0xc6ae9f31d0 pc=0xdbbcfc
k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/runtime/serializer/versioning.(*codec).doEncode(0xc000ee14a0, {0x53cf448?, 0xc8af3d7e00}, {0x53b8e60, 0xc911145290})
	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/runtime/serializer/versioning/versioning.go:251 +0x8fa fp=0xc6ae9f3588 sp=0xc6ae9f3230 pc=0xdc103a
k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/runtime/serializer/versioning.(*codec).Encode(0xc000ee14a0, {0x53cf448, 0xc8af3d7e00}, {0x53b8e60, 0xc911145290})
	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/runtime/serializer/versioning/versioning.go:191 +0x106 fp=0xc6ae9f35e8 sp=0xc6ae9f3588 pc=0xdc06e6
k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/runtime.Encode({0x7f8fa3dc1740, 0xc000ee14a0}, {0x53cf448, 0xc8af3d7e00})
	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/runtime/codec.go:50 +0x64 fp=0xc6ae9f3628 sp=0xc6ae9f35e8 pc=0x914424
k8s.io/kubernetes/vendor/k8s.io/apiserver/plugin/pkg/audit/log.(*backend).logEvent(0xc000ef7080, 0xc8af3d7e00)
	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/plugin/pkg/audit/log/backend.go:76 +0x73 fp=0xc6ae9f36b8 sp=0xc6ae9f3628 pc=0x1aa5773
k8s.io/kubernetes/vendor/k8s.io/apiserver/plugin/pkg/audit/log.(*backend).ProcessEvents(0x40d847?, {0xdd6447d438, 0x1, 0x48b501?})
	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/plugin/pkg/audit/log/backend.go:65 +0x45 fp=0xc6ae9f36f0 sp=0xc6ae9f36b8 pc=0x1aa5685
k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/options.(*ignoreErrorsBackend).ProcessEvents(0xc38f8bf800?, {0xdd6447d438?, 0x40d847?, 0x98?})
	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/options/audit.go:398 +0x26 fp=0xc6ae9f3720 sp=0xc6ae9f36f0 pc=0x1ae01a6
k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/filters.processAuditEvent({0xc6ae9f3820?, 0x176a2e5?}, {0x7f8fa3dd1298, 0xc0006fe4f0}, 0xc8af3d7e00, {0xc0006fe480?, 0x1?, 0x7c4b780?})
	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/filters/audit.go:170 +0x154 fp=0xc6ae9f3760 sp=0xc6ae9f3720 pc=0x1770094
k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/filters.WithAudit.func1.1()
	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/filters/audit.go:115 +0x3f3 fp=0xc6ae9f3858 sp=0xc6ae9f3760 pc=0x176fb33
k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/filters.WithAudit.func1({0x53e7998?, 0xc38f8bee00}, 0xcd48c7b200)
	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/filters/audit.go:118 +0x705 fp=0xc6ae9f39e8 sp=0xc6ae9f3858 pc=0x176f585
net/http.HandlerFunc.ServeHTTP(0x496e60?, {0x53e7998?, 0xc38f8bee00?}, 0xa?)
	/usr/local/go/src/net/http/server.go:2084 +0x2f fp=0xc6ae9f3a10 sp=0xc6ae9f39e8 pc=0x842bef
k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/filterlatency.trackStarted.func1({0x53e7998, 0xc38f8bee00}, 0xcd48c7b200)
	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/filterlatency/filterlatency.go:80 +0x178 fp=0xc6ae9f3ad8 sp=0xc6ae9f3a10 pc=0x1769cd8
net/http.HandlerFunc.ServeHTTP(0xd0796d3860?, {0x53e7998?, 0xc38f8bee00?}, 0x9dfd6a?)
	/usr/local/go/src/net/http/server.go:2084 +0x2f fp=0xc6ae9f3b00 sp=0xc6ae9f3ad8 pc=0x842bef
k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/filterlatency.trackCompleted.func1.1()
	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/filterlatency/filterlatency.go:98 +0x37 fp=0xc6ae9f3b30 sp=0xc6ae9f3b00 pc=0x176a377
k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/filterlatency.trackCompleted.func1({0x53e7998, 0xc38f8bee00}, 0xcd48c7b200)
	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/filterlatency/filterlatency.go:104 +0x1a5 fp=0xc6ae9f3bf0 sp=0xc6ae9f3b30 pc=0x176a2e5
net/http.HandlerFunc.ServeHTTP(0x49a33e0?, {0x53e7998?, 0xc38f8bee00?}, 0x53a9a90?)
	/usr/local/go/src/net/http/server.go:2084 +0x2f fp=0xc6ae9f3c18 sp=0xc6ae9f3bf0 pc=0x842bef
k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/filters.withAuthentication.func1({0x53e7998, 0xc38f8bee00}, 0xcd48c7b200)
	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/filters/authentication.go:80 +0x899 fp=0xc6ae9f3e78 sp=0xc6ae9f3c18 pc=0x1771359
net/http.HandlerFunc.ServeHTTP(0x49a33e0?, {0x53e7998?, 0xc38f8bee00?}, 0x53a99c8?)
	/usr/local/go/src/net/http/server.go:2084 +0x2f fp=0xc6ae9f3ea0 sp=0

```
