### PR TITLE
Add retries to some netlink calls - without tests

### DIFF
--- a/pkg/proxy/util/nfacct/nfacct.go
+++ b/pkg/proxy/util/nfacct/nfacct.go
@@ -31,6 +31,6 @@ type Interface interface {
 	Add(name string) error
 	// Get retrieves the nfacct counter with the specified name, returning an error if it doesn't exist.
 	Get(name string) (*Counter, error)
-	// List retrieves all nfacct counters.
+	// List retrieves nfacct counters, it could receive all counters or a subset of them with an unix.EINTR error.
 	List() ([]*Counter, error)
 }

--- a/pkg/proxy/util/utils_linux.go
+++ b/pkg/proxy/util/utils_linux.go
@@ -1,0 +1,31 @@
+//go:build linux
+// +build linux
+
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"errors"
+
+	"golang.org/x/sys/unix"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+var MaxAttemptsEINTR = wait.Backoff{Steps: 5}
+var ShouldRetryOnEINTR = func(err error) bool { return errors.Is(err, unix.EINTR) }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind flake

#### What this PR does / why we need it:

Some netlink calls fail with partial results. These can be retried.

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/kubernetes/issues/129562

#### Special notes for your reviewer:

Same as https://github.com/kubernetes/kubernetes/pull/129704, but without tests.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix very rare and sporadic network issues when the host is under heavy load by adding retries for interrupted netlink calls
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
