### PR TITLE
fix typo: optimitically -> optimistically

### DIFF
--- a/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
@@ -339,7 +339,7 @@ func (le *LeaderElector) tryAcquireOrRenew(ctx context.Context) bool {
 			le.setObservedRecord(&leaderElectionRecord)
 			return true
 		}
-		klog.Errorf("Failed to update lock optimitically: %v, falling back to slow path", err)
+		klog.Errorf("Failed to update lock optimistically: %v, falling back to slow path", err)
 	}
 
 	// 2. obtain or create the ElectionRecord


### PR DESCRIPTION
This PR fixes a simple typo in a log message (missing "s" in "optimistically").



#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This fixes a simple typo in a (frequently occurring) log message.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

NONE
