### PR TITLE
Remove go-cmp in data_consistency_detector.go

### DIFF
--- a/staging/src/k8s.io/client-go/util/consistencydetector/data_consistency_detector.go
+++ b/staging/src/k8s.io/client-go/util/consistencydetector/data_consistency_detector.go
@@ -22,8 +22,7 @@ import (
 	"sort"
 	"time"
 
-	"github.com/google/go-cmp/cmp" //nolint:depguard
-
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -75,8 +74,8 @@ func CheckDataConsistency[T runtime.Object, U any](ctx context.Context, identity
 	sort.Sort(byUID(listItems))
 	sort.Sort(byUID(retrievedItems))
 
-	if !cmp.Equal(listItems, retrievedItems) {
-		klog.Infof("previously received data for %s is different than received by the standard list api call against etcd, diff: %v", identity, cmp.Diff(listItems, retrievedItems))
+	if !apiequality.Semantic.DeepEqual(listItems, retrievedItems) {
+		klog.Infof("previously received data for %s is different than received by the standard list api call against etcd, expected %+q but received %+q", identity, listItems, retrievedItems)
 		msg := fmt.Sprintf("data inconsistency detected for %s, panicking!", identity)
 		panic(msg)
 	}

--- a/staging/src/k8s.io/sample-cli-plugin/go.mod
+++ b/staging/src/k8s.io/sample-cli-plugin/go.mod
@@ -27,7 +27,6 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/gnostic-models v0.6.9 // indirect
-	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Remove two uses of https://github.com/google/go-cmp in `k8s.io/client-go/util/consistencydetector/data_consistency_detector.go`.

I'm trying to enable method dead code elimination in various binaries I work on, it happens that `go-cmp` uses `reflect.Type.Method` under the hood, which disables that dead code elimination (see https://github.com/google/go-cmp/issues/373 for more details), and the only reachable uses in my binary are those two in `data_consistency_detector.go`.

You are already trying to get rid of go-cmp (https://github.com/kubernetes/kubernetes/issues/104821), so this contribution helps with that.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Contributes to https://github.com/kubernetes/kubernetes/issues/104821.

#### Special notes for your reviewer:
I believe the comparison done by `reflect.DeepEqual` and `go-cmp/cmp.Equal` is mostly similar, except if the compared type defines an `Equal` method (doesn't seem to be the case here) or has unexported fields (go-cmp panics in that case).

The log will be more verbose (it prints both lists entirely), I considered that it was a very unexpected code path so it should not be much of an issue, but let me know if you think it should be changed somehow.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
