### PR TITLE
Fixing k8s.io/kubernetes/pkg/proxy/winkernel unit tests

### DIFF
--- a/pkg/proxy/winkernel/proxier_test.go
+++ b/pkg/proxy/winkernel/proxier_test.go
@@ -1201,6 +1201,7 @@ func TestEndpointSlice(t *testing.T) {
 
 func TestNoopEndpointSlice(t *testing.T) {
 	p := Proxier{}
+	p.endpointsChanges = proxy.NewEndpointsChangeTracker(v1.IPv4Protocol, "", nil, nil)
 	p.OnEndpointSliceAdd(&discovery.EndpointSlice{})
 	p.OnEndpointSliceUpdate(&discovery.EndpointSlice{}, &discovery.EndpointSlice{})
 	p.OnEndpointSliceDelete(&discovery.EndpointSlice{})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind failing-test
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation

/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This fixes the TestNoopEndpointSlice unit test for the winkernel proxier

The reason why this is needed is because EndpointSliceUpdate checks and logs the address type and this was causing a nil deference in the unit tests

https://github.com/kubernetes/kubernetes/blob/f0077a3689669018557de723a0416fda267d132f/pkg/proxy/endpointschangetracker.go#L82-L84

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of https://github.com/kubernetes/kubernetes/issues/130149

#### Special notes for your reviewer:

The test is currently failing with

```
{Failed  === RUN   TestNoopEndpointSlice
--- FAIL: TestNoopEndpointSlice (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xc0000005 code=0x0 addr=0x10 pc=0x12e79cf]

goroutine 27 [running]:
testing.tRunner.func1.2({0x144e440, 0x24cf0e0})
	C:/Program Files/Go/src/testing/testing.go:1632 +0x225
testing.tRunner.func1()
	C:/Program Files/Go/src/testing/testing.go:1635 +0x359
panic({0x144e440?, 0x24cf0e0?})
	C:/Program Files/Go/src/runtime/panic.go:785 +0x132
k8s.io/kubernetes/pkg/proxy.(*EndpointsChangeTracker).EndpointSliceUpdate(0x0, 0xc000540dc0, 0x1?)
	C:/kubernetes/pkg/proxy/endpointschangetracker.go:82 +0x4f
k8s.io/kubernetes/pkg/proxy/winkernel.(*Proxier).OnEndpointSliceAdd(0xc000003380, 0xc00043bf28?)
	C:/kubernetes/pkg/proxy/winkernel/proxier.go:998 +0x25
k8s.io/kubernetes/pkg/proxy/winkernel.TestNoopEndpointSlice(0xc00053d520?)
	C:/kubernetes/pkg/proxy/winkernel/proxier_test.go:1204 +0x4d
testing.tRunner(0xc00053d520, 0x173afe8)
	C:/Program Files/Go/src/testing/testing.go:1690 +0xcb
created by testing.(*T).Run in goroutine 1
	C:/Program Files/Go/src/testing/testing.go:1743 +0x377
}
```

see https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-unit-windows-master/1892121218333544448


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/sig windows network