### PR TITLE
Fixing k8s.io/kubernetes/cmd/kubeadm/app/util/dryrun unit tests on Windows

### DIFF
--- a/cmd/kubeadm/app/util/dryrun/dryrun.go
+++ b/cmd/kubeadm/app/util/dryrun/dryrun.go
@@ -74,6 +74,7 @@ func PrintDryRunFiles(files []FileToPrint, w io.Writer) error {
 		if len(outputFilePath) == 0 {
 			outputFilePath = file.RealPath
 		}
+		outputFilePath = filepath.ToSlash(outputFilePath)
 
 		fmt.Fprintf(w, "[dryrun] Would write file %q with content:\n", outputFilePath)
 		fmt.Fprintf(w, "%s", fileBytes)

--- a/cmd/kubeadm/app/util/dryrun/dryrun_test.go
+++ b/cmd/kubeadm/app/util/dryrun/dryrun_test.go
@@ -36,7 +36,7 @@ func TestPrintDryRunFiles(t *testing.T) {
 	}()
 	fileContents := "apiVersion: kubeadm.k8s.io/unknownVersion"
 	filename := "testfile"
-	cfgPath := filepath.Join(tmpdir, filename)
+	cfgPath := filepath.ToSlash(filepath.Join(tmpdir, filename))
 	err = os.WriteFile(cfgPath, []byte(fileContents), 0644)
 	if err != nil {
 		t.Fatalf("Couldn't write context to file: %v", err)


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind failing-test

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation

/kind flake
/kind regression
-->

#### What this PR does / why we need it:

The TestPrintDryRunFiles unit test under k8s.io/kubernetes/cmd/kubeadm/app/util/dryrun currently fails when run on windows with

```
 dryrun_test.go:94: 
        output: "[dryrun] Would write file \"C:\\\\Users\\\\azureuser\\\\AppData\\\\Local\\\\Temp\\\\4270390652\\\\testfile\" with content:\napiVersion: kubeadm.k8s.io/unknownVersion"
        expected output: "[dryrun] Would write file \"C:\\Users\\azureuser\\AppData\\Local\\Temp\\4270390652\\testfile\" with content:\napiVersion: kubeadm.k8s.io/unknownVersion"
--- FAIL: TestPrintDryRunFiles/RealPath_is_a_readable_file (0.01s)
```

This PR cleans file paths by using `filepath.ToSlash` to make them consistent on Windows and Linux (and removes the escaped slashes when writing the io writer content to a string)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of https://github.com/kubernetes/kubernetes/issues/130149

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
/sig windows cluster-lifecycle
/milestone v1.33
/priority important-longterm
