### PR TITLE
Fixing k8s.io/kubernetes/cmd/kubeadm/app/util/staticpod unit tests on Windows

### DIFF
--- a/cmd/kubeadm/app/util/staticpod/utils_test.go
+++ b/cmd/kubeadm/app/util/staticpod/utils_test.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	goruntime "runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -695,6 +696,17 @@ func TestReadStaticPodFromDisk(t *testing.T) {
 	}
 }
 
+// getFileNotFoundForOS returns the expected error message for a file not found error on the current OS
+// - on Windows, the error message is "The system cannot find the file specified"
+// - on other, the error message is "no such file or directory"
+func getFileNotFoundForOS() string {
+	if goruntime.GOOS == "windows" {
+		return "The system cannot find the file specified"
+	} else {
+		return "no such file or directory"
+	}
+}
+
 func TestReadMultipleStaticPodsFromDisk(t *testing.T) {
 	getTestPod := func(name string) *v1.Pod {
 		return &v1.Pod{
@@ -738,9 +750,9 @@ func TestReadMultipleStaticPodsFromDisk(t *testing.T) {
 			setup:      func(dir string) {},
 			components: kubeadmconstants.ControlPlaneComponents,
 			expectedErrorContains: []string{
-				"kube-apiserver.yaml: no such file or directory",
-				"kube-controller-manager.yaml: no such file or directory",
-				"kube-scheduler.yaml: no such file or directory",
+				"kube-apiserver.yaml: " + getFileNotFoundForOS(),
+				"kube-controller-manager.yaml: " + getFileNotFoundForOS(),
+				"kube-scheduler.yaml: " + getFileNotFoundForOS(),
 			},
 		},
 	}


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind failing-test
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation

/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Unit tests for this package are currently failing when run on windows with

```
{Failed  === RUN   TestReadMultipleStaticPodsFromDisk/invalid:_all_pods_returned_errors
    utils_test.go:756: expected error to contain string: kube-apiserver.yaml: no such file or directory
        error:
        [failed to read manifest for "C:\\Users\\azureuser\\AppData\\Local\\Temp\\TestReadMultipleStaticPodsFromDiskinvalid_all_pods_returned_errors286758726\\001\\kube-apiserver.yaml": open C:\Users\azureuser\AppData\Local\Temp\TestReadMultipleStaticPodsFromDiskinvalid_all_pods_returned_errors286758726\001\kube-apiserver.yaml: The system cannot find the file specified., failed to read manifest for "C:\\Users\\azureuser\\AppData\\Local\\Temp\\TestReadMultipleStaticPodsFromDiskinvalid_all_pods_returned_errors286758726\\001\\kube-controller-manager.yaml": open C:\Users\azureuser\AppData\Local\Temp\TestReadMultipleStaticPodsFromDiskinvalid_all_pods_returned_errors286758726\001\kube-controller-manager.yaml: The system cannot find the file specified., failed to read manifest for "C:\\Users\\azureuser\\AppData\\Local\\Temp\\TestReadMultipleStaticPodsFromDiskinvalid_all_pods_returned_errors286758726\\001\\kube-scheduler.yaml": open C:\Users\azureuser\AppData\Local\Temp\TestReadMultipleStaticPodsFromDiskinvalid_all_pods_returned_errors286758726\001\kube-scheduler.yaml: The system cannot find the file specified.]
--- FAIL: TestReadMultipleStaticPodsFromDisk/invalid:_all_pods_returned_errors (0.16s)
}
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of https://github.com/kubernetes/kubernetes/issues/130149

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/sig windows cluster-lifecycle
/milestone v1.33
/priority important-longterm