### PR TITLE
KEP-4540: strict-cpu-reservation beta

### DIFF
--- a/pkg/kubelet/cm/cpumanager/policy_options.go
+++ b/pkg/kubelet/cm/cpumanager/policy_options.go
@@ -42,11 +42,11 @@ var (
 		DistributeCPUsAcrossNUMAOption,
 		AlignBySocketOption,
 		DistributeCPUsAcrossCoresOption,
-		StrictCPUReservationOption,
 		PreferAlignByUnCoreCacheOption,
 	)
 	betaOptions = sets.New[string](
 		FullPCPUsOnlyOption,
+		StrictCPUReservationOption,
 	)
 	stableOptions = sets.New[string]()
 )

--- a/pkg/kubelet/cm/cpumanager/policy_options_test.go
+++ b/pkg/kubelet/cm/cpumanager/policy_options_test.go
@@ -120,15 +120,15 @@ func TestPolicyOptionsAvailable(t *testing.T) {
 		},
 		{
 			option:            StrictCPUReservationOption,
-			featureGate:       pkgfeatures.CPUManagerPolicyAlphaOptions,
-			featureGateEnable: true,
-			expectedAvailable: true,
+			featureGate:       pkgfeatures.CPUManagerPolicyBetaOptions,
+			featureGateEnable: false,
+			expectedAvailable: false,
 		},
 		{
 			option:            StrictCPUReservationOption,
 			featureGate:       pkgfeatures.CPUManagerPolicyBetaOptions,
 			featureGateEnable: true,
-			expectedAvailable: false,
+			expectedAvailable: true,
 		},
 	}
 	for _, testCase := range testCases {

--- a/pkg/kubelet/cm/cpumanager/policy_static_test.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static_test.go
@@ -170,7 +170,6 @@ func TestStaticPolicyStart(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.description, func(t *testing.T) {
-			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.CPUManagerPolicyAlphaOptions, true)
 			p, err := NewStaticPolicy(testCase.topo, testCase.numReservedCPUs, cpuset.New(), topologymanager.NewFakeManager(), testCase.options)
 			if err != nil {
 				t.Fatalf("NewStaticPolicy() failed: %v", err)
@@ -1050,7 +1049,6 @@ func TestStaticPolicyStartWithResvList(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.description, func(t *testing.T) {
-			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.CPUManagerPolicyAlphaOptions, true)
 			p, err := NewStaticPolicy(testCase.topo, testCase.numReservedCPUs, testCase.reserved, topologymanager.NewFakeManager(), testCase.cpuPolicyOptions)
 			if !reflect.DeepEqual(err, testCase.expNewErr) {
 				t.Errorf("StaticPolicy Start() error (%v). expected error: %v but got: %v",

--- a/test/e2e_node/topology_manager_test.go
+++ b/test/e2e_node/topology_manager_test.go
@@ -19,6 +19,7 @@ package e2enode
 import (
 	"context"
 	"fmt"
+	"k8s.io/utils/cpuset"
 	"os"
 	"os/exec"
 	"regexp"
@@ -446,10 +447,10 @@ func runTopologyManagerPolicySuiteTests(ctx context.Context, f *framework.Framew
 	}
 
 	ginkgo.By("running a non-Gu pod")
-	runNonGuPodTest(ctx, f, cpuCap)
+	runNonGuPodTest(ctx, f, cpuCap, cpuset.New())
 
 	ginkgo.By("running a Gu pod")
-	runGuPodTest(ctx, f, 1)
+	runGuPodTest(ctx, f, 1, cpuset.New())
 
 	// Skip rest of the tests if CPU allocatable < 3.
 	if cpuAlloc < 3 {


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/sig node

#### What this PR does / why we need it:
This PR adds e2e tests for https://github.com/kubernetes/enhancements/pull/4541 and moves corresponding option to beta feature gate.

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/enhancements/issues/4540

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Added a new option `strict-cpu-reservation` for CPU Manager static policy. When this option is enabled, CPU cores in `reservedSystemCPUs` will be strictly used for system daemons and interrupt processing no longer available for any workload.
``` 

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```
- [KEP]: https://github.com/kubernetes/enhancements/pull/4541
- [Usage]: https://github.com/kubernetes/website/pull/48356
- [Blog]: https://github.com/kubernetes/website/pull/48371
```