### PR TITLE
Fixes kubelet volume mounted path check on Windows

### DIFF
--- a/pkg/util/filesystem/defaultfs.go
+++ b/pkg/util/filesystem/defaultfs.go
@@ -17,10 +17,8 @@ limitations under the License.
 package filesystem
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"time"
 )
@@ -85,15 +83,12 @@ func (fs *DefaultFs) MkdirAll(path string, perm os.FileMode) error {
 // (similar to symlink) and do not represent actual directory. Hence Directory existence
 // check for windows NTFS will NOT check for dir, but for symlink presence.
 func MkdirAllWithPathCheck(path string, perm os.FileMode) error {
-	if dir, err := os.Lstat(path); err == nil {
-		// If the path exists already,
-		// 1. for Unix/Linux OS, check if the path is directory.
-		// 2. for windows NTFS, check if the path is symlink instead of directory.
-		if dir.IsDir() ||
-			(runtime.GOOS == "windows" && (dir.Mode()&os.ModeSymlink != 0 || dir.Mode()&os.ModeIrregular != 0)) {
-			return nil
-		}
-		return fmt.Errorf("path %v exists but is not a directory", path)
+	valid, err := IsPathValidForMount(path)
+	if err != nil {
+		return err
+	}
+	if valid {
+		return nil
 	}
 	// If existence of path not known, attempt to create it.
 	if err := MkdirAll(path, perm); err != nil {

--- a/pkg/util/filesystem/util_unix.go
+++ b/pkg/util/filesystem/util_unix.go
@@ -51,3 +51,23 @@ func MkdirAll(path string, perm os.FileMode) error {
 func IsAbs(path string) bool {
 	return filepath.IsAbs(path)
 }
+
+// IsPathValidForMount checks if the given `path` is a valid mount point.
+// Return whether the path is valid and error encountered if any
+func IsPathValidForMount(path string) (bool, error) {
+	dir, err := os.Lstat(path)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return false, err
+		}
+
+		return false, nil
+	}
+
+	// for Unix/Linux OS, check if the path is directory.
+	if dir.IsDir() {
+		return true, nil
+	}
+
+	return false, fmt.Errorf("path %v exists but is not a mounted path", path)
+}

--- a/pkg/util/filesystem/util_windows.go
+++ b/pkg/util/filesystem/util_windows.go
@@ -285,7 +285,7 @@ func IsPathValidForMount(path string) (bool, error) {
 	isSymlink := dir.Mode()&os.ModeSymlink != 0 || dir.Mode()&os.ModeIrregular != 0
 
 	// mounted folder created by SetVolumeMountPoint may still report ModeSymlink == 0
-	mountedFolder, err := isMountedFolder(path)
+	mountedFolder, err := IsMountedFolder(path)
 	if err != nil {
 		return false, err
 	}
@@ -297,8 +297,8 @@ func IsPathValidForMount(path string) (bool, error) {
 	return false, fmt.Errorf("path %v exists but is not a mounted path", path)
 }
 
-// isMountedFolder checks whether the `path` is a mounted folder.
-func isMountedFolder(path string) (bool, error) {
+// IsMountedFolder checks whether the `path` is a mounted folder.
+func IsMountedFolder(path string) (bool, error) {
 	// https://learn.microsoft.com/en-us/windows/win32/fileio/determining-whether-a-directory-is-a-volume-mount-point
 	utf16Path, _ := windows.UTF16PtrFromString(path)
 	attrs, err := windows.GetFileAttributes(utf16Path)

--- a/pkg/util/filesystem/util_windows.go
+++ b/pkg/util/filesystem/util_windows.go
@@ -20,6 +20,7 @@ limitations under the License.
 package filesystem
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -260,4 +261,71 @@ func Chmod(path string, filemode os.FileMode) error {
 // that get validated on Unix, persisted, then consumed by Windows, etc).
 func IsAbs(path string) bool {
 	return filepath.IsAbs(path) || strings.HasPrefix(path, `\`) || strings.HasPrefix(path, `/`)
+}
+
+// IsPathValidForMount checks if the given `path` is a valid mount point.
+// Return whether the path is valid and error encountered if any
+func IsPathValidForMount(path string) (bool, error) {
+	path = strings.TrimSuffix(path, string(filepath.Separator))
+	dir, err := os.Lstat(path)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return false, err
+		}
+
+		return false, nil
+	}
+
+	if dir.IsDir() {
+		// the path may not be mounted yet
+		return true, nil
+	}
+
+	// for windows NTFS, check if the path is symlink instead of directory.
+	isSymlink := dir.Mode()&os.ModeSymlink != 0 || dir.Mode()&os.ModeIrregular != 0
+
+	// mounted folder created by SetVolumeMountPoint may still report ModeSymlink == 0
+	mountedFolder, err := isMountedFolder(path)
+	if err != nil {
+		return false, err
+	}
+
+	if isSymlink && mountedFolder {
+		return true, nil
+	}
+
+	return false, fmt.Errorf("path %v exists but is not a mounted path", path)
+}
+
+// isMountedFolder checks whether the `path` is a mounted folder.
+func isMountedFolder(path string) (bool, error) {
+	// https://learn.microsoft.com/en-us/windows/win32/fileio/determining-whether-a-directory-is-a-volume-mount-point
+	utf16Path, _ := windows.UTF16PtrFromString(path)
+	attrs, err := windows.GetFileAttributes(utf16Path)
+	if err != nil {
+		return false, err
+	}
+
+	if (attrs & windows.FILE_ATTRIBUTE_REPARSE_POINT) == 0 {
+		return false, nil
+	}
+
+	var findData windows.Win32finddata
+	findHandle, err := windows.FindFirstFile(utf16Path, &findData)
+	if err != nil && !errors.Is(err, windows.ERROR_NO_MORE_FILES) {
+		return false, err
+	}
+
+	for err == nil {
+		if findData.Reserved0&windows.IO_REPARSE_TAG_MOUNT_POINT != 0 {
+			return true, nil
+		}
+
+		err = windows.FindNextFile(findHandle, &findData)
+		if err != nil && !errors.Is(err, windows.ERROR_NO_MORE_FILES) {
+			return false, err
+		}
+	}
+
+	return false, nil
 }

--- a/pkg/util/filesystem/util_windows_test.go
+++ b/pkg/util/filesystem/util_windows_test.go
@@ -20,10 +20,12 @@ limitations under the License.
 package filesystem
 
 import (
+	"errors"
 	"fmt"
 	"math/rand"
 	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -267,4 +269,273 @@ func TestAbsWithSlash(t *testing.T) {
 
 	assert.False(t, IsAbs("./local"))
 	assert.False(t, IsAbs("local"))
+}
+
+func runPowershellCmd(t *testing.T, command string) (string, error) {
+	cmd := exec.Command("powershell", "/c", fmt.Sprintf("& { $global:ProgressPreference = 'SilentlyContinue'; %s }", command))
+	t.Logf("Executing command: %q", cmd.String())
+	result, err := cmd.CombinedOutput()
+	return string(result), err
+}
+
+func createMountedFolder(t *testing.T, vhdxPath, mountedPath string, initialSize int) {
+	cmd := fmt.Sprintf("New-VHD -Path %s -SizeBytes %d", vhdxPath, initialSize)
+	if out, err := runPowershellCmd(t, cmd); err != nil {
+		t.Fatalf("Error: %v. Command: %q. Out: %s.", err, cmd, out)
+	}
+	cmd = fmt.Sprintf("Mount-VHD -Path %s", vhdxPath)
+	if out, err := runPowershellCmd(t, cmd); err != nil {
+		t.Fatalf("Error: %v. Command: %q. Out: %s", err, cmd, out)
+	}
+	cmd = fmt.Sprintf("Mount-VHD -Path %s", vhdxPath)
+	if out, err := runPowershellCmd(t, cmd); err != nil {
+		t.Fatalf("Error: %v. Command: %q. Out: %s", err, cmd, out)
+	}
+	cmd = fmt.Sprintf("(Get-VHD -Path %s).DiskNumber", vhdxPath)
+	diskNumUnparsed, err := runPowershellCmd(t, cmd)
+	if err != nil {
+		t.Fatalf("Error: %v. Command: %s", err, cmd)
+	}
+	diskNumUnparsed = strings.TrimSpace(diskNumUnparsed)
+	cmd = fmt.Sprintf("Initialize-Disk -Number %s -PartitionStyle GPT", diskNumUnparsed)
+	if out, err := runPowershellCmd(t, cmd); err != nil {
+		t.Fatalf("Error initializing disk: %v. Command: %q. Out: %s", err, cmd, out)
+	}
+	// Create a new partition using all available space
+	cmd = fmt.Sprintf("New-Partition -DiskNumber %s -UseMaximumSize", diskNumUnparsed)
+	if out, err := runPowershellCmd(t, cmd); err != nil {
+		t.Fatalf("Error creating partition: %v. Command: %q. Out: %s", err, cmd, out)
+	}
+	// Format the partition with NTFS
+	cmd = fmt.Sprintf("(Get-Disk -Number %s | Get-Partition | Get-Volume) | Format-Volume -FileSystem NTFS -Confirm:$false", diskNumUnparsed)
+	if out, err := runPowershellCmd(t, cmd); err != nil {
+		t.Fatalf("Error formatting volume: %v. Command: %q. Out: %s", err, cmd, out)
+	}
+	cmd = fmt.Sprintf(`(Get-Disk -Number %s | Get-Partition ) | Add-PartitionAccessPath -AccessPath %s`, diskNumUnparsed, mountedPath)
+	if _, err := runPowershellCmd(t, cmd); err != nil {
+		t.Fatalf("Error: %v. Command: %s", err, cmd)
+	}
+}
+
+func unmountFolder(t *testing.T, vhdxPath, mountedPath string) {
+	cmd := fmt.Sprintf("(Get-VHD -Path %s).DiskNumber", vhdxPath)
+	diskNumUnparsed, err := runPowershellCmd(t, cmd)
+	if err != nil {
+		t.Fatalf("Error: %v. Command: %s", err, cmd)
+	}
+	diskNumUnparsed = strings.TrimSpace(diskNumUnparsed)
+	cmd = fmt.Sprintf(`Get-Disk -Number %s | Get-Partition | Remove-PartitionAccessPath -AccessPath %s`, diskNumUnparsed, mountedPath)
+	if _, err := runPowershellCmd(t, cmd); err != nil {
+		t.Fatalf("Error: %v. Command: %s", err, cmd)
+	}
+	cmd = fmt.Sprintf("Dismount-VHD -Path %s", vhdxPath)
+	if out, err := runPowershellCmd(t, cmd); err != nil {
+		t.Fatalf("Error unmounting VHD: %v. Command: %q. Out: %s", err, cmd, out)
+	}
+}
+
+func TestIsPathValidForMount(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "test-dir")
+	require.NoError(t, err, "Failed to create temporary directory.")
+
+	tests := []struct {
+		name           string
+		path           string
+		setup          func()
+		cleanup        func()
+		expectedResult bool
+		expectedError  error
+	}{
+		{
+			name:           "Non-existent path",
+			path:           filepath.Join(tempDir, "nonexistent"),
+			expectedResult: false,
+			expectedError:  nil,
+		},
+		{
+			name: "Regular directory",
+			path: filepath.Join(tempDir, "regular_dir"),
+			setup: func() {
+				err := os.MkdirAll(filepath.Join(tempDir, "regular_dir"), 0644)
+				require.NoError(t, err, "Failed to create regular_dir directory.")
+			},
+			expectedResult: true,
+			expectedError:  nil,
+		},
+		{
+			name: "Mounted folder",
+			path: filepath.Join(tempDir, "mounted_folder"),
+			setup: func() {
+				err := os.MkdirAll(filepath.Join(tempDir, "mounted_folder"), 0644)
+				require.NoError(t, err, "Failed to create regular_dir directory.")
+
+				createMountedFolder(t, filepath.Join(tempDir, "test.vhdx"), filepath.Join(tempDir, "mounted_folder"), 1024*1024*1024)
+			},
+			cleanup: func() {
+				unmountFolder(t, filepath.Join(tempDir, "test.vhdx"), filepath.Join(tempDir, "mounted_folder"))
+			},
+			expectedResult: true,
+			expectedError:  nil,
+		},
+		{
+			name: "Regular file",
+			path: filepath.Join(tempDir, "regular_file"),
+			setup: func() {
+				err := os.WriteFile(filepath.Join(tempDir, "regular_file"), []byte("just_a_test"), 0644)
+				require.NoError(t, err, "Failed to create regular_file.")
+			},
+			expectedResult: false,
+			expectedError:  fmt.Errorf("path %s exists but is not a mounted path", filepath.Join(tempDir, "regular_file")),
+		},
+		{
+			name: "Regular symlink",
+			path: filepath.Join(tempDir, "regular_symlink"),
+			setup: func() {
+				err := os.WriteFile(filepath.Join(tempDir, "regular_file"), []byte("just_a_test"), 0644)
+				require.NoError(t, err, "Failed to create regular_file.")
+
+				err = os.Symlink(filepath.Join(tempDir, "regular_file"), filepath.Join(tempDir, "regular_symlink"))
+				require.NoError(t, err, "Failed to create regular_file.")
+			},
+			cleanup: func() {
+				err := os.RemoveAll(filepath.Join(tempDir, "regular_file"))
+				require.NoError(t, err, "Failed to delete regular_file.")
+
+				err = os.RemoveAll(filepath.Join(tempDir, "regular_symlink"))
+				require.NoError(t, err, "Failed to delete regular_symlink.")
+			},
+			expectedResult: true,
+			expectedError:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.setup != nil {
+				tt.setup()
+			}
+
+			// Run test
+			result, err := IsPathValidForMount(tt.path)
+
+			if tt.cleanup != nil {
+				tt.cleanup()
+			}
+
+			// Assert results
+			if tt.expectedError != nil {
+				assert.Error(t, err)
+				assert.Equal(t, tt.expectedError.Error(), err.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.expectedResult, result)
+		})
+	}
+
+	err = os.RemoveAll(tempDir)
+	require.NoError(t, err, "Failed to remove directory.")
+}
+
+func TestIsMountedFolder(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "test-dir")
+	require.NoError(t, err, "Failed to create temporary directory.")
+
+	tests := []struct {
+		name           string
+		path           string
+		setup          func()
+		cleanup        func()
+		expectedResult bool
+		expectedError  error
+	}{
+		{
+			name:           "Non-existent path",
+			path:           filepath.Join(tempDir, "nonexistent"),
+			expectedResult: false,
+			expectedError:  errors.New("The system cannot find the file specified."),
+		},
+		{
+			name: "Regular directory",
+			path: filepath.Join(tempDir, "regular_dir"),
+			setup: func() {
+				err := os.MkdirAll(filepath.Join(tempDir, "regular_dir"), 0644)
+				require.NoError(t, err, "Failed to create regular_dir directory.")
+			},
+			expectedResult: false,
+			expectedError:  nil,
+		},
+		{
+			name: "Mounted folder",
+			path: filepath.Join(tempDir, "mounted_folder"),
+			setup: func() {
+				err := os.MkdirAll(filepath.Join(tempDir, "mounted_folder"), 0644)
+				require.NoError(t, err, "Failed to create regular_dir directory.")
+
+				createMountedFolder(t, filepath.Join(tempDir, "test.vhdx"), filepath.Join(tempDir, "mounted_folder"), 1024*1024*1024)
+			},
+			cleanup: func() {
+				unmountFolder(t, filepath.Join(tempDir, "test.vhdx"), filepath.Join(tempDir, "mounted_folder"))
+			},
+			expectedResult: true,
+			expectedError:  nil,
+		},
+		{
+			name: "Regular file",
+			path: filepath.Join(tempDir, "regular_file"),
+			setup: func() {
+				err := os.WriteFile(filepath.Join(tempDir, "regular_file"), []byte("just_a_test"), 0644)
+				require.NoError(t, err, "Failed to create regular_file.")
+			},
+			expectedResult: false,
+			expectedError:  nil,
+		},
+		{
+			name: "Regular symlink",
+			path: filepath.Join(tempDir, "regular_symlink"),
+			setup: func() {
+				err := os.WriteFile(filepath.Join(tempDir, "regular_file"), []byte("just_a_test"), 0644)
+				require.NoError(t, err, "Failed to create regular_file.")
+
+				err = os.Symlink(filepath.Join(tempDir, "regular_file"), filepath.Join(tempDir, "regular_symlink"))
+				require.NoError(t, err, "Failed to create regular_file.")
+			},
+			cleanup: func() {
+				err := os.RemoveAll(filepath.Join(tempDir, "regular_file"))
+				require.NoError(t, err, "Failed to delete regular_file.")
+
+				err = os.RemoveAll(filepath.Join(tempDir, "regular_symlink"))
+				require.NoError(t, err, "Failed to delete regular_symlink.")
+			},
+			expectedResult: true,
+			expectedError:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.setup != nil {
+				tt.setup()
+			}
+
+			// Run test
+			result, err := IsMountedFolder(tt.path)
+
+			if tt.cleanup != nil {
+				tt.cleanup()
+			}
+
+			// Assert results
+			if tt.expectedError != nil {
+				assert.Error(t, err)
+				assert.Equal(t, tt.expectedError.Error(), err.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.expectedResult, result)
+		})
+	}
+
+	err = os.RemoveAll(tempDir)
+	require.NoError(t, err, "Failed to remove directory.")
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
Fixes the CSI volume could not be mounted on Windows after kubelet crashes

#### Which issue(s) this PR fixes:
Fixes #130300

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Fixed the issue which prevents pods with mounted CSI volume from re-launch on the same node when kubelet crashes
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
```
