### PR TITLE
Automated cherry pick of #130266: Introduced additional log formatting to windows kubeproxy.

### DIFF
--- a/pkg/proxy/winkernel/hns.go
+++ b/pkg/proxy/winkernel/hns.go
@@ -168,7 +168,7 @@ func (hns hns) getAllEndpointsByNetwork(networkName string) (map[string]*(endpoi
 		}
 		endpointInfos[ep.IpConfigurations[1].IpAddress] = endpointDualstack
 	}
-	klog.V(3).InfoS("Queried endpoints from network", "network", networkName)
+	klog.V(3).InfoS("Queried endpoints from network", "network", networkName, "count", len(endpointInfos))
 	klog.V(5).InfoS("Queried endpoints details", "network", networkName, "endpointInfos", endpointInfos)
 	return endpointInfos, nil
 }


### PR DESCRIPTION
Cherry pick of #130266 on release-1.32.

#130266: Introduced additional log formatting to windows kubeproxy.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
This is needed because some logs in Windows kube-proxy are not formatted correctly, making them difficult to debug.

Eg:

I0219 05:33:44.408655 9420 proxier.go:1451] "Associated endpoints for service" **endpointsInfo=[{},{}]** serviceName="demo/l4proxysvc:tcp"

I0219 05:33:39.213312 9420 proxier.go:1740] "Skipped creating Hns Health Check LoadBalancer for loadBalancer Ingress resources" **ip={}** allEndpointsTerminating=false

I0219 05:33:44.409569 9420 hns.go:143] "Found cached Hns loadbalancer policy resource" **policies={}**

With this change, logs will look like:

I0219 09:27:49.278170   10516 proxier.go:1488] "Associated endpoints for service" **endpointsInfo="[HnsID:1c0ec2a6-bf26-46a1-a7bc-d11cb5de393b, Address:10.244.1.151:0 HnsID:cff83c68-3b3d-4308-87d6-0a675e6889d3, Address:10.244.1.208:0 HnsID:f1f861b5-704b-430e-b57b-b17e193e2f3d, Address:10.244.2.134:0 HnsID:f10a39aa-baa1-48c7-81e2-38b6eb52e011, Address:10.244.2.183:0 HnsID:3e71185d-9bf1-4144-9b6c-97a5c36cdc05, Address:10.244.2.54:0]"** serviceName="demo/tcp-server-ipv4-cluster-sameport:udp"

I0219 09:27:49.287006   10516 proxier.go:1777] "Skipped creating Hns Health Check LoadBalancer for loadBalancer Ingress resources" **IngressIPInfo="HnsID:9d4eccb9-0a4d-4ad9-9c3c-3fba6dd5de43, IP:2603:1020:203:14::43"** allEndpointsTerminating=false

I0219 09:27:49.287006   10516 proxier.go:1781] "Policy successfully applied for service" **serviceInfo="HnsID:fb59511d-7a6a-47c3-bfc5-cefad97538fe, TargetPort:4444, NodePortHnsID:9c2c2c5f-7d5d-461b-b12a-ca26dd0d5ed8, IngressIPs:[HnsID:9d4eccb9-0a4d-4ad9-9c3c-3fba6dd5de43, IP:2603:1020:203:14::43]"**

I0219 09:27:43.324232   10516 hns.go:143] "Found cached Hns loadbalancer policy resource" policies=**"HnsID:b6421245-1664-4ea3-9676-26a0a2d946f5"**

#### Which issue(s) this PR fixes:

Fixes #130265

```release-note
NONE
```