### PR TITLE
Automated cherry pick of #130266: Introduced additional log formatting to windows kubeproxy.

### DIFF
--- a/pkg/proxy/winkernel/hns.go
+++ b/pkg/proxy/winkernel/hns.go
@@ -168,7 +168,7 @@ func (hns hns) getAllEndpointsByNetwork(networkName string) (map[string]*(endpoi
 		}
 		endpointInfos[ep.IpConfigurations[1].IpAddress] = endpointDualstack
 	}
-	klog.V(3).InfoS("Queried endpoints from network", "network", networkName)
+	klog.V(3).InfoS("Queried endpoints from network", "network", networkName, "count", len(endpointInfos))
 	klog.V(5).InfoS("Queried endpoints details", "network", networkName, "endpointInfos", endpointInfos)
 	return endpointInfos, nil
 }

--- a/pkg/proxy/winkernel/proxier.go
+++ b/pkg/proxy/winkernel/proxier.go
@@ -85,14 +85,29 @@ type externalIPInfo struct {
 	hnsID string
 }
 
+func (info externalIPInfo) String() string {
+	return fmt.Sprintf("HnsID:%s, IP:%s", info.hnsID, info.ip)
+}
+
 type loadBalancerIngressInfo struct {
 	ip               string
 	hnsID            string
 	healthCheckHnsID string
 }
 
+func (info loadBalancerIngressInfo) String() string {
+	if len(info.healthCheckHnsID) > 0 {
+		return fmt.Sprintf("HealthCheckHnsID:%s, IP:%s", info.healthCheckHnsID, info.ip)
+	}
+	return fmt.Sprintf("HnsID:%s, IP:%s", info.hnsID, info.ip)
+}
+
 type loadBalancerInfo struct {
 	hnsID string
+}
+
+func (info loadBalancerInfo) String() string {
+	return fmt.Sprintf("HnsID:%s", info.hnsID)
 }
 
 type loadBalancerIdentifier struct {
@@ -101,6 +116,10 @@ type loadBalancerIdentifier struct {
 	externalPort  uint16
 	vip           string
 	endpointsHash [20]byte
+}
+
+func (info loadBalancerIdentifier) String() string {
+	return fmt.Sprintf("VIP:%s, Protocol:%d, InternalPort:%d, ExternalPort:%d", info.vip, info.protocol, info.internalPort, info.externalPort)
 }
 
 type loadBalancerFlags struct {
@@ -129,6 +148,20 @@ type serviceInfo struct {
 	localTrafficDSR        bool
 	internalTrafficLocal   bool
 	winProxyOptimization   bool
+}
+
+func (info serviceInfo) String() string {
+	svcInfoStr := fmt.Sprintf("HnsID:%s, TargetPort:%d", info.hnsID, info.targetPort)
+	if info.nodePorthnsID != "" {
+		svcInfoStr = fmt.Sprintf("%s, NodePortHnsID:%s", svcInfoStr, info.nodePorthnsID)
+	}
+	if len(info.externalIPs) > 0 {
+		svcInfoStr = fmt.Sprintf("%s, ExternalIPs:%v", svcInfoStr, info.externalIPs)
+	}
+	if len(info.loadBalancerIngressIPs) > 0 {
+		svcInfoStr = fmt.Sprintf("%s, IngressIPs:%v", svcInfoStr, info.loadBalancerIngressIPs)
+	}
+	return svcInfoStr
 }
 
 type hnsNetworkInfo struct {
@@ -291,8 +324,8 @@ type endpointInfo struct {
 }
 
 // String is part of proxy.Endpoint interface.
-func (info *endpointInfo) String() string {
-	return net.JoinHostPort(info.ip, strconv.Itoa(int(info.port)))
+func (info endpointInfo) String() string {
+	return fmt.Sprintf("HnsID:%s, Address:%s", info.hnsID, net.JoinHostPort(info.ip, strconv.Itoa(int(info.port))))
 }
 
 // IsLocal is part of proxy.Endpoint interface.
@@ -1404,7 +1437,7 @@ func (proxier *Proxier) syncProxyRules() {
 			klog.V(3).InfoS("Endpoint resource found", "endpointInfo", ep)
 		}
 
-		klog.V(3).InfoS("Associated endpoints for service", "endpointInfo", hnsEndpoints, "serviceName", svcName)
+		klog.V(3).InfoS("Associated endpoints for service", "endpointInfo", fmt.Sprintf("%v", hnsEndpoints), "serviceName", svcName)
 
 		if len(svcInfo.hnsID) > 0 {
 			// This should not happen
@@ -1590,9 +1623,9 @@ func (proxier *Proxier) syncProxyRules() {
 						continue
 					}
 					externalIP.hnsID = hnsLoadBalancer.hnsID
-					klog.V(3).InfoS("Hns LoadBalancer resource created for externalIP resources", "externalIP", externalIP, "hnsID", hnsLoadBalancer.hnsID)
+					klog.V(3).InfoS("Hns LoadBalancer resource created for externalIP resources", "externalIPInfo", externalIP, "hnsID", hnsLoadBalancer.hnsID)
 				} else {
-					klog.V(3).InfoS("Skipped creating Hns LoadBalancer for externalIP resources", "externalIP", externalIP, "allEndpointsTerminating", allEndpointsTerminating)
+					klog.V(3).InfoS("Skipped creating Hns LoadBalancer for externalIP resources", "externalIPInfo", externalIP, "allEndpointsTerminating", allEndpointsTerminating)
 				}
 			}
 		}
@@ -1640,9 +1673,9 @@ func (proxier *Proxier) syncProxyRules() {
 						continue
 					}
 					lbIngressIP.hnsID = hnsLoadBalancer.hnsID
-					klog.V(3).InfoS("Hns LoadBalancer resource created for loadBalancer Ingress resources", "lbIngressIP", lbIngressIP)
+					klog.V(3).InfoS("Hns LoadBalancer resource created for loadBalancer Ingress resources", "lbIngressIPInfo", lbIngressIP)
 				} else {
-					klog.V(3).InfoS("Skipped creating Hns LoadBalancer for loadBalancer Ingress resources", "lbIngressIP", lbIngressIP)
+					klog.V(3).InfoS("Skipped creating Hns LoadBalancer for loadBalancer Ingress resources", "lbIngressIPInfo", lbIngressIP)
 				}
 			}
 
@@ -1693,7 +1726,7 @@ func (proxier *Proxier) syncProxyRules() {
 					klog.V(3).InfoS("Hns Health Check LoadBalancer resource created for loadBalancer Ingress resources", "ip", lbIngressIP)
 				}
 			} else {
-				klog.V(3).InfoS("Skipped creating Hns Health Check LoadBalancer for loadBalancer Ingress resources", "ip", lbIngressIP, "allEndpointsTerminating", allEndpointsTerminating)
+				klog.V(3).InfoS("Skipped creating Hns Health Check LoadBalancer for loadBalancer Ingress resources", "IngressIPInfo", lbIngressIP, "allEndpointsTerminating", allEndpointsTerminating)
 			}
 		}
 		svcInfo.policyApplied = true


### PR DESCRIPTION
Cherry pick of #130266 on release-1.31.

#130266: Introduced additional log formatting to windows kubeproxy.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
This is needed because some logs in Windows kube-proxy are not formatted correctly, making them difficult to debug.

Eg:

I0219 05:33:44.408655 9420 proxier.go:1451] "Associated endpoints for service" **endpointsInfo=[{},{}]** serviceName="demo/l4proxysvc:tcp"

I0219 05:33:39.213312 9420 proxier.go:1740] "Skipped creating Hns Health Check LoadBalancer for loadBalancer Ingress resources" **ip={}** allEndpointsTerminating=false

I0219 05:33:44.409569 9420 hns.go:143] "Found cached Hns loadbalancer policy resource" **policies={}**

With this change, logs will look like:

I0219 09:27:49.278170   10516 proxier.go:1488] "Associated endpoints for service" **endpointsInfo="[HnsID:1c0ec2a6-bf26-46a1-a7bc-d11cb5de393b, Address:10.244.1.151:0 HnsID:cff83c68-3b3d-4308-87d6-0a675e6889d3, Address:10.244.1.208:0 HnsID:f1f861b5-704b-430e-b57b-b17e193e2f3d, Address:10.244.2.134:0 HnsID:f10a39aa-baa1-48c7-81e2-38b6eb52e011, Address:10.244.2.183:0 HnsID:3e71185d-9bf1-4144-9b6c-97a5c36cdc05, Address:10.244.2.54:0]"** serviceName="demo/tcp-server-ipv4-cluster-sameport:udp"

I0219 09:27:49.287006   10516 proxier.go:1777] "Skipped creating Hns Health Check LoadBalancer for loadBalancer Ingress resources" **IngressIPInfo="HnsID:9d4eccb9-0a4d-4ad9-9c3c-3fba6dd5de43, IP:2603:1020:203:14::43"** allEndpointsTerminating=false

I0219 09:27:49.287006   10516 proxier.go:1781] "Policy successfully applied for service" **serviceInfo="HnsID:fb59511d-7a6a-47c3-bfc5-cefad97538fe, TargetPort:4444, NodePortHnsID:9c2c2c5f-7d5d-461b-b12a-ca26dd0d5ed8, IngressIPs:[HnsID:9d4eccb9-0a4d-4ad9-9c3c-3fba6dd5de43, IP:2603:1020:203:14::43]"**

I0219 09:27:43.324232   10516 hns.go:143] "Found cached Hns loadbalancer policy resource" policies=**"HnsID:b6421245-1664-4ea3-9676-26a0a2d946f5"**

#### Which issue(s) this PR fixes:

Fixes #130265

```release-note
NONE
```