### PR TITLE
Ensure that kubelet updates state on restart

### DIFF
--- a/pkg/kubelet/kubelet_node_status_test.go
+++ b/pkg/kubelet/kubelet_node_status_test.go
@@ -3100,16 +3100,18 @@ func TestIsUpdateStatusPeriodExperid(t *testing.T) {
 		expectExpired              bool
 	}{
 		{
+			// Ensure that everything is properly initialized if the node status is not updated before
 			name:                       "no status update before and no delay",
 			lastStatusReportTime:       time.Time{},
 			delayAfterNodeStatusChange: 0,
-			expectExpired:              false,
+			expectExpired:              true,
 		},
 		{
+			// Ensure that everything is properly initialized if the node status is not updated before
 			name:                       "no status update before and existing delay",
 			lastStatusReportTime:       time.Time{},
 			delayAfterNodeStatusChange: 30 * time.Second,
-			expectExpired:              false,
+			expectExpired:              true,
 		},
 		{
 			name:                       "not expired and no delay",
@@ -3139,7 +3141,7 @@ func TestIsUpdateStatusPeriodExperid(t *testing.T) {
 	for _, tc := range testcases {
 		kubelet.lastStatusReportTime = tc.lastStatusReportTime
 		kubelet.delayAfterNodeStatusChange = tc.delayAfterNodeStatusChange
-		expired := kubelet.isUpdateStatusPeriodExperid()
+		expired := kubelet.isUpdateStatusPeriodExpired()
 		assert.Equal(t, tc.expectExpired, expired, tc.name)
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

If the last status report time is zero, we consider the update status period expired to ensure that the status is properly updated on restarts. Otherwise, `setLastObservedNodeAddresses` is never called until there is a change in the node's status. The `--node-status-update-frequency` flag is also not respected, since the status will not be updated until there is an actual change.

After the first update to the nodes status (when `lastStatusReportTime` is updated to a non-zero value), the updates continue as expected, respecting the `--node-status-update-frequency`. So this is only about the very first update after a kubelet (re)start.

The behavior changed in https://github.com/kubernetes/kubernetes/pull/128640, from

```go
shouldPatchNodeStatus := changed || kl.clock.Since(kl.lastStatusReportTime) >= kl.nodeStatusReportFrequency
```
to
https://github.com/kubernetes/kubernetes/blob/ad4d9b2f5119f2bcf742239018a397d3794cb6e0/pkg/kubelet/kubelet_node_status.go#L605-L608

Note that the zero case changed. The status used to be forcefully updated if the `lastStatusReportTime` was zero. Now it is not touched in that case.

The specific thing that this change breaks for us is described in more detail in https://github.com/kubernetes/kubernetes/issues/130001. The gist is that the kubelet server certificate CSR cannot be created until `getLastObservedNodeAddresses` returns an actual address. This function relies on the kubelets [internal state](https://github.com/kubernetes/kubernetes/blob/de7708f06e11efe1140805f1eb4814f358a8d31e/pkg/kubelet/kubelet.go#L1061), NOT the node status, and this internal state is not set until `patchNodeStatus` has been called because that is the only place [setLastObservedNodeAddresses](https://github.com/kubernetes/kubernetes/blob/ad4d9b2f5119f2bcf742239018a397d3794cb6e0/pkg/kubelet/kubelet_node_status.go#L747-L750) is called.

This all means that after a kubelet (re)start, as long as the node status hasn't changed, the kubelet cannot create the CSR for the serving certificate. And the `--node-status-update-frequency` flag isn't respected.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #130001

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Ensure Kubelet state is initialized on start even if the node hasn't changed
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
