### PR TITLE
fix flaky test: Subpath Container restart should verify that container can restart successfully after configmaps modified

### DIFF
--- a/test/e2e/framework/pod/utils.go
+++ b/test/e2e/framework/pod/utils.go
@@ -31,7 +31,19 @@ import (
 	"k8s.io/utils/pointer"
 )
 
+// This command runs an infinite loop, sleeping for 1 second in each iteration.
+// It sets up a trap to exit gracefully when a TERM signal is received.
+//
+// This is useful for testing scenarios where the container is terminated
+// with a zero exit code.
 const InfiniteSleepCommand = "trap exit TERM; while true; do sleep 1; done"
+
+// This command will cause the shell to remain in a sleep state indefinitely,
+// and it won't exit unless it receives a KILL signal.
+//
+// This is useful for testing scenarios where the container is terminated
+// with a non-zero exit code.
+const InfiniteSleepCommandWithoutGracefulShutdown = "sleep infinity"
 
 // GenerateScriptCmd generates the corresponding command lines to execute a command.
 func GenerateScriptCmd(command string) []string {

--- a/test/e2e/storage/testsuites/subpath.go
+++ b/test/e2e/storage/testsuites/subpath.go
@@ -793,10 +793,10 @@ func testPodContainerRestartWithHooks(ctx context.Context, f *framework.Framewor
 	pod.Spec.RestartPolicy = v1.RestartPolicyOnFailure
 
 	pod.Spec.Containers[0].Image = e2epod.GetDefaultTestImage()
-	pod.Spec.Containers[0].Command = e2epod.GenerateScriptCmd(e2epod.InfiniteSleepCommand)
+	pod.Spec.Containers[0].Command = e2epod.GenerateScriptCmd(e2epod.InfiniteSleepCommandWithoutGracefulShutdown)
 	pod.Spec.Containers[0].Args = nil
 	pod.Spec.Containers[1].Image = e2epod.GetDefaultTestImage()
-	pod.Spec.Containers[1].Command = e2epod.GenerateScriptCmd(e2epod.InfiniteSleepCommand)
+	pod.Spec.Containers[1].Command = e2epod.GenerateScriptCmd(e2epod.InfiniteSleepCommandWithoutGracefulShutdown)
 	pod.Spec.Containers[1].Args = nil
 	hooks.AddLivenessProbe(pod, probeFilePath)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

**Kubelet logs:**

```
// The container probe is failed
Feb 15 08:13:03 kind-worker kubelet[285]: I0215 08:13:03.197112     285 prober.go:153] "Exec-Probe runProbe" pod="subpath-2059/pod-subpath-test-configmap-h8zg" containerName="test-container-subpath-configmap-h8zg" execCommand=["sh","-c","cat /probe-volume/probe-file || test `cat /test-volume` = 'configmap-modified-value'"]
Feb 15 08:13:03 kind-worker kubelet[285]: I0215 08:13:03.905819     285 prober.go:120] "Probe failed" probeType="Liveness" pod="subpath-2059/pod-subpath-test-configmap-h8zg" podUID="c9f2f574-b2f4-49c0-a94f-c452d6290215" containerName="test-container-subpath-configmap-h8zg" probeResult="failure" output=<

// kubelet tried to stop the container via calling container runtime
Feb 15 08:13:03 kind-worker kubelet[285]: I0215 08:13:03.910529     285 kuberuntime_manager.go:1148] "computePodActions got for pod" podActions="KillPod: false, CreateSandbox: false, UpdatePodResources: false, Attempt: 0, InitContainersToStart: [], ContainersToStart: [0], EphemeralContainersToStart: [],ContainersToUpdate: map[], ContainersToKill: map[{containerd 89cdb4348fa177380e1188f0393d958858209128b3e2aa56308c1ea0c2b4bac1}:{0xc000b59c08 test-container-subpath-configmap-h8zg Container test-container-subpath-configmap-h8zg failed liveness probe, will be restarted LivenessProbe}]" pod="subpath-2059/pod-subpath-test-configmap-h8zg"
Feb 15 08:13:03 kind-worker kubelet[285]: I0215 08:13:03.910732     285 kuberuntime_manager.go:1182] "Killing unwanted container for pod" containerName="test-container-subpath-configmap-h8zg" containerID={"Type":"containerd","ID":"89cdb4348fa177380e1188f0393d958858209128b3e2aa56308c1ea0c2b4bac1"} pod="subpath-2059/pod-subpath-test-configmap-h8zg"
Feb 15 08:13:03 kind-worker kubelet[285]: I0215 08:13:03.910919     285 kuberuntime_container.go:809] "Killing container with a grace period" pod="subpath-2059/pod-subpath-test-configmap-h8zg" podUID="c9f2f574-b2f4-49c0-a94f-c452d6290215" containerName="test-container-subpath-configmap-h8zg" containerID="containerd://89cdb4348fa177380e1188f0393d958858209128b3e2aa56308c1ea0c2b4bac1" gracePeriod=2
Feb 15 08:13:03 kind-worker kubelet[285]: I0215 08:13:03.912334     285 event.go:389] "Event occurred" object="subpath-2059/pod-subpath-test-configmap-h8zg" fieldPath="spec.containers{test-container-subpath-configmap-h8zg}" kind="Pod" apiVersion="v1" type="Normal" reason="Killing" message="Container test-container-subpath-configmap-h8zg failed liveness probe, will be restarted"
```

**Containerd logs:** 

```
# Killing container with a grace period but timeout is reached
Feb 15 08:13:03 kind-worker containerd[185]: time="2025-02-15T08:13:03.912504992Z" level=info msg="StopContainer for \"89cdb4348fa177380e1188f0393d958858209128b3e2aa56308c1ea0c2b4bac1\" with timeout 2 (s)"
Feb 15 08:13:03 kind-worker containerd[185]: time="2025-02-15T08:13:03.913797826Z" level=info msg="Stop container \"89cdb4348fa177380e1188f0393d958858209128b3e2aa56308c1ea0c2b4bac1\" with signal terminated"

# Force killing the container but the container is already exited
Feb 15 08:13:03 kind-worker containerd[185]: time="2025-02-15T08:13:03.976463751Z" level=info msg="received exit event container_id:\"89cdb4348fa177380e1188f0393d958858209128b3e2aa56308c1ea0c2b4bac1\" id:\"89cdb4348fa177380e1188f0393d958858209128b3e2aa56308c1ea0c2b4bac1\" pid:225289 exited_at:{seconds:1739607183 nanos:962757445}"
Feb 15 08:13:03 kind-worker containerd[185]: time="2025-02-15T08:13:03.977725541Z" level=info msg="TaskExit event in podsandbox handler container_id:\"89cdb4348fa177380e1188f0393d958858209128b3e2aa56308c1ea0c2b4bac1\" id:\"89cdb4348fa177380e1188f0393d958858209128b3e2aa56308c1ea0c2b4bac1\" pid:225289 exited_at:{seconds:1739607183 nanos:962757445}"
Feb 15 08:13:05 kind-worker containerd[185]: time="2025-02-15T08:13:05.954244737Z" level=info msg="Kill container \"89cdb4348fa177380e1188f0393d958858209128b3e2aa56308c1ea0c2b4bac1\""
Feb 15 08:13:13 kind-worker containerd[185]: time="2025-02-15T08:13:12.797190089Z" level=error msg="StopContainer for \"89cdb4348fa177380e1188f0393d958858209128b3e2aa56308c1ea0c2b4bac1\" failed" error="rpc error: code = Unknown desc = failed to kill container \"89cdb4348fa177380e1188f0393d958858209128b3e2aa56308c1ea0c2b4bac1\": ttrpc: closed"
```

**Kubelet logs:** 

```
// kubelet fails to stop the container and the containerd returns an error
Feb 15 08:13:13 kind-worker kubelet[285]: E0215 08:13:12.800578     285 kuberuntime_container.go:814] "Container termination failed with gracePeriod" err="rpc error: code = Unknown desc = failed to kill container \"89cdb4348fa177380e1188f0393d958858209128b3e2aa56308c1ea0c2b4bac1\": ttrpc: closed" pod="subpath-2059/pod-subpath-test-configmap-h8zg" podUID="c9f2f574-b2f4-49c0-a94f-c452d6290215" containerName="test-container-subpath-configmap-h8zg" containerID="containerd://89cdb4348fa177380e1188f0393d958858209128b3e2aa56308c1ea0c2b4bac1" gracePeriod=2
Feb 15 08:13:13 kind-worker kubelet[285]: E0215 08:13:12.800970     285 kuberuntime_manager.go:1187] "killContainer for pod failed" err="rpc error: code = Unknown desc = failed to kill container \"89cdb4348fa177380e1188f0393d958858209128b3e2aa56308c1ea0c2b4bac1\": ttrpc: closed" containerName="test-container-subpath-configmap-h8zg" containerID={"Type":"containerd","ID":"89cdb4348fa177380e1188f0393d958858209128b3e2aa56308c1ea0c2b4bac1"} pod="subpath-2059/pod-subpath-test-configmap-h8zg"
Feb 15 08:13:13 kind-worker kubelet[285]: I0215 08:13:12.801016     285 kubelet.go:1859] "SyncPod exit" pod="subpath-2059/pod-subpath-test-configmap-h8zg" podUID="c9f2f574-b2f4-49c0-a94f-c452d6290215" isTerminal=false
Feb 15 08:13:13 kind-worker kubelet[285]: E0215 08:13:12.801142     285 pod_workers.go:1301] "Error syncing pod, skipping" err="failed to \"KillContainer\" for \"test-container-subpath-configmap-h8zg\" with KillContainerError: \"rpc error: code = Unknown desc = failed to kill container \\\"89cdb4348fa177380e1188f0393d958858209128b3e2aa56308c1ea0c2b4bac1\\\": ttrpc: closed\"" pod="subpath-2059/pod-subpath-test-configmap-h8zg" podUID="c9f2f574-b2f4-49c0-a94f-c452d6290215"
Feb 15 08:13:13 kind-worker kubelet[285]: I0215 08:13:12.801177     285 pod_workers.go:1338] "Processing pod event done" pod="subpath-2059/pod-subpath-test-configmap-h8zg" podUID="c9f2f574-b2f4-49c0-a94f-c452d6290215" updateType="sync"

// The exitCode of The container `test-container-subpath-configmap-h8zg` is 0.
Feb 15 08:13:14 kind-worker kubelet[285]: I0215 08:13:14.214763     285 helpers.go:104] "Already successfully ran container, do nothing" pod="subpath-2059/pod-subpath-test-configmap-h8zg" containerName="test-container-subpath-configmap-h8zg"
Feb 15 08:13:14 kind-worker kubelet[285]: I0215 08:13:14.214879     285 kuberuntime_manager.go:1148] "computePodActions got for pod" podActions="KillPod: false, CreateSandbox: false, UpdatePodResources: false, Attempt: 0, InitContainersToStart: [], ContainersToStart: [], EphemeralContainersToStart: [],ContainersToUpdate: map[], ContainersToKill: map[]" pod="subpath-2059/pod-subpath-test-configmap-h8zg"
Feb 15 08:13:14 kind-worker kubelet[285]: I0215 08:13:14.215172     285 container_manager.go:238] "Pod contains no container with pinned cpus" podName="pod-subpath-test-configmap-h8zg"
Feb 15 08:13:14 kind-worker kubelet[285]: I0215 08:13:14.215210     285 kuberuntime_sandbox_linux.go:62] "Enforcing CFS quota" pod="subpath-2059/pod-subpath-test-configmap-h8zg" unlimited=false
Feb 15 08:13:14 kind-worker kubelet[285]: I0215 08:13:14.215232     285 kubelet.go:1859] "SyncPod exit" pod="subpath-2059/pod-subpath-test-configmap-h8zg" podUID="c9f2f574-b2f4-49c0-a94f-c452d6290215" isTerminal=false
Feb 15 08:13:14 kind-worker kubelet[285]: I0215 08:13:14.215258     285 pod_workers.go:1338] "Processing pod event done" pod="subpath-2059/pod-subpath-test-configmap-h8zg" podUID="c9f2f574-b2f4-49c0-a94f-c452d6290215" updateType="sync"
Feb 15 08:13:14 kind-worker kubelet[285]: I0215 08:13:14.259606     285 status_manager.go:935] "Patch status for pod" pod="subpath-2059/pod-subpath-test-configmap-h8zg" podUID="c9f2f574-b2f4-49c0-a94f-c452d6290215" patch="{\"metadata\":{\"uid\":\"c9f2f574-b2f4-49c0-a94f-c452d6290215\"},\"status\":{\"$setElementOrder/conditions\":[{\"type\":\"PodReadyToStartContainers\"},{\"type\":\"Initialized\"},{\"type\":\"Ready\"},{\"type\":\"ContainersReady\"},{\"type\":\"PodScheduled\"}],\"conditions\":[{\"lastTransitionTime\":\"2025-02-15T08:13:14Z\",\"message\":\"containers with unready status: [test-container-subpath-configmap-h8zg]\",\"reason\":\"ContainersNotReady\",\"status\":\"False\",\"type\":\"Ready\"},{\"lastTransitionTime\":\"2025-02-15T08:13:14Z\",\"message\":\"containers with unready status: [test-container-subpath-configmap-h8zg]\",\"reason\":\"ContainersNotReady\",\"status\":\"False\",\"type\":\"ContainersReady\"}],\"containerStatuses\":[{\"containerID\":\"containerd://89cdb4348fa177380e1188f0393d958858209128b3e2aa56308c1ea0c2b4bac1\",\"image\":\"registry.k8s.io/e2e-test-images/busybox:1.36.1-1\",\"imageID\":\"registry.k8s.io/e2e-test-images/busybox@sha256:a9155b13325b2abef48e71de77bb8ac015412a566829f621d06bfae5c699b1b9\",\"lastState\":{},\"name\":\"test-container-subpath-configmap-h8zg\",\"ready\":false,\"restartCount\":0,\"started\":false,\"state\":{\"terminated\":{\"containerID\":\"containerd://89cdb4348fa177380e1188f0393d958858209128b3e2aa56308c1ea0c2b4bac1\",\"exitCode\":0,\"finishedAt\":\"2025-02-15T08:13:03Z\",\"reason\":\"Completed\",\"startedAt\":\"2025-02-15T08:12:57Z\"}},\"volumeMounts\":[{\"mountPath\":\"/test-volume\",\"name\":\"test-volume\"},{\"mountPath\":\"/probe-volume\",\"name\":\"liveness-probe-volume\"},{\"mountPath\":\"/var/run/secrets/kubernetes.io/serviceaccount\",\"name\":\"kube-api-access-d7bjr\",\"readOnly\":true,\"recursiveReadOnly\":\"Disabled\"}]},{\"containerID\":\"containerd://b83d07f353e6c10960e144839d90c658f1f40aea77ea78a9483620e33f98b67b\",\"image\":\"registry.k8s.io/e2e-test-images/busybox:1.36.1-1\",\"imageID\":\"registry.k8s.io/e2e-test-images/busybox@sha256:a9155b13325b2abef48e71de77bb8ac015412a566829f621d06bfae5c699b1b9\",\"lastState\":{},\"name\":\"test-container-volume-configmap-h8zg\",\"ready\":true,\"restartCount\":0,\"started\":true,\"state\":{\"running\":{\"startedAt\":\"2025-02-15T08:12:58Z\"}},\"volumeMounts\":[{\"mountPath\":\"/test-volume\",\"name\":\"test-volume\"},{\"mountPath\":\"/probe-volume\",\"name\":\"liveness-probe-volume\"},{\"mountPath\":\"/var/run/secrets/kubernetes.io/serviceaccount\",\"name\":\"kube-api-access-d7bjr\",\"readOnly\":true,\"recursiveReadOnly\":\"Disabled\"}]}]}}"
Feb 15 08:13:14 kind-worker kubelet[285]: I0215 08:13:14.259762     285 status_manager.go:944] "Status for pod updated successfully" pod="subpath-2059/pod-subpath-test-configmap-h8zg" statusVersion=5 status={"phase":"Running","conditions":[{"type":"PodReadyToStartContainers","status":"True","lastProbeTime":null,"lastTransitionTime":"2025-02-15T08:12:55Z"},{"type":"Initialized","status":"True","lastProbeTime":null,"lastTransitionTime":"2025-02-15T08:12:56Z"},{"type":"Ready","status":"False","lastProbeTime":null,"lastTransitionTime":"2025-02-15T08:13:14Z","reason":"ContainersNotReady","message":"containers with unready status: [test-container-subpath-configmap-h8zg]"},{"type":"ContainersReady","status":"False","lastProbeTime":null,"lastTransitionTime":"2025-02-15T08:13:14Z","reason":"ContainersNotReady","message":"containers with unready status: [test-container-subpath-configmap-h8zg]"},{"type":"PodScheduled","status":"True","lastProbeTime":null,"lastTransitionTime":"2025-02-15T08:12:52Z"}],"hostIP":"fc00:f853:ccd:e793::3","hostIPs":[{"ip":"fc00:f853:ccd:e793::3"}],"podIP":"fd00:10:244:1::27f","podIPs":[{"ip":"fd00:10:244:1::27f"}],"startTime":"2025-02-15T08:12:52Z","initContainerStatuses":[{"name":"init-volume-configmap-h8zg","state":{"terminated":{"exitCode":0,"reason":"Completed","startedAt":"2025-02-15T08:12:55Z","finishedAt":"2025-02-15T08:12:55Z","containerID":"containerd://caf4b3bafcaec61cd9836078209eb64b0f17b158ae2b7aea8bbca9038d50a330"}},"lastState":{},"ready":true,"restartCount":0,"image":"registry.k8s.io/e2e-test-images/busybox:1.36.1-1","imageID":"registry.k8s.io/e2e-test-images/busybox@sha256:a9155b13325b2abef48e71de77bb8ac015412a566829f621d06bfae5c699b1b9","containerID":"containerd://caf4b3bafcaec61cd9836078209eb64b0f17b158ae2b7aea8bbca9038d50a330","started":false,"volumeMounts":[{"name":"test-volume","mountPath":"/test-volume"},{"name":"liveness-probe-volume","mountPath":"/probe-volume"},{"name":"kube-api-access-d7bjr","mountPath":"/var/run/secrets/kubernetes.io/serviceaccount","readOnly":true,"recursiveReadOnly":"Disabled"}]}],"containerStatuses":[{"name":"test-container-subpath-configmap-h8zg","state":{"terminated":{"exitCode":0,"reason":"Completed","startedAt":"2025-02-15T08:12:57Z","finishedAt":"2025-02-15T08:13:03Z","containerID":"containerd://89cdb4348fa177380e1188f0393d958858209128b3e2aa56308c1ea0c2b4bac1"}},"lastState":{},"ready":false,"restartCount":0,"image":"registry.k8s.io/e2e-test-images/busybox:1.36.1-1","imageID":"registry.k8s.io/e2e-test-images/busybox@sha256:a9155b13325b2abef48e71de77bb8ac015412a566829f621d06bfae5c699b1b9","containerID":"containerd://89cdb4348fa177380e1188f0393d958858209128b3e2aa56308c1ea0c2b4bac1","started":false,"volumeMounts":[{"name":"test-volume","mountPath":"/test-volume"},{"name":"liveness-probe-volume","mountPath":"/probe-volume"},{"name":"kube-api-access-d7bjr","mountPath":"/var/run/secrets/kubernetes.io/serviceaccount","readOnly":true,"recursiveReadOnly":"Disabled"}]},{"name":"test-container-volume-configmap-h8zg","state":{"running":{"startedAt":"2025-02-15T08:12:58Z"}},"lastState":{},"ready":true,"restartCount":0,"image":"registry.k8s.io/e2e-test-images/busybox:1.36.1-1","imageID":"registry.k8s.io/e2e-test-images/busybox@sha256:a9155b13325b2abef48e71de77bb8ac015412a566829f621d06bfae5c699b1b9","containerID":"containerd://b83d07f353e6c10960e144839d90c658f1f40aea77ea78a9483620e33f98b67b","started":true,"volumeMounts":[{"name":"test-volume","mountPath":"/test-volume"},{"name":"liveness-probe-volume","mountPath":"/probe-volume"},{"name":"kube-api-access-d7bjr","mountPath":"/var/run/secrets/kubernetes.io/serviceaccount","readOnly":true,"recursiveReadOnly":"Disabled"}]}],"qosClass":"BestEffort"}

// The ContainersToStart of the computed PodActions is empty, so no new container is created to replace the previous one.
Feb 15 08:14:31 kind-worker kubelet[285]: I0215 08:14:31.576812     285 helpers.go:104] "Already successfully ran container, do nothing" pod="subpath-2059/pod-subpath-test-configmap-h8zg" containerName="test-container-subpath-configmap-h8zg"
Feb 15 08:14:31 kind-worker kubelet[285]: I0215 08:14:31.576881     285 kuberuntime_manager.go:1148] "computePodActions got for pod" podActions="KillPod: false, CreateSandbox: false, UpdatePodResources: false, Attempt: 0, InitContainersToStart: [], ContainersToStart: [], EphemeralContainersToStart: [],ContainersToUpdate: map[], ContainersToKill: map[]" pod="subpath-2059/pod-subpath-test-configmap-h8zg"
```

**Root cause:**

The RestartPolicy of the pod is `OnFailure` and the container exited successfully.

- https://github.com/kubernetes/kubernetes/blob/c2529e844395f8895ae809fa1a5775ea8181fd20/test/e2e/storage/testsuites/subpath.go#L793
- https://github.com/kubernetes/kubernetes/blob/c2529e844395f8895ae809fa1a5775ea8181fd20/pkg/kubelet/container/helpers.go#L103
- https://github.com/kubernetes/kubernetes/blob/c2529e844395f8895ae809fa1a5775ea8181fd20/test/e2e/framework/pod/utils.go#L34

**Fix it:**

Drop `trap exit TERM` from the command to make the container exit with a non-zero exit code.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #130268

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
