### PR TITLE
Add support for writing TLS client random and master secret in NSS key log format

### DIFF
--- a/staging/src/k8s.io/client-go/transport/transport.go
+++ b/staging/src/k8s.io/client-go/transport/transport.go
@@ -204,6 +204,20 @@ func TLSConfigFor(c *Config) (*tls.Config, error) {
 		}
 	}
 
+	// Add support for writing TLS client random and master secret in NSS key log format.
+	// https: //developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/Key_Log_Format
+	// Only available in debug mode.
+	if klog.V(9).Enabled() { // nolint:logcheck
+		if keylogFile := os.Getenv("SSLKEYLOGFILE"); keylogFile != "" {
+			w, err := os.OpenFile(keylogFile, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0600)
+			if err != nil {
+				klog.Warningf("Could not open SSLKEYLOGFILE %s", keylogFile)
+			} else {
+				tlsConfig.KeyLogWriter = w
+			}
+		}
+	}
+
 	return tlsConfig, nil
 }
 


### PR DESCRIPTION
Add support for writing TLS client random and master secret in NSS key log format.

https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/Key_Log_Format

This is only available with debug level >= 9, it allows to debug TLS based connections by setting the SSLKEYLOGFILE environment variable.

/kind feature

#### What this PR does / why we need it:

Debugging kubectl or client-go applications is complex, and sometimes we need to use packet captures.
It is unlikely that production workloads run without TLS, so a common technique is to use TLS description as explained in https://wiki.wireshark.org/TLS#tls-decryption

> The key log file is a text file generated by applications such as Firefox, Chrome and curl when the SSLKEYLOGFILE environment variable is set. To be precise, their underlying library (NSS, OpenSSL or boringssl) writes the required per-session secrets to a file. This file can subsequently be configured in Wireshark ([#Using the (Pre)-Master Secret](https://wiki.wireshark.org/TLS#using-the-pre-master-secret)).

#### Does this PR introduce a user-facing change?

```release-note
client-go support NSS-formatted key log file with debug level greater or equal to 9 by setting the environment variable SSLKEYLOGFILE 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

1. Start tcpdump to capture your application traffic to the kube-apiserver

```
tcpdump -i any -w apiserver_traffic.cap host <apiserver> and port <apiserver port>
```

2. Set the SSLKEYLOGFILE variable and run your application (using kubectl in this example)

```
$ export SSLKEYLOGFILE=$HOME/keylogfile.txt
$ kubectl -v9  exec test2 -i -- ls
I0220 10:31:37.150368  105776 loader.go:395] Config loaded from file:  /usr/local/google/home/aojea/.kube/config
I0220 10:31:37.154516  105776 round_trippers.go:466] curl -v -XGET  -H "Accept: application/json, */*" -H "User-Agent: kubectl/v1.31.5 (linux/amd64) kubernetes/af64d83" 'https://127.0.0.1:44979/api/v1/namespaces/default/pods/test2'
I0220 10:31:37.154748  105776 round_trippers.go:510] HTTP Trace: Dial to tcp:127.0.0.1:44979 succeed
```

3. Open the packet capture in wireshark and follow the instructions in https://wiki.wireshark.org/TLS by loading the generated `keylogfile.txt`

![image](https://github.com/user-attachments/assets/5a4ae142-3024-4793-a06e-82b7ce828259)

You can also debug the websocket protocol used for exec and streaming applications

![image](https://github.com/user-attachments/assets/ddb47f60-3e9f-4d65-98f4-be7c2390b142)


Now you are able to troubleshoot your applications that use client-go with a common feature that is already present in firefox, chrome, curl, ...

References:
- https://github.com/golang/go/issues/13057
- https://wiki.wireshark.org/TLS

