### PR TITLE
test(statefulset): return errors in framework function GetPodList for upstream handling

### DIFF
--- a/test/e2e/apps/statefulset.go
+++ b/test/e2e/apps/statefulset.go
@@ -206,7 +206,9 @@ var _ = SIGDescribe("StatefulSet", func() {
 
 			ginkgo.By("Saturating stateful set " + ss.Name)
 			e2estatefulset.Saturate(ctx, c, ss)
-			pods := e2estatefulset.GetPodList(ctx, c, ss)
+			pods, err := e2estatefulset.GetPodList(ctx, c, ss)
+			framework.ExpectNoError(err)
+
 			gomega.Expect(pods.Items).To(gomega.HaveLen(int(*ss.Spec.Replicas)))
 
 			ginkgo.By("Checking that stateful set pods are created with ControllerRef")
@@ -354,7 +356,9 @@ var _ = SIGDescribe("StatefulSet", func() {
 			currentRevision, updateRevision := ss.Status.CurrentRevision, ss.Status.UpdateRevision
 			gomega.Expect(currentRevision).To(gomega.Equal(updateRevision), "StatefulSet %s/%s created with update revision %s not equal to current revision %s",
 				ss.Namespace, ss.Name, updateRevision, currentRevision)
-			pods := e2estatefulset.GetPodList(ctx, c, ss)
+			pods, err := e2estatefulset.GetPodList(ctx, c, ss)
+			framework.ExpectNoError(err)
+
 			for i := range pods.Items {
 				gomega.Expect(pods.Items[i].Labels).To(gomega.HaveKeyWithValue(appsv1.StatefulSetRevisionLabel, currentRevision), "Pod %s/%s revision %s is not equal to currentRevision %s",
 					pods.Items[i].Namespace,
@@ -443,7 +447,9 @@ var _ = SIGDescribe("StatefulSet", func() {
 			deleteStatefulPodAtIndex(ctx, c, 2, ss)
 			e2estatefulset.WaitForRunningAndReady(ctx, c, 3, ss)
 			ss = getStatefulSet(ctx, c, ss.Namespace, ss.Name)
-			pods = e2estatefulset.GetPodList(ctx, c, ss)
+			pods, err = e2estatefulset.GetPodList(ctx, c, ss)
+			framework.ExpectNoError(err)
+
 			for i := range pods.Items {
 				if i < int(*ss.Spec.UpdateStrategy.RollingUpdate.Partition) {
 					gomega.Expect(pods.Items[i].Spec.Containers[0].Image).To(gomega.Equal(oldImage), "Pod %s/%s has image %s not equal to current image %s",
@@ -580,7 +586,9 @@ var _ = SIGDescribe("StatefulSet", func() {
 			currentRevision, updateRevision := ss.Status.CurrentRevision, ss.Status.UpdateRevision
 			gomega.Expect(currentRevision).To(gomega.Equal(updateRevision), "StatefulSet %s/%s created with update revision %s not equal to current revision %s",
 				ss.Namespace, ss.Name, updateRevision, currentRevision)
-			pods := e2estatefulset.GetPodList(ctx, c, ss)
+			pods, err := e2estatefulset.GetPodList(ctx, c, ss)
+			framework.ExpectNoError(err)
+
 			for i := range pods.Items {
 				gomega.Expect(pods.Items[i].Labels).To(gomega.HaveKeyWithValue(appsv1.StatefulSetRevisionLabel, currentRevision), "Pod %s/%s revision %s is not equal to current revision %s",
 					pods.Items[i].Namespace,
@@ -595,7 +603,9 @@ var _ = SIGDescribe("StatefulSet", func() {
 			deleteStatefulPodAtIndex(ctx, c, 2, ss)
 			e2estatefulset.WaitForRunningAndReady(ctx, c, 3, ss)
 			ss = getStatefulSet(ctx, c, ss.Namespace, ss.Name)
-			pods = e2estatefulset.GetPodList(ctx, c, ss)
+			pods, err = e2estatefulset.GetPodList(ctx, c, ss)
+			framework.ExpectNoError(err)
+
 			for i := range pods.Items {
 				gomega.Expect(pods.Items[i].Labels).To(gomega.HaveKeyWithValue(appsv1.StatefulSetRevisionLabel, currentRevision), "Pod %s/%s revision %s is not equal to current revision %s",
 					pods.Items[i].Namespace,
@@ -624,7 +634,9 @@ var _ = SIGDescribe("StatefulSet", func() {
 			deleteStatefulPodAtIndex(ctx, c, 2, ss)
 			e2estatefulset.WaitForRunningAndReady(ctx, c, 3, ss)
 			ss = getStatefulSet(ctx, c, ss.Namespace, ss.Name)
-			pods = e2estatefulset.GetPodList(ctx, c, ss)
+			pods, err = e2estatefulset.GetPodList(ctx, c, ss)
+			framework.ExpectNoError(err)
+
 			for i := range pods.Items {
 				gomega.Expect(pods.Items[i].Spec.Containers[0].Image).To(gomega.Equal(newImage), "Pod %s/%s has image %s not equal to new image %s",
 					pods.Items[i].Namespace,
@@ -1816,7 +1828,9 @@ var _ = SIGDescribe("StatefulSet", func() {
 			e2estatefulset.WaitForStatusReadyReplicas(ctx, c, ss, 2)
 
 			ginkgo.By("Confirming 2 replicas, with start ordinal 0")
-			pods := e2estatefulset.GetPodList(ctx, c, ss)
+			pods, err := e2estatefulset.GetPodList(ctx, c, ss)
+			framework.ExpectNoError(err)
+
 			err = expectPodNames(pods, []string{"ss-0", "ss-1"})
 			framework.ExpectNoError(err)
 
@@ -1851,7 +1865,9 @@ var _ = SIGDescribe("StatefulSet", func() {
 			e2estatefulset.WaitForStatusReadyReplicas(ctx, c, ss, 2)
 
 			ginkgo.By("Confirming 2 replicas, with start ordinal 2")
-			pods := e2estatefulset.GetPodList(ctx, c, ss)
+			pods, err := e2estatefulset.GetPodList(ctx, c, ss)
+			framework.ExpectNoError(err)
+
 			err = expectPodNames(pods, []string{"ss-2", "ss-3"})
 			framework.ExpectNoError(err)
 
@@ -1885,7 +1901,9 @@ var _ = SIGDescribe("StatefulSet", func() {
 			e2estatefulset.WaitForStatusReadyReplicas(ctx, c, ss, 2)
 
 			ginkgo.By("Confirming 2 replicas, with start ordinal 3")
-			pods := e2estatefulset.GetPodList(ctx, c, ss)
+			pods, err := e2estatefulset.GetPodList(ctx, c, ss)
+			framework.ExpectNoError(err)
+
 			err = expectPodNames(pods, []string{"ss-3", "ss-4"})
 			framework.ExpectNoError(err)
 
@@ -1918,7 +1936,9 @@ var _ = SIGDescribe("StatefulSet", func() {
 			e2estatefulset.WaitForStatusReadyReplicas(ctx, c, ss, 2)
 
 			ginkgo.By("Confirming 2 replicas, with start ordinal 3")
-			pods := e2estatefulset.GetPodList(ctx, c, ss)
+			pods, err := e2estatefulset.GetPodList(ctx, c, ss)
+			framework.ExpectNoError(err)
+
 			err = expectPodNames(pods, []string{"ss-3", "ss-4"})
 			framework.ExpectNoError(err)
 
@@ -2170,7 +2190,9 @@ func rollbackTest(ctx context.Context, c clientset.Interface, ns string, ss *app
 	currentRevision, updateRevision := ss.Status.CurrentRevision, ss.Status.UpdateRevision
 	gomega.Expect(currentRevision).To(gomega.Equal(updateRevision), "StatefulSet %s/%s created with update revision %s not equal to current revision %s",
 		ss.Namespace, ss.Name, updateRevision, currentRevision)
-	pods := e2estatefulset.GetPodList(ctx, c, ss)
+	pods, err := e2estatefulset.GetPodList(ctx, c, ss)
+	framework.ExpectNoError(err)
+
 	for i := range pods.Items {
 		gomega.Expect(pods.Items[i].Labels).To(gomega.HaveKeyWithValue(appsv1.StatefulSetRevisionLabel, currentRevision), "Pod %s/%s revision %s is not equal to current revision %s",
 			pods.Items[i].Namespace,
@@ -2198,7 +2220,9 @@ func rollbackTest(ctx context.Context, c clientset.Interface, ns string, ss *app
 	gomega.Expect(currentRevision).NotTo(gomega.Equal(updateRevision), "Current revision should not equal update revision during rolling update")
 
 	ginkgo.By("Updating Pods in reverse ordinal order")
-	pods = e2estatefulset.GetPodList(ctx, c, ss)
+	pods, err = e2estatefulset.GetPodList(ctx, c, ss)
+	framework.ExpectNoError(err)
+
 	e2estatefulset.SortStatefulPods(pods)
 	err = restorePodHTTPProbe(ss, &pods.Items[1])
 	framework.ExpectNoError(err)
@@ -2237,7 +2261,9 @@ func rollbackTest(ctx context.Context, c clientset.Interface, ns string, ss *app
 	gomega.Expect(currentRevision).NotTo(gomega.Equal(updateRevision), "Current revision should not equal update revision during roll back")
 
 	ginkgo.By("Rolling back update in reverse ordinal order")
-	pods = e2estatefulset.GetPodList(ctx, c, ss)
+	pods, err = e2estatefulset.GetPodList(ctx, c, ss)
+	framework.ExpectNoError(err)
+
 	e2estatefulset.SortStatefulPods(pods)
 	restorePodHTTPProbe(ss, &pods.Items[1])
 	ss, _ = e2estatefulset.WaitForPodReady(ctx, c, ss, pods.Items[1].Name)
@@ -2280,7 +2306,9 @@ func deletingPodForRollingUpdatePartitionTest(ctx context.Context, f *framework.
 	currentRevision, updateRevision := ss.Status.CurrentRevision, ss.Status.UpdateRevision
 	gomega.Expect(currentRevision).To(gomega.Equal(updateRevision), fmt.Sprintf("StatefulSet %s/%s created with update revision %s not equal to current revision %s",
 		ss.Namespace, ss.Name, updateRevision, currentRevision))
-	pods := e2estatefulset.GetPodList(ctx, c, ss)
+	pods, err := e2estatefulset.GetPodList(ctx, c, ss)
+	framework.ExpectNoError(err)
+
 	for i := range pods.Items {
 		gomega.Expect(pods.Items[i].Labels[appsv1.StatefulSetRevisionLabel]).To(gomega.Equal(currentRevision), fmt.Sprintf("Pod %s/%s revision %s is not equal to currentRevision %s",
 			pods.Items[i].Namespace,
@@ -2372,7 +2400,9 @@ func deletingPodForRollingUpdatePartitionTest(ctx context.Context, f *framework.
 	})
 
 	ginkgo.By("Verify pod images after pod-0 deletion and recreation")
-	pods = e2estatefulset.GetPodList(ctx, c, ss)
+	pods, err = e2estatefulset.GetPodList(ctx, c, ss)
+	framework.ExpectNoError(err)
+
 	for i := range pods.Items {
 		if i < int(*ss.Spec.UpdateStrategy.RollingUpdate.Partition) {
 			gomega.Expect(pods.Items[i].Spec.Containers[0].Image).To(gomega.Equal(oldImage), fmt.Sprintf("Pod %s/%s has image %s not equal to current image %s",
@@ -2406,7 +2436,9 @@ func confirmStatefulPodCount(ctx context.Context, c clientset.Interface, count i
 	start := time.Now()
 	deadline := start.Add(timeout)
 	for t := time.Now(); t.Before(deadline) && ctx.Err() == nil; t = time.Now() {
-		podList := e2estatefulset.GetPodList(ctx, c, ss)
+		podList, err := e2estatefulset.GetPodList(ctx, c, ss)
+		framework.ExpectNoError(err)
+
 		statefulPodCount := len(podList.Items)
 		if statefulPodCount != count {
 			e2epod.LogPodStates(podList.Items)

--- a/test/e2e/framework/statefulset/fixtures.go
+++ b/test/e2e/framework/statefulset/fixtures.go
@@ -156,7 +156,9 @@ func PauseNewPods(ss *appsv1.StatefulSet) {
 // or if it finds more than one paused Pod existing at the same time.
 // This is a no-op if there are no paused pods.
 func ResumeNextPod(ctx context.Context, c clientset.Interface, ss *appsv1.StatefulSet) {
-	podList := GetPodList(ctx, c, ss)
+	podList, err := GetPodList(ctx, c, ss)
+	framework.ExpectNoError(err)
+
 	resumedPod := ""
 	for _, pod := range podList.Items {
 		if pod.Status.Phase != v1.PodRunning {

--- a/test/e2e/framework/statefulset/wait.go
+++ b/test/e2e/framework/statefulset/wait.go
@@ -34,7 +34,11 @@ import (
 func WaitForRunning(ctx context.Context, c clientset.Interface, numPodsRunning, numPodsReady int32, ss *appsv1.StatefulSet) {
 	pollErr := wait.PollUntilContextTimeout(ctx, StatefulSetPoll, StatefulSetTimeout, true,
 		func(ctx context.Context) (bool, error) {
-			podList := GetPodList(ctx, c, ss)
+			podList, err := GetPodList(ctx, c, ss)
+			if err != nil {
+				return false, err
+			}
+
 			SortStatefulPods(podList)
 			if int32(len(podList.Items)) < numPodsRunning {
 				framework.Logf("Found %d stateful pods, waiting for %d", len(podList.Items), numPodsRunning)
@@ -67,7 +71,11 @@ func WaitForState(ctx context.Context, c clientset.Interface, ss *appsv1.Statefu
 			if err != nil {
 				return false, err
 			}
-			podList := GetPodList(ctx, c, ssGet)
+			podList, err := GetPodList(ctx, c, ssGet)
+			if err != nil {
+				return false, err
+			}
+
 			return until(ssGet, podList)
 		})
 	if pollErr != nil {

--- a/test/e2e/storage/persistent_volumes-local.go
+++ b/test/e2e/storage/persistent_volumes-local.go
@@ -1157,7 +1157,8 @@ func createStatefulSet(ctx context.Context, config *localTestConfig, ssReplicas 
 }
 
 func validateStatefulSet(ctx context.Context, config *localTestConfig, ss *appsv1.StatefulSet, anti bool) {
-	pods := e2estatefulset.GetPodList(ctx, config.client, ss)
+	pods, err := e2estatefulset.GetPodList(ctx, config.client, ss)
+	framework.ExpectNoError(err)
 
 	nodes := sets.NewString()
 	for _, pod := range pods.Items {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:
Framework util function GetPodList was handling errors on its own, instead of returning them to be handled by the caller, which was causing a panic when it was called from a polling loop and errored. This PR fixes this by always returning errors and modifying all places where the function was called to handle them.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #130159

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
