### PR TITLE
set restartpolicy default as always for static pods

### DIFF
--- a/pkg/kubelet/config/common.go
+++ b/pkg/kubelet/config/common.go
@@ -96,6 +96,13 @@ func applyDefaults(pod *api.Pod, source string, isFile bool, nodeName types.Node
 		})
 	}
 
+	if pod.Spec.RestartPolicy != api.RestartPolicyAlways {
+		// RestartPolicy for static pods can only be Always,
+		// since the Kubelet doesn't track the pod status in a persistent way.
+		pod.Spec.RestartPolicy = api.RestartPolicyAlways
+		klog.V(5).InfoS("Set restartPolicy for static pod as Always", "pod", klog.KObj(pod), "source", source)
+	}
+
 	// Set the default status to pending.
 	pod.Status.Phase = api.PodPending
 	return nil


### PR DESCRIPTION
Default restartPolicy for static pods as `Always`

#### What type of PR is this?

/kind bug

#### Which issue(s) this PR fixes:
Fixes #130288 

#### Does this PR introduce a user-facing change?

```release-note
StaticPods to take default restartPolicy as Always. 
```
/cc @tallclair 
