### PR TITLE
Fix kubelet restart unmounts volumes of running pods if the referenced PVC is being deleted by the user 

### DIFF
--- a/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator.go
+++ b/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"sync"
 	"time"
 
@@ -528,15 +529,21 @@ func (dswp *desiredStateOfWorldPopulator) getPVCExtractPV(
 		return nil, fmt.Errorf("failed to fetch PVC from API server: %v", err)
 	}
 
-	// Pods that uses a PVC that is being deleted must not be started.
+	// Pods that uses a PVC that is being deleted and not protected by
+	// kubernetes.io/pvc-protection must not be started.
 	//
-	// In case an old kubelet is running without this check or some kubelets
-	// have this feature disabled, the worst that can happen is that such
-	// pod is scheduled. This was the default behavior in 1.8 and earlier
-	// and users should not be that surprised.
+	// 1) In case an old kubelet is running without this check, the worst
+	// that can happen is that such pod is scheduled. This was the default
+	// behavior in 1.8 and earlier and users should not be that surprised.
 	// It should happen only in very rare case when scheduler schedules
 	// a pod and user deletes a PVC that's used by it at the same time.
-	if pvc.ObjectMeta.DeletionTimestamp != nil {
+	//
+	// 2) Adding a check for kubernetes.io/pvc-protection here to prevent
+	// the existing running pods from being affected during the rebuild of
+	// the desired state of the world cache when the kubelet is restarted.
+	// It is safe for kubelet to add this check here because the PVC will
+	// be stuck in Terminating state until the pod is deleted.
+	if pvc.ObjectMeta.DeletionTimestamp != nil && !slices.Contains(pvc.Finalizers, util.PVCProtectionFinalizer) {
 		return nil, errors.New("PVC is being deleted")
 	}
 

--- a/test/e2e/storage/csimock/csi_kubelet_restart.go
+++ b/test/e2e/storage/csimock/csi_kubelet_restart.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package csimock
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/test/e2e/feature"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	"k8s.io/kubernetes/test/e2e/storage/utils"
+	admissionapi "k8s.io/pod-security-admission/api"
+)
+
+var _ = utils.SIGDescribe("CSI Mock when kubelet restart", feature.Kind, framework.WithSerial(), framework.WithDisruptive(), func() {
+	f := framework.NewDefaultFramework("csi-mock-when-kubelet-restart")
+	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
+	m := newMockDriverSetup(f)
+
+	ginkgo.It("should not umount volume when the pvc is terminating but still used by a running pod", func(ctx context.Context) {
+		m.init(ctx, testParameters{
+			registerDriver: true,
+		})
+		ginkgo.DeferCleanup(m.cleanup)
+
+		ginkgo.By("Creating a Pod with a PVC backed by a CSI volume")
+		_, pvc, pod := m.createPod(ctx, pvcReference)
+
+		ginkgo.By("Waiting for the Pod to be running")
+		err := e2epod.WaitForPodRunningInNamespace(ctx, f.ClientSet, pod)
+		framework.ExpectNoError(err, "failed to wait for pod %s to be running", pod.Name)
+
+		ginkgo.By("Deleting the PVC")
+		err = f.ClientSet.CoreV1().PersistentVolumeClaims(pvc.Namespace).Delete(ctx, pvc.Name, metav1.DeleteOptions{})
+		framework.ExpectNoError(err, "failed to delete PVC %s", pvc.Name)
+
+		ginkgo.By("Restarting kubelet")
+		err = stopKindKubelet(ctx)
+		framework.ExpectNoError(err, "failed to stop kubelet")
+		err = startKindKubelet(ctx)
+		framework.ExpectNoError(err, "failed to start kubelet")
+
+		ginkgo.By("Verifying the PVC is terminating during kubelet restart")
+		pvc, err = f.ClientSet.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(ctx, pvc.Name, metav1.GetOptions{})
+		framework.ExpectNoError(err, "failed to get PVC %s", pvc.Name)
+		gomega.Expect(pvc.DeletionTimestamp).NotTo(gomega.BeNil(), "PVC %s should have deletion timestamp", pvc.Name)
+
+		// FIXME: the expected behavior is no NodeUnpublishVolume call is made during kubelet restart
+		ginkgo.By(fmt.Sprintf("Verifying that the driver received NodeUnpublishVolume call for PVC %s", pvc.Name))
+		gomega.Eventually(ctx, m.driver.GetCalls).
+			WithPolling(framework.Poll).
+			WithTimeout(framework.RestartNodeReadyAgainTimeout).
+			Should(gomega.ContainElement(gomega.HaveField("Method", gomega.Equal("NodeUnpublishVolume"))))
+
+		// ginkgo.By(fmt.Sprintf("Verifying that the driver didn't receive NodeUnpublishVolume call for PVC %s", pvc.Name))
+		// gomega.Consistently(ctx, m.driver.GetCalls).
+		// 	WithPolling(framework.Poll).
+		// 	WithTimeout(framework.ClaimProvisionShortTimeout).
+		// 	ShouldNot(gomega.ContainElement(gomega.HaveField("Method", gomega.Equal("NodeUnpublishVolume"))))
+
+		// ginkgo.By("Verifying the Pod is still running")
+		// err = e2epod.WaitForPodRunningInNamespace(ctx, f.ClientSet, pod)
+		// framework.ExpectNoError(err, "failed to wait for pod %s to be running", pod.Name)
+	})
+})
+
+func stopKindKubelet(ctx context.Context) error {
+	return kubeletExec("systemctl", "stop", "kubelet")
+}
+
+func startKindKubelet(ctx context.Context) error {
+	return kubeletExec("systemctl", "start", "kubelet")
+}
+
+// Run a command in container with kubelet (and the whole control plane as containers)
+func kubeletExec(command ...string) error {
+	containerName := getKindContainerName()
+	args := []string{"exec", containerName}
+	args = append(args, command...)
+	cmd := exec.Command("docker", args...)
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("command %q failed: %v\noutput:%s", prettyCmd(cmd), err, string(out))
+	}
+
+	framework.Logf("command %q succeeded:\n%s", prettyCmd(cmd), string(out))
+	return nil
+}
+
+func getKindContainerName() string {
+	clusterName := os.Getenv("KIND_CLUSTER_NAME")
+	if clusterName == "" {
+		clusterName = "kind"
+	}
+	return clusterName + "-control-plane"
+}
+
+func prettyCmd(cmd *exec.Cmd) string {
+	return fmt.Sprintf("%s %s", cmd.Path, strings.Join(cmd.Args, " "))
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

A user deletes a PVC referenced by a running pod. After the kubelet on the node is restarted (DSW rebuild), the CSI driver unmounts all volumes for the pod, triggered by NodeUnpublishVolume and NodeUnstageVolume. https://github.com/kubernetes/kubernetes/pull/130335/commits/0f40600b3160f8ecd2739fcf79ea200d30398673 and https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/130335/pull-kubernetes-e2e-storage-kind-disruptive/1892878133883834368 (https://github.com/kubernetes/kubernetes/pull/130335/commits/f904c6f46c0afe592f36164cc54192f122e83d75) can reproduce the issue.

https://github.com/kubernetes/kubernetes/pull/130335/commits/da087777a8a14013ecc826de3a5f8a22ad99b978 allows to populate the volume to dsw volume map if the claim is stuck in the terminating state. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix kubelet restart unmounts volumes of running pods if the referenced PVC is being deleted by the user 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
