### PR TITLE
hack: split up test-dockerized.sh

### DIFF
--- a/hack/jenkins/test-cmd-dockerized.sh
+++ b/hack/jenkins/test-cmd-dockerized.sh
@@ -19,7 +19,7 @@ set -o nounset
 set -o pipefail
 set -o xtrace
 
-# Runs test-cmd and test-integration,
+# Runs test-cmd,
 # producing JUnit-style XML test
 # reports in ${WORKSPACE}/artifacts. This script is intended to be run from
 # kubekins-test container with a kubernetes repo mapped in. See
@@ -27,21 +27,12 @@ set -o xtrace
 
 export PATH=${GOPATH}/bin:${PWD}/third_party/etcd:/usr/local/go/bin:${PATH}
 
-# Install tools we need
-go -C "./hack/tools" install gotest.tools/gotestsum
-
-# Disable coverage report
-export KUBE_COVER="n"
 # Set artifacts directory
 export ARTIFACTS=${ARTIFACTS:-"${WORKSPACE}/artifacts"}
-# Save the verbose stdout as well.
-export KUBE_KEEP_VERBOSE_TEST_OUTPUT=y
-export KUBE_INTEGRATION_TEST_MAX_CONCURRENCY=4
-export LOG_LEVEL=4
 
 cd "${GOPATH}/src/k8s.io/kubernetes"
 
 ./hack/install-etcd.sh
 
 make test-cmd
-make test-integration
+

--- a/hack/jenkins/test-integration-dockerized.sh
+++ b/hack/jenkins/test-integration-dockerized.sh
@@ -19,7 +19,7 @@ set -o nounset
 set -o pipefail
 set -o xtrace
 
-# Runs test-cmd and test-integration,
+# Runs test-integration,
 # producing JUnit-style XML test
 # reports in ${WORKSPACE}/artifacts. This script is intended to be run from
 # kubekins-test container with a kubernetes repo mapped in. See
@@ -43,5 +43,4 @@ cd "${GOPATH}/src/k8s.io/kubernetes"
 
 ./hack/install-etcd.sh
 
-make test-cmd
 make test-integration


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This enables testing command and integration tests separately in CI jobs. The goal is to reduce pull-kubernetes-integration to testing really just the Go test/integration tests and to add a pull-kubernetes-cmd job for command tests.

hack/jenkins/test-dockerized.sh does the same as before because some jobs will probably continue to use it.

#### Which issue(s) this PR fixes:

Discussed in https://kubernetes.slack.com/archives/C09QZ4DQB/p1740083887716479

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/hold

For testing with to-be-defined canary presubmits.

/cc @dims @aojea @BenTheElder 
/sig testing