### PR TITLE
kubeadm: Replace the yaml in the log/comments with a generic term.

### DIFF
--- a/cmd/kubeadm/app/cmd/config_test.go
+++ b/cmd/kubeadm/app/cmd/config_test.go
@@ -399,9 +399,9 @@ func TestNewCmdConfigPrintActionDefaults(t *testing.T) {
 				t.Fatalf("Error from running the print command: %v", err)
 			}
 
-			gvkmap, err := kubeadmutil.SplitYAMLDocuments(output.Bytes())
+			gvkmap, err := kubeadmutil.SplitConfigDocuments(output.Bytes())
 			if err != nil {
-				t.Fatalf("unexpected failure of SplitYAMLDocuments: %v", err)
+				t.Fatalf("unexpected failure of SplitConfigDocuments: %v", err)
 			}
 
 			gotKinds := []string{}

--- a/cmd/kubeadm/app/componentconfigs/configset.go
+++ b/cmd/kubeadm/app/componentconfigs/configset.go
@@ -86,7 +86,7 @@ func (h *handler) fromConfigMap(client clientset.Interface, cmName, cmKey string
 		return nil, errors.Errorf("unexpected error when reading %s ConfigMap: %s key value pair missing", cmName, cmKey)
 	}
 
-	gvkmap, err := kubeadmutil.SplitYAMLDocuments([]byte(configData))
+	gvkmap, err := kubeadmutil.SplitConfigDocuments([]byte(configData))
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/kubeadm/app/componentconfigs/configset_test.go
+++ b/cmd/kubeadm/app/componentconfigs/configset_test.go
@@ -78,9 +78,9 @@ func TestFetchFromDocumentMap(t *testing.T) {
 	apiVersion: kubelet.config.k8s.io/v1beta1
 	kind: KubeletConfiguration
 	`)
-	gvkmap, err := kubeadmutil.SplitYAMLDocuments([]byte(test))
+	gvkmap, err := kubeadmutil.SplitConfigDocuments([]byte(test))
 	if err != nil {
-		t.Fatalf("unexpected failure of SplitYAMLDocuments: %v", err)
+		t.Fatalf("unexpected failure of SplitConfigDocuments: %v", err)
 	}
 
 	clusterCfg := testClusterCfg()

--- a/cmd/kubeadm/app/componentconfigs/fakeconfig_test.go
+++ b/cmd/kubeadm/app/componentconfigs/fakeconfig_test.go
@@ -293,9 +293,9 @@ func TestConfigBaseUnmarshal(t *testing.T) {
 			config: validUnmarshallableClusterConfig.obj,
 		}
 
-		gvkmap, err := kubeadmutil.SplitYAMLDocuments([]byte(validUnmarshallableClusterConfig.yaml))
+		gvkmap, err := kubeadmutil.SplitConfigDocuments([]byte(validUnmarshallableClusterConfig.yaml))
 		if err != nil {
-			t.Fatalf("unexpected failure of SplitYAMLDocuments: %v", err)
+			t.Fatalf("unexpected failure of SplitConfigDocuments: %v", err)
 		}
 
 		got := &clusterConfig{
@@ -461,9 +461,9 @@ func runClusterConfigFromTest(t *testing.T, perform func(t *testing.T, in string
 
 func TestLoadingFromDocumentMap(t *testing.T) {
 	runClusterConfigFromTest(t, func(t *testing.T, in string) (kubeadmapi.ComponentConfig, error) {
-		gvkmap, err := kubeadmutil.SplitYAMLDocuments([]byte(in))
+		gvkmap, err := kubeadmutil.SplitConfigDocuments([]byte(in))
 		if err != nil {
-			t.Fatalf("unexpected failure of SplitYAMLDocuments: %v", err)
+			t.Fatalf("unexpected failure of SplitConfigDocuments: %v", err)
 		}
 
 		return clusterConfigHandler.FromDocumentMap(gvkmap)

--- a/cmd/kubeadm/app/phases/kubelet/config.go
+++ b/cmd/kubeadm/app/phases/kubelet/config.go
@@ -110,7 +110,7 @@ func ApplyPatchesToConfig(cfg *kubeadmapi.ClusterConfiguration, patchesDir strin
 		}
 	}
 
-	gvkmap, err := kubeadmutil.SplitYAMLDocuments(kubeletBytes)
+	gvkmap, err := kubeadmutil.SplitConfigDocuments(kubeletBytes)
 	if err != nil {
 		return err
 	}

--- a/cmd/kubeadm/app/util/config/cluster.go
+++ b/cmd/kubeadm/app/util/config/cluster.go
@@ -60,7 +60,7 @@ func FetchInitConfigurationFromCluster(client clientset.Interface, printer outpu
 	}
 	_, _ = printer.Printf("[%s] Reading configuration from the %q ConfigMap in namespace %q...\n",
 		logPrefix, constants.KubeadmConfigConfigMap, metav1.NamespaceSystem)
-	_, _ = printer.Printf("[%s] Use 'kubeadm init phase upload-config --config your-config.yaml' to re-upload it.\n", logPrefix)
+	_, _ = printer.Printf("[%s] Use 'kubeadm init phase upload-config --config your-config-file' to re-upload it.\n", logPrefix)
 
 	// Fetch the actual config from cluster
 	cfg, err := getInitConfigurationFromCluster(constants.KubernetesDir, client, newControlPlane, skipComponentConfigs)
@@ -214,7 +214,7 @@ func GetNodeRegistration(kubeconfigFile string, client clientset.Interface, node
 
 // getNodeNameFromKubeletConfig gets the node name from a kubelet config file
 // TODO: in future we want to switch to a more canonical way for doing this e.g. by having this
-// information in the local kubelet config.yaml
+// information in the local kubelet config configuration file.
 func getNodeNameFromKubeletConfig(fileName string) (string, error) {
 	// loads the kubelet.conf file
 	config, err := clientcmd.LoadFromFile(fileName)

--- a/cmd/kubeadm/app/util/config/common.go
+++ b/cmd/kubeadm/app/util/config/common.go
@@ -94,11 +94,11 @@ func validateSupportedVersion(gvk schema.GroupVersionKind, allowDeprecated, allo
 	gvString := gvk.GroupVersion().String()
 
 	if useKubeadmVersion := oldKnownAPIVersions[gvString]; useKubeadmVersion != "" {
-		return errors.Errorf("your configuration file uses an old API spec: %q (kind: %q). Please use kubeadm %s instead and run 'kubeadm config migrate --old-config old.yaml --new-config new.yaml', which will write the new, similar spec using a newer API version.", gvString, gvk.Kind, useKubeadmVersion)
+		return errors.Errorf("your configuration file uses an old API spec: %q (kind: %q). Please use kubeadm %s instead and run 'kubeadm config migrate --old-config old-config-file --new-config new-config-file', which will write the new, similar spec using a newer API version.", gvString, gvk.Kind, useKubeadmVersion)
 	}
 
 	if _, present := deprecatedAPIVersions[gvString]; present && !allowDeprecated {
-		klog.Warningf("your configuration file uses a deprecated API spec: %q (kind: %q). Please use 'kubeadm config migrate --old-config old.yaml --new-config new.yaml', which will write the new, similar spec using a newer API version.", gvString, gvk.Kind)
+		klog.Warningf("your configuration file uses a deprecated API spec: %q (kind: %q). Please use 'kubeadm config migrate --old-config old-config-file --new-config new-config-file', which will write the new, similar spec using a newer API version.", gvString, gvk.Kind)
 	}
 
 	if _, present := experimentalAPIVersions[gvString]; present && !allowExperimental {

--- a/cmd/kubeadm/app/util/config/common.go
+++ b/cmd/kubeadm/app/util/config/common.go
@@ -256,7 +256,7 @@ func MigrateOldConfig(oldConfig []byte, allowExperimental bool, mutators migrate
 		mutators = defaultMigrateMutators()
 	}
 
-	gvkmap, err := kubeadmutil.SplitYAMLDocuments(oldConfig)
+	gvkmap, err := kubeadmutil.SplitConfigDocuments(oldConfig)
 	if err != nil {
 		return []byte{}, err
 	}
@@ -329,7 +329,7 @@ func MigrateOldConfig(oldConfig []byte, allowExperimental bool, mutators migrate
 // ValidateConfig takes a byte slice containing a kubeadm configuration and performs conversion
 // to internal types and validation.
 func ValidateConfig(config []byte, allowExperimental bool) error {
-	gvkmap, err := kubeadmutil.SplitYAMLDocuments(config)
+	gvkmap, err := kubeadmutil.SplitConfigDocuments(config)
 	if err != nil {
 		return err
 	}

--- a/cmd/kubeadm/app/util/config/common_test.go
+++ b/cmd/kubeadm/app/util/config/common_test.go
@@ -29,8 +29,10 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/apimachinery/pkg/util/version"
 	apimachineryversion "k8s.io/apimachinery/pkg/version"
+	"sigs.k8s.io/yaml"
 
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmapiv1old "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
@@ -40,6 +42,14 @@ import (
 )
 
 const KubeadmGroupName = "kubeadm.k8s.io"
+
+var formats = []struct {
+	name    string
+	marshal func(interface{}) ([]byte, error)
+}{
+	{name: "JSON", marshal: json.Marshal},
+	{name: "YAML", marshal: yaml.Marshal},
+}
 
 func TestValidateSupportedVersion(t *testing.T) {
 	tests := []struct {

--- a/cmd/kubeadm/app/util/config/initconfiguration.go
+++ b/cmd/kubeadm/app/util/config/initconfiguration.go
@@ -295,7 +295,7 @@ func LoadOrDefaultInitConfiguration(cfgPath string, versionedInitCfg *kubeadmapi
 // and well-known ComponentConfig GroupVersionKinds are stored inside of the internal InitConfiguration struct.
 // The resulting InitConfiguration is then dynamically defaulted and validated prior to return.
 func BytesToInitConfiguration(b []byte, skipCRIDetect bool) (*kubeadmapi.InitConfiguration, error) {
-	gvkmap, err := kubeadmutil.SplitYAMLDocuments(b)
+	gvkmap, err := kubeadmutil.SplitConfigDocuments(b)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/kubeadm/app/util/config/initconfiguration.go
+++ b/cmd/kubeadm/app/util/config/initconfiguration.go
@@ -291,10 +291,11 @@ func LoadOrDefaultInitConfiguration(cfgPath string, versionedInitCfg *kubeadmapi
 }
 
 // BytesToInitConfiguration converts a byte slice to an internal, defaulted and validated InitConfiguration object.
-// The map may contain many different YAML/JSON documents. These YAML/JSON documents are parsed one-by-one
+// The map may contain many different YAML/JSON documents. These documents are parsed one-by-one
 // and well-known ComponentConfig GroupVersionKinds are stored inside of the internal InitConfiguration struct.
 // The resulting InitConfiguration is then dynamically defaulted and validated prior to return.
 func BytesToInitConfiguration(b []byte, skipCRIDetect bool) (*kubeadmapi.InitConfiguration, error) {
+	// Split the YAML/JSON documents in the file into a DocumentMap
 	gvkmap, err := kubeadmutil.SplitConfigDocuments(b)
 	if err != nil {
 		return nil, err

--- a/cmd/kubeadm/app/util/config/initconfiguration_test.go
+++ b/cmd/kubeadm/app/util/config/initconfiguration_test.go
@@ -17,110 +17,76 @@ limitations under the License.
 package config
 
 import (
-	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/lithammer/dedent"
+
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/yaml"
+	"k8s.io/utils/ptr"
 
-	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta4"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 )
 
 func TestLoadInitConfigurationFromFile(t *testing.T) {
-	certDir := "/tmp/foo"
-	clusterCfg := []byte(fmt.Sprintf(`
-apiVersion: %s
-kind: ClusterConfiguration
-certificatesDir: %s
-kubernetesVersion: %s`, kubeadmapiv1.SchemeGroupVersion.String(), certDir, constants.MinimumControlPlaneVersion.String()))
-
-	// Create temp folder for the test case
 	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("Couldn't create tmpdir: %v", err)
 	}
-	defer os.RemoveAll(tmpdir)
+	defer func() {
+		if err := os.RemoveAll(tmpdir); err != nil {
+			t.Fatalf("Couldn't remove tmpdir: %v", err)
+		}
+	}()
+	filename := "kubeadmConfig"
+	filePath := filepath.Join(tmpdir, filename)
+	options := LoadOrDefaultConfigurationOptions{}
 
-	// cfgFiles is in cluster_test.go
-	var tests = []struct {
+	tests := []struct {
 		name         string
-		fileContents []byte
-		expectErr    bool
-		validate     func(*testing.T, *kubeadm.InitConfiguration)
+		cfgPath      string
+		fileContents string
+		wantErr      bool
 	}{
 		{
-			name:         "v1beta3.partial1",
-			fileContents: cfgFiles["InitConfiguration_v1beta3"],
+			name:    "Config file does not exists",
+			cfgPath: "tmp",
+			wantErr: true,
 		},
 		{
-			name: "v1beta3.partial2",
-			fileContents: bytes.Join([][]byte{
-				cfgFiles["InitConfiguration_v1beta3"],
-				clusterCfg,
-			}, []byte(constants.YAMLDocumentSeparator)),
-			validate: func(t *testing.T, cfg *kubeadm.InitConfiguration) {
-				if cfg.ClusterConfiguration.CertificatesDir != certDir {
-					t.Errorf("CertificatesDir from ClusterConfiguration holds the wrong value, Expected: %v. Actual: %v", certDir, cfg.ClusterConfiguration.CertificatesDir)
-				}
-			},
-		},
-		{
-			name: "v1beta3.full",
-			fileContents: bytes.Join([][]byte{
-				cfgFiles["InitConfiguration_v1beta3"],
-				cfgFiles["ClusterConfiguration_v1beta3"],
-				cfgFiles["Kube-proxy_componentconfig"],
-				cfgFiles["Kubelet_componentconfig"],
-			}, []byte(constants.YAMLDocumentSeparator)),
-		},
-		{
-			name: "v1beta4.full",
-			fileContents: bytes.Join([][]byte{
-				cfgFiles["InitConfiguration_v1beta4"],
-				cfgFiles["ClusterConfiguration_v1beta4"],
-				cfgFiles["Kube-proxy_componentconfig"],
-				cfgFiles["Kubelet_componentconfig"],
-			}, []byte(constants.YAMLDocumentSeparator)),
+			name:    "Valid kubeadm config",
+			cfgPath: filePath,
+			fileContents: dedent.Dedent(`
+				apiVersion: kubeadm.k8s.io/v1beta4
+				kind: InitConfiguration
+		`),
+			wantErr: false,
 		},
 	}
-
-	for _, rt := range tests {
-		t.Run(rt.name, func(t2 *testing.T) {
-			cfgPath := filepath.Join(tmpdir, rt.name)
-			err := os.WriteFile(cfgPath, rt.fileContents, 0644)
-			if err != nil {
-				t.Errorf("Couldn't create file: %v", err)
-				return
-			}
-
-			opts := LoadOrDefaultConfigurationOptions{
-				SkipCRIDetect: true,
-			}
-
-			obj, err := LoadInitConfigurationFromFile(cfgPath, opts)
-			if rt.expectErr {
-				if err == nil {
-					t.Error("Unexpected success")
-				}
-			} else {
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.cfgPath == filePath {
+				err = os.WriteFile(tt.cfgPath, []byte(tt.fileContents), 0644)
 				if err != nil {
-					t.Errorf("Error reading file: %v", err)
-					return
+					t.Fatalf("Couldn't write content to file: %v", err)
 				}
-
-				if obj == nil {
-					t.Error("Unexpected nil return value")
-				}
+				defer func() {
+					if err := os.RemoveAll(filePath); err != nil {
+						t.Fatalf("Couldn't remove filePath: %v", err)
+					}
+				}()
 			}
-			// exec additional validation on the returned value
-			if rt.validate != nil {
-				rt.validate(t, obj)
+
+			_, err = LoadInitConfigurationFromFile(tt.cfgPath, options)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("LoadInitConfigurationFromFile() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}
@@ -184,20 +150,167 @@ func TestDefaultTaintsMarshaling(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.desc, func(t *testing.T) {
-			b, err := yaml.Marshal(tc.cfg)
-			if err != nil {
-				t.Fatalf("unexpected error while marshalling to YAML: %v", err)
-			}
+		for _, format := range formats {
+			t.Run(fmt.Sprintf("%s_%s", tc.desc, format.name), func(t *testing.T) {
+				b, err := format.marshal(tc.cfg)
+				if err != nil {
+					t.Fatalf("unexpected error while marshalling to %s: %v", format.name, err)
+				}
 
-			cfg, err := BytesToInitConfiguration(b, true)
-			if err != nil {
-				t.Fatalf("unexpected error of BytesToInitConfiguration: %v\nconfig: %s", err, string(b))
-			}
+				cfg, err := BytesToInitConfiguration(b, true)
+				if err != nil {
+					t.Fatalf("unexpected error of BytesToInitConfiguration: %v\nconfig: %s", err, string(b))
+				}
 
-			if tc.expectedTaintCnt != len(cfg.NodeRegistration.Taints) {
-				t.Fatalf("unexpected taints count\nexpected: %d\ngot: %d\ntaints: %v", tc.expectedTaintCnt, len(cfg.NodeRegistration.Taints), cfg.NodeRegistration.Taints)
-			}
-		})
+				if tc.expectedTaintCnt != len(cfg.NodeRegistration.Taints) {
+					t.Fatalf("unexpected taints count\nexpected: %d\ngot: %d\ntaints: %v", tc.expectedTaintCnt, len(cfg.NodeRegistration.Taints), cfg.NodeRegistration.Taints)
+				}
+			})
+		}
+	}
+}
+
+func TestBytesToInitConfiguration(t *testing.T) {
+	tests := []struct {
+		name          string
+		cfg           interface{}
+		expectedCfg   kubeadmapi.InitConfiguration
+		expectedError bool
+		skipCRIDetect bool
+	}{
+		{
+			name: "default config is set correctly",
+			cfg: kubeadmapiv1.InitConfiguration{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: kubeadmapiv1.SchemeGroupVersion.String(),
+					Kind:       constants.InitConfigurationKind,
+				},
+			},
+			expectedCfg: kubeadmapi.InitConfiguration{
+				LocalAPIEndpoint: kubeadmapi.APIEndpoint{
+					AdvertiseAddress: "",
+					BindPort:         0,
+				},
+				NodeRegistration: kubeadmapi.NodeRegistrationOptions{
+					CRISocket: "unix:///var/run/containerd/containerd.sock",
+					Name:      "",
+					Taints: []v1.Taint{
+						{
+							Key:    "node-role.kubernetes.io/control-plane",
+							Effect: "NoSchedule",
+						},
+					},
+					ImagePullPolicy: "IfNotPresent",
+					ImagePullSerial: ptr.To(true),
+				},
+				ClusterConfiguration: kubeadmapi.ClusterConfiguration{
+					Etcd: kubeadmapi.Etcd{
+						Local: &kubeadmapi.LocalEtcd{
+							DataDir: "/var/lib/etcd",
+						},
+					},
+					KubernetesVersion:   "stable-1",
+					ImageRepository:     kubeadmapiv1.DefaultImageRepository,
+					ClusterName:         kubeadmapiv1.DefaultClusterName,
+					EncryptionAlgorithm: kubeadmapi.EncryptionAlgorithmType(kubeadmapiv1.DefaultEncryptionAlgorithm),
+					Networking: kubeadmapi.Networking{
+						ServiceSubnet: "10.96.0.0/12",
+						DNSDomain:     "cluster.local",
+					},
+					CertificatesDir: "/etc/kubernetes/pki",
+				},
+			},
+			skipCRIDetect: true,
+		},
+		{
+			name: "partial config with custom values",
+			cfg: kubeadmapiv1.InitConfiguration{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: kubeadmapiv1.SchemeGroupVersion.String(),
+					Kind:       constants.InitConfigurationKind,
+				},
+				NodeRegistration: kubeadmapiv1.NodeRegistrationOptions{
+					Name:      "test-node",
+					CRISocket: "unix:///var/run/containerd/containerd.sock",
+				},
+			},
+			expectedCfg: kubeadmapi.InitConfiguration{
+				LocalAPIEndpoint: kubeadmapi.APIEndpoint{
+					AdvertiseAddress: "",
+					BindPort:         0,
+				},
+				NodeRegistration: kubeadmapi.NodeRegistrationOptions{
+					CRISocket: "unix:///var/run/containerd/containerd.sock",
+					Name:      "test-node",
+					Taints: []v1.Taint{
+						{
+							Key:    "node-role.kubernetes.io/control-plane",
+							Effect: "NoSchedule",
+						},
+					},
+					ImagePullPolicy: "IfNotPresent",
+					ImagePullSerial: ptr.To(true),
+				},
+				ClusterConfiguration: kubeadmapi.ClusterConfiguration{
+					Etcd: kubeadmapi.Etcd{
+						Local: &kubeadmapi.LocalEtcd{
+							DataDir: "/var/lib/etcd",
+						},
+					},
+					KubernetesVersion:   "stable-1",
+					ImageRepository:     kubeadmapiv1.DefaultImageRepository,
+					ClusterName:         kubeadmapiv1.DefaultClusterName,
+					EncryptionAlgorithm: kubeadmapi.EncryptionAlgorithmType(kubeadmapiv1.DefaultEncryptionAlgorithm),
+					Networking: kubeadmapi.Networking{
+						ServiceSubnet: "10.96.0.0/12",
+						DNSDomain:     "cluster.local",
+					},
+					CertificatesDir: "/etc/kubernetes/pki",
+				},
+			},
+			skipCRIDetect: true,
+		},
+		{
+			name: "invalid configuration type",
+			cfg: kubeadmapiv1.UpgradeConfiguration{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: kubeadmapiv1.SchemeGroupVersion.String(),
+					Kind:       constants.UpgradeConfigurationKind,
+				},
+			},
+			expectedError: true,
+			skipCRIDetect: true,
+		},
+	}
+
+	for _, tc := range tests {
+		for _, format := range formats {
+			t.Run(fmt.Sprintf("%s_%s", tc.name, format.name), func(t *testing.T) {
+				b, err := format.marshal(tc.cfg)
+				if err != nil {
+					t.Fatalf("unexpected error marshaling %s: %v", format.name, err)
+				}
+
+				cfg, err := BytesToInitConfiguration(b, tc.skipCRIDetect)
+				if (err != nil) != tc.expectedError {
+					t.Fatalf("expected error: %v, got error: %v\nError: %v", tc.expectedError, err != nil, err)
+				}
+
+				if !tc.expectedError {
+					// Ignore dynamic fields that may be set during defaulting
+					diffOpts := []cmp.Option{
+						cmpopts.IgnoreFields(kubeadmapi.NodeRegistrationOptions{}, "Name"),
+						cmpopts.IgnoreFields(kubeadmapi.InitConfiguration{}, "Timeouts", "BootstrapTokens", "LocalAPIEndpoint"),
+						cmpopts.IgnoreFields(kubeadmapi.APIServer{}, "TimeoutForControlPlane"),
+						cmpopts.IgnoreFields(kubeadmapi.ClusterConfiguration{}, "ComponentConfigs", "KubernetesVersion",
+							"CertificateValidityPeriod", "CACertificateValidityPeriod"),
+					}
+
+					if diff := cmp.Diff(*cfg, tc.expectedCfg, diffOpts...); diff != "" {
+						t.Fatalf("unexpected configuration difference (-want +got):\n%s", diff)
+					}
+				}
+			})
+		}
 	}
 }

--- a/cmd/kubeadm/app/util/config/joinconfiguration.go
+++ b/cmd/kubeadm/app/util/config/joinconfiguration.go
@@ -87,7 +87,7 @@ func LoadJoinConfigurationFromFile(cfgPath string, opts LoadOrDefaultConfigurati
 		return nil, errors.Wrapf(err, "unable to read config from %q ", cfgPath)
 	}
 
-	gvkmap, err := kubeadmutil.SplitYAMLDocuments(b)
+	gvkmap, err := kubeadmutil.SplitConfigDocuments(b)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/kubeadm/app/util/config/joinconfiguration.go
+++ b/cmd/kubeadm/app/util/config/joinconfiguration.go
@@ -102,6 +102,7 @@ func documentMapToJoinConfiguration(gvkmap kubeadmapi.DocumentMap, allowDeprecat
 	for gvk, bytes := range gvkmap {
 		// not interested in anything other than JoinConfiguration
 		if gvk.Kind != constants.JoinConfigurationKind {
+			klog.Warningf("[config] WARNING: Ignored configuration document with GroupVersionKind %v\n", gvk)
 			continue
 		}
 

--- a/cmd/kubeadm/app/util/config/joinconfiguration.go
+++ b/cmd/kubeadm/app/util/config/joinconfiguration.go
@@ -95,7 +95,7 @@ func LoadJoinConfigurationFromFile(cfgPath string, opts LoadOrDefaultConfigurati
 	return documentMapToJoinConfiguration(gvkmap, false, false, false, opts.SkipCRIDetect)
 }
 
-// documentMapToJoinConfiguration takes a map between GVKs and YAML documents (as returned by SplitYAMLDocuments),
+// documentMapToJoinConfiguration takes a map between GVKs and YAML/JSON documents (as returned by SplitYAMLDocuments),
 // finds a JoinConfiguration, decodes it, dynamically defaults it and then validates it prior to return.
 func documentMapToJoinConfiguration(gvkmap kubeadmapi.DocumentMap, allowDeprecated, allowExperimental, strictErrors, skipCRIDetect bool) (*kubeadmapi.JoinConfiguration, error) {
 	joinBytes := []byte{}
@@ -110,7 +110,7 @@ func documentMapToJoinConfiguration(gvkmap kubeadmapi.DocumentMap, allowDeprecat
 			return nil, err
 		}
 
-		// verify the validity of the YAML
+		// verify the validity of the YAML/JSON
 		if err := strict.VerifyUnmarshalStrict([]*runtime.Scheme{kubeadmscheme.Scheme}, gvk, bytes); err != nil {
 			if !strictErrors {
 				klog.Warning(err.Error())

--- a/cmd/kubeadm/app/util/config/joinconfiguration.go
+++ b/cmd/kubeadm/app/util/config/joinconfiguration.go
@@ -87,6 +87,14 @@ func LoadJoinConfigurationFromFile(cfgPath string, opts LoadOrDefaultConfigurati
 		return nil, errors.Wrapf(err, "unable to read config from %q ", cfgPath)
 	}
 
+	return BytesToJoinConfiguration(b, opts)
+}
+
+// BytesToJoinConfiguration converts a byte slice to an internal, defaulted and validated JoinConfiguration object.
+// The map may contain many different YAML/JSON documents. These documents are parsed one-by-one.
+// The resulting JoinConfiguration is then dynamically defaulted and validated prior to return.
+func BytesToJoinConfiguration(b []byte, opts LoadOrDefaultConfigurationOptions) (*kubeadmapi.JoinConfiguration, error) {
+	// Split the YAML/JSON documents in the file into a DocumentMap
 	gvkmap, err := kubeadmutil.SplitConfigDocuments(b)
 	if err != nil {
 		return nil, err

--- a/cmd/kubeadm/app/util/config/resetconfiguration.go
+++ b/cmd/kubeadm/app/util/config/resetconfiguration.go
@@ -91,7 +91,7 @@ func LoadResetConfigurationFromFile(cfgPath string, opts LoadOrDefaultConfigurat
 		return nil, errors.Wrapf(err, "unable to read config from %q ", cfgPath)
 	}
 
-	gvkmap, err := kubeadmutil.SplitYAMLDocuments(b)
+	gvkmap, err := kubeadmutil.SplitConfigDocuments(b)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/kubeadm/app/util/config/resetconfiguration.go
+++ b/cmd/kubeadm/app/util/config/resetconfiguration.go
@@ -91,6 +91,14 @@ func LoadResetConfigurationFromFile(cfgPath string, opts LoadOrDefaultConfigurat
 		return nil, errors.Wrapf(err, "unable to read config from %q ", cfgPath)
 	}
 
+	return BytesToResetConfiguration(b, opts)
+}
+
+// BytesToResetConfiguration converts a byte slice to an internal, defaulted and validated ResetConfiguration object.
+// The map may contain many different YAML/JSON documents. These documents are parsed one-by-one.
+// The resulting ResetConfiguration is then dynamically defaulted and validated prior to return.
+func BytesToResetConfiguration(b []byte, opts LoadOrDefaultConfigurationOptions) (*kubeadmapi.ResetConfiguration, error) {
+	// Split the YAML/JSON documents in the file into a DocumentMap
 	gvkmap, err := kubeadmutil.SplitConfigDocuments(b)
 	if err != nil {
 		return nil, err

--- a/cmd/kubeadm/app/util/config/resetconfiguration.go
+++ b/cmd/kubeadm/app/util/config/resetconfiguration.go
@@ -99,7 +99,7 @@ func LoadResetConfigurationFromFile(cfgPath string, opts LoadOrDefaultConfigurat
 	return documentMapToResetConfiguration(gvkmap, false, opts.AllowExperimental, false, opts.SkipCRIDetect)
 }
 
-// documentMapToResetConfiguration takes a map between GVKs and YAML documents (as returned by SplitYAMLDocuments),
+// documentMapToResetConfiguration takes a map between GVKs and YAML/JSON documents (as returned by SplitYAMLDocuments),
 // finds a ResetConfiguration, decodes it, dynamically defaults it and then validates it prior to return.
 func documentMapToResetConfiguration(gvkmap kubeadmapi.DocumentMap, allowDeprecated, allowExperimental bool, strictErrors bool, skipCRIDetect bool) (*kubeadmapi.ResetConfiguration, error) {
 	resetBytes := []byte{}
@@ -114,7 +114,7 @@ func documentMapToResetConfiguration(gvkmap kubeadmapi.DocumentMap, allowDepreca
 			return nil, err
 		}
 
-		// verify the validity of the YAML
+		// verify the validity of the YAML/JSON
 		if err := strict.VerifyUnmarshalStrict([]*runtime.Scheme{kubeadmscheme.Scheme}, gvk, bytes); err != nil {
 			if !strictErrors {
 				klog.Warning(err.Error())

--- a/cmd/kubeadm/app/util/config/resetconfiguration.go
+++ b/cmd/kubeadm/app/util/config/resetconfiguration.go
@@ -106,6 +106,7 @@ func documentMapToResetConfiguration(gvkmap kubeadmapi.DocumentMap, allowDepreca
 	for gvk, bytes := range gvkmap {
 		// not interested in anything other than ResetConfiguration
 		if gvk.Kind != constants.ResetConfigurationKind {
+			klog.Warningf("[config] WARNING: Ignored configuration document with GroupVersionKind %v\n", gvk)
 			continue
 		}
 

--- a/cmd/kubeadm/app/util/config/upgradeconfiguration.go
+++ b/cmd/kubeadm/app/util/config/upgradeconfiguration.go
@@ -77,11 +77,6 @@ func documentMapToUpgradeConfiguration(gvkmap kubeadmapi.DocumentMap, allowDepre
 	return internalcfg, nil
 }
 
-// DocMapToUpgradeConfiguration converts documentMap to an internal, defaulted and validated UpgradeConfiguration object.
-func DocMapToUpgradeConfiguration(gvkmap kubeadmapi.DocumentMap) (*kubeadmapi.UpgradeConfiguration, error) {
-	return documentMapToUpgradeConfiguration(gvkmap, false)
-}
-
 // LoadUpgradeConfigurationFromFile loads UpgradeConfiguration from a file.
 func LoadUpgradeConfigurationFromFile(cfgPath string, _ LoadOrDefaultConfigurationOptions) (*kubeadmapi.UpgradeConfiguration, error) {
 	var err error

--- a/cmd/kubeadm/app/util/config/upgradeconfiguration.go
+++ b/cmd/kubeadm/app/util/config/upgradeconfiguration.go
@@ -94,7 +94,7 @@ func LoadUpgradeConfigurationFromFile(cfgPath string, _ LoadOrDefaultConfigurati
 	}
 
 	// Split the YAML/JSON documents in the file into a DocumentMap
-	docmap, err := kubeadmutil.SplitYAMLDocuments(configBytes)
+	docmap, err := kubeadmutil.SplitConfigDocuments(configBytes)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/kubeadm/app/util/config/upgradeconfiguration_test.go
+++ b/cmd/kubeadm/app/util/config/upgradeconfiguration_test.go
@@ -122,9 +122,9 @@ func TestDocMapToUpgradeConfiguration(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error while marshalling to YAML: %v", err)
 			}
-			docmap, err := kubeadmutil.SplitYAMLDocuments(b)
+			docmap, err := kubeadmutil.SplitConfigDocuments(b)
 			if err != nil {
-				t.Fatalf("Unexpected error of SplitYAMLDocuments: %v", err)
+				t.Fatalf("Unexpected error of SplitConfigDocuments: %v", err)
 			}
 			cfg, err := DocMapToUpgradeConfiguration(docmap)
 			if (err != nil) != tc.expectedError {

--- a/cmd/kubeadm/app/util/marshal.go
+++ b/cmd/kubeadm/app/util/marshal.go
@@ -65,13 +65,13 @@ func UniversalUnmarshal(buffer []byte) (runtime.Object, error) {
 	return obj, nil
 }
 
-// SplitYAMLDocuments reads the YAML bytes per-document, unmarshals the TypeMeta information from each document
+// SplitConfigDocuments reads the YAML/JSON bytes per-document, unmarshals the TypeMeta information from each document
 // and returns a map between the GroupVersionKind of the document and the document bytes
-func SplitYAMLDocuments(yamlBytes []byte) (kubeadmapi.DocumentMap, error) {
+func SplitConfigDocuments(documentBytes []byte) (kubeadmapi.DocumentMap, error) {
 	gvkmap := kubeadmapi.DocumentMap{}
 	knownKinds := map[string]bool{}
 	errs := []error{}
-	buf := bytes.NewBuffer(yamlBytes)
+	buf := bytes.NewBuffer(documentBytes)
 	reader := utilyaml.NewYAMLReader(bufio.NewReader(buf))
 	for {
 		// Read one YAML document at a time, until io.EOF is returned
@@ -111,7 +111,7 @@ func SplitYAMLDocuments(yamlBytes []byte) (kubeadmapi.DocumentMap, error) {
 
 // GroupVersionKindsFromBytes parses the bytes and returns a gvk slice
 func GroupVersionKindsFromBytes(b []byte) ([]schema.GroupVersionKind, error) {
-	gvkmap, err := SplitYAMLDocuments(b)
+	gvkmap, err := SplitConfigDocuments(b)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/kubeadm/app/util/marshal_test.go
+++ b/cmd/kubeadm/app/util/marshal_test.go
@@ -199,7 +199,7 @@ func TestSplitYAMLDocuments(t *testing.T) {
 	for _, rt := range tests {
 		t.Run(rt.name, func(t2 *testing.T) {
 
-			gvkmap, err := SplitYAMLDocuments(rt.fileContents)
+			gvkmap, err := SplitConfigDocuments(rt.fileContents)
 			if (err != nil) != rt.expectedErr {
 				t2.Errorf("expected error: %t, actual: %t", rt.expectedErr, err != nil)
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
1. Currently, kubeadm supports both yaml and json configuration file types, but in our log output, we only explicitly mention the yaml format.
2. We haven't printed warning logs for unknown GVKs in all the documentMapToXXX functions. To ensure consistent behavior across the documentMapToXXX functions and to provide sufficient warnings to users, we should print warning logs.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubeadm/issues/3163  https://github.com/kubernetes/kubeadm/issues/3162

#### Special notes for your reviewer:
To make the functions appear more consistent, I also renamed the SplitYAMLDocuments function to SplitYAMLOrJSONDocuments. If this is an unnecessary change, I can roll it back.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: Use generic terminology in logs instead of direct mentions of yaml/json.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
