### PR TITLE
Automated cherry pick of #130348: Revert "Add random interval to nodeStatusReport interval every time after an actual node status change"

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1269,12 +1269,6 @@ type Kubelet struct {
 	// status to master. It is only used when node lease feature is enabled.
 	nodeStatusReportFrequency time.Duration
 
-	// delayAfterNodeStatusChange is the one-time random duration that we add to the next node status report interval
-	// every time when there's an actual node status change. But all future node status update that is not caused by
-	// real status change will stick with nodeStatusReportFrequency. The random duration is a uniform distribution over
-	// [-0.5*nodeStatusReportFrequency, 0.5*nodeStatusReportFrequency]
-	delayAfterNodeStatusChange time.Duration
-
 	// lastStatusReportTime is the time when node status was last reported.
 	lastStatusReportTime time.Time
 


### PR DESCRIPTION
Cherry pick of #130348 on release-1.32.

#130348: Revert "Add random interval to nodeStatusReport interval every time after an actual node status change"

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixes a 1.32 regression where nodes may fail to report status and renew serving certificates after the kubelet restarts
```

/kind bug
/kind regressions