### PR TITLE
add String API for time

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/time.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/time.go
@@ -73,6 +73,14 @@ func (t *Time) Before(u *Time) bool {
 	return false
 }
 
+// String returns the time formatted using the format string
+func (t *Time) String() string {
+	if t == nil {
+		return ""
+	}
+	return t.Time.String()
+}
+
 // Equal reports whether the time instant t is equal to u.
 func (t *Time) Equal(u *Time) bool {
 	if t == nil && u == nil {

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/time_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/time_test.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -253,6 +254,25 @@ func TestTimeEqual(t *testing.T) {
 			result := c.x.Equal(c.y)
 			if result != c.result {
 				t.Errorf("Failed equality test for '%v', '%v': expected %+v, got %+v", c.x, c.y, c.result, result)
+			}
+		})
+	}
+}
+
+func TestTimeString(t *testing.T) {
+	cases := []struct {
+		name   string
+		input  *Time
+		result string
+	}{
+		{"nil", nil, ""},
+		{"empty", &Time{}, "0001-01-01 00:00:00 +0000 UTC"},
+		{"time", &Time{Time: time.Date(1998, time.May, 5, 5, 5, 5, 0, time.UTC)}, "1998-05-05 05:05:05 +0000 UTC"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if !strings.EqualFold(c.input.String(), c.result) {
+				t.Errorf("Failed equality: input '%v': expected %+v, got %+v", c.input, c.result, c.input.String())
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind api-change

#### What this PR does / why we need it:

Currently, metav1.Time doesn't have String API. So, the following code occures nil pointer reference, then crash the program.

```go
package main

import (
	"fmt"

	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
)

func main() {
	var t *metav1.Time
	fmt.Println(t.String())
}
```

This type is often used as a optional type (e.g. Report timestamp when some event happen) and it's hard for these optional type according to transition to check perfectly.
So I propose String API to avoid unexpected crashing

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
