### PR TITLE
Refactor: Use direct Gorilla WebSocket client for tunneling connections

### DIFF
--- a/staging/src/k8s.io/client-go/tools/portforward/tunneling_connection_test.go
+++ b/staging/src/k8s.io/client-go/tools/portforward/tunneling_connection_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package portforward
 
 import (
+	"context"
 	"io"
 	"net"
 	"net/http"
@@ -165,17 +166,14 @@ func TestTunnelingConnection_ReadWriteDeadlines(t *testing.T) {
 // a websocket connection. Returns the TunnelingConnection injected with the
 // websocket connection or an error if one occurs.
 func dialForTunnelingConnection(url *url.URL) (*TunnelingConnection, error) {
-	req, err := http.NewRequest("GET", url.String(), nil)
-	if err != nil {
-		return nil, err
-	}
+
 	// Tunneling must initiate a websocket upgrade connection, using tunneling portforward protocol.
 	tunnelingProtocols := []string{constants.WebsocketsSPDYTunnelingPortForwardV1}
-	transport, holder, err := websocket.RoundTripperFor(&rest.Config{Host: url.Host})
+	client, err := websocket.NewClient(&rest.Config{Host: url.Host})
 	if err != nil {
 		return nil, err
 	}
-	conn, err := websocket.Negotiate(transport, holder, req, tunnelingProtocols...)
+	conn, err := client.Connect(context.Background(), url.String(), tunnelingProtocols...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This commit refactors the tunneling connection implementation to use the Gorilla WebSocket client directly instead of wrapping it in a custom RoundTripper.

The previous implementation used a custom roundtripper to have parity with the SPDY implementation but websockets follow different semantics and the methods make the libraries difficult to reason about.

This adds a new websocket client that is able to establish a websocket connetion using the apiserver restclient Config (also allow users to define custom dialers).

Since is a client side only type there is no risk of conflicts, since the websocket client is the one dialing the connection to the apiserver, the rest of the config just wraps transports to provide the necessary headers for authentication or/and authorization.

/kind feature
/kind api-change

```release-note

```

/hold
for dicussions
/cc @seans3 @liggitt 

