### PR TITLE
fix incorrect VERB in apiserver logs if a request uses the deprecated path pattern for watch

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics_test.go
@@ -56,7 +56,7 @@ func TestCleanVerb(t *testing.T) {
 			desc:        "LIST should be transformed to WATCH if we have the right query param on the request",
 			initialVerb: "LIST",
 			request: &http.Request{
-				Method: "GET",
+				Method: http.MethodGet,
 				URL: &url.URL{
 					RawQuery: "watch=true",
 				},
@@ -67,7 +67,7 @@ func TestCleanVerb(t *testing.T) {
 			desc:        "LIST isn't transformed to WATCH if we have query params that do not include watch",
 			initialVerb: "LIST",
 			request: &http.Request{
-				Method: "GET",
+				Method: http.MethodGet,
 				URL: &url.URL{
 					RawQuery: "blah=asdf&something=else",
 				},
@@ -81,7 +81,7 @@ func TestCleanVerb(t *testing.T) {
 			desc:        "GET is transformed to WATCH if we have the right query param on the request",
 			initialVerb: "GET",
 			request: &http.Request{
-				Method: "GET",
+				Method: http.MethodGet,
 				URL: &url.URL{
 					RawQuery: "watch=true",
 				},
@@ -93,7 +93,7 @@ func TestCleanVerb(t *testing.T) {
 			initialVerb:   "LIST",
 			suggestedVerb: "WATCH",
 			request: &http.Request{
-				Method: "GET",
+				Method: http.MethodGet,
 				URL: &url.URL{
 					RawQuery: "/api/v1/watch/pods",
 				},
@@ -105,7 +105,7 @@ func TestCleanVerb(t *testing.T) {
 			initialVerb:   "LIST",
 			suggestedVerb: "WATCHLIST",
 			request: &http.Request{
-				Method: "GET",
+				Method: http.MethodGet,
 				URL: &url.URL{
 					RawQuery: "/api/v1/watch/pods",
 				},
@@ -116,6 +116,18 @@ func TestCleanVerb(t *testing.T) {
 			desc:         "WATCHLIST should be transformed to WATCH",
 			initialVerb:  "WATCHLIST",
 			request:      nil,
+			expectedVerb: "WATCH",
+		},
+		{
+			desc:          "LIST is transformed to WATCH for the old pattern watchlist if no suggestedVerb is provided",
+			initialVerb:   "LIST",
+			suggestedVerb: "",
+			request: &http.Request{
+				Method: http.MethodGet,
+				URL: &url.URL{
+					Path: "/api/v1/watch/namespaces",
+				},
+			},
 			expectedVerb: "WATCH",
 		},
 		{
@@ -150,7 +162,7 @@ func TestCleanVerb(t *testing.T) {
 			desc:        "Pod logs should be transformed to CONNECT",
 			initialVerb: "GET",
 			request: &http.Request{
-				Method: "GET",
+				Method: http.MethodGet,
 				URL: &url.URL{
 					RawQuery: "/api/v1/namespaces/default/pods/test-pod/log",
 				},
@@ -167,7 +179,7 @@ func TestCleanVerb(t *testing.T) {
 			desc:        "Pod exec should be transformed to CONNECT",
 			initialVerb: "POST",
 			request: &http.Request{
-				Method: "POST",
+				Method: http.MethodPost,
 				URL: &url.URL{
 					RawQuery: "/api/v1/namespaces/default/pods/test-pod/exec?command=sh",
 				},
@@ -191,7 +203,7 @@ func TestCleanVerb(t *testing.T) {
 			desc:        "Pod portforward should be transformed to CONNECT",
 			initialVerb: "POST",
 			request: &http.Request{
-				Method: "POST",
+				Method: http.MethodPost,
 				URL: &url.URL{
 					RawQuery: "/api/v1/namespaces/default/pods/test-pod/portforward",
 				},
@@ -215,7 +227,7 @@ func TestCleanVerb(t *testing.T) {
 			desc:        "Deployment scale should not be transformed to CONNECT",
 			initialVerb: "PUT",
 			request: &http.Request{
-				Method: "PUT",
+				Method: http.MethodPut,
 				URL: &url.URL{
 					RawQuery: "/apis/apps/v1/namespaces/default/deployments/test-1/scale",
 				},
@@ -235,6 +247,9 @@ func TestCleanVerb(t *testing.T) {
 			req := &http.Request{URL: &url.URL{}}
 			if tt.request != nil {
 				req = tt.request
+			}
+			if req.URL == nil {
+				req.URL = &url.URL{}
 			}
 			cleansedVerb := cleanVerb(tt.initialVerb, tt.suggestedVerb, req, tt.requestInfo)
 			if cleansedVerb != tt.expectedVerb {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #130373

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NONE

```release-note
fix incorrect HTTP Verb in apiserver log if a watch request uses the deprecated path pattern "api/v1/watch/*"
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
