### PR TITLE
add a unit test for hasMore in ListPrefix

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/store_btree.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/store_btree.go
@@ -250,7 +250,6 @@ func (s *btreeStore) ListPrefix(prefix, continueKey string, limit int) ([]interf
 		if !strings.HasPrefix(item.Key, prefix) {
 			return false
 		}
-		// TODO: Might be worth to lookup one more item to provide more accurate HasMore.
 		if len(result) >= limit {
 			hasMore = true
 			return false

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/store_btree_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/store_btree_test.go
@@ -49,6 +49,14 @@ func TestStoreListPrefix(t *testing.T) {
 		testStorageElement("foo3", "bar3", 1),
 	}, items)
 
+	items, hasMore = store.ListPrefix("foo", "", 3)
+	assert.False(t, hasMore, "hasMore should be false when limit equals the # of queried items.")
+	assert.Equal(t, []interface{}{
+		testStorageElement("foo1", "bar2", 2),
+		testStorageElement("foo2", "bar1", 3),
+		testStorageElement("foo3", "bar3", 1),
+	}, items)
+
 	items, hasMore = store.ListPrefix("foo2", "", 0)
 	assert.False(t, hasMore)
 	assert.Equal(t, []interface{}{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR removes a seemingly stale TODO comment, and adds a test to ensure that the function in question behaves correctly. The TODO comment in store_btree.go is:

```go
// TODO: Might be worth to lookup one more item to provide more accurate HasMore.
if len(result) >= limit {
	hasMore = true
	return false
}
```

- The TODO suggested that `hasMore` may not be accurate when limit equals the exact number of matched items.  
  - i.e., `hasMore` may accidentally turn true even when there's no remaining items
- However, this concern is already handled because the check `len(result) >= limit` occurs **before** appending the next item.
  - This ensures that `hasMore` turns true only when the matched item is `limit + 1`th.

To ensure correctness, this PR:

- Removes the TODO.
- Adds a test case to verify that hasMore turns false when limit == number of matched items

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
