### PR TITLE
[e2e/node] update base image from busybox to agnhost

### DIFF
--- a/test/e2e/node/pods.go
+++ b/test/e2e/node/pods.go
@@ -610,7 +610,7 @@ func (s podFastDeleteScenario) Pod(worker, attempt int) *v1.Pod {
 				InitContainers: []v1.Container{
 					{
 						Name:  "fail",
-						Image: imageutils.GetE2EImage(imageutils.BusyBox),
+						Image: imageutils.GetE2EImage(imageutils.Agnhost),
 						Command: []string{
 							"/bin/false",
 						},
@@ -625,7 +625,7 @@ func (s podFastDeleteScenario) Pod(worker, attempt int) *v1.Pod {
 				Containers: []v1.Container{
 					{
 						Name:  "blocked",
-						Image: imageutils.GetE2EImage(imageutils.BusyBox),
+						Image: imageutils.GetE2EImage(imageutils.Agnhost),
 						Command: []string{
 							"/bin/true",
 						},
@@ -654,7 +654,7 @@ func (s podFastDeleteScenario) Pod(worker, attempt int) *v1.Pod {
 			Containers: []v1.Container{
 				{
 					Name:  "fail",
-					Image: imageutils.GetE2EImage(imageutils.BusyBox),
+					Image: imageutils.GetE2EImage(imageutils.Agnhost),
 					Command: []string{
 						"/bin/false",
 					},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind flake

#### What this PR does / why we need it:

Since around 2024/11/27, a Node E2E test that repeatedly creates Pods and checks whether they terminate with the expected exit code has occasionally ended with exit code 2, making it flaky. There have been no changes in kubelet that would modify the exit code before 2024/11/27, so the cause is likely elsewhere.

Rather than an issue with the container runtime, it is possible that the problem lies in the BusyBox base image. To narrow down the cause, we will replace the base image from BusyBox to Agnhost. See https://github.com/kubernetes/kubernetes/issues/129800#issuecomment-2628614980.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

https://github.com/kubernetes/kubernetes/issues/129800

#### Special notes for your reviewer:

For now, I will replace the base image only in the code paths related to the flaky test and check if the issue can be reproduced. However, since the test fails infrequently (about once every one to two weeks), it's uncertain whether we will be able to reproduce the problem in the manual run of the test on this PR.

Currently, there is https://github.com/kubernetes/kubernetes/pull/127630 that changes the base image used in e2e-node from BusyBox to Agnhost. If this PR resolves the flaky test, I will wait for it to be merged and update the code to use `framework.GetDefaultTestImageID()`.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
