### PR TITLE
[FG:InPlacePodVerticalScaling] Add Pod resize complete event

### DIFF
--- a/pkg/kubelet/events/event.go
+++ b/pkg/kubelet/events/event.go
@@ -36,6 +36,7 @@ const (
 	NetworkNotReady                = "NetworkNotReady"
 	ResizeDeferred                 = "ResizeDeferred"
 	ResizeInfeasible               = "ResizeInfeasible"
+	ResizeCompleted                = "ResizeCompleted"
 )
 
 // Image event reason list

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -686,6 +686,7 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 		klet.GetActivePods,
 		klet.podManager.GetPodByUID,
 		klet.sourcesReady,
+		kubeDeps.Recorder,
 	)
 
 	klet.resourceAnalyzer = serverstats.NewResourceAnalyzer(klet, kubeCfg.VolumeStatsAggPeriod.Duration, kubeDeps.Recorder)


### PR DESCRIPTION
**What type of PR is this?**
    /kind feature

**What this PR does / why we need it:**
    Add events when pod resize complete

**Which issue(s) this PR fixes:**
    Fixes #127172

**Special notes for your reviewer:**
    N/A

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
N/A

**Does this PR introduce a user-facing change?**
Event is a user-facing change
```release-note
Added detailed event for in-place pod vertical scaling completed, improving cluster management and debugging
```
