### PR TITLE
Add an error matcher, convert 2 tests

### DIFF
--- a/pkg/apis/apps/validation/validation_test.go
+++ b/pkg/apis/apps/validation/validation_test.go
@@ -523,7 +523,7 @@ func TestValidateStatefulSet(t *testing.T) {
 	},
 	}
 
-	cmpOpts := []cmp.Option{cmpopts.IgnoreFields(field.Error{}, "BadValue", "Detail"), cmpopts.SortSlices(func(a, b *field.Error) bool { return a.Error() < b.Error() })}
+	cmpOpts := []cmp.Option{cmpopts.IgnoreFields(field.Error{}, "BadValue", "Detail", "Origin"), cmpopts.SortSlices(func(a, b *field.Error) bool { return a.Error() < b.Error() })}
 	for _, testCase := range append(successCases, errorCases...) {
 		name := testCase.name
 		var testTitle string
@@ -936,7 +936,7 @@ func TestValidateStatefulSetUpdate(t *testing.T) {
 	}
 
 	cmpOpts := []cmp.Option{
-		cmpopts.IgnoreFields(field.Error{}, "BadValue", "Detail"),
+		cmpopts.IgnoreFields(field.Error{}, "BadValue", "Detail", "Origin"),
 		cmpopts.SortSlices(func(a, b *field.Error) bool { return a.Error() < b.Error() }),
 		cmpopts.EquateEmpty(),
 	}

--- a/pkg/apis/batch/validation/validation_test.go
+++ b/pkg/apis/batch/validation/validation_test.go
@@ -48,7 +48,7 @@ var (
 	timeZoneEmptySpace = " "
 )
 
-var ignoreErrValueDetail = cmpopts.IgnoreFields(field.Error{}, "BadValue", "Detail")
+var ignoreErrValueDetail = cmpopts.IgnoreFields(field.Error{}, "BadValue", "Detail", "Origin")
 
 func getValidManualSelector() *metav1.LabelSelector {
 	return &metav1.LabelSelector{

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -350,6 +350,15 @@ func ValidateNonnegativeQuantity(value resource.Quantity, fldPath *field.Path) f
 	return allErrs
 }
 
+// Validates that given value is positive.
+func ValidatePositiveField(value int64, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if value <= 0 {
+		allErrs = append(allErrs, field.Invalid(fldPath, value, isNotPositiveErrorMsg).WithOrigin("minimum"))
+	}
+	return allErrs
+}
+
 // Validates that a Quantity is positive
 func ValidatePositiveQuantityValue(value resource.Quantity, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
@@ -7905,8 +7914,8 @@ func validateTopologySpreadConstraints(constraints []core.TopologySpreadConstrai
 
 	for i, constraint := range constraints {
 		subFldPath := fldPath.Index(i)
-		if err := ValidateMaxSkew(subFldPath.Child("maxSkew"), constraint.MaxSkew); err != nil {
-			allErrs = append(allErrs, err)
+		if errs := ValidatePositiveField(int64(constraint.MaxSkew), subFldPath.Child("maxSkew")); len(errs) > 0 {
+			allErrs = append(allErrs, errs...)
 		}
 		if err := ValidateTopologyKey(subFldPath.Child("topologyKey"), constraint.TopologyKey); err != nil {
 			allErrs = append(allErrs, err)
@@ -7934,26 +7943,16 @@ func validateTopologySpreadConstraints(constraints []core.TopologySpreadConstrai
 	return allErrs
 }
 
-// ValidateMaxSkew tests that the argument is a valid MaxSkew.
-func ValidateMaxSkew(fldPath *field.Path, maxSkew int32) *field.Error {
-	if maxSkew <= 0 {
-		return field.Invalid(fldPath, maxSkew, isNotPositiveErrorMsg)
-	}
-	return nil
-}
-
 // validateMinDomains tests that the argument is a valid MinDomains.
 func validateMinDomains(fldPath *field.Path, minDomains *int32, action core.UnsatisfiableConstraintAction) field.ErrorList {
 	if minDomains == nil {
 		return nil
 	}
 	var allErrs field.ErrorList
-	if *minDomains <= 0 {
-		allErrs = append(allErrs, field.Invalid(fldPath, minDomains, isNotPositiveErrorMsg))
-	}
+	allErrs = append(allErrs, ValidatePositiveField(int64(*minDomains), fldPath)...)
 	// When MinDomains is non-nil, whenUnsatisfiable must be DoNotSchedule.
 	if action != core.DoNotSchedule {
-		allErrs = append(allErrs, field.Invalid(fldPath, minDomains, fmt.Sprintf("can only use minDomains if whenUnsatisfiable=%s, not %s", core.DoNotSchedule, action)))
+		allErrs = append(allErrs, field.Invalid(fldPath, minDomains, fmt.Sprintf("can only use minDomains if whenUnsatisfiable=%s, not %s", core.DoNotSchedule, action)).WithOrigin("dependsOn"))
 	}
 	return allErrs
 }
@@ -8077,7 +8076,7 @@ func validateMatchLabelKeysInTopologySpread(fldPath *field.Path, matchLabelKeys 
 	for i, key := range matchLabelKeys {
 		allErrs = append(allErrs, unversionedvalidation.ValidateLabelName(key, fldPath.Index(i))...)
 		if labelSelectorKeys.Has(key) {
-			allErrs = append(allErrs, field.Invalid(fldPath.Index(i), key, "exists in both matchLabelKeys and labelSelector"))
+			allErrs = append(allErrs, field.Invalid(fldPath.Index(i), key, "exists in both matchLabelKeys and labelSelector").WithOrigin("overlappingKeys"))
 		}
 	}
 

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -6266,7 +6266,7 @@ func ValidateReplicationControllerSpec(spec, oldSpec *core.ReplicationController
 	allErrs := field.ErrorList{}
 	allErrs = append(allErrs, ValidateNonnegativeField(int64(spec.MinReadySeconds), fldPath.Child("minReadySeconds"))...)
 	allErrs = append(allErrs, ValidateNonEmptySelector(spec.Selector, fldPath.Child("selector"))...)
-	allErrs = append(allErrs, ValidateNonnegativeField(int64(spec.Replicas), fldPath.Child("replicas")).WithOrigin("minimum")...)
+	allErrs = append(allErrs, ValidateNonnegativeField(int64(spec.Replicas), fldPath.Child("replicas"))...)
 	allErrs = append(allErrs, ValidatePodTemplateSpecForRC(spec.Template, spec.Selector, spec.Replicas, fldPath.Child("template"), opts)...)
 	return allErrs
 }
@@ -7489,18 +7489,18 @@ func ValidateNonSpecialIP(ipAddress string, fldPath *field.Path) field.ErrorList
 		return allErrs
 	}
 	if ip.IsUnspecified() {
-		allErrs = append(allErrs, field.Invalid(fldPath, ipAddress, fmt.Sprintf("may not be unspecified (%v)", ipAddress)).WithOrigin("format=non-special-ip"))
+		allErrs = append(allErrs, field.Invalid(fldPath, ipAddress, fmt.Sprintf("may not be unspecified (%v)", ipAddress)))
 	}
 	if ip.IsLoopback() {
-		allErrs = append(allErrs, field.Invalid(fldPath, ipAddress, "may not be in the loopback range (127.0.0.0/8, ::1/128)").WithOrigin("format=non-special-ip"))
+		allErrs = append(allErrs, field.Invalid(fldPath, ipAddress, "may not be in the loopback range (127.0.0.0/8, ::1/128)"))
 	}
 	if ip.IsLinkLocalUnicast() {
-		allErrs = append(allErrs, field.Invalid(fldPath, ipAddress, "may not be in the link-local range (169.254.0.0/16, fe80::/10)").WithOrigin("format=non-special-ip"))
+		allErrs = append(allErrs, field.Invalid(fldPath, ipAddress, "may not be in the link-local range (169.254.0.0/16, fe80::/10)"))
 	}
 	if ip.IsLinkLocalMulticast() {
-		allErrs = append(allErrs, field.Invalid(fldPath, ipAddress, "may not be in the link-local multicast range (224.0.0.0/24, ff02::/10)").WithOrigin("format=non-special-ip"))
+		allErrs = append(allErrs, field.Invalid(fldPath, ipAddress, "may not be in the link-local multicast range (224.0.0.0/24, ff02::/10)"))
 	}
-	return allErrs
+	return allErrs.WithOrigin("format=non-special-ip")
 }
 
 func validateEndpointPort(port *core.EndpointPort, requireName bool, fldPath *field.Path) field.ErrorList {

--- a/pkg/proxy/apis/config/validation/validation_test.go
+++ b/pkg/proxy/apis/config/validation/validation_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/assert"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -517,7 +519,10 @@ func TestValidateClientConnectionConfiguration(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			errs := validateClientConnectionConfiguration(testCase.ccc, newPath)
-			assert.Equal(t, testCase.expectedErrs, errs, "did not get expected validation errors")
+			cmpOpts := []cmp.Option{cmpopts.IgnoreFields(field.Error{}, "Origin"), cmpopts.SortSlices(func(a, b *field.Error) bool { return a.Error() < b.Error() })}
+			if diff := cmp.Diff(testCase.expectedErrs, errs, cmpOpts...); diff != "" {
+				t.Errorf("did not get expected validation errors (-want,+got):\n%s", diff)
+			}
 		})
 	}
 }

--- a/staging/src/k8s.io/apimachinery/pkg/api/validation/generic.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validation/generic.go
@@ -82,7 +82,7 @@ func maskTrailingDash(name string) string {
 func ValidateNonnegativeField(value int64, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	if value < 0 {
-		allErrs = append(allErrs, field.Invalid(fldPath, value, IsNegativeErrorMsg))
+		allErrs = append(allErrs, field.Invalid(fldPath, value, IsNegativeErrorMsg).WithOrigin("minimum"))
 	}
 	return allErrs
 }

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation.go
@@ -104,7 +104,7 @@ func ValidateLabelSelectorRequirement(sr metav1.LabelSelectorRequirement, opts L
 func ValidateLabelName(labelName string, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	for _, msg := range validation.IsQualifiedName(labelName) {
-		allErrs = append(allErrs, field.Invalid(fldPath, labelName, msg))
+		allErrs = append(allErrs, field.Invalid(fldPath, labelName, msg).WithOrigin("labelKey"))
 	}
 	return allErrs
 }

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/field/errors.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/field/errors.go
@@ -52,8 +52,8 @@ type Error struct {
 var _ error = &Error{}
 
 // Error implements the error interface.
-func (v *Error) Error() string {
-	return fmt.Sprintf("%s: %s", v.Field, v.ErrorBody())
+func (e *Error) Error() string {
+	return fmt.Sprintf("%s: %s", e.Field, e.ErrorBody())
 }
 
 type OmitValueType struct{}
@@ -62,21 +62,21 @@ var omitValue = OmitValueType{}
 
 // ErrorBody returns the error message without the field name.  This is useful
 // for building nice-looking higher-level error reporting.
-func (v *Error) ErrorBody() string {
+func (e *Error) ErrorBody() string {
 	var s string
 	switch {
-	case v.Type == ErrorTypeRequired:
-		s = v.Type.String()
-	case v.Type == ErrorTypeForbidden:
-		s = v.Type.String()
-	case v.Type == ErrorTypeTooLong:
-		s = v.Type.String()
-	case v.Type == ErrorTypeInternal:
-		s = v.Type.String()
-	case v.BadValue == omitValue:
-		s = v.Type.String()
+	case e.Type == ErrorTypeRequired:
+		s = e.Type.String()
+	case e.Type == ErrorTypeForbidden:
+		s = e.Type.String()
+	case e.Type == ErrorTypeTooLong:
+		s = e.Type.String()
+	case e.Type == ErrorTypeInternal:
+		s = e.Type.String()
+	case e.BadValue == omitValue:
+		s = e.Type.String()
 	default:
-		value := v.BadValue
+		value := e.BadValue
 		valueType := reflect.TypeOf(value)
 		if value == nil || valueType == nil {
 			value = "null"
@@ -90,30 +90,30 @@ func (v *Error) ErrorBody() string {
 		switch t := value.(type) {
 		case int64, int32, float64, float32, bool:
 			// use simple printer for simple types
-			s = fmt.Sprintf("%s: %v", v.Type, value)
+			s = fmt.Sprintf("%s: %v", e.Type, value)
 		case string:
-			s = fmt.Sprintf("%s: %q", v.Type, t)
+			s = fmt.Sprintf("%s: %q", e.Type, t)
 		case fmt.Stringer:
 			// anything that defines String() is better than raw struct
-			s = fmt.Sprintf("%s: %s", v.Type, t.String())
+			s = fmt.Sprintf("%s: %s", e.Type, t.String())
 		default:
 			// fallback to raw struct
 			// TODO: internal types have panic guards against json.Marshalling to prevent
 			// accidental use of internal types in external serialized form.  For now, use
 			// %#v, although it would be better to show a more expressive output in the future
-			s = fmt.Sprintf("%s: %#v", v.Type, value)
+			s = fmt.Sprintf("%s: %#v", e.Type, value)
 		}
 	}
-	if len(v.Detail) != 0 {
-		s += fmt.Sprintf(": %s", v.Detail)
+	if len(e.Detail) != 0 {
+		s += fmt.Sprintf(": %s", e.Detail)
 	}
 	return s
 }
 
 // WithOrigin adds origin information to the FieldError
-func (v *Error) WithOrigin(o string) *Error {
-	v.Origin = o
-	return v
+func (e *Error) WithOrigin(o string) *Error {
+	e.Origin = o
+	return e
 }
 
 // ErrorType is a machine readable value providing more detail about why

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/field/testing/match.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/field/testing/match.go
@@ -1,0 +1,203 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"fmt"
+	"reflect"
+	"regexp"
+	"strings"
+	"testing"
+
+	field "k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+// MatchErrors compares two ErrorLists with the specified matcher, and fails
+// the test if they don't match. If a given "want" error matches multiple "got"
+// errors, they will all be consumed. This might be OK (e.g. if there are
+// multiple errors on the same field from the same origin) or it might be an
+// insufficiently specific matcher, so these will be logged.
+func MatchErrors(t *testing.T, want, got field.ErrorList, matcher *Matcher) {
+	t.Helper()
+
+	remaining := got
+	for _, w := range want {
+		tmp := make(field.ErrorList, 0, len(remaining))
+		n := 0
+		for _, g := range remaining {
+			if matcher.Matches(w, g) {
+				n++
+			} else {
+				tmp = append(tmp, g)
+			}
+		}
+		if n == 0 {
+			t.Errorf("expected an error matching:\n%s", matcher.Render(w))
+		} else if n > 1 {
+			// This is not necessarily and error, but it's worth logging in
+			// case it's not what the test author intended.
+			t.Logf("multiple errors matched:\n%s", matcher.Render(w))
+		}
+		remaining = tmp
+	}
+	if len(remaining) > 0 {
+		for _, e := range remaining {
+			t.Errorf("unmatched error:\n%s", Match().Exactly().Render(e))
+		}
+	}
+}
+
+// Match returns a new Matcher.
+func Match() *Matcher {
+	return &Matcher{}
+}
+
+// Matcher is a helper for comparing field.Error objects.
+type Matcher struct {
+	matchType                bool
+	matchField               bool
+	matchValue               bool
+	matchOrigin              bool
+	matchDetail              func(want, got string) bool
+	requireOriginWhenInvalid bool
+}
+
+// Matches returns true if the two field.Error objects match according to the
+// configured criteria.
+func (m *Matcher) Matches(want, got *field.Error) bool {
+	if m.matchType && want.Type != got.Type {
+		return false
+	}
+	if m.matchField && want.Field != got.Field {
+		return false
+	}
+	if m.matchValue && !reflect.DeepEqual(want.BadValue, got.BadValue) {
+		return false
+	}
+	if m.matchOrigin {
+		if want.Origin != got.Origin {
+			return false
+		}
+		if m.requireOriginWhenInvalid && want.Type == field.ErrorTypeInvalid {
+			if want.Origin == "" || got.Origin == "" {
+				return false
+			}
+		}
+	}
+	if m.matchDetail != nil && !m.matchDetail(want.Detail, got.Detail) {
+		return false
+	}
+	return true
+}
+
+// Render returns a string representation of the specified Error object,
+// according to the criteria configured in the Matcher.
+func (m *Matcher) Render(e *field.Error) string {
+	buf := strings.Builder{}
+
+	comma := func() {
+		if buf.Len() > 0 {
+			buf.WriteString(", ")
+		}
+	}
+
+	if m.matchType {
+		comma()
+		buf.WriteString(fmt.Sprintf("Type=%q", e.Type))
+	}
+	if m.matchField {
+		comma()
+		buf.WriteString(fmt.Sprintf("Field=%q", e.Field))
+	}
+	if m.matchValue {
+		comma()
+		buf.WriteString(fmt.Sprintf("Value=%v", e.BadValue))
+	}
+	if m.matchOrigin || m.requireOriginWhenInvalid && e.Type == field.ErrorTypeInvalid {
+		comma()
+		buf.WriteString(fmt.Sprintf("Origin=%q", e.Origin))
+	}
+	if m.matchDetail != nil {
+		comma()
+		buf.WriteString(fmt.Sprintf("Detail=%q", e.Detail))
+	}
+	return "{" + buf.String() + "}"
+}
+
+// Exactly configures the matcher to match all fields exactly.
+func (m *Matcher) Exactly() *Matcher {
+	return m.ByType().ByField().ByValue().ByOrigin().ByDetailExact()
+}
+
+// Exactly configures the matcher to match errors by type.
+func (m *Matcher) ByType() *Matcher {
+	m.matchType = true
+	return m
+}
+
+// ByField configures the matcher to match errors by field path.
+func (m *Matcher) ByField() *Matcher {
+	m.matchField = true
+	return m
+}
+
+// ByValue configures the matcher to match errors by the errant value.
+func (m *Matcher) ByValue() *Matcher {
+	m.matchValue = true
+	return m
+}
+
+// ByOrigin configures the matcher to match errors by the origin.
+func (m *Matcher) ByOrigin() *Matcher {
+	m.matchOrigin = true
+	return m
+}
+
+// RequireOriginWhenInvalid configures the matcher to require the Origin field
+// to be set when the Type is Invalid and the matcher is matching by Origin.
+func (m *Matcher) RequireOriginWhenInvalid() *Matcher {
+	m.requireOriginWhenInvalid = true
+	return m
+}
+
+// ByDetailExact configures the matcher to match errors by the exact detail
+// string.
+func (m *Matcher) ByDetailExact() *Matcher {
+	m.matchDetail = func(want, got string) bool {
+		return got == want
+	}
+	return m
+}
+
+// ByDetailSubstring configures the matcher to match errors by a substring of
+// the detail string.
+func (m *Matcher) ByDetailSubstring() *Matcher {
+	m.matchDetail = func(want, got string) bool {
+		return strings.Contains(got, want)
+	}
+	return m
+}
+
+// ByDetailRegexp configures the matcher to match errors by a regular
+// expression of the detail string, where the "want" string is assumed to be a
+// valid regular expression.
+func (m *Matcher) ByDetailRegexp() *Matcher {
+	m.matchDetail = func(want, got string) bool {
+		return regexp.MustCompile(want).MatchString(got)
+	}
+	return m
+}


### PR DESCRIPTION
This builds on #130355.

The goal of the matcher is to make writing tests easier and more consistent, and less brittle in the face of validation strings changing.  With Origin, it gets even easier.
    
I fixed up the TestValidateEndpointsCreate path to show the matcher instead of manual origin checking.
    
I picked TestValidateTopologySpreadConstraints because it was the last failing test on my screen when I changed on of the commonly hard-coded error strings. I fixed exactly those validation errors that were needed to make this test pass.  Some of the Origin values can be debated.
    
The `field/testing.Matcher` interface allows tests to configure the criteria by which they want to match expected and actual errors.  The hope is that everyone will use Origin for Invalid errors.

/kind cleanup

```release-note
NONE
```