### PR TITLE
Add Job e2e for tracking failure count per index

### DIFF
--- a/test/e2e/apps/job.go
+++ b/test/e2e/apps/job.go
@@ -661,6 +661,53 @@ done`}
 	})
 
 	/*
+		Testname: Track the failure count per index in Pod annotation when backoffLimitPerIndex is used
+		Description: Create an indexed job and ensure that the Pods are
+		re-created with the failure-count Pod annotation set properly to
+		indicate the number of so-far failures per index.
+	*/
+	ginkgo.It("should record the failure-count in the Pod annotation when using backoffLimitPerIndex", func(ctx context.Context) {
+		jobName := "e2e-backofflimitperindex-" + utilrand.String(5)
+		label := map[string]string{batchv1.JobNameLabel: jobName}
+		labelSelector := labels.SelectorFromSet(label).String()
+
+		parallelism := int32(2)
+		completions := int32(2)
+		backoffLimit := int32(6) // default value
+
+		job := e2ejob.NewTestJob("fail", jobName, v1.RestartPolicyNever, parallelism, completions, nil, backoffLimit)
+		job.Spec.BackoffLimit = nil
+		job.Spec.BackoffLimitPerIndex = ptr.To[int32](1)
+		job.Spec.CompletionMode = ptr.To(batchv1.IndexedCompletion)
+
+		tracker := NewIndexedPodAnnotationTracker(jobName, f.Namespace.Name, labelSelector, batchv1.JobCompletionIndexAnnotation, batchv1.JobIndexFailureCountAnnotation)
+		trackerCancel := tracker.Start(ctx, f.ClientSet)
+		defer trackerCancel()
+
+		ginkgo.By("Creating an indexed job with backoffLimit per index and failing pods")
+		job, err := e2ejob.CreateJob(ctx, f.ClientSet, f.Namespace.Name, job)
+		framework.ExpectNoError(err, "failed to create job in namespace: %s", f.Namespace.Name)
+
+		ginkgo.By("Awaiting for the job to fail as there are failed indexes")
+		err = e2ejob.WaitForJobFailed(ctx, f.ClientSet, f.Namespace.Name, job.Name)
+		framework.ExpectNoError(err, "failed to ensure job completion in namespace: %s", f.Namespace.Name)
+
+		ginkgo.By("Verify the failure-count annotation on Pods")
+		gomega.Eventually(ctx, tracker.GetMap).
+			WithTimeout(JobTimeout).
+			WithPolling(framework.Poll).
+			Should(gomega.Equal(map[int][]string{0: {"0", "1"}, 1: {"0", "1"}}))
+
+		ginkgo.By("Verifying the Job status fields")
+		job, err = e2ejob.GetJob(ctx, f.ClientSet, f.Namespace.Name, job.Name)
+		framework.ExpectNoError(err, "failed to retrieve latest job object")
+		gomega.Expect(job.Status.FailedIndexes).Should(gomega.HaveValue(gomega.Equal("0,1")))
+		gomega.Expect(job.Status.CompletedIndexes).Should(gomega.Equal(""))
+		gomega.Expect(job.Status.Failed).Should(gomega.Equal(int32(4)))
+		gomega.Expect(job.Status.Succeeded).Should(gomega.Equal(int32(0)))
+	})
+
+	/*
 		Testcase: Mark indexes as failed when the FailIndex action is matched in podFailurePolicy
 		Description: Create an indexed job with backoffLimitPerIndex, and podFailurePolicy
 		with the FailIndex action. Verify the failed pods matching the pod failure policy

--- a/test/e2e/apps/util.go
+++ b/test/e2e/apps/util.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apps
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"strconv"
+	"sync"
+
+	"github.com/onsi/ginkgo/v2"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/watch"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	watchtools "k8s.io/client-go/tools/watch"
+	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+type IndexedPodAnnotationTracker struct {
+	sync.Mutex
+	ownerName            string
+	ownerNs              string
+	labelSelector        string
+	podIndexAnnotation   string
+	podTrackedAnnotation string
+	trackedAnnotations   map[int][]string
+}
+
+func NewIndexedPodAnnotationTracker(ownerName, ownerNs, labelSelector, podIndexAnnotation, podTrackedAnnotation string) *IndexedPodAnnotationTracker {
+	return &IndexedPodAnnotationTracker{
+		ownerName:            ownerName,
+		ownerNs:              ownerNs,
+		labelSelector:        labelSelector,
+		podIndexAnnotation:   podIndexAnnotation,
+		podTrackedAnnotation: podTrackedAnnotation,
+		trackedAnnotations:   make(map[int][]string),
+	}
+}
+
+func (t *IndexedPodAnnotationTracker) Start(ctx context.Context, c clientset.Interface) context.CancelFunc {
+	ownerKey := klog.KRef(t.ownerNs, t.ownerName)
+	podClient := c.CoreV1().Pods(t.ownerNs)
+	podsList, err := podClient.List(ctx, metav1.ListOptions{LabelSelector: t.labelSelector})
+	framework.ExpectNoError(err, "failed to list Pods")
+
+	trackerCtx, trackerCancel := context.WithCancel(ctx)
+
+	go func() {
+		defer ginkgo.GinkgoRecover()
+
+		w := &cache.ListWatch{
+			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+				options.LabelSelector = t.labelSelector
+				return podClient.Watch(ctx, options)
+			},
+		}
+
+		ginkgo.By(fmt.Sprintf("Start the Pod watch for owner: %s", ownerKey))
+		_, err = watchtools.Until(trackerCtx, podsList.ResourceVersion, w, func(event watch.Event) (bool, error) {
+			if event.Type == watch.Added {
+				if pod, ok := event.Object.(*v1.Pod); ok {
+					framework.Logf("Observed event for Pod %q with index=%v, annotation value=%v",
+						klog.KObj(pod), pod.Annotations[t.podIndexAnnotation], pod.Annotations[t.podTrackedAnnotation])
+					podIndex, err := strconv.Atoi(pod.Annotations[t.podIndexAnnotation])
+					if err != nil {
+						return true, fmt.Errorf("failed to parse pod index for Pod %q: %v", klog.KObj(pod), err.Error())
+					}
+					t.Lock()
+					defer t.Unlock()
+					t.trackedAnnotations[podIndex] = append(t.trackedAnnotations[podIndex], pod.Annotations[t.podTrackedAnnotation])
+					return false, nil
+				}
+			}
+			return false, nil
+		})
+		// We ignore the error corresponding to the context getting interrupted.
+		// The test code is expected to assert on the map before cancelling the
+		// context.
+		if err != nil && !wait.Interrupted(err) {
+			framework.Failf("failed to track Pod annotation %q for owner %q: %v", t.podTrackedAnnotation, ownerKey, err.Error())
+		}
+	}()
+	return trackerCancel
+}
+
+func (t *IndexedPodAnnotationTracker) GetMap() map[int][]string {
+	t.Lock()
+	defer t.Unlock()
+	return maps.Clone(t.trackedAnnotations)
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Tracking issue: https://github.com/kubernetes/enhancements/issues/3850

#### Special notes for your reviewer:

This is a follow up to the [discussion](https://github.com/kubernetes/kubernetes/pull/130061#discussion_r1961510861).

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
https://github.com/kubernetes/enhancements/tree/master/keps/sig-apps/3850-backoff-limits-per-index-for-indexed-jobs
```
