### PR TITLE
e2e_node: remote: fix getting pod logs

### DIFF
--- a/test/e2e_node/remote/remote.go
+++ b/test/e2e_node/remote/remote.go
@@ -239,9 +239,12 @@ func getTestArtifacts(host, testDir string) error {
 		}
 	}
 	// Copy container logs to artifacts/hostname
-	if _, err := SSH(host, "chmod", "-R", "a+r", "/var/log/pods"); err == nil {
-		if _, err = runSSHCommand(host, "scp", "-r", fmt.Sprintf("%s:/var/log/pods/", GetHostnameOrIP(host)), logPath); err != nil {
-			return err
+	klog.V(4).Info("Add 'execute' permission to /var/log/pods to copy logs")
+	if _, err := SSH(host, "chmod", "o+x", "/var/log/pods"); err == nil {
+		if _, err := SSH(host, "chmod", "-R", "a+r", "/var/log/pods"); err == nil {
+			if _, err = runSSHCommand(host, "scp", "-r", fmt.Sprintf("%s:/var/log/pods/", GetHostnameOrIP(host)), logPath); err != nil {
+				return err
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

It changes permissions for /var/log/pods sub-directories so that e2e remote runner can copy them.

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/kubernetes/issues/130369

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
