### PR TITLE
Rename CacheProxy to CacheDelegator

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/storage_factory.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/storage_factory.go
@@ -79,7 +79,7 @@ func StorageWithCacher() generic.StorageDecorator {
 			})
 		}
 
-		return cacherstorage.NewCacheProxy(cacher, s), destroyFunc, nil
+		return cacherstorage.NewCacheDelegator(cacher, s), destroyFunc, nil
 	}
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store_test.go
@@ -2459,7 +2459,7 @@ func newTestGenericStoreRegistry(t *testing.T, scheme *runtime.Scheme, hasCacheE
 			}
 		}
 		d := destroyFunc
-		s = cacherstorage.NewCacheProxy(cacher, s)
+		s = cacherstorage.NewCacheDelegator(cacher, s)
 		destroyFunc = func() {
 			cacher.Stop()
 			d()

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
@@ -694,36 +694,6 @@ func (c *Cacher) Get(ctx context.Context, key string, opts storage.GetOptions, o
 	return nil
 }
 
-// NOTICE: Keep in sync with shouldListFromStorage function in
-//
-//	staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/list_work_estimator.go
-func shouldDelegateList(opts storage.ListOptions) bool {
-	// see https://kubernetes.io/docs/reference/using-api/api-concepts/#semantics-for-get-and-list
-	switch opts.ResourceVersionMatch {
-	case metav1.ResourceVersionMatchExact:
-		return true
-	case metav1.ResourceVersionMatchNotOlderThan:
-	case "":
-		// Legacy exact match
-		if opts.Predicate.Limit > 0 && len(opts.ResourceVersion) > 0 && opts.ResourceVersion != "0" {
-			return true
-		}
-	default:
-		return true
-	}
-	// Continue
-	if len(opts.Predicate.Continue) > 0 {
-		return true
-	}
-	// Consistent Read
-	if opts.ResourceVersion == "" {
-		consistentListFromCacheEnabled := utilfeature.DefaultFeatureGate.Enabled(features.ConsistentListFromCache)
-		requestWatchProgressSupported := etcdfeature.DefaultFeatureSupportChecker.Supports(storage.RequestWatchProgress)
-		return !consistentListFromCacheEnabled || !requestWatchProgressSupported
-	}
-	return false
-}
-
 // computeListLimit determines whether the cacher should
 // apply a limit to an incoming LIST request and returns its value.
 //
@@ -736,14 +706,6 @@ func computeListLimit(opts storage.ListOptions) int64 {
 		return 0
 	}
 	return opts.Predicate.Limit
-}
-
-func shouldDelegateListOnNotReadyCache(opts storage.ListOptions) bool {
-	pred := opts.Predicate
-	noLabelSelector := pred.Label == nil || pred.Label.Empty()
-	noFieldSelector := pred.Field == nil || pred.Field.Empty()
-	hasLimit := pred.Limit > 0
-	return noLabelSelector && noFieldSelector && hasLimit
 }
 
 func (c *Cacher) listItems(ctx context.Context, listRV uint64, key string, pred storage.SelectionPredicate, recursive bool) (listResp, string, error) {

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_testing_utils_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_testing_utils_test.go
@@ -78,7 +78,7 @@ func computePodKey(obj *example.Pod) string {
 	return fmt.Sprintf("/pods/%s/%s", obj.Namespace, obj.Name)
 }
 
-func compactStorage(c *CacheProxy, client *clientv3.Client) storagetesting.Compaction {
+func compactStorage(c *CacheDelegator, client *clientv3.Client) storagetesting.Compaction {
 	return func(ctx context.Context, t *testing.T, resourceVersion string) {
 		versioner := storage.APIObjectVersioner{}
 		rv, err := versioner.ParseResourceVersion(resourceVersion)

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/list_work_estimator.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/list_work_estimator.go
@@ -162,7 +162,7 @@ func key(requestInfo *apirequest.RequestInfo) string {
 
 // NOTICE: Keep in sync with shouldDelegateList function in
 //
-//	staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
+//	staging/src/k8s.io/apiserver/pkg/storage/cacher/delegator.go
 func shouldListFromStorage(query url.Values, opts *metav1.ListOptions) bool {
 	// see https://kubernetes.io/docs/reference/using-api/api-concepts/#semantics-for-get-and-list
 	switch opts.ResourceVersionMatch {


### PR DESCRIPTION
/kind cleanup

```release-note
NONE
```
/sig api-machinery
/triage accepted
/assign @wojtek-t
/cc @liggitt 

Using name delegator based on `shouldDelegateList` seems like much better name than just proxy.
