### PR TITLE
Propagate error when creating CustomResourceStorage instead of panic'ing

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
@@ -818,7 +818,7 @@ func (r *crdHandler) getOrCreateServingInfoFor(uid types.UID, name string) (*crd
 			return nil, fmt.Errorf("the server could not properly serve the list kind")
 		}
 
-		storages[v.Name] = customresource.NewStorage(
+		storages[v.Name], err = customresource.NewStorage(
 			resource.GroupResource(),
 			singularResource.GroupResource(),
 			kind,
@@ -847,6 +847,9 @@ func (r *crdHandler) getOrCreateServingInfoFor(uid types.UID, name string) (*crd
 			table,
 			replicasPathInCustomResource,
 		)
+		if err != nil {
+			return nil, err
+		}
 
 		clusterScoped := crd.Spec.Scope == apiextensionsv1.ClusterScoped
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/etcd.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/etcd.go
@@ -41,7 +41,7 @@ type CustomResourceStorage struct {
 	Scale          *ScaleREST
 }
 
-func NewStorage(resource schema.GroupResource, singularResource schema.GroupResource, kind, listKind schema.GroupVersionKind, strategy customResourceStrategy, optsGetter generic.RESTOptionsGetter, categories []string, tableConvertor rest.TableConvertor, replicasPathMapping managedfields.ResourcePathMappings) CustomResourceStorage {
+func NewStorage(resource schema.GroupResource, singularResource schema.GroupResource, kind, listKind schema.GroupVersionKind, strategy customResourceStrategy, optsGetter generic.RESTOptionsGetter, categories []string, tableConvertor rest.TableConvertor, replicasPathMapping managedfields.ResourcePathMappings) (CustomResourceStorage, error) {
 	var storage CustomResourceStorage
 	store := &genericregistry.Store{
 		NewFunc: func() runtime.Object {
@@ -69,7 +69,7 @@ func NewStorage(resource schema.GroupResource, singularResource schema.GroupReso
 	}
 	options := &generic.StoreOptions{RESTOptions: optsGetter, AttrFunc: strategy.GetAttrs}
 	if err := store.CompleteWithOptions(options); err != nil {
-		panic(err) // TODO: Propagate error up
+		return storage, fmt.Errorf("failed to update store with options: %w", err)
 	}
 	storage.CustomResource = &REST{store, categories}
 
@@ -97,7 +97,7 @@ func NewStorage(resource schema.GroupResource, singularResource schema.GroupReso
 		}
 	}
 
-	return storage
+	return storage, nil
 }
 
 // REST implements a RESTStorage for API services against etcd

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/etcd_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/etcd_test.go
@@ -92,7 +92,7 @@ func newStorage(t *testing.T) (customresource.CustomResourceStorage, *etcd3testi
 	}
 	table, _ := tableconvertor.New(headers)
 
-	storage := customresource.NewStorage(
+	storage, err := customresource.NewStorage(
 		groupResource,
 		groupResource,
 		kind,
@@ -113,6 +113,9 @@ func newStorage(t *testing.T) (customresource.CustomResourceStorage, *etcd3testi
 		table,
 		managedfields.ResourcePathMappings{},
 	)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 
 	return storage, server
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

If an error occurs when creating a `CustomResourceStorage` , propagate it up instead of panic'ing.

We hit this in our CI and upon inspection it seemed clear that the intention for the panic was to be temporary.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
