### PR TITLE
Automated cherry pick of #128097: [sig-windows] Update kubectl exec to use correct format

### DIFF
--- a/test/e2e/windows/gmsa_full.go
+++ b/test/e2e/windows/gmsa_full.go
@@ -142,7 +142,7 @@ var _ = sigDescribe(feature.Windows, "GMSA Full", framework.WithSerial(), framew
 			ginkgo.By("checking that nltest /QUERY returns successfully")
 			var output string
 			gomega.Eventually(ctx, func() bool {
-				output, err = runKubectlExecInNamespace(f.Namespace.Name, podName, "nltest", "/QUERY")
+				output, err = runKubectlExecInNamespace(f.Namespace.Name, podName, "--", "nltest", "/QUERY")
 				if err != nil {
 					framework.Logf("unable to run command in container via exec: %s", err)
 					return false
@@ -151,7 +151,7 @@ var _ = sigDescribe(feature.Windows, "GMSA Full", framework.WithSerial(), framew
 				if !isValidOutput(output) {
 					// try repairing the secure channel by running reset command
 					// https://kubernetes.io/docs/tasks/configure-pod-container/configure-gmsa/#troubleshooting
-					output, err = runKubectlExecInNamespace(f.Namespace.Name, podName, "nltest", fmt.Sprintf("/sc_reset:%s", gmsaDomain))
+					output, err = runKubectlExecInNamespace(f.Namespace.Name, podName, "--", "nltest", fmt.Sprintf("/sc_reset:%s", gmsaDomain))
 					if err != nil {
 						framework.Logf("unable to run command in container via exec: %s", err)
 						return false
@@ -286,7 +286,7 @@ func retrieveCRDManifestFileContents(ctx context.Context, f *framework.Framework
 	}
 	e2epod.NewPodClient(f).CreateSync(ctx, pod)
 
-	output, err := runKubectlExecInNamespace(f.Namespace.Name, podName, "cmd", "/S", "/C", fmt.Sprintf("type %s", gmsaCrdManifestPath))
+	output, err := runKubectlExecInNamespace(f.Namespace.Name, podName, "--", "cmd", "/S", "/C", fmt.Sprintf("type %s", gmsaCrdManifestPath))
 	if err != nil {
 		framework.Failf("failed to retrieve the contents of %q on node %q: %v", gmsaCrdManifestPath, node.Name, err)
 	}


### PR DESCRIPTION
Cherry pick of #128097 on release-1.31.

#128097: [sig-windows] Update kubectl exec to use correct format

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```