### PR TITLE
Remove limit support from btree store

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/store.go
@@ -73,7 +73,7 @@ type storeIndexer interface {
 }
 
 type orderedLister interface {
-	ListPrefix(prefix, continueKey string, limit int) (items []interface{}, hasMore bool)
+	ListPrefix(prefix, continueKey string) []interface{}
 	Count(prefix, continueKey string) (count int)
 	Clone() orderedLister
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/store_btree_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/store_btree_test.go
@@ -41,40 +41,30 @@ func TestStoreListPrefix(t *testing.T) {
 	assert.NoError(t, store.Add(testStorageElement("foo2", "bar1", 3)))
 	assert.NoError(t, store.Add(testStorageElement("bar", "baz", 4)))
 
-	items, hasMore := store.ListPrefix("foo", "", 0)
-	assert.False(t, hasMore)
+	items := store.ListPrefix("foo", "")
 	assert.Equal(t, []interface{}{
 		testStorageElement("foo1", "bar2", 2),
 		testStorageElement("foo2", "bar1", 3),
 		testStorageElement("foo3", "bar3", 1),
 	}, items)
 
-	items, hasMore = store.ListPrefix("foo2", "", 0)
-	assert.False(t, hasMore)
+	items = store.ListPrefix("foo2", "")
 	assert.Equal(t, []interface{}{
 		testStorageElement("foo2", "bar1", 3),
 	}, items)
 
-	items, hasMore = store.ListPrefix("foo", "", 1)
-	assert.True(t, hasMore)
-	assert.Equal(t, []interface{}{
-		testStorageElement("foo1", "bar2", 2),
-	}, items)
-
-	items, hasMore = store.ListPrefix("foo", "foo1\x00", 1)
-	assert.True(t, hasMore)
+	items = store.ListPrefix("foo", "foo1\x00")
 	assert.Equal(t, []interface{}{
 		testStorageElement("foo2", "bar1", 3),
+		testStorageElement("foo3", "bar3", 1),
 	}, items)
 
-	items, hasMore = store.ListPrefix("foo", "foo2\x00", 1)
-	assert.False(t, hasMore)
+	items = store.ListPrefix("foo", "foo2\x00")
 	assert.Equal(t, []interface{}{
 		testStorageElement("foo3", "bar3", 1),
 	}, items)
 
-	items, hasMore = store.ListPrefix("bar", "", 0)
-	assert.False(t, hasMore)
+	items = store.ListPrefix("bar", "")
 	assert.Equal(t, []interface{}{
 		testStorageElement("bar", "baz", 4),
 	}, items)
@@ -143,7 +133,7 @@ func (f fakeOrderedLister) Add(obj interface{}) error    { return nil }
 func (f fakeOrderedLister) Update(obj interface{}) error { return nil }
 func (f fakeOrderedLister) Delete(obj interface{}) error { return nil }
 func (f fakeOrderedLister) Clone() orderedLister         { return f }
-func (f fakeOrderedLister) ListPrefix(prefixKey, continueKey string, limit int) ([]interface{}, bool) {
-	return nil, false
+func (f fakeOrderedLister) ListPrefix(prefixKey, continueKey string) []interface{} {
+	return nil
 }
 func (f fakeOrderedLister) Count(prefixKey, continueKey string) int { return 0 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
@@ -523,7 +523,7 @@ func (w *watchCache) WaitUntilFreshAndList(ctx context.Context, resourceVersion 
 		}
 	}
 	if store, ok := w.store.(orderedLister); ok {
-		result, _ := store.ListPrefix(key, "", 0)
+		result := store.ListPrefix(key, "")
 		return listResp{
 			Items:           result,
 			ResourceVersion: w.resourceVersion,

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_test.go
@@ -1318,7 +1318,7 @@ func TestCacheSnapshots(t *testing.T) {
 	assert.False(t, found, "Expected store to not include rev 99")
 	lister, found := store.snapshots.GetLessOrEqual(100)
 	assert.True(t, found, "Expected store to not include rev 100")
-	elements, _ := lister.ListPrefix("", "", 0)
+	elements := lister.ListPrefix("", "")
 	assert.Len(t, elements, 1)
 	assert.Equal(t, makeTestPod("foo", 100), elements[0].(*storeElement).Object)
 
@@ -1330,20 +1330,20 @@ func TestCacheSnapshots(t *testing.T) {
 	t.Log("Test cache on rev 200")
 	lister, found = store.snapshots.GetLessOrEqual(200)
 	assert.True(t, found, "Expected store to still keep rev 200")
-	elements, _ = lister.ListPrefix("", "", 0)
+	elements = lister.ListPrefix("", "")
 	assert.Len(t, elements, 1)
 	assert.Equal(t, makeTestPod("foo", 200), elements[0].(*storeElement).Object)
 
 	t.Log("Test cache on rev 300")
 	lister, found = store.snapshots.GetLessOrEqual(300)
 	assert.True(t, found, "Expected store to still keep rev 300")
-	elements, _ = lister.ListPrefix("", "", 0)
+	elements = lister.ListPrefix("", "")
 	assert.Empty(t, elements)
 
 	t.Log("Test cache on rev 400")
 	lister, found = store.snapshots.GetLessOrEqual(400)
 	assert.True(t, found, "Expected store to still keep rev 400")
-	elements, _ = lister.ListPrefix("", "", 0)
+	elements = lister.ListPrefix("", "")
 	assert.Len(t, elements, 1)
 	assert.Equal(t, makeTestPod("foo", 400), elements[0].(*storeElement).Object)
 
@@ -1359,7 +1359,7 @@ func TestCacheSnapshots(t *testing.T) {
 	t.Log("Test cache on rev 500")
 	lister, found = store.snapshots.GetLessOrEqual(500)
 	assert.True(t, found, "Expected store to still keep rev 500")
-	elements, _ = lister.ListPrefix("", "", 0)
+	elements = lister.ListPrefix("", "")
 	assert.Len(t, elements, 1)
 	assert.Equal(t, makeTestPod("foo", 500), elements[0].(*storeElement).Object)
 
@@ -1371,7 +1371,7 @@ func TestCacheSnapshots(t *testing.T) {
 	t.Log("Test cache on rev 600")
 	lister, found = store.snapshots.GetLessOrEqual(600)
 	assert.True(t, found, "Expected replace to be snapshotted")
-	elements, _ = lister.ListPrefix("", "", 0)
+	elements = lister.ListPrefix("", "")
 	assert.Len(t, elements, 1)
 	assert.Equal(t, makeTestPod("foo", 600), elements[0].(*storeElement).Object)
 
@@ -1388,7 +1388,7 @@ func TestCacheSnapshots(t *testing.T) {
 	t.Log("Test cache on rev 700")
 	lister, found = store.snapshots.GetLessOrEqual(700)
 	assert.True(t, found, "Expected replace to be snapshotted")
-	elements, _ = lister.ListPrefix("", "", 0)
+	elements = lister.ListPrefix("", "")
 	assert.Len(t, elements, 1)
 	assert.Equal(t, makeTestPod("foo", 600), elements[0].(*storeElement).Object)
 }


### PR DESCRIPTION
We cannot use limit as it would apply it before filtering, which is done in cacher. Limit is not currently used, but let's remove it to be save, until filtering is implemented in store.

/sig api-machinery
/triage accepted
/assign @wojtek-t
/cc @liggitt

/kind cleanup

```release-note
NONE
```