### PR TITLE
Make request validation consistent with etcd3 store validation

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/internalversion/validation/validation.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/internalversion/validation/validation.go
@@ -44,6 +44,9 @@ func ValidateListOptions(options *internalversion.ListOptions, isWatchListFeatur
 			allErrs = append(allErrs, field.Forbidden(field.NewPath("resourceVersionMatch"), "resourceVersionMatch \"exact\" is forbidden for resourceVersion \"0\""))
 		}
 	}
+	if len(options.Continue) > 0 && len(options.ResourceVersion) > 0 && options.ResourceVersion != "0" {
+		allErrs = append(allErrs, field.Forbidden(field.NewPath("resourceVersion"), "specifying resource version is not allowed when using continue"))
+	}
 	if options.SendInitialEvents != nil {
 		allErrs = append(allErrs, field.Forbidden(field.NewPath("sendInitialEvents"), "sendInitialEvents is forbidden for list"))
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/internalversion/validation/validation_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/internalversion/validation/validation_test.go
@@ -63,6 +63,13 @@ func TestValidateListOptions(t *testing.T) {
 		},
 		expectErrors: []string{"resourceVersionMatch: Unsupported value: \"foo\": supported values: \"Exact\", \"NotOlderThan\", \"\""},
 	}, {
+		name: "invalid-resourceversionmatch",
+		opts: internalversion.ListOptions{
+			ResourceVersion: "1",
+			Continue:        "foo",
+		},
+		expectErrors: []string{"resourceVersion: Forbidden: specifying resource version is not allowed when using continue"},
+	}, {
 		name: "list-sendInitialEvents-forbidden",
 		opts: internalversion.ListOptions{
 			SendInitialEvents: boolPtrFn(true),

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
@@ -227,8 +227,6 @@ func TestGetListCacheBypass(t *testing.T) {
 	testCases[opts{ResourceVersion: "0", ResourceVersionMatch: metav1.ResourceVersionMatchNotOlderThan, Limit: 100}] = false
 	testCases[opts{ResourceVersion: "1"}] = false
 	testCases[opts{ResourceVersion: "1", Limit: 100}] = true
-	testCases[opts{ResourceVersion: "1", Continue: "continue"}] = true
-	testCases[opts{ResourceVersion: "1", Limit: 100, Continue: "continue"}] = true
 	testCases[opts{ResourceVersion: "1", ResourceVersionMatch: metav1.ResourceVersionMatchExact}] = true
 	testCases[opts{ResourceVersion: "1", ResourceVersionMatch: metav1.ResourceVersionMatchExact, Limit: 100}] = true
 	testCases[opts{ResourceVersion: "1", ResourceVersionMatch: metav1.ResourceVersionMatchNotOlderThan}] = false

--- a/test/integration/apiserver/apiserver_test.go
+++ b/test/integration/apiserver/apiserver_test.go
@@ -526,6 +526,12 @@ func testListOptionsCase(t *testing.T, rsClient appsv1.ReplicaSetInterface, watc
 		}
 		return
 	}
+	if opts.Continue != "" && opts.ResourceVersion != "" && opts.ResourceVersion != "0" {
+		if err == nil || !strings.Contains(err.Error(), "specifying resource version is not allowed when using continue") {
+			t.Fatalf("expected forbidden error, but got: %v", err)
+		}
+		return
+	}
 	if opts.ResourceVersionMatch == invalidResourceVersionMatch {
 		if err == nil || !strings.Contains(err.Error(), "supported values") {
 			t.Fatalf("expected not supported error, but got: %v", err)


### PR DESCRIPTION
Requests setting resource version and continue passed validation, but were always passed to etcd3 and rejected internally via https://github.com/kubernetes/kubernetes/blob/126a5824de4086d4749c7a9f178fc559c30e7564/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go#L652-L655.

Moving this to request validation so we stop testing this case in TestGetListCacheBypass.

/kind cleanup

```release-note
NONE
```
/sig api-machinery
/triage accepted
/assign @wojtek-t
/cc @liggitt
