### PR TITLE
Rejigger API Priority and Fairness config

### DIFF
--- a/pkg/apis/flowcontrol/internalbootstrap/default-internal.go
+++ b/pkg/apis/flowcontrol/internalbootstrap/default-internal.go
@@ -20,6 +20,8 @@ import (
 	flowcontrolv1 "k8s.io/api/flowcontrol/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/apis/flowcontrol/bootstrap"
+	"k8s.io/apiserver/pkg/features"
+	"k8s.io/component-base/featuregate"
 	"k8s.io/kubernetes/pkg/apis/flowcontrol"
 	"k8s.io/kubernetes/pkg/apis/flowcontrol/install"
 )
@@ -30,9 +32,11 @@ type FlowSchemasMap = map[string]*flowcontrol.FlowSchema
 // GetMandatoryFlowSchemasMap returns the unversioned (internal) mandatory FlowSchema objects,
 // as a deeply immutable map.
 // The arguments are the values of the features that control which config collection to use.
-func GetMandatoryFlowSchemasMap(v134 bool) FlowSchemasMap {
-	return MandatoryFlowSchemasMap[bootstrap.CollectionID{V134: v134}]
+func GetMandatoryFlowSchemasMap(featureGate featuregate.FeatureGate) FlowSchemasMap {
+	return MandatoryFlowSchemasMap[bootstrap.CollectionID{V134: featureGate.Enabled(features.APFv134Config)}]
 }
+
+var oldConfig = bootstrap.GetV1ConfigCollection(bootstrap.MakeGate(false))
 
 // MandatoryFlowSchemasMap holds the unversioned (internal) renditions of the mandatory
 // flow schemas.  In the outer map the key is CollectionId and
@@ -40,8 +44,8 @@ func GetMandatoryFlowSchemasMap(v134 bool) FlowSchemasMap {
 // value is the `*FlowSchema`.  Nobody should mutate anything
 // reachable from this map.
 var MandatoryFlowSchemasMap = map[bootstrap.CollectionID]FlowSchemasMap{
-	{V134: false}: internalizeFSes(bootstrap.GetV1ConfigCollection(false).Mandatory.FlowSchemas),
-	{V134: true}:  internalizeFSes(bootstrap.GetV1ConfigCollection(true).Mandatory.FlowSchemas),
+	{V134: false}: internalizeFSes(oldConfig.Mandatory.FlowSchemas),
+	{V134: true}:  internalizeFSes(bootstrap.Latest.Mandatory.FlowSchemas),
 }
 
 // PriorityLevelConfigurationsMap is a collection of unversioned (internal) PriorityLevelConfiguration objects, indexed by name.
@@ -50,8 +54,8 @@ type PriorityLevelConfigurationsMap = map[string]*flowcontrol.PriorityLevelConfi
 // GetMandatoryPriorityLevelConfigurationsMap returns the mandatory PriorityLevelConfiguration objects,
 // as a deeply immutable map.
 // The arguments are the values of the features that control which config collection to use.
-func GetMandatoryPriorityLevelConfigurationsMap(v134 bool) PriorityLevelConfigurationsMap {
-	return MandatoryPriorityLevelConfigurationsMap[bootstrap.CollectionID{V134: v134}]
+func GetMandatoryPriorityLevelConfigurationsMap(featureGate featuregate.FeatureGate) PriorityLevelConfigurationsMap {
+	return MandatoryPriorityLevelConfigurationsMap[bootstrap.CollectionID{V134: featureGate.Enabled(features.APFv134Config)}]
 }
 
 // MandatoryPriorityLevelConfigurationsMap holds the untyped renditions of the
@@ -60,8 +64,8 @@ func GetMandatoryPriorityLevelConfigurationsMap(v134 bool) PriorityLevelConfigur
 // `*PriorityLevelConfiguration`.  Nobody should mutate anything
 // reachable from this map.
 var MandatoryPriorityLevelConfigurationsMap = map[bootstrap.CollectionID]PriorityLevelConfigurationsMap{
-	{V134: false}: internalizePLs(bootstrap.GetV1ConfigCollection(false).Mandatory.PriorityLevelConfigurations),
-	{V134: true}:  internalizePLs(bootstrap.GetV1ConfigCollection(true).Mandatory.PriorityLevelConfigurations),
+	{V134: false}: internalizePLs(oldConfig.Mandatory.PriorityLevelConfigurations),
+	{V134: true}:  internalizePLs(bootstrap.Latest.Mandatory.PriorityLevelConfigurations),
 }
 
 func internalizeFSes(exts []*flowcontrolv1.FlowSchema) FlowSchemasMap {

--- a/pkg/apis/flowcontrol/internalbootstrap/defaults_test.go
+++ b/pkg/apis/flowcontrol/internalbootstrap/defaults_test.go
@@ -28,35 +28,37 @@ import (
 )
 
 func TestBootstrapConfigurationWithDefaulted(t *testing.T) {
-	scheme := NewAPFScheme()
+	t.Run("false", caseFn(false))
+	t.Run("true", caseFn(true))
+}
 
-	bootstrapFlowSchemas := make([]*flowcontrol.FlowSchema, 0)
-	bootstrapFlowSchemas = append(bootstrapFlowSchemas, bootstrap.MandatoryFlowSchemas...)
-	bootstrapFlowSchemas = append(bootstrapFlowSchemas, bootstrap.SuggestedFlowSchemas...)
-	for _, original := range bootstrapFlowSchemas {
-		t.Run(fmt.Sprintf("FlowSchema/%s", original.Name), func(t *testing.T) {
-			defaulted := original.DeepCopyObject().(*flowcontrol.FlowSchema)
-			scheme.Default(defaulted)
-			if apiequality.Semantic.DeepEqual(original, defaulted) {
-				t.Logf("Defaulting makes no change to FlowSchema: %q", original.Name)
-				return
-			}
-			t.Errorf("Expected defaulting to not change FlowSchema: %q, diff: %s", original.Name, cmp.Diff(original, defaulted))
-		})
-	}
+func caseFn(v134 bool) func(*testing.T) {
+	return func(t *testing.T) {
+		scheme := NewAPFScheme()
+		bootstrapFlowSchemas := bootstrap.GetFlowSchemas(v134)
+		for _, original := range bootstrapFlowSchemas {
+			t.Run(fmt.Sprintf("FlowSchema/%s", original.Name), func(t *testing.T) {
+				defaulted := original.DeepCopyObject().(*flowcontrol.FlowSchema)
+				scheme.Default(defaulted)
+				if apiequality.Semantic.DeepEqual(original, defaulted) {
+					t.Logf("Defaulting makes no change to FlowSchema: %q", original.Name)
+					return
+				}
+				t.Errorf("Expected defaulting to not change FlowSchema: %q, diff: %s", original.Name, cmp.Diff(original, defaulted))
+			})
+		}
 
-	bootstrapPriorityLevels := make([]*flowcontrol.PriorityLevelConfiguration, 0)
-	bootstrapPriorityLevels = append(bootstrapPriorityLevels, bootstrap.MandatoryPriorityLevelConfigurations...)
-	bootstrapPriorityLevels = append(bootstrapPriorityLevels, bootstrap.SuggestedPriorityLevelConfigurations...)
-	for _, original := range bootstrapPriorityLevels {
-		t.Run(fmt.Sprintf("PriorityLevelConfiguration/%s", original.Name), func(t *testing.T) {
-			defaulted := original.DeepCopyObject().(*flowcontrol.PriorityLevelConfiguration)
-			scheme.Default(defaulted)
-			if apiequality.Semantic.DeepEqual(original, defaulted) {
-				t.Logf("Defaulting makes no change to PriorityLevelConfiguration: %q", original.Name)
-				return
-			}
-			t.Errorf("Expected defaulting to not change PriorityLevelConfiguration: %q, diff: %s", original.Name, cmp.Diff(original, defaulted))
-		})
+		bootstrapPriorityLevels := bootstrap.GetPrioritylevelConfigurations(v134)
+		for _, original := range bootstrapPriorityLevels {
+			t.Run(fmt.Sprintf("PriorityLevelConfiguration/%s", original.Name), func(t *testing.T) {
+				defaulted := original.DeepCopyObject().(*flowcontrol.PriorityLevelConfiguration)
+				scheme.Default(defaulted)
+				if apiequality.Semantic.DeepEqual(original, defaulted) {
+					t.Logf("Defaulting makes no change to PriorityLevelConfiguration: %q", original.Name)
+					return
+				}
+				t.Errorf("Expected defaulting to not change PriorityLevelConfiguration: %q, diff: %s", original.Name, cmp.Diff(original, defaulted))
+			})
+		}
 	}
 }

--- a/pkg/apis/flowcontrol/internalbootstrap/defaults_test.go
+++ b/pkg/apis/flowcontrol/internalbootstrap/defaults_test.go
@@ -25,17 +25,18 @@ import (
 	flowcontrol "k8s.io/api/flowcontrol/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apiserver/pkg/apis/flowcontrol/bootstrap"
+	"k8s.io/component-base/featuregate"
 )
 
 func TestBootstrapConfigurationWithDefaulted(t *testing.T) {
-	t.Run("false", caseFn(false))
-	t.Run("true", caseFn(true))
+	t.Run("v134Config=false", caseFn(bootstrap.MakeGate(false)))
+	t.Run("v134Config=true", caseFn(bootstrap.LatestFeatureGate))
 }
 
-func caseFn(v134 bool) func(*testing.T) {
+func caseFn(featureGate featuregate.FeatureGate) func(*testing.T) {
 	return func(t *testing.T) {
 		scheme := NewAPFScheme()
-		bootstrapFlowSchemas := bootstrap.GetFlowSchemas(v134)
+		bootstrapFlowSchemas := bootstrap.GetFlowSchemas(featureGate)
 		for _, original := range bootstrapFlowSchemas {
 			t.Run(fmt.Sprintf("FlowSchema/%s", original.Name), func(t *testing.T) {
 				defaulted := original.DeepCopyObject().(*flowcontrol.FlowSchema)
@@ -48,7 +49,7 @@ func caseFn(v134 bool) func(*testing.T) {
 			})
 		}
 
-		bootstrapPriorityLevels := bootstrap.GetPrioritylevelConfigurations(v134)
+		bootstrapPriorityLevels := bootstrap.GetPrioritylevelConfigurations(featureGate)
 		for _, original := range bootstrapPriorityLevels {
 			t.Run(fmt.Sprintf("PriorityLevelConfiguration/%s", original.Name), func(t *testing.T) {
 				defaulted := original.DeepCopyObject().(*flowcontrol.PriorityLevelConfiguration)

--- a/pkg/apis/flowcontrol/validation/validation_test.go
+++ b/pkg/apis/flowcontrol/validation/validation_test.go
@@ -28,9 +28,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	fcboot "k8s.io/apiserver/pkg/apis/flowcontrol/bootstrap"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/kubernetes/pkg/apis/flowcontrol"
-	"k8s.io/kubernetes/pkg/apis/flowcontrol/internalbootstrap"
 	"k8s.io/utils/pointer"
 )
 
@@ -263,7 +263,7 @@ func TestFlowSchemaValidation(t *testing.T) {
 			},
 			Spec: badExempt,
 		},
-		expectedErrors: field.ErrorList{field.Invalid(field.NewPath("spec"), badExempt, "spec of 'exempt' must equal the fixed value")},
+		expectedErrors: field.ErrorList{field.Invalid(field.NewPath("spec"), badExempt, "spec of 'exempt' must equal the old or new fixed value")},
 	}, {
 		name: "bad catch-all flow-schema should fail",
 		flowSchema: &flowcontrol.FlowSchema{
@@ -272,7 +272,7 @@ func TestFlowSchemaValidation(t *testing.T) {
 			},
 			Spec: badCatchAll,
 		},
-		expectedErrors: field.ErrorList{field.Invalid(field.NewPath("spec"), badCatchAll, "spec of 'catch-all' must equal the fixed value")},
+		expectedErrors: field.ErrorList{field.Invalid(field.NewPath("spec"), badCatchAll, "spec of 'catch-all' must equal the old or new fixed value")},
 	}, {
 		name: "catch-all flow-schema should work",
 		flowSchema: &flowcontrol.FlowSchema{
@@ -769,7 +769,7 @@ func TestPriorityLevelConfigurationValidation(t *testing.T) {
 	}
 
 	validChangesInExemptFieldOfExemptPLFn := func() flowcontrol.PriorityLevelConfigurationSpec {
-		have, _ := internalbootstrap.MandatoryPriorityLevelConfigurations[flowcontrol.PriorityLevelConfigurationNameExempt]
+		have := fcboot.GetV1ConfigCollection(true).PriorityLevelConfigurationExempt
 		return flowcontrol.PriorityLevelConfigurationSpec{
 			Type: flowcontrol.PriorityLevelEnablementExempt,
 			Exempt: &flowcontrol.ExemptPriorityLevelConfiguration{
@@ -949,7 +949,7 @@ func TestPriorityLevelConfigurationValidation(t *testing.T) {
 			},
 			Spec: badSpec,
 		},
-		expectedErrors: field.ErrorList{field.Invalid(field.NewPath("spec"), badSpec, "spec of 'catch-all' must equal the fixed value")},
+		expectedErrors: field.ErrorList{field.Invalid(field.NewPath("spec"), badSpec, "spec of 'catch-all' must equal the old or new fixed value")},
 	}, {
 		name: "backstop should work",
 		priorityLevelConfiguration: &flowcontrol.PriorityLevelConfiguration{

--- a/pkg/apis/flowcontrol/validation/validation_test.go
+++ b/pkg/apis/flowcontrol/validation/validation_test.go
@@ -769,7 +769,7 @@ func TestPriorityLevelConfigurationValidation(t *testing.T) {
 	}
 
 	validChangesInExemptFieldOfExemptPLFn := func() flowcontrol.PriorityLevelConfigurationSpec {
-		have := fcboot.GetV1ConfigCollection(true).PriorityLevelConfigurationExempt
+		have := fcboot.Latest.PriorityLevelConfigurationExempt
 		return flowcontrol.PriorityLevelConfigurationSpec{
 			Type: flowcontrol.PriorityLevelEnablementExempt,
 			Exempt: &flowcontrol.ExemptPriorityLevelConfiguration{

--- a/pkg/controlplane/apiserver/apis.go
+++ b/pkg/controlplane/apiserver/apis.go
@@ -78,7 +78,7 @@ func (c *CompletedConfig) GenericStorageProviders(discovery discovery.DiscoveryI
 		coordinationrest.RESTStorageProvider{},
 		rbacrest.RESTStorageProvider{Authorizer: c.Generic.Authorization.Authorizer},
 		svmrest.RESTStorageProvider{},
-		flowcontrolrest.RESTStorageProvider{InformerFactory: c.Generic.SharedInformerFactory},
+		flowcontrolrest.RESTStorageProvider{InformerFactory: c.Generic.SharedInformerFactory, FeatureGate: c.Generic.FeatureGate},
 		admissionregistrationrest.RESTStorageProvider{Authorizer: c.Generic.Authorization.Authorizer, DiscoveryClient: discovery},
 		eventsrest.RESTStorageProvider{TTL: c.EventTTL},
 	}, nil

--- a/pkg/controlplane/instance.go
+++ b/pkg/controlplane/instance.go
@@ -418,7 +418,7 @@ func (c CompletedConfig) StorageProviders(client *kubernetes.Clientset) ([]contr
 		schedulingrest.RESTStorageProvider{},
 		storagerest.RESTStorageProvider{},
 		svmrest.RESTStorageProvider{},
-		flowcontrolrest.RESTStorageProvider{InformerFactory: c.ControlPlane.Generic.SharedInformerFactory},
+		flowcontrolrest.RESTStorageProvider{InformerFactory: c.ControlPlane.Generic.SharedInformerFactory, FeatureGate: c.ControlPlane.Generic.FeatureGate},
 		// keep apps after extensions so legacy clients resolve the extensions versions of shared resource names.
 		// See https://github.com/kubernetes/kubernetes/issues/42392
 		appsrest.StorageProvider{},

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -62,6 +62,15 @@ const (
 	// Enables usage of any object for volume data source in PVCs
 	AnyVolumeDataSource featuregate.Feature = "AnyVolumeDataSource"
 
+	// owner: @MikeSpreitzer, @tkashem, @linxiulei
+	//
+	// Make API Priority and Fairness use modern configuration, which
+	// differs from the old in these ways:
+	// - introduce priority level and flow schema for events;
+	// - generally reorganize to stop working around lack of borrowing;
+	// - increase the nominal concurrency shares for leader election.
+	APFv134Config featuregate.Feature = "APFv134Config"
+
 	// owner: @liggitt
 	// kep: https://kep.k8s.io/4601
 	//
@@ -1002,6 +1011,10 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 		{Version: version.MustParse("1.18"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("1.24"), Default: true, PreRelease: featuregate.Beta},
 		{Version: version.MustParse("1.33"), Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // GA in 1.33 -> remove in 1.36
+	},
+
+	APFv134Config: {
+		{Version: version.MustParse("1.34"), Default: true, PreRelease: featuregate.Beta},
 	},
 
 	AuthorizeNodeWithSelectors: {

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -1014,6 +1014,7 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 	},
 
 	APFv134Config: {
+		{Version: version.MustParse("1.33"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("1.34"), Default: true, PreRelease: featuregate.Beta},
 	},
 

--- a/pkg/registry/flowcontrol/ensurer/flowschema_test.go
+++ b/pkg/registry/flowcontrol/ensurer/flowschema_test.go
@@ -24,7 +24,7 @@ import (
 	flowcontrolv1 "k8s.io/api/flowcontrol/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apiserver/pkg/apis/flowcontrol/bootstrap"
+	bootstrap "k8s.io/apiserver/pkg/apis/flowcontrol/bootstrap-v134"
 	"k8s.io/client-go/kubernetes/fake"
 	flowcontrollisters "k8s.io/client-go/listers/flowcontrol/v1"
 	toolscache "k8s.io/client-go/tools/cache"

--- a/pkg/registry/flowcontrol/ensurer/prioritylevelconfiguration_test.go
+++ b/pkg/registry/flowcontrol/ensurer/prioritylevelconfiguration_test.go
@@ -24,7 +24,7 @@ import (
 	flowcontrolv1 "k8s.io/api/flowcontrol/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apiserver/pkg/apis/flowcontrol/bootstrap"
+	bootstrap "k8s.io/apiserver/pkg/apis/flowcontrol/bootstrap-v134"
 	"k8s.io/client-go/kubernetes/fake"
 	flowcontrollisters "k8s.io/client-go/listers/flowcontrol/v1"
 	toolscache "k8s.io/client-go/tools/cache"

--- a/pkg/registry/flowcontrol/rest/storage_flowcontrol.go
+++ b/pkg/registry/flowcontrol/rest/storage_flowcontrol.go
@@ -136,16 +136,14 @@ func (bce *bootstrapConfigurationEnsurer) ensureAPFBootstrapConfiguration(hookCo
 	err = func() error {
 		// get a derived context that gets cancelled after 5m or
 		// when the StopCh gets closed, whichever happens first.
-		ctx, cancel := contextFromChannelAndMaxWaitDuration(hookContext.Done(), 5*time.Minute)
+		ctx, cancel := context.WithDeadline(hookContext, time.Now().Add(5*time.Minute))
 		defer cancel()
 
 		if !cache.WaitForCacheSync(ctx.Done(), bce.informersSynced...) {
 			return fmt.Errorf("APF bootstrap ensurer timed out waiting for cache sync")
 		}
 
-		err = wait.PollImmediateUntilWithContext(
-			ctx,
-			time.Second,
+		err = wait.PollUntilContextCancel(ctx, time.Second, true,
 			func(context.Context) (bool, error) {
 				if err := ensure(ctx, bce.v134Config, clientset, bce.fsLister, bce.plcLister); err != nil {
 					klog.ErrorS(err, "APF bootstrap ensurer ran into error, will retry later")
@@ -165,15 +163,14 @@ func (bce *bootstrapConfigurationEnsurer) ensureAPFBootstrapConfiguration(hookCo
 	// we have successfully initialized the bootstrap configuration, now we
 	// spin up a goroutine which reconciles the bootstrap configuration periodically.
 	go func() {
-		wait.PollImmediateUntil(
-			time.Minute,
-			func() (bool, error) {
-				if err := ensure(hookContext, bce.v134Config, clientset, bce.fsLister, bce.plcLister); err != nil {
+		_ = wait.PollUntilContextCancel(hookContext, time.Minute, true,
+			func(ctx context.Context) (bool, error) {
+				if err := ensure(ctx, bce.v134Config, clientset, bce.fsLister, bce.plcLister); err != nil {
 					klog.ErrorS(err, "APF bootstrap ensurer ran into error, will retry later")
 				}
 				// always auto update both suggested and mandatory configuration
 				return false, nil
-			}, hookContext.Done())
+			})
 		klog.Info("APF bootstrap ensurer is exiting")
 	}()
 

--- a/staging/src/k8s.io/apiserver/pkg/apis/flowcontrol/base/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/flowcontrol/base/types.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package base
+
+import (
+	flowcontrolv1 "k8s.io/api/flowcontrol/v1"
+)
+
+// V1ConfigCollection is the collection of default V1 configuration objects to use.
+// Deeply immutable.
+type V1ConfigCollection struct {
+	// Mandatory holds the objects that define an apiserver's initial behavior.  The
+	// registered defaulting procedures make no changes to these
+	// particular objects (this is verified in the unit tests of the
+	// internalbootstrap package; it can not be verified in this package
+	// because that would require importing k8s.io/kubernetes).
+	Mandatory V1ConfigSlices
+	// Suggested holds the objects that define the current suggested additional configuration.
+	Suggested V1ConfigSlices
+	// PriorityLevelConfigurationExempt also appears in `Mandatory.PriorityLevelConfigurations`.
+	PriorityLevelConfigurationExempt *flowcontrolv1.PriorityLevelConfiguration
+	// PriorityLevelConfigurationCatchAll also appears in `Mandatory.PriorityLevelConfigurations`.
+	PriorityLevelConfigurationCatchAll *flowcontrolv1.PriorityLevelConfiguration
+	// FlowSchemaExempt also appears in `Mandatory.FlowsSchemas`.
+	FlowSchemaExempt *flowcontrolv1.FlowSchema
+	// FlowSchemaCatchAll also appears in `Mandatory.FlowSchemas`.
+	FlowSchemaCatchAll *flowcontrolv1.FlowSchema
+}
+
+// V1ConfigSlices is a collection of v1 APF configuration objects.
+// Deeply immutable.
+type V1ConfigSlices struct {
+	PriorityLevelConfigurations []*flowcontrolv1.PriorityLevelConfiguration
+	FlowSchemas                 []*flowcontrolv1.FlowSchema
+}

--- a/staging/src/k8s.io/apiserver/pkg/apis/flowcontrol/bootstrap-old/default_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/flowcontrol/bootstrap-old/default_test.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bootstrap
+
+import (
+	"testing"
+
+	flowcontrol "k8s.io/api/flowcontrol/v1"
+)
+
+func TestBootstrapPriorityLevelConfigurationWithBorrowing(t *testing.T) {
+	tests := []struct {
+		name                    string
+		nominalSharesExpected   int32
+		lendablePercentexpected int32
+	}{
+		{
+			name:                    "leader-election",
+			nominalSharesExpected:   10,
+			lendablePercentexpected: 0,
+		},
+		{
+			name:                    "node-high",
+			nominalSharesExpected:   40,
+			lendablePercentexpected: 25,
+		},
+		{
+			name:                    "system",
+			nominalSharesExpected:   30,
+			lendablePercentexpected: 33,
+		},
+		{
+			name:                    "workload-high",
+			nominalSharesExpected:   40,
+			lendablePercentexpected: 50,
+		},
+		{
+			name:                    "workload-low",
+			nominalSharesExpected:   100,
+			lendablePercentexpected: 90,
+		},
+		{
+			name:                    "global-default",
+			nominalSharesExpected:   20,
+			lendablePercentexpected: 50,
+		},
+		{
+			name:                    "catch-all",
+			nominalSharesExpected:   5,
+			lendablePercentexpected: 0,
+		},
+	}
+
+	bootstrapPLs := func() map[string]*flowcontrol.PriorityLevelConfiguration {
+		list := make([]*flowcontrol.PriorityLevelConfiguration, 0)
+		list = append(list, V1ConfigCollection.Mandatory.PriorityLevelConfigurations...)
+		list = append(list, V1ConfigCollection.Suggested.PriorityLevelConfigurations...)
+
+		m := map[string]*flowcontrol.PriorityLevelConfiguration{}
+		for i := range list {
+			m[list[i].Name] = list[i]
+		}
+		return m
+	}()
+
+	for _, test := range tests {
+		bootstrapPL := bootstrapPLs[test.name]
+		if bootstrapPL == nil {
+			t.Errorf("Expected bootstrap PriorityLevelConfiguration %q, but not found in bootstrap configuration", test.name)
+			continue
+		}
+		delete(bootstrapPLs, test.name)
+
+		if bootstrapPL.Spec.Type != flowcontrol.PriorityLevelEnablementLimited {
+			t.Errorf("bootstrap PriorityLevelConfiguration %q is not %q", test.name, flowcontrol.PriorityLevelEnablementLimited)
+			continue
+		}
+		if test.nominalSharesExpected != *bootstrapPL.Spec.Limited.NominalConcurrencyShares {
+			t.Errorf("bootstrap PriorityLevelConfiguration %q: expected NominalConcurrencyShares: %d, but got: %d", test.name, test.nominalSharesExpected, bootstrapPL.Spec.Limited.NominalConcurrencyShares)
+		}
+		if test.lendablePercentexpected != *bootstrapPL.Spec.Limited.LendablePercent {
+			t.Errorf("bootstrap PriorityLevelConfiguration %q: expected NominalConcurrencyShares: %d, but got: %d", test.name, test.lendablePercentexpected, bootstrapPL.Spec.Limited.LendablePercent)
+		}
+		if bootstrapPL.Spec.Limited.BorrowingLimitPercent != nil {
+			t.Errorf("bootstrap PriorityLevelConfiguration %q: expected BorrowingLimitPercent to be nil, but got: %d", test.name, *bootstrapPL.Spec.Limited.BorrowingLimitPercent)
+		}
+	}
+
+	if len(bootstrapPLs) != 0 {
+		names := make([]string, 0)
+		for name, bpl := range bootstrapPLs {
+			if bpl.Spec.Type == flowcontrol.PriorityLevelEnablementExempt {
+				t.Logf("bootstrap PriorityLevelConfiguration %q is of %q type, skipped", name, flowcontrol.PriorityLevelConfigurationNameExempt)
+				continue
+			}
+			names = append(names, name)
+		}
+
+		if len(names) != 0 {
+			t.Errorf("bootstrap PriorityLevelConfiguration objects not accounted by this test: %v", names)
+		}
+	}
+	exemptPL := MandatoryPriorityLevelConfigurationExempt
+	if exemptPL.Spec.Exempt.NominalConcurrencyShares != nil && *exemptPL.Spec.Exempt.NominalConcurrencyShares != 0 {
+		t.Errorf("Expected exempt priority level to have NominalConcurrencyShares==0 but got %d instead", *exemptPL.Spec.Exempt.NominalConcurrencyShares)
+	}
+	if exemptPL.Spec.Exempt.LendablePercent != nil && *exemptPL.Spec.Exempt.LendablePercent != 0 {
+		t.Errorf("Expected exempt priority level to have LendablePercent==0 but got %d instead", *exemptPL.Spec.Exempt.LendablePercent)
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/apis/flowcontrol/bootstrap-v134/default.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/flowcontrol/bootstrap-v134/default.go
@@ -1,0 +1,616 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bootstrap
+
+import (
+	coordinationv1 "k8s.io/api/coordination/v1"
+	corev1 "k8s.io/api/core/v1"
+	eventsv1 "k8s.io/api/events/v1"
+	flowcontrol "k8s.io/api/flowcontrol/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/apis/flowcontrol/base"
+	"k8s.io/apiserver/pkg/authentication/serviceaccount"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/utils/ptr"
+)
+
+var V1ConfigCollection = base.V1ConfigCollection{
+	Mandatory: base.V1ConfigSlices{
+		PriorityLevelConfigurations: []*flowcontrol.PriorityLevelConfiguration{
+			MandatoryPriorityLevelConfigurationCatchAll,
+			MandatoryPriorityLevelConfigurationExempt,
+		},
+		FlowSchemas: []*flowcontrol.FlowSchema{
+			MandatoryFlowSchemaExempt,
+			MandatoryFlowSchemaCatchAll,
+		},
+	},
+	PriorityLevelConfigurationExempt:   MandatoryPriorityLevelConfigurationExempt,
+	PriorityLevelConfigurationCatchAll: MandatoryPriorityLevelConfigurationCatchAll,
+	FlowSchemaExempt:                   MandatoryFlowSchemaExempt,
+	FlowSchemaCatchAll:                 MandatoryFlowSchemaCatchAll,
+	Suggested: base.V1ConfigSlices{
+		PriorityLevelConfigurations: []*flowcontrol.PriorityLevelConfiguration{
+			// "system" priority-level is for the system components that affects self-maintenance of the
+			// cluster and the availability of those running pods in the cluster, including kubelet and
+			// kube-proxy.
+			SuggestedPriorityLevelConfigurationSystem,
+			// "node-high" priority-level is for the node health reporting. It is separated from "system"
+			// to make sure that nodes are able to report their health even if kube-apiserver is not capable of
+			// handling load caused by pod startup (fetching secrets, events etc).
+			// NOTE: In large clusters 50% - 90% of all API calls use this priority-level.
+			SuggestedPriorityLevelConfigurationNodeHigh,
+			// "leader-election" is dedicated for controllers' leader-election, which majorly affects the
+			// availability of any controller runs in the cluster.
+			SuggestedPriorityLevelConfigurationLeaderElection,
+			// "workload-high" is used by those workloads with higher priority but their failure won't directly
+			// impact the existing running pods in the cluster, which includes kube-scheduler, and those well-known
+			// built-in workloads such as "deployments", "replicasets" and other low-level custom workload which
+			// is important for the cluster.
+			SuggestedPriorityLevelConfigurationWorkloadHigh,
+			// "events" is used for requests that create/update/delete Event objects.
+			SuggestedPriorityLevelConfigurationEvent,
+			// "workload-low" is used by those workloads with lower priority which availability only has a
+			// minor impact on the cluster.
+			SuggestedPriorityLevelConfigurationWorkloadLow,
+			// "global-default" serves the rest traffic not handled by the other suggested flow-schemas above.
+			SuggestedPriorityLevelConfigurationGlobalDefault,
+		},
+		FlowSchemas: []*flowcontrol.FlowSchema{
+			SuggestedFlowSchemaSystemNodes,               // references "system" priority-level
+			SuggestedFlowSchemaEvents,                    // references "events" priority-level
+			SuggestedFlowSchemaSystemNodeHigh,            // references "node-high" priority-level
+			SuggestedFlowSchemaProbes,                    // references "exempt" priority-level
+			SuggestedFlowSchemaSystemLeaderElection,      // references "leader-election" priority-level
+			SuggestedFlowSchemaWorkloadLeaderElection,    // references "leader-election" priority-level
+			SuggestedFlowSchemaEndpointsController,       // references "workload-high" priority-level
+			SuggestedFlowSchemaKubeControllerManager,     // references "workload-high" priority-level
+			SuggestedFlowSchemaKubeScheduler,             // references "workload-high" priority-level
+			SuggestedFlowSchemaKubeSystemServiceAccounts, // references "workload-high" priority-level
+			SuggestedFlowSchemaServiceAccounts,           // references "workload-low" priority-level
+			SuggestedFlowSchemaGlobalDefault,             // references "global-default" priority-level
+		},
+	},
+}
+
+// Mandatory PriorityLevelConfiguration objects
+var (
+	MandatoryPriorityLevelConfigurationExempt = newPriorityLevelConfiguration(
+		flowcontrol.PriorityLevelConfigurationNameExempt,
+		flowcontrol.PriorityLevelConfigurationSpec{
+			Type: flowcontrol.PriorityLevelEnablementExempt,
+			Exempt: &flowcontrol.ExemptPriorityLevelConfiguration{
+				NominalConcurrencyShares: ptr.To(int32(0)),
+				LendablePercent:          ptr.To(int32(0)),
+			},
+		},
+	)
+	MandatoryPriorityLevelConfigurationCatchAll = newPriorityLevelConfiguration(
+		flowcontrol.PriorityLevelConfigurationNameCatchAll,
+		flowcontrol.PriorityLevelConfigurationSpec{
+			Type: flowcontrol.PriorityLevelEnablementLimited,
+			Limited: &flowcontrol.LimitedPriorityLevelConfiguration{
+				NominalConcurrencyShares: ptr.To(int32(5)),
+				LendablePercent:          ptr.To(int32(0)),
+				LimitResponse: flowcontrol.LimitResponse{
+					Type: flowcontrol.LimitResponseTypeReject,
+				},
+			},
+		})
+)
+
+// Mandatory FlowSchema objects
+var (
+	// "exempt" priority-level is used for preventing priority inversion and ensuring that sysadmin
+	// requests are always possible.
+	MandatoryFlowSchemaExempt = newFlowSchema(
+		"exempt",
+		flowcontrol.PriorityLevelConfigurationNameExempt,
+		1,  // matchingPrecedence
+		"", // distinguisherMethodType
+		flowcontrol.PolicyRulesWithSubjects{
+			Subjects: groups(user.SystemPrivilegedGroup),
+			ResourceRules: []flowcontrol.ResourcePolicyRule{
+				resourceRule(
+					[]string{flowcontrol.VerbAll},
+					[]string{flowcontrol.APIGroupAll},
+					[]string{flowcontrol.ResourceAll},
+					[]string{flowcontrol.NamespaceEvery},
+					true,
+				),
+			},
+			NonResourceRules: []flowcontrol.NonResourcePolicyRule{
+				nonResourceRule(
+					[]string{flowcontrol.VerbAll},
+					[]string{flowcontrol.NonResourceAll},
+				),
+			},
+		},
+	)
+	// "catch-all" priority-level only gets a minimal positive share of concurrency and won't be reaching
+	// ideally unless you intentionally deleted the suggested "global-default".
+	MandatoryFlowSchemaCatchAll = newFlowSchema(
+		flowcontrol.FlowSchemaNameCatchAll,
+		flowcontrol.PriorityLevelConfigurationNameCatchAll,
+		10000, // matchingPrecedence
+		flowcontrol.FlowDistinguisherMethodByUserType, // distinguisherMethodType
+		flowcontrol.PolicyRulesWithSubjects{
+			Subjects: groups(user.AllUnauthenticated, user.AllAuthenticated),
+			ResourceRules: []flowcontrol.ResourcePolicyRule{
+				resourceRule(
+					[]string{flowcontrol.VerbAll},
+					[]string{flowcontrol.APIGroupAll},
+					[]string{flowcontrol.ResourceAll},
+					[]string{flowcontrol.NamespaceEvery},
+					true,
+				),
+			},
+			NonResourceRules: []flowcontrol.NonResourcePolicyRule{
+				nonResourceRule(
+					[]string{flowcontrol.VerbAll},
+					[]string{flowcontrol.NonResourceAll},
+				),
+			},
+		},
+	)
+)
+
+// Suggested PriorityLevelConfiguration objects
+var (
+	// system priority-level
+	SuggestedPriorityLevelConfigurationSystem = newPriorityLevelConfiguration(
+		"system",
+		flowcontrol.PriorityLevelConfigurationSpec{
+			Type: flowcontrol.PriorityLevelEnablementLimited,
+			Limited: &flowcontrol.LimitedPriorityLevelConfiguration{
+				NominalConcurrencyShares: ptr.To(int32(40)),
+				LendablePercent:          ptr.To(int32(50)),
+				LimitResponse: flowcontrol.LimitResponse{
+					Type: flowcontrol.LimitResponseTypeQueue,
+					Queuing: &flowcontrol.QueuingConfiguration{
+						Queues:           64,
+						HandSize:         6,
+						QueueLengthLimit: 50,
+					},
+				},
+			},
+		})
+	SuggestedPriorityLevelConfigurationNodeHigh = newPriorityLevelConfiguration(
+		"node-high",
+		flowcontrol.PriorityLevelConfigurationSpec{
+			Type: flowcontrol.PriorityLevelEnablementLimited,
+			Limited: &flowcontrol.LimitedPriorityLevelConfiguration{
+				NominalConcurrencyShares: ptr.To(int32(60)),
+				LendablePercent:          ptr.To(int32(50)),
+				LimitResponse: flowcontrol.LimitResponse{
+					Type: flowcontrol.LimitResponseTypeQueue,
+					Queuing: &flowcontrol.QueuingConfiguration{
+						Queues:           64,
+						HandSize:         6,
+						QueueLengthLimit: 50,
+					},
+				},
+			},
+		})
+	// leader-election priority-level
+	SuggestedPriorityLevelConfigurationLeaderElection = newPriorityLevelConfiguration(
+		"leader-election",
+		flowcontrol.PriorityLevelConfigurationSpec{
+			Type: flowcontrol.PriorityLevelEnablementLimited,
+			Limited: &flowcontrol.LimitedPriorityLevelConfiguration{
+				NominalConcurrencyShares: ptr.To(int32(50)),
+				LendablePercent:          ptr.To(int32(80)),
+				LimitResponse: flowcontrol.LimitResponse{
+					Type: flowcontrol.LimitResponseTypeQueue,
+					Queuing: &flowcontrol.QueuingConfiguration{
+						Queues:           16,
+						HandSize:         4,
+						QueueLengthLimit: 50,
+					},
+				},
+			},
+		})
+	// workload-high priority-level
+	SuggestedPriorityLevelConfigurationWorkloadHigh = newPriorityLevelConfiguration(
+		"workload-high",
+		flowcontrol.PriorityLevelConfigurationSpec{
+			Type: flowcontrol.PriorityLevelEnablementLimited,
+			Limited: &flowcontrol.LimitedPriorityLevelConfiguration{
+				NominalConcurrencyShares: ptr.To(int32(40)),
+				LendablePercent:          ptr.To(int32(50)),
+				LimitResponse: flowcontrol.LimitResponse{
+					Type: flowcontrol.LimitResponseTypeQueue,
+					Queuing: &flowcontrol.QueuingConfiguration{
+						Queues:           128,
+						HandSize:         6,
+						QueueLengthLimit: 50,
+					},
+				},
+			},
+		})
+	// event priority-level. This is a relatively low priority configuration, loss of events
+	// is a relatively low harm thing.
+	SuggestedPriorityLevelConfigurationEvent = newPriorityLevelConfiguration(
+		"event",
+		flowcontrol.PriorityLevelConfigurationSpec{
+			Type: flowcontrol.PriorityLevelEnablementLimited,
+			Limited: &flowcontrol.LimitedPriorityLevelConfiguration{
+				NominalConcurrencyShares: ptr.To(int32(5)),
+				LendablePercent:          ptr.To(int32(0)),
+				BorrowingLimitPercent:    ptr.To(int32(100)),
+				LimitResponse: flowcontrol.LimitResponse{
+					Type: flowcontrol.LimitResponseTypeQueue,
+					Queuing: &flowcontrol.QueuingConfiguration{
+						Queues:           31,
+						HandSize:         3,
+						QueueLengthLimit: 50,
+					},
+				},
+			},
+		})
+	// workload-low priority-level
+	SuggestedPriorityLevelConfigurationWorkloadLow = newPriorityLevelConfiguration(
+		"workload-low",
+		flowcontrol.PriorityLevelConfigurationSpec{
+			Type: flowcontrol.PriorityLevelEnablementLimited,
+			Limited: &flowcontrol.LimitedPriorityLevelConfiguration{
+				NominalConcurrencyShares: ptr.To(int32(40)),
+				LendablePercent:          ptr.To(int32(75)),
+				LimitResponse: flowcontrol.LimitResponse{
+					Type: flowcontrol.LimitResponseTypeQueue,
+					Queuing: &flowcontrol.QueuingConfiguration{
+						Queues:           128,
+						HandSize:         6,
+						QueueLengthLimit: 50,
+					},
+				},
+			},
+		})
+	// global-default priority-level
+	SuggestedPriorityLevelConfigurationGlobalDefault = newPriorityLevelConfiguration(
+		"global-default",
+		flowcontrol.PriorityLevelConfigurationSpec{
+			Type: flowcontrol.PriorityLevelEnablementLimited,
+			Limited: &flowcontrol.LimitedPriorityLevelConfiguration{
+				NominalConcurrencyShares: ptr.To(int32(10)),
+				LendablePercent:          ptr.To(int32(50)),
+				LimitResponse: flowcontrol.LimitResponse{
+					Type: flowcontrol.LimitResponseTypeQueue,
+					Queuing: &flowcontrol.QueuingConfiguration{
+						Queues:           128,
+						HandSize:         6,
+						QueueLengthLimit: 50,
+					},
+				},
+			},
+		})
+)
+
+// Suggested FlowSchema objects.
+// Ordered by matching precedence, so that their interactions are easier
+// to follow while reading this source.
+var (
+	// the following flow schema exempts probes
+	SuggestedFlowSchemaProbes = newFlowSchema(
+		"probes", "exempt", 2,
+		"", // distinguisherMethodType
+		flowcontrol.PolicyRulesWithSubjects{
+			Subjects: groups(user.AllUnauthenticated, user.AllAuthenticated),
+			NonResourceRules: []flowcontrol.NonResourcePolicyRule{
+				nonResourceRule(
+					[]string{"get"},
+					[]string{"/healthz", "/readyz", "/livez"}),
+			},
+		},
+	)
+	SuggestedFlowSchemaSystemLeaderElection = newFlowSchema(
+		"system-leader-election", "leader-election", 100,
+		flowcontrol.FlowDistinguisherMethodByUserType,
+		flowcontrol.PolicyRulesWithSubjects{
+			Subjects: append(
+				users(user.KubeControllerManager, user.KubeScheduler),
+				kubeSystemServiceAccount(flowcontrol.NameAll)...),
+			ResourceRules: []flowcontrol.ResourcePolicyRule{
+				resourceRule(
+					[]string{"get", "create", "update"},
+					[]string{coordinationv1.GroupName},
+					[]string{"leases"},
+					[]string{flowcontrol.NamespaceEvery},
+					false),
+			},
+		},
+	)
+	// We add an explicit rule for endpoint-controller with high precedence
+	// to ensure that those calls won't get caught by the following
+	// <workload-leader-election> flow-schema.
+	//
+	// TODO(#80289): Get rid of this rule once we get rid of support for
+	//   using endpoints and configmaps objects for leader election.
+	SuggestedFlowSchemaEndpointsController = newFlowSchema(
+		"endpoint-controller", "workload-high", 150,
+		flowcontrol.FlowDistinguisherMethodByUserType,
+		flowcontrol.PolicyRulesWithSubjects{
+			Subjects: append(
+				users(user.KubeControllerManager),
+				kubeSystemServiceAccount("endpoint-controller", "endpointslicemirroring-controller")...),
+			ResourceRules: []flowcontrol.ResourcePolicyRule{
+				resourceRule(
+					[]string{"get", "create", "update"},
+					[]string{corev1.GroupName},
+					[]string{"endpoints"},
+					[]string{flowcontrol.NamespaceEvery},
+					false),
+			},
+		},
+	)
+	// TODO(#80289): Get rid of this rule once we get rid of support for
+	//   using endpoints and configmaps objects for leader election.
+	SuggestedFlowSchemaWorkloadLeaderElection = newFlowSchema(
+		"workload-leader-election", "leader-election", 200,
+		flowcontrol.FlowDistinguisherMethodByUserType,
+		flowcontrol.PolicyRulesWithSubjects{
+			Subjects: kubeSystemServiceAccount(flowcontrol.NameAll),
+			ResourceRules: []flowcontrol.ResourcePolicyRule{
+				resourceRule(
+					[]string{"get", "create", "update"},
+					[]string{corev1.GroupName},
+					[]string{"endpoints", "configmaps"},
+					[]string{flowcontrol.NamespaceEvery},
+					false),
+				resourceRule(
+					[]string{"get", "create", "update"},
+					[]string{coordinationv1.GroupName},
+					[]string{"leases"},
+					[]string{flowcontrol.NamespaceEvery},
+					false),
+			},
+		},
+	)
+	SuggestedFlowSchemaSystemNodeHigh = newFlowSchema(
+		"system-node-high", "node-high", 400,
+		flowcontrol.FlowDistinguisherMethodByUserType,
+		flowcontrol.PolicyRulesWithSubjects{
+			Subjects: groups(user.NodesGroup), // the nodes group
+			ResourceRules: []flowcontrol.ResourcePolicyRule{
+				resourceRule(
+					[]string{flowcontrol.VerbAll},
+					[]string{corev1.GroupName},
+					[]string{"nodes", "nodes/status"},
+					[]string{flowcontrol.NamespaceEvery},
+					true),
+				resourceRule(
+					[]string{flowcontrol.VerbAll},
+					[]string{coordinationv1.GroupName},
+					[]string{"leases"},
+					[]string{flowcontrol.NamespaceEvery},
+					false),
+			},
+		},
+	)
+	SuggestedFlowSchemaEvents = newFlowSchema(
+		"events", SuggestedPriorityLevelConfigurationEvent.Name, 450,
+		flowcontrol.FlowDistinguisherMethodByUserType,
+		flowcontrol.PolicyRulesWithSubjects{
+			Subjects: groups(user.AllAuthenticated), // the nodes group
+			ResourceRules: []flowcontrol.ResourcePolicyRule{
+				resourceRule(
+					[]string{"create", "update", "patch", "delete"},
+					[]string{corev1.GroupName, eventsv1.GroupName},
+					[]string{"events"},
+					[]string{flowcontrol.NamespaceEvery},
+					false),
+			},
+		},
+	)
+	SuggestedFlowSchemaSystemNodes = newFlowSchema(
+		"system-nodes", "system", 500,
+		flowcontrol.FlowDistinguisherMethodByUserType,
+		flowcontrol.PolicyRulesWithSubjects{
+			Subjects: groups(user.NodesGroup), // the nodes group
+			ResourceRules: []flowcontrol.ResourcePolicyRule{resourceRule(
+				[]string{flowcontrol.VerbAll},
+				[]string{flowcontrol.APIGroupAll},
+				[]string{flowcontrol.ResourceAll},
+				[]string{flowcontrol.NamespaceEvery},
+				true)},
+			NonResourceRules: []flowcontrol.NonResourcePolicyRule{
+				nonResourceRule(
+					[]string{flowcontrol.VerbAll},
+					[]string{flowcontrol.NonResourceAll}),
+			},
+		},
+	)
+	SuggestedFlowSchemaKubeControllerManager = newFlowSchema(
+		"kube-controller-manager", "workload-high", 800,
+		flowcontrol.FlowDistinguisherMethodByNamespaceType,
+		flowcontrol.PolicyRulesWithSubjects{
+			Subjects: users(user.KubeControllerManager),
+			ResourceRules: []flowcontrol.ResourcePolicyRule{resourceRule(
+				[]string{flowcontrol.VerbAll},
+				[]string{flowcontrol.APIGroupAll},
+				[]string{flowcontrol.ResourceAll},
+				[]string{flowcontrol.NamespaceEvery},
+				true)},
+			NonResourceRules: []flowcontrol.NonResourcePolicyRule{
+				nonResourceRule(
+					[]string{flowcontrol.VerbAll},
+					[]string{flowcontrol.NonResourceAll}),
+			},
+		},
+	)
+	SuggestedFlowSchemaKubeScheduler = newFlowSchema(
+		"kube-scheduler", "workload-high", 800,
+		flowcontrol.FlowDistinguisherMethodByNamespaceType,
+		flowcontrol.PolicyRulesWithSubjects{
+			Subjects: users(user.KubeScheduler),
+			ResourceRules: []flowcontrol.ResourcePolicyRule{resourceRule(
+				[]string{flowcontrol.VerbAll},
+				[]string{flowcontrol.APIGroupAll},
+				[]string{flowcontrol.ResourceAll},
+				[]string{flowcontrol.NamespaceEvery},
+				true)},
+			NonResourceRules: []flowcontrol.NonResourcePolicyRule{
+				nonResourceRule(
+					[]string{flowcontrol.VerbAll},
+					[]string{flowcontrol.NonResourceAll}),
+			},
+		},
+	)
+	SuggestedFlowSchemaKubeSystemServiceAccounts = newFlowSchema(
+		"kube-system-service-accounts", "workload-high", 900,
+		flowcontrol.FlowDistinguisherMethodByNamespaceType,
+		flowcontrol.PolicyRulesWithSubjects{
+			Subjects: kubeSystemServiceAccount(flowcontrol.NameAll),
+			ResourceRules: []flowcontrol.ResourcePolicyRule{resourceRule(
+				[]string{flowcontrol.VerbAll},
+				[]string{flowcontrol.APIGroupAll},
+				[]string{flowcontrol.ResourceAll},
+				[]string{flowcontrol.NamespaceEvery},
+				true)},
+			NonResourceRules: []flowcontrol.NonResourcePolicyRule{
+				nonResourceRule(
+					[]string{flowcontrol.VerbAll},
+					[]string{flowcontrol.NonResourceAll}),
+			},
+		},
+	)
+	SuggestedFlowSchemaServiceAccounts = newFlowSchema(
+		"service-accounts", "workload-low", 9000,
+		flowcontrol.FlowDistinguisherMethodByUserType,
+		flowcontrol.PolicyRulesWithSubjects{
+			Subjects: groups(serviceaccount.AllServiceAccountsGroup),
+			ResourceRules: []flowcontrol.ResourcePolicyRule{resourceRule(
+				[]string{flowcontrol.VerbAll},
+				[]string{flowcontrol.APIGroupAll},
+				[]string{flowcontrol.ResourceAll},
+				[]string{flowcontrol.NamespaceEvery},
+				true)},
+			NonResourceRules: []flowcontrol.NonResourcePolicyRule{
+				nonResourceRule(
+					[]string{flowcontrol.VerbAll},
+					[]string{flowcontrol.NonResourceAll}),
+			},
+		},
+	)
+	SuggestedFlowSchemaGlobalDefault = newFlowSchema(
+		"global-default", "global-default", 9900,
+		flowcontrol.FlowDistinguisherMethodByUserType,
+		flowcontrol.PolicyRulesWithSubjects{
+			Subjects: groups(user.AllUnauthenticated, user.AllAuthenticated),
+			ResourceRules: []flowcontrol.ResourcePolicyRule{resourceRule(
+				[]string{flowcontrol.VerbAll},
+				[]string{flowcontrol.APIGroupAll},
+				[]string{flowcontrol.ResourceAll},
+				[]string{flowcontrol.NamespaceEvery},
+				true)},
+			NonResourceRules: []flowcontrol.NonResourcePolicyRule{
+				nonResourceRule(
+					[]string{flowcontrol.VerbAll},
+					[]string{flowcontrol.NonResourceAll}),
+			},
+		},
+	)
+)
+
+func newPriorityLevelConfiguration(name string, spec flowcontrol.PriorityLevelConfigurationSpec) *flowcontrol.PriorityLevelConfiguration {
+	return &flowcontrol.PriorityLevelConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Annotations: map[string]string{
+				flowcontrol.AutoUpdateAnnotationKey: "true",
+			},
+		},
+		Spec: spec,
+	}
+}
+
+func newFlowSchema(name, plName string, matchingPrecedence int32, dmType flowcontrol.FlowDistinguisherMethodType, rules ...flowcontrol.PolicyRulesWithSubjects) *flowcontrol.FlowSchema {
+	var dm *flowcontrol.FlowDistinguisherMethod
+	if dmType != "" {
+		dm = &flowcontrol.FlowDistinguisherMethod{Type: dmType}
+	}
+	return &flowcontrol.FlowSchema{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Annotations: map[string]string{
+				flowcontrol.AutoUpdateAnnotationKey: "true",
+			},
+		},
+		Spec: flowcontrol.FlowSchemaSpec{
+			PriorityLevelConfiguration: flowcontrol.PriorityLevelConfigurationReference{
+				Name: plName,
+			},
+			MatchingPrecedence:  matchingPrecedence,
+			DistinguisherMethod: dm,
+			Rules:               rules},
+	}
+
+}
+
+func groups(names ...string) []flowcontrol.Subject {
+	ans := make([]flowcontrol.Subject, len(names))
+	for idx, name := range names {
+		ans[idx] = flowcontrol.Subject{
+			Kind: flowcontrol.SubjectKindGroup,
+			Group: &flowcontrol.GroupSubject{
+				Name: name,
+			},
+		}
+	}
+	return ans
+}
+
+func users(names ...string) []flowcontrol.Subject {
+	ans := make([]flowcontrol.Subject, len(names))
+	for idx, name := range names {
+		ans[idx] = flowcontrol.Subject{
+			Kind: flowcontrol.SubjectKindUser,
+			User: &flowcontrol.UserSubject{
+				Name: name,
+			},
+		}
+	}
+	return ans
+}
+
+func kubeSystemServiceAccount(names ...string) []flowcontrol.Subject {
+	subjects := []flowcontrol.Subject{}
+	for _, name := range names {
+		subjects = append(subjects, flowcontrol.Subject{
+			Kind: flowcontrol.SubjectKindServiceAccount,
+			ServiceAccount: &flowcontrol.ServiceAccountSubject{
+				Name:      name,
+				Namespace: metav1.NamespaceSystem,
+			},
+		})
+	}
+	return subjects
+}
+
+func resourceRule(verbs []string, groups []string, resources []string, namespaces []string, clusterScoped bool) flowcontrol.ResourcePolicyRule {
+	return flowcontrol.ResourcePolicyRule{
+		Verbs:        verbs,
+		APIGroups:    groups,
+		Resources:    resources,
+		Namespaces:   namespaces,
+		ClusterScope: clusterScoped,
+	}
+}
+
+func nonResourceRule(verbs []string, nonResourceURLs []string) flowcontrol.NonResourcePolicyRule {
+	return flowcontrol.NonResourcePolicyRule{Verbs: verbs, NonResourceURLs: nonResourceURLs}
+}

--- a/staging/src/k8s.io/apiserver/pkg/apis/flowcontrol/bootstrap-v134/default_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/flowcontrol/bootstrap-v134/default_test.go
@@ -76,8 +76,8 @@ func TestBootstrapPriorityLevelConfigurationWithBorrowing(t *testing.T) {
 
 	bootstrapPLs := func() map[string]*flowcontrol.PriorityLevelConfiguration {
 		list := make([]*flowcontrol.PriorityLevelConfiguration, 0)
-		list = append(list, MandatoryPriorityLevelConfigurations...)
-		list = append(list, SuggestedPriorityLevelConfigurations...)
+		list = append(list, V1ConfigCollection.Mandatory.PriorityLevelConfigurations...)
+		list = append(list, V1ConfigCollection.Suggested.PriorityLevelConfigurations...)
 
 		m := map[string]*flowcontrol.PriorityLevelConfiguration{}
 		for i := range list {
@@ -102,7 +102,7 @@ func TestBootstrapPriorityLevelConfigurationWithBorrowing(t *testing.T) {
 			t.Errorf("bootstrap PriorityLevelConfiguration %q: expected NominalConcurrencyShares: %d, but got: %d", test.name, test.nominalSharesExpected, bootstrapPL.Spec.Limited.NominalConcurrencyShares)
 		}
 		if test.lendablePercentexpected != *bootstrapPL.Spec.Limited.LendablePercent {
-			t.Errorf("bootstrap PriorityLevelConfiguration %q: expected LendablePercent: %d, but got: %d", test.name, test.lendablePercentexpected, bootstrapPL.Spec.Limited.LendablePercent)
+			t.Errorf("bootstrap PriorityLevelConfiguration %q: expected LendablePercent: %d, but got: %s", test.name, test.lendablePercentexpected, fmtPtr(bootstrapPL.Spec.Limited.LendablePercent))
 		}
 		if !ptr.Equal(test.borrowingLimitPercent, bootstrapPL.Spec.Limited.BorrowingLimitPercent) {
 			t.Errorf("bootstrap PriorityLevelConfiguration %q: expected BorrowingLimitPercent to be %s, but got: %s", test.name, fmtPtr(test.borrowingLimitPercent), fmtPtr(bootstrapPL.Spec.Limited.BorrowingLimitPercent))

--- a/staging/src/k8s.io/apiserver/pkg/apis/flowcontrol/bootstrap/collection.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/flowcontrol/bootstrap/collection.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bootstrap
+
+import (
+	flowcontrolv1 "k8s.io/api/flowcontrol/v1"
+	"k8s.io/apiserver/pkg/apis/flowcontrol/base"
+	bootstrapold "k8s.io/apiserver/pkg/apis/flowcontrol/bootstrap-old"
+	bootstrapv134 "k8s.io/apiserver/pkg/apis/flowcontrol/bootstrap-v134"
+)
+
+// This package provides access to the "default" configuration objects of
+// API Priority and Fairness according to the settings of the Feature(s)
+// that control which collection of defaults to use.
+// Currently there is exactly one such Feature, APFv134Config.
+
+// GetV1ConfigCollection is given the values of the features that define
+// the default APF configuration objects to use, and returns them (in V1 form).
+// The returned value is deeply immutable.
+// v134 is the value of the APFv134Config feature.
+func GetV1ConfigCollection(v134 bool) *base.V1ConfigCollection {
+	if v134 {
+		return &bootstrapv134.V1ConfigCollection
+	} else {
+		return &bootstrapold.V1ConfigCollection
+	}
+}
+
+// GetPrioritylevelConfigurations returns the default PriorityLevelConfiguration objects,
+// as a deeply immutable slice.
+// The types are the latest external type (version).
+// The arguments are the values of the features that control which config collection to use.
+func GetPrioritylevelConfigurations(v134 bool) []*flowcontrolv1.PriorityLevelConfiguration {
+	return PrioritylevelConfigurations[CollectionID{V134: v134}]
+}
+
+// PrioritylevelConfigurations maps CollectionId to a slice of all the default objects.
+// Deeply immutable.
+var PrioritylevelConfigurations = map[CollectionID][]*flowcontrolv1.PriorityLevelConfiguration{
+	{false}: Concat(bootstrapold.V1ConfigCollection.Mandatory.PriorityLevelConfigurations,
+		bootstrapold.V1ConfigCollection.Suggested.PriorityLevelConfigurations),
+	{true}: Concat(bootstrapv134.V1ConfigCollection.Mandatory.PriorityLevelConfigurations,
+		bootstrapv134.V1ConfigCollection.Suggested.PriorityLevelConfigurations),
+}
+
+// GetFlowSchemas returns the default FlowSchema objects,
+// as a deeply immutable slice.
+// The types are the latest external type (version).
+// The arguments are the values of the features that control which config collection to use.
+func GetFlowSchemas(v134 bool) []*flowcontrolv1.FlowSchema {
+	return FlowSchemas[CollectionID{V134: v134}]
+}
+
+// FlowSchemas maps CollectionId to a slice of all the default objects.
+// Deeply immutable.
+var FlowSchemas = map[CollectionID][]*flowcontrolv1.FlowSchema{
+	{false}: Concat(bootstrapold.V1ConfigCollection.Mandatory.FlowSchemas,
+		bootstrapold.V1ConfigCollection.Suggested.FlowSchemas),
+	{true}: Concat(bootstrapv134.V1ConfigCollection.Mandatory.FlowSchemas,
+		bootstrapv134.V1ConfigCollection.Suggested.FlowSchemas),
+}
+
+// CollectionID identifies the collection of API Priority and Fairness config objects
+// to use as the defaults.
+type CollectionID struct {
+	// V134=true means use the collection introduced for release 1.34.
+	// V134=false means use the older collection.
+	V134 bool
+}
+
+// Concat concatenates the given slices, without reusing any given backing array.
+func Concat[T any](slices ...[]T) []T {
+	var ans []T
+	for _, slice := range slices {
+		ans = append(ans, slice...)
+	}
+	return ans
+}

--- a/staging/src/k8s.io/apiserver/pkg/apis/flowcontrol/bootstrap/default.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/flowcontrol/bootstrap/default.go
@@ -209,7 +209,7 @@ var (
 			Type: flowcontrol.PriorityLevelEnablementLimited,
 			Limited: &flowcontrol.LimitedPriorityLevelConfiguration{
 				NominalConcurrencyShares: ptr.To(int32(40)),
-				LendablePercent:          ptr.To(int32(0)),
+				LendablePercent:          ptr.To(int32(75)),
 				LimitResponse: flowcontrol.LimitResponse{
 					Type: flowcontrol.LimitResponseTypeQueue,
 					Queuing: &flowcontrol.QueuingConfiguration{

--- a/staging/src/k8s.io/apiserver/pkg/apis/flowcontrol/bootstrap/default.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/flowcontrol/bootstrap/default.go
@@ -177,8 +177,8 @@ var (
 		flowcontrol.PriorityLevelConfigurationSpec{
 			Type: flowcontrol.PriorityLevelEnablementLimited,
 			Limited: &flowcontrol.LimitedPriorityLevelConfiguration{
-				NominalConcurrencyShares: ptr.To(int32(30)),
-				LendablePercent:          ptr.To(int32(33)),
+				NominalConcurrencyShares: ptr.To(int32(40)),
+				LendablePercent:          ptr.To(int32(50)),
 				LimitResponse: flowcontrol.LimitResponse{
 					Type: flowcontrol.LimitResponseTypeQueue,
 					Queuing: &flowcontrol.QueuingConfiguration{
@@ -194,8 +194,8 @@ var (
 		flowcontrol.PriorityLevelConfigurationSpec{
 			Type: flowcontrol.PriorityLevelEnablementLimited,
 			Limited: &flowcontrol.LimitedPriorityLevelConfiguration{
-				NominalConcurrencyShares: ptr.To(int32(40)),
-				LendablePercent:          ptr.To(int32(25)),
+				NominalConcurrencyShares: ptr.To(int32(60)),
+				LendablePercent:          ptr.To(int32(50)),
 				LimitResponse: flowcontrol.LimitResponse{
 					Type: flowcontrol.LimitResponseTypeQueue,
 					Queuing: &flowcontrol.QueuingConfiguration{
@@ -212,8 +212,8 @@ var (
 		flowcontrol.PriorityLevelConfigurationSpec{
 			Type: flowcontrol.PriorityLevelEnablementLimited,
 			Limited: &flowcontrol.LimitedPriorityLevelConfiguration{
-				NominalConcurrencyShares: ptr.To(int32(40)),
-				LendablePercent:          ptr.To(int32(75)),
+				NominalConcurrencyShares: ptr.To(int32(50)),
+				LendablePercent:          ptr.To(int32(80)),
 				LimitResponse: flowcontrol.LimitResponse{
 					Type: flowcontrol.LimitResponseTypeQueue,
 					Queuing: &flowcontrol.QueuingConfiguration{
@@ -268,8 +268,8 @@ var (
 		flowcontrol.PriorityLevelConfigurationSpec{
 			Type: flowcontrol.PriorityLevelEnablementLimited,
 			Limited: &flowcontrol.LimitedPriorityLevelConfiguration{
-				NominalConcurrencyShares: ptr.To(int32(100)),
-				LendablePercent:          ptr.To(int32(90)),
+				NominalConcurrencyShares: ptr.To(int32(40)),
+				LendablePercent:          ptr.To(int32(75)),
 				LimitResponse: flowcontrol.LimitResponse{
 					Type: flowcontrol.LimitResponseTypeQueue,
 					Queuing: &flowcontrol.QueuingConfiguration{
@@ -286,7 +286,7 @@ var (
 		flowcontrol.PriorityLevelConfigurationSpec{
 			Type: flowcontrol.PriorityLevelEnablementLimited,
 			Limited: &flowcontrol.LimitedPriorityLevelConfiguration{
-				NominalConcurrencyShares: ptr.To(int32(20)),
+				NominalConcurrencyShares: ptr.To(int32(10)),
 				LendablePercent:          ptr.To(int32(50)),
 				LimitResponse: flowcontrol.LimitResponse{
 					Type: flowcontrol.LimitResponseTypeQueue,

--- a/staging/src/k8s.io/apiserver/pkg/apis/flowcontrol/bootstrap/default.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/flowcontrol/bootstrap/default.go
@@ -208,7 +208,7 @@ var (
 		flowcontrol.PriorityLevelConfigurationSpec{
 			Type: flowcontrol.PriorityLevelEnablementLimited,
 			Limited: &flowcontrol.LimitedPriorityLevelConfiguration{
-				NominalConcurrencyShares: ptr.To(int32(10)),
+				NominalConcurrencyShares: ptr.To(int32(40)),
 				LendablePercent:          ptr.To(int32(0)),
 				LimitResponse: flowcontrol.LimitResponse{
 					Type: flowcontrol.LimitResponseTypeQueue,

--- a/staging/src/k8s.io/apiserver/pkg/apis/flowcontrol/bootstrap/default_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/flowcontrol/bootstrap/default_test.go
@@ -31,7 +31,7 @@ func TestBootstrapPriorityLevelConfigurationWithBorrowing(t *testing.T) {
 		{
 			name:                    "leader-election",
 			nominalSharesExpected:   40,
-			lendablePercentexpected: 0,
+			lendablePercentexpected: 75,
 		},
 		{
 			name:                    "node-high",

--- a/staging/src/k8s.io/apiserver/pkg/apis/flowcontrol/bootstrap/default_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/flowcontrol/bootstrap/default_test.go
@@ -30,7 +30,7 @@ func TestBootstrapPriorityLevelConfigurationWithBorrowing(t *testing.T) {
 	}{
 		{
 			name:                    "leader-election",
-			nominalSharesExpected:   10,
+			nominalSharesExpected:   40,
 			lendablePercentexpected: 0,
 		},
 		{

--- a/staging/src/k8s.io/apiserver/pkg/apis/flowcontrol/bootstrap/default_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/flowcontrol/bootstrap/default_test.go
@@ -33,18 +33,18 @@ func TestBootstrapPriorityLevelConfigurationWithBorrowing(t *testing.T) {
 	}{
 		{
 			name:                    "leader-election",
-			nominalSharesExpected:   40,
-			lendablePercentexpected: 75,
+			nominalSharesExpected:   50,
+			lendablePercentexpected: 80,
 		},
 		{
 			name:                    "node-high",
-			nominalSharesExpected:   40,
-			lendablePercentexpected: 25,
+			nominalSharesExpected:   60,
+			lendablePercentexpected: 50,
 		},
 		{
 			name:                    "system",
-			nominalSharesExpected:   30,
-			lendablePercentexpected: 33,
+			nominalSharesExpected:   40,
+			lendablePercentexpected: 50,
 		},
 		{
 			name:                    "workload-high",
@@ -59,12 +59,12 @@ func TestBootstrapPriorityLevelConfigurationWithBorrowing(t *testing.T) {
 		},
 		{
 			name:                    "workload-low",
-			nominalSharesExpected:   100,
-			lendablePercentexpected: 90,
+			nominalSharesExpected:   40,
+			lendablePercentexpected: 75,
 		},
 		{
 			name:                    "global-default",
-			nominalSharesExpected:   20,
+			nominalSharesExpected:   10,
 			lendablePercentexpected: 50,
 		},
 		{

--- a/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
@@ -255,7 +255,7 @@ const (
 )
 
 func init() {
-	runtime.Must(utilfeature.DefaultMutableFeatureGate.AddVersioned(defaultVersionedKubernetesFeatureGates))
+	runtime.Must(utilfeature.DefaultMutableFeatureGate.AddVersioned(DefaultVersionedKubernetesFeatureGates()))
 }
 
 // defaultVersionedKubernetesFeatureGates consists of all known Kubernetes-specific feature keys with VersionedSpecs.
@@ -264,170 +264,172 @@ func init() {
 //
 // Entries are alphabetized and separated from each other with blank lines to avoid sweeping gofmt changes
 // when adding or removing one entry.
-var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate.VersionedSpecs{
-	AggregatedDiscoveryRemoveBetaType: {
-		{Version: version.MustParse("1.0"), Default: false, PreRelease: featuregate.GA},
-		{Version: version.MustParse("1.33"), Default: true, PreRelease: featuregate.Deprecated},
-	},
+func DefaultVersionedKubernetesFeatureGates() map[featuregate.Feature]featuregate.VersionedSpecs {
+	return map[featuregate.Feature]featuregate.VersionedSpecs{
+		AggregatedDiscoveryRemoveBetaType: {
+			{Version: version.MustParse("1.0"), Default: false, PreRelease: featuregate.GA},
+			{Version: version.MustParse("1.33"), Default: true, PreRelease: featuregate.Deprecated},
+		},
 
-	AllowParsingUserUIDFromCertAuth: {
-		{Version: version.MustParse("1.33"), Default: true, PreRelease: featuregate.Beta},
-	},
+		AllowParsingUserUIDFromCertAuth: {
+			{Version: version.MustParse("1.33"), Default: true, PreRelease: featuregate.Beta},
+		},
 
-	AllowUnsafeMalformedObjectDeletion: {
-		{Version: version.MustParse("1.32"), Default: false, PreRelease: featuregate.Alpha},
-	},
+		AllowUnsafeMalformedObjectDeletion: {
+			{Version: version.MustParse("1.32"), Default: false, PreRelease: featuregate.Alpha},
+		},
 
-	APFv134Config: {
-		{Version: version.MustParse("1.33"), Default: false, PreRelease: featuregate.Alpha},
-		{Version: version.MustParse("1.34"), Default: true, PreRelease: featuregate.Beta},
-	},
+		APFv134Config: {
+			{Version: version.MustParse("1.33"), Default: false, PreRelease: featuregate.Alpha},
+			{Version: version.MustParse("1.34"), Default: true, PreRelease: featuregate.Beta},
+		},
 
-	AnonymousAuthConfigurableEndpoints: {
-		{Version: version.MustParse("1.31"), Default: false, PreRelease: featuregate.Alpha},
-		{Version: version.MustParse("1.32"), Default: true, PreRelease: featuregate.Beta},
-	},
+		AnonymousAuthConfigurableEndpoints: {
+			{Version: version.MustParse("1.31"), Default: false, PreRelease: featuregate.Alpha},
+			{Version: version.MustParse("1.32"), Default: true, PreRelease: featuregate.Beta},
+		},
 
-	APIResponseCompression: {
-		{Version: version.MustParse("1.8"), Default: false, PreRelease: featuregate.Alpha},
-		{Version: version.MustParse("1.16"), Default: true, PreRelease: featuregate.Beta},
-	},
+		APIResponseCompression: {
+			{Version: version.MustParse("1.8"), Default: false, PreRelease: featuregate.Alpha},
+			{Version: version.MustParse("1.16"), Default: true, PreRelease: featuregate.Beta},
+		},
 
-	APIServerIdentity: {
-		{Version: version.MustParse("1.20"), Default: false, PreRelease: featuregate.Alpha},
-		{Version: version.MustParse("1.26"), Default: true, PreRelease: featuregate.Beta},
-	},
+		APIServerIdentity: {
+			{Version: version.MustParse("1.20"), Default: false, PreRelease: featuregate.Alpha},
+			{Version: version.MustParse("1.26"), Default: true, PreRelease: featuregate.Beta},
+		},
 
-	APIServerTracing: {
-		{Version: version.MustParse("1.22"), Default: false, PreRelease: featuregate.Alpha},
-		{Version: version.MustParse("1.27"), Default: true, PreRelease: featuregate.Beta},
-	},
+		APIServerTracing: {
+			{Version: version.MustParse("1.22"), Default: false, PreRelease: featuregate.Alpha},
+			{Version: version.MustParse("1.27"), Default: true, PreRelease: featuregate.Beta},
+		},
 
-	APIServingWithRoutine: {
-		{Version: version.MustParse("1.30"), Default: false, PreRelease: featuregate.Alpha},
-	},
+		APIServingWithRoutine: {
+			{Version: version.MustParse("1.30"), Default: false, PreRelease: featuregate.Alpha},
+		},
 
-	BtreeWatchCache: {
-		{Version: version.MustParse("1.32"), Default: true, PreRelease: featuregate.Beta},
-		{Version: version.MustParse("1.33"), Default: true, PreRelease: featuregate.GA, LockToDefault: true},
-	},
+		BtreeWatchCache: {
+			{Version: version.MustParse("1.32"), Default: true, PreRelease: featuregate.Beta},
+			{Version: version.MustParse("1.33"), Default: true, PreRelease: featuregate.GA, LockToDefault: true},
+		},
 
-	AuthorizeWithSelectors: {
-		{Version: version.MustParse("1.31"), Default: false, PreRelease: featuregate.Alpha},
-		{Version: version.MustParse("1.32"), Default: true, PreRelease: featuregate.Beta},
-	},
+		AuthorizeWithSelectors: {
+			{Version: version.MustParse("1.31"), Default: false, PreRelease: featuregate.Alpha},
+			{Version: version.MustParse("1.32"), Default: true, PreRelease: featuregate.Beta},
+		},
 
-	CBORServingAndStorage: {
-		{Version: version.MustParse("1.32"), Default: false, PreRelease: featuregate.Alpha},
-	},
+		CBORServingAndStorage: {
+			{Version: version.MustParse("1.32"), Default: false, PreRelease: featuregate.Alpha},
+		},
 
-	ConcurrentWatchObjectDecode: {
-		{Version: version.MustParse("1.31"), Default: false, PreRelease: featuregate.Beta},
-	},
+		ConcurrentWatchObjectDecode: {
+			{Version: version.MustParse("1.31"), Default: false, PreRelease: featuregate.Beta},
+		},
 
-	ConsistentListFromCache: {
-		{Version: version.MustParse("1.28"), Default: false, PreRelease: featuregate.Alpha},
-		{Version: version.MustParse("1.31"), Default: true, PreRelease: featuregate.Beta},
-	},
+		ConsistentListFromCache: {
+			{Version: version.MustParse("1.28"), Default: false, PreRelease: featuregate.Alpha},
+			{Version: version.MustParse("1.31"), Default: true, PreRelease: featuregate.Beta},
+		},
 
-	CoordinatedLeaderElection: {
-		{Version: version.MustParse("1.31"), Default: false, PreRelease: featuregate.Alpha},
-		{Version: version.MustParse("1.33"), Default: false, PreRelease: featuregate.Beta},
-	},
+		CoordinatedLeaderElection: {
+			{Version: version.MustParse("1.31"), Default: false, PreRelease: featuregate.Alpha},
+			{Version: version.MustParse("1.33"), Default: false, PreRelease: featuregate.Beta},
+		},
 
-	KMSv1: {
-		{Version: version.MustParse("1.0"), Default: true, PreRelease: featuregate.GA},
-		{Version: version.MustParse("1.28"), Default: true, PreRelease: featuregate.Deprecated},
-		{Version: version.MustParse("1.29"), Default: false, PreRelease: featuregate.Deprecated},
-	},
+		KMSv1: {
+			{Version: version.MustParse("1.0"), Default: true, PreRelease: featuregate.GA},
+			{Version: version.MustParse("1.28"), Default: true, PreRelease: featuregate.Deprecated},
+			{Version: version.MustParse("1.29"), Default: false, PreRelease: featuregate.Deprecated},
+		},
 
-	ListFromCacheSnapshot: {
-		{Version: version.MustParse("1.33"), Default: false, PreRelease: featuregate.Alpha},
-	},
+		ListFromCacheSnapshot: {
+			{Version: version.MustParse("1.33"), Default: false, PreRelease: featuregate.Alpha},
+		},
 
-	MutatingAdmissionPolicy: {
-		{Version: version.MustParse("1.32"), Default: false, PreRelease: featuregate.Alpha},
-	},
+		MutatingAdmissionPolicy: {
+			{Version: version.MustParse("1.32"), Default: false, PreRelease: featuregate.Alpha},
+		},
 
-	OpenAPIEnums: {
-		{Version: version.MustParse("1.23"), Default: false, PreRelease: featuregate.Alpha},
-		{Version: version.MustParse("1.24"), Default: true, PreRelease: featuregate.Beta},
-	},
+		OpenAPIEnums: {
+			{Version: version.MustParse("1.23"), Default: false, PreRelease: featuregate.Alpha},
+			{Version: version.MustParse("1.24"), Default: true, PreRelease: featuregate.Beta},
+		},
 
-	RemoteRequestHeaderUID: {
-		{Version: version.MustParse("1.32"), Default: false, PreRelease: featuregate.Alpha},
-		{Version: version.MustParse("1.33"), Default: true, PreRelease: featuregate.Beta},
-	},
+		RemoteRequestHeaderUID: {
+			{Version: version.MustParse("1.32"), Default: false, PreRelease: featuregate.Alpha},
+			{Version: version.MustParse("1.33"), Default: true, PreRelease: featuregate.Beta},
+		},
 
-	ResilientWatchCacheInitialization: {
-		{Version: version.MustParse("1.31"), Default: true, PreRelease: featuregate.Beta},
-	},
+		ResilientWatchCacheInitialization: {
+			{Version: version.MustParse("1.31"), Default: true, PreRelease: featuregate.Beta},
+		},
 
-	RetryGenerateName: {
-		{Version: version.MustParse("1.30"), Default: false, PreRelease: featuregate.Alpha},
-		{Version: version.MustParse("1.31"), Default: true, PreRelease: featuregate.Beta},
-		{Version: version.MustParse("1.32"), Default: true, LockToDefault: true, PreRelease: featuregate.GA},
-	},
+		RetryGenerateName: {
+			{Version: version.MustParse("1.30"), Default: false, PreRelease: featuregate.Alpha},
+			{Version: version.MustParse("1.31"), Default: true, PreRelease: featuregate.Beta},
+			{Version: version.MustParse("1.32"), Default: true, LockToDefault: true, PreRelease: featuregate.GA},
+		},
 
-	SeparateCacheWatchRPC: {
-		{Version: version.MustParse("1.28"), Default: true, PreRelease: featuregate.Beta},
-		{Version: version.MustParse("1.33"), Default: false, PreRelease: featuregate.Deprecated},
-	},
+		SeparateCacheWatchRPC: {
+			{Version: version.MustParse("1.28"), Default: true, PreRelease: featuregate.Beta},
+			{Version: version.MustParse("1.33"), Default: false, PreRelease: featuregate.Deprecated},
+		},
 
-	StorageVersionAPI: {
-		{Version: version.MustParse("1.20"), Default: false, PreRelease: featuregate.Alpha},
-	},
+		StorageVersionAPI: {
+			{Version: version.MustParse("1.20"), Default: false, PreRelease: featuregate.Alpha},
+		},
 
-	StorageVersionHash: {
-		{Version: version.MustParse("1.14"), Default: false, PreRelease: featuregate.Alpha},
-		{Version: version.MustParse("1.15"), Default: true, PreRelease: featuregate.Beta},
-	},
+		StorageVersionHash: {
+			{Version: version.MustParse("1.14"), Default: false, PreRelease: featuregate.Alpha},
+			{Version: version.MustParse("1.15"), Default: true, PreRelease: featuregate.Beta},
+		},
 
-	StreamingCollectionEncodingToJSON: {
-		{Version: version.MustParse("1.33"), Default: true, PreRelease: featuregate.Beta},
-	},
+		StreamingCollectionEncodingToJSON: {
+			{Version: version.MustParse("1.33"), Default: true, PreRelease: featuregate.Beta},
+		},
 
-	StreamingCollectionEncodingToProtobuf: {
-		{Version: version.MustParse("1.33"), Default: true, PreRelease: featuregate.Beta},
-	},
+		StreamingCollectionEncodingToProtobuf: {
+			{Version: version.MustParse("1.33"), Default: true, PreRelease: featuregate.Beta},
+		},
 
-	StrictCostEnforcementForVAP: {
-		{Version: version.MustParse("1.30"), Default: false, PreRelease: featuregate.Beta},
-		{Version: version.MustParse("1.32"), Default: true, PreRelease: featuregate.GA, LockToDefault: true},
-	},
+		StrictCostEnforcementForVAP: {
+			{Version: version.MustParse("1.30"), Default: false, PreRelease: featuregate.Beta},
+			{Version: version.MustParse("1.32"), Default: true, PreRelease: featuregate.GA, LockToDefault: true},
+		},
 
-	StrictCostEnforcementForWebhooks: {
-		{Version: version.MustParse("1.30"), Default: false, PreRelease: featuregate.Beta},
-		{Version: version.MustParse("1.32"), Default: true, PreRelease: featuregate.GA, LockToDefault: true},
-	},
+		StrictCostEnforcementForWebhooks: {
+			{Version: version.MustParse("1.30"), Default: false, PreRelease: featuregate.Beta},
+			{Version: version.MustParse("1.32"), Default: true, PreRelease: featuregate.GA, LockToDefault: true},
+		},
 
-	StructuredAuthenticationConfiguration: {
-		{Version: version.MustParse("1.29"), Default: false, PreRelease: featuregate.Alpha},
-		{Version: version.MustParse("1.30"), Default: true, PreRelease: featuregate.Beta},
-	},
+		StructuredAuthenticationConfiguration: {
+			{Version: version.MustParse("1.29"), Default: false, PreRelease: featuregate.Alpha},
+			{Version: version.MustParse("1.30"), Default: true, PreRelease: featuregate.Beta},
+		},
 
-	StructuredAuthorizationConfiguration: {
-		{Version: version.MustParse("1.29"), Default: false, PreRelease: featuregate.Alpha},
-		{Version: version.MustParse("1.30"), Default: true, PreRelease: featuregate.Beta},
-		{Version: version.MustParse("1.32"), Default: true, PreRelease: featuregate.GA, LockToDefault: true},
-	},
+		StructuredAuthorizationConfiguration: {
+			{Version: version.MustParse("1.29"), Default: false, PreRelease: featuregate.Alpha},
+			{Version: version.MustParse("1.30"), Default: true, PreRelease: featuregate.Beta},
+			{Version: version.MustParse("1.32"), Default: true, PreRelease: featuregate.GA, LockToDefault: true},
+		},
 
-	UnauthenticatedHTTP2DOSMitigation: {
-		{Version: version.MustParse("1.25"), Default: false, PreRelease: featuregate.Beta},
-		{Version: version.MustParse("1.29"), Default: true, PreRelease: featuregate.Beta},
-	},
+		UnauthenticatedHTTP2DOSMitigation: {
+			{Version: version.MustParse("1.25"), Default: false, PreRelease: featuregate.Beta},
+			{Version: version.MustParse("1.29"), Default: true, PreRelease: featuregate.Beta},
+		},
 
-	WatchCacheInitializationPostStartHook: {
-		{Version: version.MustParse("1.31"), Default: false, PreRelease: featuregate.Beta},
-	},
+		WatchCacheInitializationPostStartHook: {
+			{Version: version.MustParse("1.31"), Default: false, PreRelease: featuregate.Beta},
+		},
 
-	WatchFromStorageWithoutResourceVersion: {
-		{Version: version.MustParse("1.27"), Default: false, PreRelease: featuregate.Beta},
-		{Version: version.MustParse("1.33"), Default: false, PreRelease: featuregate.Deprecated, LockToDefault: true},
-	},
+		WatchFromStorageWithoutResourceVersion: {
+			{Version: version.MustParse("1.27"), Default: false, PreRelease: featuregate.Beta},
+			{Version: version.MustParse("1.33"), Default: false, PreRelease: featuregate.Deprecated, LockToDefault: true},
+		},
 
-	WatchList: {
-		{Version: version.MustParse("1.27"), Default: false, PreRelease: featuregate.Alpha},
-		{Version: version.MustParse("1.32"), Default: true, PreRelease: featuregate.Beta},
-	},
+		WatchList: {
+			{Version: version.MustParse("1.27"), Default: false, PreRelease: featuregate.Alpha},
+			{Version: version.MustParse("1.32"), Default: true, PreRelease: featuregate.Beta},
+		},
+	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
@@ -279,6 +279,7 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 	},
 
 	APFv134Config: {
+		{Version: version.MustParse("1.33"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("1.34"), Default: true, PreRelease: featuregate.Beta},
 	},
 

--- a/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
@@ -61,6 +61,15 @@ const (
 	// resources using the Kubernetes API only.
 	AllowUnsafeMalformedObjectDeletion featuregate.Feature = "AllowUnsafeMalformedObjectDeletion"
 
+	// owner: @MikeSpreitzer, @tkashem, @linxiulei
+	//
+	// Make API Priority and Fairness use modern configuration, which
+	// differs from the old in these ways:
+	// - introduce priority level and flow schema for events;
+	// - generally reorganize to stop working around lack of borrowing;
+	// - increase the nominal concurrency shares for leader election.
+	APFv134Config featuregate.Feature = "APFv134Config"
+
 	// owner: @ilackams
 	//
 	// Enables compression of REST responses (GET and LIST only)
@@ -267,6 +276,10 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 
 	AllowUnsafeMalformedObjectDeletion: {
 		{Version: version.MustParse("1.32"), Default: false, PreRelease: featuregate.Alpha},
+	},
+
+	APFv134Config: {
+		{Version: version.MustParse("1.34"), Default: true, PreRelease: featuregate.Beta},
 	},
 
 	AnonymousAuthConfigurableEndpoints: {

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/priority-and-fairness_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/priority-and-fairness_test.go
@@ -35,7 +35,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
-	bootstrap "k8s.io/apiserver/pkg/apis/flowcontrol/bootstrap-v134"
+	"k8s.io/apiserver/pkg/apis/flowcontrol/bootstrap"
+	bootstraplatest "k8s.io/apiserver/pkg/apis/flowcontrol/bootstrap-v134"
 	"k8s.io/apiserver/pkg/authentication/user"
 	apifilters "k8s.io/apiserver/pkg/endpoints/filters"
 	epmetrics "k8s.io/apiserver/pkg/endpoints/metrics"
@@ -95,7 +96,7 @@ func (t fakeApfFilter) Handle(ctx context.Context,
 	if t.mockDecision == decisionSkipFilter {
 		panic("Handle should not be invoked")
 	}
-	noteFn(bootstrap.SuggestedFlowSchemaGlobalDefault, bootstrap.SuggestedPriorityLevelConfigurationGlobalDefault, requestDigest.User.GetName())
+	noteFn(bootstraplatest.SuggestedFlowSchemaGlobalDefault, bootstraplatest.SuggestedPriorityLevelConfigurationGlobalDefault, requestDigest.User.GetName())
 	switch t.mockDecision {
 	case decisionNoQueuingExecute:
 		execFn()
@@ -389,7 +390,7 @@ func (f *fakeWatchApfFilter) Handle(ctx context.Context,
 	_ fq.QueueNoteFn,
 	execFn func(),
 ) {
-	noteFn(bootstrap.SuggestedFlowSchemaGlobalDefault, bootstrap.SuggestedPriorityLevelConfigurationGlobalDefault, requestDigest.User.GetName())
+	noteFn(bootstraplatest.SuggestedFlowSchemaGlobalDefault, bootstraplatest.SuggestedPriorityLevelConfigurationGlobalDefault, requestDigest.User.GetName())
 	canExecute := false
 	func() {
 		f.lock.Lock()
@@ -645,7 +646,7 @@ func (f *fakeFilterRequestDigest) Handle(ctx context.Context,
 	_ fq.QueueNoteFn, _ func(),
 ) {
 	f.requestDigestGot = &requestDigest
-	noteFn(bootstrap.MandatoryFlowSchemaCatchAll, bootstrap.MandatoryPriorityLevelConfigurationCatchAll, "")
+	noteFn(bootstrap.Latest.FlowSchemaCatchAll, bootstrap.Latest.PriorityLevelConfigurationCatchAll, "")
 	f.workEstimateGot = workEstimator()
 }
 
@@ -1138,7 +1139,7 @@ func startAPFController(t *testing.T, stopCh <-chan struct{}, apfConfiguration [
 	clientset := newClientset(t, apfConfiguration...)
 	// this test does not rely on resync, so resync period is set to zero
 	factory := informers.NewSharedInformerFactory(clientset, 0)
-	controller := utilflowcontrol.New(factory, clientset.FlowcontrolV1(), serverConcurrency, true)
+	controller := utilflowcontrol.New(factory, clientset.FlowcontrolV1(), serverConcurrency, bootstrap.LatestFeatureGate)
 
 	factory.Start(stopCh)
 

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/priority-and-fairness_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/priority-and-fairness_test.go
@@ -35,7 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/apiserver/pkg/apis/flowcontrol/bootstrap"
+	bootstrap "k8s.io/apiserver/pkg/apis/flowcontrol/bootstrap-v134"
 	"k8s.io/apiserver/pkg/authentication/user"
 	apifilters "k8s.io/apiserver/pkg/endpoints/filters"
 	epmetrics "k8s.io/apiserver/pkg/endpoints/metrics"
@@ -1138,7 +1138,7 @@ func startAPFController(t *testing.T, stopCh <-chan struct{}, apfConfiguration [
 	clientset := newClientset(t, apfConfiguration...)
 	// this test does not rely on resync, so resync period is set to zero
 	factory := informers.NewSharedInformerFactory(clientset, 0)
-	controller := utilflowcontrol.New(factory, clientset.FlowcontrolV1(), serverConcurrency)
+	controller := utilflowcontrol.New(factory, clientset.FlowcontrolV1(), serverConcurrency, true)
 
 	factory.Start(stopCh)
 

--- a/staging/src/k8s.io/apiserver/pkg/server/options/feature.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/feature.go
@@ -22,7 +22,6 @@ import (
 	"github.com/spf13/pflag"
 
 	"k8s.io/apimachinery/pkg/runtime/serializer"
-	"k8s.io/apiserver/pkg/features"
 	"k8s.io/apiserver/pkg/server"
 	utilflowcontrol "k8s.io/apiserver/pkg/util/flowcontrol"
 	"k8s.io/client-go/informers"
@@ -79,12 +78,11 @@ func (o *FeatureOptions) ApplyTo(c *server.Config, clientset kubernetes.Interfac
 			return fmt.Errorf("invalid configuration: MaxRequestsInFlight=%d and MaxMutatingRequestsInFlight=%d; they must add up to something positive", c.MaxRequestsInFlight, c.MaxMutatingRequestsInFlight)
 
 		}
-		v134Config := c.FeatureGate.Enabled(features.APFv134Config)
 		c.FlowControl = utilflowcontrol.New(
 			informers,
 			clientset.FlowcontrolV1(),
 			c.MaxRequestsInFlight+c.MaxMutatingRequestsInFlight,
-			v134Config,
+			c.FeatureGate,
 		)
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/server/options/feature.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/feature.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apiserver/pkg/features"
 	"k8s.io/apiserver/pkg/server"
 	utilflowcontrol "k8s.io/apiserver/pkg/util/flowcontrol"
 	"k8s.io/client-go/informers"
@@ -78,10 +79,12 @@ func (o *FeatureOptions) ApplyTo(c *server.Config, clientset kubernetes.Interfac
 			return fmt.Errorf("invalid configuration: MaxRequestsInFlight=%d and MaxMutatingRequestsInFlight=%d; they must add up to something positive", c.MaxRequestsInFlight, c.MaxMutatingRequestsInFlight)
 
 		}
+		v134Config := c.FeatureGate.Enabled(features.APFv134Config)
 		c.FlowControl = utilflowcontrol.New(
 			informers,
 			clientset.FlowcontrolV1(),
 			c.MaxRequestsInFlight+c.MaxMutatingRequestsInFlight,
+			v134Config,
 		)
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_controller.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_controller.go
@@ -124,7 +124,7 @@ type configController struct {
 	queueSetFactory   fq.QueueSetFactory
 	reqsGaugeVec      metrics.RatioedGaugeVec
 	execSeatsGaugeVec metrics.RatioedGaugeVec
-	newConfig         bool
+	v134Config        bool
 
 	// How this controller appears in an ObjectMeta ManagedFieldsEntry.Manager
 	asFieldManager string
@@ -277,7 +277,7 @@ func (stats *seatDemandStats) update(obs fq.IntegratorResults) {
 // NewTestableController is extra flexible to facilitate testing
 func newTestableController(config TestableConfig) *configController {
 	cfgCtlr := &configController{
-		newConfig:              config.V134Config,
+		v134Config:             config.V134Config,
 		name:                   config.Name,
 		clock:                  config.Clock,
 		queueSetFactory:        config.QueueSetFactory,
@@ -692,10 +692,10 @@ func (cfgCtlr *configController) lockAndDigestConfigObjects(newPLs []*flowcontro
 
 	// Supply missing mandatory PriorityLevelConfiguration objects
 	if !meal.haveExemptPL {
-		meal.imaginePL(fcboot.GetV1ConfigCollection(cfgCtlr.newConfig).PriorityLevelConfigurationExempt)
+		meal.imaginePL(fcboot.GetV1ConfigCollection(cfgCtlr.v134Config).PriorityLevelConfigurationExempt)
 	}
 	if !meal.haveCatchAllPL {
-		meal.imaginePL(fcboot.GetV1ConfigCollection(cfgCtlr.newConfig).PriorityLevelConfigurationCatchAll)
+		meal.imaginePL(fcboot.GetV1ConfigCollection(cfgCtlr.v134Config).PriorityLevelConfigurationCatchAll)
 	}
 
 	meal.finishQueueSetReconfigsLocked()
@@ -787,10 +787,10 @@ func (meal *cfgMeal) digestFlowSchemasLocked(newFSs []*flowcontrol.FlowSchema) {
 
 	// Supply missing mandatory FlowSchemas, in correct position
 	if !haveExemptFS {
-		fsSeq = append(apihelpers.FlowSchemaSequence{fcboot.GetV1ConfigCollection(meal.cfgCtlr.newConfig).FlowSchemaExempt}, fsSeq...)
+		fsSeq = append(apihelpers.FlowSchemaSequence{fcboot.GetV1ConfigCollection(meal.cfgCtlr.v134Config).FlowSchemaExempt}, fsSeq...)
 	}
 	if !haveCatchAllFS {
-		fsSeq = append(fsSeq, fcboot.GetV1ConfigCollection(meal.cfgCtlr.newConfig).FlowSchemaCatchAll)
+		fsSeq = append(fsSeq, fcboot.GetV1ConfigCollection(meal.cfgCtlr.v134Config).FlowSchemaCatchAll)
 	}
 
 	meal.cfgCtlr.flowSchemas = fsSeq

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_filter.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_filter.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apiserver/pkg/util/flowcontrol/metrics"
 	fcrequest "k8s.io/apiserver/pkg/util/flowcontrol/request"
 	kubeinformers "k8s.io/client-go/informers"
+	"k8s.io/component-base/featuregate"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/clock"
 
@@ -90,7 +91,7 @@ func New(
 	informerFactory kubeinformers.SharedInformerFactory,
 	flowcontrolClient flowcontrolclient.FlowcontrolV1Interface,
 	serverConcurrencyLimit int,
-	v134Config bool,
+	featureGate featuregate.FeatureGate,
 ) Interface {
 	clk := eventclock.Real{}
 	return NewTestable(TestableConfig{
@@ -104,7 +105,7 @@ func New(
 		ReqsGaugeVec:           metrics.PriorityLevelConcurrencyGaugeVec,
 		ExecSeatsGaugeVec:      metrics.PriorityLevelExecutionSeatsGaugeVec,
 		QueueSetFactory:        fqs.NewQueueSetFactory(clk),
-		V134Config:             v134Config,
+		FeatureGate:            featureGate,
 	})
 }
 
@@ -148,8 +149,8 @@ type TestableConfig struct {
 	// QueueSetFactory for the queuing implementation
 	QueueSetFactory fq.QueueSetFactory
 
-	// Whether to use modern default config objects
-	V134Config bool
+	// FeatureGate is here so that the correct configuration can be used
+	FeatureGate featuregate.FeatureGate
 }
 
 // NewTestable is extra flexible to facilitate testing

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_filter.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_filter.go
@@ -90,6 +90,7 @@ func New(
 	informerFactory kubeinformers.SharedInformerFactory,
 	flowcontrolClient flowcontrolclient.FlowcontrolV1Interface,
 	serverConcurrencyLimit int,
+	v134Config bool,
 ) Interface {
 	clk := eventclock.Real{}
 	return NewTestable(TestableConfig{
@@ -103,6 +104,7 @@ func New(
 		ReqsGaugeVec:           metrics.PriorityLevelConcurrencyGaugeVec,
 		ExecSeatsGaugeVec:      metrics.PriorityLevelExecutionSeatsGaugeVec,
 		QueueSetFactory:        fqs.NewQueueSetFactory(clk),
+		V134Config:             v134Config,
 	})
 }
 
@@ -145,6 +147,9 @@ type TestableConfig struct {
 
 	// QueueSetFactory for the queuing implementation
 	QueueSetFactory fq.QueueSetFactory
+
+	// Whether to use modern default config objects
+	V134Config bool
 }
 
 // NewTestable is extra flexible to facilitate testing

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_filter_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_filter_test.go
@@ -25,6 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
+	fcboot "k8s.io/apiserver/pkg/apis/flowcontrol/bootstrap"
 	"k8s.io/apiserver/pkg/endpoints/request"
 	fq "k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing"
 	fqs "k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset"
@@ -103,6 +104,7 @@ func TestQueueWaitTimeLatencyTracker(t *testing.T) {
 	startTime := time.Now()
 	clk, _ := eventclock.NewFake(startTime, 0, nil)
 	controller := newTestableController(TestableConfig{
+		FeatureGate:            fcboot.LatestFeatureGate,
 		Name:                   "Controller",
 		Clock:                  clk,
 		AsFieldManager:         ConfigConsumerAsFieldManager,

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/borrowing_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/borrowing_test.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
+	fcboot "k8s.io/apiserver/pkg/apis/flowcontrol/bootstrap"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/endpoints/request"
 	fq "k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing"
@@ -137,6 +138,7 @@ func TestBorrowing(t *testing.T) {
 			flowcontrolClient := clientset.FlowcontrolV1()
 			clk := eventclock.Real{}
 			controller := newTestableController(TestableConfig{
+				FeatureGate:            fcboot.LatestFeatureGate,
 				Name:                   "Controller",
 				Clock:                  clk,
 				AsFieldManager:         ConfigConsumerAsFieldManager,

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/controller_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/controller_test.go
@@ -55,7 +55,7 @@ func TestMain(m *testing.M) {
 
 var mandPLs = func() map[string]*flowcontrol.PriorityLevelConfiguration {
 	ans := make(map[string]*flowcontrol.PriorityLevelConfiguration)
-	for _, mand := range fcboot.MandatoryPriorityLevelConfigurations {
+	for _, mand := range fcboot.GetV1ConfigCollection(true).Mandatory.PriorityLevelConfigurations {
 		ans[mand.Name] = mand
 	}
 	return ans
@@ -224,7 +224,7 @@ func (cts *ctlrTestState) popHeldRequest() (plName string, hr *heldRequest, nCou
 
 var mandQueueSetNames = func() sets.String {
 	mandQueueSetNames := sets.NewString()
-	for _, mpl := range fcboot.MandatoryPriorityLevelConfigurations {
+	for _, mpl := range fcboot.GetV1ConfigCollection(true).Mandatory.PriorityLevelConfigurations {
 		mandQueueSetNames.Insert(mpl.Name)
 	}
 	return mandQueueSetNames
@@ -523,8 +523,8 @@ func genPLs(rng *rand.Rand, trial string, oldPLNames sets.String, n int) (pls []
 func genFSs(t *testing.T, rng *rand.Rand, trial string, goodPLNames, badPLNames sets.String, n int) (newFSs []*flowcontrol.FlowSchema, newFSMap map[string]*flowcontrol.FlowSchema, newFTRs map[string]*fsTestingRecord, catchAlls map[bool]*flowcontrol.FlowSchema) {
 	newFTRs = map[string]*fsTestingRecord{}
 	catchAlls = map[bool]*flowcontrol.FlowSchema{
-		false: fcboot.MandatoryFlowSchemaCatchAll,
-		true:  fcboot.MandatoryFlowSchemaCatchAll}
+		false: fcboot.GetV1ConfigCollection(true).FlowSchemaCatchAll,
+		true:  fcboot.GetV1ConfigCollection(true).FlowSchemaCatchAll}
 	newFSMap = map[string]*flowcontrol.FlowSchema{}
 	add := func(ftr *fsTestingRecord) {
 		newFSs = append(newFSs, ftr.fs)

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/controller_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/controller_test.go
@@ -55,7 +55,7 @@ func TestMain(m *testing.M) {
 
 var mandPLs = func() map[string]*flowcontrol.PriorityLevelConfiguration {
 	ans := make(map[string]*flowcontrol.PriorityLevelConfiguration)
-	for _, mand := range fcboot.GetV1ConfigCollection(true).Mandatory.PriorityLevelConfigurations {
+	for _, mand := range fcboot.Latest.Mandatory.PriorityLevelConfigurations {
 		ans[mand.Name] = mand
 	}
 	return ans
@@ -224,7 +224,7 @@ func (cts *ctlrTestState) popHeldRequest() (plName string, hr *heldRequest, nCou
 
 var mandQueueSetNames = func() sets.String {
 	mandQueueSetNames := sets.NewString()
-	for _, mpl := range fcboot.GetV1ConfigCollection(true).Mandatory.PriorityLevelConfigurations {
+	for _, mpl := range fcboot.Latest.Mandatory.PriorityLevelConfigurations {
 		mandQueueSetNames.Insert(mpl.Name)
 	}
 	return mandQueueSetNames
@@ -246,6 +246,7 @@ func TestConfigConsumer(t *testing.T) {
 				queues:          map[string]*ctlrTestQueueSet{},
 			}
 			ctlr := newTestableController(TestableConfig{
+				FeatureGate:            fcboot.LatestFeatureGate,
 				Name:                   "Controller",
 				Clock:                  clock.RealClock{},
 				AsFieldManager:         ConfigConsumerAsFieldManager,
@@ -377,6 +378,7 @@ func TestAPFControllerWithGracefulShutdown(t *testing.T) {
 		queues:          map[string]*ctlrTestQueueSet{},
 	}
 	controller := newTestableController(TestableConfig{
+		FeatureGate:            fcboot.LatestFeatureGate,
 		Name:                   "Controller",
 		Clock:                  clock.RealClock{},
 		AsFieldManager:         ConfigConsumerAsFieldManager,
@@ -523,8 +525,8 @@ func genPLs(rng *rand.Rand, trial string, oldPLNames sets.String, n int) (pls []
 func genFSs(t *testing.T, rng *rand.Rand, trial string, goodPLNames, badPLNames sets.String, n int) (newFSs []*flowcontrol.FlowSchema, newFSMap map[string]*flowcontrol.FlowSchema, newFTRs map[string]*fsTestingRecord, catchAlls map[bool]*flowcontrol.FlowSchema) {
 	newFTRs = map[string]*fsTestingRecord{}
 	catchAlls = map[bool]*flowcontrol.FlowSchema{
-		false: fcboot.GetV1ConfigCollection(true).FlowSchemaCatchAll,
-		true:  fcboot.GetV1ConfigCollection(true).FlowSchemaCatchAll}
+		false: fcboot.Latest.FlowSchemaCatchAll,
+		true:  fcboot.Latest.FlowSchemaCatchAll}
 	newFSMap = map[string]*flowcontrol.FlowSchema{}
 	add := func(ftr *fsTestingRecord) {
 		newFSs = append(newFSs, ftr.fs)

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/exempt_borrowing_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/exempt_borrowing_test.go
@@ -20,7 +20,8 @@ import (
 	"testing"
 	"time"
 
-	fcboot "k8s.io/apiserver/pkg/apis/flowcontrol/bootstrap-v134"
+	fcboot "k8s.io/apiserver/pkg/apis/flowcontrol/bootstrap"
+	fcbootlatest "k8s.io/apiserver/pkg/apis/flowcontrol/bootstrap-v134"
 	fqs "k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset"
 	testeventclock "k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/testing/eventclock"
 	"k8s.io/apiserver/pkg/util/flowcontrol/metrics"
@@ -33,10 +34,10 @@ import (
 func TestUpdateBorrowing(t *testing.T) {
 	startTime := time.Now()
 	clk, _ := testeventclock.NewFake(startTime, 0, nil)
-	plcExempt := fcboot.MandatoryPriorityLevelConfigurationExempt
-	plcHigh := fcboot.SuggestedPriorityLevelConfigurationWorkloadHigh
-	plcMid := fcboot.SuggestedPriorityLevelConfigurationWorkloadLow
-	plcLow := fcboot.MandatoryPriorityLevelConfigurationCatchAll
+	plcExempt := fcbootlatest.MandatoryPriorityLevelConfigurationExempt
+	plcHigh := fcbootlatest.SuggestedPriorityLevelConfigurationWorkloadHigh
+	plcMid := fcbootlatest.SuggestedPriorityLevelConfigurationWorkloadLow
+	plcLow := fcbootlatest.MandatoryPriorityLevelConfigurationCatchAll
 	plcs := []*flowcontrol.PriorityLevelConfiguration{plcHigh, plcExempt, plcMid, plcLow}
 	fses := []*flowcontrol.FlowSchema{}
 	k8sClient := clientsetfake.NewSimpleClientset(plcLow, plcExempt, plcHigh, plcMid)
@@ -46,6 +47,7 @@ func TestUpdateBorrowing(t *testing.T) {
 		*plcMid.Spec.Limited.NominalConcurrencyShares+
 		*plcLow.Spec.Limited.NominalConcurrencyShares) * 6
 	config := TestableConfig{
+		FeatureGate:            fcboot.LatestFeatureGate,
 		Name:                   "test",
 		Clock:                  clk,
 		AsFieldManager:         "testfm",

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/exempt_borrowing_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/exempt_borrowing_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	fcboot "k8s.io/apiserver/pkg/apis/flowcontrol/bootstrap"
+	fcboot "k8s.io/apiserver/pkg/apis/flowcontrol/bootstrap-v134"
 	fqs "k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset"
 	testeventclock "k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/testing/eventclock"
 	"k8s.io/apiserver/pkg/util/flowcontrol/metrics"

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/gen_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/gen_test.go
@@ -94,7 +94,7 @@ var flowDistinguisherMethodTypes = sets.NewString(
 )
 
 var mandFTRExempt = &fsTestingRecord{
-	fs:         fcboot.GetV1ConfigCollection(true).FlowSchemaExempt,
+	fs:         fcboot.Latest.FlowSchemaExempt,
 	wellFormed: true,
 	digests: map[bool]map[bool][]RequestDigest{
 		false: {
@@ -151,7 +151,7 @@ var mandFTRExempt = &fsTestingRecord{
 }
 
 var mandFTRCatchAll = &fsTestingRecord{
-	fs:         fcboot.GetV1ConfigCollection(true).FlowSchemaCatchAll,
+	fs:         fcboot.Latest.FlowSchemaCatchAll,
 	wellFormed: true,
 	digests: map[bool]map[bool][]RequestDigest{
 		false: {},

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/gen_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/gen_test.go
@@ -94,7 +94,7 @@ var flowDistinguisherMethodTypes = sets.NewString(
 )
 
 var mandFTRExempt = &fsTestingRecord{
-	fs:         fcboot.MandatoryFlowSchemaExempt,
+	fs:         fcboot.GetV1ConfigCollection(true).FlowSchemaExempt,
 	wellFormed: true,
 	digests: map[bool]map[bool][]RequestDigest{
 		false: {
@@ -151,7 +151,7 @@ var mandFTRExempt = &fsTestingRecord{
 }
 
 var mandFTRCatchAll = &fsTestingRecord{
-	fs:         fcboot.MandatoryFlowSchemaCatchAll,
+	fs:         fcboot.GetV1ConfigCollection(true).FlowSchemaCatchAll,
 	wellFormed: true,
 	digests: map[bool]map[bool][]RequestDigest{
 		false: {},

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/max_seats_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/max_seats_test.go
@@ -22,6 +22,7 @@ import (
 
 	flowcontrolv1 "k8s.io/api/flowcontrol/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fcboot "k8s.io/apiserver/pkg/apis/flowcontrol/bootstrap"
 	fqs "k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset"
 	"k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/testing/eventclock"
 	"k8s.io/apiserver/pkg/util/flowcontrol/metrics"
@@ -102,6 +103,7 @@ func Test_GetMaxSeats(t *testing.T) {
 			startTime := time.Now()
 			clk, _ := eventclock.NewFake(startTime, 0, nil)
 			c := newTestableController(TestableConfig{
+				FeatureGate:       fcboot.LatestFeatureGate,
 				Name:              "Controller",
 				Clock:             clk,
 				InformerFactory:   informerFactory,

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -91,6 +91,12 @@
     lockToDefault: true
     preRelease: GA
     version: "1.33"
+- name: APFv134Config
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.34"
 - name: APIResponseCompression
   versionedSpecs:
   - default: false

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -93,6 +93,10 @@
     version: "1.33"
 - name: APFv134Config
   versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.33"
   - default: true
     lockToDefault: false
     preRelease: Beta

--- a/test/integration/apiserver/flowcontrol/config_flap_test.go
+++ b/test/integration/apiserver/flowcontrol/config_flap_test.go
@@ -1,0 +1,175 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flowcontrol
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	flowcontrolv1 "k8s.io/api/flowcontrol/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	flowcontrolbootstrap "k8s.io/apiserver/pkg/apis/flowcontrol/bootstrap"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/test/utils/ktesting"
+)
+
+// TestConfigFlap tests the ability of the APF config-producer to correctly switch
+// between old and new config in the cluster.
+// This test runs in three phases.
+// First, it runs an apiserver configured with APFv134Config=true
+// and checks that that config is established within 2.5 minutes;
+// then the server is shut down.
+// Second, it runs an apiserver configured with APFv134Config=false
+// and checks that that config is established within 2.5 minutes;
+// then the server is shut down.
+// Finally, it runs an apiserver configured with APFv134Config=true
+// and checks that that config is established within 2.5 minutes;
+// then the server is shut down.
+// Remember that the etcd server is bound in test_main, so all
+// three phases share the same etcd server.
+func TestConfigFlap(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	if !flapTo(t, tCtx, "first", true) {
+		return
+	}
+	if !flapTo(t, tCtx, "first", false) {
+		return
+	}
+	if !flapTo(t, tCtx, "second", true) {
+		return
+	}
+	tCtx.Cancel("test function done")
+}
+
+var errTestPhaseDone = errors.New("test phase done")
+
+func flapTo(t *testing.T, ctx context.Context, trial string, v134 bool) bool {
+	flapName := fmt.Sprintf("%s v134=%v", trial, v134)
+	t.Log("Preparing for " + flapName)
+	ctx, cancel := context.WithCancelCause(ctx)
+	client, _, tearDown := setupAnother(t, ctx, 100, 100, v134)
+	defer func() {
+		cancel(errTestPhaseDone)
+		tearDown()
+	}()
+	t.Log("Waiting for " + flapName)
+	if !waitForConfig(t, ctx, client, flapName, v134) {
+		t.Fatal("Failed to establish " + flapName)
+		return false
+	}
+	t.Log("Established " + flapName)
+	return true
+}
+
+var errSuccess = errors.New("gotit")
+
+func waitForConfig(t *testing.T, ctx context.Context, client clientset.Interface, phaseName string, v134 bool) bool {
+	expectedSlices := flowcontrolbootstrap.GetV1ConfigCollection(v134)
+	expectedPLCs := slicesToMap(widenToObject, expectedSlices.Mandatory.PriorityLevelConfigurations, expectedSlices.Suggested.PriorityLevelConfigurations)
+	expectedFSes := slicesToMap(widenToObject, expectedSlices.Mandatory.FlowSchemas, expectedSlices.Suggested.FlowSchemas)
+	var iteration int
+	err := wait.PollUntilContextTimeout(ctx, 20*time.Second, 150*time.Second, false, func(ctx context.Context) (done bool, err error) {
+		defer func() { iteration++ }()
+		logger := klog.FromContext(ctx)
+		step := fmt.Sprintf("%s iteration %d", phaseName, iteration)
+		t.Log("Starting " + step)
+		actualPLCList, err := client.FlowcontrolV1().PriorityLevelConfigurations().List(ctx, metav1.ListOptions{})
+		if err != nil {
+			logger.Error(err, "Failed to list PriorityLevelConfiguration objects")
+			return false, nil
+		}
+		actualPLCs := slicesToMap(plcToObject, actualPLCList.Items)
+		plcsGood := compareMaps(t, step, "PriorityLevelConfiguration", plcToSpec, expectedPLCs, actualPLCs)
+		actualFSList, err := client.FlowcontrolV1().FlowSchemas().List(ctx, metav1.ListOptions{})
+		if err != nil {
+			logger.Error(err, "Failed to list FlowSchema objects")
+			return false, nil
+		}
+		actualFSes := slicesToMap(fsToObject, actualFSList.Items)
+		fsesGood := compareMaps(t, step, "FlowSchema", fsToSpec, expectedFSes, actualFSes)
+		t.Logf("In %s, plcsGood=%v, fsesGood=%v", step, plcsGood, fsesGood)
+		if plcsGood && fsesGood {
+			return false, errSuccess
+		}
+		return false, nil
+	})
+	return errors.Is(err, errSuccess)
+}
+
+func slicesToMap[Elt any](widen func(Elt) metav1.Object, slices ...[]Elt) map[string]Elt {
+	ans := make(map[string]Elt)
+	for _, aslice := range slices {
+		for _, elt := range aslice {
+			obj := widen(elt)
+			ans[obj.GetName()] = elt
+		}
+	}
+	return ans
+}
+
+func widenToObject[Specific metav1.Object](obj Specific) metav1.Object       { return obj }
+func plcToObject(plc flowcontrolv1.PriorityLevelConfiguration) metav1.Object { return &plc }
+func fsToObject(fs flowcontrolv1.FlowSchema) metav1.Object                   { return &fs }
+func plcToSpec(plc *flowcontrolv1.PriorityLevelConfiguration) flowcontrolv1.PriorityLevelConfigurationSpec {
+	return plc.Spec
+}
+func fsToSpec(fs *flowcontrolv1.FlowSchema) flowcontrolv1.FlowSchemaSpec {
+	return fs.Spec
+}
+
+func compareMaps[Elt, Spec any](t *testing.T, step, kind string, getSpec func(*Elt) Spec, expected map[string]*Elt, actual map[string]Elt) bool {
+	allGood := true
+	for name, expectedVal := range expected {
+		actualVal, ok := actual[name]
+		if !ok {
+			allGood = false
+			t.Logf("At %s: did not find expected %s %s", step, kind, name)
+			continue
+		}
+		expectedSpec := getSpec(expectedVal)
+		actualSpec := getSpec(&actualVal)
+		if !apiequality.Semantic.DeepEqual(expectedSpec, actualSpec) {
+			allGood = false
+			expectedBytes, err := json.Marshal(expectedSpec)
+			if err != nil {
+				t.Errorf("Failed to marshal expectedSpec %#v: %s", expectedSpec, err.Error())
+				continue
+			}
+			actualBytes, err := json.Marshal(actualSpec)
+			if err != nil {
+				t.Errorf("Failed to marshal actualSpec %#v: %s", actualSpec, err.Error())
+				continue
+			}
+			t.Logf("At %s: for %s %s, expectedSpec %s != actualSpec %s", step, kind, name, string(expectedBytes), string(actualBytes))
+		}
+	}
+	for name := range actual {
+		_, ok := expected[name]
+		if !ok {
+			allGood = false
+			t.Logf("At %s: did not expect actual %s %s", step, kind, name)
+		}
+	}
+	return allGood
+}

--- a/test/integration/apiserver/flowcontrol/fight_test.go
+++ b/test/integration/apiserver/flowcontrol/fight_test.go
@@ -167,7 +167,7 @@ func (ft *fightTest) evaluate(tBeforeCreate, tAfterCreate time.Time) {
 	}
 }
 func TestConfigConsumerFight(t *testing.T) {
-	_, kubeConfig, closeFn := setup(t, 100, 100)
+	_, _, kubeConfig, closeFn := setup(t, 100, 100, true)
 	defer closeFn()
 	const teamSize = 3
 	ft := newFightTest(t, kubeConfig, teamSize)

--- a/test/integration/apiserver/flowcontrol/fight_test.go
+++ b/test/integration/apiserver/flowcontrol/fight_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	flowcontrol "k8s.io/api/flowcontrol/v1"
+	fcboot "k8s.io/apiserver/pkg/apis/flowcontrol/bootstrap"
 	utilfc "k8s.io/apiserver/pkg/util/flowcontrol"
 	fqtesting "k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/testing"
 	"k8s.io/apiserver/pkg/util/flowcontrol/metrics"
@@ -130,6 +131,7 @@ func (ft *fightTest) createController(invert bool, i int) {
 		foundToDangling = func(found bool) bool { return found }
 	}
 	ctlr := utilfc.NewTestable(utilfc.TestableConfig{
+		FeatureGate:            fcboot.LatestFeatureGate,
 		Name:                   fieldMgr,
 		FoundToDangling:        foundToDangling,
 		Clock:                  clock.RealClock{},

--- a/test/integration/apiserver/flowcontrol/fs_condition_test.go
+++ b/test/integration/apiserver/flowcontrol/fs_condition_test.go
@@ -38,7 +38,7 @@ func TestConditionIsolation(t *testing.T) {
 
 	loopbackClient := clientset.NewForConfigOrDie(kubeConfig)
 
-	fsOrig := fcboot.SuggestedFlowSchemas[0]
+	fsOrig := fcboot.GetV1ConfigCollection(true).Suggested.FlowSchemas[0]
 	t.Logf("Testing Status Condition isolation in FlowSchema %q", fsOrig.Name)
 	fsClient := loopbackClient.FlowcontrolV1().FlowSchemas()
 	var dangleOrig *flowcontrol.FlowSchemaCondition

--- a/test/integration/apiserver/flowcontrol/fs_condition_test.go
+++ b/test/integration/apiserver/flowcontrol/fs_condition_test.go
@@ -35,7 +35,7 @@ func TestConditionIsolation(t *testing.T) {
 	ctx, loopbackClient, _, closeFn := setup(t, 10, 10, true)
 	defer closeFn()
 
-	fsOrig := fcboot.GetV1ConfigCollection(true).Suggested.FlowSchemas[0]
+	fsOrig := fcboot.Latest.Suggested.FlowSchemas[0]
 	t.Logf("Testing Status Condition isolation in FlowSchema %q", fsOrig.Name)
 	fsClient := loopbackClient.FlowcontrolV1().FlowSchemas()
 	var dangleOrig *flowcontrol.FlowSchemaCondition

--- a/test/integration/apiserver/flowcontrol/fs_condition_test.go
+++ b/test/integration/apiserver/flowcontrol/fs_condition_test.go
@@ -28,15 +28,12 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	fcboot "k8s.io/apiserver/pkg/apis/flowcontrol/bootstrap"
 	flowcontrolapply "k8s.io/client-go/applyconfigurations/flowcontrol/v1"
-	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 )
 
 func TestConditionIsolation(t *testing.T) {
-	ctx, kubeConfig, closeFn := setup(t, 10, 10)
+	ctx, loopbackClient, _, closeFn := setup(t, 10, 10, true)
 	defer closeFn()
-
-	loopbackClient := clientset.NewForConfigOrDie(kubeConfig)
 
 	fsOrig := fcboot.GetV1ConfigCollection(true).Suggested.FlowSchemas[0]
 	t.Logf("Testing Status Condition isolation in FlowSchema %q", fsOrig.Name)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug

/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup
/kind bug

#### What this PR does / why we need it:
This PR tweaks the default configuration objects for API Priority and Fairness. There are two changes.

1. Introduce a FlowSchema and priority level for events.
2. Generally reshuffle the nominal concurrency shares and borrowing parameters so that the baseline is more in line with actual priority and need and can respond via borrowing. This is good because the default configuration was originally designed before borrowing was introduced and has some inversions among the nominal concurrency shares. See https://github.com/kubernetes/kubernetes/issues/121982#issuecomment-1933534198 for most of this. Also, @linxiulei has been recommending increasing the nominal concurrency shares for leader election, and testing supports this change. See #129646 and the other PRs and tests referenced in https://github.com/kubernetes/kubernetes/pull/129646#issuecomment-2649193226 .

This PR subsumes #129646 .

Also, as suggested in https://github.com/kubernetes/kubernetes/pull/129646#discussion_r1971451869 , this PR introduces a FeatureGate that allows administrators to opt out of this set of configuration changes. The FeatureGate is named "APFNewConifg".

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #121982

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The default configuration for API Priority and Fairness has changed, to work better under stress and take advantage of the borrowing of concurrency between priority levels. Note that during a rollout, while a cluster has a mixed population of kube-apiservers, they will periodically overwrite each other's configurations; this is expected to be a usable compromise. There is a new FeatureGate named "APFNewConifg" that can be disabled to opt out of the new configuration.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
