### PR TITLE
selinux: Ignore pods with Recursive policy

### DIFF
--- a/pkg/controller/volume/selinuxwarning/cache/volumecache_test.go
+++ b/pkg/controller/volume/selinuxwarning/cache/volumecache_test.go
@@ -119,21 +119,21 @@ func TestVolumeCache_AddVolumeSendConflicts(t *testing.T) {
 			podNamespace: "ns2",
 			podName:      "pod2-recursive",
 			volumeName:   "vol2",
-			label:        "system_u:system_r:label2",
+			label:        "", // labels on volumes with Recursive policy are cleared, we don't want the controller to report label conflicts on them
 			changePolicy: v1.SELinuxChangePolicyRecursive,
 		},
 		{
 			podNamespace: "ns3",
 			podName:      "pod3-1",
 			volumeName:   "vol3", // vol3 is used by 2 pods with the same label + recursive policy
-			label:        "system_u:system_r:label3",
+			label:        "",     // labels on volumes with Recursive policy are cleared, we don't want the controller to report label conflicts on them
 			changePolicy: v1.SELinuxChangePolicyRecursive,
 		},
 		{
 			podNamespace: "ns3",
 			podName:      "pod3-2",
 			volumeName:   "vol3", // vol3 is used by 2 pods with the same label + recursive policy
-			label:        "system_u:system_r:label3",
+			label:        "",     // labels on volumes with Recursive policy are cleared, we don't want the controller to report label conflicts on them
 			changePolicy: v1.SELinuxChangePolicyRecursive,
 		},
 		{
@@ -244,13 +244,13 @@ func TestVolumeCache_AddVolumeSendConflicts(t *testing.T) {
 			},
 		},
 		{
-			name:        "existing volume in a new pod with new conflicting policy and existing label",
+			name:        "existing volume in a new pod with new conflicting policy",
 			initialPods: existingPods,
 			podToAdd: podWithVolume{
 				podNamespace: "testns",
 				podName:      "testpod",
 				volumeName:   "vol1",
-				label:        "system_u:system_r:label1",
+				label:        "",
 				changePolicy: v1.SELinuxChangePolicyRecursive,
 			},
 			expectedConflicts: []Conflict{
@@ -261,35 +261,6 @@ func TestVolumeCache_AddVolumeSendConflicts(t *testing.T) {
 					PropertyValue:      "Recursive",
 					OtherPod:           cache.ObjectName{Namespace: "ns1", Name: "pod1-mountOption"},
 					OtherPropertyValue: "MountOption",
-				},
-			},
-		},
-		{
-			name:        "existing volume in a new pod with new conflicting policy and new conflicting label",
-			initialPods: existingPods,
-			podToAdd: podWithVolume{
-				podNamespace: "testns",
-				podName:      "testpod",
-				volumeName:   "vol1",
-				label:        "system_u:system_r:label-new",
-				changePolicy: v1.SELinuxChangePolicyRecursive,
-			},
-			expectedConflicts: []Conflict{
-				{
-					PropertyName:       "SELinuxChangePolicy",
-					EventReason:        "SELinuxChangePolicyConflict",
-					Pod:                cache.ObjectName{Namespace: "testns", Name: "testpod"},
-					PropertyValue:      "Recursive",
-					OtherPod:           cache.ObjectName{Namespace: "ns1", Name: "pod1-mountOption"},
-					OtherPropertyValue: "MountOption",
-				},
-				{
-					PropertyName:       "SELinuxLabel",
-					EventReason:        "SELinuxLabelConflict",
-					Pod:                cache.ObjectName{Namespace: "testns", Name: "testpod"},
-					PropertyValue:      "system_u:system_r:label-new",
-					OtherPod:           cache.ObjectName{Namespace: "ns1", Name: "pod1-mountOption"},
-					OtherPropertyValue: "system_u:system_r:label1",
 				},
 			},
 		},
@@ -307,7 +278,7 @@ func TestVolumeCache_AddVolumeSendConflicts(t *testing.T) {
 			expectedConflicts: nil,
 		},
 		{
-			name:        "existing pod is replaced with conflicting policy and label",
+			name:        "existing pod is replaced with conflicting policy",
 			initialPods: existingPods,
 			podToAdd: podWithVolume{
 
@@ -325,14 +296,6 @@ func TestVolumeCache_AddVolumeSendConflicts(t *testing.T) {
 					PropertyValue:      "MountOption",
 					OtherPod:           cache.ObjectName{Namespace: "ns3", Name: "pod3-2"},
 					OtherPropertyValue: "Recursive",
-				},
-				{
-					PropertyName:       "SELinuxLabel",
-					EventReason:        "SELinuxLabelConflict",
-					Pod:                cache.ObjectName{Namespace: "ns3", Name: "pod3-1"},
-					PropertyValue:      "system_u:system_r:label-new",
-					OtherPod:           cache.ObjectName{Namespace: "ns3", Name: "pod3-2"},
-					OtherPropertyValue: "system_u:system_r:label3",
 				},
 			},
 		},

--- a/pkg/controller/volume/selinuxwarning/selinux_warning_controller.go
+++ b/pkg/controller/volume/selinuxwarning/selinux_warning_controller.go
@@ -451,10 +451,9 @@ func (c *Controller) syncPod(ctx context.Context, pod *v1.Pod) error {
 			continue
 		}
 
-		// Ignore how the volume is going to be mounted.
-		// Report any errors when a volume is used by two pods with different SELinux labels regardless of their
-		// SELinuxChangePolicy
-		seLinuxLabel := mountInfo.SELinuxProcessLabel
+		// Use the same label as kubelet will use for mount -o context.
+		// If the Pod has opted in to Recursive policy, it will be empty string here and no conflicts will be reported for it.
+		seLinuxLabel := mountInfo.SELinuxMountLabel
 
 		err = c.syncVolume(logger, pod, spec, seLinuxLabel, mountInfo.PluginSupportsSELinuxContextMount)
 		if err != nil {

--- a/test/e2e/storage/csimock/csi_selinux_mount.go
+++ b/test/e2e/storage/csimock/csi_selinux_mount.go
@@ -506,7 +506,7 @@ var _ = utils.SIGDescribe("CSI Mock selinux on mount metrics and SELinuxWarningC
 				volumeMode:                       v1.ReadWriteOnce,
 				waitForSecondPodStart:            true,
 				expectNodeIncreases:              sets.New[string]( /* no metric is increased, admitted_total was already increased when the first pod started */ ),
-				expectControllerConflictProperty: "SELinuxLabel", /* SELinuxController does emit a warning for Recursive policy, while kubelet does not! */
+				expectControllerConflictProperty: "", /* SELinuxController does not emit any warning either */
 				testTags:                         []interface{}{framework.WithFeatureGate(features.SELinuxMountReadWriteOncePod), framework.WithFeatureGate(features.SELinuxChangePolicy), feature.SELinuxMountReadWriteOncePodOnly},
 			},
 			{
@@ -595,7 +595,7 @@ var _ = utils.SIGDescribe("CSI Mock selinux on mount metrics and SELinuxWarningC
 				volumeMode:                       v1.ReadWriteMany,
 				waitForSecondPodStart:            true,
 				expectNodeIncreases:              sets.New[string]( /* no metric is increased, admitted_total was already increased when the first pod started */ ),
-				expectControllerConflictProperty: "SELinuxLabel", /* SELinuxController does emit a warning for Recursive policy, while kubelet does not! */
+				expectControllerConflictProperty: "", /* SELinuxController does not emit any warning either */
 				testTags:                         []interface{}{framework.WithFeatureGate(features.SELinuxMountReadWriteOncePod), framework.WithFeatureGate(features.SELinuxChangePolicy), framework.WithFeatureGate(features.SELinuxMount)},
 			},
 			{


### PR DESCRIPTION
The SELinuxWarning controller should not report SELinux label conflicts on Pods that explicitly opted into "seLinuxChangePolicy: Recursive" . It will only report a conflict with other Pods using the same volume with "seLinuxChangePolicy: Mount" (or nil).

This brings the controller behavior in sync with Kubelet.

User has opted out from mounting volume with `mount -o context=<selinux label>` and wants the previous kubelet / CRI behavior (recursive relabeling of the whole volume). In all previous Kubernetes releases, this situation never caused any events or errors, so the new controller should behave the same.

The controller now emits warnings only on pods with `seLinuxChangePolicy: MountOption` or `nil`.

KEP: https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage/1710-selinux-relabeling
Enhancement issue: https://github.com/kubernetes/enhancements/issues/1710

```relase-note
NONE
```