### PR TITLE
Ensure we switch to k8s root directory for dockerized builds during e2e-node ci job

### DIFF
--- a/test/e2e_node/builder/build.go
+++ b/test/e2e_node/builder/build.go
@@ -77,6 +77,8 @@ func BuildTargets(cgo bool) error {
 		klog.Infof("Building dockerized k8s binaries targets %s for architecture %s", targets, GetTargetBuildArch())
 		// Multi-architecture build is only supported in dockerized build
 		cmd = exec.Command(filepath.Join(k8sRoot, "build/run.sh"), "make", fmt.Sprintf("WHAT=%s", what), fmt.Sprintf("KUBE_BUILD_PLATFORMS=%s", GetTargetBuildArch()))
+		// Ensure we run this command in k8s root directory for dockerized build
+		cmd.Dir = k8sRoot
 	}
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
We use dockerized build when cross building linux/arm64 based e2e_node.test and hence only the arm64 jobs were failing.

https://github.com/kubernetes/kubernetes/issues/130147

the jobs were failing because wrong git information is injected into e2e_node.test binary if the current directory is NOT the kubernetes root directory, So switch explicitly just like we use `make -C` when we are not doing dockerized builds.

Here's how you can simulate this error:
```
[1138349:1138348 - 0:1710] 03:13:08 [davanum@ip-172-31-47-86:/dev/pts/0 +1] ~/go/src/k8s.io/kubernetes
$ git rev-parse HEAD
8cca6d98a4fb855979d2a0642391b7a441673d78

[1138349:1138348 - 0:1711] 03:13:09 [davanum@ip-172-31-47-86:/dev/pts/0 +1] ~/go/src/k8s.io/kubernetes
$ cd ../../sigs.k8s.io/provider-aws-test-infra/

[1138349:1138348 - 0:1712] 03:13:18 [davanum@ip-172-31-47-86:/dev/pts/0 +1] ~/go/src/sigs.k8s.io/provider-aws-test-infra
$ git rev-parse HEAD
0b78c4c24c3d316ccd21e1a52e550df6b4786c47

[1138349:1138348 - 0:1715] 03:13:56 [davanum@ip-172-31-47-86:/dev/pts/0 +1] ~/go/src/sigs.k8s.io/provider-aws-test-infra
$ $HOME/go/src/k8s.io/kubernetes/build/run.sh make WHAT=cmd/kubectl
+++ [0227 15:14:07] Verifying Prerequisites....
+++ [0227 15:14:07] Building Docker image kube-build:build-d46189d763-5-v1.33.0-go1.23.6-bullseye.0
+++ [0227 15:14:14] Syncing sources to container
+++ [0227 15:14:15] Output from this container will be rsynced out upon completion. Set KUBE_RUN_COPY_OUTPUT=n to disable.
+++ [0227 15:14:15] Running build command...
Go version: go version go1.23.6 linux/amd64
+++ [0227 15:14:34] Building go targets for linux/amd64
    k8s.io/kubernetes/cmd/kubectl (static)
Env for linux/amd64: GOPATH=/go/src/k8s.io/kubernetes/_output/dockerized/go GOOS=linux GOARCH=amd64 GOROOT= CGO_ENABLED= CC=
Coverage is disabled.
+++ [0227 15:14:52] Placing binaries
+++ [0227 15:14:53] Syncing out of container

[1138349:1138348 - 0:1717] 03:15:08 [davanum@ip-172-31-47-86:/dev/pts/0 +1] ~/go/src/sigs.k8s.io/provider-aws-test-infra
$ find $HOME/go/src/k8s.io/kubernetes/_output -name kubectl
/home/davanum/go/src/k8s.io/kubernetes/_output/dockerized/bin/linux/amd64/kubectl

[1138349:1138348 - 0:1722] 03:15:44 [davanum@ip-172-31-47-86:/dev/pts/0 +1] ~/go/src/sigs.k8s.io/provider-aws-test-infra
$ /home/davanum/go/src/k8s.io/kubernetes/_output/dockerized/bin/linux/amd64/kubectl version --client=true
Client Version: v0.1.0-289+0b78c4c24c3d31-dirty
Kustomize Version: v5.6.0
```

Note the SHA for kubectl client version `0b78c4c24c3d31` corresponds to git HEAD of provider-aws-test-infra `0b78c4c24c3d316ccd21e1a52e550df6b4786c47`


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
