### PR TITLE
Implement consistency checking

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/storage_factory.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/storage_factory.go
@@ -71,15 +71,17 @@ func StorageWithCacher() generic.StorageDecorator {
 		if err != nil {
 			return nil, func() {}, err
 		}
+		delegator := cacherstorage.NewCacheDelegator(cacher, s)
 		var once sync.Once
 		destroyFunc := func() {
 			once.Do(func() {
+				delegator.Stop()
 				cacher.Stop()
 				d()
 			})
 		}
 
-		return cacherstorage.NewCacheDelegator(cacher, s), destroyFunc, nil
+		return delegator, destroyFunc, nil
 	}
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store_test.go
@@ -2459,8 +2459,10 @@ func newTestGenericStoreRegistry(t *testing.T, scheme *runtime.Scheme, hasCacheE
 			}
 		}
 		d := destroyFunc
-		s = cacherstorage.NewCacheDelegator(cacher, s)
+		delegator := cacherstorage.NewCacheDelegator(cacher, s)
+		s = delegator
 		destroyFunc = func() {
+			delegator.Stop()
 			cacher.Stop()
 			d()
 		}

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
@@ -729,7 +729,7 @@ type listResp struct {
 }
 
 // GetList implements storage.Interface
-func (c *Cacher) GetList(ctx context.Context, key string, opts storage.ListOptions, listObj runtime.Object, listRV uint64) error {
+func (c *Cacher) GetList(ctx context.Context, key string, opts storage.ListOptions, listObj runtime.Object) error {
 	// For recursive lists, we need to make sure the key ended with "/" so that we only
 	// get children "directories". e.g. if we have key "/a", "/a/b", "/ab", getting keys
 	// with prefix "/a" will return all three, while with prefix "/a/" will return only
@@ -737,6 +737,10 @@ func (c *Cacher) GetList(ctx context.Context, key string, opts storage.ListOptio
 	preparedKey := key
 	if opts.Recursive && !strings.HasSuffix(key, "/") {
 		preparedKey += "/"
+	}
+	listRV, err := c.versioner.ParseResourceVersion(opts.ResourceVersion)
+	if err != nil {
+		return err
 	}
 
 	ctx, span := tracing.Start(ctx, "cacher.GetList",

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/delegator_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/delegator_test.go
@@ -1,0 +1,194 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cacher
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/apis/example"
+	"k8s.io/apiserver/pkg/storage"
+)
+
+func TestCalculateDigest(t *testing.T) {
+	newListFunc := func() runtime.Object { return &example.PodList{} }
+	testCases := []struct {
+		desc            string
+		resourceVersion string
+		cacherReady     bool
+		cacherItems     []example.Pod
+		etcdItems       []example.Pod
+		resourcePrefix  string
+
+		expectListKey string
+		expectDigest  storageDigest
+		expectErr     bool
+	}{
+		{
+			desc:            "not ready",
+			cacherReady:     false,
+			resourceVersion: "1",
+			expectErr:       true,
+		},
+		{
+			desc:            "empty",
+			resourceVersion: "1",
+			cacherReady:     true,
+			expectDigest: storageDigest{
+				ResourceVersion: "1",
+				CacheDigest:     "cbf29ce484222325",
+				EtcdDigest:      "cbf29ce484222325",
+			},
+		},
+		{
+			desc:            "with one element equal",
+			resourceVersion: "2",
+			cacherReady:     true,
+			cacherItems: []example.Pod{
+				{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "pod", ResourceVersion: "2"}},
+			},
+			etcdItems: []example.Pod{
+				{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "pod", ResourceVersion: "2"}},
+			},
+			expectDigest: storageDigest{
+				ResourceVersion: "2",
+				CacheDigest:     "86bf3a5e80d1c5cb",
+				EtcdDigest:      "86bf3a5e80d1c5cb",
+			},
+		},
+		{
+			desc:            "namespace changes digest",
+			resourceVersion: "2",
+			cacherReady:     true,
+			cacherItems: []example.Pod{
+				{ObjectMeta: metav1.ObjectMeta{Namespace: "kube-system", Name: "pod", ResourceVersion: "2"}},
+			},
+			etcdItems: []example.Pod{
+				{ObjectMeta: metav1.ObjectMeta{Namespace: "kube-public", Name: "pod", ResourceVersion: "2"}},
+			},
+			expectDigest: storageDigest{
+				ResourceVersion: "2",
+				CacheDigest:     "4ae4e750bd825b17",
+				EtcdDigest:      "f940a60af965b03",
+			},
+		},
+		{
+			desc:            "name changes digest",
+			resourceVersion: "2",
+			cacherReady:     true,
+			cacherItems: []example.Pod{
+				{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "pod2", ResourceVersion: "2"}},
+			},
+			etcdItems: []example.Pod{
+				{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "pod3", ResourceVersion: "2"}},
+			},
+			expectDigest: storageDigest{
+				ResourceVersion: "2",
+				CacheDigest:     "c9120494e4c1897d",
+				EtcdDigest:      "c9156494e4c46274",
+			},
+		},
+		{
+			desc:            "resourceVersion changes digest",
+			resourceVersion: "2",
+			cacherReady:     true,
+			cacherItems: []example.Pod{
+				{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "pod", ResourceVersion: "3"}},
+			},
+			etcdItems: []example.Pod{
+				{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "pod", ResourceVersion: "4"}},
+			},
+			expectDigest: storageDigest{
+				ResourceVersion: "2",
+				CacheDigest:     "86bf3a5e80d1c5ca",
+				EtcdDigest:      "86bf3a5e80d1c5cd",
+			},
+		},
+		{
+			desc:            "watch missed write event",
+			resourceVersion: "3",
+			cacherReady:     true,
+			cacherItems: []example.Pod{
+				{ObjectMeta: metav1.ObjectMeta{Namespace: "Default", Name: "pod", ResourceVersion: "2"}},
+			},
+			etcdItems: []example.Pod{
+				{ObjectMeta: metav1.ObjectMeta{Namespace: "Default", Name: "pod", ResourceVersion: "2"}},
+				{ObjectMeta: metav1.ObjectMeta{Namespace: "Default", Name: "pod", ResourceVersion: "3"}},
+			},
+			expectDigest: storageDigest{
+				ResourceVersion: "3",
+				CacheDigest:     "1859bac707c2cb2b",
+				EtcdDigest:      "11d147fc800df0e0",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			etcd := &dummyStorage{
+				getListFn: func(_ context.Context, key string, opts storage.ListOptions, listObj runtime.Object) error {
+					if key != tc.expectListKey {
+						t.Fatalf("Expect GetList key %q, got %q", tc.expectListKey, key)
+					}
+					if opts.ResourceVersion != tc.resourceVersion {
+						t.Fatalf("Expect GetList resourceVersion %q, got %q", tc.resourceVersion, opts.ResourceVersion)
+					}
+					if opts.ResourceVersionMatch != metav1.ResourceVersionMatchExact {
+						t.Fatalf("Expect GetList match exact, got %q", opts.ResourceVersionMatch)
+					}
+					podList := listObj.(*example.PodList)
+					podList.Items = tc.etcdItems
+					podList.ResourceVersion = tc.resourceVersion
+					return nil
+				},
+			}
+			cacher := &dummyCacher{
+				ready: tc.cacherReady,
+				dummyStorage: dummyStorage{
+					getListFn: func(_ context.Context, key string, opts storage.ListOptions, listObj runtime.Object) error {
+						if key != tc.expectListKey {
+							t.Fatalf("Expect GetList key %q, got %q", tc.expectListKey, key)
+						}
+						if opts.ResourceVersion != "0" {
+							t.Fatalf("Expect GetList resourceVersion 0, got %q", opts.ResourceVersion)
+						}
+						if opts.ResourceVersionMatch != metav1.ResourceVersionMatchNotOlderThan {
+							t.Fatalf("Expect GetList match not older than, got %q", opts.ResourceVersionMatch)
+						}
+						podList := listObj.(*example.PodList)
+						podList.Items = tc.cacherItems
+						podList.ResourceVersion = tc.resourceVersion
+						return nil
+					},
+				},
+			}
+			checker := newConsistencyChecker(tc.resourcePrefix, newListFunc, cacher, etcd)
+			digest, err := checker.calculateDigests(context.Background())
+			if (err != nil) != tc.expectErr {
+				t.Fatalf("Expect error: %v, got: %v", tc.expectErr, err)
+			}
+			if err != nil {
+				return
+			}
+			if *digest != tc.expectDigest {
+				t.Errorf("Expect: %+v Got: %+v", &tc.expectDigest, *digest)
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/metrics/metrics.go
@@ -176,6 +176,14 @@ var (
 			Help:           "Counter for consistent reads from cache.",
 			StabilityLevel: compbasemetrics.ALPHA,
 		}, []string{"resource", "success", "fallback"})
+
+	StorageConsistencyCheckTotal = compbasemetrics.NewCounterVec(
+		&compbasemetrics.CounterOpts{
+			Namespace:      namespace,
+			Name:           "storage_consistency_checks_total",
+			Help:           "Counter for status of consistency checks between etcd and watch cache",
+			StabilityLevel: compbasemetrics.INTERNAL,
+		}, []string{"resource", "status"})
 )
 
 var registerMetrics sync.Once
@@ -198,6 +206,7 @@ func Register() {
 		legacyregistry.MustRegister(WatchCacheInitializations)
 		legacyregistry.MustRegister(WatchCacheReadWait)
 		legacyregistry.MustRegister(ConsistentReadTotal)
+		legacyregistry.MustRegister(StorageConsistencyCheckTotal)
 	})
 }
 


### PR DESCRIPTION
As proposed in https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/4988-snapshottable-api-server-cache/README.md#cache-inconsistency-detection-mechanism
/kind feature

```release-note
Add mechanism that every 5 minutes calculates a digest of etcd and watch cache and exposes it as `apiserver_storage_digest` metric
```

/sig api-machinery
/triage accepted
/assign @wojtek-t
/cc @liggitt