### PR TITLE
Do not look for SSH external IP for NFSPersistentVolumes tests

### DIFF
--- a/test/e2e/storage/nfs_persistent_volume-disruptive.go
+++ b/test/e2e/storage/nfs_persistent_volume-disruptive.go
@@ -49,15 +49,15 @@ var _ = utils.SIGDescribe("NFSPersistentVolumes", framework.WithDisruptive(), fu
 	f := framework.NewDefaultFramework("disruptive-pv")
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 	var (
-		c                           clientset.Interface
-		ns                          string
-		nfsServerPod                *v1.Pod
-		nfsPVconfig                 e2epv.PersistentVolumeConfig
-		pvcConfig                   e2epv.PersistentVolumeClaimConfig
-		nfsServerHost, clientNodeIP string
-		clientNode                  *v1.Node
-		volLabel                    labels.Set
-		selector                    *metav1.LabelSelector
+		c             clientset.Interface
+		ns            string
+		nfsServerPod  *v1.Pod
+		nfsPVconfig   e2epv.PersistentVolumeConfig
+		pvcConfig     e2epv.PersistentVolumeClaimConfig
+		nfsServerHost string
+		clientNode    *v1.Node
+		volLabel      labels.Set
+		selector      *metav1.LabelSelector
 	)
 
 	ginkgo.BeforeEach(func(ctx context.Context) {
@@ -88,20 +88,18 @@ var _ = utils.SIGDescribe("NFSPersistentVolumes", framework.WithDisruptive(), fu
 			Selector:         selector,
 			StorageClassName: &emptyStorageClass,
 		}
-		// Get the first ready node IP that is not hosting the NFS pod.
-		if clientNodeIP == "" {
+		if clientNode == nil {
 			framework.Logf("Designating test node")
 			nodes, err := e2enode.GetReadySchedulableNodes(ctx, c)
 			framework.ExpectNoError(err)
 			for _, node := range nodes.Items {
 				if node.Name != nfsServerPod.Spec.NodeName {
 					clientNode = &node
-					clientNodeIP, err = e2enode.GetSSHExternalIP(clientNode)
 					framework.ExpectNoError(err)
 					break
 				}
 			}
-			gomega.Expect(clientNodeIP).NotTo(gomega.BeEmpty())
+			gomega.Expect(clientNode).NotTo(gomega.BeEmpty())
 		}
 	})
 


### PR DESCRIPTION
Trying to fix failures in:
- https://testgrid.k8s.io/amazon-ec2-al2023#ci-kubernetes-e2e-ec2-eks-al2023-arm64-disruptive&width=20
- https://testgrid.k8s.io/amazon-ec2-al2023#ci-kubernetes-e2e-ec2-eks-al2023-disruptive&width=20

Do we really need an external IP? We don't even use it, so trying to see if we can remove that additional restriction.

```
{ failed [FAILED] Couldn't get the external IP of host ip-172-31-6-171.ec2.internal with addresses [{InternalIP 172.31.6.171} {Hostname ip-172-31-6-171.ec2.internal}]
In [BeforeEach] at: k8s.io/kubernetes/test/e2e/storage/nfs_persistent_volume-disruptive.go:100 @ 02/27/25 11:30:46.593
}
```

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
