### PR TITLE
feat: add DeclarativeValidation and DeclarativeValidationMismatchMetric feature gates

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -153,6 +153,21 @@ const (
 	// Enable usage of Provision of PVCs from snapshots in other namespaces
 	CrossNamespaceVolumeDataSource featuregate.Feature = "CrossNamespaceVolumeDataSource"
 
+	// owner: @thockin
+	// kep: http://kep.k8s.io/5073:
+	// beta: v1.33
+	//
+	// Enable declarative validation of APIs, where declared.
+	DeclarativeValidation featuregate.Feature = "DeclarativeValidation"
+
+	// owner: @thockin
+	// kep: http://kep.k8s.io/5073:
+	// beta: v1.33
+	//
+	// Enable declarative_validation_mismatch metric which outputs # of mismatch occurrences between
+	// hand-written and declarative validation rules.
+	DeclarativeValidationMismatchMetric featuregate.Feature = "DeclarativeValidationMismatchMetric"
+
 	// owner: @atiratree
 	// kep: http://kep.k8s.io/3973
 	//

--- a/pkg/features/versioned_kube_features.go
+++ b/pkg/features/versioned_kube_features.go
@@ -149,6 +149,14 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 		{Version: version.MustParse("1.32"), Default: true, LockToDefault: true, PreRelease: featuregate.GA},
 	},
 
+	DeclarativeValidation: {
+		{Version: version.MustParse("1.33"), Default: false, PreRelease: featuregate.Beta},
+	},
+
+	DeclarativeValidationMismatchMetric: {
+		{Version: version.MustParse("1.33"), Default: false, PreRelease: featuregate.Beta},
+	},
+
 	DeploymentPodReplacementPolicy: {
 		{Version: version.MustParse("1.32"), Default: false, PreRelease: featuregate.Alpha},
 	},

--- a/test/featuregates_linter/test_data/versioned_feature_list.yaml
+++ b/test/featuregates_linter/test_data/versioned_feature_list.yaml
@@ -374,6 +374,18 @@
     lockToDefault: true
     preRelease: GA
     version: "1.32"
+- name: DeclarativeValidation
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.33"
+- name: DeclarativeValidationMismatchMetric
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.33"
 - name: DeploymentPodReplacementPolicy
   versionedSpecs:
   - default: false


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR adds the `DeclarativeValidation` and `DeclarativeValidationMismatchMetric` feature gates touching pkg/features/kube_features.go, pkg/features/versioned_kube_features.go, and test/featuregates_linter/test_data/versioned_feature_list.yaml.  Below shows the values for the gates (from test/featuregates_linter/test_data/versioned_feature_list.yaml):

```yaml
- name: DeclarativeValidation
  versionedSpecs:
  - default: false
    lockToDefault: false
    preRelease: Beta
    version: "1.33"
- name: DeclarativeValidationMismatchMetric
  versionedSpecs:
  - default: false
    lockToDefault: false
    preRelease: Beta
    version: "1.33"
```

We are targeting these gates to be flipped from default:false -> default:true in 1.33 and are waiting to enable them once additional PRs that plumb the Declarative Validation logic land.  This PR simply adds the gates "disabled" (default: false) and they will be enabled later in 1.33 once more implementation logic lands

Related docs PR which documents these new gates is here:
https://github.com/kubernetes/website/pull/49732

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related to https://github.com/kubernetes/enhancements/issues/5073

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/5073-declarative-validation-with-validation-gen
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
