### PR TITLE
Automated cherry pick of #130479: Revert conntrack reconciler

### DIFF
--- a/pkg/proxy/conntrack/cleanup.go
+++ b/pkg/proxy/conntrack/cleanup.go
@@ -20,8 +20,6 @@ limitations under the License.
 package conntrack
 
 import (
-	"time"
-
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
 
@@ -29,96 +27,84 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/proxy"
+	proxyutil "k8s.io/kubernetes/pkg/proxy/util"
 	netutils "k8s.io/utils/net"
 )
 
-// CleanStaleEntries scans conntrack table and removes any entries
-// for a service that do not correspond to a serving endpoint.
-func CleanStaleEntries(ct Interface, ipFamily v1.IPFamily,
-	svcPortMap proxy.ServicePortMap, endpointsMap proxy.EndpointsMap) {
+// CleanStaleEntries takes care of flushing stale conntrack entries for services and endpoints.
+func CleanStaleEntries(ct Interface, ipFamily v1.IPFamily, svcPortMap proxy.ServicePortMap,
+	serviceUpdateResult proxy.UpdateServiceMapResult, endpointsUpdateResult proxy.UpdateEndpointsMapResult) {
+	deleteStaleServiceConntrackEntries(ct, ipFamily, svcPortMap, serviceUpdateResult, endpointsUpdateResult)
+	deleteStaleEndpointConntrackEntries(ct, ipFamily, svcPortMap, endpointsUpdateResult)
+}
 
-	start := time.Now()
-	klog.V(4).InfoS("Started to reconcile conntrack entries", "ipFamily", ipFamily)
-
-	entries, err := ct.ListEntries(ipFamilyMap[ipFamily])
-	if err != nil {
-		klog.ErrorS(err, "Failed to list conntrack entries")
-		return
-	}
-
-	// serviceIPEndpointIPs maps service IPs (ClusterIP, LoadBalancerIPs and ExternalIPs)
-	// to the set of serving endpoint IPs.
-	serviceIPEndpointIPs := make(map[string]sets.Set[string])
-	// serviceNodePortEndpointIPs maps service NodePort to the set of serving endpoint IPs.
-	serviceNodePortEndpointIPs := make(map[int]sets.Set[string])
-
-	for svcName, svc := range svcPortMap {
-		// we are only interested in UDP services
-		if svc.Protocol() != v1.ProtocolUDP {
-			continue
-		}
-
-		endpointIPs := sets.New[string]()
-		for _, endpoint := range endpointsMap[svcName] {
-			// We need to remove all the conntrack entries for a Service (IP or NodePort)
-			// that are not pointing to a serving endpoint.
-			// We map all the serving endpoint IPs to the service and clear all the conntrack
-			// entries which are destined for the service and are not DNATed to these endpoints.
-			// Changes to the service should not affect existing flows, so we do not take
-			// traffic policies, topology, or terminating status of the service into account.
-			// This ensures that the behavior of UDP services remains consistent with TCP
-			// services.
-			if endpoint.IsServing() {
-				endpointIPs.Insert(endpoint.IP())
-			}
-		}
-
-		serviceIPEndpointIPs[svc.ClusterIP().String()] = endpointIPs
-		for _, loadBalancerIP := range svc.LoadBalancerVIPs() {
-			serviceIPEndpointIPs[loadBalancerIP.String()] = endpointIPs
-		}
-		for _, externalIP := range svc.ExternalIPs() {
-			serviceIPEndpointIPs[externalIP.String()] = endpointIPs
-		}
-		if svc.NodePort() != 0 {
-			serviceNodePortEndpointIPs[svc.NodePort()] = endpointIPs
-		}
-	}
-
+// deleteStaleServiceConntrackEntries takes care of flushing stale conntrack entries related
+// to UDP Service IPs. When a service has no endpoints and we drop traffic to it, conntrack
+// may create "black hole" entries for that IP+port. When the service gets endpoints we
+// need to delete those entries so further traffic doesn't get dropped.
+func deleteStaleServiceConntrackEntries(ct Interface, ipFamily v1.IPFamily, svcPortMap proxy.ServicePortMap, serviceUpdateResult proxy.UpdateServiceMapResult, endpointsUpdateResult proxy.UpdateEndpointsMapResult) {
 	var filters []netlink.CustomConntrackFilter
-	for _, entry := range entries {
-		// we only deal with UDP protocol entries
-		if entry.Forward.Protocol != unix.IPPROTO_UDP {
-			continue
-		}
+	conntrackCleanupServiceIPs := serviceUpdateResult.DeletedUDPClusterIPs
+	conntrackCleanupServiceNodePorts := sets.New[int]()
 
-		origDst := entry.Forward.DstIP.String()
-		origPortDst := int(entry.Forward.DstPort)
-		replySrc := entry.Reverse.SrcIP.String()
-
-		// if the original destination (--orig-dst) of the entry is service IP (ClusterIP,
-		// LoadBalancerIPs or ExternalIPs) and the reply source (--reply-src) is not IP of
-		// any serving endpoint, we clear the entry.
-		if _, ok := serviceIPEndpointIPs[origDst]; ok {
-			if !serviceIPEndpointIPs[origDst].Has(replySrc) {
-				filters = append(filters, filterForNAT(origDst, replySrc, v1.ProtocolUDP))
+	// merge newly active services gathered from endpointsUpdateResult
+	// a UDP service that changes from 0 to non-0 endpoints is newly active.
+	for _, svcPortName := range endpointsUpdateResult.NewlyActiveUDPServices {
+		if svcInfo, ok := svcPortMap[svcPortName]; ok {
+			klog.V(4).InfoS("Newly-active UDP service may have stale conntrack entries", "servicePortName", svcPortName)
+			conntrackCleanupServiceIPs.Insert(svcInfo.ClusterIP().String())
+			for _, extIP := range svcInfo.ExternalIPs() {
+				conntrackCleanupServiceIPs.Insert(extIP.String())
 			}
-		}
-
-		// if the original port destination (--orig-port-dst) of the flow is service
-		// NodePort and the reply source (--reply-src) is not IP of any serving endpoint,
-		// we clear the entry.
-		if _, ok := serviceNodePortEndpointIPs[origPortDst]; ok {
-			if !serviceNodePortEndpointIPs[origPortDst].Has(replySrc) {
-				filters = append(filters, filterForPortNAT(replySrc, origPortDst, v1.ProtocolUDP))
+			for _, lbIP := range svcInfo.LoadBalancerVIPs() {
+				conntrackCleanupServiceIPs.Insert(lbIP.String())
+			}
+			nodePort := svcInfo.NodePort()
+			if svcInfo.Protocol() == v1.ProtocolUDP && nodePort != 0 {
+				conntrackCleanupServiceNodePorts.Insert(nodePort)
 			}
 		}
 	}
 
-	if n, err := ct.ClearEntries(ipFamilyMap[ipFamily], filters...); err != nil {
-		klog.ErrorS(err, "Failed to clear all conntrack entries", "ipFamily", ipFamily, "entriesDeleted", n, "took", time.Since(start))
-	} else {
-		klog.V(4).InfoS("Finished reconciling conntrack entries", "ipFamily", ipFamily, "entriesDeleted", n, "took", time.Since(start))
+	klog.V(4).InfoS("Deleting conntrack stale entries for services", "IPs", conntrackCleanupServiceIPs.UnsortedList())
+	for _, svcIP := range conntrackCleanupServiceIPs.UnsortedList() {
+		filters = append(filters, filterForIP(svcIP, v1.ProtocolUDP))
+	}
+	klog.V(4).InfoS("Deleting conntrack stale entries for services", "nodePorts", conntrackCleanupServiceNodePorts.UnsortedList())
+	for _, nodePort := range conntrackCleanupServiceNodePorts.UnsortedList() {
+		filters = append(filters, filterForPort(nodePort, v1.ProtocolUDP))
+	}
+
+	if err := ct.ClearEntries(ipFamilyMap[ipFamily], filters...); err != nil {
+		klog.ErrorS(err, "Failed to delete stale service connections")
+	}
+}
+
+// deleteStaleEndpointConntrackEntries takes care of flushing stale conntrack entries related
+// to UDP endpoints. After a UDP endpoint is removed we must flush any conntrack entries
+// for it so that if the same client keeps sending, the packets will get routed to a new endpoint.
+func deleteStaleEndpointConntrackEntries(ct Interface, ipFamily v1.IPFamily, svcPortMap proxy.ServicePortMap, endpointsUpdateResult proxy.UpdateEndpointsMapResult) {
+	var filters []netlink.CustomConntrackFilter
+	for _, epSvcPair := range endpointsUpdateResult.DeletedUDPEndpoints {
+		if svcInfo, ok := svcPortMap[epSvcPair.ServicePortName]; ok {
+			endpointIP := proxyutil.IPPart(epSvcPair.Endpoint)
+			nodePort := svcInfo.NodePort()
+			if nodePort != 0 {
+				filters = append(filters, filterForPortNAT(endpointIP, nodePort, v1.ProtocolUDP))
+
+			}
+			filters = append(filters, filterForNAT(svcInfo.ClusterIP().String(), endpointIP, v1.ProtocolUDP))
+			for _, extIP := range svcInfo.ExternalIPs() {
+				filters = append(filters, filterForNAT(extIP.String(), endpointIP, v1.ProtocolUDP))
+			}
+			for _, lbIP := range svcInfo.LoadBalancerVIPs() {
+				filters = append(filters, filterForNAT(lbIP.String(), endpointIP, v1.ProtocolUDP))
+			}
+		}
+	}
+
+	if err := ct.ClearEntries(ipFamilyMap[ipFamily], filters...); err != nil {
+		klog.ErrorS(err, "Failed to delete stale endpoint connections")
 	}
 }
 
@@ -134,6 +120,30 @@ var protocolMap = map[v1.Protocol]uint8{
 	v1.ProtocolTCP:  unix.IPPROTO_TCP,
 	v1.ProtocolUDP:  unix.IPPROTO_UDP,
 	v1.ProtocolSCTP: unix.IPPROTO_SCTP,
+}
+
+// filterForIP returns *conntrackFilter to delete the conntrack entries for connections
+// specified by the destination IP (original direction).
+func filterForIP(ip string, protocol v1.Protocol) *conntrackFilter {
+	klog.V(4).InfoS("Adding conntrack filter for cleanup", "org-dst", ip, "protocol", protocol)
+	return &conntrackFilter{
+		protocol: protocolMap[protocol],
+		original: &connectionTuple{
+			dstIP: netutils.ParseIPSloppy(ip),
+		},
+	}
+}
+
+// filterForPort returns *conntrackFilter to delete the conntrack entries for connections
+// specified by the destination Port (original direction).
+func filterForPort(port int, protocol v1.Protocol) *conntrackFilter {
+	klog.V(4).InfoS("Adding conntrack filter for cleanup", "org-port-dst", port, "protocol", protocol)
+	return &conntrackFilter{
+		protocol: protocolMap[protocol],
+		original: &connectionTuple{
+			dstPort: uint16(port),
+		},
+	}
 }
 
 // filterForNAT returns *conntrackFilter to delete the conntrack entries for connections

--- a/pkg/proxy/conntrack/cleanup_test.go
+++ b/pkg/proxy/conntrack/cleanup_test.go
@@ -20,74 +20,61 @@ limitations under the License.
 package conntrack
 
 import (
-	"fmt"
-	"sort"
+	"net"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"github.com/vishvananda/netlink"
-	"golang.org/x/sys/unix"
 
 	v1 "k8s.io/api/core/v1"
-	discovery "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/proxy"
 	netutils "k8s.io/utils/net"
-	"k8s.io/utils/ptr"
 )
 
 const (
-	testServiceName      = "cleanup-test"
-	testServiceNamespace = "test"
-
 	testIPFamily       = v1.IPv4Protocol
 	testClusterIP      = "172.30.1.1"
 	testExternalIP     = "192.168.99.100"
 	testLoadBalancerIP = "1.2.3.4"
 
-	testServingEndpointIP    = "10.240.0.4"
-	testNonServingEndpointIP = "10.240.1.5"
-	testDeletedEndpointIP    = "10.240.2.6"
+	testEndpointIP = "10.240.0.4"
 
-	testPort     = 8000
-	testNodePort = 32000
+	testPort         = 53
+	testNodePort     = 5353
+	testEndpointPort = "5300"
 )
 
 func TestCleanStaleEntries(t *testing.T) {
-	// We need to construct proxy.ServicePortMap and proxy.EndpointsMap to pass to
-	// CleanStaleEntries. ServicePortMap and EndpointsMap are just maps, but there are
-	// no public constructors for any implementation of proxy.ServicePort and
-	// proxy.EndpointsMap, so we have to either provide our own implementation of that
-	// interface, or else use a proxy.ServiceChangeTracker and proxy.NewEndpointsChangeTracker
-	// to construct them and fill in the maps for us.
+	// We need to construct a proxy.ServicePortMap to pass to CleanStaleEntries.
+	// ServicePortMap is just map[string]proxy.ServicePort, but there are no public
+	// constructors for any implementation of proxy.ServicePort, so we have to either
+	// provide our own implementation of that interface, or else use a
+	// proxy.ServiceChangeTracker to construct them and fill in the map for us.
 
 	sct := proxy.NewServiceChangeTracker(nil, v1.IPv4Protocol, nil, nil)
 	svc := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      testServiceName,
-			Namespace: testServiceNamespace,
+			Name:      "cleanup-test",
+			Namespace: "test",
 		},
 		Spec: v1.ServiceSpec{
 			ClusterIP:   testClusterIP,
 			ExternalIPs: []string{testExternalIP},
 			Ports: []v1.ServicePort{
 				{
-					Name:     "test-tcp",
+					Name:     "dns-tcp",
 					Port:     testPort,
 					Protocol: v1.ProtocolTCP,
 				},
 				{
-					Name:     "test-udp",
+					Name:     "dns-udp",
 					Port:     testPort,
 					NodePort: testNodePort,
 					Protocol: v1.ProtocolUDP,
-				},
-				{
-					Name:     "test-sctp",
-					Port:     testPort,
-					NodePort: testNodePort,
-					Protocol: v1.ProtocolSCTP,
 				},
 			},
 		},
@@ -99,52 +86,14 @@ func TestCleanStaleEntries(t *testing.T) {
 			},
 		},
 	}
-
 	sct.Update(nil, svc)
+
 	svcPortMap := make(proxy.ServicePortMap)
 	_ = svcPortMap.Update(sct)
 
-	ect := proxy.NewEndpointsChangeTracker("test-worker", nil, v1.IPv4Protocol, nil, nil)
-	eps := &discovery.EndpointSlice{
-		TypeMeta:    metav1.TypeMeta{},
-		AddressType: discovery.AddressTypeIPv4,
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-0", testServiceName),
-			Namespace: testServiceNamespace,
-			Labels:    map[string]string{discovery.LabelServiceName: testServiceName},
-		},
-		Endpoints: []discovery.Endpoint{
-			{
-				Addresses:  []string{testServingEndpointIP},
-				Conditions: discovery.EndpointConditions{Serving: ptr.To(true)},
-			},
-			{
-				Addresses:  []string{testNonServingEndpointIP},
-				Conditions: discovery.EndpointConditions{Serving: ptr.To(false)},
-			},
-		},
-		Ports: []discovery.EndpointPort{
-			{
-				Name:     ptr.To("test-tcp"),
-				Port:     ptr.To(int32(testPort)),
-				Protocol: ptr.To(v1.ProtocolTCP),
-			},
-			{
-				Name:     ptr.To("test-udp"),
-				Port:     ptr.To(int32(testPort)),
-				Protocol: ptr.To(v1.ProtocolUDP),
-			},
-			{
-				Name:     ptr.To("test-sctp"),
-				Port:     ptr.To(int32(testPort)),
-				Protocol: ptr.To(v1.ProtocolSCTP),
-			},
-		},
-	}
-
-	ect.EndpointSliceUpdate(eps, false)
-	endpointsMap := make(proxy.EndpointsMap)
-	_ = endpointsMap.Update(ect)
+	// (At this point we are done with sct, and in particular, we don't use sct to
+	// construct UpdateServiceMapResults, because pkg/proxy already has its own tests
+	// for that. Also, svcPortMap is read-only from this point on.)
 
 	tcpPortName := proxy.ServicePortName{
 		NamespacedName: types.NamespacedName{
@@ -164,134 +113,227 @@ func TestCleanStaleEntries(t *testing.T) {
 		Protocol: svc.Spec.Ports[1].Protocol,
 	}
 
-	sctpPortName := proxy.ServicePortName{
-		NamespacedName: types.NamespacedName{
-			Namespace: svc.Namespace,
-			Name:      svc.Name,
-		},
-		Port:     svc.Spec.Ports[2].Name,
-		Protocol: svc.Spec.Ports[2].Protocol,
-	}
+	unknownPortName := udpPortName
+	unknownPortName.Namespace = "unknown"
 
-	// Sanity-check to make sure we constructed the ServicePortMap correctly
-	if len(svcPortMap) != 3 {
+	// Sanity-check to make sure we constructed the map correctly
+	if len(svcPortMap) != 2 {
 		t.Fatalf("expected svcPortMap to have 2 entries, got %+v", svcPortMap)
 	}
 	servicePort := svcPortMap[tcpPortName]
-	if servicePort == nil || servicePort.String() != "172.30.1.1:8000/TCP" {
-		t.Fatalf("expected svcPortMap[%q] to be \"172.30.1.1:8000/TCP\", got %q", tcpPortName.String(), servicePort.String())
+	if servicePort == nil || servicePort.String() != "172.30.1.1:53/TCP" {
+		t.Fatalf("expected svcPortMap[%q] to be \"172.30.1.1:53/TCP\", got %q", tcpPortName.String(), servicePort.String())
 	}
 	servicePort = svcPortMap[udpPortName]
-	if servicePort == nil || servicePort.String() != "172.30.1.1:8000/UDP" {
-		t.Fatalf("expected svcPortMap[%q] to be \"172.30.1.1:8000/UDP\", got %q", udpPortName.String(), servicePort.String())
-	}
-	servicePort = svcPortMap[sctpPortName]
-	if servicePort == nil || servicePort.String() != "172.30.1.1:8000/SCTP" {
-		t.Fatalf("expected svcPortMap[%q] to be \"172.30.1.1:8000/SCTP\", got %q", sctpPortName.String(), servicePort.String())
+	if servicePort == nil || servicePort.String() != "172.30.1.1:53/UDP" {
+		t.Fatalf("expected svcPortMap[%q] to be \"172.30.1.1:53/UDP\", got %q", udpPortName.String(), servicePort.String())
 	}
 
-	// Sanity-check to make sure we constructed the EndpointsMap map correctly
-	if len(endpointsMap) != 3 {
-		t.Fatalf("expected endpointsMap to have 3 entries, got %+v", endpointsMap)
-	}
-	for _, svcPortName := range []proxy.ServicePortName{tcpPortName, udpPortName, sctpPortName} {
-		if len(endpointsMap[svcPortName]) != 2 {
-			t.Fatalf("expected endpointsMap[%q] to have 2 entries, got %+v", svcPortName.String(), endpointsMap[svcPortName])
-		}
-		if endpointsMap[svcPortName][0].IP() != "10.240.0.4" {
-			t.Fatalf("expected endpointsMap[%q][0] IP to be \"10.240.0.4\", got \"%s\"", svcPortName.String(), endpointsMap[svcPortName][0].IP())
-		}
-		if endpointsMap[svcPortName][1].IP() != "10.240.1.5" {
-			t.Fatalf("expected endpointsMap[%q][1] IP to be \"10.240.1.5\", got \"%s\"", svcPortName.String(), endpointsMap[svcPortName][1].IP())
-		}
-		if !endpointsMap[svcPortName][0].IsServing() {
-			t.Fatalf("expected endpointsMap[%q][0] to be serving", svcPortName.String())
-		}
-		if endpointsMap[svcPortName][1].IsServing() {
-			t.Fatalf("expected endpointsMap[%q][1] to be not serving", svcPortName.String())
-		}
-	}
+	testCases := []struct {
+		description string
 
-	// mock existing entries before cleanup
-	// we create 36 fake flow entries ( 3 Endpoints * 3 Protocols * ( 3 (ServiceIPs) + 1 (NodePort))
-	var mockEntries []*netlink.ConntrackFlow
-	// expectedEntries are the entries on which we will assert the cleanup logic
-	var expectedEntries []*netlink.ConntrackFlow
-	for _, dnatDest := range []string{testServingEndpointIP, testNonServingEndpointIP, testDeletedEndpointIP} {
-		for _, proto := range []uint8{unix.IPPROTO_TCP, unix.IPPROTO_UDP, unix.IPPROTO_SCTP} {
-			for _, origDest := range []string{testClusterIP, testLoadBalancerIP, testExternalIP} {
-				entry := &netlink.ConntrackFlow{
-					FamilyType: unix.AF_INET,
-					Forward: netlink.IPTuple{
-						DstIP:    netutils.ParseIPSloppy(origDest),
-						Protocol: proto,
-					},
-					Reverse: netlink.IPTuple{
-						Protocol: proto,
-						SrcIP:    netutils.ParseIPSloppy(dnatDest),
-					},
-				}
-				mockEntries = append(mockEntries, entry)
-				// we do not expect deleted or non-serving UDP endpoints flows to be present after cleanup
-				if !(proto == unix.IPPROTO_UDP && (dnatDest == testNonServingEndpointIP || dnatDest == testDeletedEndpointIP)) {
-					expectedEntries = append(expectedEntries, entry)
-				}
-			}
-			entry := &netlink.ConntrackFlow{
-				FamilyType: unix.AF_INET,
-				Forward: netlink.IPTuple{
-					DstPort:  testNodePort,
-					Protocol: proto,
-				},
-				Reverse: netlink.IPTuple{
-					Protocol: proto,
-					SrcIP:    netutils.ParseIPSloppy(dnatDest),
-				},
-			}
-			mockEntries = append(mockEntries, entry)
-			// we do not expect deleted or non-serving UDP endpoints entries to be present after cleanup
-			if !(proto == unix.IPPROTO_UDP && (dnatDest == testNonServingEndpointIP || dnatDest == testDeletedEndpointIP)) {
-				expectedEntries = append(expectedEntries, entry)
-			}
-		}
-	}
+		serviceUpdates   proxy.UpdateServiceMapResult
+		endpointsUpdates proxy.UpdateEndpointsMapResult
 
-	// add some non-DNATed mock entries which should be cleared up by reconciler
-	// These will exist if the proxy don't have DROP/REJECT rule for service with
-	// no endpoints, --orig-dst and --reply-src will be same for these entries.
-	for _, ip := range []string{testClusterIP, testLoadBalancerIP, testExternalIP} {
-		entry := &netlink.ConntrackFlow{
-			FamilyType: unix.AF_INET,
-			Forward: netlink.IPTuple{
-				DstIP:    netutils.ParseIPSloppy(ip),
-				Protocol: unix.IPPROTO_UDP,
+		result FakeInterface
+	}{
+		{
+			description: "DeletedUDPClusterIPs clears entries for given clusterIPs (only)",
+
+			serviceUpdates: proxy.UpdateServiceMapResult{
+				// Note: this isn't testClusterIP; it's the IP of some
+				// unknown (because deleted) service.
+				DeletedUDPClusterIPs: sets.New("172.30.99.99"),
 			},
-			Reverse: netlink.IPTuple{
-				Protocol: unix.IPPROTO_UDP,
-				SrcIP:    netutils.ParseIPSloppy(ip),
+			endpointsUpdates: proxy.UpdateEndpointsMapResult{},
+
+			result: FakeInterface{
+				ClearedIPs: sets.New("172.30.99.99"),
+
+				ClearedPorts:    sets.New[int](),
+				ClearedNATs:     map[string]string{},
+				ClearedPortNATs: map[int]string{},
 			},
-		}
-		mockEntries = append(mockEntries, entry)
+		},
+		{
+			description: "DeletedUDPEndpoints clears NAT entries for all IPs and NodePorts",
+
+			serviceUpdates: proxy.UpdateServiceMapResult{
+				DeletedUDPClusterIPs: sets.New[string](),
+			},
+			endpointsUpdates: proxy.UpdateEndpointsMapResult{
+				DeletedUDPEndpoints: []proxy.ServiceEndpoint{{
+					Endpoint:        net.JoinHostPort(testEndpointIP, testEndpointPort),
+					ServicePortName: udpPortName,
+				}},
+			},
+
+			result: FakeInterface{
+				ClearedIPs:   sets.New[string](),
+				ClearedPorts: sets.New[int](),
+
+				ClearedNATs: map[string]string{
+					testClusterIP:      testEndpointIP,
+					testExternalIP:     testEndpointIP,
+					testLoadBalancerIP: testEndpointIP,
+				},
+				ClearedPortNATs: map[int]string{
+					testNodePort: testEndpointIP,
+				},
+			},
+		},
+		{
+			description: "NewlyActiveUDPServices clears entries for all IPs and NodePorts",
+
+			serviceUpdates: proxy.UpdateServiceMapResult{
+				DeletedUDPClusterIPs: sets.New[string](),
+			},
+			endpointsUpdates: proxy.UpdateEndpointsMapResult{
+				DeletedUDPEndpoints: []proxy.ServiceEndpoint{},
+				NewlyActiveUDPServices: []proxy.ServicePortName{
+					udpPortName,
+				},
+			},
+
+			result: FakeInterface{
+				ClearedIPs:   sets.New(testClusterIP, testExternalIP, testLoadBalancerIP),
+				ClearedPorts: sets.New(testNodePort),
+
+				ClearedNATs:     map[string]string{},
+				ClearedPortNATs: map[int]string{},
+			},
+		},
+
+		{
+			description: "DeletedUDPEndpoints for unknown Service has no effect",
+
+			serviceUpdates: proxy.UpdateServiceMapResult{
+				DeletedUDPClusterIPs: sets.New[string](),
+			},
+			endpointsUpdates: proxy.UpdateEndpointsMapResult{
+				DeletedUDPEndpoints: []proxy.ServiceEndpoint{{
+					Endpoint:        "10.240.0.4:80",
+					ServicePortName: unknownPortName,
+				}},
+				NewlyActiveUDPServices: []proxy.ServicePortName{},
+			},
+
+			result: FakeInterface{
+				ClearedIPs:      sets.New[string](),
+				ClearedPorts:    sets.New[int](),
+				ClearedNATs:     map[string]string{},
+				ClearedPortNATs: map[int]string{},
+			},
+		},
+		{
+			description: "NewlyActiveUDPServices for unknown Service has no effect",
+
+			serviceUpdates: proxy.UpdateServiceMapResult{
+				DeletedUDPClusterIPs: sets.New[string](),
+			},
+			endpointsUpdates: proxy.UpdateEndpointsMapResult{
+				DeletedUDPEndpoints: []proxy.ServiceEndpoint{},
+				NewlyActiveUDPServices: []proxy.ServicePortName{
+					unknownPortName,
+				},
+			},
+
+			result: FakeInterface{
+				ClearedIPs:      sets.New[string](),
+				ClearedPorts:    sets.New[int](),
+				ClearedNATs:     map[string]string{},
+				ClearedPortNATs: map[int]string{},
+			},
+		},
 	}
 
-	fake := NewFake()
-	fake.entries = mockEntries
-	CleanStaleEntries(fake, testIPFamily, svcPortMap, endpointsMap)
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			fake := NewFake()
+			CleanStaleEntries(fake, testIPFamily, svcPortMap, tc.serviceUpdates, tc.endpointsUpdates)
+			if !fake.ClearedIPs.Equal(tc.result.ClearedIPs) {
+				t.Errorf("Expected ClearedIPs=%v, got %v", tc.result.ClearedIPs, fake.ClearedIPs)
+			}
+			if !fake.ClearedPorts.Equal(tc.result.ClearedPorts) {
+				t.Errorf("Expected ClearedPorts=%v, got %v", tc.result.ClearedPorts, fake.ClearedPorts)
+			}
+			if !reflect.DeepEqual(fake.ClearedNATs, tc.result.ClearedNATs) {
+				t.Errorf("Expected ClearedNATs=%v, got %v", tc.result.ClearedNATs, fake.ClearedNATs)
+			}
+			if !reflect.DeepEqual(fake.ClearedPortNATs, tc.result.ClearedPortNATs) {
+				t.Errorf("Expected ClearedPortNATs=%v, got %v", tc.result.ClearedPortNATs, fake.ClearedPortNATs)
+			}
+		})
+	}
+}
 
-	actualEntries, _ := fake.ListEntries(ipFamilyMap[testIPFamily])
-	require.Equal(t, len(expectedEntries), len(actualEntries))
+func TestFilterForIP(t *testing.T) {
+	testCases := []struct {
+		name           string
+		ip             string
+		protocol       v1.Protocol
+		expectedFamily netlink.InetFamily
+		expectedFilter *conntrackFilter
+	}{
+		{
+			name:     "ipv4 + UDP",
+			ip:       "10.96.0.10",
+			protocol: v1.ProtocolUDP,
+			expectedFilter: &conntrackFilter{
+				protocol: 17,
+				original: &connectionTuple{dstIP: netutils.ParseIPSloppy("10.96.0.10")},
+			},
+		},
+		{
+			name:     "ipv6 + TCP",
+			ip:       "2001:db8:1::2",
+			protocol: v1.ProtocolTCP,
+			expectedFilter: &conntrackFilter{
+				protocol: 6,
+				original: &connectionTuple{dstIP: netutils.ParseIPSloppy("2001:db8:1::2")},
+			},
+		},
+	}
 
-	// sort the actual flows before comparison
-	sort.Slice(actualEntries, func(i, j int) bool {
-		return actualEntries[i].String() < actualEntries[j].String()
-	})
-	// sort the expected flows before comparison
-	sort.Slice(expectedEntries, func(i, j int) bool {
-		return expectedEntries[i].String() < expectedEntries[j].String()
-	})
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expectedFilter, filterForIP(tc.ip, tc.protocol))
+		})
+	}
+}
 
-	for i := 0; i < len(expectedEntries); i++ {
-		require.Equal(t, expectedEntries[i], actualEntries[i])
+func TestFilterForPort(t *testing.T) {
+	testCases := []struct {
+		name           string
+		port           int
+		protocol       v1.Protocol
+		expectedFilter *conntrackFilter
+	}{
+		{
+			name:     "UDP",
+			port:     5000,
+			protocol: v1.ProtocolUDP,
+
+			expectedFilter: &conntrackFilter{
+				protocol: 17,
+				original: &connectionTuple{dstPort: 5000},
+			},
+		},
+		{
+			name:     "SCTP",
+			port:     3000,
+			protocol: v1.ProtocolSCTP,
+			expectedFilter: &conntrackFilter{
+				protocol: 132,
+				original: &connectionTuple{dstPort: 3000},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expectedFilter, filterForPort(tc.port, tc.protocol))
+		})
 	}
 }
 

--- a/pkg/proxy/conntrack/conntrack_test.go
+++ b/pkg/proxy/conntrack/conntrack_test.go
@@ -35,10 +35,6 @@ type fakeHandler struct {
 	filters   []*conntrackFilter
 }
 
-func (f *fakeHandler) ConntrackTableList(_ netlink.ConntrackTableType, _ netlink.InetFamily) ([]*netlink.ConntrackFlow, error) {
-	return nil, nil
-}
-
 func (f *fakeHandler) ConntrackDeleteFilters(tableType netlink.ConntrackTableType, family netlink.InetFamily, netlinkFilters ...netlink.CustomConntrackFilter) (uint, error) {
 	f.tableType = tableType
 	f.ipFamily = family
@@ -52,6 +48,7 @@ func (f *fakeHandler) ConntrackDeleteFilters(tableType netlink.ConntrackTableTyp
 var _ netlinkHandler = (*fakeHandler)(nil)
 
 func TestConntracker_ClearEntries(t *testing.T) {
+
 	testCases := []struct {
 		name     string
 		ipFamily uint8
@@ -94,8 +91,7 @@ func TestConntracker_ClearEntries(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			handler := &fakeHandler{}
 			ct := newConntracker(handler)
-			_, err := ct.ClearEntries(tc.ipFamily, tc.filters...)
-			require.NoError(t, err)
+			require.NoError(t, ct.ClearEntries(tc.ipFamily, tc.filters...))
 			require.Equal(t, netlink.ConntrackTableType(netlink.ConntrackTable), handler.tableType)
 			require.Equal(t, netlink.InetFamily(tc.ipFamily), handler.ipFamily)
 			require.Equal(t, len(tc.filters), len(handler.filters))

--- a/pkg/proxy/conntrack/fake.go
+++ b/pkg/proxy/conntrack/fake.go
@@ -20,42 +20,77 @@ limitations under the License.
 package conntrack
 
 import (
+	"fmt"
+
 	"github.com/vishvananda/netlink"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 // FakeInterface implements Interface by just recording entries that have been cleared.
 type FakeInterface struct {
-	entries []*netlink.ConntrackFlow
+	ClearedIPs      sets.Set[string]
+	ClearedPorts    sets.Set[int]
+	ClearedNATs     map[string]string // origin -> dest
+	ClearedPortNATs map[int]string    // port -> dest
 }
 
 var _ Interface = &FakeInterface{}
 
 // NewFake creates a new FakeInterface
 func NewFake() *FakeInterface {
-	return &FakeInterface{entries: make([]*netlink.ConntrackFlow, 0)}
+	fake := &FakeInterface{}
+	fake.Reset()
+	return fake
 }
 
-// ListEntries is part of Interface
-func (fake *FakeInterface) ListEntries(_ uint8) ([]*netlink.ConntrackFlow, error) {
-	return fake.entries, nil
+// Reset clears fake's sets/maps
+func (fake *FakeInterface) Reset() {
+	fake.ClearedIPs = sets.New[string]()
+	fake.ClearedPorts = sets.New[int]()
+	fake.ClearedNATs = make(map[string]string)
+	fake.ClearedPortNATs = make(map[int]string)
 }
 
 // ClearEntries is part of Interface
-func (fake *FakeInterface) ClearEntries(_ uint8, filters ...netlink.CustomConntrackFilter) (int, error) {
-	var flows []*netlink.ConntrackFlow
-	before := len(fake.entries)
-	for _, flow := range fake.entries {
-		var matched bool
-		for _, filter := range filters {
-			matched = filter.MatchConntrackFlow(flow)
-			if matched {
-				break
+func (fake *FakeInterface) ClearEntries(_ uint8, filters ...netlink.CustomConntrackFilter) error {
+	for _, anyFilter := range filters {
+		filter := anyFilter.(*conntrackFilter)
+		if filter.protocol != protocolMap[v1.ProtocolUDP] {
+			return fmt.Errorf("FakeInterface currently only supports UDP")
+		}
+
+		// record IP and Port entries
+		if filter.original != nil && filter.reply == nil {
+			if filter.original.dstIP != nil {
+				fake.ClearedIPs.Insert(filter.original.dstIP.String())
+			}
+			if filter.original.dstPort != 0 {
+				fake.ClearedPorts.Insert(int(filter.original.dstPort))
 			}
 		}
-		if !matched {
-			flows = append(flows, flow)
+
+		// record NAT and NATPort entries
+		if filter.original != nil && filter.reply != nil {
+			if filter.original.dstIP != nil && filter.reply.srcIP != nil {
+				origin := filter.original.dstIP.String()
+				dest := filter.reply.srcIP.String()
+				if previous, exists := fake.ClearedNATs[origin]; exists && previous != dest {
+					return fmt.Errorf("filter for NAT passed with same origin (%s), different destination (%s / %s)", origin, previous, dest)
+				}
+				fake.ClearedNATs[filter.original.dstIP.String()] = filter.reply.srcIP.String()
+			}
+
+			if filter.original.dstPort != 0 && filter.reply.srcIP != nil {
+				dest := filter.reply.srcIP.String()
+				port := int(filter.original.dstPort)
+				if previous, exists := fake.ClearedPortNATs[port]; exists && previous != dest {
+					return fmt.Errorf("filter for PortNAT passed with same port (%d), different destination (%s / %s)", port, previous, dest)
+				}
+				fake.ClearedPortNATs[port] = dest
+			}
 		}
 	}
-	fake.entries = flows
-	return before - len(fake.entries), nil
+	return nil
 }

--- a/pkg/proxy/endpointschangetracker.go
+++ b/pkg/proxy/endpointschangetracker.go
@@ -178,9 +178,18 @@ type UpdateEndpointsMapResult struct {
 	// UpdatedServices lists the names of all services with added/updated/deleted
 	// endpoints since the last Update.
 	UpdatedServices sets.Set[types.NamespacedName]
-	// ConntrackCleanupRequired will be true if any UDP ServicePort changed endpoints, false otherwise.
-	// It's used to minimise conntrack cleanup calls.
-	ConntrackCleanupRequired bool
+
+	// DeletedUDPEndpoints identifies UDP endpoints that have just been deleted.
+	// Existing conntrack NAT entries pointing to these endpoints must be deleted to
+	// ensure that no further traffic for the Service gets delivered to them.
+	DeletedUDPEndpoints []ServiceEndpoint
+
+	// NewlyActiveUDPServices identifies UDP Services that have just gone from 0 to
+	// non-0 endpoints. Existing conntrack entries caching the fact that these
+	// services are black holes must be deleted to ensure that traffic can immediately
+	// begin flowing to the new endpoints.
+	NewlyActiveUDPServices []ServicePortName
+
 	// List of the trigger times for all endpoints objects that changed. It's used to export the
 	// network programming latency.
 	// NOTE(oxddr): this can be simplified to []time.Time if memory consumption becomes an issue.
@@ -196,6 +205,8 @@ type EndpointsMap map[ServicePortName][]Endpoint
 func (em EndpointsMap) Update(ect *EndpointsChangeTracker) UpdateEndpointsMapResult {
 	result := UpdateEndpointsMapResult{
 		UpdatedServices:        sets.New[types.NamespacedName](),
+		DeletedUDPEndpoints:    make([]ServiceEndpoint, 0),
+		NewlyActiveUDPServices: make([]ServicePortName, 0),
 		LastChangeTriggerTimes: make(map[types.NamespacedName][]time.Time),
 	}
 	if ect == nil {
@@ -211,26 +222,7 @@ func (em EndpointsMap) Update(ect *EndpointsChangeTracker) UpdateEndpointsMapRes
 
 		em.unmerge(change.previous)
 		em.merge(change.current)
-
-		// result.ConntrackCleanupRequired should be true if any one of the UDP
-		// ServicePort changed endpoint. Once true, we don't update the value.
-		if result.ConntrackCleanupRequired {
-			continue
-		}
-		// Check if the changed service had any UDP ServicePort
-		for svcPort := range change.previous {
-			if svcPort.NamespacedName == nn && svcPort.Protocol == v1.ProtocolUDP {
-				result.ConntrackCleanupRequired = true
-				break
-			}
-		}
-		// Check if the changed service has any UDP ServicePort
-		for svcPort := range change.current {
-			if svcPort.NamespacedName == nn && svcPort.Protocol == v1.ProtocolUDP {
-				result.ConntrackCleanupRequired = true
-				break
-			}
-		}
+		detectStaleConntrackEntries(change.previous, change.current, &result.DeletedUDPEndpoints, &result.NewlyActiveUDPServices)
 	}
 	ect.checkoutTriggerTimes(&result.LastChangeTriggerTimes)
 
@@ -291,4 +283,69 @@ func (em EndpointsMap) LocalReadyEndpoints() map[types.NamespacedName]int {
 		eps[nsn] = len(ips)
 	}
 	return eps
+}
+
+// detectStaleConntrackEntries detects services that may be associated with stale conntrack entries.
+// (See UpdateEndpointsMapResult.DeletedUDPEndpoints and .NewlyActiveUDPServices.)
+func detectStaleConntrackEntries(oldEndpointsMap, newEndpointsMap EndpointsMap, deletedUDPEndpoints *[]ServiceEndpoint, newlyActiveUDPServices *[]ServicePortName) {
+	// Find the UDP endpoints that we were sending traffic to in oldEndpointsMap, but
+	// are no longer sending to newEndpointsMap. The proxier should make sure that
+	// conntrack does not accidentally route any new connections to them.
+	for svcPortName, epList := range oldEndpointsMap {
+		if svcPortName.Protocol != v1.ProtocolUDP {
+			continue
+		}
+
+		for _, ep := range epList {
+			// If the old endpoint wasn't Serving then there can't be stale
+			// conntrack entries since there was no traffic sent to it.
+			if !ep.IsServing() {
+				continue
+			}
+
+			deleted := true
+			// Check if the endpoint has changed, including if it went from
+			// serving to not serving. If it did change stale entries for the old
+			// endpoint have to be cleared.
+			for i := range newEndpointsMap[svcPortName] {
+				if newEndpointsMap[svcPortName][i].String() == ep.String() &&
+					newEndpointsMap[svcPortName][i].IsServing() == ep.IsServing() {
+					deleted = false
+					break
+				}
+			}
+			if deleted {
+				klog.V(4).InfoS("Deleted endpoint may have stale conntrack entries", "portName", svcPortName, "endpoint", ep)
+				*deletedUDPEndpoints = append(*deletedUDPEndpoints, ServiceEndpoint{Endpoint: ep.String(), ServicePortName: svcPortName})
+			}
+		}
+	}
+
+	// Detect services that have gone from 0 to non-0 ready endpoints. If there were
+	// previously 0 endpoints, but someone tried to connect to it, then a conntrack
+	// entry may have been created blackholing traffic to that IP, which should be
+	// deleted now.
+	for svcPortName, epList := range newEndpointsMap {
+		if svcPortName.Protocol != v1.ProtocolUDP {
+			continue
+		}
+
+		epServing := 0
+		for _, ep := range epList {
+			if ep.IsServing() {
+				epServing++
+			}
+		}
+
+		oldEpServing := 0
+		for _, ep := range oldEndpointsMap[svcPortName] {
+			if ep.IsServing() {
+				oldEpServing++
+			}
+		}
+
+		if epServing > 0 && oldEpServing == 0 {
+			*newlyActiveUDPServices = append(*newlyActiveUDPServices, svcPortName)
+		}
+	}
 }

--- a/pkg/proxy/endpointschangetracker_test.go
+++ b/pkg/proxy/endpointschangetracker_test.go
@@ -525,21 +525,23 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		// previousEndpointSlices and currentEndpointSlices are used to call appropriate
 		// handlers OnEndpointSlice* (based on whether corresponding values are nil
 		// or non-nil) and must be of equal length.
-		name                             string
-		previousEndpointSlices           []*discovery.EndpointSlice
-		currentEndpointSlices            []*discovery.EndpointSlice
-		previousEndpointsMap             map[ServicePortName][]*BaseEndpointInfo
-		expectedResult                   map[ServicePortName][]*BaseEndpointInfo
-		expectedConntrackCleanupRequired bool
-		expectedLocalEndpoints           map[types.NamespacedName]int
-		expectedChangedEndpoints         sets.Set[types.NamespacedName]
+		name                           string
+		previousEndpointSlices         []*discovery.EndpointSlice
+		currentEndpointSlices          []*discovery.EndpointSlice
+		previousEndpointsMap           map[ServicePortName][]*BaseEndpointInfo
+		expectedResult                 map[ServicePortName][]*BaseEndpointInfo
+		expectedDeletedUDPEndpoints    []ServiceEndpoint
+		expectedNewlyActiveUDPServices map[ServicePortName]bool
+		expectedLocalEndpoints         map[types.NamespacedName]int
+		expectedChangedEndpoints       sets.Set[types.NamespacedName]
 	}{{
-		name:                             "empty",
-		previousEndpointsMap:             map[ServicePortName][]*BaseEndpointInfo{},
-		expectedResult:                   map[ServicePortName][]*BaseEndpointInfo{},
-		expectedConntrackCleanupRequired: false,
-		expectedLocalEndpoints:           map[types.NamespacedName]int{},
-		expectedChangedEndpoints:         sets.New[types.NamespacedName](),
+		name:                           "empty",
+		previousEndpointsMap:           map[ServicePortName][]*BaseEndpointInfo{},
+		expectedResult:                 map[ServicePortName][]*BaseEndpointInfo{},
+		expectedDeletedUDPEndpoints:    []ServiceEndpoint{},
+		expectedNewlyActiveUDPServices: map[ServicePortName]bool{},
+		expectedLocalEndpoints:         map[types.NamespacedName]int{},
+		expectedChangedEndpoints:       sets.New[types.NamespacedName](),
 	}, {
 		name: "no change, unnamed port",
 		previousEndpointSlices: []*discovery.EndpointSlice{
@@ -558,9 +560,10 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{ip: "1.1.1.1", port: 11, endpoint: "1.1.1.1:11", isLocal: false, ready: true, serving: true, terminating: false},
 			},
 		},
-		expectedConntrackCleanupRequired: false,
-		expectedLocalEndpoints:           map[types.NamespacedName]int{},
-		expectedChangedEndpoints:         sets.New[types.NamespacedName](),
+		expectedDeletedUDPEndpoints:    []ServiceEndpoint{},
+		expectedNewlyActiveUDPServices: map[ServicePortName]bool{},
+		expectedLocalEndpoints:         map[types.NamespacedName]int{},
+		expectedChangedEndpoints:       sets.New[types.NamespacedName](),
 	}, {
 		name: "no change, named port, local",
 		previousEndpointSlices: []*discovery.EndpointSlice{
@@ -579,7 +582,8 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{ip: "1.1.1.1", port: 11, endpoint: "1.1.1.1:11", isLocal: true, ready: true, serving: true, terminating: false},
 			},
 		},
-		expectedConntrackCleanupRequired: false,
+		expectedDeletedUDPEndpoints:    []ServiceEndpoint{},
+		expectedNewlyActiveUDPServices: map[ServicePortName]bool{},
 		expectedLocalEndpoints: map[types.NamespacedName]int{
 			makeNSN("ns1", "ep1"): 1,
 		},
@@ -610,9 +614,10 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{ip: "1.1.1.2", port: 12, endpoint: "1.1.1.2:12", isLocal: false, ready: true, serving: true, terminating: false},
 			},
 		},
-		expectedConntrackCleanupRequired: false,
-		expectedLocalEndpoints:           map[types.NamespacedName]int{},
-		expectedChangedEndpoints:         sets.New[types.NamespacedName](),
+		expectedDeletedUDPEndpoints:    []ServiceEndpoint{},
+		expectedNewlyActiveUDPServices: map[ServicePortName]bool{},
+		expectedLocalEndpoints:         map[types.NamespacedName]int{},
+		expectedChangedEndpoints:       sets.New[types.NamespacedName](),
 	}, {
 		name: "no change, multiple slices, multiple ports, local",
 		previousEndpointSlices: []*discovery.EndpointSlice{
@@ -645,7 +650,8 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{ip: "1.1.1.3", port: 13, endpoint: "1.1.1.3:13", isLocal: false, ready: true, serving: true, terminating: false},
 			},
 		},
-		expectedConntrackCleanupRequired: false,
+		expectedDeletedUDPEndpoints:    []ServiceEndpoint{},
+		expectedNewlyActiveUDPServices: map[ServicePortName]bool{},
 		expectedLocalEndpoints: map[types.NamespacedName]int{
 			makeNSN("ns1", "ep1"): 1,
 		},
@@ -714,7 +720,8 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{ip: "2.2.2.2", port: 22, endpoint: "2.2.2.2:22", isLocal: true, ready: true, serving: true, terminating: false},
 			},
 		},
-		expectedConntrackCleanupRequired: false,
+		expectedDeletedUDPEndpoints:    []ServiceEndpoint{},
+		expectedNewlyActiveUDPServices: map[ServicePortName]bool{},
 		expectedLocalEndpoints: map[types.NamespacedName]int{
 			makeNSN("ns1", "ep1"): 2,
 			makeNSN("ns2", "ep2"): 1,
@@ -734,7 +741,10 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{ip: "1.1.1.1", port: 11, endpoint: "1.1.1.1:11", isLocal: true, ready: true, serving: true, terminating: false},
 			},
 		},
-		expectedConntrackCleanupRequired: true,
+		expectedDeletedUDPEndpoints: []ServiceEndpoint{},
+		expectedNewlyActiveUDPServices: map[ServicePortName]bool{
+			makeServicePortName("ns1", "ep1", "", v1.ProtocolUDP): true,
+		},
 		expectedLocalEndpoints: map[types.NamespacedName]int{
 			makeNSN("ns1", "ep1"): 1,
 		},
@@ -752,10 +762,14 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{ip: "1.1.1.1", port: 11, endpoint: "1.1.1.1:11", isLocal: true, ready: true, serving: true, terminating: false},
 			},
 		},
-		expectedConntrackCleanupRequired: true,
-		expectedResult:                   map[ServicePortName][]*BaseEndpointInfo{},
-		expectedLocalEndpoints:           map[types.NamespacedName]int{},
-		expectedChangedEndpoints:         sets.New(makeNSN("ns1", "ep1")),
+		expectedResult: map[ServicePortName][]*BaseEndpointInfo{},
+		expectedDeletedUDPEndpoints: []ServiceEndpoint{{
+			Endpoint:        "1.1.1.1:11",
+			ServicePortName: makeServicePortName("ns1", "ep1", "", v1.ProtocolUDP),
+		}},
+		expectedNewlyActiveUDPServices: map[ServicePortName]bool{},
+		expectedLocalEndpoints:         map[types.NamespacedName]int{},
+		expectedChangedEndpoints:       sets.New(makeNSN("ns1", "ep1")),
 	}, {
 		name: "add an IP and port",
 		previousEndpointSlices: []*discovery.EndpointSlice{
@@ -779,7 +793,10 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{ip: "1.1.1.2", port: 12, endpoint: "1.1.1.2:12", isLocal: true, ready: true, serving: true, terminating: false},
 			},
 		},
-		expectedConntrackCleanupRequired: true,
+		expectedDeletedUDPEndpoints: []ServiceEndpoint{},
+		expectedNewlyActiveUDPServices: map[ServicePortName]bool{
+			makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP): true,
+		},
 		expectedLocalEndpoints: map[types.NamespacedName]int{
 			makeNSN("ns1", "ep1"): 1,
 		},
@@ -807,9 +824,19 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{ip: "1.1.1.1", port: 11, endpoint: "1.1.1.1:11", isLocal: false, ready: true, serving: true, terminating: false},
 			},
 		},
-		expectedConntrackCleanupRequired: true,
-		expectedLocalEndpoints:           map[types.NamespacedName]int{},
-		expectedChangedEndpoints:         sets.New(makeNSN("ns1", "ep1")),
+		expectedDeletedUDPEndpoints: []ServiceEndpoint{{
+			Endpoint:        "1.1.1.2:11",
+			ServicePortName: makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP),
+		}, {
+			Endpoint:        "1.1.1.1:12",
+			ServicePortName: makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP),
+		}, {
+			Endpoint:        "1.1.1.2:12",
+			ServicePortName: makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP),
+		}},
+		expectedNewlyActiveUDPServices: map[ServicePortName]bool{},
+		expectedLocalEndpoints:         map[types.NamespacedName]int{},
+		expectedChangedEndpoints:       sets.New(makeNSN("ns1", "ep1")),
 	}, {
 		name: "add a slice to an endpoint",
 		previousEndpointSlices: []*discovery.EndpointSlice{
@@ -833,7 +860,10 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{ip: "1.1.1.2", port: 12, endpoint: "1.1.1.2:12", isLocal: true, ready: true, serving: true, terminating: false},
 			},
 		},
-		expectedConntrackCleanupRequired: true,
+		expectedDeletedUDPEndpoints: []ServiceEndpoint{},
+		expectedNewlyActiveUDPServices: map[ServicePortName]bool{
+			makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP): true,
+		},
 		expectedLocalEndpoints: map[types.NamespacedName]int{
 			makeNSN("ns1", "ep1"): 1,
 		},
@@ -861,9 +891,13 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{ip: "1.1.1.1", port: 11, endpoint: "1.1.1.1:11", isLocal: false, ready: true, serving: true, terminating: false},
 			},
 		},
-		expectedConntrackCleanupRequired: true,
-		expectedLocalEndpoints:           map[types.NamespacedName]int{},
-		expectedChangedEndpoints:         sets.New(makeNSN("ns1", "ep1")),
+		expectedDeletedUDPEndpoints: []ServiceEndpoint{{
+			Endpoint:        "1.1.1.2:12",
+			ServicePortName: makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP),
+		}},
+		expectedNewlyActiveUDPServices: map[ServicePortName]bool{},
+		expectedLocalEndpoints:         map[types.NamespacedName]int{},
+		expectedChangedEndpoints:       sets.New(makeNSN("ns1", "ep1")),
 	}, {
 		name: "rename a port",
 		previousEndpointSlices: []*discovery.EndpointSlice{
@@ -882,9 +916,15 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{ip: "1.1.1.1", port: 11, endpoint: "1.1.1.1:11", isLocal: false, ready: true, serving: true, terminating: false},
 			},
 		},
-		expectedConntrackCleanupRequired: true,
-		expectedLocalEndpoints:           map[types.NamespacedName]int{},
-		expectedChangedEndpoints:         sets.New(makeNSN("ns1", "ep1")),
+		expectedDeletedUDPEndpoints: []ServiceEndpoint{{
+			Endpoint:        "1.1.1.1:11",
+			ServicePortName: makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP),
+		}},
+		expectedNewlyActiveUDPServices: map[ServicePortName]bool{
+			makeServicePortName("ns1", "ep1", "p11-2", v1.ProtocolUDP): true,
+		},
+		expectedLocalEndpoints:   map[types.NamespacedName]int{},
+		expectedChangedEndpoints: sets.New(makeNSN("ns1", "ep1")),
 	}, {
 		name: "renumber a port",
 		previousEndpointSlices: []*discovery.EndpointSlice{
@@ -903,9 +943,13 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{ip: "1.1.1.1", port: 22, endpoint: "1.1.1.1:22", isLocal: false, ready: true, serving: true, terminating: false},
 			},
 		},
-		expectedConntrackCleanupRequired: true,
-		expectedLocalEndpoints:           map[types.NamespacedName]int{},
-		expectedChangedEndpoints:         sets.New(makeNSN("ns1", "ep1")),
+		expectedDeletedUDPEndpoints: []ServiceEndpoint{{
+			Endpoint:        "1.1.1.1:11",
+			ServicePortName: makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP),
+		}},
+		expectedNewlyActiveUDPServices: map[ServicePortName]bool{},
+		expectedLocalEndpoints:         map[types.NamespacedName]int{},
+		expectedChangedEndpoints:       sets.New(makeNSN("ns1", "ep1")),
 	}, {
 		name: "complex add and remove",
 		previousEndpointSlices: []*discovery.EndpointSlice{
@@ -971,7 +1015,27 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{ip: "4.4.4.4", port: 44, endpoint: "4.4.4.4:44", isLocal: true, ready: true, serving: true, terminating: false},
 			},
 		},
-		expectedConntrackCleanupRequired: true,
+		expectedDeletedUDPEndpoints: []ServiceEndpoint{{
+			Endpoint:        "2.2.2.2:22",
+			ServicePortName: makeServicePortName("ns2", "ep2", "p22", v1.ProtocolUDP),
+		}, {
+			Endpoint:        "2.2.2.22:22",
+			ServicePortName: makeServicePortName("ns2", "ep2", "p22", v1.ProtocolUDP),
+		}, {
+			Endpoint:        "2.2.2.3:23",
+			ServicePortName: makeServicePortName("ns2", "ep2", "p23", v1.ProtocolUDP),
+		}, {
+			Endpoint:        "4.4.4.5:44",
+			ServicePortName: makeServicePortName("ns4", "ep4", "p44", v1.ProtocolUDP),
+		}, {
+			Endpoint:        "4.4.4.6:45",
+			ServicePortName: makeServicePortName("ns4", "ep4", "p45", v1.ProtocolUDP),
+		}},
+		expectedNewlyActiveUDPServices: map[ServicePortName]bool{
+			makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP):  true,
+			makeServicePortName("ns1", "ep1", "p122", v1.ProtocolUDP): true,
+			makeServicePortName("ns3", "ep3", "p33", v1.ProtocolUDP):  true,
+		},
 		expectedLocalEndpoints: map[types.NamespacedName]int{
 			makeNSN("ns4", "ep4"): 1,
 		},
@@ -990,9 +1054,12 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{ip: "1.1.1.1", port: 11, endpoint: "1.1.1.1:11", isLocal: false, ready: true, serving: true, terminating: false},
 			},
 		},
-		expectedConntrackCleanupRequired: true,
-		expectedLocalEndpoints:           map[types.NamespacedName]int{},
-		expectedChangedEndpoints:         sets.New(makeNSN("ns1", "ep1")),
+		expectedDeletedUDPEndpoints: []ServiceEndpoint{},
+		expectedNewlyActiveUDPServices: map[ServicePortName]bool{
+			makeServicePortName("ns1", "ep1", "", v1.ProtocolUDP): true,
+		},
+		expectedLocalEndpoints:   map[types.NamespacedName]int{},
+		expectedChangedEndpoints: sets.New(makeNSN("ns1", "ep1")),
 	}, {
 		name: "change from ready to terminating pod",
 		previousEndpointSlices: []*discovery.EndpointSlice{
@@ -1011,9 +1078,10 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{ip: "1.1.1.1", port: 11, endpoint: "1.1.1.1:11", isLocal: false, ready: false, serving: true, terminating: true},
 			},
 		},
-		expectedConntrackCleanupRequired: true,
-		expectedLocalEndpoints:           map[types.NamespacedName]int{},
-		expectedChangedEndpoints:         sets.New(makeNSN("ns1", "ep1")),
+		expectedDeletedUDPEndpoints:    []ServiceEndpoint{},
+		expectedNewlyActiveUDPServices: map[ServicePortName]bool{},
+		expectedLocalEndpoints:         map[types.NamespacedName]int{},
+		expectedChangedEndpoints:       sets.New(makeNSN("ns1", "ep1")),
 	}, {
 		name: "change from terminating to empty pod",
 		previousEndpointSlices: []*discovery.EndpointSlice{
@@ -1027,10 +1095,14 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{ip: "1.1.1.1", port: 11, endpoint: "1.1.1.1:11", isLocal: false, ready: false, serving: true, terminating: true},
 			},
 		},
-		expectedConntrackCleanupRequired: true,
-		expectedResult:                   map[ServicePortName][]*BaseEndpointInfo{},
-		expectedLocalEndpoints:           map[types.NamespacedName]int{},
-		expectedChangedEndpoints:         sets.New(makeNSN("ns1", "ep1")),
+		expectedResult: map[ServicePortName][]*BaseEndpointInfo{},
+		expectedDeletedUDPEndpoints: []ServiceEndpoint{{
+			Endpoint:        "1.1.1.1:11",
+			ServicePortName: makeServicePortName("ns1", "ep1", "", v1.ProtocolUDP),
+		}},
+		expectedNewlyActiveUDPServices: map[ServicePortName]bool{},
+		expectedLocalEndpoints:         map[types.NamespacedName]int{},
+		expectedChangedEndpoints:       sets.New(makeNSN("ns1", "ep1")),
 	},
 	}
 
@@ -1075,9 +1147,36 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			if !result.UpdatedServices.Equal(tc.expectedChangedEndpoints) {
 				t.Errorf("[%d] expected changed endpoints %q, got %q", tci, tc.expectedChangedEndpoints.UnsortedList(), result.UpdatedServices.UnsortedList())
 			}
-			if result.ConntrackCleanupRequired != tc.expectedConntrackCleanupRequired {
-				t.Errorf("[%d] expected conntrackCleanupRequired to be %t, got %t", tci, tc.expectedConntrackCleanupRequired, result.ConntrackCleanupRequired)
+			if len(result.DeletedUDPEndpoints) != len(tc.expectedDeletedUDPEndpoints) {
+				t.Errorf("[%d] expected %d staleEndpoints, got %d: %v", tci, len(tc.expectedDeletedUDPEndpoints), len(result.DeletedUDPEndpoints), result.DeletedUDPEndpoints)
 			}
+			for _, x := range tc.expectedDeletedUDPEndpoints {
+				found := false
+				for _, stale := range result.DeletedUDPEndpoints {
+					if stale == x {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("[%d] expected staleEndpoints[%v], but didn't find it: %v", tci, x, result.DeletedUDPEndpoints)
+				}
+			}
+			if len(result.NewlyActiveUDPServices) != len(tc.expectedNewlyActiveUDPServices) {
+				t.Errorf("[%d] expected %d newlyActiveUDPServices, got %d: %v", tci, len(tc.expectedNewlyActiveUDPServices), len(result.NewlyActiveUDPServices), result.NewlyActiveUDPServices)
+			}
+			for svcName := range tc.expectedNewlyActiveUDPServices {
+				found := false
+				for _, newSvcName := range result.NewlyActiveUDPServices {
+					if newSvcName == svcName {
+						found = true
+					}
+				}
+				if !found {
+					t.Errorf("[%d] expected newlyActiveUDPServices[%v], but didn't find it: %v", tci, svcName, result.NewlyActiveUDPServices)
+				}
+			}
+
 			localReadyEndpoints := fp.endpointsMap.LocalReadyEndpoints()
 			if !reflect.DeepEqual(localReadyEndpoints, tc.expectedLocalEndpoints) {
 				t.Errorf("[%d] expected local ready endpoints %v, got %v", tci, tc.expectedLocalEndpoints, localReadyEndpoints)

--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -1594,10 +1594,8 @@ func (proxier *Proxier) syncProxyRules() {
 		proxier.logger.Error(err, "Error syncing healthcheck endpoints")
 	}
 
-	if endpointUpdateResult.ConntrackCleanupRequired {
-		// Finish housekeeping, clear stale conntrack entries for UDP Services
-		conntrack.CleanStaleEntries(proxier.conntrack, proxier.ipFamily, proxier.svcPortMap, proxier.endpointsMap)
-	}
+	// Finish housekeeping, clear stale conntrack entries for UDP Services
+	conntrack.CleanStaleEntries(proxier.conntrack, proxier.ipFamily, proxier.svcPortMap, serviceUpdateResult, endpointUpdateResult)
 }
 
 func (proxier *Proxier) writeServiceToEndpointRules(natRules proxyutil.LineBuffer, svcPortNameString string, svcInfo proxy.ServicePort, svcChain utiliptables.Chain, endpoints []proxy.Endpoint, args []string) {

--- a/pkg/proxy/iptables/proxier_test.go
+++ b/pkg/proxy/iptables/proxier_test.go
@@ -2966,9 +2966,14 @@ func TestBuildServiceMapAddRemove(t *testing.T) {
 	for i := range services {
 		fp.OnServiceAdd(services[i])
 	}
-	fp.svcPortMap.Update(fp.serviceChanges)
+	result := fp.svcPortMap.Update(fp.serviceChanges)
 	if len(fp.svcPortMap) != 10 {
 		t.Errorf("expected service map length 10, got %v", fp.svcPortMap)
+	}
+
+	if len(result.DeletedUDPClusterIPs) != 0 {
+		// Services only added, so nothing stale yet
+		t.Errorf("expected stale UDP services length 0, got %d", len(result.DeletedUDPClusterIPs))
 	}
 
 	// The only-local-loadbalancer ones get added
@@ -2995,9 +3000,22 @@ func TestBuildServiceMapAddRemove(t *testing.T) {
 	fp.OnServiceDelete(services[2])
 	fp.OnServiceDelete(services[3])
 
-	fp.svcPortMap.Update(fp.serviceChanges)
+	result = fp.svcPortMap.Update(fp.serviceChanges)
 	if len(fp.svcPortMap) != 1 {
 		t.Errorf("expected service map length 1, got %v", fp.svcPortMap)
+	}
+
+	// All services but one were deleted. While you'd expect only the ClusterIPs
+	// from the three deleted services here, we still have the ClusterIP for
+	// the not-deleted service, because one of it's ServicePorts was deleted.
+	expectedStaleUDPServices := []string{"172.30.55.10", "172.30.55.4", "172.30.55.11", "172.30.55.12"}
+	if len(result.DeletedUDPClusterIPs) != len(expectedStaleUDPServices) {
+		t.Errorf("expected stale UDP services length %d, got %v", len(expectedStaleUDPServices), result.DeletedUDPClusterIPs.UnsortedList())
+	}
+	for _, ip := range expectedStaleUDPServices {
+		if !result.DeletedUDPClusterIPs.Has(ip) {
+			t.Errorf("expected stale UDP service service %s", ip)
+		}
 	}
 
 	healthCheckNodePorts = fp.svcPortMap.HealthCheckNodePorts()
@@ -3023,9 +3041,13 @@ func TestBuildServiceMapServiceHeadless(t *testing.T) {
 	)
 
 	// Headless service should be ignored
-	fp.svcPortMap.Update(fp.serviceChanges)
+	result := fp.svcPortMap.Update(fp.serviceChanges)
 	if len(fp.svcPortMap) != 0 {
 		t.Errorf("expected service map length 0, got %d", len(fp.svcPortMap))
+	}
+
+	if len(result.DeletedUDPClusterIPs) != 0 {
+		t.Errorf("expected stale UDP services length 0, got %d", len(result.DeletedUDPClusterIPs))
 	}
 
 	// No proxied services, so no healthchecks
@@ -3048,9 +3070,12 @@ func TestBuildServiceMapServiceTypeExternalName(t *testing.T) {
 		}),
 	)
 
-	fp.svcPortMap.Update(fp.serviceChanges)
+	result := fp.svcPortMap.Update(fp.serviceChanges)
 	if len(fp.svcPortMap) != 0 {
 		t.Errorf("expected service map length 0, got %v", fp.svcPortMap)
+	}
+	if len(result.DeletedUDPClusterIPs) != 0 {
+		t.Errorf("expected stale UDP services length 0, got %v", result.DeletedUDPClusterIPs)
 	}
 	// No proxied services, so no healthchecks
 	healthCheckNodePorts := fp.svcPortMap.HealthCheckNodePorts()
@@ -3086,9 +3111,13 @@ func TestBuildServiceMapServiceUpdate(t *testing.T) {
 
 	fp.OnServiceAdd(servicev1)
 
-	fp.svcPortMap.Update(fp.serviceChanges)
+	result := fp.svcPortMap.Update(fp.serviceChanges)
 	if len(fp.svcPortMap) != 2 {
 		t.Errorf("expected service map length 2, got %v", fp.svcPortMap)
+	}
+	if len(result.DeletedUDPClusterIPs) != 0 {
+		// Services only added, so nothing stale yet
+		t.Errorf("expected stale UDP services length 0, got %d", len(result.DeletedUDPClusterIPs))
 	}
 	healthCheckNodePorts := fp.svcPortMap.HealthCheckNodePorts()
 	if len(healthCheckNodePorts) != 0 {
@@ -3097,9 +3126,12 @@ func TestBuildServiceMapServiceUpdate(t *testing.T) {
 
 	// Change service to load-balancer
 	fp.OnServiceUpdate(servicev1, servicev2)
-	fp.svcPortMap.Update(fp.serviceChanges)
+	result = fp.svcPortMap.Update(fp.serviceChanges)
 	if len(fp.svcPortMap) != 2 {
 		t.Errorf("expected service map length 2, got %v", fp.svcPortMap)
+	}
+	if len(result.DeletedUDPClusterIPs) != 0 {
+		t.Errorf("expected stale UDP services length 0, got %v", result.DeletedUDPClusterIPs.UnsortedList())
 	}
 	healthCheckNodePorts = fp.svcPortMap.HealthCheckNodePorts()
 	if len(healthCheckNodePorts) != 1 {
@@ -3109,9 +3141,12 @@ func TestBuildServiceMapServiceUpdate(t *testing.T) {
 	// No change; make sure the service map stays the same and there are
 	// no health-check changes
 	fp.OnServiceUpdate(servicev2, servicev2)
-	fp.svcPortMap.Update(fp.serviceChanges)
+	result = fp.svcPortMap.Update(fp.serviceChanges)
 	if len(fp.svcPortMap) != 2 {
 		t.Errorf("expected service map length 2, got %v", fp.svcPortMap)
+	}
+	if len(result.DeletedUDPClusterIPs) != 0 {
+		t.Errorf("expected stale UDP services length 0, got %v", result.DeletedUDPClusterIPs.UnsortedList())
 	}
 	healthCheckNodePorts = fp.svcPortMap.HealthCheckNodePorts()
 	if len(healthCheckNodePorts) != 1 {
@@ -3120,9 +3155,13 @@ func TestBuildServiceMapServiceUpdate(t *testing.T) {
 
 	// And back to ClusterIP
 	fp.OnServiceUpdate(servicev2, servicev1)
-	fp.svcPortMap.Update(fp.serviceChanges)
+	result = fp.svcPortMap.Update(fp.serviceChanges)
 	if len(fp.svcPortMap) != 2 {
 		t.Errorf("expected service map length 2, got %v", fp.svcPortMap)
+	}
+	if len(result.DeletedUDPClusterIPs) != 0 {
+		// Services only added, so nothing stale yet
+		t.Errorf("expected stale UDP services length 0, got %d", len(result.DeletedUDPClusterIPs))
 	}
 	healthCheckNodePorts = fp.svcPortMap.HealthCheckNodePorts()
 	if len(healthCheckNodePorts) != 0 {
@@ -3525,20 +3564,22 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		// previousEndpoints and currentEndpoints are used to call appropriate
 		// handlers OnEndpoints* (based on whether corresponding values are nil
 		// or non-nil) and must be of equal length.
-		name                             string
-		previousEndpoints                []*discovery.EndpointSlice
-		currentEndpoints                 []*discovery.EndpointSlice
-		oldEndpoints                     map[proxy.ServicePortName][]endpointExpectation
-		expectedResult                   map[proxy.ServicePortName][]endpointExpectation
-		expectedConntrackCleanupRequired bool
-		expectedLocalEndpoints           map[types.NamespacedName]int
+		name                           string
+		previousEndpoints              []*discovery.EndpointSlice
+		currentEndpoints               []*discovery.EndpointSlice
+		oldEndpoints                   map[proxy.ServicePortName][]endpointExpectation
+		expectedResult                 map[proxy.ServicePortName][]endpointExpectation
+		expectedDeletedUDPEndpoints    []proxy.ServiceEndpoint
+		expectedNewlyActiveUDPServices map[proxy.ServicePortName]bool
+		expectedLocalEndpoints         map[types.NamespacedName]int
 	}{{
 		// Case[0]: nothing
-		name:                             "nothing",
-		oldEndpoints:                     map[proxy.ServicePortName][]endpointExpectation{},
-		expectedResult:                   map[proxy.ServicePortName][]endpointExpectation{},
-		expectedConntrackCleanupRequired: false,
-		expectedLocalEndpoints:           map[types.NamespacedName]int{},
+		name:                           "nothing",
+		oldEndpoints:                   map[proxy.ServicePortName][]endpointExpectation{},
+		expectedResult:                 map[proxy.ServicePortName][]endpointExpectation{},
+		expectedDeletedUDPEndpoints:    []proxy.ServiceEndpoint{},
+		expectedNewlyActiveUDPServices: map[proxy.ServicePortName]bool{},
+		expectedLocalEndpoints:         map[types.NamespacedName]int{},
 	}, {
 		// Case[1]: no change, named port, local
 		name:              "no change, named port, local",
@@ -3554,7 +3595,8 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{endpoint: "10.1.1.1:11", isLocal: true},
 			},
 		},
-		expectedConntrackCleanupRequired: false,
+		expectedDeletedUDPEndpoints:    []proxy.ServiceEndpoint{},
+		expectedNewlyActiveUDPServices: map[proxy.ServicePortName]bool{},
 		expectedLocalEndpoints: map[types.NamespacedName]int{
 			makeNSN("ns1", "ep1"): 1,
 		},
@@ -3579,8 +3621,9 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{endpoint: "10.1.1.2:12", isLocal: false},
 			},
 		},
-		expectedConntrackCleanupRequired: false,
-		expectedLocalEndpoints:           map[types.NamespacedName]int{},
+		expectedDeletedUDPEndpoints:    []proxy.ServiceEndpoint{},
+		expectedNewlyActiveUDPServices: map[proxy.ServicePortName]bool{},
+		expectedLocalEndpoints:         map[types.NamespacedName]int{},
 	}, {
 		// Case[3]: no change, multiple subsets, multiple ports, local
 		name:              "no change, multiple subsets, multiple ports, local",
@@ -3608,7 +3651,8 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{endpoint: "10.1.1.3:13", isLocal: false},
 			},
 		},
-		expectedConntrackCleanupRequired: false,
+		expectedDeletedUDPEndpoints:    []proxy.ServiceEndpoint{},
+		expectedNewlyActiveUDPServices: map[proxy.ServicePortName]bool{},
 		expectedLocalEndpoints: map[types.NamespacedName]int{
 			makeNSN("ns1", "ep1"): 1,
 		},
@@ -3669,7 +3713,8 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{endpoint: "10.2.2.2:22", isLocal: true},
 			},
 		},
-		expectedConntrackCleanupRequired: false,
+		expectedDeletedUDPEndpoints:    []proxy.ServiceEndpoint{},
+		expectedNewlyActiveUDPServices: map[proxy.ServicePortName]bool{},
 		expectedLocalEndpoints: map[types.NamespacedName]int{
 			makeNSN("ns1", "ep1"): 2,
 			makeNSN("ns2", "ep2"): 1,
@@ -3685,7 +3730,10 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{endpoint: "10.1.1.1:11", isLocal: true},
 			},
 		},
-		expectedConntrackCleanupRequired: true,
+		expectedDeletedUDPEndpoints: []proxy.ServiceEndpoint{},
+		expectedNewlyActiveUDPServices: map[proxy.ServicePortName]bool{
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): true,
+		},
 		expectedLocalEndpoints: map[types.NamespacedName]int{
 			makeNSN("ns1", "ep1"): 1,
 		},
@@ -3699,9 +3747,13 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{endpoint: "10.1.1.1:11", isLocal: true},
 			},
 		},
-		expectedConntrackCleanupRequired: true,
-		expectedResult:                   map[proxy.ServicePortName][]endpointExpectation{},
-		expectedLocalEndpoints:           map[types.NamespacedName]int{},
+		expectedResult: map[proxy.ServicePortName][]endpointExpectation{},
+		expectedDeletedUDPEndpoints: []proxy.ServiceEndpoint{{
+			Endpoint:        "10.1.1.1:11",
+			ServicePortName: makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP),
+		}},
+		expectedNewlyActiveUDPServices: map[proxy.ServicePortName]bool{},
+		expectedLocalEndpoints:         map[types.NamespacedName]int{},
 	}, {
 		// Case[7]: add an IP and port
 		name:              "add an IP and port",
@@ -3722,7 +3774,10 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{endpoint: "10.1.1.2:12", isLocal: true},
 			},
 		},
-		expectedConntrackCleanupRequired: true,
+		expectedDeletedUDPEndpoints: []proxy.ServiceEndpoint{},
+		expectedNewlyActiveUDPServices: map[proxy.ServicePortName]bool{
+			makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP): true,
+		},
 		expectedLocalEndpoints: map[types.NamespacedName]int{
 			makeNSN("ns1", "ep1"): 1,
 		},
@@ -3746,8 +3801,18 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{endpoint: "10.1.1.1:11", isLocal: false},
 			},
 		},
-		expectedConntrackCleanupRequired: true,
-		expectedLocalEndpoints:           map[types.NamespacedName]int{},
+		expectedDeletedUDPEndpoints: []proxy.ServiceEndpoint{{
+			Endpoint:        "10.1.1.2:11",
+			ServicePortName: makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP),
+		}, {
+			Endpoint:        "10.1.1.1:12",
+			ServicePortName: makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP),
+		}, {
+			Endpoint:        "10.1.1.2:12",
+			ServicePortName: makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP),
+		}},
+		expectedNewlyActiveUDPServices: map[proxy.ServicePortName]bool{},
+		expectedLocalEndpoints:         map[types.NamespacedName]int{},
 	}, {
 		// Case[9]: add a subset
 		name:              "add a subset",
@@ -3766,7 +3831,10 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{endpoint: "10.1.1.2:12", isLocal: true},
 			},
 		},
-		expectedConntrackCleanupRequired: true,
+		expectedDeletedUDPEndpoints: []proxy.ServiceEndpoint{},
+		expectedNewlyActiveUDPServices: map[proxy.ServicePortName]bool{
+			makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP): true,
+		},
 		expectedLocalEndpoints: map[types.NamespacedName]int{
 			makeNSN("ns1", "ep1"): 1,
 		},
@@ -3788,8 +3856,12 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{endpoint: "10.1.1.1:11", isLocal: false},
 			},
 		},
-		expectedConntrackCleanupRequired: true,
-		expectedLocalEndpoints:           map[types.NamespacedName]int{},
+		expectedDeletedUDPEndpoints: []proxy.ServiceEndpoint{{
+			Endpoint:        "10.1.1.2:12",
+			ServicePortName: makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP),
+		}},
+		expectedNewlyActiveUDPServices: map[proxy.ServicePortName]bool{},
+		expectedLocalEndpoints:         map[types.NamespacedName]int{},
 	}, {
 		// Case[11]: rename a port
 		name:              "rename a port",
@@ -3805,8 +3877,14 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{endpoint: "10.1.1.1:11", isLocal: false},
 			},
 		},
-		expectedConntrackCleanupRequired: true,
-		expectedLocalEndpoints:           map[types.NamespacedName]int{},
+		expectedDeletedUDPEndpoints: []proxy.ServiceEndpoint{{
+			Endpoint:        "10.1.1.1:11",
+			ServicePortName: makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP),
+		}},
+		expectedNewlyActiveUDPServices: map[proxy.ServicePortName]bool{
+			makeServicePortName("ns1", "ep1", "p11-2", v1.ProtocolUDP): true,
+		},
+		expectedLocalEndpoints: map[types.NamespacedName]int{},
 	}, {
 		// Case[12]: renumber a port
 		name:              "renumber a port",
@@ -3822,8 +3900,12 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{endpoint: "10.1.1.1:22", isLocal: false},
 			},
 		},
-		expectedConntrackCleanupRequired: true,
-		expectedLocalEndpoints:           map[types.NamespacedName]int{},
+		expectedDeletedUDPEndpoints: []proxy.ServiceEndpoint{{
+			Endpoint:        "10.1.1.1:11",
+			ServicePortName: makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP),
+		}},
+		expectedNewlyActiveUDPServices: map[proxy.ServicePortName]bool{},
+		expectedLocalEndpoints:         map[types.NamespacedName]int{},
 	}, {
 		// Case[13]: complex add and remove
 		name:              "complex add and remove",
@@ -3866,7 +3948,27 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{endpoint: "10.4.4.4:44", isLocal: true},
 			},
 		},
-		expectedConntrackCleanupRequired: true,
+		expectedDeletedUDPEndpoints: []proxy.ServiceEndpoint{{
+			Endpoint:        "10.2.2.2:22",
+			ServicePortName: makeServicePortName("ns2", "ep2", "p22", v1.ProtocolUDP),
+		}, {
+			Endpoint:        "10.2.2.22:22",
+			ServicePortName: makeServicePortName("ns2", "ep2", "p22", v1.ProtocolUDP),
+		}, {
+			Endpoint:        "10.2.2.3:23",
+			ServicePortName: makeServicePortName("ns2", "ep2", "p23", v1.ProtocolUDP),
+		}, {
+			Endpoint:        "10.4.4.5:44",
+			ServicePortName: makeServicePortName("ns4", "ep4", "p44", v1.ProtocolUDP),
+		}, {
+			Endpoint:        "10.4.4.6:45",
+			ServicePortName: makeServicePortName("ns4", "ep4", "p45", v1.ProtocolUDP),
+		}},
+		expectedNewlyActiveUDPServices: map[proxy.ServicePortName]bool{
+			makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP):  true,
+			makeServicePortName("ns1", "ep1", "p122", v1.ProtocolUDP): true,
+			makeServicePortName("ns3", "ep3", "p33", v1.ProtocolUDP):  true,
+		},
 		expectedLocalEndpoints: map[types.NamespacedName]int{
 			makeNSN("ns4", "ep4"): 1,
 		},
@@ -3881,8 +3983,11 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{endpoint: "10.1.1.1:11", isLocal: false},
 			},
 		},
-		expectedConntrackCleanupRequired: true,
-		expectedLocalEndpoints:           map[types.NamespacedName]int{},
+		expectedDeletedUDPEndpoints: []proxy.ServiceEndpoint{},
+		expectedNewlyActiveUDPServices: map[proxy.ServicePortName]bool{
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): true,
+		},
+		expectedLocalEndpoints: map[types.NamespacedName]int{},
 	},
 	}
 
@@ -3921,8 +4026,34 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			result := fp.endpointsMap.Update(fp.endpointsChanges)
 			newMap := fp.endpointsMap
 			checkEndpointExpectations(t, tci, newMap, tc.expectedResult)
-			if result.ConntrackCleanupRequired != tc.expectedConntrackCleanupRequired {
-				t.Errorf("[%d] expected conntrackCleanupRequired to be %t, got %t", tci, tc.expectedConntrackCleanupRequired, result.ConntrackCleanupRequired)
+			if len(result.DeletedUDPEndpoints) != len(tc.expectedDeletedUDPEndpoints) {
+				t.Errorf("[%d] expected %d staleEndpoints, got %d: %v", tci, len(tc.expectedDeletedUDPEndpoints), len(result.DeletedUDPEndpoints), result.DeletedUDPEndpoints)
+			}
+			for _, x := range tc.expectedDeletedUDPEndpoints {
+				found := false
+				for _, stale := range result.DeletedUDPEndpoints {
+					if stale == x {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("[%d] expected staleEndpoints[%v], but didn't find it: %v", tci, x, result.DeletedUDPEndpoints)
+				}
+			}
+			if len(result.NewlyActiveUDPServices) != len(tc.expectedNewlyActiveUDPServices) {
+				t.Errorf("[%d] expected %d staleServiceNames, got %d: %v", tci, len(tc.expectedNewlyActiveUDPServices), len(result.NewlyActiveUDPServices), result.NewlyActiveUDPServices)
+			}
+			for svcName := range tc.expectedNewlyActiveUDPServices {
+				found := false
+				for _, stale := range result.NewlyActiveUDPServices {
+					if stale == svcName {
+						found = true
+					}
+				}
+				if !found {
+					t.Errorf("[%d] expected staleServiceNames[%v], but didn't find it: %v", tci, svcName, result.NewlyActiveUDPServices)
+				}
 			}
 			localReadyEndpoints := fp.endpointsMap.LocalReadyEndpoints()
 			if !reflect.DeepEqual(localReadyEndpoints, tc.expectedLocalEndpoints) {

--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -932,7 +932,7 @@ func (proxier *Proxier) syncProxyRules() {
 	// We assume that if this was called, we really want to sync them,
 	// even if nothing changed in the meantime. In other words, callers are
 	// responsible for detecting no-op changes and not calling this function.
-	_ = proxier.svcPortMap.Update(proxier.serviceChanges)
+	serviceUpdateResult := proxier.svcPortMap.Update(proxier.serviceChanges)
 	endpointUpdateResult := proxier.endpointsMap.Update(proxier.endpointsChanges)
 
 	proxier.logger.V(3).Info("Syncing ipvs proxier rules")
@@ -1497,10 +1497,8 @@ func (proxier *Proxier) syncProxyRules() {
 	metrics.SyncProxyRulesNoLocalEndpointsTotal.WithLabelValues("internal").Set(float64(proxier.serviceNoLocalEndpointsInternal.Len()))
 	metrics.SyncProxyRulesNoLocalEndpointsTotal.WithLabelValues("external").Set(float64(proxier.serviceNoLocalEndpointsExternal.Len()))
 
-	if endpointUpdateResult.ConntrackCleanupRequired {
-		// Finish housekeeping, clear stale conntrack entries for UDP Services
-		conntrack.CleanStaleEntries(proxier.conntrack, proxier.ipFamily, proxier.svcPortMap, proxier.endpointsMap)
-	}
+	// Finish housekeeping, clear stale conntrack entries for UDP Services
+	conntrack.CleanStaleEntries(proxier.conntrack, proxier.ipFamily, proxier.svcPortMap, serviceUpdateResult, endpointUpdateResult)
 }
 
 // writeIptablesRules write all iptables rules to proxier.natRules or proxier.FilterRules that ipvs proxier needed

--- a/pkg/proxy/nftables/proxier.go
+++ b/pkg/proxy/nftables/proxier.go
@@ -1838,10 +1838,8 @@ func (proxier *Proxier) syncProxyRules() {
 		proxier.logger.Error(err, "Error syncing healthcheck endpoints")
 	}
 
-	if endpointUpdateResult.ConntrackCleanupRequired {
-		// Finish housekeeping, clear stale conntrack entries for UDP Services
-		conntrack.CleanStaleEntries(proxier.conntrack, proxier.ipFamily, proxier.svcPortMap, proxier.endpointsMap)
-	}
+	// Finish housekeeping, clear stale conntrack entries for UDP Services
+	conntrack.CleanStaleEntries(proxier.conntrack, proxier.ipFamily, proxier.svcPortMap, serviceUpdateResult, endpointUpdateResult)
 }
 
 func (proxier *Proxier) writeServiceToEndpointRules(tx *knftables.Transaction, svcInfo *servicePortInfo, svcChain string, endpoints []proxy.Endpoint) {

--- a/pkg/proxy/nftables/proxier_test.go
+++ b/pkg/proxy/nftables/proxier_test.go
@@ -1374,9 +1374,14 @@ func TestBuildServiceMapAddRemove(t *testing.T) {
 	for i := range services {
 		fp.OnServiceAdd(services[i])
 	}
-	fp.svcPortMap.Update(fp.serviceChanges)
+	result := fp.svcPortMap.Update(fp.serviceChanges)
 	if len(fp.svcPortMap) != 10 {
 		t.Errorf("expected service map length 10, got %v", fp.svcPortMap)
+	}
+
+	if len(result.DeletedUDPClusterIPs) != 0 {
+		// Services only added, so nothing stale yet
+		t.Errorf("expected stale UDP services length 0, got %d", len(result.DeletedUDPClusterIPs))
 	}
 
 	// The only-local-loadbalancer ones get added
@@ -1403,9 +1408,22 @@ func TestBuildServiceMapAddRemove(t *testing.T) {
 	fp.OnServiceDelete(services[2])
 	fp.OnServiceDelete(services[3])
 
-	fp.svcPortMap.Update(fp.serviceChanges)
+	result = fp.svcPortMap.Update(fp.serviceChanges)
 	if len(fp.svcPortMap) != 1 {
 		t.Errorf("expected service map length 1, got %v", fp.svcPortMap)
+	}
+
+	// All services but one were deleted. While you'd expect only the ClusterIPs
+	// from the three deleted services here, we still have the ClusterIP for
+	// the not-deleted service, because one of it's ServicePorts was deleted.
+	expectedStaleUDPServices := []string{"172.30.55.10", "172.30.55.4", "172.30.55.11", "172.30.55.12"}
+	if len(result.DeletedUDPClusterIPs) != len(expectedStaleUDPServices) {
+		t.Errorf("expected stale UDP services length %d, got %v", len(expectedStaleUDPServices), result.DeletedUDPClusterIPs.UnsortedList())
+	}
+	for _, ip := range expectedStaleUDPServices {
+		if !result.DeletedUDPClusterIPs.Has(ip) {
+			t.Errorf("expected stale UDP service service %s", ip)
+		}
 	}
 
 	healthCheckNodePorts = fp.svcPortMap.HealthCheckNodePorts()
@@ -1430,9 +1448,13 @@ func TestBuildServiceMapServiceHeadless(t *testing.T) {
 	)
 
 	// Headless service should be ignored
-	fp.svcPortMap.Update(fp.serviceChanges)
+	result := fp.svcPortMap.Update(fp.serviceChanges)
 	if len(fp.svcPortMap) != 0 {
 		t.Errorf("expected service map length 0, got %d", len(fp.svcPortMap))
+	}
+
+	if len(result.DeletedUDPClusterIPs) != 0 {
+		t.Errorf("expected stale UDP services length 0, got %d", len(result.DeletedUDPClusterIPs))
 	}
 
 	// No proxied services, so no healthchecks
@@ -1454,9 +1476,12 @@ func TestBuildServiceMapServiceTypeExternalName(t *testing.T) {
 		}),
 	)
 
-	fp.svcPortMap.Update(fp.serviceChanges)
+	result := fp.svcPortMap.Update(fp.serviceChanges)
 	if len(fp.svcPortMap) != 0 {
 		t.Errorf("expected service map length 0, got %v", fp.svcPortMap)
+	}
+	if len(result.DeletedUDPClusterIPs) != 0 {
+		t.Errorf("expected stale UDP services length 0, got %v", result.DeletedUDPClusterIPs)
 	}
 	// No proxied services, so no healthchecks
 	healthCheckNodePorts := fp.svcPortMap.HealthCheckNodePorts()
@@ -1491,9 +1516,13 @@ func TestBuildServiceMapServiceUpdate(t *testing.T) {
 
 	fp.OnServiceAdd(servicev1)
 
-	fp.svcPortMap.Update(fp.serviceChanges)
+	result := fp.svcPortMap.Update(fp.serviceChanges)
 	if len(fp.svcPortMap) != 2 {
 		t.Errorf("expected service map length 2, got %v", fp.svcPortMap)
+	}
+	if len(result.DeletedUDPClusterIPs) != 0 {
+		// Services only added, so nothing stale yet
+		t.Errorf("expected stale UDP services length 0, got %d", len(result.DeletedUDPClusterIPs))
 	}
 	healthCheckNodePorts := fp.svcPortMap.HealthCheckNodePorts()
 	if len(healthCheckNodePorts) != 0 {
@@ -1502,9 +1531,12 @@ func TestBuildServiceMapServiceUpdate(t *testing.T) {
 
 	// Change service to load-balancer
 	fp.OnServiceUpdate(servicev1, servicev2)
-	fp.svcPortMap.Update(fp.serviceChanges)
+	result = fp.svcPortMap.Update(fp.serviceChanges)
 	if len(fp.svcPortMap) != 2 {
 		t.Errorf("expected service map length 2, got %v", fp.svcPortMap)
+	}
+	if len(result.DeletedUDPClusterIPs) != 0 {
+		t.Errorf("expected stale UDP services length 0, got %v", result.DeletedUDPClusterIPs.UnsortedList())
 	}
 	healthCheckNodePorts = fp.svcPortMap.HealthCheckNodePorts()
 	if len(healthCheckNodePorts) != 1 {
@@ -1514,9 +1546,12 @@ func TestBuildServiceMapServiceUpdate(t *testing.T) {
 	// No change; make sure the service map stays the same and there are
 	// no health-check changes
 	fp.OnServiceUpdate(servicev2, servicev2)
-	fp.svcPortMap.Update(fp.serviceChanges)
+	result = fp.svcPortMap.Update(fp.serviceChanges)
 	if len(fp.svcPortMap) != 2 {
 		t.Errorf("expected service map length 2, got %v", fp.svcPortMap)
+	}
+	if len(result.DeletedUDPClusterIPs) != 0 {
+		t.Errorf("expected stale UDP services length 0, got %v", result.DeletedUDPClusterIPs.UnsortedList())
 	}
 	healthCheckNodePorts = fp.svcPortMap.HealthCheckNodePorts()
 	if len(healthCheckNodePorts) != 1 {
@@ -1525,9 +1560,13 @@ func TestBuildServiceMapServiceUpdate(t *testing.T) {
 
 	// And back to ClusterIP
 	fp.OnServiceUpdate(servicev2, servicev1)
-	fp.svcPortMap.Update(fp.serviceChanges)
+	result = fp.svcPortMap.Update(fp.serviceChanges)
 	if len(fp.svcPortMap) != 2 {
 		t.Errorf("expected service map length 2, got %v", fp.svcPortMap)
+	}
+	if len(result.DeletedUDPClusterIPs) != 0 {
+		// Services only added, so nothing stale yet
+		t.Errorf("expected stale UDP services length 0, got %d", len(result.DeletedUDPClusterIPs))
 	}
 	healthCheckNodePorts = fp.svcPortMap.HealthCheckNodePorts()
 	if len(healthCheckNodePorts) != 0 {
@@ -1930,20 +1969,22 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		// previousEndpoints and currentEndpoints are used to call appropriate
 		// handlers OnEndpoints* (based on whether corresponding values are nil
 		// or non-nil) and must be of equal length.
-		name                             string
-		previousEndpoints                []*discovery.EndpointSlice
-		currentEndpoints                 []*discovery.EndpointSlice
-		oldEndpoints                     map[proxy.ServicePortName][]endpointExpectation
-		expectedResult                   map[proxy.ServicePortName][]endpointExpectation
-		expectedConntrackCleanupRequired bool
-		expectedLocalEndpoints           map[types.NamespacedName]int
+		name                           string
+		previousEndpoints              []*discovery.EndpointSlice
+		currentEndpoints               []*discovery.EndpointSlice
+		oldEndpoints                   map[proxy.ServicePortName][]endpointExpectation
+		expectedResult                 map[proxy.ServicePortName][]endpointExpectation
+		expectedDeletedUDPEndpoints    []proxy.ServiceEndpoint
+		expectedNewlyActiveUDPServices map[proxy.ServicePortName]bool
+		expectedLocalEndpoints         map[types.NamespacedName]int
 	}{{
 		// Case[0]: nothing
-		name:                             "nothing",
-		oldEndpoints:                     map[proxy.ServicePortName][]endpointExpectation{},
-		expectedResult:                   map[proxy.ServicePortName][]endpointExpectation{},
-		expectedConntrackCleanupRequired: false,
-		expectedLocalEndpoints:           map[types.NamespacedName]int{},
+		name:                           "nothing",
+		oldEndpoints:                   map[proxy.ServicePortName][]endpointExpectation{},
+		expectedResult:                 map[proxy.ServicePortName][]endpointExpectation{},
+		expectedDeletedUDPEndpoints:    []proxy.ServiceEndpoint{},
+		expectedNewlyActiveUDPServices: map[proxy.ServicePortName]bool{},
+		expectedLocalEndpoints:         map[types.NamespacedName]int{},
 	}, {
 		// Case[1]: no change, named port, local
 		name:              "no change, named port, local",
@@ -1959,7 +2000,8 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{endpoint: "10.1.1.1:11", isLocal: true},
 			},
 		},
-		expectedConntrackCleanupRequired: false,
+		expectedDeletedUDPEndpoints:    []proxy.ServiceEndpoint{},
+		expectedNewlyActiveUDPServices: map[proxy.ServicePortName]bool{},
 		expectedLocalEndpoints: map[types.NamespacedName]int{
 			makeNSN("ns1", "ep1"): 1,
 		},
@@ -1984,8 +2026,9 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{endpoint: "10.1.1.2:12", isLocal: false},
 			},
 		},
-		expectedConntrackCleanupRequired: false,
-		expectedLocalEndpoints:           map[types.NamespacedName]int{},
+		expectedDeletedUDPEndpoints:    []proxy.ServiceEndpoint{},
+		expectedNewlyActiveUDPServices: map[proxy.ServicePortName]bool{},
+		expectedLocalEndpoints:         map[types.NamespacedName]int{},
 	}, {
 		// Case[3]: no change, multiple subsets, multiple ports, local
 		name:              "no change, multiple subsets, multiple ports, local",
@@ -2013,7 +2056,8 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{endpoint: "10.1.1.3:13", isLocal: false},
 			},
 		},
-		expectedConntrackCleanupRequired: false,
+		expectedDeletedUDPEndpoints:    []proxy.ServiceEndpoint{},
+		expectedNewlyActiveUDPServices: map[proxy.ServicePortName]bool{},
 		expectedLocalEndpoints: map[types.NamespacedName]int{
 			makeNSN("ns1", "ep1"): 1,
 		},
@@ -2074,7 +2118,8 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{endpoint: "10.2.2.2:22", isLocal: true},
 			},
 		},
-		expectedConntrackCleanupRequired: false,
+		expectedDeletedUDPEndpoints:    []proxy.ServiceEndpoint{},
+		expectedNewlyActiveUDPServices: map[proxy.ServicePortName]bool{},
 		expectedLocalEndpoints: map[types.NamespacedName]int{
 			makeNSN("ns1", "ep1"): 2,
 			makeNSN("ns2", "ep2"): 1,
@@ -2090,7 +2135,10 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{endpoint: "10.1.1.1:11", isLocal: true},
 			},
 		},
-		expectedConntrackCleanupRequired: true,
+		expectedDeletedUDPEndpoints: []proxy.ServiceEndpoint{},
+		expectedNewlyActiveUDPServices: map[proxy.ServicePortName]bool{
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): true,
+		},
 		expectedLocalEndpoints: map[types.NamespacedName]int{
 			makeNSN("ns1", "ep1"): 1,
 		},
@@ -2104,8 +2152,13 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{endpoint: "10.1.1.1:11", isLocal: true},
 			},
 		},
-		expectedConntrackCleanupRequired: true,
-		expectedLocalEndpoints:           map[types.NamespacedName]int{},
+		expectedResult: map[proxy.ServicePortName][]endpointExpectation{},
+		expectedDeletedUDPEndpoints: []proxy.ServiceEndpoint{{
+			Endpoint:        "10.1.1.1:11",
+			ServicePortName: makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP),
+		}},
+		expectedNewlyActiveUDPServices: map[proxy.ServicePortName]bool{},
+		expectedLocalEndpoints:         map[types.NamespacedName]int{},
 	}, {
 		// Case[7]: add an IP and port
 		name:              "add an IP and port",
@@ -2126,7 +2179,10 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{endpoint: "10.1.1.2:12", isLocal: true},
 			},
 		},
-		expectedConntrackCleanupRequired: true,
+		expectedDeletedUDPEndpoints: []proxy.ServiceEndpoint{},
+		expectedNewlyActiveUDPServices: map[proxy.ServicePortName]bool{
+			makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP): true,
+		},
 		expectedLocalEndpoints: map[types.NamespacedName]int{
 			makeNSN("ns1", "ep1"): 1,
 		},
@@ -2150,8 +2206,18 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{endpoint: "10.1.1.1:11", isLocal: false},
 			},
 		},
-		expectedConntrackCleanupRequired: true,
-		expectedLocalEndpoints:           map[types.NamespacedName]int{},
+		expectedDeletedUDPEndpoints: []proxy.ServiceEndpoint{{
+			Endpoint:        "10.1.1.2:11",
+			ServicePortName: makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP),
+		}, {
+			Endpoint:        "10.1.1.1:12",
+			ServicePortName: makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP),
+		}, {
+			Endpoint:        "10.1.1.2:12",
+			ServicePortName: makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP),
+		}},
+		expectedNewlyActiveUDPServices: map[proxy.ServicePortName]bool{},
+		expectedLocalEndpoints:         map[types.NamespacedName]int{},
 	}, {
 		// Case[9]: add a subset
 		name:              "add a subset",
@@ -2170,7 +2236,10 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{endpoint: "10.1.1.2:12", isLocal: true},
 			},
 		},
-		expectedConntrackCleanupRequired: true,
+		expectedDeletedUDPEndpoints: []proxy.ServiceEndpoint{},
+		expectedNewlyActiveUDPServices: map[proxy.ServicePortName]bool{
+			makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP): true,
+		},
 		expectedLocalEndpoints: map[types.NamespacedName]int{
 			makeNSN("ns1", "ep1"): 1,
 		},
@@ -2192,8 +2261,12 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{endpoint: "10.1.1.1:11", isLocal: false},
 			},
 		},
-		expectedConntrackCleanupRequired: true,
-		expectedLocalEndpoints:           map[types.NamespacedName]int{},
+		expectedDeletedUDPEndpoints: []proxy.ServiceEndpoint{{
+			Endpoint:        "10.1.1.2:12",
+			ServicePortName: makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP),
+		}},
+		expectedNewlyActiveUDPServices: map[proxy.ServicePortName]bool{},
+		expectedLocalEndpoints:         map[types.NamespacedName]int{},
 	}, {
 		// Case[11]: rename a port
 		name:              "rename a port",
@@ -2209,8 +2282,14 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{endpoint: "10.1.1.1:11", isLocal: false},
 			},
 		},
-		expectedConntrackCleanupRequired: true,
-		expectedLocalEndpoints:           map[types.NamespacedName]int{},
+		expectedDeletedUDPEndpoints: []proxy.ServiceEndpoint{{
+			Endpoint:        "10.1.1.1:11",
+			ServicePortName: makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP),
+		}},
+		expectedNewlyActiveUDPServices: map[proxy.ServicePortName]bool{
+			makeServicePortName("ns1", "ep1", "p11-2", v1.ProtocolUDP): true,
+		},
+		expectedLocalEndpoints: map[types.NamespacedName]int{},
 	}, {
 		// Case[12]: renumber a port
 		name:              "renumber a port",
@@ -2226,8 +2305,12 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{endpoint: "10.1.1.1:22", isLocal: false},
 			},
 		},
-		expectedConntrackCleanupRequired: true,
-		expectedLocalEndpoints:           map[types.NamespacedName]int{},
+		expectedDeletedUDPEndpoints: []proxy.ServiceEndpoint{{
+			Endpoint:        "10.1.1.1:11",
+			ServicePortName: makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP),
+		}},
+		expectedNewlyActiveUDPServices: map[proxy.ServicePortName]bool{},
+		expectedLocalEndpoints:         map[types.NamespacedName]int{},
 	}, {
 		// Case[13]: complex add and remove
 		name:              "complex add and remove",
@@ -2270,7 +2353,27 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{endpoint: "10.4.4.4:44", isLocal: true},
 			},
 		},
-		expectedConntrackCleanupRequired: true,
+		expectedDeletedUDPEndpoints: []proxy.ServiceEndpoint{{
+			Endpoint:        "10.2.2.2:22",
+			ServicePortName: makeServicePortName("ns2", "ep2", "p22", v1.ProtocolUDP),
+		}, {
+			Endpoint:        "10.2.2.22:22",
+			ServicePortName: makeServicePortName("ns2", "ep2", "p22", v1.ProtocolUDP),
+		}, {
+			Endpoint:        "10.2.2.3:23",
+			ServicePortName: makeServicePortName("ns2", "ep2", "p23", v1.ProtocolUDP),
+		}, {
+			Endpoint:        "10.4.4.5:44",
+			ServicePortName: makeServicePortName("ns4", "ep4", "p44", v1.ProtocolUDP),
+		}, {
+			Endpoint:        "10.4.4.6:45",
+			ServicePortName: makeServicePortName("ns4", "ep4", "p45", v1.ProtocolUDP),
+		}},
+		expectedNewlyActiveUDPServices: map[proxy.ServicePortName]bool{
+			makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP):  true,
+			makeServicePortName("ns1", "ep1", "p122", v1.ProtocolUDP): true,
+			makeServicePortName("ns3", "ep3", "p33", v1.ProtocolUDP):  true,
+		},
 		expectedLocalEndpoints: map[types.NamespacedName]int{
 			makeNSN("ns4", "ep4"): 1,
 		},
@@ -2285,8 +2388,11 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{endpoint: "10.1.1.1:11", isLocal: false},
 			},
 		},
-		expectedConntrackCleanupRequired: true,
-		expectedLocalEndpoints:           map[types.NamespacedName]int{},
+		expectedDeletedUDPEndpoints: []proxy.ServiceEndpoint{},
+		expectedNewlyActiveUDPServices: map[proxy.ServicePortName]bool{
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): true,
+		},
+		expectedLocalEndpoints: map[types.NamespacedName]int{},
 	},
 	}
 
@@ -2324,8 +2430,34 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			result := fp.endpointsMap.Update(fp.endpointsChanges)
 			newMap := fp.endpointsMap
 			checkEndpointExpectations(t, tci, newMap, tc.expectedResult)
-			if result.ConntrackCleanupRequired != tc.expectedConntrackCleanupRequired {
-				t.Errorf("[%d] expected conntrackCleanupRequired to be %t, got %t", tci, tc.expectedConntrackCleanupRequired, result.ConntrackCleanupRequired)
+			if len(result.DeletedUDPEndpoints) != len(tc.expectedDeletedUDPEndpoints) {
+				t.Errorf("[%d] expected %d staleEndpoints, got %d: %v", tci, len(tc.expectedDeletedUDPEndpoints), len(result.DeletedUDPEndpoints), result.DeletedUDPEndpoints)
+			}
+			for _, x := range tc.expectedDeletedUDPEndpoints {
+				found := false
+				for _, stale := range result.DeletedUDPEndpoints {
+					if stale == x {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("[%d] expected staleEndpoints[%v], but didn't find it: %v", tci, x, result.DeletedUDPEndpoints)
+				}
+			}
+			if len(result.NewlyActiveUDPServices) != len(tc.expectedNewlyActiveUDPServices) {
+				t.Errorf("[%d] expected %d staleServiceNames, got %d: %v", tci, len(tc.expectedNewlyActiveUDPServices), len(result.NewlyActiveUDPServices), result.NewlyActiveUDPServices)
+			}
+			for svcName := range tc.expectedNewlyActiveUDPServices {
+				found := false
+				for _, stale := range result.NewlyActiveUDPServices {
+					if stale == svcName {
+						found = true
+					}
+				}
+				if !found {
+					t.Errorf("[%d] expected staleServiceNames[%v], but didn't find it: %v", tci, svcName, result.NewlyActiveUDPServices)
+				}
 			}
 			localReadyEndpoints := fp.endpointsMap.LocalReadyEndpoints()
 			if !reflect.DeepEqual(localReadyEndpoints, tc.expectedLocalEndpoints) {

--- a/pkg/proxy/servicechangetracker.go
+++ b/pkg/proxy/servicechangetracker.go
@@ -117,6 +117,11 @@ type UpdateServiceMapResult struct {
 	// UpdatedServices lists the names of all services added/updated/deleted since the
 	// last Update.
 	UpdatedServices sets.Set[types.NamespacedName]
+
+	// DeletedUDPClusterIPs holds stale (no longer assigned to a Service) Service IPs
+	// that had UDP ports. Callers can use this to abort timeout-waits or clear
+	// connection-tracking information.
+	DeletedUDPClusterIPs sets.Set[string]
 }
 
 // HealthCheckNodePorts returns a map of Service names to HealthCheckNodePort values
@@ -173,7 +178,8 @@ func (sm ServicePortMap) Update(sct *ServiceChangeTracker) UpdateServiceMapResul
 	defer sct.lock.Unlock()
 
 	result := UpdateServiceMapResult{
-		UpdatedServices: sets.New[types.NamespacedName](),
+		UpdatedServices:      sets.New[types.NamespacedName](),
+		DeletedUDPClusterIPs: sets.New[string](),
 	}
 
 	for nn, change := range sct.items {
@@ -186,7 +192,7 @@ func (sm ServicePortMap) Update(sct *ServiceChangeTracker) UpdateServiceMapResul
 		// filter out the Update event of current changes from previous changes
 		// before calling unmerge() so that can skip deleting the Update events.
 		change.previous.filter(change.current)
-		sm.unmerge(change.previous)
+		sm.unmerge(change.previous, result.DeletedUDPClusterIPs)
 	}
 	// clear changes after applying them to ServicePortMap.
 	sct.items = make(map[types.NamespacedName]*serviceChange)
@@ -220,12 +226,16 @@ func (sm *ServicePortMap) filter(other ServicePortMap) {
 	}
 }
 
-// unmerge deletes all other ServicePortMap's elements from current ServicePortMap.
-func (sm *ServicePortMap) unmerge(other ServicePortMap) {
+// unmerge deletes all other ServicePortMap's elements from current ServicePortMap and
+// updates deletedUDPClusterIPs with all of the newly-deleted UDP cluster IPs.
+func (sm *ServicePortMap) unmerge(other ServicePortMap, deletedUDPClusterIPs sets.Set[string]) {
 	for svcPortName := range other {
-		_, exists := (*sm)[svcPortName]
+		info, exists := (*sm)[svcPortName]
 		if exists {
 			klog.V(4).InfoS("Removing service port", "portName", svcPortName)
+			if info.Protocol() == v1.ProtocolUDP {
+				deletedUDPClusterIPs.Insert(info.ClusterIP().String())
+			}
 			delete(*sm, svcPortName)
 		} else {
 			klog.ErrorS(nil, "Service port does not exists", "portName", svcPortName)

--- a/pkg/proxy/servicechangetracker_test.go
+++ b/pkg/proxy/servicechangetracker_test.go
@@ -680,6 +680,9 @@ func TestServiceMapUpdateHeadless(t *testing.T) {
 	if len(result.UpdatedServices) != 0 {
 		t.Errorf("expected 0 updated services, got %d", len(result.UpdatedServices))
 	}
+	if len(result.DeletedUDPClusterIPs) != 0 {
+		t.Errorf("expected stale UDP services length 0, got %d", len(result.DeletedUDPClusterIPs))
+	}
 
 	// No proxied services, so no healthchecks
 	healthCheckNodePorts := fp.svcPortMap.HealthCheckNodePorts()
@@ -706,6 +709,9 @@ func TestUpdateServiceTypeExternalName(t *testing.T) {
 	}
 	if len(result.UpdatedServices) != 0 {
 		t.Errorf("expected 0 updated services, got %v", result.UpdatedServices)
+	}
+	if len(result.DeletedUDPClusterIPs) != 0 {
+		t.Errorf("expected stale UDP services length 0, got %v", result.DeletedUDPClusterIPs)
 	}
 
 	// No proxied services, so no healthchecks
@@ -776,6 +782,10 @@ func TestBuildServiceMapAddRemove(t *testing.T) {
 	if len(result.UpdatedServices) != len(services) {
 		t.Errorf("expected %d updated services, got %d", len(services), len(result.UpdatedServices))
 	}
+	if len(result.DeletedUDPClusterIPs) != 0 {
+		// Services only added, so nothing stale yet
+		t.Errorf("expected stale UDP services length 0, got %d", len(result.DeletedUDPClusterIPs))
+	}
 
 	// The only-local-loadbalancer ones get added
 	healthCheckNodePorts := fp.svcPortMap.HealthCheckNodePorts()
@@ -813,6 +823,19 @@ func TestBuildServiceMapAddRemove(t *testing.T) {
 	if len(healthCheckNodePorts) != 0 {
 		t.Errorf("expected 0 healthcheck ports, got %v", healthCheckNodePorts)
 	}
+
+	// All services but one were deleted. While you'd expect only the ClusterIPs
+	// from the three deleted services here, we still have the ClusterIP for
+	// the not-deleted service, because one of it's ServicePorts was deleted.
+	expectedDeletedUDPClusterIPs := []string{"172.16.55.10", "172.16.55.4", "172.16.55.11", "172.16.55.12"}
+	if len(result.DeletedUDPClusterIPs) != len(expectedDeletedUDPClusterIPs) {
+		t.Errorf("expected stale UDP services length %d, got %v", len(expectedDeletedUDPClusterIPs), result.DeletedUDPClusterIPs.UnsortedList())
+	}
+	for _, ip := range expectedDeletedUDPClusterIPs {
+		if !result.DeletedUDPClusterIPs.Has(ip) {
+			t.Errorf("expected stale UDP service service %s", ip)
+		}
+	}
 }
 
 func TestBuildServiceMapServiceUpdate(t *testing.T) {
@@ -848,6 +871,10 @@ func TestBuildServiceMapServiceUpdate(t *testing.T) {
 	if len(result.UpdatedServices) != 1 {
 		t.Errorf("expected 1 updated service, got %d", len(result.UpdatedServices))
 	}
+	if len(result.DeletedUDPClusterIPs) != 0 {
+		// Services only added, so nothing stale yet
+		t.Errorf("expected stale UDP services length 0, got %d", len(result.DeletedUDPClusterIPs))
+	}
 
 	healthCheckNodePorts := fp.svcPortMap.HealthCheckNodePorts()
 	if len(healthCheckNodePorts) != 0 {
@@ -862,6 +889,9 @@ func TestBuildServiceMapServiceUpdate(t *testing.T) {
 	}
 	if len(result.UpdatedServices) != 1 {
 		t.Errorf("expected 1 updated service, got %d", len(result.UpdatedServices))
+	}
+	if len(result.DeletedUDPClusterIPs) != 0 {
+		t.Errorf("expected stale UDP services length 0, got %v", result.DeletedUDPClusterIPs.UnsortedList())
 	}
 
 	healthCheckNodePorts = fp.svcPortMap.HealthCheckNodePorts()
@@ -879,6 +909,9 @@ func TestBuildServiceMapServiceUpdate(t *testing.T) {
 	if len(result.UpdatedServices) != 0 {
 		t.Errorf("expected 0 updated services, got %d", len(result.UpdatedServices))
 	}
+	if len(result.DeletedUDPClusterIPs) != 0 {
+		t.Errorf("expected stale UDP services length 0, got %v", result.DeletedUDPClusterIPs.UnsortedList())
+	}
 
 	healthCheckNodePorts = fp.svcPortMap.HealthCheckNodePorts()
 	if len(healthCheckNodePorts) != 1 {
@@ -893,6 +926,10 @@ func TestBuildServiceMapServiceUpdate(t *testing.T) {
 	}
 	if len(result.UpdatedServices) != 1 {
 		t.Errorf("expected 1 updated service, got %d", len(result.UpdatedServices))
+	}
+	if len(result.DeletedUDPClusterIPs) != 0 {
+		// Services only added, so nothing stale yet
+		t.Errorf("expected stale UDP services length 0, got %d", len(result.DeletedUDPClusterIPs))
 	}
 
 	healthCheckNodePorts = fp.svcPortMap.HealthCheckNodePorts()

--- a/pkg/proxy/winkernel/proxier.go
+++ b/pkg/proxy/winkernel/proxier.go
@@ -1166,9 +1166,17 @@ func (proxier *Proxier) syncProxyRules() {
 	// We assume that if this was called, we really want to sync them,
 	// even if nothing changed in the meantime. In other words, callers are
 	// responsible for detecting no-op changes and not calling this function.
-	_ = proxier.svcPortMap.Update(proxier.serviceChanges)
-	_ = proxier.endpointsMap.Update(proxier.endpointsChanges)
+	serviceUpdateResult := proxier.svcPortMap.Update(proxier.serviceChanges)
+	endpointUpdateResult := proxier.endpointsMap.Update(proxier.endpointsChanges)
 
+	deletedUDPClusterIPs := serviceUpdateResult.DeletedUDPClusterIPs
+	// merge stale services gathered from EndpointsMap.Update
+	for _, svcPortName := range endpointUpdateResult.NewlyActiveUDPServices {
+		if svcInfo, ok := proxier.svcPortMap[svcPortName]; ok && svcInfo != nil && svcInfo.Protocol() == v1.ProtocolUDP {
+			klog.V(2).InfoS("Newly-active UDP service may have stale conntrack entries", "servicePortName", svcPortName)
+			deletedUDPClusterIPs.Insert(svcInfo.ClusterIP().String())
+		}
+	}
 	// Query HNS for endpoints and load balancers
 	queriedEndpoints, err := hns.getAllEndpointsByNetwork(hnsNetworkName)
 	if err != nil {
@@ -1705,6 +1713,13 @@ func (proxier *Proxier) syncProxyRules() {
 	}
 	if err := proxier.serviceHealthServer.SyncEndpoints(proxier.endpointsMap.LocalReadyEndpoints()); err != nil {
 		klog.ErrorS(err, "Error syncing healthcheck endpoints")
+	}
+
+	// Finish housekeeping.
+	// TODO: these could be made more consistent.
+	for _, svcIP := range deletedUDPClusterIPs.UnsortedList() {
+		// TODO : Check if this is required to cleanup stale services here
+		klog.V(5).InfoS("Pending delete stale service IP connections", "IP", svcIP)
 	}
 
 	// remove stale endpoint refcount entries


### PR DESCRIPTION
Cherry pick of #130479 on release-1.32.

#130479: Revert conntrack reconciler

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
revert kube-proxy conntrack reconciler functionality as it can cause excessive CPU usage when using UDP services with ExternalIPs or LoadBalancerIPs that contain a large number of UDP entries
```