### PR TITLE
Clarify ordering requirements of client-gen --input

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/client-gen/args/args.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/args/args.go
@@ -85,7 +85,7 @@ func (args *Args) AddFlags(fs *pflag.FlagSet, inputBase string) {
 	fs.StringVar(&args.GoHeaderFile, "go-header-file", "",
 		"the path to a file containing boilerplate header text; the string \"YEAR\" will be replaced with the current 4-digit year")
 	fs.Var(NewGVPackagesValue(gvsBuilder, nil), "input",
-		"group/versions that client-gen will generate clients for. At most one version per group is allowed. Specified in the format \"group1/version1,group2/version2...\".")
+		`group/versions that client-gen will generate clients for. At most one version per group is allowed. Specified in the format "group1/version1,group2/version2...". The order in which group/versions are listed defines the order of the generated client code. To avoid non-deterministic output, sort this list before providing it to client-gen.`)
 	fs.Var(NewGVTypesValue(&args.IncludedTypesOverrides, []string{}), "included-types-overrides",
 		"list of group/version/type for which client should be generated. By default, client is generated for all types which have genclient in types.go. This overrides that. For each groupVersion in this list, only the types mentioned here will be included. The default check of genclient will be used for other group versions.")
 	fs.Var(NewInputBasePathValue(gvsBuilder, inputBase), "input-base",


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

A "generated code keeps changing order" problem for API gateway was traced down to this.  xref: https://github.com/kubernetes-sigs/gateway-api/pull/3652

#### Which issue(s) this PR fixes:

Ideally, client-gen would sort it's `--input` argument after receiving it to enforce consistent order.

Problem is, there are many build pipelines already using client-gen, and changing client-gen to sort after receiving the list would impact their code generation (could be breaking to those pipelines).

So let's at least document that a sorted `--input` is expected.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

