### PR TITLE
fix volumeAttachment leak when  kube-controller restarts during the execution of DetachVolume

### DIFF
--- a/pkg/controller/volume/attachdetach/attach_detach_controller.go
+++ b/pkg/controller/volume/attachdetach/attach_detach_controller.go
@@ -21,10 +21,10 @@ package attachdetach
 import (
 	"context"
 	"fmt"
+	"k8s.io/klog/v2"
 	"net"
 	"time"
 
-	"k8s.io/klog/v2"
 	"k8s.io/mount-utils"
 	utilexec "k8s.io/utils/exec"
 
@@ -734,7 +734,7 @@ func (adc *attachDetachController) processVolumeAttachments(logger klog.Logger) 
 			continue
 		}
 		attachState := adc.actualStateOfWorld.GetAttachState(volumeName, nodeName)
-		if attachState == cache.AttachStateDetached {
+		if attachState == cache.AttachStateDetached || (!va.DeletionTimestamp.IsZero() && va.Status.Attached) {
 			logger.V(1).Info("Marking volume attachment as uncertain as volume is not attached", "node", klog.KRef("", string(nodeName)), "volumeName", volumeName, "attachState", attachState)
 			err = adc.actualStateOfWorld.MarkVolumeAsUncertain(logger, volumeName, volumeSpec, nodeName)
 			if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug


Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
When the kube-controller-manager restarts during the execution of DetachVolume, orphaned volumeAttachment objects may persist in the API server, leading to resource leaks. This occurs due to inconsistencies between node status updates and volumeAttachment cleanup logic during controller recovery.

Workflow Leading to Leak:

DetachVolume Initiation

The volume is removed from node.status.volumeAttached before DetachVolume execution.

Controller Restart

If kube-controller-manager restarts at this point, attach_detach_controller rebuilds the actualStateOfWorld cache by iterating over node.Status.VolumesAttached. Since the volume was already removed from the node status, it is not added to the cache.

Orphaned volumeAttachment Handling

During processVolumeAttachments, the controller checks if the volume exists in actualStateOfWorld with AttachStateDetached:
```
                attachState := adc.actualStateOfWorld.GetAttachState(volumeName, nodeName)
		if attachState == cache.AttachStateDetached {
		  err = adc.actualStateOfWorld.MarkVolumeAsUncertain(logger, volumeName, volumeSpec, nodeName)
		}
```
Because the volume is absent from the cache (due to step 2), the orphaned volumeAttachment is not re-added to actualStateOfWorld, resulting in a persistent leak.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
