### PR TITLE
Reduce number of (versions of!) images we pull in our e2e tests

### DIFF
--- a/test/e2e/dra/test-driver/deploy/example/pod-external.yaml
+++ b/test/e2e/dra/test-driver/deploy/example/pod-external.yaml
@@ -23,13 +23,13 @@ spec:
   restartPolicy: Never
   containers:
   - name: with-resource
-    image: registry.k8s.io/e2e-test-images/busybox:1.29-2
+    image: registry.k8s.io/e2e-test-images/busybox:1.36.1-1
     command: ["sh", "-c", "set && mount && ls -la /dev/"]
     resources:
       claims:
       - name: resource
   - name: without-resource
-    image: registry.k8s.io/e2e-test-images/busybox:1.29-2
+    image: registry.k8s.io/e2e-test-images/busybox:1.36.1-1
     command: ["sh", "-c", "set && mount && ls -la /dev/"]
   resourceClaims:
   - name: resource

--- a/test/e2e/dra/test-driver/deploy/example/pod-inline.yaml
+++ b/test/e2e/dra/test-driver/deploy/example/pod-inline.yaml
@@ -28,13 +28,13 @@ spec:
   restartPolicy: Never
   containers:
   - name: with-resource
-    image: registry.k8s.io/e2e-test-images/busybox:1.29-2
+    image: registry.k8s.io/e2e-test-images/busybox:1.36.1-1
     command: ["sh", "-c", "set && mount && ls -la /dev/"]
     resources:
       claims:
       - name: resource
   - name: without-resource
-    image: registry.k8s.io/e2e-test-images/busybox:1.29-2
+    image: registry.k8s.io/e2e-test-images/busybox:1.36.1-1
     command: ["sh", "-c", "set && mount && ls -la /dev/"]
   resourceClaims:
   - name: resource

--- a/test/e2e/dra/test-driver/deploy/example/pod-shared.yaml
+++ b/test/e2e/dra/test-driver/deploy/example/pod-shared.yaml
@@ -24,13 +24,13 @@ spec:
   restartPolicy: Never
   containers:
   - name: with-resource
-    image: registry.k8s.io/e2e-test-images/busybox:1.29-2
+    image: registry.k8s.io/e2e-test-images/busybox:1.36.1-1
     command: ["sh", "-c", "set && mount && ls -la /dev/"]
     resources:
       claims:
       - name: resource
   - name: without-resource
-    image: registry.k8s.io/e2e-test-images/busybox:1.29-2
+    image: registry.k8s.io/e2e-test-images/busybox:1.36.1-1
     command: ["sh", "-c", "set && mount && ls -la /dev/"]
   resourceClaims:
   - name: resource
@@ -44,13 +44,13 @@ spec:
   restartPolicy: Never
   containers:
   - name: with-resource
-    image: registry.k8s.io/e2e-test-images/busybox:1.29-2
+    image: registry.k8s.io/e2e-test-images/busybox:1.36.1-1
     command: ["sh", "-c", "set && mount && ls -la /dev/"]
     resources:
       claims:
       - name: resource
   - name: without-resource
-    image: registry.k8s.io/e2e-test-images/busybox:1.29-2
+    image: registry.k8s.io/e2e-test-images/busybox:1.36.1-1
     command: ["sh", "-c", "set && mount && ls -la /dev/"]
   resourceClaims:
   - name: resource

--- a/test/e2e/testing-manifests/storage-csi/external-snapshotter/volume-group-snapshots/csi-hostpath-plugin.yaml
+++ b/test/e2e/testing-manifests/storage-csi/external-snapshotter/volume-group-snapshots/csi-hostpath-plugin.yaml
@@ -276,7 +276,7 @@ spec:
               mountPath: /csi
 
         - name: node-driver-registrar
-          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.10.1
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.13.0
           args:
             - --v=5
             - --csi-address=/csi/csi.sock
@@ -304,13 +304,13 @@ spec:
           volumeMounts:
           - mountPath: /csi
             name: socket-dir
-          image: registry.k8s.io/sig-storage/livenessprobe:v2.12.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.15.0
           args:
           - --csi-address=/csi/csi.sock
           - --health-port=9898
 
         - name: csi-attacher
-          image: registry.k8s.io/sig-storage/csi-attacher:v4.6.1
+          image: registry.k8s.io/sig-storage/csi-attacher:v4.8.0
           args:
             - --v=5
             - --csi-address=/csi/csi.sock
@@ -324,7 +324,7 @@ spec:
             name: socket-dir
 
         - name: csi-provisioner
-          image: registry.k8s.io/sig-storage/csi-provisioner:v5.0.1
+          image: registry.k8s.io/sig-storage/csi-provisioner:v5.1.0
           args:
             - -v=5
             - --csi-address=/csi/csi.sock
@@ -340,7 +340,7 @@ spec:
               name: socket-dir
 
         - name: csi-resizer
-          image: registry.k8s.io/sig-storage/csi-resizer:v1.11.1
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.13.1
           args:
             - -v=5
             - -csi-address=/csi/csi.sock

--- a/test/e2e/testing-manifests/storage-csi/gce-pd/node_ds.yaml
+++ b/test/e2e/testing-manifests/storage-csi/gce-pd/node_ds.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: csi-driver-registrar
-          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.1
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.13.0
           args:
             - "--v=5"
             - "--csi-address=/csi/csi.sock"
@@ -48,7 +48,7 @@ spec:
         - name: gce-pd-driver
           securityContext:
             privileged: true
-          image: registry.k8s.io/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver:v1.2.2
+          image: registry.k8s.io/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver:v1.4.0
           args:
             - "--v=5"
             - "--endpoint=unix:/csi/csi.sock"

--- a/test/e2e/testing-manifests/storage-csi/mock/csi-mock-proxy.yaml
+++ b/test/e2e/testing-manifests/storage-csi/mock/csi-mock-proxy.yaml
@@ -77,7 +77,7 @@ spec:
         # test for directories or create them. It needs additional privileges
         # for that.
         - name: busybox
-          image: registry.k8s.io/e2e-test-images/busybox:1.29-2
+          image: registry.k8s.io/e2e-test-images/busybox:1.36.1-1
           securityContext:
             privileged: true
           command:


### PR DESCRIPTION
Periodic revisit of https://github.com/kubernetes/kubernetes/issues/122566

Run the following command before and after this PR and compare the list:
```
./_output/bin/e2e.test --list-images | sort
```

before this PR the command above returned 50 images. After the commit in this PR, it's cut down to 42.

so we were able to reduce number of versions of some of the images (total of 8 images):
```
❯ diff -Bbwu before.txt after.txt
--- before.txt  2025-03-01 21:05:27.881699025 -0500
+++ after.txt   2025-03-01 21:05:33.719460133 -0500
@@ -3,11 +3,9 @@
 gcr.io/k8s-authenticated-test/agnhost:2.6
 invalid.registry.k8s.io/invalid/alpine:3.1
 registry.k8s.io/build-image/distroless-iptables:v0.7.3
-registry.k8s.io/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver:v1.2.2
 registry.k8s.io/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver:v1.4.0
 registry.k8s.io/e2e-test-images/agnhost:2.53
 registry.k8s.io/e2e-test-images/apparmor-loader:1.4
-registry.k8s.io/e2e-test-images/busybox:1.29-2
 registry.k8s.io/e2e-test-images/busybox:1.36.1-1
 registry.k8s.io/e2e-test-images/httpd:2.4.38-4
 registry.k8s.io/e2e-test-images/httpd:2.4.39-4
@@ -31,20 +29,14 @@
 registry.k8s.io/e2e-test-images/volume/nfs:1.4
 registry.k8s.io/etcd:3.5.17-0
 registry.k8s.io/pause:3.10
-registry.k8s.io/sig-storage/csi-attacher:v4.6.1
 registry.k8s.io/sig-storage/csi-attacher:v4.8.0
 registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.12.1
-registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.10.1
 registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.13.0
-registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.1
-registry.k8s.io/sig-storage/csi-provisioner:v5.0.1
 registry.k8s.io/sig-storage/csi-provisioner:v5.1.0
-registry.k8s.io/sig-storage/csi-resizer:v1.11.1
 registry.k8s.io/sig-storage/csi-resizer:v1.13.1
 registry.k8s.io/sig-storage/csi-snapshotter:v8.2.0
 registry.k8s.io/sig-storage/hello-populator:v1.0.1
 registry.k8s.io/sig-storage/hostpathplugin:v1.15.0
-registry.k8s.io/sig-storage/livenessprobe:v2.12.0
 registry.k8s.io/sig-storage/livenessprobe:v2.15.0
 registry.k8s.io/sig-storage/nfs-provisioner:v4.0.8
 registry.k8s.io/sig-storage/volume-data-source-validator:v1.0.0
```


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
