### PR TITLE
flake(cloud-provieder): fix unexpected panic in unit test

### DIFF
--- a/staging/src/k8s.io/cloud-provider/options/options_test.go
+++ b/staging/src/k8s.io/cloud-provider/options/options_test.go
@@ -508,18 +508,14 @@ func TestCreateConfigWithoutWebHooks(t *testing.T) {
 		"--use-service-account-credentials=false",
 	}
 	err = fs.Parse(args)
-	if err != nil {
-		t.Errorf("error parsing the arguments, error : %v", err)
-	}
+	require.NoError(t, err, "unexpected error: %s", err)
 
 	fs.VisitAll(func(f *pflag.Flag) {
 		fmt.Printf("%s: %s\n", f.Name, f.Value)
 	})
 
 	c, err := s.Config([]string{"foo", "bar"}, []string{}, nil, []string{"foo", "bar", "baz"}, []string{})
-	if err != nil {
-		t.Errorf("error generating config, error : %v", err)
-	}
+	require.NoError(t, err, "unexpected error: %s", err)
 
 	expected := &appconfig.Config{
 		ComponentConfig: cpconfig.CloudControllerManagerConfiguration{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind flake

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
- fix unexpected panic in unit test

more detailed: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/129535/pull-kubernetes-unit/1895502991805386752

before: 
```bash
I0302 12:16:38.138467   37114 serving.go:380] Generated self-signed cert (/var/folders/j3/b8896xf92g7d60x2ghdpcnd40000gn/T/options_test1090613299/certs/cloud-controller-manager.crt, /var/folders/j3/b8896xf92g7d60x2ghdpcnd40000gn/T/options_test1090613299/certs/cloud-controller-manager.key)
I0302 12:16:38.560868   37114 serving.go:386] Generated self-signed cert in-memory
--- FAIL: TestCreateConfigWithoutWebHooks (0.50s)
    options_test.go:522: error generating config, error : failed to create listener: failed to listen on 0.0.0.0:10200: listen tcp 0.0.0.0:10200: bind: address already in use
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x104f85bf0]

goroutine 148 [running]:
testing.tRunner.func1.2({0x10581be00, 0x107304c10})
        /opt/homebrew/Cellar/go/1.24.0/libexec/src/testing/testing.go:1734 +0x2bc
testing.tRunner.func1()
        /opt/homebrew/Cellar/go/1.24.0/libexec/src/testing/testing.go:1737 +0x47c
panic({0x10581be00?, 0x107304c10?})
        /opt/homebrew/Cellar/go/1.24.0/libexec/src/runtime/panic.go:787 +0x124
k8s.io/cloud-provider/options.TestCreateConfigWithoutWebHooks(0xc00049fc00)
        /Users/zhenyu.jiang/go/src/golanglearning/new_project/pr_kubernetes/kubernetes/staging/src/k8s.io/cloud-provider/options/options_test.go:580 +0xbb0
testing.tRunner(0xc00049fc00, 0x105c47168)
        /opt/homebrew/Cellar/go/1.24.0/libexec/src/testing/testing.go:1792 +0x184
created by testing.(*T).Run in goroutine 1
        /opt/homebrew/Cellar/go/1.24.0/libexec/src/testing/testing.go:1851 +0x688
FAIL    k8s.io/cloud-provider/options   15.353s
FAIL

```
after: 
```bash
I0302 12:18:07.098902   37226 serving.go:380] Generated self-signed cert (/var/folders/j3/b8896xf92g7d60x2ghdpcnd40000gn/T/options_test3402480739/certs/cloud-controller-manager.crt, /var/folders/j3/b8896xf92g7d60x2ghdpcnd40000gn/T/options_test3402480739/certs/cloud-controller-manager.key)
I0302 12:18:07.607027   37226 serving.go:386] Generated self-signed cert in-memory
--- FAIL: TestCreateConfigWithoutWebHooks (0.89s)
    options_test.go:518: 
                Error Trace:    /Users/zhenyu.jiang/go/src/golanglearning/new_project/pr_kubernetes/kubernetes/staging/src/k8s.io/cloud-provider/options/options_test.go:518
                Error:          Received unexpected error:
                                failed to create listener: failed to listen on 0.0.0.0:10200: listen tcp 0.0.0.0:10200: bind: address already in use
                Test:           TestCreateConfigWithoutWebHooks
                Messages:       unexpected error: failed to create listener: failed to listen on 0.0.0.0:10200: listen tcp 0.0.0.0:10200: bind: address already in use
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
