### PR TITLE
add output flag for kubectl top pod

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod_flags.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod_flags.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package top
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/printers"
+	"k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/metricsutil"
+)
+
+// PrintFlags composes common printer flag structs used in the Top Pod command.
+type PrintFlags struct {
+	PodPrintFlags *metricsutil.PodPrintFlags
+
+	OutputFormat *string
+}
+
+// EnsureWithSort ensures that flags return a printer capable of printing sorted pods list using specified field.
+func (f *PrintFlags) EnsureWithSort(sortBy string) error {
+	return f.PodPrintFlags.EnsureWithSort(sortBy)
+}
+
+// EnsureWithContainers ensures that flags return a printer capable of printing usage of containers within a pod.
+func (f *PrintFlags) EnsureWithContainers() error {
+	return f.PodPrintFlags.EnsureWithContainers()
+}
+
+// EnsureWithNamespaces ensures that flags return a printer capable of printing with a "namespace" column.
+func (f *PrintFlags) EnsureWithNamespaces() error {
+	return f.PodPrintFlags.EnsureWithNamespaces()
+}
+
+// EnsureWithNoHeaders ensures that flags return a printer capable of printing without headers.
+func (f *PrintFlags) EnsureWithNoHeaders() error {
+	return f.PodPrintFlags.EnsureWithNoHeaders()
+}
+
+// EnsureWithSum ensures that flags return a printer capable of printing with the sum of the resource usage.
+func (f *PrintFlags) EnsureWithSum() error {
+	return f.PodPrintFlags.EnsureWithSum()
+}
+
+// SetPodsInfo add PodsInfo for custom output.
+func (f *PrintFlags) SetPodsInfo(pods *[]v1.Pod) error {
+	return f.PodPrintFlags.SetPodsInfo(pods)
+}
+
+// AllowedFormats is the list of formats in which data can be displayed
+func (f *PrintFlags) AllowedFormats() []string {
+	formats := f.PodPrintFlags.AllowedFormats()
+	return formats
+}
+
+// ToPrinter attempts to find a composed set of PrintFlags suitable for returning a printer based on current flag values.
+func (f *PrintFlags) ToPrinter() (printers.ResourcePrinter, error) {
+	outputFormat := ""
+	if f.OutputFormat != nil {
+		outputFormat = *f.OutputFormat
+	}
+
+	if p, err := f.PodPrintFlags.ToPrinter(outputFormat); !genericclioptions.IsNoCompatiblePrinterError(err) {
+		return p, err
+	}
+
+	return nil, genericclioptions.NoCompatiblePrinterError{OutputFormat: &outputFormat, AllowedFormats: f.AllowedFormats()}
+}
+
+// AddFlags receives a *cobra.Command reference and binds flags related to printing.
+func (f *PrintFlags) AddFlags(cmd *cobra.Command) {
+	f.PodPrintFlags.AddFlags(cmd)
+
+	if f.OutputFormat != nil {
+		cmd.Flags().StringVarP(f.OutputFormat, "output", "o", *f.OutputFormat, fmt.Sprintf(`Output format. One of: (%s).`, strings.Join(f.AllowedFormats(), ", ")))
+		util.CheckErr(cmd.RegisterFlagCompletionFunc(
+			"output",
+			func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+				var comps []string
+				for _, format := range f.AllowedFormats() {
+					if strings.HasPrefix(format, toComplete) {
+						comps = append(comps, format)
+					}
+				}
+				return comps, cobra.ShellCompDirectiveNoFileComp
+			},
+		))
+	}
+}
+
+// NewPrintFlags returns flags associated with printing, with default values set.
+func NewPrintFlags(out io.Writer) *PrintFlags {
+	outputFormat := ""
+
+	return &PrintFlags{
+		OutputFormat: &outputFormat,
+
+		PodPrintFlags: metricsutil.NewPodPrintFlags(out),
+	}
+}

--- a/staging/src/k8s.io/kubectl/pkg/metricsutil/metrics_printer.go
+++ b/staging/src/k8s.io/kubectl/pkg/metricsutil/metrics_printer.go
@@ -17,14 +17,20 @@ limitations under the License.
 package metricsutil
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"sort"
+	"strings"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/cli-runtime/pkg/printers"
 	metricsapi "k8s.io/metrics/pkg/apis/metrics"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 var (
@@ -36,6 +42,17 @@ var (
 	PodColumns      = []string{"NAME", "CPU(cores)", "MEMORY(bytes)"}
 	NamespaceColumn = "NAMESPACE"
 	PodColumn       = "POD"
+
+	PodColumnsDefinitions = []metav1.TableColumnDefinition{
+		{Name: "Name", Type: "string", Format: "name", Description: metav1.ObjectMeta{}.SwaggerDoc()["name"]},
+		{Name: "CPU", Type: "string", Description: "CPU usage in cores."},
+		{Name: "Memory", Type: "string", Description: "Memory usage in bytes."},
+	}
+	NamespaceColumnDefinition   = metav1.TableColumnDefinition{Name: "Namespace", Type: "string", Description: "Namespace where the pod is scheduled."}
+	PodColumnDefinition         = metav1.TableColumnDefinition{Name: "Pod", Type: "string", Description: "This column is pod name, and Name column is container name."}
+	PodCustomColumnsDefinitions = []metav1.TableColumnDefinition{
+		{Name: "Node", Type: "string", Description: "Node where pod is scheduled."},
+	}
 )
 
 type ResourceMetricsInfo struct {
@@ -46,6 +63,9 @@ type ResourceMetricsInfo struct {
 
 type TopCmdPrinter struct {
 	out io.Writer
+
+	// Value is nil when executing the `top node`
+	PodPrintOptions *PodPrintOptions
 }
 
 func NewTopCmdPrinter(out io.Writer) *TopCmdPrinter {
@@ -233,4 +253,254 @@ func printPodResourcesSum(out io.Writer, total v1.ResourceList, columnWidth int)
 		Available: v1.ResourceList{},
 	})
 
+}
+
+type PodPrintOptions struct {
+	SortBy          string
+	PrintContainers bool
+	PrintNamespaces bool
+	NoHeaders       bool
+	Sum             bool
+
+	Wide     bool
+	PodsInfo *[]v1.Pod
+}
+
+// PrintObj implements printers.ResourcePrinter.
+func (printer TopCmdPrinter) PrintObj(obj runtime.Object, output io.Writer) error {
+	w := printers.GetNewTabWriter(output)
+	defer w.Flush()
+
+	if podMetricsList, ok := obj.(*metricsapi.PodMetricsList); ok {
+		options := printer.PodPrintOptions
+		if options == nil {
+			options = &PodPrintOptions{}
+		}
+
+		table, err := printTopPodMetricsList(podMetricsList, *options)
+		if err != nil {
+			return nil
+		}
+
+		if !options.NoHeaders {
+			// avoid printing if no rows
+			if len(table.Rows) == 0 {
+				return nil
+			}
+
+			for _, column := range table.ColumnDefinitions {
+				if !options.Wide && column.Priority != 0 {
+					continue
+				}
+				// Keep the same output as before: "NAME  CPU(cores)  MEMORY(bytes)"
+				columnName := strings.ToUpper(column.Name)
+				if column.Name == "CPU" {
+					columnName = "CPU(cores)"
+				}
+				if column.Name == "Memory" {
+					columnName = "MEMORY(bytes)"
+				}
+				fmt.Fprintf(w, "%v\t", columnName)
+			}
+			fmt.Fprint(w, "\n")
+		}
+		for _, row := range table.Rows {
+			for i, cell := range row.Cells {
+				// don't panic if more cells
+				if i >= len(table.ColumnDefinitions) {
+					break
+				}
+				column := table.ColumnDefinitions[i]
+				if !options.Wide && column.Priority != 0 {
+					continue
+				}
+				// Keep the same output as before
+				fmt.Fprintf(w, "%v\t", cell)
+			}
+			fmt.Fprint(w, "\n")
+		}
+		return nil
+	}
+
+	return errors.New("printing node metrics is not yet supported")
+}
+
+func printTopPodMetricsList(podMetricsList *metricsapi.PodMetricsList, options PodPrintOptions) (metav1.Table, error) {
+	metrics := podMetricsList.Items
+
+	tableColumns := PodColumnsDefinitions
+	columnWidth := len(tableColumns)
+
+	// ->[POD]  NAME  CPU(cores)  MEMORY(bytes)
+	if options.PrintContainers {
+		columnWidth++
+		columns := make([]metav1.TableColumnDefinition, 0, columnWidth)
+		columns = append(columns, PodColumnDefinition)
+		tableColumns = append(columns, tableColumns...)
+	}
+
+	// ->[NAMESPACE]  [POD]  NAME  CPU(cores)  MEMORY(bytes)
+	if options.PrintNamespaces {
+		columnWidth++
+		columns := make([]metav1.TableColumnDefinition, 0, columnWidth)
+		columns = append(columns, NamespaceColumnDefinition)
+		tableColumns = append(columns, tableColumns...)
+	}
+
+	sort.Sort(NewPodMetricsSorter(metrics, options.PrintNamespaces, options.SortBy))
+
+	rows := make([]metav1.TableRow, 0, len(metrics))
+	for _, m := range metrics {
+		if options.PrintContainers {
+			// POD  NAME  CPU(cores)  MEMORY(bytes)
+			sort.Sort(NewContainerMetricsSorter(m.Containers, options.SortBy))
+			for _, c := range m.Containers {
+				cpuQuantity, _ := resource.ParseQuantity("0")
+				cpuQuantity.Add(c.Usage[v1.ResourceCPU])
+				memQuantity, _ := resource.ParseQuantity("0")
+				memQuantity.Add(c.Usage[v1.ResourceMemory])
+
+				r := metav1.TableRow{Object: runtime.RawExtension{Object: &m}}
+				r.Cells = append(r.Cells, m.Name, c.Name, printResourceUsage(v1.ResourceCPU, cpuQuantity), printResourceUsage(v1.ResourceMemory, memQuantity))
+				rows = append(rows, r)
+			}
+		} else {
+			// NAME  CPU(cores)  MEMORY(bytes)
+			cpuQuantity, _ := resource.ParseQuantity("0")
+			memQuantity, _ := resource.ParseQuantity("0")
+			for _, c := range m.Containers {
+				cpuQuantity.Add(c.Usage[v1.ResourceCPU])
+				memQuantity.Add(c.Usage[v1.ResourceMemory])
+			}
+
+			r := metav1.TableRow{Object: runtime.RawExtension{Object: &m}}
+			r.Cells = append(r.Cells, m.Name, printResourceUsage(v1.ResourceCPU, cpuQuantity), printResourceUsage(v1.ResourceMemory, memQuantity))
+			rows = append(rows, r)
+		}
+	}
+
+	// ->[NAMESPACE]  [POD]  NAME  CPU(cores)  MEMORY(bytes)
+	if options.PrintNamespaces {
+		for i := range rows {
+			row := rows[i]
+
+			var m metav1.Object
+			if obj := row.Object.Object; obj != nil {
+				if acc, err := meta.Accessor(obj); err == nil {
+					m = acc
+				}
+			}
+
+			r := make([]interface{}, 1, columnWidth)
+			r[0] = "<unknown>"
+			if m != nil {
+				r[0] = m.GetNamespace()
+			}
+			row.Cells = append(r, row.Cells...)
+
+			rows[i] = row
+		}
+	}
+
+	// [NAMESPACE]  [POD]  NAME  ->[NODE...]  CPU(cores)  MEMORY(bytes)
+	if options.Wide {
+		// Insert column after NAME and before CPU to align the output of options.Sum
+		nameColumn := -1
+		for i := range tableColumns {
+			if tableColumns[i].Format == "name" && tableColumns[i].Type == "string" {
+				nameColumn = i
+				break
+			}
+		}
+
+		if nameColumn != -1 {
+			insertIndex := nameColumn + 1
+
+			columnWidth = columnWidth + len(PodCustomColumnsDefinitions)
+			columns := make([]metav1.TableColumnDefinition, 0, columnWidth)
+			columns = append(columns, tableColumns[:insertIndex]...)
+			columns = append(columns, PodCustomColumnsDefinitions...)
+			tableColumns = append(columns, tableColumns[insertIndex:]...)
+
+			// obj[namespace][podName][nodeName]
+			podsNodeInfo := make(map[string]map[string]string)
+			if options.PodsInfo != nil {
+				for _, pod := range *options.PodsInfo {
+					if podsNodeInfo[pod.Namespace] == nil {
+						podsNodeInfo[pod.Namespace] = make(map[string]string)
+					}
+					podsNodeInfo[pod.Namespace][pod.Name] = pod.Spec.NodeName
+				}
+			}
+
+			for i := range rows {
+				row := rows[i]
+
+				var m metav1.Object
+				if obj := row.Object.Object; obj != nil {
+					if acc, err := meta.Accessor(obj); err == nil {
+						m = acc
+					}
+				}
+
+				nodeName := "<none>"
+				if m != nil {
+					if nsPodsNodeInfo, found := podsNodeInfo[m.GetNamespace()]; found {
+						if node, found := nsPodsNodeInfo[m.GetName()]; found {
+							nodeName = node
+						}
+					}
+				}
+				r := make([]interface{}, 0, columnWidth)
+				r = append(r, row.Cells[:insertIndex]...)
+				// Adding custom data
+				r = append(r, nodeName)
+				row.Cells = append(r, row.Cells[insertIndex:]...)
+
+				rows[i] = row
+			}
+		}
+	}
+
+	// [NAMESPACE]  [POD]  NAME  [NODE...]  CPU(cores)  MEMORY(bytes)
+	//                                   ->[________    ________]
+	//                                   ->[sum(CPU)    sum(MEM)]
+	if options.Sum {
+		cpuQuantity, _ := resource.ParseQuantity("0")
+		memQuantity, _ := resource.ParseQuantity("0")
+		for _, m := range metrics {
+			for _, c := range m.Containers {
+				cpuQuantity.Add(c.Usage[v1.ResourceCPU])
+				memQuantity.Add(c.Usage[v1.ResourceMemory])
+			}
+		}
+
+		r1 := make([]interface{}, columnWidth, columnWidth)
+		r2 := make([]interface{}, columnWidth, columnWidth)
+		for i := 0; i < columnWidth-2; i++ {
+			r1[i] = ""
+			r2[i] = ""
+		}
+
+		r1[columnWidth-2] = "________"
+		r1[columnWidth-1] = "________"
+		rows = append(rows, metav1.TableRow{Cells: r1})
+
+		r2[columnWidth-2] = printResourceUsage(v1.ResourceCPU, cpuQuantity)
+		r2[columnWidth-1] = printResourceUsage(v1.ResourceMemory, memQuantity)
+		rows = append(rows, metav1.TableRow{Cells: r2})
+	}
+
+	return metav1.Table{ColumnDefinitions: tableColumns, Rows: rows}, nil
+}
+
+func printResourceUsage(resourceType v1.ResourceName, quantity resource.Quantity) string {
+	switch resourceType {
+	case v1.ResourceCPU:
+		return fmt.Sprintf("%vm", quantity.MilliValue())
+	case v1.ResourceMemory:
+		return fmt.Sprintf("%vMi", quantity.Value()/(1024*1024))
+	default:
+		return fmt.Sprintf("%v", quantity.Value())
+	}
 }

--- a/staging/src/k8s.io/kubectl/pkg/metricsutil/metrics_printer_flags.go
+++ b/staging/src/k8s.io/kubectl/pkg/metricsutil/metrics_printer_flags.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metricsutil
+
+import (
+	"io"
+
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/spf13/cobra"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/printers"
+)
+
+type PodPrintFlags struct {
+	SortBy          string
+	PrintContainers bool
+	PrintNamespaces bool
+	NoHeaders       bool
+	Sum             bool
+
+	PodsInfo *[]v1.Pod
+
+	// Not used, just for create TopCmdPrinter.
+	out io.Writer
+}
+
+// EnsureWithSort sets the "SortBy" option.
+func (f *PodPrintFlags) EnsureWithSort(sortBy string) error {
+	f.SortBy = sortBy
+	return nil
+}
+
+// EnsureWithContainers sets the "PrintContainers" option to true.
+func (f *PodPrintFlags) EnsureWithContainers() error {
+	f.PrintContainers = true
+	return nil
+}
+
+// EnsureWithNamespaces sets the "PrintNamespaces" option to true.
+func (f *PodPrintFlags) EnsureWithNamespaces() error {
+	f.PrintNamespaces = true
+	return nil
+}
+
+// EnsureWithNoHeaders sets the "NoHeaders" option to true.
+func (f *PodPrintFlags) EnsureWithNoHeaders() error {
+	f.NoHeaders = true
+	return nil
+}
+
+// EnsureWithSum sets the "Sum" option to true.
+func (f *PodPrintFlags) EnsureWithSum() error {
+	f.Sum = true
+	return nil
+}
+
+// SetPodsInfo sets the "PodsInfo" option.
+func (f *PodPrintFlags) SetPodsInfo(pods *[]v1.Pod) error {
+	f.PodsInfo = pods
+	return nil
+}
+
+// AllowedFormats returns more customized formating options
+func (f *PodPrintFlags) AllowedFormats() []string {
+	return []string{"wide"}
+}
+
+// ToPrinter receives an outputFormat and returns a printer capable of handling output.
+func (f *PodPrintFlags) ToPrinter(outputFormat string) (printers.ResourcePrinter, error) {
+	if len(outputFormat) > 0 && outputFormat != "wide" {
+		return nil, genericclioptions.NoCompatiblePrinterError{Options: f, AllowedFormats: f.AllowedFormats()}
+	}
+
+	podPrintOptions := &PodPrintOptions{
+		SortBy:          f.SortBy,
+		PrintContainers: f.PrintContainers,
+		PrintNamespaces: f.PrintNamespaces,
+		NoHeaders:       f.NoHeaders,
+		Sum:             f.Sum,
+		Wide:            outputFormat == "wide",
+		PodsInfo:        f.PodsInfo,
+	}
+	p := &TopCmdPrinter{out: f.out, PodPrintOptions: podPrintOptions}
+
+	return p, nil
+}
+
+// AddFlags receives a *cobra.Command reference and binds flags related to printing to it
+func (f *PodPrintFlags) AddFlags(c *cobra.Command) {}
+
+// NewPodPrintFlags returns flags associated with printing, with default values set.
+func NewPodPrintFlags(out io.Writer) *PodPrintFlags {
+	return &PodPrintFlags{out: out}
+}

--- a/staging/src/k8s.io/kubectl/pkg/metricsutil/metrics_printer_flags_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/metricsutil/metrics_printer_flags_test.go
@@ -1,0 +1,361 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metricsutil
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	metricsapi "k8s.io/metrics/pkg/apis/metrics"
+)
+
+func TestTopCmdPrinterSupportsExpectedPodPrintOptions(t *testing.T) {
+	podsInfo := &[]v1.Pod{
+		{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: "default"}, Spec: v1.PodSpec{NodeName: "node1"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "pod2", Namespace: "ns2"}, Spec: v1.PodSpec{NodeName: "node2"}},
+	}
+	metrics := metricsapi.PodMetricsList{Items: []metricsapi.PodMetrics{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: "default"},
+			Timestamp:  metav1.Time{Time: time.Now()},
+			Window:     metav1.Duration{Duration: time.Minute},
+			Containers: []metricsapi.ContainerMetrics{
+				{
+					Name: "container1",
+					Usage: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("0.2"),
+						v1.ResourceMemory: resource.MustParse("1Gi"),
+					},
+				},
+				{
+					Name: "container2",
+					Usage: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("0.3"),
+						v1.ResourceMemory: resource.MustParse("3Gi"),
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "pod2", Namespace: "ns2"},
+			Timestamp:  metav1.Time{Time: time.Now()},
+			Window:     metav1.Duration{Duration: time.Minute},
+			Containers: []metricsapi.ContainerMetrics{
+				{
+					Name: "container1",
+					Usage: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("1"),
+						v1.ResourceMemory: resource.MustParse("1Gi"),
+					},
+				},
+			},
+		},
+	}}
+
+	testCases := []struct {
+		name       string
+		testObject runtime.Object
+
+		sortBy          string
+		PrintContainers bool
+		PrintNamespaces bool
+		noHeaders       bool
+		Sum             bool
+
+		PodsInfo *[]v1.Pod
+
+		outputFormat string
+
+		expectedError  string
+		expectedOutput string
+		expectNoMatch  bool
+	}{
+		{
+			name:       "empty output format matches a TopCmdPrinter printer",
+			testObject: metrics.DeepCopy(),
+			expectedOutput: `NAME   CPU(cores)   MEMORY(bytes)   
+pod1   500m         4096Mi          
+pod2   1000m        1024Mi          
+`,
+		},
+		{
+			name:         "wide output format prints without pods info",
+			testObject:   metrics.DeepCopy(),
+			outputFormat: "wide",
+			expectedOutput: `NAME   NODE     CPU(cores)   MEMORY(bytes)   
+pod1   <none>   500m         4096Mi          
+pod2   <none>   1000m        1024Mi          
+`,
+		},
+		{
+			name:         "wide output format prints with pods info",
+			PodsInfo:     podsInfo,
+			testObject:   metrics.DeepCopy(),
+			outputFormat: "wide",
+			expectedOutput: `NAME   NODE    CPU(cores)   MEMORY(bytes)   
+pod1   node1   500m         4096Mi          
+pod2   node2   1000m        1024Mi          
+`,
+		},
+		{
+			name:       "no-headers prints output with no headers",
+			testObject: metrics.DeepCopy(),
+			noHeaders:  true,
+			expectedOutput: `pod1   500m    4096Mi   
+pod2   1000m   1024Mi   
+`,
+		},
+		{
+			name:         "no-headers prints output with no headers and wide",
+			outputFormat: "wide",
+			testObject:   metrics.DeepCopy(),
+			noHeaders:    true,
+			expectedOutput: `pod1   <none>   500m    4096Mi   
+pod2   <none>   1000m   1024Mi   
+`,
+		},
+		{
+			name:         "no-headers prints output with no headers and pods info and wide",
+			PodsInfo:     podsInfo,
+			outputFormat: "wide",
+			testObject:   metrics.DeepCopy(),
+			noHeaders:    true,
+			expectedOutput: `pod1   node1   500m    4096Mi   
+pod2   node2   1000m   1024Mi   
+`,
+		},
+		{
+			name:            "containers displays containers list",
+			testObject:      metrics.DeepCopy(),
+			PrintContainers: true,
+			expectedOutput: `POD    NAME         CPU(cores)   MEMORY(bytes)   
+pod1   container1   200m         1024Mi          
+pod1   container2   300m         3072Mi          
+pod2   container1   1000m        1024Mi          
+`,
+		},
+		{
+			name:            "containers displays containers list and wide without pods info",
+			testObject:      metrics.DeepCopy(),
+			outputFormat:    "wide",
+			PrintContainers: true,
+			expectedOutput: `POD    NAME         NODE     CPU(cores)   MEMORY(bytes)   
+pod1   container1   <none>   200m         1024Mi          
+pod1   container2   <none>   300m         3072Mi          
+pod2   container1   <none>   1000m        1024Mi          
+`},
+		{
+			name:            "containers displays containers list and wide with pods info",
+			testObject:      metrics.DeepCopy(),
+			PodsInfo:        podsInfo,
+			outputFormat:    "wide",
+			PrintContainers: true,
+			expectedOutput: `POD    NAME         NODE    CPU(cores)   MEMORY(bytes)   
+pod1   container1   node1   200m         1024Mi          
+pod1   container2   node1   300m         3072Mi          
+pod2   container1   node2   1000m        1024Mi          
+`,
+		},
+		{
+			name:            "all-namespaces displays all namespaces metrics",
+			testObject:      metrics.DeepCopy(),
+			PrintNamespaces: true,
+			expectedOutput: `NAMESPACE   NAME   CPU(cores)   MEMORY(bytes)   
+default     pod1   500m         4096Mi          
+ns2         pod2   1000m        1024Mi          
+`,
+		},
+		{
+			name:            "all-namespaces displays all namespaces metrics and wide without pods info",
+			testObject:      metrics.DeepCopy(),
+			outputFormat:    "wide",
+			PrintNamespaces: true,
+			expectedOutput: `NAMESPACE   NAME   NODE     CPU(cores)   MEMORY(bytes)   
+default     pod1   <none>   500m         4096Mi          
+ns2         pod2   <none>   1000m        1024Mi          
+`,
+		},
+		{
+			name:            "all-namespaces displays all namespaces metrics and wide and pods info",
+			testObject:      metrics.DeepCopy(),
+			outputFormat:    "wide",
+			PodsInfo:        podsInfo,
+			PrintNamespaces: true,
+			expectedOutput: `NAMESPACE   NAME   NODE    CPU(cores)   MEMORY(bytes)   
+default     pod1   node1   500m         4096Mi          
+ns2         pod2   node2   1000m        1024Mi          
+`,
+		},
+		{
+			name:       "sort-by cpu sorted",
+			sortBy:     "cpu",
+			testObject: metrics.DeepCopy(),
+			expectedOutput: `NAME   CPU(cores)   MEMORY(bytes)   
+pod2   1000m        1024Mi          
+pod1   500m         4096Mi          
+`,
+		},
+		{
+			name:            "sort-by cpu sorted with containers",
+			sortBy:          "cpu",
+			PrintContainers: true,
+			testObject:      metrics.DeepCopy(),
+			expectedOutput: `POD    NAME         CPU(cores)   MEMORY(bytes)   
+pod2   container1   1000m        1024Mi          
+pod1   container2   300m         3072Mi          
+pod1   container1   200m         1024Mi          
+`,
+		},
+		{
+			name:            "sort-by cpu sorted with containers and wide and pods info",
+			sortBy:          "cpu",
+			PrintContainers: true,
+			PodsInfo:        podsInfo,
+			outputFormat:    "wide",
+			testObject:      metrics.DeepCopy(),
+			expectedOutput: `POD    NAME         NODE    CPU(cores)   MEMORY(bytes)   
+pod2   container1   node2   1000m        1024Mi          
+pod1   container2   node1   300m         3072Mi          
+pod1   container1   node1   200m         1024Mi          
+`,
+		},
+		{
+			name:       "sort-by memory sorted",
+			sortBy:     "memory",
+			testObject: metrics.DeepCopy(),
+			expectedOutput: `NAME   CPU(cores)   MEMORY(bytes)   
+pod1   500m         4096Mi          
+pod2   1000m        1024Mi          
+`,
+		},
+		{
+			name:            "sort-by memory sorted with containers",
+			sortBy:          "memory",
+			testObject:      metrics.DeepCopy(),
+			PrintContainers: true,
+			expectedOutput: `POD    NAME         CPU(cores)   MEMORY(bytes)   
+pod1   container2   300m         3072Mi          
+pod1   container1   200m         1024Mi          
+pod2   container1   1000m        1024Mi          
+`,
+		},
+		{
+			name:       "sum display total resource usage",
+			testObject: metrics.DeepCopy(),
+			Sum:        true,
+			expectedOutput: `NAME   CPU(cores)   MEMORY(bytes)   
+pod1   500m         4096Mi          
+pod2   1000m        1024Mi          
+       ________     ________        
+       1500m        5120Mi          
+`,
+		},
+		{
+			name:            "all options",
+			testObject:      metrics.DeepCopy(),
+			sortBy:          "cpu",
+			PrintContainers: true,
+			PrintNamespaces: true,
+			noHeaders:       true,
+			Sum:             true,
+			outputFormat:    "wide",
+			PodsInfo:        podsInfo,
+			expectedOutput: `ns2       pod2   container1   node2   1000m      1024Mi     
+default   pod1   container2   node1   300m       3072Mi     
+default   pod1   container1   node1   200m       1024Mi     
+                                      ________   ________   
+                                      1500m      5120Mi     
+`,
+		},
+		{
+			name:            "all options without no-headers",
+			testObject:      metrics.DeepCopy(),
+			sortBy:          "cpu",
+			PrintContainers: true,
+			PrintNamespaces: true,
+			Sum:             true,
+			outputFormat:    "wide",
+			PodsInfo:        podsInfo,
+			expectedOutput: `NAMESPACE   POD    NAME         NODE    CPU(cores)   MEMORY(bytes)   
+ns2         pod2   container1   node2   1000m        1024Mi          
+default     pod1   container2   node1   300m         3072Mi          
+default     pod1   container1   node1   200m         1024Mi          
+                                        ________     ________        
+                                        1500m        5120Mi          
+`,
+		},
+		{
+			name:          "no printer is matched on an invalid outputFormat",
+			testObject:    metrics.DeepCopy(),
+			outputFormat:  "invalid",
+			expectNoMatch: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%s %T", tc.name, tc.testObject), func(t *testing.T) {
+			printFlags := PodPrintFlags{
+				SortBy:          tc.sortBy,
+				PrintContainers: tc.PrintContainers,
+				PrintNamespaces: tc.PrintNamespaces,
+				NoHeaders:       tc.noHeaders,
+				Sum:             tc.Sum,
+				PodsInfo:        tc.PodsInfo,
+			}
+
+			p, err := printFlags.ToPrinter(tc.outputFormat)
+			if tc.expectNoMatch {
+				if !genericclioptions.IsNoCompatiblePrinterError(err) {
+					t.Fatalf("expected no printer matches for output format %q", tc.outputFormat)
+				}
+				return
+			}
+			if genericclioptions.IsNoCompatiblePrinterError(err) {
+				t.Fatalf("expected to match template printer for output format %q", tc.outputFormat)
+			}
+
+			if len(tc.expectedError) > 0 {
+				if err == nil || !strings.Contains(err.Error(), tc.expectedError) {
+					t.Errorf("expecting error %q, got %v", tc.expectedError, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			_, _, out, _ := genericiooptions.NewTestIOStreams()
+
+			err = p.PrintObj(tc.testObject, out)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			assert.Equal(t, tc.expectedOutput, out.String())
+		})
+	}
+}

--- a/staging/src/k8s.io/kubectl/pkg/metricsutil/metrics_printer_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/metricsutil/metrics_printer_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package metricsutil
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -377,6 +378,822 @@ test-1   400m         5120Mi
 			top := NewTopCmdPrinter(out)
 			err := top.PrintPodMetrics(test.podMetric, test.printContainers,
 				test.withNamespace, test.noHeader, test.sortBy, test.sum)
+			assert.Equal(t, test.expectedErr, err)
+			assert.Equal(t, test.expectedOutput, out.String())
+		})
+	}
+}
+
+func TestPrintObjOutputSameAsPrintPodMetrics(t *testing.T) {
+
+	tests := []struct {
+		name            string
+		podMetric       []metricsapi.PodMetrics
+		printContainers bool
+		withNamespace   bool
+		noHeader        bool
+		sortBy          string
+		sum             bool
+		expectedErr     error
+		expectedOutput  string
+	}{
+		{
+			name: "Single Pod with Multiple Containers",
+			podMetric: []metricsapi.PodMetrics{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "default",
+					},
+					Timestamp: metav1.Time{Time: time.Now()},
+					Window:    metav1.Duration{Duration: time.Minute},
+					Containers: []metricsapi.ContainerMetrics{
+						{
+							Name: "container1",
+							Usage: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0.2"),
+								v1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+						},
+						{
+							Name: "container2",
+							Usage: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0.2"),
+								v1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+						},
+					},
+				},
+			},
+			expectedOutput: `NAME   CPU(cores)   MEMORY(bytes)   
+test   400m         2048Mi          
+`,
+		},
+		{
+			name: "Single Pod with Multiple Containers - Print Containers",
+			podMetric: []metricsapi.PodMetrics{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "default",
+					},
+					Timestamp: metav1.Time{Time: time.Now()},
+					Window:    metav1.Duration{Duration: time.Minute},
+					Containers: []metricsapi.ContainerMetrics{
+						{
+							Name: "container1",
+							Usage: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0.2"),
+								v1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+						},
+						{
+							Name: "container2",
+							Usage: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0.2"),
+								v1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+						},
+					},
+				},
+			},
+			printContainers: true,
+			expectedOutput: `POD    NAME         CPU(cores)   MEMORY(bytes)   
+test   container1   200m         1024Mi          
+test   container2   200m         1024Mi          
+`,
+		},
+		{
+			name: "Single Pod with Multiple Containers - Calculate Resource Usage Without Header",
+			podMetric: []metricsapi.PodMetrics{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "default",
+					},
+					Timestamp: metav1.Time{Time: time.Now()},
+					Window:    metav1.Duration{Duration: time.Minute},
+					Containers: []metricsapi.ContainerMetrics{
+						{
+							Name: "container1",
+							Usage: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0.2"),
+								v1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+						},
+						{
+							Name: "container2",
+							Usage: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0.2"),
+								v1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+						},
+					},
+				},
+			},
+			noHeader: true,
+			expectedOutput: `test   400m   2048Mi   
+`,
+		},
+		{
+			name: "Multiple Pods with Multiple Containers - Sort by Memory Usage",
+			podMetric: []metricsapi.PodMetrics{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "default",
+					},
+					Timestamp: metav1.Time{Time: time.Now()},
+					Window:    metav1.Duration{Duration: time.Minute},
+					Containers: []metricsapi.ContainerMetrics{
+						{
+							Name: "container1",
+							Usage: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0.2"),
+								v1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+						},
+						{
+							Name: "container2",
+							Usage: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0.2"),
+								v1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-1",
+						Namespace: "default",
+					},
+					Timestamp: metav1.Time{Time: time.Now()},
+					Window:    metav1.Duration{Duration: time.Minute},
+					Containers: []metricsapi.ContainerMetrics{
+						{
+							Name: "container1",
+							Usage: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0.2"),
+								v1.ResourceMemory: resource.MustParse("3Gi"),
+							},
+						},
+						{
+							Name: "container2",
+							Usage: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0.2"),
+								v1.ResourceMemory: resource.MustParse("2Gi"),
+							},
+						},
+					},
+				},
+			},
+			sortBy: "memory",
+			expectedOutput: `NAME     CPU(cores)   MEMORY(bytes)   
+test-1   400m         5120Mi          
+test     400m         2048Mi          
+`,
+		},
+		{
+			name: "Multiple Pods with Multiple Containers - Calculate Total Resource Usage",
+			podMetric: []metricsapi.PodMetrics{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "default",
+					},
+					Timestamp: metav1.Time{Time: time.Now()},
+					Window:    metav1.Duration{Duration: time.Minute},
+					Containers: []metricsapi.ContainerMetrics{
+						{
+							Name: "container1",
+							Usage: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0.2"),
+								v1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+						},
+						{
+							Name: "container2",
+							Usage: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0.2"),
+								v1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-1",
+						Namespace: "default",
+					},
+					Timestamp: metav1.Time{Time: time.Now()},
+					Window:    metav1.Duration{Duration: time.Minute},
+					Containers: []metricsapi.ContainerMetrics{
+						{
+							Name: "container1",
+							Usage: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0.2"),
+								v1.ResourceMemory: resource.MustParse("3Gi"),
+							},
+						},
+						{
+							Name: "container2",
+							Usage: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0.2"),
+								v1.ResourceMemory: resource.MustParse("2Gi"),
+							},
+						},
+					},
+				},
+			},
+			sum: true,
+			expectedOutput: `NAME     CPU(cores)   MEMORY(bytes)   
+test     400m         2048Mi          
+test-1   400m         5120Mi          
+         ________     ________        
+         800m         7168Mi          
+`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Create a new TopCmdPrinter with a test writer.
+			_, _, out, _ := genericiooptions.NewTestIOStreams()
+
+			options := &PodPrintOptions{
+				PrintContainers: test.printContainers,
+				PrintNamespaces: test.withNamespace,
+				NoHeaders:       test.noHeader,
+				SortBy:          test.sortBy,
+				Sum:             test.sum,
+			}
+			top := &TopCmdPrinter{out: out, PodPrintOptions: options}
+			metrics := &metricsapi.PodMetricsList{Items: test.podMetric}
+			err := top.PrintObj(metrics, out)
+			assert.Equal(t, test.expectedErr, err)
+			assert.Equal(t, test.expectedOutput, out.String())
+		})
+	}
+}
+
+func TestPrintObj(t *testing.T) {
+	t.Run("print node metrics", func(t *testing.T) {
+		// Create a new TopCmdPrinter with a test writer.
+		_, _, out, _ := genericiooptions.NewTestIOStreams()
+
+		top := &TopCmdPrinter{out: out}
+		metrics := &metricsapi.NodeMetricsList{}
+		err := top.PrintObj(metrics, out)
+		assert.Equal(t, errors.New("printing node metrics is not yet supported"), err)
+		assert.Equal(t, "", out.String())
+	})
+
+	t.Run("print pod metrics without options", func(t *testing.T) {
+		// Create a new TopCmdPrinter with a test writer.
+		_, _, out, _ := genericiooptions.NewTestIOStreams()
+
+		top := &TopCmdPrinter{out: out}
+		metrics := &metricsapi.PodMetricsList{}
+		err := top.PrintObj(metrics, out)
+		assert.Equal(t, nil, err)
+		assert.Equal(t, "", out.String())
+	})
+
+}
+
+func TestPrintObjPrintPodMetrics(t *testing.T) {
+
+	tests := []struct {
+		name            string
+		podMetric       []metricsapi.PodMetrics
+		printContainers bool
+		withNamespace   bool
+		noHeader        bool
+		sortBy          string
+		sum             bool
+		expectedErr     error
+		expectedOutput  string
+
+		wide     bool
+		podsInfo *[]v1.Pod
+	}{
+		{
+			name: "Single Pod with Multiple Containers and Wide",
+			wide: true,
+			podsInfo: &[]v1.Pod{
+				{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"}, Spec: v1.PodSpec{NodeName: "node1"}},
+			},
+			podMetric: []metricsapi.PodMetrics{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "default",
+					},
+					Timestamp: metav1.Time{Time: time.Now()},
+					Window:    metav1.Duration{Duration: time.Minute},
+					Containers: []metricsapi.ContainerMetrics{
+						{
+							Name: "container1",
+							Usage: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0.2"),
+								v1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+						},
+						{
+							Name: "container2",
+							Usage: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0.2"),
+								v1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+						},
+					},
+				},
+			},
+			expectedOutput: `NAME   NODE    CPU(cores)   MEMORY(bytes)   
+test   node1   400m         2048Mi          
+`,
+		},
+		{
+			name: "Single Pod with Multiple Containers and Wide but no pods info",
+			wide: true,
+			podMetric: []metricsapi.PodMetrics{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "default",
+					},
+					Timestamp: metav1.Time{Time: time.Now()},
+					Window:    metav1.Duration{Duration: time.Minute},
+					Containers: []metricsapi.ContainerMetrics{
+						{
+							Name: "container1",
+							Usage: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0.2"),
+								v1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+						},
+						{
+							Name: "container2",
+							Usage: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0.2"),
+								v1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+						},
+					},
+				},
+			},
+			expectedOutput: `NAME   NODE     CPU(cores)   MEMORY(bytes)   
+test   <none>   400m         2048Mi          
+`,
+		},
+		{
+			name: "Single Pod with Multiple Containers and Wide but no spec pods info",
+			wide: true,
+			podsInfo: &[]v1.Pod{
+				{ObjectMeta: metav1.ObjectMeta{Name: "testother", Namespace: "default"}, Spec: v1.PodSpec{NodeName: "node1"}},
+			},
+			podMetric: []metricsapi.PodMetrics{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "default",
+					},
+					Timestamp: metav1.Time{Time: time.Now()},
+					Window:    metav1.Duration{Duration: time.Minute},
+					Containers: []metricsapi.ContainerMetrics{
+						{
+							Name: "container1",
+							Usage: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0.2"),
+								v1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+						},
+						{
+							Name: "container2",
+							Usage: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0.2"),
+								v1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+						},
+					},
+				},
+			},
+			expectedOutput: `NAME   NODE     CPU(cores)   MEMORY(bytes)   
+test   <none>   400m         2048Mi          
+`,
+		},
+		{
+			name: "Single Pod with Multiple Containers - Print Containers and Wide",
+			wide: true,
+			podsInfo: &[]v1.Pod{
+				{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"}, Spec: v1.PodSpec{NodeName: "node1"}},
+			},
+			podMetric: []metricsapi.PodMetrics{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "default",
+					},
+					Timestamp: metav1.Time{Time: time.Now()},
+					Window:    metav1.Duration{Duration: time.Minute},
+					Containers: []metricsapi.ContainerMetrics{
+						{
+							Name: "container1",
+							Usage: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0.2"),
+								v1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+						},
+						{
+							Name: "container2",
+							Usage: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0.2"),
+								v1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+						},
+					},
+				},
+			},
+			printContainers: true,
+			expectedOutput: `POD    NAME         NODE    CPU(cores)   MEMORY(bytes)   
+test   container1   node1   200m         1024Mi          
+test   container2   node1   200m         1024Mi          
+`,
+		},
+		{
+			name: "Single Pod with Multiple Containers - Print Containers and Wide but no spec pods info",
+			wide: true,
+			podsInfo: &[]v1.Pod{
+				{ObjectMeta: metav1.ObjectMeta{Name: "testother", Namespace: "default"}, Spec: v1.PodSpec{NodeName: "node1"}},
+			},
+			podMetric: []metricsapi.PodMetrics{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "default",
+					},
+					Timestamp: metav1.Time{Time: time.Now()},
+					Window:    metav1.Duration{Duration: time.Minute},
+					Containers: []metricsapi.ContainerMetrics{
+						{
+							Name: "container1",
+							Usage: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0.2"),
+								v1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+						},
+						{
+							Name: "container2",
+							Usage: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0.2"),
+								v1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+						},
+					},
+				},
+			},
+			printContainers: true,
+			expectedOutput: `POD    NAME         NODE     CPU(cores)   MEMORY(bytes)   
+test   container1   <none>   200m         1024Mi          
+test   container2   <none>   200m         1024Mi          
+`,
+		},
+		{
+			name: "Single Pod with Multiple Containers - Wide and Calculate Resource Usage Without Header",
+			wide: true,
+			podsInfo: &[]v1.Pod{
+				{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"}, Spec: v1.PodSpec{NodeName: "node1"}},
+			},
+			podMetric: []metricsapi.PodMetrics{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "default",
+					},
+					Timestamp: metav1.Time{Time: time.Now()},
+					Window:    metav1.Duration{Duration: time.Minute},
+					Containers: []metricsapi.ContainerMetrics{
+						{
+							Name: "container1",
+							Usage: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0.2"),
+								v1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+						},
+						{
+							Name: "container2",
+							Usage: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0.2"),
+								v1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+						},
+					},
+				},
+			},
+			noHeader: true,
+			expectedOutput: `test   node1   400m   2048Mi   
+`,
+		},
+		{
+			name: "Single Pod with Multiple Containers - Wide and no podInfo and Calculate Resource Usage Without Header",
+			wide: true,
+			podMetric: []metricsapi.PodMetrics{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "default",
+					},
+					Timestamp: metav1.Time{Time: time.Now()},
+					Window:    metav1.Duration{Duration: time.Minute},
+					Containers: []metricsapi.ContainerMetrics{
+						{
+							Name: "container1",
+							Usage: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0.2"),
+								v1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+						},
+						{
+							Name: "container2",
+							Usage: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0.2"),
+								v1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+						},
+					},
+				},
+			},
+			noHeader: true,
+			expectedOutput: `test   <none>   400m   2048Mi   
+`,
+		},
+		{
+			name: "Multiple Pods with Multiple Containers - Wide and Sort by Memory Usage",
+			wide: true,
+			podsInfo: &[]v1.Pod{
+				{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"}, Spec: v1.PodSpec{NodeName: "node1"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "test-1", Namespace: "default"}, Spec: v1.PodSpec{NodeName: "node3"}},
+			},
+			podMetric: []metricsapi.PodMetrics{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "default",
+					},
+					Timestamp: metav1.Time{Time: time.Now()},
+					Window:    metav1.Duration{Duration: time.Minute},
+					Containers: []metricsapi.ContainerMetrics{
+						{
+							Name: "container1",
+							Usage: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0.2"),
+								v1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+						},
+						{
+							Name: "container2",
+							Usage: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0.2"),
+								v1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-1",
+						Namespace: "default",
+					},
+					Timestamp: metav1.Time{Time: time.Now()},
+					Window:    metav1.Duration{Duration: time.Minute},
+					Containers: []metricsapi.ContainerMetrics{
+						{
+							Name: "container1",
+							Usage: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0.2"),
+								v1.ResourceMemory: resource.MustParse("3Gi"),
+							},
+						},
+						{
+							Name: "container2",
+							Usage: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0.2"),
+								v1.ResourceMemory: resource.MustParse("2Gi"),
+							},
+						},
+					},
+				},
+			},
+			sortBy: "memory",
+			expectedOutput: `NAME     NODE    CPU(cores)   MEMORY(bytes)   
+test-1   node3   400m         5120Mi          
+test     node1   400m         2048Mi          
+`,
+		},
+		{
+			name: "Multiple Pods with Multiple Containers - Wide and Calculate Total Resource Usage",
+			wide: true,
+			podsInfo: &[]v1.Pod{
+				{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"}, Spec: v1.PodSpec{NodeName: "node1"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "test-1", Namespace: "default"}, Spec: v1.PodSpec{NodeName: "node3"}},
+			},
+			podMetric: []metricsapi.PodMetrics{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "default",
+					},
+					Timestamp: metav1.Time{Time: time.Now()},
+					Window:    metav1.Duration{Duration: time.Minute},
+					Containers: []metricsapi.ContainerMetrics{
+						{
+							Name: "container1",
+							Usage: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0.2"),
+								v1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+						},
+						{
+							Name: "container2",
+							Usage: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0.2"),
+								v1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-1",
+						Namespace: "default",
+					},
+					Timestamp: metav1.Time{Time: time.Now()},
+					Window:    metav1.Duration{Duration: time.Minute},
+					Containers: []metricsapi.ContainerMetrics{
+						{
+							Name: "container1",
+							Usage: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0.2"),
+								v1.ResourceMemory: resource.MustParse("3Gi"),
+							},
+						},
+						{
+							Name: "container2",
+							Usage: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0.2"),
+								v1.ResourceMemory: resource.MustParse("2Gi"),
+							},
+						},
+					},
+				},
+			},
+			sum: true,
+			expectedOutput: `NAME     NODE    CPU(cores)   MEMORY(bytes)   
+test     node1   400m         2048Mi          
+test-1   node3   400m         5120Mi          
+                 ________     ________        
+                 800m         7168Mi          
+`,
+		},
+		{
+			name:          "Multiple Pods with Multiple Containers with difference namespace and sort by cpu - Wide and Calculate Total Resource Usage",
+			wide:          true,
+			sortBy:        "cpu",
+			withNamespace: true,
+			podsInfo: &[]v1.Pod{
+				{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"}, Spec: v1.PodSpec{NodeName: "node1"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "test2", Namespace: "ns2"}, Spec: v1.PodSpec{NodeName: "node2"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "test3", Namespace: "otherns"}, Spec: v1.PodSpec{NodeName: "node3"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "test-1", Namespace: "default"}, Spec: v1.PodSpec{NodeName: "node-1"}},
+			},
+			podMetric: []metricsapi.PodMetrics{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "default",
+					},
+					Timestamp: metav1.Time{Time: time.Now()},
+					Window:    metav1.Duration{Duration: time.Minute},
+					Containers: []metricsapi.ContainerMetrics{
+						{
+							Name: "container1",
+							Usage: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0.2"),
+								v1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+						},
+						{
+							Name: "container2",
+							Usage: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0.2"),
+								v1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test2",
+						Namespace: "ns2",
+					},
+					Timestamp: metav1.Time{Time: time.Now()},
+					Window:    metav1.Duration{Duration: time.Minute},
+					Containers: []metricsapi.ContainerMetrics{
+						{
+							Name: "container1",
+							Usage: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0.5"),
+								v1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+						},
+						{
+							Name: "container2",
+							Usage: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0.2"),
+								v1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test3",
+						Namespace: "ns2",
+					},
+					Timestamp: metav1.Time{Time: time.Now()},
+					Window:    metav1.Duration{Duration: time.Minute},
+					Containers: []metricsapi.ContainerMetrics{
+						{
+							Name: "container1",
+							Usage: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0.3"),
+								v1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+						},
+						{
+							Name: "container2",
+							Usage: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0.3"),
+								v1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-1",
+						Namespace: "default",
+					},
+					Timestamp: metav1.Time{Time: time.Now()},
+					Window:    metav1.Duration{Duration: time.Minute},
+					Containers: []metricsapi.ContainerMetrics{
+						{
+							Name: "container1",
+							Usage: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0.6"),
+								v1.ResourceMemory: resource.MustParse("3Gi"),
+							},
+						},
+						{
+							Name: "container2",
+							Usage: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0.3"),
+								v1.ResourceMemory: resource.MustParse("2Gi"),
+							},
+						},
+					},
+				},
+			},
+			sum: true,
+			expectedOutput: `NAMESPACE   NAME     NODE     CPU(cores)   MEMORY(bytes)   
+default     test-1   node-1   900m         5120Mi          
+ns2         test2    node2    700m         2048Mi          
+ns2         test3    <none>   600m         2048Mi          
+default     test     node1    400m         2048Mi          
+                              ________     ________        
+                              2600m        11264Mi         
+`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Create a new TopCmdPrinter with a test writer.
+			_, _, out, _ := genericiooptions.NewTestIOStreams()
+
+			options := &PodPrintOptions{
+				PrintContainers: test.printContainers,
+				PrintNamespaces: test.withNamespace,
+				NoHeaders:       test.noHeader,
+				SortBy:          test.sortBy,
+				Sum:             test.sum,
+
+				Wide:     test.wide,
+				PodsInfo: test.podsInfo,
+			}
+			top := &TopCmdPrinter{out: out, PodPrintOptions: options}
+			metrics := &metricsapi.PodMetricsList{Items: test.podMetric}
+			err := top.PrintObj(metrics, out)
 			assert.Equal(t, test.expectedErr, err)
 			assert.Equal(t, test.expectedOutput, out.String())
 		})


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
add output flag `-o`, `--output` for `kubectl top pod`.

use `-o wide` or `--output wide` to display NODE info like:
```
NAME                   NODE     CPU(cores)   MEMORY(bytes)   
db-5977df8496-p8s2f    node1    1m           57Mi
one-d48cbd8b8-znqcx    node2    2m           1Mi
two-55445bbdb9-bt72c   node3    5m           2Mi
```

Convenient to view the pod status of the specified node: `kubectl top pod -o wide | grep node-name`.
Convenient to check the load and node distribution of pods: `kubectl top pod -o wide -l app=label`.
When sudden surge in node load, convenient to check the status of the corresponding pods.

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubectl/issues/1706

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add output flag [(-o|--output=)wide] for kubectl top pod command.
Can be used to output more detailed information.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
