### PR TITLE
e2e network policies test support network policies with finalizers

### DIFF
--- a/test/e2e/network/netpol/network_policy_api.go
+++ b/test/e2e/network/netpol/network_policy_api.go
@@ -221,7 +221,7 @@ var _ = common.SIGDescribe("Netpol API", func() {
 				return false, err
 			}
 			if len(nps.Items) > 0 {
-				framework.Logf("still %d network policies present, retrying ...")
+				framework.Logf("still %d network policies present, retrying ...", len(nps.Items))
 				return false, nil
 			}
 			return true, nil

--- a/test/e2e/network/netpol/network_policy_api.go
+++ b/test/e2e/network/netpol/network_policy_api.go
@@ -291,7 +291,7 @@ var _ = common.SIGDescribe("Netpol API", func() {
 				return false, err
 			}
 			if len(nps.Items) > 0 {
-				framework.Logf("still %d network policies present, retrying ...", len(nps.Items) )
+				framework.Logf("still %d network policies present, retrying ...", len(nps.Items))
 				return false, nil
 			}
 			return true, nil

--- a/test/e2e/network/netpol/network_policy_api.go
+++ b/test/e2e/network/netpol/network_policy_api.go
@@ -291,7 +291,7 @@ var _ = common.SIGDescribe("Netpol API", func() {
 				return false, err
 			}
 			if len(nps.Items) > 0 {
-				framework.Logf("still %d network policies present, retrying ...")
+				framework.Logf("still %d network policies present, retrying ...", len(nps.Items) )
 				return false, nil
 			}
 			return true, nil

--- a/test/e2e/network/netpol/network_policy_api.go
+++ b/test/e2e/network/netpol/network_policy_api.go
@@ -197,9 +197,16 @@ var _ = common.SIGDescribe("Netpol API", func() {
 		ginkgo.By("deleting")
 		err = npClient.Delete(ctx, createdNetPol.Name, metav1.DeleteOptions{})
 		framework.ExpectNoError(err)
-		_, err = npClient.Get(ctx, createdNetPol.Name, metav1.GetOptions{})
-		if !apierrors.IsNotFound(err) {
-			framework.Failf("expected 404, got %#v", err)
+		err = wait.PollUntilContextTimeout(ctx, 2*time.Second, 1*time.Minute, false, func(ctx context.Context) (done bool, err error) {
+			_, err = npClient.Get(ctx, createdNetPol.Name, metav1.GetOptions{})
+			if !apierrors.IsNotFound(err) {
+				framework.Logf("expected 404, got %#v", err)
+				return false, nil
+			}
+			return true, nil
+		})
+		if err != nil {
+			framework.Failf("unexpected error deleting existing network policy: %v", err)
 		}
 		nps, err = npClient.List(ctx, metav1.ListOptions{LabelSelector: "special-label=" + f.UniqueName})
 		framework.ExpectNoError(err)
@@ -208,9 +215,20 @@ var _ = common.SIGDescribe("Netpol API", func() {
 		ginkgo.By("deleting a collection")
 		err = npClient.DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: "special-label=" + f.UniqueName})
 		framework.ExpectNoError(err)
-		nps, err = npClient.List(ctx, metav1.ListOptions{LabelSelector: "special-label=" + f.UniqueName})
-		framework.ExpectNoError(err)
-		gomega.Expect(nps.Items).To(gomega.BeEmpty(), "filtered list should have 0 items")
+		err = wait.PollUntilContextTimeout(ctx, 2*time.Second, 1*time.Minute, false, func(ctx context.Context) (done bool, err error) {
+			nps, err = npClient.List(ctx, metav1.ListOptions{LabelSelector: "special-label=" + f.UniqueName})
+			if err != nil {
+				return false, err
+			}
+			if len(nps.Items) > 0 {
+				framework.Logf("still %d network policies present, retrying ...")
+				return false, nil
+			}
+			return true, nil
+		})
+		if err != nil {
+			framework.Failf("unexpected error deleting existing network policies: %v", err)
+		}
 	})
 
 	/*
@@ -267,8 +285,19 @@ var _ = common.SIGDescribe("Netpol API", func() {
 		ginkgo.By("deleting all test collection")
 		err = npClient.DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: "special-label=" + f.UniqueName})
 		framework.ExpectNoError(err)
-		nps, err := npClient.List(ctx, metav1.ListOptions{LabelSelector: "special-label=" + f.UniqueName})
-		framework.ExpectNoError(err)
-		gomega.Expect(nps.Items).To(gomega.BeEmpty(), "filtered list should be 0 items")
+		err = wait.PollUntilContextTimeout(ctx, 2*time.Second, 1*time.Minute, false, func(ctx context.Context) (done bool, err error) {
+			nps, err := npClient.List(ctx, metav1.ListOptions{LabelSelector: "special-label=" + f.UniqueName})
+			if err != nil {
+				return false, err
+			}
+			if len(nps.Items) > 0 {
+				framework.Logf("still %d network policies present, retrying ...")
+				return false, nil
+			}
+			return true, nil
+		})
+		if err != nil {
+			framework.Failf("unexpected error deleting existing network policies: %v", err)
+		}
 	})
 })


### PR DESCRIPTION
/kind cleanup
/kind failing-test

Fixes https://github.com/kubernetes-sigs/network-policy-finalizer/issues/3
Fixes https://github.com/kubernetes-sigs/network-policy-finalizer/issues/2


```release-note
NONE
```

The e2e test expect the deletion of network policies to be synchronous, but there are some cases where is needed to use finalizer to avoid security issues, so the tests must consider the network policy object deletion to be asynchronous.

/sig network
/assign @danwinship @adrianmoisey 