### PR TITLE
EndpointSlice cleanups

### DIFF
--- a/staging/src/k8s.io/endpointslice/metrics/cache.go
+++ b/staging/src/k8s.io/endpointslice/metrics/cache.go
@@ -20,7 +20,6 @@ import (
 	"math"
 	"sync"
 
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	endpointsliceutil "k8s.io/endpointslice/util"
 )
@@ -59,12 +58,6 @@ type Cache struct {
 	// The type should be read as map[trafficDistribution]setOfServices
 	servicesByTrafficDistribution map[string]map[types.NamespacedName]bool
 }
-
-const (
-	// Label value for cases when service.spec.trafficDistribution is set to an
-	// unknown value.
-	trafficDistributionImplementationSpecific = "ImplementationSpecific"
-)
 
 // ServicePortCache tracks values for total numbers of desired endpoints as well
 // as the efficiency of EndpointSlice endpoints distribution for each unique
@@ -151,13 +144,6 @@ func (c *Cache) UpdateTrafficDistributionForService(serviceNN types.NamespacedNa
 	}
 
 	trafficDistribution := *trafficDistributionPtr
-	// If we don't explicitly recognize a value for trafficDistribution, it should
-	// be treated as an implementation specific value. All such implementation
-	// specific values should use the label value "ImplementationSpecific" to not
-	// explode the metric labels cardinality.
-	if trafficDistribution != corev1.ServiceTrafficDistributionPreferClose {
-		trafficDistribution = trafficDistributionImplementationSpecific
-	}
 	serviceSet, ok := c.servicesByTrafficDistribution[trafficDistribution]
 	if !ok {
 		serviceSet = make(map[types.NamespacedName]bool)

--- a/staging/src/k8s.io/endpointslice/metrics/cache_test.go
+++ b/staging/src/k8s.io/endpointslice/metrics/cache_test.go
@@ -25,17 +25,14 @@ import (
 	discovery "k8s.io/api/discovery/v1"
 	"k8s.io/apimachinery/pkg/types"
 	endpointsliceutil "k8s.io/endpointslice/util"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestNumEndpointsAndSlices(t *testing.T) {
 	c := NewCache(int32(100))
 
-	p80 := int32(80)
-	p443 := int32(443)
-
-	pmKey80443 := endpointsliceutil.NewPortMapKey([]discovery.EndpointPort{{Port: &p80}, {Port: &p443}})
-	pmKey80 := endpointsliceutil.NewPortMapKey([]discovery.EndpointPort{{Port: &p80}})
+	pmKey80443 := endpointsliceutil.NewPortMapKey([]discovery.EndpointPort{{Port: ptr.To[int32](80)}, {Port: ptr.To[int32](443)}})
+	pmKey80 := endpointsliceutil.NewPortMapKey([]discovery.EndpointPort{{Port: ptr.To[int32](80)}})
 
 	spCacheEfficient := NewServicePortCache()
 	spCacheEfficient.Set(pmKey80, EfficiencyInfo{Endpoints: 45, Slices: 1})
@@ -64,11 +61,8 @@ func TestNumEndpointsAndSlices(t *testing.T) {
 func TestPlaceHolderSlice(t *testing.T) {
 	c := NewCache(int32(100))
 
-	p80 := int32(80)
-	p443 := int32(443)
-
-	pmKey80443 := endpointsliceutil.NewPortMapKey([]discovery.EndpointPort{{Port: &p80}, {Port: &p443}})
-	pmKey80 := endpointsliceutil.NewPortMapKey([]discovery.EndpointPort{{Port: &p80}})
+	pmKey80443 := endpointsliceutil.NewPortMapKey([]discovery.EndpointPort{{Port: ptr.To[int32](80)}, {Port: ptr.To[int32](443)}})
+	pmKey80 := endpointsliceutil.NewPortMapKey([]discovery.EndpointPort{{Port: ptr.To[int32](80)}})
 
 	sp := NewServicePortCache()
 	sp.Set(pmKey80, EfficiencyInfo{Endpoints: 0, Slices: 1})
@@ -113,25 +107,25 @@ func TestCache_ServicesByTrafficDistribution(t *testing.T) {
 	// Mutate and make assertions
 
 	desc := "service1 starts using trafficDistribution=PreferClose"
-	cache.UpdateTrafficDistributionForService(service1, ptrTo(corev1.ServiceTrafficDistributionPreferClose))
+	cache.UpdateTrafficDistributionForService(service1, ptr.To(corev1.ServiceTrafficDistributionPreferClose))
 	mustHaveServicesByTrafficDistribution(map[string]map[types.NamespacedName]bool{
 		corev1.ServiceTrafficDistributionPreferClose: {service1: true},
 	}, desc)
 
 	desc = "service1 starts using trafficDistribution=PreferClose, retries of similar mutation should be idempotent"
-	cache.UpdateTrafficDistributionForService(service1, ptrTo(corev1.ServiceTrafficDistributionPreferClose))
+	cache.UpdateTrafficDistributionForService(service1, ptr.To(corev1.ServiceTrafficDistributionPreferClose))
 	mustHaveServicesByTrafficDistribution(map[string]map[types.NamespacedName]bool{ // No delta
 		corev1.ServiceTrafficDistributionPreferClose: {service1: true},
 	}, desc)
 
 	desc = "service2 starts using trafficDistribution=PreferClose"
-	cache.UpdateTrafficDistributionForService(service2, ptrTo(corev1.ServiceTrafficDistributionPreferClose))
+	cache.UpdateTrafficDistributionForService(service2, ptr.To(corev1.ServiceTrafficDistributionPreferClose))
 	mustHaveServicesByTrafficDistribution(map[string]map[types.NamespacedName]bool{
 		corev1.ServiceTrafficDistributionPreferClose: {service1: true, service2: true}, // Delta
 	}, desc)
 
 	desc = "service3 starts using trafficDistribution=InvalidValue"
-	cache.UpdateTrafficDistributionForService(service3, ptrTo("InvalidValue"))
+	cache.UpdateTrafficDistributionForService(service3, ptr.To("InvalidValue"))
 	mustHaveServicesByTrafficDistribution(map[string]map[types.NamespacedName]bool{
 		corev1.ServiceTrafficDistributionPreferClose: {service1: true, service2: true},
 		trafficDistributionImplementationSpecific:    {service3: true}, // Delta
@@ -145,7 +139,7 @@ func TestCache_ServicesByTrafficDistribution(t *testing.T) {
 	}, desc)
 
 	desc = "service2 transitions trafficDistribution: PreferClose -> InvalidValue"
-	cache.UpdateTrafficDistributionForService(service2, ptrTo("InvalidValue"))
+	cache.UpdateTrafficDistributionForService(service2, ptr.To("InvalidValue"))
 	mustHaveServicesByTrafficDistribution(map[string]map[types.NamespacedName]bool{
 		corev1.ServiceTrafficDistributionPreferClose: {service1: true},                 // Delta
 		trafficDistributionImplementationSpecific:    {service3: true, service2: true}, // Delta
@@ -159,7 +153,7 @@ func TestCache_ServicesByTrafficDistribution(t *testing.T) {
 	}, desc)
 
 	desc = "service1 transitions trafficDistribution: PreferClose -> empty"
-	cache.UpdateTrafficDistributionForService(service1, ptrTo(""))
+	cache.UpdateTrafficDistributionForService(service1, ptr.To(""))
 	mustHaveServicesByTrafficDistribution(map[string]map[types.NamespacedName]bool{
 		corev1.ServiceTrafficDistributionPreferClose: {},                               // Delta
 		trafficDistributionImplementationSpecific:    {service1: true, service2: true}, // Delta
@@ -184,8 +178,8 @@ func TestCache_ServicesByTrafficDistribution(t *testing.T) {
 func benchmarkUpdateServicePortCache(b *testing.B, num int) {
 	c := NewCache(int32(100))
 	ns := "benchmark"
-	httpKey := endpointsliceutil.NewPortMapKey([]discovery.EndpointPort{{Port: pointer.Int32(80)}})
-	httpsKey := endpointsliceutil.NewPortMapKey([]discovery.EndpointPort{{Port: pointer.Int32(443)}})
+	httpKey := endpointsliceutil.NewPortMapKey([]discovery.EndpointPort{{Port: ptr.To[int32](80)}})
+	httpsKey := endpointsliceutil.NewPortMapKey([]discovery.EndpointPort{{Port: ptr.To[int32](443)}})
 	spCache := &ServicePortCache{items: map[endpointsliceutil.PortMapKey]EfficiencyInfo{
 		httpKey: {
 			Endpoints: 182,
@@ -223,8 +217,4 @@ func BenchmarkUpdateServicePortCache10000(b *testing.B) {
 
 func BenchmarkUpdateServicePortCache100000(b *testing.B) {
 	benchmarkUpdateServicePortCache(b, 100000)
-}
-
-func ptrTo[T any](obj T) *T {
-	return &obj
 }

--- a/staging/src/k8s.io/endpointslice/metrics/cache_test.go
+++ b/staging/src/k8s.io/endpointslice/metrics/cache_test.go
@@ -124,53 +124,50 @@ func TestCache_ServicesByTrafficDistribution(t *testing.T) {
 		corev1.ServiceTrafficDistributionPreferClose: {service1: true, service2: true}, // Delta
 	}, desc)
 
-	desc = "service3 starts using trafficDistribution=InvalidValue"
-	cache.UpdateTrafficDistributionForService(service3, ptr.To("InvalidValue"))
+	desc = "service3 starts using trafficDistribution=FutureValue"
+	cache.UpdateTrafficDistributionForService(service3, ptr.To("FutureValue"))
 	mustHaveServicesByTrafficDistribution(map[string]map[types.NamespacedName]bool{
 		corev1.ServiceTrafficDistributionPreferClose: {service1: true, service2: true},
-		trafficDistributionImplementationSpecific:    {service3: true}, // Delta
+		"FutureValue": {service3: true}, // Delta
 	}, desc)
 
 	desc = "service4 starts using trafficDistribution=nil"
 	cache.UpdateTrafficDistributionForService(service4, nil)
 	mustHaveServicesByTrafficDistribution(map[string]map[types.NamespacedName]bool{ // No delta
 		corev1.ServiceTrafficDistributionPreferClose: {service1: true, service2: true},
-		trafficDistributionImplementationSpecific:    {service3: true},
+		"FutureValue": {service3: true},
 	}, desc)
 
-	desc = "service2 transitions trafficDistribution: PreferClose -> InvalidValue"
-	cache.UpdateTrafficDistributionForService(service2, ptr.To("InvalidValue"))
+	desc = "service2 transitions trafficDistribution: PreferClose -> AnotherFutureValue"
+	cache.UpdateTrafficDistributionForService(service2, ptr.To("AnotherFutureValue"))
 	mustHaveServicesByTrafficDistribution(map[string]map[types.NamespacedName]bool{
-		corev1.ServiceTrafficDistributionPreferClose: {service1: true},                 // Delta
-		trafficDistributionImplementationSpecific:    {service3: true, service2: true}, // Delta
+		corev1.ServiceTrafficDistributionPreferClose: {service1: true}, // Delta
+		"FutureValue":        {service3: true},
+		"AnotherFutureValue": {service2: true}, // Delta
 	}, desc)
 
 	desc = "service3 gets deleted"
 	cache.DeleteService(service3)
 	mustHaveServicesByTrafficDistribution(map[string]map[types.NamespacedName]bool{
 		corev1.ServiceTrafficDistributionPreferClose: {service1: true},
-		trafficDistributionImplementationSpecific:    {service2: true}, // Delta
+		"FutureValue":        {}, // Delta
+		"AnotherFutureValue": {service2: true},
 	}, desc)
 
-	desc = "service1 transitions trafficDistribution: PreferClose -> empty"
-	cache.UpdateTrafficDistributionForService(service1, ptr.To(""))
-	mustHaveServicesByTrafficDistribution(map[string]map[types.NamespacedName]bool{
-		corev1.ServiceTrafficDistributionPreferClose: {},                               // Delta
-		trafficDistributionImplementationSpecific:    {service1: true, service2: true}, // Delta
-	}, desc)
-
-	desc = "service1 transitions trafficDistribution: InvalidValue -> nil"
+	desc = "service1 transitions trafficDistribution: PreferClose -> nil"
 	cache.UpdateTrafficDistributionForService(service1, nil)
 	mustHaveServicesByTrafficDistribution(map[string]map[types.NamespacedName]bool{
-		corev1.ServiceTrafficDistributionPreferClose: {},
-		trafficDistributionImplementationSpecific:    {service2: true}, // Delta
+		corev1.ServiceTrafficDistributionPreferClose: {}, // Delta
+		"FutureValue":        {},
+		"AnotherFutureValue": {service2: true},
 	}, desc)
 
-	desc = "service2 transitions trafficDistribution: InvalidValue -> nil"
+	desc = "service2 transitions trafficDistribution: AnotherFutureValue -> nil"
 	cache.UpdateTrafficDistributionForService(service2, nil)
 	mustHaveServicesByTrafficDistribution(map[string]map[types.NamespacedName]bool{
 		corev1.ServiceTrafficDistributionPreferClose: {},
-		trafficDistributionImplementationSpecific:    {}, // Delta
+		"FutureValue":        {},
+		"AnotherFutureValue": {}, // Delta
 	}, desc)
 
 }

--- a/staging/src/k8s.io/endpointslice/metrics/metrics.go
+++ b/staging/src/k8s.io/endpointslice/metrics/metrics.go
@@ -129,7 +129,7 @@ var (
 			Help:           "Number of Services using some specific trafficDistribution",
 			StabilityLevel: metrics.ALPHA,
 		},
-		[]string{"traffic_distribution"}, // One of ["PreferClose", "ImplementationSpecific"]
+		[]string{"traffic_distribution"}, // A trafficDistribution value
 	)
 )
 

--- a/staging/src/k8s.io/endpointslice/reconciler_test.go
+++ b/staging/src/k8s.io/endpointslice/reconciler_test.go
@@ -44,7 +44,7 @@ import (
 	"k8s.io/endpointslice/topologycache"
 	endpointsliceutil "k8s.io/endpointslice/util"
 	"k8s.io/klog/v2/ktesting"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -189,12 +189,12 @@ func TestReconcile1Pod(t *testing.T) {
 					{
 						Addresses: []string{"1.2.3.4"},
 						Conditions: discovery.EndpointConditions{
-							Ready:       pointer.Bool(true),
-							Serving:     pointer.Bool(true),
-							Terminating: pointer.Bool(false),
+							Ready:       ptr.To(true),
+							Serving:     ptr.To(true),
+							Terminating: ptr.To(false),
 						},
-						Zone:     pointer.String("us-central1-a"),
-						NodeName: pointer.String("node-1"),
+						Zone:     ptr.To("us-central1-a"),
+						NodeName: ptr.To("node-1"),
 						TargetRef: &corev1.ObjectReference{
 							Kind:      "Pod",
 							Namespace: namespace,
@@ -215,12 +215,12 @@ func TestReconcile1Pod(t *testing.T) {
 					{
 						Addresses: []string{"1.2.3.4"},
 						Conditions: discovery.EndpointConditions{
-							Ready:       pointer.Bool(true),
-							Serving:     pointer.Bool(true),
-							Terminating: pointer.Bool(false),
+							Ready:       ptr.To(true),
+							Serving:     ptr.To(true),
+							Terminating: ptr.To(false),
 						},
-						Zone:     pointer.String("us-central1-a"),
-						NodeName: pointer.String("node-1"),
+						Zone:     ptr.To("us-central1-a"),
+						NodeName: ptr.To("node-1"),
 						TargetRef: &corev1.ObjectReference{
 							Kind:      "Pod",
 							Namespace: namespace,
@@ -242,12 +242,12 @@ func TestReconcile1Pod(t *testing.T) {
 					{
 						Addresses: []string{"1.2.3.4"},
 						Conditions: discovery.EndpointConditions{
-							Ready:       pointer.Bool(true),
-							Serving:     pointer.Bool(true),
-							Terminating: pointer.Bool(false),
+							Ready:       ptr.To(true),
+							Serving:     ptr.To(true),
+							Terminating: ptr.To(false),
 						},
-						Zone:     pointer.String("us-central1-a"),
-						NodeName: pointer.String("node-1"),
+						Zone:     ptr.To("us-central1-a"),
+						NodeName: ptr.To("node-1"),
 						TargetRef: &corev1.ObjectReference{
 							Kind:      "Pod",
 							Namespace: namespace,
@@ -260,12 +260,12 @@ func TestReconcile1Pod(t *testing.T) {
 			expectedEndpoint: discovery.Endpoint{
 				Addresses: []string{"1.2.3.4"},
 				Conditions: discovery.EndpointConditions{
-					Ready:       pointer.Bool(true),
-					Serving:     pointer.Bool(true),
-					Terminating: pointer.Bool(false),
+					Ready:       ptr.To(true),
+					Serving:     ptr.To(true),
+					Terminating: ptr.To(false),
 				},
-				Zone:     pointer.String("us-central1-a"),
-				NodeName: pointer.String("node-1"),
+				Zone:     ptr.To("us-central1-a"),
+				NodeName: ptr.To("node-1"),
 				TargetRef: &corev1.ObjectReference{
 					Kind:      "Pod",
 					Namespace: namespace,
@@ -284,12 +284,12 @@ func TestReconcile1Pod(t *testing.T) {
 					{
 						Addresses: []string{"1.2.3.4"},
 						Conditions: discovery.EndpointConditions{
-							Ready:       pointer.Bool(true),
-							Serving:     pointer.Bool(true),
-							Terminating: pointer.Bool(false),
+							Ready:       ptr.To(true),
+							Serving:     ptr.To(true),
+							Terminating: ptr.To(false),
 						},
-						Zone:     pointer.String("us-central1-a"),
-						NodeName: pointer.String("node-1"),
+						Zone:     ptr.To("us-central1-a"),
+						NodeName: ptr.To("node-1"),
 						TargetRef: &corev1.ObjectReference{
 							Kind:      "Pod",
 							Namespace: namespace,
@@ -302,12 +302,12 @@ func TestReconcile1Pod(t *testing.T) {
 			expectedEndpoint: discovery.Endpoint{
 				Addresses: []string{"1.2.3.4"},
 				Conditions: discovery.EndpointConditions{
-					Ready:       pointer.Bool(true),
-					Serving:     pointer.Bool(true),
-					Terminating: pointer.Bool(false),
+					Ready:       ptr.To(true),
+					Serving:     ptr.To(true),
+					Terminating: ptr.To(false),
 				},
-				Zone:     pointer.String("us-central1-a"),
-				NodeName: pointer.String("node-1"),
+				Zone:     ptr.To("us-central1-a"),
+				NodeName: ptr.To("node-1"),
 				TargetRef: &corev1.ObjectReference{
 					Kind:      "Pod",
 					Namespace: namespace,
@@ -328,12 +328,12 @@ func TestReconcile1Pod(t *testing.T) {
 					{
 						Addresses: []string{"1.2.3.4"},
 						Conditions: discovery.EndpointConditions{
-							Ready:       pointer.Bool(true),
-							Serving:     pointer.Bool(true),
-							Terminating: pointer.Bool(false),
+							Ready:       ptr.To(true),
+							Serving:     ptr.To(true),
+							Terminating: ptr.To(false),
 						},
-						Zone:     pointer.String("us-central1-a"),
-						NodeName: pointer.String("node-1"),
+						Zone:     ptr.To("us-central1-a"),
+						NodeName: ptr.To("node-1"),
 						TargetRef: &corev1.ObjectReference{
 							Kind:      "Pod",
 							Namespace: namespace,
@@ -346,12 +346,12 @@ func TestReconcile1Pod(t *testing.T) {
 			expectedEndpoint: discovery.Endpoint{
 				Addresses: []string{"1.2.3.4"},
 				Conditions: discovery.EndpointConditions{
-					Ready:       pointer.Bool(true),
-					Serving:     pointer.Bool(true),
-					Terminating: pointer.Bool(false),
+					Ready:       ptr.To(true),
+					Serving:     ptr.To(true),
+					Terminating: ptr.To(false),
 				},
-				Zone:     pointer.String("us-central1-a"),
-				NodeName: pointer.String("node-1"),
+				Zone:     ptr.To("us-central1-a"),
+				NodeName: ptr.To("node-1"),
 				TargetRef: &corev1.ObjectReference{
 					Kind:      "Pod",
 					Namespace: namespace,
@@ -372,12 +372,12 @@ func TestReconcile1Pod(t *testing.T) {
 					{
 						Addresses: []string{"1234::5678:0:0:9abc:def0"},
 						Conditions: discovery.EndpointConditions{
-							Ready:       pointer.Bool(true),
-							Serving:     pointer.Bool(true),
-							Terminating: pointer.Bool(false),
+							Ready:       ptr.To(true),
+							Serving:     ptr.To(true),
+							Terminating: ptr.To(false),
 						},
-						Zone:     pointer.String("us-central1-a"),
-						NodeName: pointer.String("node-1"),
+						Zone:     ptr.To("us-central1-a"),
+						NodeName: ptr.To("node-1"),
 						TargetRef: &corev1.ObjectReference{
 							Kind:      "Pod",
 							Namespace: namespace,
@@ -400,12 +400,12 @@ func TestReconcile1Pod(t *testing.T) {
 					{
 						Addresses: []string{"1234::5678:0:0:9abc:def0"},
 						Conditions: discovery.EndpointConditions{
-							Ready:       pointer.Bool(true),
-							Serving:     pointer.Bool(true),
-							Terminating: pointer.Bool(false),
+							Ready:       ptr.To(true),
+							Serving:     ptr.To(true),
+							Terminating: ptr.To(false),
 						},
-						Zone:     pointer.String("us-central1-a"),
-						NodeName: pointer.String("node-1"),
+						Zone:     ptr.To("us-central1-a"),
+						NodeName: ptr.To("node-1"),
 						TargetRef: &corev1.ObjectReference{
 							Kind:      "Pod",
 							Namespace: namespace,
@@ -427,12 +427,12 @@ func TestReconcile1Pod(t *testing.T) {
 					{
 						Addresses: []string{"1234::5678:0:0:9abc:def0"},
 						Conditions: discovery.EndpointConditions{
-							Ready:       pointer.Bool(true),
-							Serving:     pointer.Bool(true),
-							Terminating: pointer.Bool(false),
+							Ready:       ptr.To(true),
+							Serving:     ptr.To(true),
+							Terminating: ptr.To(false),
 						},
-						Zone:     pointer.String("us-central1-a"),
-						NodeName: pointer.String("node-1"),
+						Zone:     ptr.To("us-central1-a"),
+						NodeName: ptr.To("node-1"),
 						TargetRef: &corev1.ObjectReference{
 							Kind:      "Pod",
 							Namespace: namespace,
@@ -444,12 +444,12 @@ func TestReconcile1Pod(t *testing.T) {
 					{
 						Addresses: []string{"1.2.3.4"},
 						Conditions: discovery.EndpointConditions{
-							Ready:       pointer.Bool(true),
-							Serving:     pointer.Bool(true),
-							Terminating: pointer.Bool(false),
+							Ready:       ptr.To(true),
+							Serving:     ptr.To(true),
+							Terminating: ptr.To(false),
 						},
-						Zone:     pointer.String("us-central1-a"),
-						NodeName: pointer.String("node-1"),
+						Zone:     ptr.To("us-central1-a"),
+						NodeName: ptr.To("node-1"),
 						TargetRef: &corev1.ObjectReference{
 							Kind:      "Pod",
 							Namespace: namespace,
@@ -1252,14 +1252,13 @@ func TestReconcileEndpointSlicesNamedPorts(t *testing.T) {
 	expectUnorderedSlicesWithLengths(t, fetchedSlices, []int{60, 60, 60, 60, 60})
 
 	// generate data structures for expected slice ports and address types
-	protoTCP := corev1.ProtocolTCP
 	expectedSlices := []discovery.EndpointSlice{}
 	for i := range fetchedSlices {
 		expectedSlices = append(expectedSlices, discovery.EndpointSlice{
 			Ports: []discovery.EndpointPort{{
-				Name:     pointer.String(""),
-				Protocol: &protoTCP,
-				Port:     pointer.Int32(int32(8080 + i)),
+				Name:     ptr.To(""),
+				Protocol: ptr.To(corev1.ProtocolTCP),
+				Port:     ptr.To[int32](int32(8080 + i)),
 			}},
 			AddressType: discovery.AddressTypeIPv4,
 		})

--- a/staging/src/k8s.io/endpointslice/topologycache/sliceinfo_test.go
+++ b/staging/src/k8s.io/endpointslice/topologycache/sliceinfo_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 
 	discovery "k8s.io/api/discovery/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func Test_getTotalReadyEndpoints(t *testing.T) {
@@ -93,14 +93,14 @@ func sliceWithNEndpoints(ready, unready int) *discovery.EndpointSlice {
 	for i := 0; i < ready; i++ {
 		endpoints[i] = discovery.Endpoint{
 			Addresses:  []string{fmt.Sprintf("10.1.2.%d", i)},
-			Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
+			Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
 		}
 	}
 
 	for i := 0; i < unready; i++ {
 		endpoints[ready+i] = discovery.Endpoint{
 			Addresses:  []string{fmt.Sprintf("10.1.2.%d", ready+i)},
-			Conditions: discovery.EndpointConditions{Ready: pointer.Bool(false)},
+			Conditions: discovery.EndpointConditions{Ready: ptr.To(false)},
 		}
 	}
 

--- a/staging/src/k8s.io/endpointslice/topologycache/topologycache_test.go
+++ b/staging/src/k8s.io/endpointslice/topologycache/topologycache_test.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2/ktesting"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestAddHints(t *testing.T) {
@@ -66,8 +66,8 @@ func TestAddHints(t *testing.T) {
 			ToCreate: []*discovery.EndpointSlice{{
 				Endpoints: []discovery.Endpoint{{
 					Addresses:  []string{"10.1.2.3"},
-					Zone:       pointer.String("zone-a"),
-					Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
+					Zone:       ptr.To("zone-a"),
+					Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
 				}},
 			}},
 		},
@@ -75,8 +75,8 @@ func TestAddHints(t *testing.T) {
 		expectedSlicesToCreate: []*discovery.EndpointSlice{{
 			Endpoints: []discovery.Endpoint{{
 				Addresses:  []string{"10.1.2.3"},
-				Zone:       pointer.String("zone-a"),
-				Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
+				Zone:       ptr.To("zone-a"),
+				Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
 			}},
 		}},
 		expectedSlicesToUpdate: []*discovery.EndpointSlice{},
@@ -100,12 +100,12 @@ func TestAddHints(t *testing.T) {
 			ToCreate: []*discovery.EndpointSlice{{
 				Endpoints: []discovery.Endpoint{{
 					Addresses:  []string{"10.1.2.3"},
-					Zone:       pointer.String("zone-a"),
-					Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
+					Zone:       ptr.To("zone-a"),
+					Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
 				}, {
 					Addresses:  []string{"10.1.2.4"},
-					Zone:       pointer.String("zone-b"),
-					Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
+					Zone:       ptr.To("zone-b"),
+					Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
 				}},
 			}},
 		},
@@ -113,12 +113,12 @@ func TestAddHints(t *testing.T) {
 		expectedSlicesToCreate: []*discovery.EndpointSlice{{
 			Endpoints: []discovery.Endpoint{{
 				Addresses:  []string{"10.1.2.3"},
-				Zone:       pointer.String("zone-a"),
-				Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
+				Zone:       ptr.To("zone-a"),
+				Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
 			}, {
 				Addresses:  []string{"10.1.2.4"},
-				Zone:       pointer.String("zone-b"),
-				Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
+				Zone:       ptr.To("zone-b"),
+				Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
 			}},
 		}},
 		expectedSlicesToUpdate: []*discovery.EndpointSlice{},
@@ -141,12 +141,12 @@ func TestAddHints(t *testing.T) {
 			ToCreate: []*discovery.EndpointSlice{{
 				Endpoints: []discovery.Endpoint{{
 					Addresses:  []string{"10.1.2.3"},
-					Zone:       pointer.String("zone-a"),
-					Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
+					Zone:       ptr.To("zone-a"),
+					Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
 				}, {
 					Addresses:  []string{"10.1.2.4"},
-					Zone:       pointer.String("zone-b"),
-					Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
+					Zone:       ptr.To("zone-b"),
+					Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
 				}},
 			}},
 		},
@@ -159,14 +159,14 @@ func TestAddHints(t *testing.T) {
 		expectedSlicesToCreate: []*discovery.EndpointSlice{{
 			Endpoints: []discovery.Endpoint{{
 				Addresses:  []string{"10.1.2.3"},
-				Zone:       pointer.String("zone-a"),
+				Zone:       ptr.To("zone-a"),
 				Hints:      &discovery.EndpointHints{ForZones: []discovery.ForZone{{Name: "zone-a"}}},
-				Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
+				Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
 			}, {
 				Addresses:  []string{"10.1.2.4"},
-				Zone:       pointer.String("zone-b"),
+				Zone:       ptr.To("zone-b"),
 				Hints:      &discovery.EndpointHints{ForZones: []discovery.ForZone{{Name: "zone-b"}}},
-				Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
+				Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
 			}},
 		}},
 		expectedSlicesToUpdate: []*discovery.EndpointSlice{},
@@ -189,19 +189,19 @@ func TestAddHints(t *testing.T) {
 			ToCreate: []*discovery.EndpointSlice{{
 				Endpoints: []discovery.Endpoint{{
 					Addresses:  []string{"10.1.2.3"},
-					Zone:       pointer.String("zone-a"),
-					Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
+					Zone:       ptr.To("zone-a"),
+					Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
 				}, {
 					Addresses:  []string{"10.1.2.4"},
-					Zone:       pointer.String("zone-b"),
-					Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
+					Zone:       ptr.To("zone-b"),
+					Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
 				}, {
 					Addresses:  []string{"10.1.2.5"},
-					Zone:       pointer.String("zone-b"),
-					Conditions: discovery.EndpointConditions{Ready: pointer.Bool(false)},
+					Zone:       ptr.To("zone-b"),
+					Conditions: discovery.EndpointConditions{Ready: ptr.To(false)},
 				}, {
 					Addresses: []string{"10.1.2.6"},
-					Zone:      pointer.String("zone-b"),
+					Zone:      ptr.To("zone-b"),
 				}},
 			}},
 		},
@@ -214,22 +214,22 @@ func TestAddHints(t *testing.T) {
 		expectedSlicesToCreate: []*discovery.EndpointSlice{{
 			Endpoints: []discovery.Endpoint{{
 				Addresses:  []string{"10.1.2.3"},
-				Zone:       pointer.String("zone-a"),
+				Zone:       ptr.To("zone-a"),
 				Hints:      &discovery.EndpointHints{ForZones: []discovery.ForZone{{Name: "zone-a"}}},
-				Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
+				Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
 			}, {
 				Addresses:  []string{"10.1.2.4"},
-				Zone:       pointer.String("zone-b"),
+				Zone:       ptr.To("zone-b"),
 				Hints:      &discovery.EndpointHints{ForZones: []discovery.ForZone{{Name: "zone-b"}}},
-				Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
+				Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
 			}, {
 				Addresses:  []string{"10.1.2.5"},
-				Zone:       pointer.String("zone-b"),
+				Zone:       ptr.To("zone-b"),
 				Hints:      nil,
-				Conditions: discovery.EndpointConditions{Ready: pointer.Bool(false)},
+				Conditions: discovery.EndpointConditions{Ready: ptr.To(false)},
 			}, {
 				Addresses: []string{"10.1.2.6"},
-				Zone:      pointer.String("zone-b"),
+				Zone:      ptr.To("zone-b"),
 				Hints:     nil,
 			}},
 		}},
@@ -254,51 +254,51 @@ func TestAddHints(t *testing.T) {
 			ToCreate: []*discovery.EndpointSlice{{
 				Endpoints: []discovery.Endpoint{{
 					Addresses:  []string{"10.1.2.3"},
-					Zone:       pointer.String("zone-a"),
-					Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
+					Zone:       ptr.To("zone-a"),
+					Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
 				}, {
 					Addresses:  []string{"10.1.2.4"},
-					Zone:       pointer.String("zone-b"),
-					Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
+					Zone:       ptr.To("zone-b"),
+					Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
 				}},
 			}, {
 				Endpoints: []discovery.Endpoint{{
 					Addresses:  []string{"10.1.3.3"},
-					Zone:       pointer.String("zone-c"),
-					Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
+					Zone:       ptr.To("zone-c"),
+					Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
 				}, {
 					Addresses:  []string{"10.1.3.4"},
-					Zone:       pointer.String("zone-c"),
-					Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
+					Zone:       ptr.To("zone-c"),
+					Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
 				}, {
 					Addresses:  []string{"10.1.3.4"},
-					Zone:       pointer.String("zone-a"),
-					Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
+					Zone:       ptr.To("zone-a"),
+					Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
 				}},
 			}},
 			ToUpdate: []*discovery.EndpointSlice{{
 				Endpoints: []discovery.Endpoint{{
 					Addresses:  []string{"10.2.2.3"},
-					Zone:       pointer.String("zone-a"),
-					Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
+					Zone:       ptr.To("zone-a"),
+					Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
 				}, {
 					Addresses:  []string{"10.2.2.4"},
-					Zone:       pointer.String("zone-a"),
-					Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
+					Zone:       ptr.To("zone-a"),
+					Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
 				}},
 			}, {
 				Endpoints: []discovery.Endpoint{{
 					Addresses:  []string{"10.2.3.3"},
-					Zone:       pointer.String("zone-b"),
-					Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
+					Zone:       ptr.To("zone-b"),
+					Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
 				}, {
 					Addresses:  []string{"10.2.3.4"},
-					Zone:       pointer.String("zone-c"),
-					Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
+					Zone:       ptr.To("zone-c"),
+					Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
 				}, {
 					Addresses:  []string{"10.2.3.4"},
-					Zone:       pointer.String("zone-a"),
-					Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
+					Zone:       ptr.To("zone-a"),
+					Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
 				}},
 			}},
 		},
@@ -312,61 +312,61 @@ func TestAddHints(t *testing.T) {
 		expectedSlicesToCreate: []*discovery.EndpointSlice{{
 			Endpoints: []discovery.Endpoint{{
 				Addresses:  []string{"10.1.2.3"},
-				Zone:       pointer.String("zone-a"),
+				Zone:       ptr.To("zone-a"),
 				Hints:      &discovery.EndpointHints{ForZones: []discovery.ForZone{{Name: "zone-b"}}},
-				Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
+				Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
 			}, {
 				Addresses:  []string{"10.1.2.4"},
-				Zone:       pointer.String("zone-b"),
+				Zone:       ptr.To("zone-b"),
 				Hints:      &discovery.EndpointHints{ForZones: []discovery.ForZone{{Name: "zone-b"}}},
-				Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
+				Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
 			}},
 		}, {
 			Endpoints: []discovery.Endpoint{{
 				Addresses:  []string{"10.1.3.3"},
-				Zone:       pointer.String("zone-c"),
+				Zone:       ptr.To("zone-c"),
 				Hints:      &discovery.EndpointHints{ForZones: []discovery.ForZone{{Name: "zone-c"}}},
-				Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
+				Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
 			}, {
 				Addresses:  []string{"10.1.3.4"},
-				Zone:       pointer.String("zone-c"),
+				Zone:       ptr.To("zone-c"),
 				Hints:      &discovery.EndpointHints{ForZones: []discovery.ForZone{{Name: "zone-c"}}},
-				Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
+				Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
 			}, {
 				Addresses:  []string{"10.1.3.4"},
-				Zone:       pointer.String("zone-a"),
+				Zone:       ptr.To("zone-a"),
 				Hints:      &discovery.EndpointHints{ForZones: []discovery.ForZone{{Name: "zone-a"}}},
-				Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
+				Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
 			}},
 		}},
 		expectedSlicesToUpdate: []*discovery.EndpointSlice{{
 			Endpoints: []discovery.Endpoint{{
 				Addresses:  []string{"10.2.2.3"},
-				Zone:       pointer.String("zone-a"),
+				Zone:       ptr.To("zone-a"),
 				Hints:      &discovery.EndpointHints{ForZones: []discovery.ForZone{{Name: "zone-a"}}},
-				Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
+				Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
 			}, {
 				Addresses:  []string{"10.2.2.4"},
-				Zone:       pointer.String("zone-a"),
+				Zone:       ptr.To("zone-a"),
 				Hints:      &discovery.EndpointHints{ForZones: []discovery.ForZone{{Name: "zone-a"}}},
-				Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
+				Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
 			}},
 		}, {
 			Endpoints: []discovery.Endpoint{{
 				Addresses:  []string{"10.2.3.3"},
-				Zone:       pointer.String("zone-b"),
+				Zone:       ptr.To("zone-b"),
 				Hints:      &discovery.EndpointHints{ForZones: []discovery.ForZone{{Name: "zone-b"}}},
-				Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
+				Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
 			}, {
 				Addresses:  []string{"10.2.3.4"},
-				Zone:       pointer.String("zone-c"),
+				Zone:       ptr.To("zone-c"),
 				Hints:      &discovery.EndpointHints{ForZones: []discovery.ForZone{{Name: "zone-c"}}},
-				Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
+				Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
 			}, {
 				Addresses:  []string{"10.2.3.4"},
-				Zone:       pointer.String("zone-a"),
+				Zone:       ptr.To("zone-a"),
 				Hints:      &discovery.EndpointHints{ForZones: []discovery.ForZone{{Name: "zone-a"}}},
-				Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
+				Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
 			}},
 		}},
 		expectedEvents: []*EventBuilder{
@@ -635,12 +635,12 @@ func TestTopologyCacheRace(t *testing.T) {
 		ToCreate: []*discovery.EndpointSlice{{
 			Endpoints: []discovery.Endpoint{{
 				Addresses:  []string{"10.1.2.3"},
-				Zone:       pointer.String("zone-a"),
-				Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
+				Zone:       ptr.To("zone-a"),
+				Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
 			}, {
 				Addresses:  []string{"10.1.2.4"},
-				Zone:       pointer.String("zone-b"),
-				Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
+				Zone:       ptr.To("zone-b"),
+				Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
 			}},
 		}}}
 	type nodeInfo struct {

--- a/staging/src/k8s.io/endpointslice/topologycache/utils_test.go
+++ b/staging/src/k8s.io/endpointslice/topologycache/utils_test.go
@@ -22,7 +22,7 @@ import (
 
 	discovery "k8s.io/api/discovery/v1"
 	"k8s.io/klog/v2/ktesting"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func Test_redistributeHints(t *testing.T) {
@@ -42,9 +42,9 @@ func Test_redistributeHints(t *testing.T) {
 		name: "single endpoint",
 		slices: []*discovery.EndpointSlice{{
 			Endpoints: []discovery.Endpoint{{
-				Zone:       pointer.String("zone-a"),
+				Zone:       ptr.To("zone-a"),
 				Hints:      &discovery.EndpointHints{ForZones: []discovery.ForZone{{Name: "zone-a"}}},
-				Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
+				Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
 			}},
 		}},
 		givingZones:             map[string]int{"zone-a": 1},
@@ -54,17 +54,17 @@ func Test_redistributeHints(t *testing.T) {
 		name: "endpoints from 1 zone redistributed to 2 other zones",
 		slices: []*discovery.EndpointSlice{{
 			Endpoints: []discovery.Endpoint{{
-				Zone:       pointer.String("zone-a"),
+				Zone:       ptr.To("zone-a"),
 				Hints:      &discovery.EndpointHints{ForZones: []discovery.ForZone{{Name: "zone-a"}}},
-				Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
+				Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
 			}, {
-				Zone:       pointer.String("zone-a"),
+				Zone:       ptr.To("zone-a"),
 				Hints:      &discovery.EndpointHints{ForZones: []discovery.ForZone{{Name: "zone-a"}}},
-				Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
+				Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
 			}, {
-				Zone:       pointer.String("zone-a"),
+				Zone:       ptr.To("zone-a"),
 				Hints:      &discovery.EndpointHints{ForZones: []discovery.ForZone{{Name: "zone-a"}}},
-				Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
+				Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
 			}},
 		}},
 		givingZones:             map[string]int{"zone-a": 2},
@@ -217,9 +217,9 @@ func Test_getHintsByZone(t *testing.T) {
 		name: "single zone hint",
 		slice: discovery.EndpointSlice{
 			Endpoints: []discovery.Endpoint{{
-				Zone:       pointer.String("zone-a"),
+				Zone:       ptr.To("zone-a"),
 				Hints:      &discovery.EndpointHints{ForZones: []discovery.ForZone{{Name: "zone-a"}}},
-				Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
+				Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
 			}},
 		},
 		allocations: map[string]allocation{
@@ -233,15 +233,15 @@ func Test_getHintsByZone(t *testing.T) {
 		name: "single zone hint with 1 unready endpoint and 1 unknown endpoint",
 		slice: discovery.EndpointSlice{
 			Endpoints: []discovery.Endpoint{{
-				Zone:       pointer.String("zone-a"),
+				Zone:       ptr.To("zone-a"),
 				Hints:      &discovery.EndpointHints{ForZones: []discovery.ForZone{{Name: "zone-a"}}},
-				Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
+				Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
 			}, {
-				Zone:       pointer.String("zone-a"),
+				Zone:       ptr.To("zone-a"),
 				Hints:      &discovery.EndpointHints{ForZones: []discovery.ForZone{{Name: "zone-a"}}},
-				Conditions: discovery.EndpointConditions{Ready: pointer.Bool(false)},
+				Conditions: discovery.EndpointConditions{Ready: ptr.To(false)},
 			}, {
-				Zone:  pointer.String("zone-a"),
+				Zone:  ptr.To("zone-a"),
 				Hints: &discovery.EndpointHints{ForZones: []discovery.ForZone{{Name: "zone-a"}}},
 			}},
 		},
@@ -257,19 +257,19 @@ func Test_getHintsByZone(t *testing.T) {
 		slice: discovery.EndpointSlice{
 			Endpoints: []discovery.Endpoint{
 				{
-					Zone:       pointer.String("zone-a"),
+					Zone:       ptr.To("zone-a"),
 					Hints:      &discovery.EndpointHints{ForZones: []discovery.ForZone{{Name: "zone-a"}}},
-					Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
+					Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
 				},
 				{
-					Zone:       pointer.String("zone-a"),
+					Zone:       ptr.To("zone-a"),
 					Hints:      &discovery.EndpointHints{ForZones: []discovery.ForZone{{Name: "zone-b"}}},
-					Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
+					Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
 				},
 				{
-					Zone:       pointer.String("zone-b"),
+					Zone:       ptr.To("zone-b"),
 					Hints:      &discovery.EndpointHints{ForZones: []discovery.ForZone{{Name: "zone-b"}}},
-					Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
+					Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
 				},
 			},
 		},
@@ -288,9 +288,9 @@ func Test_getHintsByZone(t *testing.T) {
 		slice: discovery.EndpointSlice{
 			Endpoints: []discovery.Endpoint{
 				{
-					Zone:       pointer.String("zone-a"),
+					Zone:       ptr.To("zone-a"),
 					Hints:      &discovery.EndpointHints{ForZones: []discovery.ForZone{{Name: "zone-non-existent"}}},
-					Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
+					Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
 				},
 			},
 		},
@@ -304,9 +304,9 @@ func Test_getHintsByZone(t *testing.T) {
 		slice: discovery.EndpointSlice{
 			Endpoints: []discovery.Endpoint{
 				{
-					Zone:       pointer.String("zone-a"),
+					Zone:       ptr.To("zone-a"),
 					Hints:      nil,
-					Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
+					Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
 				},
 			},
 		},
@@ -320,9 +320,9 @@ func Test_getHintsByZone(t *testing.T) {
 		slice: discovery.EndpointSlice{
 			Endpoints: []discovery.Endpoint{
 				{
-					Zone:       pointer.String("zone-a"),
+					Zone:       ptr.To("zone-a"),
 					Hints:      &discovery.EndpointHints{ForZones: []discovery.ForZone{}},
-					Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
+					Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
 				},
 			},
 		},
@@ -336,14 +336,14 @@ func Test_getHintsByZone(t *testing.T) {
 		slice: discovery.EndpointSlice{
 			Endpoints: []discovery.Endpoint{
 				{
-					Zone:       pointer.String("zone-a"),
+					Zone:       ptr.To("zone-a"),
 					Hints:      &discovery.EndpointHints{ForZones: []discovery.ForZone{{Name: "zone-a"}}},
-					Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
+					Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
 				},
 				{
-					Zone:       pointer.String("zone-a"),
+					Zone:       ptr.To("zone-a"),
 					Hints:      &discovery.EndpointHints{ForZones: []discovery.ForZone{{Name: "zone-a"}}},
-					Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
+					Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
 				},
 			},
 		},

--- a/staging/src/k8s.io/endpointslice/trafficdist/trafficdist_test.go
+++ b/staging/src/k8s.io/endpointslice/trafficdist/trafficdist_test.go
@@ -41,7 +41,7 @@ func TestReconcileHints_trafficDistribution_is_PreferClose(t *testing.T) {
 	}{
 		{
 			name:                "should set same zone hints",
-			trafficDistribution: ptrTo(corev1.ServiceTrafficDistributionPreferClose),
+			trafficDistribution: ptr.To(corev1.ServiceTrafficDistributionPreferClose),
 			slicesToCreate: []*discoveryv1.EndpointSlice{
 				{
 					Endpoints: []discoveryv1.Endpoint{
@@ -173,7 +173,7 @@ func TestReconcileHints_trafficDistribution_is_PreferClose(t *testing.T) {
 		},
 		{
 			name:                "incorrect hints should be corrected",
-			trafficDistribution: ptrTo(corev1.ServiceTrafficDistributionPreferClose),
+			trafficDistribution: ptr.To(corev1.ServiceTrafficDistributionPreferClose),
 			slicesToUpdate: []*discoveryv1.EndpointSlice{
 				{
 					Endpoints: []discoveryv1.Endpoint{
@@ -242,7 +242,7 @@ func TestReconcileHints_trafficDistribution_is_PreferClose(t *testing.T) {
 		},
 		{
 			name:                "unready endpoints should not trigger updates",
-			trafficDistribution: ptrTo(corev1.ServiceTrafficDistributionPreferClose),
+			trafficDistribution: ptr.To(corev1.ServiceTrafficDistributionPreferClose),
 			slicesUnchanged: []*discoveryv1.EndpointSlice{
 				{
 					Endpoints: []discoveryv1.Endpoint{
@@ -300,7 +300,7 @@ func TestReconcileHints_trafficDistribution_is_nil_or_empty(t *testing.T) {
 	}{
 		{
 			name:                "trafficDistribution='' should remove zone hints",
-			trafficDistribution: ptrTo(""),
+			trafficDistribution: ptr.To(""),
 			slicesToCreate: []*discoveryv1.EndpointSlice{
 				{
 					Endpoints: []discoveryv1.Endpoint{
@@ -459,12 +459,8 @@ func TestReconcileHints_doesNotMutateUnchangedSlices(t *testing.T) {
 	clonedEps := originalEps.DeepCopy()
 
 	// originalEps should not get modified.
-	ReconcileHints(ptrTo(corev1.ServiceTrafficDistributionPreferClose), nil, nil, []*discoveryv1.EndpointSlice{originalEps})
+	ReconcileHints(ptr.To(corev1.ServiceTrafficDistributionPreferClose), nil, nil, []*discoveryv1.EndpointSlice{originalEps})
 	if diff := cmp.Diff(clonedEps, originalEps); diff != "" {
 		t.Errorf("ReconcileHints(...) modified objects within slicesUnchanged, want objects within slicesUnchanged to remain unmodified: (-want, +got)\n%v", diff)
 	}
-}
-
-func ptrTo[T any](obj T) *T {
-	return &obj
 }

--- a/staging/src/k8s.io/endpointslice/util/controller_utils_test.go
+++ b/staging/src/k8s.io/endpointslice/util/controller_utils_test.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestDetermineNeededServiceUpdates(t *testing.T) {
@@ -621,19 +621,19 @@ func TestEndpointsEqualBeyondHash(t *testing.T) {
 			name: "No change",
 			ep1: &discovery.Endpoint{
 				Conditions: discovery.EndpointConditions{
-					Ready: pointer.Bool(true),
+					Ready: ptr.To(true),
 				},
 				Addresses: []string{"10.0.0.1"},
 				TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "default", Name: "pod0"},
-				NodeName:  pointer.String("node-1"),
+				NodeName:  ptr.To("node-1"),
 			},
 			ep2: &discovery.Endpoint{
 				Conditions: discovery.EndpointConditions{
-					Ready: pointer.Bool(true),
+					Ready: ptr.To(true),
 				},
 				Addresses: []string{"10.0.0.1"},
 				TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "default", Name: "pod0"},
-				NodeName:  pointer.String("node-1"),
+				NodeName:  ptr.To("node-1"),
 			},
 			expected: true,
 		},
@@ -641,19 +641,19 @@ func TestEndpointsEqualBeyondHash(t *testing.T) {
 			name: "NodeName changed",
 			ep1: &discovery.Endpoint{
 				Conditions: discovery.EndpointConditions{
-					Ready: pointer.Bool(true),
+					Ready: ptr.To(true),
 				},
 				Addresses: []string{"10.0.0.1"},
 				TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "default", Name: "pod0"},
-				NodeName:  pointer.String("node-1"),
+				NodeName:  ptr.To("node-1"),
 			},
 			ep2: &discovery.Endpoint{
 				Conditions: discovery.EndpointConditions{
-					Ready: pointer.Bool(true),
+					Ready: ptr.To(true),
 				},
 				Addresses: []string{"10.0.0.1"},
 				TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "default", Name: "pod0"},
-				NodeName:  pointer.String("node-2"),
+				NodeName:  ptr.To("node-2"),
 			},
 			expected: false,
 		},
@@ -661,19 +661,19 @@ func TestEndpointsEqualBeyondHash(t *testing.T) {
 			name: "Zone changed",
 			ep1: &discovery.Endpoint{
 				Conditions: discovery.EndpointConditions{
-					Ready: pointer.Bool(true),
+					Ready: ptr.To(true),
 				},
 				Addresses: []string{"10.0.0.1"},
 				TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "default", Name: "pod0"},
-				Zone:      pointer.String("zone-1"),
+				Zone:      ptr.To("zone-1"),
 			},
 			ep2: &discovery.Endpoint{
 				Conditions: discovery.EndpointConditions{
-					Ready: pointer.Bool(true),
+					Ready: ptr.To(true),
 				},
 				Addresses: []string{"10.0.0.1"},
 				TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "default", Name: "pod0"},
-				Zone:      pointer.String("zone-2"),
+				Zone:      ptr.To("zone-2"),
 			},
 			expected: false,
 		},
@@ -681,21 +681,21 @@ func TestEndpointsEqualBeyondHash(t *testing.T) {
 			name: "Ready condition changed",
 			ep1: &discovery.Endpoint{
 				Conditions: discovery.EndpointConditions{
-					Ready: pointer.Bool(true),
+					Ready: ptr.To(true),
 				},
 				Addresses: []string{"10.0.0.1"},
 				TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "default", Name: "pod0"},
-				Zone:      pointer.String("zone-1"),
-				NodeName:  pointer.String("node-1"),
+				Zone:      ptr.To("zone-1"),
+				NodeName:  ptr.To("node-1"),
 			},
 			ep2: &discovery.Endpoint{
 				Conditions: discovery.EndpointConditions{
-					Ready: pointer.Bool(false),
+					Ready: ptr.To(false),
 				},
 				Addresses: []string{"10.0.0.1"},
 				TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "default", Name: "pod0"},
-				Zone:      pointer.String("zone-1"),
-				NodeName:  pointer.String("node-1"),
+				Zone:      ptr.To("zone-1"),
+				NodeName:  ptr.To("node-1"),
 			},
 			expected: false,
 		},
@@ -703,25 +703,25 @@ func TestEndpointsEqualBeyondHash(t *testing.T) {
 			name: "Serving condition changed from nil to true",
 			ep1: &discovery.Endpoint{
 				Conditions: discovery.EndpointConditions{
-					Ready:       pointer.Bool(true),
+					Ready:       ptr.To(true),
 					Serving:     nil,
 					Terminating: nil,
 				},
 				Addresses: []string{"10.0.0.1"},
 				TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "default", Name: "pod0"},
-				Zone:      pointer.String("zone-1"),
-				NodeName:  pointer.String("node-1"),
+				Zone:      ptr.To("zone-1"),
+				NodeName:  ptr.To("node-1"),
 			},
 			ep2: &discovery.Endpoint{
 				Conditions: discovery.EndpointConditions{
-					Ready:       pointer.Bool(true),
-					Serving:     pointer.Bool(true),
-					Terminating: pointer.Bool(false),
+					Ready:       ptr.To(true),
+					Serving:     ptr.To(true),
+					Terminating: ptr.To(false),
 				},
 				Addresses: []string{"10.0.0.1"},
 				TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "default", Name: "pod0"},
-				Zone:      pointer.String("zone-1"),
-				NodeName:  pointer.String("node-1"),
+				Zone:      ptr.To("zone-1"),
+				NodeName:  ptr.To("node-1"),
 			},
 			expected: false,
 		},
@@ -729,25 +729,25 @@ func TestEndpointsEqualBeyondHash(t *testing.T) {
 			name: "Serving condition changed from false to true",
 			ep1: &discovery.Endpoint{
 				Conditions: discovery.EndpointConditions{
-					Ready:       pointer.Bool(true),
-					Serving:     pointer.Bool(false),
-					Terminating: pointer.Bool(false),
+					Ready:       ptr.To(true),
+					Serving:     ptr.To(false),
+					Terminating: ptr.To(false),
 				},
 				Addresses: []string{"10.0.0.1"},
 				TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "default", Name: "pod0"},
-				Zone:      pointer.String("zone-1"),
-				NodeName:  pointer.String("node-1"),
+				Zone:      ptr.To("zone-1"),
+				NodeName:  ptr.To("node-1"),
 			},
 			ep2: &discovery.Endpoint{
 				Conditions: discovery.EndpointConditions{
-					Ready:       pointer.Bool(true),
-					Serving:     pointer.Bool(true),
-					Terminating: pointer.Bool(false),
+					Ready:       ptr.To(true),
+					Serving:     ptr.To(true),
+					Terminating: ptr.To(false),
 				},
 				Addresses: []string{"10.0.0.1"},
 				TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "default", Name: "pod0"},
-				Zone:      pointer.String("zone-1"),
-				NodeName:  pointer.String("node-1"),
+				Zone:      ptr.To("zone-1"),
+				NodeName:  ptr.To("node-1"),
 			},
 			expected: false,
 		},
@@ -755,21 +755,21 @@ func TestEndpointsEqualBeyondHash(t *testing.T) {
 			name: "Pod name changed",
 			ep1: &discovery.Endpoint{
 				Conditions: discovery.EndpointConditions{
-					Ready: pointer.Bool(true),
+					Ready: ptr.To(true),
 				},
 				Addresses: []string{"10.0.0.1"},
 				TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "default", Name: "pod0"},
-				Zone:      pointer.String("zone-1"),
-				NodeName:  pointer.String("node-1"),
+				Zone:      ptr.To("zone-1"),
+				NodeName:  ptr.To("node-1"),
 			},
 			ep2: &discovery.Endpoint{
 				Conditions: discovery.EndpointConditions{
-					Ready: pointer.Bool(true),
+					Ready: ptr.To(true),
 				},
 				Addresses: []string{"10.0.0.1"},
 				TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "default", Name: "pod1"},
-				Zone:      pointer.String("zone-1"),
-				NodeName:  pointer.String("node-1"),
+				Zone:      ptr.To("zone-1"),
+				NodeName:  ptr.To("node-1"),
 			},
 			expected: false,
 		},
@@ -777,21 +777,21 @@ func TestEndpointsEqualBeyondHash(t *testing.T) {
 			name: "Pod resourceVersion changed",
 			ep1: &discovery.Endpoint{
 				Conditions: discovery.EndpointConditions{
-					Ready: pointer.Bool(true),
+					Ready: ptr.To(true),
 				},
 				Addresses: []string{"10.0.0.1"},
 				TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "default", Name: "pod0", ResourceVersion: "1"},
-				Zone:      pointer.String("zone-1"),
-				NodeName:  pointer.String("node-1"),
+				Zone:      ptr.To("zone-1"),
+				NodeName:  ptr.To("node-1"),
 			},
 			ep2: &discovery.Endpoint{
 				Conditions: discovery.EndpointConditions{
-					Ready: pointer.Bool(true),
+					Ready: ptr.To(true),
 				},
 				Addresses: []string{"10.0.0.1"},
 				TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "default", Name: "pod0", ResourceVersion: "2"},
-				Zone:      pointer.String("zone-1"),
-				NodeName:  pointer.String("node-1"),
+				Zone:      ptr.To("zone-1"),
+				NodeName:  ptr.To("node-1"),
 			},
 			expected: true,
 		},
@@ -799,21 +799,21 @@ func TestEndpointsEqualBeyondHash(t *testing.T) {
 			name: "Pod resourceVersion removed",
 			ep1: &discovery.Endpoint{
 				Conditions: discovery.EndpointConditions{
-					Ready: pointer.Bool(true),
+					Ready: ptr.To(true),
 				},
 				Addresses: []string{"10.0.0.1"},
 				TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "default", Name: "pod0", ResourceVersion: "1"},
-				Zone:      pointer.String("zone-1"),
-				NodeName:  pointer.String("node-1"),
+				Zone:      ptr.To("zone-1"),
+				NodeName:  ptr.To("node-1"),
 			},
 			ep2: &discovery.Endpoint{
 				Conditions: discovery.EndpointConditions{
-					Ready: pointer.Bool(true),
+					Ready: ptr.To(true),
 				},
 				Addresses: []string{"10.0.0.1"},
 				TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "default", Name: "pod0", ResourceVersion: ""},
-				Zone:      pointer.String("zone-1"),
-				NodeName:  pointer.String("node-1"),
+				Zone:      ptr.To("zone-1"),
+				NodeName:  ptr.To("node-1"),
 			},
 			expected: true,
 		},

--- a/staging/src/k8s.io/endpointslice/util/endpointslice_tracker_test.go
+++ b/staging/src/k8s.io/endpointslice/util/endpointslice_tracker_test.go
@@ -23,6 +23,7 @@ import (
 	discovery "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 )
 
 func TestEndpointSliceTrackerUpdate(t *testing.T) {
@@ -125,8 +126,7 @@ func TestEndpointSliceTrackerStaleSlices(t *testing.T) {
 	epSlice1NewerGen.Generation = 2
 
 	epTerminatingSlice := epSlice1.DeepCopy()
-	now := metav1.Now()
-	epTerminatingSlice.DeletionTimestamp = &now
+	epTerminatingSlice.DeletionTimestamp = ptr.To(metav1.Now())
 
 	testCases := []struct {
 		name         string

--- a/staging/src/k8s.io/endpointslice/utils_test.go
+++ b/staging/src/k8s.io/endpointslice/utils_test.go
@@ -34,15 +34,17 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
 	"k8s.io/klog/v2/ktesting"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestNewEndpointSlice(t *testing.T) {
 	ipAddressType := discovery.AddressTypeIPv4
 	portName := "foo"
-	protocol := v1.ProtocolTCP
 	endpointMeta := endpointMeta{
-		ports:       []discovery.EndpointPort{{Name: &portName, Protocol: &protocol}},
+		ports: []discovery.EndpointPort{{
+			Name:     &portName,
+			Protocol: ptr.To(v1.ProtocolTCP),
+		}},
 		addressType: ipAddressType,
 	}
 	service := v1.Service{
@@ -258,11 +260,11 @@ func TestPodToEndpoint(t *testing.T) {
 			expectedEndpoint: discovery.Endpoint{
 				Addresses: []string{"1.2.3.5"},
 				Conditions: discovery.EndpointConditions{
-					Ready:       pointer.Bool(true),
-					Serving:     pointer.Bool(true),
-					Terminating: pointer.Bool(false),
+					Ready:       ptr.To(true),
+					Serving:     ptr.To(true),
+					Terminating: ptr.To(false),
 				},
-				NodeName: pointer.String("node-1"),
+				NodeName: ptr.To("node-1"),
 				TargetRef: &v1.ObjectReference{
 					Kind:      "Pod",
 					Namespace: ns,
@@ -278,11 +280,11 @@ func TestPodToEndpoint(t *testing.T) {
 			expectedEndpoint: discovery.Endpoint{
 				Addresses: []string{"1.2.3.5"},
 				Conditions: discovery.EndpointConditions{
-					Ready:       pointer.Bool(true),
-					Serving:     pointer.Bool(true),
-					Terminating: pointer.Bool(false),
+					Ready:       ptr.To(true),
+					Serving:     ptr.To(true),
+					Terminating: ptr.To(false),
 				},
-				NodeName: pointer.String("node-1"),
+				NodeName: ptr.To("node-1"),
 				TargetRef: &v1.ObjectReference{
 					Kind:      "Pod",
 					Namespace: ns,
@@ -298,11 +300,11 @@ func TestPodToEndpoint(t *testing.T) {
 			expectedEndpoint: discovery.Endpoint{
 				Addresses: []string{"1.2.3.5"},
 				Conditions: discovery.EndpointConditions{
-					Ready:       pointer.Bool(false),
-					Serving:     pointer.Bool(false),
-					Terminating: pointer.Bool(false),
+					Ready:       ptr.To(false),
+					Serving:     ptr.To(false),
+					Terminating: ptr.To(false),
 				},
-				NodeName: pointer.String("node-1"),
+				NodeName: ptr.To("node-1"),
 				TargetRef: &v1.ObjectReference{
 					Kind:      "Pod",
 					Namespace: ns,
@@ -318,11 +320,11 @@ func TestPodToEndpoint(t *testing.T) {
 			expectedEndpoint: discovery.Endpoint{
 				Addresses: []string{"1.2.3.5"},
 				Conditions: discovery.EndpointConditions{
-					Ready:       pointer.Bool(true),
-					Serving:     pointer.Bool(false),
-					Terminating: pointer.Bool(false),
+					Ready:       ptr.To(true),
+					Serving:     ptr.To(false),
+					Terminating: ptr.To(false),
 				},
-				NodeName: pointer.String("node-1"),
+				NodeName: ptr.To("node-1"),
 				TargetRef: &v1.ObjectReference{
 					Kind:      "Pod",
 					Namespace: ns,
@@ -339,12 +341,12 @@ func TestPodToEndpoint(t *testing.T) {
 			expectedEndpoint: discovery.Endpoint{
 				Addresses: []string{"1.2.3.5"},
 				Conditions: discovery.EndpointConditions{
-					Ready:       pointer.Bool(true),
-					Serving:     pointer.Bool(true),
-					Terminating: pointer.Bool(false),
+					Ready:       ptr.To(true),
+					Serving:     ptr.To(true),
+					Terminating: ptr.To(false),
 				},
-				Zone:     pointer.String("us-central1-a"),
-				NodeName: pointer.String("node-1"),
+				Zone:     ptr.To("us-central1-a"),
+				NodeName: ptr.To("node-1"),
 				TargetRef: &v1.ObjectReference{
 					Kind:      "Pod",
 					Namespace: ns,
@@ -361,12 +363,12 @@ func TestPodToEndpoint(t *testing.T) {
 			expectedEndpoint: discovery.Endpoint{
 				Addresses: []string{"1.2.3.4"},
 				Conditions: discovery.EndpointConditions{
-					Ready:       pointer.Bool(true),
-					Serving:     pointer.Bool(true),
-					Terminating: pointer.Bool(false),
+					Ready:       ptr.To(true),
+					Serving:     ptr.To(true),
+					Terminating: ptr.To(false),
 				},
-				Zone:     pointer.String("us-central1-a"),
-				NodeName: pointer.String("node-1"),
+				Zone:     ptr.To("us-central1-a"),
+				NodeName: ptr.To("node-1"),
 				TargetRef: &v1.ObjectReference{
 					Kind:      "Pod",
 					Namespace: ns,
@@ -383,13 +385,13 @@ func TestPodToEndpoint(t *testing.T) {
 			expectedEndpoint: discovery.Endpoint{
 				Addresses: []string{"1.2.3.5"},
 				Conditions: discovery.EndpointConditions{
-					Ready:       pointer.Bool(true),
-					Serving:     pointer.Bool(true),
-					Terminating: pointer.Bool(false),
+					Ready:       ptr.To(true),
+					Serving:     ptr.To(true),
+					Terminating: ptr.To(false),
 				},
 				Hostname: &readyPodHostname.Spec.Hostname,
-				Zone:     pointer.String("us-central1-a"),
-				NodeName: pointer.String("node-1"),
+				Zone:     ptr.To("us-central1-a"),
+				NodeName: ptr.To("node-1"),
 				TargetRef: &v1.ObjectReference{
 					Kind:      "Pod",
 					Namespace: ns,
@@ -405,11 +407,11 @@ func TestPodToEndpoint(t *testing.T) {
 			expectedEndpoint: discovery.Endpoint{
 				Addresses: []string{"1.2.3.5"},
 				Conditions: discovery.EndpointConditions{
-					Ready:       pointer.Bool(true),
-					Serving:     pointer.Bool(true),
-					Terminating: pointer.Bool(false),
+					Ready:       ptr.To(true),
+					Serving:     ptr.To(true),
+					Terminating: ptr.To(false),
 				},
-				NodeName: pointer.String("node-1"),
+				NodeName: ptr.To("node-1"),
 				TargetRef: &v1.ObjectReference{
 					Kind:      "Pod",
 					Namespace: ns,
@@ -425,11 +427,11 @@ func TestPodToEndpoint(t *testing.T) {
 			expectedEndpoint: discovery.Endpoint{
 				Addresses: []string{"1.2.3.5"},
 				Conditions: discovery.EndpointConditions{
-					Ready:       pointer.Bool(false),
-					Serving:     pointer.Bool(true),
-					Terminating: pointer.Bool(true),
+					Ready:       ptr.To(false),
+					Serving:     ptr.To(true),
+					Terminating: ptr.To(true),
 				},
-				NodeName: pointer.String("node-1"),
+				NodeName: ptr.To("node-1"),
 				TargetRef: &v1.ObjectReference{
 					Kind:      "Pod",
 					Namespace: ns,
@@ -445,11 +447,11 @@ func TestPodToEndpoint(t *testing.T) {
 			expectedEndpoint: discovery.Endpoint{
 				Addresses: []string{"1.2.3.5"},
 				Conditions: discovery.EndpointConditions{
-					Ready:       pointer.Bool(false),
-					Serving:     pointer.Bool(false),
-					Terminating: pointer.Bool(true),
+					Ready:       ptr.To(false),
+					Serving:     ptr.To(false),
+					Terminating: ptr.To(true),
 				},
-				NodeName: pointer.String("node-1"),
+				NodeName: ptr.To("node-1"),
 				TargetRef: &v1.ObjectReference{
 					Kind:      "Pod",
 					Namespace: ns,
@@ -514,7 +516,6 @@ func TestServiceControllerKey(t *testing.T) {
 }
 
 func TestGetEndpointPorts(t *testing.T) {
-	protoTCP := v1.ProtocolTCP
 	restartPolicyAlways := v1.ContainerRestartPolicyAlways
 
 	testCases := map[string]struct {
@@ -529,8 +530,8 @@ func TestGetEndpointPorts(t *testing.T) {
 						Name:        "http",
 						Port:        80,
 						TargetPort:  intstr.FromInt32(80),
-						Protocol:    protoTCP,
-						AppProtocol: pointer.String("example.com/custom-protocol"),
+						Protocol:    v1.ProtocolTCP,
+						AppProtocol: ptr.To("example.com/custom-protocol"),
 					}},
 				},
 			},
@@ -542,10 +543,10 @@ func TestGetEndpointPorts(t *testing.T) {
 				},
 			},
 			expectedPorts: []*discovery.EndpointPort{{
-				Name:        pointer.String("http"),
-				Port:        pointer.Int32(80),
-				Protocol:    &protoTCP,
-				AppProtocol: pointer.String("example.com/custom-protocol"),
+				Name:        ptr.To("http"),
+				Port:        ptr.To[int32](80),
+				Protocol:    ptr.To(v1.ProtocolTCP),
+				AppProtocol: ptr.To("example.com/custom-protocol"),
 			}},
 		},
 		"service with named port and AppProtocol on one port": {
@@ -555,12 +556,12 @@ func TestGetEndpointPorts(t *testing.T) {
 						Name:       "http",
 						Port:       80,
 						TargetPort: intstr.FromInt32(80),
-						Protocol:   protoTCP,
+						Protocol:   v1.ProtocolTCP,
 					}, {
 						Name:        "https",
-						Protocol:    protoTCP,
+						Protocol:    v1.ProtocolTCP,
 						TargetPort:  intstr.FromString("https"),
-						AppProtocol: pointer.String("https"),
+						AppProtocol: ptr.To("https"),
 					}},
 				},
 			},
@@ -570,20 +571,20 @@ func TestGetEndpointPorts(t *testing.T) {
 						Ports: []v1.ContainerPort{{
 							Name:          "https",
 							ContainerPort: int32(443),
-							Protocol:      protoTCP,
+							Protocol:      v1.ProtocolTCP,
 						}},
 					}},
 				},
 			},
 			expectedPorts: []*discovery.EndpointPort{{
-				Name:     pointer.String("http"),
-				Port:     pointer.Int32(80),
-				Protocol: &protoTCP,
+				Name:     ptr.To("http"),
+				Port:     ptr.To[int32](80),
+				Protocol: ptr.To(v1.ProtocolTCP),
 			}, {
-				Name:        pointer.String("https"),
-				Port:        pointer.Int32(443),
-				Protocol:    &protoTCP,
-				AppProtocol: pointer.String("https"),
+				Name:        ptr.To("https"),
+				Port:        ptr.To[int32](443),
+				Protocol:    ptr.To(v1.ProtocolTCP),
+				AppProtocol: ptr.To("https"),
 			}},
 		},
 		"service with named port for restartable init container": {
@@ -593,12 +594,12 @@ func TestGetEndpointPorts(t *testing.T) {
 						Name:       "http-sidecar",
 						Port:       8080,
 						TargetPort: intstr.FromInt32(8080),
-						Protocol:   protoTCP,
+						Protocol:   v1.ProtocolTCP,
 					}, {
 						Name:       "http",
 						Port:       8090,
 						TargetPort: intstr.FromString("http"),
-						Protocol:   protoTCP,
+						Protocol:   v1.ProtocolTCP,
 					}},
 				},
 			},
@@ -608,7 +609,7 @@ func TestGetEndpointPorts(t *testing.T) {
 						Ports: []v1.ContainerPort{{
 							Name:          "http-sidecar",
 							ContainerPort: int32(8080),
-							Protocol:      protoTCP,
+							Protocol:      v1.ProtocolTCP,
 						}},
 						RestartPolicy: &restartPolicyAlways,
 					}},
@@ -616,19 +617,19 @@ func TestGetEndpointPorts(t *testing.T) {
 						Ports: []v1.ContainerPort{{
 							Name:          "http",
 							ContainerPort: int32(8090),
-							Protocol:      protoTCP,
+							Protocol:      v1.ProtocolTCP,
 						}},
 					}},
 				},
 			},
 			expectedPorts: []*discovery.EndpointPort{{
-				Name:     pointer.String("http-sidecar"),
-				Port:     pointer.Int32(8080),
-				Protocol: &protoTCP,
+				Name:     ptr.To("http-sidecar"),
+				Port:     ptr.To[int32](8080),
+				Protocol: ptr.To(v1.ProtocolTCP),
 			}, {
-				Name:     pointer.String("http"),
-				Port:     pointer.Int32(8090),
-				Protocol: &protoTCP,
+				Name:     ptr.To("http"),
+				Port:     ptr.To[int32](8090),
+				Protocol: ptr.To(v1.ProtocolTCP),
 			}},
 		},
 		"service with same named port for regular and restartable init container": {
@@ -639,7 +640,7 @@ func TestGetEndpointPorts(t *testing.T) {
 							Name:       "http",
 							Port:       80,
 							TargetPort: intstr.FromString("http"),
-							Protocol:   protoTCP,
+							Protocol:   v1.ProtocolTCP,
 						}},
 				},
 			},
@@ -649,7 +650,7 @@ func TestGetEndpointPorts(t *testing.T) {
 						Ports: []v1.ContainerPort{{
 							Name:          "http",
 							ContainerPort: int32(8080),
-							Protocol:      protoTCP,
+							Protocol:      v1.ProtocolTCP,
 						}},
 						RestartPolicy: &restartPolicyAlways,
 					}},
@@ -657,15 +658,15 @@ func TestGetEndpointPorts(t *testing.T) {
 						Ports: []v1.ContainerPort{{
 							Name:          "http",
 							ContainerPort: int32(8090),
-							Protocol:      protoTCP,
+							Protocol:      v1.ProtocolTCP,
 						}},
 					}},
 				},
 			},
 			expectedPorts: []*discovery.EndpointPort{{
-				Name:     pointer.String("http"),
-				Port:     pointer.Int32(8090),
-				Protocol: &protoTCP,
+				Name:     ptr.To("http"),
+				Port:     ptr.To[int32](8090),
+				Protocol: ptr.To(v1.ProtocolTCP),
 			}},
 		},
 	}
@@ -1042,10 +1043,9 @@ func newClientset() *fake.Clientset {
 }
 
 func newServiceAndEndpointMeta(name, namespace string) (v1.Service, endpointMeta) {
-	portNum := int32(80)
 	portNameIntStr := intstr.IntOrString{
 		Type:   intstr.Int,
-		IntVal: portNum,
+		IntVal: 80,
 	}
 
 	svc := v1.Service{
@@ -1065,11 +1065,13 @@ func newServiceAndEndpointMeta(name, namespace string) (v1.Service, endpointMeta
 		},
 	}
 
-	addressType := discovery.AddressTypeIPv4
-	protocol := v1.ProtocolTCP
 	endpointMeta := endpointMeta{
-		addressType: addressType,
-		ports:       []discovery.EndpointPort{{Name: &name, Port: &portNum, Protocol: &protocol}},
+		addressType: discovery.AddressTypeIPv4,
+		ports: []discovery.EndpointPort{{
+			Name:     &name,
+			Port:     &portNameIntStr.IntVal,
+			Protocol: ptr.To(v1.ProtocolTCP),
+		}},
 	}
 
 	return svc, endpointMeta


### PR DESCRIPTION
#### What this PR does / why we need it:
Drive-by fixes while working on new TrafficDistribution stuff.
1. Use `"k8s.io/utils/ptr"` instead of `"k8s.io/utils/pointer"` (and take advantage of some more places where we could use it).
2. Remove EndpointSlice controller metrics code to deal with cases that can't actually happen.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/kind cleanup
/sig network