### PR TITLE
authentication: when cert verification fails store details in audit log

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/util.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/util.go
@@ -62,5 +62,5 @@ func GetHumanCertDetail(certificate *x509.Certificate) string {
 	}
 
 	return fmt.Sprintf("%q [%s]%s%s issuer=%q (%v to %v (now=%v))", humanName, strings.Join(usages, ","), groupString, servingString, signerHumanName, certificate.NotBefore.UTC(), certificate.NotAfter.UTC(),
-		time.Now().UTC())
+		time.Now().Truncate(time.Second).UTC())
 }

--- a/test/integration/auth/certs_test.go
+++ b/test/integration/auth/certs_test.go
@@ -1,0 +1,150 @@
+package auth
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"os"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	auditinternal "k8s.io/apiserver/pkg/apis/audit"
+	auditv1 "k8s.io/apiserver/pkg/apis/audit/v1"
+	kubex509 "k8s.io/apiserver/pkg/authentication/request/x509"
+
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	utiltesting "k8s.io/client-go/util/testing"
+	kubeapiservertesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
+	"k8s.io/kubernetes/test/integration/framework"
+	"k8s.io/kubernetes/test/utils"
+)
+
+var (
+	auditPolicy = `
+apiVersion: audit.k8s.io/v1
+kind: Policy
+rules:
+  - level: Request
+    resources:
+    - group: ""
+      resources: ["pods"]
+    verbs: ["get"]
+`
+)
+
+func TestCerts(t *testing.T) {
+	logFile, err := os.CreateTemp("", "audit.log")
+	if err != nil {
+		t.Fatalf("Failed to create audit log file: %v", err)
+	}
+	defer utiltesting.CloseAndRemove(t, logFile)
+
+	policyFile, err := os.CreateTemp("", "audit-policy.yaml")
+	if err != nil {
+		t.Fatalf("Failed to create audit policy file: %v", err)
+	}
+	if _, err := policyFile.Write([]byte(auditPolicy)); err != nil {
+		t.Fatalf("Failed to write audit policy file: %v", err)
+	}
+
+	s := kubeapiservertesting.StartTestServerOrDie(t, kubeapiservertesting.NewDefaultTestServerOptions(), []string{
+		"--audit-policy-file", policyFile.Name(),
+		"--audit-log-version", "audit.k8s.io/v1",
+		"--audit-log-mode", "blocking",
+		"--audit-log-path", logFile.Name(),
+	}, framework.SharedEtcd())
+	defer s.TearDownFn()
+
+	// Generate self-signed certificate
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyRaw, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	commonName := "test-cn"
+	notBefore := time.Now().Truncate(time.Second)
+	notAfter := notBefore.Add(time.Hour)
+	cert := &x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject:      pkix.Name{CommonName: commonName},
+		NotBefore:    notBefore,
+		NotAfter:     notAfter,
+
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		BasicConstraintsValid: true,
+	}
+	certRaw, err := x509.CreateCertificate(rand.Reader, cert, cert, key.Public(), key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Use self-signed certificate in client config
+	clientConfig := rest.CopyConfig(s.ClientConfig)
+	clientConfig.BearerToken = ""
+	clientConfig.CertData = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certRaw})
+	clientConfig.KeyData = pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyRaw})
+	client, err := clientset.NewForConfig(clientConfig)
+	if err != nil {
+		t.Fatalf("error occurred: %v", err)
+	}
+
+	// Make a request using the client
+	podName := "foobar"
+	currentTime := time.Now().Truncate(time.Second)
+	_, err = client.CoreV1().Pods("default").Get(context.TODO(), podName, metav1.GetOptions{})
+	if err == nil {
+		t.Fatal("expected error, but it was nil")
+	}
+
+	// Verify that audit log has the expected entry
+	stream, err := os.OpenFile(logFile.Name(), os.O_RDWR, 0600)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	defer stream.Close()
+
+	annotationDetails := fmt.Sprintf(`certificate "%s" [client] issuer="<self>" (%s to %s (now=%s)) failed: x509: certificate signed by unknown authority`, commonName, notBefore.UTC(), notAfter.UTC(), currentTime.UTC())
+	expectedEvents := []utils.AuditEvent{
+		{
+			Level:      auditinternal.LevelRequest,
+			Stage:      auditinternal.StageResponseStarted,
+			RequestURI: fmt.Sprintf("/api/v1/namespaces/default/pods/%s", podName),
+			Verb:       "get",
+			Resource:   "pods",
+			Namespace:  "default",
+			Code:       401,
+			CustomAuditAnnotations: map[string]string{
+				kubex509.CertificateErrorAuditAnnotation: annotationDetails,
+			},
+		},
+	}
+
+	auditAnnotationFilter := func(key, val string) bool {
+		return key == kubex509.CertificateErrorAuditAnnotation
+	}
+
+	missing, err := utils.CheckAuditLinesFiltered(stream, expectedEvents, auditv1.SchemeGroupVersion, auditAnnotationFilter)
+	if err != nil {
+		t.Errorf("unexpected error checking audit lines: %v", err)
+	}
+	if len(missing.MissingEvents) > 0 {
+		t.Errorf("failed to get expected events -- missing: %s", missing)
+	}
+}


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
In some cases finding the invalid cert by its serial number is tedious. However we can't expose more PII in kube-apiserver logs.

This commit will add an audit log annotations with additional details: common name, issuer common name and serial number

Alternative solution to https://github.com/kubernetes/kubernetes/pull/130137

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/129600

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Audit log entry for a request failed due to invalid certificate now has additional information - namely certificate's Common Name, Issuer Common Name and Serial number
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
