### PR TITLE
Conntrack reconciler now considers service's target port during cleanup of stale flow entries

### DIFF
--- a/pkg/proxy/conntrack/cleanup.go
+++ b/pkg/proxy/conntrack/cleanup.go
@@ -59,11 +59,11 @@ func CleanStaleEntries(ct Interface, ipFamily v1.IPFamily,
 		}
 	}
 
-	// serviceIPEndpointIPs maps service IPs (ClusterIP, LoadBalancerIPs and ExternalIPs) and Service Port
-	// to the set of serving endpoint IPs.
-	serviceIPEndpointIPs := make(map[string]sets.Set[string])
-	// serviceNodePortEndpointIPs maps service NodePort to the set of serving endpoint IPs.
-	serviceNodePortEndpointIPs := make(map[int]sets.Set[string])
+	// serviceIPEndpoints maps service IPs (ClusterIP, LoadBalancerIPs and ExternalIPs) and Service Port
+	// to the set of serving endpoints (Endpoint IP and Port).
+	serviceIPEndpoints := make(map[string]sets.Set[string])
+	// serviceNodePortEndpoints maps service NodePort to the set of serving endpoints  (Endpoint IP and Port).
+	serviceNodePortEndpoints := make(map[int]sets.Set[string])
 
 	for svcName, svc := range svcPortMap {
 		// we are only interested in UDP services
@@ -71,44 +71,45 @@ func CleanStaleEntries(ct Interface, ipFamily v1.IPFamily,
 			continue
 		}
 
-		endpointIPs := sets.New[string]()
+		endpoints := sets.New[string]()
 		for _, endpoint := range endpointsMap[svcName] {
 			// We need to remove all the conntrack entries for a Service (IP or NodePort)
 			// that are not pointing to a serving endpoint.
-			// We map all the serving endpoint IPs to the service and clear all the conntrack
+			// We map all the serving endpoints of the service and clear all the conntrack
 			// entries which are destined for the service and are not DNATed to these endpoints.
 			// Changes to the service should not affect existing flows, so we do not take
 			// traffic policies, topology, or terminating status of the service into account.
 			// This ensures that the behavior of UDP services remains consistent with TCP
 			// services.
 			if endpoint.IsServing() {
-				endpointIPs.Insert(endpoint.IP())
+				portStr := strconv.Itoa(int(endpoint.Port()))
+				endpoints.Insert(net.JoinHostPort(endpoint.IP(), portStr))
 			}
 		}
 
 		// a Service without endpoints does not require to clean the conntrack entries associated.
-		if endpointIPs.Len() == 0 {
+		if endpoints.Len() == 0 {
 			continue
 		}
 
 		// we need to filter entries that are directed to a Service IP:Port frontend
-		// that does not have a backend as part of the endpoints IPs
+		// that does not have an Endpoint IP:Port backend as part of the serving endpoints
 		portStr := strconv.Itoa(svc.Port())
 		// clusterIP:Port
-		serviceIPEndpointIPs[net.JoinHostPort(svc.ClusterIP().String(), portStr)] = endpointIPs
+		serviceIPEndpoints[net.JoinHostPort(svc.ClusterIP().String(), portStr)] = endpoints
 		// loadbalancerIP:Port
 		for _, loadBalancerIP := range svc.LoadBalancerVIPs() {
-			serviceIPEndpointIPs[net.JoinHostPort(loadBalancerIP.String(), portStr)] = endpointIPs
+			serviceIPEndpoints[net.JoinHostPort(loadBalancerIP.String(), portStr)] = endpoints
 		}
 		// externalIP:Port
 		for _, externalIP := range svc.ExternalIPs() {
-			serviceIPEndpointIPs[net.JoinHostPort(externalIP.String(), portStr)] = endpointIPs
+			serviceIPEndpoints[net.JoinHostPort(externalIP.String(), portStr)] = endpoints
 		}
-		// we need to filter entries that are directed to a *:NodePort
-		// that does not have a backend as part of the endpoints IPs
+		// we need to filter entries that are directed to a *:NodePort that does not have
+		// an Endpoint IP:Port backend as part of the serving endpoints
 		if svc.NodePort() != 0 {
 			// *:NodePort
-			serviceNodePortEndpointIPs[svc.NodePort()] = endpointIPs
+			serviceNodePortEndpoints[svc.NodePort()] = endpoints
 		}
 	}
 
@@ -122,22 +123,25 @@ func CleanStaleEntries(ct Interface, ipFamily v1.IPFamily,
 		origDst := entry.Forward.DstIP.String()   // match Service IP
 		origPortDst := int(entry.Forward.DstPort) // match Service Port
 		origPortDstStr := strconv.Itoa(origPortDst)
-		replySrc := entry.Reverse.SrcIP.String() // match Serving Endpoint IP
+		replySrc := entry.Reverse.SrcIP.String()   // match Serving Endpoint IP
+		replyPortSrc := int(entry.Reverse.SrcPort) // match Serving Endpoint Port
+		replyPortSrcStr := strconv.Itoa(replyPortSrc)
 
 		// if the original destination (--orig-dst) of the entry is service IP (ClusterIP,
-		// LoadBalancerIPs or ExternalIPs) and (--orig-port-dst) of the flow is service Port
-		// and the reply source (--reply-src) is not IP of any serving endpoint, we clear the entry.
-		endpoints, ok := serviceIPEndpointIPs[net.JoinHostPort(origDst, origPortDstStr)]
-		if ok && !endpoints.Has(replySrc) {
-			filters = append(filters, filterForIPPortNAT(entry.Forward.DstIP, entry.Forward.DstPort, entry.Reverse.SrcIP, v1.ProtocolUDP))
+		// LoadBalancerIPs or ExternalIPs) and (--orig-port-dst) is service Port and
+		// the reply source IP (--reply-src) and port (--reply-port-src) does not
+		// represent a serving endpoint of the service, we clear the entry.
+		endpoints, ok := serviceIPEndpoints[net.JoinHostPort(origDst, origPortDstStr)]
+		if ok && !endpoints.Has(net.JoinHostPort(replySrc, replyPortSrcStr)) {
+			filters = append(filters, filterForIPPortNAT(entry.Forward.DstIP, entry.Forward.DstPort, entry.Reverse.SrcIP, entry.Reverse.SrcPort, v1.ProtocolUDP))
 		}
 
-		// if the original port destination (--orig-port-dst) of the flow is service
-		// NodePort and the reply source (--reply-src) is not IP of any serving endpoint,
-		// we clear the entry.
-		endpoints, ok = serviceNodePortEndpointIPs[origPortDst]
-		if ok && !endpoints.Has(replySrc) {
-			filters = append(filters, filterForPortNAT(entry.Forward.DstPort, entry.Reverse.SrcIP, v1.ProtocolUDP))
+		// if the original destination port (--orig-port-dst) of the entry is service
+		// NodePort and the reply source IP (--reply-src) and port (--reply-port-src)
+		// does not represent a serving endpoint of the service, we clear the entry.
+		endpoints, ok = serviceNodePortEndpoints[origPortDst]
+		if ok && !endpoints.Has(net.JoinHostPort(replySrc, replyPortSrcStr)) {
+			filters = append(filters, filterForPortNAT(entry.Forward.DstPort, entry.Reverse.SrcIP, entry.Reverse.SrcPort, v1.ProtocolUDP))
 		}
 	}
 
@@ -167,9 +171,9 @@ var protocolMap = map[v1.Protocol]uint8{
 
 // filterForIPPortNAT returns *conntrackFilter to delete the conntrack entries for connections
 // specified by the destination IP (original direction) and destination port (original direction)
-// and source IP (reply direction).
-func filterForIPPortNAT(origDst net.IP, origPortDst uint16, replySrc net.IP, protocol v1.Protocol) *conntrackFilter {
-	klog.V(6).InfoS("Adding conntrack filter for cleanup", "orig-dst", origDst.String(), "orig-port-dst", origPortDst, "reply-src", replySrc.String(), "protocol", protocol)
+// and source IP (reply direction) and source port (reply direction).
+func filterForIPPortNAT(origDst net.IP, origPortDst uint16, replySrc net.IP, replyPortSrc uint16, protocol v1.Protocol) *conntrackFilter {
+	klog.V(6).InfoS("Adding conntrack filter for cleanup", "orig-dst", origDst.String(), "orig-port-dst", origPortDst, "reply-src", replySrc.String(), "reply-port-src", replyPortSrc, "protocol", protocol)
 	return &conntrackFilter{
 		protocol: protocolMap[protocol],
 		original: &connectionTuple{
@@ -177,22 +181,24 @@ func filterForIPPortNAT(origDst net.IP, origPortDst uint16, replySrc net.IP, pro
 			dstPort: origPortDst,
 		},
 		reply: &connectionTuple{
-			srcIP: replySrc,
+			srcIP:   replySrc,
+			srcPort: replyPortSrc,
 		},
 	}
 }
 
-// filterForPortNAT returns *conntrackFilter to delete the conntrack entries for connections
-// specified by the destination Port (original direction) and source IP (reply direction).
-func filterForPortNAT(origPortDst uint16, replySrc net.IP, protocol v1.Protocol) *conntrackFilter {
-	klog.V(6).InfoS("Adding conntrack filter for cleanup", "orig-port-dst", origPortDst, "reply-src", replySrc.String(), "protocol", protocol)
+// filterForPortNAT returns *conntrackFilter to delete the conntrack entries for connections specified by the
+// destination Port (original direction) and source IP (reply direction) and source port (reply direction).
+func filterForPortNAT(origPortDst uint16, replySrc net.IP, replyPortSrc uint16, protocol v1.Protocol) *conntrackFilter {
+	klog.V(6).InfoS("Adding conntrack filter for cleanup", "orig-port-dst", origPortDst, "reply-src", replySrc.String(), "reply-port-src", replyPortSrc, "protocol", protocol)
 	return &conntrackFilter{
 		protocol: protocolMap[protocol],
 		original: &connectionTuple{
 			dstPort: origPortDst,
 		},
 		reply: &connectionTuple{
-			srcIP: replySrc,
+			srcIP:   replySrc,
+			srcPort: replyPortSrc,
 		},
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Followup from https://github.com/kubernetes/kubernetes/pull/127318#discussion_r1758764457
Conntrack cleanup doesn't consider service target port (--reply-port-src) during cleanup. This can leave the cluster with stale flow entries when when any UDP service changes target port.

This PR fixes that.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Conntrack reconciler now considers service's target port during cleanup of stale flow entries.
```
