### PR TITLE
order sandbox by attempt or create time

### DIFF
--- a/pkg/kubelet/kuberuntime/helpers.go
+++ b/pkg/kubelet/kuberuntime/helpers.go
@@ -47,9 +47,14 @@ func (b containersByID) Less(i, j int) bool { return b[i].ID.ID < b[j].ID.ID }
 // Newest first.
 type podSandboxByCreated []*runtimeapi.PodSandbox
 
-func (p podSandboxByCreated) Len() int           { return len(p) }
-func (p podSandboxByCreated) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
-func (p podSandboxByCreated) Less(i, j int) bool { return p[i].CreatedAt > p[j].CreatedAt }
+func (p podSandboxByCreated) Len() int      { return len(p) }
+func (p podSandboxByCreated) Swap(i, j int) { p[i], p[j] = p[j], p[i] }
+func (p podSandboxByCreated) Less(i, j int) bool {
+	if p[i].Metadata == nil || p[j].Metadata == nil {
+		return p[i].CreatedAt > p[j].CreatedAt
+	}
+	return p[i].Metadata.Attempt > p[j].Metadata.Attempt
+}
 
 type containerStatusByCreated []*kubecontainer.Status
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This issue is caused by system clock rollback, which is prone to occur during system startup, especially when NTP starts around static pods.

**Detailed Reproduction Steps:**

1.  **Set up a node:**  Install a Kubernetes node using kubeadm and cri-o. Refer to the tutorial: [https://github.com/cri-o/cri-o/blob/main/tutorials/kubeadm.md](https://github.com/cri-o/cri-o/blob/main/tutorials/kubeadm.md)
2.  **Stop NTP Service:** Stop the NTP service (or chrony, systemd-timesyncd) on the node.
    ```bash
    systemctl stop ntp  // or chrony, systemd-timesyncd
    ```
3.  **Create a Busybox Deployment:** Deploy a simple busybox deployment in the Kubernetes cluster.
    ```bash
    kubectl create -f busybox-deploy
    ```
4.  **Simulate Clock Rollback:** Set the system date back to the epoch start (or a very early time) to simulate a clock rollback.
    ```bash
    date -s '0:0:0'
    ```
5.  **Stop the Busybox Pod (Initial Stop):** Stop the busybox pod using `crictl`.
    ```bash
    crictl stopp $(crictl pods |grep -w busybox|awk '{print $1}')
    ```
6.  **Start NTP Service:** Start the NTP service (or chrony, systemd-timesyncd) on the node.
    ```bash
    systemctl start ntp  // or chrony, systemd-timesyncd
    ```
7.  **Stop the Busybox Pod (Second Stop):** Stop the busybox pod again using `crictl`.
    ```bash
    crictl stopp $(crictl pods |grep -w busybox|awk '{print $1}')
    ```
8. **Log crio sevice**
    ```bash
    journalctl -eu crio --no-pager -ocat
    ...
    time="2025-03-11T04:48:10.760615237Z" level=info msg="Running pod sandbox: default/busybox-74c5fcfb8-5kbmh/POD" id=07cdd735-da9d-4217-8987-bbac8656f566 name=/runtime.v1.RuntimeService/RunPodSandbox
    time="2025-03-11T04:48:10.76067006Z" level=warning msg="error reserving pod name k8s_busybox-74c5fcfb8-5kbmh_default_240ce90c-efe1-432b-aae0-88006b9ff369_2 for id 5d0d17bf66724375923d4467c4869bc822a6151195573e9e3afb418b0f302066: name is reserved
    ...
    ```
Making kubelet dependent on time services like NTP during system startup is unnecessary. 

It's would be a more convenient and robust approach if kubelet use logical time to determine the number of sandbox creations 

This could potentially mitigate issues arising from clock rollback, especially in scenarios where NTP synchronization is delayed or fails during early system boot.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Fixes #126514

#### Special notes for your reviewer:

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
