### PR TITLE
added user extra for kubectl auth

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/auth/auth.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/auth/auth.go
@@ -33,9 +33,16 @@ func NewCmdAuth(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Co
 		Run:   cmdutil.DefaultSubCommandRun(streams.ErrOut),
 	}
 
+	var asUserExtra map[string]string
+
+	cmds.PersistentFlags().StringToStringVar(&asUserExtra, "as-user-extra", nil, "Additional user attributes for impersonation")
 	cmds.AddCommand(NewCmdCanI(f, streams))
 	cmds.AddCommand(NewCmdReconcile(f, streams))
 	cmds.AddCommand(NewCmdWhoAmI(f, streams))
+
+	for _, subCmd := range cmds.Commands() {
+		subCmd.PersistentFlags().StringToStringVar(&asUserExtra, "as-user-extra", nil, "Additional user attributes for impersonation")
+	}
 
 	return cmds
 }


### PR DESCRIPTION
Added --as-user-extra in kubectl auth

This PR fixes issue #130389 