### PR TITLE
[FG:InPlacePodVerticalScaling] Fix use CamelCase for memory manager policy in InPlacePodVerticalScalingExclusiveCPUs

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2829,7 +2829,7 @@ func (kl *Kubelet) canResizePod(pod *v1.Pod) (bool, v1.PodResizeStatus, string) 
 			}
 		}
 		if utilfeature.DefaultFeatureGate.Enabled(features.MemoryManager) {
-			if kl.containerManager.GetNodeConfig().MemoryManagerPolicy == "static" {
+			if kl.containerManager.GetNodeConfig().MemoryManagerPolicy == "Static" {
 				msg := "Resize is infeasible for Guaranteed Pods alongside Memory Manager static policy"
 				klog.V(3).InfoS(msg, "pod", format.Pod(pod))
 				return false, v1.PodResizeStatusInfeasible, msg


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

[This commit](https://github.com/kubernetes/kubernetes/commit/2d8939c4aef8f060d413bb27272ba38cd7171fbe#diff-67dd9e8f3ee257072765326cb4f242852554a2c0753563fa51e292c0a63a7b94R2849 ) introduced a bug, as explained [here](https://github.com/kubernetes/kubernetes/pull/128728#discussion_r1835696883)

#### Which issue(s) this PR fixes:

Relates to https://github.com/kubernetes/kubernetes/pull/128728#discussion_r1835696883

Temp fix of the bug on InPlacePodVerticalScalingExclusiveCPUs feature gate exclusive assigment availability check, until new API to expose this information is merged, https://github.com/kubernetes/kubernetes/issues/129531 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Fix a bug on InPlacePodVerticalScalingExclusiveCPUs feature gate exclusive assignment availability check.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
