### PR TITLE
Switch cluster trust bundle e2e tests to feature-gate tagging

### DIFF
--- a/test/e2e/auth/projected_clustertrustbundle.go
+++ b/test/e2e/auth/projected_clustertrustbundle.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/util/wait"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
+	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/test/e2e/feature"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2epodoutput "k8s.io/kubernetes/test/e2e/framework/pod/output"
@@ -57,7 +58,7 @@ const (
 	noSignerKey       = "no-signer"
 )
 
-var _ = SIGDescribe(feature.ClusterTrustBundle, feature.ClusterTrustBundleProjection, func() {
+var _ = SIGDescribe(feature.Alpha, framework.WithFeatureGate(features.ClusterTrustBundle), framework.WithFeatureGate(features.ClusterTrustBundleProjection), func() {
 	f := framework.NewDefaultFramework("projected-clustertrustbundle")
 	f.NamespacePodSecurityLevel = admissionapi.LevelBaseline
 

--- a/test/e2e/feature/feature.go
+++ b/test/e2e/feature/feature.go
@@ -23,6 +23,12 @@ import (
 )
 
 var (
+	// This is a generic feature for tests which only require alpha API and alpha feature gate enablement
+	Alpha = framework.WithFeature(framework.ValidFeatures.Add("Alpha"))
+
+	// This is a generic feature for tests which only require beta API and beta feature gate enablement
+	Beta = framework.WithFeature(framework.ValidFeatures.Add("Beta"))
+
 	// Please keep the list in alphabetical order.
 
 	// TODO: document the feature (owning SIG, when to use this feature for a test)
@@ -59,12 +65,6 @@ var (
 
 	// Owner: sig-autoscaling
 	ClusterSizeAutoscalingScaleUp = framework.WithFeature(framework.ValidFeatures.Add("ClusterSizeAutoscalingScaleUp"))
-
-	// TODO: document the feature (owning SIG, when to use this feature for a test)
-	ClusterTrustBundle = framework.WithFeature(framework.ValidFeatures.Add("ClusterTrustBundle"))
-
-	// TODO: document the feature (owning SIG, when to use this feature for a test)
-	ClusterTrustBundleProjection = framework.WithFeature(framework.ValidFeatures.Add("ClusterTrustBundleProjection"))
 
 	// TODO: document the feature (owning SIG, when to use this feature for a test)
 	ClusterUpgrade = framework.WithFeature(framework.ValidFeatures.Add("ClusterUpgrade"))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Adjusts CTB e2e test tagging to be selected correctly by alpha / beta test jobs.

xref discussion in https://github.com/kubernetes/test-infra/pull/34451

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```


- [ ] pull-kubernetes-e2e-gce-cos-alpha-features (should run CTB tests)
  - ❌ before merge of https://github.com/kubernetes/test-infra/pull/34456 - https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/130567/pull-kubernetes-e2e-gce-cos-alpha-features/1897023220503023616
  - [ ] after merge of https://github.com/kubernetes/test-infra/pull/34456
- [x] ✅  pull-kubernetes-e2e-kind-alpha-features (should run CTB tests) - https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/130567/pull-kubernetes-e2e-kind-alpha-features/1897023443153457152
- [ ] pull-kubernetes-e2e-kind-alpha-beta-features (should run CTB tests)
- [x] ✅  pull-kubernetes-e2e-kind-beta-features (should not run CTB tests) - https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/130567/pull-kubernetes-e2e-kind-beta-features/1897023443220566016
