### PR TITLE
[FG:PodObservedGenerationTracking] kubelet sets observedGeneration on pod conditions

### DIFF
--- a/pkg/api/v1/pod/util.go
+++ b/pkg/api/v1/pod/util.go
@@ -432,16 +432,16 @@ func GetPodObservedGenerationIfEnabled(pod *v1.Pod) int64 {
 // We will emit condition.observedGeneration if the feature is enabled OR if condition.observedGeneration is already set.
 // This protects against an infinite loop of kubelet trying to clear the value after the FG is turned off, and
 // the API server preserving existing values when an incoming update tries to clear it.
-func GetPodObservedGenerationIfEnabledOnCondition(pod *v1.Pod, conditionType v1.PodConditionType) int64 {
-	if pod == nil {
+func GetPodObservedGenerationIfEnabledOnCondition(podStatus *v1.PodStatus, generation int64, conditionType v1.PodConditionType) int64 {
+	if podStatus == nil {
 		return 0
 	}
 	if utilfeature.DefaultFeatureGate.Enabled(features.PodObservedGenerationTracking) {
-		return pod.Generation
+		return generation
 	}
-	for _, condition := range pod.Status.Conditions {
+	for _, condition := range podStatus.Conditions {
 		if condition.Type == conditionType && condition.ObservedGeneration != 0 {
-			return pod.Generation
+			return generation
 		}
 	}
 	return 0

--- a/pkg/controller/disruption/disruption.go
+++ b/pkg/controller/disruption/disruption.go
@@ -790,7 +790,7 @@ func (dc *DisruptionController) syncStalePodDisruption(ctx context.Context, key 
 	newPod := pod.DeepCopy()
 	updated := apipod.UpdatePodCondition(&newPod.Status, &v1.PodCondition{
 		Type:               v1.DisruptionTarget,
-		ObservedGeneration: apipod.GetPodObservedGenerationIfEnabledOnCondition(newPod, v1.DisruptionTarget),
+		ObservedGeneration: apipod.GetPodObservedGenerationIfEnabledOnCondition(&newPod.Status, newPod.Generation, v1.DisruptionTarget),
 		Status:             v1.ConditionFalse,
 	})
 	if !updated {

--- a/pkg/controller/podgc/gc_controller.go
+++ b/pkg/controller/podgc/gc_controller.go
@@ -247,7 +247,7 @@ func (gcc *PodGCController) gcOrphaned(ctx context.Context, pods []*v1.Pod, node
 		logger.V(2).Info("Found orphaned Pod assigned to the Node, deleting", "pod", klog.KObj(pod), "node", klog.KRef("", pod.Spec.NodeName))
 		condition := &v1.PodCondition{
 			Type:               v1.DisruptionTarget,
-			ObservedGeneration: apipod.GetPodObservedGenerationIfEnabledOnCondition(pod, v1.DisruptionTarget),
+			ObservedGeneration: apipod.GetPodObservedGenerationIfEnabledOnCondition(&pod.Status, pod.Generation, v1.DisruptionTarget),
 			Status:             v1.ConditionTrue,
 			Reason:             "DeletionByPodGC",
 			Message:            "PodGC: node no longer exists",

--- a/pkg/controller/tainteviction/taint_eviction.go
+++ b/pkg/controller/tainteviction/taint_eviction.go
@@ -134,7 +134,7 @@ func addConditionAndDeletePod(ctx context.Context, c clientset.Interface, name, 
 	newStatus := pod.Status.DeepCopy()
 	updated := apipod.UpdatePodCondition(newStatus, &v1.PodCondition{
 		Type:               v1.DisruptionTarget,
-		ObservedGeneration: apipod.GetPodObservedGenerationIfEnabledOnCondition(pod, v1.DisruptionTarget),
+		ObservedGeneration: apipod.GetPodObservedGenerationIfEnabledOnCondition(&pod.Status, pod.Generation, v1.DisruptionTarget),
 		Status:             v1.ConditionTrue,
 		Reason:             "DeletionByTaintManager",
 		Message:            "Taint manager: deleting due to NoExecute taint",

--- a/pkg/kubelet/eviction/eviction_manager.go
+++ b/pkg/kubelet/eviction/eviction_manager.go
@@ -425,10 +425,11 @@ func (m *managerImpl) synchronize(diskInfoProvider DiskInfoProvider, podFunc Act
 
 		message, annotations := evictionMessage(resourceToReclaim, pod, statsFunc, thresholds, observations)
 		condition := &v1.PodCondition{
-			Type:    v1.DisruptionTarget,
-			Status:  v1.ConditionTrue,
-			Reason:  v1.PodReasonTerminationByKubelet,
-			Message: message,
+			Type:               v1.DisruptionTarget,
+			ObservedGeneration: pod.Generation,
+			Status:             v1.ConditionTrue,
+			Reason:             v1.PodReasonTerminationByKubelet,
+			Message:            message,
 		}
 		if m.evictPod(pod, gracePeriodOverride, message, annotations, condition) {
 			metrics.Evictions.WithLabelValues(string(thresholdToReclaim.Signal)).Inc()
@@ -618,6 +619,7 @@ func (m *managerImpl) evictPod(pod *v1.Pod, gracePeriodOverride int64, evictMsg 
 		status.Reason = Reason
 		status.Message = evictMsg
 		if condition != nil {
+			condition.ObservedGeneration = podutil.GetPodObservedGenerationIfEnabledOnCondition(status, pod.Generation, v1.DisruptionTarget)
 			podutil.UpdatePodCondition(status, condition)
 		}
 	})

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -1828,6 +1828,7 @@ func (kl *Kubelet) generateAPIPodStatus(pod *v1.Pod, podStatus *kubecontainer.Po
 	if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {
 		resizeStatus := kl.determinePodResizeStatus(pod, podIsTerminal)
 		for _, c := range resizeStatus {
+			c.ObservedGeneration = podutil.GetPodObservedGenerationIfEnabledOnCondition(&oldPodStatus, pod.Generation, c.Type)
 			s.Conditions = append(s.Conditions, *c)
 		}
 	}
@@ -1843,15 +1844,16 @@ func (kl *Kubelet) generateAPIPodStatus(pod *v1.Pod, podStatus *kubecontainer.Po
 
 	// set all Kubelet-owned conditions
 	if utilfeature.DefaultFeatureGate.Enabled(features.PodReadyToStartContainersCondition) {
-		s.Conditions = append(s.Conditions, status.GeneratePodReadyToStartContainersCondition(pod, podStatus))
+		s.Conditions = append(s.Conditions, status.GeneratePodReadyToStartContainersCondition(pod, &oldPodStatus, podStatus))
 	}
 	allContainerStatuses := append(s.InitContainerStatuses, s.ContainerStatuses...)
-	s.Conditions = append(s.Conditions, status.GeneratePodInitializedCondition(&pod.Spec, allContainerStatuses, s.Phase))
-	s.Conditions = append(s.Conditions, status.GeneratePodReadyCondition(&pod.Spec, s.Conditions, allContainerStatuses, s.Phase))
-	s.Conditions = append(s.Conditions, status.GenerateContainersReadyCondition(&pod.Spec, allContainerStatuses, s.Phase))
+	s.Conditions = append(s.Conditions, status.GeneratePodInitializedCondition(pod, &oldPodStatus, allContainerStatuses, s.Phase))
+	s.Conditions = append(s.Conditions, status.GeneratePodReadyCondition(pod, &oldPodStatus, s.Conditions, allContainerStatuses, s.Phase))
+	s.Conditions = append(s.Conditions, status.GenerateContainersReadyCondition(pod, &oldPodStatus, allContainerStatuses, s.Phase))
 	s.Conditions = append(s.Conditions, v1.PodCondition{
-		Type:   v1.PodScheduled,
-		Status: v1.ConditionTrue,
+		Type:               v1.PodScheduled,
+		ObservedGeneration: podutil.GetPodObservedGenerationIfEnabledOnCondition(&oldPodStatus, pod.Generation, v1.PodScheduled),
+		Status:             v1.ConditionTrue,
 	})
 	// set HostIP/HostIPs and initialize PodIP/PodIPs for host network pods
 	if kl.kubeClient != nil {

--- a/pkg/kubelet/nodeshutdown/nodeshutdown_manager.go
+++ b/pkg/kubelet/nodeshutdown/nodeshutdown_manager.go
@@ -160,10 +160,11 @@ func (m *podManager) killPods(activePods []*v1.Pod) error {
 					status.Message = nodeShutdownMessage
 					status.Reason = nodeShutdownReason
 					podutil.UpdatePodCondition(status, &v1.PodCondition{
-						Type:    v1.DisruptionTarget,
-						Status:  v1.ConditionTrue,
-						Reason:  v1.PodReasonTerminationByKubelet,
-						Message: nodeShutdownMessage,
+						Type:               v1.DisruptionTarget,
+						ObservedGeneration: podutil.GetPodObservedGenerationIfEnabledOnCondition(status, pod.Generation, v1.DisruptionTarget),
+						Status:             v1.ConditionTrue,
+						Reason:             v1.PodReasonTerminationByKubelet,
+						Message:            nodeShutdownMessage,
 					})
 				}); err != nil {
 					m.logger.V(1).Info("Shutdown manager failed killing pod", "pod", klog.KObj(pod), "err", err)

--- a/pkg/kubelet/preemption/preemption.go
+++ b/pkg/kubelet/preemption/preemption.go
@@ -105,10 +105,11 @@ func (c *CriticalPodAdmissionHandler) evictPodsToFreeRequests(admitPod *v1.Pod, 
 			status.Reason = events.PreemptContainer
 			status.Message = message
 			podutil.UpdatePodCondition(status, &v1.PodCondition{
-				Type:    v1.DisruptionTarget,
-				Status:  v1.ConditionTrue,
-				Reason:  v1.PodReasonTerminationByKubelet,
-				Message: "Pod was preempted by Kubelet to accommodate a critical pod.",
+				Type:               v1.DisruptionTarget,
+				ObservedGeneration: podutil.GetPodObservedGenerationIfEnabledOnCondition(status, pod.Generation, v1.DisruptionTarget),
+				Status:             v1.ConditionTrue,
+				Reason:             v1.PodReasonTerminationByKubelet,
+				Message:            "Pod was preempted by Kubelet to accommodate a critical pod.",
 			})
 		})
 		if err != nil {

--- a/pkg/kubelet/status/generate.go
+++ b/pkg/kubelet/status/generate.go
@@ -43,19 +43,20 @@ const (
 
 // GenerateContainersReadyCondition returns the status of "ContainersReady" condition.
 // The status of "ContainersReady" condition is true when all containers are ready.
-func GenerateContainersReadyCondition(spec *v1.PodSpec, containerStatuses []v1.ContainerStatus, podPhase v1.PodPhase) v1.PodCondition {
+func GenerateContainersReadyCondition(pod *v1.Pod, oldPodStatus *v1.PodStatus, containerStatuses []v1.ContainerStatus, podPhase v1.PodPhase) v1.PodCondition {
 	// Find if all containers are ready or not.
 	if containerStatuses == nil {
 		return v1.PodCondition{
-			Type:   v1.ContainersReady,
-			Status: v1.ConditionFalse,
-			Reason: UnknownContainerStatuses,
+			Type:               v1.ContainersReady,
+			ObservedGeneration: podutil.GetPodObservedGenerationIfEnabledOnCondition(oldPodStatus, pod.Generation, v1.ContainersReady),
+			Status:             v1.ConditionFalse,
+			Reason:             UnknownContainerStatuses,
 		}
 	}
 	unknownContainers := []string{}
 	unreadyContainers := []string{}
 
-	for _, container := range spec.InitContainers {
+	for _, container := range pod.Spec.InitContainers {
 		if !podutil.IsRestartableInitContainer(&container) {
 			continue
 		}
@@ -69,7 +70,7 @@ func GenerateContainersReadyCondition(spec *v1.PodSpec, containerStatuses []v1.C
 		}
 	}
 
-	for _, container := range spec.Containers {
+	for _, container := range pod.Spec.Containers {
 		if containerStatus, ok := podutil.GetContainerStatus(containerStatuses, container.Name); ok {
 			if !containerStatus.Ready {
 				unreadyContainers = append(unreadyContainers, container.Name)
@@ -81,12 +82,12 @@ func GenerateContainersReadyCondition(spec *v1.PodSpec, containerStatuses []v1.C
 
 	// If all containers are known and succeeded, just return PodCompleted.
 	if podPhase == v1.PodSucceeded && len(unknownContainers) == 0 {
-		return generateContainersReadyConditionForTerminalPhase(podPhase)
+		return generateContainersReadyConditionForTerminalPhase(pod, oldPodStatus, podPhase)
 	}
 
 	// If the pod phase is failed, explicitly set the ready condition to false for containers since they may be in progress of terminating.
 	if podPhase == v1.PodFailed {
-		return generateContainersReadyConditionForTerminalPhase(podPhase)
+		return generateContainersReadyConditionForTerminalPhase(pod, oldPodStatus, podPhase)
 	}
 
 	// Generate message for containers in unknown condition.
@@ -100,38 +101,41 @@ func GenerateContainersReadyCondition(spec *v1.PodSpec, containerStatuses []v1.C
 	unreadyMessage := strings.Join(unreadyMessages, ", ")
 	if unreadyMessage != "" {
 		return v1.PodCondition{
-			Type:    v1.ContainersReady,
-			Status:  v1.ConditionFalse,
-			Reason:  ContainersNotReady,
-			Message: unreadyMessage,
+			Type:               v1.ContainersReady,
+			ObservedGeneration: podutil.GetPodObservedGenerationIfEnabledOnCondition(oldPodStatus, pod.Generation, v1.ContainersReady),
+			Status:             v1.ConditionFalse,
+			Reason:             ContainersNotReady,
+			Message:            unreadyMessage,
 		}
 	}
 
 	return v1.PodCondition{
-		Type:   v1.ContainersReady,
-		Status: v1.ConditionTrue,
+		Type:               v1.ContainersReady,
+		ObservedGeneration: podutil.GetPodObservedGenerationIfEnabledOnCondition(oldPodStatus, pod.Generation, v1.ContainersReady),
+		Status:             v1.ConditionTrue,
 	}
 }
 
 // GeneratePodReadyCondition returns "Ready" condition of a pod.
 // The status of "Ready" condition is "True", if all containers in a pod are ready
 // AND all matching conditions specified in the ReadinessGates have status equal to "True".
-func GeneratePodReadyCondition(spec *v1.PodSpec, conditions []v1.PodCondition, containerStatuses []v1.ContainerStatus, podPhase v1.PodPhase) v1.PodCondition {
-	containersReady := GenerateContainersReadyCondition(spec, containerStatuses, podPhase)
+func GeneratePodReadyCondition(pod *v1.Pod, oldPodStatus *v1.PodStatus, conditions []v1.PodCondition, containerStatuses []v1.ContainerStatus, podPhase v1.PodPhase) v1.PodCondition {
+	containersReady := GenerateContainersReadyCondition(pod, oldPodStatus, containerStatuses, podPhase)
 	// If the status of ContainersReady is not True, return the same status, reason and message as ContainersReady.
 	if containersReady.Status != v1.ConditionTrue {
 		return v1.PodCondition{
-			Type:    v1.PodReady,
-			Status:  containersReady.Status,
-			Reason:  containersReady.Reason,
-			Message: containersReady.Message,
+			Type:               v1.PodReady,
+			ObservedGeneration: podutil.GetPodObservedGenerationIfEnabledOnCondition(oldPodStatus, pod.Generation, v1.PodReady),
+			Status:             containersReady.Status,
+			Reason:             containersReady.Reason,
+			Message:            containersReady.Message,
 		}
 	}
 
 	// Evaluate corresponding conditions specified in readiness gate
 	// Generate message if any readiness gate is not satisfied.
 	unreadyMessages := []string{}
-	for _, rg := range spec.ReadinessGates {
+	for _, rg := range pod.Spec.ReadinessGates {
 		_, c := podutil.GetPodConditionFromList(conditions, rg.ConditionType)
 		if c == nil {
 			unreadyMessages = append(unreadyMessages, fmt.Sprintf("corresponding condition of pod readiness gate %q does not exist.", string(rg.ConditionType)))
@@ -144,16 +148,18 @@ func GeneratePodReadyCondition(spec *v1.PodSpec, conditions []v1.PodCondition, c
 	if len(unreadyMessages) != 0 {
 		unreadyMessage := strings.Join(unreadyMessages, ", ")
 		return v1.PodCondition{
-			Type:    v1.PodReady,
-			Status:  v1.ConditionFalse,
-			Reason:  ReadinessGatesNotReady,
-			Message: unreadyMessage,
+			Type:               v1.PodReady,
+			ObservedGeneration: podutil.GetPodObservedGenerationIfEnabledOnCondition(oldPodStatus, pod.Generation, v1.PodReady),
+			Status:             v1.ConditionFalse,
+			Reason:             ReadinessGatesNotReady,
+			Message:            unreadyMessage,
 		}
 	}
 
 	return v1.PodCondition{
-		Type:   v1.PodReady,
-		Status: v1.ConditionTrue,
+		Type:               v1.PodReady,
+		ObservedGeneration: podutil.GetPodObservedGenerationIfEnabledOnCondition(oldPodStatus, pod.Generation, v1.PodReady),
+		Status:             v1.ConditionTrue,
 	}
 }
 
@@ -172,19 +178,20 @@ func isInitContainerInitialized(initContainer *v1.Container, containerStatus *v1
 
 // GeneratePodInitializedCondition returns initialized condition if all init containers in a pod are ready, else it
 // returns an uninitialized condition.
-func GeneratePodInitializedCondition(spec *v1.PodSpec, containerStatuses []v1.ContainerStatus, podPhase v1.PodPhase) v1.PodCondition {
+func GeneratePodInitializedCondition(pod *v1.Pod, oldPodStatus *v1.PodStatus, containerStatuses []v1.ContainerStatus, podPhase v1.PodPhase) v1.PodCondition {
 	// Find if all containers are ready or not.
-	if containerStatuses == nil && len(spec.InitContainers) > 0 {
+	if containerStatuses == nil && len(pod.Spec.InitContainers) > 0 {
 		return v1.PodCondition{
-			Type:   v1.PodInitialized,
-			Status: v1.ConditionFalse,
-			Reason: UnknownContainerStatuses,
+			Type:               v1.PodInitialized,
+			ObservedGeneration: podutil.GetPodObservedGenerationIfEnabledOnCondition(oldPodStatus, pod.Generation, v1.PodInitialized),
+			Status:             v1.ConditionFalse,
+			Reason:             UnknownContainerStatuses,
 		}
 	}
 
 	unknownContainers := []string{}
 	incompleteContainers := []string{}
-	for _, container := range spec.InitContainers {
+	for _, container := range pod.Spec.InitContainers {
 		containerStatus, ok := podutil.GetContainerStatus(containerStatuses, container.Name)
 		if !ok {
 			unknownContainers = append(unknownContainers, container.Name)
@@ -198,9 +205,10 @@ func GeneratePodInitializedCondition(spec *v1.PodSpec, containerStatuses []v1.Co
 	// If all init containers are known and succeeded, just return PodCompleted.
 	if podPhase == v1.PodSucceeded && len(unknownContainers) == 0 {
 		return v1.PodCondition{
-			Type:   v1.PodInitialized,
-			Status: v1.ConditionTrue,
-			Reason: PodCompleted,
+			Type:               v1.PodInitialized,
+			ObservedGeneration: podutil.GetPodObservedGenerationIfEnabledOnCondition(oldPodStatus, pod.Generation, v1.PodInitialized),
+			Status:             v1.ConditionTrue,
+			Reason:             PodCompleted,
 		}
 	}
 
@@ -208,10 +216,11 @@ func GeneratePodInitializedCondition(spec *v1.PodSpec, containerStatuses []v1.Co
 	// been initialized before.
 	// This is needed to handle the case where the pod has been initialized but
 	// the restartable init containers are restarting.
-	if kubecontainer.HasAnyRegularContainerStarted(spec, containerStatuses) {
+	if kubecontainer.HasAnyRegularContainerStarted(&pod.Spec, containerStatuses) {
 		return v1.PodCondition{
-			Type:   v1.PodInitialized,
-			Status: v1.ConditionTrue,
+			Type:               v1.PodInitialized,
+			ObservedGeneration: podutil.GetPodObservedGenerationIfEnabledOnCondition(oldPodStatus, pod.Generation, v1.PodInitialized),
+			Status:             v1.ConditionTrue,
 		}
 	}
 
@@ -225,20 +234,22 @@ func GeneratePodInitializedCondition(spec *v1.PodSpec, containerStatuses []v1.Co
 	unreadyMessage := strings.Join(unreadyMessages, ", ")
 	if unreadyMessage != "" {
 		return v1.PodCondition{
-			Type:    v1.PodInitialized,
-			Status:  v1.ConditionFalse,
-			Reason:  ContainersNotInitialized,
-			Message: unreadyMessage,
+			Type:               v1.PodInitialized,
+			ObservedGeneration: podutil.GetPodObservedGenerationIfEnabledOnCondition(oldPodStatus, pod.Generation, v1.PodInitialized),
+			Status:             v1.ConditionFalse,
+			Reason:             ContainersNotInitialized,
+			Message:            unreadyMessage,
 		}
 	}
 
 	return v1.PodCondition{
-		Type:   v1.PodInitialized,
-		Status: v1.ConditionTrue,
+		Type:               v1.PodInitialized,
+		ObservedGeneration: podutil.GetPodObservedGenerationIfEnabledOnCondition(oldPodStatus, pod.Generation, v1.PodInitialized),
+		Status:             v1.ConditionTrue,
 	}
 }
 
-func GeneratePodReadyToStartContainersCondition(pod *v1.Pod, podStatus *kubecontainer.PodStatus) v1.PodCondition {
+func GeneratePodReadyToStartContainersCondition(pod *v1.Pod, oldPodStatus *v1.PodStatus, podStatus *kubecontainer.PodStatus) v1.PodCondition {
 	newSandboxNeeded, _, _ := runtimeutil.PodSandboxChanged(pod, podStatus)
 	// if a new sandbox does not need to be created for a pod, it indicates that
 	// a sandbox for the pod with networking configured already exists.
@@ -246,20 +257,23 @@ func GeneratePodReadyToStartContainersCondition(pod *v1.Pod, podStatus *kubecont
 	// fresh sandbox and configure networking for the sandbox.
 	if !newSandboxNeeded {
 		return v1.PodCondition{
-			Type:   v1.PodReadyToStartContainers,
-			Status: v1.ConditionTrue,
+			Type:               v1.PodReadyToStartContainers,
+			ObservedGeneration: podutil.GetPodObservedGenerationIfEnabledOnCondition(oldPodStatus, pod.Generation, v1.PodReadyToStartContainers),
+			Status:             v1.ConditionTrue,
 		}
 	}
 	return v1.PodCondition{
-		Type:   v1.PodReadyToStartContainers,
-		Status: v1.ConditionFalse,
+		Type:               v1.PodReadyToStartContainers,
+		ObservedGeneration: podutil.GetPodObservedGenerationIfEnabledOnCondition(oldPodStatus, pod.Generation, v1.PodReadyToStartContainers),
+		Status:             v1.ConditionFalse,
 	}
 }
 
-func generateContainersReadyConditionForTerminalPhase(podPhase v1.PodPhase) v1.PodCondition {
+func generateContainersReadyConditionForTerminalPhase(pod *v1.Pod, oldPodStatus *v1.PodStatus, podPhase v1.PodPhase) v1.PodCondition {
 	condition := v1.PodCondition{
-		Type:   v1.ContainersReady,
-		Status: v1.ConditionFalse,
+		Type:               v1.ContainersReady,
+		ObservedGeneration: podutil.GetPodObservedGenerationIfEnabledOnCondition(oldPodStatus, pod.Generation, v1.ContainersReady),
+		Status:             v1.ConditionFalse,
 	}
 
 	if podPhase == v1.PodFailed {
@@ -271,10 +285,11 @@ func generateContainersReadyConditionForTerminalPhase(podPhase v1.PodPhase) v1.P
 	return condition
 }
 
-func generatePodReadyConditionForTerminalPhase(podPhase v1.PodPhase) v1.PodCondition {
+func generatePodReadyConditionForTerminalPhase(pod *v1.Pod, oldPodStatus *v1.PodStatus, podPhase v1.PodPhase) v1.PodCondition {
 	condition := v1.PodCondition{
-		Type:   v1.PodReady,
-		Status: v1.ConditionFalse,
+		Type:               v1.PodReady,
+		ObservedGeneration: podutil.GetPodObservedGenerationIfEnabledOnCondition(oldPodStatus, pod.Generation, v1.PodReady),
+		Status:             v1.ConditionFalse,
 	}
 
 	if podPhase == v1.PodFailed {

--- a/pkg/kubelet/status/status_manager_test.go
+++ b/pkg/kubelet/status/status_manager_test.go
@@ -2020,7 +2020,9 @@ func TestMergePodStatus(t *testing.T) {
 
 	for _, tc := range useCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			output := mergePodStatus(tc.oldPodStatus(getPodStatus()), tc.newPodStatus(getPodStatus()), tc.hasRunningContainers)
+			oldPodStatus := tc.oldPodStatus(getPodStatus())
+			pod := &v1.Pod{Status: oldPodStatus}
+			output := mergePodStatus(pod, oldPodStatus, tc.newPodStatus(getPodStatus()), tc.hasRunningContainers)
 			if !conditionsEqual(output.Conditions, tc.expectPodStatus.Conditions) || !statusEqual(output, tc.expectPodStatus) {
 				t.Fatalf("unexpected output: %s", cmp.Diff(tc.expectPodStatus, output))
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

This PR has the kubelet set the condition's `observedGeneration` field as discussed in https://kep.k8s.io/5067. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Pod generation KEP: https://kep.k8s.io/5067

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The kubelet will set the `observedGeneration` field on pod conditions when the `PodObservedGenerationTracking` feature gate is set.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://kep.k8s.io/5067
```
