### PR TITLE
Change allocation manager pod UID to types.UID

### DIFF
--- a/pkg/kubelet/allocation/allocation_manager_test.go
+++ b/pkg/kubelet/allocation/allocation_manager_test.go
@@ -110,7 +110,7 @@ func TestUpdatePodFromAllocation(t *testing.T) {
 		name: "steady state",
 		pod:  pod,
 		allocs: state.PodResourceAllocation{
-			string(pod.UID): map[string]v1.ResourceRequirements{
+			pod.UID: map[string]v1.ResourceRequirements{
 				"c1":                  *pod.Spec.Containers[0].Resources.DeepCopy(),
 				"c2":                  *pod.Spec.Containers[1].Resources.DeepCopy(),
 				"c1-restartable-init": *pod.Spec.InitContainers[0].Resources.DeepCopy(),
@@ -127,7 +127,7 @@ func TestUpdatePodFromAllocation(t *testing.T) {
 		name: "missing container allocation",
 		pod:  pod,
 		allocs: state.PodResourceAllocation{
-			string(pod.UID): map[string]v1.ResourceRequirements{
+			pod.UID: map[string]v1.ResourceRequirements{
 				"c2": *pod.Spec.Containers[1].Resources.DeepCopy(),
 			},
 		},
@@ -136,7 +136,7 @@ func TestUpdatePodFromAllocation(t *testing.T) {
 		name: "resized container",
 		pod:  pod,
 		allocs: state.PodResourceAllocation{
-			string(pod.UID): map[string]v1.ResourceRequirements{
+			pod.UID: map[string]v1.ResourceRequirements{
 				"c1":                  *resizedPod.Spec.Containers[0].Resources.DeepCopy(),
 				"c2":                  *resizedPod.Spec.Containers[1].Resources.DeepCopy(),
 				"c1-restartable-init": *resizedPod.Spec.InitContainers[0].Resources.DeepCopy(),

--- a/pkg/kubelet/allocation/state/checkpoint.go
+++ b/pkg/kubelet/allocation/state/checkpoint.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager/checksum"
 )
@@ -28,7 +29,7 @@ import (
 var _ checkpointmanager.Checkpoint = &Checkpoint{}
 
 type PodResourceAllocationInfo struct {
-	AllocationEntries map[string]map[string]v1.ResourceRequirements `json:"allocationEntries,omitempty"`
+	AllocationEntries map[types.UID]map[string]v1.ResourceRequirements `json:"allocationEntries,omitempty"`
 }
 
 // Checkpoint represents a structure to store pod resource allocation checkpoint data

--- a/pkg/kubelet/allocation/state/state.go
+++ b/pkg/kubelet/allocation/state/state.go
@@ -23,10 +23,7 @@ import (
 )
 
 // PodResourceAllocation type is used in tracking resources allocated to pod's containers
-type PodResourceAllocation map[string]map[string]v1.ResourceRequirements
-
-// PodResizeStatus type is used in tracking the last resize decision for pod
-type PodResizeStatus map[string]v1.PodResizeStatus
+type PodResourceAllocation map[types.UID]map[string]v1.ResourceRequirements
 
 // Clone returns a copy of PodResourceAllocation
 func (pr PodResourceAllocation) Clone() PodResourceAllocation {
@@ -42,14 +39,14 @@ func (pr PodResourceAllocation) Clone() PodResourceAllocation {
 
 // Reader interface used to read current pod resource allocation state
 type Reader interface {
-	GetContainerResourceAllocation(podUID string, containerName string) (v1.ResourceRequirements, bool)
+	GetContainerResourceAllocation(podUID types.UID, containerName string) (v1.ResourceRequirements, bool)
 	GetPodResourceAllocation() PodResourceAllocation
 }
 
 type writer interface {
-	SetContainerResourceAllocation(podUID string, containerName string, alloc v1.ResourceRequirements) error
-	SetPodResourceAllocation(podUID string, alloc map[string]v1.ResourceRequirements) error
-	Delete(podUID string, containerName string) error
+	SetContainerResourceAllocation(podUID types.UID, containerName string, alloc v1.ResourceRequirements) error
+	SetPodResourceAllocation(podUID types.UID, alloc map[string]v1.ResourceRequirements) error
+	Delete(podUID types.UID, containerName string) error
 	// RemoveOrphanedPods removes the stored state for any pods not included in the set of remaining pods.
 	RemoveOrphanedPods(remainingPods sets.Set[types.UID])
 }

--- a/pkg/kubelet/allocation/state/state_checkpoint.go
+++ b/pkg/kubelet/allocation/state/state_checkpoint.go
@@ -68,7 +68,7 @@ func restoreState(checkpointManager checkpointmanager.CheckpointManager, checkpo
 	if err = checkpointManager.GetCheckpoint(checkpointName, checkpoint); err != nil {
 		if err == errors.ErrCheckpointNotFound {
 			return &PodResourceAllocationInfo{
-				AllocationEntries: make(map[string]map[string]v1.ResourceRequirements),
+				AllocationEntries: make(map[types.UID]map[string]v1.ResourceRequirements),
 			}, nil
 		}
 		return nil, err
@@ -101,7 +101,7 @@ func (sc *stateCheckpoint) storeState() error {
 }
 
 // GetContainerResourceAllocation returns current resources allocated to a pod's container
-func (sc *stateCheckpoint) GetContainerResourceAllocation(podUID string, containerName string) (v1.ResourceRequirements, bool) {
+func (sc *stateCheckpoint) GetContainerResourceAllocation(podUID types.UID, containerName string) (v1.ResourceRequirements, bool) {
 	sc.mux.RLock()
 	defer sc.mux.RUnlock()
 	return sc.cache.GetContainerResourceAllocation(podUID, containerName)
@@ -115,7 +115,7 @@ func (sc *stateCheckpoint) GetPodResourceAllocation() PodResourceAllocation {
 }
 
 // SetContainerResourceAllocation sets resources allocated to a pod's container
-func (sc *stateCheckpoint) SetContainerResourceAllocation(podUID string, containerName string, alloc v1.ResourceRequirements) error {
+func (sc *stateCheckpoint) SetContainerResourceAllocation(podUID types.UID, containerName string, alloc v1.ResourceRequirements) error {
 	sc.mux.Lock()
 	defer sc.mux.Unlock()
 	sc.cache.SetContainerResourceAllocation(podUID, containerName, alloc)
@@ -123,7 +123,7 @@ func (sc *stateCheckpoint) SetContainerResourceAllocation(podUID string, contain
 }
 
 // SetPodResourceAllocation sets pod resource allocation
-func (sc *stateCheckpoint) SetPodResourceAllocation(podUID string, alloc map[string]v1.ResourceRequirements) error {
+func (sc *stateCheckpoint) SetPodResourceAllocation(podUID types.UID, alloc map[string]v1.ResourceRequirements) error {
 	sc.mux.Lock()
 	defer sc.mux.Unlock()
 	err := sc.cache.SetPodResourceAllocation(podUID, alloc)
@@ -134,7 +134,7 @@ func (sc *stateCheckpoint) SetPodResourceAllocation(podUID string, alloc map[str
 }
 
 // Delete deletes allocations for specified pod
-func (sc *stateCheckpoint) Delete(podUID string, containerName string) error {
+func (sc *stateCheckpoint) Delete(podUID types.UID, containerName string) error {
 	sc.mux.Lock()
 	defer sc.mux.Unlock()
 	sc.cache.Delete(podUID, containerName)
@@ -154,7 +154,7 @@ func NewNoopStateCheckpoint() State {
 	return &noopStateCheckpoint{}
 }
 
-func (sc *noopStateCheckpoint) GetContainerResourceAllocation(_ string, _ string) (v1.ResourceRequirements, bool) {
+func (sc *noopStateCheckpoint) GetContainerResourceAllocation(_ types.UID, _ string) (v1.ResourceRequirements, bool) {
 	return v1.ResourceRequirements{}, false
 }
 
@@ -162,15 +162,15 @@ func (sc *noopStateCheckpoint) GetPodResourceAllocation() PodResourceAllocation 
 	return nil
 }
 
-func (sc *noopStateCheckpoint) SetContainerResourceAllocation(_ string, _ string, _ v1.ResourceRequirements) error {
+func (sc *noopStateCheckpoint) SetContainerResourceAllocation(_ types.UID, _ string, _ v1.ResourceRequirements) error {
 	return nil
 }
 
-func (sc *noopStateCheckpoint) SetPodResourceAllocation(_ string, _ map[string]v1.ResourceRequirements) error {
+func (sc *noopStateCheckpoint) SetPodResourceAllocation(_ types.UID, _ map[string]v1.ResourceRequirements) error {
 	return nil
 }
 
-func (sc *noopStateCheckpoint) Delete(_ string, _ string) error {
+func (sc *noopStateCheckpoint) Delete(_ types.UID, _ string) error {
 	return nil
 }
 

--- a/pkg/kubelet/allocation/state/state_checkpoint_test.go
+++ b/pkg/kubelet/allocation/state/state_checkpoint_test.go
@@ -25,6 +25,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager"
 )
 
@@ -138,7 +139,7 @@ func Test_stateCheckpoint_formatUpgraded(t *testing.T) {
 	// pretend that the old checkpoint is unaware for the field ResizeStatusEntries
 	const checkpointContent = `{"data":"{\"allocationEntries\":{\"pod1\":{\"container1\":{\"requests\":{\"cpu\":\"1Ki\",\"memory\":\"1Ki\"}}}}}","checksum":1555601526}`
 	expectedPodResourceAllocationInfo := &PodResourceAllocationInfo{
-		AllocationEntries: map[string]map[string]v1.ResourceRequirements{
+		AllocationEntries: map[types.UID]map[string]v1.ResourceRequirements{
 			"pod1": {
 				"container1": {
 					Requests: v1.ResourceList{

--- a/pkg/kubelet/allocation/state/state_mem.go
+++ b/pkg/kubelet/allocation/state/state_mem.go
@@ -43,7 +43,7 @@ func NewStateMemory(alloc PodResourceAllocation) State {
 	}
 }
 
-func (s *stateMemory) GetContainerResourceAllocation(podUID string, containerName string) (v1.ResourceRequirements, bool) {
+func (s *stateMemory) GetContainerResourceAllocation(podUID types.UID, containerName string) (v1.ResourceRequirements, bool) {
 	s.RLock()
 	defer s.RUnlock()
 
@@ -57,7 +57,7 @@ func (s *stateMemory) GetPodResourceAllocation() PodResourceAllocation {
 	return s.podAllocation.Clone()
 }
 
-func (s *stateMemory) SetContainerResourceAllocation(podUID string, containerName string, alloc v1.ResourceRequirements) error {
+func (s *stateMemory) SetContainerResourceAllocation(podUID types.UID, containerName string, alloc v1.ResourceRequirements) error {
 	s.Lock()
 	defer s.Unlock()
 
@@ -70,7 +70,7 @@ func (s *stateMemory) SetContainerResourceAllocation(podUID string, containerNam
 	return nil
 }
 
-func (s *stateMemory) SetPodResourceAllocation(podUID string, alloc map[string]v1.ResourceRequirements) error {
+func (s *stateMemory) SetPodResourceAllocation(podUID types.UID, alloc map[string]v1.ResourceRequirements) error {
 	s.Lock()
 	defer s.Unlock()
 
@@ -79,7 +79,7 @@ func (s *stateMemory) SetPodResourceAllocation(podUID string, alloc map[string]v
 	return nil
 }
 
-func (s *stateMemory) deleteContainer(podUID string, containerName string) {
+func (s *stateMemory) deleteContainer(podUID types.UID, containerName string) {
 	delete(s.podAllocation[podUID], containerName)
 	if len(s.podAllocation[podUID]) == 0 {
 		delete(s.podAllocation, podUID)
@@ -87,7 +87,7 @@ func (s *stateMemory) deleteContainer(podUID string, containerName string) {
 	klog.V(3).InfoS("Deleted pod resource allocation", "podUID", podUID, "containerName", containerName)
 }
 
-func (s *stateMemory) Delete(podUID string, containerName string) error {
+func (s *stateMemory) Delete(podUID types.UID, containerName string) error {
 	s.Lock()
 	defer s.Unlock()
 	if len(containerName) == 0 {

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -2153,7 +2153,7 @@ func (kl *Kubelet) convertToAPIContainerStatuses(pod *v1.Pod, podStatus *kubecon
 
 		// Always set the status to the latest allocated resources, even if it differs from the
 		// allocation used by the current sync loop.
-		alloc, found := kl.allocationManager.GetContainerResourceAllocation(string(pod.UID), cName)
+		alloc, found := kl.allocationManager.GetContainerResourceAllocation(pod.UID, cName)
 		if !found {
 			// This case is expected for non-resizable containers (ephemeral & non-restartable init containers).
 			// Don't set status.Resources in this case.
@@ -2373,7 +2373,7 @@ func (kl *Kubelet) convertToAPIContainerStatuses(pod *v1.Pod, podStatus *kubecon
 			status.Resources = convertContainerStatusResources(cName, status, cStatus, oldStatuses)
 
 			if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScalingAllocatedStatus) {
-				if alloc, found := kl.allocationManager.GetContainerResourceAllocation(string(pod.UID), cName); found {
+				if alloc, found := kl.allocationManager.GetContainerResourceAllocation(pod.UID, cName); found {
 					status.AllocatedResources = alloc.Requests
 				}
 			}

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -2575,11 +2575,11 @@ func TestPodResourceAllocationReset(t *testing.T) {
 			}
 			kubelet.HandlePodAdditions([]*v1.Pod{tc.pod})
 
-			allocatedResources, found := kubelet.allocationManager.GetContainerResourceAllocation(string(tc.pod.UID), tc.pod.Spec.Containers[0].Name)
+			allocatedResources, found := kubelet.allocationManager.GetContainerResourceAllocation(tc.pod.UID, tc.pod.Spec.Containers[0].Name)
 			if !found {
 				t.Fatalf("resource allocation should exist: (pod: %#v, container: %s)", tc.pod, tc.pod.Spec.Containers[0].Name)
 			}
-			assert.Equal(t, tc.expectedPodResourceAllocation[string(tc.pod.UID)][tc.pod.Spec.Containers[0].Name], allocatedResources, tc.name)
+			assert.Equal(t, tc.expectedPodResourceAllocation[tc.pod.UID][tc.pod.Spec.Containers[0].Name], allocatedResources, tc.name)
 		})
 	}
 }
@@ -2953,7 +2953,7 @@ func TestHandlePodResourcesResize(t *testing.T) {
 				assert.Equal(t, tt.expectedAllocatedReqs, updatedPodCtr.Resources.Requests, "updated pod spec requests")
 				assert.Equal(t, tt.expectedAllocatedLims, updatedPodCtr.Resources.Limits, "updated pod spec limits")
 
-				alloc, found := kubelet.allocationManager.GetContainerResourceAllocation(string(newPod.UID), updatedPodCtr.Name)
+				alloc, found := kubelet.allocationManager.GetContainerResourceAllocation(newPod.UID, updatedPodCtr.Name)
 				require.True(t, found, "container allocation")
 				assert.Equal(t, tt.expectedAllocatedReqs, alloc.Requests, "stored container request allocation")
 				assert.Equal(t, tt.expectedAllocatedLims, alloc.Limits, "stored container limit allocation")


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Lots of unnecessary casting between `string` and `types.UID`. This just changes the allocation state and allocation manager to use `types.UID` for all UIDs, thus removing the need for type casting.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/sig node
/area kubelet
/triage accepted
/priority important-soon