### PR TITLE
e2e framework: add [Feature:Alpha] or [Feature:Beta] via WithFeatureGate

### DIFF
--- a/test/e2e/auth/projected_clustertrustbundle.go
+++ b/test/e2e/auth/projected_clustertrustbundle.go
@@ -39,7 +39,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/util/wait"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
-	"k8s.io/kubernetes/test/e2e/feature"
+	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2epodoutput "k8s.io/kubernetes/test/e2e/framework/pod/output"
 	imageutils "k8s.io/kubernetes/test/utils/image"
@@ -57,7 +57,7 @@ const (
 	noSignerKey       = "no-signer"
 )
 
-var _ = SIGDescribe(feature.ClusterTrustBundle, feature.ClusterTrustBundleProjection, func() {
+var _ = SIGDescribe(framework.WithFeatureGate(features.ClusterTrustBundle), framework.WithFeatureGate(features.ClusterTrustBundleProjection), func() {
 	f := framework.NewDefaultFramework("projected-clustertrustbundle")
 	f.NamespacePodSecurityLevel = admissionapi.LevelBaseline
 

--- a/test/e2e/feature/feature.go
+++ b/test/e2e/feature/feature.go
@@ -61,12 +61,6 @@ var (
 	ClusterSizeAutoscalingScaleUp = framework.WithFeature(framework.ValidFeatures.Add("ClusterSizeAutoscalingScaleUp"))
 
 	// TODO: document the feature (owning SIG, when to use this feature for a test)
-	ClusterTrustBundle = framework.WithFeature(framework.ValidFeatures.Add("ClusterTrustBundle"))
-
-	// TODO: document the feature (owning SIG, when to use this feature for a test)
-	ClusterTrustBundleProjection = framework.WithFeature(framework.ValidFeatures.Add("ClusterTrustBundleProjection"))
-
-	// TODO: document the feature (owning SIG, when to use this feature for a test)
 	ClusterUpgrade = framework.WithFeature(framework.ValidFeatures.Add("ClusterUpgrade"))
 
 	// TODO: document the feature (owning SIG, when to use this feature for a test)

--- a/test/e2e/framework/ginkgowrapper.go
+++ b/test/e2e/framework/ginkgowrapper.go
@@ -208,9 +208,9 @@ func registerInSuite(ginkgoCall func(string, ...interface{}) bool, args []interf
 		case label:
 			fullLabel := strings.Join(arg.parts, ":")
 			addLabel(fullLabel)
-			if arg.extraFeature != "" {
-				texts = append(texts, fmt.Sprintf("[%s]", arg.extraFeature))
-				ginkgoArgs = append(ginkgoArgs, ginkgo.Label("Feature:"+arg.extraFeature))
+			if arg.alphaBetaLevel != "" {
+				texts = append(texts, fmt.Sprintf("[%[1]s] [Feature:%[1]s]", arg.alphaBetaLevel))
+				ginkgoArgs = append(ginkgoArgs, ginkgo.Label("Feature:"+arg.alphaBetaLevel))
 			}
 			if fullLabel == "Serial" {
 				ginkgoArgs = append(ginkgoArgs, ginkgo.Serial)
@@ -350,7 +350,8 @@ func withFeature(name Feature) interface{} {
 }
 
 // WithFeatureGate specifies that a certain test or group of tests depends on a
-// feature gate being enabled. The return value must be passed as additional
+// feature gate and the corresponding API group (if there is one)
+// being enabled. The return value must be passed as additional
 // argument to [framework.It], [framework.Describe], [framework.Context].
 //
 // The feature gate must be listed in
@@ -359,9 +360,15 @@ func withFeature(name Feature) interface{} {
 // also need to be removed.
 //
 // [Alpha] resp. [Beta] get added to the test name automatically depending
-// on the current stability level of the feature. Feature:Alpha resp.
-// Feature:Beta get added to the Ginkgo labels because this is a special
-// requirement for how the cluster needs to be configured.
+// on the current stability level of the feature, to emulate historic
+// usage of those tags.
+//
+// In addition, [Feature:Alpha] resp. [Feature:Beta] get added to support
+// skipping a test with a dependency on an alpha or beta feature gate in
+// jobs which use the traditional \[Feature:.*\] skip regular expression.
+//
+// For label filtering, Feature:Alpha resp. Feature:Beta get added to the
+// Ginkgo labels.
 //
 // If the test can run in any cluster that has alpha resp. beta features and
 // API groups enabled, then annotating it with just WithFeatureGate is
@@ -390,7 +397,7 @@ func withFeatureGate(featureGate featuregate.Feature) interface{} {
 	}
 
 	l := newLabel("FeatureGate", string(featureGate))
-	l.extraFeature = level
+	l.alphaBetaLevel = level
 	return l
 }
 
@@ -536,9 +543,10 @@ func withFlaky() interface{} {
 type label struct {
 	// parts get concatenated with ":" to build the full label.
 	parts []string
-	// extra is an optional feature name. It gets added as [<extraFeature>]
-	// to the test name and as Feature:<extraFeature> to the labels.
-	extraFeature string
+	// alphaBetaLevel is "Alpha", "Beta" or empty for GA features
+	// It gets added as [<level>] [Feature:<level>]
+	// to the test name and as Feature:<level> to the labels.
+	alphaBetaLevel string
 	// explanation gets set for each label to help developers
 	// who pass a label to a ginkgo function. They need to use
 	// the corresponding framework function instead.
@@ -565,7 +573,7 @@ func TagsEqual(a, b interface{}) bool {
 	if !ok {
 		return false
 	}
-	if al.extraFeature != bl.extraFeature {
+	if al.alphaBetaLevel != bl.alphaBetaLevel {
 		return false
 	}
 	return slices.Equal(al.parts, bl.parts)

--- a/test/e2e/framework/internal/unittests/bugs/bugs.go
+++ b/test/e2e/framework/internal/unittests/bugs/bugs.go
@@ -122,8 +122,8 @@ ERROR: some/relative/path/buggy.go:200: with spaces
 `
 	// Used by unittests/list-tests. It's sorted by test name, not source code location.
 	ListTestsOutput = `The following spec names can be used with 'ginkgo run --focus/skip':
-    ../bugs/bugs.go:100: [sig-testing] abc   space1 space2  [Feature:no-such-feature] [Feature:feature-foo] [Environment:no-such-env] [Environment:Linux] [FeatureGate:no-such-feature-gate] [FeatureGate:TestAlphaFeature] [Alpha] [FeatureGate:TestBetaFeature] [Beta] [FeatureGate:TestGAFeature] [Conformance] [NodeConformance] [Slow] [Serial] [Disruptive] [custom-label] xyz x [foo] should [bar]
-    ../bugs/bugs.go:95: [sig-testing] abc   space1 space2  [Feature:no-such-feature] [Feature:feature-foo] [Environment:no-such-env] [Environment:Linux] [FeatureGate:no-such-feature-gate] [FeatureGate:TestAlphaFeature] [Alpha] [FeatureGate:TestBetaFeature] [Beta] [FeatureGate:TestGAFeature] [Conformance] [NodeConformance] [Slow] [Serial] [Disruptive] [custom-label] xyz y [foo] should [bar]
+    ../bugs/bugs.go:100: [sig-testing] abc   space1 space2  [Feature:no-such-feature] [Feature:feature-foo] [Environment:no-such-env] [Environment:Linux] [FeatureGate:no-such-feature-gate] [FeatureGate:TestAlphaFeature] [Alpha] [Feature:Alpha] [FeatureGate:TestBetaFeature] [Beta] [Feature:Beta] [FeatureGate:TestGAFeature] [Conformance] [NodeConformance] [Slow] [Serial] [Disruptive] [custom-label] xyz x [foo] should [bar]
+    ../bugs/bugs.go:95: [sig-testing] abc   space1 space2  [Feature:no-such-feature] [Feature:feature-foo] [Environment:no-such-env] [Environment:Linux] [FeatureGate:no-such-feature-gate] [FeatureGate:TestAlphaFeature] [Alpha] [Feature:Alpha] [FeatureGate:TestBetaFeature] [Beta] [Feature:Beta] [FeatureGate:TestGAFeature] [Conformance] [NodeConformance] [Slow] [Serial] [Disruptive] [custom-label] xyz y [foo] should [bar]
 
 `
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This revises a decision that was made when introducing WithFeatureGate: At that time, [Alpha] and [Beta] were already in use, so those got added and not [Feature:Alpha] and [Feature:Beta], to avoid the redundant tagging and to minimize changes in the test names.
    
The expectation was that jobs would get converted to label filtering quickly, which would have worked because "Feature:Alpha" and "Feature:Beta" were already added as Ginkgo labels.
    
In practice, that conversion is still [going on](https://github.com/kubernetes/test-infra/issues/32911), which was blocking the migration to simpler test labeling. By adding [Feature:Alpha] or [Feature:Beta], it is now safe to label a test which only depends on a feature gate and the corresponding API group only with WithFeatureGate. Such a test doesn't need to be updated again later and already now can run in the generic kind alpha/beta jobs.

#### Which issue(s) this PR fixes:

Related-to: https://github.com/kubernetes/test-infra/issues/32911

#### Special notes for your reviewer:

This replaces https://github.com/kubernetes/kubernetes/pull/130567. The cluster trust bundle E2E tests get converted from WithFeature to WithFeatureGate as a proof-of-concept.

/cc @BenTheElder @aojea @liggitt 

If this gets merged, https://github.com/kubernetes/kubernetes/pull/125452 probably can be merged, too.

/cc @carlory 

Here are diffs of the test names before and after this PR:

* e2e.test:

```patch
101,103c101,103
<     apimachinery/mutatingadmissionpolicy.go:72: [sig-api-machinery] MutatingAdmissionPolicy [Privileged:ClusterAdmin] [Feature:MutatingAdmissionPolicy] [FeatureGate:MutatingAdmissionPolicy] [Alpha] should mutate a Deployment
<     apimachinery/mutatingadmissionpolicy.go:183: [sig-api-machinery] MutatingAdmissionPolicy [Privileged:ClusterAdmin] [Feature:MutatingAdmissionPolicy] [FeatureGate:MutatingAdmissionPolicy] [Alpha] should support MutatingAdmissionPolicy API operations
<     apimachinery/mutatingadmissionpolicy.go:411: [sig-api-machinery] MutatingAdmissionPolicy [Privileged:ClusterAdmin] [Feature:MutatingAdmissionPolicy] [FeatureGate:MutatingAdmissionPolicy] [Alpha] should support MutatingAdmissionPolicyBinding API operations
---
>     apimachinery/mutatingadmissionpolicy.go:72: [sig-api-machinery] MutatingAdmissionPolicy [Privileged:ClusterAdmin] [Feature:MutatingAdmissionPolicy] [FeatureGate:MutatingAdmissionPolicy] [Alpha] [Feature:Alpha] should mutate a Deployment
>     apimachinery/mutatingadmissionpolicy.go:183: [sig-api-machinery] MutatingAdmissionPolicy [Privileged:ClusterAdmin] [Feature:MutatingAdmissionPolicy] [FeatureGate:MutatingAdmissionPolicy] [Alpha] [Feature:Alpha] should support MutatingAdmissionPolicy API operations
>     apimachinery/mutatingadmissionpolicy.go:411: [sig-api-machinery] MutatingAdmissionPolicy [Privileged:ClusterAdmin] [Feature:MutatingAdmissionPolicy] [FeatureGate:MutatingAdmissionPolicy] [Alpha] [Feature:Alpha] should support MutatingAdmissionPolicyBinding API operations

[truncated, full diff too large]
```

* e2e_node.test:

No changes.

#### Does this PR introduce a user-facing change?

```release-note
e2e.test: [Feature:Alpha] resp. [Feature:Beta] now get added to test names in addition to [Alpha] resp. [Beta] when a test depends on a feature gate which is alpha or beta.
```
