### PR TITLE
Hardcode btree for locked feature flag

### DIFF
--- a/pkg/registry/core/pod/strategy.go
+++ b/pkg/registry/core/pod/strategy.go
@@ -40,7 +40,6 @@ import (
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	utilvalidation "k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	apiserverfeatures "k8s.io/apiserver/pkg/features"
 	"k8s.io/apiserver/pkg/registry/generic"
 	"k8s.io/apiserver/pkg/storage"
 	"k8s.io/apiserver/pkg/storage/names"
@@ -384,9 +383,6 @@ func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, error) {
 // MatchPod returns a generic matcher for a given label and field selector.
 func MatchPod(label labels.Selector, field fields.Selector) storage.SelectionPredicate {
 	var indexFields = []string{"spec.nodeName"}
-	if utilfeature.DefaultFeatureGate.Enabled(features.StorageNamespaceIndex) && !utilfeature.DefaultFeatureGate.Enabled(apiserverfeatures.BtreeWatchCache) {
-		indexFields = append(indexFields, "metadata.namespace")
-	}
 	return storage.SelectionPredicate{
 		Label:       label,
 		Field:       field,
@@ -422,9 +418,6 @@ func NamespaceIndexFunc(obj interface{}) ([]string, error) {
 func Indexers() *cache.Indexers {
 	var indexers = cache.Indexers{
 		storage.FieldIndex("spec.nodeName"): NodeNameIndexFunc,
-	}
-	if utilfeature.DefaultFeatureGate.Enabled(features.StorageNamespaceIndex) && !utilfeature.DefaultFeatureGate.Enabled(apiserverfeatures.BtreeWatchCache) {
-		indexers[storage.FieldIndex("metadata.namespace")] = NamespaceIndexFunc
 	}
 	return &indexers
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cache_watcher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cache_watcher_test.go
@@ -34,7 +34,6 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/apiserver/pkg/storage"
 	utilflowcontrol "k8s.io/apiserver/pkg/util/flowcontrol"
-	"k8s.io/client-go/tools/cache"
 	testingclock "k8s.io/utils/clock/testing"
 )
 
@@ -288,7 +287,7 @@ func TestCacheWatcherStoppedOnDestroy(t *testing.T) {
 
 func TestResourceVersionAfterInitEvents(t *testing.T) {
 	const numObjects = 10
-	store := cache.NewIndexer(storeElementKey, storeElementIndexers(nil))
+	store := newStoreIndexer(nil)
 
 	for i := 0; i < numObjects; i++ {
 		elem := makeTestStoreElement(makeTestPod(fmt.Sprintf("pod-%d", i), uint64(i)))

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_test.go
@@ -544,35 +544,17 @@ func (c *createWrapper) Create(ctx context.Context, key string, obj, out runtime
 
 func BenchmarkStoreCreateList(b *testing.B) {
 	klog.SetLogger(logr.Discard())
-	storeOptions := []struct {
-		name         string
-		btreeEnabled bool
-	}{
-		{
-			name:         "Btree",
-			btreeEnabled: true,
-		},
-		{
-			name:         "Map",
-			btreeEnabled: false,
-		},
-	}
-	for _, store := range storeOptions {
-		b.Run(fmt.Sprintf("Store=%s", store.name), func(b *testing.B) {
-			featuregatetesting.SetFeatureGateDuringTest(b, utilfeature.DefaultFeatureGate, features.BtreeWatchCache, store.btreeEnabled)
-			for _, rvm := range []metav1.ResourceVersionMatch{metav1.ResourceVersionMatchNotOlderThan, metav1.ResourceVersionMatchExact} {
-				b.Run(fmt.Sprintf("RV=%s", rvm), func(b *testing.B) {
-					for _, useIndex := range []bool{true, false} {
-						b.Run(fmt.Sprintf("Indexed=%v", useIndex), func(b *testing.B) {
-							opts := []setupOption{}
-							if useIndex {
-								opts = append(opts, withNodeNameAndNamespaceIndex)
-							}
-							ctx, cacher, _, terminate := testSetupWithEtcdServer(b, opts...)
-							b.Cleanup(terminate)
-							storagetesting.RunBenchmarkStoreListCreate(ctx, b, cacher, rvm)
-						})
+	for _, rvm := range []metav1.ResourceVersionMatch{metav1.ResourceVersionMatchNotOlderThan, metav1.ResourceVersionMatchExact} {
+		b.Run(fmt.Sprintf("RV=%s", rvm), func(b *testing.B) {
+			for _, useIndex := range []bool{true, false} {
+				b.Run(fmt.Sprintf("Indexed=%v", useIndex), func(b *testing.B) {
+					opts := []setupOption{}
+					if useIndex {
+						opts = append(opts, withNodeNameAndNamespaceIndex)
 					}
+					ctx, cacher, _, terminate := testSetupWithEtcdServer(b, opts...)
+					b.Cleanup(terminate)
+					storagetesting.RunBenchmarkStoreListCreate(ctx, b, cacher, rvm)
 				})
 			}
 		})
@@ -606,36 +588,18 @@ func BenchmarkStoreList(b *testing.B) {
 	for _, dims := range dimensions {
 		b.Run(fmt.Sprintf("Namespaces=%d/Pods=%d/Nodes=%d", dims.namespaceCount, dims.namespaceCount*dims.podPerNamespaceCount, dims.nodeCount), func(b *testing.B) {
 			data := storagetesting.PrepareBenchchmarkData(dims.namespaceCount, dims.podPerNamespaceCount, dims.nodeCount)
-			storeOptions := []struct {
-				name         string
-				btreeEnabled bool
-			}{
-				{
-					name:         "Btree",
-					btreeEnabled: true,
-				},
-				{
-					name:         "Map",
-					btreeEnabled: false,
-				},
+			ctx, cacher, _, terminate := testSetupWithEtcdServer(b, withNodeNameAndNamespaceIndex)
+			b.Cleanup(terminate)
+			var out example.Pod
+			for _, pod := range data.Pods {
+				err := cacher.Create(ctx, computePodKey(pod), pod, &out, 0)
+				if err != nil {
+					b.Fatal(err)
+				}
 			}
-			for _, store := range storeOptions {
-				b.Run(fmt.Sprintf("Store=%s", store.name), func(b *testing.B) {
-					featuregatetesting.SetFeatureGateDuringTest(b, utilfeature.DefaultFeatureGate, features.BtreeWatchCache, store.btreeEnabled)
-					ctx, cacher, _, terminate := testSetupWithEtcdServer(b, withNodeNameAndNamespaceIndex)
-					b.Cleanup(terminate)
-					var out example.Pod
-					for _, pod := range data.Pods {
-						err := cacher.Create(ctx, computePodKey(pod), pod, &out, 0)
-						if err != nil {
-							b.Fatal(err)
-						}
-					}
-					for _, useIndex := range []bool{true, false} {
-						b.Run(fmt.Sprintf("Indexed=%v", useIndex), func(b *testing.B) {
-							storagetesting.RunBenchmarkStoreList(ctx, b, cacher, data, useIndex)
-						})
-					}
+			for _, useIndex := range []bool{true, false} {
+				b.Run(fmt.Sprintf("Indexed=%v", useIndex), func(b *testing.B) {
+					storagetesting.RunBenchmarkStoreList(ctx, b, cacher, data, useIndex)
 				})
 			}
 		})

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/store.go
@@ -22,8 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apiserver/pkg/features"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/tools/cache"
 )
 
@@ -70,6 +68,7 @@ type storeIndexer interface {
 	GetByKey(key string) (item interface{}, exists bool, err error)
 	Replace([]interface{}, string) error
 	ByIndex(indexName, indexedValue string) ([]interface{}, error)
+	orderedLister
 }
 
 type orderedLister interface {
@@ -79,10 +78,8 @@ type orderedLister interface {
 }
 
 func newStoreIndexer(indexers *cache.Indexers) storeIndexer {
-	if utilfeature.DefaultFeatureGate.Enabled(features.BtreeWatchCache) {
-		return newThreadedBtreeStoreIndexer(storeElementIndexers(indexers), btreeDegree)
-	}
-	return cache.NewIndexer(storeElementKey, storeElementIndexers(indexers))
+	return newThreadedBtreeStoreIndexer(storeElementIndexers(indexers), btreeDegree)
+	// return cache.NewIndexer(storeElementKey, storeElementIndexers(indexers))
 }
 
 // Computing a key of an object is generally non-trivial (it performs

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_interval_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_interval_test.go
@@ -371,7 +371,7 @@ func TestCacheIntervalNextFromStore(t *testing.T) {
 		return labels.Set(pod.Labels), fields.Set{"spec.nodeName": pod.Spec.NodeName}, nil
 	}
 	const numEvents = 50
-	store := cache.NewIndexer(storeElementKey, storeElementIndexers(nil))
+	store := newStoreIndexer(nil)
 	events := make(map[string]*watchCacheEvent)
 	var rv uint64 = 1 // arbitrary number; rv till which the watch cache has progressed.
 


### PR DESCRIPTION
/kind cleanup
```release-note
NONE
```
/sig api-machinery
/triage accepted
/assign @wojtek-t
/cc @liggitt

BtreeWatchCache flag was graduated in https://github.com/kubernetes/kubernetes/pull/129934 and now is locked to true. This technically mean can be treated always as true.

Useful to cleanup code for https://github.com/kubernetes/kubernetes/issues/130308