### PR TITLE
Fix non-portable use of "sleep infinity"

### DIFF
--- a/test/e2e/framework/pod/utils.go
+++ b/test/e2e/framework/pod/utils.go
@@ -43,7 +43,7 @@ const InfiniteSleepCommand = "trap exit TERM; while true; do sleep 1; done"
 //
 // This is useful for testing scenarios where the container is terminated
 // with a non-zero exit code.
-const InfiniteSleepCommandWithoutGracefulShutdown = "while true; do sleep 1; done"
+const InfiniteSleepCommandWithoutGracefulShutdown = "while true; do sleep 100000; done"
 
 // GenerateScriptCmd generates the corresponding command lines to execute a command.
 func GenerateScriptCmd(command string) []string {

--- a/test/e2e/framework/pod/utils.go
+++ b/test/e2e/framework/pod/utils.go
@@ -43,7 +43,7 @@ const InfiniteSleepCommand = "trap exit TERM; while true; do sleep 1; done"
 //
 // This is useful for testing scenarios where the container is terminated
 // with a non-zero exit code.
-const InfiniteSleepCommandWithoutGracefulShutdown = "sleep infinity"
+const InfiniteSleepCommandWithoutGracefulShutdown = "while true; do sleep 1; done"
 
 // GenerateScriptCmd generates the corresponding command lines to execute a command.
 func GenerateScriptCmd(command string) []string {

--- a/test/e2e/storage/testsuites/subpath.go
+++ b/test/e2e/storage/testsuites/subpath.go
@@ -806,8 +806,8 @@ func testPodContainerRestartWithHooks(ctx context.Context, f *framework.Framewor
 	pod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
 	framework.ExpectNoError(err, "while creating pod")
 	ginkgo.DeferCleanup(e2epod.DeletePodWithWait, f.ClientSet, pod)
-	err = e2epod.WaitTimeoutForPodRunningInNamespace(ctx, f.ClientSet, pod.Name, pod.Namespace, f.Timeouts.PodStart)
-	framework.ExpectNoError(err, "while waiting for pod to be running")
+	err = e2epod.WaitTimeoutForPodRunningReadyInNamespace(ctx, f.ClientSet, pod.Name, pod.Namespace, f.Timeouts.PodStart)
+	framework.ExpectNoError(err, "while waiting for pod to be running and ready")
 
 	ginkgo.By("Failing liveness probe")
 	hooks.FailLivenessProbe(pod, probeFilePath)


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:

windows does not support sleep infinity

https://testgrid.k8s.io/provider-gcp-compute-persistent-disk-csi-driver#ci-windows-2019-provider-gcp-compute-persistent-disk-csi-driver
![image](https://github.com/user-attachments/assets/3a89c4d1-7043-4c2f-a515-b64b6ede13fa)

https://storage.googleapis.com/kubernetes-ci-logs/logs/ci-gce-pd-csi-driver-latest-k8s-master-windows-2019/1897475943908249600/build-log.txt
![image](https://github.com/user-attachments/assets/43096f0e-a3a6-4c87-b772-ee459dbc36c8)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

https://github.com/kubernetes/kubernetes/pull/130306 caused the test to fail on the Windows node because the shell script `sleep infinity` is not supported on Windows. 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
