### PR TITLE
Update OWNERS_ALIASES for sig scalability

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -469,12 +469,16 @@ aliases:
   sig-scalability-approvers:
     - marseel
     - mborsz
+    - mengqiy
+    - shyamjvs
     - wojtek-t
   # emeritus:
   # - mm4tt
   sig-scalability-reviewers:
     - marseel
     - mborsz
+    - mengqiy
+    - shyamjvs
     - wojtek-t
   # emeritus:
   # - mm4tt


### PR DESCRIPTION
Per https://github.com/kubernetes/community/pull/8343 and https://github.com/kubernetes/community/issues/8370

@shyamjvs is stepping down from sig scalability chair but still serves as one of the TLs in sig scalability.
It seems we forgot to add him before, so adding his name as well.


```release-note
NONE
```

