### PR TITLE
Add validation for duplicate keys in MatchLabelKeys

### DIFF
--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -11872,6 +11872,152 @@ func TestValidatePod(t *testing.T) {
 				}),
 			),
 		},
+		"invalid soft pod affinity, duplicate key exists in MatchLabelKeys": {
+			expectedError: "is duplicated in matchLabelKeys",
+			spec: *podtest.MakePod("123",
+				podtest.SetAffinity(&core.Affinity{
+					PodAffinity: &core.PodAffinity{
+						PreferredDuringSchedulingIgnoredDuringExecution: []core.WeightedPodAffinityTerm{
+							{
+								Weight: 10,
+								PodAffinityTerm: core.PodAffinityTerm{
+									LabelSelector: &metav1.LabelSelector{
+										MatchExpressions: []metav1.LabelSelectorRequirement{
+											// These ones should be created from MatchLabelKeys.
+											{
+												Key:      "key1",
+												Operator: metav1.LabelSelectorOpIn,
+												Values:   []string{"value1"},
+											},
+											{
+												Key:      "key2",
+												Operator: metav1.LabelSelectorOpIn,
+												Values:   []string{"value2"},
+											},
+											{
+												Key:      "key1",
+												Operator: metav1.LabelSelectorOpIn,
+												Values:   []string{"value1"},
+											},
+										},
+									},
+									TopologyKey:    "k8s.io/zone",
+									MatchLabelKeys: []string{"key1", "key2", "key1"},
+								},
+							},
+						},
+					},
+				}),
+			),
+		},
+		"invalid hard pod affinity, duplicate key exists in MatchLabelKeys": {
+			expectedError: "is duplicated in matchLabelKeys",
+			spec: *podtest.MakePod("123",
+				podtest.SetAffinity(&core.Affinity{
+					PodAffinity: &core.PodAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: []core.PodAffinityTerm{
+							{
+								LabelSelector: &metav1.LabelSelector{
+									MatchExpressions: []metav1.LabelSelectorRequirement{
+										// These ones should be created from MatchLabelKeys.
+										{
+											Key:      "key1",
+											Operator: metav1.LabelSelectorOpIn,
+											Values:   []string{"value1"},
+										},
+										{
+											Key:      "key2",
+											Operator: metav1.LabelSelectorOpIn,
+											Values:   []string{"value2"},
+										},
+										{
+											Key:      "key1",
+											Operator: metav1.LabelSelectorOpIn,
+											Values:   []string{"value1"},
+										},
+									},
+								},
+								TopologyKey:    "k8s.io/zone",
+								MatchLabelKeys: []string{"key1", "key2", "key1"},
+							},
+						},
+					},
+				}),
+			),
+		},
+		"invalid soft pod anti-affinity, duplicate key exists in MatchLabelKeys": {
+			expectedError: "is duplicated in matchLabelKeys",
+			spec: *podtest.MakePod("123",
+				podtest.SetAffinity(&core.Affinity{
+					PodAntiAffinity: &core.PodAntiAffinity{
+						PreferredDuringSchedulingIgnoredDuringExecution: []core.WeightedPodAffinityTerm{
+							{
+								Weight: 10,
+								PodAffinityTerm: core.PodAffinityTerm{
+									LabelSelector: &metav1.LabelSelector{
+										MatchExpressions: []metav1.LabelSelectorRequirement{
+											// These ones should be created from MatchLabelKeys.
+											{
+												Key:      "key1",
+												Operator: metav1.LabelSelectorOpIn,
+												Values:   []string{"value1"},
+											},
+											{
+												Key:      "key2",
+												Operator: metav1.LabelSelectorOpIn,
+												Values:   []string{"value2"},
+											},
+											{
+												Key:      "key1",
+												Operator: metav1.LabelSelectorOpIn,
+												Values:   []string{"value1"},
+											},
+										},
+									},
+									TopologyKey:    "k8s.io/zone",
+									MatchLabelKeys: []string{"key1", "key2", "key1"},
+								},
+							},
+						},
+					},
+				}),
+			),
+		},
+		"invalid hard pod anti-affinity, duplicate key exists in MatchLabelKeys": {
+			expectedError: "is duplicated in matchLabelKeys",
+			spec: *podtest.MakePod("123",
+				podtest.SetAffinity(&core.Affinity{
+					PodAntiAffinity: &core.PodAntiAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: []core.PodAffinityTerm{
+							{
+								LabelSelector: &metav1.LabelSelector{
+									MatchExpressions: []metav1.LabelSelectorRequirement{
+										// These ones should be created from MatchLabelKeys.
+										{
+											Key:      "key1",
+											Operator: metav1.LabelSelectorOpIn,
+											Values:   []string{"value1"},
+										},
+										{
+											Key:      "key2",
+											Operator: metav1.LabelSelectorOpIn,
+											Values:   []string{"value2"},
+										},
+										{
+											Key:      "key1",
+											Operator: metav1.LabelSelectorOpIn,
+											Values:   []string{"value1"},
+										},
+									},
+								},
+								TopologyKey:    "k8s.io/zone",
+								MatchLabelKeys: []string{"key1", "key2", "key1"},
+							},
+						},
+					},
+				}),
+			),
+		},
 		"invalid toleration key": {
 			expectedError: "spec.tolerations[0].key",
 			spec: *podtest.MakePod("123",
@@ -23571,6 +23717,38 @@ func TestValidateTopologySpreadConstraints(t *testing.T) {
 			AllowMatchLabelKeysInPodTopologySpreadSelectorMerge: false,
 		},
 	}, {
+		name: "duplicate key exists in MatchLabelKeys",
+		constraints: []core.TopologySpreadConstraint{{
+			MaxSkew:           1,
+			TopologyKey:       "k8s.io/zone",
+			WhenUnsatisfiable: core.DoNotSchedule,
+			MatchLabelKeys:    []string{"key1", "key2", "key1"},
+			LabelSelector:     &metav1.LabelSelector{},
+		}},
+		wantFieldErrors: field.ErrorList{
+			field.Invalid(fieldPathMatchLabelKeys.Index(2), nil, "").WithOrigin("duplicatedMatchLabelKeys"),
+		},
+		opts: PodValidationOptions{
+			AllowMatchLabelKeysInPodTopologySpread:              true,
+			AllowMatchLabelKeysInPodTopologySpreadSelectorMerge: true,
+		},
+	}, {
+		name: "duplicate key exists in MatchLabelKeys and AllowMatchLabelKeysInPodTopologySpreadSelectorMerge is false",
+		constraints: []core.TopologySpreadConstraint{{
+			MaxSkew:           1,
+			TopologyKey:       "k8s.io/zone",
+			WhenUnsatisfiable: core.DoNotSchedule,
+			MatchLabelKeys:    []string{"key1", "key2", "key1"},
+			LabelSelector:     &metav1.LabelSelector{},
+		}},
+		wantFieldErrors: field.ErrorList{
+			field.Invalid(fieldPathMatchLabelKeys.Index(2), nil, "").WithOrigin("duplicatedMatchLabelKeys"),
+		},
+		opts: PodValidationOptions{
+			AllowMatchLabelKeysInPodTopologySpread:              true,
+			AllowMatchLabelKeysInPodTopologySpreadSelectorMerge: false,
+		},
+	}, {
 		name: "key in MatchLabelKeys is forbidden to be specified when LabelSelector is not set",
 		constraints: []core.TopologySpreadConstraint{{
 			MaxSkew:           1,
@@ -24502,7 +24680,7 @@ func TestValidateSeccompAnnotationsAndFieldsMatch(t *testing.T) {
 	}
 }
 
-func TestValidatePodTemplateSpecSeccomp(t *testing.T) {
+func TestValidatePodTemplateSpecSeccomp(t *testing.T) { // TODO: This function name should be more general, and will be fixed in #130155.
 	rootFld := field.NewPath("template")
 	tests := []struct {
 		description string
@@ -24577,6 +24755,128 @@ func TestValidatePodTemplateSpecSeccomp(t *testing.T) {
 							Type: core.SeccompProfileTypeRuntimeDefault,
 						},
 					}))),
+			),
+		},
+	}, {
+		description: "invalid soft pod affinity, duplicate key exists in MatchLabelKeys",
+		fldPath:     rootFld,
+		expectedErr: field.ErrorList{
+			field.Invalid(rootFld.Child("spec").Child("affinity").Child("podAffinity").Child("preferredDuringSchedulingIgnoredDuringExecution").Index(0).Child("podAffinityTerm").Child("matchLabelKeys").Index(2), "key1", "is duplicated in matchLabelKeys").WithOrigin("duplicatedMatchLabelKeys"),
+		},
+		spec: &core.PodTemplateSpec{
+			Spec: podtest.MakePodSpec(
+				podtest.SetContainers(
+					podtest.MakeContainer("test1"),
+				),
+				podtest.SetAffinity(&core.Affinity{
+					PodAffinity: &core.PodAffinity{
+						PreferredDuringSchedulingIgnoredDuringExecution: []core.WeightedPodAffinityTerm{
+							{
+								PodAffinityTerm: core.PodAffinityTerm{
+									LabelSelector:  &metav1.LabelSelector{},
+									TopologyKey:    "k8s.io/zone",
+									MatchLabelKeys: []string{"key1", "key2", "key1"},
+								},
+								Weight: 10,
+							},
+						},
+					},
+				}),
+			),
+		},
+	}, {
+		description: "invalid hard pod affinity, duplicate key exists in MatchLabelKeys",
+		fldPath:     rootFld,
+		expectedErr: field.ErrorList{
+			field.Invalid(rootFld.Child("spec").Child("affinity").Child("podAffinity").Child("requiredDuringSchedulingIgnoredDuringExecution").Index(0).Child("matchLabelKeys").Index(2), "key1", "is duplicated in matchLabelKeys").WithOrigin("duplicatedMatchLabelKeys"),
+		},
+		spec: &core.PodTemplateSpec{
+			Spec: podtest.MakePodSpec(
+				podtest.SetContainers(
+					podtest.MakeContainer("test1"),
+				),
+				podtest.SetAffinity(&core.Affinity{
+					PodAffinity: &core.PodAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: []core.PodAffinityTerm{
+							{
+								LabelSelector:  &metav1.LabelSelector{},
+								TopologyKey:    "k8s.io/zone",
+								MatchLabelKeys: []string{"key1", "key2", "key1"},
+							},
+						},
+					},
+				}),
+			),
+		},
+	}, {
+		description: "invalid soft pod anti-affinity, duplicate key exists in MatchLabelKeys",
+		fldPath:     rootFld,
+		expectedErr: field.ErrorList{
+			field.Invalid(rootFld.Child("spec").Child("affinity").Child("podAntiAffinity").Child("preferredDuringSchedulingIgnoredDuringExecution").Index(0).Child("podAffinityTerm").Child("matchLabelKeys").Index(2), "key1", "is duplicated in matchLabelKeys").WithOrigin("duplicatedMatchLabelKeys"),
+		},
+		spec: &core.PodTemplateSpec{
+			Spec: podtest.MakePodSpec(
+				podtest.SetContainers(
+					podtest.MakeContainer("test1"),
+				),
+				podtest.SetAffinity(&core.Affinity{
+					PodAntiAffinity: &core.PodAntiAffinity{
+						PreferredDuringSchedulingIgnoredDuringExecution: []core.WeightedPodAffinityTerm{
+							{
+								PodAffinityTerm: core.PodAffinityTerm{
+									LabelSelector:  &metav1.LabelSelector{},
+									TopologyKey:    "k8s.io/zone",
+									MatchLabelKeys: []string{"key1", "key2", "key1"},
+								},
+								Weight: 10,
+							},
+						},
+					},
+				}),
+			),
+		},
+	}, {
+		description: "invalid hard pod anti-affinity, duplicate key exists in MatchLabelKeys",
+		fldPath:     rootFld,
+		expectedErr: field.ErrorList{
+			field.Invalid(rootFld.Child("spec").Child("affinity").Child("podAntiAffinity").Child("requiredDuringSchedulingIgnoredDuringExecution").Index(0).Child("matchLabelKeys").Index(2), "key1", "is duplicated in matchLabelKeys").WithOrigin("duplicatedMatchLabelKeys"),
+		},
+		spec: &core.PodTemplateSpec{
+			Spec: podtest.MakePodSpec(
+				podtest.SetContainers(
+					podtest.MakeContainer("test1"),
+				),
+				podtest.SetAffinity(&core.Affinity{
+					PodAntiAffinity: &core.PodAntiAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: []core.PodAffinityTerm{
+							{
+								LabelSelector:  &metav1.LabelSelector{},
+								TopologyKey:    "k8s.io/zone",
+								MatchLabelKeys: []string{"key1", "key2", "key1"},
+							},
+						},
+					},
+				}),
+			),
+		},
+	}, {
+		description: "invalid topology spread constraint, duplicate key exists in MatchLabelKeys",
+		fldPath:     rootFld,
+		expectedErr: field.ErrorList{
+			field.Invalid(rootFld.Child("spec").Child("topologySpreadConstraints").Index(0).Child("matchLabelKeys").Index(2), "key1", "is duplicated in matchLabelKeys").WithOrigin("duplicatedMatchLabelKeys"),
+		},
+		spec: &core.PodTemplateSpec{
+			Spec: podtest.MakePodSpec(
+				podtest.SetContainers(
+					podtest.MakeContainer("test1"),
+				),
+				podtest.SetTopologySpreadConstraints(core.TopologySpreadConstraint{
+					MaxSkew:           1,
+					TopologyKey:       "k8s.io/zone",
+					LabelSelector:     &metav1.LabelSelector{},
+					WhenUnsatisfiable: core.DoNotSchedule,
+					MatchLabelKeys:    []string{"key1", "key2", "key1"},
+				}),
 			),
 		},
 	},


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/sig scheduling

#### What this PR does / why we need it:
Currently, the validation for duplicated keys registered on `matchLabelKeys` is not implemented explicitly.

In the case of `affinity`, as described in #130554, validation will fail with "exists in both matchLabelKeys and labelSelector" error in such situation:

`sample-affinity.yaml`
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: sample-affinity
  labels:
    app: sample-affinity
spec:
  containers:
  - image: nginx
    name: nginx
  affinity:
    podAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
      - labelSelector: {}
        topologyKey: kubernetes.io/hostname
        matchLabelKeys:
        - app
        - app
```
 
```console
$ kubectl apply -f sample-affinity.yaml
The Pod "sample-affinity" is invalid: spec.affinity.podAffinity.requiredDuringSchedulingIgnoredDuringExecution[0][1]: Invalid value: "app": exists in both matchLabelKeys and labelSelector
```


On the other hand, in the case of `topologySpreadConstraints`,  validation will not fail and duplicate keys will be registered on 
 the created Pod's `matchLabelKeys` field.
However, it doesn't make sense.

`sample-pod-matchlabelkey.yaml`
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: sample-matchlabelkey
  labels:
    app: sample-matchlabelkey
spec:
  containers:
  - image: nginx
    name: nginx
  topologySpreadConstraints:
  - maxSkew: 1
    topologyKey: kubernetes.io/hostname
    whenUnsatisfiable: DoNotSchedule
    labelSelector: {}
    matchLabelKeys:
    - app
    - app
```

```console
$ kubectl apply -f sample-pod-matchlabelkey.yaml
pod/sample-matchlabelkey created

 $ kubectl get pod sample-matchlabelkey -o=jsonpath="{.spec.topologySpreadConstraints[0].matchLabelKeys}"
["app","app"]
```


In this PR,  the validation will fail with an explicit error when duplicated keys are registered on `matchLabelKeys`.

In the case of `affinity`:
```console
$ kubectl apply -f sample-affinity.yaml 
The Pod "sample-affinity" is invalid: 
* spec.affinity.podAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].matchLabelKeys[1]: Invalid value: "app": is duplicated in matchLabelKeys
* spec.affinity.podAffinity.requiredDuringSchedulingIgnoredDuringExecution[0][1]: Invalid value: "app": exists in both matchLabelKeys and labelSelector
```

In the case of `topologySpreadConstraints`:
```console
$ kubectl apply -f sample-pod-matchlabelkey.yaml
The Pod "sample-matchlabelkey" is invalid: spec.topologySpreadConstraints[0].matchLabelKeys[1]: Invalid value: "app": is duplicated in matchLabelKeys
```

#### Which issue(s) this PR fixes:
Fixes #130554

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Added validation for `matchLabelKeys` duplicates. When duplicated keys are provided for `matchLabelKeys` (either for Pod creation or in an update), the API server now returns an error.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
