### PR TITLE
add highScoreNode check

### DIFF
--- a/test/integration/scheduler/plugins/plugins_test.go
+++ b/test/integration/scheduler/plugins/plugins_test.go
@@ -1057,6 +1057,11 @@ func TestScorePlugin(t *testing.T) {
 			if numScoreCalled := scorePlugin.deepCopy().numScoreCalled; numScoreCalled == 0 {
 				t.Errorf("Expected the score plugin to be called.")
 			}
+
+			if scorePlugin.highScoreNode == "" && !test.fail {
+	                        t.Errorf("Expected the highScoreNode to be set, but it was empty.")
+                        }
+
 		})
 	}
 }


### PR DESCRIPTION
What type of PR is this?

/kind cleanup

What this PR does / why we need it:

This PR adds an additional assertion in the Kubernetes scheduler plugin integration tests to verify that the highScore internal state is properly set during scoring. This change improves test coverage and ensures internal plugin states are correctly managed.

Which issue(s) this PR fixes:

NONE

Special notes for your reviewer:

This is a minor test improvement aimed at increasing robustness.

Does this PR introduce a user-facing change?

NONE

Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

NONE

