### PR TITLE
DRA: Prioritized Alternatives in Device Requests, II

### DIFF
--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
@@ -415,6 +415,9 @@ func (pl *DynamicResources) PreFilter(ctx context.Context, state *framework.Cycl
 						return nil, status
 					}
 				} else {
+					if !pl.enablePrioritizedList {
+						return nil, statusUnschedulable(logger, fmt.Sprintf("resource claim %s, request %s: has subrequests, but the DRAPrioritizedList feature is disabled", klog.KObj(claim), request.Name))
+					}
 					for _, subRequest := range request.FirstAvailable {
 						qualRequestName := strings.Join([]string{request.Name, subRequest.Name}, "/")
 						if status := pl.validateDeviceClass(logger, subRequest.DeviceClassName, qualRequestName); status != nil {

--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
@@ -861,10 +861,11 @@ func TestPlugin(t *testing.T) {
 			claims:                   []*resourceapi.ResourceClaim{claimWithPrioritzedList},
 			classes:                  []*resourceapi.DeviceClass{deviceClass},
 			want: want{
-				filter: perNodeResult{
-					workerNode.Name: {
-						status: framework.NewStatus(framework.UnschedulableAndUnresolvable, `claim default/my-pod-my-resource, request req-1: has subrequests, but the feature is disabled`),
-					},
+				prefilter: result{
+					status: framework.NewStatus(framework.UnschedulableAndUnresolvable, `claim default/my-pod-my-resource, request req-1: has subrequests, but the DRAPrioritizedList feature is disabled`),
+				},
+				postfilter: result{
+					status: framework.NewStatus(framework.Unschedulable, `no new claims to deallocate`),
 				},
 			},
 		},

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/allocator.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/allocator.go
@@ -171,7 +171,7 @@ func (a *Allocator) Allocate(ctx context.Context, node *v1.Node) (finalResult []
 			// Error out if the prioritizedList feature is not enabled and the request
 			// has subrequests. This is to avoid surprising behavior for users.
 			if !a.prioritizedListEnabled && hasSubRequests {
-				return nil, fmt.Errorf("claim %s, request %s: has subrequests, but the feature is disabled", klog.KObj(claim), request.Name)
+				return nil, fmt.Errorf("claim %s, request %s: has subrequests, but the DRAPrioritizedList feature is disabled", klog.KObj(claim), request.Name)
 			}
 
 			if hasSubRequests {

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/allocator_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/allocator_test.go
@@ -1923,7 +1923,7 @@ func TestAllocator(t *testing.T) {
 			node:    node(node1, region1),
 
 			expectResults: nil,
-			expectError:   gomega.MatchError(gomega.ContainSubstring("claim claim-0, request req-0: has subrequests, but the feature is disabled")),
+			expectError:   gomega.MatchError(gomega.ContainSubstring("claim claim-0, request req-0: has subrequests, but the DRAPrioritizedList feature is disabled")),
 		},
 		"prioritized-list-multi-request": {
 			prioritizedList: true,

--- a/test/integration/scheduler_perf/dra/performance-config.yaml
+++ b/test/integration/scheduler_perf/dra/performance-config.yaml
@@ -294,6 +294,66 @@
       maxClaimsPerNode: 10
       duration: 10s
 
+# SteadyStateResourceClaimTemplateFirstAvailable is a variant of SteadyStateResourceClaimTemplate
+# with a claim template that uses the "firstAvailable" subrequests, aka DRAPrioritizedList.
+- name: SteadyStateClusterResourceClaimTemplateFirstAvailable
+  featureGates:
+    DynamicResourceAllocation: true
+    DRAPrioritizedList: true
+  workloadTemplate:
+  - opcode: createNodes
+    countParam: $nodesWithoutDRA
+  - opcode: createNodes
+    nodeTemplatePath: templates/node-with-dra-test-driver.yaml
+    countParam: $nodesWithDRA
+  - opcode: createResourceDriver
+    driverName: test-driver.cdi.k8s.io
+    nodes: scheduler-perf-dra-*
+    maxClaimsPerNodeParam: $maxClaimsPerNode
+  - opcode: createAny
+    templatePath: templates/deviceclass.yaml
+  - opcode: createAny
+    templatePath: templates/resourceclaim.yaml
+    countParam: $initClaims
+    namespace: init
+  - opcode: allocResourceClaims
+    namespace: init
+  - opcode: createAny
+    templatePath: templates/resourceclaimtemplate-first-available.yaml
+    namespace: test
+  - opcode: createPods
+    namespace: test
+    count: 10
+    steadyState: true
+    durationParam: $duration
+    podTemplatePath: templates/pod-with-claim-template.yaml
+    collectMetrics: true
+  workloads:
+  - name: fast
+    featureGates:
+      SchedulerQueueingHints: false
+    labels: [integration-test, short]
+    params:
+      # This testcase runs through all code paths without
+      # taking too long overall.
+      nodesWithDRA: 1
+      nodesWithoutDRA: 1
+      initClaims: 0
+      maxClaimsPerNode: 10
+      duration: 2s
+  - name: fast_QueueingHintsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
+    labels: [integration-test, short]
+    params:
+      # This testcase runs through all code paths without
+      # taking too long overall.
+      nodesWithDRA: 1
+      nodesWithoutDRA: 1
+      initClaims: 0
+      maxClaimsPerNode: 10
+      duration: 2s
+ 
 # SchedulingWithResourceClaimTemplate uses ResourceClaims
 # with deterministic names that are shared between pods.
 # There is a fixed ratio of 1:5 between claims and pods.

--- a/test/integration/scheduler_perf/dra/templates/resourceclaimtemplate-first-available.yaml
+++ b/test/integration/scheduler_perf/dra/templates/resourceclaimtemplate-first-available.yaml
@@ -1,0 +1,14 @@
+apiVersion: resource.k8s.io/v1alpha3
+kind: ResourceClaimTemplate
+metadata:
+  name: test-claim-template
+spec:
+  spec:
+    devices:
+      requests:
+      - name: req-0
+        firstAvailable:
+        - name: sub-0
+          deviceClassName: no-such-class
+        - name: sub-1
+          deviceClassName: test-class


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This is a follow-up to address some review comments in https://github.com/kubernetes/kubernetes/pull/128586:
- Abort scheduling of a pod sooner in PreFilter when it depends on the feature and the feature is disabled (https://github.com/kubernetes/kubernetes/pull/128586#discussion_r1982767989).
- Add some integration tests (https://github.com/kubernetes/kubernetes/pull/128586#discussion_r1982759300).

#### Which issue(s) this PR fixes:

Related-to: https://github.com/kubernetes/enhancements/issues/4816

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

NONE because this is not a functional changed compared to 1.32. Listing the feature once is enough.

```release-note
NONE
```
