### PR TITLE
Fixing unit tests in k8s.io/kubernetes/pkg/volume/util/subpath on Win…

### DIFF
--- a/pkg/volume/util/subpath/subpath_windows_test.go
+++ b/pkg/volume/util/subpath/subpath_windows_test.go
@@ -40,7 +40,7 @@ func makeLink(link, target string) error {
 func TestDoSafeMakeDir(t *testing.T) {
 	base, err := ioutil.TempDir("", "TestDoSafeMakeDir")
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatalf("failed to create temporary directory: %v", err)
 	}
 
 	defer os.RemoveAll(base)
@@ -136,7 +136,7 @@ func TestDoSafeMakeDir(t *testing.T) {
 func TestLockAndCheckSubPath(t *testing.T) {
 	base, err := ioutil.TempDir("", "TestLockAndCheckSubPath")
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatalf("failed to create temporary directory: %v", err)
 	}
 
 	defer os.RemoveAll(base)
@@ -240,7 +240,7 @@ func TestLockAndCheckSubPath(t *testing.T) {
 func TestLockAndCheckSubPathWithoutSymlink(t *testing.T) {
 	base, err := ioutil.TempDir("", "TestLockAndCheckSubPathWithoutSymlink")
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatalf("failed to create temporary directory: %v", err)
 	}
 
 	defer os.RemoveAll(base)
@@ -344,7 +344,7 @@ func TestLockAndCheckSubPathWithoutSymlink(t *testing.T) {
 func TestFindExistingPrefix(t *testing.T) {
 	base, err := ioutil.TempDir("", "TestFindExistingPrefix")
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatalf("failed to create temporary directory: %v", err)
 	}
 
 	defer os.RemoveAll(base)


### PR DESCRIPTION
…dows

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
/kind failing-test

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
When run on windows the unit tests in this package are failing with the following errors

```cmd
c:\src\github.com\marosset\kubernetes\pkg\volume\util\subpath>go test ./... -v
go: downloading go1.24.0 (windows/amd64)
# k8s.io/kubernetes/pkg/volume/util/subpath
# [k8s.io/kubernetes/pkg/volume/util/subpath]
.\subpath_windows_test.go:43:12: non-constant format string in call to (*testing.common).Fatalf
.\subpath_windows_test.go:139:12: non-constant format string in call to (*testing.common).Fatalf
.\subpath_windows_test.go:243:12: non-constant format string in call to (*testing.common).Fatalf
.\subpath_windows_test.go:347:12: non-constant format string in call to (*testing.common).Fatalf
FAIL    k8s.io/kubernetes/pkg/volume/util/subpath [build failed]
FAIL
```

This PR fixes the build issues so they can run.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of https://github.com/kubernetes/kubernetes/issues/130149


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/sig windows
/milestone v1.33
