### PR TITLE
sort client-gen output

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/client-gen/args/args.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/args/args.go
@@ -85,7 +85,7 @@ func (args *Args) AddFlags(fs *pflag.FlagSet, inputBase string) {
 	fs.StringVar(&args.GoHeaderFile, "go-header-file", "",
 		"the path to a file containing boilerplate header text; the string \"YEAR\" will be replaced with the current 4-digit year")
 	fs.Var(NewGVPackagesValue(gvsBuilder, nil), "input",
-		`group/versions that client-gen will generate clients for. At most one version per group is allowed. Specified in the format "group1/version1,group2/version2...". The order in which group/versions are listed defines the order of the generated client code. To avoid non-deterministic output, sort this list before providing it to client-gen.`)
+		`group/versions that client-gen will generate clients for. At most one version per group is allowed. Specified in the format "group1/version1,group2/version2...".`)
 	fs.Var(NewGVTypesValue(&args.IncludedTypesOverrides, []string{}), "included-types-overrides",
 		"list of group/version/type for which client should be generated. By default, client is generated for all types which have genclient in types.go. This overrides that. For each groupVersion in this list, only the types mentioned here will be included. The default check of genclient will be used for other group versions.")
 	fs.Var(NewInputBasePathValue(gvsBuilder, inputBase), "input-base",

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/main.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/main.go
@@ -19,6 +19,7 @@ package main
 
 import (
 	"flag"
+	"slices"
 
 	"github.com/spf13/pflag"
 	"k8s.io/klog/v2"
@@ -46,6 +47,8 @@ func main() {
 			inputPkgs = append(inputPkgs, v.Package)
 		}
 	}
+	// ensure stable code generation output
+	slices.Sort(inputPkgs)
 
 	if err := args.Validate(); err != nil {
 		klog.Fatalf("Error: %v", err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:

Sorts the group version input to client-gen so the output is stable even if the inputs are not sorted by the caller.
https://github.com/kubernetes/kubernetes/pull/130506/files

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

The downside to this PR is:
1. You can no longer _manually_ sort the output, but I don't think that matters much.
2. You may need to regenerate code once after upgrading to a release with this commit.

The upside to this PR is:
1. Prevents surprises when intput is collected programmatically and is not stable (https://github.com/kubernetes-sigs/gateway-api/pull/3652)

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
client-gen now sorts input group/versions to ensure stable output generation even with unsorted inputs
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/sig api-machinery
Holding for further discussion. See also https://github.com/kubernetes/kubernetes/pull/130506
/hold
