### PR TITLE
Add all extra_pkgs needed by main API types to validation-gen

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -430,8 +430,16 @@ function codegen::validation() {
         tag_pkgs+=("./$dir")
     done
 
+    # This list needs to cover all of the types used transitively from the
+    # main API types. Validations defined on types in these packages will be
+    # used, but not regenerated, unless they are also listed as a "regular"
+    # input on the command-line.
     local extra_pkgs=(
         k8s.io/apimachinery/pkg/apis/meta/v1
+        k8s.io/apimachinery/pkg/api/resource
+        k8s.io/apimachinery/pkg/runtime
+        k8s.io/apimachinery/pkg/types
+        k8s.io/apimachinery/pkg/util/intstr
     )
 
     kube::log::status "Generating validation code for ${#tag_pkgs[@]} targets"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validation.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validation.go
@@ -27,14 +27,15 @@ import (
 	"strings"
 	"unicode"
 
-	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/code-generator/cmd/validation-gen/validators"
 	"k8s.io/gengo/v2/generator"
 	"k8s.io/gengo/v2/namer"
 	"k8s.io/gengo/v2/parser/tags"
 	"k8s.io/gengo/v2/types"
 	"k8s.io/klog/v2"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/code-generator/cmd/validation-gen/validators"
 )
 
 func mkPkgNames(pkg string, names ...string) []types.Name {
@@ -345,7 +346,7 @@ func (td *typeDiscoverer) discover(t *types.Type, fldPath *field.Path) (*typeNod
 
 	// Discover into this type before extracting type validations.
 	switch t.Kind {
-	case types.Builtin:
+	case types.Builtin, types.Interface:
 		// Nothing more to do.
 	case types.Alias:
 		// Discover the underlying type.


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

These imports will be needed as we start to migrate built-in API groups from validation to declarative.  This also includes a fix to skip over `types.Interface` in validation-gen, which I believe was discovered when processing the core api group.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
