### PR TITLE
bugfix: print log after get storage monitors failed

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics.go
@@ -284,6 +284,7 @@ func (c *monitorCollector) DescribeWithStability(ch chan<- *compbasemetrics.Desc
 func (c *monitorCollector) CollectWithStability(ch chan<- compbasemetrics.Metric) {
 	monitors, err := c.getGetter()()
 	if err != nil {
+		klog.ErrorS(err, "Failed to get monitors")
 		return
 	}
 
@@ -296,7 +297,7 @@ func (c *monitorCollector) CollectWithStability(ch chan<- compbasemetrics.Metric
 		cancel()
 		m.Close()
 		if err != nil {
-			klog.InfoS("Failed to get storage metrics", "storage_cluster_id", storageClusterID, "err", err)
+			klog.ErrorS(err, "Failed to get storage metrics", "storage_cluster_id", storageClusterID)
 			continue
 		}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

We need to be able to see in the logs that there was an error building the storage monitors (when /metrics is requested)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

Every time the `/metrics` API of kube-apiserver is requested, the APIServer will read etcdclientv3#Status to obtain DBSize and generate 'apiserver_storage_size_bytes'. However, this error will be "hidden" in the process of getting monitors.

https://github.com/kubernetes/kubernetes/blob/fb5140f562289f3ffe596b4a3af4650b850a0941/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics.go#L285-L288

https://github.com/kubernetes/kubernetes/blob/403301bfdf2c7312591077827abd2e72f445a53a/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go#L269-L272

We want the error to be logged.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
