### PR TITLE
Return correct error upon websocket message read failure

### DIFF
--- a/staging/src/k8s.io/client-go/tools/remotecommand/websocket.go
+++ b/staging/src/k8s.io/client-go/tools/remotecommand/websocket.go
@@ -312,7 +312,7 @@ func (c *wsStreamCreator) readDemuxLoop(bufferSize int, period time.Duration, de
 				if errRead == io.EOF {
 					break
 				}
-				c.closeAllStreamReaders(fmt.Errorf("read message: %w", err))
+				c.closeAllStreamReaders(fmt.Errorf("read message: %w", errRead))
 				return
 			}
 		}


### PR DESCRIPTION
This fixes variable passed as error reason upon websocket message read failure. Previously a wrong variable was passed resulting in returning failure with nil error reason.

#### What type of PR is this?
/sig api-machinery
/kind bug

#### What this PR does / why we need it:

It will reveal real reason why reading fails, possibly help tracing other issues (f.e https://github.com/kubernetes/kubernetes/issues/60140)

#### Which issue(s) this PR fixes:

Fixes #130634


#### Does this PR introduce a user-facing change?
```release-note
NONE
```
