### PR TITLE
fix typo

### DIFF
--- a/pkg/scheduler/testing/wrappers.go
+++ b/pkg/scheduler/testing/wrappers.go
@@ -53,7 +53,7 @@ const (
 
 // In injects a matchExpression (with an operator IN) as a selectorTerm
 // to the inner nodeSelector.
-// NOTE: appended selecterTerms are ORed.
+// NOTE: appended selectorTerms are ORed.
 func (s *NodeSelectorWrapper) In(key string, vals []string, t NodeSelectorType) *NodeSelectorWrapper {
 	expression := v1.NodeSelectorRequirement{
 		Key:      key,

--- a/pkg/scheduler/testing/wrappers.go
+++ b/pkg/scheduler/testing/wrappers.go
@@ -435,7 +435,7 @@ func (p *PodWrapper) NodeAffinityIn(key string, vals []string, t NodeSelectorTyp
 	return p
 }
 
-// NodeAffinityNotIn creates a HARD node affinity (with MatchExpressinos and the operator NotIn)
+// NodeAffinityNotIn creates a HARD node affinity (with MatchExpressions and the operator NotIn)
 // and injects into the inner pod.
 func (p *PodWrapper) NodeAffinityNotIn(key string, vals []string) *PodWrapper {
 	if p.Spec.Affinity == nil {


### PR DESCRIPTION
What type of PR is this?

/kind cleanup

What this PR does / why we need it:

Fixes a typo in the comment for the NodeAffinityNotIn method. The term "MatchExpressinos" is corrected to "MatchExpressions".

Which issue(s) this PR fixes:

None

What type of PR is this?

/kind cleanup

What this PR does / why we need it:

Fixes a typo in the comment for the `` method. The term "MatchExpressinos" is corrected to "MatchExpressions".

Which issue(s) this PR fixes:

None

Special notes for your reviewer:

This is a simple documentation fix and does not affect any functionality.

Does this PR introduce a user-facing change?

NONE

Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

NONE



Special notes for your reviewer:

This is a simple documentation fix and does not affect any functionality.

Does this PR introduce a user-facing change?

NONE

Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

NONE

