### PR TITLE
hack: fix settings for forbidigo linter

### DIFF
--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -205,7 +205,7 @@ linters-settings: # please keep this alphabetized
       msg: should not be used because managedFields was removed
     - p: \.Add$
       pkg: ^k8s\.io/component-base/featuregate$
-      msg: should not use MutableFeatureGate.Add, use AddVersioned instead
+      msg: should not use Add, use AddVersioned instead
     - p: ^gomega\.BeTrue$
       pkg: ^github.com/onsi/gomega$
       msg: "it does not produce a good failure message - use BeTrueBecause with an explicit printf-style failure message instead, or plain Go: if ... { ginkgo.Fail(...) }"

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -48,7 +48,7 @@ issues:
     # Adding unversioned feature gates is allowed in tests
     - linters:
         - forbidigo
-      text: should not use MutableFeatureGate.Add, use AddVersioned instead
+      text: should not use Add, use AddVersioned instead
       path: _test.go$
 
     # The Kubernetes naming convention for conversion functions uses underscores

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -205,7 +205,6 @@ linters-settings: # please keep this alphabetized
       msg: should not be used because managedFields was removed
     - p: \.Add$
       pkg: ^k8s\.io/component-base/featuregate$
-      type: ^MutableFeatureGate$
       msg: should not use MutableFeatureGate.Add, use AddVersioned instead
     - p: ^gomega\.BeTrue$
       pkg: ^github.com/onsi/gomega$

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -48,7 +48,7 @@ issues:
     # Adding unversioned feature gates is allowed in tests
     - linters:
         - forbidigo
-      text: should not use MutableFeatureGate.Add, use AddVersioned instead
+      text: should not use Add, use AddVersioned instead
       path: _test.go$
 
     # TODO(oscr) Remove these excluded directories and fix findings. Due to large amount of findings in different components

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -271,7 +271,7 @@ linters-settings: # please keep this alphabetized
       msg: should not be used because managedFields was removed
     - p: \.Add$
       pkg: ^k8s\.io/component-base/featuregate$
-      msg: should not use MutableFeatureGate.Add, use AddVersioned instead
+      msg: should not use Add, use AddVersioned instead
   gocritic:
     enabled-checks:
       - equalFold

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -271,7 +271,6 @@ linters-settings: # please keep this alphabetized
       msg: should not be used because managedFields was removed
     - p: \.Add$
       pkg: ^k8s\.io/component-base/featuregate$
-      type: ^MutableFeatureGate$
       msg: should not use MutableFeatureGate.Add, use AddVersioned instead
   gocritic:
     enabled-checks:

--- a/hack/golangci.yaml.in
+++ b/hack/golangci.yaml.in
@@ -223,7 +223,6 @@ linters-settings: # please keep this alphabetized
       msg: should not be used because managedFields was removed
     - p: \.Add$
       pkg: ^k8s\.io/component-base/featuregate$
-      type: ^MutableFeatureGate$
       msg: should not use MutableFeatureGate.Add, use AddVersioned instead
     {{- if .Hints}}
     - p: ^gomega\.BeTrue$

--- a/hack/golangci.yaml.in
+++ b/hack/golangci.yaml.in
@@ -223,7 +223,7 @@ linters-settings: # please keep this alphabetized
       msg: should not be used because managedFields was removed
     - p: \.Add$
       pkg: ^k8s\.io/component-base/featuregate$
-      msg: should not use MutableFeatureGate.Add, use AddVersioned instead
+      msg: should not use Add, use AddVersioned instead
     {{- if .Hints}}
     - p: ^gomega\.BeTrue$
       pkg: ^github.com/onsi/gomega$

--- a/hack/golangci.yaml.in
+++ b/hack/golangci.yaml.in
@@ -48,7 +48,7 @@ issues:
     # Adding unversioned feature gates is allowed in tests
     - linters:
         - forbidigo
-      text: should not use MutableFeatureGate.Add, use AddVersioned instead
+      text: should not use Add, use AddVersioned instead
       path: _test.go$
 
     {{- if .Base}}

--- a/hack/verify-golangci-lint-config.sh
+++ b/hack/verify-golangci-lint-config.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # This script checks that all generated golangci-lint configurations
-# are up-to-date.
+# are up-to-date and the config hack/golangci.yaml is valid.
 
 set -o errexit
 set -o nounset
@@ -24,4 +24,9 @@ set -o pipefail
 KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 source "${KUBE_ROOT}/hack/lib/verify-generated.sh"
 
+golangci=("${GOBIN}/golangci-lint")
+golangci_config="${KUBE_ROOT}/hack/golangci.yaml"
+
 kube::verify::generated "" "Please run 'hack/update-golangci-lint-config.sh'" hack/update-golangci-lint-config.sh
+
+"${golangci[@]}" config verify --config="${golangci_config}"

--- a/hack/verify-golangci-lint-config.sh
+++ b/hack/verify-golangci-lint-config.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # This script checks that all generated golangci-lint configurations
-# are up-to-date and the config hack/golangci.yaml is valid.
+# are up-to-date.
 
 set -o errexit
 set -o nounset
@@ -24,9 +24,4 @@ set -o pipefail
 KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 source "${KUBE_ROOT}/hack/lib/verify-generated.sh"
 
-golangci=("${GOBIN}/golangci-lint")
-golangci_config="${KUBE_ROOT}/hack/golangci.yaml"
-
 kube::verify::generated "" "Please run 'hack/update-golangci-lint-config.sh'" hack/update-golangci-lint-config.sh
-
-"${golangci[@]}" config verify --config="${golangci_config}"

--- a/hack/verify-golangci-lint.sh
+++ b/hack/verify-golangci-lint.sh
@@ -134,7 +134,7 @@ fi
 if ! failures=$( "${GOBIN}/golangci-lint" config verify --config="${golangci_config:-}" 2>&1 ); then
   cat >&2 <<EOF
 
-Verification of the configuration failed. Command:
+Verification of the golangci-lint configuration failed. Command:
 
    ${GOBIN}/golangci-lint config verify --config="${golangci_config:-}")
 

--- a/hack/verify-golangci-lint.sh
+++ b/hack/verify-golangci-lint.sh
@@ -131,7 +131,7 @@ fi
 
 # Verify that the given config is valid. "golangci-lint run" does not
 # do that, which makes it easy to miss mistakes while editing the configuration.
-if ! failures=$( ${GOBIN}/golangci-lint config verify --config="${golangci_config:-}" 2>&1 ); then
+if ! failures=$( "${GOBIN}/golangci-lint" config verify --config="${golangci_config:-}" 2>&1 ); then
   cat >&2 <<EOF
 
 Verification of the configuration failed. Command:

--- a/hack/verify-golangci-lint.sh
+++ b/hack/verify-golangci-lint.sh
@@ -129,6 +129,22 @@ if [ "${golangci_config}" ]; then
   GOTOOLCHAIN="$(kube::golang::hack_tools_gotoolchain)" go -C "${KUBE_ROOT}/hack/tools" build -o "${GOBIN}/logcheck.so" -buildmode=plugin sigs.k8s.io/logtools/logcheck/plugin
 fi
 
+# Verify that the given config is valid. "golangci-lint run" does not
+# do that, which makes it easy to miss mistakes while editing the configuration.
+if ! failures=$( ${GOBIN}/golangci-lint config verify --config="${golangci_config:-}" 2>&1 ); then
+  cat >&2 <<EOF
+
+Verification of the configuration failed. Command:
+
+   ${GOBIN}/golangci-lint config verify --config="${golangci_config:-}")
+
+Result:
+
+$failures
+EOF
+    exit 1
+fi
+
 if [ "${golangci_config}" ]; then
   # The relative path to _output/local/bin only works if that actually is the
   # GOBIN. If not, then we have to make a temporary copy of the config and


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Fixes the golangci-lint config that contains an incorrect `forbidigo.forbid.type` property.

#### Special notes for your reviewer:

See schema https://golangci-lint.run/jsonschema/golangci.jsonschema.json and https://github.com/golangci/golangci-lint/blob/v1.64.6/.golangci.reference.yml#L554

It's possible to verify the config with the command `golangci-lint config verify`.

Before:

```sh
$ golangci-lint config verify --config ./hack/golangci.yaml
jsonschema: "linters-settings.forbidigo.forbid.2" does not validate with "/properties/linters-settings/properties/forbidigo/properties/forbid/items/anyOf/0/type": got object, want string
jsonschema: "linters-settings.forbidigo.forbid.2" does not validate with "/properties/linters-settings/properties/forbidigo/properties/forbid/items/anyOf/1/additionalProperties": additional properties 'type' not allowed
Failed executing command with error: the configuration contains invalid elements
```

After:

```sh
$  golangci-lint config verify --config ./hack/golangci.yaml

```

This incorrect option was added in #129813.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```