### PR TITLE
Enable Semver CEL library, add normalization support

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/cel/environment/base.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/environment/base.go
@@ -176,6 +176,13 @@ var baseOptsWithoutStrictCost = []VersionedOptions{
 			ext.TwoVarComprehensions(),
 		},
 	},
+	// Semver
+	{
+		IntroducedVersion: version.MajorMinor(1, 33),
+		EnvOptions: []cel.EnvOption{
+			library.SemverLib(library.SemverVersion(1)),
+		},
+	},
 }
 
 var (

--- a/staging/src/k8s.io/apiserver/pkg/cel/library/cost.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/library/cost.go
@@ -18,13 +18,14 @@ package library
 
 import (
 	"fmt"
+	"math"
+
 	"github.com/google/cel-go/checker"
 	"github.com/google/cel-go/common"
 	"github.com/google/cel-go/common/ast"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/common/types/traits"
-	"math"
 
 	"k8s.io/apiserver/pkg/cel"
 )
@@ -202,7 +203,7 @@ func (l *CostEstimator) CallCost(function, overloadId string, args []ref.Val, re
 
 			return &cost
 		}
-	case "quantity", "isQuantity":
+	case "quantity", "isQuantity", "semver", "isSemver":
 		if len(args) >= 1 {
 			cost := uint64(math.Ceil(float64(actualSize(args[0])) * common.StringTraversalCostFactor))
 			return &cost
@@ -236,7 +237,7 @@ func (l *CostEstimator) CallCost(function, overloadId string, args []ref.Val, re
 		// Simply dictionary lookup
 		cost := uint64(1)
 		return &cost
-	case "sign", "asInteger", "isInteger", "asApproximateFloat", "isGreaterThan", "isLessThan", "compareTo", "add", "sub":
+	case "sign", "asInteger", "isInteger", "asApproximateFloat", "isGreaterThan", "isLessThan", "compareTo", "add", "sub", "major", "minor", "patch":
 		cost := uint64(1)
 		return &cost
 	case "getScheme", "getHostname", "getHost", "getPort", "getEscapedPath", "getQuery":
@@ -486,7 +487,7 @@ func (l *CostEstimator) EstimateCallCost(function, overloadId string, target *ch
 
 			return &checker.CallEstimate{CostEstimate: ipCompCost}
 		}
-	case "quantity", "isQuantity":
+	case "quantity", "isQuantity", "semver", "isSemver":
 		if target != nil {
 			sz := l.sizeEstimate(args[0])
 			return &checker.CallEstimate{CostEstimate: sz.MultiplyByCostFactor(common.StringTraversalCostFactor)}
@@ -498,7 +499,7 @@ func (l *CostEstimator) EstimateCallCost(function, overloadId string, target *ch
 		}
 	case "format.named":
 		return &checker.CallEstimate{CostEstimate: checker.CostEstimate{Min: 1, Max: 1}}
-	case "sign", "asInteger", "isInteger", "asApproximateFloat", "isGreaterThan", "isLessThan", "compareTo", "add", "sub":
+	case "sign", "asInteger", "isInteger", "asApproximateFloat", "isGreaterThan", "isLessThan", "compareTo", "add", "sub", "major", "minor", "patch":
 		return &checker.CallEstimate{CostEstimate: checker.CostEstimate{Min: 1, Max: 1}}
 	case "getScheme", "getHostname", "getHost", "getPort", "getEscapedPath", "getQuery":
 		// url accessors

--- a/staging/src/k8s.io/apiserver/pkg/cel/library/library_compatibility_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/library/library_compatibility_test.go
@@ -17,11 +17,12 @@ limitations under the License.
 package library
 
 import (
+	"strings"
+	"testing"
+
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/common/decls"
 	"github.com/google/cel-go/common/types"
-	"strings"
-	"testing"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 )
@@ -56,6 +57,8 @@ func TestLibraryCompatibility(t *testing.T) {
 		"fieldSelector", "labelSelector", "validate", "format.named", "isSemver", "major", "minor", "patch", "semver",
 		// Kubernetes <1.32>:
 		"jsonpatch.escapeKey",
+		// Kubernetes <1.33>:
+		"semver", "isSemver", "major", "minor", "patch",
 		// Kubernetes <1.??>:
 	)
 

--- a/staging/src/k8s.io/apiserver/pkg/cel/library/semverlib.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/library/semverlib.go
@@ -48,8 +48,8 @@ import (
 //	semver('Three') // error
 //	semver('Mi') // error
 //	semver('v1.0.0', true) // Applies normalization to remove the leading "v". Returns a Semver of "1.0.0".
-//	semver('1.0') // Applies normalization to add the missing patch version. Returns a Semver of "1.0.0"
-//	semver('01.01.01') // Applies normalization to remove leading zeros. Returns a Semver of "1.1.1"
+//	semver('1.0', true) // Applies normalization to add the missing patch version. Returns a Semver of "1.0.0"
+//	semver('01.01.01', true) // Applies normalization to remove leading zeros. Returns a Semver of "1.1.1"
 //
 // isSemver
 //
@@ -66,9 +66,9 @@ import (
 //	isSemver('1.0.0') // returns true
 //	isSemver('hello') // returns false
 //  isSemver('v1.0')  // returns false (leading "v" is not allowed unless normalization is enabled)
-//	isSemver('v1.0') // Applies normalization to remove leading "v". returns true
-//	semver('1.0') // Applies normalization to add the missing patch version. Returns true
-//	semver('01.01.01') // Applies normalization to remove leading zeros. Returns true
+//	isSemver('v1.0', true) // Applies normalization to remove leading "v". returns true
+//	semver('1.0', true) // Applies normalization to add the missing patch version. Returns true
+//	semver('01.01.01', true) // Applies normalization to remove leading zeros. Returns true
 //
 // Conversion to Scalars:
 //

--- a/staging/src/k8s.io/dynamic-resource-allocation/cel/compile.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/cel/compile.go
@@ -298,8 +298,6 @@ func newCompiler() *compiler {
 			EnvOptions: []cel.EnvOption{
 				cel.Variable(deviceVar, deviceType.CelType()),
 
-				library.SemverLib(library.SemverVersion(0)),
-
 				// https://pkg.go.dev/github.com/google/cel-go/ext#Bindings
 				//
 				// This is useful to simplify attribute lookups because the
@@ -310,6 +308,22 @@ func newCompiler() *compiler {
 			},
 			DeclTypes: []*apiservercel.DeclType{
 				deviceType,
+			},
+		},
+		{
+			IntroducedVersion: version.MajorMinor(1, 31),
+			// This library has added to base environment of Kubernetes
+			// in 1.33 at version 1. It will continue to be available for
+			// use in this environment, but does not need to be included
+			// directly since it becomes available indirectly via the base
+			// environment shared across Kubernetes.
+			// In Kubernetes 1.34, version 1 feature of this library will
+			// become available, and will be rollback safe to 1.33.
+			// TODO: In Kubernetes 1.34: Add compile tests that demonstrate that
+			// `isSemver("v1.0.0", true)` and `semver("v1.0.0", true)` are supported.
+			RemovedVersion: version.MajorMinor(1, 33),
+			EnvOptions: []cel.EnvOption{
+				library.SemverLib(library.SemverVersion(0)),
 			},
 		},
 	}

--- a/staging/src/k8s.io/dynamic-resource-allocation/cel/compile.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/cel/compile.go
@@ -33,13 +33,14 @@ import (
 	"github.com/google/cel-go/common/types/traits"
 	"github.com/google/cel-go/ext"
 
+	"k8s.io/utils/ptr"
+
 	resourceapi "k8s.io/api/resource/v1beta1"
 	"k8s.io/apimachinery/pkg/util/version"
 	celconfig "k8s.io/apiserver/pkg/apis/cel"
 	apiservercel "k8s.io/apiserver/pkg/cel"
 	"k8s.io/apiserver/pkg/cel/environment"
 	"k8s.io/apiserver/pkg/cel/library"
-	"k8s.io/utils/ptr"
 )
 
 const (
@@ -297,7 +298,7 @@ func newCompiler() *compiler {
 			EnvOptions: []cel.EnvOption{
 				cel.Variable(deviceVar, deviceType.CelType()),
 
-				environment.UnversionedLib(library.SemverLib),
+				library.SemverLib(library.SemverVersion(0)),
 
 				// https://pkg.go.dev/github.com/google/cel-go/ext#Bindings
 				//


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

The semver library was added via https://github.com/kubernetes/kubernetes/pull/123516.

This enables the library in the base environment.  It will become available for general use in 1.34 for all field in the Kubernetes API that accept CEL expressions.

An option to normalize inputs with leading "v"s, leading "0"s on version parts, and missing minor or patch parts is supported in Version 2 of the library when calling the new overloads "semver(..., true)" or "isSemver(..., true)".

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

Since all CEL libraries must be introduced one version before they are available, there is no 1.33 release note for this change.

```release-note
NONE
```

/sig api-machinery

