### PR TITLE
KEP-3998: Promote JobSuccessPolicy E2E to Conformance

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -1154,6 +1154,32 @@
     exceeds maxFailedIndexes.
   release: v1.33
   file: test/e2e/apps/job.go
+- testname: Ensure that job with successPolicy succeeded when all indexes succeeded
+  codename: '[sig-apps] Job with successPolicy should succeeded when all indexes succeeded
+    [Conformance]'
+  description: Create an indexed job with successPolicy. Verify that job got SuccessCriteriaMet
+    with SuccessPolicy reason and Complete condition once all indexes succeeded.
+  release: v1.33
+  file: test/e2e/apps/job.go
+- testname: Ensure that job with successPolicy succeededCount rule succeeded even
+    when some indexes remain pending
+  codename: '[sig-apps] Job with successPolicy succeededCount rule should succeeded
+    even when some indexes remain pending [Conformance]'
+  description: Create an indexed job with successPolicy succeededCount rule. Verify
+    that the job got the SuccessCriteriaMet with SuccessPolicy reason condition and
+    Complete condition when the job met successPolicy even if some indexed remain
+    pending.
+  release: v1.33
+  file: test/e2e/apps/job.go
+- testname: Ensure that job with successPolicy succeededIndexes rule succeeded even
+    when some indexes remain pending
+  codename: '[sig-apps] Job with successPolicy succeededIndexes rule should succeeded
+    even when some indexes remain pending [Conformance]'
+  description: Create an indexed job with successPolicy succeededIndexes rule. Verify
+    that the job got SuccessCriteriaMet with SuccessPolicy reason condition and Complete
+    condition when the job met successPolicy even if some indexed remain pending.
+  release: v1.33
+  file: test/e2e/apps/job.go
 - testname: ReplicaSet, is created, Replaced and Patched
   codename: '[sig-apps] ReplicaSet Replace and Patch tests [Conformance]'
   description: Create a ReplicaSet (RS) with a single Pod. The Pod MUST be verified

--- a/test/e2e/apps/job.go
+++ b/test/e2e/apps/job.go
@@ -476,12 +476,13 @@ done`}
 	})
 
 	/*
-		Testcase: Ensure that job with successPolicy succeeded when all indexes succeeded
+		Release: v1.33
+		Testname: Ensure that job with successPolicy succeeded when all indexes succeeded
 		Description: Create an indexed job with successPolicy.
 		Verify that job got SuccessCriteriaMet with SuccessPolicy reason and Complete condition
 		once all indexes succeeded.
 	*/
-	ginkgo.It("with successPolicy should succeeded when all indexes succeeded", func(ctx context.Context) {
+	framework.ConformanceIt("with successPolicy should succeeded when all indexes succeeded", func(ctx context.Context) {
 		parallelism := int32(2)
 		completions := int32(2)
 		backoffLimit := int32(6) // default value
@@ -510,17 +511,19 @@ done`}
 		framework.ExpectNoError(err, "failed to get latest job object")
 		gomega.Expect(job.Status.Active).Should(gomega.Equal(int32(0)))
 		gomega.Expect(job.Status.Ready).Should(gomega.Equal(ptr.To[int32](0)))
-		gomega.Expect(job.Status.Terminating).Should(gomega.Equal(ptr.To[int32](0)))
+		// TODO (https://github.com/kubernetes/enhancements/issues/3939): Restore the assert on .status.terminating when PodReplacementPolicy goes GA.
+		// gomega.Expect(job.Status.Terminating).Should(gomega.Equal(ptr.To[int32](0)))
 		gomega.Expect(job.Status.Failed).Should(gomega.Equal(int32(0)))
 	})
 
 	/*
-		Testcase: Ensure that job with successPolicy succeededIndexes rule succeeded even when some indexes remain pending
+		Release: v1.33
+		Testname: Ensure that job with successPolicy succeededIndexes rule succeeded even when some indexes remain pending
 		Description: Create an indexed job with successPolicy succeededIndexes rule.
 		Verify that the job got SuccessCriteriaMet with SuccessPolicy reason condition and Complete condition
 		when the job met successPolicy even if some indexed remain pending.
 	*/
-	ginkgo.It("with successPolicy succeededIndexes rule should succeeded even when some indexes remain pending", func(ctx context.Context) {
+	framework.ConformanceIt("with successPolicy succeededIndexes rule should succeeded even when some indexes remain pending", func(ctx context.Context) {
 		parallelism := int32(2)
 		completions := int32(5)
 		backoffLimit := int32(6) // default value
@@ -550,16 +553,18 @@ done`}
 		gomega.Expect(job.Status.CompletedIndexes).Should(gomega.Equal("0"))
 		gomega.Expect(job.Status.Active).Should(gomega.Equal(int32(0)))
 		gomega.Expect(job.Status.Ready).Should(gomega.Equal(ptr.To[int32](0)))
-		gomega.Expect(job.Status.Terminating).Should(gomega.Equal(ptr.To[int32](0)))
+		// TODO (https://github.com/kubernetes/enhancements/issues/3939): Restore the assert on .status.terminating when PodReplacementPolicy goes GA.
+		// gomega.Expect(job.Status.Terminating).Should(gomega.Equal(ptr.To[int32](0)))
 	})
 
 	/*
-		Testcase: Ensure that job with successPolicy succeededCount rule succeeded even when some indexes remain pending
+		Release: v1.33
+		Testname: Ensure that job with successPolicy succeededCount rule succeeded even when some indexes remain pending
 		Description: Create an indexed job with successPolicy succeededCount rule.
 		Verify that the job got the SuccessCriteriaMet with SuccessPolicy reason condition and Complete condition
 		when the job met successPolicy even if some indexed remain pending.
 	*/
-	ginkgo.It("with successPolicy succeededCount rule should succeeded even when some indexes remain pending", func(ctx context.Context) {
+	framework.ConformanceIt("with successPolicy succeededCount rule should succeeded even when some indexes remain pending", func(ctx context.Context) {
 		parallelism := int32(2)
 		completions := int32(5)
 		backoffLimit := int32(math.MaxInt32)
@@ -589,7 +594,8 @@ done`}
 		gomega.Expect(job.Status.CompletedIndexes).Should(gomega.Equal("0"))
 		gomega.Expect(job.Status.Active).Should(gomega.Equal(int32(0)))
 		gomega.Expect(job.Status.Ready).Should(gomega.Equal(ptr.To[int32](0)))
-		gomega.Expect(job.Status.Terminating).Should(gomega.Equal(ptr.To[int32](0)))
+		// TODO (https://github.com/kubernetes/enhancements/issues/3939): Restore the assert on .status.terminating when PodReplacementPolicy goes GA.
+		// gomega.Expect(job.Status.Terminating).Should(gomega.Equal(ptr.To[int32](0)))
 	})
 
 	/*


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

I promoted JobSuccessPolicy E2E tests to Conformance Tests

Additionally, I removed the Job `.status.terminating` confirmation (ex. https://github.com/kubernetes/kubernetes/pull/130536/files#diff-909ebfa7fcb2a94030da3371d35863a2d723fc93356334e35f68816f5e313379L513) from JobSuccessPolicy E2E test cases since the value depends on another Beta feature, JobPodReplacementPolicy (https://github.com/kubernetes/enhancements/issues/3939).

- Enabled JobPodReplacementPolicy: .status.terminating: 0
- Disabled JobPodReplacementPolicy: .status.terminating: nil

So, I'm wondering if we should mention adding a `.status.terminating` confirmation to Job E2E as JobPodReplacementPolicy GA criteria in JobPodReplacementPolicy KEP.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part-of https://github.com/kubernetes/enhancements/issues/3998

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Promote JobSuccessPolicy E2E to Conformance
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-apps/3998-job-success-completion-policy
```
