### PR TITLE
Show CEL library doc comments in godoc

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/cel/library/cidr.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/library/cidr.go
@@ -82,24 +82,24 @@ import (
 //
 // Examples:
 //
-// cidr('192.168.0.0/24').containsIP(ip('192.168.0.1')) // returns true
-// cidr('192.168.0.0/24').containsIP(ip('192.168.1.1')) // returns false
-// cidr('192.168.0.0/24').containsIP('192.168.0.1') // returns true
-// cidr('192.168.0.0/24').containsIP('192.168.1.1') // returns false
-// cidr('192.168.0.0/16').containsCIDR(cidr('192.168.10.0/24')) // returns true
-// cidr('192.168.1.0/24').containsCIDR(cidr('192.168.2.0/24')) // returns false
-// cidr('192.168.0.0/16').containsCIDR('192.168.10.0/24') // returns true
-// cidr('192.168.1.0/24').containsCIDR('192.168.2.0/24') // returns false
-// cidr('192.168.0.1/24').ip() // returns ipAddr('192.168.0.1')
-// cidr('192.168.0.1/24').ip().family() // returns '4'
-// cidr('::1/128').ip() // returns ipAddr('::1')
-// cidr('::1/128').ip().family() // returns '6'
-// cidr('192.168.0.0/24').masked() // returns cidr('192.168.0.0/24')
-// cidr('192.168.0.1/24').masked() // returns cidr('192.168.0.0/24')
-// cidr('192.168.0.0/24') == cidr('192.168.0.0/24').masked() // returns true, CIDR was already in canonical format
-// cidr('192.168.0.1/24') == cidr('192.168.0.1/24').masked() // returns false, CIDR was not in canonical format
-// cidr('192.168.0.0/16').prefixLength() // returns 16
-// cidr('::1/128').prefixLength() // returns 128
+//	cidr('192.168.0.0/24').containsIP(ip('192.168.0.1')) // returns true
+//	cidr('192.168.0.0/24').containsIP(ip('192.168.1.1')) // returns false
+//	cidr('192.168.0.0/24').containsIP('192.168.0.1') // returns true
+//	cidr('192.168.0.0/24').containsIP('192.168.1.1') // returns false
+//	cidr('192.168.0.0/16').containsCIDR(cidr('192.168.10.0/24')) // returns true
+//	cidr('192.168.1.0/24').containsCIDR(cidr('192.168.2.0/24')) // returns false
+//	cidr('192.168.0.0/16').containsCIDR('192.168.10.0/24') // returns true
+//	cidr('192.168.1.0/24').containsCIDR('192.168.2.0/24') // returns false
+//	cidr('192.168.0.1/24').ip() // returns ipAddr('192.168.0.1')
+//	cidr('192.168.0.1/24').ip().family() // returns '4'
+//	cidr('::1/128').ip() // returns ipAddr('::1')
+//	cidr('::1/128').ip().family() // returns '6'
+//	cidr('192.168.0.0/24').masked() // returns cidr('192.168.0.0/24')
+//	cidr('192.168.0.1/24').masked() // returns cidr('192.168.0.0/24')
+//	cidr('192.168.0.0/24') == cidr('192.168.0.0/24').masked() // returns true, CIDR was already in canonical format
+//	cidr('192.168.0.1/24') == cidr('192.168.0.1/24').masked() // returns false, CIDR was not in canonical format
+//	cidr('192.168.0.0/16').prefixLength() // returns 16
+//	cidr('::1/128').prefixLength() // returns 128
 func CIDR() cel.EnvOption {
 	return cel.Lib(cidrsLib)
 }

--- a/staging/src/k8s.io/apiserver/pkg/cel/library/format.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/library/format.go
@@ -41,53 +41,53 @@ var (
 // Format provides a CEL library exposing common named Kubernetes string
 // validations. Can be used in CRD ValidationRules messageExpression.
 //
-//  Example:
+// Example:
 //
-//    rule:              format.dns1123label.validate(object.metadata.name).hasValue()
-//    messageExpression: format.dns1123label.validate(object.metadata.name).value().join("\n")
+//	rule:              format.dns1123label.validate(object.metadata.name).hasValue()
+//	messageExpression: format.dns1123label.validate(object.metadata.name).value().join("\n")
 //
 // format.named(name: string) -> ?Format
 //
-//  Returns the Format with the given name, if it exists. Otherwise, optional.none
-//  Allowed names are:
-// 	 - `dns1123Label`
-// 	 - `dns1123Subdomain`
-// 	 - `dns1035Label`
-// 	 - `qualifiedName`
-// 	 - `dns1123LabelPrefix`
-// 	 - `dns1123SubdomainPrefix`
-// 	 - `dns1035LabelPrefix`
-// 	 - `labelValue`
-// 	 - `uri`
-// 	 - `uuid`
-// 	 - `byte`
-// 	 - `date`
-// 	 - `datetime`
+// Returns the Format with the given name, if it exists. Otherwise, optional.none
+// Allowed names are:
+//   - `dns1123Label`
+//   - `dns1123Subdomain`
+//   - `dns1035Label`
+//   - `qualifiedName`
+//   - `dns1123LabelPrefix`
+//   - `dns1123SubdomainPrefix`
+//   - `dns1035LabelPrefix`
+//   - `labelValue`
+//   - `uri`
+//   - `uuid`
+//   - `byte`
+//   - `date`
+//   - `datetime`
 //
 // format.<formatName>() -> Format
 //
-//  Convenience functions for all the named formats are also available
+// Convenience functions for all the named formats are also available.
 //
-//  Examples:
-//      format.dns1123Label().validate("my-label-name")
-//      format.dns1123Subdomain().validate("apiextensions.k8s.io")
-//      format.dns1035Label().validate("my-label-name")
-//      format.qualifiedName().validate("apiextensions.k8s.io/v1beta1")
-//      format.dns1123LabelPrefix().validate("my-label-prefix-")
-//      format.dns1123SubdomainPrefix().validate("mysubdomain.prefix.-")
-//      format.dns1035LabelPrefix().validate("my-label-prefix-")
-//      format.uri().validate("http://example.com")
-//          Uses same pattern as isURL, but returns an error
-//      format.uuid().validate("123e4567-e89b-12d3-a456-426614174000")
-//      format.byte().validate("aGVsbG8=")
-//      format.date().validate("2021-01-01")
-//      format.datetime().validate("2021-01-01T00:00:00Z")
+// Examples:
 //
-
+//	format.dns1123Label().validate("my-label-name")
+//	format.dns1123Subdomain().validate("apiextensions.k8s.io")
+//	format.dns1035Label().validate("my-label-name")
+//	format.qualifiedName().validate("apiextensions.k8s.io/v1beta1")
+//	format.dns1123LabelPrefix().validate("my-label-prefix-")
+//	format.dns1123SubdomainPrefix().validate("mysubdomain.prefix.-")
+//	format.dns1035LabelPrefix().validate("my-label-prefix-")
+//	format.uri().validate("http://example.com")
+//	    Uses same pattern as isURL, but returns an error
+//	format.uuid().validate("123e4567-e89b-12d3-a456-426614174000")
+//	format.byte().validate("aGVsbG8=")
+//	format.date().validate("2021-01-01")
+//	format.datetime().validate("2021-01-01T00:00:00Z")
+//
 // <Format>.validate(str: string) -> ?list<string>
 //
-//	Validates the given string against the given format. Returns optional.none
-//	if the string is valid, otherwise a list of validation error strings.
+// Validates the given string against the given format. Returns optional.none
+// if the string is valid, otherwise a list of validation error strings.
 func Format() cel.EnvOption {
 	return cel.Lib(formatLib)
 }

--- a/staging/src/k8s.io/apiserver/pkg/cel/library/ip.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/library/ip.go
@@ -99,30 +99,30 @@ import (
 //
 // Examples:
 //
-// ip('127.0.0.1').family() // returns '4”
-// ip('::1').family() // returns '6'
-// ip('127.0.0.1').family() == 4 // returns true
-// ip('::1').family() == 6 // returns true
-// ip('0.0.0.0').isUnspecified() // returns true
-// ip('127.0.0.1').isUnspecified() // returns false
-// ip('::').isUnspecified() // returns true
-// ip('::1').isUnspecified() // returns false
-// ip('127.0.0.1').isLoopback() // returns true
-// ip('192.168.0.1').isLoopback() // returns false
-// ip('::1').isLoopback() // returns true
-// ip('2001:db8::abcd').isLoopback() // returns false
-// ip('224.0.0.1').isLinkLocalMulticast() // returns true
-// ip('224.0.1.1').isLinkLocalMulticast() // returns false
-// ip('ff02::1').isLinkLocalMulticast() // returns true
-// ip('fd00::1').isLinkLocalMulticast() // returns false
-// ip('169.254.169.254').isLinkLocalUnicast() // returns true
-// ip('192.168.0.1').isLinkLocalUnicast() // returns false
-// ip('fe80::1').isLinkLocalUnicast() // returns true
-// ip('fd80::1').isLinkLocalUnicast() // returns false
-// ip('192.168.0.1').isGlobalUnicast() // returns true
-// ip('255.255.255.255').isGlobalUnicast() // returns false
-// ip('2001:db8::abcd').isGlobalUnicast() // returns true
-// ip('ff00::1').isGlobalUnicast() // returns false
+//	ip('127.0.0.1').family() // returns '4”
+//	ip('::1').family() // returns '6'
+//	ip('127.0.0.1').family() == 4 // returns true
+//	ip('::1').family() == 6 // returns true
+//	ip('0.0.0.0').isUnspecified() // returns true
+//	ip('127.0.0.1').isUnspecified() // returns false
+//	ip('::').isUnspecified() // returns true
+//	ip('::1').isUnspecified() // returns false
+//	ip('127.0.0.1').isLoopback() // returns true
+//	ip('192.168.0.1').isLoopback() // returns false
+//	ip('::1').isLoopback() // returns true
+//	ip('2001:db8::abcd').isLoopback() // returns false
+//	ip('224.0.0.1').isLinkLocalMulticast() // returns true
+//	ip('224.0.1.1').isLinkLocalMulticast() // returns false
+//	ip('ff02::1').isLinkLocalMulticast() // returns true
+//	ip('fd00::1').isLinkLocalMulticast() // returns false
+//	ip('169.254.169.254').isLinkLocalUnicast() // returns true
+//	ip('192.168.0.1').isLinkLocalUnicast() // returns false
+//	ip('fe80::1').isLinkLocalUnicast() // returns true
+//	ip('fd80::1').isLinkLocalUnicast() // returns false
+//	ip('192.168.0.1').isGlobalUnicast() // returns true
+//	ip('255.255.255.255').isGlobalUnicast() // returns false
+//	ip('2001:db8::abcd').isGlobalUnicast() // returns true
+//	ip('ff00::1').isGlobalUnicast() // returns false
 func IP() cel.EnvOption {
 	return cel.Lib(ipLib)
 }

--- a/staging/src/k8s.io/apiserver/pkg/cel/library/quantity.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/library/quantity.go
@@ -82,12 +82,12 @@ import (
 //
 // Examples:
 //
-// quantity("50000000G").isInteger() // returns true
-// quantity("50k").isInteger() // returns true
-// quantity("9999999999999999999999999999999999999G").asInteger() // error: cannot convert value to integer
-// quantity("9999999999999999999999999999999999999G").isInteger() // returns false
-// quantity("50k").asInteger() == 50000 // returns true
-// quantity("50k").sub(20000).asApproximateFloat() == 30000 // returns true
+//	quantity("50000000G").isInteger() // returns true
+//	quantity("50k").isInteger() // returns true
+//	quantity("9999999999999999999999999999999999999G").asInteger() // error: cannot convert value to integer
+//	quantity("9999999999999999999999999999999999999G").isInteger() // returns false
+//	quantity("50k").asInteger() == 50000 // returns true
+//	quantity("50k").sub(20000).asApproximateFloat() == 30000 // returns true
 //
 // Arithmetic
 //
@@ -105,11 +105,11 @@ import (
 //
 // Examples:
 //
-// quantity("50k").add("20k") == quantity("70k") // returns true
-// quantity("50k").add(20) == quantity("50020") // returns true
-// quantity("50k").sub("20k") == quantity("30k") // returns true
-// quantity("50k").sub(20000) == quantity("30k") // returns true
-// quantity("50k").add(20).sub(quantity("100k")).sub(-50000) == quantity("20") // returns true
+//	quantity("50k").add("20k") == quantity("70k") // returns true
+//	quantity("50k").add(20) == quantity("50020") // returns true
+//	quantity("50k").sub("20k") == quantity("30k") // returns true
+//	quantity("50k").sub(20000) == quantity("30k") // returns true
+//	quantity("50k").add(20).sub(quantity("100k")).sub(-50000) == quantity("20") // returns true
 //
 // Comparisons
 //
@@ -125,13 +125,13 @@ import (
 //
 // Examples:
 //
-// quantity("200M").compareTo(quantity("0.2G")) // returns 0
-// quantity("50M").compareTo(quantity("50Mi")) // returns -1
-// quantity("50Mi").compareTo(quantity("50M")) // returns 1
-// quantity("150Mi").isGreaterThan(quantity("100Mi")) // returns true
-// quantity("50Mi").isGreaterThan(quantity("100Mi")) // returns false
-// quantity("50M").isLessThan(quantity("100M")) // returns true
-// quantity("100M").isLessThan(quantity("50M")) // returns false
+//	quantity("200M").compareTo(quantity("0.2G")) // returns 0
+//	quantity("50M").compareTo(quantity("50Mi")) // returns -1
+//	quantity("50Mi").compareTo(quantity("50M")) // returns 1
+//	quantity("150Mi").isGreaterThan(quantity("100Mi")) // returns true
+//	quantity("50Mi").isGreaterThan(quantity("100Mi")) // returns false
+//	quantity("50M").isLessThan(quantity("100M")) // returns true
+//	quantity("100M").isLessThan(quantity("50M")) // returns false
 func Quantity() cel.EnvOption {
 	return cel.Lib(quantityLib)
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

I was reading up on the functions available for CRD validation and noticed that there are excellent doc comments in `.../pkg/cel/library`, but they weren't showing at pkg.go.dev.

For example, the [Format library docs](https://pkg.go.dev/k8s.io/apiserver@v0.33.3/pkg/cel/library#Format) don't mention `format.named()` or `dns1123Label`.

Documentation for the Format, SemVer, and Quantity libraries now appears in godoc and at pkg.go.dev.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

This is kind of the minimum to have docs appear on pkgsite. I can do some more to tidy up the formatting, but only wanted to get into it if you felt it was worthwhile.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<table>
<tr><td valign=top>

before this change:

<img width="400" alt="Screenshot 2025-08-15 8 43 10 AM" src="https://github.com/user-attachments/assets/95ea47ef-ef18-4de8-8341-d77a1eeac256" />

</td><td valign=top>

after this change:

<img width="400" height="772" alt="Screenshot 2025-08-15 8 43 26 AM" src="https://github.com/user-attachments/assets/6d7ae911-2f52-4632-968f-836230bb2686" />

</td></tr>
</table>