### PR TITLE
Add time to extra-pkgs for validation-gen

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -440,6 +440,7 @@ function codegen::validation() {
         k8s.io/apimachinery/pkg/runtime
         k8s.io/apimachinery/pkg/types
         k8s.io/apimachinery/pkg/util/intstr
+        time
     )
 
     kube::log::status "Generating validation code for ${#tag_pkgs[@]} targets"


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Needed to use validation-gen with TypeMeta.  This got missed in https://github.com/kubernetes/kubernetes/pull/130627 by accident

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
