### PR TITLE
fix a flake of TestRoundTripTypes: for FirstAvailable[].AllocationMode

### DIFF
--- a/pkg/apis/resource/fuzzer/fuzzer.go
+++ b/pkg/apis/resource/fuzzer/fuzzer.go
@@ -39,6 +39,15 @@ var Funcs = func(codecs runtimeserializer.CodecFactory) []interface{} {
 				}[c.Int31n(2)]
 			}
 		},
+		func(r *resource.DeviceSubRequest, c randfill.Continue) {
+			c.FillNoCustom(r) // fuzz self without calling this function again
+			if r.AllocationMode == "" {
+				r.AllocationMode = []resource.DeviceAllocationMode{
+					resource.DeviceAllocationModeAll,
+					resource.DeviceAllocationModeExactCount,
+				}[c.Int31n(2)]
+			}
+		},
 		func(r *resource.DeviceAllocationConfiguration, c randfill.Continue) {
 			c.FillNoCustom(r)
 			if r.Source == "" {


### PR DESCRIPTION
#### What type of PR is this?
/kind flake
/sig scheduling 

#### What this PR does / why we need it:
The flake started after https://github.com/kubernetes/kubernetes/pull/128586 was merged.

#### Which issue(s) this PR fixes:

Fixes #130674

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```