### PR TITLE
list pods with resourceVersion when kubectl drain

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/drain/drain.go
+++ b/staging/src/k8s.io/kubectl/pkg/drain/drain.go
@@ -186,9 +186,10 @@ func (d *Helper) GetPodsForDeletion(nodeName string) (*PodDeleteList, []error) {
 
 	podList := &corev1.PodList{}
 	initialOpts := &metav1.ListOptions{
-		LabelSelector: labelSelector.String(),
-		FieldSelector: fields.SelectorFromSet(fields.Set{"spec.nodeName": nodeName}).String(),
-		Limit:         d.ChunkSize,
+		LabelSelector:   labelSelector.String(),
+		FieldSelector:   fields.SelectorFromSet(fields.Set{"spec.nodeName": nodeName}).String(),
+		ResourceVersion: "0",
+		Limit:           d.ChunkSize,
 	}
 
 	err = resource.FollowContinue(initialOpts, func(options metav1.ListOptions) (runtime.Object, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Reduce  load pressure on kube-server/etcd caused by draining nodes in  large-scale cluster.


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```

Changed `kubectl` to list pods with `resourceVersion` while draining. In a large cluster that does not have the _consistent reads from cache_ feature active, draining nodes without `resourceVersion` can impose significant pressure on etcd; this change provides a client-side performance improvement.
```

