### PR TITLE
Add metric for watch cache ready

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
@@ -467,11 +467,13 @@ func (c *Cacher) startCaching(stopChannel <-chan struct{}) {
 	c.watchCache.SetOnReplace(func() {
 		c.ready.setReady()
 		klog.V(1).Infof("cacher (%v): initialized", c.groupResource.String())
+		metrics.WatchCacheReady.WithLabelValues(c.groupResource.String()).Set(1)
 		metrics.WatchCacheInitializations.WithLabelValues(c.groupResource.String()).Inc()
 	})
 	var err error
 	defer func() {
 		c.ready.setError(err)
+		metrics.WatchCacheReady.WithLabelValues(c.groupResource.String()).Set(0)
 	}()
 
 	c.terminateAllWatchers()

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/metrics/metrics.go
@@ -35,6 +35,8 @@ const (
  * Promoting the stability level of the metric is a responsibility of the component owner, since it
  * involves explicitly acknowledging support for the metric across multiple releases, in accordance with
  * the metric stability policy.
+ *
+ * Most metrics here use a "resource" label. The number of unique values for this label is limited by the number of watch caches the apiserver creates.
  */
 var (
 	listCacheCount = compbasemetrics.NewCounterVec(
@@ -147,6 +149,17 @@ var (
 		[]string{"resource"},
 	)
 
+	WatchCacheReady = compbasemetrics.NewGaugeVec(
+		&compbasemetrics.GaugeOpts{
+			Namespace:      namespace,
+			Subsystem:      subsystem,
+			Name:           "ready",
+			Help:           "Readiness of the watch cache broken by resource type.",
+			StabilityLevel: compbasemetrics.ALPHA,
+		},
+		[]string{"resource"},
+	)
+
 	WatchCacheInitializations = compbasemetrics.NewCounterVec(
 		&compbasemetrics.CounterOpts{
 			Namespace:      namespace,
@@ -203,6 +216,7 @@ func Register() {
 		legacyregistry.MustRegister(watchCacheCapacityIncreaseTotal)
 		legacyregistry.MustRegister(watchCacheCapacityDecreaseTotal)
 		legacyregistry.MustRegister(WatchCacheCapacity)
+		legacyregistry.MustRegister(WatchCacheReady)
 		legacyregistry.MustRegister(WatchCacheInitializations)
 		legacyregistry.MustRegister(WatchCacheReadWait)
 		legacyregistry.MustRegister(ConsistentReadTotal)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind feature

#### What this PR does / why we need it:

This patch introduces a metric to track the readiness state of the watch cache in the API server. This is useful in cases where the etcd cluster loses quorum, causing the watch cache to remain unready for an extended period.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

/assign @p0lyn0mial @benluddy 
