### PR TITLE
DRA kubeletplugin: turn helper into wrapper

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/doc.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/doc.go
@@ -16,4 +16,52 @@ limitations under the License.
 
 // Package kubeletplugin provides helper functions for running a dynamic
 // resource allocation kubelet plugin.
+//
+// A DRA driver using this package can be deployed as a DaemonSet on suitable
+// nodes. Node labeling, for example through NFD
+// (https://github.com/kubernetes-sigs/node-feature-discovery), can be used
+// to run the driver only on nodes which have the necessary hardware.
+//
+// The service account of the DaemonSet must have sufficient RBAC permissions
+// to read ResourceClaims and to create and update ResourceSlices, if
+// the driver intends to publish per-node ResourceSlices. It is good
+// security practice (but not required) to limit access to ResourceSlices
+// associated with the node a specific Pod is running on. This can be done
+// with a Validating Admission Policy (VAP). For more information,
+// see the deployment of the DRA example driver
+// (https://github.com/kubernetes-sigs/dra-example-driver/tree/main/deployments/helm/dra-example-driver/templates).
+//
+// Traditionally, the kubelet has not supported rolling updates of plugins.
+// Therefore the DaemonSet must not set `maxSurge` to a value larger than
+// zero. With the default `maxSurge: 0`, updating the DaemonSet of the driver
+// will first shut down the old driver Pod, then start the replacement.
+//
+// This leads to a short downtime for operations that need the driver:
+//   - Pods cannot start unless the claims they depend on were already
+//     prepared for use.
+//   - Cleanup after the last pod which used a claim gets delayed
+//     until the driver is available again. The pod is not marked
+//     as terminated. This prevents reusing the resources used by
+//     the pod for other pods.
+//   - Running pods are *not* affected as far as Kubernetes is
+//     concerned. However, a DRA driver might provide required runtime
+//     services. Vendors need to document this.
+//
+// Note that the second point also means that draining a node should
+// first evict normal pods, then the driver DaemonSet Pod.
+//
+// Starting with Kubernetes 1.33, the kubelet supports rolling updates
+// such that old and new Pod run at the same time for a short while
+// and hand over work gracefully, with no downtime.
+// However, there is no mechanism for determining in advance whether
+// the node the DaemonSet runs on supports that. Trying
+// to do a rolling update with a kubelet which does not support it yet
+// will fail because shutting down the old Pod unregisters the driver
+// even though the new Pod is running. See https://github.com/kubernetes/kubernetes/pull/129832
+// for details (TODO: link to doc after merging instead).
+//
+// A DRA driver can either require 1.33 as minimal Kubernetes version or
+// provide two variants of its DaemonSet deployment. In the variant with
+// support for rolling updates, `maxSurge` can be set to a non-zero
+// value. Administrators have to be careful about running the right variant.
 package kubeletplugin

--- a/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/endpoint.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/endpoint.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubeletplugin
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path"
+)
+
+// endpoint defines where and how to listen for incoming connections.
+// The listener always gets closed when shutting down.
+//
+// If the listen function is not set, a new listener for a Unix domain socket gets
+// created at the path.
+type endpoint struct {
+	dir, file  string
+	listenFunc func(ctx context.Context, socketpath string) (net.Listener, error)
+}
+
+func (e endpoint) path() string {
+	return path.Join(e.dir, e.file)
+}
+
+func (e endpoint) listen(ctx context.Context) (net.Listener, error) {
+	socketpath := e.path()
+
+	if e.listenFunc != nil {
+		return e.listenFunc(ctx, socketpath)
+	}
+
+	// Remove stale sockets, listen would fail otherwise.
+	if err := e.removeSocket(); err != nil {
+		return nil, err
+	}
+	cfg := net.ListenConfig{}
+	listener, err := cfg.Listen(ctx, "unix", socketpath)
+	if err != nil {
+		if removeErr := e.removeSocket(); removeErr != nil {
+			err = errors.Join(err, err)
+		}
+		return nil, err
+	}
+	return &unixListener{Listener: listener, endpoint: e}, nil
+}
+
+func (e endpoint) removeSocket() error {
+	if err := os.Remove(e.path()); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove Unix domain socket: %w", err)
+	}
+	return nil
+}
+
+// unixListener adds removing of the Unix domain socket on Close.
+type unixListener struct {
+	net.Listener
+	endpoint endpoint
+}
+
+func (l *unixListener) Close() error {
+	err := l.Listener.Close()
+	if removeErr := l.endpoint.removeSocket(); removeErr != nil {
+		err = errors.Join(err, err)
+	}
+	return err
+}

--- a/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/endpoint_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/endpoint_test.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubeletplugin
+
+import (
+	"context"
+	"net"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/kubernetes/test/utils/ktesting"
+)
+
+func TestEndpointLifecycle(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
+	tempDir := t.TempDir()
+	socketname := "test.sock"
+	e := endpoint{dir: tempDir, file: socketname}
+	listener, err := e.listen(ctx)
+	require.NoError(t, err, "listen")
+	assert.FileExists(t, path.Join(tempDir, socketname))
+	require.NoError(t, listener.Close(), "close")
+	assert.NoFileExists(t, path.Join(tempDir, socketname))
+}
+
+func TestEndpointListener(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
+	tempDir := t.TempDir()
+	socketname := "test.sock"
+	listen := func(ctx2 context.Context, socketpath string) (net.Listener, error) {
+		assert.Equal(t, path.Join(tempDir, socketname), socketpath)
+		return nil, nil
+	}
+	e := endpoint{dir: tempDir, file: socketname, listenFunc: listen}
+	listener, err := e.listen(ctx)
+	require.NoError(t, err, "listen")
+	assert.NoFileExists(t, path.Join(tempDir, socketname))
+	assert.Nil(t, listener)
+}

--- a/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/endpoint_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/endpoint_test.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"k8s.io/kubernetes/test/utils/ktesting"
+	"k8s.io/klog/v2/ktesting"
 )
 
 func TestEndpointLifecycle(t *testing.T) {

--- a/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/namespacedobject.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/namespacedobject.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubeletplugin
+
+import (
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// NamespacedObject comprises a resource name with a mandatory namespace
+// and optional UID. It gets rendered as "<namespace>/<name>:[<uid>]"
+// (text output) or as an object (JSON output).
+type NamespacedObject struct {
+	types.NamespacedName
+	UID types.UID
+}
+
+// String returns the general purpose string representation
+func (n NamespacedObject) String() string {
+	if n.UID != "" {
+		return n.Namespace + string(types.Separator) + n.Name + ":" + string(n.UID)
+	}
+	return n.Namespace + string(types.Separator) + n.Name
+}
+
+// MarshalLog emits a struct containing required key/value pair
+func (n NamespacedObject) MarshalLog() interface{} {
+	return struct {
+		Name      string    `json:"name"`
+		Namespace string    `json:"namespace,omitempty"`
+		UID       types.UID `json:"uid,omitempty"`
+	}{
+		Name:      n.Name,
+		Namespace: n.Namespace,
+		UID:       n.UID,
+	}
+}

--- a/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/noderegistrar.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/noderegistrar.go
@@ -17,10 +17,10 @@ limitations under the License.
 package kubeletplugin
 
 import (
-	"context"
 	"fmt"
 
 	"google.golang.org/grpc"
+	"k8s.io/klog/v2"
 	registerapi "k8s.io/kubelet/pkg/apis/pluginregistration/v1"
 )
 
@@ -30,17 +30,15 @@ type nodeRegistrar struct {
 }
 
 // startRegistrar returns a running instance.
-//
-// The context is only used for additional values, cancellation is ignored.
-func startRegistrar(valueCtx context.Context, grpcVerbosity int, interceptors []grpc.UnaryServerInterceptor, streamInterceptors []grpc.StreamServerInterceptor, driverName string, supportedServices []string, endpoint string, pluginRegistrationEndpoint endpoint) (*nodeRegistrar, error) {
+func startRegistrar(logger klog.Logger, grpcVerbosity int, interceptors []grpc.UnaryServerInterceptor, streamInterceptors []grpc.StreamServerInterceptor, driverName string, supportedServices []string, socketpath string, pluginRegistrationEndpoint endpoint) (*nodeRegistrar, error) {
 	n := &nodeRegistrar{
 		registrationServer: registrationServer{
 			driverName:        driverName,
-			endpoint:          endpoint,
+			endpoint:          socketpath,
 			supportedVersions: supportedServices, // DRA uses this field to describe provided services (e.g. "v1beta1.DRAPlugin").
 		},
 	}
-	s, err := startGRPCServer(valueCtx, grpcVerbosity, interceptors, streamInterceptors, pluginRegistrationEndpoint, func(grpcServer *grpc.Server) {
+	s, err := startGRPCServer(logger, grpcVerbosity, interceptors, streamInterceptors, pluginRegistrationEndpoint, func(grpcServer *grpc.Server) {
 		registerapi.RegisterRegistrationServer(grpcServer, n)
 	})
 	if err != nil {

--- a/test/e2e/dra/deploy.go
+++ b/test/e2e/dra/deploy.go
@@ -430,7 +430,6 @@ func (d *Driver) SetUp(nodes *Nodes, resources Resources, devicesPerNode ...map[
 			kubeletplugin.PluginListener(listen(ctx, d.f, pod.Name, "plugin", 9001)),
 			kubeletplugin.RegistrarListener(listen(ctx, d.f, pod.Name, "registrar", 9000)),
 			kubeletplugin.KubeletPluginSocketPath(draAddr),
-			kubeletplugin.NodeV1alpha4(d.NodeV1alpha4),
 			kubeletplugin.NodeV1beta1(d.NodeV1beta1),
 		)
 		framework.ExpectNoError(err, "start kubelet plugin for node %s", pod.Spec.NodeName)

--- a/test/e2e/dra/dra.go
+++ b/test/e2e/dra/dra.go
@@ -1737,15 +1737,13 @@ var _ = framework.SIGDescribe("node")("DRA", feature.DynamicResourceAllocation, 
 		})
 	})
 
-	multipleDrivers := func(nodeV1alpha4, nodeV1beta1 bool) {
+	multipleDrivers := func(nodeV1beta1 bool) {
 		nodes := NewNodes(f, 1, 4)
 		driver1 := NewDriver(f, nodes, perNode(2, nodes))
-		driver1.NodeV1alpha4 = nodeV1alpha4
 		driver1.NodeV1beta1 = nodeV1beta1
 		b1 := newBuilder(f, driver1)
 
 		driver2 := NewDriver(f, nodes, perNode(2, nodes))
-		driver2.NodeV1alpha4 = nodeV1alpha4
 		driver2.NodeV1beta1 = nodeV1beta1
 		driver2.NameSuffix = "-other"
 		b2 := newBuilder(f, driver2)
@@ -1769,16 +1767,14 @@ var _ = framework.SIGDescribe("node")("DRA", feature.DynamicResourceAllocation, 
 			b1.testPod(ctx, f, pod)
 		})
 	}
-	multipleDriversContext := func(prefix string, nodeV1alpha4, nodeV1beta1 bool) {
+	multipleDriversContext := func(prefix string, nodeV1beta1 bool) {
 		ginkgo.Context(prefix, func() {
-			multipleDrivers(nodeV1alpha4, nodeV1beta1)
+			multipleDrivers(nodeV1beta1)
 		})
 	}
 
 	ginkgo.Context("multiple drivers", func() {
-		multipleDriversContext("using only drapbv1alpha4", true, false)
-		multipleDriversContext("using only drapbv1beta1", false, true)
-		multipleDriversContext("using both drav1alpha4 and drapbv1beta1", true, true)
+		multipleDriversContext("using only drapbv1beta1", true)
 	})
 
 	ginkgo.It("runs pod after driver starts", func(ctx context.Context) {

--- a/test/e2e/dra/test-driver/README.md
+++ b/test/e2e/dra/test-driver/README.md
@@ -60,7 +60,11 @@ RUNTIME_CONFIG="resource.k8s.io/v1alpha3" FEATURE_GATES=DynamicResourceAllocatio
 
 In another:
 ```
-sudo mkdir -p /var/run/cdi && sudo chmod a+rwx /var/run/cdi /var/lib/kubelet/plugins_registry
+sudo mkdir -p /var/run/cdi
+sudo mkdir -p /var/lib/kubelet/plugins
+sudo mkdir -p /var/lib/kubelet/plugins_registry
+sudo chmod a+rx /var/lib/kubelet /var/lib/kubelet/plugins
+sudo chmod a+rwx /var/run/cdi /var/lib/kubelet/plugins_registry
 KUBECONFIG=/var/run/kubernetes/admin.kubeconfig go run ./test/e2e/dra/test-driver -v=5 kubelet-plugin --node-name=127.0.0.1
 ```
 

--- a/test/e2e/dra/test-driver/README.md
+++ b/test/e2e/dra/test-driver/README.md
@@ -61,10 +61,10 @@ RUNTIME_CONFIG="resource.k8s.io/v1alpha3" FEATURE_GATES=DynamicResourceAllocatio
 In another:
 ```
 sudo mkdir -p /var/run/cdi
-sudo mkdir -p /var/lib/kubelet/plugins
+sudo mkdir -p /var/lib/kubelet/plugins/test-driver.cdi.k8s.io
 sudo mkdir -p /var/lib/kubelet/plugins_registry
 sudo chmod a+rx /var/lib/kubelet /var/lib/kubelet/plugins
-sudo chmod a+rwx /var/run/cdi /var/lib/kubelet/plugins_registry
+sudo chmod a+rwx /var/run/cdi /var/lib/kubelet/plugins_registry /var/lib/kubelet/plugins/test-driver.cdi.k8s.io
 KUBECONFIG=/var/run/kubernetes/admin.kubeconfig go run ./test/e2e/dra/test-driver -v=5 kubelet-plugin --node-name=127.0.0.1
 ```
 

--- a/test/e2e/dra/test-driver/app/kubeletplugin.go
+++ b/test/e2e/dra/test-driver/app/kubeletplugin.go
@@ -40,15 +40,13 @@ import (
 	"k8s.io/dynamic-resource-allocation/resourceclaim"
 	"k8s.io/dynamic-resource-allocation/resourceslice"
 	"k8s.io/klog/v2"
-	drapbv1alpha4 "k8s.io/kubelet/pkg/apis/dra/v1alpha4"
-	drapb "k8s.io/kubelet/pkg/apis/dra/v1beta1"
 )
 
 type ExamplePlugin struct {
 	stopCh     <-chan struct{}
 	logger     klog.Logger
 	kubeClient kubernetes.Interface
-	d          kubeletplugin.DRAPlugin
+	d          *kubeletplugin.Helper
 	fileOps    FileOperations
 
 	cdiDir      string
@@ -56,8 +54,11 @@ type ExamplePlugin struct {
 	nodeName    string
 	deviceNames sets.Set[string]
 
+	// The mutex is needed because there are other goroutines checking the state.
+	// Serializing in the gRPC server alone is not enough because writing would
+	// race with reading.
 	mutex     sync.Mutex
-	prepared  map[ClaimID][]Device // prepared claims -> result of nodePrepareResource
+	prepared  map[ClaimID][]kubeletplugin.Device // prepared claims -> result of nodePrepareResource
 	gRPCCalls []GRPCCall
 
 	blockPrepareResourcesMutex   sync.Mutex
@@ -89,7 +90,7 @@ type GRPCCall struct {
 // sufficient to make the ClaimID unique.
 type ClaimID struct {
 	Name string
-	UID  string
+	UID  types.UID
 }
 
 type Device struct {
@@ -99,10 +100,10 @@ type Device struct {
 	CDIDeviceID string
 }
 
-var _ drapb.DRAPluginServer = &ExamplePlugin{}
+var _ kubeletplugin.DRAPlugin = &ExamplePlugin{}
 
 // getJSONFilePath returns the absolute path where CDI file is/should be.
-func (ex *ExamplePlugin) getJSONFilePath(claimUID string, requestName string) string {
+func (ex *ExamplePlugin) getJSONFilePath(claimUID types.UID, requestName string) string {
 	baseRequestRef := resourceclaim.BaseRequestRef(requestName)
 	return filepath.Join(ex.cdiDir, fmt.Sprintf("%s-%s-%s.json", ex.driverName, claimUID, baseRequestRef))
 }
@@ -151,7 +152,7 @@ func StartPlugin(ctx context.Context, cdiDir, driverName string, kubeClient kube
 		cdiDir:      cdiDir,
 		driverName:  driverName,
 		nodeName:    nodeName,
-		prepared:    make(map[ClaimID][]Device),
+		prepared:    make(map[ClaimID][]kubeletplugin.Device),
 		deviceNames: sets.New[string](),
 	}
 
@@ -167,16 +168,9 @@ func StartPlugin(ctx context.Context, cdiDir, driverName string, kubeClient kube
 		kubeletplugin.KubeClient(kubeClient),
 		kubeletplugin.GRPCInterceptor(ex.recordGRPCCall),
 		kubeletplugin.GRPCStreamInterceptor(ex.recordGRPCStream),
+		kubeletplugin.Serialize(false), // The example plugin does its own locking.
 	)
-	// Both APIs get provided, the legacy one via wrapping. The options
-	// determine which one(s) really get served (by default, both).
-	// The options are a bit redundant now because a single instance cannot
-	// implement both, but that might be different in the future.
-	nodeServers := []any{
-		drapb.DRAPluginServer(ex), // Casting is done only for clarity here, it's not needed.
-		drapbv1alpha4.V1Beta1ServerWrapper{DRAPluginServer: ex},
-	}
-	d, err := kubeletplugin.Start(ctx, nodeServers, opts...)
+	d, err := kubeletplugin.Start(ctx, ex, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("start kubelet plugin: %w", err)
 	}
@@ -300,34 +294,21 @@ func (ex *ExamplePlugin) getUnprepareResourcesFailure() error {
 // a deterministic name to simplify NodeUnprepareResource (no need to remember
 // or discover the name) and idempotency (when called again, the file simply
 // gets written again).
-func (ex *ExamplePlugin) nodePrepareResource(ctx context.Context, claimReq *drapb.Claim) ([]Device, error) {
+func (ex *ExamplePlugin) nodePrepareResource(ctx context.Context, claim *resourceapi.ResourceClaim) ([]kubeletplugin.Device, error) {
 	logger := klog.FromContext(ctx)
-
-	// The plugin must retrieve the claim itself to get it in the version
-	// that it understands.
-	claim, err := ex.kubeClient.ResourceV1beta1().ResourceClaims(claimReq.Namespace).Get(ctx, claimReq.Name, metav1.GetOptions{})
-	if err != nil {
-		return nil, fmt.Errorf("retrieve claim %s/%s: %w", claimReq.Namespace, claimReq.Name, err)
-	}
-	if claim.Status.Allocation == nil {
-		return nil, fmt.Errorf("claim %s/%s not allocated", claimReq.Namespace, claimReq.Name)
-	}
-	if claim.UID != types.UID(claimReq.UID) {
-		return nil, fmt.Errorf("claim %s/%s got replaced", claimReq.Namespace, claimReq.Name)
-	}
 
 	ex.mutex.Lock()
 	defer ex.mutex.Unlock()
 	ex.blockPrepareResourcesMutex.Lock()
 	defer ex.blockPrepareResourcesMutex.Unlock()
 
-	claimID := ClaimID{Name: claimReq.Name, UID: claimReq.UID}
+	claimID := ClaimID{Name: claim.Name, UID: claim.UID}
 	if result, ok := ex.prepared[claimID]; ok {
 		// Idempotent call, nothing to do.
 		return result, nil
 	}
 
-	var devices []Device
+	var devices []kubeletplugin.Device
 	for _, result := range claim.Status.Allocation.Devices.Results {
 		// Only handle allocations for the current driver.
 		if ex.driverName != result.Driver {
@@ -356,7 +337,7 @@ func (ex *ExamplePlugin) nodePrepareResource(ctx context.Context, claimReq *drap
 		claimReqName = regexp.MustCompile(`[^a-zA-Z0-9]`).ReplaceAllString(claimReqName, "_")
 		env[claimReqName] = "true"
 
-		deviceName := "claim-" + claimReq.UID + "-" + baseRequestName
+		deviceName := "claim-" + string(claim.UID) + "-" + baseRequestName
 		vendor := ex.driverName
 		class := "test"
 		cdiDeviceID := vendor + "/" + class + "=" + deviceName
@@ -391,7 +372,7 @@ func (ex *ExamplePlugin) nodePrepareResource(ctx context.Context, claimReq *drap
 				},
 			},
 		}
-		filePath := ex.getJSONFilePath(claimReq.UID, baseRequestName)
+		filePath := ex.getJSONFilePath(claim.UID, baseRequestName)
 		buffer, err := json.Marshal(spec)
 		if err != nil {
 			return nil, fmt.Errorf("marshal spec: %w", err)
@@ -399,11 +380,11 @@ func (ex *ExamplePlugin) nodePrepareResource(ctx context.Context, claimReq *drap
 		if err := ex.fileOps.Create(filePath, buffer); err != nil {
 			return nil, fmt.Errorf("failed to write CDI file: %w", err)
 		}
-		device := Device{
-			PoolName:    result.Pool,
-			DeviceName:  result.Device,
-			RequestName: baseRequestName,
-			CDIDeviceID: cdiDeviceID,
+		device := kubeletplugin.Device{
+			PoolName:     result.Pool,
+			DeviceName:   result.Device,
+			Requests:     []string{result.Request}, // May also return baseRequestName here.
+			CDIDeviceIDs: []string{cdiDeviceID},
 		}
 		devices = append(devices, device)
 	}
@@ -434,48 +415,35 @@ func extractParameters(parameters runtime.RawExtension, env *map[string]string, 
 	return nil
 }
 
-func (ex *ExamplePlugin) NodePrepareResources(ctx context.Context, req *drapb.NodePrepareResourcesRequest) (*drapb.NodePrepareResourcesResponse, error) {
-	resp := &drapb.NodePrepareResourcesResponse{
-		Claims: make(map[string]*drapb.NodePrepareResourceResponse),
-	}
-
+func (ex *ExamplePlugin) PrepareResourceClaims(ctx context.Context, claims []*resourceapi.ResourceClaim) (map[types.UID]kubeletplugin.PrepareResult, error) {
 	if failure := ex.getPrepareResourcesFailure(); failure != nil {
-		return resp, failure
+		return nil, failure
 	}
 
-	for _, claimReq := range req.Claims {
-		devices, err := ex.nodePrepareResource(ctx, claimReq)
+	result := make(map[types.UID]kubeletplugin.PrepareResult)
+	for _, claim := range claims {
+		devices, err := ex.nodePrepareResource(ctx, claim)
+		var claimResult kubeletplugin.PrepareResult
 		if err != nil {
-			resp.Claims[claimReq.UID] = &drapb.NodePrepareResourceResponse{
-				Error: err.Error(),
-			}
+			claimResult.Err = err
 		} else {
-			r := &drapb.NodePrepareResourceResponse{}
-			for _, device := range devices {
-				pbDevice := &drapb.Device{
-					PoolName:     device.PoolName,
-					DeviceName:   device.DeviceName,
-					RequestNames: []string{device.RequestName},
-					CDIDeviceIDs: []string{device.CDIDeviceID},
-				}
-				r.Devices = append(r.Devices, pbDevice)
-			}
-			resp.Claims[claimReq.UID] = r
+			claimResult.Devices = devices
 		}
+		result[claim.UID] = claimResult
 	}
-	return resp, nil
+	return result, nil
 }
 
 // NodeUnprepareResource removes the CDI file created by
 // NodePrepareResource. It's idempotent, therefore it is not an error when that
 // file is already gone.
-func (ex *ExamplePlugin) nodeUnprepareResource(ctx context.Context, claimReq *drapb.Claim) error {
+func (ex *ExamplePlugin) nodeUnprepareResource(ctx context.Context, claimRef kubeletplugin.NamespacedObject) error {
 	ex.blockUnprepareResourcesMutex.Lock()
 	defer ex.blockUnprepareResourcesMutex.Unlock()
 
 	logger := klog.FromContext(ctx)
 
-	claimID := ClaimID{Name: claimReq.Name, UID: claimReq.UID}
+	claimID := ClaimID{Name: claimRef.Name, UID: claimRef.UID}
 	devices, ok := ex.prepared[claimID]
 	if !ok {
 		// Idempotent call, nothing to do.
@@ -483,11 +451,14 @@ func (ex *ExamplePlugin) nodeUnprepareResource(ctx context.Context, claimReq *dr
 	}
 
 	for _, device := range devices {
-		filePath := ex.getJSONFilePath(claimReq.UID, device.RequestName)
-		if err := ex.fileOps.Remove(filePath); err != nil {
-			return fmt.Errorf("error removing CDI file: %w", err)
+		// In practice we only prepare one, but let's not assume that here.
+		for _, request := range device.Requests {
+			filePath := ex.getJSONFilePath(claimRef.UID, request)
+			if err := ex.fileOps.Remove(filePath); err != nil {
+				return fmt.Errorf("error removing CDI file: %w", err)
+			}
+			logger.V(3).Info("CDI file removed", "path", filePath)
 		}
-		logger.V(3).Info("CDI file removed", "path", filePath)
 	}
 
 	delete(ex.prepared, claimID)
@@ -495,26 +466,18 @@ func (ex *ExamplePlugin) nodeUnprepareResource(ctx context.Context, claimReq *dr
 	return nil
 }
 
-func (ex *ExamplePlugin) NodeUnprepareResources(ctx context.Context, req *drapb.NodeUnprepareResourcesRequest) (*drapb.NodeUnprepareResourcesResponse, error) {
-	resp := &drapb.NodeUnprepareResourcesResponse{
-		Claims: make(map[string]*drapb.NodeUnprepareResourceResponse),
-	}
+func (ex *ExamplePlugin) UnprepareResourceClaims(ctx context.Context, claims []kubeletplugin.NamespacedObject) (map[types.UID]error, error) {
+	result := make(map[types.UID]error)
 
 	if failure := ex.getUnprepareResourcesFailure(); failure != nil {
-		return resp, failure
+		return nil, failure
 	}
 
-	for _, claimReq := range req.Claims {
-		err := ex.nodeUnprepareResource(ctx, claimReq)
-		if err != nil {
-			resp.Claims[claimReq.UID] = &drapb.NodeUnprepareResourceResponse{
-				Error: err.Error(),
-			}
-		} else {
-			resp.Claims[claimReq.UID] = &drapb.NodeUnprepareResourceResponse{}
-		}
+	for _, claimRef := range claims {
+		err := ex.nodeUnprepareResource(ctx, claimRef)
+		result[claimRef.UID] = err
 	}
-	return resp, nil
+	return result, nil
 }
 
 func (ex *ExamplePlugin) GetPreparedResources() []ClaimID {

--- a/test/e2e/testing-manifests/dra/dra-test-driver-proxy.yaml
+++ b/test/e2e/testing-manifests/dra/dra-test-driver-proxy.yaml
@@ -50,29 +50,32 @@ spec:
           image: registry.k8s.io/sig-storage/hostpathplugin:v1.7.3
           args:
             - "--v=5"
-            - "--endpoint=/plugins_registry/dra-test-driver-reg.sock"
+            - "--endpoint=/var/lib/kubelet/plugins_registry/test-driver.dra.k8s.io-reg.sock"
             - "--proxy-endpoint=tcp://:9000"
           volumeMounts:
-            - mountPath: /plugins_registry
+            - mountPath: /var/lib/kubelet/plugins_registry
               name: registration-dir
 
         - name: plugin
           image: registry.k8s.io/sig-storage/hostpathplugin:v1.7.3
           args:
             - "--v=5"
-            - "--endpoint=/dra/dra-test-driver.sock"
+            - "--endpoint=/var/lib/kubelet/plugins/test-driver.dra.k8s.io/dra.sock"
             - "--proxy-endpoint=tcp://:9001"
           securityContext:
             privileged: true
           volumeMounts:
-            - mountPath: /dra
+            - mountPath: /var/lib/kubelet/plugins/test-driver.dra.k8s.io
               name: socket-dir
             - mountPath: /cdi
               name: cdi-dir
 
       volumes:
         - hostPath:
-            path: /var/lib/kubelet/plugins
+            # There's no way to remove this. Conceptually, it may have to
+            # survive Pod restarts and there's no way to tell the kubelet
+            # that this isn't the case for this Pod.
+            path: /var/lib/kubelet/plugins/test-driver.dra.k8s.io
             type: DirectoryOrCreate
           name: socket-dir
         - hostPath:

--- a/test/e2e/testing-manifests/dra/dra-test-driver-proxy.yaml
+++ b/test/e2e/testing-manifests/dra/dra-test-driver-proxy.yaml
@@ -46,29 +46,21 @@ spec:
             topologyKey: kubernetes.io/hostname
 
       containers:
-        - name: registrar
+        - name: pause
           image: registry.k8s.io/sig-storage/hostpathplugin:v1.7.3
-          args:
-            - "--v=5"
-            - "--endpoint=/var/lib/kubelet/plugins_registry/test-driver.dra.k8s.io-reg.sock"
-            - "--proxy-endpoint=tcp://:9000"
-          volumeMounts:
-            - mountPath: /var/lib/kubelet/plugins_registry
-              name: registration-dir
-
-        - name: plugin
-          image: registry.k8s.io/sig-storage/hostpathplugin:v1.7.3
-          args:
-            - "--v=5"
-            - "--endpoint=/var/lib/kubelet/plugins/test-driver.dra.k8s.io/dra.sock"
-            - "--proxy-endpoint=tcp://:9001"
-          securityContext:
-            privileged: true
+          command:
+            - /bin/sh
+            - -c
+            - while true; do sleep 10000; done
           volumeMounts:
             - mountPath: /var/lib/kubelet/plugins/test-driver.dra.k8s.io
               name: socket-dir
+            - mountPath: /var/lib/kubelet/plugins_registry
+              name: registration-dir
             - mountPath: /cdi
               name: cdi-dir
+          securityContext:
+            privileged: true
 
       volumes:
         - hostPath:
@@ -79,10 +71,10 @@ spec:
             type: DirectoryOrCreate
           name: socket-dir
         - hostPath:
-            path: /var/run/cdi
-            type: DirectoryOrCreate
-          name: cdi-dir
-        - hostPath:
             path: /var/lib/kubelet/plugins_registry
             type: DirectoryOrCreate
           name: registration-dir
+        - hostPath:
+            path: /var/run/cdi
+            type: DirectoryOrCreate
+          name: cdi-dir

--- a/test/e2e_node/dra_test.go
+++ b/test/e2e_node/dra_test.go
@@ -29,7 +29,6 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
@@ -62,8 +61,6 @@ const (
 	kubeletPlugin1Name        = "test-driver1.cdi.k8s.io"
 	kubeletPlugin2Name        = "test-driver2.cdi.k8s.io"
 	cdiDir                    = "/var/run/cdi"
-	endpointTemplate          = "/var/lib/kubelet/plugins/%s/dra.sock"
-	pluginRegistrationPath    = "/var/lib/kubelet/plugins_registry"
 	pluginRegistrationTimeout = time.Second * 60 // how long to wait for a node plugin to be registered
 	podInPendingStateTimeout  = time.Second * 60 // how long to wait for a pod to stay in pending state
 
@@ -554,9 +551,9 @@ func newKubeletPlugin(ctx context.Context, clientSet kubernetes.Interface, nodeN
 	// creating those directories.
 	err := os.MkdirAll(cdiDir, os.FileMode(0750))
 	framework.ExpectNoError(err, "create CDI directory")
-	endpoint := fmt.Sprintf(endpointTemplate, pluginName)
-	err = os.MkdirAll(filepath.Dir(endpoint), 0750)
-	framework.ExpectNoError(err, "create socket directory")
+	datadir := path.Join(kubeletplugin.KubeletPluginsDir, pluginName) // The default, not set below.
+	err = os.MkdirAll(datadir, 0750)
+	framework.ExpectNoError(err, "create DRA socket directory")
 
 	plugin, err := testdriver.StartPlugin(
 		ctx,
@@ -565,9 +562,6 @@ func newKubeletPlugin(ctx context.Context, clientSet kubernetes.Interface, nodeN
 		clientSet,
 		nodeName,
 		testdriver.FileOperations{},
-		kubeletplugin.PluginSocketPath(endpoint),
-		kubeletplugin.RegistrarSocketPath(path.Join(pluginRegistrationPath, pluginName+"-reg.sock")),
-		kubeletplugin.KubeletPluginSocketPath(endpoint),
 	)
 	framework.ExpectNoError(err)
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

The goal is to simplify writing DRA drivers. This is also a first step towards supporting seamless upgrades.

DRA drivers no longer need to implement the kubelet plugin API directly. Instead, the helper wraps an implementation of an interface. The helper then provides common functionality:

- retrieve and validate ResourceClaims
- serialize gRPC calls (enabled by default, can be opted out)
- gRPC logging

The definition of that interface is meant to be comprehensive enough that a correct DRA driver can be implemented by following the documentation of the package, without having to cross-reference KEPs.

#### Which issue(s) this PR fixes:
Related-to: https://github.com/kubernetes/kubernetes/issues/128964

#### Special notes for your reviewer:

The DRAPlugin interface used to be the abstract API of the helper. Now it's what the DRA driver kubelet plugin needs to implement. The helper is a concrete Server struct with no exported fields. It only exports the methods that drivers need when using the helper.

While at it, support for the v1alpha4 API gets removed from the helper, which implies removing the corresponding E2E tests. The kubelet implementation will be dropped separately.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/cc @byako @elezar @bart0sh 