### PR TITLE
[PodLevelResources] Limit Range Pod type defaults

### DIFF
--- a/pkg/apis/core/v1/defaults.go
+++ b/pkg/apis/core/v1/defaults.go
@@ -363,8 +363,8 @@ func SetDefaults_ObjectFieldSelector(obj *v1.ObjectFieldSelector) {
 }
 func SetDefaults_LimitRangeItem(obj *v1.LimitRangeItem) {
 	// for container limits, we apply default values
-	if obj.Type == v1.LimitTypeContainer {
-
+	// for pod limits, we apply default values if PodLevelResources feature is enabled
+	if obj.Type == v1.LimitTypeContainer || (obj.Type == v1.LimitTypePod && utilfeature.DefaultFeatureGate.Enabled(features.PodLevelResources)) {
 		if obj.Default == nil {
 			obj.Default = make(v1.ResourceList)
 		}

--- a/pkg/apis/core/v1/defaults.go
+++ b/pkg/apis/core/v1/defaults.go
@@ -363,8 +363,7 @@ func SetDefaults_ObjectFieldSelector(obj *v1.ObjectFieldSelector) {
 }
 func SetDefaults_LimitRangeItem(obj *v1.LimitRangeItem) {
 	// for container limits, we apply default values
-	// for pod limits, we apply default values if PodLevelResources feature is enabled
-	if obj.Type == v1.LimitTypeContainer || (obj.Type == v1.LimitTypePod && utilfeature.DefaultFeatureGate.Enabled(features.PodLevelResources)) {
+	if obj.Type == v1.LimitTypeContainer {
 		if obj.Default == nil {
 			obj.Default = make(v1.ResourceList)
 		}

--- a/pkg/apis/core/v1/defaults_test.go
+++ b/pkg/apis/core/v1/defaults_test.go
@@ -2825,23 +2825,14 @@ func TestDefaultRequestIsNotSetForReplicationController(t *testing.T) {
 	}
 }
 
-func TestSetDefaultLimitRangeContainer(t *testing.T) {
-	testSetDefaultLimitRange(t, v1.LimitTypeContainer)
-}
-
-func TestSetDefaultLimitRangePod(t *testing.T) {
-	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PodLevelResources, true)
-	testSetDefaultLimitRange(t, v1.LimitTypePod)
-}
-
-func testSetDefaultLimitRange(t *testing.T, limitType v1.LimitType) {
+func TestSetDefaultLimitRangeItem(t *testing.T) {
 	limitRange := &v1.LimitRange{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-defaults",
 		},
 		Spec: v1.LimitRangeSpec{
 			Limits: []v1.LimitRangeItem{{
-				Type: limitType,
+				Type: v1.LimitTypeContainer,
 				Max: v1.ResourceList{
 					v1.ResourceCPU: resource.MustParse("100m"),
 				},

--- a/pkg/apis/core/v1/defaults_test.go
+++ b/pkg/apis/core/v1/defaults_test.go
@@ -2825,14 +2825,23 @@ func TestDefaultRequestIsNotSetForReplicationController(t *testing.T) {
 	}
 }
 
-func TestSetDefaultLimitRangeItem(t *testing.T) {
+func TestSetDefaultLimitRangeContainer(t *testing.T) {
+	testSetDefaultLimitRange(t, v1.LimitTypeContainer)
+}
+
+func TestSetDefaultLimitRangePod(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PodLevelResources, true)
+	testSetDefaultLimitRange(t, v1.LimitTypePod)
+}
+
+func testSetDefaultLimitRange(t *testing.T, limitType v1.LimitType) {
 	limitRange := &v1.LimitRange{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-defaults",
 		},
 		Spec: v1.LimitRangeSpec{
 			Limits: []v1.LimitRangeItem{{
-				Type: v1.LimitTypeContainer,
+				Type: limitType,
 				Max: v1.ResourceList{
 					v1.ResourceCPU: resource.MustParse("100m"),
 				},

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -6781,7 +6781,8 @@ func ValidateLimitRange(limitRange *core.LimitRange) field.ErrorList {
 			min[string(k)] = q
 		}
 
-		if limit.Type == core.LimitTypePod {
+		// We allow default and defaultRequest when Pod Level Resources are enabled
+		if limit.Type == core.LimitTypePod && !utilfeature.DefaultFeatureGate.Enabled(features.PodLevelResources) {
 			if len(limit.Default) > 0 {
 				allErrs = append(allErrs, field.Forbidden(idxPath.Child("default"), "may not be specified when `type` is 'Pod'"))
 			}

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -19066,7 +19066,7 @@ func TestValidateLimitRangeForLocalStorage(t *testing.T) {
 
 	for _, testCase := range testCases {
 		limitRange := &core.LimitRange{ObjectMeta: metav1.ObjectMeta{Name: testCase.name, Namespace: "foo"}, Spec: testCase.spec}
-		if errs := ValidateLimitRange(limitRange); len(errs) != 0 {
+		if errs := ValidateLimitRange(limitRange, false); len(errs) != 0 {
 			t.Errorf("Case %v, unexpected error: %v", testCase.name, errs)
 		}
 	}
@@ -19323,7 +19323,6 @@ func TestValidateLimitRange(t *testing.T) {
 			}
 		}
 	}
-
 }
 
 func TestValidatePersistentVolumeClaimStatusUpdate(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR implements Limit Ranger Pod Level Resources that require following changes:
1. Limit Range pod type support default and defaultRequest
1. Unit tests for limit range pod defaults
1. End to end tests for limit range pod defaults

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
- Enabled defaults for limit ranger of pod type to set pod-level resources.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/2837-pod-level-resource-spec/README.md#admission-controller
```