### PR TITLE
Remove usage of assertion libraries in pkg/scheduler tests

### DIFF
--- a/pkg/scheduler/framework/autoscaler_contract/framework_contract_test.go
+++ b/pkg/scheduler/framework/autoscaler_contract/framework_contract_test.go
@@ -24,7 +24,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/google/go-cmp/cmp"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -42,20 +42,26 @@ type frameworkContract interface {
 func TestFrameworkContract(t *testing.T) {
 	var f framework.Framework
 	var c frameworkContract = f
-	assert.Nil(t, c)
+	if !cmp.Equal(c, nil) {
+		t.Errorf("Expected nil, but got: %+v", c)
+	}
+
 }
 
 func TestNewFramework(t *testing.T) {
 	_, ctx := ktesting.NewTestContext(t)
 	var f interface{}
 	if f, _ = runtime.NewFramework(ctx, nil, nil); f != nil {
-		_, ok := f.(framework.Framework)
-		assert.True(t, ok)
+		if _, ok := f.(framework.Framework); !ok {
+			t.Errorf("Expected f to be of type framework.Framework, but got: %T", f)
+		}
 	}
 }
 
 func TestNewCycleState(t *testing.T) {
 	var state interface{} = framework.NewCycleState()
-	_, ok := state.(*framework.CycleState)
-	assert.True(t, ok)
+	if _, ok := state.(*framework.CycleState); !ok {
+		t.Errorf("Expected state to be of type *framework.CycleState, but got: %T", state)
+	}
+
 }

--- a/pkg/scheduler/framework/plugins/noderesources/requested_to_capacity_ratio_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/requested_to_capacity_ratio_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/stretchr/testify/assert"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -214,7 +213,13 @@ func TestBrokenLinearFunction(t *testing.T) {
 		t.Run(fmt.Sprintf("case_%d", i), func(t *testing.T) {
 			function := helper.BuildBrokenLinearFunction(test.points)
 			for _, assertion := range test.assertions {
-				assert.InDelta(t, assertion.expected, function(assertion.p), 0.1, "points=%v, p=%d", test.points, assertion.p)
+				actual := function(assertion.p)
+				delta := 0.1
+				expectedAsFloat := float64(assertion.expected)
+				actualAsFloat := float64(actual)
+				if (expectedAsFloat-actualAsFloat) > delta || (actualAsFloat-expectedAsFloat) > delta {
+					t.Errorf("Mismatch in values with delta threshold (%.2f): expected %.2f, actual %.2f", delta, expectedAsFloat, actualAsFloat)
+				}
 			}
 		})
 	}

--- a/pkg/scheduler/framework/plugins/volumebinding/volume_binding_test.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/volume_binding_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -778,8 +777,12 @@ func TestVolumeBinding(t *testing.T) {
 
 			t.Logf("Verify: call PreFilter and check status")
 			gotPreFilterResult, gotPreFilterStatus := p.PreFilter(ctx, state, item.pod)
-			assert.Equal(t, item.wantPreFilterStatus, gotPreFilterStatus)
-			assert.Equal(t, item.wantPreFilterResult, gotPreFilterResult)
+			if diff := cmp.Diff(item.wantPreFilterStatus, gotPreFilterStatus); diff != "" {
+				t.Errorf("Mismatch in wantPreFilterStatus (- expected, + actual):\n%s", diff)
+			}
+			if diff := cmp.Diff(item.wantPreFilterResult, gotPreFilterResult); diff != "" {
+				t.Errorf("Mismatch in wantPreFilterResult (- expected, + actual):\n%s", diff)
+			}
 
 			if !gotPreFilterStatus.IsSuccess() {
 				// scheduler framework will skip Filter if PreFilter fails
@@ -809,7 +812,9 @@ func TestVolumeBinding(t *testing.T) {
 			t.Logf("Verify: call Filter and check status")
 			for i, nodeInfo := range nodeInfos {
 				gotStatus := p.Filter(ctx, state, item.pod, nodeInfo)
-				assert.Equal(t, item.wantFilterStatus[i], gotStatus)
+				if diff := cmp.Diff(item.wantFilterStatus[i], gotStatus); diff != "" {
+					t.Errorf("Mismatch in wantFilterStatus[%d] (-want,+got):\n%s", i, diff)
+				}
 			}
 
 			t.Logf("Verify: call PreScore and check status")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/sig scheduling

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it: 
Removed the usage of assertion libraries as per the [style guide](https://github.com/kubernetes/community/blob/master/sig-scheduling/CONTRIBUTING.md#technical-and-style-guidelines)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #130407

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
