### PR TITLE
Use generic set in pkg/controller/nodelifecycle

### DIFF
--- a/pkg/controller/nodelifecycle/scheduler/rate_limited_queue.go
+++ b/pkg/controller/nodelifecycle/scheduler/rate_limited_queue.go
@@ -81,7 +81,7 @@ func (h *TimedQueue) Pop() interface{} {
 type UniqueQueue struct {
 	lock  sync.Mutex
 	queue TimedQueue
-	set   sets.String
+	set   sets.Set[string]
 }
 
 // Add a new value to the queue if it wasn't added before, or was
@@ -189,7 +189,7 @@ func (q *UniqueQueue) Clear() {
 		q.queue = make(TimedQueue, 0)
 	}
 	if len(q.set) > 0 {
-		q.set = sets.NewString()
+		q.set = sets.New[string]()
 	}
 }
 
@@ -207,7 +207,7 @@ func NewRateLimitedTimedQueue(limiter flowcontrol.RateLimiter) *RateLimitedTimed
 	return &RateLimitedTimedQueue{
 		queue: UniqueQueue{
 			queue: TimedQueue{},
-			set:   sets.NewString(),
+			set:   sets.New[string](),
 		},
 		limiter: limiter,
 	}

--- a/pkg/controller/nodelifecycle/scheduler/rate_limited_queue_test.go
+++ b/pkg/controller/nodelifecycle/scheduler/rate_limited_queue_test.go
@@ -35,7 +35,7 @@ func CheckQueueEq(lhs []string, rhs TimedQueue) bool {
 	return true
 }
 
-func CheckSetEq(lhs, rhs sets.String) bool {
+func CheckSetEq(lhs, rhs sets.Set[string]) bool {
 	return lhs.IsSuperset(rhs) && rhs.IsSuperset(lhs)
 }
 
@@ -49,7 +49,7 @@ func TestUniqueQueueGet(t *testing.T) {
 
 	queue := UniqueQueue{
 		queue: TimedQueue{},
-		set:   sets.NewString(),
+		set:   sets.New[string](),
 	}
 	queue.Add(TimedValue{Value: "first", UID: "11111", AddedAt: now(), ProcessAt: now()})
 	queue.Add(TimedValue{Value: "second", UID: "22222", AddedAt: now(), ProcessAt: now()})
@@ -63,7 +63,7 @@ func TestUniqueQueueGet(t *testing.T) {
 		t.Errorf("Invalid queue. Got %v, expected %v", queue.queue, queuePattern)
 	}
 
-	setPattern := sets.NewString("first", "second", "third")
+	setPattern := sets.New[string]("first", "second", "third")
 	if len(queue.set) != len(setPattern) {
 		t.Fatalf("Map %v should have length %d", queue.set, len(setPattern))
 	}
@@ -80,7 +80,7 @@ func TestUniqueQueueGet(t *testing.T) {
 		t.Errorf("Invalid queue. Got %v, expected %v", queue.queue, queuePattern)
 	}
 
-	setPattern = sets.NewString("second", "third")
+	setPattern = sets.New[string]("second", "third")
 	if len(queue.set) != len(setPattern) {
 		t.Fatalf("Map %v should have length %d", queue.set, len(setPattern))
 	}
@@ -103,7 +103,7 @@ func TestAddNode(t *testing.T) {
 		t.Errorf("Invalid queue. Got %v, expected %v", evictor.queue.queue, queuePattern)
 	}
 
-	setPattern := sets.NewString("first", "second", "third")
+	setPattern := sets.New[string]("first", "second", "third")
 	if len(evictor.queue.set) != len(setPattern) {
 		t.Fatalf("Map %v should have length %d", evictor.queue.set, len(setPattern))
 	}
@@ -134,7 +134,7 @@ func TestDelNode(t *testing.T) {
 		t.Errorf("Invalid queue. Got %v, expected %v", evictor.queue.queue, queuePattern)
 	}
 
-	setPattern := sets.NewString("second", "third")
+	setPattern := sets.New[string]("second", "third")
 	if len(evictor.queue.set) != len(setPattern) {
 		t.Fatalf("Map %v should have length %d", evictor.queue.set, len(setPattern))
 	}
@@ -156,7 +156,7 @@ func TestDelNode(t *testing.T) {
 		t.Errorf("Invalid queue. Got %v, expected %v", evictor.queue.queue, queuePattern)
 	}
 
-	setPattern = sets.NewString("first", "third")
+	setPattern = sets.New[string]("first", "third")
 	if len(evictor.queue.set) != len(setPattern) {
 		t.Fatalf("Map %v should have length %d", evictor.queue.set, len(setPattern))
 	}
@@ -178,7 +178,7 @@ func TestDelNode(t *testing.T) {
 		t.Errorf("Invalid queue. Got %v, expected %v", evictor.queue.queue, queuePattern)
 	}
 
-	setPattern = sets.NewString("first", "second")
+	setPattern = sets.New[string]("first", "second")
 	if len(evictor.queue.set) != len(setPattern) {
 		t.Fatalf("Map %v should have length %d", evictor.queue.set, len(setPattern))
 	}
@@ -194,14 +194,14 @@ func TestTry(t *testing.T) {
 	evictor.Add("third", "33333")
 	evictor.Remove("second")
 
-	deletedMap := sets.NewString()
+	deletedMap := sets.New[string]()
 	logger, _ := ktesting.NewTestContext(t)
 	evictor.Try(logger, func(value TimedValue) (bool, time.Duration) {
 		deletedMap.Insert(value.Value)
 		return true, 0
 	})
 
-	setPattern := sets.NewString("first", "third")
+	setPattern := sets.New[string]("first", "third")
 	if len(deletedMap) != len(setPattern) {
 		t.Fatalf("Map %v should have length %d", evictor.queue.set, len(setPattern))
 	}
@@ -371,14 +371,14 @@ func TestAddAfterTry(t *testing.T) {
 	evictor.Add("third", "33333")
 	evictor.Remove("second")
 
-	deletedMap := sets.NewString()
+	deletedMap := sets.New[string]()
 	logger, _ := ktesting.NewTestContext(t)
 	evictor.Try(logger, func(value TimedValue) (bool, time.Duration) {
 		deletedMap.Insert(value.Value)
 		return true, 0
 	})
 
-	setPattern := sets.NewString("first", "third")
+	setPattern := sets.New[string]("first", "third")
 	if len(deletedMap) != len(setPattern) {
 		t.Fatalf("Map %v should have length %d", evictor.queue.set, len(setPattern))
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR is for the sig/node sets.String usage cleanup and moving over to the new generic Set type.
ref: https://github.com/kubernetes/kubernetes/pull/116940

Firstly, I clean up `pkg/controller/nodelifecycle` directory.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #130719

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
