### PR TITLE
fix: shared informer typos

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
+++ b/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
@@ -735,7 +735,7 @@ func (s *sharedIndexInformer) HandleDeltas(obj interface{}, isInInitialList bool
 // Conforms to ResourceEventHandler
 func (s *sharedIndexInformer) OnAdd(obj interface{}, isInInitialList bool) {
 	// Invocation of this function is locked under s.blockDeltas, so it is
-	// save to distribute the notification
+	// safe to distribute the notification
 	s.cacheMutationDetector.AddObject(obj)
 	s.processor.distribute(addNotification{newObj: obj, isInInitialList: isInInitialList}, false)
 }
@@ -757,7 +757,7 @@ func (s *sharedIndexInformer) OnUpdate(old, new interface{}) {
 	}
 
 	// Invocation of this function is locked under s.blockDeltas, so it is
-	// save to distribute the notification
+	// safe to distribute the notification
 	s.cacheMutationDetector.AddObject(new)
 	s.processor.distribute(updateNotification{oldObj: old, newObj: new}, isSync)
 }
@@ -765,7 +765,7 @@ func (s *sharedIndexInformer) OnUpdate(old, new interface{}) {
 // Conforms to ResourceEventHandler
 func (s *sharedIndexInformer) OnDelete(old interface{}) {
 	// Invocation of this function is locked under s.blockDeltas, so it is
-	// save to distribute the notification
+	// safe to distribute the notification
 	s.processor.distribute(deleteNotification{oldObj: old}, false)
 }
 
@@ -1088,7 +1088,7 @@ func (p *processorListener) run() {
 	}
 }
 
-// shouldResync deterimines if the listener needs a resync. If the listener's resyncPeriod is 0,
+// shouldResync determines if the listener needs a resync. If the listener's resyncPeriod is 0,
 // this always returns false.
 func (p *processorListener) shouldResync(now time.Time) bool {
 	p.resyncLock.Lock()


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR fixes some typos in the comments of the shared informer code:

- Fixed `save` to  `safe`
- Fixed `deterimines ` to `determines `

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
