### PR TITLE
util/pointer->ptr for core v1 fuzzer and validation tests

### DIFF
--- a/pkg/apis/core/fuzzer/fuzzer.go
+++ b/pkg/apis/core/fuzzer/fuzzer.go
@@ -31,7 +31,7 @@ import (
 	runtimeserializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/kubernetes/pkg/apis/core"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 // Funcs returns the fuzzer functions for the core group.
@@ -528,7 +528,7 @@ var Funcs = func(codecs runtimeserializer.CodecFactory) []interface{} {
 				ss.SessionAffinityConfig = nil
 			}
 			if ss.AllocateLoadBalancerNodePorts == nil {
-				ss.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+				ss.AllocateLoadBalancerNodePorts = ptr.To(true)
 			}
 		},
 		func(s *core.NodeStatus, c randfill.Continue) {

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
+
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -48,7 +49,6 @@ import (
 	"k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/capabilities"
 	"k8s.io/kubernetes/pkg/features"
-	utilpointer "k8s.io/utils/pointer"
 	"k8s.io/utils/ptr"
 )
 
@@ -2758,7 +2758,7 @@ func TestValidatePersistentVolumeClaimUpdate(t *testing.T) {
 		Phase: core.ClaimBound,
 	})
 	validClaimEmptyVolumeAttributesClass := testVolumeClaimWithStatus("foo", "ns", core.PersistentVolumeClaimSpec{
-		VolumeAttributesClassName: utilpointer.String(""),
+		VolumeAttributesClassName: ptr.To(""),
 		AccessModes: []core.PersistentVolumeAccessMode{
 			core.ReadWriteOnce,
 			core.ReadOnlyMany,
@@ -2772,7 +2772,7 @@ func TestValidatePersistentVolumeClaimUpdate(t *testing.T) {
 		Phase: core.ClaimBound,
 	})
 	validClaimVolumeAttributesClass1 := testVolumeClaimWithStatus("foo", "ns", core.PersistentVolumeClaimSpec{
-		VolumeAttributesClassName: utilpointer.String("vac1"),
+		VolumeAttributesClassName: ptr.To("vac1"),
 		AccessModes: []core.PersistentVolumeAccessMode{
 			core.ReadWriteOnce,
 			core.ReadOnlyMany,
@@ -2786,7 +2786,7 @@ func TestValidatePersistentVolumeClaimUpdate(t *testing.T) {
 		Phase: core.ClaimBound,
 	})
 	validClaimVolumeAttributesClass2 := testVolumeClaimWithStatus("foo", "ns", core.PersistentVolumeClaimSpec{
-		VolumeAttributesClassName: utilpointer.String("vac2"),
+		VolumeAttributesClassName: ptr.To("vac2"),
 		AccessModes: []core.PersistentVolumeAccessMode{
 			core.ReadWriteOnce,
 			core.ReadOnlyMany,
@@ -3128,7 +3128,7 @@ func TestValidationOptionsForPersistentVolumeClaim(t *testing.T) {
 			},
 		},
 		"volume attributes class allowed because feature enable": {
-			oldPvc:                      pvcWithVolumeAttributesClassName(utilpointer.String("foo")),
+			oldPvc:                      pvcWithVolumeAttributesClassName(ptr.To("foo")),
 			enableVolumeAttributesClass: true,
 			expectValidationOpts: PersistentVolumeClaimSpecValidationOptions{
 				EnableRecoverFromExpansionFailure: true,
@@ -3136,7 +3136,7 @@ func TestValidationOptionsForPersistentVolumeClaim(t *testing.T) {
 			},
 		},
 		"volume attributes class validated because used and feature disabled": {
-			oldPvc:                      pvcWithVolumeAttributesClassName(utilpointer.String("foo")),
+			oldPvc:                      pvcWithVolumeAttributesClassName(ptr.To("foo")),
 			enableVolumeAttributesClass: false,
 			expectValidationOpts: PersistentVolumeClaimSpecValidationOptions{
 				EnableRecoverFromExpansionFailure: true,
@@ -3168,7 +3168,7 @@ func TestValidationOptionsForPersistentVolumeClaimTemplate(t *testing.T) {
 			expectValidationOpts: PersistentVolumeClaimSpecValidationOptions{},
 		},
 		"volume attributes class allowed because feature enable": {
-			oldPvcTemplate:              pvcTemplateWithVolumeAttributesClassName(utilpointer.String("foo")),
+			oldPvcTemplate:              pvcTemplateWithVolumeAttributesClassName(ptr.To("foo")),
 			enableVolumeAttributesClass: true,
 			expectValidationOpts: PersistentVolumeClaimSpecValidationOptions{
 				EnableVolumeAttributesClass: true,
@@ -3203,7 +3203,7 @@ func TestValidateKeyToPath(t *testing.T) {
 		kp: core.KeyToPath{Key: "k", Path: "p/..p/p../p..p"},
 		ok: true,
 	}, {
-		kp: core.KeyToPath{Key: "k", Path: "p", Mode: utilpointer.Int32(0644)},
+		kp: core.KeyToPath{Key: "k", Path: "p", Mode: ptr.To[int32](0644)},
 		ok: true,
 	}, {
 		kp:      core.KeyToPath{Key: "", Path: "p"},
@@ -3230,11 +3230,11 @@ func TestValidateKeyToPath(t *testing.T) {
 		ok:      false,
 		errtype: field.ErrorTypeInvalid,
 	}, {
-		kp:      core.KeyToPath{Key: "k", Path: "p", Mode: utilpointer.Int32(01000)},
+		kp:      core.KeyToPath{Key: "k", Path: "p", Mode: ptr.To[int32](01000)},
 		ok:      false,
 		errtype: field.ErrorTypeInvalid,
 	}, {
-		kp:      core.KeyToPath{Key: "k", Path: "p", Mode: utilpointer.Int32(-1)},
+		kp:      core.KeyToPath{Key: "k", Path: "p", Mode: ptr.To[int32](-1)},
 		ok:      false,
 		errtype: field.ErrorTypeInvalid,
 	},
@@ -4191,7 +4191,7 @@ func TestValidateVolumes(t *testing.T) {
 				VolumeSource: core.VolumeSource{
 					Secret: &core.SecretVolumeSource{
 						SecretName:  "my-secret",
-						DefaultMode: utilpointer.Int32(0644),
+						DefaultMode: ptr.To[int32](0644),
 					},
 				},
 			},
@@ -4205,7 +4205,7 @@ func TestValidateVolumes(t *testing.T) {
 						Items: []core.KeyToPath{{
 							Key:  "key",
 							Path: "filename",
-							Mode: utilpointer.Int32(0644),
+							Mode: ptr.To[int32](0644),
 						}},
 					},
 				},
@@ -4276,7 +4276,7 @@ func TestValidateVolumes(t *testing.T) {
 				VolumeSource: core.VolumeSource{
 					Secret: &core.SecretVolumeSource{
 						SecretName:  "s",
-						DefaultMode: utilpointer.Int32(01000),
+						DefaultMode: ptr.To[int32](01000),
 					},
 				},
 			},
@@ -4291,7 +4291,7 @@ func TestValidateVolumes(t *testing.T) {
 				VolumeSource: core.VolumeSource{
 					Secret: &core.SecretVolumeSource{
 						SecretName:  "s",
-						DefaultMode: utilpointer.Int32(-1),
+						DefaultMode: ptr.To[int32](-1),
 					},
 				},
 			},
@@ -4322,7 +4322,7 @@ func TestValidateVolumes(t *testing.T) {
 						LocalObjectReference: core.LocalObjectReference{
 							Name: "my-cfgmap",
 						},
-						DefaultMode: utilpointer.Int32(0644),
+						DefaultMode: ptr.To[int32](0644),
 					},
 				},
 			},
@@ -4337,7 +4337,7 @@ func TestValidateVolumes(t *testing.T) {
 						Items: []core.KeyToPath{{
 							Key:  "key",
 							Path: "filename",
-							Mode: utilpointer.Int32(0644),
+							Mode: ptr.To[int32](0644),
 						}},
 					},
 				},
@@ -4409,7 +4409,7 @@ func TestValidateVolumes(t *testing.T) {
 				VolumeSource: core.VolumeSource{
 					ConfigMap: &core.ConfigMapVolumeSource{
 						LocalObjectReference: core.LocalObjectReference{Name: "c"},
-						DefaultMode:          utilpointer.Int32(01000),
+						DefaultMode:          ptr.To[int32](01000),
 					},
 				},
 			},
@@ -4424,7 +4424,7 @@ func TestValidateVolumes(t *testing.T) {
 				VolumeSource: core.VolumeSource{
 					ConfigMap: &core.ConfigMapVolumeSource{
 						LocalObjectReference: core.LocalObjectReference{Name: "c"},
-						DefaultMode:          utilpointer.Int32(-1),
+						DefaultMode:          ptr.To[int32](-1),
 					},
 				},
 			},
@@ -4766,7 +4766,7 @@ func TestValidateVolumes(t *testing.T) {
 				Name: "downapi",
 				VolumeSource: core.VolumeSource{
 					DownwardAPI: &core.DownwardAPIVolumeSource{
-						DefaultMode: utilpointer.Int32(0644),
+						DefaultMode: ptr.To[int32](0644),
 					},
 				},
 			},
@@ -4777,7 +4777,7 @@ func TestValidateVolumes(t *testing.T) {
 				VolumeSource: core.VolumeSource{
 					DownwardAPI: &core.DownwardAPIVolumeSource{
 						Items: []core.DownwardAPIVolumeFile{{
-							Mode: utilpointer.Int32(0644),
+							Mode: ptr.To[int32](0644),
 							Path: "path",
 							FieldRef: &core.ObjectFieldSelector{
 								APIVersion: "v1",
@@ -4794,7 +4794,7 @@ func TestValidateVolumes(t *testing.T) {
 				VolumeSource: core.VolumeSource{
 					DownwardAPI: &core.DownwardAPIVolumeSource{
 						Items: []core.DownwardAPIVolumeFile{{
-							Mode: utilpointer.Int32(01000),
+							Mode: ptr.To[int32](01000),
 							Path: "path",
 							FieldRef: &core.ObjectFieldSelector{
 								APIVersion: "v1",
@@ -4815,7 +4815,7 @@ func TestValidateVolumes(t *testing.T) {
 				VolumeSource: core.VolumeSource{
 					DownwardAPI: &core.DownwardAPIVolumeSource{
 						Items: []core.DownwardAPIVolumeFile{{
-							Mode: utilpointer.Int32(-1),
+							Mode: ptr.To[int32](-1),
 							Path: "path",
 							FieldRef: &core.ObjectFieldSelector{
 								APIVersion: "v1",
@@ -4963,7 +4963,7 @@ func TestValidateVolumes(t *testing.T) {
 				Name: "downapi",
 				VolumeSource: core.VolumeSource{
 					DownwardAPI: &core.DownwardAPIVolumeSource{
-						DefaultMode: utilpointer.Int32(01000),
+						DefaultMode: ptr.To[int32](01000),
 					},
 				},
 			},
@@ -4977,7 +4977,7 @@ func TestValidateVolumes(t *testing.T) {
 				Name: "downapi",
 				VolumeSource: core.VolumeSource{
 					DownwardAPI: &core.DownwardAPIVolumeSource{
-						DefaultMode: utilpointer.Int32(-1),
+						DefaultMode: ptr.To[int32](-1),
 					},
 				},
 			},
@@ -4994,7 +4994,7 @@ func TestValidateVolumes(t *testing.T) {
 				VolumeSource: core.VolumeSource{
 					FC: &core.FCVolumeSource{
 						TargetWWNs: []string{"some_wwn"},
-						Lun:        utilpointer.Int32(1),
+						Lun:        ptr.To[int32](1),
 						FSType:     "ext4",
 						ReadOnly:   false,
 					},
@@ -5019,7 +5019,7 @@ func TestValidateVolumes(t *testing.T) {
 				VolumeSource: core.VolumeSource{
 					FC: &core.FCVolumeSource{
 						TargetWWNs: []string{},
-						Lun:        utilpointer.Int32(1),
+						Lun:        ptr.To[int32](1),
 						WWIDs:      []string{},
 						FSType:     "ext4",
 						ReadOnly:   false,
@@ -5038,7 +5038,7 @@ func TestValidateVolumes(t *testing.T) {
 				VolumeSource: core.VolumeSource{
 					FC: &core.FCVolumeSource{
 						TargetWWNs: []string{"some_wwn"},
-						Lun:        utilpointer.Int32(1),
+						Lun:        ptr.To[int32](1),
 						WWIDs:      []string{"some_wwid"},
 						FSType:     "ext4",
 						ReadOnly:   false,
@@ -5075,7 +5075,7 @@ func TestValidateVolumes(t *testing.T) {
 				VolumeSource: core.VolumeSource{
 					FC: &core.FCVolumeSource{
 						TargetWWNs: []string{"wwn"},
-						Lun:        utilpointer.Int32(256),
+						Lun:        ptr.To[int32](256),
 						FSType:     "ext4",
 						ReadOnly:   false,
 					},
@@ -7581,7 +7581,7 @@ func Test_validateProbe(t *testing.T) {
 		args: args{
 			probe: &core.Probe{
 				ProbeHandler:                  core.ProbeHandler{Exec: &core.ExecAction{Command: []string{"echo"}}},
-				TerminationGracePeriodSeconds: utilpointer.Int64(-1),
+				TerminationGracePeriodSeconds: ptr.To[int64](-1),
 			},
 			fldPath: fldPath,
 		},
@@ -7590,7 +7590,7 @@ func Test_validateProbe(t *testing.T) {
 		args: args{
 			probe: &core.Probe{
 				ProbeHandler:                  core.ProbeHandler{Exec: &core.ExecAction{Command: []string{"echo"}}},
-				TerminationGracePeriodSeconds: utilpointer.Int64(0),
+				TerminationGracePeriodSeconds: ptr.To[int64](0),
 			},
 			fldPath: fldPath,
 		},
@@ -7599,7 +7599,7 @@ func Test_validateProbe(t *testing.T) {
 		args: args{
 			probe: &core.Probe{
 				ProbeHandler:                  core.ProbeHandler{Exec: &core.ExecAction{Command: []string{"echo"}}},
-				TerminationGracePeriodSeconds: utilpointer.Int64(1),
+				TerminationGracePeriodSeconds: ptr.To[int64](1),
 			},
 			fldPath: fldPath,
 		},
@@ -8277,7 +8277,7 @@ func TestValidateEphemeralContainers(t *testing.T) {
 }
 
 func TestValidateWindowsPodSecurityContext(t *testing.T) {
-	validWindowsSC := &core.PodSecurityContext{WindowsOptions: &core.WindowsSecurityContextOptions{RunAsUserName: utilpointer.String("dummy")}}
+	validWindowsSC := &core.PodSecurityContext{WindowsOptions: &core.WindowsSecurityContextOptions{RunAsUserName: ptr.To("dummy")}}
 	invalidWindowsSC := &core.PodSecurityContext{SELinuxOptions: &core.SELinuxOptions{Role: "dummyRole"}}
 	cases := map[string]struct {
 		podSec      *core.PodSpec
@@ -8325,7 +8325,7 @@ func TestValidateLinuxPodSecurityContext(t *testing.T) {
 		RunAsUser: &runAsUser,
 	}
 	invalidLinuxSC := &core.PodSecurityContext{
-		WindowsOptions: &core.WindowsSecurityContextOptions{RunAsUserName: utilpointer.String("myUser")},
+		WindowsOptions: &core.WindowsSecurityContextOptions{RunAsUserName: ptr.To("myUser")},
 	}
 
 	cases := map[string]struct {
@@ -8760,7 +8760,7 @@ func TestValidateContainers(t *testing.T) {
 						Port: intstr.FromInt32(80),
 					},
 				},
-				TerminationGracePeriodSeconds: utilpointer.Int64(10),
+				TerminationGracePeriodSeconds: ptr.To[int64](10),
 			},
 			ImagePullPolicy:          "IfNotPresent",
 			TerminationMessagePolicy: "File",
@@ -8849,7 +8849,7 @@ func TestValidateContainers(t *testing.T) {
 				PeriodSeconds:                 -1,
 				SuccessThreshold:              -1,
 				FailureThreshold:              -1,
-				TerminationGracePeriodSeconds: utilpointer.Int64(-1),
+				TerminationGracePeriodSeconds: ptr.To[int64](-1),
 			},
 			ImagePullPolicy:          "IfNotPresent",
 			TerminationMessagePolicy: "File",
@@ -8880,7 +8880,7 @@ func TestValidateContainers(t *testing.T) {
 				PeriodSeconds:                 -1,
 				SuccessThreshold:              -1,
 				FailureThreshold:              -1,
-				TerminationGracePeriodSeconds: utilpointer.Int64(-1),
+				TerminationGracePeriodSeconds: ptr.To[int64](-1),
 			},
 			ImagePullPolicy:          "IfNotPresent",
 			TerminationMessagePolicy: "File",
@@ -8914,7 +8914,7 @@ func TestValidateContainers(t *testing.T) {
 				PeriodSeconds:                 -1,
 				SuccessThreshold:              -1,
 				FailureThreshold:              -1,
-				TerminationGracePeriodSeconds: utilpointer.Int64(-1),
+				TerminationGracePeriodSeconds: ptr.To[int64](-1),
 			},
 			ImagePullPolicy:          "IfNotPresent",
 			TerminationMessagePolicy: "File",
@@ -9428,7 +9428,7 @@ func TestValidateInitContainers(t *testing.T) {
 				PeriodSeconds:                 -1,
 				SuccessThreshold:              -1,
 				FailureThreshold:              -1,
-				TerminationGracePeriodSeconds: utilpointer.Int64(-1),
+				TerminationGracePeriodSeconds: ptr.To[int64](-1),
 			},
 		}},
 		field.ErrorList{{Type: field.ErrorTypeForbidden, Field: "initContainers[0].startupProbe", BadValue: ""}},
@@ -9508,10 +9508,10 @@ func TestValidateInitContainers(t *testing.T) {
 						Port: intstr.FromInt32(80),
 					},
 				},
-				TerminationGracePeriodSeconds: utilpointer.Int64(10),
+				TerminationGracePeriodSeconds: ptr.To[int64](10),
 			},
 		}},
-		field.ErrorList{{Type: field.ErrorTypeInvalid, Field: "initContainers[0].readinessProbe.terminationGracePeriodSeconds", BadValue: utilpointer.Int64(10)}},
+		field.ErrorList{{Type: field.ErrorTypeInvalid, Field: "initContainers[0].readinessProbe.terminationGracePeriodSeconds", BadValue: ptr.To[int64](10)}},
 	}, {
 		"invalid liveness probe, successThreshold != 1",
 		line(),
@@ -10600,7 +10600,7 @@ func TestValidatePod(t *testing.T) {
 			podtest.SetSecurityContext(&core.PodSecurityContext{
 				SeccompProfile: &core.SeccompProfile{
 					Type:             core.SeccompProfileTypeLocalhost,
-					LocalhostProfile: utilpointer.String("filename.json"),
+					LocalhostProfile: ptr.To("filename.json"),
 				},
 			}),
 		),
@@ -10609,7 +10609,7 @@ func TestValidatePod(t *testing.T) {
 				podtest.SetContainerSecurityContext(core.SecurityContext{
 					SeccompProfile: &core.SeccompProfile{
 						Type:             core.SeccompProfileTypeLocalhost,
-						LocalhostProfile: utilpointer.String("filename.json"),
+						LocalhostProfile: ptr.To("filename.json"),
 					},
 				}),
 			)),
@@ -10770,7 +10770,7 @@ func TestValidatePod(t *testing.T) {
 							{
 								ClusterTrustBundle: &core.ClusterTrustBundleProjection{
 									Path: "foo-path",
-									Name: utilpointer.String("foo"),
+									Name: ptr.To("foo"),
 								},
 							},
 						},
@@ -10787,7 +10787,7 @@ func TestValidatePod(t *testing.T) {
 							{
 								ClusterTrustBundle: &core.ClusterTrustBundleProjection{
 									Path:       "foo-path",
-									SignerName: utilpointer.String("example.com/foo"),
+									SignerName: ptr.To("example.com/foo"),
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
 											"version": "live",
@@ -12186,13 +12186,13 @@ func TestValidatePod(t *testing.T) {
 								{
 									ClusterTrustBundle: &core.ClusterTrustBundleProjection{
 										Path:       "foo-path",
-										SignerName: utilpointer.String("example.com/foo"),
+										SignerName: ptr.To("example.com/foo"),
 										LabelSelector: &metav1.LabelSelector{
 											MatchLabels: map[string]string{
 												"version": "live",
 											},
 										},
-										Name: utilpointer.String("foo"),
+										Name: ptr.To("foo"),
 									},
 								},
 							},
@@ -12212,7 +12212,7 @@ func TestValidatePod(t *testing.T) {
 								{
 									ClusterTrustBundle: &core.ClusterTrustBundleProjection{
 										Path: "foo-path",
-										Name: utilpointer.String(""),
+										Name: ptr.To(""),
 									},
 								},
 							},
@@ -12232,7 +12232,7 @@ func TestValidatePod(t *testing.T) {
 								{
 									ClusterTrustBundle: &core.ClusterTrustBundleProjection{
 										Path:       "foo-path",
-										SignerName: utilpointer.String(""),
+										SignerName: ptr.To(""),
 										LabelSelector: &metav1.LabelSelector{
 											MatchLabels: map[string]string{
 												"foo": "bar",
@@ -12257,7 +12257,7 @@ func TestValidatePod(t *testing.T) {
 								{
 									ClusterTrustBundle: &core.ClusterTrustBundleProjection{
 										Path:       "foo-path",
-										SignerName: utilpointer.String("example.com/foo/invalid"),
+										SignerName: ptr.To("example.com/foo/invalid"),
 									},
 								},
 							},
@@ -14353,7 +14353,7 @@ func TestValidatePodStatusUpdate(t *testing.T) {
 		*podtest.MakePod("foo",
 			podtest.SetStatus(core.PodStatus{
 				ResourceClaimStatuses: []core.PodResourceClaimStatus{
-					{Name: "no-such-claim", ResourceClaimName: utilpointer.String("my-claim")},
+					{Name: "no-such-claim", ResourceClaimName: ptr.To("my-claim")},
 				},
 			}),
 		),
@@ -14365,7 +14365,7 @@ func TestValidatePodStatusUpdate(t *testing.T) {
 			podtest.SetResourceClaims(core.PodResourceClaim{Name: "my-claim"}),
 			podtest.SetStatus(core.PodStatus{
 				ResourceClaimStatuses: []core.PodResourceClaimStatus{
-					{Name: "my-claim", ResourceClaimName: utilpointer.String("%$!#")},
+					{Name: "my-claim", ResourceClaimName: ptr.To("%$!#")},
 				},
 			}),
 		),
@@ -14382,7 +14382,7 @@ func TestValidatePodStatusUpdate(t *testing.T) {
 			),
 			podtest.SetStatus(core.PodStatus{
 				ResourceClaimStatuses: []core.PodResourceClaimStatus{
-					{Name: "my-claim", ResourceClaimName: utilpointer.String("foo-my-claim-12345")},
+					{Name: "my-claim", ResourceClaimName: ptr.To("foo-my-claim-12345")},
 					{Name: "my-other-claim", ResourceClaimName: nil},
 					{Name: "my-other-claim", ResourceClaimName: nil},
 				},
@@ -14401,7 +14401,7 @@ func TestValidatePodStatusUpdate(t *testing.T) {
 			),
 			podtest.SetStatus(core.PodStatus{
 				ResourceClaimStatuses: []core.PodResourceClaimStatus{
-					{Name: "my-claim", ResourceClaimName: utilpointer.String("foo-my-claim-12345")},
+					{Name: "my-claim", ResourceClaimName: ptr.To("foo-my-claim-12345")},
 					{Name: "my-other-claim", ResourceClaimName: nil},
 				},
 			}),
@@ -15348,7 +15348,7 @@ func TestValidateServiceCreate(t *testing.T) {
 		tweakSvc: func(s *core.Service) {
 			s.Spec.Type = core.ServiceTypeLoadBalancer
 			s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-			s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+			s.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 			s.Spec.Ports[0].Protocol = "UDP"
 		},
 		numErrs: 0,
@@ -15357,7 +15357,7 @@ func TestValidateServiceCreate(t *testing.T) {
 		tweakSvc: func(s *core.Service) {
 			s.Spec.Type = core.ServiceTypeLoadBalancer
 			s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-			s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+			s.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 			s.Spec.Ports[0] = core.ServicePort{Name: "q", Port: 12345, Protocol: "UDP", TargetPort: intstr.FromInt32(12345)}
 		},
 		numErrs: 0,
@@ -15366,7 +15366,7 @@ func TestValidateServiceCreate(t *testing.T) {
 		tweakSvc: func(s *core.Service) {
 			s.Spec.Type = core.ServiceTypeLoadBalancer
 			s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-			s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+			s.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 			s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "q", Port: 12345, Protocol: "UDP", TargetPort: intstr.FromInt32(12345)})
 		},
 		numErrs: 0,
@@ -15414,7 +15414,7 @@ func TestValidateServiceCreate(t *testing.T) {
 		tweakSvc: func(s *core.Service) {
 			s.Spec.Type = core.ServiceTypeLoadBalancer
 			s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-			s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+			s.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 		},
 		numErrs: 0,
 	}, {
@@ -15422,7 +15422,7 @@ func TestValidateServiceCreate(t *testing.T) {
 		tweakSvc: func(s *core.Service) {
 			s.Spec.Type = core.ServiceTypeLoadBalancer
 			s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-			s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(false)
+			s.Spec.AllocateLoadBalancerNodePorts = ptr.To(false)
 		},
 		numErrs: 0,
 	}, {
@@ -15437,7 +15437,7 @@ func TestValidateServiceCreate(t *testing.T) {
 		tweakSvc: func(s *core.Service) {
 			s.Spec.Type = core.ServiceTypeLoadBalancer
 			s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-			s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+			s.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 			s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "q", Port: 12345, Protocol: "TCP", TargetPort: intstr.FromInt32(12345)})
 		},
 		numErrs: 0,
@@ -15446,7 +15446,7 @@ func TestValidateServiceCreate(t *testing.T) {
 		tweakSvc: func(s *core.Service) {
 			s.Spec.Type = core.ServiceTypeLoadBalancer
 			s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-			s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+			s.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 			s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "q", Port: 12345, Protocol: "TCP", TargetPort: intstr.FromInt32(12345)})
 		},
 		numErrs: 0,
@@ -15504,7 +15504,7 @@ func TestValidateServiceCreate(t *testing.T) {
 		tweakSvc: func(s *core.Service) {
 			s.Spec.Type = core.ServiceTypeLoadBalancer
 			s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-			s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+			s.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 		},
 		numErrs: 0,
 	}, {
@@ -15512,7 +15512,7 @@ func TestValidateServiceCreate(t *testing.T) {
 		tweakSvc: func(s *core.Service) {
 			s.Spec.Type = core.ServiceTypeLoadBalancer
 			s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-			s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+			s.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 			s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "q", Port: 12345, Protocol: "TCP", TargetPort: intstr.FromInt32(12345)})
 		},
 		numErrs: 0,
@@ -15521,7 +15521,7 @@ func TestValidateServiceCreate(t *testing.T) {
 		tweakSvc: func(s *core.Service) {
 			s.Spec.Type = core.ServiceTypeLoadBalancer
 			s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-			s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+			s.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 			s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "q", Port: 12345, Protocol: "TCP", NodePort: 12345, TargetPort: intstr.FromInt32(12345)})
 		},
 		numErrs: 0,
@@ -15569,7 +15569,7 @@ func TestValidateServiceCreate(t *testing.T) {
 		tweakSvc: func(s *core.Service) {
 			s.Spec.Type = core.ServiceTypeLoadBalancer
 			s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-			s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+			s.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 			s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "q", Port: 12345, Protocol: "TCP", TargetPort: intstr.FromInt32(12345)})
 		},
 		numErrs: 0,
@@ -15579,7 +15579,7 @@ func TestValidateServiceCreate(t *testing.T) {
 		tweakSvc: func(s *core.Service) {
 			s.Spec.Type = core.ServiceTypeLoadBalancer
 			s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-			s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+			s.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 			s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "kubelet", Port: 10250, Protocol: "TCP", TargetPort: intstr.FromInt32(12345)})
 		},
 		numErrs: 0,
@@ -15588,7 +15588,7 @@ func TestValidateServiceCreate(t *testing.T) {
 		tweakSvc: func(s *core.Service) {
 			s.Spec.Type = core.ServiceTypeLoadBalancer
 			s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-			s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+			s.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 			s.Annotations[core.AnnotationLoadBalancerSourceRangesKey] = "1.2.3.0/24,  5.6.0.0/16"
 		},
 		numErrs: 0,
@@ -15597,7 +15597,7 @@ func TestValidateServiceCreate(t *testing.T) {
 		tweakSvc: func(s *core.Service) {
 			s.Spec.Type = core.ServiceTypeLoadBalancer
 			s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-			s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+			s.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 			s.Annotations[core.AnnotationLoadBalancerSourceRangesKey] = ""
 		},
 		numErrs: 0,
@@ -15606,7 +15606,7 @@ func TestValidateServiceCreate(t *testing.T) {
 		tweakSvc: func(s *core.Service) {
 			s.Spec.Type = core.ServiceTypeLoadBalancer
 			s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-			s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+			s.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 			s.Annotations[core.AnnotationLoadBalancerSourceRangesKey] = "  "
 		},
 		numErrs: 0,
@@ -15615,7 +15615,7 @@ func TestValidateServiceCreate(t *testing.T) {
 		tweakSvc: func(s *core.Service) {
 			s.Spec.Type = core.ServiceTypeLoadBalancer
 			s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-			s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+			s.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 			s.Annotations[core.AnnotationLoadBalancerSourceRangesKey] = "foo.bar"
 		},
 		numErrs: 1,
@@ -15624,7 +15624,7 @@ func TestValidateServiceCreate(t *testing.T) {
 		tweakSvc: func(s *core.Service) {
 			s.Spec.Type = core.ServiceTypeLoadBalancer
 			s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-			s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+			s.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 			s.Annotations[core.AnnotationLoadBalancerSourceRangesKey] = "1.2.3.4/33"
 		},
 		numErrs: 1,
@@ -15645,7 +15645,7 @@ func TestValidateServiceCreate(t *testing.T) {
 		tweakSvc: func(s *core.Service) {
 			s.Spec.Type = core.ServiceTypeLoadBalancer
 			s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-			s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+			s.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 			s.Spec.LoadBalancerSourceRanges = []string{"1.2.3.0/24", "5.6.0.0/16"}
 		},
 		numErrs: 0,
@@ -15654,7 +15654,7 @@ func TestValidateServiceCreate(t *testing.T) {
 		tweakSvc: func(s *core.Service) {
 			s.Spec.Type = core.ServiceTypeLoadBalancer
 			s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-			s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+			s.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 			s.Spec.LoadBalancerSourceRanges = []string{"1.2.3.0/24  ", " 5.6.0.0/16"}
 		},
 		numErrs: 0,
@@ -15663,7 +15663,7 @@ func TestValidateServiceCreate(t *testing.T) {
 		tweakSvc: func(s *core.Service) {
 			s.Spec.Type = core.ServiceTypeLoadBalancer
 			s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-			s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+			s.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 			s.Spec.LoadBalancerSourceRanges = []string{"   "}
 		},
 		numErrs: 1,
@@ -15672,7 +15672,7 @@ func TestValidateServiceCreate(t *testing.T) {
 		tweakSvc: func(s *core.Service) {
 			s.Spec.Type = core.ServiceTypeLoadBalancer
 			s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-			s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+			s.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 			s.Spec.LoadBalancerSourceRanges = []string{"foo.bar"}
 		},
 		numErrs: 1,
@@ -15681,7 +15681,7 @@ func TestValidateServiceCreate(t *testing.T) {
 		tweakSvc: func(s *core.Service) {
 			s.Spec.Type = core.ServiceTypeLoadBalancer
 			s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-			s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+			s.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 			s.Spec.LoadBalancerSourceRanges = []string{"1.2.3.4/33"}
 		},
 		numErrs: 1,
@@ -15696,7 +15696,7 @@ func TestValidateServiceCreate(t *testing.T) {
 		tweakSvc: func(s *core.Service) {
 			s.Spec.Type = core.ServiceTypeLoadBalancer
 			s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-			s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+			s.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 			s.Annotations[core.AnnotationLoadBalancerSourceRangesKey] = "foo.bar"
 			s.Spec.LoadBalancerSourceRanges = []string{"1.2.3.0/24", "5.6.0.0/16"}
 		},
@@ -15747,7 +15747,7 @@ func TestValidateServiceCreate(t *testing.T) {
 			s.Spec.ClusterIPs = []string{"None"}
 			s.Spec.Type = core.ServiceTypeLoadBalancer
 			s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-			s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+			s.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 		},
 		numErrs: 1,
 	}, {
@@ -15766,7 +15766,7 @@ func TestValidateServiceCreate(t *testing.T) {
 			name: "invalid externalTraffic field",
 			tweakSvc: func(s *core.Service) {
 				s.Spec.Type = core.ServiceTypeLoadBalancer
-				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+				s.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 				s.Spec.ExternalTrafficPolicy = "invalid"
 			},
 			numErrs: 1,
@@ -15822,7 +15822,7 @@ func TestValidateServiceCreate(t *testing.T) {
 			name: "negative healthCheckNodePort field",
 			tweakSvc: func(s *core.Service) {
 				s.Spec.Type = core.ServiceTypeLoadBalancer
-				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+				s.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 				s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyLocal
 				s.Spec.HealthCheckNodePort = -1
 			},
@@ -15831,7 +15831,7 @@ func TestValidateServiceCreate(t *testing.T) {
 			name: "negative healthCheckNodePort field",
 			tweakSvc: func(s *core.Service) {
 				s.Spec.Type = core.ServiceTypeLoadBalancer
-				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+				s.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 				s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyLocal
 				s.Spec.HealthCheckNodePort = 31100
 			},
@@ -15845,7 +15845,7 @@ func TestValidateServiceCreate(t *testing.T) {
 				s.Spec.SessionAffinity = core.ServiceAffinityClientIP
 				s.Spec.SessionAffinityConfig = &core.SessionAffinityConfig{
 					ClientIP: &core.ClientIPConfig{
-						TimeoutSeconds: utilpointer.Int32(-1),
+						TimeoutSeconds: ptr.To[int32](-1),
 					},
 				}
 			},
@@ -15855,11 +15855,11 @@ func TestValidateServiceCreate(t *testing.T) {
 			tweakSvc: func(s *core.Service) {
 				s.Spec.Type = core.ServiceTypeLoadBalancer
 				s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+				s.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 				s.Spec.SessionAffinity = core.ServiceAffinityNone
 				s.Spec.SessionAffinityConfig = &core.SessionAffinityConfig{
 					ClientIP: &core.ClientIPConfig{
-						TimeoutSeconds: utilpointer.Int32(90),
+						TimeoutSeconds: ptr.To[int32](90),
 					},
 				}
 			},
@@ -16213,7 +16213,7 @@ func TestValidateServiceCreate(t *testing.T) {
 					Port:        12345,
 					TargetPort:  intstr.FromInt32(12345),
 					Protocol:    "TCP",
-					AppProtocol: utilpointer.String("HTTP"),
+					AppProtocol: ptr.To("HTTP"),
 				}}
 			},
 			numErrs: 0,
@@ -16224,7 +16224,7 @@ func TestValidateServiceCreate(t *testing.T) {
 					Port:        12345,
 					TargetPort:  intstr.FromInt32(12345),
 					Protocol:    "TCP",
-					AppProtocol: utilpointer.String("example.com/protocol"),
+					AppProtocol: ptr.To("example.com/protocol"),
 				}}
 			},
 			numErrs: 0,
@@ -16235,7 +16235,7 @@ func TestValidateServiceCreate(t *testing.T) {
 					Port:        12345,
 					TargetPort:  intstr.FromInt32(12345),
 					Protocol:    "TCP",
-					AppProtocol: utilpointer.String("example.com/protocol_with{invalid}[characters]"),
+					AppProtocol: ptr.To("example.com/protocol_with{invalid}[characters]"),
 				}}
 			},
 			numErrs: 1,
@@ -16259,7 +16259,7 @@ func TestValidateServiceCreate(t *testing.T) {
 		}, {
 			name: "Use AllocateLoadBalancerNodePorts when type is not LoadBalancer",
 			tweakSvc: func(s *core.Service) {
-				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+				s.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 			},
 			numErrs: 1,
 		}, {
@@ -16267,8 +16267,8 @@ func TestValidateServiceCreate(t *testing.T) {
 			tweakSvc: func(s *core.Service) {
 				s.Spec.Type = core.ServiceTypeLoadBalancer
 				s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
-				s.Spec.LoadBalancerClass = utilpointer.String("test.com/test-load-balancer-class")
+				s.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
+				s.Spec.LoadBalancerClass = ptr.To("test.com/test-load-balancer-class")
 			},
 			numErrs: 0,
 		}, {
@@ -16276,15 +16276,15 @@ func TestValidateServiceCreate(t *testing.T) {
 			tweakSvc: func(s *core.Service) {
 				s.Spec.Type = core.ServiceTypeLoadBalancer
 				s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
-				s.Spec.LoadBalancerClass = utilpointer.String("Bad/LoadBalancerClass")
+				s.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
+				s.Spec.LoadBalancerClass = ptr.To("Bad/LoadBalancerClass")
 			},
 			numErrs: 1,
 		}, {
 			name: "invalid: set LoadBalancerClass when type is not LoadBalancer",
 			tweakSvc: func(s *core.Service) {
 				s.Spec.Type = core.ServiceTypeClusterIP
-				s.Spec.LoadBalancerClass = utilpointer.String("test.com/test-load-balancer-class")
+				s.Spec.LoadBalancerClass = ptr.To("test.com/test-load-balancer-class")
 			},
 			numErrs: 1,
 		}, {
@@ -16297,13 +16297,13 @@ func TestValidateServiceCreate(t *testing.T) {
 		}, {
 			name: "valid: trafficDistribution field set to PreferClose",
 			tweakSvc: func(s *core.Service) {
-				s.Spec.TrafficDistribution = utilpointer.String("PreferClose")
+				s.Spec.TrafficDistribution = ptr.To("PreferClose")
 			},
 			numErrs: 0,
 		}, {
 			name: "invalid: trafficDistribution field set to Random",
 			tweakSvc: func(s *core.Service) {
-				s.Spec.TrafficDistribution = utilpointer.String("Random")
+				s.Spec.TrafficDistribution = ptr.To("Random")
 			},
 			numErrs: 1,
 		},
@@ -16333,7 +16333,7 @@ func TestValidateServiceExternalTrafficPolicy(t *testing.T) {
 		name: "valid loadBalancer service with externalTrafficPolicy and healthCheckNodePort set",
 		tweakSvc: func(s *core.Service) {
 			s.Spec.Type = core.ServiceTypeLoadBalancer
-			s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+			s.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 			s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyLocal
 			s.Spec.HealthCheckNodePort = 34567
 		},
@@ -16355,7 +16355,7 @@ func TestValidateServiceExternalTrafficPolicy(t *testing.T) {
 		name: "cannot set healthCheckNodePort field on loadBalancer service with externalTrafficPolicy!=Local",
 		tweakSvc: func(s *core.Service) {
 			s.Spec.Type = core.ServiceTypeLoadBalancer
-			s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+			s.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 			s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
 			s.Spec.HealthCheckNodePort = 34567
 		},
@@ -17721,7 +17721,7 @@ func TestValidateServiceUpdate(t *testing.T) {
 			newSvc.Spec.SessionAffinity = "ClientIP"
 			newSvc.Spec.SessionAffinityConfig = &core.SessionAffinityConfig{
 				ClientIP: &core.ClientIPConfig{
-					TimeoutSeconds: utilpointer.Int32(90),
+					TimeoutSeconds: ptr.To[int32](90),
 				},
 			}
 		},
@@ -17737,7 +17737,7 @@ func TestValidateServiceUpdate(t *testing.T) {
 		tweakSvc: func(oldSvc, newSvc *core.Service) {
 			newSvc.Spec.Type = core.ServiceTypeLoadBalancer
 			newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-			newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+			newSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 		},
 		numErrs: 0,
 	}, {
@@ -17757,10 +17757,10 @@ func TestValidateServiceUpdate(t *testing.T) {
 		name: "add loadBalancerSourceRanges",
 		tweakSvc: func(oldSvc, newSvc *core.Service) {
 			oldSvc.Spec.Type = core.ServiceTypeLoadBalancer
-			oldSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+			oldSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 			newSvc.Spec.Type = core.ServiceTypeLoadBalancer
 			newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-			newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+			newSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 			newSvc.Spec.LoadBalancerSourceRanges = []string{"10.0.0.0/8"}
 		},
 		numErrs: 0,
@@ -17768,11 +17768,11 @@ func TestValidateServiceUpdate(t *testing.T) {
 		name: "update loadBalancerSourceRanges",
 		tweakSvc: func(oldSvc, newSvc *core.Service) {
 			oldSvc.Spec.Type = core.ServiceTypeLoadBalancer
-			oldSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+			oldSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 			oldSvc.Spec.LoadBalancerSourceRanges = []string{"10.0.0.0/8"}
 			newSvc.Spec.Type = core.ServiceTypeLoadBalancer
 			newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-			newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+			newSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 			newSvc.Spec.LoadBalancerSourceRanges = []string{"10.100.0.0/16"}
 		},
 		numErrs: 0,
@@ -17783,7 +17783,7 @@ func TestValidateServiceUpdate(t *testing.T) {
 			newSvc.Spec.ClusterIPs = []string{"None"}
 			newSvc.Spec.Type = core.ServiceTypeLoadBalancer
 			newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-			newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+			newSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 		},
 		numErrs: 1,
 	}, {
@@ -17880,7 +17880,7 @@ func TestValidateServiceUpdate(t *testing.T) {
 				oldSvc.Spec.Type = core.ServiceTypeClusterIP
 				newSvc.Spec.Type = core.ServiceTypeLoadBalancer
 				newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+				newSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 
 				oldSvc.Spec.ClusterIP = "1.2.3.4"
 				oldSvc.Spec.ClusterIPs = []string{"1.2.3.4"}
@@ -17895,7 +17895,7 @@ func TestValidateServiceUpdate(t *testing.T) {
 				oldSvc.Spec.Type = core.ServiceTypeClusterIP
 				newSvc.Spec.Type = core.ServiceTypeLoadBalancer
 				newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+				newSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 
 				oldSvc.Spec.ClusterIP = ""
 				oldSvc.Spec.ClusterIPs = nil
@@ -17908,20 +17908,20 @@ func TestValidateServiceUpdate(t *testing.T) {
 			name: "Service with LoadBalancer type can change its AllocateLoadBalancerNodePorts from true to false",
 			tweakSvc: func(oldSvc, newSvc *core.Service) {
 				oldSvc.Spec.Type = core.ServiceTypeLoadBalancer
-				oldSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+				oldSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 				newSvc.Spec.Type = core.ServiceTypeLoadBalancer
 				newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(false)
+				newSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(false)
 			},
 			numErrs: 0,
 		}, {
 			name: "Service with LoadBalancer type can change its AllocateLoadBalancerNodePorts from false to true",
 			tweakSvc: func(oldSvc, newSvc *core.Service) {
 				oldSvc.Spec.Type = core.ServiceTypeLoadBalancer
-				oldSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(false)
+				oldSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(false)
 				newSvc.Spec.Type = core.ServiceTypeLoadBalancer
 				newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+				newSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 			},
 			numErrs: 0,
 		}, {
@@ -17984,7 +17984,7 @@ func TestValidateServiceUpdate(t *testing.T) {
 				oldSvc.Spec.Type = core.ServiceTypeNodePort
 				newSvc.Spec.Type = core.ServiceTypeLoadBalancer
 				newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+				newSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 
 				oldSvc.Spec.ClusterIP = "1.2.3.4"
 				oldSvc.Spec.ClusterIPs = []string{"1.2.3.4"}
@@ -17999,7 +17999,7 @@ func TestValidateServiceUpdate(t *testing.T) {
 				oldSvc.Spec.Type = core.ServiceTypeNodePort
 				newSvc.Spec.Type = core.ServiceTypeLoadBalancer
 				newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+				newSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 
 				oldSvc.Spec.ClusterIP = ""
 				oldSvc.Spec.ClusterIPs = nil
@@ -18012,10 +18012,10 @@ func TestValidateServiceUpdate(t *testing.T) {
 			name: "Service with LoadBalancer type cannot change its set ClusterIP",
 			tweakSvc: func(oldSvc, newSvc *core.Service) {
 				oldSvc.Spec.Type = core.ServiceTypeLoadBalancer
-				oldSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+				oldSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 				newSvc.Spec.Type = core.ServiceTypeLoadBalancer
 				newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+				newSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 
 				oldSvc.Spec.ClusterIP = "1.2.3.4"
 				oldSvc.Spec.ClusterIPs = []string{"1.2.3.4"}
@@ -18028,10 +18028,10 @@ func TestValidateServiceUpdate(t *testing.T) {
 			name: "Service with LoadBalancer type can change its empty ClusterIP",
 			tweakSvc: func(oldSvc, newSvc *core.Service) {
 				oldSvc.Spec.Type = core.ServiceTypeLoadBalancer
-				oldSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+				oldSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 				newSvc.Spec.Type = core.ServiceTypeLoadBalancer
 				newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+				newSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 
 				oldSvc.Spec.ClusterIP = ""
 				oldSvc.Spec.ClusterIPs = nil
@@ -18044,7 +18044,7 @@ func TestValidateServiceUpdate(t *testing.T) {
 			name: "Service with LoadBalancer type cannot change its set ClusterIP when changing type to ClusterIP",
 			tweakSvc: func(oldSvc, newSvc *core.Service) {
 				oldSvc.Spec.Type = core.ServiceTypeLoadBalancer
-				oldSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+				oldSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 				newSvc.Spec.Type = core.ServiceTypeClusterIP
 
 				oldSvc.Spec.ClusterIP = "1.2.3.4"
@@ -18058,7 +18058,7 @@ func TestValidateServiceUpdate(t *testing.T) {
 			name: "Service with LoadBalancer type can change its empty ClusterIP when changing type to ClusterIP",
 			tweakSvc: func(oldSvc, newSvc *core.Service) {
 				oldSvc.Spec.Type = core.ServiceTypeLoadBalancer
-				oldSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+				oldSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 				newSvc.Spec.Type = core.ServiceTypeClusterIP
 
 				oldSvc.Spec.ClusterIP = ""
@@ -18072,7 +18072,7 @@ func TestValidateServiceUpdate(t *testing.T) {
 			name: "Service with LoadBalancer type cannot change its set ClusterIP when changing type to NodePort",
 			tweakSvc: func(oldSvc, newSvc *core.Service) {
 				oldSvc.Spec.Type = core.ServiceTypeLoadBalancer
-				oldSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+				oldSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 				newSvc.Spec.Type = core.ServiceTypeNodePort
 				newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
 
@@ -18087,7 +18087,7 @@ func TestValidateServiceUpdate(t *testing.T) {
 			name: "Service with LoadBalancer type can change its empty ClusterIP when changing type to NodePort",
 			tweakSvc: func(oldSvc, newSvc *core.Service) {
 				oldSvc.Spec.Type = core.ServiceTypeLoadBalancer
-				oldSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+				oldSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 				newSvc.Spec.Type = core.ServiceTypeNodePort
 				newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
 
@@ -18535,58 +18535,58 @@ func TestValidateServiceUpdate(t *testing.T) {
 			name: "update to valid app protocol",
 			tweakSvc: func(oldSvc, newSvc *core.Service) {
 				oldSvc.Spec.Ports = []core.ServicePort{{Name: "a", Port: 443, TargetPort: intstr.FromInt32(3000), Protocol: "TCP"}}
-				newSvc.Spec.Ports = []core.ServicePort{{Name: "a", Port: 443, TargetPort: intstr.FromInt32(3000), Protocol: "TCP", AppProtocol: utilpointer.String("https")}}
+				newSvc.Spec.Ports = []core.ServicePort{{Name: "a", Port: 443, TargetPort: intstr.FromInt32(3000), Protocol: "TCP", AppProtocol: ptr.To("https")}}
 			},
 			numErrs: 0,
 		}, {
 			name: "update to invalid app protocol",
 			tweakSvc: func(oldSvc, newSvc *core.Service) {
 				oldSvc.Spec.Ports = []core.ServicePort{{Name: "a", Port: 443, TargetPort: intstr.FromInt32(3000), Protocol: "TCP"}}
-				newSvc.Spec.Ports = []core.ServicePort{{Name: "a", Port: 443, TargetPort: intstr.FromInt32(3000), Protocol: "TCP", AppProtocol: utilpointer.String("~https")}}
+				newSvc.Spec.Ports = []core.ServicePort{{Name: "a", Port: 443, TargetPort: intstr.FromInt32(3000), Protocol: "TCP", AppProtocol: ptr.To("~https")}}
 			},
 			numErrs: 1,
 		}, {
 			name: "Set AllocateLoadBalancerNodePorts when type is not LoadBalancer",
 			tweakSvc: func(oldSvc, newSvc *core.Service) {
-				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+				newSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 			},
 			numErrs: 1,
 		}, {
 			name: "update LoadBalancer type of service without change LoadBalancerClass",
 			tweakSvc: func(oldSvc, newSvc *core.Service) {
 				oldSvc.Spec.Type = core.ServiceTypeLoadBalancer
-				oldSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
-				oldSvc.Spec.LoadBalancerClass = utilpointer.String("test.com/test-old")
+				oldSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
+				oldSvc.Spec.LoadBalancerClass = ptr.To("test.com/test-old")
 
 				newSvc.Spec.Type = core.ServiceTypeLoadBalancer
 				newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
-				newSvc.Spec.LoadBalancerClass = utilpointer.String("test.com/test-old")
+				newSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
+				newSvc.Spec.LoadBalancerClass = ptr.To("test.com/test-old")
 			},
 			numErrs: 0,
 		}, {
 			name: "invalid: change LoadBalancerClass when update service",
 			tweakSvc: func(oldSvc, newSvc *core.Service) {
 				oldSvc.Spec.Type = core.ServiceTypeLoadBalancer
-				oldSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
-				oldSvc.Spec.LoadBalancerClass = utilpointer.String("test.com/test-old")
+				oldSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
+				oldSvc.Spec.LoadBalancerClass = ptr.To("test.com/test-old")
 
 				newSvc.Spec.Type = core.ServiceTypeLoadBalancer
 				newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
-				newSvc.Spec.LoadBalancerClass = utilpointer.String("test.com/test-new")
+				newSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
+				newSvc.Spec.LoadBalancerClass = ptr.To("test.com/test-new")
 			},
 			numErrs: 1,
 		}, {
 			name: "invalid: unset LoadBalancerClass when update service",
 			tweakSvc: func(oldSvc, newSvc *core.Service) {
 				oldSvc.Spec.Type = core.ServiceTypeLoadBalancer
-				oldSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
-				oldSvc.Spec.LoadBalancerClass = utilpointer.String("test.com/test-old")
+				oldSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
+				oldSvc.Spec.LoadBalancerClass = ptr.To("test.com/test-old")
 
 				newSvc.Spec.Type = core.ServiceTypeLoadBalancer
 				newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+				newSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 				newSvc.Spec.LoadBalancerClass = nil
 			},
 			numErrs: 1,
@@ -18594,13 +18594,13 @@ func TestValidateServiceUpdate(t *testing.T) {
 			name: "invalid: set LoadBalancerClass when update service",
 			tweakSvc: func(oldSvc, newSvc *core.Service) {
 				oldSvc.Spec.Type = core.ServiceTypeLoadBalancer
-				oldSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+				oldSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 				oldSvc.Spec.LoadBalancerClass = nil
 
 				newSvc.Spec.Type = core.ServiceTypeLoadBalancer
 				newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
-				newSvc.Spec.LoadBalancerClass = utilpointer.String("test.com/test-new")
+				newSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
+				newSvc.Spec.LoadBalancerClass = ptr.To("test.com/test-new")
 			},
 			numErrs: 1,
 		}, {
@@ -18610,8 +18610,8 @@ func TestValidateServiceUpdate(t *testing.T) {
 
 				newSvc.Spec.Type = core.ServiceTypeLoadBalancer
 				newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
-				newSvc.Spec.LoadBalancerClass = utilpointer.String("test.com/test-load-balancer-class")
+				newSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
+				newSvc.Spec.LoadBalancerClass = ptr.To("test.com/test-load-balancer-class")
 			},
 			numErrs: 0,
 		}, {
@@ -18621,7 +18621,7 @@ func TestValidateServiceUpdate(t *testing.T) {
 
 				newSvc.Spec.Type = core.ServiceTypeLoadBalancer
 				newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+				newSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 				newSvc.Spec.LoadBalancerClass = nil
 			},
 			numErrs: 0,
@@ -18632,8 +18632,8 @@ func TestValidateServiceUpdate(t *testing.T) {
 
 				newSvc.Spec.Type = core.ServiceTypeLoadBalancer
 				newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
-				newSvc.Spec.LoadBalancerClass = utilpointer.String("Bad/LoadBalancerclass")
+				newSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
+				newSvc.Spec.LoadBalancerClass = ptr.To("Bad/LoadBalancerclass")
 			},
 			numErrs: 2,
 		}, {
@@ -18642,7 +18642,7 @@ func TestValidateServiceUpdate(t *testing.T) {
 				oldSvc.Spec.Type = core.ServiceTypeClusterIP
 
 				newSvc.Spec.Type = core.ServiceTypeClusterIP
-				newSvc.Spec.LoadBalancerClass = utilpointer.String("test.com/test-load-balancer-class")
+				newSvc.Spec.LoadBalancerClass = ptr.To("test.com/test-load-balancer-class")
 			},
 			numErrs: 2,
 		}, {
@@ -18651,7 +18651,7 @@ func TestValidateServiceUpdate(t *testing.T) {
 				oldSvc.Spec.Type = core.ServiceTypeExternalName
 
 				newSvc.Spec.Type = core.ServiceTypeExternalName
-				newSvc.Spec.LoadBalancerClass = utilpointer.String("test.com/test-load-balancer-class")
+				newSvc.Spec.LoadBalancerClass = ptr.To("test.com/test-load-balancer-class")
 			},
 			numErrs: 3,
 		}, {
@@ -18661,41 +18661,41 @@ func TestValidateServiceUpdate(t *testing.T) {
 
 				newSvc.Spec.Type = core.ServiceTypeNodePort
 				newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				newSvc.Spec.LoadBalancerClass = utilpointer.String("test.com/test-load-balancer-class")
+				newSvc.Spec.LoadBalancerClass = ptr.To("test.com/test-load-balancer-class")
 			},
 			numErrs: 2,
 		}, {
 			name: "invalid: set LoadBalancerClass when update from LoadBalancer service to non LoadBalancer type of service",
 			tweakSvc: func(oldSvc, newSvc *core.Service) {
 				oldSvc.Spec.Type = core.ServiceTypeLoadBalancer
-				oldSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
-				oldSvc.Spec.LoadBalancerClass = utilpointer.String("test.com/test-load-balancer-class")
+				oldSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
+				oldSvc.Spec.LoadBalancerClass = ptr.To("test.com/test-load-balancer-class")
 
 				newSvc.Spec.Type = core.ServiceTypeClusterIP
-				newSvc.Spec.LoadBalancerClass = utilpointer.String("test.com/test-load-balancer-class")
+				newSvc.Spec.LoadBalancerClass = ptr.To("test.com/test-load-balancer-class")
 			},
 			numErrs: 2,
 		}, {
 			name: "invalid: set LoadBalancerClass when update from LoadBalancer service to non LoadBalancer type of service",
 			tweakSvc: func(oldSvc, newSvc *core.Service) {
 				oldSvc.Spec.Type = core.ServiceTypeLoadBalancer
-				oldSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
-				oldSvc.Spec.LoadBalancerClass = utilpointer.String("test.com/test-load-balancer-class")
+				oldSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
+				oldSvc.Spec.LoadBalancerClass = ptr.To("test.com/test-load-balancer-class")
 
 				newSvc.Spec.Type = core.ServiceTypeExternalName
-				newSvc.Spec.LoadBalancerClass = utilpointer.String("test.com/test-load-balancer-class")
+				newSvc.Spec.LoadBalancerClass = ptr.To("test.com/test-load-balancer-class")
 			},
 			numErrs: 3,
 		}, {
 			name: "invalid: set LoadBalancerClass when update from LoadBalancer service to non LoadBalancer type of service",
 			tweakSvc: func(oldSvc, newSvc *core.Service) {
 				oldSvc.Spec.Type = core.ServiceTypeLoadBalancer
-				oldSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
-				oldSvc.Spec.LoadBalancerClass = utilpointer.String("test.com/test-load-balancer-class")
+				oldSvc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
+				oldSvc.Spec.LoadBalancerClass = ptr.To("test.com/test-load-balancer-class")
 
 				newSvc.Spec.Type = core.ServiceTypeNodePort
 				newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				newSvc.Spec.LoadBalancerClass = utilpointer.String("test.com/test-load-balancer-class")
+				newSvc.Spec.LoadBalancerClass = ptr.To("test.com/test-load-balancer-class")
 			},
 			numErrs: 2,
 		}, {
@@ -20569,7 +20569,7 @@ func TestValidateEndpointsCreate(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "mysvc", Namespace: "namespace"},
 				Subsets: []core.EndpointSubset{{
 					Addresses: []core.EndpointAddress{{IP: "10.10.1.1"}},
-					Ports:     []core.EndpointPort{{Port: 8675, Protocol: "TCP", AppProtocol: utilpointer.String("HTTP")}},
+					Ports:     []core.EndpointPort{{Port: 8675, Protocol: "TCP", AppProtocol: ptr.To("HTTP")}},
 				}},
 			},
 		},
@@ -20757,7 +20757,7 @@ func TestValidateEndpointsCreate(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "mysvc", Namespace: "namespace"},
 				Subsets: []core.EndpointSubset{{
 					Addresses: []core.EndpointAddress{{IP: "10.10.1.1"}},
-					Ports:     []core.EndpointPort{{Name: "p", Port: 93, Protocol: "TCP", AppProtocol: utilpointer.String("lots-of[invalid]-{chars}")}},
+					Ports:     []core.EndpointPort{{Name: "p", Port: 93, Protocol: "TCP", AppProtocol: ptr.To("lots-of[invalid]-{chars}")}},
 				}},
 			},
 			expectedErrs: field.ErrorList{
@@ -20794,7 +20794,7 @@ func TestValidateEndpointsUpdate(t *testing.T) {
 				ep.Subsets[0].Ports = []core.EndpointPort{{Name: "a", Port: 8675, Protocol: "TCP"}}
 			},
 			tweakNewEndpoints: func(ep *core.Endpoints) {
-				ep.Subsets[0].Ports = []core.EndpointPort{{Name: "a", Port: 8675, Protocol: "TCP", AppProtocol: utilpointer.String("https")}}
+				ep.Subsets[0].Ports = []core.EndpointPort{{Name: "a", Port: 8675, Protocol: "TCP", AppProtocol: ptr.To("https")}}
 			},
 			numExpectedErrors: 0,
 		},
@@ -20803,7 +20803,7 @@ func TestValidateEndpointsUpdate(t *testing.T) {
 				ep.Subsets[0].Ports = []core.EndpointPort{{Name: "a", Port: 8675, Protocol: "TCP"}}
 			},
 			tweakNewEndpoints: func(ep *core.Endpoints) {
-				ep.Subsets[0].Ports = []core.EndpointPort{{Name: "a", Port: 8675, Protocol: "TCP", AppProtocol: utilpointer.String("~https")}}
+				ep.Subsets[0].Ports = []core.EndpointPort{{Name: "a", Port: 8675, Protocol: "TCP", AppProtocol: ptr.To("~https")}}
 			},
 			numExpectedErrors: 1,
 		},
@@ -20840,7 +20840,7 @@ func TestValidateWindowsSecurityContext(t *testing.T) {
 		errorType:   "FieldValueForbidden",
 	}, {
 		name:        "pod with SeccompProfile",
-		sc:          &core.PodSpec{Containers: []core.Container{{SecurityContext: &core.SecurityContext{SeccompProfile: &core.SeccompProfile{LocalhostProfile: utilpointer.String("dummy")}}}}},
+		sc:          &core.PodSpec{Containers: []core.Container{{SecurityContext: &core.SecurityContext{SeccompProfile: &core.SeccompProfile{LocalhostProfile: ptr.To("dummy")}}}}},
 		expectError: true,
 		errorMsg:    "cannot be set for a windows pod",
 		errorType:   "FieldValueForbidden",
@@ -20852,7 +20852,7 @@ func TestValidateWindowsSecurityContext(t *testing.T) {
 		errorType:   "FieldValueForbidden",
 	}, {
 		name:        "pod with WindowsOptions, no error",
-		sc:          &core.PodSpec{Containers: []core.Container{{SecurityContext: &core.SecurityContext{WindowsOptions: &core.WindowsSecurityContextOptions{RunAsUserName: utilpointer.String("dummy")}}}}},
+		sc:          &core.PodSpec{Containers: []core.Container{{SecurityContext: &core.SecurityContext{WindowsOptions: &core.WindowsSecurityContextOptions{RunAsUserName: ptr.To("dummy")}}}}},
 		expectError: false,
 	},
 	}
@@ -21216,7 +21216,7 @@ func TestValidateTLSSecret(t *testing.T) {
 func TestValidateLinuxSecurityContext(t *testing.T) {
 	runAsUser := int64(1)
 	validLinuxSC := &core.SecurityContext{
-		Privileged: utilpointer.Bool(false),
+		Privileged: ptr.To(false),
 		Capabilities: &core.Capabilities{
 			Add:  []core.Capability{"foo"},
 			Drop: []core.Capability{"bar"},
@@ -21230,7 +21230,7 @@ func TestValidateLinuxSecurityContext(t *testing.T) {
 		RunAsUser: &runAsUser,
 	}
 	invalidLinuxSC := &core.SecurityContext{
-		WindowsOptions: &core.WindowsSecurityContextOptions{RunAsUserName: utilpointer.String("myUser")},
+		WindowsOptions: &core.WindowsSecurityContextOptions{RunAsUserName: ptr.To("myUser")},
 	}
 	cases := map[string]struct {
 		sc          *core.PodSpec
@@ -21270,7 +21270,7 @@ func TestValidateSecurityContext(t *testing.T) {
 	runAsUser := int64(1)
 	fullValidSC := func() *core.SecurityContext {
 		return &core.SecurityContext{
-			Privileged: utilpointer.Bool(false),
+			Privileged: ptr.To(false),
 			Capabilities: &core.Capabilities{
 				Add:  []core.Capability{"foo"},
 				Drop: []core.Capability{"bar"},
@@ -21326,19 +21326,19 @@ func TestValidateSecurityContext(t *testing.T) {
 	}
 
 	privRequestWithGlobalDeny := fullValidSC()
-	privRequestWithGlobalDeny.Privileged = utilpointer.Bool(true)
+	privRequestWithGlobalDeny.Privileged = ptr.To(true)
 
 	negativeRunAsUser := fullValidSC()
 	negativeUser := int64(-1)
 	negativeRunAsUser.RunAsUser = &negativeUser
 
 	privWithoutEscalation := fullValidSC()
-	privWithoutEscalation.Privileged = utilpointer.Bool(true)
-	privWithoutEscalation.AllowPrivilegeEscalation = utilpointer.Bool(false)
+	privWithoutEscalation.Privileged = ptr.To(true)
+	privWithoutEscalation.AllowPrivilegeEscalation = ptr.To(false)
 
 	capSysAdminWithoutEscalation := fullValidSC()
 	capSysAdminWithoutEscalation.Capabilities.Add = []core.Capability{"CAP_SYS_ADMIN"}
-	capSysAdminWithoutEscalation.AllowPrivilegeEscalation = utilpointer.Bool(false)
+	capSysAdminWithoutEscalation.AllowPrivilegeEscalation = ptr.To(false)
 
 	errorCases := map[string]struct {
 		sc           *core.SecurityContext
@@ -21994,17 +21994,17 @@ func TestValidateOrSetClientIPAffinityConfig(t *testing.T) {
 	successCases := map[string]*core.SessionAffinityConfig{
 		"non-empty config, valid timeout: 1": {
 			ClientIP: &core.ClientIPConfig{
-				TimeoutSeconds: utilpointer.Int32(1),
+				TimeoutSeconds: ptr.To[int32](1),
 			},
 		},
 		"non-empty config, valid timeout: core.MaxClientIPServiceAffinitySeconds-1": {
 			ClientIP: &core.ClientIPConfig{
-				TimeoutSeconds: utilpointer.Int32(core.MaxClientIPServiceAffinitySeconds - 1),
+				TimeoutSeconds: ptr.To[int32](core.MaxClientIPServiceAffinitySeconds - 1),
 			},
 		},
 		"non-empty config, valid timeout: core.MaxClientIPServiceAffinitySeconds": {
 			ClientIP: &core.ClientIPConfig{
-				TimeoutSeconds: utilpointer.Int32(core.MaxClientIPServiceAffinitySeconds),
+				TimeoutSeconds: ptr.To[int32](core.MaxClientIPServiceAffinitySeconds),
 			},
 		},
 	}
@@ -22027,17 +22027,17 @@ func TestValidateOrSetClientIPAffinityConfig(t *testing.T) {
 		},
 		"non-empty config, invalid timeout: core.MaxClientIPServiceAffinitySeconds+1": {
 			ClientIP: &core.ClientIPConfig{
-				TimeoutSeconds: utilpointer.Int32(core.MaxClientIPServiceAffinitySeconds + 1),
+				TimeoutSeconds: ptr.To[int32](core.MaxClientIPServiceAffinitySeconds + 1),
 			},
 		},
 		"non-empty config, invalid timeout: -1": {
 			ClientIP: &core.ClientIPConfig{
-				TimeoutSeconds: utilpointer.Int32(-1),
+				TimeoutSeconds: ptr.To[int32](-1),
 			},
 		},
 		"non-empty config, invalid timeout: 0": {
 			ClientIP: &core.ClientIPConfig{
-				TimeoutSeconds: utilpointer.Int32(0),
+				TimeoutSeconds: ptr.To[int32](0),
 			},
 		},
 	}
@@ -22481,19 +22481,19 @@ func TestVolumeAttributesClass(t *testing.T) {
 			testName:                    "Feature gate enabled and an empty volumeAttributesClassName specified",
 			expectedFail:                false,
 			enableVolumeAttributesClass: true,
-			claimSpec:                   pvcSpecWithVolumeAttributesClassName(utilpointer.String("")),
+			claimSpec:                   pvcSpecWithVolumeAttributesClassName(ptr.To("")),
 		},
 		{
 			testName:                    "Feature gate enabled and valid volumeAttributesClassName specified",
 			expectedFail:                false,
 			enableVolumeAttributesClass: true,
-			claimSpec:                   pvcSpecWithVolumeAttributesClassName(utilpointer.String("foo")),
+			claimSpec:                   pvcSpecWithVolumeAttributesClassName(ptr.To("foo")),
 		},
 		{
 			testName:                    "Feature gate enabled and invalid volumeAttributesClassName specified",
 			expectedFail:                true,
 			enableVolumeAttributesClass: true,
-			claimSpec:                   pvcSpecWithVolumeAttributesClassName(utilpointer.String("-invalid-")),
+			claimSpec:                   pvcSpecWithVolumeAttributesClassName(ptr.To("-invalid-")),
 		},
 	}
 	for _, tc := range testCases {
@@ -22539,7 +22539,7 @@ func TestValidateTopologySpreadConstraints(t *testing.T) {
 			MaxSkew:           1,
 			TopologyKey:       "k8s.io/zone",
 			WhenUnsatisfiable: core.DoNotSchedule,
-			MinDomains:        utilpointer.Int32(3),
+			MinDomains:        ptr.To[int32](3),
 		}},
 		wantFieldErrors: nil,
 	}, {
@@ -22573,7 +22573,7 @@ func TestValidateTopologySpreadConstraints(t *testing.T) {
 			MaxSkew:           1,
 			TopologyKey:       "k8s.io/zone",
 			WhenUnsatisfiable: core.DoNotSchedule,
-			MinDomains:        utilpointer.Int32(-1),
+			MinDomains:        ptr.To[int32](-1),
 		}},
 		wantFieldErrors: field.ErrorList{
 			field.Invalid(fieldPathMinDomains, nil, "").WithOrigin("minimum"),
@@ -22584,7 +22584,7 @@ func TestValidateTopologySpreadConstraints(t *testing.T) {
 			MaxSkew:           1,
 			TopologyKey:       "k8s.io/zone",
 			WhenUnsatisfiable: core.ScheduleAnyway,
-			MinDomains:        utilpointer.Int32(10),
+			MinDomains:        ptr.To[int32](10),
 		}},
 		wantFieldErrors: field.ErrorList{
 			field.Invalid(fieldPathMinDomains, nil, "").WithOrigin("dependsOn"),
@@ -22595,7 +22595,7 @@ func TestValidateTopologySpreadConstraints(t *testing.T) {
 			MaxSkew:           1,
 			TopologyKey:       "k8s.io/zone",
 			WhenUnsatisfiable: core.ScheduleAnyway,
-			MinDomains:        utilpointer.Int32(-1),
+			MinDomains:        ptr.To[int32](-1),
 		}},
 		wantFieldErrors: field.ErrorList{
 			field.Invalid(fieldPathMinDomains, nil, "").WithOrigin("minimum"),
@@ -23356,7 +23356,7 @@ func TestValidateSeccompAnnotationsAndFieldsMatch(t *testing.T) {
 	}, {
 		description:     "localhost/test.json annotation and SeccompProfileTypeLocalhost with correct profile should return empty",
 		annotationValue: "localhost/test.json",
-		seccompField:    &core.SeccompProfile{Type: core.SeccompProfileTypeLocalhost, LocalhostProfile: utilpointer.String("test.json")},
+		seccompField:    &core.SeccompProfile{Type: core.SeccompProfileTypeLocalhost, LocalhostProfile: ptr.To("test.json")},
 		expectedErr:     nil,
 	}, {
 		description:     "localhost/test.json annotation and SeccompProfileTypeLocalhost without profile should error",
@@ -23367,7 +23367,7 @@ func TestValidateSeccompAnnotationsAndFieldsMatch(t *testing.T) {
 	}, {
 		description:     "localhost/test.json annotation and SeccompProfileTypeLocalhost with different profile should error",
 		annotationValue: "localhost/test.json",
-		seccompField:    &core.SeccompProfile{Type: core.SeccompProfileTypeLocalhost, LocalhostProfile: utilpointer.String("different.json")},
+		seccompField:    &core.SeccompProfile{Type: core.SeccompProfileTypeLocalhost, LocalhostProfile: ptr.To("different.json")},
 		fldPath:         rootFld,
 		expectedErr:     field.Forbidden(rootFld.Child("localhostProfile"), "seccomp profile in annotation and field must match"),
 	}, {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

https://github.com/kubernetes/kubernetes/pull/130725 touches these fields and the linter demands we migrate.  But we don't want the pollute that PR with this change since that PR it is intended to serve as an example of how to migrate fields to declarative validation.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
