### PR TITLE
CLE: Remove invalid emulated version and add lexographical order test

### DIFF
--- a/pkg/controlplane/controller/leaderelection/election_test.go
+++ b/pkg/controlplane/controller/leaderelection/election_test.go
@@ -404,6 +404,22 @@ func TestCompare(t *testing.T) {
 			},
 			expectedResult: 1,
 		},
+		{
+			name: "lhs less than rhs, lexographical order check",
+			lhs: &v1alpha2.LeaseCandidate{
+				Spec: v1alpha2.LeaseCandidateSpec{
+					EmulationVersion: "1.2.0",
+					BinaryVersion:    "1.20.0",
+				},
+			},
+			rhs: &v1alpha2.LeaseCandidate{
+				Spec: v1alpha2.LeaseCandidateSpec{
+					EmulationVersion: "1.19.0",
+					BinaryVersion:    "1.20.0",
+				},
+			},
+			expectedResult: -1,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/test/integration/apiserver/coordinated_leader_election_test.go
+++ b/test/integration/apiserver/coordinated_leader_election_test.go
@@ -149,8 +149,7 @@ func TestMultipleLeaseCandidate(t *testing.T) {
 			go cletest.createAndRunFakeController("baz1", "default", "baz", "1.20.0", "1.20.0", tc.preferredStrategy)
 			go cletest.createAndRunFakeController("baz2", "default", "baz", "1.20.0", "1.19.0", tc.preferredStrategy)
 			go cletest.createAndRunFakeController("baz3", "default", "baz", "1.19.0", "1.19.0", tc.preferredStrategy)
-			go cletest.createAndRunFakeController("baz4", "default", "baz", "1.2.0", "1.19.0", tc.preferredStrategy)
-			go cletest.createAndRunFakeController("baz5", "default", "baz", "1.20.0", "1.19.0", tc.preferredStrategy)
+			go cletest.createAndRunFakeController("baz4", "default", "baz", "1.20.0", "1.19.0", tc.preferredStrategy)
 			cletest.pollForLease(ctx, "baz", "default", tc.expectedHolderIdentity)
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Remove an integration test line because binaryVersion < emulationVersion so the controller fails to start because it is invalid. The log line was hidden since the test passes without that particular controller running. Add another test case in election.go to ensure that `1.2 < 1.19` is true for semver comparison (despite not being true in lexicographical comparison)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/triage accepted
/assign @Henrywu573 @jpbetz 
