### PR TITLE
Promote TopologyAwareHints feature-gate to GA

### DIFF
--- a/pkg/features/versioned_kube_features.go
+++ b/pkg/features/versioned_kube_features.go
@@ -786,6 +786,7 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 		{Version: version.MustParse("1.21"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("1.23"), Default: false, PreRelease: featuregate.Beta},
 		{Version: version.MustParse("1.24"), Default: true, PreRelease: featuregate.Beta},
+		{Version: version.MustParse("1.33"), Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	},
 
 	TopologyManagerPolicyAlphaOptions: {

--- a/pkg/proxy/endpointslicecache.go
+++ b/pkg/proxy/endpointslicecache.go
@@ -25,9 +25,7 @@ import (
 	discovery "k8s.io/api/discovery/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/klog/v2"
-	"k8s.io/kubernetes/pkg/features"
 	utilnet "k8s.io/utils/net"
 )
 
@@ -213,12 +211,10 @@ func (cache *EndpointSliceCache) addEndpoints(svcPortName *ServicePortName, port
 		terminating := endpoint.Conditions.Terminating != nil && *endpoint.Conditions.Terminating
 
 		var zoneHints sets.Set[string]
-		if utilfeature.DefaultFeatureGate.Enabled(features.TopologyAwareHints) {
-			if endpoint.Hints != nil && len(endpoint.Hints.ForZones) > 0 {
-				zoneHints = sets.New[string]()
-				for _, zone := range endpoint.Hints.ForZones {
-					zoneHints.Insert(zone.Name)
-				}
+		if endpoint.Hints != nil && len(endpoint.Hints.ForZones) > 0 {
+			zoneHints = sets.New[string]()
+			for _, zone := range endpoint.Hints.ForZones {
+				zoneHints.Insert(zone.Name)
 			}
 		}
 

--- a/pkg/proxy/serviceport.go
+++ b/pkg/proxy/serviceport.go
@@ -56,8 +56,6 @@ type ServicePort interface {
 	ExternalPolicyLocal() bool
 	// InternalPolicyLocal returns if a service has only node local endpoints for internal traffic.
 	InternalPolicyLocal() bool
-	// HintsAnnotation returns the value of the v1.DeprecatedAnnotationTopologyAwareHints annotation.
-	HintsAnnotation() string
 	// ExternallyAccessible returns true if the service port is reachable via something
 	// other than ClusterIP (NodePort/ExternalIP/LoadBalancer)
 	ExternallyAccessible() bool
@@ -86,7 +84,6 @@ type BaseServicePortInfo struct {
 	healthCheckNodePort      int
 	externalPolicyLocal      bool
 	internalPolicyLocal      bool
-	hintsAnnotation          string
 }
 
 var _ ServicePort = &BaseServicePortInfo{}
@@ -156,11 +153,6 @@ func (bsvcPortInfo *BaseServicePortInfo) InternalPolicyLocal() bool {
 	return bsvcPortInfo.internalPolicyLocal
 }
 
-// HintsAnnotation is part of ServicePort interface.
-func (bsvcPortInfo *BaseServicePortInfo) HintsAnnotation() string {
-	return bsvcPortInfo.hintsAnnotation
-}
-
 // ExternallyAccessible is part of ServicePort interface.
 func (bsvcPortInfo *BaseServicePortInfo) ExternallyAccessible() bool {
 	return bsvcPortInfo.nodePort != 0 || len(bsvcPortInfo.loadBalancerVIPs) != 0 || len(bsvcPortInfo.externalIPs) != 0
@@ -199,13 +191,6 @@ func newBaseServiceInfo(service *v1.Service, ipFamily v1.IPFamily, port *v1.Serv
 		stickyMaxAgeSeconds: stickyMaxAgeSeconds,
 		externalPolicyLocal: externalPolicyLocal,
 		internalPolicyLocal: internalPolicyLocal,
-	}
-
-	// v1.DeprecatedAnnotationTopologyAwareHints has precedence over v1.AnnotationTopologyMode.
-	var exists bool
-	info.hintsAnnotation, exists = service.Annotations[v1.DeprecatedAnnotationTopologyAwareHints]
-	if !exists {
-		info.hintsAnnotation = service.Annotations[v1.AnnotationTopologyMode]
 	}
 
 	// Filter ExternalIPs to correct IP family

--- a/pkg/proxy/topology.go
+++ b/pkg/proxy/topology.go
@@ -135,7 +135,7 @@ func CategorizeEndpoints(endpoints []Endpoint, svcInfo ServicePort, nodeLabels m
 	return
 }
 
-// canUseTopology returns true if all of the following is true:
+// canUseTopology returns true if all of the following are true:
 //   - The node's labels include "topology.kubernetes.io/zone".
 //   - All of the endpoints for this Service have a topology hint.
 //   - At least one endpoint for this Service is hinted for this node's zone.

--- a/pkg/registry/discovery/endpointslice/strategy_test.go
+++ b/pkg/registry/discovery/endpointslice/strategy_test.go
@@ -25,6 +25,7 @@ import (
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/version"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
@@ -67,6 +68,9 @@ func Test_dropDisabledFieldsOnCreate(t *testing.T) {
 
 	for _, testcase := range testcases {
 		t.Run(testcase.name, func(t *testing.T) {
+			if !testcase.hintsGateEnabled {
+				featuregatetesting.SetFeatureGateEmulationVersionDuringTest(t, utilfeature.DefaultFeatureGate, version.MustParse("1.32"))
+			}
 			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.TopologyAwareHints, testcase.hintsGateEnabled)
 
 			dropDisabledFieldsOnCreate(testcase.eps)
@@ -283,6 +287,9 @@ func Test_dropDisabledFieldsOnUpdate(t *testing.T) {
 
 	for _, testcase := range testcases {
 		t.Run(testcase.name, func(t *testing.T) {
+			if !testcase.hintsGateEnabled {
+				featuregatetesting.SetFeatureGateEmulationVersionDuringTest(t, utilfeature.DefaultFeatureGate, version.MustParse("1.32"))
+			}
 			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.TopologyAwareHints, testcase.hintsGateEnabled)
 
 			dropDisabledFieldsOnUpdate(testcase.oldEPS, testcase.newEPS)

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -1475,6 +1475,10 @@
     lockToDefault: false
     preRelease: Beta
     version: "1.24"
+  - default: true
+    lockToDefault: true
+    preRelease: GA
+    version: "1.33"
 - name: TopologyManagerPolicyAlphaOptions
   versionedSpecs:
   - default: false


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind documentation

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

* Promote TopologyAwareHints feature-gate to GA
* Remove usage of feature-gate from kube-proxy packages. Update tests accordingly.

This PR builds on top of https://github.com/kubernetes/kubernetes/pull/130673 and will be rebased once it gets submitted

/hold

#### Special notes for your reviewer:

* Documentation like https://kubernetes.io/docs/concepts/services-networking/topology-aware-routing/ which links the `service.kubernetes.io/topology-mode=Auto` annotation to the `TopologyAwareHints` feature gate will be updated separately (in https://github.com/kubernetes/website/pull/49914) to accurately reflect that the annotation is not considered GA, despite sharing the same underlying as the GA'd hints field.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The EndpointSlice `hints` field has graduated to GA. The beta annotation `service.kubernetes.io/topology-mode` is now considered deprecated and will not graduate to GA. It remains operational for backward compatibility. Users are encouraged to use the `spec.trafficDistribution` field in the Service API for topology-aware routing configuration.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/efd94f0918a8a48d9a1afcef3cb54cb630d8d4ce/keps/sig-network/2433-topology-aware-hints
```

/sig network
/priority important-soon

/assign @danwinship 
/assign @thockin 
