### PR TITLE
Fix TestGenericListerListMethod by not validating order of elements returned by indexer

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/listers_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/listers_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -122,9 +123,7 @@ func TestGenericListerListMethod(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !reflect.DeepEqual(expectedOutput, actualOutput) {
-		t.Fatalf("unexpected object has been returned expected = %v actual = %v, diff = %v", expectedOutput, actualOutput, cmp.Diff(expectedOutput, actualOutput))
-	}
+	assert.ElementsMatch(t, expectedOutput, actualOutput)
 }
 
 func TestGenericListerByNamespaceMethod(t *testing.T) {


### PR DESCRIPTION

/kind flake

```release-note
NONE
```

/assign @jpbetz @thockin 
Fix flake introduced in https://github.com/kubernetes/kubernetes/pull/125102

/sig api-machinery
