### PR TITLE
Define type alias for getServiceAccount function

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -224,7 +224,7 @@ func NewKubeGenericRuntimeManager(
 	podPullingTimeRecorder images.ImagePodPullingTimeRecorder,
 	tracerProvider trace.TracerProvider,
 	tokenManager *token.Manager,
-	getServiceAccount func(string, string) (*v1.ServiceAccount, error),
+	getServiceAccount plugin.GetServiceAccountFunc,
 ) (KubeGenericRuntime, error) {
 	ctx := context.Background()
 	runtimeService = newInstrumentedRuntimeService(runtimeService)


### PR DESCRIPTION
follow-up to https://github.com/kubernetes/kubernetes/pull/128372

Introduced `GetServiceAccountFunc` type alias to improve readability  
and avoid repeating the function signature.

/kind cleanup
/sig auth
/triage accepted
/priority important-soon

```release-note
NONE
```

```docs
[KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-auth/4412-projected-service-account-tokens-for-kubelet-image-credential-providers/README.md
```
