### PR TITLE
[Declarative Validation] chore: change Info->Error log level related to declarative validation runtime tests and refactor panic wrapper names

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/validate_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/validate_test.go
@@ -394,8 +394,8 @@ func TestCompareDeclarativeErrorsAndEmitMismatches(t *testing.T) {
 			declarativeErrs: field.ErrorList{errA},
 			takeover:        true,
 			expectLogs:      true,
-			// logs have a prefix of the form - I0309 21:05:33.865030 1926106 validate.go:199]
-			expectedRegex: "I.*Unexpected difference between hand written validation and declarative validation error results.*Consider disabling the DeclarativeValidationTakeover feature gate to keep data persisted in etcd consistent with prior versions of Kubernetes",
+			// logs have a prefix of the form - E0309 21:05:33.865030 1926106 validate.go:199]
+			expectedRegex: "E.*Unexpected difference between hand written validation and declarative validation error results.*Consider disabling the DeclarativeValidationTakeover feature gate to keep data persisted in etcd consistent with prior versions of Kubernetes",
 		},
 		{
 			name:            "matching errors, don't log info",
@@ -468,8 +468,8 @@ func TestWithRecover(t *testing.T) {
 			},
 			takeoverEnabled: false,
 			wantErrs:        nil,
-			// logs have a prefix of the form - I0309 21:05:33.865030 1926106 validate.go:199]
-			expectLogRegex: "I.*panic during declarative validation: test panic",
+			// logs have a prefix of the form - E0309 21:05:33.865030 1926106 validate.go:199]
+			expectLogRegex: "E.*panic during declarative validation: test panic",
 		},
 		{
 			name: "panic with takeover enabled",
@@ -500,8 +500,8 @@ func TestWithRecover(t *testing.T) {
 			klog.LogToStderr(false)
 			defer klog.LogToStderr(true)
 
-			// Pass the takeover flag to withRecover instead of relying on the feature gate
-			wrapped := withRecover(tc.validateFn, tc.takeoverEnabled)
+			// Pass the takeover flag to panicSafeValidateFunc instead of relying on the feature gate
+			wrapped := panicSafeValidateFunc(tc.validateFn, tc.takeoverEnabled)
 			gotErrs := wrapped(ctx, options, scheme, obj)
 
 			klog.Flush()
@@ -509,7 +509,7 @@ func TestWithRecover(t *testing.T) {
 
 			// Compare gotErrs vs. tc.wantErrs
 			if !equalErrorLists(gotErrs, tc.wantErrs) {
-				t.Errorf("withRecover() gotErrs = %#v, want %#v", gotErrs, tc.wantErrs)
+				t.Errorf("panicSafeValidateFunc() gotErrs = %#v, want %#v", gotErrs, tc.wantErrs)
 			}
 
 			// Check logs if needed
@@ -562,8 +562,8 @@ func TestWithRecoverUpdate(t *testing.T) {
 			},
 			takeoverEnabled: false,
 			wantErrs:        nil,
-			// logs have a prefix of the form - I0309 21:05:33.865030 1926106 validate.go:199]
-			expectLogRegex: "I.*panic during declarative validation: test update panic",
+			// logs have a prefix of the form - E0309 21:05:33.865030 1926106 validate.go:199]
+			expectLogRegex: "E.*panic during declarative validation: test update panic",
 		},
 		{
 			name: "panic with takeover enabled",
@@ -594,8 +594,8 @@ func TestWithRecoverUpdate(t *testing.T) {
 			klog.LogToStderr(false)
 			defer klog.LogToStderr(true)
 
-			// Pass the takeover flag to withRecoverUpdate instead of relying on the feature gate
-			wrapped := withRecoverUpdate(tc.validateFn, tc.takeoverEnabled)
+			// Pass the takeover flag to panicSafeValidateUpdateFunc instead of relying on the feature gate
+			wrapped := panicSafeValidateUpdateFunc(tc.validateFn, tc.takeoverEnabled)
 			gotErrs := wrapped(ctx, options, scheme, obj, oldObj)
 
 			klog.Flush()
@@ -603,7 +603,7 @@ func TestWithRecoverUpdate(t *testing.T) {
 
 			// Compare gotErrs with wantErrs
 			if !equalErrorLists(gotErrs, tc.wantErrs) {
-				t.Errorf("withRecoverUpdate() gotErrs = %#v, want %#v", gotErrs, tc.wantErrs)
+				t.Errorf("panicSafeValidateUpdateFunc() gotErrs = %#v, want %#v", gotErrs, tc.wantErrs)
 			}
 
 			// Verify log output


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR addresses some minor comments from the merged PR here: https://github.com/kubernetes/kubernetes/pull/130705
- https://github.com/kubernetes/kubernetes/pull/130705#discussion_r1991929861
- https://github.com/kubernetes/kubernetes/pull/130705#discussion_r1991971092

This PR:
- changes the logging related to declarative validation runtime testing from `Info` -> `Error`
- changes the names of the methods: withRecover -> panicSafeValidateFunc & withRecoverUpdate -> panicSafeValidateUpdateFunc

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
It is part of https://github.com/kubernetes/enhancements/issues/5073
Related to comments on the PR here: https://github.com/kubernetes/kubernetes/pull/130705
- https://github.com/kubernetes/kubernetes/pull/130705#discussion_r1991929861
- https://github.com/kubernetes/kubernetes/pull/130705#discussion_r1991971092

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/5073-declarative-validation-with-validation-gen/README.md
```
