### PR TITLE
Cleanup CI integration scripts

### DIFF
--- a/hack/install-etcd.sh
+++ b/hack/install-etcd.sh
@@ -27,4 +27,4 @@ source "${KUBE_ROOT}/hack/lib/init.sh"
 
 FOUND="$(echo "${PATH}" | sed 's/:/\n/g' | grep -q "^${KUBE_ROOT}/third_party/etcd$" || true)"
 kube::etcd::install
-test -n "${FOUND}" || echo "  PATH=\"\$PATH:${KUBE_ROOT}/third_party/etcd\""
+test -n "${FOUND}" || echo "export PATH=\"\${PATH}:${KUBE_ROOT}/third_party/etcd\""

--- a/hack/jenkins/benchmark-dockerized.sh
+++ b/hack/jenkins/benchmark-dockerized.sh
@@ -48,7 +48,6 @@ if [ -n "${KUBE_HACK_TOOLS_GOTOOLCHAIN:-}" ]; then
   hack_tools_gotoolchain="${KUBE_HACK_TOOLS_GOTOOLCHAIN}";
 fi
 GOTOOLCHAIN="${hack_tools_gotoolchain}" go -C "${KUBE_ROOT}/hack/tools" install github.com/cespare/prettybench
-GOTOOLCHAIN="${hack_tools_gotoolchain}" go -C "${KUBE_ROOT}/hack/tools" install gotest.tools/gotestsum
 
 # Disable the Go race detector.
 export KUBE_RACE=" "

--- a/hack/jenkins/test-cmd-dockerized.sh
+++ b/hack/jenkins/test-cmd-dockerized.sh
@@ -19,20 +19,11 @@ set -o nounset
 set -o pipefail
 set -o xtrace
 
-# Runs test-cmd,
-# producing JUnit-style XML test
-# reports in ${WORKSPACE}/artifacts. This script is intended to be run from
-# kubekins-test container with a kubernetes repo mapped in. See
-# k8s.io/test-infra/scenarios/kubernetes_verify.py
+# Runs test-cmd, intended to be run in prow.k8s.io
+set -x;
 
-export PATH=${GOPATH}/bin:${PWD}/third_party/etcd:/usr/local/go/bin:${PATH}
-
-# Set artifacts directory
-export ARTIFACTS=${ARTIFACTS:-"${WORKSPACE}/artifacts"}
-
-cd "${GOPATH}/src/k8s.io/kubernetes"
-
-./hack/install-etcd.sh
+# TODO: make test-cmd should handle this automatically
+source ./hack/install-etcd.sh
 
 make test-cmd
 

--- a/hack/jenkins/test-dockerized.sh
+++ b/hack/jenkins/test-dockerized.sh
@@ -19,32 +19,14 @@ set -o nounset
 set -o pipefail
 set -o xtrace
 
-# Runs test-cmd and test-integration,
-# producing JUnit-style XML test
-# reports in ${WORKSPACE}/artifacts. This script is intended to be run from
-# kubekins-test container with a kubernetes repo mapped in. See
-# k8s.io/test-infra/scenarios/kubernetes_verify.py
+# Runs test-cmd and test-integration, intended to be run in prow.k8s.io
+set -x;
 
-export PATH=${GOPATH}/bin:${PWD}/third_party/etcd:/usr/local/go/bin:${PATH}
+# TODO: make test-integration should handle this automatically
+source ./hack/install-etcd.sh
 
-# Install tools we need
-hack_tools_gotoolchain="${GOTOOLCHAIN:-}"
-if [ -n "${KUBE_HACK_TOOLS_GOTOOLCHAIN:-}" ]; then
-  hack_tools_gotoolchain="${KUBE_HACK_TOOLS_GOTOOLCHAIN}";
-fi
-GOTOOLCHAIN="${hack_tools_gotoolchain}" go -C "./hack/tools" install gotest.tools/gotestsum
-
-# Disable coverage report
-export KUBE_COVER="n"
-# Set artifacts directory
-export ARTIFACTS=${ARTIFACTS:-"${WORKSPACE}/artifacts"}
 # Save the verbose stdout as well.
 export KUBE_KEEP_VERBOSE_TEST_OUTPUT=y
 export LOG_LEVEL=4
-
-cd "${GOPATH}/src/k8s.io/kubernetes"
-
-./hack/install-etcd.sh
-
 make test-cmd
 make test-integration

--- a/hack/jenkins/test-integration-dockerized.sh
+++ b/hack/jenkins/test-integration-dockerized.sh
@@ -19,27 +19,11 @@ set -o nounset
 set -o pipefail
 set -o xtrace
 
-# Runs test-integration,
-# producing JUnit-style XML test
-# reports in ${WORKSPACE}/artifacts. This script is intended to be run from
-# kubekins-test container with a kubernetes repo mapped in. See
-# k8s.io/test-infra/scenarios/kubernetes_verify.py
+# Runs test-integration
+# This script is intended to be run from prow.k8s.io
+set -x;
 
-export PATH=${GOPATH}/bin:${PWD}/third_party/etcd:/usr/local/go/bin:${PATH}
+# TODO: make test-integration should handle this automatically
+source ./hack/install-etcd.sh
 
-# Install tools we need
-go -C "./hack/tools" install gotest.tools/gotestsum
-
-# Disable coverage report
-export KUBE_COVER="n"
-# Set artifacts directory
-export ARTIFACTS=${ARTIFACTS:-"${WORKSPACE}/artifacts"}
-# Save the verbose stdout as well.
-export KUBE_KEEP_VERBOSE_TEST_OUTPUT=y
-export LOG_LEVEL=4
-
-cd "${GOPATH}/src/k8s.io/kubernetes"
-
-./hack/install-etcd.sh
-
-make test-integration
+make test-integration KUBE_KEEP_VERBOSE_TEST_OUTPUT=y LOG_LEVEL=4


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:

Most of what these scripts do at this point is redundant or bad practice

I've done:
- stop setting ARTIFACTS from WORKSPACE, CI handles setting ARTIFACTS and WORKSPACE isn't used anymore (bazel?)
- stop cd-ing GOPATH, CI sets the working dir already and local users won't necessarily have GOPATH
- stop clobbering PATH with hardcoded assumptions, source install-etcd.sh instead (which updates PATH)
- don't redundantly set KUBE_COVER to the default
- pass logging env inline so the command can be pasted locally
- set -x so the command is visible
- add TODO about needing a wrapper script just to call install-etcd



#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

builds on top of https://github.com/kubernetes/kubernetes/pull/130758 because I'd prioritize merging that smaller change first.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
