### PR TITLE
Sync `pkg/credentialprovider/OWNERS` with `k8s.io/client-go/tools/auth/OWNERS`

### DIFF
--- a/pkg/credentialprovider/OWNERS
+++ b/pkg/credentialprovider/OWNERS
@@ -1,16 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - deads2k
-  - liggitt
+  - sig-auth-authenticators-approvers
 reviewers:
-  - thockin
-  - smarterclayton
-  - yujuhong
-  - derekwaynecarr
-  - mikedanese
-  - dchen1107
-  - justinsb
-  - dims
-  - andrewsykim
-  - andyzhangx
+  - sig-auth-authenticators-reviewers
+labels:
+  - sig/auth


### PR DESCRIPTION
Note that `k8s.io/client-go/plugin/pkg/client/auth/OWNERS` also has the same contents.

/kind cleanup

```release-note
NONE
```