### PR TITLE
Fix subresource parsing for declarative validation

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/validate.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/validate.go
@@ -102,10 +102,12 @@ func parseSubresourcePath(subresourcePath string) ([]string, error) {
 	if len(subresourcePath) == 0 {
 		return nil, nil
 	}
-	if subresourcePath[0] != '/' {
-		return nil, fmt.Errorf("invalid subresource path: %s", subresourcePath)
+	parts := strings.Split(subresourcePath, "/")
+	for _, part := range parts {
+		if len(part) == 0 {
+			return nil, fmt.Errorf("invalid subresource path: %s", subresourcePath)
+		}
 	}
-	parts := strings.Split(subresourcePath[1:], "/")
 	return parts, nil
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/validate_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/validate_test.go
@@ -85,15 +85,22 @@ func TestValidateDeclaratively(t *testing.T) {
 			expected:  field.ErrorList{invalidRestartPolicyErr, mutatedRestartPolicyErr},
 		},
 		{
-			name:        "update subresource",
-			subresource: "/status",
+			name:        "update subresource with declarative validation",
+			subresource: "status",
 			object:      valid,
 			oldObject:   valid,
 			expected:    field.ErrorList{invalidStatusErr},
 		},
 		{
+			name:        "update subresource without declarative validation",
+			subresource: "scale",
+			object:      valid,
+			oldObject:   valid,
+			expected:    field.ErrorList{}, // Expect no errors if there is no registered validation
+		},
+		{
 			name:        "invalid subresource",
-			subresource: "invalid/status",
+			subresource: "/invalid/status",
 			object:      valid,
 			oldObject:   valid,
 			expected:    field.ErrorList{invalidSubresourceErr},


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Declarative validation had mistakenly assumed that subresource strings start with a `/`, but they do not.

#### Which issue(s) this PR fixes:

From kind-alpha:

```
> { failed [FAILED] Failed to patch ReplicationControllerScale: ReplicationController "rc-test" is invalid: <nil>: Internal error: unexpected error parsing subresource path: invalid subresource path: scale
In [It] at: [k8s.io/kubernetes/test/e2e/apps/rc.go:298](http://k8s.io/kubernetes/test/e2e/apps/rc.go:298) @ 03/13/25 07:29:58.881
```

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
