### PR TITLE
Validation-gen: emit comments before validations

### DIFF
--- a/pkg/apis/core/v1/zz_generated.validations.go
+++ b/pkg/apis/core/v1/zz_generated.validations.go
@@ -101,8 +101,8 @@ func Validate_ReplicationControllerSpec(ctx context.Context, op operation.Operat
 	// field corev1.ReplicationControllerSpec.MinReadySeconds
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *int32) (errs field.ErrorList) {
-			errs = append(errs, validate.Minimum(ctx, op, fldPath, obj, oldObj, 0)...)
 			// optional value-type fields with zero-value defaults are purely documentation
+			errs = append(errs, validate.Minimum(ctx, op, fldPath, obj, oldObj, 0)...)
 			return
 		}(fldPath.Child("minReadySeconds"), &obj.MinReadySeconds, safe.Field(oldObj, func(oldObj *corev1.ReplicationControllerSpec) *int32 { return &oldObj.MinReadySeconds }))...)
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validation.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validation.go
@@ -969,8 +969,8 @@ func (g *genValidations) emitValidationForChild(c *generator.Context, thisChild 
 			panic(fmt.Sprintf("unexpected type-validations on type %v, kind %s", thisNode.valueType, thisNode.valueType.Kind))
 		}
 		sw.Do("// type $.inType|raw$\n", targs)
-		emitCallsToValidators(c, validations.Functions, sw)
 		emitComments(validations.Comments, sw)
+		emitCallsToValidators(c, validations.Functions, sw)
 		sw.Do("\n", nil)
 		didSome = true
 	}
@@ -998,8 +998,8 @@ func (g *genValidations) emitValidationForChild(c *generator.Context, thisChild 
 
 			validations := fld.fieldValidations
 			if !validations.Empty() {
-				emitCallsToValidators(c, validations.Functions, bufsw)
 				emitComments(validations.Comments, bufsw)
+				emitCallsToValidators(c, validations.Functions, bufsw)
 			}
 
 			// If the node is nil, this must be a type in a package we are not


### PR DESCRIPTION
Based on feedback from @deads2k, builds on #130725

/kind cleanup

```release-note
NONE
```
