### PR TITLE
Replace PodResourceAllocation with PodResourceInfoMap type and cleanup

### DIFF
--- a/pkg/kubelet/allocation/allocation_manager_test.go
+++ b/pkg/kubelet/allocation/allocation_manager_test.go
@@ -103,44 +103,50 @@ func TestUpdatePodFromAllocation(t *testing.T) {
 	tests := []struct {
 		name         string
 		pod          *v1.Pod
-		allocs       state.PodResourceAllocation
+		allocs       state.PodResourceInfoMap
 		expectPod    *v1.Pod
 		expectUpdate bool
 	}{{
 		name: "steady state",
 		pod:  pod,
-		allocs: state.PodResourceAllocation{
-			pod.UID: map[string]v1.ResourceRequirements{
-				"c1":                  *pod.Spec.Containers[0].Resources.DeepCopy(),
-				"c2":                  *pod.Spec.Containers[1].Resources.DeepCopy(),
-				"c1-restartable-init": *pod.Spec.InitContainers[0].Resources.DeepCopy(),
-				"c1-init":             *pod.Spec.InitContainers[1].Resources.DeepCopy(),
+		allocs: state.PodResourceInfoMap{
+			pod.UID: state.PodResourceInfo{
+				ContainerResources: map[string]v1.ResourceRequirements{
+					"c1":                  *pod.Spec.Containers[0].Resources.DeepCopy(),
+					"c2":                  *pod.Spec.Containers[1].Resources.DeepCopy(),
+					"c1-restartable-init": *pod.Spec.InitContainers[0].Resources.DeepCopy(),
+					"c1-init":             *pod.Spec.InitContainers[1].Resources.DeepCopy(),
+				},
 			},
 		},
 		expectUpdate: false,
 	}, {
 		name:         "no allocations",
 		pod:          pod,
-		allocs:       state.PodResourceAllocation{},
+		allocs:       state.PodResourceInfoMap{},
 		expectUpdate: false,
 	}, {
 		name: "missing container allocation",
 		pod:  pod,
-		allocs: state.PodResourceAllocation{
-			pod.UID: map[string]v1.ResourceRequirements{
-				"c2": *pod.Spec.Containers[1].Resources.DeepCopy(),
+		allocs: state.PodResourceInfoMap{
+			pod.UID: state.PodResourceInfo{
+				ContainerResources: map[string]v1.ResourceRequirements{
+					"c2": *pod.Spec.Containers[1].Resources.DeepCopy(),
+				},
 			},
 		},
 		expectUpdate: false,
 	}, {
 		name: "resized container",
 		pod:  pod,
-		allocs: state.PodResourceAllocation{
-			pod.UID: map[string]v1.ResourceRequirements{
-				"c1":                  *resizedPod.Spec.Containers[0].Resources.DeepCopy(),
-				"c2":                  *resizedPod.Spec.Containers[1].Resources.DeepCopy(),
-				"c1-restartable-init": *resizedPod.Spec.InitContainers[0].Resources.DeepCopy(),
-				"c1-init":             *resizedPod.Spec.InitContainers[1].Resources.DeepCopy(),
+		allocs: state.PodResourceInfoMap{
+			pod.UID: state.PodResourceInfo{
+				ContainerResources: map[string]v1.ResourceRequirements{
+					"c1":                  *resizedPod.Spec.Containers[0].Resources.DeepCopy(),
+					"c2":                  *resizedPod.Spec.Containers[1].Resources.DeepCopy(),
+					"c1-restartable-init": *resizedPod.Spec.InitContainers[0].Resources.DeepCopy(),
+					"c1-init":             *resizedPod.Spec.InitContainers[1].Resources.DeepCopy(),
+				},
 			},
 		},
 		expectUpdate: true,

--- a/pkg/kubelet/allocation/state/checkpoint.go
+++ b/pkg/kubelet/allocation/state/checkpoint.go
@@ -20,16 +20,14 @@ import (
 	"encoding/json"
 	"fmt"
 
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager/checksum"
 )
 
 var _ checkpointmanager.Checkpoint = &Checkpoint{}
 
-type PodResourceAllocationInfo struct {
-	AllocationEntries map[types.UID]map[string]v1.ResourceRequirements `json:"allocationEntries,omitempty"`
+type PodResourceCheckpointInfo struct {
+	Entries PodResourceInfoMap `json:"entries,omitempty"`
 }
 
 // Checkpoint represents a structure to store pod resource allocation checkpoint data
@@ -41,7 +39,7 @@ type Checkpoint struct {
 }
 
 // NewCheckpoint creates a new checkpoint from a list of claim info states
-func NewCheckpoint(allocations *PodResourceAllocationInfo) (*Checkpoint, error) {
+func NewCheckpoint(allocations *PodResourceCheckpointInfo) (*Checkpoint, error) {
 
 	serializedAllocations, err := json.Marshal(allocations)
 	if err != nil {
@@ -70,9 +68,9 @@ func (cp *Checkpoint) VerifyChecksum() error {
 	return cp.Checksum.Verify(cp.Data)
 }
 
-// GetPodResourceAllocationInfo returns Pod Resource Allocation info states from checkpoint
-func (cp *Checkpoint) GetPodResourceAllocationInfo() (*PodResourceAllocationInfo, error) {
-	var data PodResourceAllocationInfo
+// GetPodResourceCheckpointInfo returns Pod Resource Allocation info states from checkpoint
+func (cp *Checkpoint) GetPodResourceCheckpointInfo() (*PodResourceCheckpointInfo, error) {
+	var data PodResourceCheckpointInfo
 	if err := json.Unmarshal([]byte(cp.Data), &data); err != nil {
 		return nil, err
 	}

--- a/pkg/kubelet/allocation/state/state_checkpoint.go
+++ b/pkg/kubelet/allocation/state/state_checkpoint.go
@@ -40,17 +40,17 @@ type stateCheckpoint struct {
 	lastChecksum      checksum.Checksum
 }
 
-// NewStateCheckpoint creates new State for keeping track of pod resource allocations with checkpoint backend
+// NewStateCheckpoint creates new State for keeping track of pod resource information with checkpoint backend
 func NewStateCheckpoint(stateDir, checkpointName string) (State, error) {
 	checkpointManager, err := checkpointmanager.NewCheckpointManager(stateDir)
 	if err != nil {
-		return nil, fmt.Errorf("failed to initialize checkpoint manager for pod allocation tracking: %v", err)
+		return nil, fmt.Errorf("failed to initialize checkpoint manager for pod resource information tracking: %w", err)
 	}
 
 	pra, checksum, err := restoreState(checkpointManager, checkpointName)
 	if err != nil {
 		//lint:ignore ST1005 user-facing error message
-		return nil, fmt.Errorf("could not restore state from checkpoint: %w, please drain this node and delete pod allocation checkpoint file %q before restarting Kubelet",
+		return nil, fmt.Errorf("could not restore state from checkpoint: %w, please drain this node and delete pod resource information checkpoint file %q before restarting Kubelet",
 			err, path.Join(stateDir, checkpointName))
 	}
 
@@ -64,7 +64,7 @@ func NewStateCheckpoint(stateDir, checkpointName string) (State, error) {
 }
 
 // restores state from a checkpoint and creates it if it doesn't exist
-func restoreState(checkpointManager checkpointmanager.CheckpointManager, checkpointName string) (PodResourceAllocation, checksum.Checksum, error) {
+func restoreState(checkpointManager checkpointmanager.CheckpointManager, checkpointName string) (PodResourceInfoMap, checksum.Checksum, error) {
 	checkpoint := &Checkpoint{}
 	if err := checkpointManager.GetCheckpoint(checkpointName, checkpoint); err != nil {
 		if err == errors.ErrCheckpointNotFound {
@@ -73,21 +73,21 @@ func restoreState(checkpointManager checkpointmanager.CheckpointManager, checkpo
 		return nil, 0, err
 	}
 
-	praInfo, err := checkpoint.GetPodResourceAllocationInfo()
+	praInfo, err := checkpoint.GetPodResourceCheckpointInfo()
 	if err != nil {
-		return nil, 0, fmt.Errorf("failed to get pod resource allocation info: %w", err)
+		return nil, 0, fmt.Errorf("failed to get pod resource information: %w", err)
 	}
 
-	klog.V(2).InfoS("State checkpoint: restored pod resource allocation state from checkpoint")
-	return praInfo.AllocationEntries, checkpoint.Checksum, nil
+	klog.V(2).InfoS("State checkpoint: restored pod resource state from checkpoint")
+	return praInfo.Entries, checkpoint.Checksum, nil
 }
 
 // saves state to a checkpoint, caller is responsible for locking
 func (sc *stateCheckpoint) storeState() error {
-	podAllocation := sc.cache.GetPodResourceAllocation()
+	resourceInfo := sc.cache.GetPodResourceInfoMap()
 
-	checkpoint, err := NewCheckpoint(&PodResourceAllocationInfo{
-		AllocationEntries: podAllocation,
+	checkpoint, err := NewCheckpoint(&PodResourceCheckpointInfo{
+		Entries: resourceInfo,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create checkpoint: %w", err)
@@ -98,47 +98,50 @@ func (sc *stateCheckpoint) storeState() error {
 	}
 	err = sc.checkpointManager.CreateCheckpoint(sc.checkpointName, checkpoint)
 	if err != nil {
-		klog.ErrorS(err, "Failed to save pod allocation checkpoint")
+		klog.ErrorS(err, "Failed to save pod resource information checkpoint")
 		return err
 	}
 	sc.lastChecksum = checkpoint.Checksum
 	return nil
 }
 
-// GetContainerResourceAllocation returns current resources allocated to a pod's container
-func (sc *stateCheckpoint) GetContainerResourceAllocation(podUID types.UID, containerName string) (v1.ResourceRequirements, bool) {
+// GetContainerResources returns current resources information to a pod's container
+func (sc *stateCheckpoint) GetContainerResources(podUID types.UID, containerName string) (v1.ResourceRequirements, bool) {
 	sc.mux.RLock()
 	defer sc.mux.RUnlock()
-	return sc.cache.GetContainerResourceAllocation(podUID, containerName)
+	return sc.cache.GetContainerResources(podUID, containerName)
 }
 
-// GetPodResourceAllocation returns current pod resource allocation
-func (sc *stateCheckpoint) GetPodResourceAllocation() PodResourceAllocation {
+// GetPodResourceInfoMap returns current pod resource information
+func (sc *stateCheckpoint) GetPodResourceInfoMap() PodResourceInfoMap {
 	sc.mux.RLock()
 	defer sc.mux.RUnlock()
-	return sc.cache.GetPodResourceAllocation()
+	return sc.cache.GetPodResourceInfoMap()
 }
 
-// SetContainerResourceAllocation sets resources allocated to a pod's container
-func (sc *stateCheckpoint) SetContainerResourceAllocation(podUID types.UID, containerName string, alloc v1.ResourceRequirements) error {
+// SetContainerResoruces sets resources information for a pod's container
+func (sc *stateCheckpoint) SetContainerResources(podUID types.UID, containerName string, resources v1.ResourceRequirements) error {
 	sc.mux.Lock()
 	defer sc.mux.Unlock()
-	sc.cache.SetContainerResourceAllocation(podUID, containerName, alloc)
-	return sc.storeState()
-}
-
-// SetPodResourceAllocation sets pod resource allocation
-func (sc *stateCheckpoint) SetPodResourceAllocation(podUID types.UID, alloc map[string]v1.ResourceRequirements) error {
-	sc.mux.Lock()
-	defer sc.mux.Unlock()
-	err := sc.cache.SetPodResourceAllocation(podUID, alloc)
+	err := sc.cache.SetContainerResources(podUID, containerName, resources)
 	if err != nil {
 		return err
 	}
 	return sc.storeState()
 }
 
-// Delete deletes allocations for specified pod
+// SetPodResourceInfo sets pod resource information
+func (sc *stateCheckpoint) SetPodResourceInfo(podUID types.UID, resourceInfo PodResourceInfo) error {
+	sc.mux.Lock()
+	defer sc.mux.Unlock()
+	err := sc.cache.SetPodResourceInfo(podUID, resourceInfo)
+	if err != nil {
+		return err
+	}
+	return sc.storeState()
+}
+
+// Delete deletes resource information for specified pod
 func (sc *stateCheckpoint) RemovePod(podUID types.UID) error {
 	sc.mux.Lock()
 	defer sc.mux.Unlock()
@@ -161,19 +164,19 @@ func NewNoopStateCheckpoint() State {
 	return &noopStateCheckpoint{}
 }
 
-func (sc *noopStateCheckpoint) GetContainerResourceAllocation(_ types.UID, _ string) (v1.ResourceRequirements, bool) {
+func (sc *noopStateCheckpoint) GetContainerResources(_ types.UID, _ string) (v1.ResourceRequirements, bool) {
 	return v1.ResourceRequirements{}, false
 }
 
-func (sc *noopStateCheckpoint) GetPodResourceAllocation() PodResourceAllocation {
+func (sc *noopStateCheckpoint) GetPodResourceInfoMap() PodResourceInfoMap {
 	return nil
 }
 
-func (sc *noopStateCheckpoint) SetContainerResourceAllocation(_ types.UID, _ string, _ v1.ResourceRequirements) error {
+func (sc *noopStateCheckpoint) SetContainerResources(_ types.UID, _ string, _ v1.ResourceRequirements) error {
 	return nil
 }
 
-func (sc *noopStateCheckpoint) SetPodResourceAllocation(_ types.UID, _ map[string]v1.ResourceRequirements) error {
+func (sc *noopStateCheckpoint) SetPodResourceInfo(_ types.UID, _ PodResourceInfo) error {
 	return nil
 }
 

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -2458,17 +2458,19 @@ func TestPodResourceAllocationReset(t *testing.T) {
 	emptyPodSpec.Containers[0].Resources.Requests = v1.ResourceList{}
 
 	tests := []struct {
-		name                          string
-		pod                           *v1.Pod
-		existingPodAllocation         *v1.Pod
-		expectedPodResourceAllocation state.PodResourceAllocation
+		name                       string
+		pod                        *v1.Pod
+		existingPodAllocation      *v1.Pod
+		expectedPodResourceInfoMap state.PodResourceInfoMap
 	}{
 		{
 			name: "Having both memory and cpu, resource allocation not exists",
 			pod:  podWithUIDNameNsSpec("1", "pod1", "foo", *cpu500mMem500MPodSpec),
-			expectedPodResourceAllocation: state.PodResourceAllocation{
-				"1": map[string]v1.ResourceRequirements{
-					cpu500mMem500MPodSpec.Containers[0].Name: cpu500mMem500MPodSpec.Containers[0].Resources,
+			expectedPodResourceInfoMap: state.PodResourceInfoMap{
+				"1": {
+					ContainerResources: map[string]v1.ResourceRequirements{
+						cpu500mMem500MPodSpec.Containers[0].Name: cpu500mMem500MPodSpec.Containers[0].Resources,
+					},
 				},
 			},
 		},
@@ -2476,9 +2478,11 @@ func TestPodResourceAllocationReset(t *testing.T) {
 			name:                  "Having both memory and cpu, resource allocation exists",
 			pod:                   podWithUIDNameNsSpec("2", "pod2", "foo", *cpu500mMem500MPodSpec),
 			existingPodAllocation: podWithUIDNameNsSpec("2", "pod2", "foo", *cpu500mMem500MPodSpec),
-			expectedPodResourceAllocation: state.PodResourceAllocation{
-				"2": map[string]v1.ResourceRequirements{
-					cpu500mMem500MPodSpec.Containers[0].Name: cpu500mMem500MPodSpec.Containers[0].Resources,
+			expectedPodResourceInfoMap: state.PodResourceInfoMap{
+				"2": {
+					ContainerResources: map[string]v1.ResourceRequirements{
+						cpu500mMem500MPodSpec.Containers[0].Name: cpu500mMem500MPodSpec.Containers[0].Resources,
+					},
 				},
 			},
 		},
@@ -2486,18 +2490,22 @@ func TestPodResourceAllocationReset(t *testing.T) {
 			name:                  "Having both memory and cpu, resource allocation exists (with different value)",
 			pod:                   podWithUIDNameNsSpec("3", "pod3", "foo", *cpu500mMem500MPodSpec),
 			existingPodAllocation: podWithUIDNameNsSpec("3", "pod3", "foo", *cpu800mMem800MPodSpec),
-			expectedPodResourceAllocation: state.PodResourceAllocation{
-				"3": map[string]v1.ResourceRequirements{
-					cpu800mMem800MPodSpec.Containers[0].Name: cpu800mMem800MPodSpec.Containers[0].Resources,
+			expectedPodResourceInfoMap: state.PodResourceInfoMap{
+				"3": state.PodResourceInfo{
+					ContainerResources: map[string]v1.ResourceRequirements{
+						cpu800mMem800MPodSpec.Containers[0].Name: cpu800mMem800MPodSpec.Containers[0].Resources,
+					},
 				},
 			},
 		},
 		{
 			name: "Only has cpu, resource allocation not exists",
 			pod:  podWithUIDNameNsSpec("4", "pod5", "foo", *cpu500mPodSpec),
-			expectedPodResourceAllocation: state.PodResourceAllocation{
-				"4": map[string]v1.ResourceRequirements{
-					cpu500mPodSpec.Containers[0].Name: cpu500mPodSpec.Containers[0].Resources,
+			expectedPodResourceInfoMap: state.PodResourceInfoMap{
+				"4": state.PodResourceInfo{
+					ContainerResources: map[string]v1.ResourceRequirements{
+						cpu500mPodSpec.Containers[0].Name: cpu500mPodSpec.Containers[0].Resources,
+					},
 				},
 			},
 		},
@@ -2505,9 +2513,11 @@ func TestPodResourceAllocationReset(t *testing.T) {
 			name:                  "Only has cpu, resource allocation exists",
 			pod:                   podWithUIDNameNsSpec("5", "pod5", "foo", *cpu500mPodSpec),
 			existingPodAllocation: podWithUIDNameNsSpec("5", "pod5", "foo", *cpu500mPodSpec),
-			expectedPodResourceAllocation: state.PodResourceAllocation{
-				"5": map[string]v1.ResourceRequirements{
-					cpu500mPodSpec.Containers[0].Name: cpu500mPodSpec.Containers[0].Resources,
+			expectedPodResourceInfoMap: state.PodResourceInfoMap{
+				"5": state.PodResourceInfo{
+					ContainerResources: map[string]v1.ResourceRequirements{
+						cpu500mPodSpec.Containers[0].Name: cpu500mPodSpec.Containers[0].Resources,
+					},
 				},
 			},
 		},
@@ -2515,18 +2525,22 @@ func TestPodResourceAllocationReset(t *testing.T) {
 			name:                  "Only has cpu, resource allocation exists (with different value)",
 			pod:                   podWithUIDNameNsSpec("6", "pod6", "foo", *cpu500mPodSpec),
 			existingPodAllocation: podWithUIDNameNsSpec("6", "pod6", "foo", *cpu800mPodSpec),
-			expectedPodResourceAllocation: state.PodResourceAllocation{
-				"6": map[string]v1.ResourceRequirements{
-					cpu800mPodSpec.Containers[0].Name: cpu800mPodSpec.Containers[0].Resources,
+			expectedPodResourceInfoMap: state.PodResourceInfoMap{
+				"6": state.PodResourceInfo{
+					ContainerResources: map[string]v1.ResourceRequirements{
+						cpu800mPodSpec.Containers[0].Name: cpu800mPodSpec.Containers[0].Resources,
+					},
 				},
 			},
 		},
 		{
 			name: "Only has memory, resource allocation not exists",
 			pod:  podWithUIDNameNsSpec("7", "pod7", "foo", *mem500MPodSpec),
-			expectedPodResourceAllocation: state.PodResourceAllocation{
-				"7": map[string]v1.ResourceRequirements{
-					mem500MPodSpec.Containers[0].Name: mem500MPodSpec.Containers[0].Resources,
+			expectedPodResourceInfoMap: state.PodResourceInfoMap{
+				"7": state.PodResourceInfo{
+					ContainerResources: map[string]v1.ResourceRequirements{
+						mem500MPodSpec.Containers[0].Name: mem500MPodSpec.Containers[0].Resources,
+					},
 				},
 			},
 		},
@@ -2534,9 +2548,11 @@ func TestPodResourceAllocationReset(t *testing.T) {
 			name:                  "Only has memory, resource allocation exists",
 			pod:                   podWithUIDNameNsSpec("8", "pod8", "foo", *mem500MPodSpec),
 			existingPodAllocation: podWithUIDNameNsSpec("8", "pod8", "foo", *mem500MPodSpec),
-			expectedPodResourceAllocation: state.PodResourceAllocation{
-				"8": map[string]v1.ResourceRequirements{
-					mem500MPodSpec.Containers[0].Name: mem500MPodSpec.Containers[0].Resources,
+			expectedPodResourceInfoMap: state.PodResourceInfoMap{
+				"8": state.PodResourceInfo{
+					ContainerResources: map[string]v1.ResourceRequirements{
+						mem500MPodSpec.Containers[0].Name: mem500MPodSpec.Containers[0].Resources,
+					},
 				},
 			},
 		},
@@ -2544,18 +2560,22 @@ func TestPodResourceAllocationReset(t *testing.T) {
 			name:                  "Only has memory, resource allocation exists (with different value)",
 			pod:                   podWithUIDNameNsSpec("9", "pod9", "foo", *mem500MPodSpec),
 			existingPodAllocation: podWithUIDNameNsSpec("9", "pod9", "foo", *mem800MPodSpec),
-			expectedPodResourceAllocation: state.PodResourceAllocation{
-				"9": map[string]v1.ResourceRequirements{
-					mem800MPodSpec.Containers[0].Name: mem800MPodSpec.Containers[0].Resources,
+			expectedPodResourceInfoMap: state.PodResourceInfoMap{
+				"9": state.PodResourceInfo{
+					ContainerResources: map[string]v1.ResourceRequirements{
+						mem800MPodSpec.Containers[0].Name: mem800MPodSpec.Containers[0].Resources,
+					},
 				},
 			},
 		},
 		{
 			name: "No CPU and memory, resource allocation not exists",
 			pod:  podWithUIDNameNsSpec("10", "pod10", "foo", *emptyPodSpec),
-			expectedPodResourceAllocation: state.PodResourceAllocation{
-				"10": map[string]v1.ResourceRequirements{
-					emptyPodSpec.Containers[0].Name: emptyPodSpec.Containers[0].Resources,
+			expectedPodResourceInfoMap: state.PodResourceInfoMap{
+				"10": state.PodResourceInfo{
+					ContainerResources: map[string]v1.ResourceRequirements{
+						emptyPodSpec.Containers[0].Name: emptyPodSpec.Containers[0].Resources,
+					},
 				},
 			},
 		},
@@ -2563,9 +2583,11 @@ func TestPodResourceAllocationReset(t *testing.T) {
 			name:                  "No CPU and memory, resource allocation exists",
 			pod:                   podWithUIDNameNsSpec("11", "pod11", "foo", *emptyPodSpec),
 			existingPodAllocation: podWithUIDNameNsSpec("11", "pod11", "foo", *emptyPodSpec),
-			expectedPodResourceAllocation: state.PodResourceAllocation{
-				"11": map[string]v1.ResourceRequirements{
-					emptyPodSpec.Containers[0].Name: emptyPodSpec.Containers[0].Resources,
+			expectedPodResourceInfoMap: state.PodResourceInfoMap{
+				"11": state.PodResourceInfo{
+					ContainerResources: map[string]v1.ResourceRequirements{
+						emptyPodSpec.Containers[0].Name: emptyPodSpec.Containers[0].Resources,
+					},
 				},
 			},
 		},
@@ -2585,7 +2607,7 @@ func TestPodResourceAllocationReset(t *testing.T) {
 			if !found {
 				t.Fatalf("resource allocation should exist: (pod: %#v, container: %s)", tc.pod, tc.pod.Spec.Containers[0].Name)
 			}
-			assert.Equal(t, tc.expectedPodResourceAllocation[tc.pod.UID][tc.pod.Spec.Containers[0].Name], allocatedResources, tc.name)
+			assert.Equal(t, tc.expectedPodResourceInfoMap[tc.pod.UID].ContainerResources[tc.pod.Spec.Containers[0].Name], allocatedResources, tc.name)
 		})
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

* Introduction of PodResourceInfoMap & PodResourceInfo data types to replace PodResourceAllocation which can be extended to support pod level resources.
* Variable name changes 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
