### PR TITLE
Optimize Statefulset Controller Performance: Reduce Work Duration Time & Minimize Cache Locking.

### DIFF
--- a/pkg/controller/statefulset/stateful_set.go
+++ b/pkg/controller/statefulset/stateful_set.go
@@ -61,6 +61,8 @@ type StatefulSetController struct {
 	control StatefulSetControlInterface
 	// podControl is used for patching pods.
 	podControl controller.PodControlInterface
+	// podIndexer allows looking up pods by ControllerRef UID
+	podIndexer cache.Indexer
 	// podLister is able to list/get pods from a shared informer's store
 	podLister corelisters.PodLister
 	// podListerSynced returns true if the pod shared informer has synced at least once
@@ -129,7 +131,8 @@ func NewStatefulSetController(
 	})
 	ssc.podLister = podInformer.Lister()
 	ssc.podListerSynced = podInformer.Informer().HasSynced
-
+	controller.AddPodControllerUIDIndexer(podInformer.Informer())
+	ssc.podIndexer = podInformer.Informer().GetIndexer()
 	setInformer.Informer().AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: ssc.enqueueStatefulSet,
@@ -309,11 +312,24 @@ func (ssc *StatefulSetController) deletePod(logger klog.Logger, obj interface{})
 // NOTE: Returned Pods are pointers to objects from the cache.
 // If you need to modify one, you need to copy it first.
 func (ssc *StatefulSetController) getPodsForStatefulSet(ctx context.Context, set *apps.StatefulSet, selector labels.Selector) ([]*v1.Pod, error) {
-	// List all pods to include the pods that don't match the selector anymore but
-	// has a ControllerRef pointing to this StatefulSet.
-	pods, err := ssc.podLister.Pods(set.Namespace).List(labels.Everything())
-	if err != nil {
-		return nil, err
+	// Iterate over two keys:
+	//  The UID of the StatefulSet, which identifies Pods that are controlled by the StatefulSet.
+	//  The OrphanPodIndexKey, which helps identify orphaned Pods that are not currently managed by any controller,
+	//   but may be adopted later on if they have matching labels with the StatefulSet.
+	podsForSts := []*v1.Pod{}
+	for _, key := range []string{string(set.UID), controller.OrphanPodIndexKey} {
+		podObjs, err := ssc.podIndexer.ByIndex(controller.PodControllerUIDIndex, key)
+		if err != nil {
+			return nil, err
+		}
+		for _, obj := range podObjs {
+			pod, ok := obj.(*v1.Pod)
+			if !ok {
+				utilruntime.HandleError(fmt.Errorf("unexpected object type in pod indexer: %v", obj))
+				continue
+			}
+			podsForSts = append(podsForSts, pod)
+		}
 	}
 
 	filter := func(pod *v1.Pod) bool {
@@ -322,7 +338,7 @@ func (ssc *StatefulSetController) getPodsForStatefulSet(ctx context.Context, set
 	}
 
 	cm := controller.NewPodControllerRefManager(ssc.podControl, set, selector, controllerKind, ssc.canAdoptFunc(ctx, set))
-	return cm.ClaimPods(ctx, pods, filter)
+	return cm.ClaimPods(ctx, podsForSts, filter)
 }
 
 // If any adoptions are attempted, we should first recheck for deletion with


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup 

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR introduces a StatefulSet indexer for the PodInformer to efficiently query Pods belonging to StatefulSets or Orphans from the InformerCache, avoiding a full namespace scan.

This improves performance and correctness at scale by minimizing the time a read lock is held on the cache, reducing blockage of CacheController delta processing. It also helps lower workqueue processing time per object/key.



- The graph below illustrates that the 5-minute P99 average of work_queue_work_duration_seconds varies between approximately 1 second and 8 seconds, indicating the time required to process each item in the StatefulSet queue.

<img width="906" alt="Screenshot 2025-03-08 at 4 26 38 PM" src="https://github.com/user-attachments/assets/50ddf6d0-7277-43be-b982-358c251882fa" />

- PProf analysis indicates that a significant portion of the sync loop cycles is spent in the `getPodsForStatefulset` phase, particularly in the ListAllByNamespace call. Another major contributor is the ClaimPods phase, which involves processing all those pods. Reducing the number of pods processed per cycle would not only alleviate lock contention on the cache (allowing the CacheController to write more efficiently) but also decrease work_queue_processing_time within the sync loop. This optimization would enhance the performance and throughput of the DaemonSet (DS) controller.


<img width="1483" alt="Screenshot 2025-03-09 at 10 46 20 PM (1)" src="https://github.com/user-attachments/assets/42ebb17a-f73b-4fa2-bcf3-225a3bb6a19d" />

- The following graph illustrates the average p99 of work_queue_queue_duration in seconds. The 5-minute P99 average wait time for an item in the queue before processing is approximately 1 second.

<img width="904" alt="Screenshot 2025-03-08 at 4 21 36 PM" src="https://github.com/user-attachments/assets/ab89310f-5468-4c4c-9864-e1dae964ecda" />


Optimizing this list call will provide the following benefits:

1. Reduce Read Lock Duration on the InformerCache, allowing writes to proceed faster and reducing chances of cache staleness at scale.
2. Lower Work Queue Processing Time, enabling faster convergence to the desired state.
3. Reduce Queue Wait Time, ensuring items are dispatched and processed more efficiently.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#130767

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
