### PR TITLE
resourceclaim update status metrics

### DIFF
--- a/pkg/registry/resource/resourceclaim/storage/metrics.go
+++ b/pkg/registry/resource/resourceclaim/storage/metrics.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage
+
+import (
+	"sync"
+
+	"k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
+)
+
+const (
+	namespace = "kube_apiserver"
+	subsystem = "resourceclaim"
+)
+
+var (
+	// resourceClaimUpdateStatusDevicesAttempts tracks the number of
+	// ResourceClaims().Update calls (both successful and unsuccessful)
+	resourceClaimUpdateStatusDevicesAttempts = metrics.NewCounter(
+		&metrics.CounterOpts{
+			Namespace:      namespace,
+			Subsystem:      subsystem,
+			Name:           "update_status_devices_attempts_total",
+			Help:           "Number of ResourceClaims update requests",
+			StabilityLevel: metrics.ALPHA,
+		})
+	// resourceClaimUpdateStatusDevicesFailures tracks the number of unsuccessful
+	// ResourceClaims().Update calls
+	resourceClaimUpdateStatusDevicesFailures = metrics.NewCounter(
+		&metrics.CounterOpts{
+			Namespace:      namespace,
+			Subsystem:      subsystem,
+			Name:           "update_status_devices_failures_total",
+			Help:           "Number of ResourceClaims update request failures",
+			StabilityLevel: metrics.ALPHA,
+		})
+)
+
+func init() {
+	registerMetricsOnce.Do(func() {
+		legacyregistry.MustRegister(resourceClaimUpdateStatusDevicesAttempts)
+		legacyregistry.MustRegister(resourceClaimUpdateStatusDevicesFailures)
+	})
+}
+
+var registerMetricsOnce sync.Once

--- a/pkg/registry/resource/resourceclaim/storage/storage.go
+++ b/pkg/registry/resource/resourceclaim/storage/storage.go
@@ -90,9 +90,14 @@ func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOp
 
 // Update alters the status subset of an object.
 func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc, forceAllowCreate bool, options *metav1.UpdateOptions) (runtime.Object, bool, error) {
+	resourceClaimUpdateStatusDevicesAttempts.Inc()
 	// We are explicitly setting forceAllowCreate to false in the call to the underlying storage because
 	// subresources should never allow create on update.
-	return r.store.Update(ctx, name, objInfo, createValidation, updateValidation, false, options)
+	obj, ok, err := r.store.Update(ctx, name, objInfo, createValidation, updateValidation, false, options)
+	if err != nil {
+		resourceClaimUpdateStatusDevicesFailures.Inc()
+	}
+	return obj, ok, err
 }
 
 // GetResetFields implements rest.ResetFieldsStrategy


### PR DESCRIPTION
Add metrics:

- kube_apiserver_resourceclaim_update_status_devices_attempts_total
- kube_apiserver_resourceclaim_update_status_devices_failures_total

Reference KEP-4817

/kind feature

```release-note
NONE
```

```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/4817-resource-claim-device-status
```
