### PR TITLE
validation-gen: Simplify FunctionGen and VariableGen

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validation.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validation.go
@@ -1211,21 +1211,20 @@ func (g *genValidations) emitValidationVariables(c *generator.Context, t *types.
 	tn := g.discovered.typeNodes[t]
 
 	variables := tn.typeValidations.Variables
-	slices.SortFunc(variables, func(a, b validators.VariableGen) int {
-		return cmp.Compare(a.Var().Name, b.Var().Name)
+	slices.SortFunc(variables, func(a, b *validators.VariableGen) int {
+		return cmp.Compare(a.Variable.Name, b.Variable.Name)
 	})
 	for _, variable := range variables {
-		fn := variable.Init()
+		fn := variable.InitFunc
 		targs := generator.Args{
-			"varName": c.Universe.Type(types.Name(variable.Var())),
+			"varName": c.Universe.Type(types.Name(variable.Variable)),
 			"initFn":  c.Universe.Type(fn.Function),
 		}
 		for _, comment := range fn.Comments {
 			sw.Do("// $.$\n", comment)
 		}
 		sw.Do("var $.varName|private$ = $.initFn|raw$", targs)
-		typeArgs := variable.Init().TypeArgs
-		if len(typeArgs) > 0 {
+		if typeArgs := fn.TypeArgs; len(typeArgs) > 0 {
 			sw.Do("[", nil)
 			for i, typeArg := range typeArgs {
 				sw.Do("$.|raw$", c.Universe.Type(typeArg))

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validation.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validation.go
@@ -1093,11 +1093,11 @@ func (g *genValidations) emitCallToOtherTypeFunc(c *generator.Context, node *typ
 // Emitted code assumes that the value in question is always a pair of nilable
 // variables named "obj" and "oldObj", and the field path to this value is
 // named "fldPath".
-func emitCallsToValidators(c *generator.Context, validations []*validators.FunctionGen, sw *generator.SnippetWriter) {
+func emitCallsToValidators(c *generator.Context, validations []validators.FunctionGen, sw *generator.SnippetWriter) {
 	// Helper func
-	sort := func(in []*validators.FunctionGen) []*validators.FunctionGen {
-		sooner := make([]*validators.FunctionGen, 0, len(in))
-		later := make([]*validators.FunctionGen, 0, len(in))
+	sort := func(in []validators.FunctionGen) []validators.FunctionGen {
+		sooner := make([]validators.FunctionGen, 0, len(in))
+		later := make([]validators.FunctionGen, 0, len(in))
 
 		for _, fg := range in {
 			isShortCircuit := (fg.Flags.IsSet(validators.ShortCircuit))

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validation.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validation.go
@@ -1211,7 +1211,7 @@ func (g *genValidations) emitValidationVariables(c *generator.Context, t *types.
 	tn := g.discovered.typeNodes[t]
 
 	variables := tn.typeValidations.Variables
-	slices.SortFunc(variables, func(a, b *validators.VariableGen) int {
+	slices.SortFunc(variables, func(a, b validators.VariableGen) int {
 		return cmp.Compare(a.Variable.Name, b.Variable.Name)
 	})
 	for _, variable := range variables {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/each.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/each.go
@@ -250,8 +250,8 @@ func (evtv eachValTagValidator) getValidations(fldPath *field.Path, t *types.Typ
 
 // ForEachVal returns a validation that applies a function to each element of
 // a list or map.
-func ForEachVal(fldPath *field.Path, t *types.Type, fn FunctionGen) (Validations, error) {
-	return globalEachVal.getValidations(fldPath, t, Validations{Functions: []FunctionGen{fn}})
+func ForEachVal(fldPath *field.Path, t *types.Type, fn *FunctionGen) (Validations, error) {
+	return globalEachVal.getValidations(fldPath, t, Validations{Functions: []*FunctionGen{fn}})
 }
 
 func (evtv eachValTagValidator) getListValidations(fldPath *field.Path, t *types.Type, validations Validations) (Validations, error) {
@@ -286,7 +286,7 @@ func (evtv eachValTagValidator) getListValidations(fldPath *field.Path, t *types
 			cmpFn.Body = buf.String()
 			cmpArg = cmpFn
 		}
-		f := Function(eachValTagName, vfn.Flags(), validateEachSliceVal, cmpArg, WrapperFunction{vfn, t.Elem})
+		f := Function(eachValTagName, vfn.Flags, validateEachSliceVal, cmpArg, WrapperFunction{vfn, t.Elem})
 		result.Functions = append(result.Functions, f)
 	}
 
@@ -298,7 +298,7 @@ func (evtv eachValTagValidator) getMapValidations(t *types.Type, validations Val
 	result.OpaqueValType = validations.OpaqueType
 
 	for _, vfn := range validations.Functions {
-		f := Function(eachValTagName, vfn.Flags(), validateEachMapVal, WrapperFunction{vfn, t.Elem})
+		f := Function(eachValTagName, vfn.Flags, validateEachMapVal, WrapperFunction{vfn, t.Elem})
 		result.Functions = append(result.Functions, f)
 	}
 
@@ -369,7 +369,7 @@ func (ektv eachKeyTagValidator) getValidations(t *types.Type, validations Valida
 	result := Validations{}
 	result.OpaqueKeyType = validations.OpaqueType
 	for _, vfn := range validations.Functions {
-		f := Function(eachKeyTagName, vfn.Flags(), validateEachMapKey, WrapperFunction{vfn, t.Key})
+		f := Function(eachKeyTagName, vfn.Flags, validateEachMapKey, WrapperFunction{vfn, t.Key})
 		result.Functions = append(result.Functions, f)
 	}
 	return result, nil
@@ -377,8 +377,8 @@ func (ektv eachKeyTagValidator) getValidations(t *types.Type, validations Valida
 
 // ForEachKey returns a validation that applies a function to each key of
 // a map.
-func ForEachKey(_ *field.Path, t *types.Type, fn FunctionGen) (Validations, error) {
-	return globalEachKey.getValidations(t, Validations{Functions: []FunctionGen{fn}})
+func ForEachKey(_ *field.Path, t *types.Type, fn *FunctionGen) (Validations, error) {
+	return globalEachKey.getValidations(t, Validations{Functions: []*FunctionGen{fn}})
 }
 
 func (ektv eachKeyTagValidator) Docs() TagDoc {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/each.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/each.go
@@ -250,8 +250,8 @@ func (evtv eachValTagValidator) getValidations(fldPath *field.Path, t *types.Typ
 
 // ForEachVal returns a validation that applies a function to each element of
 // a list or map.
-func ForEachVal(fldPath *field.Path, t *types.Type, fn *FunctionGen) (Validations, error) {
-	return globalEachVal.getValidations(fldPath, t, Validations{Functions: []*FunctionGen{fn}})
+func ForEachVal(fldPath *field.Path, t *types.Type, fn FunctionGen) (Validations, error) {
+	return globalEachVal.getValidations(fldPath, t, Validations{Functions: []FunctionGen{fn}})
 }
 
 func (evtv eachValTagValidator) getListValidations(fldPath *field.Path, t *types.Type, validations Validations) (Validations, error) {
@@ -377,8 +377,8 @@ func (ektv eachKeyTagValidator) getValidations(t *types.Type, validations Valida
 
 // ForEachKey returns a validation that applies a function to each key of
 // a map.
-func ForEachKey(_ *field.Path, t *types.Type, fn *FunctionGen) (Validations, error) {
-	return globalEachKey.getValidations(t, Validations{Functions: []*FunctionGen{fn}})
+func ForEachKey(_ *field.Path, t *types.Type, fn FunctionGen) (Validations, error) {
+	return globalEachKey.getValidations(t, Validations{Functions: []FunctionGen{fn}})
 }
 
 func (ektv eachKeyTagValidator) Docs() TagDoc {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/registry.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/registry.go
@@ -165,7 +165,7 @@ func (reg *registry) sortTagsIntoPhases(tags map[string][]gengo.Tag) [][]string 
 	// Tag extraction will retain the relative order between 111 and 222, but
 	// 333 is extracted as tag "k8s:ifOptionEnabled".  Those are all in a map,
 	// which we iterate (in a random order).  When it reaches the emit stage,
-	// the "ifOptionEnabled" part is gone, and we will have 3 functionGen
+	// the "ifOptionEnabled" part is gone, and we will have 3 FunctionGen
 	// objects, all with tag "k8s:validateFalse", in a non-deterministic order
 	// because of the map iteration.  If we sort them at that point, we won't
 	// have enough information to do something smart, unless we look at the

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/required.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/required.go
@@ -96,11 +96,11 @@ func (rtv requirednessTagValidator) doRequired(context Context) (Validations, er
 	// do manual dispatch here.
 	switch context.Type.Kind {
 	case types.Slice:
-		return Validations{Functions: []*FunctionGen{Function(requiredTagName, ShortCircuit, requiredSliceValidator)}}, nil
+		return Validations{Functions: []FunctionGen{Function(requiredTagName, ShortCircuit, requiredSliceValidator)}}, nil
 	case types.Map:
-		return Validations{Functions: []*FunctionGen{Function(requiredTagName, ShortCircuit, requiredMapValidator)}}, nil
+		return Validations{Functions: []FunctionGen{Function(requiredTagName, ShortCircuit, requiredMapValidator)}}, nil
 	case types.Pointer:
-		return Validations{Functions: []*FunctionGen{Function(requiredTagName, ShortCircuit, requiredPointerValidator)}}, nil
+		return Validations{Functions: []FunctionGen{Function(requiredTagName, ShortCircuit, requiredPointerValidator)}}, nil
 	case types.Struct:
 		// The +k8s:required tag on a non-pointer struct is not supported.
 		// If you encounter this error and believe you have a valid use case
@@ -109,7 +109,7 @@ func (rtv requirednessTagValidator) doRequired(context Context) (Validations, er
 		// this behavior or provide alternative validation mechanisms.
 		return Validations{}, fmt.Errorf("non-pointer structs cannot use the %q tag", requiredTagName)
 	}
-	return Validations{Functions: []*FunctionGen{Function(requiredTagName, ShortCircuit, requiredValueValidator)}}, nil
+	return Validations{Functions: []FunctionGen{Function(requiredTagName, ShortCircuit, requiredValueValidator)}}, nil
 }
 
 var (
@@ -156,7 +156,7 @@ func (rtv requirednessTagValidator) doOptional(context Context) (Validations, er
 			return Validations{}, err
 		}
 		for i, fn := range validations.Functions {
-			validations.Functions[i] = WithComment(fn, "optional fields with default values are effectively required")
+			validations.Functions[i] = fn.WithComment("optional fields with default values are effectively required")
 		}
 		return validations, nil
 	}
@@ -167,11 +167,11 @@ func (rtv requirednessTagValidator) doOptional(context Context) (Validations, er
 	// do manual dispatch here.
 	switch context.Type.Kind {
 	case types.Slice:
-		return Validations{Functions: []*FunctionGen{Function(optionalTagName, ShortCircuit|NonError, optionalSliceValidator)}}, nil
+		return Validations{Functions: []FunctionGen{Function(optionalTagName, ShortCircuit|NonError, optionalSliceValidator)}}, nil
 	case types.Map:
-		return Validations{Functions: []*FunctionGen{Function(optionalTagName, ShortCircuit|NonError, optionalMapValidator)}}, nil
+		return Validations{Functions: []FunctionGen{Function(optionalTagName, ShortCircuit|NonError, optionalMapValidator)}}, nil
 	case types.Pointer:
-		return Validations{Functions: []*FunctionGen{Function(optionalTagName, ShortCircuit|NonError, optionalPointerValidator)}}, nil
+		return Validations{Functions: []FunctionGen{Function(optionalTagName, ShortCircuit|NonError, optionalPointerValidator)}}, nil
 	case types.Struct:
 		// The +k8s:optional tag on a non-pointer struct is not supported.
 		// If you encounter this error and believe you have a valid use case
@@ -180,7 +180,7 @@ func (rtv requirednessTagValidator) doOptional(context Context) (Validations, er
 		// this behavior or provide alternative validation mechanisms.
 		return Validations{}, fmt.Errorf("non-pointer structs cannot use the %q tag", optionalTagName)
 	}
-	return Validations{Functions: []*FunctionGen{Function(optionalTagName, ShortCircuit|NonError, optionalValueValidator)}}, nil
+	return Validations{Functions: []FunctionGen{Function(optionalTagName, ShortCircuit|NonError, optionalValueValidator)}}, nil
 }
 
 // hasZeroDefault returns whether the field has a default value and whether
@@ -268,21 +268,21 @@ func (requirednessTagValidator) doForbidden(context Context) (Validations, error
 	switch context.Type.Kind {
 	case types.Slice:
 		return Validations{
-			Functions: []*FunctionGen{
+			Functions: []FunctionGen{
 				Function(forbiddenTagName, ShortCircuit, forbiddenSliceValidator),
 				Function(forbiddenTagName, ShortCircuit|NonError, optionalSliceValidator),
 			},
 		}, nil
 	case types.Map:
 		return Validations{
-			Functions: []*FunctionGen{
+			Functions: []FunctionGen{
 				Function(forbiddenTagName, ShortCircuit, forbiddenMapValidator),
 				Function(forbiddenTagName, ShortCircuit|NonError, optionalMapValidator),
 			},
 		}, nil
 	case types.Pointer:
 		return Validations{
-			Functions: []*FunctionGen{
+			Functions: []FunctionGen{
 				Function(forbiddenTagName, ShortCircuit, forbiddenPointerValidator),
 				Function(forbiddenTagName, ShortCircuit|NonError, optionalPointerValidator),
 			},
@@ -296,7 +296,7 @@ func (requirednessTagValidator) doForbidden(context Context) (Validations, error
 		return Validations{}, fmt.Errorf("non-pointer structs cannot use the %q tag", forbiddenTagName)
 	}
 	return Validations{
-		Functions: []*FunctionGen{
+		Functions: []FunctionGen{
 			Function(forbiddenTagName, ShortCircuit, forbiddenValueValidator),
 			Function(forbiddenTagName, ShortCircuit|NonError, optionalValueValidator),
 		},

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/required.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/required.go
@@ -96,11 +96,11 @@ func (rtv requirednessTagValidator) doRequired(context Context) (Validations, er
 	// do manual dispatch here.
 	switch context.Type.Kind {
 	case types.Slice:
-		return Validations{Functions: []FunctionGen{Function(requiredTagName, ShortCircuit, requiredSliceValidator)}}, nil
+		return Validations{Functions: []*FunctionGen{Function(requiredTagName, ShortCircuit, requiredSliceValidator)}}, nil
 	case types.Map:
-		return Validations{Functions: []FunctionGen{Function(requiredTagName, ShortCircuit, requiredMapValidator)}}, nil
+		return Validations{Functions: []*FunctionGen{Function(requiredTagName, ShortCircuit, requiredMapValidator)}}, nil
 	case types.Pointer:
-		return Validations{Functions: []FunctionGen{Function(requiredTagName, ShortCircuit, requiredPointerValidator)}}, nil
+		return Validations{Functions: []*FunctionGen{Function(requiredTagName, ShortCircuit, requiredPointerValidator)}}, nil
 	case types.Struct:
 		// The +k8s:required tag on a non-pointer struct is not supported.
 		// If you encounter this error and believe you have a valid use case
@@ -109,7 +109,7 @@ func (rtv requirednessTagValidator) doRequired(context Context) (Validations, er
 		// this behavior or provide alternative validation mechanisms.
 		return Validations{}, fmt.Errorf("non-pointer structs cannot use the %q tag", requiredTagName)
 	}
-	return Validations{Functions: []FunctionGen{Function(requiredTagName, ShortCircuit, requiredValueValidator)}}, nil
+	return Validations{Functions: []*FunctionGen{Function(requiredTagName, ShortCircuit, requiredValueValidator)}}, nil
 }
 
 var (
@@ -167,11 +167,11 @@ func (rtv requirednessTagValidator) doOptional(context Context) (Validations, er
 	// do manual dispatch here.
 	switch context.Type.Kind {
 	case types.Slice:
-		return Validations{Functions: []FunctionGen{Function(optionalTagName, ShortCircuit|NonError, optionalSliceValidator)}}, nil
+		return Validations{Functions: []*FunctionGen{Function(optionalTagName, ShortCircuit|NonError, optionalSliceValidator)}}, nil
 	case types.Map:
-		return Validations{Functions: []FunctionGen{Function(optionalTagName, ShortCircuit|NonError, optionalMapValidator)}}, nil
+		return Validations{Functions: []*FunctionGen{Function(optionalTagName, ShortCircuit|NonError, optionalMapValidator)}}, nil
 	case types.Pointer:
-		return Validations{Functions: []FunctionGen{Function(optionalTagName, ShortCircuit|NonError, optionalPointerValidator)}}, nil
+		return Validations{Functions: []*FunctionGen{Function(optionalTagName, ShortCircuit|NonError, optionalPointerValidator)}}, nil
 	case types.Struct:
 		// The +k8s:optional tag on a non-pointer struct is not supported.
 		// If you encounter this error and believe you have a valid use case
@@ -180,7 +180,7 @@ func (rtv requirednessTagValidator) doOptional(context Context) (Validations, er
 		// this behavior or provide alternative validation mechanisms.
 		return Validations{}, fmt.Errorf("non-pointer structs cannot use the %q tag", optionalTagName)
 	}
-	return Validations{Functions: []FunctionGen{Function(optionalTagName, ShortCircuit|NonError, optionalValueValidator)}}, nil
+	return Validations{Functions: []*FunctionGen{Function(optionalTagName, ShortCircuit|NonError, optionalValueValidator)}}, nil
 }
 
 // hasZeroDefault returns whether the field has a default value and whether
@@ -268,21 +268,21 @@ func (requirednessTagValidator) doForbidden(context Context) (Validations, error
 	switch context.Type.Kind {
 	case types.Slice:
 		return Validations{
-			Functions: []FunctionGen{
+			Functions: []*FunctionGen{
 				Function(forbiddenTagName, ShortCircuit, forbiddenSliceValidator),
 				Function(forbiddenTagName, ShortCircuit|NonError, optionalSliceValidator),
 			},
 		}, nil
 	case types.Map:
 		return Validations{
-			Functions: []FunctionGen{
+			Functions: []*FunctionGen{
 				Function(forbiddenTagName, ShortCircuit, forbiddenMapValidator),
 				Function(forbiddenTagName, ShortCircuit|NonError, optionalMapValidator),
 			},
 		}, nil
 	case types.Pointer:
 		return Validations{
-			Functions: []FunctionGen{
+			Functions: []*FunctionGen{
 				Function(forbiddenTagName, ShortCircuit, forbiddenPointerValidator),
 				Function(forbiddenTagName, ShortCircuit|NonError, optionalPointerValidator),
 			},
@@ -296,7 +296,7 @@ func (requirednessTagValidator) doForbidden(context Context) (Validations, error
 		return Validations{}, fmt.Errorf("non-pointer structs cannot use the %q tag", forbiddenTagName)
 	}
 	return Validations{
-		Functions: []FunctionGen{
+		Functions: []*FunctionGen{
 			Function(forbiddenTagName, ShortCircuit, forbiddenValueValidator),
 			Function(forbiddenTagName, ShortCircuit|NonError, optionalValueValidator),
 		},

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/subfield.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/subfield.go
@@ -100,7 +100,7 @@ func (stv subfieldTagValidator) GetValidations(context Context, args []string, p
 				Results:    []ParamResult{{"", nilableFieldType}},
 			}
 			getFn.Body = fmt.Sprintf("return %so.%s", fieldExprPrefix, submemb.Name)
-			f := Function(subfieldTagName, vfn.Flags(), validateSubfield, subname, getFn, WrapperFunction{vfn, submemb.Type})
+			f := Function(subfieldTagName, vfn.Flags, validateSubfield, subname, getFn, WrapperFunction{vfn, submemb.Type})
 			result.Functions = append(result.Functions, f)
 			result.Variables = append(result.Variables, validations.Variables...)
 		}

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/testing.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/testing.go
@@ -73,7 +73,7 @@ func (frtv fixedResultTagValidator) GetValidations(context Context, _ []string, 
 	if err != nil {
 		return result, fmt.Errorf("can't decode tag payload: %w", err)
 	}
-	result.AddFunction(GenericFunction(frtv.TagName(), tag.flags, fixedResultValidator, tag.typeArgs, frtv.result, tag.msg))
+	result.AddFunction(Function(frtv.TagName(), tag.flags, fixedResultValidator, frtv.result, tag.msg).WithTypeArgs(tag.typeArgs...))
 
 	return result, nil
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/validators.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/validators.go
@@ -228,7 +228,7 @@ type Validations struct {
 	//        Args[N] <Args[N]Type>)
 	//
 	// The standard arguments are not included in the FunctionGen.Args list.
-	Functions []*FunctionGen
+	Functions []FunctionGen
 
 	// Variables holds any variables which must be generated to perform
 	// validation.  Variables are not permitted in every context.
@@ -259,7 +259,7 @@ func (v *Validations) Len() int {
 	return len(v.Functions) + len(v.Variables) + len(v.Comments)
 }
 
-func (v *Validations) AddFunction(f *FunctionGen) {
+func (v *Validations) AddFunction(f FunctionGen) {
 	v.Functions = append(v.Functions, f)
 }
 
@@ -336,12 +336,12 @@ type VariableGen interface {
 	Var() PrivateVar
 
 	// Init generates the function call that the variable is assigned to.
-	Init() *FunctionGen
+	Init() FunctionGen
 }
 
 // Function creates a FunctionGen for a given function name and extraArgs.
-func Function(tagName string, flags FunctionFlags, function types.Name, extraArgs ...any) *FunctionGen {
-	return &FunctionGen{
+func Function(tagName string, flags FunctionFlags, function types.Name, extraArgs ...any) FunctionGen {
+	return FunctionGen{
 		TagName:  tagName,
 		Flags:    flags,
 		Function: function,
@@ -386,26 +386,26 @@ type FunctionGen struct {
 	Comments []string
 }
 
-// WithTypeArgs sets the type arguments for a FunctionGen.
-func (fg *FunctionGen) WithTypeArgs(typeArgs ...types.Name) *FunctionGen {
+// WithTypeArgs returns a derived FunctionGen with type arguments.
+func (fg FunctionGen) WithTypeArgs(typeArgs ...types.Name) FunctionGen {
 	fg.TypeArgs = typeArgs
 	return fg
 }
 
-// WithConditions sets the conditions for a FunctionGen.
-func (fg *FunctionGen) WithConditions(conditions Conditions) *FunctionGen {
+// WithConditions returns a derived FunctionGen with conditions.
+func (fg FunctionGen) WithConditions(conditions Conditions) FunctionGen {
 	fg.Conditions = conditions
 	return fg
 }
 
-// AddComment adds a comment to a FunctionGen.
-func (fg *FunctionGen) AddComment(comment string) *FunctionGen {
+// WithComment returns a new FunctionGen with a comment.
+func (fg FunctionGen) WithComment(comment string) FunctionGen {
 	fg.Comments = append(fg.Comments, comment)
 	return fg
 }
 
 // Variable creates a VariableGen for a given function name and extraArgs.
-func Variable(variable PrivateVar, init *FunctionGen) VariableGen {
+func Variable(variable PrivateVar, init FunctionGen) VariableGen {
 	return &variableGen{
 		variable: variable,
 		init:     init,
@@ -414,7 +414,7 @@ func Variable(variable PrivateVar, init *FunctionGen) VariableGen {
 
 type variableGen struct {
 	variable PrivateVar
-	init     *FunctionGen
+	init     FunctionGen
 }
 
 func (v variableGen) TagName() string {
@@ -425,7 +425,7 @@ func (v variableGen) Var() PrivateVar {
 	return v.variable
 }
 
-func (v variableGen) Init() *FunctionGen {
+func (v variableGen) Init() FunctionGen {
 	return v.init
 }
 
@@ -433,7 +433,7 @@ func (v variableGen) Init() *FunctionGen {
 // regular validation function (op, fldPath, obj, oldObj) and calls another
 // validation function with the same signature, plus extra args if needed.
 type WrapperFunction struct {
-	Function *FunctionGen
+	Function FunctionGen
 	ObjType  *types.Type
 }
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/validators.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/validators.go
@@ -232,7 +232,7 @@ type Validations struct {
 
 	// Variables holds any variables which must be generated to perform
 	// validation.  Variables are not permitted in every context.
-	Variables []VariableGen
+	Variables []*VariableGen
 
 	// Comments holds comments to emit (without the leanding "//").
 	Comments []string
@@ -263,7 +263,7 @@ func (v *Validations) AddFunction(f FunctionGen) {
 	v.Functions = append(v.Functions, f)
 }
 
-func (v *Validations) AddVariable(variable VariableGen) {
+func (v *Validations) AddVariable(variable *VariableGen) {
 	v.Variables = append(v.Variables, variable)
 }
 
@@ -324,20 +324,6 @@ type Identifier types.Name
 // PrivateVar is a variable name that the generator will output as a private identifier.
 // PrivateVars are generated using the PrivateNamer strategy.
 type PrivateVar types.Name
-
-// VariableGen provides validation-gen with the information needed to generate variable.
-// Variables typically support generated functions by providing static information such
-// as the list of supported symbols for an enum.
-type VariableGen interface {
-	// TagName returns the tag which triggers this validator.
-	TagName() string
-
-	// Var returns the variable identifier.
-	Var() PrivateVar
-
-	// Init generates the function call that the variable is assigned to.
-	Init() FunctionGen
-}
 
 // Function creates a FunctionGen for a given function name and extraArgs.
 func Function(tagName string, flags FunctionFlags, function types.Name, extraArgs ...any) FunctionGen {
@@ -405,28 +391,19 @@ func (fg FunctionGen) WithComment(comment string) FunctionGen {
 }
 
 // Variable creates a VariableGen for a given function name and extraArgs.
-func Variable(variable PrivateVar, init FunctionGen) VariableGen {
-	return &variableGen{
-		variable: variable,
-		init:     init,
+func Variable(variable PrivateVar, initFunc FunctionGen) *VariableGen {
+	return &VariableGen{
+		Variable: variable,
+		InitFunc: initFunc,
 	}
 }
 
-type variableGen struct {
-	variable PrivateVar
-	init     FunctionGen
-}
+type VariableGen struct {
+	// Variable holds the variable identifier.
+	Variable PrivateVar
 
-func (v variableGen) TagName() string {
-	return v.init.TagName
-}
-
-func (v variableGen) Var() PrivateVar {
-	return v.variable
-}
-
-func (v variableGen) Init() FunctionGen {
-	return v.init
+	// InitFunc describes the function call that the variable is assigned to.
+	InitFunc FunctionGen
 }
 
 // WrapperFunction describes a function literal which has the fingerprint of a

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/validators.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/validators.go
@@ -232,7 +232,7 @@ type Validations struct {
 
 	// Variables holds any variables which must be generated to perform
 	// validation.  Variables are not permitted in every context.
-	Variables []*VariableGen
+	Variables []VariableGen
 
 	// Comments holds comments to emit (without the leanding "//").
 	Comments []string
@@ -259,12 +259,12 @@ func (v *Validations) Len() int {
 	return len(v.Functions) + len(v.Variables) + len(v.Comments)
 }
 
-func (v *Validations) AddFunction(f FunctionGen) {
-	v.Functions = append(v.Functions, f)
+func (v *Validations) AddFunction(fn FunctionGen) {
+	v.Functions = append(v.Functions, fn)
 }
 
-func (v *Validations) AddVariable(variable *VariableGen) {
-	v.Variables = append(v.Variables, variable)
+func (v *Validations) AddVariable(vr VariableGen) {
+	v.Variables = append(v.Variables, vr)
 }
 
 func (v *Validations) AddComment(comment string) {
@@ -391,8 +391,8 @@ func (fg FunctionGen) WithComment(comment string) FunctionGen {
 }
 
 // Variable creates a VariableGen for a given function name and extraArgs.
-func Variable(variable PrivateVar, initFunc FunctionGen) *VariableGen {
-	return &VariableGen{
+func Variable(variable PrivateVar, initFunc FunctionGen) VariableGen {
+	return VariableGen{
 		Variable: variable,
 		InitFunc: initFunc,
 	}


### PR DESCRIPTION
These commits exist on our dev branch.  I wanted to wait until everything else was landed before sending them up to k/k.  No impact on generated code, just internals.

/kind cleanup

-->
```release-note
NONE
```