### PR TITLE
fix: Size computation for allocation may overflow

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/printers/tableprinter.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/printers/tableprinter.go
@@ -307,7 +307,12 @@ func addColumns(pos columnAddPosition, table *metav1.Table, columns []metav1.Tab
 // does not expose metadata). It returns an error if the table cannot
 // be decorated.
 func decorateTable(table *metav1.Table, options PrintOptions) error {
-	width := len(table.ColumnDefinitions) + len(options.ColumnLabels)
+	columnDefinitionsLen := len(table.ColumnDefinitions)
+	columnLabelsLen := len(options.ColumnLabels)
+	if columnDefinitionsLen > (int(^uint(0) >> 1)) - columnLabelsLen - 2 {
+		return fmt.Errorf("table is too large to process")
+	}
+	width := columnDefinitionsLen + columnLabelsLen
 	if options.WithNamespace {
 		width++
 	}


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/blob/88642906f0e1f85a6d107076961cab87e69e1979/staging/src/k8s.io/cli-runtime/pkg/printers/tableprinter.go#L310-L310

Performing calculations involving the size of potentially large strings or slices can result in an overflow (for signed integer types) or a wraparound (for unsigned types). An overflow causes the result of the calculation to become negative, while a wraparound results in a small (positive) number.

This can cause further issues. If, for example, the result is then used in an allocation, it will cause a runtime panic if it is negative, and allocate an unexpectedly small buffer otherwise.



To fix the problem, we need to ensure that the calculation of `width` does not overflow. This can be done by validating the size of `table.ColumnDefinitions` and other components involved in the calculation before performing the arithmetic operation. Specifically, we can check if the sum of these lengths exceeds the maximum value for an `int` type.

1. Add a validation step before calculating `width` to ensure that the sum of `len(table.ColumnDefinitions)`, `len(options.ColumnLabels)`, and the potential increments for `options.WithNamespace` and `options.ShowLabels` does not exceed the maximum value for an `int`.
2. If the validation fails, return an error indicating that the table is too large to process.