### PR TITLE
Add ingressclasses to default edit & view RBAC policies #130841

### DIFF
--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -137,7 +137,7 @@ func viewRules() []rbacv1.PolicyRule {
 
 		rbacv1helpers.NewRule(Read...).Groups(policyGroup).Resources("poddisruptionbudgets", "poddisruptionbudgets/status").RuleOrDie(),
 
-		rbacv1helpers.NewRule(Read...).Groups(networkingGroup).Resources("networkpolicies", "ingresses", "ingresses/status").RuleOrDie(),
+		rbacv1helpers.NewRule(Read...).Groups(networkingGroup).Resources("networkpolicies", "ingresses", "ingresses/status", "ingressclasses").RuleOrDie(),
 	}
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.DynamicResourceAllocation) {
@@ -175,7 +175,7 @@ func editRules() []rbacv1.PolicyRule {
 
 		rbacv1helpers.NewRule(Write...).Groups(policyGroup).Resources("poddisruptionbudgets").RuleOrDie(),
 
-		rbacv1helpers.NewRule(Write...).Groups(networkingGroup).Resources("networkpolicies", "ingresses").RuleOrDie(),
+		rbacv1helpers.NewRule(Write...).Groups(networkingGroup).Resources("networkpolicies", "ingresses", "ingressclasses").RuleOrDie(),
 
 		rbacv1helpers.NewRule(ReadWrite...).Groups(coordinationGroup).Resources("leases").RuleOrDie(),
 	}

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles-featuregates.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles-featuregates.yaml
@@ -223,6 +223,7 @@ items:
   - apiGroups:
     - networking.k8s.io
     resources:
+    - ingressclasses
     - ingresses
     - networkpolicies
     verbs:
@@ -385,6 +386,7 @@ items:
   - apiGroups:
     - networking.k8s.io
     resources:
+    - ingressclasses
     - ingresses
     - ingresses/status
     - networkpolicies

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
@@ -223,6 +223,7 @@ items:
   - apiGroups:
     - networking.k8s.io
     resources:
+    - ingressclasses
     - ingresses
     - networkpolicies
     verbs:
@@ -374,6 +375,7 @@ items:
   - apiGroups:
     - networking.k8s.io
     resources:
+    - ingressclasses
     - ingresses
     - ingresses/status
     - networkpolicies


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

/sig auth

#### What this PR does / why we need it:

Add ingressclasses to default view & edit RBAC policies, and tests.

For example, I can't show ingressclass in `k8s-dashboard` with only `view` permission.

#### Which issue(s) this PR fixes:

- Fixes #130841

#### Special notes for your reviewer:

- This PR is sililar to #101203

#### Does this PR introduce a user-facing change?

```release-note
Added privileges for IngressClass to the default view & edit RBAC roles
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

