### PR TITLE
Fix kubelet_config_dir_test after KubeletServiceAccountTokenForCredentialProviders was added

### DIFF
--- a/test/e2e_node/kubelet_config_dir_test.go
+++ b/test/e2e_node/kubelet_config_dir_test.go
@@ -118,6 +118,7 @@ shutdownGracePeriodByPodPriority:
   - priority: 6
     shutdownGracePeriodSeconds: 30
 featureGates:
+  KubeletServiceAccountTokenForCredentialProviders: true
   PodAndContainerStatsFromCRI: false
   DynamicResourceAllocation: true`)
 			framework.ExpectNoError(os.WriteFile(filepath.Join(configDir, "20-kubelet.conf"), contents, 0755))
@@ -163,7 +164,11 @@ featureGates:
 				},
 			}
 			// This covers the case where the fields within the map are overridden.
-			overrides := map[string]bool{"PodAndContainerStatsFromCRI": false, "DynamicResourceAllocation": true}
+			overrides := map[string]bool{
+				"PodAndContainerStatsFromCRI":                      false,
+				"DynamicResourceAllocation":                        true,
+				"KubeletServiceAccountTokenForCredentialProviders": true,
+			}
 			// In some CI jobs, `NodeSwap` is explicitly disabled as the images are cgroupv1 based,
 			// so such flags should be picked up directly from the initial configuration
 			if _, ok := initialConfig.FeatureGates["NodeSwap"]; ok {


### PR DESCRIPTION
Fix for the following error in various node e2e jobs (see [log](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-cgroupv2-containerd-node-e2e-serial-ec2/1901542193055666176) for example):
```
[FAILED] Merged kubelet config does not match the expected configuration.
Expected object to be comparable, diff:   &config.KubeletConfiguration{
  	... // 83 identical fields
  	IPTablesMasqueradeBit: 14,
  	IPTablesDropBit:       15,
  	FeatureGates: map[string]bool{
  		"DynamicResourceAllocation":                        true,
+ 		"KubeletServiceAccountTokenForCredentialProviders": true,
  		"PodAndContainerStatsFromCRI":                      false,
  	},
  	FailSwapOn: true,
  	MemorySwap: {},
  	... // 33 identical fields
  }
```

See https://storage.googleapis.com/k8s-triage/index.html?text=Merged%20kubelet%20config%20does%20not%20match%20the%20expected%20configuration for the full list of jobs that fail.

This just extends the pattern originally set by authors in:
https://github.com/kubernetes/kubernetes/commit/3b630ae1af7801221e43a21c933d3c9992017773#diff-951ced586752b46725ea01450086b20991b5930e861d70f92bb48d50f9e04343R172

Things broke when newer gates are added here but missed above
https://github.com/kubernetes/kubernetes/pull/128372/files#diff-bdf2ec5e5c7292fd0919f529a1332017b73a4db729302f67a68268bc0ee63779R113-R119

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind failing-test

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
