### PR TITLE
Validate UID range when runasnonroot is true

### DIFF
--- a/pkg/kubelet/kuberuntime/security_context_others.go
+++ b/pkg/kubelet/kuberuntime/security_context_others.go
@@ -21,8 +21,11 @@ package kuberuntime
 
 import (
 	"fmt"
+	"math"
+	"strings"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/kubernetes/pkg/kubelet/util/format"
 	"k8s.io/kubernetes/pkg/securitycontext"
 )
@@ -43,10 +46,23 @@ func verifyRunAsNonRoot(pod *v1.Pod, container *v1.Container, uid *int64, userna
 	}
 
 	switch {
-	case uid != nil && *uid == 0:
-		return fmt.Errorf("container has runAsNonRoot and image will run as root (pod: %q, container: %s)", format.Pod(pod), container.Name)
 	case uid == nil && len(username) > 0:
 		return fmt.Errorf("container has runAsNonRoot and image has non-numeric user (%s), cannot verify user is non-root (pod: %q, container: %s)", username, format.Pod(pod), container.Name)
+	case uid != nil:
+		if *uid == 0 {
+			return fmt.Errorf("container has runAsNonRoot and image will run as root (pod: %q, container: %s)", format.Pod(pod), container.Name)
+		}
+		if errs := validation.IsValidUserID(*uid); len(errs) > 0 {
+			return fmt.Errorf(
+				"container has runAsNonRoot and image has an invalid user id (%d). (Must be 1-(%d)): %s (pod: %q, container: %s)",
+				*uid,
+				math.MaxInt32,
+				strings.Join(errs, "; "),
+				format.Pod(pod),
+				container.Name,
+			)
+		}
+		return nil
 	default:
 		return nil
 	}

--- a/pkg/kubelet/kuberuntime/security_context_others_test.go
+++ b/pkg/kubelet/kuberuntime/security_context_others_test.go
@@ -20,6 +20,7 @@ limitations under the License.
 package kuberuntime
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -50,6 +51,9 @@ func TestVerifyRunAsNonRoot(t *testing.T) {
 
 	rootUser := int64(0)
 	anyUser := int64(1000)
+	invalidUser := int64(2147483648)
+	negativeUser := int64(-1000)
+	maxInt32User := int64(math.MaxInt32)
 	runAsNonRootTrue := true
 	runAsNonRootFalse := false
 	for _, test := range []struct {
@@ -136,6 +140,30 @@ func TestVerifyRunAsNonRoot(t *testing.T) {
 			sc: &v1.SecurityContext{
 				RunAsNonRoot: &runAsNonRootTrue,
 			},
+			fail: false,
+		},
+		{
+			desc: "Fail if image's user is invalid and RunAsNonRoot is true",
+			sc: &v1.SecurityContext{
+				RunAsNonRoot: &runAsNonRootTrue,
+			},
+			uid:  &invalidUser,
+			fail: true,
+		},
+		{
+			desc: "Fail if image's user is negative and RunAsNonRoot is true",
+			sc: &v1.SecurityContext{
+				RunAsNonRoot: &runAsNonRootTrue,
+			},
+			uid:  &negativeUser,
+			fail: true,
+		},
+		{
+			desc: "Pass if image's user is math.MaxInt32 and RunAsNonRoot is true",
+			sc: &v1.SecurityContext{
+				RunAsNonRoot: &runAsNonRootTrue,
+			},
+			uid:  &maxInt32User,
 			fail: false,
 		},
 	} {


### PR DESCRIPTION
#### What type of PR is this?

This is a hardening fix related to CVE-2024-40635 in containerd. 

https://github.com/containerd/containerd/security/advisories/GHSA-265r-hfxg-fhmg

/kind bug
/area security
/committee security-response
/sig node
/area kubelet

#### What this PR does / why we need it:

Updating containerd to the versions listed in the advisory will fix this issue.

I am introducing this change just as an extra check on valid UID ranges when using `RunAsNonRoot`. 

#### Which issue(s) this PR fixes:
N/A

#### Special notes for your reviewer:
N/A

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

