### PR TITLE
Panic on failed consistency check and fix typo in logs

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/delegator.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/delegator.go
@@ -352,16 +352,18 @@ func (c consistencyChecker) startChecking(stopCh <-chan struct{}) {
 func (c *consistencyChecker) check(ctx context.Context) {
 	digests, err := c.calculateDigests(ctx)
 	if err != nil {
-		klog.ErrorS(err, "Cache consistentency check error", "resource", c.resourcePrefix)
+		klog.ErrorS(err, "Cache consistency check error", "resource", c.resourcePrefix)
 		metrics.StorageConsistencyCheckTotal.WithLabelValues(c.resourcePrefix, "error").Inc()
 		return
 	}
 	if digests.CacheDigest == digests.EtcdDigest {
-		klog.V(3).InfoS("Cache consistentency check passed", "resource", c.resourcePrefix, "resourceVersion", digests.ResourceVersion, "digest", digests.CacheDigest)
+		klog.V(3).InfoS("Cache consistency check passed", "resource", c.resourcePrefix, "resourceVersion", digests.ResourceVersion, "digest", digests.CacheDigest)
 		metrics.StorageConsistencyCheckTotal.WithLabelValues(c.resourcePrefix, "success").Inc()
 	} else {
-		klog.ErrorS(nil, "Cache consistentency check failed", "resource", c.resourcePrefix, "resourceVersion", digests.ResourceVersion, "etcdDigest", digests.EtcdDigest, "cacheDigest", digests.CacheDigest)
+		klog.ErrorS(nil, "Cache consistency check failed", "resource", c.resourcePrefix, "resourceVersion", digests.ResourceVersion, "etcdDigest", digests.EtcdDigest, "cacheDigest", digests.CacheDigest)
 		metrics.StorageConsistencyCheckTotal.WithLabelValues(c.resourcePrefix, "failure").Inc()
+		// Panic on internal consistency checking enabled only by environment variable. R
+		panic(fmt.Sprintf("Cache consistency check failed, resource: %q, resourceVersion: %q, etcdDigest: %q, cacheDigest: %q", c.resourcePrefix, digests.ResourceVersion, digests.EtcdDigest, digests.CacheDigest))
 	}
 }
 
@@ -370,6 +372,7 @@ func (c *consistencyChecker) calculateDigests(ctx context.Context) (*storageDige
 		return nil, fmt.Errorf("cache is not ready")
 	}
 	cacheDigest, resourceVersion, err := c.calculateStoreDigest(ctx, c.cacher, storage.ListOptions{
+		Recursive:            true,
 		ResourceVersion:      "0",
 		Predicate:            storage.Everything,
 		ResourceVersionMatch: metav1.ResourceVersionMatchNotOlderThan,
@@ -378,6 +381,7 @@ func (c *consistencyChecker) calculateDigests(ctx context.Context) (*storageDige
 		return nil, fmt.Errorf("failed calculating cache digest: %w", err)
 	}
 	etcdDigest, _, err := c.calculateStoreDigest(ctx, c.etcd, storage.ListOptions{
+		Recursive:            true,
 		ResourceVersion:      resourceVersion,
 		Predicate:            storage.Everything,
 		ResourceVersionMatch: metav1.ResourceVersionMatchExact,


### PR DESCRIPTION
Confirmed that the check is already running and passing, however found couple of small issues.

Enabling panic here is ok because the check is already enabled, so it should prevent submitting a bug.

Missing recursive was not found as it's not easy to test in cacher on because you only have access to storage mock.

/kind cleanup

```release-note
NONE
```

/sig api-machinery
/triage accepted
/assign @wojtek-t
/cc @liggitt
