### PR TITLE
[RFC] Don't actuate pod resizes with untolerated NoSchedule taints

### DIFF
--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -3356,6 +3356,7 @@ const (
 	// but allow all pods submitted to Kubelet without going through the scheduler
 	// to start, and allow all already-running pods to continue running.
 	// Enforced by the scheduler.
+	// Do not allow pods to be resized unless they tolerate the taint (enforced by Kubelet).
 	TaintEffectNoSchedule TaintEffect = "NoSchedule"
 	// Like TaintEffectNoSchedule, but the scheduler tries not to schedule
 	// new pods onto the node, rather than prohibiting new pods from scheduling

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -3740,6 +3740,7 @@ const (
 	// but allow all pods submitted to Kubelet without going through the scheduler
 	// to start, and allow all already-running pods to continue running.
 	// Enforced by the scheduler.
+	// Do not allow pods to be resized unless they tolerate the taint (enforced by Kubelet).
 	TaintEffectNoSchedule TaintEffect = "NoSchedule"
 	// Like TaintEffectNoSchedule, but the scheduler tries not to schedule
 	// new pods onto the node, rather than prohibiting new pods from scheduling


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

I'm opening this PR for discussion, but we (sig-node) are not yet committed to the direction.
/hold

#### What this PR does / why we need it:

Don't admit pod resizes in the presence of an untolerated `NoSchedule` taint.

This was first raised by a use case where a third party controller is using a NoSchedule taint to "pause" resource changes on the node to avoid race conditions, but this assumption is broken in the presence of pod resizes, which don't pass through the scheduler.

That use case aside, we may eventually want to sync resizes with the scheduler (https://github.com/kubernetes/kubernetes/issues/126891). By checking for a NoSchedule taint, we have more freedom to move resize acceptance logic to the scheduler in the future (TBD if that's desired though).

Moreover, if we were building from scratch the Kubelet should probably have been checking for the `NoSchedule` taint in admission all along. That ship has sailed, but we have an opportunity to do the right thing with resize.

#### Does this PR introduce a user-facing change?
```release-note
Pods must tolerate all NoSchedule taints to be resized
```

/sig node
/priority important-soon
