### PR TITLE
Disable checking list response in tests when watchcache cannot initialize

### DIFF
--- a/cmd/kube-apiserver/app/testing/testserver.go
+++ b/cmd/kube-apiserver/app/testing/testserver.go
@@ -107,7 +107,8 @@ type TestServerInstanceOptions struct {
 	// If empty, effective version will default to DefaultKubeEffectiveVersion.
 	BinaryVersion string
 	// Set non-default request timeout in the server.
-	RequestTimeout time.Duration
+	RequestTimeout    time.Duration
+	WatchCacheEnabled bool
 }
 
 // TestServer return values supplied by kube-test-ApiServer
@@ -141,7 +142,8 @@ type ProxyCA struct {
 // NewDefaultTestServerOptions Default options for TestServer instances
 func NewDefaultTestServerOptions() *TestServerInstanceOptions {
 	return &TestServerInstanceOptions{
-		EnableCertAuth: true,
+		EnableCertAuth:    true,
+		WatchCacheEnabled: true,
 	}
 }
 
@@ -339,6 +341,7 @@ func StartTestServer(t ktesting.TB, instanceOptions *TestServerInstanceOptions, 
 
 	s.ServiceClusterIPRanges = "10.0.0.0/16"
 	s.Etcd.StorageConfig = *storageConfig
+	s.Etcd.EnableWatchCache = instanceOptions.WatchCacheEnabled
 
 	if err := fs.Parse(customFlags); err != nil {
 		return result, err

--- a/test/integration/controlplane/transformation/transformation_test.go
+++ b/test/integration/controlplane/transformation/transformation_test.go
@@ -93,6 +93,7 @@ type transformTestConfig struct {
 	configDir             string
 	storageConfig         *storagebackend.Config
 	runtimeConfig         []string
+	watchCacheDisabled    bool
 }
 
 func newTransformTest(tb testing.TB, config transformTestConfig) (*transformTest, error) {
@@ -128,8 +129,10 @@ func newTransformTest(tb testing.TB, config transformTestConfig) (*transformTest
 	if len(config.runtimeConfig) > 0 {
 		flags = append(flags, "--runtime-config="+strings.Join(config.runtimeConfig, ","))
 	}
+	opts := kubeapiservertesting.NewDefaultTestServerOptions()
+	opts.WatchCacheEnabled = !config.watchCacheDisabled
 	if e.kubeAPIServer, err = kubeapiservertesting.StartTestServer(
-		tb, nil,
+		tb, opts,
 		flags, e.storageConfig); err != nil {
 		e.cleanUp()
 		return nil, fmt.Errorf("failed to start KubeAPI server: %w", err)


### PR DESCRIPTION
Invalid webhook and corrupt object will prevent watchcache initialization returning a different error than etcd.

This is needed for KEP-4988 as it delegates even more requests to watch cache making the webhook tests for list obsolete.

Alternative would be to expose ListWatcher errors to watchcache and combine two errors `storage is (re)initializing: returned 0 objects, expected 1`. That might be good improvement for users, however we don't have time to implement it for v1.33

/kind feature

```release-note
NONE
```


/sig api-machinery
/triage accepted
/assign @wojtek-t
/cc @liggitt
