### PR TITLE
DRA scheduler: fix potential panic during unit test verification

### DIFF
--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
@@ -1047,7 +1047,9 @@ type testContext struct {
 
 func (tc *testContext) verify(t *testing.T, expected result, initialObjects []metav1.Object, result interface{}, status *framework.Status) {
 	t.Helper()
-	if actualErr := status.AsError(); actualErr != nil {
+	if expected.status == nil {
+		assert.Nil(t, status)
+	} else if actualErr := status.AsError(); actualErr != nil {
 		// Compare only the error strings.
 		assert.ErrorContains(t, actualErr, expected.status.AsError().Error())
 	} else {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test
/kind flake

#### What this PR does / why we need it:

If there was an unexpected status, the code extracting the expected error message crashed with a panic. Happened once so far, for unknown reasons because the unexpected status then didn't get logged.

#### Which issue(s) this PR fixes:
Related-to: https://github.com/kubernetes/kubernetes/issues/130884

#### Special notes for your reviewer:

This only fixes the panic. It does not fix whatever caused the unexpected status in  https://github.com/kubernetes/kubernetes/issues/130884.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/priority important-soon
/assign @bart0sh 