### PR TITLE
apiserver: return 4xx for invalid binding api request

### DIFF
--- a/pkg/registry/core/pod/storage/storage.go
+++ b/pkg/registry/core/pod/storage/storage.go
@@ -182,7 +182,7 @@ func (r *BindingREST) Create(ctx context.Context, name string, obj runtime.Objec
 
 	// TODO: move me to a binding strategy
 	if errs := validation.ValidatePodBinding(binding); len(errs) != 0 {
-		return nil, errs.ToAggregate()
+		return nil, errors.NewInvalid(api.Kind("Binding"), "", errs)
 	}
 
 	if createValidation != nil {

--- a/test/integration/apiserver/apiserver_test.go
+++ b/test/integration/apiserver/apiserver_test.go
@@ -169,17 +169,33 @@ var cascDel = `
 }
 `
 
-func Test422StatusCodeInvalidBindings(t *testing.T) {
+func Test422StatusCodeInvalidPodsBinding(t *testing.T) {
 	ctx, client, _, tearDownFn := setup(t)
 	defer tearDownFn()
 
-	body := []byte(`{"target":{}}`)
 	var statusCode int
+
+	bodyPodsBinding := []byte(`{"apiVersion":"v1","kind":"Binding","metadata":{"name":"my-pod","namespace":"default"},"target":{}}`)
 	result := client.CoreV1().RESTClient().
 		Post().
 		Namespace("default").
+		Resource("pods").
+		Name("my-pod").
+		SubResource("binding").
+		Body(bodyPodsBinding).
+		Do(ctx)
+	result.StatusCode(&statusCode)
+
+	if statusCode != 422 {
+		t.Fatalf("Expected status code to be 422, got %v (%#v)", statusCode, result)
+	}
+
+	bodyBindings := []byte(`{"target":{}}`)
+	result = client.CoreV1().RESTClient().
+		Post().
+		Namespace("default").
 		Resource("bindings").
-		Body(body).
+		Body(bodyBindings).
 		Do(ctx)
 	result.StatusCode(&statusCode)
 

--- a/test/integration/apiserver/apiserver_test.go
+++ b/test/integration/apiserver/apiserver_test.go
@@ -169,6 +169,25 @@ var cascDel = `
 }
 `
 
+func Test422StatusCodeInvalidBindings(t *testing.T) {
+	ctx, client, _, tearDownFn := setup(t)
+	defer tearDownFn()
+
+	body := []byte(`{"target":{}}`)
+	var statusCode int
+	result := client.CoreV1().RESTClient().
+		Post().
+		Namespace("default").
+		Resource("bindings").
+		Body(body).
+		Do(ctx)
+	result.StatusCode(&statusCode)
+
+	if statusCode != 422 {
+		t.Fatalf("Expected status code to be 422, got %v (%#v)", statusCode, result)
+	}
+}
+
 func Test4xxStatusCodeInvalidPatch(t *testing.T) {
 	ctx, client, _, tearDownFn := setup(t)
 	defer tearDownFn()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind api-change

#### What this PR does / why we need it:

In short, I discovered a reproducible bug in the Kubernetes REST API, identified the root cause, and implemented a fix. Additionally, I wrote a unit test to verify the resolution.

##### Steps to Reproduce Manually
1. Start a Kubernetes cluster (I used the `StartTestServer` function from the `testing` package, but I believe the results would be the same with other methods).

2. Send the following request (ensure the required credentials, such as tokens, are properly configured beforehand—omitted here for brevity):

```shell
curl -X POST "https://$IP:$PORT/api/v1/namespaces/default/bindings" \
     -H "Accept: application/json" \
     -H "Content-Type: application/json" \
     -d '{"target":{}}'
```
In other words, we send a `POST` request to `/api/v1/namespaces/default/bindings` with the request body JSON as `{"target":{}}`. Clearly, this JSON is invalid, so the expected response should be a `4xx` error.

3. However, the actual response is:
```json
{
  "kind": "Status",
  "apiVersion": "v1",
  "metadata": {},
  "status": "Failure",
  "message": "target.name: Required value",
  "code": 500
}
```
This is unexpected. The request should be properly handled and return a `4xx` response instead of an `Internal Server Error` (500).

4. Additionally, I observed a panic stack trace in the Kubernetes cluster logs.

##### Unit Test & Fix

**To facilitate reproduction of the issue, I added a unit test. Running this test consistently reproduces the issue as described above.**

After investigation, I found that the root cause was an error (`err`) that was not properly wrapped as a `StatusError`. I applied the necessary fix in the source code, and after making the modification, the newly added unit test now behaves as expected.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

Should we respond with `422` or `400`? My current implementation returns `422`, based on my understanding of how similar cases are handled in the source code.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
return 4xx for invalid binding in POST REST APIs
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
