### PR TITLE
Implement WithFeatureGate label proposal

### DIFF
--- a/test/e2e/framework/ginkgowrapper.go
+++ b/test/e2e/framework/ginkgowrapper.go
@@ -210,12 +210,16 @@ func registerInSuite(ginkgoCall func(string, ...interface{}) bool, args []interf
 			addLabel(fullLabel)
 			if arg.alphaBetaLevel != "" {
 				texts = append(texts, fmt.Sprintf("[%[1]s]", arg.alphaBetaLevel))
-				ginkgoArgs = append(ginkgoArgs, ginkgo.Label("Feature:"+arg.alphaBetaLevel))
+				ginkgoArgs = append(ginkgoArgs, ginkgo.Label(arg.alphaBetaLevel))
 			}
 			if arg.offByDefault {
 				texts = append(texts, "[Feature:OffByDefault]")
-				// TODO: consider this once we have a plan to update the alpha/beta job filters
-				// ginkgoArgs = append(ginkgoArgs, ginkgo.Label("Feature:OffByDefault"))
+				ginkgoArgs = append(ginkgoArgs, ginkgo.Label("Feature:OffByDefault"))
+				// Alphas are always off by default but we may want to select
+				// betas based on defaulted-ness.
+				if arg.alphaBetaLevel == "Beta" {
+					ginkgoArgs = append(ginkgoArgs, ginkgo.Label("BetaOffByDefault"))
+				}
 			}
 			if fullLabel == "Serial" {
 				ginkgoArgs = append(ginkgoArgs, ginkgo.Serial)
@@ -374,12 +378,18 @@ func withFeature(name Feature) interface{} {
 // on the current stability level of the feature, to emulate historic
 // usage of those tags.
 //
-// In addition, [Feature:Alpha] resp. [Feature:Beta] get added to support
-// skipping a test with a dependency on an alpha or beta feature gate in
-// jobs which use the traditional \[Feature:.*\] skip regular expression.
+// For label filtering, Alpha resp. Beta get added to the Ginkgo labels.
 //
-// For label filtering, Feature:Alpha resp. Feature:Beta get added to the
-// Ginkgo labels.
+// [Feature:OffByDefault] gets added to support skipping a test with
+// a dependency on an alpha or beta feature gate in jobs which use the
+// traditional \[Feature:.*\] skip regular expression.
+//
+// Feature:OffByDefault is also available for label filtering.
+//
+// BetaOffByDefault is also added *only as a label* when the feature gate is
+// an off by default beta feature. This can be used to include/exclude based
+// on beta + defaulted-ness. Alpha has no equivalent because all alphas are
+// off by default.
 //
 // If the test can run in any cluster that has alpha resp. beta features and
 // API groups enabled, then annotating it with just WithFeatureGate is

--- a/test/e2e/framework/internal/unittests/bugs/bugs.go
+++ b/test/e2e/framework/internal/unittests/bugs/bugs.go
@@ -129,12 +129,14 @@ ERROR: some/relative/path/buggy.go:200: with spaces
 
 	// Used by unittests/list-labels.
 	ListLabelsOutput = `The following labels can be used with 'ginkgo run --label-filter':
+    Alpha
+    Beta
+    BetaOffByDefault
     Conformance
     Disruptive
     Environment:Linux
     Environment:no-such-env
-    Feature:Alpha
-    Feature:Beta
+    Feature:OffByDefault
     Feature:feature-foo
     Feature:no-such-feature
     FeatureGate:TestAlphaFeature

--- a/test/e2e/framework/internal/unittests/bugs/bugs.go
+++ b/test/e2e/framework/internal/unittests/bugs/bugs.go
@@ -80,6 +80,7 @@ func Describe() {
 		framework.WithFeatureGate("no-such-feature-gate"),
 		framework.WithFeatureGate(features.Alpha),
 		framework.WithFeatureGate(features.Beta),
+		framework.WithFeatureGate(features.BetaDefaultOff),
 		framework.WithFeatureGate(features.GA),
 		framework.WithConformance(),
 		framework.WithNodeConformance(),
@@ -116,14 +117,14 @@ ERROR: bugs.go:71: trailing or leading spaces are unnecessary and need to be rem
 ERROR: bugs.go:76: WithFeature: unknown feature "no-such-feature"
 ERROR: bugs.go:78: WithEnvironment: unknown environment "no-such-env"
 ERROR: bugs.go:80: WithFeatureGate: the feature gate "no-such-feature-gate" is unknown
-ERROR: bugs.go:106: SIG label must be lowercase, no spaces and no sig- prefix, got instead: "123"
+ERROR: bugs.go:107: SIG label must be lowercase, no spaces and no sig- prefix, got instead: "123"
 ERROR: buggy/buggy.go:100: hello world
 ERROR: some/relative/path/buggy.go:200: with spaces
 `
 	// Used by unittests/list-tests. It's sorted by test name, not source code location.
 	ListTestsOutput = `The following spec names can be used with 'ginkgo run --focus/skip':
-    ../bugs/bugs.go:100: [sig-testing] abc   space1 space2  [Feature:no-such-feature] [Feature:feature-foo] [Environment:no-such-env] [Environment:Linux] [FeatureGate:no-such-feature-gate] [Feature:OffByDefault] [FeatureGate:TestAlphaFeature] [Alpha] [Feature:OffByDefault] [FeatureGate:TestBetaFeature] [Beta] [FeatureGate:TestGAFeature] [Conformance] [NodeConformance] [Slow] [Serial] [Disruptive] [custom-label] xyz x [foo] should [bar]
-    ../bugs/bugs.go:95: [sig-testing] abc   space1 space2  [Feature:no-such-feature] [Feature:feature-foo] [Environment:no-such-env] [Environment:Linux] [FeatureGate:no-such-feature-gate] [Feature:OffByDefault] [FeatureGate:TestAlphaFeature] [Alpha] [Feature:OffByDefault] [FeatureGate:TestBetaFeature] [Beta] [FeatureGate:TestGAFeature] [Conformance] [NodeConformance] [Slow] [Serial] [Disruptive] [custom-label] xyz y [foo] should [bar]
+    ../bugs/bugs.go:101: [sig-testing] abc   space1 space2  [Feature:no-such-feature] [Feature:feature-foo] [Environment:no-such-env] [Environment:Linux] [FeatureGate:no-such-feature-gate] [Feature:OffByDefault] [FeatureGate:TestAlphaFeature] [Alpha] [Feature:OffByDefault] [FeatureGate:TestBetaFeature] [Beta] [FeatureGate:TestBetaDefaultOffFeature] [Beta] [Feature:OffByDefault] [FeatureGate:TestGAFeature] [Conformance] [NodeConformance] [Slow] [Serial] [Disruptive] [custom-label] xyz x [foo] should [bar]
+    ../bugs/bugs.go:96: [sig-testing] abc   space1 space2  [Feature:no-such-feature] [Feature:feature-foo] [Environment:no-such-env] [Environment:Linux] [FeatureGate:no-such-feature-gate] [Feature:OffByDefault] [FeatureGate:TestAlphaFeature] [Alpha] [Feature:OffByDefault] [FeatureGate:TestBetaFeature] [Beta] [FeatureGate:TestBetaDefaultOffFeature] [Beta] [Feature:OffByDefault] [FeatureGate:TestGAFeature] [Conformance] [NodeConformance] [Slow] [Serial] [Disruptive] [custom-label] xyz y [foo] should [bar]
 
 `
 
@@ -140,6 +141,7 @@ ERROR: some/relative/path/buggy.go:200: with spaces
     Feature:feature-foo
     Feature:no-such-feature
     FeatureGate:TestAlphaFeature
+    FeatureGate:TestBetaDefaultOffFeature
     FeatureGate:TestBetaFeature
     FeatureGate:TestGAFeature
     FeatureGate:no-such-feature-gate

--- a/test/e2e/framework/internal/unittests/bugs/features/features.go
+++ b/test/e2e/framework/internal/unittests/bugs/features/features.go
@@ -24,9 +24,10 @@ import (
 )
 
 const (
-	Alpha featuregate.Feature = "TestAlphaFeature"
-	Beta  featuregate.Feature = "TestBetaFeature"
-	GA    featuregate.Feature = "TestGAFeature"
+	Alpha          featuregate.Feature = "TestAlphaFeature"
+	Beta           featuregate.Feature = "TestBetaFeature"
+	BetaDefaultOff featuregate.Feature = "TestBetaDefaultOffFeature"
+	GA             featuregate.Feature = "TestGAFeature"
 )
 
 func init() {
@@ -40,6 +41,9 @@ var testFeatureGates = map[featuregate.Feature]featuregate.VersionedSpecs{
 	Beta: {
 		{Version: version.MustParse("1.27"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("1.28"), Default: true, PreRelease: featuregate.Beta},
+	},
+	BetaDefaultOff: {
+		{Version: version.MustParse("1.28"), Default: false, PreRelease: featuregate.Beta},
 	},
 	GA: {
 		{Version: version.MustParse("1.27"), Default: false, PreRelease: featuregate.Alpha},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:

Implements [Feature Gated Test Labeling Proposal](https://docs.google.com/document/d/1YkU7EusfOZO9jgJbHvCwMCfMZ5CxYMxZHAblpDdKbUQ/edit?tab=t.0) (shared with dev@kubernetes.io and kubernetes-sig-testing@googlegroups.com)


Label changes:
- Feature:Alpha => Alpha
- Feature:Beta => Beta
- Feature:OffByDefault mirrored to labels from test name
- BetaOffByDefault label added

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
e2e framework: `framework.WithFeatureGate` `[Alpha]`, `[Beta]` and `[Feature:OffByDefault]` tags are now set 1:1 with `Alpha`,  `Beta`, `Feature:OffByDefault` Ginkgo labels, replacing`Feature:Alpha` and `Feature:Beta` labels. `BetaOffByDefault` is also added as a Ginkgo label only for off-by-default beta features
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/hold
/assign @aojea @pohly 
cc @liggitt 

We will want to coordinate updating a few CI jobs following this. I'm drafting that PR next: https://github.com/kubernetes/test-infra/pull/34541
/hold 