### PR TITLE
Invoke UpdateContainerResources or trigger container restarts when memory requests are resized

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2989,7 +2989,6 @@ func (kl *Kubelet) handlePodResourcesResize(pod *v1.Pod, podStatus *kubecontaine
 // for any running containers. Specifically, the following differences are ignored:
 // - Non-resizable containers: non-restartable init containers, ephemeral containers
 // - Non-resizable resources: only CPU & memory are resizable
-// - Non-actuated resources: memory requests are not actuated
 // - Non-running containers: they will be sized correctly when (re)started
 func (kl *Kubelet) isPodResizeInProgress(allocatedPod *v1.Pod, podStatus *kubecontainer.PodStatus) bool {
 	return !podutil.VisitContainers(&allocatedPod.Spec, podutil.InitContainers|podutil.Containers,
@@ -3007,9 +3006,9 @@ func (kl *Kubelet) isPodResizeInProgress(allocatedPod *v1.Pod, podStatus *kubeco
 			actuatedResources, _ := kl.allocationManager.GetActuatedResources(allocatedPod.UID, allocatedContainer.Name)
 			allocatedResources := allocatedContainer.Resources
 
-			// Memory requests are excluded since they don't need to be actuated.
 			return allocatedResources.Requests[v1.ResourceCPU].Equal(actuatedResources.Requests[v1.ResourceCPU]) &&
 				allocatedResources.Limits[v1.ResourceCPU].Equal(actuatedResources.Limits[v1.ResourceCPU]) &&
+				allocatedResources.Requests[v1.ResourceMemory].Equal(actuatedResources.Requests[v1.ResourceMemory]) &&
 				allocatedResources.Limits[v1.ResourceMemory].Equal(actuatedResources.Limits[v1.ResourceMemory])
 		})
 }

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -2105,6 +2105,13 @@ func (kl *Kubelet) convertToAPIContainerStatuses(pod *v1.Pod, podStatus *kubecon
 			} else {
 				preserveOldResourcesValue(v1.ResourceCPU, oldStatus.Resources.Requests, resources.Requests)
 			}
+			// TODO(tallclair,vinaykul,InPlacePodVerticalScaling): Investigate defaulting to actuated resources instead of allocated resources above
+			if _, exists := resources.Requests[v1.ResourceMemory]; exists {
+				// Get memory requests from actuated resources
+				if actuatedResources, found := kl.allocationManager.GetActuatedResources(pod.UID, allocatedContainer.Name); found {
+					resources.Requests[v1.ResourceMemory] = actuatedResources.Requests.Memory().DeepCopy()
+				}
+			}
 		}
 
 		return resources

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -2109,7 +2109,7 @@ func (kl *Kubelet) convertToAPIContainerStatuses(pod *v1.Pod, podStatus *kubecon
 			if _, exists := resources.Requests[v1.ResourceMemory]; exists {
 				// Get memory requests from actuated resources
 				if actuatedResources, found := kl.allocationManager.GetActuatedResources(pod.UID, allocatedContainer.Name); found {
-					resources.Requests[v1.ResourceMemory] = actuatedResources.Requests.Memory().DeepCopy()
+					resources.Requests[v1.ResourceMemory] = *actuatedResources.Requests.Memory()
 				}
 			}
 		}

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -3857,8 +3857,7 @@ func TestIsPodResizeInProgress(t *testing.T) {
 			actuated:  &testResources{100, 200, 150, 200},
 			isRunning: true,
 		}},
-		// Memory requests aren't actuated and should be ignored.
-		expectHasResize: false,
+		expectHasResize: true,
 	}, {
 		name: "simple resized container/cpu+mem req",
 		containers: []testContainer{{

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -77,7 +77,6 @@ const (
 	kubeRuntimeAPIVersion = "0.1.0"
 	// A minimal shutdown window for avoiding unnecessary SIGKILLs
 	minimumGracePeriodInSeconds = 2
-	MinimumGracePeriodInSeconds = int64(minimumGracePeriodInSeconds)
 
 	// The expiration time of version cache.
 	versionCacheTTL = 60 * time.Second

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -77,6 +77,7 @@ const (
 	kubeRuntimeAPIVersion = "0.1.0"
 	// A minimal shutdown window for avoiding unnecessary SIGKILLs
 	minimumGracePeriodInSeconds = 2
+	MinimumGracePeriodInSeconds = int64(minimumGracePeriodInSeconds)
 
 	// The expiration time of version cache.
 	versionCacheTTL = 60 * time.Second
@@ -84,6 +85,7 @@ const (
 	identicalErrorDelay = 1 * time.Minute
 	// OpenTelemetry instrumentation scope name
 	instrumentationScope = "k8s.io/kubernetes/pkg/kubelet/kuberuntime"
+
 )
 
 var (

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -85,7 +85,6 @@ const (
 	identicalErrorDelay = 1 * time.Minute
 	// OpenTelemetry instrumentation scope name
 	instrumentationScope = "k8s.io/kubernetes/pkg/kubelet/kuberuntime"
-
 )
 
 var (

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -2890,6 +2890,96 @@ func TestComputePodActionsForPodResize(t *testing.T) {
 				return &pa
 			},
 		},
+		"Update container memory (requests only) with RestartContainer policy for memory": {
+			setupFn: func(pod *v1.Pod) {
+				c := &pod.Spec.Containers[2]
+				c.ResizePolicy = []v1.ContainerResizePolicy{cpuPolicyRestartNotRequired, memPolicyRestartRequired}
+				c.Resources = v1.ResourceRequirements{
+					Limits:   v1.ResourceList{v1.ResourceCPU: cpu200m, v1.ResourceMemory: mem200M},
+					Requests: v1.ResourceList{v1.ResourceCPU: cpu100m, v1.ResourceMemory: mem100M},
+				}
+				setupActuatedResources(pod, c, v1.ResourceRequirements{
+					Limits: v1.ResourceList{
+						v1.ResourceCPU:    cpu200m.DeepCopy(),
+						v1.ResourceMemory: mem200M.DeepCopy(),
+					},
+					Requests: v1.ResourceList{
+						v1.ResourceCPU:    cpu100m.DeepCopy(),
+						v1.ResourceMemory: mem200M.DeepCopy(),
+					},
+				})
+			},
+			getExpectedPodActionsFn: func(pod *v1.Pod, podStatus *kubecontainer.PodStatus) *podActions {
+				kcs := podStatus.FindContainerStatusByName(pod.Spec.Containers[2].Name)
+				killMap := make(map[kubecontainer.ContainerID]containerToKillInfo)
+				killMap[kcs.ID] = containerToKillInfo{
+					container: &pod.Spec.Containers[2],
+					name:      pod.Spec.Containers[2].Name,
+				}
+				pa := podActions{
+					SandboxID:          podStatus.SandboxStatuses[0].Id,
+					ContainersToStart:  []int{2},
+					ContainersToKill:   killMap,
+					ContainersToUpdate: map[v1.ResourceName][]containerToUpdateInfo{},
+					UpdatePodResources: true,
+				}
+				return &pa
+			},
+		},
+		"Update container memory (requests only) with RestartNotRequired policy for memory": {
+			setupFn: func(pod *v1.Pod) {
+				c := &pod.Spec.Containers[2]
+				c.ResizePolicy = []v1.ContainerResizePolicy{cpuPolicyRestartNotRequired, memPolicyRestartNotRequired}
+				c.Resources = v1.ResourceRequirements{
+					Limits:   v1.ResourceList{v1.ResourceCPU: cpu200m, v1.ResourceMemory: mem200M},
+					Requests: v1.ResourceList{v1.ResourceCPU: cpu100m, v1.ResourceMemory: mem100M},
+				}
+				setupActuatedResources(pod, c, v1.ResourceRequirements{
+					Limits: v1.ResourceList{
+						v1.ResourceCPU:    cpu200m.DeepCopy(),
+						v1.ResourceMemory: mem200M.DeepCopy(),
+					},
+					Requests: v1.ResourceList{
+						v1.ResourceCPU:    cpu100m.DeepCopy(),
+						v1.ResourceMemory: mem200M.DeepCopy(),
+					},
+				})
+			},
+			getExpectedPodActionsFn: func(pod *v1.Pod, podStatus *kubecontainer.PodStatus) *podActions {
+				kcs := podStatus.FindContainerStatusByName(pod.Spec.Containers[2].Name)
+				killMap := make(map[kubecontainer.ContainerID]containerToKillInfo)
+				killMap[kcs.ID] = containerToKillInfo{
+					container: &pod.Spec.Containers[2],
+					name:      pod.Spec.Containers[2].Name,
+				}
+				pa := podActions{
+					SandboxID:         podStatus.SandboxStatuses[0].Id,
+					ContainersToStart: []int{},
+					ContainersToKill:  getKillMap(pod, podStatus, []int{}),
+					ContainersToUpdate: map[v1.ResourceName][]containerToUpdateInfo{
+						v1.ResourceMemory: {
+							{
+								container:       &pod.Spec.Containers[2],
+								kubeContainerID: kcs.ID,
+								desiredContainerResources: containerResources{
+									memoryLimit:   mem200M.Value(),
+									memoryRequest: mem100M.Value(),
+									cpuLimit:      cpu200m.MilliValue(),
+									cpuRequest:    cpu100m.MilliValue(),
+								},
+								currentContainerResources: &containerResources{
+									memoryLimit:   mem200M.Value(),
+									memoryRequest: mem200M.Value(),
+									cpuLimit:      cpu200m.MilliValue(),
+									cpuRequest:    cpu100m.MilliValue(),
+								},
+							},
+						},
+					},
+				}
+				return &pa
+			},
+		},
 	} {
 		t.Run(desc, func(t *testing.T) {
 			pod, status := makeBasePodAndStatus()

--- a/test/e2e/common/node/pod_resize.go
+++ b/test/e2e/common/node/pod_resize.go
@@ -1440,7 +1440,7 @@ func doPodResizeErrorTests() {
 //       Above tests are performed by doSheduletTests() and doPodResizeResourceQuotaTests()
 //       in test/e2e/node/pod_resize.go
 
-var _ = SIGDescribe("[InPlacePodResize] Pod InPlace Resize Container", feature.InPlacePodVerticalScaling, func() {
+var _ = SIGDescribe("Pod InPlace Resize Container", feature.InPlacePodVerticalScaling, func() {
 	f := framework.NewDefaultFramework("pod-resize-tests")
 
 	ginkgo.BeforeEach(func(ctx context.Context) {

--- a/test/e2e/common/node/pod_resize.go
+++ b/test/e2e/common/node/pod_resize.go
@@ -93,8 +93,8 @@ func doPodResizeTests() {
 				},
 			},
 			patchString: fmt.Sprintf(`{"spec":{"containers":[
-				{"name":"c1", "resources":{"requests":{"cpu":"%s","memory":"%s"},"limits":{"cpu":"%s","memory":"%s"}}}
-			]}}`, increasedCPU, increasedMem, increasedCPU, increasedMem),
+					{"name":"c1", "resources":{"requests":{"cpu":"%s","memory":"%s"},"limits":{"cpu":"%s","memory":"%s"}}}
+				]}}`, increasedCPU, increasedMem, increasedCPU, increasedMem),
 			expected: []e2epod.ResizableContainerInfo{
 				{
 					Name:      "c1",
@@ -105,8 +105,7 @@ func doPodResizeTests() {
 			},
 		},
 		{
-			name:         "Guaranteed QoS pod, one container - decrease CPU only",
-			testRollback: true,
+			name: "Guaranteed QoS pod, one container - decrease CPU only",
 			containers: []e2epod.ResizableContainerInfo{
 				{
 					Name:      "c1",
@@ -116,8 +115,8 @@ func doPodResizeTests() {
 				},
 			},
 			patchString: fmt.Sprintf(`{"spec":{"containers":[
-						{"name":"c1", "resources":{"requests":{"cpu":"%s"},"limits":{"cpu":"%s"}}}
-					]}}`, reducedCPU, reducedCPU),
+							{"name":"c1", "resources":{"requests":{"cpu":"%s"},"limits":{"cpu":"%s"}}}
+						]}}`, reducedCPU, reducedCPU),
 			expected: []e2epod.ResizableContainerInfo{
 				{
 					Name:      "c1",
@@ -126,6 +125,7 @@ func doPodResizeTests() {
 					MemPolicy: &noRestart,
 				},
 			},
+			testRollback: true,
 		},
 		{
 			name: "Guaranteed QoS pod, three containers (c1, c2, c3) - increase: CPU (c1,c3), memory (c2, c3) ; decrease: CPU (c2)",
@@ -150,10 +150,10 @@ func doPodResizeTests() {
 				},
 			},
 			patchString: fmt.Sprintf(`{"spec":{"containers":[
-						{"name":"c1", "resources":{"requests":{"cpu":"%s"},"limits":{"cpu":"%s"}}},
-						{"name":"c2", "resources":{"requests":{"cpu":"%s","memory":"%s"},"limits":{"cpu":"%s","memory":"%s"}}},
-						{"name":"c3", "resources":{"requests":{"cpu":"%s","memory":"%s"},"limits":{"cpu":"%s","memory":"%s"}}}
-					]}}`,
+							{"name":"c1", "resources":{"requests":{"cpu":"%s"},"limits":{"cpu":"%s"}}},
+							{"name":"c2", "resources":{"requests":{"cpu":"%s","memory":"%s"},"limits":{"cpu":"%s","memory":"%s"}}},
+							{"name":"c3", "resources":{"requests":{"cpu":"%s","memory":"%s"},"limits":{"cpu":"%s","memory":"%s"}}}
+						]}}`,
 				increasedCPU, increasedCPU,
 				offsetCPU(1, reducedCPU), offsetMemory(1, increasedMem), offsetCPU(1, reducedCPU), offsetMemory(1, increasedMem),
 				offsetCPU(2, increasedCPU), offsetMemory(2, increasedMem), offsetCPU(2, increasedCPU), offsetMemory(2, increasedMem)),
@@ -179,8 +179,7 @@ func doPodResizeTests() {
 			},
 		},
 		{
-			name:         "Burstable QoS pod, one container with cpu & memory requests + limits - decrease memory requests only",
-			testRollback: true,
+			name: "Burstable QoS pod, one container with cpu & memory requests + limits - decrease memory requests only",
 			containers: []e2epod.ResizableContainerInfo{
 				{
 					Name:      "c1",
@@ -188,14 +187,15 @@ func doPodResizeTests() {
 				},
 			},
 			patchString: fmt.Sprintf(`{"spec":{"containers":[
-						{"name":"c1", "resources":{"requests":{"memory":"%s"}}}
-					]}}`, reducedMem),
+							{"name":"c1", "resources":{"requests":{"memory":"%s"}}}
+						]}}`, reducedMem),
 			expected: []e2epod.ResizableContainerInfo{
 				{
 					Name:      "c1",
 					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: reducedMem, MemLim: originalMemLimit},
 				},
 			},
+			testRollback: true,
 		},
 		{
 			name: "Burstable QoS pod, one container with cpu & memory requests + limits - increase memory requests only",
@@ -206,8 +206,8 @@ func doPodResizeTests() {
 				},
 			},
 			patchString: fmt.Sprintf(`{"spec":{"containers":[
-						{"name":"c1", "resources":{"requests":{"memory":"%s"}}}
-					]}}`, increasedMem),
+							{"name":"c1", "resources":{"requests":{"memory":"%s"}}}
+						]}}`, increasedMem),
 			expected: []e2epod.ResizableContainerInfo{
 				{
 					Name:      "c1",
@@ -224,8 +224,8 @@ func doPodResizeTests() {
 				},
 			},
 			patchString: fmt.Sprintf(`{"spec":{"containers":[
-						{"name":"c1", "resources":{"limits":{"memory":"%s"}}}
-					]}}`, increasedMemLimit),
+							{"name":"c1", "resources":{"limits":{"memory":"%s"}}}
+						]}}`, increasedMemLimit),
 			expected: []e2epod.ResizableContainerInfo{
 				{
 					Name:      "c1",
@@ -234,8 +234,7 @@ func doPodResizeTests() {
 			},
 		},
 		{
-			name:         "Burstable QoS pod, one container with cpu & memory requests + limits - decrease CPU requests only",
-			testRollback: true,
+			name: "Burstable QoS pod, one container with cpu & memory requests + limits - decrease CPU requests only",
 			containers: []e2epod.ResizableContainerInfo{
 				{
 					Name:      "c1",
@@ -243,18 +242,18 @@ func doPodResizeTests() {
 				},
 			},
 			patchString: fmt.Sprintf(`{"spec":{"containers":[
-						{"name":"c1", "resources":{"requests":{"cpu":"%s"}}}
-					]}}`, reducedCPU),
+							{"name":"c1", "resources":{"requests":{"cpu":"%s"}}}
+						]}}`, reducedCPU),
 			expected: []e2epod.ResizableContainerInfo{
 				{
 					Name:      "c1",
 					Resources: &e2epod.ContainerResources{CPUReq: reducedCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
 				},
 			},
+			testRollback: true,
 		},
 		{
-			name:         "Burstable QoS pod, one container with cpu & memory requests + limits - decrease CPU limits only",
-			testRollback: true,
+			name: "Burstable QoS pod, one container with cpu & memory requests + limits - decrease CPU limits only",
 			containers: []e2epod.ResizableContainerInfo{
 				{
 					Name:      "c1",
@@ -262,14 +261,15 @@ func doPodResizeTests() {
 				},
 			},
 			patchString: fmt.Sprintf(`{"spec":{"containers":[
-						{"name":"c1", "resources":{"limits":{"cpu":"%s"}}}
-					]}}`, reducedCPULimit),
+							{"name":"c1", "resources":{"limits":{"cpu":"%s"}}}
+						]}}`, reducedCPULimit),
 			expected: []e2epod.ResizableContainerInfo{
 				{
 					Name:      "c1",
 					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: reducedCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
 				},
 			},
+			testRollback: true,
 		},
 		{
 			name: "Burstable QoS pod, one container with cpu & memory requests + limits - increase CPU requests only",
@@ -280,8 +280,8 @@ func doPodResizeTests() {
 				},
 			},
 			patchString: fmt.Sprintf(`{"spec":{"containers":[
-						{"name":"c1", "resources":{"requests":{"cpu":"%s"}}}
-					]}}`, increasedCPU),
+							{"name":"c1", "resources":{"requests":{"cpu":"%s"}}}
+						]}}`, increasedCPU),
 			expected: []e2epod.ResizableContainerInfo{
 				{
 					Name:      "c1",
@@ -298,8 +298,8 @@ func doPodResizeTests() {
 				},
 			},
 			patchString: fmt.Sprintf(`{"spec":{"containers":[
-						{"name":"c1", "resources":{"limits":{"cpu":"%s"}}}
-					]}}`, increasedCPULimit),
+							{"name":"c1", "resources":{"limits":{"cpu":"%s"}}}
+						]}}`, increasedCPULimit),
 			expected: []e2epod.ResizableContainerInfo{
 				{
 					Name:      "c1",
@@ -316,8 +316,8 @@ func doPodResizeTests() {
 				},
 			},
 			patchString: fmt.Sprintf(`{"spec":{"containers":[
-						{"name":"c1", "resources":{"requests":{"cpu":"%s"},"limits":{"cpu":"%s"}}}
-					]}}`, reducedCPU, reducedCPULimit),
+							{"name":"c1", "resources":{"requests":{"cpu":"%s"},"limits":{"cpu":"%s"}}}
+						]}}`, reducedCPU, reducedCPULimit),
 			expected: []e2epod.ResizableContainerInfo{
 				{
 					Name:      "c1",
@@ -334,8 +334,8 @@ func doPodResizeTests() {
 				},
 			},
 			patchString: fmt.Sprintf(`{"spec":{"containers":[
-						{"name":"c1", "resources":{"requests":{"cpu":"%s"},"limits":{"cpu":"%s"}}}
-					]}}`, increasedCPU, increasedCPULimit),
+							{"name":"c1", "resources":{"requests":{"cpu":"%s"},"limits":{"cpu":"%s"}}}
+						]}}`, increasedCPU, increasedCPULimit),
 			expected: []e2epod.ResizableContainerInfo{
 				{
 					Name:      "c1",
@@ -352,8 +352,8 @@ func doPodResizeTests() {
 				},
 			},
 			patchString: fmt.Sprintf(`{"spec":{"containers":[
-						{"name":"c1", "resources":{"requests":{"cpu":"%s"},"limits":{"cpu":"%s"}}}
-					]}}`, reducedCPU, increasedCPULimit),
+							{"name":"c1", "resources":{"requests":{"cpu":"%s"},"limits":{"cpu":"%s"}}}
+						]}}`, reducedCPU, increasedCPULimit),
 			expected: []e2epod.ResizableContainerInfo{
 				{
 					Name:      "c1",
@@ -370,8 +370,8 @@ func doPodResizeTests() {
 				},
 			},
 			patchString: fmt.Sprintf(`{"spec":{"containers":[
-						{"name":"c1", "resources":{"requests":{"cpu":"%s"},"limits":{"cpu":"%s"}}}
-					]}}`, increasedCPU, reducedCPULimit),
+							{"name":"c1", "resources":{"requests":{"cpu":"%s"},"limits":{"cpu":"%s"}}}
+						]}}`, increasedCPU, reducedCPULimit),
 			expected: []e2epod.ResizableContainerInfo{
 				{
 					Name:      "c1",
@@ -388,8 +388,8 @@ func doPodResizeTests() {
 				},
 			},
 			patchString: fmt.Sprintf(`{"spec":{"containers":[
-						{"name":"c1", "resources":{"requests":{"memory":"%s"},"limits":{"memory":"%s"}}}
-					]}}`, increasedMem, increasedMemLimit),
+							{"name":"c1", "resources":{"requests":{"memory":"%s"},"limits":{"memory":"%s"}}}
+						]}}`, increasedMem, increasedMemLimit),
 			expected: []e2epod.ResizableContainerInfo{
 				{
 					Name:      "c1",
@@ -406,8 +406,8 @@ func doPodResizeTests() {
 				},
 			},
 			patchString: fmt.Sprintf(`{"spec":{"containers":[
-						{"name":"c1", "resources":{"requests":{"memory":"%s"},"limits":{"memory":"%s"}}}
-					]}}`, reducedMem, increasedMemLimit),
+							{"name":"c1", "resources":{"requests":{"memory":"%s"},"limits":{"memory":"%s"}}}
+						]}}`, reducedMem, increasedMemLimit),
 			expected: []e2epod.ResizableContainerInfo{
 				{
 					Name:      "c1",
@@ -424,8 +424,8 @@ func doPodResizeTests() {
 				},
 			},
 			patchString: fmt.Sprintf(`{"spec":{"containers":[
-						{"name":"c1", "resources":{"requests":{"cpu":"%s"},"limits":{"memory":"%s"}}}
-					]}}`, reducedCPU, increasedMemLimit),
+							{"name":"c1", "resources":{"requests":{"cpu":"%s"},"limits":{"memory":"%s"}}}
+						]}}`, reducedCPU, increasedMemLimit),
 			expected: []e2epod.ResizableContainerInfo{
 				{
 					Name:      "c1",
@@ -442,8 +442,8 @@ func doPodResizeTests() {
 				},
 			},
 			patchString: fmt.Sprintf(`{"spec":{"containers":[
-						{"name":"c1", "resources":{"requests":{"memory":"%s"},"limits":{"cpu":"%s"}}}
-					]}}`, reducedMem, increasedCPULimit),
+							{"name":"c1", "resources":{"requests":{"memory":"%s"},"limits":{"cpu":"%s"}}}
+						]}}`, reducedMem, increasedCPULimit),
 			expected: []e2epod.ResizableContainerInfo{
 				{
 					Name:      "c1",
@@ -460,8 +460,8 @@ func doPodResizeTests() {
 				},
 			},
 			patchString: fmt.Sprintf(`{"spec":{"containers":[
-						{"name":"c1", "resources":{"requests":{"memory":"%s"},"limits":{"cpu":"%s"}}}
-					]}}`, increasedMem, reducedCPULimit),
+							{"name":"c1", "resources":{"requests":{"memory":"%s"},"limits":{"cpu":"%s"}}}
+						]}}`, increasedMem, reducedCPULimit),
 			expected: []e2epod.ResizableContainerInfo{
 				{
 					Name:      "c1",
@@ -478,8 +478,8 @@ func doPodResizeTests() {
 				},
 			},
 			patchString: fmt.Sprintf(`{"spec":{"containers":[
-						{"name":"c1", "resources":{"requests":{"memory":"%s"}}}
-					]}}`, reducedMem),
+							{"name":"c1", "resources":{"requests":{"memory":"%s"}}}
+						]}}`, reducedMem),
 			expected: []e2epod.ResizableContainerInfo{
 				{
 					Name:      "c1",
@@ -496,8 +496,8 @@ func doPodResizeTests() {
 				},
 			},
 			patchString: fmt.Sprintf(`{"spec":{"containers":[
-						{"name":"c1", "resources":{"requests":{"cpu":"%s"}}}
-					]}}`, increasedCPU),
+							{"name":"c1", "resources":{"requests":{"cpu":"%s"}}}
+						]}}`, increasedCPU),
 			expected: []e2epod.ResizableContainerInfo{
 				{
 					Name:      "c1",
@@ -514,8 +514,8 @@ func doPodResizeTests() {
 				},
 			},
 			patchString: `{"spec":{"containers":[
-						{"name":"c1", "resources":{"requests":{"cpu":"1m"},"limits":{"cpu":"5m"}}}
-					]}}`,
+							{"name":"c1", "resources":{"requests":{"cpu":"1m"},"limits":{"cpu":"5m"}}}
+						]}}`,
 			expected: []e2epod.ResizableContainerInfo{
 				{
 					Name:      "c1",
@@ -524,8 +524,7 @@ func doPodResizeTests() {
 			},
 		},
 		{
-			name:         "Guaranteed QoS pod, one container - increase CPU (NotRequired) & memory (RestartContainer)",
-			testRollback: true,
+			name: "Guaranteed QoS pod, one container - increase CPU (NotRequired) & memory (RestartContainer)",
 			containers: []e2epod.ResizableContainerInfo{
 				{
 					Name:      "c1",
@@ -535,8 +534,8 @@ func doPodResizeTests() {
 				},
 			},
 			patchString: fmt.Sprintf(`{"spec":{"containers":[
-						{"name":"c1", "resources":{"requests":{"cpu":"%s","memory":"%s"},"limits":{"cpu":"%s","memory":"%s"}}}
-					]}}`, increasedCPU, increasedMem, increasedCPU, increasedMem),
+							{"name":"c1", "resources":{"requests":{"cpu":"%s","memory":"%s"},"limits":{"cpu":"%s","memory":"%s"}}}
+						]}}`, increasedCPU, increasedMem, increasedCPU, increasedMem),
 			expected: []e2epod.ResizableContainerInfo{
 				{
 					Name:         "c1",
@@ -546,10 +545,34 @@ func doPodResizeTests() {
 					RestartCount: 1,
 				},
 			},
+			testRollback: true,
 		},
 		{
-			name:         "Burstable QoS pod, one container - decrease CPU (NotRequired) & memory (RestartContainer)",
+			name: "Burstable QoS pod, one container - decrease CPU (NotRequired) & memory (RestartContainer)",
+			containers: []e2epod.ResizableContainerInfo{
+				{
+					Name:      "c1",
+					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
+					CPUPolicy: &noRestart,
+					MemPolicy: &doRestart,
+				},
+			},
+			patchString: fmt.Sprintf(`{"spec":{"containers":[
+							{"name":"c1", "resources":{"requests":{"cpu":"%s","memory":"%s"},"limits":{"cpu":"%s","memory":"%s"}}}
+						]}}`, reducedCPU, reducedMem, reducedCPULimit, reducedMemLimit),
+			expected: []e2epod.ResizableContainerInfo{
+				{
+					Name:         "c1",
+					Resources:    &e2epod.ContainerResources{CPUReq: reducedCPU, CPULim: reducedCPULimit, MemReq: reducedMem, MemLim: reducedMemLimit},
+					CPUPolicy:    &noRestart,
+					MemPolicy:    &doRestart,
+					RestartCount: 1,
+				},
+			},
 			testRollback: true,
+		},
+		{
+			name: "Burstable QoS pod, one container - decrease memory request (RestartContainer memory resize policy)",
 			containers: []e2epod.ResizableContainerInfo{
 				{
 					Name:      "c1",
@@ -560,14 +583,37 @@ func doPodResizeTests() {
 			},
 			patchString: fmt.Sprintf(`{"spec":{"containers":[
 						{"name":"c1", "resources":{"requests":{"cpu":"%s","memory":"%s"},"limits":{"cpu":"%s","memory":"%s"}}}
-					]}}`, reducedCPU, reducedMem, reducedCPULimit, reducedMemLimit),
+					]}}`, originalCPU, reducedMem, originalCPULimit, originalMemLimit),
 			expected: []e2epod.ResizableContainerInfo{
 				{
 					Name:         "c1",
-					Resources:    &e2epod.ContainerResources{CPUReq: reducedCPU, CPULim: reducedCPULimit, MemReq: reducedMem, MemLim: reducedMemLimit},
+					Resources:    &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: reducedMem, MemLim: originalMemLimit},
 					CPUPolicy:    &noRestart,
 					MemPolicy:    &doRestart,
 					RestartCount: 1,
+				},
+			},
+		},
+		{
+			name: "Burstable QoS pod, one container - increase memory request (NoRestart memory resize policy)",
+			containers: []e2epod.ResizableContainerInfo{
+				{
+					Name:      "c1",
+					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
+					CPUPolicy: &noRestart,
+					MemPolicy: &noRestart,
+				},
+			},
+			patchString: fmt.Sprintf(`{"spec":{"containers":[
+							{"name":"c1", "resources":{"requests":{"cpu":"%s","memory":"%s"},"limits":{"cpu":"%s","memory":"%s"}}}
+						]}}`, originalCPU, increasedMem, originalCPULimit, originalMemLimit),
+			expected: []e2epod.ResizableContainerInfo{
+				{
+					Name:         "c1",
+					Resources:    &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: increasedMem, MemLim: originalMemLimit},
+					CPUPolicy:    &noRestart,
+					MemPolicy:    &noRestart,
+					RestartCount: 0,
 				},
 			},
 		},
@@ -594,9 +640,9 @@ func doPodResizeTests() {
 				},
 			},
 			patchString: fmt.Sprintf(`{"spec":{"containers":[
-						{"name":"c1", "resources":{"requests":{"cpu":"%s","memory":"%s"},"limits":{"cpu":"%s","memory":"%s"}}},
-						{"name":"c3", "resources":{"requests":{"cpu":"%s","memory":"%s"},"limits":{"cpu":"%s"}}}
-					]}}`,
+							{"name":"c1", "resources":{"requests":{"cpu":"%s","memory":"%s"},"limits":{"cpu":"%s","memory":"%s"}}},
+							{"name":"c3", "resources":{"requests":{"cpu":"%s","memory":"%s"},"limits":{"cpu":"%s"}}}
+						]}}`,
 				increasedCPU, increasedMem, increasedCPULimit, increasedMemLimit,
 				offsetCPU(2, reducedCPU), offsetMemory(2, reducedMem), offsetCPU(2, reducedCPULimit)),
 			expected: []e2epod.ResizableContainerInfo{
@@ -643,9 +689,9 @@ func doPodResizeTests() {
 				},
 			},
 			patchString: fmt.Sprintf(`{"spec":{"containers":[
-						{"name":"c1", "resources":{"requests":{"cpu":"%s","memory":"%s"},"limits":{"cpu":"%s"}}},
-						{"name":"c2", "resources":{"requests":{"cpu":"%s","memory":"%s"},"limits":{"cpu":"%s","memory":"%s"}}}
-					]}}`,
+							{"name":"c1", "resources":{"requests":{"cpu":"%s","memory":"%s"},"limits":{"cpu":"%s"}}},
+							{"name":"c2", "resources":{"requests":{"cpu":"%s","memory":"%s"},"limits":{"cpu":"%s","memory":"%s"}}}
+						]}}`,
 				reducedCPU, reducedMem, reducedCPULimit,
 				offsetCPU(2, increasedCPU), offsetMemory(2, increasedMem), offsetCPU(2, increasedCPULimit), offsetMemory(2, increasedMemLimit)),
 			expected: []e2epod.ResizableContainerInfo{
@@ -693,9 +739,9 @@ func doPodResizeTests() {
 				},
 			},
 			patchString: fmt.Sprintf(`{"spec":{"containers":[
-						{"name":"c2", "resources":{"requests":{"cpu":"%s","memory":"%s"},"limits":{"cpu":"%s","memory":"%s"}}},
-						{"name":"c3", "resources":{"requests":{"cpu":"%s","memory":"%s"},"limits":{"cpu":"%s","memory":"%s"}}}
-					]}}`,
+							{"name":"c2", "resources":{"requests":{"cpu":"%s","memory":"%s"},"limits":{"cpu":"%s","memory":"%s"}}},
+							{"name":"c3", "resources":{"requests":{"cpu":"%s","memory":"%s"},"limits":{"cpu":"%s","memory":"%s"}}}
+						]}}`,
 				offsetCPU(1, increasedCPU), offsetMemory(1, increasedMem), offsetCPU(1, increasedCPULimit), offsetMemory(1, increasedMemLimit),
 				reducedCPU, reducedMem, reducedCPULimit, reducedMemLimit),
 			expected: []e2epod.ResizableContainerInfo{
@@ -736,8 +782,8 @@ func doPodResizeTests() {
 				},
 			},
 			patchString: fmt.Sprintf(`{"spec":{"containers":[
-						{"name":"c1", "resources":{"requests":{"cpu":"%s","memory":"%s"},"limits":{"cpu":"%s","memory":"%s"}}}
-					]}}`, increasedCPU, increasedMem, increasedCPU, increasedMem),
+							{"name":"c1", "resources":{"requests":{"cpu":"%s","memory":"%s"},"limits":{"cpu":"%s","memory":"%s"}}}
+						]}}`, increasedCPU, increasedMem, increasedCPU, increasedMem),
 			expected: []e2epod.ResizableContainerInfo{
 				{
 					Name:      "c1",
@@ -766,8 +812,8 @@ func doPodResizeTests() {
 				},
 			},
 			patchString: fmt.Sprintf(`{"spec":{"containers":[
-						{"name":"c2", "resources":{"requests":{"cpu":"%s","memory":"%s"}}}
-					]}}`, originalCPU, originalMem),
+							{"name":"c2", "resources":{"requests":{"cpu":"%s","memory":"%s"}}}
+						]}}`, originalCPU, originalMem),
 			expected: []e2epod.ResizableContainerInfo{
 				{
 					Name:      "c1",
@@ -800,8 +846,8 @@ func doPodResizeTests() {
 				},
 			},
 			patchString: fmt.Sprintf(`{"spec":{"containers":[
-						{"name":"c2", "resources":{"limits":{"cpu":"%s"}}}
-					]}}`, originalCPULimit),
+							{"name":"c2", "resources":{"limits":{"cpu":"%s"}}}
+						]}}`, originalCPULimit),
 			expected: []e2epod.ResizableContainerInfo{
 				{
 					Name:      "c1",
@@ -829,8 +875,8 @@ func doPodResizeTests() {
 				},
 			},
 			patchString: fmt.Sprintf(`{"spec":{"containers":[
-					{"name":"c1", "resources":{"requests":{"cpu":"%s","memory":"%s"},"limits":{"cpu":"%s","memory":"%s"}}}
-					]}}`, increasedCPU, increasedMem, increasedCPU, increasedMem),
+						{"name":"c1", "resources":{"requests":{"cpu":"%s","memory":"%s"},"limits":{"cpu":"%s","memory":"%s"}}}
+						]}}`, increasedCPU, increasedMem, increasedCPU, increasedMem),
 			expected: []e2epod.ResizableContainerInfo{
 				{
 					Name: "c1",
@@ -877,8 +923,8 @@ func doPodResizeTests() {
 				},
 			},
 			patchString: fmt.Sprintf(`{"spec":{"initContainers":[
-						{"name":"c1-init", "resources":{"requests":{"cpu":"%s","memory":"%s"},"limits":{"cpu":"%s","memory":"%s"}}}
-					]}}`, increasedCPU, increasedMem, increasedCPU, increasedMem),
+							{"name":"c1-init", "resources":{"requests":{"cpu":"%s","memory":"%s"},"limits":{"cpu":"%s","memory":"%s"}}}
+						]}}`, increasedCPU, increasedMem, increasedCPU, increasedMem),
 			expected: []e2epod.ResizableContainerInfo{
 				{
 					Name:      "c1",
@@ -911,8 +957,8 @@ func doPodResizeTests() {
 				},
 			},
 			patchString: fmt.Sprintf(`{"spec":{"initContainers":[
-						{"name":"c1-init", "resources":{"requests":{"cpu":"%s","memory":"%s"},"limits":{"cpu":"%s","memory":"%s"}}}
-					]}}`, reducedCPU, increasedMem, reducedCPU, increasedMem),
+							{"name":"c1-init", "resources":{"requests":{"cpu":"%s","memory":"%s"},"limits":{"cpu":"%s","memory":"%s"}}}
+						]}}`, reducedCPU, increasedMem, reducedCPU, increasedMem),
 			expected: []e2epod.ResizableContainerInfo{
 				{
 					Name:      "c1",
@@ -941,8 +987,8 @@ func doPodResizeTests() {
 				},
 			},
 			patchString: fmt.Sprintf(`{"spec":{"initContainers":[
-						{"name":"c1-init", "resources":{"requests":{"cpu":"%s"},"limits":{"cpu":"%s"}}}
-					]}}`, reducedCPU, reducedCPU),
+							{"name":"c1-init", "resources":{"requests":{"cpu":"%s"},"limits":{"cpu":"%s"}}}
+						]}}`, reducedCPU, reducedCPU),
 			expected: []e2epod.ResizableContainerInfo{
 				{
 					Name:      "c1",
@@ -971,8 +1017,8 @@ func doPodResizeTests() {
 				},
 			},
 			patchString: fmt.Sprintf(`{"spec":{"initContainers":[
-						{"name":"c1-init", "resources":{"requests":{"cpu":"%s","memory":"%s"},"limits":{"cpu":"%s","memory":"%s"}}}
-					]}}`, increasedCPU, increasedMem, increasedCPULimit, increasedMemLimit),
+							{"name":"c1-init", "resources":{"requests":{"cpu":"%s","memory":"%s"},"limits":{"cpu":"%s","memory":"%s"}}}
+						]}}`, increasedCPU, increasedMem, increasedCPULimit, increasedMemLimit),
 			expected: []e2epod.ResizableContainerInfo{
 				{
 					Name:      "c1",
@@ -1001,8 +1047,8 @@ func doPodResizeTests() {
 				},
 			},
 			patchString: fmt.Sprintf(`{"spec":{"initContainers":[
-						{"name":"c1-init", "resources":{"requests":{"cpu":"%s"},"limits":{"cpu":"%s"}}}
-					]}}`, reducedCPU, reducedCPULimit),
+							{"name":"c1-init", "resources":{"requests":{"cpu":"%s"},"limits":{"cpu":"%s"}}}
+						]}}`, reducedCPU, reducedCPULimit),
 			expected: []e2epod.ResizableContainerInfo{
 				{
 					Name:      "c1",
@@ -1031,8 +1077,8 @@ func doPodResizeTests() {
 				},
 			},
 			patchString: fmt.Sprintf(`{"spec":{"initContainers":[
-						{"name":"c1-init", "resources":{"requests":{"cpu":"%s"},"limits":{"cpu":"%s"}}}
-					]}}`, increasedCPU, increasedCPULimit),
+							{"name":"c1-init", "resources":{"requests":{"cpu":"%s"},"limits":{"cpu":"%s"}}}
+						]}}`, increasedCPU, increasedCPULimit),
 			expected: []e2epod.ResizableContainerInfo{
 				{
 					Name:      "c1",
@@ -1061,8 +1107,8 @@ func doPodResizeTests() {
 				},
 			},
 			patchString: fmt.Sprintf(`{"spec":{"initContainers":[
-						{"name":"c1-init", "resources":{"requests":{"memory":"%s"}}}
-					]}}`, reducedMem),
+							{"name":"c1-init", "resources":{"requests":{"memory":"%s"}}}
+						]}}`, reducedMem),
 			expected: []e2epod.ResizableContainerInfo{
 				{
 					Name:      "c1",
@@ -1091,8 +1137,8 @@ func doPodResizeTests() {
 				},
 			},
 			patchString: fmt.Sprintf(`{"spec":{"initContainers":[
-						{"name":"c1-init", "resources":{"requests":{"memory":"%s"},"limits":{"memory":"%s"}}}
-					]}}`, increasedMem, increasedMemLimit),
+							{"name":"c1-init", "resources":{"requests":{"memory":"%s"},"limits":{"memory":"%s"}}}
+						]}}`, increasedMem, increasedMemLimit),
 			expected: []e2epod.ResizableContainerInfo{
 				{
 					Name:      "c1",
@@ -1394,13 +1440,13 @@ func doPodResizeErrorTests() {
 //       Above tests are performed by doSheduletTests() and doPodResizeResourceQuotaTests()
 //       in test/e2e/node/pod_resize.go
 
-var _ = SIGDescribe("Pod InPlace Resize Container", feature.InPlacePodVerticalScaling, func() {
+var _ = SIGDescribe("[InPlacePodResize] Pod InPlace Resize Container", feature.InPlacePodVerticalScaling, func() {
 	f := framework.NewDefaultFramework("pod-resize-tests")
 
 	ginkgo.BeforeEach(func(ctx context.Context) {
-		node, err := e2enode.GetRandomReadySchedulableNode(ctx, f.ClientSet)
+		_, err := e2enode.GetRandomReadySchedulableNode(ctx, f.ClientSet)
 		framework.ExpectNoError(err)
-		if framework.NodeOSDistroIs("windows") || e2enode.IsARM64(node) {
+		if framework.NodeOSDistroIs("windows") {
 			e2eskipper.Skipf("runtime does not support InPlacePodVerticalScaling -- skipping")
 		}
 	})

--- a/test/e2e/framework/pod/resize.go
+++ b/test/e2e/framework/pod/resize.go
@@ -31,7 +31,6 @@ import (
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	helpers "k8s.io/component-helpers/resource"
 	kubecm "k8s.io/kubernetes/pkg/kubelet/cm"
-	"k8s.io/kubernetes/pkg/kubelet/kuberuntime"
 	"k8s.io/kubernetes/test/e2e/framework"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 
@@ -170,7 +169,7 @@ func makeResizableContainer(tcInfo ResizableContainerInfo) v1.Container {
 func MakePodWithResizableContainers(ns, name, timeStamp string, tcInfo []ResizableContainerInfo) *v1.Pod {
 	testInitContainers, testContainers := separateContainers(tcInfo)
 
-	minGracePeriodSeconds := kuberuntime.MinimumGracePeriodInSeconds
+	minGracePeriodSeconds := int64(0)
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -433,6 +432,7 @@ func WaitForPodResizeActuation(ctx context.Context, f *framework.Framework, podC
 		containerRestartWaitPeriod = MinRestartWaitPeriod
 	}
 	time.Sleep(time.Duration(containerRestartWaitPeriod) * time.Second)
+
 	resizedPod, err := framework.GetObject(podClient.Get, pod.Name, metav1.GetOptions{})(ctx)
 	framework.ExpectNoError(err, "failed to get resized pod")
 	return resizedPod

--- a/test/e2e/framework/pod/resize.go
+++ b/test/e2e/framework/pod/resize.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"time"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -49,7 +48,6 @@ const (
 	Cgroupv2CPURequest         string = "/sys/fs/cgroup/cpu.weight"
 	CPUPeriod                  string = "100000"
 	MinContainerRuntimeVersion string = "1.6.9"
-	MinRestartWaitPeriod       int    = 10
 )
 
 var (
@@ -425,13 +423,6 @@ func WaitForPodResizeActuation(ctx context.Context, f *framework.Framework, podC
 			return nil, nil
 		})),
 	)
-
-	// Wait min(3 x termination grace period, MinRestartWaitPeriod) to catch any restarts - expected or not
-	containerRestartWaitPeriod := int(*pod.Spec.TerminationGracePeriodSeconds) * 3
-	if containerRestartWaitPeriod < MinRestartWaitPeriod {
-		containerRestartWaitPeriod = MinRestartWaitPeriod
-	}
-	time.Sleep(time.Duration(containerRestartWaitPeriod) * time.Second)
 
 	resizedPod, err := framework.GetObject(podClient.Get, pod.Name, metav1.GetOptions{})(ctx)
 	framework.ExpectNoError(err, "failed to get resized pod")

--- a/test/e2e/framework/pod/resize.go
+++ b/test/e2e/framework/pod/resize.go
@@ -50,7 +50,7 @@ const (
 	Cgroupv2CPURequest         string = "/sys/fs/cgroup/cpu.weight"
 	CPUPeriod                  string = "100000"
 	MinContainerRuntimeVersion string = "1.6.9"
-	MinRestartWaitPeriod          int = 10
+	MinRestartWaitPeriod       int    = 10
 )
 
 var (

--- a/test/e2e/framework/pod/utils.go
+++ b/test/e2e/framework/pod/utils.go
@@ -298,7 +298,7 @@ func VerifyCgroupValue(f *framework.Framework, pod *v1.Pod, cName, cgPath, expec
 // has the expected value in specified container of the pod. It execs into the container,
 // reads the oom_score_adj value from procfs, and compares it against the expected value.
 func VerifyOomScoreAdjValue(f *framework.Framework, pod *v1.Pod, cName, expectedOomScoreAdj string) error {
-	cmd := fmt.Sprintf("cat /proc/1/oom_score_adj")
+	cmd := "cat /proc/1/oom_score_adj"
 	framework.Logf("Namespace %s Pod %s Container %s - looking for oom_score_adj value %s",
 		pod.Namespace, pod.Name, cName, expectedOomScoreAdj)
 	oomScoreAdj, _, err := ExecCommandInContainerWithFullOutput(f, pod.Name, cName, "/bin/sh", "-c", cmd)

--- a/test/e2e/framework/pod/utils.go
+++ b/test/e2e/framework/pod/utils.go
@@ -256,7 +256,7 @@ func FindPodConditionByType(podStatus *v1.PodStatus, conditionType v1.PodConditi
 	return nil
 }
 
-// FindContainerByName finds the v1.Container in a pod by its name in the provided pod
+// FindContainerInPod finds the container in a pod by its name
 func FindContainerInPod(pod *v1.Pod, containerName string) *v1.Container {
 	for _, container := range pod.Spec.InitContainers {
 		if container.Name == containerName {

--- a/test/e2e/framework/pod/utils.go
+++ b/test/e2e/framework/pod/utils.go
@@ -309,7 +309,6 @@ func VerifyOomScoreAdjValue(f *framework.Framework, pod *v1.Pod, cName, expected
 	if oomScoreAdj != expectedOomScoreAdj {
 		return fmt.Errorf("oom_score_adj value %s not equal to expected %s", oomScoreAdj, expectedOomScoreAdj)
 	}
-	fmt.Printf("VDBG: POD: %s EXPECTED_OOM_ADJ %s ACTUAL_OOM_ADJ %s\n", pod.Name, expectedOomScoreAdj, oomScoreAdj)
 	return nil
 }
 

--- a/test/e2e/framework/pod/utils.go
+++ b/test/e2e/framework/pod/utils.go
@@ -256,6 +256,21 @@ func FindPodConditionByType(podStatus *v1.PodStatus, conditionType v1.PodConditi
 	return nil
 }
 
+// FindContainerByName finds the v1.Container in a pod by its name in the provided pod
+func FindContainerInPod(pod *v1.Pod, containerName string) *v1.Container {
+	for _, container := range pod.Spec.InitContainers {
+		if container.Name == containerName {
+			return &container
+		}
+	}
+	for _, container := range pod.Spec.Containers {
+		if container.Name == containerName {
+			return &container
+		}
+	}
+	return nil
+}
+
 // FindContainerStatusInPod finds a container status by its name in the provided pod
 func FindContainerStatusInPod(pod *v1.Pod, containerName string) *v1.ContainerStatus {
 	for _, containerStatus := range pod.Status.InitContainerStatuses {


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it: 
When memory requests are resized, we must invoke UpdateContainerResources or trigger container stop/start (if RestartContainer resize policy is in force) in order to update the oom_score_adj (and perhaps resize memory.min ... in the future, under memoryQoS feature-gate). This omission was an oversight in my initial implementation, and this PR fixes it.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #130657 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.: 
https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/1287-in-place-update-pod-resources/README.md

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
