### PR TITLE
Change precedence order for continue and legacy exact match

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/delegator.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/delegator.go
@@ -257,13 +257,13 @@ func shouldDelegateList(opts storage.ListOptions, cache delegator.Helper) (deleg
 	case metav1.ResourceVersionMatchNotOlderThan:
 		return delegator.Result{ShouldDelegate: false}, nil
 	case "":
-		// Legacy exact match
-		if opts.Predicate.Limit > 0 && len(opts.ResourceVersion) > 0 && opts.ResourceVersion != "0" {
-			return cache.ShouldDelegateExactRV(opts.ResourceVersion, opts.Recursive)
-		}
 		// Continue
 		if len(opts.Predicate.Continue) > 0 {
 			return cache.ShouldDelegateContinue(opts.Predicate.Continue, opts.Recursive)
+		}
+		// Legacy exact match
+		if opts.Predicate.Limit > 0 && len(opts.ResourceVersion) > 0 && opts.ResourceVersion != "0" {
+			return cache.ShouldDelegateExactRV(opts.ResourceVersion, opts.Recursive)
 		}
 		// Consistent Read
 		if opts.ResourceVersion == "" {

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/list_work_estimator.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/list_work_estimator.go
@@ -172,13 +172,13 @@ func shouldDelegateList(opts *metav1.ListOptions, cache delegator.Helper) (deleg
 	case metav1.ResourceVersionMatchNotOlderThan:
 		return delegator.Result{ShouldDelegate: false}, nil
 	case "":
-		// Legacy exact match
-		if opts.Limit > 0 && len(opts.ResourceVersion) > 0 && opts.ResourceVersion != "0" {
-			return cache.ShouldDelegateExactRV(opts.ResourceVersion, defaultRecursive)
-		}
 		// Continue
 		if len(opts.Continue) > 0 {
 			return cache.ShouldDelegateContinue(opts.Continue, defaultRecursive)
+		}
+		// Legacy exact match
+		if opts.Limit > 0 && len(opts.ResourceVersion) > 0 && opts.ResourceVersion != "0" {
+			return cache.ShouldDelegateExactRV(opts.ResourceVersion, defaultRecursive)
 		}
 		// Consistent Read
 		if opts.ResourceVersion == "" {


### PR DESCRIPTION
This doesn't matter for shouldDelegateList, but matters when picking source of RV. 

For etcd RV from continue takes precedence.

https://github.com/kubernetes/kubernetes/blob/73f54b67b29d77601b0bd42ad8b4992925b9df47/staging/src/k8s.io/apiserver/pkg/storage/interfaces.go#L334-L372

/kind feature

```release-note
NONE
```
/sig api-machinery
/triage accepted
/assign @wojtek-t
/cc @liggitt
