### PR TITLE
test: switch gotestsum quiet output format

### DIFF
--- a/hack/make-rules/test.sh
+++ b/hack/make-rules/test.sh
@@ -139,7 +139,8 @@ testargs=()
 eval "testargs=(${KUBE_TEST_ARGS:-})"
 
 # gotestsum --format value
-gotestsum_format=standard-quiet
+# "standard-quiet" let's some stderr log messages through, "pkgname-and-test-fails" is similar and doesn't (https://github.com/kubernetes/kubernetes/issues/130934#issuecomment-2739957840).
+gotestsum_format=pkgname-and-test-fails
 if [[ -n "${FULL_LOG:-}" ]] ; then
   gotestsum_format=standard-verbose
 fi


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

"--format standard-quiet" shows log output on stderr (= klog logging) if it occurs outside of a test (= test has leaked something). That is inconsistent with "go test" without -v and a problem for pull-kubernetes-unit because many tests do not clean up properly.

"pkgname-and-test-fails" hides the extra output and seems similar enough:

       pkgname-and-test-fails   print a line for each package and failed test output

    $ gotestsum --format pkgname-and-test-fails ./test/internal/logging --count=1
    ✓  test/internal/logging (5.007s)

    DONE 1 tests in 5.384s


#### Which issue(s) this PR fixes:
Fixes #130934

#### Special notes for your reviewer:

See https://github.com/kubernetes/kubernetes/issues/130934#issuecomment-2739957840 for a more complete analysis.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @BenTheElder 