### PR TITLE
DRA E2E: fix "cluster must manage ResourceSlices" test

### DIFF
--- a/test/e2e/dra/dra.go
+++ b/test/e2e/dra/dra.go
@@ -1776,7 +1776,9 @@ var _ = framework.SIGDescribe("node")("DRA", feature.DynamicResourceAllocation, 
 								}),
 							),
 						}),
-						"Spec": gstruct.MatchAllFields(gstruct.Fields{
+						// Ignoring some fields, like SharedCounters, because we don't run this test
+						// for PRs (it's slow) and don't want CI breaks when fields get added or renamed.
+						"Spec": gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
 							"Driver":       gomega.Equal(driver.Name),
 							"NodeName":     gomega.Equal(nodeName),
 							"NodeSelector": gomega.BeNil(),


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:

Adding SharedCounters broke the test and wasn't detected in the presubmit because the test is slow and didn't run.

#### Which issue(s) this PR fixes:
Fixes https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kind-dra/1902685816916807680

#### Special notes for your reviewer:

We could add a "SharedCounters is empty" clause, but probably it is safer to be less strict in the test and tolerate unknown fields. This will also minimize the work which needs to be done in the v1beta2 PR.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @mortent @cici37 