### PR TITLE
Implement CSI e2e test for MutableCSINodeAllocatableCount

### DIFF
--- a/test/e2e/storage/drivers/csi.go
+++ b/test/e2e/storage/drivers/csi.go
@@ -94,9 +94,10 @@ const (
 
 // hostpathCSI
 type hostpathCSIDriver struct {
-	driverInfo       storageframework.DriverInfo
-	manifests        []string
-	volumeAttributes []map[string]string
+	driverInfo               storageframework.DriverInfo
+	manifests                []string
+	volumeAttributes         []map[string]string
+	enableDynamicAllocatable bool
 }
 
 func initHostPathCSIDriver(name string, capabilities map[storageframework.Capability]bool, volumeAttributes []map[string]string, manifests ...string) storageframework.TestDriver {
@@ -180,6 +181,13 @@ func InitHostPathCSIDriver() storageframework.TestDriver {
 		"test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-plugin.yaml",
 		"test/e2e/testing-manifests/storage-csi/hostpath/hostpath/e2e-test-rbac.yaml",
 	)
+}
+
+func InitHostPathCSIDriverWithDynamicAllocatable() storageframework.TestDriver {
+	driver := InitHostPathCSIDriver()
+	hostpathDriver := driver.(*hostpathCSIDriver)
+	hostpathDriver.enableDynamicAllocatable = true
+	return driver
 }
 
 func (h *hostpathCSIDriver) GetDriverInfo() *storageframework.DriverInfo {
@@ -269,6 +277,16 @@ func (h *hostpathCSIDriver) PrepareTest(ctx context.Context, f *framework.Framew
 		SnapshotterContainerName: "csi-snapshotter",
 		NodeName:                 node.Name,
 	})
+
+	if h.enableDynamicAllocatable {
+		patches = append(patches, utils.PatchCSIOptions{
+			NodeAllocatableUpdatePeriodSeconds: &[]int64{10}[0],
+		})
+		patches = append(patches, utils.PatchCSIOptions{
+			DriverContainerName:      "hostpath",
+			DriverContainerArguments: []string{"--attach-limit=-1"},
+		})
+	}
 
 	// VAC E2E HostPath patch
 	// Enables ModifyVolume support in the hostpath CSI driver, and adds an enabled parameter name

--- a/test/e2e/storage/mutable_csinode_allocatable.go
+++ b/test/e2e/storage/mutable_csinode_allocatable.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/pkg/features"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
+	"k8s.io/kubernetes/test/e2e/storage/drivers"
+	storageframework "k8s.io/kubernetes/test/e2e/storage/framework"
+	"k8s.io/kubernetes/test/e2e/storage/utils"
+	admissionapi "k8s.io/pod-security-admission/api"
+)
+
+var _ = utils.SIGDescribe("MutableCSINodeAllocatableCount", framework.WithFeatureGate(features.MutableCSINodeAllocatableCount), func() {
+	f := framework.NewDefaultFramework("dynamic-allocatable")
+	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
+
+	var (
+		driver     storageframework.DynamicPVTestDriver
+		testConfig *storageframework.PerTestConfig
+	)
+
+	ginkgo.BeforeEach(func(ctx context.Context) {
+		driver = drivers.InitHostPathCSIDriverWithDynamicAllocatable().(storageframework.DynamicPVTestDriver)
+		testConfig = driver.PrepareTest(ctx, f)
+	})
+
+	f.It("should observe dynamic changes in CSINode allocatable count", func(ctx context.Context) {
+		cs := f.ClientSet
+
+		ginkgo.By("Retrieving node for testing")
+		nodeName := testConfig.ClientNodeSelection.Name
+		if nodeName == "" {
+			node, err := e2enode.GetRandomReadySchedulableNode(ctx, cs)
+			framework.ExpectNoError(err)
+			nodeName = node.Name
+		}
+
+		ginkgo.By("Retrieving driver details")
+		sc := driver.GetDynamicProvisionStorageClass(ctx, testConfig, "")
+		driverName := sc.Provisioner
+
+		ginkgo.By("Retrieving initial allocatable value")
+		initialLimit, err := getCSINodeLimits(ctx, cs, testConfig, nodeName, driverName)
+		framework.ExpectNoError(err, "error retrieving initial CSINode limit")
+		framework.Logf("Initial allocatable count: %d", initialLimit)
+
+		ginkgo.By("Polling until value changes")
+		err = wait.PollUntilContextTimeout(ctx, 10*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+			currentLimit, err := getCSINodeLimits(ctx, cs, testConfig, nodeName, driverName)
+			if err != nil {
+				framework.Logf("Error getting CSINode limits: %v", err)
+				return false, nil
+			}
+			framework.Logf("Current allocatable count: %d", currentLimit)
+			if currentLimit != initialLimit {
+				framework.Logf("Detected change in allocatable count from %d to %d", initialLimit, currentLimit)
+				return true, nil
+			}
+			return false, nil
+		})
+		framework.ExpectNoError(err, "CSINode allocatable count did not change within timeout")
+		framework.Logf("Successfully verified that CSINode allocatable count was updated")
+	})
+})
+
+func getCSINodeLimits(ctx context.Context, cs clientset.Interface, config *storageframework.PerTestConfig, nodeName, driverName string) (int, error) {
+	var limit int
+	err := wait.PollUntilContextTimeout(ctx, 2*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+		csiNode, err := cs.StorageV1().CSINodes().Get(ctx, nodeName, metav1.GetOptions{})
+		if err != nil {
+			framework.Logf("%s", err)
+			return false, nil
+		}
+		var csiDriver *storagev1.CSINodeDriver
+		for i, c := range csiNode.Spec.Drivers {
+			if c.Name == driverName || c.Name == config.GetUniqueDriverName() {
+				csiDriver = &csiNode.Spec.Drivers[i]
+				break
+			}
+		}
+		if csiDriver == nil {
+			framework.Logf("CSINodeInfo does not have driver %s yet", driverName)
+			return false, nil
+		}
+		if csiDriver.Allocatable == nil {
+			return false, fmt.Errorf("CSINodeInfo does not have Allocatable for driver %s", driverName)
+		}
+		if csiDriver.Allocatable.Count == nil {
+			return false, fmt.Errorf("CSINodeInfo does not have Allocatable.Count for driver %s", driverName)
+		}
+		limit = int(*csiDriver.Allocatable.Count)
+		return true, nil
+	})
+	if err != nil {
+		return 0, fmt.Errorf("could not get CSINode limit for driver %s: %w", driverName, err)
+	}
+	return limit, nil
+}

--- a/test/e2e/storage/utils/deployment.go
+++ b/test/e2e/storage/utils/deployment.go
@@ -161,6 +161,9 @@ func PatchCSIDeployment(f *e2eframework.Framework, o PatchCSIOptions, object int
 		if o.SELinuxMount != nil {
 			object.Spec.SELinuxMount = o.SELinuxMount
 		}
+		if o.NodeAllocatableUpdatePeriodSeconds != nil {
+			object.Spec.NodeAllocatableUpdatePeriodSeconds = o.NodeAllocatableUpdatePeriodSeconds
+		}
 	}
 
 	return nil
@@ -224,6 +227,9 @@ type PatchCSIOptions struct {
 	// field *if* the driver deploys a CSIDriver object. Ignored
 	// otherwise.
 	SELinuxMount *bool
+	// If not nil, the value to use for the CSIDriver.Spec.NodeAllocatableUpdatePeriodSeconds
+	// field *if* the driver deploys a CSIDriver object. Ignored otherwise.
+	NodeAllocatableUpdatePeriodSeconds *int64
 	// If not nil, the values will be used for setting feature arguments to
 	// specific sidecar.
 	// Feature is a map - where key is sidecar name such as:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

Test

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR implements an e2e test for a new alpha storage feature `MutableCSINodeAllocatableCount`.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

Ran test locally:

```
make WHAT=test/e2e/e2e.test && _output/bin/e2e.test --ginkgo.focus="MutableCSINodeAllocatableCount.*should.observe.dynamic.changes" --provider=local --kubeconfig=$HOME/.kube/config --ginkgo.v -v=4
```

```
  I0320 00:30:25.998557 10826 mutable_csinode_allocatable.go:71] Initial allocatable count: 5
  STEP: Polling until value changes @ 03/20/25 00:30:25.998
  I0320 00:30:26.065996 10826 mutable_csinode_allocatable.go:80] Current allocatable count: 5
  I0320 00:30:36.070110 10826 mutable_csinode_allocatable.go:80] Current allocatable count: 8
  I0320 00:30:36.070155 10826 mutable_csinode_allocatable.go:82] Detected change in allocatable count from 5 to 8
  I0320 00:30:36.070179 10826 mutable_csinode_allocatable.go:88] Successfully verified that CSINode allocatable count was updated
```

```
Ran 1 of 6708 Specs in 31.919 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 6707 Skipped
PASS
```
