### PR TITLE
CI integration scripts: reduce log noise from installing etcd

### DIFF
--- a/hack/jenkins/test-cmd-dockerized.sh
+++ b/hack/jenkins/test-cmd-dockerized.sh
@@ -20,10 +20,10 @@ set -o pipefail
 set -o xtrace
 
 # Runs test-cmd, intended to be run in prow.k8s.io
-set -x;
 
 # TODO: make test-cmd should handle this automatically
 source ./hack/install-etcd.sh
 
+set -x;
 make test-cmd
 

--- a/hack/jenkins/test-dockerized.sh
+++ b/hack/jenkins/test-dockerized.sh
@@ -20,7 +20,6 @@ set -o pipefail
 set -o xtrace
 
 # Runs test-cmd and test-integration, intended to be run in prow.k8s.io
-set -x;
 
 # TODO: make test-integration should handle this automatically
 source ./hack/install-etcd.sh
@@ -32,5 +31,6 @@ export KUBE_INTEGRATION_TEST_MAX_CONCURRENCY=4
 # Save the verbose stdout as well.
 export KUBE_KEEP_VERBOSE_TEST_OUTPUT=y
 export LOG_LEVEL=4
+set -x;
 make test-cmd
 make test-integration


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup
/sig testing

#### What this PR does / why we need it:

Reduces log noise, since we now source install-etcd.sh in order to get the PATH updated in the current process, we wind up logging a LOT of internals very noisily

I moved the set -x down so we still log the make commands, install-etcd.sh logs itself.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
