### PR TITLE
Adding metrics for Maxunavailable feature in StatefulSet

### DIFF
--- a/pkg/controller/statefulset/metrics/metrics.go
+++ b/pkg/controller/statefulset/metrics/metrics.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"sync"
+
+	"k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
+)
+
+const StatefulSetControllerSubsystem = "statefulset_controller"
+
+var (
+	// MaxUnavailableViolations tracks the number of times that
+	// spec.replicas - availableReplicas > maxUnavailable.
+	MaxUnavailableViolations = metrics.NewCounterVec(
+		&metrics.CounterOpts{
+			Subsystem:      StatefulSetControllerSubsystem,
+			Name:           "statefulset_unavailability_violation",
+			Help:           "Number of times maxunavailable has been violated",
+			StabilityLevel: metrics.BETA,
+		}, []string{"statefulset_namespace", "statefulset_name"},
+	)
+)
+
+var registerMetrics sync.Once
+
+func Register() {
+	registerMetrics.Do(func() {
+		legacyregistry.MustRegister(MaxUnavailableViolations)
+	})
+}

--- a/pkg/controller/statefulset/metrics/metrics.go
+++ b/pkg/controller/statefulset/metrics/metrics.go
@@ -34,7 +34,7 @@ var (
 			Name:           "statefulset_unavailability_violation",
 			Help:           "Number of times maxunavailable has been violated",
 			StabilityLevel: metrics.BETA,
-		}, []string{"statefulset_namespace", "statefulset_name"},
+		}, []string{"statefulset_namespace", "statefulset_name", "pod_management_policy"},
 	)
 )
 

--- a/pkg/controller/statefulset/metrics/metrics.go
+++ b/pkg/controller/statefulset/metrics/metrics.go
@@ -27,7 +27,7 @@ const StatefulSetControllerSubsystem = "statefulset_controller"
 
 var (
 	// MaxUnavailableViolations tracks the number of times that
-	// spec.replicas - availableReplicas > maxUnavailable.
+	// .spec.replicas - .status.availableReplicas > .spec.updateStrategy.rollingUpdate.maxUnavailable.
 	MaxUnavailableViolations = metrics.NewCounterVec(
 		&metrics.CounterOpts{
 			Subsystem:      StatefulSetControllerSubsystem,

--- a/pkg/controller/statefulset/metrics/metrics.go
+++ b/pkg/controller/statefulset/metrics/metrics.go
@@ -26,9 +26,10 @@ import (
 const StatefulSetControllerSubsystem = "statefulset_controller"
 
 var (
-	// MaxUnavailable tracks the current maxUnavailable configuration value for StatefulSets with the
+	// MaxUnavailable tracks the current .spec.updateStrategy.rollingUpdate.maxUnavailable value with the
 	// MaxUnavailableStatefulSet feature enabled. This gauge reflects the configured maximum number of pods
 	// that can be unavailable during rolling updates, providing visibility into the availability constraints.
+	// The metric is set to 1 by default.
 	//
 	// Sample monitoring queries:
 	// - Current maxUnavailable setting: statefulset_max_unavailable
@@ -45,8 +46,8 @@ var (
 	)
 
 	// UnavailableReplicas tracks the current number of unavailable pods in a StatefulSet.
-	// This gauge reflects the real-time count of pods that are not running and available,
-	// providing immediate visibility into StatefulSet health and availability status.
+	// This gauge reflects the real-time count of pods that are either missing or unavailable
+	// (i.e., not ready for .spec.minReadySeconds).
 	//
 	// Sample monitoring queries:
 	// - Current unavailable pods: statefulset_unavailable_replicas

--- a/pkg/controller/statefulset/metrics/metrics.go
+++ b/pkg/controller/statefulset/metrics/metrics.go
@@ -41,7 +41,7 @@ var (
 			Subsystem:      StatefulSetControllerSubsystem,
 			Name:           "statefulset_max_unavailable",
 			Help:           "Maximum number of unavailable pods allowed during StatefulSet rolling updates",
-			StabilityLevel: metrics.BETA,
+			StabilityLevel: metrics.ALPHA,
 		}, []string{"statefulset_namespace", "statefulset_name", "pod_management_policy"},
 	)
 
@@ -59,7 +59,7 @@ var (
 			Subsystem:      StatefulSetControllerSubsystem,
 			Name:           "statefulset_unavailable_replicas",
 			Help:           "Current number of unavailable pods in StatefulSet",
-			StabilityLevel: metrics.BETA,
+			StabilityLevel: metrics.ALPHA,
 		}, []string{"statefulset_namespace", "statefulset_name", "pod_management_policy"},
 	)
 )

--- a/pkg/controller/statefulset/stateful_set.go
+++ b/pkg/controller/statefulset/stateful_set.go
@@ -42,6 +42,7 @@ import (
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/controller"
 	"k8s.io/kubernetes/pkg/controller/history"
+	"k8s.io/kubernetes/pkg/controller/statefulset/metrics"
 
 	"k8s.io/klog/v2"
 )
@@ -93,6 +94,9 @@ func NewStatefulSetController(
 	logger := klog.FromContext(ctx)
 	eventBroadcaster := record.NewBroadcaster(record.WithContext(ctx))
 	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "statefulset-controller"})
+
+	// Register metrics
+	metrics.Register()
 	ssc := &StatefulSetController{
 		kubeClient: kubeClient,
 		control: NewDefaultStatefulSetControl(

--- a/pkg/controller/statefulset/stateful_set_control.go
+++ b/pkg/controller/statefulset/stateful_set_control.go
@@ -730,15 +730,15 @@ func updateStatefulSetAfterInvariantEstablished(
 	// (MaxUnavailable - Unavailable) Pods, in order with respect to their ordinal for termination. Delete
 	// those pods and count the successful deletions. Update the status with the correct number of deletions.
 	unavailablePods := 0
-	
+
 	for target := len(replicas) - 1; target >= 0; target-- {
 		if isUnavailable(replicas[target], set.Spec.MinReadySeconds) {
 			unavailablePods++
 		}
 	}
 	metrics.UnavailableReplicas.WithLabelValues(set.Namespace, set.Name, podManagementPolicy).Set(float64(unavailablePods))
-	
-	if unavailablePods > maxUnavailable {
+
+	if unavailablePods >= maxUnavailable {
 		logger.V(4).Info("StatefulSet found unavailablePods, more than the allowed maxUnavailable",
 			"statefulSet", klog.KObj(set),
 			"unavailablePods", unavailablePods,

--- a/pkg/controller/statefulset/stateful_set_control.go
+++ b/pkg/controller/statefulset/stateful_set_control.go
@@ -29,6 +29,7 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/controller/history"
+	"k8s.io/kubernetes/pkg/controller/statefulset/metrics"
 	"k8s.io/kubernetes/pkg/features"
 )
 
@@ -739,6 +740,9 @@ func updateStatefulSetAfterInvariantEstablished(
 			"statefulSet", klog.KObj(set),
 			"unavailablePods", unavailablePods,
 			"maxUnavailable", maxUnavailable)
+		if unavailablePods > maxUnavailable {
+			metrics.MaxUnavailableViolations.WithLabelValues(set.Namespace, set.Name).Inc()
+		}
 		return &status, nil
 	}
 

--- a/pkg/controller/statefulset/stateful_set_control.go
+++ b/pkg/controller/statefulset/stateful_set_control.go
@@ -735,14 +735,13 @@ func updateStatefulSetAfterInvariantEstablished(
 		}
 	}
 
-	if unavailablePods >= maxUnavailable {
-		logger.V(2).Info("StatefulSet found unavailablePods, more than or equal to allowed maxUnavailable",
+	if unavailablePods > maxUnavailable {
+		logger.V(4).Info("StatefulSet found unavailablePods, more than the allowed maxUnavailable",
 			"statefulSet", klog.KObj(set),
 			"unavailablePods", unavailablePods,
 			"maxUnavailable", maxUnavailable)
-		if unavailablePods > maxUnavailable {
-			metrics.MaxUnavailableViolations.WithLabelValues(set.Namespace, set.Name).Inc()
-		}
+		
+		metrics.MaxUnavailableViolations.WithLabelValues(set.Namespace, set.Name, string(set.Spec.PodManagementPolicy)).Inc()
 		return &status, nil
 	}
 

--- a/pkg/controller/statefulset/stateful_set_control.go
+++ b/pkg/controller/statefulset/stateful_set_control.go
@@ -740,8 +740,12 @@ func updateStatefulSetAfterInvariantEstablished(
 			"statefulSet", klog.KObj(set),
 			"unavailablePods", unavailablePods,
 			"maxUnavailable", maxUnavailable)
-		
-		metrics.MaxUnavailableViolations.WithLabelValues(set.Namespace, set.Name, string(set.Spec.PodManagementPolicy)).Inc()
+
+		// Only increment metric if StatefulSet status is consistent (not changing) to avoid false positives
+		// during initial rollouts, scaling operations, or updates
+		if !inconsistentStatus(set, &status) {
+			metrics.MaxUnavailableViolations.WithLabelValues(set.Namespace, set.Name, string(set.Spec.PodManagementPolicy)).Inc()
+		}
 		return &status, nil
 	}
 
@@ -792,6 +796,32 @@ func (ssc *defaultStatefulSetControl) updateStatefulSetStatus(
 	}
 
 	return nil
+}
+
+// wasStatefulSetPreviouslyHealthy determines if a StatefulSet was previously healthy
+// to distinguish between expected unavailability (during initial rollouts, scaling)
+// and unexpected unavailability that should be reported as violations
+func wasStatefulSetPreviouslyHealthy(set *apps.StatefulSet, status *apps.StatefulSetStatus) bool {
+	// Don't report violations during initial rollout - if ObservedGeneration is 0 or
+	// less than current generation, this is likely an initial deployment
+	if status.ObservedGeneration == 0 || status.ObservedGeneration < set.Generation {
+		return false
+	}
+
+	// Don't report if this is the first time we're seeing this StatefulSet
+	// (no previous status exists)
+	if set.Status.Replicas == 0 && set.Status.ReadyReplicas == 0 {
+		return false
+	}
+
+	// Don't report if we're in a scaling operation (replica count changed)
+	if set.Status.Replicas != *set.Spec.Replicas {
+		return false
+	}
+
+	// Only report if the StatefulSet was previously at desired state
+	// (had all replicas ready and available)
+	return set.Status.ReadyReplicas == *set.Spec.Replicas
 }
 
 var _ StatefulSetControlInterface = &defaultStatefulSetControl{}

--- a/pkg/controller/statefulset/stateful_set_control.go
+++ b/pkg/controller/statefulset/stateful_set_control.go
@@ -722,8 +722,9 @@ func updateStatefulSetAfterInvariantEstablished(
 		if err != nil {
 			return &status, err
 		}
-		metrics.MaxUnavailable.WithLabelValues(set.Namespace, set.Name, podManagementPolicy).Set(float64(maxUnavailable))
 	}
+	// Always set the MaxUnavailable metric, defaulting to 1 for all update strategies
+	metrics.MaxUnavailable.WithLabelValues(set.Namespace, set.Name, podManagementPolicy).Set(float64(maxUnavailable))
 
 	// Collect all targets in the range between getStartOrdinal(set) and getEndOrdinal(set). Count any targets in that range
 	// that are unavailable. Select the

--- a/pkg/controller/statefulset/stateful_set_control_test.go
+++ b/pkg/controller/statefulset/stateful_set_control_test.go
@@ -1034,7 +1034,7 @@ func TestStatefulSetControlRollingUpdateWithMaxUnavailable(t *testing.T) {
 			t.Fatalf("Expected create pods 5, got pods %v", len(pods))
 		}
 		spc.setPodRunning(set, 4)
-		spc.setPodReadyCondition(set, 4, true)
+		_, _ = spc.setPodReadyCondition(set, 4, true)
 
 		// create new pod 4 (only one pod gets created at a time due to OrderedReady)
 		if _, err := ssc.UpdateStatefulSet(context.TODO(), set, pods); err != nil {
@@ -3775,7 +3775,7 @@ func TestStatefulSetMetrics(t *testing.T) {
 		var pods []*v1.Pod
 		for i := 0; i < test.unavailablePodCount; i++ {
 			if test.podManagementPolicy == apps.OrderedReadyPodManagement {
-				spc.setPodRunning(set, i)
+				_, _ = spc.setPodRunning(set, i)
 				pods, _ = spc.setPodReadyCondition(set, i, false)
 			} else {
 				pods, _ = spc.addTerminatingPod(set, i)
@@ -3784,7 +3784,7 @@ func TestStatefulSetMetrics(t *testing.T) {
 
 		// Make remaining pods ready
 		for i := test.unavailablePodCount; i < int(test.totalPods); i++ {
-			spc.setPodRunning(set, i)
+			_, _ = spc.setPodRunning(set, i)
 			pods, _ = spc.setPodReadyCondition(set, i, true)
 		}
 		sort.Sort(ascendingOrdinal(pods))

--- a/pkg/controller/statefulset/stateful_set_control_test.go
+++ b/pkg/controller/statefulset/stateful_set_control_test.go
@@ -1034,7 +1034,7 @@ func TestStatefulSetControlRollingUpdateWithMaxUnavailable(t *testing.T) {
 			t.Fatalf("Expected create pods 5, got pods %v", len(pods))
 		}
 		spc.setPodRunning(set, 4)
-		pods, _ = spc.setPodReadyCondition(set, 4, true)
+		spc.setPodReadyCondition(set, 4, true)
 
 		// create new pods 4(only one pod gets created at a time due to OrderedReady)
 		if _, err := ssc.UpdateStatefulSet(context.TODO(), set, pods); err != nil {
@@ -1163,7 +1163,6 @@ func TestStatefulSetControlRollingUpdateWithMaxUnavailable(t *testing.T) {
 		// pods 3/4/5 ready, should not update other pods
 		spc.setPodRunning(set, 3)
 		spc.setPodRunning(set, 5)
-		spc.setPodReadyCondition(set, 5, true)
 		originalPods, _ = spc.setPodReadyCondition(set, 3, true)
 		sort.Sort(ascendingOrdinal(originalPods))
 		if _, err = ssc.UpdateStatefulSet(context.TODO(), set, originalPods); err != nil {
@@ -3779,7 +3778,7 @@ func TestStatefulSetMetrics(t *testing.T) {
 		set.Status.CollisionCount = new(int32)
 
 		// Setup controller
-		client := fake.NewSimpleClientset(set)
+		client := fake.NewClientset(set)
 		spc, _, ssc := setupController(client)
 
 		// Scale up StatefulSet

--- a/pkg/controller/statefulset/stateful_set_control_test.go
+++ b/pkg/controller/statefulset/stateful_set_control_test.go
@@ -3733,3 +3733,86 @@ func TestStatefulSetPartitionRollingUpdateWithMinReadySeconds(t *testing.T) {
 		t.Errorf("expected 4 pods to still exist (partition update blocked), got %d", len(newPods))
 	}
 }
+
+// TestInconsistentStatusForViolationReporting tests using inconsistentStatus to determine when
+// MaxUnavailableViolations should be reported to avoid false positives.
+func TestInconsistentStatusForViolationReporting(t *testing.T) {
+	// Base StatefulSet with typical configuration
+	baseSet := &apps.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{Generation: 1},
+		Spec:       apps.StatefulSetSpec{Replicas: ptr.To(int32(3))},
+		Status: apps.StatefulSetStatus{
+			Replicas:           3,
+			ReadyReplicas:      3,
+			AvailableReplicas:  3,
+			ObservedGeneration: 1,
+		},
+	}
+
+	testCases := []struct {
+		name               string
+		setStatus          apps.StatefulSetStatus
+		newStatus          apps.StatefulSetStatus
+		expectInconsistent bool
+		description        string
+	}{
+		{
+			name:      "initial deployment",
+			setStatus: apps.StatefulSetStatus{}, // Empty initial status
+			newStatus: apps.StatefulSetStatus{
+				Replicas:      3,
+				ReadyReplicas: 1,
+			},
+			expectInconsistent: true,
+			description:        "Initial deployment with changing status should not report violations",
+		},
+		{
+			name: "scaling operation",
+			setStatus: apps.StatefulSetStatus{
+				Replicas:      3, // Was 3
+				ReadyReplicas: 3,
+			},
+			newStatus: apps.StatefulSetStatus{
+				Replicas:      5, // Now 5
+				ReadyReplicas: 3,
+			},
+			expectInconsistent: true,
+			description:        "Scaling operation should not report violations",
+		},
+		{
+			name: "stable StatefulSet",
+			setStatus: apps.StatefulSetStatus{
+				Replicas:          3,
+				ReadyReplicas:     3,
+				AvailableReplicas: 3,
+			},
+			newStatus: apps.StatefulSetStatus{
+				Replicas:          3,
+				ReadyReplicas:     3,
+				AvailableReplicas: 3,
+			},
+			expectInconsistent: false,
+			description:        "Stable StatefulSet should report violations",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create test StatefulSet with specific status
+			set := baseSet.DeepCopy()
+			set.Status = tc.setStatus
+
+			result := inconsistentStatus(set, &tc.newStatus)
+			shouldReport := !result // We report violations when status is NOT inconsistent
+
+			if result != tc.expectInconsistent {
+				t.Errorf("%s: Expected inconsistentStatus=%v, got %v", tc.description, tc.expectInconsistent, result)
+			}
+
+			expectedShouldReport := !tc.expectInconsistent
+			if shouldReport != expectedShouldReport {
+				t.Errorf("%s: Expected shouldReport=%v, got %v", tc.description, expectedShouldReport, shouldReport)
+			}
+		})
+	}
+}

--- a/pkg/controller/statefulset/stateful_set_control_test.go
+++ b/pkg/controller/statefulset/stateful_set_control_test.go
@@ -989,9 +989,8 @@ func TestStatefulSetControlRollingUpdateWithMaxUnavailable(t *testing.T) {
 			t.Fatalf("Expected create pods 4/5, got pods %v", len(pods))
 		}
 
-		// if pod 4 ready, start to update pod 3, even though 5 is not ready
+		// if pod 4 ready, start to update pod 3.
 		spc.setPodRunning(set, 4)
-		spc.setPodRunning(set, 5)
 		originalPods, _ := spc.setPodReadyCondition(set, 4, true)
 		sort.Sort(ascendingOrdinal(originalPods))
 		if _, err := ssc.UpdateStatefulSet(context.TODO(), set, originalPods); err != nil {
@@ -1034,7 +1033,7 @@ func TestStatefulSetControlRollingUpdateWithMaxUnavailable(t *testing.T) {
 			t.Fatalf("Expected create pods 5, got pods %v", len(pods))
 		}
 		spc.setPodRunning(set, 4)
-		_, _ = spc.setPodReadyCondition(set, 4, true)
+		spc.setPodReadyCondition(set, 4, true)
 
 		// create new pod 4 (only one pod gets created at a time due to OrderedReady)
 		if _, err := ssc.UpdateStatefulSet(context.TODO(), set, pods); err != nil {
@@ -1045,7 +1044,7 @@ func TestStatefulSetControlRollingUpdateWithMaxUnavailable(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		// In OrderedReady mode, only 5 pods exist at this point (pod 5 not created yet)
+		// In OrderedReady mode, only 4 pods exist at this point (pod 5 not created yet)
 		if len(pods) != totalPods-1 {
 			t.Fatalf("Expected create pods %d, got pods %v", totalPods-1, len(pods))
 		}
@@ -1135,6 +1134,7 @@ func TestStatefulSetControlRollingUpdateWithMaxUnavailable(t *testing.T) {
 		// pods 3/4/5 ready, should not update other pods
 		spc.setPodRunning(set, 3)
 		spc.setPodRunning(set, 5)
+		spc.setPodReadyCondition(set, 5, true)
 		originalPods, _ = spc.setPodReadyCondition(set, 3, true)
 		sort.Sort(ascendingOrdinal(originalPods))
 		if _, err = ssc.UpdateStatefulSet(context.TODO(), set, originalPods); err != nil {

--- a/pkg/controller/statefulset/stateful_set_test.go
+++ b/pkg/controller/statefulset/stateful_set_test.go
@@ -721,7 +721,7 @@ func TestOrphanedPodsWithPVCDeletePolicy(t *testing.T) {
 		}
 
 		for i := range pods {
-			if _, err := om.setPodReady(set, i); err != nil {
+			if _, err := om.setPodReady(set, i, true); err != nil {
 				t.Errorf("%d: %v", i, err)
 			}
 			if _, err := om.setPodRunning(set, i); err != nil {
@@ -980,7 +980,7 @@ func scaleUpStatefulSetControllerBounded(logger klog.Logger, set *apps.StatefulS
 		fakeWorker(ssc)
 		pod = getPodAtOrdinal(pods, ord)
 		prev = *pod
-		if pods, err = om.setPodReady(set, ord); err != nil {
+		if pods, err = om.setPodReady(set, ord, true); err != nil {
 			return err
 		}
 		pod = getPodAtOrdinal(pods, ord)

--- a/pkg/controller/statefulset/stateful_set_test.go
+++ b/pkg/controller/statefulset/stateful_set_test.go
@@ -721,7 +721,7 @@ func TestOrphanedPodsWithPVCDeletePolicy(t *testing.T) {
 		}
 
 		for i := range pods {
-			if _, err := om.setPodReady(set, i, true); err != nil {
+			if _, err := om.setPodReadyCondition(set, i, true); err != nil {
 				t.Errorf("%d: %v", i, err)
 			}
 			if _, err := om.setPodRunning(set, i); err != nil {
@@ -980,7 +980,7 @@ func scaleUpStatefulSetControllerBounded(logger klog.Logger, set *apps.StatefulS
 		fakeWorker(ssc)
 		pod = getPodAtOrdinal(pods, ord)
 		prev = *pod
-		if pods, err = om.setPodReady(set, ord, true); err != nil {
+		if pods, err = om.setPodReadyCondition(set, ord, true); err != nil {
 			return err
 		}
 		pod = getPodAtOrdinal(pods, ord)

--- a/test/instrumentation/testdata/stable-metrics-list.yaml
+++ b/test/instrumentation/testdata/stable-metrics-list.yaml
@@ -241,6 +241,14 @@
   - 1310.72
   - 2621.44
   - 5242.88
+- name: statefulset_unavailability_violation
+  subsystem: statefulset_controller
+  help: Number of times maxunavailable has been violated
+  type: Counter
+  stabilityLevel: BETA
+  labels:
+  - statefulset_name
+  - statefulset_namespace
 - name: controller_admission_duration_seconds
   subsystem: admission
   namespace: apiserver

--- a/test/instrumentation/testdata/stable-metrics-list.yaml
+++ b/test/instrumentation/testdata/stable-metrics-list.yaml
@@ -249,6 +249,7 @@
   labels:
   - statefulset_name
   - statefulset_namespace
+  - pod_management_policy
 - name: controller_admission_duration_seconds
   subsystem: admission
   namespace: apiserver

--- a/test/instrumentation/testdata/stable-metrics-list.yaml
+++ b/test/instrumentation/testdata/stable-metrics-list.yaml
@@ -247,9 +247,9 @@
   type: Counter
   stabilityLevel: BETA
   labels:
+  - pod_management_policy
   - statefulset_name
   - statefulset_namespace
-  - pod_management_policy
 - name: controller_admission_duration_seconds
   subsystem: admission
   namespace: apiserver

--- a/test/instrumentation/testdata/stable-metrics-list.yaml
+++ b/test/instrumentation/testdata/stable-metrics-list.yaml
@@ -241,10 +241,19 @@
   - 1310.72
   - 2621.44
   - 5242.88
-- name: statefulset_unavailability_violation
+- name: statefulset_max_unavailable
   subsystem: statefulset_controller
-  help: Number of times maxunavailable has been violated
-  type: Counter
+  help: Maximum number of unavailable pods allowed during StatefulSet rolling updates
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+  - pod_management_policy
+  - statefulset_name
+  - statefulset_namespace
+- name: statefulset_unavailable_replicas
+  subsystem: statefulset_controller
+  help: Current number of unavailable pods in StatefulSet
+  type: Gauge
   stabilityLevel: BETA
   labels:
   - pod_management_policy

--- a/test/instrumentation/testdata/stable-metrics-list.yaml
+++ b/test/instrumentation/testdata/stable-metrics-list.yaml
@@ -241,24 +241,6 @@
   - 1310.72
   - 2621.44
   - 5242.88
-- name: statefulset_max_unavailable
-  subsystem: statefulset_controller
-  help: Maximum number of unavailable pods allowed during StatefulSet rolling updates
-  type: Gauge
-  stabilityLevel: BETA
-  labels:
-  - pod_management_policy
-  - statefulset_name
-  - statefulset_namespace
-- name: statefulset_unavailable_replicas
-  subsystem: statefulset_controller
-  help: Current number of unavailable pods in StatefulSet
-  type: Gauge
-  stabilityLevel: BETA
-  labels:
-  - pod_management_policy
-  - statefulset_name
-  - statefulset_namespace
 - name: controller_admission_duration_seconds
   subsystem: admission
   namespace: apiserver


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Adds a metric to track how many times there has been a `maxunavailable` violation, requirement for https://github.com/kubernetes/enhancements/issues/961 beta graduation.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of https://github.com/kubernetes/enhancements/issues/961

#### Special notes for your reviewer:

This is a follow up to the discussion on the KEP update PR https://github.com/kubernetes/enhancements/pull/4474#discussion_r1478412256. 

General consensus seems to be that this metric should be in tree instead of in [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics/tree/main). 

Open question:
- Should the metric be generic like the one exposed by [deployment](https://github.com/kubernetes/kube-state-metrics/blob/122e5e899943eb78eaf3e366733d5dbec6613ac0/internal/store/deployment.go#L221)? 

cc @atiratree @dgrisonnet @wojtek-t who were part of the original discussion.


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Adds metric for Maxunavailable feature
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
