### PR TITLE
Add structured PrivilegeEscalationError

### DIFF
--- a/pkg/registry/rbac/validation/rule.go
+++ b/pkg/registry/rbac/validation/rule.go
@@ -49,6 +49,27 @@ type AuthorizationRuleResolver interface {
 	VisitRulesFor(ctx context.Context, user user.Info, namespace string, visitor func(source fmt.Stringer, rule *rbacv1.PolicyRule, err error) bool)
 }
 
+type PrivilegeEscalationError struct {
+	User                 user.Info
+	Namespace            string
+	MissingRules         []rbacv1.PolicyRule
+	RuleResolutionErrors []error
+}
+
+func (e *PrivilegeEscalationError) Error() string {
+	missingDescriptions := sets.NewString()
+	for _, missing := range e.MissingRules {
+		missingDescriptions.Insert(rbacv1helpers.CompactString(missing))
+	}
+
+	msg := fmt.Sprintf("user %q (groups=%q) is attempting to grant RBAC permissions not currently held:\n%s", e.User.GetName(), e.User.GetGroups(), strings.Join(missingDescriptions.List(), "\n"))
+	if len(e.RuleResolutionErrors) > 0 {
+		msg += fmt.Sprintf("; resolution errors: %v", e.RuleResolutionErrors)
+	}
+
+	return msg
+}
+
 // ConfirmNoEscalation determines if the roles for a given user in a given namespace encompass the provided role.
 func ConfirmNoEscalation(ctx context.Context, ruleResolver AuthorizationRuleResolver, rules []rbacv1.PolicyRule) error {
 	ruleResolutionErrors := []error{}
@@ -73,17 +94,12 @@ func ConfirmNoEscalation(ctx context.Context, ruleResolver AuthorizationRuleReso
 			compactMissingRights = compact
 		}
 
-		missingDescriptions := sets.NewString()
-		for _, missing := range compactMissingRights {
-			missingDescriptions.Insert(rbacv1helpers.CompactString(missing))
+		return &PrivilegeEscalationError{
+			User:                 user,
+			Namespace:            namespace,
+			MissingRules:         compactMissingRights,
+			RuleResolutionErrors: ruleResolutionErrors,
 		}
-
-		msg := fmt.Sprintf("user %q (groups=%q) is attempting to grant RBAC permissions not currently held:\n%s", user.GetName(), user.GetGroups(), strings.Join(missingDescriptions.List(), "\n"))
-		if len(ruleResolutionErrors) > 0 {
-			msg = msg + fmt.Sprintf("; resolution errors: %v", ruleResolutionErrors)
-		}
-
-		return errors.New(msg)
 	}
 	return nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Introduces a structured error type for privilege escalation errors in ConfirmNoEscalation. The String() formatting matches the previous string used in the error output of ConfirmNoEscalation. The new PrivilegeEscalationError struct, however, allows further action to be taken on such an error and allows accessing the actual missing v1.PolicyRules--this is something that would be useful in github.com/operator-framework/operator-controller for outputting missing required RBAC rules in a validation check we are adding.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
