### PR TITLE
DRA API: fix DeviceTaintRule REST storage test

### DIFF
--- a/pkg/registry/resource/devicetaintrule/storage/storage_test.go
+++ b/pkg/registry/resource/devicetaintrule/storage/storage_test.go
@@ -18,6 +18,7 @@ package storage
 
 import (
 	"testing"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -53,8 +54,9 @@ func validNewDeviceTaint(name string) *resource.DeviceTaintRule {
 		},
 		Spec: resource.DeviceTaintRuleSpec{
 			Taint: resource.DeviceTaint{
-				Key:    "example.com/taint",
-				Effect: resource.DeviceTaintEffectNoExecute,
+				Key:       "example.com/taint",
+				Effect:    resource.DeviceTaintEffectNoExecute,
+				TimeAdded: &metav1.Time{Time: time.Now().Truncate(time.Second)}, // Must know in advance what will be stored.
 			},
 		},
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test
/kind flake

#### What this PR does / why we need it:

The defaulting of TimeAdded randomly broke some of the tests:

    TestList:
       resttest.go:1393: expected:
       []runtime.Object{(*resource.DeviceTaintRule)(0xc000b83080), (*resource.DeviceTaintRule)(0xc000b831e0)},
       got:
       []runtime.Object{(*resource.DeviceTaintRule)(0xc0003db608), (*resource.DeviceTaintRule)(0xc0003db750)}
       ...

    TestCreate:
       resttest.go:346: unexpected obj: &resource.DeviceTaintRule{TypeMeta:v1.TypeMeta{Kind:"", APIVersion:""}, ObjectMeta:v1.ObjectMeta{Name:"foo2", GenerateName:"", Namespace:"", SelfLink:"", UID:"18d3084d-7d11-4575-8730-4650b81cf1a7", ResourceVersion:"8", Generation:1, CreationTimestamp:time.Date(2025, time.March, 21, 8, 27, 23, 0, time.Local), DeletionTimestamp:<nil>, DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string(nil), Annotations:map[string]string(nil), OwnerReferences:[]v1.OwnerReference(nil), Finalizers:[]string(nil), ManagedFields:[]v1.ManagedFieldsEntry(nil)}, Spec:resource.DeviceTaintRuleSpec{DeviceSelector:(*resource.DeviceTaintSelector)(nil), Taint:resource.DeviceTaint{Key:"example.com/taint", Value:"", Effect:"NoExecute", TimeAdded:time.Date(2025, time.March, 21, 8, 27, 23, 0, time.Local)}}}, expected &resource.DeviceTaintRule{TypeMeta:v1.TypeMeta{Kind:"", APIVersion:""}, ObjectMeta:v1.ObjectMeta{Name:"foo2", GenerateName:"", Namespace:"", SelfLink:"", UID:"18d3084d-7d11-4575-8730-4650b81cf1a7", ResourceVersion:"8", Generation:1, CreationTimestamp:time.Date(2025, time.March, 21, 8, 27, 23, 0, time.Local), DeletionTimestamp:<nil>, DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string(nil), Annotations:map[string]string(nil), OwnerReferences:[]v1.OwnerReference(nil), Finalizers:[]string(nil), ManagedFields:[]v1.ManagedFieldsEntry(nil)}, Spec:resource.DeviceTaintRuleSpec{DeviceSelector:(*resource.DeviceTaintSelector)(nil), Taint:resource.DeviceTaint{Key:"example.com/taint", Value:"", Effect:"NoExecute", TimeAdded:time.Date(2025, time.March, 21, 8, 27, 24, 0, time.Local)}}}

Failure rate before: 3m40s: 1332 runs so far, 7 failures (0.53%)

It's not obvious from the test failure, but the difference is the TimeAdded. Setting it beforehand to a value that can be encoded (i.e. truncated to seconds) fixes the flake.

Failure rate after: 5m0s: 1825 runs so far, 0 failures

#### Which issue(s) this PR fixes:
Related-to: https://github.com/kubernetes/kubernetes/pull/130938#issuecomment-2742479145

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
