### PR TITLE
Increase number of pods in PreemptionBasic and PreemptionPVs

### DIFF
--- a/test/integration/scheduler_perf/misc/performance-config.yaml
+++ b/test/integration/scheduler_perf/misc/performance-config.yaml
@@ -163,24 +163,24 @@
       initNodes: 5
       initPods: 20
       measurePods: 5
-  - name: 500Nodes
+  - name: 1000Nodes
     featureGates:
       SchedulerQueueingHints: false
     labels: [performance, short]
     threshold: 18
     params:
-      initNodes: 500
-      initPods: 2000
-      measurePods: 500
-  - name: 500Nodes_QueueingHintsEnabled
+      initNodes: 1000
+      initPods: 4000
+      measurePods: 1000
+  - name: 1000Nodes_QueueingHintsEnabled
     featureGates:
       SchedulerQueueingHints: true
     labels: [performance, short]
     threshold: 18
     params:
-      initNodes: 500
-      initPods: 2000
-      measurePods: 500
+      initNodes: 1000
+      initPods: 4000
+      measurePods: 1000
 # This test case always seems to fail.
 # https://github.com/kubernetes/kubernetes/issues/108308
 #

--- a/test/integration/scheduler_perf/volumes/performance-config.yaml
+++ b/test/integration/scheduler_perf/volumes/performance-config.yaml
@@ -304,24 +304,24 @@
       initNodes: 5
       initPods: 20
       measurePods: 5
-  - name: 500Nodes
+  - name: 1000Nodes
     featureGates:
       SchedulerQueueingHints: false
     labels: [performance, short]
     threshold: 18
     params:
-      initNodes: 500
-      initPods: 2000
-      measurePods: 500
-  - name: 500Nodes_QueueingHintsEnabled
+      initNodes: 1000
+      initPods: 4000
+      measurePods: 1000
+  - name: 1000Nodes_QueueingHintsEnabled
     featureGates:
       SchedulerQueueingHints: true
     labels: [performance, short]
     threshold: 18
     params:
-      initNodes: 500
-      initPods: 2000
-      measurePods: 500
+      initNodes: 1000
+      initPods: 4000
+      measurePods: 1000
 # This test case always seems to fail.
 # https://github.com/kubernetes/kubernetes/issues/108308
 #


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup
/kind failing-test

#### What this PR does / why we need it:

At the moment, the PreemptionBasic and PreemptionPVs tests in scheduler_perf are too short, leading to ignoring last batch of results from time to time. Due to the structure of these tests, the observed throughput is much lower than actual. As a short fix, number of pods could be increased to lengthen the measurement time.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #130974

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
