### PR TITLE
Set LANGUAGE env variable in TestDiffProgram for consistent locale be…

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/diff/diff_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/diff/diff_test.go
@@ -64,6 +64,7 @@ func TestDiffProgram(t *testing.T) {
 	externalDiffCommands := [3]string{"diff", "diff -ruN", "diff --report-identical-files"}
 
 	t.Setenv("LANG", "C")
+	t.Setenv("LANGUAGE", "en_US")
 
 	for i, c := range externalDiffCommands {
 		t.Setenv("KUBECTL_EXTERNAL_DIFF", c)


### PR DESCRIPTION
`kubectl` `TestDiffProgram` test fails when `LANGUAGE` environment variable is set.

Reproducing the bug:

```
export LANGUAGE=fr_FR
```

```
 go test -vet=off -v -p 10 --count 1 ./...
 ```

```
=== RUN   TestDiffProgram
    diff_test.go:84: stdout = "Les fichiers /dev/zero et /dev/zero sont identiques\n", expected = Files /dev/zero and /dev/zero are identical
        "
--- FAIL: TestDiffProgram (0.03s)
```

That behaviour occurs because `LANGUAGE` takes precedence over `LANG`.

This bug was found in a reprotest stage pipeline while building the package for Debian OS.

- https://salsa.debian.org/kubernetes-team/packages/kubernetes/-/jobs/7261946
- https://kubernetes-team.pages.debian.net/-/packages/kubernetes/-/jobs/7261946/artifacts/debian/output/reprotest.log

The reprotest stage builds the package twice making sure is reproducible across different system settings.



<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug
/kind failing-test
/kind flake

#### What this PR does / why we need it:

This commit modifies the `TestDiffProgram` test to explicitly set the `LANGUAGE` environment variable to ensure consistent locale behavior during test execution.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

These changes help eliminate potential issues caused by varying locales, especially in environments with non-standard locale settings (such as French `fr_FR`), ensuring predictable test behavior across different systems.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

NONE


#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
