### PR TITLE
Default to closing watch requests during graceful shutdown

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/options/server_run_options_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/server_run_options_test.go
@@ -414,10 +414,10 @@ func TestServerRunOptionsWithShutdownWatchTerminationGracePeriod(t *testing.T) {
 		})
 	}
 
-	t.Run("default should be zero", func(t *testing.T) {
+	t.Run("default should be 67s", func(t *testing.T) {
 		options := NewServerRunOptions()
-		if options.ShutdownWatchTerminationGracePeriod != time.Duration(0) {
-			t.Errorf("expected default of ShutdownWatchTerminationGracePeriod to be zero, but got: %s", options.ShutdownWatchTerminationGracePeriod)
+		if options.ShutdownWatchTerminationGracePeriod != 67*time.Second {
+			t.Errorf("expected default of ShutdownWatchTerminationGracePeriod to be 67s, but got: %s", options.ShutdownWatchTerminationGracePeriod)
 		}
 	})
 }


### PR DESCRIPTION
The change gives `--shutdown-watch-termination-grace-period` a default value of 67 seconds so that the API server will wait up to that duration for watches to drain before signaling that requests have been drained.

Among other things, this prevents the API server from terminating gRPC connections to KMS plugins until after draining has been attempted.

xref #130898

/kind bug
/kind api-change

```release-note
The `--shutdown-watch-termination-grace-period` flag now defaults to 67 seconds.
```