### PR TITLE
Fix container_spec_memory_swap_limit_bytes in ci-cos-cgroupv1-containerd-node-e2e CI jobs

### DIFF
--- a/test/e2e_node/container_metrics_test.go
+++ b/test/e2e_node/container_metrics_test.go
@@ -73,7 +73,7 @@ var _ = SIGDescribe("ContainerMetrics", "[LinuxOnly]", framework.WithNodeConform
 				"container_spec_cpu_shares":                     preciseSample(2),
 				"container_spec_memory_limit_bytes":             preciseSample(79998976),
 				"container_spec_memory_reservation_limit_bytes": preciseSample(0),
-				"container_spec_memory_swap_limit_bytes":        preciseSample(0),
+				"container_spec_memory_swap_limit_bytes":        boundedSample(0, 80*e2evolume.Mb),
 				"container_start_time_seconds":                  boundedSample(time.Now().Add(-maxStatsAge).Unix(), time.Now().Add(2*time.Minute).Unix()),
 				"container_tasks_state":                         preciseSample(0),
 				"container_threads":                             boundedSample(0, 10),


### PR DESCRIPTION
See failures in https://storage.googleapis.com/k8s-triage/index.html?pr=1&test=when%20querying%20%2Fmetrics%2Fcadvisor%20should%20report%20container%20metrics

Here's what we see in the logs:
```
[FAILED] Timed out after 60.000s.
Expected
    <string>: KubeletMetrics
to match keys: {
[."container_spec_memory_swap_limit_bytes"[container-metrics-2886::stats-busybox-0::busybox-container]:
	Expected
	    <string>: Sample
	to match fields: {
	.Value:
		Expected
		    <model.SampleValue>: 7.9998976e+07
		to be equivalent to
		    <int>: 0
	}
	, ."container_spec_memory_swap_limit_bytes"[container-metrics-2886::stats-busybox-1::busybox-container]:
	Expected
	    <string>: Sample
	to match fields: {
	.Value:
		Expected
		    <model.SampleValue>: 7.9998976e+07
		to be equivalent to
		    <int>: 0
	}
	]
}
In [It] at: k8s.io/kubernetes/test/e2e_node/container_metrics_test.go:119 @ 03/21/25 19:13:13.333
```

In this PR, instead of a precise sample of `0`, using a bounded sample upto 80mb which is what we are seeing reported in those specific settings/images from the CI job.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
