### PR TITLE
Use established pattern for kubelet metrics url

### DIFF
--- a/test/e2e_node/container_metrics_test.go
+++ b/test/e2e_node/container_metrics_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/onsi/gomega/gstruct"
 	"github.com/onsi/gomega/types"
 
+	"k8s.io/kubernetes/pkg/cluster/ports"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2emetrics "k8s.io/kubernetes/test/e2e/framework/metrics"
 	e2evolume "k8s.io/kubernetes/test/e2e/framework/volume"
@@ -125,7 +126,7 @@ var _ = SIGDescribe("ContainerMetrics", "[LinuxOnly]", framework.WithNodeConform
 
 func getContainerMetrics(ctx context.Context) (e2emetrics.KubeletMetrics, error) {
 	ginkgo.By("getting container metrics from cadvisor")
-	return e2emetrics.GrabKubeletMetricsWithoutProxy(ctx, framework.TestContext.NodeName+":10255", "/metrics/cadvisor")
+	return e2emetrics.GrabKubeletMetricsWithoutProxy(ctx, fmt.Sprintf("%s:%d", nodeNameOrIP(), ports.KubeletReadOnlyPort), "/metrics/cadvisor")
 }
 
 func preciseSample(value interface{}) types.GomegaMatcher {


### PR DESCRIPTION
Fix for the the following error:
https://storage.googleapis.com/k8s-triage/index.html?text=container_metrics_test.go%3A119&xtext=container_spec_memory_swap_limit_bytes

from the logs:
```
[FAILED] Timed out after 60.001s.
The function passed to Eventually returned the following error:
    <*url.Error | 0x40009356b0>: 
    Get "http://i-0784eddc5b539f8e0:10255/metrics/cadvisor": dial tcp: lookup i-0784eddc5b539f8e0 on 172.31.0.2:53: no such host
    {
        Op: "Get",
        URL: "http://i-0784eddc5b539f8e0:10255/metrics/cadvisor",
        Err: <*net.OpError | 0x400054e910>{
            Op: "dial",
            Net: "tcp",
            Source: nil,
            Addr: nil,
            Err: <*net.DNSError | 0x400054e8c0>{
                UnwrapErr: nil,
                Err: "no such host",
                Name: "i-0784eddc5b539f8e0",
                Server: "172.31.0.2:53",
                IsTimeout: false,
                IsTemporary: false,
                IsNotFound: true,
            },
        },
    }
In [It] at: k8s.io/kubernetes/test/e2e_node/container_metrics_test.go:119 @ 03/21/25 03:16:17.564
```

The DNS lookup may not work properly, we currently use a pattern, so let's not invent a new one just for this test.

problem introduced by the same PR! https://github.com/kubernetes/kubernetes/pull/126213

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind failing-test

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
