### PR TITLE
Added stacktrace and logging for list and watch panics in reflector.go

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/reflector.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector.go
@@ -565,8 +565,6 @@ func (r *Reflector) watch(ctx context.Context, w watch.Interface, resyncerrc cha
 // list simply lists all items and records a resource version obtained from the server at the moment of the call.
 // the resource version can be used for further progress notification (aka. watch).
 func (r *Reflector) list(ctx context.Context) error {
-	// Catch panics and log them via Kubernetes crash handlers
-
 	var resourceVersion string
 	options := metav1.ListOptions{ResourceVersion: r.relistResourceVersion()}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
This PR enhances the `Reflector` in `client-go/tools/cache` by adding panic handling mechanisms in the `list` and `watch` operations. The panic handling captures detailed stack trace information when a panic occurs, which helps to accurately identify the source of the panic. Without this improvement, panic messages may not provide sufficient context, making debugging difficult.

#### Which issue(s) this PR fixes:
Fixes #130817

#### Special notes for your reviewer:
The following changes were made:
- Improved logging by providing complete stack trace information in `watch` and  `list` methods of `reflector.go`.
- Added `recover()` mechanisms in `watch`.
- Added test cases to ensure proper panic handling and logging for both `list` and `watch` operations.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
```

