### PR TITLE
Adjust metrics ranges to reflect additional CI job environments

### DIFF
--- a/test/e2e_node/container_metrics_test.go
+++ b/test/e2e_node/container_metrics_test.go
@@ -56,9 +56,9 @@ var _ = SIGDescribe("ContainerMetrics", "[LinuxOnly]", framework.WithNodeConform
 				"container_fs_reads_total":                      boundedSample(0, 100),
 				"container_fs_usage_bytes":                      boundedSample(0, 1000000),
 				"container_fs_writes_bytes_total":               boundedSample(0, 1000000),
-				"container_fs_writes_total":                     boundedSample(0, 100),
+				"container_fs_writes_total":                     boundedSample(0, 200),
 				"container_last_seen":                           boundedSample(time.Now().Add(-maxStatsAge).Unix(), time.Now().Add(2*time.Minute).Unix()),
-				"container_memory_cache":                        boundedSample(1*e2evolume.Kb, 10*e2evolume.Mb),
+				"container_memory_cache":                        boundedSample(0, 10*e2evolume.Mb),
 				"container_memory_failcnt":                      preciseSample(0),
 				"container_memory_failures_total":               boundedSample(0, 1000000),
 				"container_memory_mapped_file":                  boundedSample(0, 10000000),
@@ -79,7 +79,7 @@ var _ = SIGDescribe("ContainerMetrics", "[LinuxOnly]", framework.WithNodeConform
 				"container_tasks_state":                         preciseSample(0),
 				"container_threads":                             boundedSample(0, 10),
 				"container_threads_max":                         boundedSample(0, 100000),
-				"container_ulimits_soft":                        boundedSample(0, 10000000),
+				"container_ulimits_soft":                        boundedSample(0, 1073741816),
 			}
 			appendMatchesForContainer(f.Namespace.Name, pod0, pod1, "busybox-container", ctrMatches, keys, gstruct.AllowDuplicates|gstruct.IgnoreExtras)
 


### PR DESCRIPTION
Follow up to https://github.com/kubernetes/kubernetes/pull/130997 (and issue https://github.com/kubernetes/kubernetes/issues/130988)

From the following CI runs:
- https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-node-arm64-e2e-containerd-ec2/1903910648882925568
- https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-node-arm64-e2e-containerd-ec2/1903729201358311424
- https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-node-arm64-e2e-containerd-ec2/1903910648882925568
- https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-cgroupv2-containerd-node-e2e-ec2/1903807719756795904

```
container_fs_writes_total - 100 upper bound -> 200
```

From the following CI runs:
- https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-cgroupv2-containerd-node-arm64-al2023-e2e-ec2-eks/1903910145595805696
- https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-cgroupv2-containerd-node-arm64-al2023-e2e-ec2-eks/1903819296035835904
- https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-cgroupv2-containerd-node-arm64-al2023-e2e-ec2-eks/1903728698230575104
- https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-cgroupv2-containerd-node-al2023-e2e-ec2-eks/1903898820631072768
- https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-cgroupv2-containerd-node-al2023-e2e-ec2-eks/1903807971498921984
- https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-cgroupv2-containerd-node-al2023-e2e-ec2-eks/1903717373613969408

```
container_ulimits_soft - 10000000 upper bound -> 1073741816
```

From the following CI runs:
- https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-cgroupv1-containerd-node-e2e-ec2-eks/1903807971410841600
- https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-cgroupv1-containerd-node-e2e-ec2-eks/1903717373551054848
- https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-cgroupv1-containerd-node-arm64-e2e-ec2-eks/1903819044566339584
- https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-cgroupv1-containerd-node-arm64-e2e-ec2-eks/1903728446702358528

```
container_memory_cache - 1000 lower bound to 0
```

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind failing-test

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
