### PR TITLE
Mask Linux thermal interrupt info in /proc and /sys.

### DIFF
--- a/pkg/securitycontext/util_darwin.go
+++ b/pkg/securitycontext/util_darwin.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package securitycontext
+
+func possibleCPUs() []int {
+	return nil
+}

--- a/pkg/securitycontext/util_linux.go
+++ b/pkg/securitycontext/util_linux.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package securitycontext
+
+import (
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// possibleCPUs returns the number of possible CPUs on this host.
+func possibleCPUs() (cpus []int) {
+	if ncpu := possibleCPUsParsed(); ncpu != nil {
+		return ncpu
+	}
+
+	for i := range runtime.NumCPU() {
+		cpus = append(cpus, i)
+	}
+
+	return cpus
+}
+
+// possibleCPUsParsed is parsing the amount of possible CPUs on this host from
+// /sys/devices.
+var possibleCPUsParsed = sync.OnceValue(func() (cpus []int) {
+	data, err := os.ReadFile("/sys/devices/system/cpu/possible")
+	if err != nil {
+		return nil
+	}
+
+	ranges := strings.SplitSeq(strings.TrimSpace(string(data)), ",")
+
+	for r := range ranges {
+		if rStart, rEnd, ok := strings.Cut(r, "-"); !ok {
+			cpu, err := strconv.Atoi(rStart)
+			if err != nil {
+				return nil
+			}
+			cpus = append(cpus, cpu)
+		} else {
+			var start, end int
+			start, err := strconv.Atoi(rStart)
+			if err != nil {
+				return nil
+			}
+			end, err = strconv.Atoi(rEnd)
+			if err != nil {
+				return nil
+			}
+			for i := start; i <= end; i++ {
+				cpus = append(cpus, i)
+			}
+		}
+	}
+
+	return cpus
+})

--- a/pkg/securitycontext/util_test.go
+++ b/pkg/securitycontext/util_test.go
@@ -73,11 +73,11 @@ func TestConvertToRuntimeMaskedPaths(t *testing.T) {
 	}{
 		"procMount nil": {
 			pm:     nil,
-			expect: defaultMaskedPaths,
+			expect: defaultMaskedPaths(),
 		},
 		"procMount default": {
 			pm:     &dPM,
-			expect: defaultMaskedPaths,
+			expect: defaultMaskedPaths(),
 		},
 		"procMount unmasked": {
 			pm:     &uPM,

--- a/pkg/securitycontext/util_windows.go
+++ b/pkg/securitycontext/util_windows.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package securitycontext
+
+func possibleCPUs() []int {
+	return nil
+}


### PR DESCRIPTION

#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
On Linux, mask "/proc/interrupts" and "/sys/devices/system/cpu/cpu<x>/thermal_throttle" inside containers by default. Privileged containers or containers started with --security-opt="systempaths=unconfined" are not affected.

Mitigates potential Thermal Side-Channel Vulnerability Exploit (https://github.com/moby/moby/security/advisories/GHSA-6fw5-f8r9-fgfm).

Also: improve integration test TestCreateWithCustomMaskedPaths() to ensure default masked paths don't apply to privileged containers.


#### Which issue(s) this PR fixes:
Refers to https://github.com/moby/moby/pull/49560, https://github.com/cri-o/cri-o/pull/9069


#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Masked off access to Linux thermal interrupt info in `/proc` and `/sys`.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
