### PR TITLE
Fix race for sending errors in watch

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher_test.go
@@ -155,6 +155,11 @@ func TestWatchListMatchSingle(t *testing.T) {
 	storagetesting.RunWatchListMatchSingle(ctx, t, store)
 }
 
+func TestWatchErrorEventIsBlockingFurtherEvent(t *testing.T) {
+	ctx, store, _ := testSetup(t)
+	storagetesting.RunWatchErrorIsBlockingFurtherEvents(ctx, t, &storeWithPrefixTransformer{store})
+}
+
 // =======================================================================
 // Implementation-specific tests are following.
 // The following tests are exercising the details of the implementation


### PR DESCRIPTION
Ref #130898

Note that this bug is present even in watchcache is disabled.

/kind bug
/priority critical-urgent

-->
```release-note
Fix a bug where kube-apiserver could emit an further watch even even if decryption failed for earlier event and it was not emitted.
```
