### PR TITLE
Make ToUnstructured match stdlib omitempty and anonymous behavior

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/converter.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/converter.go
@@ -376,17 +376,20 @@ func fieldInfoFromField(structType reflect.Type, field int) *fieldInfo {
 	typeField := structType.Field(field)
 	jsonTag := typeField.Tag.Get("json")
 	if len(jsonTag) == 0 {
-		// Make the first character lowercase.
-		if typeField.Name == "" {
+		if !typeField.Anonymous {
+			// match stdlib behavior for naming fields that don't specify a json tag name
 			info.name = typeField.Name
-		} else {
-			info.name = strings.ToLower(typeField.Name[:1]) + typeField.Name[1:]
 		}
 	} else {
 		items := strings.Split(jsonTag, ",")
 		info.name = items[0]
+		if len(info.name) == 0 && !typeField.Anonymous {
+			// match stdlib behavior for naming fields that don't specify a json tag name
+			info.name = typeField.Name
+		}
+
 		for i := range items {
-			if items[i] == "omitempty" {
+			if i > 0 && items[i] == "omitempty" {
 				info.omitempty = true
 				break
 			}

--- a/staging/src/k8s.io/client-go/dynamic/golden_test.go
+++ b/staging/src/k8s.io/client-go/dynamic/golden_test.go
@@ -32,6 +32,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -338,7 +339,10 @@ func TestGoldenResponse(t *testing.T) {
 
 				var got []interface{}
 				for e := range w.ResultChan() {
-					u, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&e)
+					u, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&metav1.WatchEvent{
+						Type:   string(e.Type),
+						Object: runtime.RawExtension{Object: e.Object},
+					})
 					if err != nil {
 						t.Fatalf("failed to convert watch event to unstructured content: %v", err)
 					}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind bug

#### What this PR does / why we need it:

Fixes ways our ToUnstructured convertor does not match stdlib JSON marshaling.

Discovered while working on https://github.com/kubernetes/kubernetes/pull/130989 and making sure new omitzero behavior was consistent with stdlib.

We didn't actually have built-in types that this fix changes, since we define JSON tags, embed our inline fields, and don't use the field name `omitempty`, but this makes apimachinery helpers correct for other types if they do.

/sig api-machinery

```release-note
NONE
```

/cc @benluddy @deads2k 