### PR TITLE
kubeadm: fix WaitForAllControlPlaneComponents with anonymous auth

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/join/waitcontrolplane.go
+++ b/cmd/kubeadm/app/cmd/phases/join/waitcontrolplane.go
@@ -67,7 +67,12 @@ func runWaitControlPlanePhase(c workflow.RunData) error {
 		return nil
 	}
 
-	waiter, err := newControlPlaneWaiter(data.DryRun(), 0, nil, data.OutputWriter())
+	client, err := data.Client()
+	if err != nil {
+		return err
+	}
+
+	waiter, err := newControlPlaneWaiter(data.DryRun(), 0, client, data.OutputWriter())
 	if err != nil {
 		return errors.Wrap(err, "error creating waiter")
 	}

--- a/cmd/kubeadm/app/util/apiclient/wait_test.go
+++ b/cmd/kubeadm/app/util/apiclient/wait_test.go
@@ -73,9 +73,9 @@ func TestGetControlPlaneComponents(t *testing.T) {
 				return podMap
 			},
 			expected: []controlPlaneComponent{
-				{name: "kube-apiserver", url: fmt.Sprintf("https://[fd00:1::]:1111/%s", endpointLivez)},
-				{name: "kube-controller-manager", url: fmt.Sprintf("https://127.0.0.1:2222/%s", endpointHealthz)},
-				{name: "kube-scheduler", url: fmt.Sprintf("https://127.0.0.1:3333/%s", endpointLivez)},
+				{name: "kube-apiserver", addressPort: "[fd00:1::]:1111", endpoint: endpointLivez},
+				{name: "kube-controller-manager", addressPort: "127.0.0.1:2222", endpoint: endpointHealthz},
+				{name: "kube-scheduler", addressPort: "127.0.0.1:3333", endpoint: endpointLivez},
 			},
 		},
 		{
@@ -106,9 +106,9 @@ func TestGetControlPlaneComponents(t *testing.T) {
 				return podMap
 			},
 			expected: []controlPlaneComponent{
-				{name: "kube-apiserver", url: fmt.Sprintf("https://[fd00:1::]:1111/%s", endpointLivez)},
-				{name: "kube-controller-manager", url: fmt.Sprintf("https://127.0.0.1:2222/%s", endpointHealthz)},
-				{name: "kube-scheduler", url: fmt.Sprintf("https://127.0.0.1:3333/%s", endpointLivez)},
+				{name: "kube-apiserver", addressPort: "[fd00:1::]:1111", endpoint: endpointLivez},
+				{name: "kube-controller-manager", addressPort: "127.0.0.1:2222", endpoint: endpointHealthz},
+				{name: "kube-scheduler", addressPort: "127.0.0.1:3333", endpoint: endpointLivez},
 			},
 		},
 		{
@@ -133,9 +133,9 @@ func TestGetControlPlaneComponents(t *testing.T) {
 				return podMap
 			},
 			expected: []controlPlaneComponent{
-				{name: "kube-apiserver", url: fmt.Sprintf("https://192.168.0.1:6443/%s", endpointLivez)},
-				{name: "kube-controller-manager", url: fmt.Sprintf("https://127.0.0.1:10257/%s", endpointHealthz)},
-				{name: "kube-scheduler", url: fmt.Sprintf("https://127.0.0.1:10259/%s", endpointLivez)},
+				{name: "kube-apiserver", addressPort: "192.168.0.1:6443", endpoint: endpointLivez},
+				{name: "kube-controller-manager", addressPort: "127.0.0.1:10257", endpoint: endpointHealthz},
+				{name: "kube-scheduler", addressPort: "127.0.0.1:10259", endpoint: endpointLivez},
 			},
 		},
 		{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

When the kube-apiserver has --anonymous-auth=false, the regular http.Client.Get() that WaitForAllControlPlaneComponents does will not work.

Always use the discovery client when checking the health status of the kube-apiserver.

Do a minor rework of struct fields and unit tests.

Replace nil client in cmd/phases/join/waitcontrolplane.go.

Second commit does a consistency fix to use the same io.Writer everywhere in wait.go.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubeadm/issues/3174

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: make sure that it is possible to health check the kube-apiserver when it has --anonymous-auth=false set and the WaitForAllControlPlaneComponents feature gate is enabled.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
