### PR TITLE
Fix InPlacePodVerticalScaling flake test

### DIFF
--- a/test/e2e/common/node/pod_resize.go
+++ b/test/e2e/common/node/pod_resize.go
@@ -510,16 +510,16 @@ func doPodResizeTests() {
 			containers: []e2epod.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: "2m", CPULim: "10m"},
+					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit},
 				},
 			},
-			patchString: `{"spec":{"containers":[
-							{"name":"c1", "resources":{"requests":{"cpu":"1m"},"limits":{"cpu":"5m"}}}
-						]}}`,
+			patchString: fmt.Sprintf(`{"spec":{"containers":[
+							{"name":"c1", "resources":{"requests":{"cpu":"%s"},"limits":{"cpu":"%s"}}}
+						]}}`, increasedCPU, increasedCPULimit),
 			expected: []e2epod.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: "1m", CPULim: "5m"},
+					Resources: &e2epod.ContainerResources{CPUReq: increasedCPU, CPULim: increasedCPULimit},
 				},
 			},
 		},
@@ -1206,6 +1206,8 @@ func doPodResizeTests() {
 
 				ginkgo.By(fmt.Sprintf("waiting for %s to be actuated", opStr))
 				resizedPod := e2epod.WaitForPodResizeActuation(ctx, f, podClient, newPod, expectedContainers)
+
+				ginkgo.By(fmt.Sprintf("verifying pod resized for %s", opStr))
 				e2epod.ExpectPodResized(ctx, f, resizedPod, expectedContainers)
 			}
 

--- a/test/e2e/common/node/pod_resize.go
+++ b/test/e2e/common/node/pod_resize.go
@@ -515,11 +515,11 @@ func doPodResizeTests() {
 			},
 			patchString: fmt.Sprintf(`{"spec":{"containers":[
 							{"name":"c1", "resources":{"requests":{"cpu":"%s"},"limits":{"cpu":"%s"}}}
-						]}}`, increasedCPU, increasedCPULimit),
+						]}}`, reducedCPU, reducedCPULimit),
 			expected: []e2epod.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: increasedCPU, CPULim: increasedCPULimit},
+					Resources: &e2epod.ContainerResources{CPUReq: reducedCPU, CPULim: reducedCPULimit},
 				},
 			},
 		},

--- a/test/e2e/node/pod_resize.go
+++ b/test/e2e/node/pod_resize.go
@@ -161,6 +161,8 @@ func doPodResizeAdmissionPluginsTests() {
 
 			ginkgo.By("waiting for resize to be actuated")
 			resizedPod := e2epod.WaitForPodResizeActuation(ctx, f, podClient, newPods[0], expected)
+
+			ginkgo.By("verifying pod resized")
 			e2epod.ExpectPodResized(ctx, f, resizedPod, expected)
 
 			ginkgo.By("verifying pod resources after resize")
@@ -399,7 +401,11 @@ func doPodResizeSchedulerTests(f *framework.Framework) {
 				Resources: &e2epod.ContainerResources{CPUReq: testPod1CPUQuantity.String(), CPULim: testPod1CPUQuantity.String()},
 			},
 		}
+
+		ginkgo.By("waiting for resize to be actuated")
 		resizedPod := e2epod.WaitForPodResizeActuation(ctx, f, podClient, testPod1, expected)
+
+		ginkgo.By("verifying pod resized")
 		e2epod.ExpectPodResized(ctx, f, resizedPod, expected)
 
 		ginkgo.By(fmt.Sprintf("TEST3: Resize pod '%s' to exceed the node capacity", testPod1.Name))


### PR DESCRIPTION
Use existing constant CPU value for CPU request
and limit in flaky test instead of low values
set manually.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:

Investigating the flaky test checking https://storage.googleapis.com/k8s-triage/index.html?test=InPlacePodVerticalScaling#63b79a3e01a8d60f94d3

![image](https://github.com/user-attachments/assets/f734ac2d-f91d-45f8-b36e-9121fe46180d)

22 occurrences are seen for Burstable QoS pod, one container with cpu requests and limits - resize with equivalents

checking the code noticed that for this specific test there are not used CPU Limits from the existing constants but much less limits. I have the suspicion that the use of very low cpu results to restart of the container because it couldn't started. 

In addition this commit adds Gikgo log to make easier the troubleshotting in the future of similar error, as it was now in one STEP two indepent tasks were done making it difficult to understand in which method it failed. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #131043 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
