### PR TITLE
WIP add ReplicaSetFailedPodsBackoff: limit pod creation when kubelet fails V2

### DIFF
--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -1012,6 +1012,16 @@ func FilterTerminatingPods(pods []*v1.Pod) []*v1.Pod {
 	return result
 }
 
+func FilterFailedPods(pods []*v1.Pod) []*v1.Pod {
+	var result []*v1.Pod
+	for _, p := range pods {
+		if v1.PodFailed == p.Status.Phase {
+			result = append(result, p)
+		}
+	}
+	return result
+}
+
 func CountTerminatingPods(pods []*v1.Pod) int32 {
 	numberOfTerminatingPods := 0
 	for _, p := range pods {

--- a/pkg/controller/replicaset/replica_set_test.go
+++ b/pkg/controller/replicaset/replica_set_test.go
@@ -1829,7 +1829,7 @@ func TestSlowStartBatch(t *testing.T) {
 	for _, test := range tests {
 		callCnt = 0
 		callLimit = test.callLimit
-		successes, err := slowStartBatch(test.count, 1, test.fn)
+		successes, err := slowStartBatch(test.count, 1, nil, test.fn)
 		if successes != test.expectedSuccesses {
 			t.Errorf("%s: unexpected processed batch size, expected %d, got %d", test.name, test.expectedSuccesses, successes)
 		}

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -632,6 +632,11 @@ const (
 	// No effect for other cases such as using serverTLSbootstap.
 	ReloadKubeletServerCertificateFile featuregate.Feature = "ReloadKubeletServerCertificateFile"
 
+	// owner: @atiratree
+	//
+	// ReplicaSets will limit pod creation when kubelet moves pods to a Failed phase.
+	ReplicaSetFailedPodsBackoff featuregate.Feature = "ReplicaSetFailedPodsBackoff"
+
 	// owner: @SergeyKanzhelev
 	// kep: https://kep.k8s.io/4680
 	//
@@ -1612,6 +1617,10 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 
 	ReloadKubeletServerCertificateFile: {
 		{Version: version.MustParse("1.31"), Default: true, PreRelease: featuregate.Beta},
+	},
+
+	ReplicaSetFailedPodsBackoff: {
+		{Version: version.MustParse("1.33"), Default: true, PreRelease: featuregate.Beta},
 	},
 
 	ResourceHealthStatus: {

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -1161,6 +1161,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "1.33"
+- name: ReplicaSetFailedPodsBackoff
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.33"
 - name: ResilientWatchCacheInitialization
   versionedSpecs:
   - default: true


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

Solution alternative to https://github.com/kubernetes/kubernetes/pull/130411

#### Which issue(s) this PR fixes:
Partially solves https://github.com/kubernetes/kubernetes/issues/72593

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
