### PR TITLE
[FG:InPlacePodVerticalScaling] accept rounded container cpu limits in container cgroup tests

### DIFF
--- a/test/e2e/common/node/pod_level_resources.go
+++ b/test/e2e/common/node/pod_level_resources.go
@@ -233,10 +233,9 @@ func verifyPodCgroups(ctx context.Context, f *framework.Framework, pod *v1.Pod, 
 	}
 
 	cpuLimCgPath := fmt.Sprintf("%s/%s", podCgPath, cgroupv2CPULimit)
-	cpuQuota := kubecm.MilliCPUToQuota(expectedResources.Limits.Cpu().MilliValue(), kubecm.QuotaPeriod)
-	expectedCPULimit := strconv.FormatInt(cpuQuota, 10)
-	expectedCPULimit = fmt.Sprintf("%s %s", expectedCPULimit, CPUPeriod)
-	err = e2epod.VerifyCgroupValue(f, pod, pod.Spec.Containers[0].Name, cpuLimCgPath, expectedCPULimit)
+	expectedCPULimits := e2epod.GetCPULimitCgroupExpectations(expectedResources.Limits.Cpu())
+
+	err = e2epod.VerifyCgroupValue(f, pod, pod.Spec.Containers[0].Name, cpuLimCgPath, expectedCPULimits...)
 	if err != nil {
 		errs = append(errs, fmt.Errorf("failed to verify cpu limit cgroup value: %w", err))
 	}
@@ -395,10 +394,8 @@ func verifyContainersCgroupLimits(f *framework.Framework, pod *v1.Pod) error {
 
 		if pod.Spec.Resources != nil && pod.Spec.Resources.Limits.Cpu() != nil &&
 			container.Resources.Limits.Cpu() == nil {
-			cpuQuota := kubecm.MilliCPUToQuota(pod.Spec.Resources.Limits.Cpu().MilliValue(), kubecm.QuotaPeriod)
-			expectedCPULimit := strconv.FormatInt(cpuQuota, 10)
-			expectedCPULimit = fmt.Sprintf("%s %s", expectedCPULimit, CPUPeriod)
-			err := e2epod.VerifyCgroupValue(f, pod, container.Name, fmt.Sprintf("%s/%s", cgroupFsPath, cgroupv2CPULimit), expectedCPULimit)
+			expectedCPULimits := e2epod.GetCPULimitCgroupExpectations(pod.Spec.Resources.Limits.Cpu())
+			err := e2epod.VerifyCgroupValue(f, pod, container.Name, fmt.Sprintf("%s/%s", cgroupFsPath, cgroupv2CPULimit), expectedCPULimits...)
 			if err != nil {
 				errs = append(errs, fmt.Errorf("failed to verify cpu limit cgroup value: %w", err))
 			}

--- a/test/e2e/framework/pod/resize.go
+++ b/test/e2e/framework/pod/resize.go
@@ -321,7 +321,7 @@ func VerifyPodContainersCgroupValues(ctx context.Context, f *framework.Framework
 		tc := makeResizableContainer(ci)
 		if tc.Resources.Limits != nil || tc.Resources.Requests != nil {
 			var expectedCPUShares int64
-			var expectedCPULimitString, expectedMemLimitString string
+			var expectedMemLimitString string
 			expectedMemLimitInBytes := tc.Resources.Limits.Memory().Value()
 			cpuRequest := tc.Resources.Requests.Cpu()
 			cpuLimit := tc.Resources.Limits.Cpu()
@@ -330,17 +330,10 @@ func VerifyPodContainersCgroupValues(ctx context.Context, f *framework.Framework
 			} else {
 				expectedCPUShares = int64(kubecm.MilliCPUToShares(cpuRequest.MilliValue()))
 			}
-			cpuQuota := kubecm.MilliCPUToQuota(cpuLimit.MilliValue(), kubecm.QuotaPeriod)
-			if cpuLimit.IsZero() {
-				cpuQuota = -1
-			}
-			expectedCPULimitString = strconv.FormatInt(cpuQuota, 10)
+
+			expectedCPULimits := GetCPULimitCgroupExpectations(cpuLimit)
 			expectedMemLimitString = strconv.FormatInt(expectedMemLimitInBytes, 10)
 			if *podOnCgroupv2Node {
-				if expectedCPULimitString == "-1" {
-					expectedCPULimitString = "max"
-				}
-				expectedCPULimitString = fmt.Sprintf("%s %s", expectedCPULimitString, CPUPeriod)
 				if expectedMemLimitString == "0" {
 					expectedMemLimitString = "max"
 				}
@@ -348,10 +341,11 @@ func VerifyPodContainersCgroupValues(ctx context.Context, f *framework.Framework
 				// https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/2254-cgroup-v2#phase-1-convert-from-cgroups-v1-settings-to-v2
 				expectedCPUShares = int64(1 + ((expectedCPUShares-2)*9999)/262142)
 			}
+
 			if expectedMemLimitString != "0" {
 				errs = append(errs, VerifyCgroupValue(f, pod, ci.Name, cgroupMemLimit, expectedMemLimitString))
 			}
-			errs = append(errs, VerifyCgroupValue(f, pod, ci.Name, cgroupCPULimit, expectedCPULimitString))
+			errs = append(errs, VerifyCgroupValue(f, pod, ci.Name, cgroupCPULimit, expectedCPULimits...))
 			errs = append(errs, VerifyCgroupValue(f, pod, ci.Name, cgroupCPURequest, strconv.FormatInt(expectedCPUShares, 10)))
 			// TODO(vinaykul,InPlacePodVerticalScaling): Verify oom_score_adj when runc adds support for updating it
 			// See https://github.com/opencontainers/runc/pull/4669

--- a/test/e2e/framework/pod/utils_linux_test.go
+++ b/test/e2e/framework/pod/utils_linux_test.go
@@ -1,0 +1,84 @@
+//go:build linux
+// +build linux
+
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pod
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func TestGetCPULimitCgroupExpectations(t *testing.T) {
+	testCases := []struct {
+		name              string
+		cpuLimit          *resource.Quantity
+		podOnCgroupv2Node bool
+		expected          []string
+	}{
+		{
+			name:              "rounding required, podOnCGroupv2Node=true",
+			cpuLimit:          resource.NewMilliQuantity(15, resource.DecimalSI),
+			podOnCgroupv2Node: true,
+			expected:          []string{"1500 100000", "2000 100000"},
+		},
+		{
+			name:              "rounding not required, podOnCGroupv2Node=true",
+			cpuLimit:          resource.NewMilliQuantity(20, resource.DecimalSI),
+			podOnCgroupv2Node: true,
+			expected:          []string{"2000 100000"},
+		},
+		{
+			name:              "rounding required, podOnCGroupv2Node=false",
+			cpuLimit:          resource.NewMilliQuantity(15, resource.DecimalSI),
+			podOnCgroupv2Node: false,
+			expected:          []string{"1500", "2000"},
+		},
+		{
+			name:              "rounding not required, podOnCGroupv2Node=false",
+			cpuLimit:          resource.NewMilliQuantity(20, resource.DecimalSI),
+			podOnCgroupv2Node: false,
+			expected:          []string{"2000"},
+		},
+		{
+			name:              "cpuQuota=0, podOnCGroupv2Node=true",
+			cpuLimit:          resource.NewMilliQuantity(0, resource.DecimalSI),
+			podOnCgroupv2Node: true,
+			expected:          []string{"max 100000"},
+		},
+		{
+			name:              "cpuQuota=0, podOnCGroupv2Node=false",
+			cpuLimit:          resource.NewMilliQuantity(0, resource.DecimalSI),
+			podOnCgroupv2Node: false,
+			expected:          []string{"-1"},
+		},
+	}
+
+	originalPodOnCgroupv2Node := podOnCgroupv2Node
+	t.Cleanup(func() { podOnCgroupv2Node = originalPodOnCgroupv2Node })
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			podOnCgroupv2Node = &tc.podOnCgroupv2Node
+			actual := GetCPULimitCgroupExpectations(tc.cpuLimit)
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind flake

#### What this PR does / why we need it:

Trying to see if this addresses the flakes in https://github.com/kubernetes/kubernetes/issues/131031, which look suspiciously like rounding errors. There is a rounding issue in runc: https://github.com/opencontainers/runc/issues/4622. This might be related to https://github.com/kubernetes/kubernetes/issues/129357. 

I talked with @tallclair offline, the plan is to make this change and see if the flakes go away.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related to https://github.com/kubernetes/kubernetes/issues/131031

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
