### PR TITLE
clarify mutual exclusivity of service account annotation keys in godoc

### DIFF
--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -65528,7 +65528,7 @@ func schema_k8sio_kubelet_config_v1_ServiceAccountTokenAttributes(ref common.Ref
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "requiredServiceAccountAnnotationKeys is the list of annotation keys that the plugin is interested in and that are required to be present in the service account. The keys defined in this list will be extracted from the corresponding service account and passed to the plugin as part of the CredentialProviderRequest. If any of the keys defined in this list are not present in the service account, kubelet will not invoke the plugin and will return an error. This field is optional and may be empty. Plugins may use this field to extract additional information required to fetch credentials or allow workloads to opt in to using service account tokens for image pull. If non-empty, requireServiceAccount must be set to true.",
+							Description: "requiredServiceAccountAnnotationKeys is the list of annotation keys that the plugin is interested in and that are required to be present in the service account. The keys defined in this list will be extracted from the corresponding service account and passed to the plugin as part of the CredentialProviderRequest. If any of the keys defined in this list are not present in the service account, kubelet will not invoke the plugin and will return an error. This field is optional and may be empty. Plugins may use this field to extract additional information required to fetch credentials or allow workloads to opt in to using service account tokens for image pull. If non-empty, requireServiceAccount must be set to true. Keys in this list must be unique. This list needs to be mutually exclusive with optionalServiceAccountAnnotationKeys.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -65548,7 +65548,7 @@ func schema_k8sio_kubelet_config_v1_ServiceAccountTokenAttributes(ref common.Ref
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "optionalServiceAccountAnnotationKeys is the list of annotation keys that the plugin is interested in and that are optional to be present in the service account. The keys defined in this list will be extracted from the corresponding service account and passed to the plugin as part of the CredentialProviderRequest. The plugin is responsible for validating the existence of annotations and their values. This field is optional and may be empty. Plugins may use this field to extract additional information required to fetch credentials.",
+							Description: "optionalServiceAccountAnnotationKeys is the list of annotation keys that the plugin is interested in and that are optional to be present in the service account. The keys defined in this list will be extracted from the corresponding service account and passed to the plugin as part of the CredentialProviderRequest. The plugin is responsible for validating the existence of annotations and their values. This field is optional and may be empty. Plugins may use this field to extract additional information required to fetch credentials. Keys in this list must be unique.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{

--- a/pkg/kubelet/apis/config/types.go
+++ b/pkg/kubelet/apis/config/types.go
@@ -737,6 +737,8 @@ type ServiceAccountTokenAttributes struct {
 	// additional information required to fetch credentials or allow workloads to opt in to
 	// using service account tokens for image pull.
 	// If non-empty, requireServiceAccount must be set to true.
+	// Keys in this list must be unique.
+	// This list needs to be mutually exclusive with optionalServiceAccountAnnotationKeys.
 	// +optional
 	RequiredServiceAccountAnnotationKeys []string
 
@@ -747,6 +749,7 @@ type ServiceAccountTokenAttributes struct {
 	// the existence of annotations and their values.
 	// This field is optional and may be empty. Plugins may use this field to extract
 	// additional information required to fetch credentials.
+	// Keys in this list must be unique.
 	// +optional
 	OptionalServiceAccountAnnotationKeys []string
 }

--- a/staging/src/k8s.io/kubelet/config/v1/types.go
+++ b/staging/src/k8s.io/kubelet/config/v1/types.go
@@ -134,6 +134,8 @@ type ServiceAccountTokenAttributes struct {
 	// additional information required to fetch credentials or allow workloads to opt in to
 	// using service account tokens for image pull.
 	// If non-empty, requireServiceAccount must be set to true.
+	// Keys in this list must be unique.
+	// This list needs to be mutually exclusive with optionalServiceAccountAnnotationKeys.
 	// +optional
 	// +listType=set
 	RequiredServiceAccountAnnotationKeys []string `json:"requiredServiceAccountAnnotationKeys,omitempty"`
@@ -145,6 +147,7 @@ type ServiceAccountTokenAttributes struct {
 	// the existence of annotations and their values.
 	// This field is optional and may be empty. Plugins may use this field to extract
 	// additional information required to fetch credentials.
+	// Keys in this list must be unique.
 	// +optional
 	// +listType=set
 	OptionalServiceAccountAnnotationKeys []string `json:"optionalServiceAccountAnnotationKeys,omitempty"`


### PR DESCRIPTION
Clarify mutual exclusivity of service account annotation keys in godoc.

/kind cleanup
/kind api-change

/sig auth
/triage accepted
/priority important-soon

```release-note
NONE
```

```docs
[KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-auth/4412-projected-service-account-tokens-for-kubelet-image-credential-providers/README.md
```

/assign enj liggitt