### PR TITLE
    fix (*suffixHandler) interpret: prevent int32 overflow in exponent parsing

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/suffix.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/suffix.go
@@ -187,7 +187,7 @@ func (sh *suffixHandler) interpret(suffix suffix) (base, exponent int32, fmt For
 	}
 
 	if len(suffix) > 1 && (suffix[0] == 'E' || suffix[0] == 'e') {
-		parsed, err := strconv.ParseInt(string(suffix[1:]), 10, 64)
+		parsed, err := strconv.ParseInt(string(suffix[1:]), 10, 32)
 		if err != nil {
 			return 0, 0, DecimalExponent, false
 		}

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/suffix_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/suffix_test.go
@@ -1,32 +1,31 @@
 package resource
 
 import (
-    "testing"
+	"testing"
 )
 
 func TestDecimalExponentEdgeCases(t *testing.T) {
-    table := []struct {
-        input         string
-        expect_base   int32
-        expect_exp    int32
-        expect_format Format
-        expect_status bool
-    }{
-        {"E6024865272343", 0, 0, DecimalExponent, false},
-        {"e14", 10, 14, DecimalExponent, true},
-	{"E2147483647", 10, 2147483647, DecimalExponent, true},
-	{"E2147483648", 0, 0, DecimalExponent, false},
-	{"E-2147483648", 10, -2147483648, DecimalExponent, true},
-	{"E-2147483649", 0, 0, DecimalExponent, false},
-    }
+	table := []struct {
+		input         string
+		expect_base   int32
+		expect_exp    int32
+		expect_format Format
+		expect_status bool
+	}{
+		{"E6024865272343", 0, 0, DecimalExponent, false},
+		{"e14", 10, 14, DecimalExponent, true},
+		{"E2147483647", 10, 2147483647, DecimalExponent, true},
+		{"E2147483648", 0, 0, DecimalExponent, false},
+		{"E-2147483648", 10, -2147483648, DecimalExponent, true},
+		{"E-2147483649", 0, 0, DecimalExponent, false},
+	}
 
-    for _, item := range table {
-        base, exp, format, ok := quantitySuffixer.interpret(suffix(item.input))
-        if base != item.expect_base || exp != item.expect_exp || format != item.expect_format || item.expect_status != ok {
-            t.Errorf("expected base=%v exp=%v format=%v status=%v; got base=%v exp=%v format=%v status=%v",
-                item.expect_base, item.expect_exp, item.expect_format, item.expect_status,
-                base, exp, format, ok)
-        }
-    }
+	for _, item := range table {
+		base, exp, format, ok := quantitySuffixer.interpret(suffix(item.input))
+		if base != item.expect_base || exp != item.expect_exp || format != item.expect_format || item.expect_status != ok {
+			t.Errorf("expected base=%v exp=%v format=%v status=%v; got base=%v exp=%v format=%v status=%v",
+				item.expect_base, item.expect_exp, item.expect_format, item.expect_status,
+				base, exp, format, ok)
+		}
+	}
 }
-

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/suffix_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/suffix_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package resource
 
 import (

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/suffix_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/suffix_test.go
@@ -6,11 +6,11 @@ import (
 
 func TestDecimalExponentEdgeCases(t *testing.T) {
 	table := []struct {
-		input         string
-		expect_base   int32
-		expect_exp    int32
-		expect_format Format
-		expect_status bool
+		input        string
+		expectBase   int32
+		expectExp    int32
+		expectFormat Format
+		expectStatus bool
 	}{
 		{"E6024865272343", 0, 0, DecimalExponent, false},
 		{"e14", 10, 14, DecimalExponent, true},
@@ -22,9 +22,9 @@ func TestDecimalExponentEdgeCases(t *testing.T) {
 
 	for _, item := range table {
 		base, exp, format, ok := quantitySuffixer.interpret(suffix(item.input))
-		if base != item.expect_base || exp != item.expect_exp || format != item.expect_format || item.expect_status != ok {
+		if base != item.expectBase || exp != item.expectExp || format != item.expectFormat || item.expectStatus != ok {
 			t.Errorf("expected base=%v exp=%v format=%v status=%v; got base=%v exp=%v format=%v status=%v",
-				item.expect_base, item.expect_exp, item.expect_format, item.expect_status,
+				item.expectBase, item.expectExp, item.expectFormat, item.expectStatus,
 				base, exp, format, ok)
 		}
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/suffix_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/suffix_test.go
@@ -1,0 +1,32 @@
+package resource
+
+import (
+    "testing"
+)
+
+func TestDecimalExponentEdgeCases(t *testing.T) {
+    table := []struct {
+        input         string
+        expect_base   int32
+        expect_exp    int32
+        expect_format Format
+        expect_status bool
+    }{
+        {"E6024865272343", 0, 0, DecimalExponent, false},
+        {"e14", 10, 14, DecimalExponent, true},
+	{"E2147483647", 10, 2147483647, DecimalExponent, true},
+	{"E2147483648", 0, 0, DecimalExponent, false},
+	{"E-2147483648", 10, -2147483648, DecimalExponent, true},
+	{"E-2147483649", 0, 0, DecimalExponent, false},
+    }
+
+    for _, item := range table {
+        base, exp, format, ok := quantitySuffixer.interpret(suffix(item.input))
+        if base != item.expect_base || exp != item.expect_exp || format != item.expect_format || item.expect_status != ok {
+            t.Errorf("expected base=%v exp=%v format=%v status=%v; got base=%v exp=%v format=%v status=%v",
+                item.expect_base, item.expect_exp, item.expect_format, item.expect_status,
+                base, exp, format, ok)
+        }
+    }
+}
+


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
When parsing large exponents like in "2E6024865272343", the interpret()
function would:
1. Parse to int64 with bitSize=64
2. Truncate to int32 causing overflow
3. Result in extremely small rounded values
4. Cause ParseQuantity to hang during rounding

The fix changes ParseInt's bitSize from 64 to 32 to properly reject
exponents that don't fit in int32 range.

Now invalid large exponents will return ok=false instead of causing
silent overflow and subsequent hangs.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->


#### Special notes for your reviewer:
Reproduce:
package main
import (
	"k8s.io/apimachinery/pkg/api/resource"
)

func main() {
	input := "2E6024865272343"
	res, err := resource.ParseQuantity(input)
	if err != nil {
	    return
        }
}
Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
There is no longer a dependency when specifying large numbers with exponential notation
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
