### PR TITLE
hack/ginkgo-e2e.sh: fix misplaced brackets

### DIFF
--- a/hack/ginkgo-e2e.sh
+++ b/hack/ginkgo-e2e.sh
@@ -233,7 +233,7 @@ EOF
     kill -TERM "-${GINKGO_CLI_PID}" || true
 
     echo "Waiting for Ginkgo with pid ${GINKGO_CLI_PID}..."
-    wait "{$GINKGO_CLI_PID}"
+    wait "${GINKGO_CLI_PID}"
     echo "Ginkgo terminated."
   fi
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

If the script got killed, it failed to wait properly:

    Waiting for Ginkgo with pid 73873...
    ./hack/ginkgo-e2e.sh: line 236: wait: `{73873}': not a pid or valid job spec

#### Which issue(s) this PR fixes:
Related-to: https://github.com/kubernetes/test-infra/pull/34607#issuecomment-2753459048

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
