### PR TITLE
DRA: monitor plugin connection

### DIFF
--- a/pkg/kubelet/cm/dra/manager_test.go
+++ b/pkg/kubelet/cm/dra/manager_test.go
@@ -22,6 +22,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	goruntime "runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -895,6 +896,9 @@ func TestGetContainerClaimInfos(t *testing.T) {
 // TestParallelPrepareUnprepareResources calls PrepareResources and UnprepareResources APIs in parallel
 // to detect possible data races
 func TestParallelPrepareUnprepareResources(t *testing.T) {
+	if goruntime.GOOS == "windows" {
+		t.Skip("DRA is not currently supported on Windows.")
+	}
 	tCtx := ktesting.Init(t)
 
 	// Setup and register fake DRA driver

--- a/pkg/kubelet/cm/dra/plugin/cleanup.go
+++ b/pkg/kubelet/cm/dra/plugin/cleanup.go
@@ -1,0 +1,242 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugin
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	resourceapi "k8s.io/api/resource/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+)
+
+// CleanupHandler is the handler which is responsible for handling
+// resource cleanups for DRA plugins. It is used to cleanup
+// plugin resource slices when a plugin is deregistered or when the
+// connection to the plugin is lost.
+// It manages the cleanup process, including delaying the cleanup
+// to allow the plugin to potentially recover and cancel pending
+// cleanup.
+type cleanupHandler struct {
+	// backgroundCtx is used for all future activities of the handler.
+	// This is necessary because it implements APIs which don't
+	// provide a context.
+	backgroundCtx context.Context
+
+	cancel      func(err error)
+	kubeClient  kubernetes.Interface
+	getNode     func() (*v1.Node, error)
+	wipingDelay time.Duration
+
+	wg    sync.WaitGroup
+	mutex sync.Mutex
+
+	// pendingWipes maps a plugin name to a cancel function for
+	// wiping of that plugin's ResourceSlices. Entries get added
+	// in DeRegisterPlugin and check in RegisterPlugin. If
+	// wiping is pending during RegisterPlugin, it gets canceled.
+	//
+	// Must use pointers to functions because the entries have to
+	// be comparable.
+	pendingWipes map[string]*context.CancelCauseFunc
+}
+
+// newCleanupHandler returns new cleanup handler.
+//
+// Must only be called once per process because it manages global state.
+func newCleanupHandler(ctx context.Context, kubeClient kubernetes.Interface, getNode func() (*v1.Node, error), wipingDelay time.Duration) *cleanupHandler {
+	ctx, cancel := context.WithCancelCause(ctx)
+	handler := &cleanupHandler{
+		backgroundCtx: klog.NewContext(ctx, klog.LoggerWithName(klog.FromContext(ctx), "DRA registration handler")),
+		cancel:        cancel,
+		kubeClient:    kubeClient,
+		getNode:       getNode,
+		wipingDelay:   wipingDelay,
+		pendingWipes:  make(map[string]*context.CancelCauseFunc),
+	}
+
+	// When kubelet starts up, no DRA driver has registered yet. None of
+	// the drivers are usable until they come back, which might not happen
+	// at all. Therefore it is better to not advertise any local resources
+	// because pods could get stuck on the node waiting for the driver
+	// to start up.
+	//
+	// This has to run in the background.
+	handler.wg.Add(1)
+	go func() {
+		defer handler.wg.Done()
+
+		logger := klog.LoggerWithName(klog.FromContext(handler.backgroundCtx), "startup")
+		ctx := klog.NewContext(handler.backgroundCtx, logger)
+		handler.wipeResourceSlices(ctx, 0 /* no delay */, "" /* all drivers */)
+	}()
+
+	return handler
+}
+
+// Stop cancels any remaining background activities and blocks until all goroutines have stopped.
+func (c *cleanupHandler) Stop() {
+	c.cancel(errors.New("Stop was called"))
+	c.wg.Wait()
+}
+
+// wipeResourceSlices deletes ResourceSlices of the node, optionally just for a specific driver.
+// Wiping will delay for a while and can be canceled by canceling the context.
+func (c *cleanupHandler) wipeResourceSlices(ctx context.Context, delay time.Duration, driver string) {
+	if c.kubeClient == nil {
+		return
+	}
+	logger := klog.FromContext(ctx)
+
+	if delay != 0 {
+		// Before we start deleting, give the driver time to bounce back.
+		// Perhaps it got removed as part of a DaemonSet update and the
+		// replacement pod is about to start.
+		logger.V(4).Info("Starting to wait before wiping ResourceSlices", "delay", delay)
+		select {
+		case <-ctx.Done():
+			logger.V(4).Info("Aborting wiping of ResourceSlices", "reason", context.Cause(ctx))
+		case <-time.After(delay):
+			logger.V(4).Info("Starting to wipe ResourceSlices after waiting", "delay", delay)
+		}
+	}
+
+	backoff := wait.Backoff{
+		Duration: time.Second,
+		Factor:   2,
+		Jitter:   0.2,
+		Cap:      5 * time.Minute,
+		Steps:    100,
+	}
+
+	// Error logging is done inside the loop. Context cancellation doesn't get logged.
+	_ = wait.ExponentialBackoffWithContext(ctx, backoff, func(ctx context.Context) (bool, error) {
+		node, err := c.getNode()
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		if err != nil {
+			logger.Error(err, "Unexpected error checking for node")
+			return false, nil
+		}
+		fieldSelector := fields.Set{resourceapi.ResourceSliceSelectorNodeName: node.Name}
+		if driver != "" {
+			fieldSelector[resourceapi.ResourceSliceSelectorDriver] = driver
+		}
+
+		err = c.kubeClient.ResourceV1beta1().ResourceSlices().DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{FieldSelector: fieldSelector.String()})
+		switch {
+		case err == nil:
+			logger.V(3).Info("Deleted ResourceSlices", "fieldSelector", fieldSelector)
+			return true, nil
+		case apierrors.IsUnauthorized(err):
+			// This can happen while kubelet is still figuring out
+			// its credentials.
+			logger.V(5).Info("Deleting ResourceSlice failed, retrying", "fieldSelector", fieldSelector, "err", err)
+			return false, nil
+		default:
+			// Log and retry for other errors.
+			logger.V(3).Info("Deleting ResourceSlice failed, retrying", "fieldSelector", fieldSelector, "err", err)
+			return false, nil
+		}
+	})
+}
+
+func (c *cleanupHandler) cancelPendingWipe(pluginName, errMsg string) {
+	if c == nil {
+		return
+	}
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	if cancel, ok := c.pendingWipes[pluginName]; ok {
+		if cancel != nil {
+			(*cancel)(errors.New(errMsg))
+		}
+		delete(c.pendingWipes, pluginName)
+	}
+}
+
+// cleanupResourceSlices initiates the cleanup process for ResourceSlices
+// associated with a given plugin. It prepares a new context and logger for
+// the cleanup operation, ensuring that any previous cleanup for the same
+// plugin is canceled if still pending. The cleanup is performed
+// asynchronously in a background goroutine, which will remove the
+// ResourceSlices after a delay unless the plugin is back online before the
+// cleanup completes.
+func (c *cleanupHandler) cleanupResourceSlices(pluginName string) {
+	if c == nil {
+		return
+	}
+	if draPlugins.pluginConnected(pluginName) {
+		// If at least one plugin is connected, no cleanup is needed.
+		return
+	}
+
+	// Prepare for canceling the background wiping. This needs to run
+	// in the context of the registration handler, the one from
+	// the plugin is canceled.
+	logger := klog.FromContext(c.backgroundCtx)
+	logger = klog.LoggerWithName(logger, "driver-cleanup")
+	logger = klog.LoggerWithValues(logger, "pluginName", pluginName)
+
+	logger.V(3).Info("Starting ResourceSlices cleanup")
+
+	// Clean up the ResourceSlices for the Plugin since it
+	// may have died without doing so itself and might never come
+	// back.
+	//
+	// May get canceled if the plugin comes back quickly enough
+	// (see RegisterPlugin).
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	if cancel := c.pendingWipes[pluginName]; cancel != nil {
+		logger.V(3).Info("Previously started cleanup detected, do nothing")
+		return
+	}
+
+	ctx, cancel := context.WithCancelCause(c.backgroundCtx)
+	ctx = klog.NewContext(ctx, logger)
+	c.pendingWipes[pluginName] = &cancel
+
+	c.wg.Add(1)
+	go func() {
+		defer c.wg.Done()
+		defer c.cancelPendingWipe(pluginName, "cleanup done")
+		c.wipeResourceSlices(ctx, c.wipingDelay, pluginName)
+	}()
+}
+
+// isCleanupPending checks if a cleanup operation is pending for the
+// specified plugin.
+func (c *cleanupHandler) isCleanupPending(pluginName string) bool {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	if c.pendingWipes == nil {
+		return false
+	}
+	cancel, ok := c.pendingWipes[pluginName]
+	return ok && cancel != nil
+}

--- a/pkg/kubelet/cm/dra/plugin/plugin_test.go
+++ b/pkg/kubelet/cm/dra/plugin/plugin_test.go
@@ -22,6 +22,7 @@ import (
 	"net"
 	"os"
 	"path"
+	goruntime "runtime"
 	"strings"
 	"testing"
 
@@ -151,6 +152,9 @@ func TestGRPCConnIsReused(t *testing.T) {
 }
 
 func TestNewDRAPluginClient(t *testing.T) {
+	if goruntime.GOOS == "windows" {
+		t.Skip("DRA is not currently supported on Windows.")
+	}
 	// Create a plugin gRPC server.
 	service := drapbv1beta1.DRAPluginService
 	endpoint := path.Join(t.TempDir(), "dra-plugin-test.sock")

--- a/pkg/kubelet/cm/dra/plugin/plugins_store.go
+++ b/pkg/kubelet/cm/dra/plugin/plugins_store.go
@@ -34,8 +34,9 @@ type pluginsStore struct {
 // and their corresponding sockets.
 var draPlugins = &pluginsStore{}
 
-// Get lets you retrieve a DRA Plugin by name.
-// This method is protected by a mutex.
+// get returns the most recent connected plugin instance
+// for the given plugin name or nil if no connected plugin
+// instance is found.
 func (s *pluginsStore) get(pluginName string) *Plugin {
 	s.RLock()
 	defer s.RUnlock()
@@ -48,6 +49,8 @@ func (s *pluginsStore) get(pluginName string) *Plugin {
 	// the newest, except when plugin disconnects or kubelet got restarted
 	// and registered all running plugins in random order.
 	for i := len(instances) - 1; i >= 0; i-- {
+		instances[i].mutex.Lock()
+		defer instances[i].mutex.Unlock()
 		if instances[i].connected {
 			return instances[i]
 		}

--- a/pkg/kubelet/cm/dra/plugin/plugins_store.go
+++ b/pkg/kubelet/cm/dra/plugin/plugins_store.go
@@ -103,14 +103,15 @@ func (s *pluginsStore) remove(pluginName, endpoint string) (*Plugin, bool) {
 	return p, last
 }
 
-// pluginRegistered checks if the plugin with the specified name and
-// endpoint is registered in the pluginsStore.
-// Returns true if a plugin registered, otherwise returns false.
-func (s *pluginsStore) pluginRegistered(pluginName, endpoint string) bool {
+// pluginConnected checks if at least one plugin with the
+// specified name is connected.
+func (s *pluginsStore) pluginConnected(pluginName string) bool {
 	s.RLock()
 	defer s.RUnlock()
 
 	return slices.ContainsFunc(s.store[pluginName], func(p *Plugin) bool {
-		return p.name == pluginName && p.endpoint == endpoint
+		p.mutex.Lock()
+		defer p.mutex.Unlock()
+		return p.name == pluginName && p.connected
 	})
 }

--- a/pkg/kubelet/cm/dra/plugin/registration_test.go
+++ b/pkg/kubelet/cm/dra/plugin/registration_test.go
@@ -19,6 +19,7 @@ package plugin
 import (
 	"context"
 	"path"
+	goruntime "runtime"
 	"sort"
 	"strings"
 	"testing"
@@ -116,6 +117,9 @@ func requireNoSlices(t *testing.T, ctx context.Context, client kubernetes.Interf
 }
 
 func TestRegistrationHandler(t *testing.T) {
+	if goruntime.GOOS == "windows" {
+		t.Skip("DRA is not currently supported on Windows.")
+	}
 	endpointA := path.Join(t.TempDir(), "dra-plugin-a.sock")
 	endpointB := path.Join(t.TempDir(), "dra-plugin-b.sock")
 	slice := &resourceapi.ResourceSlice{

--- a/pkg/kubelet/cm/dra/plugin/testing.go
+++ b/pkg/kubelet/cm/dra/plugin/testing.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugin
+
+import (
+	"context"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// This file contains helper functions intended **solely for use in tests**.
+// These APIs are not meant to be used in production code and may change or be
+// removed at any time without notice.
+//
+// While placed in the main package for accessibility by external tests, these
+// functions are test-only utilities and should be treated as internal to the
+// testing environment.
+
+const (
+	// ConnectionTimeout is the default timeout for establishing
+	// a gRPC connection to a DRA plugin.
+	ConnectionTimeout = 20 * time.Second
+	// ConnectionPollInterval is the default interval for polling
+	// the connection status of a DRA plugin.
+	ConnectionPollInterval = 100 * time.Millisecond
+)
+
+// WaitForConnection repeatedly attempts to establish a connection to a DRA
+// plugin within the specified timeout. It polls at the given interval until
+// a connection is established or the timeout is reached. The function returns
+// an error if a connection cannot be established within the timeout period.
+func WaitForConnection(ctx context.Context, pluginName, endpoint string, interval, timeout time.Duration) error {
+	return wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(ctx context.Context) (bool, error) {
+		p, err := NewDRAPluginClient(pluginName)
+		return err == nil && p != nil && p.endpoint == endpoint && p.isConnected(), nil
+	})
+}

--- a/pkg/kubelet/pluginmanager/pluginwatcher/README.md
+++ b/pkg/kubelet/pluginmanager/pluginwatcher/README.md
@@ -22,6 +22,57 @@ should end with a DNS domain that is unique for the plugin. Each time a plugin
 starts, it has to delete old sockets if they exist and listen anew under the
 same filename.
 
+## Monitoring Plugin Connection
+
+**Warning**: Monitoring the plugin connection is only supported
+for DRA at the moment.
+
+The Kubelet monitors the gRPC connection to a plugin's **service socket** using
+a [gRPC stats handler](https://github.com/grpc/grpc-go/blob/master/examples/features/stats_monitoring/README.md).
+
+This enables the Kubelet to:
+- Detect when the plugin process has crashed, exited, or restarted
+- Trigger cleanup of the plugin’s resources on connection drop
+- Cancel pending cleanup if the connection is restored
+
+
+The **registration socket** is used by the plugin manager. It registers the
+plugin when registration socket is created by the plugin and the GetInfo gRPC
+call succeeds. It  deregisters the plugin when the socket is removed.
+The plugin should be ready to handle gRPC requests over the **service socket**
+that it returned in response to the GetInfo call because the kubelet might try
+to use the service immediately. Monitoring this service socket is therefore
+more accurate for detecting the real availability of the plugin.
+
+### How It Works
+
+Internally, the plugin client configures a gRPC stats handler to observe
+`ConnBegin` and `ConnEnd` events on the service socket connection. The
+connection is established over a Unix Domain Socket, which provides reliable
+semantics — if the connection drops, it definitively indicates that the plugin
+closed its end (e.g., due to crash or shutdown).
+
+1. During plugin registration, the Kubelet connects to plugin's
+   **service socket** and attaches the stats handler.
+2. A long-lived gRPC connection is established and actively monitored.
+3. If the plugin process exits and the connection drops, the stats
+   handler observes a `ConnEnd` event.
+4. This triggers cleanup of `ResourceSlice` objects associated with
+   the plugin.
+5. A gRPC reconnect is initiated immediately after connection loss.
+6. When the plugin resumes serving on the same service socket, the connection
+   is re-established and a `ConnBegin` event is observed.
+7. This cancels any in-progress resource cleanup and restores communication.
+
+### Key Properties
+
+- The plugin is **not** deregistered when the connection drops.
+- This model supports multi-container plugin deployments (e.g., CSI-style
+  sidecar setups) where the service container may restart independently of
+  the registrar container.
+- Cleanup is only finalized if the connection is not restored before the
+  timeout.
+
 ## Seamless Upgrade
 
 To avoid downtime of a plugin on a node, it would be nice to support running an


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind feature

#### What this PR does / why we need it:

It implements gRPC connection monitoring for DRA plugins to enable automatic deregistration and resource cleanup.

This is an alternative implementation of connection monitoring. [Previous implementation](https://github.com/kubernetes/kubernetes/pull/129799) raised certain concerns that should be addressed in this PR.

Unlike the previous implementation, this one:
- doesn't use GetInfo requests to monitor plugin connection. It uses native gRPC connection monitoring capabilities instead.
- has much smaller impact area as it monitors only DRA connections. Previous implementation impacted all 3 plugin types: CSI, Device and DRA. 
- monitors service connection. Previous implementation monitored registration connection.
- doesn't run any monitoring goroutines. Previous implementation run monitoring goroutine for every registered plugin.

#### Which issue(s) this PR fixes:

Fixes #128696
Ref #127457

#### Special notes for your reviewer:

This PR includes unit test fix from #131065. It will be removed when #131065 is merged.

#### Does this PR introduce a user-facing change?

```release-note
Kubelet unregisters DRA plugins and removes resource slices on connection drops.
```

/sig node
/cc @SergeyKanzhelev @ffromani @lauralorenz @pohly @swatisehgal 


