### PR TITLE
Add dom4ha to SIG-Scheduling approvers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -160,6 +160,7 @@ aliases:
   sig-scheduling-maintainers:
     - alculquicondor
     - ahg-g
+    - dom4ha
     - Huang-Wei
     - kerthcet
     - macsko


### PR DESCRIPTION
/kind documentation

#### What this PR does / why we need it:

This PR is to nominate @dom4ha for the SIG Scheduling approver role.
He has already taken a crucial role in the team; in fact, we can say recently almost all PR reviews (including KEPs) and issue discussions at SIG-Scheduling are driven by him, @macsko, and me. In the team leading side as well, we host the SIG scheduling meetings.
I believe he deserves it for sure, and adding him to the approvers would enhance our development process.

Main activities:
- 37 + 5 open kubernetes [code reviews](https://github.com/kubernetes/kubernetes/pulls?q=is%3Apr++label%3Asig%2Fscheduling+reviewed-by%3A%40me+)
- 8 + 1 open enhancements [reviews](https://github.com/kubernetes/enhancements/pulls?q=is%3Apr++label%3Asig%2Fscheduling+reviewed-by%3A%40me+)
- 12 [PRs](https://github.com/kubernetes/kubernetes/pulls?q=is%3Apr+author%3Adom4ha+)
- The substantial code reviews:
   - https://github.com/kubernetes/kubernetes/pull/130772
   - https://github.com/kubernetes/kubernetes/pull/130680
   - https://github.com/kubernetes/kubernetes/pull/130492
   - https://github.com/kubernetes/kubernetes/pull/130416
   - https://github.com/kubernetes/kubernetes/pull/130317
   - https://github.com/kubernetes/kubernetes/pull/130214
   - https://github.com/kubernetes/kubernetes/pull/129983
   -  https://github.com/kubernetes/kubernetes/pull/129635
   - https://github.com/kubernetes/kubernetes/pull/128999
   - https://github.com/kubernetes/kubernetes/pull/128987
- Wrote KEP-5147 https://github.com/kubernetes/enhancements/pull/5149 but had to close it
- Proposed backoff queue improvement, which got implemented in 1.33 https://github.com/kubernetes/kubernetes/issues/129806

/cc @kubernetes/sig-scheduling-leads 

```release-note
NONE
```
