### PR TITLE
feat(cloud-provider): reconcile all instance metadata

### DIFF
--- a/test/integration/cloudprovider/ccm_test.go
+++ b/test/integration/cloudprovider/ccm_test.go
@@ -120,9 +120,10 @@ func Test_RemoveExternalCloudProviderTaint(t *testing.T) {
 	ccm := ccmservertesting.StartTestServerOrDie(ctx, args)
 	defer ccm.TearDownFn()
 
+	var n *v1.Node
 	// There should be only the taint TaintNodeNotReady, added by the admission plugin TaintNodesByCondition
 	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 50*time.Second, true, func(ctx context.Context) (done bool, err error) {
-		n, err := client.CoreV1().Nodes().Get(ctx, "node0", metav1.GetOptions{})
+		n, err = client.CoreV1().Nodes().Get(ctx, "node0", metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}
@@ -139,7 +140,7 @@ func Test_RemoveExternalCloudProviderTaint(t *testing.T) {
 	})
 	if err != nil {
 		t.Logf("Fake Cloud Provider calls: %v", fakeCloud.Calls)
-		t.Fatalf("expected node to not have Taint: %v", err)
+		t.Fatalf("expected node to not have Taint: %v: %+v", err, n)
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
/kind bug

#### What this PR does / why we need it:

In #123223, the cloud-provider node controller gained the ability to apply additional labels to nodes. However, the node controller would only apply these labels during the "initial sync" of the node, when the `uninitialized` taint is still present.

This poses a problem when a cloud provider's CCM is updated to include a new label, because existing nodes will not receive the label.

This PR combines the behavior of the initial and periodic syncs using the existing `nodeModifier` pattern. This includes applying the `AdditionalLabels`. I'm considering it more feature than bug, because of the behavior change(s); but the current handling of `AdditionalLabels` is not correct IMO.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

There are two important changes here:
1. The `uninitialized` taint is no longer removed before the node's addresses are applied. I remember OpenShift having an opinion about this behavior, but I don't remember the details. If it's an issue, it's easy enough to separate out.
2. All node modifications use `PATCH`, instead of `UPDATE`. The patch is less likely to encounter a conflict, and conflicts are likely early in a nodes life (around the time the initial sync occurs).

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The cloud-provider node controller now reconciles additional instance metadata, such as labels, in addition to addresses.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
