### PR TITLE
Increase kubectl cp command timeout to 30 seconds

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/cp/cp.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cp/cp.go
@@ -280,7 +280,7 @@ func (o *CopyOptions) checkDestinationIsDir(dest fileSpec) error {
 		Executor: &exec.DefaultRemoteExecutor{},
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	done := make(chan error)


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
This PR increases the timeout value of kubectl cp command from 10 seconds to 30 seconds to give a more chance to the pods that suffering from insufficient resources.

#### Does this PR introduce a user-facing change?
```release-note
None
```