### PR TITLE
Fix flake, non-consistent list doesn't give any guarantees about staleness

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/store_tests.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/store_tests.go
@@ -1186,7 +1186,7 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, inc
 			prefix:       "/pods/empty",
 			pred:         storage.Everything,
 			rv:           "0",
-			expectRVFunc: resourceVersionNotOlderThan(list.ResourceVersion),
+			expectRVFunc: resourceVersionNotOlderThan(initialRV),
 			expectedOut:  []example.Pod{},
 		},
 		// match=Exact


### PR DESCRIPTION
/kind flake
```release-note
NONE
```

Found flake 
![image](https://github.com/user-attachments/assets/9535df66-44af-4b7c-8fee-8cf23eb1b194)

https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-unit/1906356791306883072

```
=== CONT  TestList/ConsistentListFromCache=false/ListFromCacheSnapsthot=false/test_non-consistent_List
    store_tests.go:1626: resourceVersion in list response invalid: expected a resourceVersion no smaller than than 9, but got 1
```