### PR TITLE
kubectl delete: update interactive delete to break on new line

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete.go
@@ -534,9 +534,9 @@ func (o *DeleteOptions) confirmation(infos []*resource.Info) bool {
 
 		fmt.Fprintf(o.Out, "%s/%s\n", kindString, info.Name)
 	}
-	fmt.Fprint(o.Out, i18n.T("Do you want to continue?")+" (y/n): ")
+	fmt.Fprint(o.Out, i18n.T("Do you want to continue?")+" (y/N): ")
 	var input string
-	_, err := fmt.Fscan(o.In, &input)
+	_, err := fmt.Fscanln(o.In, &input)
 	if err != nil {
 		return false
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Currently, entering an empty newline during interactive delete sends a new line until a character is entered.

This PR treats an empty newline in kubectl interactive delete as N. This is common behavior when being prompted for a dangerous operation. Convetion goes that a captial `N` here is the default.

#### Which issue(s) this PR fixes:

ref: https://github.com/kubernetes/kubernetes/pull/114530/files#r1259635470

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
kubectl interactive delete: treat empty newline input as N
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/hold
