### PR TITLE
Ensure that cacher is terminated in TestGetListRecursivePrefix

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_test.go
@@ -224,7 +224,8 @@ func TestGetListNonRecursive(t *testing.T) {
 }
 
 func TestGetListRecursivePrefix(t *testing.T) {
-	ctx, store, _ := testSetup(t)
+	ctx, store, terminate := testSetup(t)
+	t.Cleanup(terminate)
 	storagetesting.RunTestGetListRecursivePrefix(ctx, t, store)
 }
 


### PR DESCRIPTION
Closing the cacher removes a long running watch connection allowing for earlier termination. 
Reduces the runtime in from 9s to 2s https://github.com/kubernetes/kubernetes/pull/131103

/kind flake
```release-note
NONE
```

