### PR TITLE
Clarifies the expected usage of the timestamp and containers_statuses fields in PodSandboxStatusResponse

### DIFF
--- a/staging/src/k8s.io/cri-api/pkg/apis/runtime/v1/api.proto
+++ b/staging/src/k8s.io/cri-api/pkg/apis/runtime/v1/api.proto
@@ -618,14 +618,22 @@ message PodSandboxStatus {
 message PodSandboxStatusResponse {
     // Status of the PodSandbox.
     PodSandboxStatus status = 1;
-    // Info is extra information of the PodSandbox. The key could be arbitrary string, and
+
+    // Info is extra information of the PodSandbox. The key could be an arbitrary string, and
     // value should be in json format. The information could include anything useful for
-    // debug, e.g. network namespace for linux container based container runtime.
+    // debugging, e.g., network namespace for Linux container-based container runtimes.
     // It should only be returned non-empty when Verbose is true.
     map<string, string> info = 2;
-    // Container statuses
+
+    // Container statuses.
+    // This field MUST be populated if the `timestamp` field is set.
+    // When returning Evented PLEG-compatible responses, runtimes must include the status
+    // of all containers in the pod here.
     repeated ContainerStatus containers_statuses = 3;
-    // Timestamp in nanoseconds at which container and pod statuses were recorded
+
+    // Timestamp in nanoseconds at which container and pod statuses were recorded.
+    // When this field is set, it signals to the kubelet that the runtime supports
+    // Evented PLEG. If set, the `containers_statuses` field must also be populated.
     int64 timestamp = 4;
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Clarifies the expected usage of the `timestamp` and `containers_statuses` fields in `PodSandboxStatusResponse`, specifically noting that both must be set when the runtime supports evented PLEG. This avoids misinterpretation by container runtime developers and helps maintain correct behavior in the kubelet.

#### Which issue(s) this PR fixes:

Fixes #129857

#### Special notes for your reviewer:

User reported / found the issue in this issue: relate: https://github.com/kubernetes/kubernetes/issues/129818

#### Does this PR introduce a user-facing change?

`none`