### PR TITLE
Parallelize cacher list tests

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_test.go
@@ -176,50 +176,34 @@ func TestListPaging(t *testing.T) {
 	storagetesting.RunTestListPaging(ctx, t, cacher)
 }
 
-func TestList(t *testing.T) {
+func TestLists(t *testing.T) {
 	for _, consistentRead := range []bool{true, false} {
-		t.Run(fmt.Sprintf("ConsistentListFromCache=%v", consistentRead), func(t *testing.T) {
-			for _, listFromCacheSnapshot := range []bool{true, false} {
-				t.Run(fmt.Sprintf("ListFromCacheSnapsthot=%v", listFromCacheSnapshot), func(t *testing.T) {
-					featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ListFromCacheSnapshot, listFromCacheSnapshot)
-					featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ConsistentListFromCache, consistentRead)
+		for _, listFromCacheSnapshot := range []bool{true, false} {
+			t.Run(fmt.Sprintf("ConsistentListFromCache=%v,ListFromCacheSnapshot=%v", consistentRead, listFromCacheSnapshot), func(t *testing.T) {
+				featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ListFromCacheSnapshot, listFromCacheSnapshot)
+				featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ConsistentListFromCache, consistentRead)
+				t.Run("List", func(t *testing.T) {
+					t.Parallel()
 					ctx, cacher, server, terminate := testSetupWithEtcdServer(t)
 					t.Cleanup(terminate)
 					storagetesting.RunTestList(ctx, t, cacher, increaseRV(server.V3Client.Client), true)
 				})
-			}
-		})
-	}
-}
-func TestConsistentList(t *testing.T) {
-	for _, consistentRead := range []bool{true, false} {
-		t.Run(fmt.Sprintf("ConsistentListFromCache=%v", consistentRead), func(t *testing.T) {
-			for _, listFromCacheSnapshot := range []bool{true, false} {
-				t.Run(fmt.Sprintf("ListFromCacheSnapsthot=%v", listFromCacheSnapshot), func(t *testing.T) {
-					featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ListFromCacheSnapshot, listFromCacheSnapshot)
-					featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ConsistentListFromCache, consistentRead)
+
+				t.Run("ConsistentList", func(t *testing.T) {
+					t.Parallel()
 					ctx, cacher, server, terminate := testSetupWithEtcdServer(t)
 					t.Cleanup(terminate)
 					storagetesting.RunTestConsistentList(ctx, t, cacher, increaseRV(server.V3Client.Client), true, consistentRead, listFromCacheSnapshot)
 				})
-			}
-		})
-	}
-}
 
-func TestGetListNonRecursive(t *testing.T) {
-	for _, consistentRead := range []bool{true, false} {
-		t.Run(fmt.Sprintf("ConsistentListFromCache=%v", consistentRead), func(t *testing.T) {
-			for _, listFromCacheSnapshot := range []bool{true, false} {
-				t.Run(fmt.Sprintf("ListFromCacheSnapsthot=%v", listFromCacheSnapshot), func(t *testing.T) {
-					featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ListFromCacheSnapshot, listFromCacheSnapshot)
-					featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ConsistentListFromCache, consistentRead)
+				t.Run("GetListNonRecursive", func(t *testing.T) {
+					t.Parallel()
 					ctx, cacher, server, terminate := testSetupWithEtcdServer(t)
 					t.Cleanup(terminate)
 					storagetesting.RunTestGetListNonRecursive(ctx, t, increaseRV(server.V3Client.Client), cacher)
 				})
-			}
-		})
+			})
+		}
 	}
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/testserver/test_server.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/testserver/test_server.go
@@ -22,6 +22,7 @@ import (
 	"net/url"
 	"os"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -79,6 +80,8 @@ func NewTestConfig(t testing.TB) *embed.Config {
 	return cfg
 }
 
+var autoPortLock sync.Mutex
+
 // RunEtcd starts an embedded etcd server with the provided config
 // (or NewTestConfig(t) if nil), and returns a client connected to the server.
 // The server is terminated when the test ends.
@@ -86,6 +89,9 @@ func RunEtcd(t testing.TB, cfg *embed.Config) *kubernetes.Client {
 	t.Helper()
 
 	if cfg == nil {
+		// if we have to autopick free ports, lock until we successfully start the server on the ports we chose
+		autoPortLock.Lock()
+		defer autoPortLock.Unlock()
 		cfg = NewTestConfig(t)
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test
/kind flake

#### What this PR does / why we need it:

Shares 2x2 feature gate configurations between three parallel cacher list test scenarios to reduce `cacher` package runtime.

xref https://github.com/kubernetes/kubernetes/pull/128419#issuecomment-2759141859 https://github.com/kubernetes/kubernetes/pull/131103#issuecomment-2765271022

`go test -race k8s.io/apiserver/pkg/storage/cacher -count 1 -run '^(TestLists|TestList|TestConsistentList|TestGetListNonRecursive)$'`

on this branch:
```
ok  	k8s.io/apiserver/pkg/storage/cacher	21.883s
```
on master:
```
ok  	k8s.io/apiserver/pkg/storage/cacher	46.200s
```

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/cc @serathius @ahrtr 