### PR TITLE
feat(kubectl): implement support for image pull secrets for debug

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"time"
 
@@ -76,7 +77,7 @@ var (
 		* Node: Create a new pod that runs in the node's host namespaces and can access
 		        the node's filesystem.
 
-		Note: When a non-root user is configured for the entire target Pod, some capabilities granted 
+		Note: When a non-root user is configured for the entire target Pod, some capabilities granted
 		by debug profile may not work.
 `))
 
@@ -115,35 +116,37 @@ type DebugAttachFunc func(ctx context.Context, restClientGetter genericclioption
 
 // DebugOptions holds the options for an invocation of kubectl debug.
 type DebugOptions struct {
-	Args               []string
-	ArgsOnly           bool
-	Attach             bool
-	AttachFunc         DebugAttachFunc
-	Container          string
-	CopyTo             string
-	Replace            bool
-	Env                []corev1.EnvVar
-	Image              string
-	Interactive        bool
-	KeepLabels         bool
-	KeepAnnotations    bool
-	KeepLiveness       bool
-	KeepReadiness      bool
-	KeepStartup        bool
-	KeepInitContainers bool
-	Namespace          string
-	TargetNames        []string
-	PullPolicy         corev1.PullPolicy
-	Quiet              bool
-	SameNode           bool
-	SetImages          map[string]string
-	ShareProcesses     bool
-	TargetContainer    string
-	TTY                bool
-	Profile            string
-	CustomProfileFile  string
-	CustomProfile      *corev1.Container
-	Applier            ProfileApplier
+	Args                       []string
+	ArgsOnly                   bool
+	Attach                     bool
+	AttachFunc                 DebugAttachFunc
+	Container                  string
+	CopyTo                     string
+	Replace                    bool
+	Env                        []corev1.EnvVar
+	Image                      string
+	Interactive                bool
+	KeepLabels                 bool
+	KeepAnnotations            bool
+	KeepLiveness               bool
+	KeepReadiness              bool
+	KeepStartup                bool
+	KeepInitContainers         bool
+	Namespace                  string
+	TargetNames                []string
+	PullPolicy                 corev1.PullPolicy
+	DebugImagePullSecretConfig string
+	DebugImagePullSecret       *corev1.Secret
+	Quiet                      bool
+	SameNode                   bool
+	SetImages                  map[string]string
+	ShareProcesses             bool
+	TargetContainer            string
+	TTY                        bool
+	Profile                    string
+	CustomProfileFile          string
+	CustomProfile              *corev1.Container
+	Applier                    ProfileApplier
 
 	explicitNamespace     bool
 	attachChanged         bool
@@ -208,6 +211,7 @@ func (o *DebugOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&o.KeepInitContainers, "keep-init-containers", o.KeepInitContainers, i18n.T("Run the init containers for the pod. Defaults to true.(This flag only works when used with '--copy-to')"))
 	cmd.Flags().StringToStringVar(&o.SetImages, "set-image", o.SetImages, i18n.T("When used with '--copy-to', a list of name=image pairs for changing container images, similar to how 'kubectl set image' works."))
 	cmd.Flags().String("image-pull-policy", "", i18n.T("The image pull policy for the container. If left empty, this value will not be specified by the client and defaulted by the server."))
+	cmd.Flags().StringVar(&o.DebugImagePullSecretConfig, "image-pull-secret-config", o.DebugImagePullSecretConfig, i18n.T("A docker configuration file path to use for pulling image of the debug container."))
 	cmd.Flags().BoolVarP(&o.Interactive, "stdin", "i", o.Interactive, i18n.T("Keep stdin open on the container(s) in the pod, even if nothing is attached."))
 	cmd.Flags().BoolVarP(&o.Quiet, "quiet", "q", o.Quiet, i18n.T("If true, suppress informational messages."))
 	cmd.Flags().BoolVar(&o.SameNode, "same-node", o.SameNode, i18n.T("When used with '--copy-to', schedule the copy of target Pod on the same node."))
@@ -464,6 +468,19 @@ func (o *DebugOptions) visitNode(ctx context.Context, node *corev1.Node) (*corev
 	if err != nil {
 		return nil, "", err
 	}
+
+	if len(o.DebugImagePullSecretConfig) > 0 {
+		secret, err := o.generateDebugImagePullsecret(debugPod)
+		if err != nil {
+			return nil, "", err
+		}
+
+		o.DebugImagePullSecret, err = o.podClient.Secrets(debugPod.Namespace).Create(ctx, secret, metav1.CreateOptions{})
+		if err != nil {
+			return nil, "", err
+		}
+	}
+
 	newPod, err := pods.Create(ctx, debugPod, metav1.CreateOptions{})
 	if err != nil {
 		return nil, "", err
@@ -617,6 +634,18 @@ func (o *DebugOptions) debugByCopy(ctx context.Context, pod *corev1.Pod) (*corev
 		return nil, "", err
 	}
 
+	if len(o.DebugImagePullSecretConfig) > 0 {
+		secret, err := o.generateDebugImagePullsecret(pod)
+		if err != nil {
+			return nil, "", err
+		}
+
+		o.DebugImagePullSecret, err = o.podClient.Secrets(copied.Namespace).Create(ctx, secret, metav1.CreateOptions{})
+		if err != nil {
+			return nil, "", err
+		}
+	}
+
 	var debugContainer *corev1.Container
 	for i := range copied.Spec.Containers {
 		if copied.Spec.Containers[i].Name == dc {
@@ -750,6 +779,14 @@ func (o *DebugOptions) generateNodeDebugPod(node *corev1.Node) (*corev1.Pod, err
 		},
 	}
 
+	if len(o.DebugImagePullSecretConfig) > 0 {
+		p.Spec.ImagePullSecrets = []corev1.LocalObjectReference{
+			{
+				Name: o.pullSecretName(p),
+			},
+		}
+	}
+
 	if o.ArgsOnly {
 		p.Spec.Containers[0].Args = o.Args
 	} else {
@@ -825,6 +862,13 @@ func (o *DebugOptions) generatePodCopyWithDebugContainer(pod *corev1.Pod) (*core
 		c = &copied.Spec.Containers[len(copied.Spec.Containers)-1]
 	}
 
+	if len(o.DebugImagePullSecretConfig) > 0 {
+		copied.Spec.ImagePullSecrets = append(copied.Spec.ImagePullSecrets,
+			corev1.LocalObjectReference{
+				Name: o.pullSecretName(copied),
+			})
+	}
+
 	if len(o.Args) > 0 {
 		if o.ArgsOnly {
 			c.Args = o.Args
@@ -842,6 +886,7 @@ func (o *DebugOptions) generatePodCopyWithDebugContainer(pod *corev1.Pod) (*core
 	if len(o.PullPolicy) > 0 {
 		c.ImagePullPolicy = o.PullPolicy
 	}
+
 	c.Stdin = o.Interactive
 	c.TTY = o.TTY
 
@@ -971,6 +1016,24 @@ func (o *DebugOptions) handleAttachPod(ctx context.Context, restClientGetter gen
 		return err
 	}
 
+	if o.DebugImagePullSecret != nil {
+		o.DebugImagePullSecret.ObjectMeta.OwnerReferences = []metav1.OwnerReference{{
+			APIVersion: "v1",
+			Kind:       "pod",
+			Name:       podName,
+			UID:        pod.UID,
+		}}
+
+		o.DebugImagePullSecret, err = o.podClient.Secrets(pod.Namespace).Update(ctx, o.DebugImagePullSecret, metav1.UpdateOptions{})
+		if err != nil {
+			deleteErr := o.podClient.Secrets(pod.Namespace).Delete(ctx, o.DebugImagePullSecret.ObjectMeta.Name, metav1.DeleteOptions{})
+			if deleteErr != nil {
+				err = fmt.Errorf("%w\n%w", err, deleteErr)
+			}
+			return err
+		}
+	}
+
 	opts.Namespace = ns
 	opts.Pod = pod
 	opts.PodName = podName
@@ -994,6 +1057,37 @@ func (o *DebugOptions) handleAttachPod(ctx context.Context, restClientGetter gen
 		return logOpts(ctx, restClientGetter, pod, opts)
 	}
 	return nil
+}
+
+func (o *DebugOptions) generateDebugImagePullsecret(pod *corev1.Pod) (*corev1.Secret, error) {
+	var config []byte
+	var err error
+
+	if o.DebugImagePullSecretConfig == "-" {
+		config, err = io.ReadAll(os.Stdin)
+	} else {
+		config, err = os.ReadFile(o.DebugImagePullSecretConfig)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	secret := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      o.pullSecretName(pod),
+			Namespace: pod.Namespace,
+		},
+		Type: corev1.SecretTypeDockercfg,
+		Data: map[string][]byte{
+			corev1.DockerConfigKey: config,
+		},
+	}
+	return &secret, nil
+}
+
+func (o *DebugOptions) pullSecretName(pod *corev1.Pod) string {
+	return fmt.Sprintf("debug-secret-%s", pod.Name)
 }
 
 func getContainerStatusByName(pod *corev1.Pod, containerName string) *corev1.ContainerStatus {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug_test.go
@@ -1410,6 +1410,49 @@ func TestGeneratePodCopyWithDebugContainer(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "with custom image pull secret",
+			opts: &DebugOptions{
+				CopyTo:                     "debugger",
+				Container:                  "debugger",
+				Image:                      "busybox",
+				PullPolicy:                 corev1.PullIfNotPresent,
+				DebugImagePullSecretConfig: "testdata/test-docker-config.json",
+				Profile:                    ProfileLegacy,
+			},
+			havePod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "target",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "debugger",
+						},
+					},
+					NodeName: "node-1",
+				},
+			},
+			wantPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "debugger",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:            "debugger",
+							Image:           "busybox",
+							ImagePullPolicy: corev1.PullIfNotPresent,
+						},
+					},
+					ImagePullSecrets: []corev1.LocalObjectReference{
+						{
+							Name: "debug-secret-debugger",
+						},
+					},
+				},
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			var err error
@@ -1793,6 +1836,64 @@ func TestGenerateNodeDebugPod(t *testing.T) {
 					NodeName:      "node-XXX",
 					RestartPolicy: corev1.RestartPolicyNever,
 					Volumes:       nil,
+					Tolerations: []corev1.Toleration{
+						{
+							Operator: corev1.TolerationOpExists,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "with image pull secret",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node-XXX",
+				},
+			},
+			opts: &DebugOptions{
+				Image:                      "busybox",
+				PullPolicy:                 corev1.PullIfNotPresent,
+				DebugImagePullSecretConfig: "testdata/test-docker-config.json",
+				Profile:                    ProfileLegacy,
+			},
+			expected: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node-debugger-node-XXX-1",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:                     "debugger",
+							Image:                    "busybox",
+							ImagePullPolicy:          corev1.PullIfNotPresent,
+							TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									MountPath: "/host",
+									Name:      "host-root",
+								},
+							},
+						},
+					},
+					ImagePullSecrets: []corev1.LocalObjectReference{
+						{
+							Name: "debug-secret-node-debugger-node-XXX-1",
+						},
+					},
+					HostIPC:       true,
+					HostNetwork:   true,
+					HostPID:       true,
+					NodeName:      "node-XXX",
+					RestartPolicy: corev1.RestartPolicyNever,
+					Volumes: []corev1.Volume{
+						{
+							Name: "host-root",
+							VolumeSource: corev1.VolumeSource{
+								HostPath: &corev1.HostPathVolumeSource{Path: "/"},
+							},
+						},
+					},
 					Tolerations: []corev1.Toleration{
 						{
 							Operator: corev1.TolerationOpExists,

--- a/staging/src/k8s.io/kubectl/pkg/cmd/debug/testdata/test-docker-config.json
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/debug/testdata/test-docker-config.json
@@ -1,0 +1,19 @@
+{
+    "auths": {},
+    "credsStore": "desktop",
+    "currentContext": "desktop-linux",
+    "plugins": {
+        "-x-cli-hints": {
+            "enabled": "true"
+        },
+        "debug": {
+            "hooks": "exec"
+        },
+        "scout": {
+            "hooks": "pull,buildx build"
+        }
+    },
+    "features": {
+        "hooks": "true"
+    }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

The current implementation of the debug command does not support using images from private repositories. This patch adds the `--image-pull-secret-config` option that allows to provide a Docker configuration that will be used to create a temporary secret which will be added to the pod created for the debugging session.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes kubernetes/kubectl#1671
Supersede #128061 

#### Special notes for your reviewer:

The rewrite has been done following the sig-cli meeting from March 5.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
A new parameter has been added to the kubectl debug command: --image-pull-secret-config.
This parameter will create a secret out of the Docker configuration passed and add it to the list of image pull secrets of the pod where the ephemeral container is created.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
