### PR TITLE
[Optimise](pvc): Use StorageClassName field first

### DIFF
--- a/pkg/apis/core/helper/helpers.go
+++ b/pkg/apis/core/helper/helpers.go
@@ -435,24 +435,28 @@ func GetTaintsFromNodeAnnotations(annotations map[string]string) ([]core.Taint, 
 
 // GetPersistentVolumeClass returns StorageClassName.
 func GetPersistentVolumeClass(volume *core.PersistentVolume) string {
-	// Use beta annotation first
+	// Use StorageClassName field first
+	if len(volume.Spec.StorageClassName) > 0 {
+		return volume.Spec.StorageClassName
+	}
+
 	if class, found := volume.Annotations[core.BetaStorageClassAnnotation]; found {
 		return class
 	}
 
-	return volume.Spec.StorageClassName
+	return ""
 }
 
 // GetPersistentVolumeClaimClass returns StorageClassName. If no storage class was
 // requested, it returns "".
 func GetPersistentVolumeClaimClass(claim *core.PersistentVolumeClaim) string {
-	// Use beta annotation first
-	if class, found := claim.Annotations[core.BetaStorageClassAnnotation]; found {
-		return class
-	}
-
+	// Use StorageClassName field first
 	if claim.Spec.StorageClassName != nil {
 		return *claim.Spec.StorageClassName
+	}
+
+	if class, found := claim.Annotations[core.BetaStorageClassAnnotation]; found {
+		return class
 	}
 
 	return ""

--- a/pkg/apis/core/helper/helpers.go
+++ b/pkg/apis/core/helper/helpers.go
@@ -372,25 +372,11 @@ func ContainsAccessMode(modes []core.PersistentVolumeAccessMode, mode core.Persi
 }
 
 func ClaimContainsAllocatedResources(pvc *core.PersistentVolumeClaim) bool {
-	if pvc == nil {
-		return false
-	}
-
-	if pvc.Status.AllocatedResources != nil {
-		return true
-	}
-	return false
+	return pvc != nil && pvc.Status.AllocatedResources != nil
 }
 
 func ClaimContainsAllocatedResourceStatus(pvc *core.PersistentVolumeClaim) bool {
-	if pvc == nil {
-		return false
-	}
-
-	if pvc.Status.AllocatedResourceStatuses != nil {
-		return true
-	}
-	return false
+	return pvc != nil && pvc.Status.AllocatedResourceStatuses != nil
 }
 
 // GetTolerationsFromPodAnnotations gets the json serialized tolerations data from Pod.Annotations
@@ -474,12 +460,12 @@ func GetPersistentVolumeClaimClass(claim *core.PersistentVolumeClaim) string {
 
 // PersistentVolumeClaimHasClass returns true if given claim has set StorageClassName field.
 func PersistentVolumeClaimHasClass(claim *core.PersistentVolumeClaim) bool {
-	// Use beta annotation first
-	if _, found := claim.Annotations[core.BetaStorageClassAnnotation]; found {
+	// Use StorageClassName field first
+	if claim.Spec.StorageClassName != nil {
 		return true
 	}
 
-	if claim.Spec.StorageClassName != nil {
+	if _, found := claim.Annotations[core.BetaStorageClassAnnotation]; found {
 		return true
 	}
 

--- a/staging/src/k8s.io/component-helpers/storage/volume/helpers.go
+++ b/staging/src/k8s.io/component-helpers/storage/volume/helpers.go
@@ -26,12 +26,12 @@ import (
 
 // PersistentVolumeClaimHasClass returns true if given claim has set StorageClassName field.
 func PersistentVolumeClaimHasClass(claim *v1.PersistentVolumeClaim) bool {
-	// Use beta annotation first
-	if _, found := claim.Annotations[v1.BetaStorageClassAnnotation]; found {
+	// Use StorageClassName field first
+	if claim.Spec.StorageClassName != nil {
 		return true
 	}
 
-	if claim.Spec.StorageClassName != nil {
+	if _, found := claim.Annotations[v1.BetaStorageClassAnnotation]; found {
 		return true
 	}
 
@@ -41,13 +41,13 @@ func PersistentVolumeClaimHasClass(claim *v1.PersistentVolumeClaim) bool {
 // GetPersistentVolumeClaimClass returns StorageClassName. If no storage class was
 // requested, it returns "".
 func GetPersistentVolumeClaimClass(claim *v1.PersistentVolumeClaim) string {
-	// Use beta annotation first
-	if class, found := claim.Annotations[v1.BetaStorageClassAnnotation]; found {
-		return class
-	}
-
+	//Use StorageClassName field first
 	if claim.Spec.StorageClassName != nil {
 		return *claim.Spec.StorageClassName
+	}
+
+	if class, found := claim.Annotations[v1.BetaStorageClassAnnotation]; found {
+		return class
 	}
 
 	return ""
@@ -55,12 +55,16 @@ func GetPersistentVolumeClaimClass(claim *v1.PersistentVolumeClaim) string {
 
 // GetPersistentVolumeClass returns StorageClassName.
 func GetPersistentVolumeClass(volume *v1.PersistentVolume) string {
-	// Use beta annotation first
+	// Use StorageClassName field first
+	if len(volume.Spec.StorageClassName) > 0 {
+		return volume.Spec.StorageClassName
+	}
+
 	if class, found := volume.Annotations[v1.BetaStorageClassAnnotation]; found {
 		return class
 	}
 
-	return volume.Spec.StorageClassName
+	return ""
 }
 
 // CheckNodeAffinity looks at the PV node affinity, and checks if the node has the same corresponding labels

--- a/staging/src/k8s.io/kubectl/pkg/util/storage/storage.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/storage/storage.go
@@ -86,24 +86,28 @@ func ContainsAccessMode(modes []v1.PersistentVolumeAccessMode, mode v1.Persisten
 
 // GetPersistentVolumeClass returns StorageClassName.
 func GetPersistentVolumeClass(volume *v1.PersistentVolume) string {
-	// Use beta annotation first
+	// Use StorageClassName field first
+	if len(volume.Spec.StorageClassName) > 0 {
+		return volume.Spec.StorageClassName
+	}
+
 	if class, found := volume.Annotations[v1.BetaStorageClassAnnotation]; found {
 		return class
 	}
 
-	return volume.Spec.StorageClassName
+	return ""
 }
 
 // GetPersistentVolumeClaimClass returns StorageClassName. If no storage class was
 // requested, it returns "".
 func GetPersistentVolumeClaimClass(claim *v1.PersistentVolumeClaim) string {
-	// Use beta annotation first
-	if class, found := claim.Annotations[v1.BetaStorageClassAnnotation]; found {
-		return class
-	}
-
+	// Use StorageClassName field first
 	if claim.Spec.StorageClassName != nil {
 		return *claim.Spec.StorageClassName
+	}
+
+	if class, found := claim.Annotations[v1.BetaStorageClassAnnotation]; found {
+		return class
 	}
 
 	return ""


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind deprecation
-->

#### What this PR does / why we need it:
https://kubernetes.io/docs/concepts/storage/persistent-volumes/#class
I encountered a situation where both `volume.beta.kubernetes.io/storage-class` and `storageClassName` were present in the configuration. According to the documentation, I recommend prioritizing the use of the storageClassName field as it's the preferred method in current Kubernetes versions. The beta annotation is considered deprecated, and using the standard field provides better compatibility with modern Kubernetes practices.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
