### PR TITLE
Clean up leaked goroutines in cache unit tests

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/fifo_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/fifo_test.go
@@ -117,6 +117,7 @@ func TestFIFO_basic(t *testing.T) {
 
 func TestFIFO_addUpdate(t *testing.T) {
 	f := NewFIFO(testFifoObjectKeyFunc)
+	defer f.Close()
 	f.Add(mkFifoObj("foo", 10))
 	f.Update(mkFifoObj("foo", 15))
 
@@ -130,7 +131,11 @@ func TestFIFO_addUpdate(t *testing.T) {
 	got := make(chan testFifoObject, 2)
 	go func() {
 		for {
-			got <- Pop(f).(testFifoObject)
+			obj := Pop(f)
+			if obj == nil {
+				return
+			}
+			got <- obj.(testFifoObject)
 		}
 	}()
 
@@ -151,12 +156,17 @@ func TestFIFO_addUpdate(t *testing.T) {
 
 func TestFIFO_addReplace(t *testing.T) {
 	f := NewFIFO(testFifoObjectKeyFunc)
+	defer f.Close()
 	f.Add(mkFifoObj("foo", 10))
 	f.Replace([]interface{}{mkFifoObj("foo", 15)}, "15")
 	got := make(chan testFifoObject, 2)
 	go func() {
 		for {
-			got <- Pop(f).(testFifoObject)
+			obj := Pop(f)
+			if obj == nil {
+				return
+			}
+			got <- obj.(testFifoObject)
 		}
 	}()
 

--- a/staging/src/k8s.io/client-go/tools/cache/main_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/main_test.go
@@ -23,13 +23,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	options := []goleak.Option{
-		// These tests run goroutines which get stuck in Pop.
-		// This cannot be fixed without modifying the API.
-		goleak.IgnoreAnyFunction("k8s.io/client-go/tools/cache.TestFIFO_addReplace.func1"),
-		goleak.IgnoreAnyFunction("k8s.io/client-go/tools/cache.TestFIFO_addUpdate.func1"),
-		goleak.IgnoreAnyFunction("k8s.io/client-go/tools/cache.TestDeltaFIFO_addReplace.func1"),
-		goleak.IgnoreAnyFunction("k8s.io/client-go/tools/cache.TestDeltaFIFO_addUpdate.func1"),
-	}
-	goleak.VerifyTestMain(m, options...)
+	goleak.VerifyTestMain(m)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Cleans up unnecessary exceptions to goroutine leak detection in client-go cache unit tests

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
