### PR TITLE
Bump CSI Proxy to v1.2.1-gke.2

### DIFF
--- a/cluster/gce/config-common.sh
+++ b/cluster/gce/config-common.sh
@@ -158,7 +158,7 @@ export WINDOWS_INFRA_CONTAINER="registry.k8s.io/pause:3.10"
 # Storage Path for csi-proxy. csi-proxy only needs to be installed for Windows.
 export CSI_PROXY_STORAGE_PATH="https://storage.googleapis.com/gke-release/csi-proxy"
 # Version for csi-proxy
-export CSI_PROXY_VERSION="${CSI_PROXY_VERSION:-v1.1.1-gke.0}"
+export CSI_PROXY_VERSION="${CSI_PROXY_VERSION:-v1.2.1-gke.2}"
 # csi-proxy additional flags, there are additional flags that cannot be unset in k8s-node-setup.psm1
 export CSI_PROXY_FLAGS="${CSI_PROXY_FLAGS:-}"
 # Storage path for auth-provider-gcp binaries


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Bump CSI Proxy to v1.2.1-gke.2, it includes a potential fix for a flaky Volume resize test https://github.com/kubernetes-csi/csi-proxy/pull/364.

The binary is available at:

```
gcloud storage ls --recursive "gs://gke-release/csi-proxy/v1.2.1-gke.2"
gs://gke-release/csi-proxy/v1.2.1-gke.2/:
gs://gke-release/csi-proxy/v1.2.1-gke.2/csi-proxy.exe
gs://gke-release/csi-proxy/v1.2.1-gke.2/notices.tar.gz
```

The changelog is https://github.com/kubernetes-csi/csi-proxy/blob/master/CHANGELOG/CHANGELOG-1.2.1.md.

This is a test only change, testing happens outside k/k through CI jobs for the GCE PD CSI Driver. We'll see results after the PR is merged in https://testgrid.k8s.io/provider-gcp-compute-persistent-disk-csi-driver#ci-windows-2019-provider-gcp-compute-persistent-disk-csi-driver

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/cc @sunnylovestiramisu @tonyzhc 