### PR TITLE
scheduler-perf: add option to enable api-server initialization

### DIFF
--- a/test/integration/scheduler_perf/option.go
+++ b/test/integration/scheduler_perf/option.go
@@ -1,0 +1,20 @@
+package benchmark
+
+import "k8s.io/kubernetes/test/utils/ktesting"
+
+type SchedulerPerfOption func(options *schedulerPerfOptions)
+
+// PrepareFn is a function that is called before the benchmarks run.
+type PrepareFn func(tCtx ktesting.TContext) error
+
+type schedulerPerfOptions struct {
+	prepareFn PrepareFn
+}
+
+// WithPrepareFn is the option to set a function that is called
+// before the benchmarks run. (e.g. applying CRDs for custom plugins)
+func WithPrepareFn(prepareFn PrepareFn) SchedulerPerfOption {
+	return func(s *schedulerPerfOptions) {
+		s.prepareFn = prepareFn
+	}
+}

--- a/test/integration/scheduler_perf/options.go
+++ b/test/integration/scheduler_perf/options.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package benchmark
 
 import "k8s.io/kubernetes/test/utils/ktesting"

--- a/test/integration/scheduler_perf/options.go
+++ b/test/integration/scheduler_perf/options.go
@@ -20,7 +20,7 @@ import "k8s.io/kubernetes/test/utils/ktesting"
 
 type SchedulerPerfOption func(options *schedulerPerfOptions)
 
-// PrepareFn is a function that is called before the benchmarks run.
+// PrepareFn is a function that is called before each workload is run.
 type PrepareFn func(tCtx ktesting.TContext) error
 
 type schedulerPerfOptions struct {
@@ -28,7 +28,7 @@ type schedulerPerfOptions struct {
 }
 
 // WithPrepareFn is the option to set a function that is called
-// before the benchmarks run. (e.g. applying CRDs for custom plugins)
+// before each workload is run. (e.g. applying CRDs for custom plugins)
 func WithPrepareFn(prepareFn PrepareFn) SchedulerPerfOption {
 	return func(s *schedulerPerfOptions) {
 		s.prepareFn = prepareFn

--- a/test/integration/scheduler_perf/scheduler_perf.go
+++ b/test/integration/scheduler_perf/scheduler_perf.go
@@ -1156,10 +1156,6 @@ func RunBenchmarkPerfScheduling(b *testing.B, configFile string, topicName strin
 		option(opts)
 	}
 
-	runBenchmarkPerSchedulingImpl(b, configFile, topicName, outOfTreePluginRegistry, opts)
-}
-
-func runBenchmarkPerSchedulingImpl(b *testing.B, configFile string, topicName string, outOfTreePluginRegistry frameworkruntime.Registry, options *schedulerPerfOptions) {
 	testCases, err := getTestCases(configFile)
 	if err != nil {
 		b.Fatal(err)
@@ -1206,8 +1202,8 @@ func runBenchmarkPerSchedulingImpl(b *testing.B, configFile string, topicName st
 						b.Fatalf("workload %s is not valid: %v", w.Name, err)
 					}
 
-					if options.prepareFn != nil {
-						err = options.prepareFn(tCtx)
+					if opts.prepareFn != nil {
+						err = opts.prepareFn(tCtx)
 						if err != nil {
 							b.Fatalf("failed to run prepareFn: %v", err)
 						}

--- a/test/integration/scheduler_perf/scheduler_perf.go
+++ b/test/integration/scheduler_perf/scheduler_perf.go
@@ -1148,9 +1148,7 @@ func fixJSONOutput(b *testing.B) {
 // Also, you may want to put your plugins in PluginNames variable in this package
 // to collect metrics for them.
 func RunBenchmarkPerfScheduling(b *testing.B, configFile string, topicName string, outOfTreePluginRegistry frameworkruntime.Registry, options ...SchedulerPerfOption) {
-	opts := &schedulerPerfOptions{
-		prepareFn: nil,
-	}
+	opts := &schedulerPerfOptions{}
 
 	for _, option := range options {
 		option(opts)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
/kind api-change

<!--
Add one of the following kinds:
/kind bug

/kind documentation


Optionally add one or more of the following kinds if applicable:

/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

When you import scheduler-perf to test your own scheduler by importing it, you sometimes want to initialize the target api-server, such as applying crds or some resources.

This PR enables it by adding an option to add a function that is called before scheduler_perf starts.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #130861 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```