### PR TITLE
Migrate deprecated syscall functions in winstats package

### DIFF
--- a/pkg/kubelet/winstats/perfcounter_nodestats_windows.go
+++ b/pkg/kubelet/winstats/perfcounter_nodestats_windows.go
@@ -219,7 +219,7 @@ func ProcessorCount() int {
 }
 
 func getActiveProcessorCount(groupNumber uint16) int {
-	r0, _, _ := syscall.Syscall(procGetActiveProcessorCount.Addr(), 1, uintptr(groupNumber), 0, 0)
+	r0, _, _ := syscall.SyscallN(procGetActiveProcessorCount.Addr(), uintptr(groupNumber))
 	return int(r0)
 }
 

--- a/pkg/kubelet/winstats/winstats.go
+++ b/pkg/kubelet/winstats/winstats.go
@@ -165,15 +165,17 @@ func (c *StatsClient) GetDirFsInfo(path string) (cadvisorapiv2.FsInfo, error) {
 	var freeBytesAvailable, totalNumberOfBytes, totalNumberOfFreeBytes int64
 	var err error
 
-	ret, _, err := syscall.Syscall6(
+	utf16Ptr, err := syscall.UTF16PtrFromString(path)
+	if err != nil {
+		return cadvisorapiv2.FsInfo{}, err
+	}
+
+	ret, _, err := syscall.SyscallN(
 		procGetDiskFreeSpaceEx.Addr(),
-		4,
-		uintptr(unsafe.Pointer(syscall.StringToUTF16Ptr(path))),
+		uintptr(unsafe.Pointer(utf16Ptr)),
 		uintptr(unsafe.Pointer(&freeBytesAvailable)),
 		uintptr(unsafe.Pointer(&totalNumberOfBytes)),
 		uintptr(unsafe.Pointer(&totalNumberOfFreeBytes)),
-		0,
-		0,
 	)
 	if ret == 0 {
 		return cadvisorapiv2.FsInfo{}, err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
`pkg/kubelet/winstats` package contains multiple deprecated syscall functions. This PR is to migrate them to ensure compatibility with future Go versions.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #131084

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/sig node