### PR TITLE
Make Request#RequestURI honor configured context root

### DIFF
--- a/staging/src/k8s.io/client-go/openapi/client.go
+++ b/staging/src/k8s.io/client-go/openapi/client.go
@@ -56,9 +56,13 @@ func (c *client) Paths() (map[string]GroupVersion, error) {
 		return nil, err
 	}
 
+	// Calculate the client-side prefix for a "root" request
+	rootPrefix := strings.TrimSuffix(c.restClient.Get().AbsPath("/").URL().Path, "/")
 	// Create GroupVersions for each element of the result
 	result := map[string]GroupVersion{}
 	for k, v := range discoMap.Paths {
+		// Trim off the prefix that will always be added in client-side
+		v.ServerRelativeURL = strings.TrimPrefix(v.ServerRelativeURL, rootPrefix)
 		// If the server returned a URL rooted at /openapi/v3, preserve any additional client-side prefix.
 		// If the server returned a URL not rooted at /openapi/v3, treat it as an actual server-relative URL.
 		// See https://github.com/kubernetes/kubernetes/issues/117463 for details

--- a/staging/src/k8s.io/client-go/rest/request.go
+++ b/staging/src/k8s.io/client-go/rest/request.go
@@ -378,8 +378,9 @@ func (r *Request) NamespaceIfScoped(namespace string, scoped bool) *Request {
 	return r
 }
 
-// AbsPath overwrites an existing path with the segments provided. Trailing slashes are preserved
-// when a single segment is passed.
+// AbsPath overwrites an existing path with the segments provided.
+// Trailing slashes are preserved when a single segment is passed.
+// Any path in the request's REST client's base URL is preserved as a prefix.
 func (r *Request) AbsPath(segments ...string) *Request {
 	if r.err != nil {
 		return r
@@ -392,8 +393,8 @@ func (r *Request) AbsPath(segments ...string) *Request {
 	return r
 }
 
-// RequestURI overwrites existing path and parameters with the value of the provided server relative
-// URI.
+// RequestURI overwrites existing path and parameters with the value of the provided server relative URI.
+// This is equivalent to clearing params, then calling AbsPath() + Param() for each query parameter.
 func (r *Request) RequestURI(uri string) *Request {
 	if r.err != nil {
 		return r
@@ -403,14 +404,17 @@ func (r *Request) RequestURI(uri string) *Request {
 		r.err = err
 		return r
 	}
-	r.pathPrefix = locator.Path
+	// AbsPath handles prepending r.c.base.Path, if set
+	r.AbsPath(locator.Path)
 	if len(locator.Query()) > 0 {
-		if r.params == nil {
-			r.params = make(url.Values)
-		}
+		// clear any existing params
+		r.params = make(url.Values)
 		for k, v := range locator.Query() {
 			r.params[k] = v
 		}
+	} else {
+		// clear any existing params
+		r.params = nil
 	}
 	return r
 }

--- a/staging/src/k8s.io/client-go/rest/request_test.go
+++ b/staging/src/k8s.io/client-go/rest/request_test.go
@@ -292,14 +292,36 @@ func TestRequestError(t *testing.T) {
 }
 
 func TestRequestURI(t *testing.T) {
-	r := (&Request{}).Param("foo", "a")
+	r := (&Request{c: &RESTClient{base: &url.URL{Path: "/"}}}).Param("foo", "a").Param("bar", "b")
 	r.Prefix("other")
 	r.RequestURI("/test?foo=b&a=b&c=1&c=2")
 	if r.pathPrefix != "/test" {
 		t.Errorf("path is wrong: %#v", r)
 	}
 	if !reflect.DeepEqual(r.params, url.Values{"a": []string{"b"}, "foo": []string{"b"}, "c": []string{"1", "2"}}) {
-		t.Errorf("should have set a param: %#v", r)
+		t.Errorf("should have set a param, got: %#v", r.params)
+	}
+}
+
+func TestRequestURIContext(t *testing.T) {
+	r := (&Request{c: &RESTClient{base: &url.URL{Path: "/context"}}}).Param("foo", "a").Param("bar", "b")
+	r.Prefix("other")
+	r.RequestURI("/test?foo=b&a=b&c=1&c=2")
+	if r.pathPrefix != "/context/test" {
+		t.Errorf("path is wrong: %#v", r)
+	}
+	if !reflect.DeepEqual(r.params, url.Values{"a": []string{"b"}, "foo": []string{"b"}, "c": []string{"1", "2"}}) {
+		t.Errorf("should have set a param, got: %#v", r.params)
+	}
+
+	r = (&Request{c: &RESTClient{base: &url.URL{Path: "/context"}}}).Param("foo", "a").Param("bar", "b")
+	r.Prefix("other")
+	r.RequestURI("../test?foo=b&a=b&c=1&c=2")
+	if r.pathPrefix != "/test" {
+		t.Errorf("path is wrong: %#v", r)
+	}
+	if !reflect.DeepEqual(r.params, url.Values{"a": []string{"b"}, "foo": []string{"b"}, "c": []string{"1", "2"}}) {
+		t.Errorf("should have set a param, got: %#v", r.params)
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Makes use of client-go Request#RequestURI honor the configured base path in the REST client.

This systemically fixes e2e tests and `kubectl ... -raw` commands that run with kubeconfig files set to point to something other than the root of a server.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #115276

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
`kubectl create|delete|get|replace --raw` commands now honor server root paths specified in the kubeconfig file.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
