### PR TITLE
apiserver: fix status code of future resourceVersion api request

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/errors.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/errors.go
@@ -70,6 +70,8 @@ func interpretListError(err error, paging bool, continueKey, keyPrefix string) e
 			return handleCompactedErrorForPaging(continueKey, keyPrefix)
 		}
 		return errors.NewResourceExpired(expired)
+	case goerrors.Is(err, etcdrpc.ErrFutureRev):
+		return errors.NewTimeoutError(etcdrpc.ErrFutureRev.Error(), 0)
 	}
 	return err
 }

--- a/test/integration/apiserver/apiserver_test.go
+++ b/test/integration/apiserver/apiserver_test.go
@@ -234,6 +234,25 @@ func Test4xxStatusCodeInvalidPatch(t *testing.T) {
 	}
 }
 
+func TestResourceVersionFutureRev(t *testing.T) {
+	ctx, client, _, tearDownFn := setup(t)
+	defer tearDownFn()
+
+	var statusCode int
+
+	result := client.AppsV1().RESTClient().
+		Get().
+		Resource("deployments").
+		Param("resourceVersion", "2147483647").
+		Param("limit", "1").
+		Do(ctx)
+	result.StatusCode(&statusCode)
+
+	if statusCode != http.StatusGatewayTimeout {
+		t.Fatalf("Expected status code to be 504, got %v (%#v)", statusCode, result)
+	}
+}
+
 func TestCacheControl(t *testing.T) {
 	server := kubeapiservertesting.StartTestServerOrDie(t, nil, framework.DefaultTestServerFlags(), framework.SharedEtcd())
 	defer server.TearDownFn()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
In short, I discovered a reproducible bug in the Kubernetes REST API, identified the root cause, and implemented a fix. Additionally, I wrote a unit test to verify the resolution.

##### Steps to Reproduce Manually

1. Start a Kubernetes cluster (I used the `StartTestServer` function from the `testing` package, but I believe the results would be the same with other methods).
2. Send the following request (ensure the required credentials, such as tokens, are properly configured beforehand—omitted here for brevity):

```bash
curl -X GET "https://$IP:$PORT/apis/apps/v1/deployments?resourceVersion=2147483647&limit=1"
```

In other words, we send a GET request to `/apis/apps/v1/deployments` with a request parameter that includes an extremely large and obviously non-existent `resourceVersion`. Clearly, the server should return a 4xx error.

3. However, the actual response is:

```json
{
    "kind": "Status",
    "apiVersion": "v1",
    "metadata": {},
    "status": "Failure",
    "message": "etcdserver: mvcc: required revision is a future revision",
    "code": 500
}
```

This is unexpected. The request should be properly handled and return a `504` response instead of an `Internal Server Error` (500).

4. Additionally, I observed a panic stack trace in the Kubernetes cluster logs.

##### Unit Test & Fix

**To facilitate reproduction of the issue, I added a unit test. Running this test consistently reproduces the issue as described above.**

After investigation, I found that the root cause of this issue lies in etcd's response to a non-existent high `resourceVersion`, which is `etcdrpc.ErrFutureRev`. However, this response is not properly handled in the Kubernetes API server. I applied the necessary fix in the source code, and after making the modification, the newly added unit test now behaves as expected.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
return 504 for "future" resource version in REST APIs
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
