### PR TITLE
apiserver: return 400 for invalid resourceVersion api requests

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
@@ -490,7 +490,7 @@ func (c *Cacher) Watch(ctx context.Context, key string, opts storage.ListOptions
 	pred := opts.Predicate
 	requestedWatchRV, err := c.versioner.ParseResourceVersion(opts.ResourceVersion)
 	if err != nil {
-		return nil, err
+		return nil, errors.NewBadRequest(fmt.Sprintf("invalid resource version: %v", err))
 	}
 
 	var readyGeneration int

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/delegator.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/delegator.go
@@ -157,7 +157,7 @@ func (c *CacheDelegator) Get(ctx context.Context, key string, opts storage.GetOp
 	// fresh as the given resourceVersion.
 	getRV, err := c.cacher.versioner.ParseResourceVersion(opts.ResourceVersion)
 	if err != nil {
-		return err
+		return errors.NewBadRequest(fmt.Sprintf("invalid resource version: %v", err))
 	}
 	// Do not create a trace - it's not for free and there are tons
 	// of Get requests. We can add it if it will be really needed.

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
@@ -907,7 +907,7 @@ func (s *store) Watch(ctx context.Context, key string, opts storage.ListOptions)
 	}
 	rev, err := s.versioner.ParseResourceVersion(opts.ResourceVersion)
 	if err != nil {
-		return nil, err
+		return nil, apierrors.NewBadRequest(fmt.Sprintf("invalid resource version: %v", err))
 	}
 	return s.watcher.Watch(s.watchContext(ctx), preparedKey, int64(rev), opts)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

In short, I discovered **three reproducible bugs** in the Kubernetes REST API, identified the root cause, and implemented fixes. Additionally, I wrote a unit test to verify the resolution.

##### Steps to Reproduce Manually

1. Start a Kubernetes cluster (I used the `StartTestServer` function from the `testing` package, but I believe the results would be the same with other methods).
2. Send the following requests (ensure the required credentials, such as tokens, are properly configured beforehand—omitted here for brevity):

```bash
curl "https://$IP:$PORT/api/v1/persistentvolumes?watch=true&resourceVersion=-1"
curl "https://$IP:$PORT/api/v1/persistentvolumes/foo?resourceVersion=-1"
curl "https://$IP:$PORT/apis/events.k8s.io/v1/events?watch=true&resourceVersion=-1"
```

In other words, we sent a GET request to the `/api/v1/persistentvolumes` API with a `resourceVersion` parameter that contains an invalid value (to the best of my understanding, `resourceVersion` can currently only be a `uint`). Clearly, the server should return a 4xx error.

3. However, the actual response is:

```json
{
    "kind": "Status",
    "apiVersion": "v1",
    "metadata": {},
    "status": "Failure",
    "message": "resourceVersion: Invalid value: \"-1\": strconv.ParseUint: parsing \"-1\": invalid syntax",
    "code": 500
}
```

This is unexpected. The request should be properly handled and return a `400` response instead of an `Internal Server Error` (500).

4. Additionally, I observed a panic stack traces in the Kubernetes cluster logs.

##### Unit Test & Fix

**To facilitate reproduction of the issue, I added a unit test. Running this test consistently reproduces the issue as described above.**

After investigation, I found that the root cause of this issue is that when `strconv.ParseUint` receives an invalid value, the error it throws is not properly handled. In addition, I discovered that this issue is relatively common in the Go source files under the `staging/src/k8s.io/apiserver/pkg/storage/cacher` directory. Some of these cases do not cause actual problems because the request does not reach the affected implementation. I applied the necessary fix in the source code, and after making the modification, the newly added unit test now behaves as expected. To be safe, I added four API calls in the unit test, with the following purposes:

1. **watch persistentvolumes**: Without the changes in this PR, it triggers an error in `staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go#Watch`, resulting in a 500 error.
2. **watch events:** Without the changes in this PR, it triggers an error in 
`*staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go#Watch`, resulting in a 500 error.
3. **get persistentvolumes**: Without the changes in this PR, it triggers an error in `staging/src/k8s.io/apiserver/pkg/storage/cacher/delegator.go#Get`, also leading to a 500 error.
4. **get persistentvolumes list**: It’s important to note that this API call returns a 400 response even without the changes in this PR, which is as expected. I included it in the unit tests both to demonstrate what a correct response should look like, and because the procedure it follows also potentially contains the same issue. For safety, I added a test for it as well.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

NONE

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
return 400 for invalid resourceVersion in REST APIs
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
