### PR TITLE
Update PodSecurityLevel used during Service CIDRs tests

### DIFF
--- a/test/e2e/network/service_cidrs.go
+++ b/test/e2e/network/service_cidrs.go
@@ -39,7 +39,7 @@ import (
 var _ = common.SIGDescribe("Service CIDRs", func() {
 
 	fr := framework.NewDefaultFramework("servicecidrs")
-	fr.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	fr.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 
 	var (
 		cs clientset.Interface


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:

Found this while bumping k8s in OpenShift. It seems like these tests were added recently, so they are setting just the enforcement labels.

More context: https://github.com/kubernetes/kubernetes/pull/124889#issuecomment-2112796273

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
