### PR TITLE
controller-manager: enable mutex profiling when --contention-profiling is true

### DIFF
--- a/staging/src/k8s.io/controller-manager/app/serve.go
+++ b/staging/src/k8s.io/controller-manager/app/serve.go
@@ -62,6 +62,7 @@ func NewBaseHandler(c *componentbaseconfig.DebuggingConfiguration, healthzHandle
 		routes.Profiling{}.Install(mux)
 		if c.EnableContentionProfiling {
 			goruntime.SetBlockProfileRate(1)
+			goruntime.SetMutexProfileFraction(1)
 		}
 		routes.DebugFlags{}.Install(mux, "v", routes.StringFlagPutHandler(logs.GlogSetter))
 	}

--- a/staging/src/k8s.io/controller-manager/app/serve_test.go
+++ b/staging/src/k8s.io/controller-manager/app/serve_test.go
@@ -1,0 +1,51 @@
+package app
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	componentbaseconfig "k8s.io/component-base/config"
+)
+
+func TestProfilingRoutesRegistered(t *testing.T) {
+	conf := &componentbaseconfig.DebuggingConfiguration{
+		EnableProfiling:           true,
+		EnableContentionProfiling: false,
+	}
+
+	handler := NewBaseHandler(conf, http.NewServeMux())
+
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "/debug/pprof/")
+	if err != nil || resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected /debug/pprof/ to be accessible, got err=%v, status=%d", err, resp.StatusCode)
+	}
+}
+
+func TestContentionProfiling_EnablesMutexProfiling(t *testing.T) {
+	conf := &componentbaseconfig.DebuggingConfiguration{
+		EnableProfiling:           true,
+		EnableContentionProfiling: true,
+	}
+
+	handler := NewBaseHandler(conf, http.NewServeMux())
+
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "/debug/pprof/mutex?debug=1")
+	if err != nil {
+		t.Fatalf("failed to GET /debug/pprof/mutex: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if !bytes.Contains(body, []byte("sampling period=1")) {
+		t.Errorf("expected sampling period=1 in /debug/pprof/mutex, but got:\n%s", body)
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR enables mutex profiling at `/debug/pprof/mutex` when both `--profiling` and `--contention-profiling` flags are set.

Currently, even when `--contention-profiling=true`, mutex profiling is not enabled due to missing a call to `goruntime.SetMutexProfileFraction(1)`. This PR fixes that by explicitly enabling it when the flag is set.

This helps users and developers diagnose performance bottlenecks caused by lock contention.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #130802

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Enable mutex profiling at /debug/pprof/mutex when --profiling and --contention-profiling are both enabled.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
