### PR TITLE
Fix several goroutine leaks on controllers

### DIFF
--- a/cmd/kube-controller-manager/app/autoscaling.go
+++ b/cmd/kube-controller-manager/app/autoscaling.go
@@ -76,8 +76,7 @@ func startHPAControllerWithMetricsClient(ctx context.Context, controllerContext 
 		return nil, false, err
 	}
 
-	go podautoscaler.NewHorizontalController(
-		ctx,
+	hpa, err := podautoscaler.NewHorizontalController(
 		hpaClient.CoreV1(),
 		scaleClient,
 		hpaClient.AutoscalingV2(),
@@ -90,6 +89,11 @@ func startHPAControllerWithMetricsClient(ctx context.Context, controllerContext 
 		controllerContext.ComponentConfig.HPAController.HorizontalPodAutoscalerTolerance,
 		controllerContext.ComponentConfig.HPAController.HorizontalPodAutoscalerCPUInitializationPeriod.Duration,
 		controllerContext.ComponentConfig.HPAController.HorizontalPodAutoscalerInitialReadinessDelay.Duration,
-	).Run(ctx, int(controllerContext.ComponentConfig.HPAController.ConcurrentHorizontalPodAutoscalerSyncs))
+	)
+	if err != nil {
+		return nil, false, err
+	}
+
+	go hpa.Run(ctx, int(controllerContext.ComponentConfig.HPAController.ConcurrentHorizontalPodAutoscalerSyncs))
 	return nil, true, nil
 }

--- a/pkg/controller/garbagecollector/garbagecollector.go
+++ b/pkg/controller/garbagecollector/garbagecollector.go
@@ -133,7 +133,6 @@ func (gc *GarbageCollector) Run(ctx context.Context, workers int, initialSyncTim
 	defer utilruntime.HandleCrash()
 	defer gc.attemptToDelete.ShutDown()
 	defer gc.attemptToOrphan.ShutDown()
-	defer gc.dependencyGraphBuilder.graphChanges.ShutDown()
 
 	// Start events processing pipeline.
 	gc.eventBroadcaster.StartStructuredLogging(3)

--- a/pkg/controller/namespace/namespace_controller_test.go
+++ b/pkg/controller/namespace/namespace_controller_test.go
@@ -1,0 +1,72 @@
+package namespace
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"go.uber.org/goleak"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/kubernetes/pkg/controller"
+	"k8s.io/kubernetes/test/utils/ktesting"
+)
+
+func TestNamespaceController_Shutdown(t *testing.T) {
+	cases := map[string]struct {
+		runner func(ctx context.Context, nm *NamespaceController)
+	}{
+		"run": {
+			runner: func(ctx context.Context, nm *NamespaceController) { nm.Run(ctx, 1) },
+		},
+		"shutdown": {
+			runner: func(ctx context.Context, nm *NamespaceController) { nm.ShutDown() },
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, tCtx := ktesting.NewTestContext(t)
+
+			// Mock discoverResourcesFn to return a list of resources, without
+			// this the NamespacedResourcesDeleter will call os.Exit in
+			// initOpCache as there are no applicable resources.
+			discoverResourcesFn := func() ([]*metav1.APIResourceList, error) {
+				return []*metav1.APIResourceList{
+					{
+						GroupVersion: "v1",
+						APIResources: []metav1.APIResource{
+							{
+								Name:       "pods",
+								Namespaced: true,
+								Kind:       "Pod",
+								Verbs:      []string{"get", "list", "delete", "deletecollection", "create", "update"},
+							},
+						},
+					},
+				}, nil
+			}
+
+			cl := fake.NewSimpleClientset()
+
+			informerFactory := informers.NewSharedInformerFactory(cl, controller.NoResyncPeriodFunc())
+			namespaceInformer := informerFactory.Core().V1().Namespaces()
+			informerFactory.Start(tCtx.Done())
+
+			informerFactory.WaitForCacheSync(tCtx.Done())
+
+			defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+			nm, err := NewNamespaceController(tCtx, cl, nil, discoverResourcesFn, namespaceInformer, 0, v1.FinalizerKubernetes)
+			if err != nil {
+				t.Errorf("failed to create namespace controller: %v", err)
+			}
+
+			ctx, _ := context.WithTimeout(tCtx, 100*time.Millisecond)
+			tc.runner(ctx, nm)
+		},
+		)
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

As reported in https://github.com/kcp-dev/kcp/issues/3350 several controllers are leaking goroutines as they are registering handlers with informers but are not cleaning those registrations up on shutdown.

I presume that this also occurs in Kubernetes on leader changes.
When the `ResourceQuota` controller starts and stops `QuotaMonitors` each stopped `QuotaMonitor` leaks goroutines as well.

Additionally if the informer returns an error and doesn't actually register handlers the controller will do nothing with almost no indication as to why as the erros are silently ignored.

```release-note
Fix several goroutine leaks in controllers on controller shutdown
```

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

I'd be happy to split this PR into multiple PRs e.g. based on controller.

#### Does this PR introduce a user-facing change?

Some functions creating controllers are now returning the error from the handler registration. This was previously ignored.
IMHO returning the errors would be the correct choice as without the handlers the controllers would do nothing.
Alternatively the errors could be logged using the `(util)runtime.HandleError` function.

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

None