### PR TITLE
Replace os.Exit with return

### DIFF
--- a/cmd/kube-controller-manager/app/core.go
+++ b/cmd/kube-controller-manager/app/core.go
@@ -563,10 +563,16 @@ func startNamespaceController(ctx context.Context, controllerContext ControllerC
 	// the namespace cleanup controller is very chatty.  It makes lots of discovery calls and then it makes lots of delete calls
 	// the ratelimiter negatively affects its speed.  Deleting 100 total items in a namespace (that's only a few of each resource
 	// including events), takes ~10 seconds by default.
-	nsKubeconfig := controllerContext.ClientBuilder.ConfigOrDie("namespace-controller")
+	nsKubeconfig, err := controllerContext.ClientBuilder.Config("namespace-controller")
+	if err != nil {
+		return nil, false, fmt.Errorf("error building client config: %v", err)
+	}
 	nsKubeconfig.QPS *= 20
 	nsKubeconfig.Burst *= 100
-	namespaceKubeClient := clientset.NewForConfigOrDie(nsKubeconfig)
+	namespaceKubeClient, err := clientset.NewForConfig(nsKubeconfig)
+	if err != nil {
+		return nil, false, fmt.Errorf("error building client: %v", err)
+	}
 	return startModifiedNamespaceController(ctx, controllerContext, namespaceKubeClient, nsKubeconfig)
 }
 

--- a/pkg/controller/namespace/deletion/namespaced_resources_deleter.go
+++ b/pkg/controller/namespace/deletion/namespaced_resources_deleter.go
@@ -162,11 +162,12 @@ func (d *namespacedResourcesDeleter) initOpCache(ctx context.Context) {
 	resources, err := d.discoverResourcesFn()
 	if err != nil {
 		utilruntime.HandleError(fmt.Errorf("unable to get all supported resources from server: %v", err))
+		return
 	}
 	logger := klog.FromContext(ctx)
 	if len(resources) == 0 {
 		logger.Error(err, "Unable to get any supported resources from server")
-		klog.FlushAndExit(klog.ExitFlushTimeout, 1)
+		return
 	}
 
 	for _, rl := range resources {

--- a/pkg/controller/namespace/deletion/namespaced_resources_deleter_test.go
+++ b/pkg/controller/namespace/deletion/namespaced_resources_deleter_test.go
@@ -203,7 +203,10 @@ func testSyncNamespaceThatIsTerminating(t *testing.T, versions *metav1.APIVersio
 				return resources, testInput.gvrError
 			}
 			_, ctx := ktesting.NewTestContext(t)
-			d := NewNamespacedResourcesDeleter(ctx, mockClient.CoreV1().Namespaces(), metadataClient, mockClient.CoreV1(), fn, v1.FinalizerKubernetes)
+			d, err := NewNamespacedResourcesDeleter(ctx, mockClient.CoreV1().Namespaces(), metadataClient, mockClient.CoreV1(), fn, v1.FinalizerKubernetes)
+			if err != nil {
+				t.Fatal(err)
+			}
 			if err := d.Delete(ctx, testInput.testNamespace.Name); !matchErrors(err, testInput.expectErrorOnDelete) {
 				t.Errorf("expected error %q when syncing namespace, got %q, %v", testInput.expectErrorOnDelete, err, testInput.expectErrorOnDelete == err)
 			}
@@ -301,8 +304,11 @@ func TestSyncNamespaceThatIsActive(t *testing.T) {
 		return testResources(), nil
 	}
 	_, ctx := ktesting.NewTestContext(t)
-	d := NewNamespacedResourcesDeleter(ctx, mockClient.CoreV1().Namespaces(), nil, mockClient.CoreV1(),
+	d, err := NewNamespacedResourcesDeleter(ctx, mockClient.CoreV1().Namespaces(), nil, mockClient.CoreV1(),
 		fn, v1.FinalizerKubernetes)
+	if err != nil {
+		t.Fatal(err)
+	}
 	err := d.Delete(ctx, testNamespace.Name)
 	if err != nil {
 		t.Errorf("Unexpected error when synching namespace %v", err)
@@ -434,7 +440,10 @@ func TestDeleteEncounters404(t *testing.T) {
 		}}, nil
 	}
 	_, ctx := ktesting.NewTestContext(t)
-	d := NewNamespacedResourcesDeleter(ctx, mockClient.CoreV1().Namespaces(), mockMetadataClient, mockClient.CoreV1(), resourcesFn, v1.FinalizerKubernetes)
+	d, err := NewNamespacedResourcesDeleter(ctx, mockClient.CoreV1().Namespaces(), mockMetadataClient, mockClient.CoreV1(), resourcesFn, v1.FinalizerKubernetes)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Delete ns1 and get NotFound errors for the flakes resource
 	mockMetadataClient.ClearActions()

--- a/test/e2e_node/services/namespace_controller.go
+++ b/test/e2e_node/services/namespace_controller.go
@@ -74,7 +74,7 @@ func (n *NamespaceController) Start(ctx context.Context) error {
 	discoverResourcesFn := client.Discovery().ServerPreferredNamespacedResources
 	informerFactory := informers.NewSharedInformerFactory(client, ncResyncPeriod)
 
-	nc := namespacecontroller.NewNamespaceController(
+	nc, err := namespacecontroller.NewNamespaceController(
 		ctx,
 		client,
 		metadataClient,
@@ -82,6 +82,9 @@ func (n *NamespaceController) Start(ctx context.Context) error {
 		informerFactory.Core().V1().Namespaces(),
 		ncResyncPeriod, v1.FinalizerKubernetes,
 	)
+	if err != nil {
+		return err
+	}
 	informerFactory.Start(n.stopCh)
 	go nc.Run(ctx, ncConcurrency)
 	return nil

--- a/test/integration/namespace/ns_conditions_test.go
+++ b/test/integration/namespace/ns_conditions_test.go
@@ -195,7 +195,7 @@ func namespaceLifecycleSetup(t *testing.T) (context.Context, kubeapiservertestin
 
 	discoverResourcesFn := clientSet.Discovery().ServerPreferredNamespacedResources
 	_, ctx := ktesting.NewTestContext(t)
-	controller := namespace.NewNamespaceController(
+	controller, err := namespace.NewNamespaceController(
 		ctx,
 		clientSet,
 		metadataClient,
@@ -203,6 +203,9 @@ func namespaceLifecycleSetup(t *testing.T) (context.Context, kubeapiservertestin
 		informers.Core().V1().Namespaces(),
 		10*time.Hour,
 		corev1.FinalizerKubernetes)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	return ctx, server.TearDownFn, controller, informers, clientSet, dynamic.NewForConfigOrDie(config)
 }

--- a/test/integration/util/util.go
+++ b/test/integration/util/util.go
@@ -239,7 +239,7 @@ func CreateNamespaceController(ctx context.Context, tb ktesting.TB, restConfig r
 		tb.Fatalf("Failed to create metadataClient: %v", err)
 	}
 	discoverResourcesFn := clientSet.Discovery().ServerPreferredNamespacedResources
-	controller := namespace.NewNamespaceController(
+	controller, err := namespace.NewNamespaceController(
 		ctx,
 		clientSet,
 		metadataClient,
@@ -247,6 +247,9 @@ func CreateNamespaceController(ctx context.Context, tb ktesting.TB, restConfig r
 		informerSet.Core().V1().Namespaces(),
 		10*time.Hour,
 		v1.FinalizerKubernetes)
+	if err != nil {
+		tb.Fatalf("Failed creating namespace controller: %v", err)
+	}
 	return func() {
 		go controller.Run(ctx, 5)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

If the `namespacedResourceDeleter` is setup with a discovery function that returns no resources it effectly calls `os.Exit`.

The call to `klog.FlushAndExit` lands here:
https://github.com/kubernetes/kubernetes/blob/195803cde570ad1025a78e36cdbef76bddbc4c33/vendor/k8s.io/klog/v2/exit.go#L49-L52

Which calls `OsExit` which is an alias for `os.Exit`:
https://github.com/kubernetes/kubernetes/blob/195803cde570ad1025a78e36cdbef76bddbc4c33/vendor/k8s.io/klog/v2/exit.go#L43

This could happen when the discovery function errors and returns no resources - the error was logged but the function keeps going and then runs into the `os.Exit`.
I don't think this is something that can happen normally but it did catch me when implementing a test for #131199.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
