### PR TITLE
workqueue: add an interruptible queue

### DIFF
--- a/staging/src/k8s.io/client-go/util/workqueue/interruptible_queue.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/interruptible_queue.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workqueue
+
+import (
+	"context"
+	"time"
+)
+
+var _ TypedInterruptibleInterface[any] = &interruptibleType[any]{}
+
+// TypedInterruptibleInterface is an Interface that can interruptible from Get operation.
+// TypedInterruptibleInterface is an Interface that can be interrupted during Get operations.
+type TypedInterruptibleInterface[T comparable] interface {
+	TypedInterface[T]
+	GetWithContext(ctx context.Context) (item T, shutdown bool, err error)
+}
+
+// NewTypedInterruptibleQueue constructs a new workqueue with interruptible ability.
+// NewTypedInterruptibleQueue does not emit metrics. For use with a MetricsProvider, please use
+// NewTypedInterruptibleQueueWithConfig instead and specify a name.
+func NewTypedInterruptibleQueue[T comparable]() TypedInterruptibleInterface[T] {
+	return NewTypedInterruptibleQueueWithConfig(TypedQueueConfig[T]{})
+}
+
+// NewTypedInterruptibleQueueWithConfig constructs a new workqueue with options to
+// customize different properties.
+func NewTypedInterruptibleQueueWithConfig[T comparable](config TypedQueueConfig[T]) TypedInterruptibleInterface[T] {
+	return newInterruptibleQueue(config, defaultUnfinishedWorkUpdatePeriod)
+}
+
+func newInterruptibleQueue[T comparable](config TypedQueueConfig[T], updatePeriod time.Duration) *interruptibleType[T] {
+	return &interruptibleType[T]{
+		newQueueWithConfig(config, defaultUnfinishedWorkUpdatePeriod),
+	}
+}
+
+type interruptibleType[T comparable] struct {
+	*Typed[T]
+}
+
+// GetWithContext tries to get an item to process, but allows context cancellation to
+// interrupt the blocking. It returns the item, a bool indicating if the queue is
+// shutting down, and an error which is set to ctx.Err() if the context was cancelled.
+func (q *interruptibleType[T]) GetWithContext(ctx context.Context) (item T, shutdown bool, err error) {
+	// Fast path for cancelled context
+	if ctx.Err() != nil {
+		return *new(T), false, ctx.Err()
+	}
+
+	q.cond.L.Lock()
+
+	// Fast path for non-empty queue
+	if q.queue.Len() > 0 {
+		item = q.queue.Pop()
+		q.metrics.get(item)
+		q.processing.insert(item)
+		q.dirty.delete(item)
+		q.cond.L.Unlock()
+		return item, false, nil
+	}
+
+	if q.shuttingDown {
+		q.cond.L.Unlock()
+		return *new(T), true, nil
+	}
+
+	// Set up for waiting
+	waitCh := make(chan struct{})
+	go func() {
+		q.cond.L.Lock()
+		for q.queue.Len() == 0 && !q.shuttingDown {
+			q.cond.Wait()
+		}
+		close(waitCh)
+		q.cond.L.Unlock()
+	}()
+
+	q.cond.L.Unlock()
+
+	// Wait for either context cancellation or condition signaling
+	select {
+	case <-ctx.Done():
+		// Need to reacquire lock to ensure proper state
+		q.cond.L.Lock()
+		defer q.cond.L.Unlock()
+
+		// Double check if queue got items or shutdown while we were waiting for context
+		if q.queue.Len() > 0 {
+			item = q.queue.Pop()
+			q.metrics.get(item)
+			q.processing.insert(item)
+			q.dirty.delete(item)
+			return item, false, nil
+		}
+
+		if q.shuttingDown {
+			return *new(T), true, nil
+		}
+
+		return *new(T), false, ctx.Err()
+
+	case <-waitCh:
+		// Condition was signaled, get the item
+		q.cond.L.Lock()
+		defer q.cond.L.Unlock()
+
+		if q.queue.Len() == 0 {
+			// Queue is empty, must be shutting down
+			return *new(T), true, nil
+		}
+
+		item = q.queue.Pop()
+		q.metrics.get(item)
+		q.processing.insert(item)
+		q.dirty.delete(item)
+		return item, false, nil
+	}
+}

--- a/staging/src/k8s.io/client-go/util/workqueue/interruptible_queue_test.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/interruptible_queue_test.go
@@ -1,0 +1,236 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workqueue_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"k8s.io/client-go/util/workqueue"
+)
+
+func TestInterruptibleQueueBasic(t *testing.T) {
+	q := workqueue.NewTypedInterruptibleQueue[string]()
+
+	// Add item to queue
+	q.Add("item1")
+
+	// Get item using normal Get
+	item, shutdown := q.Get()
+	if shutdown {
+		t.Errorf("Expected queue to not be shutdown")
+	}
+	if item != "item1" {
+		t.Errorf("Expected %v, got %v", "item1", item)
+	}
+
+	// Done with processing
+	q.Done(item)
+
+	// Test with GetWithContext
+	q.Add("item2")
+	ctx := context.Background()
+	item, shutdown, err := q.GetWithContext(ctx)
+	if err != nil {
+		t.Errorf("Did not expect error: %v", err)
+	}
+	if shutdown {
+		t.Errorf("Expected queue to not be shutdown")
+	}
+	if item != "item2" {
+		t.Errorf("Expected %v, got %v", "item2", item)
+	}
+	q.Done(item)
+
+	// Queue should be empty now
+	if q.Len() != 0 {
+		t.Errorf("Expected queue to be empty. Has %v items", q.Len())
+	}
+
+	// Shutdown the queue
+	q.ShutDown()
+	_, shutdown = q.Get()
+	if !shutdown {
+		t.Errorf("Expected queue to be shutdown")
+	}
+
+	// ShutDown queue should return shutdown = true with GetWithContext
+	_, shutdown, _ = q.GetWithContext(ctx)
+	if !shutdown {
+		t.Errorf("Expected queue to be shutdown with GetWithContext")
+	}
+}
+
+func TestInterruptibleQueueWithContextCancellation(t *testing.T) {
+	q := workqueue.NewTypedInterruptibleQueue[string]()
+
+	// Create a context that will be cancelled
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Start a goroutine that will cancel the context after a short delay
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	// Try to get from empty queue with context that will be cancelled
+	start := time.Now()
+	_, shutdown, err := q.GetWithContext(ctx)
+	elapsed := time.Since(start)
+
+	// Verify we got cancelled and didn't wait too long
+	if shutdown {
+		t.Errorf("Expected queue to not be shutdown")
+	}
+	if err == nil {
+		t.Errorf("Expected error from context cancellation")
+	}
+	if elapsed > 200*time.Millisecond {
+		t.Errorf("Get took too long: %v", elapsed)
+	}
+}
+
+func TestInterruptibleQueueAddWhileWaiting(t *testing.T) {
+	q := workqueue.NewTypedInterruptibleQueue[string]()
+
+	// Create a context with long timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Start a goroutine that will add an item after a short delay
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		q.Add("delayed-item")
+	}()
+
+	// Try to get from empty queue, should wait until item is added
+	start := time.Now()
+	item, shutdown, err := q.GetWithContext(ctx)
+	elapsed := time.Since(start)
+
+	// Verify we got the item and didn't return immediately
+	if err != nil {
+		t.Errorf("Did not expect error: %v", err)
+	}
+	if shutdown {
+		t.Errorf("Expected queue to not be shutdown")
+	}
+	if item != "delayed-item" {
+		t.Errorf("Expected %v, got %v", "delayed-item", item)
+	}
+	if elapsed < 40*time.Millisecond {
+		t.Errorf("Get returned too quickly: %v", elapsed)
+	}
+
+	q.Done(item)
+}
+
+func TestInterruptibleQueueShutdownWhileWaiting(t *testing.T) {
+	q := workqueue.NewTypedInterruptibleQueue[string]()
+
+	// Create a context with long timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Start a goroutine that will shutdown the queue after a short delay
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		q.ShutDown()
+	}()
+
+	// Try to get from empty queue, should return shutdown=true when queue is shutdown
+	start := time.Now()
+	_, shutdown, err := q.GetWithContext(ctx)
+	elapsed := time.Since(start)
+
+	// Verify we detected shutdown
+	if err != nil {
+		t.Errorf("Did not expect error: %v", err)
+	}
+	if !shutdown {
+		t.Errorf("Expected queue to be shutdown")
+	}
+	if elapsed < 40*time.Millisecond {
+		t.Errorf("Get returned too quickly: %v", elapsed)
+	}
+}
+
+func TestInterruptibleQueueCancelledContext(t *testing.T) {
+	q := workqueue.NewTypedInterruptibleQueue[string]()
+
+	// Create already cancelled context
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	// Try to get with already cancelled context
+	_, shutdown, err := q.GetWithContext(ctx)
+
+	// Verify we get error without being shutdown
+	if shutdown {
+		t.Errorf("Expected queue to not be shutdown")
+	}
+	if err == nil {
+		t.Errorf("Expected context cancellation error")
+	}
+}
+
+func TestInterruptibleQueueWithDrain(t *testing.T) {
+	q := workqueue.NewTypedInterruptibleQueue[string]()
+
+	// Add items
+	q.Add("item1")
+	q.Add("item2")
+
+	// Get one item
+	item, _ := q.Get()
+	if item != "item1" {
+		t.Errorf("Expected %v, got %v", "item1", item)
+	}
+
+	// Must mark the processing item as done before calling ShutDownWithDrain
+	q.Done(item)
+
+	// Shutdown with drain
+	q.ShutDownWithDrain()
+
+	// Try to add after shutdown
+	q.Add("item3")
+
+	// Should still be able to get remaining item
+	ctx := context.Background()
+	item, shutdown, err := q.GetWithContext(ctx)
+	if err != nil {
+		t.Errorf("Did not expect error: %v", err)
+	}
+	// Note: At this point the queue is marked as shuttingDown, but since there are still items in the queue, the shutdown flag is false
+	if shutdown {
+		t.Errorf("Expected queue to not return shutdown=true as there are still items in queue")
+	}
+	if item != "item2" {
+		t.Errorf("Expected %v, got %v", "item2", item)
+	}
+
+	// Complete processing the last item
+	q.Done(item)
+
+	// Queue should now return empty results with shutdown=true
+	_, shutdown, _ = q.GetWithContext(ctx)
+	if !shutdown {
+		t.Errorf("Expected queue to be shutdown")
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Add an interruptible queue, then we can shut down unused workers.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes [#131185](https://github.com/kubernetes/kubernetes/issues/131185)

#### Special notes for your reviewer:
Is adding GetWithContext to the existing default queue acceptable? If acceptable, I prefer to add this method to the basic TypedQueue interface.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add a new kind of workqueue "interruptible queue"
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
