### PR TITLE
make sure all streams are created before start demux websocket

### DIFF
--- a/staging/src/k8s.io/client-go/tools/remotecommand/remotecommand.go
+++ b/staging/src/k8s.io/client-go/tools/remotecommand/remotecommand.go
@@ -54,5 +54,5 @@ type streamCreator interface {
 }
 
 type streamProtocolHandler interface {
-	stream(conn streamCreator) error
+	stream(conn streamCreator, ready chan<- struct{}) error
 }

--- a/staging/src/k8s.io/client-go/tools/remotecommand/spdy.go
+++ b/staging/src/k8s.io/client-go/tools/remotecommand/spdy.go
@@ -157,7 +157,11 @@ func (e *spdyStreamExecutor) StreamWithContext(ctx context.Context, options Stre
 				panicChan <- p
 			}
 		}()
-		errorChan <- streamer.stream(conn)
+
+		// The SPDY executor does not need to synchronize stream creation, so we pass a nil
+		// ready channel. The underlying spdystream library handles stream multiplexing
+		// without a race condition.
+		errorChan <- streamer.stream(conn, nil)
 	}()
 
 	select {

--- a/staging/src/k8s.io/client-go/tools/remotecommand/spdy_test.go
+++ b/staging/src/k8s.io/client-go/tools/remotecommand/spdy_test.go
@@ -352,7 +352,7 @@ func TestStreamExitsAfterConnectionIsClosed(t *testing.T) {
 
 	errorChan := make(chan error)
 	go func() {
-		errorChan <- streamer.stream(conn)
+		errorChan <- streamer.stream(conn, nil)
 	}()
 
 	// Wait until stream goroutine starts.

--- a/staging/src/k8s.io/client-go/tools/remotecommand/v1.go
+++ b/staging/src/k8s.io/client-go/tools/remotecommand/v1.go
@@ -47,7 +47,7 @@ func newStreamProtocolV1(options StreamOptions) streamProtocolHandler {
 	}
 }
 
-func (p *streamProtocolV1) stream(conn streamCreator) error {
+func (p *streamProtocolV1) stream(conn streamCreator, ready chan<- struct{}) error {
 	doneChan := make(chan struct{}, 2)
 	errorChan := make(chan error)
 
@@ -104,6 +104,11 @@ func (p *streamProtocolV1) stream(conn streamCreator) error {
 			return err
 		}
 		defer p.remoteStderr.Reset()
+	}
+
+	// Signal that all streams have been created.
+	if ready != nil {
+		close(ready)
 	}
 
 	// now that all the streams have been created, proceed with reading & copying

--- a/staging/src/k8s.io/client-go/tools/remotecommand/v2.go
+++ b/staging/src/k8s.io/client-go/tools/remotecommand/v2.go
@@ -169,9 +169,14 @@ func (p *streamProtocolV2) copyStderr(wg *sync.WaitGroup) {
 	}()
 }
 
-func (p *streamProtocolV2) stream(conn streamCreator) error {
+func (p *streamProtocolV2) stream(conn streamCreator, ready chan<- struct{}) error {
 	if err := p.createStreams(conn); err != nil {
 		return err
+	}
+
+	// Signal that all streams have been created.
+	if ready != nil {
+		close(ready)
 	}
 
 	// now that all the streams have been created, proceed with reading & copying

--- a/staging/src/k8s.io/client-go/tools/remotecommand/v3.go
+++ b/staging/src/k8s.io/client-go/tools/remotecommand/v3.go
@@ -82,9 +82,14 @@ func (p *streamProtocolV3) handleResizes() {
 	}()
 }
 
-func (p *streamProtocolV3) stream(conn streamCreator) error {
+func (p *streamProtocolV3) stream(conn streamCreator, ready chan<- struct{}) error {
 	if err := p.createStreams(conn); err != nil {
 		return err
+	}
+
+	// Signal that all streams have been created.
+	if ready != nil {
+		close(ready)
 	}
 
 	// now that all the streams have been created, proceed with reading & copying

--- a/staging/src/k8s.io/client-go/tools/remotecommand/v4.go
+++ b/staging/src/k8s.io/client-go/tools/remotecommand/v4.go
@@ -51,9 +51,14 @@ func (p *streamProtocolV4) handleResizes() {
 	p.streamProtocolV3.handleResizes()
 }
 
-func (p *streamProtocolV4) stream(conn streamCreator) error {
+func (p *streamProtocolV4) stream(conn streamCreator, ready chan<- struct{}) error {
 	if err := p.createStreams(conn); err != nil {
 		return err
+	}
+
+	// Signal that all streams have been created.
+	if ready != nil {
+		close(ready)
 	}
 
 	// now that all the streams have been created, proceed with reading & copying

--- a/staging/src/k8s.io/client-go/tools/remotecommand/v5.go
+++ b/staging/src/k8s.io/client-go/tools/remotecommand/v5.go
@@ -30,6 +30,6 @@ func newStreamProtocolV5(options StreamOptions) streamProtocolHandler {
 	}
 }
 
-func (p *streamProtocolV5) stream(conn streamCreator) error {
-	return p.streamProtocolV4.stream(conn)
+func (p *streamProtocolV5) stream(conn streamCreator, ready chan<- struct{}) error {
+	return p.streamProtocolV4.stream(conn, ready)
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
Fixes #131189

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
make sure all streams of websockets are created and then do `readDemuxLoop` to avoid race condition.

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
