### PR TITLE
Add QosClass Compare function for apis helper

### DIFF
--- a/pkg/apis/core/helper/qos/qos.go
+++ b/pkg/apis/core/helper/qos/qos.go
@@ -169,3 +169,26 @@ func ComputePodQOS(pod *core.Pod) core.PodQOSClass {
 	}
 	return core.PodQOSBurstable
 }
+
+// ComparePodQOS compares the QoS classes of two Pods and returns:
+//
+// 1 if p1 has a higher precedence QoS class than p2,
+// -1 if p2 has a higher precedence QoS class than p1,
+// 0 if both have the same QoS class.
+func ComparePodQOS(p1, p2 *core.Pod) int {
+	p1QOS, p2QOS := GetPodQOS(p1), GetPodQOS(p2)
+
+	// Define the precedence order of QoS classes using a map
+	qosOrder := map[core.PodQOSClass]int{
+		core.PodQOSBestEffort: 1,
+		core.PodQOSBurstable:  2,
+		core.PodQOSGuaranteed: 3,
+	}
+
+	if qosOrder[p1QOS] > qosOrder[p2QOS] {
+		return 1
+	} else if qosOrder[p1QOS] < qosOrder[p2QOS] {
+		return -1
+	}
+	return 0
+}

--- a/pkg/apis/core/v1/helper/qos/qos.go
+++ b/pkg/apis/core/v1/helper/qos/qos.go
@@ -172,3 +172,26 @@ func ComputePodQOS(pod *v1.Pod) v1.PodQOSClass {
 	}
 	return v1.PodQOSBurstable
 }
+
+// ComparePodQOS compares the QoS classes of two Pods and returns:
+//
+// 1 if p1 has a higher precedence QoS class than p2,
+// -1 if p2 has a higher precedence QoS class than p1,
+// 0 if both have the same QoS class.
+func ComparePodQOS(p1, p2 *v1.Pod) int {
+	p1QOS, p2QOS := GetPodQOS(p1), GetPodQOS(p2)
+
+	// Define the precedence order of QoS classes using a map
+	qosOrder := map[v1.PodQOSClass]int{
+		v1.PodQOSBestEffort: 1,
+		v1.PodQOSBurstable:  2,
+		v1.PodQOSGuaranteed: 3,
+	}
+
+	if qosOrder[p1QOS] > qosOrder[p2QOS] {
+		return 1
+	} else if qosOrder[p1QOS] < qosOrder[p2QOS] {
+		return -1
+	}
+	return 0
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

Add QosClass Compare function for Pods Sort

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add QosClass Compare function
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
