### PR TITLE
cleanup unneeded code

### DIFF
--- a/pkg/apis/storage/util/helpers.go
+++ b/pkg/apis/storage/util/helpers.go
@@ -26,9 +26,6 @@ const IsDefaultStorageClassAnnotation = "storageclass.kubernetes.io/is-default-c
 // TODO: remove Beta when no longer used
 const BetaIsDefaultStorageClassAnnotation = "storageclass.beta.kubernetes.io/is-default-class"
 
-// AlphaIsDefaultVolumeAttributesClassAnnotation is the alpha version of IsDefaultVolumeAttributesClassAnnotation.
-const AlphaIsDefaultVolumeAttributesClassAnnotation = "volumeattributesclass.alpha.kubernetes.io/is-default-class"
-
 // IsDefaultAnnotation returns a boolean if
 // the annotation is set
 // TODO: remove Beta when no longer needed
@@ -41,10 +38,4 @@ func IsDefaultAnnotation(obj metav1.ObjectMeta) bool {
 	}
 
 	return false
-}
-
-// IsDefaultAnnotationForVolumeAttributesClass returns a boolean if
-// the annotation is set
-func IsDefaultAnnotationForVolumeAttributesClass(obj metav1.ObjectMeta) bool {
-	return obj.Annotations[AlphaIsDefaultVolumeAttributesClassAnnotation] == "true"
 }

--- a/pkg/printers/internalversion/printers.go
+++ b/pkg/printers/internalversion/printers.go
@@ -2618,12 +2618,7 @@ func printVolumeAttributesClass(obj *storage.VolumeAttributesClass, options prin
 		Object: runtime.RawExtension{Object: obj},
 	}
 
-	name := obj.Name
-	if storageutil.IsDefaultAnnotationForVolumeAttributesClass(obj.ObjectMeta) {
-		name += " (default)"
-	}
-
-	row.Cells = append(row.Cells, name, obj.DriverName, translateTimestampSince(obj.CreationTimestamp))
+	row.Cells = append(row.Cells, obj.Name, obj.DriverName, translateTimestampSince(obj.CreationTimestamp))
 
 	return []metav1.TableRow{row}, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

We don't support the default class for the vac feature. And the annotation is not implemented yet. so it is safe to be removed.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related to https://github.com/kubernetes/enhancements/pull/5024

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
