### PR TITLE
Remove FlowSchemas handling non-leases-backed leader election

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/apis/flowcontrol/bootstrap/default.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/flowcontrol/bootstrap/default.go
@@ -73,8 +73,6 @@ var (
 		SuggestedFlowSchemaSystemNodeHigh,            // references "node-high" priority-level
 		SuggestedFlowSchemaProbes,                    // references "exempt" priority-level
 		SuggestedFlowSchemaSystemLeaderElection,      // references "leader-election" priority-level
-		SuggestedFlowSchemaWorkloadLeaderElection,    // references "leader-election" priority-level
-		SuggestedFlowSchemaEndpointsController,       // references "workload-high" priority-level
 		SuggestedFlowSchemaKubeControllerManager,     // references "workload-high" priority-level
 		SuggestedFlowSchemaKubeScheduler,             // references "workload-high" priority-level
 		SuggestedFlowSchemaKubeSystemServiceAccounts, // references "workload-high" priority-level
@@ -301,52 +299,6 @@ var (
 				users(user.KubeControllerManager, user.KubeScheduler),
 				kubeSystemServiceAccount(flowcontrol.NameAll)...),
 			ResourceRules: []flowcontrol.ResourcePolicyRule{
-				resourceRule(
-					[]string{"get", "create", "update"},
-					[]string{coordinationv1.GroupName},
-					[]string{"leases"},
-					[]string{flowcontrol.NamespaceEvery},
-					false),
-			},
-		},
-	)
-	// We add an explicit rule for endpoint-controller with high precedence
-	// to ensure that those calls won't get caught by the following
-	// <workload-leader-election> flow-schema.
-	//
-	// TODO(#80289): Get rid of this rule once we get rid of support for
-	//   using endpoints and configmaps objects for leader election.
-	SuggestedFlowSchemaEndpointsController = newFlowSchema(
-		"endpoint-controller", "workload-high", 150,
-		flowcontrol.FlowDistinguisherMethodByUserType,
-		flowcontrol.PolicyRulesWithSubjects{
-			Subjects: append(
-				users(user.KubeControllerManager),
-				kubeSystemServiceAccount("endpoint-controller", "endpointslicemirroring-controller")...),
-			ResourceRules: []flowcontrol.ResourcePolicyRule{
-				resourceRule(
-					[]string{"get", "create", "update"},
-					[]string{corev1.GroupName},
-					[]string{"endpoints"},
-					[]string{flowcontrol.NamespaceEvery},
-					false),
-			},
-		},
-	)
-	// TODO(#80289): Get rid of this rule once we get rid of support for
-	//   using endpoints and configmaps objects for leader election.
-	SuggestedFlowSchemaWorkloadLeaderElection = newFlowSchema(
-		"workload-leader-election", "leader-election", 200,
-		flowcontrol.FlowDistinguisherMethodByUserType,
-		flowcontrol.PolicyRulesWithSubjects{
-			Subjects: kubeSystemServiceAccount(flowcontrol.NameAll),
-			ResourceRules: []flowcontrol.ResourcePolicyRule{
-				resourceRule(
-					[]string{"get", "create", "update"},
-					[]string{corev1.GroupName},
-					[]string{"endpoints", "configmaps"},
-					[]string{flowcontrol.NamespaceEvery},
-					false),
 				resourceRule(
 					[]string{"get", "create", "update"},
 					[]string{coordinationv1.GroupName},


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/kind feature

#### What this PR does / why we need it:
This PR eliminates the leftover FlowSchema objects that were specific to leader election which used the lock types that are unsupported since K8s 1.28 (xref https://github.com/kubernetes/kubernetes/pull/117558) from the default APF configuration.

The `workload-leader-election` FlowSchema is bad enough for controllers that read/create/change individual ConfigMaps or Endpoints:
- In the default APF configuration, API calls concerning the ConfigMaps would land in the `leader-election` Priority Level,
- This could easily result in that Priority Level's saturation, hence making leader-elected controllers restart due to failing to refresh their leader Lease on time,

At the same time, leases-based leader election-related API calls would land in the `leader-election` Priority Level thanks to the `system-leader-election` FlowSchema.

In addition, after removing `workload-leader-election`, the `endpoint-controller` FlowSchema would become unnecessary as well - the `kube-controller-manager` FlowSchema would be completely sufficient.

#### Which issue(s) this PR fixes:
Contributes to https://github.com/kubernetes/kubernetes/issues/80289.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Removed "endpoint-controller" and "workload-leader-election" FlowSchemas from the default APF configuration.

Action required: migrate the lock type used in the leader election in your workloads from configmapsleases/endpointsleases to leases.
```