### PR TITLE
Shorten long directory names with e2e pod logs

### DIFF
--- a/test/e2e/storage/utils/file.go
+++ b/test/e2e/storage/utils/file.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"fmt"
+	"hash/crc32"
+)
+
+// The max length for ntfs, ext4, xfs and btrfs.
+const maxFileNameLength = 255
+
+// Shorten a file name to size allowed by the most common filesystems.
+// If the filename is too long, cut it + add a short hash (crc32) that makes it unique.
+// Note that the input should be a single file / directory name, not a path
+// composed of several directories.
+func ShortenFileName(filename string) string {
+	if len(filename) <= maxFileNameLength {
+		return filename
+	}
+
+	hash := crc32.ChecksumIEEE([]byte(filename))
+	hashString := fmt.Sprintf("%x", hash)
+	hashLen := len(hashString)
+
+	return fmt.Sprintf("%s-%s", filename[:maxFileNameLength-1-hashLen], hashString)
+}

--- a/test/e2e/storage/utils/file_test.go
+++ b/test/e2e/storage/utils/file_test.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShortenFileName(t *testing.T) {
+	tests := []struct {
+		name     string
+		filename string
+		expected string
+	}{
+		{
+			name:     "Shorter than max length",
+			filename: "short file name",
+			expected: "short file name",
+		},
+		{
+			name:     "Longer than max length, truncated",
+			filename: "a very long string that has exactly 256 characters a very long string that has exactly 256 characters a very long string that has exactly 256 characters a very long string that has exactly 256 characters a very long string that has exactly 256 characters..",
+			expected: "a very long string that has exactly 256 characters a very long string that has exactly 256 characters a very long string that has exactly 256 characters a very long string that has exactly 256 characters a very long string that has exactly 256 ch-ad31f675",
+		},
+		{
+			name:     "Exactly max length, not truncated",
+			filename: "a very long string that has exactly 255 characters a very long string that has exactly 255 characters a very long string that has exactly 255 characters a very long string that has exactly 255 characters a very long string that has exactly 255 characters.",
+			expected: "a very long string that has exactly 255 characters a very long string that has exactly 255 characters a very long string that has exactly 255 characters a very long string that has exactly 255 characters a very long string that has exactly 255 characters.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ShortenFileName(tt.filename)
+			assert.Equal(t, tt.expected, result)
+			assert.LessOrEqual(t, len(result), maxFileNameLength)
+		})
+	}
+}

--- a/test/e2e/storage/utils/pod.go
+++ b/test/e2e/storage/utils/pod.go
@@ -22,8 +22,8 @@ import (
 	"io"
 	"os"
 	"path"
+	"path/filepath"
 	"regexp"
-	"strings"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -68,6 +68,12 @@ func StartPodLogs(ctx context.Context, f *framework.Framework, driverNamespace *
 				testName = append(testName, reg.ReplaceAllString(test.LeafNodeText, "_"))
 			}
 		}
+
+		// Make sure each directory name is short enough for Linux + Windows
+		for i, testNameComponent := range testName {
+			testName[i] = ShortenFileName(testNameComponent)
+		}
+
 		// We end the prefix with a slash to ensure that all logs
 		// end up in a directory named after the current test.
 		//
@@ -76,7 +82,7 @@ func StartPodLogs(ctx context.Context, f *framework.Framework, driverNamespace *
 		// keeps each directory name smaller (the full test
 		// name at one point exceeded 256 characters, which was
 		// too much for some filesystems).
-		logDir := framework.TestContext.ReportDir + "/" + strings.Join(testName, "/")
+		logDir := filepath.Join(framework.TestContext.ReportDir, filepath.Join(testName...))
 		to.LogPathPrefix = logDir + "/"
 
 		err := os.MkdirAll(logDir, 0755)


### PR DESCRIPTION
#### What type of PR is this?
sort of
/kind bug

#### What this PR does / why we need it:
In a downstream test job, I've seen an e2e test failing to create a directory for Pod logs when running an e2e test. Shorten them to 255 characters.

For example, consider this existing upstream test: `"[sig-storage] CSI Mock selinux on mount metrics and SELinuxWarningController SELinuxMount metrics [LinuxOnly] [Feature:SELinux] [Serial] error is not bumped on two Pods with a different policy RWX volume (MountOption + MountOption) [FeatureGate:SELinuxMountReadWriteOncePod] [Beta] [FeatureGate:SELinuxChangePolicy] [Beta] [FeatureGate:SELinuxMount] [Beta] [Feature:OffByDefault] [sig-storage, Feature:SELinux, Serial, FeatureGate:SELinuxMountReadWriteOncePod, Beta, FeatureGate:SELinuxChangePolicy, FeatureGate:SELinuxMount, Feature:OffByDefault, BetaOffByDefault]"`

During its execution, the test will create a directory `error_is_not_bumped_on_two_Pods_with_Recursive_policy_and_a_different_context_on_RWX_volume_FeatureGate_SELinuxMountReadWriteOncePod_Beta_FeatureGate_SELinuxChangePolicy_Beta_FeatureGate_SELinuxMount_Beta_Feature_OffByDefault_` to store logs of the CSI driver used for testing. The directory name has 226 characters and it's close to the limit (256).

#### Which issue(s) this PR fixes:
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
