### PR TITLE
feat(ccm): watch-based route controller reconciliation

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -1992,12 +1992,12 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 		{Version: version.MustParse("1.34"), Default: true, PreRelease: featuregate.Beta},
 	},
 
-	kcmfeatures.CloudControllerManagerWebhook: {
-		{Version: version.MustParse("1.27"), Default: false, PreRelease: featuregate.Alpha},
-	},
-
 	kcmfeatures.CloudControllerManagerWatchBasedRoutesReconciliation: {
 		{Version: version.MustParse("1.35"), Default: false, PreRelease: featuregate.Alpha},
+	},
+
+	kcmfeatures.CloudControllerManagerWebhook: {
+		{Version: version.MustParse("1.27"), Default: false, PreRelease: featuregate.Alpha},
 	},
 
 	zpagesfeatures.ComponentFlagz: {

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -2392,6 +2392,8 @@ var defaultKubernetesFeatureGateDependencies = map[featuregate.Feature][]feature
 
 	genericfeatures.WatchList: {},
 
+	kcmfeatures.CloudControllerManagerWatchBasedRoutesReconciliation: {},
+
 	kcmfeatures.CloudControllerManagerWebhook: {},
 
 	zpagesfeatures.ComponentFlagz: {},

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -1996,6 +1996,10 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 		{Version: version.MustParse("1.27"), Default: false, PreRelease: featuregate.Alpha},
 	},
 
+	kcmfeatures.CloudControllerManagerWatchBasedRoutesReconciliation: {
+		{Version: version.MustParse("1.35"), Default: false, PreRelease: featuregate.Alpha},
+	},
+
 	zpagesfeatures.ComponentFlagz: {
 		{Version: version.MustParse("1.32"), Default: false, PreRelease: featuregate.Alpha},
 	},

--- a/staging/src/k8s.io/cloud-provider/app/core.go
+++ b/staging/src/k8s.io/cloud-provider/app/core.go
@@ -128,13 +128,16 @@ func startRouteController(ctx context.Context, initContext ControllerInitContext
 		return nil, false, fmt.Errorf("length of clusterCIDRs is:%v more than max allowed of 2", len(clusterCIDRs))
 	}
 
-	routeController := routecontroller.New(
+	routeController, err := routecontroller.New(
 		routes,
 		completedConfig.ClientBuilder.ClientOrDie(initContext.ClientName),
 		completedConfig.SharedInformers.Core().V1().Nodes(),
 		completedConfig.ComponentConfig.KubeCloudShared.ClusterName,
 		clusterCIDRs,
 	)
+	if err != nil {
+		return nil, false, err
+	}
 	go routeController.Run(ctx, completedConfig.ComponentConfig.KubeCloudShared.RouteReconciliationPeriod.Duration, controlexContext.ControllerManagerMetrics)
 
 	return nil, true, nil

--- a/staging/src/k8s.io/cloud-provider/controllers/route/route_controller.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/route/route_controller.go
@@ -48,7 +48,6 @@ import (
 	controllersmetrics "k8s.io/component-base/metrics/prometheus/controllers"
 	nodeutil "k8s.io/component-helpers/node/util"
 	"k8s.io/controller-manager/pkg/features"
-	_ "k8s.io/controller-manager/pkg/features/register"
 )
 
 const (

--- a/staging/src/k8s.io/cloud-provider/controllers/route/route_controller.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/route/route_controller.go
@@ -163,7 +163,7 @@ func (rc *RouteController) handleNodeUpdate(oldObj, newObj interface{}) {
 func (rc *RouteController) Run(ctx context.Context, syncPeriod time.Duration, controllerManagerMetrics *controllersmetrics.ControllerManagerMetrics) {
 	defer utilruntime.HandleCrash()
 
-	if utilfeature.DefaultFeatureGate.Enabled(features.CloudControllerManagerWatchBasedRoutesReconciliation) {
+	if utilfeature.DefaultFeatureGate.Enabled(features.CloudControllerManagerWatchBasedRoutesReconciliation) && rc.workqueue != nil {
 		defer rc.workqueue.ShutDown()
 	}
 

--- a/staging/src/k8s.io/cloud-provider/controllers/route/route_controller.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/route/route_controller.go
@@ -55,8 +55,10 @@ const (
 	// Maximal number of concurrent route operation API calls.
 	// TODO: This should be per-provider.
 	maxConcurrentRouteOperations int = 200
-	// In the scenarios with a burst of node events,
-	// we don't want to be worse than a 10s interval (current default reconcile interval).
+	// In the scenarios with a burst of node events, we don't want to be worse
+	// than a 10s interval.
+	// The 10s interval was defined in KEP 5237, it is equivalent to the default
+	// sync period of the route controller.
 	minRouteResyncInterval time.Duration = 10 * time.Second
 )
 

--- a/staging/src/k8s.io/cloud-provider/controllers/route/route_controller.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/route/route_controller.go
@@ -148,7 +148,9 @@ func (rc *RouteController) handleNodeUpdate(oldObj, newObj interface{}) {
 		return
 	}
 
-	// Resync sends an update with old==new.
+	// The Node informer triggers a periodic update event.
+	// In these cases, the old and new Node objects are identical. We use this event as a signal to perform
+	// a route reconciliation — our regular cleanup process — as described in the KEP 5237.
 	resync := oldNode.GetResourceVersion() == newNode.GetResourceVersion()
 	diffInPodCIDR := !reflect.DeepEqual(oldNode.Spec.PodCIDRs, newNode.Spec.PodCIDRs)
 	diffInNodeAddresses := !reflect.DeepEqual(oldNode.Status.Addresses, newNode.Status.Addresses)

--- a/staging/src/k8s.io/cloud-provider/controllers/route/route_controller_test.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/route/route_controller_test.go
@@ -25,6 +25,7 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/controller-manager/pkg/features"
+	_ "k8s.io/controller-manager/pkg/features/register"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/staging/src/k8s.io/cloud-provider/controllers/route/route_controller_test.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/route/route_controller_test.go
@@ -22,6 +22,10 @@ import (
 	"testing"
 	"time"
 
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	"k8s.io/controller-manager/pkg/features"
+
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -510,6 +514,91 @@ func TestReconcile(t *testing.T) {
 			}
 		})
 
+	}
+}
+
+func TestHandleNodeUpdate(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.CloudControllerManagerWatchBasedRoutesReconciliation, true)
+
+	cluster := "my-k8s"
+	node := v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1", UID: "01"}, Spec: v1.NodeSpec{PodCIDR: "10.120.0.0/24", PodCIDRs: []string{"10.120.0.0/24"}}, Status: v1.NodeStatus{Addresses: []v1.NodeAddress{{Type: v1.NodeInternalIP, Address: "10.0.1.1"}}}}
+
+	testCases := []struct {
+		description           string
+		clientset             *fake.Clientset
+		updatedNode           v1.Node
+		expectedWorkqueueItem string
+	}{
+		{
+			description:           "internal IP updated",
+			clientset:             fake.NewClientset(&v1.NodeList{Items: []v1.Node{node}}),
+			updatedNode:           v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1", UID: "01"}, Spec: v1.NodeSpec{PodCIDR: "10.120.0.0/24", PodCIDRs: []string{"10.120.0.0/24"}}, Status: v1.NodeStatus{Addresses: []v1.NodeAddress{{Type: v1.NodeInternalIP, Address: "10.0.1.2"}}}},
+			expectedWorkqueueItem: "routes",
+		},
+		{
+			description:           "pod CIDR updated",
+			clientset:             fake.NewClientset(&v1.NodeList{Items: []v1.Node{node}}),
+			updatedNode:           v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1", UID: "01"}, Spec: v1.NodeSpec{PodCIDR: "10.121.0.0/24", PodCIDRs: []string{"10.121.0.0/24"}}, Status: v1.NodeStatus{Addresses: []v1.NodeAddress{{Type: v1.NodeInternalIP, Address: "10.0.1.1"}}}},
+			expectedWorkqueueItem: "routes",
+		},
+		{
+			description: "node object not updated",
+			clientset:   fake.NewClientset(&v1.NodeList{Items: []v1.Node{node}}),
+			updatedNode: node,
+		},
+		{
+			description: "unrelated node update",
+			clientset:   fake.NewClientset(&v1.NodeList{Items: []v1.Node{node}}),
+			updatedNode: v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node-1",
+					UID:  "01",
+				},
+				Spec: v1.NodeSpec{
+					PodCIDR:  "10.120.0.0/24",
+					PodCIDRs: []string{"10.120.0.0/24"},
+				},
+				Status: v1.NodeStatus{
+					Addresses: []v1.NodeAddress{
+						{
+							Type:    v1.NodeInternalIP,
+							Address: "10.0.1.1",
+						},
+					},
+					Images: []v1.ContainerImage{
+						{
+							Names: []string{
+								"registry.k8s.io/pause:latest",
+							},
+							SizeBytes: 239840,
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			cloud := &fakecloud.Cloud{RouteMap: make(map[string]*fakecloud.Route)}
+			routes, ok := cloud.Routes()
+			assert.True(t, ok, "fakecloud failed to run Routes()")
+
+			cidrs := make([]*net.IPNet, 0)
+			_, cidr, _ := netutils.ParseCIDRSloppy("10.120.0.0/16")
+			cidrs = append(cidrs, cidr)
+
+			informerFactory := informers.NewSharedInformerFactory(testCase.clientset, 0)
+			rc := New(routes, testCase.clientset, informerFactory.Core().V1().Nodes(), cluster, cidrs)
+			require.NotNil(t, rc.workqueue)
+
+			rc.handleNodeUpdate(&node, &testCase.updatedNode)
+
+			if testCase.expectedWorkqueueItem != "" {
+				item, shutdown := rc.workqueue.Get()
+				require.False(t, shutdown, "workqueue is shutdown")
+				assert.Equal(t, testCase.expectedWorkqueueItem, item, "unexpected item from workqueue")
+			}
+		})
 	}
 }
 

--- a/staging/src/k8s.io/cloud-provider/controllers/route/route_controller_test.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/route/route_controller_test.go
@@ -77,7 +77,8 @@ func TestIsResponsibleForRoute(t *testing.T) {
 		}
 		client := fake.NewSimpleClientset()
 		informerFactory := informers.NewSharedInformerFactory(client, 0)
-		rc := New(nil, nil, informerFactory.Core().V1().Nodes(), myClusterName, []*net.IPNet{cidr})
+		rc, err := New(nil, nil, informerFactory.Core().V1().Nodes(), myClusterName, []*net.IPNet{cidr})
+		require.NoError(t, err)
 		rc.nodeListerSynced = alwaysReady
 		route := &cloudprovider.Route{
 			Name:            testCase.routeName,
@@ -457,7 +458,9 @@ func TestReconcile(t *testing.T) {
 			}
 
 			informerFactory := informers.NewSharedInformerFactory(testCase.clientset, 0)
-			rc := New(routes, testCase.clientset, informerFactory.Core().V1().Nodes(), cluster, cidrs)
+
+			rc, err := New(routes, testCase.clientset, informerFactory.Core().V1().Nodes(), cluster, cidrs)
+			require.NoError(t, err)
 
 			recorder := record.NewBroadcaster(record.WithContext(ctx))
 			rc.recorder = recorder.NewRecorder(scheme.Scheme, v1.EventSource{Component: "route_controller"})
@@ -493,7 +496,6 @@ func TestReconcile(t *testing.T) {
 				}
 			}
 			var finalRoutes []*cloudprovider.Route
-			var err error
 			timeoutChan := time.After(200 * time.Millisecond)
 			tick := time.NewTicker(10 * time.Millisecond)
 			defer tick.Stop()
@@ -588,7 +590,8 @@ func TestHandleNodeUpdate(t *testing.T) {
 			cidrs = append(cidrs, cidr)
 
 			informerFactory := informers.NewSharedInformerFactory(testCase.clientset, 0)
-			rc := New(routes, testCase.clientset, informerFactory.Core().V1().Nodes(), cluster, cidrs)
+			rc, err := New(routes, testCase.clientset, informerFactory.Core().V1().Nodes(), cluster, cidrs)
+			require.NoError(t, err)
 			require.NotNil(t, rc.workqueue)
 
 			rc.handleNodeUpdate(&node, &testCase.updatedNode)

--- a/staging/src/k8s.io/cloud-provider/go.mod
+++ b/staging/src/k8s.io/cloud-provider/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/spf13/cobra v1.10.0
 	github.com/spf13/pflag v1.0.9
 	github.com/stretchr/testify v1.11.1
+	golang.org/x/time v0.9.0
 	k8s.io/api v0.0.0
 	k8s.io/apimachinery v0.0.0
 	k8s.io/apiserver v0.0.0
@@ -93,7 +94,6 @@ require (
 	golang.org/x/sys v0.37.0 // indirect
 	golang.org/x/term v0.36.0 // indirect
 	golang.org/x/text v0.29.0 // indirect
-	golang.org/x/time v0.9.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250303144028-a0af3efb3deb // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250528174236-200df99c418a // indirect
 	google.golang.org/grpc v1.72.2 // indirect

--- a/staging/src/k8s.io/controller-manager/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/controller-manager/pkg/features/kube_features.go
@@ -31,17 +31,8 @@ import (
 // of code conflicts because changes are more likely to be scattered
 // across the file.
 const (
-	// Every feature gate should add method here following this template:
-	//
-	// // owner: @username
-	// MyFeature featuregate.Feature = "MyFeature"
-	//
-	// Feature gates should be listed in alphabetical, case-sensitive
-	// (upper before any lower case character) order. This reduces the risk
-	// of code conflicts because changes are more likely to be scattered
-	// across the file.
-
 	// owner: @lukasmetzner
+	// kep:  http://kep.k8s.io/5237
 	// Use watch based route controller reconciliation instead of frequent periodic reconciliation.
 	CloudControllerManagerWatchBasedRoutesReconciliation featuregate.Feature = "CloudControllerManagerWatchBasedRoutesReconciliation"
 

--- a/staging/src/k8s.io/controller-manager/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/controller-manager/pkg/features/kube_features.go
@@ -31,6 +31,20 @@ import (
 // of code conflicts because changes are more likely to be scattered
 // across the file.
 const (
+	// Every feature gate should add method here following this template:
+	//
+	// // owner: @username
+	// MyFeature featuregate.Feature = "MyFeature"
+	//
+	// Feature gates should be listed in alphabetical, case-sensitive
+	// (upper before any lower case character) order. This reduces the risk
+	// of code conflicts because changes are more likely to be scattered
+	// across the file.
+
+	// owner: @lukasmetzner
+	// Use watch based route controller reconcilation instead of frequent periodic reconciliation.
+	CloudControllerManagerWatchBasedRoutesReconciliation featuregate.Feature = "CloudControllerManagerWatchBasedRoutesReconciliation"
+
 	// owner: @nckturner
 	// kep:  http://kep.k8s.io/2699
 	// Enable webhook in cloud controller manager
@@ -44,6 +58,10 @@ func SetupCurrentKubernetesSpecificFeatureGates(featuregates featuregate.Mutable
 // versionedCloudPublicFeatureGates consists of versioned cloud-specific feature keys.
 // To add a new feature, define a key for it above and add it here.
 var versionedCloudPublicFeatureGates = map[featuregate.Feature]featuregate.VersionedSpecs{
+	CloudControllerManagerWatchBasedRoutesReconciliation: {
+		// TODO: Update to 1.34 once the Kubernetes version is changed
+		{Version: version.MustParse("1.33"), Default: false, PreRelease: featuregate.Alpha},
+	},
 	CloudControllerManagerWebhook: {
 		{Version: version.MustParse("1.27"), Default: false, PreRelease: featuregate.Alpha},
 	},

--- a/staging/src/k8s.io/controller-manager/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/controller-manager/pkg/features/kube_features.go
@@ -42,7 +42,7 @@ const (
 	// across the file.
 
 	// owner: @lukasmetzner
-	// Use watch based route controller reconcilation instead of frequent periodic reconciliation.
+	// Use watch based route controller reconciliation instead of frequent periodic reconciliation.
 	CloudControllerManagerWatchBasedRoutesReconciliation featuregate.Feature = "CloudControllerManagerWatchBasedRoutesReconciliation"
 
 	// owner: @nckturner

--- a/staging/src/k8s.io/controller-manager/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/controller-manager/pkg/features/kube_features.go
@@ -50,7 +50,6 @@ func SetupCurrentKubernetesSpecificFeatureGates(featuregates featuregate.Mutable
 // To add a new feature, define a key for it above and add it here.
 var versionedCloudPublicFeatureGates = map[featuregate.Feature]featuregate.VersionedSpecs{
 	CloudControllerManagerWatchBasedRoutesReconciliation: {
-		// TODO: Update to 1.34 once the Kubernetes version is changed
 		{Version: version.MustParse("1.35"), Default: false, PreRelease: featuregate.Alpha},
 	},
 	CloudControllerManagerWebhook: {

--- a/staging/src/k8s.io/controller-manager/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/controller-manager/pkg/features/kube_features.go
@@ -60,7 +60,7 @@ func SetupCurrentKubernetesSpecificFeatureGates(featuregates featuregate.Mutable
 var versionedCloudPublicFeatureGates = map[featuregate.Feature]featuregate.VersionedSpecs{
 	CloudControllerManagerWatchBasedRoutesReconciliation: {
 		// TODO: Update to 1.34 once the Kubernetes version is changed
-		{Version: version.MustParse("1.33"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.35"), Default: false, PreRelease: featuregate.Alpha},
 	},
 	CloudControllerManagerWebhook: {
 		{Version: version.MustParse("1.27"), Default: false, PreRelease: featuregate.Alpha},

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -181,6 +181,12 @@
     lockToDefault: false
     preRelease: Alpha
     version: "1.34"
+- name: CloudControllerManagerWatchBasedRoutesReconciliation
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.33"
 - name: CloudControllerManagerWebhook
   versionedSpecs:
   - default: false

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -186,7 +186,7 @@
   - default: false
     lockToDefault: false
     preRelease: Alpha
-    version: "1.33"
+    version: "1.35"
 - name: CloudControllerManagerWebhook
   versionedSpecs:
   - default: false


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
The route controller in the cloud-controller-manager currently operates with a static reconciliation interval. Depending on the scale of the cluster, this can quickly lead to exceeding the rate limits set by cloud providers.

This PR introduces a new watch-based route controller that triggers reconciliation only when a node is added, deleted, or when there are updates to the `Status.Addresses` or `PodCIDR` fields.

Additionally, a new feature gate, `CloudControllerManagerWatchBasedRoutesReconciliation`, is introduced, which is disabled by default.

#### Which issue(s) this PR fixes:
Fixes #60646

#### Special notes for your reviewer:
KEP [5237](https://github.com/kubernetes/enhancements/issues/5237) is merged and has status implementable.

#### Does this PR introduce a user-facing change?
```release-note
Add cloud-controller-manager feature gate CloudControllerManagerWatchBasedRoutesReconciliation
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
Implementation of KEP 5237
```
