### PR TITLE
Refactor validateNodeIP with switch statement for improved readability

### DIFF
--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -772,19 +772,16 @@ func (kl *Kubelet) defaultNodeStatusFuncs() []func(context.Context, *v1.Node) er
 // Validate given node IP belongs to the current host
 func validateNodeIP(nodeIP net.IP) error {
 	// Honor IP limitations set in setNodeStatus()
-	if nodeIP.To4() == nil && nodeIP.To16() == nil {
+	switch {
+	case nodeIP.To4() == nil && nodeIP.To16() == nil:
 		return fmt.Errorf("nodeIP must be a valid IP address")
-	}
-	if nodeIP.IsLoopback() {
+	case nodeIP.IsLoopback():
 		return fmt.Errorf("nodeIP can't be loopback address")
-	}
-	if nodeIP.IsMulticast() {
+	case nodeIP.IsMulticast():
 		return fmt.Errorf("nodeIP can't be a multicast address")
-	}
-	if nodeIP.IsLinkLocalUnicast() {
+	case nodeIP.IsLinkLocalUnicast():
 		return fmt.Errorf("nodeIP can't be a link-local unicast address")
-	}
-	if nodeIP.IsUnspecified() {
+	case nodeIP.IsUnspecified():
 		return fmt.Errorf("nodeIP can't be an all zeros address")
 	}
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Converted the validateNodeIP function implementation from cascading if-else statements to a more structured switch statement approach. This modification improves code clarity and simplifies future maintenance without altering functionality.

#### Special notes for your reviewer:
The main change is structural - moving from conditional chains to switch cases for better organization. Would appreciate your thoughts on this refactoring approach.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
NONE
```