### PR TITLE
Add SharedInformer.AddContextEventHandler and AddContextEventHandlerW…

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
+++ b/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
@@ -173,6 +173,13 @@ type SharedInformer interface {
 	// AddEventHandlerWithOptions is a variant of AddEventHandlerWithResyncPeriod where
 	// all optional parameters are passed in a struct.
 	AddEventHandlerWithOptions(handler ResourceEventHandler, options HandlerOptions) (ResourceEventHandlerRegistration, error)
+	// AddContextEventHandler is a variant of AddEventHandler where the
+	// handler is removed when the context is cancelled.
+	AddContextEventHandler(ctx context.Context, handler ResourceEventHandler) (ResourceEventHandlerRegistration, error)
+	// AddContextEventHandlerWithOptions is a variant of
+	// AddEventHandlerWithOptions where the handler is removed when the
+	// context is cancelled.
+	AddContextEventHandlerWithOptions(ctx context.Context, handler ResourceEventHandler, options HandlerOptions) (ResourceEventHandlerRegistration, error)
 	// RemoveEventHandler removes a formerly added event handler given by
 	// its registration handle.
 	// This function is guaranteed to be idempotent, and thread-safe.
@@ -935,6 +942,22 @@ func (s *sharedIndexInformer) AddEventHandlerWithOptions(handler ResourceEventHa
 	s.processor.wg.Start(listener.watchSynced)
 
 	return handle, nil
+}
+
+func (s *sharedIndexInformer) AddContextEventHandler(ctx context.Context, handler ResourceEventHandler) (ResourceEventHandlerRegistration, error) {
+	return s.AddContextEventHandlerWithOptions(ctx, handler, HandlerOptions{})
+}
+
+func (s *sharedIndexInformer) AddContextEventHandlerWithOptions(ctx context.Context, handler ResourceEventHandler, options HandlerOptions) (ResourceEventHandlerRegistration, error) {
+	registration, err := s.AddEventHandlerWithOptions(handler, options)
+	if err != nil {
+		return nil, err
+	}
+	go func() {
+		<-ctx.Done()
+		utilruntime.HandleError(s.RemoveEventHandler(registration))
+	}()
+	return registration, nil
 }
 
 func (s *sharedIndexInformer) handleDeltas(logger klog.Logger, obj interface{}, isInInitialList bool) error {

--- a/staging/src/k8s.io/client-go/tools/cache/shared_informer_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/shared_informer_test.go
@@ -419,6 +419,55 @@ func TestResyncCheckPeriod(t *testing.T) {
 	}
 }
 
+// TestContextHandlers verifies that handlers do not receive further
+// events when their context is canceled without affecting other
+// handlers.
+func TestContextHandlers(t *testing.T) {
+	source := newFakeControllerSource(t)
+	informer := NewSharedInformer(source, &v1.Pod{}, 1*time.Second).(*sharedIndexInformer)
+
+	listener1Ctx, listener1Cancel := context.WithCancel(context.Background())
+	listener1 := newTestListener("listener1", 0, "pod1")
+	listener1Reg, err := informer.AddContextEventHandler(listener1Ctx, listener1)
+	if err != nil {
+		t.Fatalf("informer did not add handler for listener1: %v", err)
+	}
+
+	listener2 := newTestListener("listener2", 0, "pod1", "pod2")
+	if _, err := informer.AddEventHandler(listener2); err != nil {
+		t.Fatalf("informer did not add handler for listener2: %v", err)
+	}
+	listeners := []*testListener{listener1, listener2}
+
+	informerCtx, informerCancel := context.WithCancel(context.Background())
+	defer informerCancel()
+	go informer.RunWithContext(informerCtx)
+
+	source.Add(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1"}})
+	// wait until listener1 has synced pod1
+	assert.Eventually(t, listener1Reg.HasSynced, time.Second*1, time.Millisecond)
+	// cancel listener1
+	listener1Cancel()
+	// wait until listener1 is removed from the processor
+	assert.Eventually(t, func() bool {
+		return informer.processor.getListener(listener1Reg.(*processorListener)) == nil
+	}, time.Second*1, time.Millisecond)
+
+	source.Add(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod2"}})
+
+	for _, listener := range listeners {
+		if !listener.ok() {
+			t.Errorf("%s: expected %v, got %v", listener.name, listener.expectedItemNames, listener.receivedItemNames)
+		}
+	}
+
+	// ensure calling `.RemoveEventHandler` on a context-cancelled
+	// handler registration does not error
+	if err := informer.RemoveEventHandler(listener1Reg); err != nil {
+		t.Fatalf("removing handler registration of context-cancelled handler failed: %s", err)
+	}
+}
+
 // verify that https://github.com/kubernetes/kubernetes/issues/59822 is fixed
 func TestSharedInformerInitializationRace(t *testing.T) {
 	source := newFakeControllerSource(t)


### PR DESCRIPTION
…ithOptions

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

When handlers are registered with the shared informer goroutines are started. 

To stop these goroutines the handlers need to be either removed through `RemoveEventHandler` or the shared informer needs to be shut down.

Controllers rely on the shared informer being shutdown instead of removing handlers themselves - providing a context-aware way of adding handlers would make it easier to ensure handlers are stopped with their controllers.

See discussion in #131199, particularly from here on:
https://github.com/kubernetes/kubernetes/pull/131199#issuecomment-2788726873

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

cc @aojea @Jefftree 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add AddContextEventHandler and AddContextEventHandlerWithOptions to SharedInformer
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
