### PR TITLE
Suppress Timeout error on long-running proxied requests

### DIFF
--- a/cmd/kube-scheduler/app/server.go
+++ b/cmd/kube-scheduler/app/server.go
@@ -348,7 +348,7 @@ func buildHandlerChain(handler http.Handler, authn authenticator.Request, authz 
 	handler = genericapifilters.WithRequestInfo(handler, requestInfoResolver)
 	handler = genericapifilters.WithCacheControl(handler)
 	handler = genericfilters.WithHTTPLogging(handler)
-	handler = genericfilters.WithPanicRecovery(handler, requestInfoResolver)
+	handler = genericfilters.WithPanicRecovery(handler, requestInfoResolver, nil)
 
 	return handler
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -1085,7 +1085,7 @@ func DefaultBuildHandlerChain(apiHandler http.Handler, c *Config) http.Handler {
 	handler = genericapifilters.WithRequestInfo(handler, c.RequestInfoResolver)
 	handler = genericapifilters.WithRequestReceivedTimestamp(handler)
 	handler = genericapifilters.WithMuxAndDiscoveryComplete(handler, c.lifecycleSignals.MuxAndDiscoveryComplete.Signaled())
-	handler = genericfilters.WithPanicRecovery(handler, c.RequestInfoResolver)
+	handler = genericfilters.WithPanicRecovery(handler, c.RequestInfoResolver, c.LongRunningFunc)
 	handler = genericapifilters.WithAuditInit(handler)
 	return handler
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/priority-and-fairness_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/priority-and-fairness_test.go
@@ -1254,7 +1254,7 @@ func newHandlerChain(t *testing.T, handler http.Handler, filter utilflowcontrol.
 	// we don't have any request with invalid timeout, so leaving audit policy and sink nil.
 	handler = apifilters.WithRequestDeadline(handler, nil, nil, longRunningRequestCheck, nil, requestTimeout)
 	handler = apifilters.WithRequestInfo(handler, requestInfoFactory)
-	handler = WithPanicRecovery(handler, requestInfoFactory)
+	handler = WithPanicRecovery(handler, requestInfoFactory, longRunningRequestCheck)
 	handler = apifilters.WithAuditInit(handler)
 	return handler
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/timeout_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/timeout_test.go
@@ -392,7 +392,7 @@ func TestErrConnKilled(t *testing.T) {
 		GrouplessAPIPrefixes: sets.NewString("api"),
 	}
 
-	ts := httptest.NewServer(WithPanicRecovery(handler, resolver))
+	ts := httptest.NewServer(WithPanicRecovery(handler, resolver, nil))
 	defer ts.Close()
 
 	_, err := http.Get(ts.URL)
@@ -455,7 +455,7 @@ func TestErrConnKilledHTTP2(t *testing.T) {
 	}
 
 	// test server
-	ts := httptest.NewUnstartedServer(WithPanicRecovery(handler, resolver))
+	ts := httptest.NewUnstartedServer(WithPanicRecovery(handler, resolver, nil))
 	tsCert, err := tls.X509KeyPair(tsCrt, tsKey)
 	if err != nil {
 		t.Fatalf("backend: invalid x509/key pair: %v", err)

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/wrap_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/wrap_test.go
@@ -18,72 +18,122 @@ package filters
 
 import (
 	"bytes"
+	"context"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/server/routine"
+	"k8s.io/klog/v2"
 	klogtest "k8s.io/klog/v2/test"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
-
-	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/apiserver/pkg/endpoints/request"
-	"k8s.io/apiserver/pkg/server/routine"
-	"k8s.io/klog/v2"
+	"time"
 )
 
-func TestPropogatingPanicLongRunning(t *testing.T) {
+func TestPropagatingPanicLongRunning(t *testing.T) {
 	panicMsg := "panic as designed"
-	capturedOutput := runHandlerWithPanic(t, true, panicMsg)
+	capturedOutput := runHandlerCaptureOutput(t, longRunning, context.Background(), func(http.ResponseWriter, *http.Request) {
+		panic(panicMsg)
+	})
 
 	if !strings.Contains(capturedOutput, panicMsg) || !strings.Contains(capturedOutput, "apiserver panic'd") {
 		t.Errorf("unexpected out captured actual = %v", capturedOutput)
 	}
 }
 
-func TestPropogatingPanicNotLongRunning(t *testing.T) {
+func TestPropagatingPanicNotLongRunning(t *testing.T) {
 	panicMsg := "panic as designed"
-	capturedOutput := runHandlerWithPanic(t, false, panicMsg)
+	capturedOutput := runHandlerCaptureOutput(t, notLongRunning, context.Background(), func(http.ResponseWriter, *http.Request) {
+		panic(panicMsg)
+	})
 
 	if !strings.Contains(capturedOutput, panicMsg) || !strings.Contains(capturedOutput, "apiserver panic'd") {
 		t.Errorf("unexpected out captured actual = %v", capturedOutput)
 	}
 }
 
-func TestSuppressErrAbortHandlerPanic(t *testing.T) {
-	capturedOutput := runHandlerWithPanic(t, true, http.ErrAbortHandler)
+func TestSuppressClientSideAbort(t *testing.T) {
+	clientCtx, cancelClientConnection := context.WithCancel(context.Background())
+	defer cancelClientConnection()
 
-	if !strings.Contains(capturedOutput, "Ignoring ErrAbortHandler") ||
+	capturedOutput := runHandlerCaptureOutput(t, longRunning, clientCtx, func(_ http.ResponseWriter, req *http.Request) {
+		// Simulate the client closing the connection.
+		cancelClientConnection()
+
+		// Wait for that cancelation to propagate to the server
+		select {
+		case <-req.Context().Done():
+		case <-time.After(5 * time.Second):
+			t.Fatal("timed out waiting for cancelation to propagate")
+		}
+
+		// Simulate (for example) ReverseProxy detecting the client closed connection.
+		panic(http.ErrAbortHandler)
+	})
+
+	if !strings.Contains(capturedOutput, "suppressing timeout log") ||
 		strings.Contains(capturedOutput, "apiserver panic'd") {
 		t.Errorf("unexpected out captured actual = %v", capturedOutput)
 	}
 }
 
-func runHandlerWithPanic(t *testing.T, longRunning bool, panicVal any) string {
-	buf := captureKlog(t)
-
-	// Panic with the special sigil value http.ErrAbortHandler.  This
-	// should result in no log for a long-running request.
-	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		panic(panicVal)
+func TestPropagateServerSideAbort(t *testing.T) {
+	capturedOutput := runHandlerCaptureOutput(t, longRunning, context.Background(), func(_ http.ResponseWriter, req *http.Request) {
+		// Simulate (for example) ReverseProxy detecting an upstream failure.
+		panic(http.ErrAbortHandler)
 	})
+
+	if strings.Contains(capturedOutput, "suppressing timeout log") ||
+		strings.Contains(capturedOutput, "panic'd") ||
+		!strings.Contains(capturedOutput, "Timeout or abort") {
+		t.Errorf("unexpected out captured actual = %v", capturedOutput)
+	}
+}
+
+func runHandlerCaptureOutput(t *testing.T, longRunning request.LongRunningRequestCheck, clientCtx context.Context, handler http.HandlerFunc) string {
+	logBuf := captureKlog(t)
+
 	resolver := &request.RequestInfoFactory{
 		APIPrefixes:          sets.NewString("api", "apis"),
 		GrouplessAPIPrefixes: sets.NewString("api"),
 	}
 
-	longRunningFn := func(r *http.Request, requestInfo *request.RequestInfo) bool {
-		return longRunning
-	}
-	ts := httptest.NewServer(routine.WithRoutine(WithPanicRecovery(handler, resolver, longRunningFn), longRunningFn))
+	ts := httptest.NewServer(
+		routine.WithRoutine(
+			WithPanicRecovery(handler, resolver, longRunning),
+			longRunning,
+		),
+	)
 	defer ts.Close()
-	_, err := http.Get(ts.URL)
+
+	req, err := http.NewRequest(http.MethodGet, ts.URL, nil)
+	if err != nil {
+		t.Fatal("Failed to create request", err)
+	}
+	req = req.Clone(clientCtx)
+	_, err = http.DefaultClient.Do(req)
 	if err == nil {
 		t.Error("expected to receive an error")
 	}
 
+	// Wait for the server-side processing to finish so that all logs must have
+	// been emitted.  Close() is idempotent.
+	ts.Close()
+
 	klog.Flush()
-	klog.SetOutput(&bytes.Buffer{}) // prevent further writes into buf
-	capturedOutput := buf.String()
+	klog.SetOutput(&bytes.Buffer{}) // prevent further writes into logBuf
+	capturedOutput := logBuf.String()
+
 	return capturedOutput
+}
+
+func longRunning(r *http.Request, requestInfo *request.RequestInfo) bool {
+	return true
+}
+
+func notLongRunning(r *http.Request, requestInfo *request.RequestInfo) bool {
+	return false
 }
 
 func captureKlog(t *testing.T) *bytes.Buffer {

--- a/staging/src/k8s.io/controller-manager/app/serve.go
+++ b/staging/src/k8s.io/controller-manager/app/serve.go
@@ -49,7 +49,7 @@ func BuildHandlerChain(apiHandler http.Handler, authorizationInfo *apiserver.Aut
 	handler = genericapifilters.WithRequestInfo(handler, requestInfoResolver)
 	handler = genericapifilters.WithCacheControl(handler)
 	handler = genericfilters.WithHTTPLogging(handler)
-	handler = genericfilters.WithPanicRecovery(handler, requestInfoResolver)
+	handler = genericfilters.WithPanicRecovery(handler, requestInfoResolver, nil)
 
 	return handler
 }


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR suppresses a spammy "Timeout or abort" error log triggered when a client closes a long-running connection that has been proxied to an aggregated API server.

`http.ReverseProxy` panics with `http.ErrAbortHandler` if _either_ the upstream read, or the downstream write fails.

That panic triggered a "Timeout or abort while handling" error in `WithPanicRecovery`, which is overkill for client closing the connection, especially for proxied watch requests. We don't log this error for non-proxied connection closures.

- Pass the long-running check function into `WithPanicRecovery` so it can determine if a request is long-lived.
- Suppress the log on long-running requests by checking the long-runningness in the panic handler.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #130410

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Suppressed "timeout or abort" errors from kube-apiserver when client closes long-running proxied connection.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
