### PR TITLE
Kubelet: Randomize ClusterRole name in e2e

### DIFF
--- a/test/e2e/framework/auth/helpers.go
+++ b/test/e2e/framework/auth/helpers.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/onsi/ginkgo/v2"
 	authorizationv1 "k8s.io/api/authorization/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -103,13 +104,13 @@ func WaitForNamedAuthorizationUpdate(ctx context.Context, c v1authorization.Subj
 
 // BindClusterRole binds the cluster role at the cluster scope. If RBAC is not enabled, nil
 // is returned with no action.
-func BindClusterRole(ctx context.Context, c bindingsGetter, clusterRole, ns string, subjects ...rbacv1.Subject) error {
+func BindClusterRole(ctx context.Context, c bindingsGetter, clusterRole, ns string, subjects ...rbacv1.Subject) (func(ctx context.Context), error) {
 	if !IsRBACEnabled(ctx, c) {
-		return nil
+		return func(ctx context.Context) {}, nil
 	}
 
 	// Since the namespace names are unique, we can leave this lying around so we don't have to race any caches
-	_, err := c.ClusterRoleBindings().Create(ctx, &rbacv1.ClusterRoleBinding{
+	clusterRoleBinding, err := c.ClusterRoleBindings().Create(ctx, &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: ns + "--" + clusterRole,
 		},
@@ -122,10 +123,15 @@ func BindClusterRole(ctx context.Context, c bindingsGetter, clusterRole, ns stri
 	}, metav1.CreateOptions{})
 
 	if err != nil {
-		return fmt.Errorf("binding clusterrole/%s for %q for %v: %w", clusterRole, ns, subjects, err)
+		return nil, fmt.Errorf("binding clusterrole/%s for %q for %v: %w", clusterRole, ns, subjects, err)
 	}
 
-	return nil
+	cleanupFunc := func(ctx context.Context) {
+		ginkgo.By(fmt.Sprintf("Destroying ClusterRoleBindings %q for this suite.", clusterRoleBinding.Name))
+		framework.ExpectNoError(c.ClusterRoleBindings().Delete(ctx, clusterRoleBinding.Name, metav1.DeleteOptions{}))
+	}
+
+	return cleanupFunc, nil
 }
 
 // BindClusterRoleInNamespace binds the cluster role at the namespace scope. If RBAC is not enabled, nil

--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -573,9 +573,10 @@ var _ = SIGDescribe("Kubectl client", func() {
 
 				ginkgo.By("adding rbac permissions")
 				// grant the view permission widely to allow inspection of the `invalid` namespace and the default namespace
-				err := e2eauth.BindClusterRole(ctx, f.ClientSet.RbacV1(), "view", f.Namespace.Name,
+				cleanupFunc, err := e2eauth.BindClusterRole(ctx, f.ClientSet.RbacV1(), "view", f.Namespace.Name,
 					rbacv1.Subject{Kind: rbacv1.ServiceAccountKind, Namespace: f.Namespace.Name, Name: "default"})
 				framework.ExpectNoError(err)
+				defer cleanupFunc(ctx)
 
 				err = e2eauth.WaitForAuthorizationUpdate(ctx, f.ClientSet.AuthorizationV1(),
 					serviceaccount.MakeUsername(f.Namespace.Name, "default"),

--- a/test/e2e/node/kubelet_authz.go
+++ b/test/e2e/node/kubelet_authz.go
@@ -59,7 +59,6 @@ var _ = SIGDescribe(feature.KubeletFineGrainedAuthz, func() {
 func runKubeletAuthzTest(ctx context.Context, f *framework.Framework, endpoint, authzSubresource string) string {
 	ns := f.Namespace.Name
 	saName := authzSubresource
-	crName := authzSubresource
 	verb := "get"
 	resource := "nodes"
 
@@ -73,11 +72,11 @@ func runKubeletAuthzTest(ctx context.Context, f *framework.Framework, endpoint, 
 	}, metav1.CreateOptions{})
 	framework.ExpectNoError(err)
 
-	ginkgo.By(fmt.Sprintf("Creating ClusterRole %s with for %s/%s", crName, resource, authzSubresource))
+	ginkgo.By(fmt.Sprintf("Creating ClusterRole with prefix %s with for %s/%s", authzSubresource, resource, authzSubresource))
 
-	_, err = f.ClientSet.RbacV1().ClusterRoles().Create(ctx, &rbacv1.ClusterRole{
+	clusterRole, err := f.ClientSet.RbacV1().ClusterRoles().Create(ctx, &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: crName,
+			GenerateName: authzSubresource + "-",
 		},
 		Rules: []rbacv1.PolicyRule{
 			{
@@ -88,6 +87,10 @@ func runKubeletAuthzTest(ctx context.Context, f *framework.Framework, endpoint, 
 		},
 	}, metav1.CreateOptions{})
 	framework.ExpectNoError(err)
+	defer func() {
+		ginkgo.By(fmt.Sprintf("Destroying ClusterRoles %q for this suite.", clusterRole.Name))
+		framework.ExpectNoError(f.ClientSet.RbacV1().ClusterRoles().Delete(ctx, clusterRole.Name, metav1.DeleteOptions{}))
+	}()
 
 	subject := rbacv1.Subject{
 		Kind:      rbacv1.ServiceAccountKind,
@@ -95,10 +98,11 @@ func runKubeletAuthzTest(ctx context.Context, f *framework.Framework, endpoint, 
 		Name:      saName,
 	}
 
-	ginkgo.By(fmt.Sprintf("Creating ClusterRoleBinding with ClusterRole %s with subject %s/%s", crName, ns, saName))
+	ginkgo.By(fmt.Sprintf("Creating ClusterRoleBinding with ClusterRole %s with subject %s/%s", clusterRole.Name, ns, saName))
 
-	err = e2eauth.BindClusterRole(ctx, f.ClientSet.RbacV1(), crName, ns, subject)
+	cleanupFunc, err := e2eauth.BindClusterRole(ctx, f.ClientSet.RbacV1(), clusterRole.Name, ns, subject)
 	framework.ExpectNoError(err)
+	defer cleanupFunc(ctx)
 
 	ginkgo.By("Waiting for Authorization Update.")
 

--- a/test/e2e/storage/drivers/in_tree.go
+++ b/test/e2e/storage/drivers/in_tree.go
@@ -165,10 +165,10 @@ func (n *nfsDriver) PrepareTest(ctx context.Context, f *framework.Framework) *st
 
 	// TODO(mkimuram): cluster-admin gives too much right but system:persistent-volume-provisioner
 	// is not enough. We should create new clusterrole for testing.
-	err := e2eauth.BindClusterRole(ctx, cs.RbacV1(), "cluster-admin", ns.Name,
+	cleanupFunc, err := e2eauth.BindClusterRole(ctx, cs.RbacV1(), "cluster-admin", ns.Name,
 		rbacv1.Subject{Kind: rbacv1.ServiceAccountKind, Namespace: ns.Name, Name: "default"})
 	framework.ExpectNoError(err)
-	ginkgo.DeferCleanup(cs.RbacV1().ClusterRoleBindings().Delete, ns.Name+"--"+"cluster-admin", *metav1.NewDeleteOptions(0))
+	ginkgo.DeferCleanup(cleanupFunc)
 
 	err = e2eauth.WaitForAuthorizationUpdate(ctx, cs.AuthorizationV1(),
 		serviceaccount.MakeUsername(ns.Name, "default"),

--- a/test/e2e/storage/volume_provisioning.go
+++ b/test/e2e/storage/volume_provisioning.go
@@ -442,8 +442,9 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 				Name:      serviceAccountName,
 			}
 
-			err := e2eauth.BindClusterRole(ctx, c.RbacV1(), "system:persistent-volume-provisioner", ns, subject)
+			cleanupFunc, err := e2eauth.BindClusterRole(ctx, c.RbacV1(), "system:persistent-volume-provisioner", ns, subject)
 			framework.ExpectNoError(err)
+			defer cleanupFunc(ctx)
 
 			roleName := "leader-locking-nfs-provisioner"
 			_, err = f.ClientSet.RbacV1().Roles(ns).Create(ctx, &rbacv1.Role{


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug




#### What this PR does / why we need it:
It's possible that a conflict will happen when
attempting to create a `ClusterRole` resource
without a randomized name given that is a cluster
scoped object and another object with same name
might exist. This commit fixes this issue by ensuring
the name of the `ClusterRole` is randomized. Additionally,
it adds clean up for the `clusterRole` and `clusterRoleBinding`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
