### PR TITLE
staging/publishing: add release-1.33 rules

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -29,6 +29,12 @@ rules:
       branch: release-1.32
       dirs:
       - staging/src/k8s.io/apimachinery
+  - name: release-1.33
+    go: 1.24.0
+    source:
+      branch: release-1.33
+      dirs:
+      - staging/src/k8s.io/apimachinery
   library: true
 - destination: api
   branches:
@@ -73,6 +79,15 @@ rules:
       branch: release-1.32
     source:
       branch: release-1.32
+      dirs:
+      - staging/src/k8s.io/api
+  - name: release-1.33
+    go: 1.24.0
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.33
+    source:
+      branch: release-1.33
       dirs:
       - staging/src/k8s.io/api
   library: true
@@ -151,6 +166,21 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod ./...
       go test -mod=mod ./...
+  - name: release-1.33
+    go: 1.24.0
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.33
+    - repository: api
+      branch: release-1.33
+    source:
+      branch: release-1.33
+      dirs:
+      - staging/src/k8s.io/client-go
+    smoke-test: |
+      # assumes GO111MODULE=on
+      go build -mod=mod ./...
+      go test -mod=mod ./...
   library: true
 - destination: code-generator
   branches:
@@ -192,6 +222,15 @@ rules:
       branch: release-1.32
     source:
       branch: release-1.32
+      dirs:
+      - staging/src/k8s.io/code-generator
+  - name: release-1.33
+    go: 1.24.0
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.33
+    source:
+      branch: release-1.33
       dirs:
       - staging/src/k8s.io/code-generator
 - destination: component-base
@@ -257,6 +296,19 @@ rules:
       branch: release-1.32
     source:
       branch: release-1.32
+      dirs:
+      - staging/src/k8s.io/component-base
+  - name: release-1.33
+    go: 1.24.0
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.33
+    - repository: api
+      branch: release-1.33
+    - repository: client-go
+      branch: release-1.33
+    source:
+      branch: release-1.33
       dirs:
       - staging/src/k8s.io/component-base
   library: true
@@ -325,6 +377,19 @@ rules:
       branch: release-1.32
       dirs:
       - staging/src/k8s.io/component-helpers
+  - name: release-1.33
+    go: 1.24.0
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.33
+    - repository: api
+      branch: release-1.33
+    - repository: client-go
+      branch: release-1.33
+    source:
+      branch: release-1.33
+      dirs:
+      - staging/src/k8s.io/component-helpers
   library: true
 - destination: kms
   branches:
@@ -369,6 +434,15 @@ rules:
       branch: release-1.32
     source:
       branch: release-1.32
+      dirs:
+      - staging/src/k8s.io/kms
+  - name: release-1.33
+    go: 1.24.0
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.33
+    source:
+      branch: release-1.33
       dirs:
       - staging/src/k8s.io/kms
   library: true
@@ -455,6 +529,23 @@ rules:
       branch: release-1.32
     source:
       branch: release-1.32
+      dirs:
+      - staging/src/k8s.io/apiserver
+  - name: release-1.33
+    go: 1.24.0
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.33
+    - repository: api
+      branch: release-1.33
+    - repository: client-go
+      branch: release-1.33
+    - repository: component-base
+      branch: release-1.33
+    - repository: kms
+      branch: release-1.33
+    source:
+      branch: release-1.33
       dirs:
       - staging/src/k8s.io/apiserver
   library: true
@@ -561,6 +652,27 @@ rules:
       branch: release-1.32
     source:
       branch: release-1.32
+      dirs:
+      - staging/src/k8s.io/kube-aggregator
+  - name: release-1.33
+    go: 1.24.0
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.33
+    - repository: api
+      branch: release-1.33
+    - repository: client-go
+      branch: release-1.33
+    - repository: apiserver
+      branch: release-1.33
+    - repository: component-base
+      branch: release-1.33
+    - repository: kms
+      branch: release-1.33
+    - repository: code-generator
+      branch: release-1.33
+    source:
+      branch: release-1.33
       dirs:
       - staging/src/k8s.io/kube-aggregator
 - destination: sample-apiserver
@@ -693,6 +805,32 @@ rules:
     smoke-test: |
       # assumes GO111MODULE=on
       go build -mod=mod .
+  - name: release-1.33
+    go: 1.24.0
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.33
+    - repository: api
+      branch: release-1.33
+    - repository: client-go
+      branch: release-1.33
+    - repository: apiserver
+      branch: release-1.33
+    - repository: code-generator
+      branch: release-1.33
+    - repository: kms
+      branch: release-1.33
+    - repository: component-base
+      branch: release-1.33
+    source:
+      branch: release-1.33
+      dirs:
+      - staging/src/k8s.io/sample-apiserver
+    required-packages:
+    - k8s.io/code-generator
+    smoke-test: |
+      # assumes GO111MODULE=on
+      go build -mod=mod .
 - destination: sample-controller
   branches:
   - name: master
@@ -786,6 +924,26 @@ rules:
       branch: release-1.32
     source:
       branch: release-1.32
+      dirs:
+      - staging/src/k8s.io/sample-controller
+    required-packages:
+    - k8s.io/code-generator
+    smoke-test: |
+      # assumes GO111MODULE=on
+      go build -mod=mod .
+  - name: release-1.33
+    go: 1.24.0
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.33
+    - repository: api
+      branch: release-1.33
+    - repository: client-go
+      branch: release-1.33
+    - repository: code-generator
+      branch: release-1.33
+    source:
+      branch: release-1.33
       dirs:
       - staging/src/k8s.io/sample-controller
     required-packages:
@@ -908,6 +1066,29 @@ rules:
       - staging/src/k8s.io/apiextensions-apiserver
     required-packages:
     - k8s.io/code-generator
+  - name: release-1.33
+    go: 1.24.0
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.33
+    - repository: api
+      branch: release-1.33
+    - repository: client-go
+      branch: release-1.33
+    - repository: apiserver
+      branch: release-1.33
+    - repository: code-generator
+      branch: release-1.33
+    - repository: component-base
+      branch: release-1.33
+    - repository: kms
+      branch: release-1.33
+    source:
+      branch: release-1.33
+      dirs:
+      - staging/src/k8s.io/apiextensions-apiserver
+    required-packages:
+    - k8s.io/code-generator
 - destination: metrics
   branches:
   - name: master
@@ -983,6 +1164,21 @@ rules:
       branch: release-1.32
       dirs:
       - staging/src/k8s.io/metrics
+  - name: release-1.33
+    go: 1.24.0
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.33
+    - repository: api
+      branch: release-1.33
+    - repository: client-go
+      branch: release-1.33
+    - repository: code-generator
+      branch: release-1.33
+    source:
+      branch: release-1.33
+      dirs:
+      - staging/src/k8s.io/metrics
   library: true
 - destination: cli-runtime
   branches:
@@ -1047,6 +1243,19 @@ rules:
       branch: release-1.32
     source:
       branch: release-1.32
+      dirs:
+      - staging/src/k8s.io/cli-runtime
+  - name: release-1.33
+    go: 1.24.0
+    dependencies:
+    - repository: api
+      branch: release-1.33
+    - repository: apimachinery
+      branch: release-1.33
+    - repository: client-go
+      branch: release-1.33
+    source:
+      branch: release-1.33
       dirs:
       - staging/src/k8s.io/cli-runtime
   library: true
@@ -1125,6 +1334,21 @@ rules:
       branch: release-1.32
       dirs:
       - staging/src/k8s.io/sample-cli-plugin
+  - name: release-1.33
+    go: 1.24.0
+    dependencies:
+    - repository: api
+      branch: release-1.33
+    - repository: apimachinery
+      branch: release-1.33
+    - repository: cli-runtime
+      branch: release-1.33
+    - repository: client-go
+      branch: release-1.33
+    source:
+      branch: release-1.33
+      dirs:
+      - staging/src/k8s.io/sample-cli-plugin
 - destination: kube-proxy
   branches:
   - name: master
@@ -1200,6 +1424,21 @@ rules:
       branch: release-1.32
       dirs:
       - staging/src/k8s.io/kube-proxy
+  - name: release-1.33
+    go: 1.24.0
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.33
+    - repository: component-base
+      branch: release-1.33
+    - repository: api
+      branch: release-1.33
+    - repository: client-go
+      branch: release-1.33
+    source:
+      branch: release-1.33
+      dirs:
+      - staging/src/k8s.io/kube-proxy
   library: true
 - destination: cri-api
   branches:
@@ -1229,6 +1468,12 @@ rules:
   - name: release-1.32
     source:
       branch: release-1.32
+      dirs:
+      - staging/src/k8s.io/cri-api
+  - name: release-1.33
+    go: 1.24.0
+    source:
+      branch: release-1.33
       dirs:
       - staging/src/k8s.io/cri-api
   library: true
@@ -1281,6 +1526,23 @@ rules:
       branch: release-1.32
     source:
       branch: release-1.32
+      dirs:
+      - staging/src/k8s.io/cri-client
+  - name: release-1.33
+    go: 1.24.0
+    dependencies:
+    - repository: api
+      branch: release-1.33
+    - repository: apimachinery
+      branch: release-1.33
+    - repository: client-go
+      branch: release-1.33
+    - repository: component-base
+      branch: release-1.33
+    - repository: cri-api
+      branch: release-1.33
+    source:
+      branch: release-1.33
       dirs:
       - staging/src/k8s.io/cri-client
   library: true
@@ -1389,6 +1651,27 @@ rules:
       branch: release-1.32
       dirs:
       - staging/src/k8s.io/kubelet
+  - name: release-1.33
+    go: 1.24.0
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.33
+    - repository: apiserver
+      branch: release-1.33
+    - repository: api
+      branch: release-1.33
+    - repository: client-go
+      branch: release-1.33
+    - repository: cri-api
+      branch: release-1.33
+    - repository: component-base
+      branch: release-1.33
+    - repository: kms
+      branch: release-1.33
+    source:
+      branch: release-1.33
+      dirs:
+      - staging/src/k8s.io/kubelet
   library: true
 - destination: kube-scheduler
   branches:
@@ -1463,6 +1746,21 @@ rules:
       branch: release-1.32
     source:
       branch: release-1.32
+      dirs:
+      - staging/src/k8s.io/kube-scheduler
+  - name: release-1.33
+    go: 1.24.0
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.33
+    - repository: component-base
+      branch: release-1.33
+    - repository: api
+      branch: release-1.33
+    - repository: client-go
+      branch: release-1.33
+    source:
+      branch: release-1.33
       dirs:
       - staging/src/k8s.io/kube-scheduler
   library: true
@@ -1559,6 +1857,25 @@ rules:
       branch: release-1.32
     source:
       branch: release-1.32
+      dirs:
+      - staging/src/k8s.io/controller-manager
+  - name: release-1.33
+    go: 1.24.0
+    dependencies:
+    - repository: api
+      branch: release-1.33
+    - repository: apimachinery
+      branch: release-1.33
+    - repository: client-go
+      branch: release-1.33
+    - repository: component-base
+      branch: release-1.33
+    - repository: apiserver
+      branch: release-1.33
+    - repository: kms
+      branch: release-1.33
+    source:
+      branch: release-1.33
       dirs:
       - staging/src/k8s.io/controller-manager
   library: true
@@ -1675,6 +1992,29 @@ rules:
       branch: release-1.32
     source:
       branch: release-1.32
+      dirs:
+      - staging/src/k8s.io/cloud-provider
+  - name: release-1.33
+    go: 1.24.0
+    dependencies:
+    - repository: api
+      branch: release-1.33
+    - repository: apimachinery
+      branch: release-1.33
+    - repository: apiserver
+      branch: release-1.33
+    - repository: client-go
+      branch: release-1.33
+    - repository: component-base
+      branch: release-1.33
+    - repository: controller-manager
+      branch: release-1.33
+    - repository: component-helpers
+      branch: release-1.33
+    - repository: kms
+      branch: release-1.33
+    source:
+      branch: release-1.33
       dirs:
       - staging/src/k8s.io/cloud-provider
   library: true
@@ -1803,6 +2143,31 @@ rules:
       branch: release-1.32
       dirs:
       - staging/src/k8s.io/kube-controller-manager
+  - name: release-1.33
+    go: 1.24.0
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.33
+    - repository: apiserver
+      branch: release-1.33
+    - repository: component-base
+      branch: release-1.33
+    - repository: api
+      branch: release-1.33
+    - repository: client-go
+      branch: release-1.33
+    - repository: controller-manager
+      branch: release-1.33
+    - repository: cloud-provider
+      branch: release-1.33
+    - repository: component-helpers
+      branch: release-1.33
+    - repository: kms
+      branch: release-1.33
+    source:
+      branch: release-1.33
+      dirs:
+      - staging/src/k8s.io/kube-controller-manager
   library: true
 - destination: cluster-bootstrap
   branches:
@@ -1857,6 +2222,17 @@ rules:
       branch: release-1.32
     source:
       branch: release-1.32
+      dirs:
+      - staging/src/k8s.io/cluster-bootstrap
+  - name: release-1.33
+    go: 1.24.0
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.33
+    - repository: api
+      branch: release-1.33
+    source:
+      branch: release-1.33
       dirs:
       - staging/src/k8s.io/cluster-bootstrap
   library: true
@@ -1915,6 +2291,17 @@ rules:
       branch: release-1.32
       dirs:
       - staging/src/k8s.io/csi-translation-lib
+  - name: release-1.33
+    go: 1.24.0
+    dependencies:
+    - repository: api
+      branch: release-1.33
+    - repository: apimachinery
+      branch: release-1.33
+    source:
+      branch: release-1.33
+      dirs:
+      - staging/src/k8s.io/csi-translation-lib
   library: true
 - destination: mount-utils
   branches:
@@ -1944,6 +2331,12 @@ rules:
   - name: release-1.32
     source:
       branch: release-1.32
+      dirs:
+      - staging/src/k8s.io/mount-utils
+  - name: release-1.33
+    go: 1.24.0
+    source:
+      branch: release-1.33
       dirs:
       - staging/src/k8s.io/mount-utils
   library: true
@@ -2115,6 +2508,29 @@ rules:
       branch: release-1.32
       dirs:
       - staging/src/k8s.io/kubectl
+  - name: release-1.33
+    go: 1.24.0
+    dependencies:
+    - repository: api
+      branch: release-1.33
+    - repository: apimachinery
+      branch: release-1.33
+    - repository: cli-runtime
+      branch: release-1.33
+    - repository: client-go
+      branch: release-1.33
+    - repository: code-generator
+      branch: release-1.33
+    - repository: component-base
+      branch: release-1.33
+    - repository: component-helpers
+      branch: release-1.33
+    - repository: metrics
+      branch: release-1.33
+    source:
+      branch: release-1.33
+      dirs:
+      - staging/src/k8s.io/kubectl
   library: true
 - destination: pod-security-admission
   branches:
@@ -2209,6 +2625,25 @@ rules:
       branch: release-1.32
     source:
       branch: release-1.32
+      dirs:
+      - staging/src/k8s.io/pod-security-admission
+  - name: release-1.33
+    go: 1.24.0
+    dependencies:
+    - repository: api
+      branch: release-1.33
+    - repository: apimachinery
+      branch: release-1.33
+    - repository: apiserver
+      branch: release-1.33
+    - repository: client-go
+      branch: release-1.33
+    - repository: component-base
+      branch: release-1.33
+    - repository: kms
+      branch: release-1.33
+    source:
+      branch: release-1.33
       dirs:
       - staging/src/k8s.io/pod-security-admission
   library: true
@@ -2331,6 +2766,31 @@ rules:
       branch: release-1.32
       dirs:
       - staging/src/k8s.io/dynamic-resource-allocation
+  - name: release-1.33
+    go: 1.24.0
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.33
+    - repository: apiserver
+      branch: release-1.33
+    - repository: api
+      branch: release-1.33
+    - repository: client-go
+      branch: release-1.33
+    - repository: cri-api
+      branch: release-1.33
+    - repository: component-base
+      branch: release-1.33
+    - repository: component-helpers
+      branch: release-1.33
+    - repository: kms
+      branch: release-1.33
+    - repository: kubelet
+      branch: release-1.33
+    source:
+      branch: release-1.33
+      dirs:
+      - staging/src/k8s.io/dynamic-resource-allocation
 - destination: endpointslice
   branches:
   - name: master
@@ -2406,6 +2866,21 @@ rules:
       branch: release-1.32
       dirs:
       - staging/src/k8s.io/endpointslice
+  - name: release-1.33
+    go: 1.24.0
+    dependencies:
+    - repository: api
+      branch: release-1.33
+    - repository: apimachinery
+      branch: release-1.33
+    - repository: client-go
+      branch: release-1.33
+    - repository: component-base
+      branch: release-1.33
+    source:
+      branch: release-1.33
+      dirs:
+      - staging/src/k8s.io/endpointslice
 - destination: externaljwt
   branches:
   - name: master
@@ -2416,6 +2891,12 @@ rules:
   - name: release-1.32
     source:
       branch: release-1.32
+      dirs:
+      - staging/src/k8s.io/externaljwt
+  - name: release-1.33
+    go: 1.24.0
+    source:
+      branch: release-1.33
       dirs:
       - staging/src/k8s.io/externaljwt
 recursive-delete-patterns:


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Needed to publish v1.33 tags

#### Special notes for your reviewer:

See [slack thread](https://kubernetes.slack.com/archives/CJH2GBF7Y/p1744125003875769) for more context

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
Ref: https://github.com/kubernetes/sig-release/issues/2755
/assign @xmudrii 
cc @kubernetes/release-managers @mbianchidev 