### PR TITLE
fix(kubelet): acquire imageRecordsLock when removing image

### DIFF
--- a/pkg/kubelet/images/image_gc_manager.go
+++ b/pkg/kubelet/images/image_gc_manager.go
@@ -521,7 +521,10 @@ func (im *realImageGCManager) freeImage(ctx context.Context, image evictionInfo,
 	if isRuntimeClassInImageCriAPIEnabled {
 		imageKey = getImageTuple(image.id, image.runtimeHandlerUsedToPullImage)
 	}
+
+	im.imageRecordsLock.Lock()
 	delete(im.imageRecords, imageKey)
+	im.imageRecordsLock.Unlock()
 
 	metrics.ImageGarbageCollectedTotal.WithLabelValues(reason).Inc()
 	return err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:

/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

This PR fixes a potential race condition for freeing images between the kubelet Garbage Collector and the Eviction Manager.

The [`(*realImageGCManager).freeImage`](https://github.com/kubernetes/kubernetes/blob/88dfcb225d41326113990e87b11137641c121a32/pkg/kubelet/images/image_gc_manager.go#L510-L528) function is the only time when the [`(*realImageGCManager).imageRecordLock`](https://github.com/kubernetes/kubernetes/blob/88dfcb225d41326113990e87b11137641c121a32/pkg/kubelet/images/image_gc_manager.go#L119) is not acquired. this can lead to `fatal error: concurrent map writes` in kubelet.

This failure has been recorded to happen when the `image-gc-threshold` and eviction `imagefs.available` are both triggered, enabling both GC and eviction manager code paths to call `(*realImageGCManager).freeImage`.

<details>
<summary>
See Goroutine Dumps
</summary>

```
fatal error: concurrent map writes

...

goroutine 549 [running]:
k8s.io/kubernetes/pkg/kubelet/images.(*realImageGCManager).freeImage(0xc0005cce60, {0x44f8c88, 0x6406e80}, {{0xc0011a64b0, 0x47}, {{0x0, 0x0}, {0xc1ede86c73cb5c0d, 0x12a82f96958d0, 0x63a4240}, ...}}, ...)
k8s.io/kubernetes/pkg/kubelet/images/image_gc_manager.go:470 +0x345
k8s.io/kubernetes/pkg/kubelet/images.(*realImageGCManager).freeSpace(0xc0005cce60, {0x44f8c88, 0x6406e80}, 0x7fffffffffffffff, {0xc1ee294d37f7e151, 0x166ef18293c17, 0x63a4240}, {0xc0042fe008, 0xe, 0x20})
k8s.io/kubernetes/pkg/kubelet/images/image_gc_manager.go:439 +0x745
k8s.io/kubernetes/pkg/kubelet/images.(*realImageGCManager).DeleteUnusedImages(0xc0005cce60, {0x44f8c88, 0x6406e80})
k8s.io/kubernetes/pkg/kubelet/images/image_gc_manager.go:410 +0xf7
k8s.io/kubernetes/pkg/kubelet/eviction.(*managerImpl).reclaimNodeLevelResources(0xc000852160, {0x44f8c88, 0x6406e80}, {0xc00097e000?, 0x44d3d60?}, {0x3f32e6a, 0x11})
k8s.io/kubernetes/pkg/kubelet/eviction/eviction_manager.go:460 +0xba
k8s.io/kubernetes/pkg/kubelet/eviction.(*managerImpl).synchronize(0xc000852160, {0x44c9d40, 0xc000a78a40}, 0xc000060f80)
k8s.io/kubernetes/pkg/kubelet/eviction/eviction_manager.go:372 +0x1579
k8s.io/kubernetes/pkg/kubelet/eviction.(*managerImpl).Start.func2()
k8s.io/kubernetes/pkg/kubelet/eviction/eviction_manager.go:203 +0x85
created by k8s.io/kubernetes/pkg/kubelet/eviction.(*managerImpl).Start in goroutine 378

...

k8s.io/kubernetes/pkg/kubelet/images.(*realImageGCManager).freeImage(0xc0005cce60, {0x44f8df0, 0xc003dfb200}, {{0xc003706eb0, 0x47}, {{0x0, 0x0}, {0xc1edd0b15c18ef30, 0x1146918d8b3f3, 0x63a4240}, ...}}, ...)
k8s.io/kubernetes/pkg/kubelet/images/image_gc_manager.go:470 +0x345
k8s.io/kubernetes/pkg/kubelet/images.(*realImageGCManager).freeSpace(0xc0005cce60, {0x44f8df0, 0xc003dfb200}, 0xd58af6333, {0xc1ee294d1e07e6c4, 0x166eefe394188, 0x63a4240}, {0xc003f5c008, 0xe, 0x20})
k8s.io/kubernetes/pkg/kubelet/images/image_gc_manager.go:439 +0x745
k8s.io/kubernetes/pkg/kubelet/images.(*realImageGCManager).GarbageCollect(0xc0005cce60, {0x44f8c88?, 0x6406e80?}, {0x0?, 0x40e9430?, 0x63a4240?})
k8s.io/kubernetes/pkg/kubelet/images/image_gc_manager.go:357 +0x619
k8s.io/kubernetes/pkg/kubelet.(*Kubelet).StartGarbageCollection.func2()
k8s.io/kubernetes/pkg/kubelet/kubelet.go:1471 +0x58
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0xc004469f40?)
k8s.io/apimachinery/pkg/util/wait/backoff.go:226 +0x33
k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xc0009712f0, {0x44c99a0, 0xc000ec4030}, 0x1, 0xc00010e960)
k8s.io/apimachinery/pkg/util/wait/backoff.go:227 +0xaf
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc0009712f0, 0x45d964b800, 0x0, 0x1, 0xc00010e960)
k8s.io/apimachinery/pkg/util/wait/backoff.go:204 +0x7f
k8s.io/apimachinery/pkg/util/wait.Until(...)
k8s.io/apimachinery/pkg/util/wait/backoff.go:161
created by k8s.io/kubernetes/pkg/kubelet.(*Kubelet).StartGarbageCollection in goroutine 1
k8s.io/kubernetes/pkg/kubelet/kubelet.go:1469 +0x247
```

</details>

**Tests:**

```bash
> make test WHAT=./pkg/kubelet GOFLAGS=-v

...
✓  pkg/kubelet (23.913s)

DONE 561 tests in 62.521s
```


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
