### PR TITLE
Fix `windows-pause-image-base:<tag>@<digest>` invalid reference format 

### DIFF
--- a/build/pause/Makefile
+++ b/build/pause/Makefile
@@ -24,18 +24,23 @@ REV = $(shell git describe --contains --always --match='v*')
 ARCH ?= amd64
 # Operating systems supported: linux, windows
 OS ?= linux
-# OS Version for the Windows images: 1809, ltsc2022
-OSVERSION ?= 1809 ltsc2022
 
 # The output type could either be docker (local), or registry.
 # If it is registry, it will also allow us to push the Windows images.
 OUTPUT_TYPE ?= docker
 
+BASE.linux := scratch
+# Source for windows pause image base is located at https://github.com/microsoft/windows-pause-image-base
+# BASE.windows includes separate manifests per os.version.
+BASE.windows := mcr.microsoft.com/oss/kubernetes/windows-pause-image-base:v0.4.1@sha256:37cc10768383b55611d724a05eb18564cb5184c89b0c2faa7d4eff63475092df
+BASE := ${BASE.${OS}}
+
 ALL_OS = linux windows
 ALL_ARCH.linux = amd64 arm arm64 ppc64le s390x
 ALL_OS_ARCH.linux = $(foreach arch, ${ALL_ARCH.linux}, linux-$(arch))
 ALL_ARCH.windows = amd64
-ALL_OSVERSIONS.windows := 1809 ltsc2022
+# ALL_OSVERSIONS lists all os.versions in BASE.windows.
+ALL_OSVERSIONS.windows := $(shell docker manifest inspect ${BASE.windows} | jq '.manifests' | jq -c '.[]' | jq '.platform."os.version"' | tr -d '"')
 ALL_OS_ARCH.windows = $(foreach arch, $(ALL_ARCH.windows), $(foreach osversion, ${ALL_OSVERSIONS.windows}, windows-$(arch)-${osversion}))
 ALL_OS_ARCH = $(foreach os, $(ALL_OS), ${ALL_OS_ARCH.${os}})
 
@@ -67,10 +72,6 @@ TRIPLE.linux-arm64 := aarch64-linux-gnu
 TRIPLE.linux-ppc64le := powerpc64le-linux-gnu
 TRIPLE.linux-s390x := s390x-linux-gnu
 TRIPLE := ${TRIPLE.${OS}-${ARCH}}
-BASE.linux := scratch
-# Source for windows pause image base is located at https://github.com/microsoft/windows-pause-image-base
-BASE.windows := mcr.microsoft.com/oss/kubernetes/windows-pause-image-base:v0.4.1@sha256:37cc10768383b55611d724a05eb18564cb5184c89b0c2faa7d4eff63475092df
-BASE := ${BASE.${OS}}
 
 # If you want to build AND push all containers, see the 'all-push' rule.
 all: all-container-docker
@@ -83,17 +84,10 @@ push-manifest:
 	docker manifest create --amend $(IMAGE):$(TAG) $(shell echo $(ALL_OS_ARCH) | sed -e "s~[^ ]*~$(IMAGE):$(TAG)\-&~g")
 	set -x; for arch in $(ALL_ARCH.linux); do docker manifest annotate --os linux --arch $${arch} ${IMAGE}:${TAG} ${IMAGE}:${TAG}-linux-$${arch}; done
 	# For Windows images, we also need to include the "os.version" in the manifest list, so the Windows node can pull the proper image it needs.
-	# we use awk to also trim the quotes around the OS version string.
 	set -x; \
-	# tagToKernelVersionMap maps the container images tags for different Windows Server releases (ex: ltsc2022 for Windows Server 2022)
-	# to the kernel version for that OS release (ex: 20348 for Windows Server 2022). This is needed to fetch the servicing revision from the
-	# pause base image manifest (which containers an entry for each Windows Server version) so we can add the approrite 'os.version'
-	# field to the pause image manifest.
-	declare -A tagToKernelVersionMap=( ['1809']='17763' ['ltsc2022']='20348' );\
 	for arch in $(ALL_ARCH.windows);  do \
-		for osversion in ${ALL_OSVERSIONS.windows}; do \
-			full_version=`docker manifest inspect ${BASE.windows} | grep "10.0.$${tagToKernelVersionMap[$$osversion]}" | head -n 1 | awk -F\" '{print $$4}'` || true; \
-			docker manifest annotate --os windows --arch $${arch} --os-version $${full_version} ${IMAGE}:${TAG} ${IMAGE}:${TAG}-windows-$${arch}-$${osversion}; \
+		for osversion in $(ALL_OSVERSIONS.windows); do \
+			docker manifest annotate --os windows --arch $${arch} --os-version $${osversion} ${IMAGE}:${TAG} ${IMAGE}:${TAG}-windows-$${arch}-$${osversion}; \
 		done; \
 	done
 	docker manifest push --purge ${IMAGE}:${TAG}
@@ -132,9 +126,17 @@ container: .container-${OS}-$(ARCH)
 		-t $(IMAGE):$(TAG)-${OS}-$(ARCH) --build-arg BASE=${BASE} --build-arg ARCH=$(ARCH) .
 	touch $@
 
+.container-windows-$(ARCH): SHELL:=/bin/bash
 .container-windows-$(ARCH): $(foreach binary, ${BIN}, bin/${binary}-${OS}-${ARCH})
-	docker buildx build --provenance=false --sbom=false --pull --output=type=${OUTPUT_TYPE} --platform ${OS}/$(ARCH) \
-		-t $(IMAGE):$(TAG)-${OS}-$(ARCH)-${OSVERSION} --build-arg BASE=${BASE}-windows-${OSVERSION}-${ARCH} --build-arg ARCH=$(ARCH) -f Dockerfile_windows .
+	# For Windows images, each "os.version" maps to a specific image "digest" that serves as a base to build corresponding windows-pause image variant.
+	set -x; \
+	image_manifests=$$(docker manifest inspect "${BASE.windows}" | jq '.manifests'); \
+	for osversion in $(ALL_OSVERSIONS.windows); do \
+			digest=$$(echo "$${image_manifests}" | jq -r '.[]|select(.platform."os.version" | contains("'$${osversion}'"))' | jq '.digest' | awk -F\" '{print $$2}'); \
+			base_image=$$(echo "${BASE.windows}" | awk -F: '{print $$1}')@$${digest}; \
+			docker buildx build --provenance=false --sbom=false --pull --output=type=${OUTPUT_TYPE} --platform ${OS}/$(ARCH) \
+							-t $(IMAGE):$(TAG)-${OS}-$(ARCH)-$${osversion} --build-arg BASE=$${base_image} --build-arg ARCH=$(ARCH) -f Dockerfile_windows .; \
+	done; \
 	touch $@
 
 # Useful for testing, not automatically included in container image


### PR DESCRIPTION
This PR will fix the windows pause image build logic to be able to build from `windows-pause-image-base:<tag>@<digest>`, which currently only accepts `windows-pause-image-base:<tag>` due to which build is failing with `invalid reference format`.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR will fix the pause windows image to use only `tag`. Currently it is having `tag@digest` which is causing build failure.
Ref: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-kubernetes-push-image-pause/1889748429312102400
Discussion: https://kubernetes.slack.com/archives/CCK68P2Q2/p1742839354591189?thread_ts=1742832454.449449&cid=CCK68P2Q2

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://github.com/kubernetes/kubernetes/issues/131257

#### Special notes for your reviewer:
Blocks dependency bump for pause: https://github.com/kubernetes/kubernetes/pull/130713

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
