### PR TITLE
Pod Lifecycle: propagate context to image puller

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -130,6 +130,11 @@ const (
 
 	// owner: @HirazawaUi
 	//
+	// Allow kubelet to cancel pulling images after pod deletion.
+	CancelPullImage featuregate.Feature = "CancelPullImage"
+
+	// owner: @HirazawaUi
+	//
 	// Enabling this feature gate will cause the pod's status to change due to a kubelet restart.
 	ChangeContainerStatusOnKubeletRestart = "ChangeContainerStatusOnKubeletRestart"
 
@@ -1186,6 +1191,10 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 		{Version: version.MustParse("1.21"), Default: false, PreRelease: featuregate.Alpha},
 	},
 
+	CancelPullImage: {
+		{Version: version.MustParse("1.36"), Default: true, PreRelease: featuregate.Beta},
+	},
+
 	ChangeContainerStatusOnKubeletRestart: {
 		{Version: version.MustParse("1.0"), Default: true, PreRelease: featuregate.GA},
 		{Version: version.MustParse("1.35"), Default: false, PreRelease: featuregate.Deprecated},
@@ -2190,6 +2199,8 @@ var defaultKubernetesFeatureGateDependencies = map[featuregate.Feature][]feature
 	CSIServiceAccountTokenSecrets: {},
 
 	CSIVolumeHealth: {},
+
+	CancelPullImage: {},
 
 	ChangeContainerStatusOnKubeletRestart: {},
 

--- a/pkg/kubelet/images/image_manager.go
+++ b/pkg/kubelet/images/image_manager.go
@@ -359,6 +359,9 @@ func (m *imageManager) pullImage(ctx context.Context, logPrefix string, objRef *
 	imagePullResult := <-pullChan
 	if imagePullResult.err != nil {
 		m.logIt(objRef, v1.EventTypeWarning, events.FailedToPullImage, logPrefix, fmt.Sprintf("Failed to pull image %q: %v", image, imagePullResult.err), klog.Warning)
+		if ctx.Err() != nil {
+			return "", "", imagePullResult.err
+		}
 		m.backOff.Next(backOffKey, m.backOff.Clock.Now())
 		msg, err := evalCRIPullErr(image, imagePullResult.err)
 

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -173,6 +173,12 @@
     lockToDefault: true
     preRelease: GA
     version: "1.33"
+- name: CancelPullImage
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.36"
 - name: CBORServingAndStorage
   versionedSpecs:
   - default: false

--- a/test/e2e_node/image_pull_test.go
+++ b/test/e2e_node/image_pull_test.go
@@ -32,6 +32,10 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	internalapi "k8s.io/cri-api/pkg/apis"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	"k8s.io/kubernetes/pkg/features"
 	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
 	kubeletevents "k8s.io/kubernetes/pkg/kubelet/events"
 	"k8s.io/kubernetes/pkg/kubelet/images"
@@ -39,6 +43,7 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	"k8s.io/kubernetes/test/e2e_node/criproxy"
+	"k8s.io/kubernetes/test/utils/format"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 	admissionapi "k8s.io/pod-security-admission/api"
 	"k8s.io/utils/ptr"
@@ -262,6 +267,415 @@ var _ = SIGDescribe("Pull Image", feature.CriProxy, framework.WithSerial(), func
 
 })
 
+var _ = SIGDescribe("Allow cancel pull image", framework.WithSerial(), framework.WithFeatureGate(features.CancelPullImage), func() {
+	f := framework.NewDefaultFramework("pull-image-test")
+	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
+	var is internalapi.ImageManagerService
+
+	ginkgo.BeforeEach(func() {
+		var err error
+		_, is, err = getCRIClient()
+		framework.ExpectNoError(err)
+	})
+
+	ginkgo.Context("with parallel image pull", func() {
+		// Configure kubelet to use parallel image pulls
+		tempSetCurrentKubeletConfig(f, func(ctx context.Context, initialConfig *kubeletconfig.KubeletConfiguration) {
+			initialConfig.SerializeImagePulls = false
+			initialConfig.MaxParallelImagePulls = ptr.To[int32](5)
+		})
+
+		ginkgo.It("Should not pull image after pod deletion with parallel pull", func(ctx context.Context) {
+			// Get a test image
+			image := imageutils.GetE2EImage(imageutils.Agnhost)
+
+			// 1. Remove the image before creating the pod
+			ginkgo.By("Removing the image before creating the pod")
+			err := removeImageWithCRI(context.Background(), is, image)
+			framework.ExpectNoError(err)
+
+			// Verify image is removed
+			exists, err := isImageExistWithCRI(context.Background(), is, image)
+			framework.ExpectNoError(err)
+			gomega.Expect(exists).To(gomega.BeFalseBecause("Image should not exist before test"))
+
+			// 2. Create a pod with the image
+			ginkgo.By("Creating a pod with the image")
+			testpod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "image-pull-deletion-parallel-test",
+					Namespace: f.Namespace.Name,
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{{
+						Name:            "test-container",
+						Image:           image,
+						ImagePullPolicy: v1.PullAlways,
+					}},
+					RestartPolicy: v1.RestartPolicyNever,
+				},
+			}
+
+			pod := e2epod.NewPodClient(f).Create(context.Background(), testpod)
+
+			// 3. Waiting for the pod to be scheduled
+			ginkgo.By("Waiting for the pod to be scheduled so that kubelet owns it")
+			err = waitForPodConditionWithShortPoll(ctx, f.ClientSet, pod.Namespace, pod.Name, "pod is scheduled", time.Minute, func(pod *v1.Pod) (bool, error) {
+				return pod.Spec.NodeName != "", nil
+			})
+			framework.ExpectNoError(err, "Failed to await for the pod to be scheduled: %q", pod.Name)
+
+			// 4. Wait for the "Pulling" event and then delete the pod
+			ginkgo.By("Waiting for the 'Pulling' event")
+			gomega.Eventually(ctx, func(ctx context.Context) string {
+				pullingEvent, err := getImagePullAttempts(ctx, f, pod.Name)
+				framework.ExpectNoError(err)
+				return pullingEvent.Reason
+			}).WithTimeout(time.Minute).WithPolling(time.Millisecond * 10).Should(gomega.Equal(kubeletevents.PullingImage))
+
+			err = e2epod.NewPodClient(f).Delete(ctx, testpod.Name, *metav1.NewDeleteOptions(0))
+			framework.ExpectNoError(err)
+
+			// 5. Wait for 10 seconds and check if the image is pulled
+			ginkgo.By("Waiting for 10 seconds")
+			time.Sleep(10 * time.Second)
+
+			ginkgo.By("Checking if the image is pulled")
+			exists, err = isImageExistWithCRI(context.Background(), is, image)
+			framework.ExpectNoError(err)
+
+			// With parallel pull, the image might still be pulled even after pod deletion
+			// If image is pulled, test should fail
+			gomega.Expect(exists).To(gomega.BeFalseBecause("Image should not be pulled after pod deletion with parallel pull"))
+
+			// 6. Ensure the image is available after the test
+			ginkgo.DeferCleanup(func() error {
+				ginkgo.By("Pulling the image back after test")
+				return pullImageWithCRI(context.Background(), is, image)
+			})
+		})
+
+		ginkgo.It("canceling one of the concurrent image pulls should not affect the others", func(ctx context.Context) {
+			// Get a test image
+			image := imageutils.GetE2EImage(imageutils.Agnhost)
+
+			// 1. Remove the image before creating the pod
+			ginkgo.By("Removing the image before creating the pod")
+			err := removeImageWithCRI(context.Background(), is, image)
+			framework.ExpectNoError(err)
+
+			// Verify image is removed
+			exists, err := isImageExistWithCRI(context.Background(), is, image)
+			framework.ExpectNoError(err)
+			gomega.Expect(exists).To(gomega.BeFalseBecause("Image should not exist before test"))
+
+			// 2. Create three pods with the same image concurrently
+			ginkgo.By("Creating three pods with the same image concurrently")
+			var pods []*v1.Pod
+			for i := 0; i < 3; i++ {
+				pod := e2epod.NewPodClient(f).Create(ctx, &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      fmt.Sprintf("image-pull-cancel-%d", i),
+						Namespace: f.Namespace.Name,
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{{
+							Name:            "test-container",
+							Image:           image,
+							ImagePullPolicy: v1.PullAlways,
+						}},
+						RestartPolicy: v1.RestartPolicyNever,
+					},
+				})
+				pods = append(pods, pod)
+			}
+
+			// 3. Wait for all pods to be scheduled
+			ginkgo.By("Waiting for all pods to be scheduled")
+			for _, pod := range pods {
+				err = waitForPodConditionWithShortPoll(ctx, f.ClientSet, pod.Namespace, pod.Name, "pod is scheduled", time.Minute, func(pod *v1.Pod) (bool, error) {
+					return pod.Spec.NodeName != "", nil
+				})
+				framework.ExpectNoError(err, "Failed to await for the pod to be scheduled: %q", pod.Name)
+			}
+
+			// 4. Wait for the "Pulling" event and then delete the pod
+			ginkgo.By("Waiting for the 'Pulling' event")
+			gomega.Eventually(ctx, func(ctx context.Context) string {
+				pullingEvent, err := getImagePullAttempts(ctx, f, pods[0].Name)
+				framework.ExpectNoError(err)
+				return pullingEvent.Reason
+			}).WithTimeout(time.Minute).WithPolling(time.Millisecond * 10).Should(gomega.Equal(kubeletevents.PullingImage))
+			ginkgo.By("Deleting the first pod")
+
+			err = e2epod.NewPodClient(f).Delete(ctx, pods[0].Name, *metav1.NewDeleteOptions(0))
+			framework.ExpectNoError(err)
+
+			// 5. Wait for 10 seconds and check if the other pods are running
+			ginkgo.By("Waiting for 10 seconds and checking other pods")
+			time.Sleep(10 * time.Second)
+
+			// Check the remaining pods
+			for i := 1; i < len(pods); i++ {
+				pod := pods[i]
+				ginkgo.By(fmt.Sprintf("Waiting for pod %s to be running", pod.Name))
+				err := e2epod.WaitForPodRunningInNamespace(ctx, f.ClientSet, pod)
+				framework.ExpectNoError(err, "Pod %s should be running", pod.Name)
+			}
+
+			// 6. Ensure the image is available after the test
+			ginkgo.DeferCleanup(func() error {
+				ginkgo.By("Pulling the image back after test")
+				return pullImageWithCRI(context.Background(), is, image)
+			})
+		})
+	})
+
+	ginkgo.Context("with serialized image pull", func() {
+		// Configure kubelet to use serialized image pulls
+		tempSetCurrentKubeletConfig(f, func(ctx context.Context, initialConfig *kubeletconfig.KubeletConfiguration) {
+			initialConfig.SerializeImagePulls = true
+			initialConfig.MaxParallelImagePulls = ptr.To[int32](1)
+		})
+		ginkgo.It("Should not pull image after pod deletion with serialized pull", func(ctx context.Context) {
+			// Get a test image
+			image := imageutils.GetE2EImage(imageutils.Agnhost)
+
+			// 1. Remove the image before creating the pod
+			ginkgo.By("Removing the image before creating the pod")
+			err := removeImageWithCRI(context.Background(), is, image)
+			framework.ExpectNoError(err)
+
+			// Verify image is removed
+			exists, err := isImageExistWithCRI(context.Background(), is, image)
+			framework.ExpectNoError(err)
+			gomega.Expect(exists).To(gomega.BeFalseBecause("Image should not exist before test"))
+
+			// 2. Create a pod with the image
+			ginkgo.By("Creating a pod with the image")
+			testpod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "image-pull-deletion-serial-test",
+					Namespace: f.Namespace.Name,
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{{
+						Name:            "test-container",
+						Image:           image,
+						ImagePullPolicy: v1.PullAlways,
+					}},
+					RestartPolicy: v1.RestartPolicyNever,
+				},
+			}
+
+			pod := e2epod.NewPodClient(f).Create(context.Background(), testpod)
+
+			// 3. Waiting for the pod to be scheduled
+			ginkgo.By("Waiting for the pod to be scheduled so that kubelet owns it")
+			err = waitForPodConditionWithShortPoll(ctx, f.ClientSet, pod.Namespace, pod.Name, "pod is scheduled", time.Minute, func(pod *v1.Pod) (bool, error) {
+				return pod.Spec.NodeName != "", nil
+			})
+			framework.ExpectNoError(err, "Failed to await for the pod to be scheduled: %q", pod.Name)
+
+			// 4. Wait for the "Pulling" event and then delete the pod
+			ginkgo.By("Waiting for the 'Pulling' event")
+			gomega.Eventually(ctx, func(ctx context.Context) string {
+				pullingEvent, err := getImagePullAttempts(ctx, f, pod.Name)
+				framework.ExpectNoError(err)
+				return pullingEvent.Reason
+			}).WithTimeout(time.Minute).WithPolling(time.Millisecond * 10).Should(gomega.Equal(kubeletevents.PullingImage))
+
+			ginkgo.By("Deleting the pod")
+			err = e2epod.NewPodClient(f).Delete(context.Background(), pod.Name, *metav1.NewDeleteOptions(0))
+			framework.ExpectNoError(err)
+
+			// 5. Wait for 10 seconds and check if the image is pulled
+			ginkgo.By("Waiting for 10 seconds")
+			time.Sleep(10 * time.Second)
+
+			ginkgo.By("Checking if the image is pulled")
+			exists, err = isImageExistWithCRI(context.Background(), is, image)
+			framework.ExpectNoError(err)
+
+			// With serialized pull, the image should be pulled after pod deletion
+			gomega.Expect(exists).To(gomega.BeFalseBecause("Image should not be pulled after pod deletion with serialized pull"))
+
+			// 6. Ensure the image is available after the test
+			ginkgo.DeferCleanup(func() error {
+				ginkgo.By("Pulling the image back after test")
+				return pullImageWithCRI(context.Background(), is, image)
+			})
+		})
+	})
+})
+
+var _ = SIGDescribe("Disallow cancel pull image", framework.WithSerial(), func() {
+	f := framework.NewDefaultFramework("pull-image-test")
+	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
+	var is internalapi.ImageManagerService
+
+	ginkgo.BeforeEach(func() {
+		var err error
+		_, is, err = getCRIClient()
+		framework.ExpectNoError(err)
+	})
+
+	ginkgo.Context("with parallel image pull", func() {
+		// Configure kubelet to use parallel image pulls
+		tempSetCurrentKubeletConfig(f, func(ctx context.Context, initialConfig *kubeletconfig.KubeletConfiguration) {
+			initialConfig.SerializeImagePulls = false
+			initialConfig.MaxParallelImagePulls = ptr.To[int32](5)
+		})
+
+		ginkgo.It("Should pull image after pod deletion with parallel pull", func(ctx context.Context) {
+			// Get a test image
+			image := imageutils.GetE2EImage(imageutils.Agnhost)
+
+			// 1. Remove the image before creating the pod
+			ginkgo.By("Removing the image before creating the pod")
+			err := removeImageWithCRI(context.Background(), is, image)
+			framework.ExpectNoError(err)
+
+			// Verify image is removed
+			exists, err := isImageExistWithCRI(context.Background(), is, image)
+			framework.ExpectNoError(err)
+			gomega.Expect(exists).To(gomega.BeFalseBecause("Image should not exist before test"))
+
+			// 2. Create a pod with the image
+			ginkgo.By("Creating a pod with the image")
+			testpod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "image-pull-deletion-parallel-test",
+					Namespace: f.Namespace.Name,
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{{
+						Name:            "test-container",
+						Image:           image,
+						ImagePullPolicy: v1.PullAlways,
+					}},
+					RestartPolicy: v1.RestartPolicyNever,
+				},
+			}
+
+			pod := e2epod.NewPodClient(f).Create(context.Background(), testpod)
+
+			// 3. Waiting for the pod to be scheduled
+			ginkgo.By("Waiting for the pod to be scheduled so that kubelet owns it")
+			err = waitForPodConditionWithShortPoll(ctx, f.ClientSet, pod.Namespace, pod.Name, "pod is scheduled", time.Minute, func(pod *v1.Pod) (bool, error) {
+				return pod.Spec.NodeName != "", nil
+			})
+			framework.ExpectNoError(err, "Failed to await for the pod to be scheduled: %q", pod.Name)
+
+			// 4. Wait for the "Pulling" event and then delete the pod
+			ginkgo.By("Waiting for the 'Pulling' event")
+			gomega.Eventually(ctx, func(ctx context.Context) string {
+				pullingEvent, err := getImagePullAttempts(ctx, f, pod.Name)
+				framework.ExpectNoError(err)
+				return pullingEvent.Reason
+			}).WithTimeout(time.Minute).WithPolling(time.Millisecond * 10).Should(gomega.Equal(kubeletevents.PullingImage))
+
+			ginkgo.By("Deleting the pod")
+			err = e2epod.NewPodClient(f).Delete(context.Background(), pod.Name, *metav1.NewDeleteOptions(0))
+			framework.ExpectNoError(err)
+
+			// 5. Wait for 10 seconds and check if the image is pulled
+			ginkgo.By("Waiting for 10 seconds")
+			time.Sleep(10 * time.Second)
+
+			ginkgo.By("Checking if the image is pulled")
+			exists, err = isImageExistWithCRI(context.Background(), is, image)
+			framework.ExpectNoError(err)
+
+			// With parallel pull, the image should be pulled after pod deletion
+			gomega.Expect(exists).To(gomega.BeTrueBecause("Image should be pulled after pod deletion with parallel pull"))
+
+			// 6. Ensure the image is available after the test
+			ginkgo.DeferCleanup(func() error {
+				ginkgo.By("Pulling the image back after test")
+				return pullImageWithCRI(context.Background(), is, image)
+			})
+		})
+	})
+
+	ginkgo.Context("with serialized image pull", func() {
+		// Configure kubelet to use serialized image pulls
+		tempSetCurrentKubeletConfig(f, func(ctx context.Context, initialConfig *kubeletconfig.KubeletConfiguration) {
+			initialConfig.SerializeImagePulls = true
+			initialConfig.MaxParallelImagePulls = ptr.To[int32](1)
+		})
+		ginkgo.It("Should pull image after pod deletion with serialized pull", func(ctx context.Context) {
+			// Get a test image
+			image := imageutils.GetE2EImage(imageutils.Agnhost)
+
+			// 1. Remove the image before creating the pod
+			ginkgo.By("Removing the image before creating the pod")
+			err := removeImageWithCRI(context.Background(), is, image)
+			framework.ExpectNoError(err)
+
+			// Verify image is removed
+			exists, err := isImageExistWithCRI(context.Background(), is, image)
+			framework.ExpectNoError(err)
+			gomega.Expect(exists).To(gomega.BeFalseBecause("Image should not exist before test"))
+
+			// 2. Create a pod with the image
+			ginkgo.By("Creating a pod with the image")
+			testpod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "image-pull-deletion-serial-test",
+					Namespace: f.Namespace.Name,
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{{
+						Name:            "test-container",
+						Image:           image,
+						ImagePullPolicy: v1.PullAlways,
+					}},
+					RestartPolicy: v1.RestartPolicyNever,
+				},
+			}
+
+			pod := e2epod.NewPodClient(f).Create(context.Background(), testpod)
+
+			// 3. Waiting for the pod to be scheduled
+			ginkgo.By("Waiting for the pod to be scheduled so that kubelet owns it")
+			err = waitForPodConditionWithShortPoll(ctx, f.ClientSet, pod.Namespace, pod.Name, "pod is scheduled", time.Minute, func(pod *v1.Pod) (bool, error) {
+				return pod.Spec.NodeName != "", nil
+			})
+			framework.ExpectNoError(err, "Failed to await for the pod to be scheduled: %q", pod.Name)
+
+			// 4. Wait for the "Pulling" event and then delete the pod
+			ginkgo.By("Waiting for the 'Pulling' event")
+			gomega.Eventually(ctx, func(ctx context.Context) string {
+				pullingEvent, err := getImagePullAttempts(ctx, f, pod.Name)
+				framework.ExpectNoError(err)
+				return pullingEvent.Reason
+			}).WithTimeout(time.Minute).WithPolling(time.Millisecond * 10).Should(gomega.Equal(kubeletevents.PullingImage))
+
+			ginkgo.By("Deleting the pod")
+			err = e2epod.NewPodClient(f).Delete(context.Background(), pod.Name, *metav1.NewDeleteOptions(0))
+			framework.ExpectNoError(err)
+
+			// 5. Wait for 10 seconds and check if the image is pulled
+			ginkgo.By("Waiting for 10 seconds")
+			time.Sleep(10 * time.Second)
+
+			ginkgo.By("Checking if the image is pulled")
+			exists, err = isImageExistWithCRI(context.Background(), is, image)
+			framework.ExpectNoError(err)
+
+			// With serialized pull, the image should not be pulled after pod deletion
+			gomega.Expect(exists).To(gomega.BeTrueBecause("Image should be pulled after pod deletion with serialized pull"))
+
+			// 6. Ensure the image is available after the test
+			ginkgo.DeferCleanup(func() error {
+				ginkgo.By("Pulling the image back after test")
+				return pullImageWithCRI(context.Background(), is, image)
+			})
+		})
+	})
+})
+
 func getPodImagePullDurations(ctx context.Context, f *framework.Framework, testpods []*v1.Pod) (map[string]*pulledStruct, map[string]metav1.Time, map[string]metav1.Time, error) {
 	events, err := f.ClientSet.CoreV1().Events(f.Namespace.Name).List(ctx, metav1.ListOptions{})
 	if err != nil {
@@ -291,6 +705,27 @@ func getPodImagePullDurations(ctx context.Context, f *framework.Framework, testp
 	}
 
 	return imagePulled, podStartTime, podEndTime, nil
+}
+
+// waitForPodConditionWithShortPoll waits for a pod to match the specified condition.
+// Compared to the generic WaitForPodCondition, it uses a shorter polling interval for faster response.
+func waitForPodConditionWithShortPoll(ctx context.Context, c clientset.Interface, ns, podName, conditionDesc string, timeout time.Duration, condition podCondition) error {
+	return framework.Gomega().
+		Eventually(ctx, framework.RetryNotFound(framework.GetObject(c.CoreV1().Pods(ns).Get, podName, metav1.GetOptions{}))).
+		WithTimeout(timeout).
+		WithPolling(time.Millisecond * 50).
+		Should(framework.MakeMatcher(func(pod *v1.Pod) (func() string, error) {
+			done, err := condition(pod)
+			if err != nil {
+				return nil, err
+			}
+			if done {
+				return nil, nil
+			}
+			return func() string {
+				return fmt.Sprintf("expected pod to be %s, got instead:\n%s", conditionDesc, format.Object(pod, 1))
+			}, nil
+		}))
 }
 
 // as pods are created at the same time and image pull will delay 15s, the image pull time should be overlapped
@@ -387,4 +822,54 @@ func getImagePullAttempts(ctx context.Context, f *framework.Framework, podName s
 		}
 	}
 	return event, nil
+}
+
+// isImageExistWithCRI checks if the image exists using CRI client
+// Returns true if the image exists, false otherwise
+func isImageExistWithCRI(ctx context.Context, is internalapi.ImageManagerService, image string) (bool, error) {
+	// List all images using CRI client
+	resp, err := is.ListImages(ctx, &runtimeapi.ImageFilter{})
+	if err != nil {
+		return false, fmt.Errorf("failed to list images: %w", err)
+	}
+
+	// Check if the image exists in the list
+	for _, img := range resp {
+		for _, tag := range img.RepoTags {
+			if tag == image {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+// removeImageWithCRI removes the specified image using CRI client
+// If the image doesn't exist, it returns nil
+func removeImageWithCRI(ctx context.Context, is internalapi.ImageManagerService, image string) error {
+	// First check if the image exists
+	exists, err := isImageExistWithCRI(ctx, is, image)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return nil // Image already doesn't exist
+	}
+
+	// Remove the image using CRI client
+	err = is.RemoveImage(ctx, &runtimeapi.ImageSpec{Image: image})
+	if err != nil {
+		return fmt.Errorf("failed to remove image: %w", err)
+	}
+	return nil
+}
+
+// pullImageWithCRI pulls the specified image using CRI client
+func pullImageWithCRI(ctx context.Context, is internalapi.ImageManagerService, image string) error {
+	// Pull the image using CRI client
+	_, err := is.PullImage(ctx, &runtimeapi.ImageSpec{Image: image}, nil, nil)
+	if err != nil {
+		return fmt.Errorf("failed to pull image: %w", err)
+	}
+	return nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:
Due to the failure to correctly propagate the context to SyncPod, kubelet is unable to cancel the image pull action when deleting a pod.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #125050 #122905

#### Special notes for your reviewer:
In PR #127122, I attempted to propagate context to all CRI calls within SyncPod. However, the e2e tests could not complete successfully due to issues in containerd/runc. Specifically, after the tests finished, containerd failed to clean up stalled containers, causing the test jobs to hang indefinitely.

I have opened PRs in containerd and runc to fix these issues:

Fixes in containerd:
* https://github.com/containerd/containerd/pull/11588 (Merged)

* https://github.com/containerd/containerd/pull/11755 (Under review; this PR might become unnecessary if the runc PR is merged)

Fix in runc:
* https://github.com/opencontainers/runc/pull/4757 (Merged)


Even if these PRs are merged, we cannot resolve the issue quickly because users might need to update their environment's containerd and runc versions.

To avoid version skew issues between containerd/runc/kubelet, in this PR, I have narrowed the scope of context propagation to only the container runtime's PullImage interface. This avoids blocking kubelet's image pull channel when pulling large images.


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubelet: Fixed deleting pod during image pulling would not terminate the image pull operation.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
