### PR TITLE
Allow to convert clusters Service CIDRs from single to dual stack

### DIFF
--- a/pkg/controlplane/controller/defaultservicecidr/default_servicecidr_controller_test.go
+++ b/pkg/controlplane/controller/defaultservicecidr/default_servicecidr_controller_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	networkingapiv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
@@ -35,8 +36,13 @@ const (
 	defaultIPv6CIDR = "2001:db8::/64"
 )
 
-func newController(t *testing.T, objects []*networkingapiv1.ServiceCIDR) (*fake.Clientset, *Controller) {
-	client := fake.NewSimpleClientset()
+func newController(t *testing.T, cidrsFromFlags []string, objects ...*networkingapiv1.ServiceCIDR) (*fake.Clientset, *Controller) {
+	var runtimeObjects []runtime.Object
+	for _, cidr := range objects {
+		runtimeObjects = append(runtimeObjects, cidr)
+	}
+
+	client := fake.NewSimpleClientset(runtimeObjects...)
 
 	informerFactory := informers.NewSharedInformerFactory(client, 0)
 	serviceCIDRInformer := informerFactory.Networking().V1().ServiceCIDRs()
@@ -47,12 +53,11 @@ func newController(t *testing.T, objects []*networkingapiv1.ServiceCIDR) (*fake.
 		if err != nil {
 			t.Fatal(err)
 		}
-
 	}
 	c := &Controller{
 		client:             client,
 		interval:           time.Second,
-		cidrs:              []string{defaultIPv4CIDR, defaultIPv6CIDR},
+		cidrs:              cidrsFromFlags,
 		eventRecorder:      record.NewFakeRecorder(100),
 		serviceCIDRLister:  serviceCIDRInformer.Lister(),
 		serviceCIDRsSynced: func() bool { return true },
@@ -151,9 +156,191 @@ func TestControllerSync(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			client, controller := newController(t, tc.cidrs)
+			client, controller := newController(t, []string{defaultIPv4CIDR, defaultIPv6CIDR}, tc.cidrs...)
 			controller.sync()
 			expectAction(t, client.Actions(), tc.actions)
+		})
+	}
+}
+
+func TestControllerSyncConversions(t *testing.T) {
+	testCases := []struct {
+		name            string
+		controllerCIDRs []string
+		existingCIDR    *networkingapiv1.ServiceCIDR
+		expectedAction  [][]string // verb, resource, [subresource]
+	}{
+		{
+			name:            "flags match ServiceCIDRs",
+			controllerCIDRs: []string{defaultIPv4CIDR, defaultIPv6CIDR},
+			existingCIDR: &networkingapiv1.ServiceCIDR{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: DefaultServiceCIDRName,
+				},
+				Spec: networkingapiv1.ServiceCIDRSpec{
+					CIDRs: []string{defaultIPv4CIDR, defaultIPv6CIDR},
+				},
+				Status: networkingapiv1.ServiceCIDRStatus{}, // No conditions
+			},
+			expectedAction: [][]string{{"patch", "servicecidrs", "status"}},
+		},
+		{
+			name:            "existing Ready=False condition, cidrs match -> no patch",
+			controllerCIDRs: []string{defaultIPv4CIDR, defaultIPv6CIDR},
+			existingCIDR: &networkingapiv1.ServiceCIDR{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: DefaultServiceCIDRName,
+				},
+				Spec: networkingapiv1.ServiceCIDRSpec{
+					CIDRs: []string{defaultIPv4CIDR, defaultIPv6CIDR},
+				},
+				Status: networkingapiv1.ServiceCIDRStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:   networkingapiv1.ServiceCIDRConditionReady,
+							Status: metav1.ConditionFalse,
+							Reason: "SomeReason",
+						},
+					},
+				},
+			},
+			expectedAction: [][]string{}, // No patch expected, just logs/events
+		},
+		{
+			name:            "existing Ready=True condition -> no patch",
+			controllerCIDRs: []string{defaultIPv4CIDR, defaultIPv6CIDR},
+			existingCIDR: &networkingapiv1.ServiceCIDR{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: DefaultServiceCIDRName,
+				},
+				Spec: networkingapiv1.ServiceCIDRSpec{
+					CIDRs: []string{defaultIPv4CIDR, defaultIPv6CIDR},
+				},
+				Status: networkingapiv1.ServiceCIDRStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:   networkingapiv1.ServiceCIDRConditionReady,
+							Status: metav1.ConditionTrue,
+						},
+					},
+				},
+			},
+			expectedAction: [][]string{},
+		},
+		{
+			name:            "ServiceCIDR being deleted -> no patch",
+			controllerCIDRs: []string{defaultIPv4CIDR, defaultIPv6CIDR},
+			existingCIDR: &networkingapiv1.ServiceCIDR{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              DefaultServiceCIDRName,
+					DeletionTimestamp: ptr.To(metav1.Now()),
+				},
+				Spec: networkingapiv1.ServiceCIDRSpec{
+					CIDRs: []string{defaultIPv4CIDR, defaultIPv6CIDR},
+				},
+				Status: networkingapiv1.ServiceCIDRStatus{},
+			},
+			expectedAction: [][]string{},
+		},
+		{
+			name:            "IPv4 to IPv4 IPv6 is ok",
+			controllerCIDRs: []string{defaultIPv4CIDR, defaultIPv6CIDR},
+			existingCIDR: &networkingapiv1.ServiceCIDR{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: DefaultServiceCIDRName,
+				},
+				Spec: networkingapiv1.ServiceCIDRSpec{
+					CIDRs: []string{defaultIPv4CIDR}, // Existing has both
+				},
+				Status: networkingapiv1.ServiceCIDRStatus{},
+			},
+			expectedAction: [][]string{{"update", "servicecidrs"}},
+		},
+		{
+			name:            "IPv4 to IPv6 IPv4 - switching primary IP family leaves in inconsistent state",
+			controllerCIDRs: []string{defaultIPv6CIDR, defaultIPv4CIDR},
+			existingCIDR: &networkingapiv1.ServiceCIDR{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: DefaultServiceCIDRName,
+				},
+				Spec: networkingapiv1.ServiceCIDRSpec{
+					CIDRs: []string{defaultIPv4CIDR}, // Existing has both
+				},
+				Status: networkingapiv1.ServiceCIDRStatus{},
+			},
+			expectedAction: [][]string{},
+		},
+		{
+			name:            "IPv6 to IPv6 IPv4",
+			controllerCIDRs: []string{defaultIPv6CIDR, defaultIPv4CIDR},
+			existingCIDR: &networkingapiv1.ServiceCIDR{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: DefaultServiceCIDRName,
+				},
+				Spec: networkingapiv1.ServiceCIDRSpec{
+					CIDRs: []string{defaultIPv6CIDR}, // Existing has both
+				},
+				Status: networkingapiv1.ServiceCIDRStatus{},
+			},
+			expectedAction: [][]string{{"update", "servicecidrs"}},
+		},
+		{
+			name:            "IPv6 to IPv4 IPv6 - switching primary IP family leaves in inconsistent state",
+			controllerCIDRs: []string{defaultIPv4CIDR, defaultIPv6CIDR},
+			existingCIDR: &networkingapiv1.ServiceCIDR{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: DefaultServiceCIDRName,
+				},
+				Spec: networkingapiv1.ServiceCIDRSpec{
+					CIDRs: []string{defaultIPv6CIDR}, // Existing has both
+				},
+				Status: networkingapiv1.ServiceCIDRStatus{},
+			},
+			expectedAction: [][]string{},
+		},
+		{
+			name:            "IPv6 IPv4 to IPv4 IPv6 - switching primary IP family leaves in inconsistent state",
+			controllerCIDRs: []string{defaultIPv4CIDR, defaultIPv6CIDR},
+			existingCIDR: &networkingapiv1.ServiceCIDR{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: DefaultServiceCIDRName,
+				},
+				Spec: networkingapiv1.ServiceCIDRSpec{
+					CIDRs: []string{defaultIPv6CIDR, defaultIPv4CIDR}, // Existing has both
+				},
+				Status: networkingapiv1.ServiceCIDRStatus{},
+			},
+			expectedAction: [][]string{},
+		},
+		{
+			name:            "IPv4 IPv6 to IPv4 - needs operator attention for the IPv6 remaining Services",
+			controllerCIDRs: []string{defaultIPv4CIDR},
+			existingCIDR: &networkingapiv1.ServiceCIDR{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: DefaultServiceCIDRName,
+				},
+				Spec: networkingapiv1.ServiceCIDRSpec{
+					CIDRs: []string{defaultIPv4CIDR, defaultIPv6CIDR},
+				},
+				Status: networkingapiv1.ServiceCIDRStatus{},
+			},
+			expectedAction: [][]string{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Initialize controller and client with the existing ServiceCIDR
+			client, controller := newController(t, tc.controllerCIDRs, tc.existingCIDR)
+
+			// Call the syncStatus method directly
+			err := controller.sync()
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			// Verify the expected actions
+			expectAction(t, client.Actions(), tc.expectedAction)
 		})
 	}
 }

--- a/pkg/registry/networking/servicecidr/strategy.go
+++ b/pkg/registry/networking/servicecidr/strategy.go
@@ -106,8 +106,7 @@ func (serviceCIDRStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Obj
 func (serviceCIDRStrategy) ValidateUpdate(ctx context.Context, new, old runtime.Object) field.ErrorList {
 	newServiceCIDR := new.(*networking.ServiceCIDR)
 	oldServiceCIDR := old.(*networking.ServiceCIDR)
-	errList := validation.ValidateServiceCIDR(newServiceCIDR)
-	errList = append(errList, validation.ValidateServiceCIDRUpdate(newServiceCIDR, oldServiceCIDR)...)
+	errList := validation.ValidateServiceCIDRUpdate(newServiceCIDR, oldServiceCIDR)
 	return errList
 }
 

--- a/pkg/registry/networking/servicecidr/strategy_test.go
+++ b/pkg/registry/networking/servicecidr/strategy_test.go
@@ -47,15 +47,15 @@ func TestServiceCIDRStrategy(t *testing.T) {
 
 	errors := Strategy.Validate(context.TODO(), obj)
 	if len(errors) != 2 {
-		t.Errorf("Expected 2 validation errors for invalid object, got %d", len(errors))
+		t.Errorf("Expected 2 validation errors for invalid object, got %d : %v", len(errors), errors)
 	}
 
 	oldObj := newServiceCIDR()
 	newObj := oldObj.DeepCopy()
 	newObj.Spec.CIDRs = []string{"bad cidr"}
 	errors = Strategy.ValidateUpdate(context.TODO(), newObj, oldObj)
-	if len(errors) != 2 {
-		t.Errorf("Expected 2 validation errors for invalid update, got %d", len(errors))
+	if len(errors) != 1 {
+		t.Errorf("Expected 1 validation error for invalid update, got %d : %v", len(errors), errors)
 	}
 }
 


### PR DESCRIPTION
/kind bug

Allow single-to-dual-stack conversion for ServiceCIDR

This change modifies the validation logic for ServiceCIDR updates
(`ValidateServiceCIDRUpdate`) to specifically permit converting a
single-stack ServiceCIDR (either IPv4 or IPv6) to a dual-stack
configuration.

This conversion path is considered safe because it only involves adding
a new CIDR range without altering the existing primary CIDR. This
ensures that existing Service IP allocations are not disrupted.

Other modifications, such as:
- Converting from dual-stack to single-stack
- Reordering CIDRs in a dual-stack configuration
- Changing the primary CIDR during a single-to-dual-stack upgrade

remain disallowed by the validation. These operations carry a higher
risk of breaking existing Services or cluster networking
configurations. Preventing these updates automatically encourages
administrators to perform such changes manually after carefully
assessing the potential impact on their specific cluster environment.
The validation errors and controller logs provide guidance when such
disallowed changes are attempted.


Fixes: #131261
Related: https://github.com/kubernetes/kubernetes/issues/114743

```release-note
kube-apiserver: Fixes an issue updating the default ServiceCIDR API object and creating dual-stack Service API objects when `--service-cluster-ip-range` flag passed to kube-apiserver is changed from single-stack to dual-stack
```
