### PR TITLE
Move pod resize e2e utilities out of e2e/framework

### DIFF
--- a/test/e2e/common/node/framework/podresize/resize_linux_test.go
+++ b/test/e2e/common/node/framework/podresize/resize_linux_test.go
@@ -17,7 +17,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package pod
+package podresize
 
 import (
 	"testing"

--- a/test/e2e/common/node/pod_level_resources.go
+++ b/test/e2e/common/node/pod_level_resources.go
@@ -30,6 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	kubecm "k8s.io/kubernetes/pkg/kubelet/cm"
+	"k8s.io/kubernetes/test/e2e/common/node/framework/podresize"
 	"k8s.io/kubernetes/test/e2e/feature"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
@@ -44,7 +45,6 @@ const (
 	cgroupv2CPULimit  string = "cpu.max"
 	cgroupv2MemLimit  string = "memory.max"
 	cgroupFsPath      string = "/sys/fs/cgroup"
-	CPUPeriod         string = "100000"
 	mountPath         string = "/sysfscgroup"
 )
 
@@ -233,7 +233,7 @@ func verifyPodCgroups(ctx context.Context, f *framework.Framework, pod *v1.Pod, 
 	}
 
 	cpuLimCgPath := fmt.Sprintf("%s/%s", podCgPath, cgroupv2CPULimit)
-	expectedCPULimits := e2epod.GetCPULimitCgroupExpectations(expectedResources.Limits.Cpu())
+	expectedCPULimits := podresize.GetCPULimitCgroupExpectations(expectedResources.Limits.Cpu())
 
 	err = e2epod.VerifyCgroupValue(f, pod, pod.Spec.Containers[0].Name, cpuLimCgPath, expectedCPULimits...)
 	if err != nil {
@@ -394,7 +394,7 @@ func verifyContainersCgroupLimits(f *framework.Framework, pod *v1.Pod) error {
 
 		if pod.Spec.Resources != nil && pod.Spec.Resources.Limits.Cpu() != nil &&
 			container.Resources.Limits.Cpu() == nil {
-			expectedCPULimits := e2epod.GetCPULimitCgroupExpectations(pod.Spec.Resources.Limits.Cpu())
+			expectedCPULimits := podresize.GetCPULimitCgroupExpectations(pod.Spec.Resources.Limits.Cpu())
 			err := e2epod.VerifyCgroupValue(f, pod, container.Name, fmt.Sprintf("%s/%s", cgroupFsPath, cgroupv2CPULimit), expectedCPULimits...)
 			if err != nil {
 				errs = append(errs, fmt.Errorf("failed to verify cpu limit cgroup value: %w", err))

--- a/test/e2e/common/node/pod_resize.go
+++ b/test/e2e/common/node/pod_resize.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/kubernetes/pkg/features"
+	"k8s.io/kubernetes/test/e2e/common/node/framework/podresize"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
@@ -71,9 +72,9 @@ func offsetMemory(index int64, value string) string {
 func doPodResizeTests() {
 	type testCase struct {
 		name                string
-		containers          []e2epod.ResizableContainerInfo
+		containers          []podresize.ResizableContainerInfo
 		patchString         string
-		expected            []e2epod.ResizableContainerInfo
+		expected            []podresize.ResizableContainerInfo
 		addExtendedResource bool
 		// TODO(123940): test rollback for all test cases once resize is more responsive.
 		testRollback bool
@@ -84,10 +85,10 @@ func doPodResizeTests() {
 	tests := []testCase{
 		{
 			name: "Guaranteed QoS pod, one container - increase CPU & memory",
-			containers: []e2epod.ResizableContainerInfo{
+			containers: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPU, MemReq: originalMem, MemLim: originalMem},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPU, MemReq: originalMem, MemLim: originalMem},
 					CPUPolicy: &noRestart,
 					MemPolicy: &noRestart,
 				},
@@ -95,10 +96,10 @@ func doPodResizeTests() {
 			patchString: fmt.Sprintf(`{"spec":{"containers":[
 					{"name":"c1", "resources":{"requests":{"cpu":"%s","memory":"%s"},"limits":{"cpu":"%s","memory":"%s"}}}
 				]}}`, increasedCPU, increasedMem, increasedCPU, increasedMem),
-			expected: []e2epod.ResizableContainerInfo{
+			expected: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: increasedCPU, CPULim: increasedCPU, MemReq: increasedMem, MemLim: increasedMem},
+					Resources: &podresize.ContainerResources{CPUReq: increasedCPU, CPULim: increasedCPU, MemReq: increasedMem, MemLim: increasedMem},
 					CPUPolicy: &noRestart,
 					MemPolicy: &noRestart,
 				},
@@ -106,10 +107,10 @@ func doPodResizeTests() {
 		},
 		{
 			name: "Guaranteed QoS pod, one container - decrease CPU only",
-			containers: []e2epod.ResizableContainerInfo{
+			containers: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPU, MemReq: originalMem, MemLim: originalMem},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPU, MemReq: originalMem, MemLim: originalMem},
 					CPUPolicy: &noRestart,
 					MemPolicy: &noRestart,
 				},
@@ -117,10 +118,10 @@ func doPodResizeTests() {
 			patchString: fmt.Sprintf(`{"spec":{"containers":[
 							{"name":"c1", "resources":{"requests":{"cpu":"%s"},"limits":{"cpu":"%s"}}}
 						]}}`, reducedCPU, reducedCPU),
-			expected: []e2epod.ResizableContainerInfo{
+			expected: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: reducedCPU, CPULim: reducedCPU, MemReq: originalMem, MemLim: originalMem},
+					Resources: &podresize.ContainerResources{CPUReq: reducedCPU, CPULim: reducedCPU, MemReq: originalMem, MemLim: originalMem},
 					CPUPolicy: &noRestart,
 					MemPolicy: &noRestart,
 				},
@@ -129,22 +130,22 @@ func doPodResizeTests() {
 		},
 		{
 			name: "Guaranteed QoS pod, three containers (c1, c2, c3) - increase: CPU (c1,c3), memory (c2, c3) ; decrease: CPU (c2)",
-			containers: []e2epod.ResizableContainerInfo{
+			containers: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPU, MemReq: originalMem, MemLim: originalMem},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPU, MemReq: originalMem, MemLim: originalMem},
 					CPUPolicy: &noRestart,
 					MemPolicy: &noRestart,
 				},
 				{
 					Name:      "c2",
-					Resources: &e2epod.ContainerResources{CPUReq: offsetCPU(1, originalCPU), CPULim: offsetCPU(1, originalCPU), MemReq: offsetMemory(1, originalMem), MemLim: offsetMemory(1, originalMem)},
+					Resources: &podresize.ContainerResources{CPUReq: offsetCPU(1, originalCPU), CPULim: offsetCPU(1, originalCPU), MemReq: offsetMemory(1, originalMem), MemLim: offsetMemory(1, originalMem)},
 					CPUPolicy: &noRestart,
 					MemPolicy: &noRestart,
 				},
 				{
 					Name:      "c3",
-					Resources: &e2epod.ContainerResources{CPUReq: offsetCPU(2, originalCPU), CPULim: offsetCPU(2, originalCPU), MemReq: offsetMemory(2, originalMem), MemLim: offsetMemory(2, originalMem)},
+					Resources: &podresize.ContainerResources{CPUReq: offsetCPU(2, originalCPU), CPULim: offsetCPU(2, originalCPU), MemReq: offsetMemory(2, originalMem), MemLim: offsetMemory(2, originalMem)},
 					CPUPolicy: &noRestart,
 					MemPolicy: &noRestart,
 				},
@@ -157,22 +158,22 @@ func doPodResizeTests() {
 				increasedCPU, increasedCPU,
 				offsetCPU(1, reducedCPU), offsetMemory(1, increasedMem), offsetCPU(1, reducedCPU), offsetMemory(1, increasedMem),
 				offsetCPU(2, increasedCPU), offsetMemory(2, increasedMem), offsetCPU(2, increasedCPU), offsetMemory(2, increasedMem)),
-			expected: []e2epod.ResizableContainerInfo{
+			expected: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: increasedCPU, CPULim: increasedCPU, MemReq: originalMem, MemLim: originalMem},
+					Resources: &podresize.ContainerResources{CPUReq: increasedCPU, CPULim: increasedCPU, MemReq: originalMem, MemLim: originalMem},
 					CPUPolicy: &noRestart,
 					MemPolicy: &noRestart,
 				},
 				{
 					Name:      "c2",
-					Resources: &e2epod.ContainerResources{CPUReq: offsetCPU(1, reducedCPU), CPULim: offsetCPU(1, reducedCPU), MemReq: offsetMemory(1, increasedMem), MemLim: offsetMemory(1, increasedMem)},
+					Resources: &podresize.ContainerResources{CPUReq: offsetCPU(1, reducedCPU), CPULim: offsetCPU(1, reducedCPU), MemReq: offsetMemory(1, increasedMem), MemLim: offsetMemory(1, increasedMem)},
 					CPUPolicy: &noRestart,
 					MemPolicy: &noRestart,
 				},
 				{
 					Name:      "c3",
-					Resources: &e2epod.ContainerResources{CPUReq: offsetCPU(2, increasedCPU), CPULim: offsetCPU(2, increasedCPU), MemReq: offsetMemory(2, increasedMem), MemLim: offsetMemory(2, increasedMem)},
+					Resources: &podresize.ContainerResources{CPUReq: offsetCPU(2, increasedCPU), CPULim: offsetCPU(2, increasedCPU), MemReq: offsetMemory(2, increasedMem), MemLim: offsetMemory(2, increasedMem)},
 					CPUPolicy: &noRestart,
 					MemPolicy: &noRestart,
 				},
@@ -180,355 +181,355 @@ func doPodResizeTests() {
 		},
 		{
 			name: "Burstable QoS pod, one container with cpu & memory requests + limits - decrease memory requests only",
-			containers: []e2epod.ResizableContainerInfo{
+			containers: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
 				},
 			},
 			patchString: fmt.Sprintf(`{"spec":{"containers":[
 							{"name":"c1", "resources":{"requests":{"memory":"%s"}}}
 						]}}`, reducedMem),
-			expected: []e2epod.ResizableContainerInfo{
+			expected: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: reducedMem, MemLim: originalMemLimit},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: reducedMem, MemLim: originalMemLimit},
 				},
 			},
 			testRollback: true,
 		},
 		{
 			name: "Burstable QoS pod, one container with cpu & memory requests + limits - increase memory requests only",
-			containers: []e2epod.ResizableContainerInfo{
+			containers: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
 				},
 			},
 			patchString: fmt.Sprintf(`{"spec":{"containers":[
 							{"name":"c1", "resources":{"requests":{"memory":"%s"}}}
 						]}}`, increasedMem),
-			expected: []e2epod.ResizableContainerInfo{
+			expected: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: increasedMem, MemLim: originalMemLimit},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: increasedMem, MemLim: originalMemLimit},
 				},
 			},
 		},
 		{
 			name: "Burstable QoS pod, one container with cpu & memory requests + limits - increase memory limits only",
-			containers: []e2epod.ResizableContainerInfo{
+			containers: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
 				},
 			},
 			patchString: fmt.Sprintf(`{"spec":{"containers":[
 							{"name":"c1", "resources":{"limits":{"memory":"%s"}}}
 						]}}`, increasedMemLimit),
-			expected: []e2epod.ResizableContainerInfo{
+			expected: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: increasedMemLimit},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: increasedMemLimit},
 				},
 			},
 		},
 		{
 			name: "Burstable QoS pod, one container with cpu & memory requests + limits - decrease CPU requests only",
-			containers: []e2epod.ResizableContainerInfo{
+			containers: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
 				},
 			},
 			patchString: fmt.Sprintf(`{"spec":{"containers":[
 							{"name":"c1", "resources":{"requests":{"cpu":"%s"}}}
 						]}}`, reducedCPU),
-			expected: []e2epod.ResizableContainerInfo{
+			expected: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: reducedCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
+					Resources: &podresize.ContainerResources{CPUReq: reducedCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
 				},
 			},
 			testRollback: true,
 		},
 		{
 			name: "Burstable QoS pod, one container with cpu & memory requests + limits - decrease CPU limits only",
-			containers: []e2epod.ResizableContainerInfo{
+			containers: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
 				},
 			},
 			patchString: fmt.Sprintf(`{"spec":{"containers":[
 							{"name":"c1", "resources":{"limits":{"cpu":"%s"}}}
 						]}}`, reducedCPULimit),
-			expected: []e2epod.ResizableContainerInfo{
+			expected: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: reducedCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: reducedCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
 				},
 			},
 			testRollback: true,
 		},
 		{
 			name: "Burstable QoS pod, one container with cpu & memory requests + limits - increase CPU requests only",
-			containers: []e2epod.ResizableContainerInfo{
+			containers: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
 				},
 			},
 			patchString: fmt.Sprintf(`{"spec":{"containers":[
 							{"name":"c1", "resources":{"requests":{"cpu":"%s"}}}
 						]}}`, increasedCPU),
-			expected: []e2epod.ResizableContainerInfo{
+			expected: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: increasedCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
+					Resources: &podresize.ContainerResources{CPUReq: increasedCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
 				},
 			},
 		},
 		{
 			name: "Burstable QoS pod, one container with cpu & memory requests + limits - increase CPU limits only",
-			containers: []e2epod.ResizableContainerInfo{
+			containers: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
 				},
 			},
 			patchString: fmt.Sprintf(`{"spec":{"containers":[
 							{"name":"c1", "resources":{"limits":{"cpu":"%s"}}}
 						]}}`, increasedCPULimit),
-			expected: []e2epod.ResizableContainerInfo{
+			expected: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: increasedCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: increasedCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
 				},
 			},
 		},
 		{
 			name: "Burstable QoS pod, one container with cpu & memory requests + limits - decrease CPU requests and limits",
-			containers: []e2epod.ResizableContainerInfo{
+			containers: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
 				},
 			},
 			patchString: fmt.Sprintf(`{"spec":{"containers":[
 							{"name":"c1", "resources":{"requests":{"cpu":"%s"},"limits":{"cpu":"%s"}}}
 						]}}`, reducedCPU, reducedCPULimit),
-			expected: []e2epod.ResizableContainerInfo{
+			expected: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: reducedCPU, CPULim: reducedCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
+					Resources: &podresize.ContainerResources{CPUReq: reducedCPU, CPULim: reducedCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
 				},
 			},
 		},
 		{
 			name: "Burstable QoS pod, one container with cpu & memory requests + limits - increase CPU requests and limits",
-			containers: []e2epod.ResizableContainerInfo{
+			containers: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
 				},
 			},
 			patchString: fmt.Sprintf(`{"spec":{"containers":[
 							{"name":"c1", "resources":{"requests":{"cpu":"%s"},"limits":{"cpu":"%s"}}}
 						]}}`, increasedCPU, increasedCPULimit),
-			expected: []e2epod.ResizableContainerInfo{
+			expected: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: increasedCPU, CPULim: increasedCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
+					Resources: &podresize.ContainerResources{CPUReq: increasedCPU, CPULim: increasedCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
 				},
 			},
 		},
 		{
 			name: "Burstable QoS pod, one container with cpu & memory requests + limits - decrease CPU requests and increase CPU limits",
-			containers: []e2epod.ResizableContainerInfo{
+			containers: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
 				},
 			},
 			patchString: fmt.Sprintf(`{"spec":{"containers":[
 							{"name":"c1", "resources":{"requests":{"cpu":"%s"},"limits":{"cpu":"%s"}}}
 						]}}`, reducedCPU, increasedCPULimit),
-			expected: []e2epod.ResizableContainerInfo{
+			expected: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: reducedCPU, CPULim: increasedCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
+					Resources: &podresize.ContainerResources{CPUReq: reducedCPU, CPULim: increasedCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
 				},
 			},
 		},
 		{
 			name: "Burstable QoS pod, one container with cpu & memory requests + limits - increase CPU requests and decrease CPU limits",
-			containers: []e2epod.ResizableContainerInfo{
+			containers: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
 				},
 			},
 			patchString: fmt.Sprintf(`{"spec":{"containers":[
 							{"name":"c1", "resources":{"requests":{"cpu":"%s"},"limits":{"cpu":"%s"}}}
 						]}}`, increasedCPU, reducedCPULimit),
-			expected: []e2epod.ResizableContainerInfo{
+			expected: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: increasedCPU, CPULim: reducedCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
+					Resources: &podresize.ContainerResources{CPUReq: increasedCPU, CPULim: reducedCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
 				},
 			},
 		},
 		{
 			name: "Burstable QoS pod, one container with cpu & memory requests + limits - increase memory requests and limits",
-			containers: []e2epod.ResizableContainerInfo{
+			containers: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
 				},
 			},
 			patchString: fmt.Sprintf(`{"spec":{"containers":[
 							{"name":"c1", "resources":{"requests":{"memory":"%s"},"limits":{"memory":"%s"}}}
 						]}}`, increasedMem, increasedMemLimit),
-			expected: []e2epod.ResizableContainerInfo{
+			expected: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: increasedMem, MemLim: increasedMemLimit},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: increasedMem, MemLim: increasedMemLimit},
 				},
 			},
 		},
 		{
 			name: "Burstable QoS pod, one container with cpu & memory requests + limits - decrease memory requests and increase memory limits",
-			containers: []e2epod.ResizableContainerInfo{
+			containers: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
 				},
 			},
 			patchString: fmt.Sprintf(`{"spec":{"containers":[
 							{"name":"c1", "resources":{"requests":{"memory":"%s"},"limits":{"memory":"%s"}}}
 						]}}`, reducedMem, increasedMemLimit),
-			expected: []e2epod.ResizableContainerInfo{
+			expected: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: reducedMem, MemLim: increasedMemLimit},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: reducedMem, MemLim: increasedMemLimit},
 				},
 			},
 		},
 		{
 			name: "Burstable QoS pod, one container with cpu & memory requests + limits - decrease CPU requests and increase memory limits",
-			containers: []e2epod.ResizableContainerInfo{
+			containers: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
 				},
 			},
 			patchString: fmt.Sprintf(`{"spec":{"containers":[
 							{"name":"c1", "resources":{"requests":{"cpu":"%s"},"limits":{"memory":"%s"}}}
 						]}}`, reducedCPU, increasedMemLimit),
-			expected: []e2epod.ResizableContainerInfo{
+			expected: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: reducedCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: increasedMemLimit},
+					Resources: &podresize.ContainerResources{CPUReq: reducedCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: increasedMemLimit},
 				},
 			},
 		},
 		{
 			name: "Burstable QoS pod, one container with cpu & memory requests + limits - decrease memory requests and increase CPU limits",
-			containers: []e2epod.ResizableContainerInfo{
+			containers: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
 				},
 			},
 			patchString: fmt.Sprintf(`{"spec":{"containers":[
 							{"name":"c1", "resources":{"requests":{"memory":"%s"},"limits":{"cpu":"%s"}}}
 						]}}`, reducedMem, increasedCPULimit),
-			expected: []e2epod.ResizableContainerInfo{
+			expected: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: increasedCPULimit, MemReq: reducedMem, MemLim: originalMemLimit},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: increasedCPULimit, MemReq: reducedMem, MemLim: originalMemLimit},
 				},
 			},
 		},
 		{
 			name: "Burstable QoS pod, one container with cpu & memory requests + limits - increase memory requests and decrease CPU limits",
-			containers: []e2epod.ResizableContainerInfo{
+			containers: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
 				},
 			},
 			patchString: fmt.Sprintf(`{"spec":{"containers":[
 							{"name":"c1", "resources":{"requests":{"memory":"%s"},"limits":{"cpu":"%s"}}}
 						]}}`, increasedMem, reducedCPULimit),
-			expected: []e2epod.ResizableContainerInfo{
+			expected: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: reducedCPULimit, MemReq: increasedMem, MemLim: originalMemLimit},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: reducedCPULimit, MemReq: increasedMem, MemLim: originalMemLimit},
 				},
 			},
 		},
 		{
 			name: "Burstable QoS pod, one container with cpu & memory requests - decrease memory request",
-			containers: []e2epod.ResizableContainerInfo{
+			containers: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, MemReq: originalMem},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, MemReq: originalMem},
 				},
 			},
 			patchString: fmt.Sprintf(`{"spec":{"containers":[
 							{"name":"c1", "resources":{"requests":{"memory":"%s"}}}
 						]}}`, reducedMem),
-			expected: []e2epod.ResizableContainerInfo{
+			expected: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, MemReq: reducedMem},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, MemReq: reducedMem},
 				},
 			},
 		},
 		{
 			name: "Burstable QoS pod, one container with cpu & memory requests - increase cpu request",
-			containers: []e2epod.ResizableContainerInfo{
+			containers: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, MemReq: originalMem},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, MemReq: originalMem},
 				},
 			},
 			patchString: fmt.Sprintf(`{"spec":{"containers":[
 							{"name":"c1", "resources":{"requests":{"cpu":"%s"}}}
 						]}}`, increasedCPU),
-			expected: []e2epod.ResizableContainerInfo{
+			expected: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: increasedCPU, MemReq: originalMem},
+					Resources: &podresize.ContainerResources{CPUReq: increasedCPU, MemReq: originalMem},
 				},
 			},
 		},
 		{
 			name: "Burstable QoS pod, one container with cpu requests and limits - resize with equivalents",
-			containers: []e2epod.ResizableContainerInfo{
+			containers: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: "2m", CPULim: "10m"},
+					Resources: &podresize.ContainerResources{CPUReq: "2m", CPULim: "10m"},
 				},
 			},
 			patchString: `{"spec":{"containers":[
 							{"name":"c1", "resources":{"requests":{"cpu":"1m"},"limits":{"cpu":"5m"}}}
 						]}}`,
-			expected: []e2epod.ResizableContainerInfo{
+			expected: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: "1m", CPULim: "5m"},
+					Resources: &podresize.ContainerResources{CPUReq: "1m", CPULim: "5m"},
 				},
 			},
 		},
 		{
 			name: "Guaranteed QoS pod, one container - increase CPU (NotRequired) & memory (RestartContainer)",
-			containers: []e2epod.ResizableContainerInfo{
+			containers: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPU, MemReq: originalMem, MemLim: originalMem},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPU, MemReq: originalMem, MemLim: originalMem},
 					CPUPolicy: &noRestart,
 					MemPolicy: &doRestart,
 				},
@@ -536,10 +537,10 @@ func doPodResizeTests() {
 			patchString: fmt.Sprintf(`{"spec":{"containers":[
 							{"name":"c1", "resources":{"requests":{"cpu":"%s","memory":"%s"},"limits":{"cpu":"%s","memory":"%s"}}}
 						]}}`, increasedCPU, increasedMem, increasedCPU, increasedMem),
-			expected: []e2epod.ResizableContainerInfo{
+			expected: []podresize.ResizableContainerInfo{
 				{
 					Name:         "c1",
-					Resources:    &e2epod.ContainerResources{CPUReq: increasedCPU, CPULim: increasedCPU, MemReq: increasedMem, MemLim: increasedMem},
+					Resources:    &podresize.ContainerResources{CPUReq: increasedCPU, CPULim: increasedCPU, MemReq: increasedMem, MemLim: increasedMem},
 					CPUPolicy:    &noRestart,
 					MemPolicy:    &doRestart,
 					RestartCount: 1,
@@ -549,10 +550,10 @@ func doPodResizeTests() {
 		},
 		{
 			name: "Burstable QoS pod, one container - decrease CPU (NotRequired) & memory (RestartContainer)",
-			containers: []e2epod.ResizableContainerInfo{
+			containers: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
 					CPUPolicy: &noRestart,
 					MemPolicy: &doRestart,
 				},
@@ -560,10 +561,10 @@ func doPodResizeTests() {
 			patchString: fmt.Sprintf(`{"spec":{"containers":[
 							{"name":"c1", "resources":{"requests":{"cpu":"%s","memory":"%s"},"limits":{"cpu":"%s","memory":"%s"}}}
 						]}}`, reducedCPU, reducedMem, reducedCPULimit, reducedMemLimit),
-			expected: []e2epod.ResizableContainerInfo{
+			expected: []podresize.ResizableContainerInfo{
 				{
 					Name:         "c1",
-					Resources:    &e2epod.ContainerResources{CPUReq: reducedCPU, CPULim: reducedCPULimit, MemReq: reducedMem, MemLim: reducedMemLimit},
+					Resources:    &podresize.ContainerResources{CPUReq: reducedCPU, CPULim: reducedCPULimit, MemReq: reducedMem, MemLim: reducedMemLimit},
 					CPUPolicy:    &noRestart,
 					MemPolicy:    &doRestart,
 					RestartCount: 1,
@@ -573,10 +574,10 @@ func doPodResizeTests() {
 		},
 		{
 			name: "Burstable QoS pod, one container - decrease memory request (RestartContainer memory resize policy)",
-			containers: []e2epod.ResizableContainerInfo{
+			containers: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
 					CPUPolicy: &noRestart,
 					MemPolicy: &doRestart,
 				},
@@ -584,10 +585,10 @@ func doPodResizeTests() {
 			patchString: fmt.Sprintf(`{"spec":{"containers":[
 						{"name":"c1", "resources":{"requests":{"cpu":"%s","memory":"%s"},"limits":{"cpu":"%s","memory":"%s"}}}
 					]}}`, originalCPU, reducedMem, originalCPULimit, originalMemLimit),
-			expected: []e2epod.ResizableContainerInfo{
+			expected: []podresize.ResizableContainerInfo{
 				{
 					Name:         "c1",
-					Resources:    &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: reducedMem, MemLim: originalMemLimit},
+					Resources:    &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: reducedMem, MemLim: originalMemLimit},
 					CPUPolicy:    &noRestart,
 					MemPolicy:    &doRestart,
 					RestartCount: 1,
@@ -596,10 +597,10 @@ func doPodResizeTests() {
 		},
 		{
 			name: "Burstable QoS pod, one container - increase memory request (NoRestart memory resize policy)",
-			containers: []e2epod.ResizableContainerInfo{
+			containers: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
 					CPUPolicy: &noRestart,
 					MemPolicy: &noRestart,
 				},
@@ -607,10 +608,10 @@ func doPodResizeTests() {
 			patchString: fmt.Sprintf(`{"spec":{"containers":[
 							{"name":"c1", "resources":{"requests":{"cpu":"%s","memory":"%s"},"limits":{"cpu":"%s","memory":"%s"}}}
 						]}}`, originalCPU, increasedMem, originalCPULimit, originalMemLimit),
-			expected: []e2epod.ResizableContainerInfo{
+			expected: []podresize.ResizableContainerInfo{
 				{
 					Name:         "c1",
-					Resources:    &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: increasedMem, MemLim: originalMemLimit},
+					Resources:    &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: increasedMem, MemLim: originalMemLimit},
 					CPUPolicy:    &noRestart,
 					MemPolicy:    &noRestart,
 					RestartCount: 0,
@@ -619,22 +620,22 @@ func doPodResizeTests() {
 		},
 		{
 			name: "Burstable QoS pod, three containers - increase c1 resources, no change for c2, decrease c3 resources (no net change for pod)",
-			containers: []e2epod.ResizableContainerInfo{
+			containers: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
 					CPUPolicy: &noRestart,
 					MemPolicy: &noRestart,
 				},
 				{
 					Name:      "c2",
-					Resources: &e2epod.ContainerResources{CPUReq: offsetCPU(1, originalCPU), CPULim: offsetCPU(1, originalCPULimit), MemReq: offsetMemory(1, originalMem), MemLim: offsetMemory(1, originalMemLimit)},
+					Resources: &podresize.ContainerResources{CPUReq: offsetCPU(1, originalCPU), CPULim: offsetCPU(1, originalCPULimit), MemReq: offsetMemory(1, originalMem), MemLim: offsetMemory(1, originalMemLimit)},
 					CPUPolicy: &noRestart,
 					MemPolicy: &doRestart,
 				},
 				{
 					Name:      "c3",
-					Resources: &e2epod.ContainerResources{CPUReq: offsetCPU(2, originalCPU), CPULim: offsetCPU(2, originalCPULimit), MemReq: offsetMemory(2, originalMem), MemLim: offsetMemory(2, originalMemLimit)},
+					Resources: &podresize.ContainerResources{CPUReq: offsetCPU(2, originalCPU), CPULim: offsetCPU(2, originalCPULimit), MemReq: offsetMemory(2, originalMem), MemLim: offsetMemory(2, originalMemLimit)},
 					CPUPolicy: &noRestart,
 					MemPolicy: &noRestart,
 				},
@@ -645,22 +646,22 @@ func doPodResizeTests() {
 						]}}`,
 				increasedCPU, increasedMem, increasedCPULimit, increasedMemLimit,
 				offsetCPU(2, reducedCPU), offsetMemory(2, reducedMem), offsetCPU(2, reducedCPULimit)),
-			expected: []e2epod.ResizableContainerInfo{
+			expected: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: increasedCPU, CPULim: increasedCPULimit, MemReq: increasedMem, MemLim: increasedMemLimit},
+					Resources: &podresize.ContainerResources{CPUReq: increasedCPU, CPULim: increasedCPULimit, MemReq: increasedMem, MemLim: increasedMemLimit},
 					CPUPolicy: &noRestart,
 					MemPolicy: &noRestart,
 				},
 				{
 					Name:      "c2",
-					Resources: &e2epod.ContainerResources{CPUReq: offsetCPU(1, originalCPU), CPULim: offsetCPU(1, originalCPULimit), MemReq: offsetMemory(1, originalMem), MemLim: offsetMemory(1, originalMemLimit)},
+					Resources: &podresize.ContainerResources{CPUReq: offsetCPU(1, originalCPU), CPULim: offsetCPU(1, originalCPULimit), MemReq: offsetMemory(1, originalMem), MemLim: offsetMemory(1, originalMemLimit)},
 					CPUPolicy: &noRestart,
 					MemPolicy: &doRestart,
 				},
 				{
 					Name:      "c3",
-					Resources: &e2epod.ContainerResources{CPUReq: offsetCPU(2, reducedCPU), CPULim: offsetCPU(2, reducedCPULimit), MemReq: offsetMemory(2, reducedMem), MemLim: offsetMemory(2, originalMemLimit)},
+					Resources: &podresize.ContainerResources{CPUReq: offsetCPU(2, reducedCPU), CPULim: offsetCPU(2, reducedCPULimit), MemReq: offsetMemory(2, reducedMem), MemLim: offsetMemory(2, originalMemLimit)},
 					CPUPolicy: &noRestart,
 					MemPolicy: &noRestart,
 				},
@@ -668,22 +669,22 @@ func doPodResizeTests() {
 		},
 		{
 			name: "Burstable QoS pod, three containers - decrease c1 resources, increase c2 resources, no change for c3 (net increase for pod)",
-			containers: []e2epod.ResizableContainerInfo{
+			containers: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
 					CPUPolicy: &noRestart,
 					MemPolicy: &noRestart,
 				},
 				{
 					Name:      "c2",
-					Resources: &e2epod.ContainerResources{CPUReq: offsetCPU(1, originalCPU), CPULim: offsetCPU(1, originalCPULimit), MemReq: offsetMemory(1, originalMem), MemLim: offsetMemory(1, originalMemLimit)},
+					Resources: &podresize.ContainerResources{CPUReq: offsetCPU(1, originalCPU), CPULim: offsetCPU(1, originalCPULimit), MemReq: offsetMemory(1, originalMem), MemLim: offsetMemory(1, originalMemLimit)},
 					CPUPolicy: &noRestart,
 					MemPolicy: &doRestart,
 				},
 				{
 					Name:      "c3",
-					Resources: &e2epod.ContainerResources{CPUReq: offsetCPU(2, originalCPU), CPULim: offsetCPU(2, originalCPULimit), MemReq: offsetMemory(2, originalMem), MemLim: offsetMemory(2, originalMemLimit)},
+					Resources: &podresize.ContainerResources{CPUReq: offsetCPU(2, originalCPU), CPULim: offsetCPU(2, originalCPULimit), MemReq: offsetMemory(2, originalMem), MemLim: offsetMemory(2, originalMemLimit)},
 					CPUPolicy: &noRestart,
 					MemPolicy: &noRestart,
 				},
@@ -694,23 +695,23 @@ func doPodResizeTests() {
 						]}}`,
 				reducedCPU, reducedMem, reducedCPULimit,
 				offsetCPU(2, increasedCPU), offsetMemory(2, increasedMem), offsetCPU(2, increasedCPULimit), offsetMemory(2, increasedMemLimit)),
-			expected: []e2epod.ResizableContainerInfo{
+			expected: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: reducedCPU, CPULim: reducedCPULimit, MemReq: reducedMem, MemLim: originalMemLimit},
+					Resources: &podresize.ContainerResources{CPUReq: reducedCPU, CPULim: reducedCPULimit, MemReq: reducedMem, MemLim: originalMemLimit},
 					CPUPolicy: &noRestart,
 					MemPolicy: &noRestart,
 				},
 				{
 					Name:         "c2",
-					Resources:    &e2epod.ContainerResources{CPUReq: offsetCPU(2, increasedCPU), CPULim: offsetCPU(2, increasedCPULimit), MemReq: offsetMemory(2, increasedMem), MemLim: offsetMemory(2, increasedMemLimit)},
+					Resources:    &podresize.ContainerResources{CPUReq: offsetCPU(2, increasedCPU), CPULim: offsetCPU(2, increasedCPULimit), MemReq: offsetMemory(2, increasedMem), MemLim: offsetMemory(2, increasedMemLimit)},
 					CPUPolicy:    &noRestart,
 					MemPolicy:    &doRestart,
 					RestartCount: 1,
 				},
 				{
 					Name:      "c3",
-					Resources: &e2epod.ContainerResources{CPUReq: offsetCPU(2, originalCPU), CPULim: offsetCPU(2, originalCPULimit), MemReq: offsetMemory(2, originalMem), MemLim: offsetMemory(2, originalMemLimit)},
+					Resources: &podresize.ContainerResources{CPUReq: offsetCPU(2, originalCPU), CPULim: offsetCPU(2, originalCPULimit), MemReq: offsetMemory(2, originalMem), MemLim: offsetMemory(2, originalMemLimit)},
 					CPUPolicy: &noRestart,
 					MemPolicy: &noRestart,
 				},
@@ -718,22 +719,22 @@ func doPodResizeTests() {
 		},
 		{
 			name: "Burstable QoS pod, three containers - no change for c1, increase c2 resources, decrease c3 (net decrease for pod)",
-			containers: []e2epod.ResizableContainerInfo{
+			containers: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
 					CPUPolicy: &doRestart,
 					MemPolicy: &doRestart,
 				},
 				{
 					Name:      "c2",
-					Resources: &e2epod.ContainerResources{CPUReq: offsetCPU(1, originalCPU), CPULim: offsetCPU(1, originalCPULimit), MemReq: offsetMemory(1, originalMem), MemLim: offsetMemory(1, originalMemLimit)},
+					Resources: &podresize.ContainerResources{CPUReq: offsetCPU(1, originalCPU), CPULim: offsetCPU(1, originalCPULimit), MemReq: offsetMemory(1, originalMem), MemLim: offsetMemory(1, originalMemLimit)},
 					CPUPolicy: &doRestart,
 					MemPolicy: &noRestart,
 				},
 				{
 					Name:      "c3",
-					Resources: &e2epod.ContainerResources{CPUReq: offsetCPU(2, originalCPU), CPULim: offsetCPU(2, originalCPULimit), MemReq: offsetMemory(2, originalMem), MemLim: offsetMemory(2, originalMemLimit)},
+					Resources: &podresize.ContainerResources{CPUReq: offsetCPU(2, originalCPU), CPULim: offsetCPU(2, originalCPULimit), MemReq: offsetMemory(2, originalMem), MemLim: offsetMemory(2, originalMemLimit)},
 					CPUPolicy: &noRestart,
 					MemPolicy: &doRestart,
 				},
@@ -744,23 +745,23 @@ func doPodResizeTests() {
 						]}}`,
 				offsetCPU(1, increasedCPU), offsetMemory(1, increasedMem), offsetCPU(1, increasedCPULimit), offsetMemory(1, increasedMemLimit),
 				reducedCPU, reducedMem, reducedCPULimit, reducedMemLimit),
-			expected: []e2epod.ResizableContainerInfo{
+			expected: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
 					CPUPolicy: &doRestart,
 					MemPolicy: &doRestart,
 				},
 				{
 					Name:         "c2",
-					Resources:    &e2epod.ContainerResources{CPUReq: offsetCPU(1, increasedCPU), CPULim: offsetCPU(1, increasedCPULimit), MemReq: offsetMemory(1, increasedMem), MemLim: offsetMemory(1, increasedMemLimit)},
+					Resources:    &podresize.ContainerResources{CPUReq: offsetCPU(1, increasedCPU), CPULim: offsetCPU(1, increasedCPULimit), MemReq: offsetMemory(1, increasedMem), MemLim: offsetMemory(1, increasedMemLimit)},
 					CPUPolicy:    &doRestart,
 					MemPolicy:    &noRestart,
 					RestartCount: 1,
 				},
 				{
 					Name:         "c3",
-					Resources:    &e2epod.ContainerResources{CPUReq: reducedCPU, CPULim: reducedCPULimit, MemReq: reducedMem, MemLim: reducedMemLimit},
+					Resources:    &podresize.ContainerResources{CPUReq: reducedCPU, CPULim: reducedCPULimit, MemReq: reducedMem, MemLim: reducedMemLimit},
 					CPUPolicy:    &noRestart,
 					MemPolicy:    &doRestart,
 					RestartCount: 1,
@@ -769,61 +770,61 @@ func doPodResizeTests() {
 		},
 		{
 			name: "Burstable QoS pod, mixed containers - scale up cpu and memory",
-			containers: []e2epod.ResizableContainerInfo{
+			containers: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPU, MemReq: originalMem, MemLim: originalMem},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPU, MemReq: originalMem, MemLim: originalMem},
 					CPUPolicy: &noRestart,
 					MemPolicy: &noRestart,
 				},
 				{
 					Name:      "c2",
-					Resources: &e2epod.ContainerResources{},
+					Resources: &podresize.ContainerResources{},
 				},
 			},
 			patchString: fmt.Sprintf(`{"spec":{"containers":[
 							{"name":"c1", "resources":{"requests":{"cpu":"%s","memory":"%s"},"limits":{"cpu":"%s","memory":"%s"}}}
 						]}}`, increasedCPU, increasedMem, increasedCPU, increasedMem),
-			expected: []e2epod.ResizableContainerInfo{
+			expected: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: increasedCPU, CPULim: increasedCPU, MemReq: increasedMem, MemLim: increasedMem},
+					Resources: &podresize.ContainerResources{CPUReq: increasedCPU, CPULim: increasedCPU, MemReq: increasedMem, MemLim: increasedMem},
 					CPUPolicy: &noRestart,
 					MemPolicy: &noRestart,
 				},
 				{
 					Name:      "c2",
-					Resources: &e2epod.ContainerResources{},
+					Resources: &podresize.ContainerResources{},
 				},
 			},
 		},
 		{
 			name: "Burstable QoS pod, mixed containers - add requests",
-			containers: []e2epod.ResizableContainerInfo{
+			containers: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPU, MemReq: originalMem, MemLim: originalMem},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPU, MemReq: originalMem, MemLim: originalMem},
 					CPUPolicy: &noRestart,
 					MemPolicy: &noRestart,
 				},
 				{
 					Name:      "c2",
-					Resources: &e2epod.ContainerResources{},
+					Resources: &podresize.ContainerResources{},
 				},
 			},
 			patchString: fmt.Sprintf(`{"spec":{"containers":[
 							{"name":"c2", "resources":{"requests":{"cpu":"%s","memory":"%s"}}}
 						]}}`, originalCPU, originalMem),
-			expected: []e2epod.ResizableContainerInfo{
+			expected: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPU, MemReq: originalMem, MemLim: originalMem},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPU, MemReq: originalMem, MemLim: originalMem},
 					CPUPolicy: &noRestart,
 					MemPolicy: &noRestart,
 				},
 				{
 					Name:      "c2",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, MemReq: originalMem},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, MemReq: originalMem},
 					CPUPolicy: &noRestart,
 					MemPolicy: &noRestart,
 				},
@@ -831,16 +832,16 @@ func doPodResizeTests() {
 		},
 		{
 			name: "Burstable QoS pod, mixed containers - add limits",
-			containers: []e2epod.ResizableContainerInfo{
+			containers: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPU, MemReq: originalMem, MemLim: originalMem},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPU, MemReq: originalMem, MemLim: originalMem},
 					CPUPolicy: &noRestart,
 					MemPolicy: &noRestart,
 				},
 				{
 					Name:      "c2",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, MemReq: originalMem},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, MemReq: originalMem},
 					CPUPolicy: &noRestart,
 					MemPolicy: &noRestart,
 				},
@@ -848,16 +849,16 @@ func doPodResizeTests() {
 			patchString: fmt.Sprintf(`{"spec":{"containers":[
 							{"name":"c2", "resources":{"limits":{"cpu":"%s"}}}
 						]}}`, originalCPULimit),
-			expected: []e2epod.ResizableContainerInfo{
+			expected: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPU, MemReq: originalMem, MemLim: originalMem},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPU, MemReq: originalMem, MemLim: originalMem},
 					CPUPolicy: &noRestart,
 					MemPolicy: &noRestart,
 				},
 				{
 					Name:      "c2",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem},
 					CPUPolicy: &noRestart,
 					MemPolicy: &noRestart,
 				},
@@ -865,10 +866,10 @@ func doPodResizeTests() {
 		},
 		{
 			name: "Guaranteed QoS pod, one container - increase CPU & memory with an extended resource",
-			containers: []e2epod.ResizableContainerInfo{
+			containers: []podresize.ResizableContainerInfo{
 				{
 					Name: "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPU, MemReq: originalMem, MemLim: originalMem,
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPU, MemReq: originalMem, MemLim: originalMem,
 						ExtendedResourceReq: "1", ExtendedResourceLim: "1"},
 					CPUPolicy: &noRestart,
 					MemPolicy: &noRestart,
@@ -877,10 +878,10 @@ func doPodResizeTests() {
 			patchString: fmt.Sprintf(`{"spec":{"containers":[
 						{"name":"c1", "resources":{"requests":{"cpu":"%s","memory":"%s"},"limits":{"cpu":"%s","memory":"%s"}}}
 						]}}`, increasedCPU, increasedMem, increasedCPU, increasedMem),
-			expected: []e2epod.ResizableContainerInfo{
+			expected: []podresize.ResizableContainerInfo{
 				{
 					Name: "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: increasedCPU, CPULim: increasedCPU, MemReq: increasedMem, MemLim: increasedMem,
+					Resources: &podresize.ContainerResources{CPUReq: increasedCPU, CPULim: increasedCPU, MemReq: increasedMem, MemLim: increasedMem,
 						ExtendedResourceReq: "1", ExtendedResourceLim: "1"},
 					CPUPolicy: &noRestart,
 					MemPolicy: &noRestart,
@@ -890,32 +891,32 @@ func doPodResizeTests() {
 		},
 		{
 			name: "BestEffort QoS pod - empty resize",
-			containers: []e2epod.ResizableContainerInfo{
+			containers: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{},
+					Resources: &podresize.ContainerResources{},
 				},
 			},
 			patchString: `{}`,
-			expected: []e2epod.ResizableContainerInfo{
+			expected: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{},
+					Resources: &podresize.ContainerResources{},
 				},
 			},
 		},
 		{
 			name: "Guaranteed QoS pod, one restartable init container - increase CPU & memory",
-			containers: []e2epod.ResizableContainerInfo{
+			containers: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPU, MemReq: originalMem, MemLim: originalMem},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPU, MemReq: originalMem, MemLim: originalMem},
 					CPUPolicy: &noRestart,
 					MemPolicy: &noRestart,
 				},
 				{
 					Name:          "c1-init",
-					Resources:     &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPU, MemReq: originalMem, MemLim: originalMem},
+					Resources:     &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPU, MemReq: originalMem, MemLim: originalMem},
 					CPUPolicy:     &noRestart,
 					MemPolicy:     &noRestart,
 					InitCtr:       true,
@@ -925,16 +926,16 @@ func doPodResizeTests() {
 			patchString: fmt.Sprintf(`{"spec":{"initContainers":[
 							{"name":"c1-init", "resources":{"requests":{"cpu":"%s","memory":"%s"},"limits":{"cpu":"%s","memory":"%s"}}}
 						]}}`, increasedCPU, increasedMem, increasedCPU, increasedMem),
-			expected: []e2epod.ResizableContainerInfo{
+			expected: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPU, MemReq: originalMem, MemLim: originalMem},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPU, MemReq: originalMem, MemLim: originalMem},
 					CPUPolicy: &noRestart,
 					MemPolicy: &noRestart,
 				},
 				{
 					Name:          "c1-init",
-					Resources:     &e2epod.ContainerResources{CPUReq: increasedCPU, CPULim: increasedCPU, MemReq: increasedMem, MemLim: increasedMem},
+					Resources:     &podresize.ContainerResources{CPUReq: increasedCPU, CPULim: increasedCPU, MemReq: increasedMem, MemLim: increasedMem},
 					CPUPolicy:     &noRestart,
 					MemPolicy:     &noRestart,
 					InitCtr:       true,
@@ -944,14 +945,14 @@ func doPodResizeTests() {
 		},
 		{
 			name: "Guaranteed QoS pod, one restartable init container - decrease CPU & increase memory",
-			containers: []e2epod.ResizableContainerInfo{
+			containers: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPU, MemReq: originalMem, MemLim: originalMem},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPU, MemReq: originalMem, MemLim: originalMem},
 				},
 				{
 					Name:          "c1-init",
-					Resources:     &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPU, MemReq: originalMem, MemLim: originalMem},
+					Resources:     &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPU, MemReq: originalMem, MemLim: originalMem},
 					InitCtr:       true,
 					RestartPolicy: v1.ContainerRestartPolicyAlways,
 				},
@@ -959,14 +960,14 @@ func doPodResizeTests() {
 			patchString: fmt.Sprintf(`{"spec":{"initContainers":[
 							{"name":"c1-init", "resources":{"requests":{"cpu":"%s","memory":"%s"},"limits":{"cpu":"%s","memory":"%s"}}}
 						]}}`, reducedCPU, increasedMem, reducedCPU, increasedMem),
-			expected: []e2epod.ResizableContainerInfo{
+			expected: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPU, MemReq: originalMem, MemLim: originalMem},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPU, MemReq: originalMem, MemLim: originalMem},
 				},
 				{
 					Name:          "c1-init",
-					Resources:     &e2epod.ContainerResources{CPUReq: reducedCPU, CPULim: reducedCPU, MemReq: increasedMem, MemLim: increasedMem},
+					Resources:     &podresize.ContainerResources{CPUReq: reducedCPU, CPULim: reducedCPU, MemReq: increasedMem, MemLim: increasedMem},
 					InitCtr:       true,
 					RestartPolicy: v1.ContainerRestartPolicyAlways,
 				},
@@ -974,14 +975,14 @@ func doPodResizeTests() {
 		},
 		{
 			name: "Guaranteed QoS pod, one container, one restartable init container - decrease init container CPU",
-			containers: []e2epod.ResizableContainerInfo{
+			containers: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPU, MemReq: originalMem, MemLim: originalMem},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPU, MemReq: originalMem, MemLim: originalMem},
 				},
 				{
 					Name:          "c1-init",
-					Resources:     &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPU, MemReq: originalMem, MemLim: originalMem},
+					Resources:     &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPU, MemReq: originalMem, MemLim: originalMem},
 					InitCtr:       true,
 					RestartPolicy: v1.ContainerRestartPolicyAlways,
 				},
@@ -989,14 +990,14 @@ func doPodResizeTests() {
 			patchString: fmt.Sprintf(`{"spec":{"initContainers":[
 							{"name":"c1-init", "resources":{"requests":{"cpu":"%s"},"limits":{"cpu":"%s"}}}
 						]}}`, reducedCPU, reducedCPU),
-			expected: []e2epod.ResizableContainerInfo{
+			expected: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPU, MemReq: originalMem, MemLim: originalMem},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPU, MemReq: originalMem, MemLim: originalMem},
 				},
 				{
 					Name:          "c1-init",
-					Resources:     &e2epod.ContainerResources{CPUReq: reducedCPU, CPULim: reducedCPU, MemReq: originalMem, MemLim: originalMem},
+					Resources:     &podresize.ContainerResources{CPUReq: reducedCPU, CPULim: reducedCPU, MemReq: originalMem, MemLim: originalMem},
 					InitCtr:       true,
 					RestartPolicy: v1.ContainerRestartPolicyAlways,
 				},
@@ -1004,14 +1005,14 @@ func doPodResizeTests() {
 		},
 		{
 			name: "Burstable QoS pod, one container, one restartable init container - increase init container CPU & memory",
-			containers: []e2epod.ResizableContainerInfo{
+			containers: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
 				},
 				{
 					Name:          "c1-init",
-					Resources:     &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
+					Resources:     &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
 					InitCtr:       true,
 					RestartPolicy: v1.ContainerRestartPolicyAlways,
 				},
@@ -1019,14 +1020,14 @@ func doPodResizeTests() {
 			patchString: fmt.Sprintf(`{"spec":{"initContainers":[
 							{"name":"c1-init", "resources":{"requests":{"cpu":"%s","memory":"%s"},"limits":{"cpu":"%s","memory":"%s"}}}
 						]}}`, increasedCPU, increasedMem, increasedCPULimit, increasedMemLimit),
-			expected: []e2epod.ResizableContainerInfo{
+			expected: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
 				},
 				{
 					Name:          "c1-init",
-					Resources:     &e2epod.ContainerResources{CPUReq: increasedCPU, CPULim: increasedCPULimit, MemReq: increasedMem, MemLim: increasedMemLimit},
+					Resources:     &podresize.ContainerResources{CPUReq: increasedCPU, CPULim: increasedCPULimit, MemReq: increasedMem, MemLim: increasedMemLimit},
 					InitCtr:       true,
 					RestartPolicy: v1.ContainerRestartPolicyAlways,
 				},
@@ -1034,14 +1035,14 @@ func doPodResizeTests() {
 		},
 		{
 			name: "Burstable QoS pod, one container, one restartable init container - decrease init container CPU only",
-			containers: []e2epod.ResizableContainerInfo{
+			containers: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
 				},
 				{
 					Name:          "c1-init",
-					Resources:     &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
+					Resources:     &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
 					InitCtr:       true,
 					RestartPolicy: v1.ContainerRestartPolicyAlways,
 				},
@@ -1049,14 +1050,14 @@ func doPodResizeTests() {
 			patchString: fmt.Sprintf(`{"spec":{"initContainers":[
 							{"name":"c1-init", "resources":{"requests":{"cpu":"%s"},"limits":{"cpu":"%s"}}}
 						]}}`, reducedCPU, reducedCPULimit),
-			expected: []e2epod.ResizableContainerInfo{
+			expected: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
 				},
 				{
 					Name:          "c1-init",
-					Resources:     &e2epod.ContainerResources{CPUReq: reducedCPU, CPULim: reducedCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
+					Resources:     &podresize.ContainerResources{CPUReq: reducedCPU, CPULim: reducedCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
 					InitCtr:       true,
 					RestartPolicy: v1.ContainerRestartPolicyAlways,
 				},
@@ -1064,14 +1065,14 @@ func doPodResizeTests() {
 		},
 		{
 			name: "Burstable QoS pod, one container, one restartable init container - increase init container CPU only",
-			containers: []e2epod.ResizableContainerInfo{
+			containers: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
 				},
 				{
 					Name:          "c1-init",
-					Resources:     &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
+					Resources:     &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
 					InitCtr:       true,
 					RestartPolicy: v1.ContainerRestartPolicyAlways,
 				},
@@ -1079,14 +1080,14 @@ func doPodResizeTests() {
 			patchString: fmt.Sprintf(`{"spec":{"initContainers":[
 							{"name":"c1-init", "resources":{"requests":{"cpu":"%s"},"limits":{"cpu":"%s"}}}
 						]}}`, increasedCPU, increasedCPULimit),
-			expected: []e2epod.ResizableContainerInfo{
+			expected: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
 				},
 				{
 					Name:          "c1-init",
-					Resources:     &e2epod.ContainerResources{CPUReq: increasedCPU, CPULim: increasedCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
+					Resources:     &podresize.ContainerResources{CPUReq: increasedCPU, CPULim: increasedCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
 					InitCtr:       true,
 					RestartPolicy: v1.ContainerRestartPolicyAlways,
 				},
@@ -1094,14 +1095,14 @@ func doPodResizeTests() {
 		},
 		{
 			name: "Burstable QoS pod, one container, one restartable init container - decrease init container memory requests only",
-			containers: []e2epod.ResizableContainerInfo{
+			containers: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPU, MemReq: originalMem, MemLim: originalMem},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPU, MemReq: originalMem, MemLim: originalMem},
 				},
 				{
 					Name:          "c1-init",
-					Resources:     &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
+					Resources:     &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
 					InitCtr:       true,
 					RestartPolicy: v1.ContainerRestartPolicyAlways,
 				},
@@ -1109,14 +1110,14 @@ func doPodResizeTests() {
 			patchString: fmt.Sprintf(`{"spec":{"initContainers":[
 							{"name":"c1-init", "resources":{"requests":{"memory":"%s"}}}
 						]}}`, reducedMem),
-			expected: []e2epod.ResizableContainerInfo{
+			expected: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPU, MemReq: originalMem, MemLim: originalMem},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPU, MemReq: originalMem, MemLim: originalMem},
 				},
 				{
 					Name:          "c1-init",
-					Resources:     &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: reducedMem, MemLim: originalMemLimit},
+					Resources:     &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: reducedMem, MemLim: originalMemLimit},
 					InitCtr:       true,
 					RestartPolicy: v1.ContainerRestartPolicyAlways,
 				},
@@ -1124,14 +1125,14 @@ func doPodResizeTests() {
 		},
 		{
 			name: "Burstable QoS pod, one container, one restartable init container - increase init container memory only",
-			containers: []e2epod.ResizableContainerInfo{
+			containers: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPU, MemReq: originalMem, MemLim: originalMem},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPU, MemReq: originalMem, MemLim: originalMem},
 				},
 				{
 					Name:          "c1-init",
-					Resources:     &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
+					Resources:     &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
 					InitCtr:       true,
 					RestartPolicy: v1.ContainerRestartPolicyAlways,
 				},
@@ -1139,14 +1140,14 @@ func doPodResizeTests() {
 			patchString: fmt.Sprintf(`{"spec":{"initContainers":[
 							{"name":"c1-init", "resources":{"requests":{"memory":"%s"},"limits":{"memory":"%s"}}}
 						]}}`, increasedMem, increasedMemLimit),
-			expected: []e2epod.ResizableContainerInfo{
+			expected: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPU, MemReq: originalMem, MemLim: originalMem},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPU, MemReq: originalMem, MemLim: originalMem},
 				},
 				{
 					Name:          "c1-init",
-					Resources:     &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: increasedMem, MemLim: increasedMemLimit},
+					Resources:     &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: increasedMem, MemLim: increasedMemLimit},
 					InitCtr:       true,
 					RestartPolicy: v1.ContainerRestartPolicyAlways,
 				},
@@ -1164,7 +1165,7 @@ func doPodResizeTests() {
 			var pErr error
 
 			tStamp := strconv.Itoa(time.Now().Nanosecond())
-			testPod = e2epod.MakePodWithResizableContainers(f.Namespace.Name, "", tStamp, tc.containers)
+			testPod = podresize.MakePodWithResizableContainers(f.Namespace.Name, "", tStamp, tc.containers)
 			testPod.GenerateName = "resize-test-"
 			testPod = e2epod.MustMixinRestrictedPodSecurity(testPod)
 
@@ -1186,35 +1187,35 @@ func doPodResizeTests() {
 			newPod := podClient.CreateSync(ctx, testPod)
 
 			ginkgo.By("verifying initial pod resources are as expected")
-			e2epod.VerifyPodResources(newPod, tc.containers)
+			podresize.VerifyPodResources(newPod, tc.containers)
 			ginkgo.By("verifying initial pod resize policy is as expected")
-			e2epod.VerifyPodResizePolicy(newPod, tc.containers)
+			podresize.VerifyPodResizePolicy(newPod, tc.containers)
 
 			ginkgo.By("verifying initial pod status resources are as expected")
-			framework.ExpectNoError(e2epod.VerifyPodStatusResources(newPod, tc.containers))
+			framework.ExpectNoError(podresize.VerifyPodStatusResources(newPod, tc.containers))
 			ginkgo.By("verifying initial cgroup config are as expected")
-			framework.ExpectNoError(e2epod.VerifyPodContainersCgroupValues(ctx, f, newPod, tc.containers))
+			framework.ExpectNoError(podresize.VerifyPodContainersCgroupValues(ctx, f, newPod, tc.containers))
 
-			patchAndVerify := func(patchString string, expectedContainers []e2epod.ResizableContainerInfo, opStr string) {
+			patchAndVerify := func(patchString string, expectedContainers []podresize.ResizableContainerInfo, opStr string) {
 				ginkgo.By(fmt.Sprintf("patching pod for %s", opStr))
 				patchedPod, pErr = f.ClientSet.CoreV1().Pods(newPod.Namespace).Patch(ctx, newPod.Name,
 					types.StrategicMergePatchType, []byte(patchString), metav1.PatchOptions{}, "resize")
 				framework.ExpectNoError(pErr, fmt.Sprintf("failed to patch pod for %s", opStr))
-				expected := e2epod.UpdateExpectedContainerRestarts(ctx, patchedPod, expectedContainers)
+				expected := podresize.UpdateExpectedContainerRestarts(ctx, patchedPod, expectedContainers)
 
 				ginkgo.By(fmt.Sprintf("verifying pod patched for %s", opStr))
-				e2epod.VerifyPodResources(patchedPod, expected)
+				podresize.VerifyPodResources(patchedPod, expected)
 
 				ginkgo.By(fmt.Sprintf("waiting for %s to be actuated", opStr))
-				resizedPod := e2epod.WaitForPodResizeActuation(ctx, f, podClient, newPod, expected)
-				e2epod.ExpectPodResized(ctx, f, resizedPod, expected)
+				resizedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, newPod, expected)
+				podresize.ExpectPodResized(ctx, f, resizedPod, expected)
 			}
 
 			patchAndVerify(tc.patchString, tc.expected, "resize")
 
 			if tc.testRollback {
 				// Resize has been actuated, test rollback
-				rollbackContainers := make([]e2epod.ResizableContainerInfo, len(tc.containers))
+				rollbackContainers := make([]podresize.ResizableContainerInfo, len(tc.containers))
 				copy(rollbackContainers, tc.containers)
 				for i, c := range rollbackContainers {
 					gomega.Expect(c.Name).To(gomega.Equal(tc.expected[i].Name),
@@ -1223,7 +1224,7 @@ func doPodResizeTests() {
 					rollbackContainers[i].RestartCount = tc.expected[i].RestartCount
 				}
 
-				rbPatchStr, err := e2epod.ResizeContainerPatch(tc.containers)
+				rbPatchStr, err := podresize.ResizeContainerPatch(tc.containers)
 				framework.ExpectNoError(err)
 				patchAndVerify(rbPatchStr, rollbackContainers, "rollback")
 			}
@@ -1238,16 +1239,16 @@ func doPodResizeErrorTests() {
 
 	type testCase struct {
 		name        string
-		containers  []e2epod.ResizableContainerInfo
+		containers  []podresize.ResizableContainerInfo
 		patchString string
 		patchError  string
-		expected    []e2epod.ResizableContainerInfo
+		expected    []podresize.ResizableContainerInfo
 	}
 
 	tests := []testCase{
 		{
 			name: "BestEffort pod - try requesting memory, expect error",
-			containers: []e2epod.ResizableContainerInfo{
+			containers: []podresize.ResizableContainerInfo{
 				{
 					Name: "c1",
 				},
@@ -1256,7 +1257,7 @@ func doPodResizeErrorTests() {
 						{"name":"c1", "resources":{"requests":{"memory":"40Mi"}}}
 					]}}`,
 			patchError: "Pod QOS Class may not change as a result of resizing",
-			expected: []e2epod.ResizableContainerInfo{
+			expected: []podresize.ResizableContainerInfo{
 				{
 					Name: "c1",
 				},
@@ -1264,90 +1265,90 @@ func doPodResizeErrorTests() {
 		},
 		{
 			name: "Burstable QoS pod, one container with cpu & memory requests + limits - remove memory limits",
-			containers: []e2epod.ResizableContainerInfo{
+			containers: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
 				},
 			},
 			patchString: `{"spec":{"containers":[
 						{"name":"c1", "resources":{"limits":{"memory": null}}}
 					]}}`,
 			patchError: "resource limits cannot be removed",
-			expected: []e2epod.ResizableContainerInfo{
+			expected: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
 				},
 			},
 		},
 		{
 			name: "Burstable QoS pod, one container with cpu & memory requests + limits - remove CPU limits",
-			containers: []e2epod.ResizableContainerInfo{
+			containers: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
 				},
 			},
 			patchString: `{"spec":{"containers":[
 						{"name":"c1", "resources":{"limits":{"cpu": null}}}
 					]}}`,
 			patchError: "resource limits cannot be removed",
-			expected: []e2epod.ResizableContainerInfo{
+			expected: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
 				},
 			},
 		},
 		{
 			name: "Burstable QoS pod, one container with memory requests + limits, cpu requests - remove CPU requests",
-			containers: []e2epod.ResizableContainerInfo{
+			containers: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, MemReq: originalMem, MemLim: originalMemLimit},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, MemReq: originalMem, MemLim: originalMemLimit},
 				},
 			},
 			patchString: `{"spec":{"containers":[
 						{"name":"c1", "resources":{"requests":{"cpu": null}}}
 					]}}`,
 			patchError: "resource requests cannot be removed",
-			expected: []e2epod.ResizableContainerInfo{
+			expected: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, MemReq: originalMem, MemLim: originalMemLimit},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, MemReq: originalMem, MemLim: originalMemLimit},
 				},
 			},
 		},
 		{
 			name: "Burstable QoS pod, one container with CPU requests + limits, cpu requests - remove memory requests",
-			containers: []e2epod.ResizableContainerInfo{
+			containers: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem},
 				},
 			},
 			patchString: `{"spec":{"containers":[
 						{"name":"c1", "resources":{"requests":{"memory": null}}}
 					]}}`,
 			patchError: "resource requests cannot be removed",
-			expected: []e2epod.ResizableContainerInfo{
+			expected: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem},
 				},
 			},
 		},
 		{
 			name: "Burstable QoS pod, two containers with cpu & memory requests + limits - reorder containers",
-			containers: []e2epod.ResizableContainerInfo{
+			containers: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
 				},
 				{
 					Name:      "c2",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
 				},
 			},
 			patchString: fmt.Sprintf(`{"spec":{"containers":[
@@ -1355,33 +1356,33 @@ func doPodResizeErrorTests() {
 				{"name":"c1", "resources":{"requests":{"cpu":"%s","memory":"%s"},"limits":{"cpu":"%s","memory":"%s"}}}
 			]}}`, originalCPU, originalMem, originalCPULimit, originalMemLimit, originalCPU, originalMem, originalCPULimit, originalMemLimit),
 			patchError: "spec.containers[0].name: Forbidden: containers may not be renamed or reordered on resize, spec.containers[1].name: Forbidden: containers may not be renamed or reordered on resize",
-			expected: []e2epod.ResizableContainerInfo{
+			expected: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
 				},
 				{
 					Name:      "c2",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
 				},
 			},
 		},
 		{
 			name: "Burstable QoS pod with memory requests + limits - decrease memory limit",
-			containers: []e2epod.ResizableContainerInfo{
+			containers: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
 				},
 			},
 			patchString: fmt.Sprintf(`{"spec":{"containers":[
 						{"name":"c1", "resources":{"limits":{"memory":"%s"}}}
 					]}}`, reducedMemLimit),
 			patchError: "memory limits cannot be decreased",
-			expected: []e2epod.ResizableContainerInfo{
+			expected: []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
+					Resources: &podresize.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
 				},
 			},
 		},
@@ -1397,18 +1398,18 @@ func doPodResizeErrorTests() {
 			var pErr error
 
 			tStamp := strconv.Itoa(time.Now().Nanosecond())
-			testPod = e2epod.MakePodWithResizableContainers(f.Namespace.Name, "testpod", tStamp, tc.containers)
+			testPod = podresize.MakePodWithResizableContainers(f.Namespace.Name, "testpod", tStamp, tc.containers)
 			testPod = e2epod.MustMixinRestrictedPodSecurity(testPod)
 
 			ginkgo.By("creating pod")
 			newPod := podClient.CreateSync(ctx, testPod)
 
 			ginkgo.By("verifying initial pod resources, and policy are as expected")
-			e2epod.VerifyPodResources(newPod, tc.containers)
-			e2epod.VerifyPodResizePolicy(newPod, tc.containers)
+			podresize.VerifyPodResources(newPod, tc.containers)
+			podresize.VerifyPodResizePolicy(newPod, tc.containers)
 
 			ginkgo.By("verifying initial pod status resources and cgroup config are as expected")
-			framework.ExpectNoError(e2epod.VerifyPodStatusResources(newPod, tc.containers))
+			framework.ExpectNoError(podresize.VerifyPodStatusResources(newPod, tc.containers))
 
 			ginkgo.By("patching pod for resize")
 			patchedPod, pErr = f.ClientSet.CoreV1().Pods(newPod.Namespace).Patch(ctx, newPod.Name,
@@ -1422,10 +1423,10 @@ func doPodResizeErrorTests() {
 			}
 
 			ginkgo.By("verifying pod resources after patch")
-			e2epod.VerifyPodResources(patchedPod, tc.expected)
+			podresize.VerifyPodResources(patchedPod, tc.expected)
 
 			ginkgo.By("verifying pod status resources after patch")
-			framework.ExpectNoError(e2epod.VerifyPodStatusResources(patchedPod, tc.expected))
+			framework.ExpectNoError(podresize.VerifyPodStatusResources(patchedPod, tc.expected))
 
 			ginkgo.By("deleting pod")
 			podClient.DeleteSync(ctx, newPod.Name, metav1.DeleteOptions{}, f.Timeouts.PodDelete)

--- a/test/e2e/framework/pod/utils.go
+++ b/test/e2e/framework/pod/utils.go
@@ -18,15 +18,12 @@ package pod
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
-	kubecm "k8s.io/kubernetes/pkg/kubelet/cm"
 	"k8s.io/kubernetes/test/e2e/framework"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 	psaapi "k8s.io/pod-security-admission/api"
@@ -343,36 +340,4 @@ func IsPodOnCgroupv2Node(f *framework.Framework, pod *v1.Pod) bool {
 		return false
 	}
 	return len(out) != 0
-}
-
-// TODO: Remove the rounded cpu limit values when https://github.com/opencontainers/runc/issues/4622
-// is fixed.
-func GetCPULimitCgroupExpectations(cpuLimit *resource.Quantity) []string {
-	var expectedCPULimits []string
-	milliCPULimit := cpuLimit.MilliValue()
-
-	cpuQuota := kubecm.MilliCPUToQuota(milliCPULimit, kubecm.QuotaPeriod)
-	if cpuLimit.IsZero() {
-		cpuQuota = -1
-	}
-	expectedCPULimits = append(expectedCPULimits, getExpectedCPULimitFromCPUQuota(cpuQuota))
-
-	if milliCPULimit%10 != 0 && cpuQuota != -1 {
-		roundedCPULimit := (milliCPULimit/10 + 1) * 10
-		cpuQuotaRounded := kubecm.MilliCPUToQuota(roundedCPULimit, kubecm.QuotaPeriod)
-		expectedCPULimits = append(expectedCPULimits, getExpectedCPULimitFromCPUQuota(cpuQuotaRounded))
-	}
-
-	return expectedCPULimits
-}
-
-func getExpectedCPULimitFromCPUQuota(cpuQuota int64) string {
-	expectedCPULimitString := strconv.FormatInt(cpuQuota, 10)
-	if *podOnCgroupv2Node {
-		if expectedCPULimitString == "-1" {
-			expectedCPULimitString = "max"
-		}
-		expectedCPULimitString = fmt.Sprintf("%s %s", expectedCPULimitString, CPUPeriod)
-	}
-	return expectedCPULimitString
 }

--- a/test/e2e/node/pod_resize.go
+++ b/test/e2e/node/pod_resize.go
@@ -29,6 +29,7 @@ import (
 	helpers "k8s.io/component-helpers/resource"
 	resourceapi "k8s.io/kubernetes/pkg/api/v1/resource"
 	"k8s.io/kubernetes/pkg/features"
+	"k8s.io/kubernetes/test/e2e/common/node/framework/podresize"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
@@ -114,19 +115,19 @@ func doPodResizeAdmissionPluginsTests() {
 		f := framework.NewDefaultFramework(tc.name)
 
 		ginkgo.It(tc.name, func(ctx context.Context) {
-			containers := []e2epod.ResizableContainerInfo{
+			containers := []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: "300m", CPULim: "300m", MemReq: "300Mi", MemLim: "300Mi"},
+					Resources: &podresize.ContainerResources{CPUReq: "300m", CPULim: "300m", MemReq: "300Mi", MemLim: "300Mi"},
 				},
 			}
 			patchString := `{"spec":{"containers":[
 				{"name":"c1", "resources":{"requests":{"cpu":"400m","memory":"400Mi"},"limits":{"cpu":"400m","memory":"400Mi"}}}
 			]}}`
-			expected := []e2epod.ResizableContainerInfo{
+			expected := []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
-					Resources: &e2epod.ContainerResources{CPUReq: "400m", CPULim: "400m", MemReq: "400Mi", MemLim: "400Mi"},
+					Resources: &podresize.ContainerResources{CPUReq: "400m", CPULim: "400m", MemReq: "400Mi", MemLim: "400Mi"},
 				},
 			}
 			patchStringExceedCPU := `{"spec":{"containers":[
@@ -139,9 +140,9 @@ func doPodResizeAdmissionPluginsTests() {
 			tc.enableAdmissionPlugin(ctx, f)
 
 			tStamp := strconv.Itoa(time.Now().Nanosecond())
-			testPod1 := e2epod.MakePodWithResizableContainers(f.Namespace.Name, "testpod1", tStamp, containers)
+			testPod1 := podresize.MakePodWithResizableContainers(f.Namespace.Name, "testpod1", tStamp, containers)
 			testPod1 = e2epod.MustMixinRestrictedPodSecurity(testPod1)
-			testPod2 := e2epod.MakePodWithResizableContainers(f.Namespace.Name, "testpod2", tStamp, containers)
+			testPod2 := podresize.MakePodWithResizableContainers(f.Namespace.Name, "testpod2", tStamp, containers)
 			testPod2 = e2epod.MustMixinRestrictedPodSecurity(testPod2)
 
 			ginkgo.By("creating pods")
@@ -149,23 +150,23 @@ func doPodResizeAdmissionPluginsTests() {
 			newPods := podClient.CreateBatch(ctx, []*v1.Pod{testPod1, testPod2})
 
 			ginkgo.By("verifying initial pod resources, and policy are as expected")
-			e2epod.VerifyPodResources(newPods[0], containers)
+			podresize.VerifyPodResources(newPods[0], containers)
 
 			ginkgo.By("patching pod for resize within resource quota")
 			patchedPod, pErr := f.ClientSet.CoreV1().Pods(newPods[0].Namespace).Patch(ctx, newPods[0].Name,
 				types.StrategicMergePatchType, []byte(patchString), metav1.PatchOptions{}, "resize")
 			framework.ExpectNoError(pErr, "failed to patch pod for resize")
-			expected = e2epod.UpdateExpectedContainerRestarts(ctx, patchedPod, expected)
+			expected = podresize.UpdateExpectedContainerRestarts(ctx, patchedPod, expected)
 
 			ginkgo.By("verifying pod patched for resize within resource quota")
-			e2epod.VerifyPodResources(patchedPod, expected)
+			podresize.VerifyPodResources(patchedPod, expected)
 
 			ginkgo.By("waiting for resize to be actuated")
-			resizedPod := e2epod.WaitForPodResizeActuation(ctx, f, podClient, newPods[0], expected)
-			e2epod.ExpectPodResized(ctx, f, resizedPod, expected)
+			resizedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, newPods[0], expected)
+			podresize.ExpectPodResized(ctx, f, resizedPod, expected)
 
 			ginkgo.By("verifying pod resources after resize")
-			e2epod.VerifyPodResources(resizedPod, expected)
+			podresize.VerifyPodResources(resizedPod, expected)
 
 			ginkgo.By("patching pod for resize with memory exceeding resource quota")
 			framework.ExpectNoError(framework.Gomega().
@@ -181,8 +182,8 @@ func doPodResizeAdmissionPluginsTests() {
 			ginkgo.By("verifying pod patched for resize exceeding memory resource quota remains unchanged")
 			patchedPodExceedMemory, pErrEx2 := podClient.Get(ctx, resizedPod.Name, metav1.GetOptions{})
 			framework.ExpectNoError(pErrEx2, "failed to get pod post exceed memory resize")
-			e2epod.VerifyPodResources(patchedPodExceedMemory, expected)
-			framework.ExpectNoError(e2epod.VerifyPodStatusResources(patchedPodExceedMemory, expected))
+			podresize.VerifyPodResources(patchedPodExceedMemory, expected)
+			framework.ExpectNoError(podresize.VerifyPodStatusResources(patchedPodExceedMemory, expected))
 
 			ginkgo.By(fmt.Sprintf("patching pod %s for resize with CPU exceeding resource quota", resizedPod.Name))
 			framework.ExpectNoError(framework.Gomega().
@@ -198,8 +199,8 @@ func doPodResizeAdmissionPluginsTests() {
 			ginkgo.By("verifying pod patched for resize exceeding CPU resource quota remains unchanged")
 			patchedPodExceedCPU, pErrEx1 := podClient.Get(ctx, resizedPod.Name, metav1.GetOptions{})
 			framework.ExpectNoError(pErrEx1, "failed to get pod post exceed CPU resize")
-			e2epod.VerifyPodResources(patchedPodExceedCPU, expected)
-			framework.ExpectNoError(e2epod.VerifyPodStatusResources(patchedPodExceedMemory, expected))
+			podresize.VerifyPodResources(patchedPodExceedCPU, expected)
+			framework.ExpectNoError(podresize.VerifyPodStatusResources(patchedPodExceedMemory, expected))
 		})
 	}
 
@@ -255,16 +256,16 @@ func doPodResizeSchedulerTests(f *framework.Framework) {
 		framework.Logf("TEST1: testPod2 initial CPU request is '%dm'", testPod2CPUQuantity.MilliValue())
 		framework.Logf("TEST1: testPod2 resized CPU request is '%dm'", testPod2CPUQuantityResized.MilliValue())
 
-		c1 := []e2epod.ResizableContainerInfo{
+		c1 := []podresize.ResizableContainerInfo{
 			{
 				Name:      "c1",
-				Resources: &e2epod.ContainerResources{CPUReq: testPod1CPUQuantity.String(), CPULim: testPod1CPUQuantity.String()},
+				Resources: &podresize.ContainerResources{CPUReq: testPod1CPUQuantity.String(), CPULim: testPod1CPUQuantity.String()},
 			},
 		}
-		c2 := []e2epod.ResizableContainerInfo{
+		c2 := []podresize.ResizableContainerInfo{
 			{
 				Name:      "c2",
-				Resources: &e2epod.ContainerResources{CPUReq: testPod2CPUQuantity.String(), CPULim: testPod2CPUQuantity.String()},
+				Resources: &podresize.ContainerResources{CPUReq: testPod2CPUQuantity.String(), CPULim: testPod2CPUQuantity.String()},
 			},
 		}
 		patchTestpod2ToFitNode := fmt.Sprintf(`{
@@ -279,9 +280,9 @@ func doPodResizeSchedulerTests(f *framework.Framework) {
 			}`, testPod2CPUQuantityResized.MilliValue(), testPod2CPUQuantityResized.MilliValue())
 
 		tStamp := strconv.Itoa(time.Now().Nanosecond())
-		testPod1 := e2epod.MakePodWithResizableContainers(f.Namespace.Name, "testpod1", tStamp, c1)
+		testPod1 := podresize.MakePodWithResizableContainers(f.Namespace.Name, "testpod1", tStamp, c1)
 		testPod1 = e2epod.MustMixinRestrictedPodSecurity(testPod1)
-		testPod2 := e2epod.MakePodWithResizableContainers(f.Namespace.Name, "testpod2", tStamp, c2)
+		testPod2 := podresize.MakePodWithResizableContainers(f.Namespace.Name, "testpod2", tStamp, c2)
 		testPod2 = e2epod.MustMixinRestrictedPodSecurity(testPod2)
 		e2epod.SetNodeAffinity(&testPod1.Spec, node.Name)
 		e2epod.SetNodeAffinity(&testPod2.Spec, node.Name)
@@ -319,10 +320,10 @@ func doPodResizeSchedulerTests(f *framework.Framework) {
 		testPod1CPUQuantityResized := resource.NewMilliQuantity(testPod1CPUQuantity.MilliValue()/3, resource.DecimalSI)
 		framework.Logf("TEST2: testPod1 MilliCPUs after resize '%dm'", testPod1CPUQuantityResized.MilliValue())
 
-		c3 := []e2epod.ResizableContainerInfo{
+		c3 := []podresize.ResizableContainerInfo{
 			{
 				Name:      "c3",
-				Resources: &e2epod.ContainerResources{CPUReq: testPod3CPUQuantity.String(), CPULim: testPod3CPUQuantity.String()},
+				Resources: &podresize.ContainerResources{CPUReq: testPod3CPUQuantity.String(), CPULim: testPod3CPUQuantity.String()},
 			},
 		}
 		patchTestpod1ToMakeSpaceForPod3 := fmt.Sprintf(`{
@@ -337,7 +338,7 @@ func doPodResizeSchedulerTests(f *framework.Framework) {
 			}`, testPod1CPUQuantityResized.MilliValue(), testPod1CPUQuantityResized.MilliValue())
 
 		tStamp = strconv.Itoa(time.Now().Nanosecond())
-		testPod3 := e2epod.MakePodWithResizableContainers(f.Namespace.Name, "testpod3", tStamp, c3)
+		testPod3 := podresize.MakePodWithResizableContainers(f.Namespace.Name, "testpod3", tStamp, c3)
 		testPod3 = e2epod.MustMixinRestrictedPodSecurity(testPod3)
 		e2epod.SetNodeAffinity(&testPod3.Spec, node.Name)
 
@@ -404,15 +405,15 @@ func doPodResizeSchedulerTests(f *framework.Framework) {
 		framework.ExpectNoError(delErr3, "failed to delete pod %s", testPod3.Name)
 
 		ginkgo.By(fmt.Sprintf("TEST3: Verify pod '%s' is resized successfully after pod deletion '%s' and '%s", testPod1.Name, testPod2.Name, testPod3.Name))
-		expected := []e2epod.ResizableContainerInfo{
+		expected := []podresize.ResizableContainerInfo{
 			{
 				Name:         "c1",
-				Resources:    &e2epod.ContainerResources{CPUReq: testPod1CPUQuantity.String(), CPULim: testPod1CPUQuantity.String()},
+				Resources:    &podresize.ContainerResources{CPUReq: testPod1CPUQuantity.String(), CPULim: testPod1CPUQuantity.String()},
 				RestartCount: testPod1.Status.ContainerStatuses[0].RestartCount,
 			},
 		}
-		resizedPod := e2epod.WaitForPodResizeActuation(ctx, f, podClient, testPod1, expected)
-		e2epod.ExpectPodResized(ctx, f, resizedPod, expected)
+		resizedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, testPod1, expected)
+		podresize.ExpectPodResized(ctx, f, resizedPod, expected)
 
 		ginkgo.By(fmt.Sprintf("TEST3: Resize pod '%s' to exceed the node capacity", testPod1.Name))
 		testPod1, p1Err = f.ClientSet.CoreV1().Pods(testPod1.Namespace).Patch(ctx,


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Move pod resize e2e helpers out of the test/e2e/framework directory and into a package owned by SIG-Node. The motivation for this change is mainly so that node approvers can approve changes to these helper functions (which are only used in node tests).

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/sig node testing
/priority important-longterm
/assign @pohly 
/cc @hshiina @natasha41575 