### PR TITLE
Run all permutations of input events in ResourceSlice tracker tests

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/tracker/tracker_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/tracker/tracker_test.go
@@ -338,7 +338,7 @@ func TestListPatchedResourceSlices(t *testing.T) {
 		// the order in those nested lists is preserved.
 		events                []any
 		expectedPatchedSlices []*resourceapi.ResourceSlice
-		expectHandlerEvents   func(t *testing.T, events []handlerEvent)
+		expectedHandlerEvents []handlerEvent
 		expectEvents          func(t *assert.CollectT, events *v1.EventList)
 		expectUnhandledErrors func(t *testing.T, errs []error)
 	}
@@ -352,15 +352,9 @@ func TestListPatchedResourceSlices(t *testing.T) {
 				slice1,
 				slice2,
 			},
-			expectHandlerEvents: func(t *testing.T, events []handlerEvent) {
-				assert.Equal(
-					t,
-					[]handlerEvent{
-						{event: handlerEventAdd, newObj: slice1},
-						{event: handlerEventAdd, newObj: slice2},
-					},
-					events,
-				)
+			expectedHandlerEvents: []handlerEvent{
+				{event: handlerEventAdd, newObj: slice1},
+				{event: handlerEventAdd, newObj: slice2},
 			},
 		},
 		"update-slices-no-patches": {
@@ -380,18 +374,12 @@ func TestListPatchedResourceSlices(t *testing.T) {
 				slice2,
 				unchangedSlice,
 			},
-			expectHandlerEvents: func(t *testing.T, events []handlerEvent) {
-				assert.Equal(
-					t,
-					[]handlerEvent{
-						{event: handlerEventAdd, newObj: slice1NoDevices},
-						{event: handlerEventUpdate, oldObj: slice1NoDevices, newObj: slice1},
-						{event: handlerEventAdd, newObj: slice2NoDevices},
-						{event: handlerEventUpdate, oldObj: slice2NoDevices, newObj: slice2},
-						{event: handlerEventAdd, newObj: unchangedSlice},
-					},
-					events,
-				)
+			expectedHandlerEvents: []handlerEvent{
+				{event: handlerEventAdd, newObj: slice1NoDevices},
+				{event: handlerEventUpdate, oldObj: slice1NoDevices, newObj: slice1},
+				{event: handlerEventAdd, newObj: slice2NoDevices},
+				{event: handlerEventUpdate, oldObj: slice2NoDevices, newObj: slice2},
+				{event: handlerEventAdd, newObj: unchangedSlice},
 			},
 		},
 		"delete-slices": {
@@ -403,18 +391,12 @@ func TestListPatchedResourceSlices(t *testing.T) {
 			expectedPatchedSlices: []*resourceapi.ResourceSlice{
 				unchangedSlice,
 			},
-			expectHandlerEvents: func(t *testing.T, events []handlerEvent) {
-				assert.Equal(
-					t,
-					[]handlerEvent{
-						{event: handlerEventAdd, newObj: slice1},
-						{event: handlerEventDelete, oldObj: slice1},
-						{event: handlerEventAdd, newObj: slice2},
-						{event: handlerEventDelete, oldObj: slice2},
-						{event: handlerEventAdd, newObj: unchangedSlice},
-					},
-					events,
-				)
+			expectedHandlerEvents: []handlerEvent{
+				{event: handlerEventAdd, newObj: slice1},
+				{event: handlerEventDelete, oldObj: slice1},
+				{event: handlerEventAdd, newObj: slice2},
+				{event: handlerEventDelete, oldObj: slice2},
+				{event: handlerEventAdd, newObj: unchangedSlice},
 			},
 		},
 		"patch-all-slices": {
@@ -425,15 +407,9 @@ func TestListPatchedResourceSlices(t *testing.T) {
 			expectedPatchedSlices: []*resourceapi.ResourceSlice{
 				slice1Tainted,
 			},
-			expectHandlerEvents: func(t *testing.T, events []handlerEvent) {
-				assert.Equal(
-					t,
-					[]handlerEvent{
-						{event: handlerEventAdd, newObj: slice1},
-						{event: handlerEventUpdate, oldObj: slice1, newObj: slice1Tainted},
-					},
-					events,
-				)
+			expectedHandlerEvents: []handlerEvent{
+				{event: handlerEventAdd, newObj: slice1},
+				{event: handlerEventUpdate, oldObj: slice1, newObj: slice1Tainted},
 			},
 		},
 		"update-patch": {
@@ -449,15 +425,9 @@ func TestListPatchedResourceSlices(t *testing.T) {
 				slice1,
 				slice2Tainted,
 			},
-			expectHandlerEvents: func(t *testing.T, events []handlerEvent) {
-				assert.Equal(
-					t,
-					[]handlerEvent{
-						{event: handlerEventAdd, newObj: slice1},
-						{event: handlerEventAdd, newObj: slice2Tainted},
-					},
-					events,
-				)
+			expectedHandlerEvents: []handlerEvent{
+				{event: handlerEventAdd, newObj: slice1},
+				{event: handlerEventAdd, newObj: slice2Tainted},
 			},
 		},
 		"merge-taints": {
@@ -468,14 +438,8 @@ func TestListPatchedResourceSlices(t *testing.T) {
 			expectedPatchedSlices: []*resourceapi.ResourceSlice{
 				slice1MergedTaints,
 			},
-			expectHandlerEvents: func(t *testing.T, events []handlerEvent) {
-				assert.Equal(
-					t,
-					[]handlerEvent{
-						{event: handlerEventAdd, newObj: slice1MergedTaints},
-					},
-					events,
-				)
+			expectedHandlerEvents: []handlerEvent{
+				{event: handlerEventAdd, newObj: slice1MergedTaints},
 			},
 		},
 		"add-taint-for-driver": {
@@ -488,15 +452,9 @@ func TestListPatchedResourceSlices(t *testing.T) {
 				slice1Tainted,
 				slice2,
 			},
-			expectHandlerEvents: func(t *testing.T, events []handlerEvent) {
-				assert.Equal(
-					t,
-					[]handlerEvent{
-						{event: handlerEventAdd, newObj: slice1Tainted},
-						{event: handlerEventAdd, newObj: slice2},
-					},
-					events,
-				)
+			expectedHandlerEvents: []handlerEvent{
+				{event: handlerEventAdd, newObj: slice1Tainted},
+				{event: handlerEventAdd, newObj: slice2},
 			},
 		},
 		"add-taint-for-pool": {
@@ -509,15 +467,9 @@ func TestListPatchedResourceSlices(t *testing.T) {
 				slice1Tainted,
 				slice2,
 			},
-			expectHandlerEvents: func(t *testing.T, events []handlerEvent) {
-				assert.Equal(
-					t,
-					[]handlerEvent{
-						{event: handlerEventAdd, newObj: slice1Tainted},
-						{event: handlerEventAdd, newObj: slice2},
-					},
-					events,
-				)
+			expectedHandlerEvents: []handlerEvent{
+				{event: handlerEventAdd, newObj: slice1Tainted},
+				{event: handlerEventAdd, newObj: slice2},
 			},
 		},
 		"add-taint-for-device": {
@@ -530,15 +482,9 @@ func TestListPatchedResourceSlices(t *testing.T) {
 				slice1Tainted,
 				slice2,
 			},
-			expectHandlerEvents: func(t *testing.T, events []handlerEvent) {
-				assert.Equal(
-					t,
-					[]handlerEvent{
-						{event: handlerEventAdd, newObj: slice1Tainted},
-						{event: handlerEventAdd, newObj: slice2},
-					},
-					events,
-				)
+			expectedHandlerEvents: []handlerEvent{
+				{event: handlerEventAdd, newObj: slice1Tainted},
+				{event: handlerEventAdd, newObj: slice2},
 			},
 		},
 		"add-attribute-for-selector": {
@@ -551,15 +497,9 @@ func TestListPatchedResourceSlices(t *testing.T) {
 				slice1Tainted,
 				slice2,
 			},
-			expectHandlerEvents: func(t *testing.T, events []handlerEvent) {
-				assert.Equal(
-					t,
-					[]handlerEvent{
-						{event: handlerEventAdd, newObj: slice1Tainted},
-						{event: handlerEventAdd, newObj: slice2},
-					},
-					events,
-				)
+			expectedHandlerEvents: []handlerEvent{
+				{event: handlerEventAdd, newObj: slice1Tainted},
+				{event: handlerEventAdd, newObj: slice2},
 			},
 		},
 		"selector-does-not-match": {
@@ -570,14 +510,8 @@ func TestListPatchedResourceSlices(t *testing.T) {
 			expectedPatchedSlices: []*resourceapi.ResourceSlice{
 				slice1,
 			},
-			expectHandlerEvents: func(t *testing.T, events []handlerEvent) {
-				assert.Equal(
-					t,
-					[]handlerEvent{
-						{event: handlerEventAdd, newObj: slice1},
-					},
-					events,
-				)
+			expectedHandlerEvents: []handlerEvent{
+				{event: handlerEventAdd, newObj: slice1},
 			},
 		},
 		"runtime-CEL-errors-skip-devices": {
@@ -595,14 +529,8 @@ func TestListPatchedResourceSlices(t *testing.T) {
 				assert.Equal(t, taintNoDevicesCELRuntimeErrorRule.Name, events.Items[0].InvolvedObject.Name)
 				assert.Equal(t, "CELRuntimeError", events.Items[0].Reason)
 			},
-			expectHandlerEvents: func(t *testing.T, events []handlerEvent) {
-				assert.Equal(
-					t,
-					[]handlerEvent{
-						{event: handlerEventAdd, newObj: slice1},
-					},
-					events,
-				)
+			expectedHandlerEvents: []handlerEvent{
+				{event: handlerEventAdd, newObj: slice1},
 			},
 		},
 		"invalid-CEL-expression-throws-error": {
@@ -631,15 +559,9 @@ func TestListPatchedResourceSlices(t *testing.T) {
 				slice1Tainted,
 				slice2,
 			},
-			expectHandlerEvents: func(t *testing.T, events []handlerEvent) {
-				assert.Equal(
-					t,
-					[]handlerEvent{
-						{event: handlerEventAdd, newObj: slice1Tainted},
-						{event: handlerEventAdd, newObj: slice2},
-					},
-					events,
-				)
+			expectedHandlerEvents: []handlerEvent{
+				{event: handlerEventAdd, newObj: slice1Tainted},
+				{event: handlerEventAdd, newObj: slice2},
 			},
 		},
 		"filter-all-criteria": {
@@ -670,15 +592,9 @@ func TestListPatchedResourceSlices(t *testing.T) {
 				slice1Tainted,
 				slice2,
 			},
-			expectHandlerEvents: func(t *testing.T, events []handlerEvent) {
-				assert.Equal(
-					t,
-					[]handlerEvent{
-						{event: handlerEventAdd, newObj: slice1Tainted},
-						{event: handlerEventAdd, newObj: slice2},
-					},
-					events,
-				)
+			expectedHandlerEvents: []handlerEvent{
+				{event: handlerEventAdd, newObj: slice1Tainted},
+				{event: handlerEventAdd, newObj: slice2},
 			},
 		},
 		"update-patched-slice": {
@@ -697,17 +613,11 @@ func TestListPatchedResourceSlices(t *testing.T) {
 				sliceWithDevices(slice1, threeDevicesOneTainted),
 				sliceWithDevices(slice2, taintedDevices),
 			},
-			expectHandlerEvents: func(t *testing.T, events []handlerEvent) {
-				assert.Equal(
-					t,
-					[]handlerEvent{
-						{event: handlerEventAdd, newObj: slice1Tainted},
-						{event: handlerEventUpdate, oldObj: slice1Tainted, newObj: sliceWithDevices(slice1, threeDevicesOneTainted)},
-						{event: handlerEventAdd, newObj: sliceWithDevices(slice2, threeDevicesOneTainted)},
-						{event: handlerEventUpdate, oldObj: sliceWithDevices(slice2, threeDevicesOneTainted), newObj: sliceWithDevices(slice2, taintedDevices)},
-					},
-					events,
-				)
+			expectedHandlerEvents: []handlerEvent{
+				{event: handlerEventAdd, newObj: slice1Tainted},
+				{event: handlerEventUpdate, oldObj: slice1Tainted, newObj: sliceWithDevices(slice1, threeDevicesOneTainted)},
+				{event: handlerEventAdd, newObj: sliceWithDevices(slice2, threeDevicesOneTainted)},
+				{event: handlerEventUpdate, oldObj: sliceWithDevices(slice2, threeDevicesOneTainted), newObj: sliceWithDevices(slice2, taintedDevices)},
 			},
 		},
 	}
@@ -759,13 +669,7 @@ func TestListPatchedResourceSlices(t *testing.T) {
 		runInputEvents(tCtx, test.events)
 
 		if testExpectedEmittedEvents {
-			expectHandlerEvents := test.expectHandlerEvents
-			if expectHandlerEvents == nil {
-				expectHandlerEvents = func(t *testing.T, events []handlerEvent) {
-					assert.Empty(tCtx, events)
-				}
-			}
-			expectHandlerEvents(t, handlerEvents)
+			assert.Equal(tCtx, test.expectedHandlerEvents, handlerEvents)
 		}
 
 		expectUnhandledErrors := test.expectUnhandledErrors


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR steals the idea and related code from the device taint eviction controller tests from @pohly to exercise the event handlers in the ResourceSlice tracker unit tests by permuting the input events every possible way for each test case since they should all produce the same output. This increases the total number of test cases run here from 16 to 185. More details in the commit messages.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

This involved a fair bit of refactoring the tests in a few phases that I left as separate commits in case that's easier to review.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
