### PR TITLE
Update OWNERS_ALIASES add aojea to sig-network-api-reviews

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -375,8 +375,7 @@ aliases:
     - smarterclayton
     - thockin
   sig-network-api-reviewers:
-    - andrewsykim
-    - caseydavenport
+    - aojea
     - danwinship
     - thockin
   sig-scheduling-api-approvers:


### PR DESCRIPTION
Also remove andrew sykim and casey davenport since they are inactive for some time

/kind cleanup
```release-note
NONE
```

/sig network
/assign @thockin @danwinship 