### PR TITLE
Refactor: Unify the pattern of the string concatenations spanning the line breaks

### DIFF
--- a/cmd/kube-proxy/app/options.go
+++ b/cmd/kube-proxy/app/options.go
@@ -127,7 +127,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 			"rather than being surprised when they are permanently removed in the release after that. "+
 			"This parameter is ignored if a config file is specified by --config.")
 	fs.BoolVar(&o.InitAndExit, "init-only", o.InitAndExit, "If true, perform any initialization steps that must be done with full root privileges, and then exit. After doing this, you can run kube-proxy again with only the CAP_NET_ADMIN capability.")
-	fs.Var(&o.config.Mode, "proxy-mode", "Which proxy mode to use: on Linux this can be 'iptables' (default), 'ipvs', or 'nftables'. On Windows the only supported value is 'kernelspace'."+
+	fs.Var(&o.config.Mode, "proxy-mode", "Which proxy mode to use: on Linux this can be 'iptables' (default), 'ipvs', or 'nftables'. On Windows the only supported value is 'kernelspace'. "+
 		"This parameter is ignored if a config file is specified by --config.")
 
 	fs.Int32Var(o.config.IPTables.MasqueradeBit, "iptables-masquerade-bit", ptr.Deref(o.config.IPTables.MasqueradeBit, 14), "If using the iptables or ipvs proxy mode, the bit of the fwmark space to mark packets requiring SNAT with.  Must be within the range [0, 31].")

--- a/cmd/kubeadm/app/cmd/phases/init/waitcontrolplane.go
+++ b/cmd/kubeadm/app/cmd/phases/init/waitcontrolplane.go
@@ -74,8 +74,8 @@ func runWaitControlPlanePhase(c workflow.RunData) error {
 		return errors.Wrap(err, "error creating waiter")
 	}
 
-	fmt.Printf("[wait-control-plane] Waiting for the kubelet to boot up the control plane as static Pods"+
-		" from directory %q\n",
+	fmt.Printf("[wait-control-plane] Waiting for the kubelet to boot up the control plane as static Pods "+
+		"from directory %q\n",
 		data.ManifestDir())
 
 	waiter.SetTimeout(data.Cfg().Timeouts.KubeletHealthCheck.Duration)

--- a/cmd/kubeadm/app/discovery/token/token.go
+++ b/cmd/kubeadm/app/discovery/token/token.go
@@ -227,8 +227,8 @@ func getClusterInfo(client clientset.Interface, cfg *kubeadmapi.Discovery, inter
 				return true, lastError
 			}
 
-			klog.V(1).Infof("[discovery] Waiting for the cluster-info ConfigMap to receive a JWS signature"+
-				" for token ID %q", token.ID)
+			klog.V(1).Infof("[discovery] Waiting for the cluster-info ConfigMap to receive a JWS signature "+
+				"for token ID %q", token.ID)
 
 			cm, err = client.CoreV1().ConfigMaps(metav1.NamespacePublic).
 				Get(context.Background(), bootstrapapi.ConfigMapClusterInfo, metav1.GetOptions{})
@@ -239,8 +239,8 @@ func getClusterInfo(client clientset.Interface, cfg *kubeadmapi.Discovery, inter
 			}
 			// Even if the ConfigMap is available the JWS signature is patched-in a bit later.
 			if _, ok := cm.Data[bootstrapapi.JWSSignatureKeyPrefix+token.ID]; !ok {
-				lastError = errors.Errorf("could not find a JWS signature in the cluster-info ConfigMap"+
-					" for token ID %q", token.ID)
+				lastError = errors.Errorf("could not find a JWS signature in the cluster-info ConfigMap "+
+					"for token ID %q", token.ID)
 				if dryRun {
 					// Assume the user is dry-running with a token that will never appear in the cluster-info
 					// ConfigMap. Use the default dry-run token and CA cert hash.

--- a/cmd/kubeadm/app/phases/controlplane/manifests_test.go
+++ b/cmd/kubeadm/app/phases/controlplane/manifests_test.go
@@ -669,8 +669,8 @@ func errorDiffArguments(t *testing.T, name string, actual, expected []string) {
 	expectedShort := removeCommon(expected, actual)
 	actualShort := removeCommon(actual, expected)
 	t.Errorf(
-		"[%s] failed getAPIServerCommand:\nexpected:\n%v\nsaw:\n%v"+
-			"\nexpectedShort:\n%v\nsawShort:\n%v\n",
+		"[%s] failed getAPIServerCommand:\nexpected:\n%v\nsaw:\n%v\n"+
+			"expectedShort:\n%v\nsawShort:\n%v\n",
 		name, expected, actual,
 		expectedShort, actualShort)
 }

--- a/cmd/kubeadm/app/phases/upgrade/compute.go
+++ b/cmd/kubeadm/app/phases/upgrade/compute.go
@@ -90,8 +90,8 @@ func GetAvailableUpgrades(versionGetterImpl VersionGetter, experimentalUpgradesA
 		for version, nodes := range kubeAPIServerVersions {
 			verMsg = append(verMsg, fmt.Sprintf("%s on nodes %v", version, nodes))
 		}
-		klog.Warningf("Different API server versions in the cluster were discovered: %v. Please upgrade your control plane"+
-			" nodes to the same version of Kubernetes", strings.Join(verMsg, ", "))
+		klog.Warningf("Different API server versions in the cluster were discovered: %v. Please upgrade your control plane "+
+			"nodes to the same version of Kubernetes", strings.Join(verMsg, ", "))
 	}
 
 	// Get the latest cluster version

--- a/cmd/kubeadm/app/preflight/checks.go
+++ b/cmd/kubeadm/app/preflight/checks.go
@@ -843,7 +843,7 @@ func (ipc ImagePullCheck) Check() (warnings, errorList []error) {
 	if err != nil {
 		klog.V(4).Infof("failed to detect the sandbox image for local container runtime, %v", err)
 	} else if criSandboxImage != ipc.sandboxImage {
-		klog.Warningf("detected that the sandbox image %q of the container runtime is inconsistent with that used by kubeadm."+
+		klog.Warningf("detected that the sandbox image %q of the container runtime is inconsistent with that used by kubeadm. "+
 			"It is recommended to use %q as the CRI sandbox image.", criSandboxImage, ipc.sandboxImage)
 	}
 

--- a/cmd/kubeadm/app/util/apiclient/wait.go
+++ b/cmd/kubeadm/app/util/apiclient/wait.go
@@ -246,8 +246,8 @@ func getControlPlaneComponents(podMap map[string]*v1.Pod, addressAPIServer strin
 
 // WaitForControlPlaneComponents waits for all control plane components to report "ok".
 func (w *KubeWaiter) WaitForControlPlaneComponents(podMap map[string]*v1.Pod, apiSeverAddress string) error {
-	_, _ = fmt.Fprintf(w.writer, "[control-plane-check] Waiting for healthy control plane components."+
-		" This can take up to %v\n", w.timeout)
+	_, _ = fmt.Fprintf(w.writer, "[control-plane-check] Waiting for healthy control plane components. "+
+		"This can take up to %v\n", w.timeout)
 
 	components, err := getControlPlaneComponents(podMap, apiSeverAddress)
 	if err != nil {

--- a/pkg/apis/networking/validation/validation_test.go
+++ b/pkg/apis/networking/validation/validation_test.go
@@ -1652,9 +1652,9 @@ func TestValidateIngressClass(t *testing.T) {
 				setParams(makeIngressClassParams(nil, "foo", "bar", utilpointer.String("Namespace"), utilpointer.String("foo_ns"))),
 			),
 			expectedErrs: field.ErrorList{field.Invalid(field.NewPath("spec.parameters.namespace"), "foo_ns",
-				"a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-',"+
-					" and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', "+
-					"regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')")},
+				"a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', "+
+				"and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', "+
+				"regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')")},
 		},
 		"valid name, valid controller, valid Cluster scope": {
 			ingressClass: makeValidIngressClass("test123", "foo.co/bar",

--- a/pkg/controller/volume/attachdetach/populator/desired_state_of_world_populator.go
+++ b/pkg/controller/volume/attachdetach/populator/desired_state_of_world_populator.go
@@ -169,8 +169,8 @@ func (dswp *desiredStateOfWorldPopulator) findAndRemoveDeletedPods(logger klog.L
 			for _, scheduledPod := range volumeToAttach.ScheduledPods {
 				podUID := volutil.GetUniquePodName(scheduledPod)
 				dswp.desiredStateOfWorld.DeletePod(podUID, volumeToAttach.VolumeName, volumeToAttach.NodeName)
-				logger.V(4).Info("Removing podUID and volume on node from desired state of world"+
-					" because of the change of volume attachability", "node", klog.KRef("", string(volumeToAttach.NodeName)), "podUID", podUID, "volumeName", volumeToAttach.VolumeName)
+				logger.V(4).Info("Removing podUID and volume on node from desired state of world "+
+					"because of the change of volume attachability", "node", klog.KRef("", string(volumeToAttach.NodeName)), "podUID", podUID, "volumeName", volumeToAttach.VolumeName)
 			}
 		}
 	}

--- a/pkg/controlplane/apiserver/server.go
+++ b/pkg/controlplane/apiserver/server.go
@@ -114,9 +114,9 @@ func (c completedConfig) New(name string, delegationTarget genericapiserver.Dele
 		// error, but continue on. We don't return the error because the
 		// metadata responses require additional, backwards incompatible
 		// validation of command-line options.
-		msg := fmt.Sprintf("Could not construct pre-rendered responses for"+
-			" ServiceAccountIssuerDiscovery endpoints. Endpoints will not be"+
-			" enabled. Error: %v", err)
+		msg := fmt.Sprintf("Could not construct pre-rendered responses for "+
+			"ServiceAccountIssuerDiscovery endpoints. Endpoints will not be "+
+			"enabled. Error: %v", err)
 		if c.ServiceAccountIssuerURL != "" {
 			// The user likely expects this feature to be enabled if issuer URL is
 			// set and the feature gate is enabled. In the future, if there is no

--- a/pkg/kubeapiserver/options/authentication.go
+++ b/pkg/kubeapiserver/options/authentication.go
@@ -429,9 +429,9 @@ func (o *BuiltInAuthenticationOptions) AddFlags(fs *pflag.FlagSet) {
 
 		fs.StringVar(&o.ServiceAccounts.JWKSURI, "service-account-jwks-uri", o.ServiceAccounts.JWKSURI, ""+
 			"Overrides the URI for the JSON Web Key Set in the discovery doc served at "+
-			"/.well-known/openid-configuration. This flag is useful if the discovery doc"+
+			"/.well-known/openid-configuration. This flag is useful if the discovery doc "+
 			"and key set are served to relying parties from a URL other than the "+
-			"API server's external (as auto-detected or overridden with external-hostname). ")
+			"API server's external (as auto-detected or overridden with external-hostname).")
 
 		fs.DurationVar(&o.ServiceAccounts.MaxExpiration, "service-account-max-token-expiration", o.ServiceAccounts.MaxExpiration, ""+
 			"The maximum validity duration of a token created by the service account token issuer. If an otherwise valid "+

--- a/pkg/proxy/endpointschangetracker_test.go
+++ b/pkg/proxy/endpointschangetracker_test.go
@@ -1628,7 +1628,7 @@ func compareEndpointsMapsStr(t *testing.T, newMap EndpointsMap, expected map[Ser
 					t.Fatalf("Failed to cast endpointInfo")
 				}
 				if !endpointEqual(newEp, expected[x][i]) {
-					t.Fatalf("expected new[%v][%d] to be %v, got %v"+
+					t.Fatalf("expected new[%v][%d] to be %v, got %v "+
 						"(IsLocal expected %v, got %v) (Ready expected %v, got %v) (Serving expected %v, got %v) (Terminating expected %v got %v)",
 						x, i, expected[x][i], newEp, expected[x][i].isLocal, newEp.isLocal, expected[x][i].ready, newEp.ready,
 						expected[x][i].serving, newEp.serving, expected[x][i].terminating, newEp.terminating)

--- a/pkg/scheduler/backend/cache/cache.go
+++ b/pkg/scheduler/backend/cache/cache.go
@@ -264,9 +264,9 @@ func (cache *cacheImpl) UpdateSnapshot(logger klog.Logger, nodeSnapshot *Snapsho
 	}
 
 	if len(nodeSnapshot.nodeInfoList) != cache.nodeTree.numNodes {
-		errMsg := fmt.Sprintf("snapshot state is not consistent, length of NodeInfoList=%v not equal to length of nodes in tree=%v "+
-			", length of NodeInfoMap=%v, length of nodes in cache=%v"+
-			", trying to recover",
+		errMsg := fmt.Sprintf("snapshot state is not consistent, length of NodeInfoList=%v not equal to length of nodes in tree=%v, "+
+			"length of NodeInfoMap=%v, length of nodes in cache=%v, "+
+			"trying to recover",
 			len(nodeSnapshot.nodeInfoList), cache.nodeTree.numNodes,
 			len(nodeSnapshot.nodeInfoMap), len(cache.nodes))
 		logger.Error(nil, errMsg)

--- a/plugin/pkg/admission/defaulttolerationseconds/admission.go
+++ b/plugin/pkg/admission/defaulttolerationseconds/admission.go
@@ -33,12 +33,12 @@ const PluginName = "DefaultTolerationSeconds"
 
 var (
 	defaultNotReadyTolerationSeconds = flag.Int64("default-not-ready-toleration-seconds", 300,
-		"Indicates the tolerationSeconds of the toleration for notReady:NoExecute"+
-			" that is added by default to every pod that does not already have such a toleration.")
+		"Indicates the tolerationSeconds of the toleration for notReady:NoExecute "+
+		"that is added by default to every pod that does not already have such a toleration.")
 
 	defaultUnreachableTolerationSeconds = flag.Int64("default-unreachable-toleration-seconds", 300,
-		"Indicates the tolerationSeconds of the toleration for unreachable:NoExecute"+
-			" that is added by default to every pod that does not already have such a toleration.")
+		"Indicates the tolerationSeconds of the toleration for unreachable:NoExecute "+
+		"that is added by default to every pod that does not already have such a toleration.")
 
 	notReadyToleration = api.Toleration{
 		Key:               v1.TaintNodeNotReady,

--- a/staging/src/k8s.io/apimachinery/pkg/util/net/http.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/net/http.go
@@ -148,8 +148,8 @@ func readIdleTimeoutSeconds() int {
 	if s := os.Getenv("HTTP2_READ_IDLE_TIMEOUT_SECONDS"); len(s) > 0 {
 		i, err := strconv.Atoi(s)
 		if err != nil {
-			klog.Warningf("Illegal HTTP2_READ_IDLE_TIMEOUT_SECONDS(%q): %v."+
-				" Default value %d is used", s, err, ret)
+			klog.Warningf("Illegal HTTP2_READ_IDLE_TIMEOUT_SECONDS(%q): %v. "+
+				"Default value %d is used", s, err, ret)
 			return ret
 		}
 		ret = i
@@ -162,8 +162,8 @@ func pingTimeoutSeconds() int {
 	if s := os.Getenv("HTTP2_PING_TIMEOUT_SECONDS"); len(s) > 0 {
 		i, err := strconv.Atoi(s)
 		if err != nil {
-			klog.Warningf("Illegal HTTP2_PING_TIMEOUT_SECONDS(%q): %v."+
-				" Default value %d is used", s, err, ret)
+			klog.Warningf("Illegal HTTP2_PING_TIMEOUT_SECONDS(%q): %v. "+
+				"Default value %d is used", s, err, ret)
 			return ret
 		}
 		ret = i

--- a/staging/src/k8s.io/apiserver/pkg/server/options/audit.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/audit.go
@@ -356,9 +356,9 @@ func (o *AuditOptions) newPolicyRuleEvaluator() (audit.PolicyRuleEvaluator, erro
 
 func (o *AuditBatchOptions) AddFlags(pluginName string, fs *pflag.FlagSet) {
 	fs.StringVar(&o.Mode, fmt.Sprintf("audit-%s-mode", pluginName), o.Mode,
-		"Strategy for sending audit events. Blocking indicates sending events should block"+
-			" server responses. Batch causes the backend to buffer and write events"+
-			" asynchronously. Known modes are "+strings.Join(AllowedModes, ",")+".")
+		"Strategy for sending audit events. Blocking indicates sending events should block "+
+			"server responses. Batch causes the backend to buffer and write events "+
+			"asynchronously. Known modes are "+strings.Join(AllowedModes, ",")+".")
 	fs.IntVar(&o.BatchConfig.BufferSize, fmt.Sprintf("audit-%s-batch-buffer-size", pluginName),
 		o.BatchConfig.BufferSize, "The size of the buffer to store events before "+
 			"batching and writing. Only used in batch mode.")
@@ -442,8 +442,8 @@ func (o *AuditLogOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&o.MaxSize, "audit-log-maxsize", o.MaxSize,
 		"The maximum size in megabytes of the audit log file before it gets rotated.")
 	fs.StringVar(&o.Format, "audit-log-format", o.Format,
-		"Format of saved audits. \"legacy\" indicates 1-line text format for each event."+
-			" \"json\" indicates structured json format. Known formats are "+
+		"Format of saved audits. \"legacy\" indicates 1-line text format for each event. "+
+			"\"json\" indicates structured json format. Known formats are "+
 			strings.Join(pluginlog.AllowedFormats, ",")+".")
 	fs.StringVar(&o.GroupVersionString, "audit-log-version", o.GroupVersionString,
 		"API group and version used for serializing audit events written to log.")

--- a/staging/src/k8s.io/cloud-provider/plugins.go
+++ b/staging/src/k8s.io/cloud-provider/plugins.go
@@ -83,7 +83,7 @@ func IsExternal(name string) bool {
 // DisableWarningForProvider logs information about disabled cloud provider state
 func DisableWarningForProvider(providerName string) {
 	if !IsExternal(providerName) {
-		klog.Infof("INFO: Please make sure you are running an external cloud controller manager binary for provider %q."+
+		klog.Infof("INFO: Please make sure you are running an external cloud controller manager binary for provider %q. "+
 			"In-tree cloud providers are disabled. Refer to https://github.com/kubernetes/kubernetes/tree/master/staging/src/k8s.io/cloud-provider/sample "+
 			"for an example implementation.", providerName)
 		klog.Warningf("WARNING: built-in cloud providers are disabled. Please set \"--cloud-provider=external\" and migrate to an external cloud controller manager for provider %q", providerName)

--- a/staging/src/k8s.io/code-generator/cmd/applyconfiguration-gen/args/args.go
+++ b/staging/src/k8s.io/code-generator/cmd/applyconfiguration-gen/args/args.go
@@ -70,8 +70,8 @@ func (args *Args) AddFlags(fs *pflag.FlagSet, inputBase string) {
 	fs.StringVar(&args.GoHeaderFile, "go-header-file", "",
 		"the path to a file containing boilerplate header text; the string \"YEAR\" will be replaced with the current 4-digit year")
 	fs.Var(NewExternalApplyConfigurationValue(&args.ExternalApplyConfigurations, nil), "external-applyconfigurations",
-		"list of comma separated external apply configurations locations in <type-package>.<type-name>:<applyconfiguration-package> form."+
-			"For example: k8s.io/api/apps/v1.Deployment:k8s.io/client-go/applyconfigurations/apps/v1")
+		"list of comma separated external apply configurations locations in <type-package>.<type-name>:<applyconfiguration-package> form. "+
+		"For example: k8s.io/api/apps/v1.Deployment:k8s.io/client-go/applyconfigurations/apps/v1")
 	fs.StringVar(&args.OpenAPISchemaFilePath, "openapi-schema", "",
 		"path to the openapi schema containing all the types that apply configurations will be generated for")
 }

--- a/staging/src/k8s.io/component-base/compatibility/registry.go
+++ b/staging/src/k8s.io/component-base/compatibility/registry.go
@@ -241,7 +241,7 @@ func (r *componentGlobalsRegistry) AddFlags(fs *pflag.FlagSet) {
 		r.featureGatesConfigFlags = cliflag.NewColonSeparatedMultimapStringStringAllowDefaultEmptyKey(&r.featureGatesConfig)
 	}
 	fs.Var(r.featureGatesConfigFlags, "feature-gates", "Comma-separated list of component:key=value pairs that describe feature gates for alpha/experimental features of different components.\n"+
-		"If the component is not specified, defaults to \"kube\". This flag can be repeatedly invoked. For example: --feature-gates 'wardle:featureA=true,wardle:featureB=false' --feature-gates 'kube:featureC=true'"+
+		"If the component is not specified, defaults to \"kube\". This flag can be repeatedly invoked. For example: --feature-gates 'wardle:featureA=true,wardle:featureB=false' --feature-gates 'kube:featureC=true' "+
 		"Options are:\n"+strings.Join(r.unsafeKnownFeatures(), "\n"))
 }
 

--- a/staging/src/k8s.io/component-base/metrics/options.go
+++ b/staging/src/k8s.io/component-base/metrics/options.go
@@ -80,7 +80,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 			"Disclaimer: disabling metrics is higher in precedence than showing hidden metrics.")
 	fs.StringToStringVar(&o.AllowListMapping, "allow-metric-labels", o.AllowListMapping,
 		"The map from metric-label to value allow-list of this label. The key's format is <MetricName>,<LabelName>. "+
-			"The value's format is <allowed_value>,<allowed_value>..."+
+			"The value's format is <allowed_value>,<allowed_value>... "+
 			"e.g. metric1,label1='v1,v2,v3', metric1,label2='v1,v2,v3' metric2,label1='v1,v2,v3'.")
 	fs.StringVar(&o.AllowListMappingManifest, "allow-metric-labels-manifest", o.AllowListMappingManifest,
 		"The path to the manifest file that contains the allow-list mapping. "+

--- a/test/e2e/storage/drivers/csi_objects.go
+++ b/test/e2e/storage/drivers/csi_objects.go
@@ -66,9 +66,9 @@ func createGCESecrets(client clientset.Interface, ns string) {
 
 	premadeSAFile, ok := os.LookupEnv(saEnv)
 	if !ok {
-		framework.Logf("Could not find env var %v, please either create cloud-sa"+
-			" secret manually or rerun test after setting %v to the filepath of"+
-			" the GCP Service Account to give to the GCE Persistent Disk CSI Driver", saEnv, saEnv)
+		framework.Logf("Could not find env var %v, please either create cloud-sa "+
+			"secret manually or rerun test after setting %v to the filepath of "+
+			"the GCP Service Account to give to the GCE Persistent Disk CSI Driver", saEnv, saEnv)
 		return
 	}
 

--- a/test/e2e_kubeadm/admin_test.go
+++ b/test/e2e_kubeadm/admin_test.go
@@ -46,8 +46,8 @@ var _ = Describe("admin", func() {
 	// so we are disabling the creation of a namespace in order to get a faster execution
 	f.SkipNamespaceCreation = true
 
-	ginkgo.It("kubeadm:cluster-admins CRB must exist and be binding the cluster-admin ClusterRole"+
-		" to the kubeadm:cluster-admins Group", func(ctx context.Context) {
+	ginkgo.It("kubeadm:cluster-admins CRB must exist and be binding the cluster-admin ClusterRole "+
+		"to the kubeadm:cluster-admins Group", func(ctx context.Context) {
 
 		// Use the ClusterConfiguration.kubernetesVersion to decide whether to look for the CRB.
 		// It was added in kubeadm v1.29-pre, but kubeadm supports a maximum skew of N-1

--- a/test/e2e_node/remote/node_conformance.go
+++ b/test/e2e_node/remote/node_conformance.go
@@ -182,9 +182,9 @@ func launchKubelet(host, workspace, results, testArgs, bearerToken string) error
 		return fmt.Errorf("failed to create kubelet pod manifest path %q: error - %v output - %q",
 			podManifestPath, err, output)
 	}
-	startKubeletCmd := fmt.Sprintf("./%s --run-kubelet-mode --node-name=%s"+
-		" --bearer-token=%s"+
-		" --report-dir=%s %s --kubelet-flags=--pod-manifest-path=%s > %s 2>&1",
+	startKubeletCmd := fmt.Sprintf("./%s --run-kubelet-mode --node-name=%s "+
+		"--bearer-token=%s "+
+		"--report-dir=%s %s --kubelet-flags=--pod-manifest-path=%s > %s 2>&1",
 		conformanceTestBinary, host, bearerToken, results, testArgs, podManifestPath, filepath.Join(results, kubeletLauncherLog))
 	var cmd []string
 	systemd, err := isSystemd(host)

--- a/test/integration/controlplane/transformation/kmsv2_transformation_test.go
+++ b/test/integration/controlplane/transformation/kmsv2_transformation_test.go
@@ -908,8 +908,8 @@ resources:
 	pluginMock2.EnterFailedState()
 	mustBeUnHealthy(t, "/kms-providers",
 		"internal server error: "+
-			"[kms-provider-0: failed to perform status section of the healthz check for KMS Provider provider-1, error: rpc error: code = FailedPrecondition desc = failed precondition - key disabled,"+
-			" kms-provider-1: failed to perform status section of the healthz check for KMS Provider provider-2, error: rpc error: code = FailedPrecondition desc = failed precondition - key disabled]",
+			"[kms-provider-0: failed to perform status section of the healthz check for KMS Provider provider-1, error: rpc error: code = FailedPrecondition desc = failed precondition - key disabled, "+
+			"kms-provider-1: failed to perform status section of the healthz check for KMS Provider provider-2, error: rpc error: code = FailedPrecondition desc = failed precondition - key disabled]",
 		test.kubeAPIServer.ClientConfig)
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

There are two types of string concatenations spanning the line breaks.

1. Insert whitespace / `\n` at the last of the upper line
```go
fs.StringVar(&o.ServiceAccounts.JWKSURI, "service-account-jwks-uri", o.ServiceAccounts.JWKSURI, ""+
	"Overrides the URI for the JSON Web Key Set in the discovery doc served at "+
	"/.well-known/openid-configuration. This flag is useful if the discovery doc "+
	"and key set are served to relying parties from a URL other than the "+
	"API server's external (as auto-detected or overridden with external-hostname).")
```
2. Insert whitespace / `\n` at the beginning of the lower line
```go
fs.StringVar(&o.ServiceAccounts.JWKSURI, "service-account-jwks-uri", o.ServiceAccounts.JWKSURI, ""+
	"Overrides the URI for the JSON Web Key Set in the discovery doc served at"+
	" /.well-known/openid-configuration. This flag is useful if the discovery doc"+
	" and key set are served to relying parties from a URL other than the"+
	" API server's external (as auto-detected or overridden with external-hostname).")
```

The inconsistency of the concatenation sometimes causes the missing whitespace like this.
https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/#:~:text=%2D%2Dservice%2Daccount%2Djwks%2Duri
![IMG_0253](https://github.com/user-attachments/assets/e73b832f-a732-4492-91c9-03ee83216409)

With a few inspections, I assumed the first one (Insert whitespace / `\n` at the last of the upper line) is the current majority.
Thus, I grep all the second patterns by a regex `[^" (]"\+\n` (and excluding the line ends with `\n`) and converted them to the first pattern.

#### Which issue(s) this PR fixes:

No issues

#### Special notes for your reviewer:

- This PR is a band-aid solution, we may need a linter for the continuous solution.
- I skipped `vendor` directory since they are auto-generated.
- Some of them are not only the refactoring but also the bug fixes of the missing white space. The list of fixes:
  - `cmd/kube-proxy/app/options.go`
  - `cmd/kubeadm/app/preflight/checks.go`
  - `pkg/kubeapiserver/options/authentication.go`
  - `pkg/proxy/endpointschangetracker_test.go`
  - `staging/src/k8s.io/cloud-provider/plugins.go`
  - `staging/src/k8s.io/code-generator/cmd/applyconfiguration-gen/args/args.go`
  - `staging/src/k8s.io/component-base/compatibility/registry.go`
  - `staging/src/k8s.io/component-base/metrics/options.go`

#### Does this PR introduce a user-facing change?
```release-note
Fixed some missing white spaces in the flag description, logs, etc.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

No docs