### PR TITLE
Update hpa OWNERS

### DIFF
--- a/pkg/controller/podautoscaler/OWNERS
+++ b/pkg/controller/podautoscaler/OWNERS
@@ -1,14 +1,17 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
+  - adrianmoisey
   - gjtempleton
-  - mwielgus
+  - omerap12
+  - raywainman
 approvers:
-  - mwielgus
+  - gjtempleton
 emeritus_approvers:
   - jszczepkowski
   - piosz
   - MaciekPytel
   - josephburnett
+  - mwielgus
 labels:
   - sig/autoscaling


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Refreshes the list of HPA reviewers and approvers, per #128948.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```