### PR TITLE
e2e: stabilize Windows memory pressure eviction test

### DIFF
--- a/test/e2e/windows/eviction.go
+++ b/test/e2e/windows/eviction.go
@@ -29,12 +29,14 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/kubernetes/test/e2e/feature"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	imageutils "k8s.io/kubernetes/test/utils/image"
+	metrics "k8s.io/metrics/pkg/client/clientset/versioned"
 	admissionapi "k8s.io/pod-security-admission/api"
 )
 
@@ -44,6 +46,9 @@ const (
 	// it and the wait for the taint to be removed so other serial/slow tests can run
 	// against the same node.
 	waitForNodeMemoryPressureTaintDelayDuration = 45 * time.Second
+
+	// eviction pod namespace base name
+	evictionPodNamespaceBaseName = "eviction-test-windows"
 )
 
 var _ = sigDescribe(feature.Windows, "Eviction", framework.WithSerial(), framework.WithSlow(), framework.WithDisruptive(), (func() {
@@ -51,7 +56,7 @@ var _ = sigDescribe(feature.Windows, "Eviction", framework.WithSerial(), framewo
 		e2eskipper.SkipUnlessNodeOSDistroIs("windows")
 	})
 
-	f := framework.NewDefaultFramework("eviction-test-windows")
+	f := framework.NewDefaultFramework(evictionPodNamespaceBaseName)
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 
 	// This test will first find a Windows node memory-pressure hard-eviction enabled.
@@ -83,24 +88,16 @@ var _ = sigDescribe(feature.Windows, "Eviction", framework.WithSerial(), framewo
 			e2eskipper.Skipf("No Windows nodes with hard memory-pressure eviction found")
 		}
 
-		// Delete img-puller pods if they exist because eviction manager keeps selecting them for eviction first
-		// Note we cannot just delete the namespace because a deferred cleanup task tries to delete the ns if
-		// image pre-pulling was enabled.
-		nsList, err := f.ClientSet.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
-		framework.ExpectNoError(err)
-		for _, ns := range nsList.Items {
-			if strings.Contains(ns.Name, "img-puller") {
-				framework.Logf("Deleting pods in namespace %s", ns.Name)
-				podList, err := f.ClientSet.CoreV1().Pods(ns.Name).List(ctx, metav1.ListOptions{})
-				framework.ExpectNoError(err)
-				for _, pod := range podList.Items {
-					framework.Logf("  Deleting pod %s", pod.Name)
-					err = f.ClientSet.CoreV1().Pods(ns.Name).Delete(ctx, pod.Name, metav1.DeleteOptions{})
-					framework.ExpectNoError(err)
-				}
-				break
-			}
-		}
+		framework.Logf("Node %q capacity: %v Mi", node.Name, nodeMem.capacity.Value()/(1024*1024))
+		framework.Logf("Node %q hard eviction threshold: %v Mi", node.Name, nodeMem.hardEviction.Value()/(1024*1024))
+		framework.Logf("Available memory before eviction: %v Mi", (nodeMem.capacity.Value()-nodeMem.hardEviction.Value())/(1024*1024))
+
+		err = waitForMemoryPressureTaintRemoval(ctx, f, node.Name, 10*time.Minute)
+		framework.ExpectNoError(err, "Timed out waiting for memory-pressure taint to be removed from node %q", node.Name)
+
+		cleanupImagePullerPods(ctx, f)
+
+		ginkgo.DeferCleanup(f.DeleteNamespace, f.Namespace.Name)
 
 		ginkgo.By("Scheduling a pod that requests and consumes 500Mi of Memory")
 
@@ -136,12 +133,16 @@ var _ = sigDescribe(feature.Windows, "Eviction", framework.WithSerial(), framewo
 				NodeName: node.Name,
 			},
 		}
-		_, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod1, metav1.CreateOptions{})
+		pod1, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod1, metav1.CreateOptions{})
+		framework.ExpectNoError(err)
+
+		err = e2epod.WaitForPodRunningInNamespace(ctx, f.ClientSet, pod1)
 		framework.ExpectNoError(err)
 
 		ginkgo.By("Scheduling another pod will consume the rest of the node's memory")
 		chunks := int((nodeMem.capacity.Value()-nodeMem.hardEviction.Value())/(300*1024*1024) + 3)
-		framework.Logf("Pod2 will consume %d chunks of 300Mi", chunks)
+		framework.Logf("Pod2 will request approximately %v Mi total memory (%d chunks × 300Mi)", chunks*300, chunks)
+
 		pod2 := &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "pod2",
@@ -169,28 +170,63 @@ var _ = sigDescribe(feature.Windows, "Eviction", framework.WithSerial(), framewo
 				NodeName: node.Name,
 			},
 		}
-		_, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod2, metav1.CreateOptions{})
+		pod2, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod2, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
 
-		ginkgo.By("Waiting for pods to start running")
-		err = e2epod.WaitForPodsRunningReady(ctx, f.ClientSet, f.Namespace.Name, 2, 3*time.Minute)
+		if ginkgo.CurrentSpecReport().Failed() {
+			logNodeMemoryDebugInfo(ctx, f, node.Name, f.Namespace.Name, "pod2")
+		}
+
+		ginkgo.By("Waiting for pod2 to start running")
+		err = e2epod.WaitForPodRunningInNamespace(ctx, f.ClientSet, pod2)
 		framework.ExpectNoError(err)
 
-		framework.Logf("Waiting for pod2 to get evicted")
+		framework.Logf("Waiting for pod2 to be evicted")
+
 		gomega.Eventually(ctx, func() error {
-			eventList, err := f.ClientSet.CoreV1().Events(f.Namespace.Name).List(ctx, metav1.ListOptions{})
+			// Get updated node info
+			node, err = f.ClientSet.CoreV1().Nodes().Get(ctx, node.Name, metav1.GetOptions{})
 			if err != nil {
-				return fmt.Errorf("error getting events: %w", err)
+				return fmt.Errorf("failed to get node: %w", err)
 			}
-			for _, e := range eventList.Items {
-				// Look for an event that shows FailedScheduling
-				if e.Type == "Warning" && e.Reason == "Evicted" && strings.Contains(e.Message, "pod2") {
-					framework.Logf("Found %+v event with message %+v", e.Reason, e.Message)
-					return nil
+
+			// Log node memory pressure condition and taints
+			for _, cond := range node.Status.Conditions {
+				if cond.Type == v1.NodeMemoryPressure {
+					framework.Logf("Node condition: MemoryPressure = %v (Reason: %s, Message: %s)",
+						cond.Status, cond.Reason, cond.Message)
 				}
 			}
-			return fmt.Errorf("did not find any FailedScheduling event for pod %s", pod2.ObjectMeta.Name)
-		}, 10*time.Minute, 10*time.Second).Should(gomega.Succeed())
+			for _, taint := range node.Spec.Taints {
+				framework.Logf("Node %q has taint %q (Effect: %q)", node.Name, taint.Key, taint.Effect)
+			}
+
+			// Check for eviction events in the namespace
+			events, err := f.ClientSet.CoreV1().Events(f.Namespace.Name).List(ctx, metav1.ListOptions{})
+			if err != nil {
+				return fmt.Errorf("failed to list events: %w", err)
+			}
+
+			evicted := false
+			for _, e := range events.Items {
+				if e.Reason == "Evicted" {
+					if e.InvolvedObject.Name == pod2.Name {
+						framework.Logf("Eviction event for pod2: %q", e.Message)
+						evicted = true
+					} else {
+						framework.Logf("Eviction event for other pod %q: %q", e.InvolvedObject.Name, e.Message)
+					}
+				}
+				if e.InvolvedObject.Name == pod2.Name {
+					framework.Logf("Event for pod2: Type=%s, Reason=%s, Message=%q", e.Type, e.Reason, e.Message)
+				}
+			}
+
+			if evicted {
+				return nil
+			}
+			return fmt.Errorf("pod2 not evicted yet; still waiting")
+		}).WithTimeout(10*time.Minute).WithPolling(10*time.Second).Should(gomega.Succeed(), "pod2 should eventually be evicted")
 
 		ginkgo.By("Waiting for node.kubernetes.io/memory-pressure taint to be removed")
 		// ensure e2e test framework catches the memory-pressure taint
@@ -200,3 +236,139 @@ var _ = sigDescribe(feature.Windows, "Eviction", framework.WithSerial(), framewo
 		framework.ExpectNoError(err)
 	})
 }))
+
+// Delete img-puller pods if they exist because eviction manager keeps selecting them for eviction first
+// Note we cannot just delete the namespace because a deferred cleanup task tries to delete the ns if
+// image pre-pulling was enabled.
+func cleanupImagePullerPods(ctx context.Context, f *framework.Framework) {
+	nsList, err := f.ClientSet.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
+	framework.ExpectNoError(err)
+	for _, ns := range nsList.Items {
+		if strings.Contains(ns.Name, "img-puller") {
+			framework.Logf("Deleting pods in namespace %s", ns.Name)
+			podList, err := f.ClientSet.CoreV1().Pods(ns.Name).List(ctx, metav1.ListOptions{})
+			framework.ExpectNoError(err)
+			for _, pod := range podList.Items {
+				framework.Logf("  Deleting pod %s", pod.Name)
+				err = f.ClientSet.CoreV1().Pods(ns.Name).Delete(ctx, pod.Name, metav1.DeleteOptions{})
+				framework.ExpectNoError(err)
+			}
+			break
+		}
+	}
+}
+
+func waitForMemoryPressureTaintRemoval(ctx context.Context, f *framework.Framework, nodeName string, timeout time.Duration) error {
+	framework.Logf("Waiting for memory-pressure taint to be removed from node %q", nodeName)
+	return wait.PollUntilContextTimeout(ctx, 10*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		node, err := f.ClientSet.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+		if err != nil {
+			framework.Logf("Failed to get node %q: %v", nodeName, err)
+			return false, err
+		}
+
+		// Log node conditions
+		for _, cond := range node.Status.Conditions {
+			if cond.Type == v1.NodeMemoryPressure {
+				framework.Logf("Node condition: MemoryPressure = %v (reason: %s, message: %s)", cond.Status, cond.Reason, cond.Message)
+			}
+		}
+
+		// Log taints
+		hasTaint := false
+		for _, taint := range node.Spec.Taints {
+			if taint.Key == v1.TaintNodeMemoryPressure && taint.Effect == v1.TaintEffectNoSchedule {
+				framework.Logf("Node %q still has memory-pressure taint (Effect: %s, TimeAdded: %v)", nodeName, taint.Effect, taint.TimeAdded)
+				hasTaint = true
+			}
+		}
+
+		// Log all pods on the node
+		podList, err := f.ClientSet.CoreV1().Pods("").List(ctx, metav1.ListOptions{
+			FieldSelector: fmt.Sprintf("spec.nodeName=%s", nodeName),
+		})
+		if err != nil {
+			framework.Logf("Failed to list pods on node %q: %v", nodeName, err)
+		} else {
+			for _, pod := range podList.Items {
+				framework.Logf("Pod %q in ns %q phase: %s", pod.Name, pod.Namespace, pod.Status.Phase)
+			}
+		}
+
+		if !hasTaint {
+			framework.Logf("Memory-pressure taint has been removed from node %q", nodeName)
+			return true, nil
+		}
+		return false, nil
+	})
+}
+
+func logNodeMemoryDebugInfo(ctx context.Context, f *framework.Framework, nodeName string, namespace string, podName string) {
+	framework.Logf("========== DEBUG INFO FOR NODE: %q ==========", nodeName)
+
+	// Node description
+	node, err := f.ClientSet.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+	if err != nil {
+		framework.Logf("Error fetching node %q: %v", nodeName, err)
+	} else {
+		for _, cond := range node.Status.Conditions {
+			if cond.Type == v1.NodeMemoryPressure {
+				framework.Logf("Node condition - MemoryPressure: %v (Reason: %s, Message: %s, LastHeartbeat: %s)",
+					cond.Status, cond.Reason, cond.Message, cond.LastHeartbeatTime)
+			}
+		}
+		for _, taint := range node.Spec.Taints {
+			if taint.Key == v1.TaintNodeMemoryPressure {
+				framework.Logf("Node taint - memory-pressure: Effect=%s, TimeAdded=%v", taint.Effect, taint.TimeAdded)
+			}
+		}
+	}
+
+	// Pods on node
+	pods, err := f.ClientSet.CoreV1().Pods("").List(ctx, metav1.ListOptions{
+		FieldSelector: fmt.Sprintf("spec.nodeName=%s", nodeName),
+	})
+	if err != nil {
+		framework.Logf("Error listing pods on node %q: %v", nodeName, err)
+	} else {
+		for _, p := range pods.Items {
+			framework.Logf("Pod %q in ns %q is in phase: %s", p.Name, p.Namespace, p.Status.Phase)
+		}
+	}
+
+	metricsClient, err := metrics.NewForConfig(f.ClientConfig())
+	if err == nil {
+		// Node metrics
+		nodeMetrics, err := metricsClient.MetricsV1beta1().NodeMetricses().Get(ctx, nodeName, metav1.GetOptions{})
+		if err == nil {
+			memUsage := nodeMetrics.Usage.Memory().ScaledValue(resource.Mega)
+			framework.Logf("Node %q is using %d Mi of memory", nodeName, memUsage)
+		}
+
+		// Pod metrics
+		podMetricsList, err := metricsClient.MetricsV1beta1().PodMetricses(namespace).List(ctx, metav1.ListOptions{})
+		if err == nil {
+			for _, podMetrics := range podMetricsList.Items {
+				if podMetrics.Name == podName {
+					var totalMem int64
+					for _, c := range podMetrics.Containers {
+						totalMem += c.Usage.Memory().ScaledValue(resource.Mega)
+					}
+					framework.Logf("Pod %q is using %d Mi of memory", podMetrics.Name, totalMem)
+				}
+			}
+		}
+	}
+
+	// Events in pod's namespace
+	events, err := f.ClientSet.CoreV1().Events(namespace).List(ctx, metav1.ListOptions{})
+	if err == nil {
+		for _, e := range events.Items {
+			if strings.Contains(e.Message, podName) || e.InvolvedObject.Name == podName {
+				framework.Logf("Event for pod %q: Type=%s, Reason=%s, Message=%q", podName, e.Type, e.Reason, e.Message)
+			}
+		}
+	}
+
+	framework.Logf("========== END DEBUG INFO FOR NODE: %q ==========", nodeName)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind flake
/sig windows

#### What this PR does / why we need it:

Add logic to wait until memory-pressure taint is cleared before running the test.

This reduces test flakiness due to lingering node conditions between retries.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes (https://github.com/kubernetes/kubernetes/issues/130419)

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
