### PR TITLE
DRA: prevent admin access claims from getting duplicate devices

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/allocator.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/allocator.go
@@ -259,7 +259,7 @@ func (a *Allocator) Allocate(ctx context.Context, node *v1.Node) (finalResult []
 	alloc.deviceMatchesRequest = make(map[matchKey]bool)
 
 	// We can estimate the size based on what we need to allocate.
-	alloc.allocatingDevices = make(map[DeviceID]bool, minDevicesTotal)
+	alloc.allocatingDevices = make(map[DeviceID]sets.Set[int], minDevicesTotal)
 
 	alloc.logger.V(6).Info("Gathered information about devices", "numAllocated", len(alloc.allocatedDevices), "minDevicesToBeAllocated", minDevicesTotal)
 
@@ -468,8 +468,13 @@ type allocator struct {
 	deviceMatchesRequest map[matchKey]bool
 	constraints          [][]constraint                 // one list of constraints per claim
 	requestData          map[requestIndices]requestData // one entry per request with no subrequests and one entry per subrequest
-	allocatingDevices    map[DeviceID]bool
-	result               []internalAllocationResult
+	// allocatingDevices tracks which devices will be newly allocated for a
+	// particular attempt to find a solution. The map is indexed by device
+	// and its values represent for which of a pod's claims the device will
+	// be allocated.
+	// Claims are identified by their index in claimsToAllocate.
+	allocatingDevices map[DeviceID]sets.Set[int]
+	result            []internalAllocationResult
 }
 
 // matchKey identifies a device/request pair.
@@ -793,7 +798,11 @@ func (alloc *allocator) allocateOne(r deviceIndices, allocateSubRequest bool) (b
 				deviceID := DeviceID{Driver: pool.Driver, Pool: pool.Pool, Device: slice.Spec.Devices[deviceIndex].Name}
 
 				// Checking for "in use" is cheap and thus gets done first.
-				if !request.adminAccess() && (alloc.allocatedDevices.Has(deviceID) || alloc.allocatingDevices[deviceID]) {
+				if request.adminAccess() && alloc.allocatingDeviceForClaim(deviceID, r.claimIndex) {
+					alloc.logger.V(7).Info("Device in use in same claim", "device", deviceID)
+					continue
+				}
+				if !request.adminAccess() && alloc.deviceInUse(deviceID) {
 					alloc.logger.V(7).Info("Device in use", "device", deviceID)
 					continue
 				}
@@ -967,7 +976,11 @@ func (alloc *allocator) allocateDevice(r deviceIndices, device deviceWithID, mus
 	requestKey := requestIndices{claimIndex: r.claimIndex, requestIndex: r.requestIndex, subRequestIndex: r.subRequestIndex}
 	requestData := alloc.requestData[requestKey]
 	request := requestData.request
-	if !request.adminAccess() && (alloc.allocatedDevices.Has(device.id) || alloc.allocatingDevices[device.id]) {
+	if request.adminAccess() && alloc.allocatingDeviceForClaim(device.id, r.claimIndex) {
+		alloc.logger.V(7).Info("Device in use in same claim", "device", device.id)
+		return false, nil, nil
+	}
+	if !request.adminAccess() && alloc.deviceInUse(device.id) {
 		alloc.logger.V(7).Info("Device in use", "device", device.id)
 		return false, nil, nil
 	}
@@ -1024,9 +1037,12 @@ func (alloc *allocator) allocateDevice(r deviceIndices, device deviceWithID, mus
 	// All constraints satisfied. Mark as in use (unless we do admin access)
 	// and record the result.
 	alloc.logger.V(7).Info("Device allocated", "device", device.id)
-	if !request.adminAccess() {
-		alloc.allocatingDevices[device.id] = true
+
+	if alloc.allocatingDevices[device.id] == nil {
+		alloc.allocatingDevices[device.id] = make(sets.Set[int])
 	}
+	alloc.allocatingDevices[device.id].Insert(r.claimIndex)
+
 	result := internalDeviceResult{
 		request:       request.name(),
 		parentRequest: parentRequestName,
@@ -1044,9 +1060,7 @@ func (alloc *allocator) allocateDevice(r deviceIndices, device deviceWithID, mus
 		for _, constraint := range alloc.constraints[r.claimIndex] {
 			constraint.remove(baseRequestName, subRequestName, device.basic, device.id)
 		}
-		if !request.adminAccess() {
-			alloc.allocatingDevices[device.id] = false
-		}
+		alloc.allocatingDevices[device.id].Delete(r.claimIndex)
 		// Truncate, but keep the underlying slice.
 		alloc.result[r.claimIndex].devices = alloc.result[r.claimIndex].devices[:previousNumResults]
 		alloc.logger.V(7).Info("Device deallocated", "device", device.id)
@@ -1101,7 +1115,7 @@ func (alloc *allocator) checkAvailableCapacity(device deviceWithID) (bool, error
 			Pool:   slice.Spec.Pool.Name,
 			Device: device.Name,
 		}
-		if !alloc.allocatedDevices.Has(deviceID) && !alloc.allocatingDevices[deviceID] {
+		if !alloc.allocatedDevices.Has(deviceID) && !alloc.allocatingDeviceForAnyClaim(deviceID) {
 			continue
 		}
 		for _, consumedCounter := range device.Basic.ConsumesCounters {
@@ -1139,6 +1153,18 @@ func (alloc *allocator) checkAvailableCapacity(device deviceWithID) (bool, error
 	}
 
 	return true, nil
+}
+
+func (alloc *allocator) deviceInUse(deviceID DeviceID) bool {
+	return alloc.allocatedDevices.Has(deviceID) || alloc.allocatingDeviceForAnyClaim(deviceID)
+}
+
+func (alloc *allocator) allocatingDeviceForAnyClaim(deviceID DeviceID) bool {
+	return alloc.allocatingDevices[deviceID].Len() > 0
+}
+
+func (alloc *allocator) allocatingDeviceForClaim(deviceID DeviceID, claimIndex int) bool {
+	return alloc.allocatingDevices[deviceID].Has(claimIndex)
 }
 
 // createNodeSelector constructs a node selector for the allocation, if needed,

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/allocator_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/allocator_test.go
@@ -1152,6 +1152,104 @@ func TestAllocator(t *testing.T) {
 				deviceAllocationResult(req0, driverA, pool1, device2, true),
 			)},
 		},
+		"all-devices-some-allocating-admin-access": {
+			features: Features{
+				AdminAccess: true,
+			},
+			claimsToAllocate: func() []wrapResourceClaim {
+				c := claimWithRequests(claim0, nil, request(req0, classA, 1), request(req1, classA, 1))
+				c.Spec.Devices.Requests[0].AdminAccess = ptr.To(true)
+				// Second request for `All` cannot be fulfilled because
+				// the first request claims a device.
+				c.Spec.Devices.Requests[1].AdminAccess = ptr.To(true)
+				c.Spec.Devices.Requests[1].AllocationMode = resourceapi.DeviceAllocationModeAll
+				return []wrapResourceClaim{c}
+			}(),
+			classes: objects(class(classA, driverA)),
+			slices: objects(
+				slice(slice1, node1, pool1, driverA, device(device1, nil, nil), device(device2, nil, nil)),
+			),
+			node:          node(node1, region1),
+			expectResults: nil,
+		},
+		"count-devices-some-allocated-admin-access": {
+			features: Features{
+				AdminAccess: true,
+			},
+			claimsToAllocate: func() []wrapResourceClaim {
+				c := claim(claim0, req0, classA)
+				c.Spec.Devices.Requests[0].AdminAccess = ptr.To(true)
+				c.Spec.Devices.Requests[0].AllocationMode = resourceapi.DeviceAllocationModeExactCount
+				c.Spec.Devices.Requests[0].Count = 2
+				return []wrapResourceClaim{c}
+			}(),
+			allocatedDevices: []DeviceID{
+				MakeDeviceID(driverA, pool1, device1),
+			},
+			classes: objects(class(classA, driverA)),
+			slices: objects(
+				slice(slice1, node1, pool1, driverA, device(device1, nil, nil), device(device2, nil, nil)),
+			),
+			node: node(node1, region1),
+			expectResults: []any{allocationResult(
+				localNodeSelector(node1),
+				deviceAllocationResult(req0, driverA, pool1, device1, true),
+				deviceAllocationResult(req0, driverA, pool1, device2, true),
+			)},
+		},
+		"separate-claims-share-device-admin-access": {
+			features: Features{
+				AdminAccess: true,
+			},
+			claimsToAllocate: func() []wrapResourceClaim {
+				c1 := claim(claim0, req0, classA)
+				c1.Spec.Devices.Requests[0].AdminAccess = ptr.To(true)
+
+				c2 := claim(claim1, req0, classA)
+				c2.Spec.Devices.Requests[0].AdminAccess = ptr.To(true)
+				return []wrapResourceClaim{c1, c2}
+			}(),
+			classes: objects(class(classA, driverA)),
+			slices: objects(
+				slice(slice1, node1, pool1, driverA, device(device1, nil, nil), device(device2, nil, nil)),
+			),
+			node: node(node1, region1),
+			expectResults: []any{
+				allocationResult(
+					localNodeSelector(node1),
+					deviceAllocationResult(req0, driverA, pool1, device1, true),
+				),
+				allocationResult(
+					localNodeSelector(node1),
+					deviceAllocationResult(req0, driverA, pool1, device1, true),
+				),
+			},
+		},
+		"admin-access-claims-device-allocating-for-non-admin-access": {
+			features: Features{
+				AdminAccess: true,
+			},
+			claimsToAllocate: func() []wrapResourceClaim {
+				admin := claim(claim1, req0, classA)
+				admin.Spec.Devices.Requests[0].AdminAccess = ptr.To(true)
+				return []wrapResourceClaim{claim(claim0, req0, classA), admin}
+			}(),
+			classes: objects(class(classA, driverA)),
+			slices: objects(
+				slice(slice1, node1, pool1, driverA, device(device1, nil, nil), device(device2, nil, nil)),
+			),
+			node: node(node1, region1),
+			expectResults: []any{
+				allocationResult(
+					localNodeSelector(node1),
+					deviceAllocationResult(req0, driverA, pool1, device1, false),
+				),
+				allocationResult(
+					localNodeSelector(node1),
+					deviceAllocationResult(req0, driverA, pool1, device1, true),
+				),
+			},
+		},
 		"all-devices-slice-without-devices-prioritized-list": {
 			features: Features{
 				PrioritizedList: true,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR adds an additional check to the DRA allocator that the same device is not referenced more than once for the same ResourceClaim. Since admin access claims do not "count" as being allocated, the scheduler plugin's search for an acceptable solution to a request for N devices with admin access would result in N allocations for the same device, leading to the CDI errors described in the linked issue.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #131269

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
DRA: ResourceClaims requesting a fixed number of devices with `adminAccess` will no longer be allocated the same device multiple times.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/4381
```
