### PR TITLE
Fix kubectl writing current-context to the wrong kubeconfig file when using multiple kubeconfig files.

### DIFF
--- a/staging/src/k8s.io/client-go/tools/clientcmd/config_test.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/config_test.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clientcmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestModifyConfigWritesToFirstKubeconfigFile(t *testing.T) {
+	const (
+		contextNameA   = "context-a"
+		contextNameB   = "context-b"
+		newContextName = "new-context"
+	)
+
+	tempdir := t.TempDir()
+	configFile1, _ := os.Create(filepath.Join(tempdir, "kubeconfig-a"))
+	configFile2, _ := os.Create(filepath.Join(tempdir, "kubeconfig-b"))
+
+	// The first kubeconfig has everything.
+	err := os.WriteFile(configFile1.Name(), []byte(`
+kind: Config
+apiVersion: v1
+clusters:
+- cluster:
+    api-version: v1
+    server: https://kubernetes.default.svc:443
+    certificate-authority: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+  name: kubeconfig-cluster
+contexts:
+- context:
+    cluster: kubeconfig-cluster
+    namespace: default
+    user: kubeconfig-user
+  name: `+contextNameA+`
+current-context: `+contextNameA+`
+users:
+- name: kubeconfig-user
+  user:
+    tokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+`), os.FileMode(0755))
+
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	// The second kubeconfig declares a new context and activates it.
+	err = os.WriteFile(configFile2.Name(), []byte(`
+kind: Config
+apiVersion: v1
+contexts:
+- context:
+    cluster: kubeconfig-cluster
+    namespace: a-different-namespace
+    user: kubeconfig-user
+  name: `+contextNameB+`
+current-context: `+contextNameB+`
+`), os.FileMode(0755))
+
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	// Set KUBECONFIG to the files, in descending alphabetical order.
+	// This will be used to check that they don't get sorted.
+	envVarValue := fmt.Sprintf("%s%c%s", configFile2.Name(), filepath.ListSeparator, configFile1.Name())
+	t.Setenv(RecommendedConfigPathEnvVar, envVarValue)
+
+	// Load the kubeconfigs, change the active context, and call ModifyConfig.
+	loadingRules := NewDefaultClientConfigLoadingRules()
+	config, err := loadingRules.Load()
+
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	newConfig := config.DeepCopy()
+	newConfig.CurrentContext = newContextName
+	err = ModifyConfig(loadingRules, *newConfig, false)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// Load the files again and check that only configFile2 was changed.
+	config1, err := LoadFromFile(configFile1.Name()) // file sorts first, but was specified last
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if config1.CurrentContext != contextNameA {
+		t.Errorf("Config should not be modified, but was. Expected %q, got %q", contextNameA, config1.CurrentContext)
+	}
+
+	config2, err := LoadFromFile(configFile2.Name()) // file sorts last, but was specified first
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if config2.CurrentContext != newContextName {
+		t.Errorf("Config should be modified, but was not. Expected %q, got %q", newContextName, config2.CurrentContext)
+	}
+}

--- a/staging/src/k8s.io/client-go/tools/clientcmd/loader.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/loader.go
@@ -331,7 +331,10 @@ func (rules *ClientConfigLoadingRules) GetLoadingPrecedence() []string {
 		return []string{rules.ExplicitPath}
 	}
 
-	return rules.Precedence
+	// Create a copy in case something tries to sort the returned slice.
+	precedence := make([]string, len(rules.Precedence))
+	copy(precedence, rules.Precedence)
+	return precedence
 }
 
 // GetStartingConfig implements ConfigAccess


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:

Under certain circumstances, when a `clientcmd` auth plugin calls the `AuthProviderConfigPersister.Persist` function, `kubectl` may write the `current-context` to the first alphabetically-sorted file in `$KUBECONFIG` instead of the file that appears first in the environment variable.

<ins>The bug can be reproduced by performing the following steps:</ins>

 1. Create a cluster using OIDC for auth.

 2. Save that cluster's kubeconfig file as `ccc.yaml`

    The `kubectl` executable *must* refresh the token for this to happen. You can force it to happen by modifying this file's `id-token` and setting the JWT's `exp` field to `0`.

 3. Create two more kubeconfig files containing new contexts:

    ```yaml
    # aaa.yaml
    apiVersion: v1
    kind: Config
    current-context: context-aaa
    contexts:
      - name: context-aaa
        context:
          cluster: <cluster from ccc.yaml>
          user: <user from ccc.yaml>

    # bbb.yaml
    apiVersion: v1
    kind: Config
    current-context: context-bbb
    contexts:
      - name: context-bbb
        context:
          cluster: <cluster from ccc.yaml>
          user: <user from ccc.yaml>
    ```

 4. Set the `KUBECONFIG` environment variable to `bbb.yaml:ccc.yaml:aaa.yaml`.

 5. Run `kubectl get pod` to make `kubectl` refresh the token.

<ins>What should happen:</ins>

The first file, `bbb.yaml` remains unchanged.  
The second file, `ccc.yaml` is updated.  
The third file, `aaa.yaml` remains unchanged.

<ins>What actually happens:</ins>

The first file, `bbb.yaml` remains unchanged.  
The second file, `ccc.yaml` is updated.  
*The third file, `aaa.yaml` has its current-context set to `context-bbb`.*

<ins>Why it happens:</ins>

The `clientcmd.ModifyConfig` [in-place sorts the slice](https://github.com/kubernetes/kubernetes/blob/30469e180361d7da07b0fee6d47c776fa2cf3e86/staging/src/k8s.io/client-go/tools/clientcmd/config.go#L170) returned by the `ConfigAccess` interface.

When the `ConfigAccess` interface is a `ClientConfigLoadingRules`, [it returns the slice held in its `Precendence` field](https://github.com/kubernetes/kubernetes/blob/30469e180361d7da07b0fee6d47c776fa2cf3e86/staging/src/k8s.io/client-go/tools/clientcmd/loader.go#L334).

Consequently, the `configAccess`'s `Precedence` field gets modified. This causes the `GetDefaultFilename` and `GetStartingConfig` functions to return the wrong file and config data. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
N/A

#### Special notes for your reviewer:

 1. This is my first contribution, so please let me know if any part of the change is inconsistent with Kubernetes code conventions.

 2. The fix itself is a 3-line change. The rest of the additions are a test to catch the issue this solves.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

This is a fix for an unreported issue.

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
