### PR TITLE
Fix Multiple RemoveContainer Calls Due to Race Condition

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -648,6 +648,7 @@ func NewMainKubelet(ctx context.Context,
 		podStartupLatencyTracker:     kubeDeps.PodStartupLatencyTracker,
 		healthChecker:                kubeDeps.HealthChecker,
 		flagz:                        kubeDeps.Flagz,
+		podCleanupTracker:            sync.Map{},
 	}
 
 	var secretManager secret.Manager
@@ -1587,6 +1588,10 @@ type Kubelet struct {
 
 	// podsServer is the server that provides the pods gRPC service.
 	podsServer *pods.PodsServer
+
+	// podCleanupTracker tracks pods that have already been processed for cleanup
+	// to avoid duplicate cleanup operations for the same pod
+	podCleanupTracker sync.Map
 }
 
 // ListPodStats is delegated to StatsProvider, which implements stats.Provider interface
@@ -3368,10 +3373,37 @@ func (kl *Kubelet) ListenAndServePods(ctx context.Context) {
 
 // Delete the eligible dead container instances in a pod. Depending on the configuration, the latest dead containers may be kept around.
 func (kl *Kubelet) cleanUpContainersInPod(ctx context.Context, podID types.UID, exitedContainerID string) {
+	logger := klog.FromContext(ctx)
 	if podStatus, err := kl.podCache.Get(podID); err == nil {
-		// When an evicted or deleted pod has already synced, all containers can be removed.
-		removeAll := kl.podWorkers.ShouldPodContentBeRemoved(podID)
-		kl.containerDeletor.deleteContainersInPod(exitedContainerID, podStatus, removeAll)
+		for _, sandboxStatus := range podStatus.SandboxStatuses {
+			// If exitedContainerID is the ID of the sandbox container,
+			// we skip deleting this container to avoid duplicate RemoveContainer calls.
+			if sandboxStatus.GetId() == exitedContainerID {
+				logger.V(4).Info("exitedContainerID is a sandbox container, skipping container deletion", "exitedContainerID", exitedContainerID)
+				return
+			}
+		}
+
+		keepContainers := !kl.podWorkers.ShouldPodContentBeRemoved(podID)
+
+		// When the pod is terminating, use tracking mechanism to ensure only one full cleanup
+		if !keepContainers {
+			if _, alreadyCleaned := kl.podCleanupTracker.LoadOrStore(podID, struct{}{}); alreadyCleaned {
+				// If cleanup has already been performed, only clean the current exited container
+				logger.V(4).Info("Pod cleanup already in progress, only cleaning current container",
+					"pod", podID, "container", exitedContainerID)
+				kl.containerDeletor.deleteContainersInPod(exitedContainerID, podStatus, true)
+				return
+			}
+
+			// First time performing cleanup, clean all containers
+			logger.V(4).Info("Pod is terminating, cleaning up all containers", "pod", podID)
+			kl.containerDeletor.deleteContainersInPod("", podStatus, true)
+			return
+		}
+
+		// For non-terminating pods, only clean the current exited container
+		kl.containerDeletor.deleteContainersInPod(exitedContainerID, podStatus, !keepContainers)
 	}
 }
 

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -1201,6 +1201,16 @@ func (kl *Kubelet) removeOrphanedPodStatuses(logger klog.Logger, pods []*v1.Pod,
 // updates are delivered to the pod workers while this method is running.
 func (kl *Kubelet) HandlePodCleanups(ctx context.Context) error {
 	logger := klog.FromContext(ctx)
+
+	kl.podCleanupTracker.Range(func(key, value interface{}) bool {
+		podUID := key.(types.UID)
+		if _, ok := kl.podManager.GetPodByUID(podUID); !ok {
+			kl.podCleanupTracker.Delete(podUID)
+			logger.V(4).Info("Cleaned up tracking record for removed pod", "podUID", podUID)
+		}
+		return true
+	})
+
 	// The kubelet lacks checkpointing, so we need to introspect the set of pods
 	// in the cgroup tree prior to inspecting the set of pods in our pod manager.
 	// this ensures our view of the cgroup tree does not mistakenly observe pods

--- a/pkg/kubelet/pod_container_deletor.go
+++ b/pkg/kubelet/pod_container_deletor.go
@@ -100,11 +100,12 @@ func getContainersToDeleteInPod(filterContainerID string, podStatus *kubecontain
 }
 
 // deleteContainersInPod issues container deletion requests for containers selected by getContainersToDeleteInPod.
+// If removeAll is true, all containers matching filterContainerID will be removed.
+// Otherwise, the oldest containers will be removed, but a minimum number of containers will be preserved.
 func (p *podContainerDeletor) deleteContainersInPod(filterContainerID string, podStatus *kubecontainer.PodStatus, removeAll bool) {
 	containersToKeep := p.containersToKeep
 	if removeAll {
 		containersToKeep = 0
-		filterContainerID = ""
 	}
 
 	for _, candidate := range getContainersToDeleteInPod(filterContainerID, podStatus, containersToKeep) {

--- a/test/e2e_node/criproxy_test.go
+++ b/test/e2e_node/criproxy_test.go
@@ -35,6 +35,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/kubernetes/pkg/features"
 	kubeletevents "k8s.io/kubernetes/pkg/kubelet/events"
 	"k8s.io/kubernetes/pkg/kubelet/images"
@@ -502,4 +503,215 @@ func verifyErrorInKubeletLogs(errorMsg string) error {
 	}
 
 	return nil
+}
+
+var _ = SIGDescribe("Deleted pods handling", feature.CriProxy, framework.WithSerial(), func() {
+	f := framework.NewDefaultFramework("deleted-pods-test")
+	f.NamespacePodSecurityLevel = admissionapi.LevelBaseline
+
+	ginkgo.Context("Verify RemoveContainer call count for single container pod", func() {
+		ginkgo.BeforeEach(func() {
+			if err := resetCRIProxyInjector(e2eCriProxy); err != nil {
+				ginkgo.Skip("Skip the test since the CRI Proxy is undefined.")
+			}
+			ginkgo.DeferCleanup(func() error {
+				return resetCRIProxyInjector(e2eCriProxy)
+			})
+		})
+
+		ginkgo.It("Should call RemoveContainer at most once for single container pod deletion", func(ctx context.Context) {
+			// Wait for cluster to be clean before starting test
+			err := waitForNoTerminatingPods(ctx, f)
+			framework.ExpectNoError(err)
+
+			// Set up RemoveContainer call tracking
+			removeContainerCallCount := 0
+			err = addCRIProxyInjector(e2eCriProxy, func(apiName string) error {
+				if apiName == criproxy.RemoveContainer {
+					removeContainerCallCount++
+					framework.Logf("RemoveContainer called, total count: %d", removeContainerCallCount)
+				}
+				return nil
+			})
+			framework.ExpectNoError(err)
+
+			// Create and wait for pod to be running
+			pod := e2epod.NewPodClient(f).Create(ctx, newSingleContainerPod())
+			podErr := e2epod.WaitForPodRunningInNamespace(ctx, f.ClientSet, pod)
+			framework.ExpectNoError(podErr)
+
+			// Record the baseline count before deletion
+			baselineCount := removeContainerCallCount
+			framework.Logf("Baseline RemoveContainer count before pod deletion: %d", baselineCount)
+
+			// Delete the pod
+			err = e2epod.NewPodClient(f).Delete(ctx, pod.Name, metav1.DeleteOptions{})
+			framework.ExpectNoError(err)
+
+			// Wait for pod to be deleted
+			err = e2epod.WaitForPodNotFoundInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name, 2*time.Minute)
+			framework.ExpectNoError(err)
+
+			// Calculate calls made during this pod's deletion
+			podDeletionCalls := removeContainerCallCount - baselineCount
+			framework.Logf("RemoveContainer calls for this pod deletion: %d", podDeletionCalls)
+
+			// Verify that RemoveContainer was called at least once for this pod
+			gomega.Expect(podDeletionCalls).To(gomega.BeNumerically(">", 0),
+				"RemoveContainer should be called at least once for a single container pod")
+
+			// Verify that RemoveContainer was called at most once for this pod
+			gomega.Expect(podDeletionCalls).To(gomega.BeNumerically("<=", 1),
+				"RemoveContainer should be called at most once for a single container pod")
+		})
+	})
+
+	ginkgo.Context("Verify RemoveContainer call count for two container pod", func() {
+		ginkgo.BeforeEach(func() {
+			if err := resetCRIProxyInjector(e2eCriProxy); err != nil {
+				ginkgo.Skip("Skip the test since the CRI Proxy is undefined.")
+			}
+			ginkgo.DeferCleanup(func() error {
+				return resetCRIProxyInjector(e2eCriProxy)
+			})
+		})
+
+		ginkgo.It("Should call RemoveContainer at most three times for two container pod deletion", func(ctx context.Context) {
+			// Wait for cluster to be clean before starting test
+			err := waitForNoTerminatingPods(ctx, f)
+			framework.ExpectNoError(err)
+
+			// Set up RemoveContainer call tracking
+			removeContainerCallCount := 0
+			err = addCRIProxyInjector(e2eCriProxy, func(apiName string) error {
+				if apiName == criproxy.RemoveContainer {
+					removeContainerCallCount++
+					framework.Logf("RemoveContainer called, total count: %d", removeContainerCallCount)
+				}
+				return nil
+			})
+			framework.ExpectNoError(err)
+
+			// Create and wait for pod to be running
+			pod := e2epod.NewPodClient(f).Create(ctx, newTwoContainerPod())
+			podErr := e2epod.WaitForPodRunningInNamespace(ctx, f.ClientSet, pod)
+			framework.ExpectNoError(podErr)
+
+			// Record the baseline count before deletion
+			baselineCount := removeContainerCallCount
+			framework.Logf("Baseline RemoveContainer count before pod deletion: %d", baselineCount)
+
+			// Delete the pod
+			err = e2epod.NewPodClient(f).Delete(ctx, pod.Name, metav1.DeleteOptions{})
+			framework.ExpectNoError(err)
+
+			// Wait for pod to be deleted
+			err = e2epod.WaitForPodNotFoundInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name, 2*time.Minute)
+			framework.ExpectNoError(err)
+
+			// Calculate calls made during this pod's deletion
+			podDeletionCalls := removeContainerCallCount - baselineCount
+			framework.Logf("RemoveContainer calls for this pod deletion: %d", podDeletionCalls)
+
+			// Verify that RemoveContainer was called at least once for this pod
+			gomega.Expect(podDeletionCalls).To(gomega.BeNumerically(">", 0),
+				"RemoveContainer should be called at least once for a two container pod")
+
+			// Verify that RemoveContainer was called at most three times for this pod
+			// If two containers in a pod terminate simultaneously,
+			// PLEG will detect both exits and trigger two ContainerDied events.
+			// During the first event, all containers are removed since they're all
+			// in the Exited state in the pod cache. The second event then triggers an additional RemoveContainer() call.
+			//
+			// We have no complete solution for this, but compared to the previous
+			// implementation where RemoveContainer() calls grew exponentially with the
+			// number of containers in a pod, this already represents an improvement.
+			gomega.Expect(podDeletionCalls).To(gomega.BeNumerically("<=", 3),
+				"RemoveContainer should be called at most three times for a two container pod")
+		})
+	})
+})
+
+func newSingleContainerPod() *v1.Pod {
+	podName := "single-container-pod-" + string(uuid.NewUUID())
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: podName,
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Image: imageutils.GetE2EImage(imageutils.BusyBox),
+					Name:  "container1",
+					Command: []string{
+						"sh",
+						"-c",
+						"trap \"exit 0\" SIGTERM; while true; do sleep 1; done",
+					},
+				},
+			},
+		},
+	}
+	return pod
+}
+
+func newTwoContainerPod() *v1.Pod {
+	podName := "two-container-pod-" + string(uuid.NewUUID())
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: podName,
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Image: imageutils.GetE2EImage(imageutils.BusyBox),
+					Name:  "container1",
+					Command: []string{
+						"sh",
+						"-c",
+						"trap \"exit 0\" SIGTERM; while true; do sleep 1; done",
+					},
+				},
+				{
+					Image: imageutils.GetE2EImage(imageutils.BusyBox),
+					Name:  "container2",
+					Command: []string{
+						"sh",
+						"-c",
+						"trap \"exit 0\" SIGTERM; while true; do sleep 1; done",
+					},
+				},
+			},
+		},
+	}
+	return pod
+}
+
+// waitForNoTerminatingPods waits for cluster to be clean with no terminating pods
+func waitForNoTerminatingPods(ctx context.Context, f *framework.Framework) error {
+	ctx, cancel := context.WithTimeout(ctx, time.Minute*5)
+	defer cancel()
+	return wait.PollUntilContextCancel(ctx, time.Second, true, func(ctx context.Context) (bool, error) {
+		// Check all namespaces for terminating pods
+		pods, err := f.ClientSet.CoreV1().Pods("").List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return false, err
+		}
+
+		terminatingPods := []string{}
+		for _, pod := range pods.Items {
+			if pod.DeletionTimestamp != nil {
+				terminatingPods = append(terminatingPods, fmt.Sprintf("%s/%s", pod.Namespace, pod.Name))
+			}
+		}
+
+		if len(terminatingPods) > 0 {
+			framework.Logf("Still waiting for %d terminating pods to be fully deleted: %v",
+				len(terminatingPods), terminatingPods)
+			return false, nil
+		}
+
+		framework.Logf("No terminating pods found, cluster is clean")
+		return true, nil
+	})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
During the pod deletion process, due to concurrent conditions, removeContainer may be executed multiple times.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #131275

#### Special notes for your reviewer:

In PLEG, we send the `ContainerDied` events for both the sandbox and regular containers to `plegCh` simultaneously. In syncLoopIteration, upon receiving a `ContainerDied` event, we execute `kl.cleanUpContainersInPod(e.ID, containerID)` to clean up the containers in the pod.
https://github.com/kubernetes/kubernetes/blob/30469e180361d7da07b0fee6d47c776fa2cf3e86/pkg/kubelet/pleg/generic.go#L387-L397
https://github.com/kubernetes/kubernetes/blob/30469e180361d7da07b0fee6d47c776fa2cf3e86/pkg/kubelet/kubelet.go#L2550-L2566

In `cleanUpContainersInPod.deleteContainersInPod.getContainersToDeleteInPod`, we explicitly select only the container ID from `podStatus.ContainerStatuses` that matches `exitedContainerID`. This is to avoid triggering unnecessary `RemoveContainer` calls due to the sandbox's `ContainerDied` event.
https://github.com/kubernetes/kubernetes/blob/30469e180361d7da07b0fee6d47c776fa2cf3e86/pkg/kubelet/pod_container_deletor.go#L67-L77

However, there may be a race condition: if `SyncTerminatingPod` completes before the `ContainerDied` event is received, the pod's `status.terminatedAt` is set. In this case, the `removeAll` variable in `cleanUpContainersInPod` function is set to true, causing both sandbox and regular container `ContainerDied` events to trigger equivalent `RemoveContainer` executions.
https://github.com/kubernetes/kubernetes/blob/30469e180361d7da07b0fee6d47c776fa2cf3e86/pkg/kubelet/kubelet.go#L3181-L3187

However, since the removeAll parameter is set to true at this point, when removeAll is true, the deleteContainersInPod function iterates over all containers in the pod with an exited status and executes RemoveContainer for each of them. This results in the actual number of RemoveContainer executions being the square of the number of containers in the pod.
https://github.com/kubernetes/kubernetes/blob/b53b9fb5573323484af9a19cf3f5bfe80760abba/pkg/kubelet/pod_container_deletor.go#L103-L108
https://github.com/kubernetes/kubernetes/blob/b53b9fb5573323484af9a19cf3f5bfe80760abba/pkg/kubelet/pod_container_deletor.go#L85-L93

In the fix for this PR, I modified `deleteContainersInPod` to no longer accept the `removeAll` parameter. When `filterContainerID` is passed as an empty string, it follows the previous logic to delete all containers by default (previously, when the `removeAll` parameter was passed, `deleteContainersInPod` explicitly set `filterContainerID` to empty to achieve this, making the `removeAll` parameter unnecessary).

Additionally, I added a `keepMinimContainers` parameter to `deleteContainersInPod`. After a pod completes `SyncTerminatingPod`, we will delete the containers in the pod one by one based on the `ContainerDied` events generated by PLEG, and we will no longer retain a minimum number of containers in the pod. When `SyncTerminatingPod` is not yet complete, it adheres to the previous behavior, deleting containers in the pod one by one while retaining a minimum number of containers.
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
