### PR TITLE
chore: Add VeryShortWatchError typed error

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/reflector_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector_test.go
@@ -291,8 +291,7 @@ func TestReflectorHandleWatchResultChanClosedBefore(t *testing.T) {
 	// Simulate the result channel being closed by the producer before handleWatch is called.
 	close(resultCh)
 	err := handleWatch(ctx, time.Now(), fw, s, g.expectedType, g.expectedGVK, g.name, g.typeDescription, g.setLastSyncResourceVersion, g.clock, nevererrc)
-	// TODO(karlkfi): Add exact error type for "very short watch"
-	require.Error(t, err)
+	require.Equal(t, &VeryShortWatchError{Name: g.name}, err)
 	// Ensure handleWatch calls ResultChan and Stop
 	assert.Equal(t, []string{"ResultChan", "Stop"}, calls)
 }
@@ -323,8 +322,7 @@ func TestReflectorHandleWatchResultChanClosedAfter(t *testing.T) {
 		},
 	}
 	err := handleWatch(ctx, time.Now(), fw, s, g.expectedType, g.expectedGVK, g.name, g.typeDescription, g.setLastSyncResourceVersion, g.clock, nevererrc)
-	// TODO(karlkfi): Add exact error type for "very short watch"
-	require.Error(t, err)
+	require.Equal(t, &VeryShortWatchError{Name: g.name}, err)
 	// Ensure handleWatch calls ResultChan and Stop
 	assert.Equal(t, []string{"ResultChan", "Stop"}, calls)
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it?
- Clean up the Reflector unit tests to expect specific errors.
- Add a new `VeryShortWatchError` to make it possible to compare by type with `errors.Is` & `errors.As`.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

Technically the error type changed, but the error message is the same. Should not affect end users, but might require some client-go users to change their test expectations, if matching by exact error type.