### PR TITLE
Fix negative pod startup duration values

### DIFF
--- a/pkg/kubelet/images/image_manager.go
+++ b/pkg/kubelet/images/image_manager.go
@@ -181,6 +181,11 @@ func (m *imageManager) EnsureImageExists(ctx context.Context, objRef *v1.ObjectR
 	if imageRef != "" && !utilfeature.DefaultFeatureGate.Enabled(features.KubeletEnsureSecretPulledImages) {
 		msg := fmt.Sprintf("Container image %q already present on machine", requestedImage)
 		m.logIt(objRef, v1.EventTypeNormal, events.PulledImage, logPrefix, msg, klog.Info)
+
+		// we need to stop recording if it is still in progress, as the image
+		// has already been pulled by another pod.
+		m.podPullingTimeRecorder.RecordImageFinishedPulling(pod.UID)
+
 		return imageRef, msg, nil
 	}
 

--- a/pkg/kubelet/images/image_manager.go
+++ b/pkg/kubelet/images/image_manager.go
@@ -243,6 +243,11 @@ func (m *imageManager) EnsureImageExists(ctx context.Context, objRef *v1.ObjectR
 		if !pullRequired {
 			msg := fmt.Sprintf("Container image %q already present on machine and can be accessed by the pod", requestedImage)
 			m.logIt(objRef, v1.EventTypeNormal, events.PulledImage, logPrefix, msg, klog.Info)
+
+			// we need to stop recording if it is still in progress, as the image
+			// has already been pulled by another pod.
+			m.podPullingTimeRecorder.RecordImageFinishedPulling(pod.UID)
+
 			return imageRef, msg, nil
 		}
 	}

--- a/pkg/kubelet/images/image_manager_test.go
+++ b/pkg/kubelet/images/image_manager_test.go
@@ -665,27 +665,33 @@ func ensureSecretImagesTestCases() []pullerTestCase {
 
 type mockPodPullingTimeRecorder struct {
 	sync.Mutex
-	startedPullingRecorded  bool
-	finishedPullingRecorded bool
+	startedPullingRecorded  map[types.UID]bool
+	finishedPullingRecorded map[types.UID]bool
 }
 
 func (m *mockPodPullingTimeRecorder) RecordImageStartedPulling(podUID types.UID) {
 	m.Lock()
 	defer m.Unlock()
-	m.startedPullingRecorded = true
+
+	if !m.startedPullingRecorded[podUID] {
+		m.startedPullingRecorded[podUID] = true
+	}
 }
 
 func (m *mockPodPullingTimeRecorder) RecordImageFinishedPulling(podUID types.UID) {
 	m.Lock()
 	defer m.Unlock()
-	m.finishedPullingRecorded = true
+
+	if m.startedPullingRecorded[podUID] {
+		m.finishedPullingRecorded[podUID] = true
+	}
 }
 
 func (m *mockPodPullingTimeRecorder) reset() {
 	m.Lock()
 	defer m.Unlock()
-	m.startedPullingRecorded = false
-	m.finishedPullingRecorded = false
+	clear(m.startedPullingRecorded)
+	clear(m.finishedPullingRecorded)
 }
 
 type mockImagePullManager struct {
@@ -799,7 +805,10 @@ func pullerTestEnv(
 	fakeRuntime.Err = c.pullerErr
 	fakeRuntime.InspectErr = c.inspectErr
 
-	fakePodPullingTimeRecorder = &mockPodPullingTimeRecorder{}
+	fakePodPullingTimeRecorder = &mockPodPullingTimeRecorder{
+		startedPullingRecorded:  make(map[types.UID]bool),
+		finishedPullingRecorded: make(map[types.UID]bool),
+	}
 
 	pullManager := &mockImagePullManager{
 		config: c.allowedCredentials,
@@ -865,8 +874,8 @@ func TestParallelPuller(t *testing.T) {
 				_, msg, err := puller.EnsureImageExists(ctx, nil, pod, container.Image, c.pullSecrets, podSandboxConfig, "", container.ImagePullPolicy)
 				fakeRuntime.AssertCalls(expected.calls)
 				assert.Equal(t, expected.err, err)
-				assert.Equal(t, expected.shouldRecordStartedPullingTime, fakePodPullingTimeRecorder.startedPullingRecorded)
-				assert.Equal(t, expected.shouldRecordFinishedPullingTime, fakePodPullingTimeRecorder.finishedPullingRecorded)
+				assert.Equal(t, expected.shouldRecordStartedPullingTime, fakePodPullingTimeRecorder.startedPullingRecorded[pod.UID])
+				assert.Equal(t, expected.shouldRecordFinishedPullingTime, fakePodPullingTimeRecorder.finishedPullingRecorded[pod.UID])
 				assert.Contains(t, msg, expected.msg)
 				fakePodPullingTimeRecorder.reset()
 			}
@@ -911,8 +920,8 @@ func TestSerializedPuller(t *testing.T) {
 				_, msg, err := puller.EnsureImageExists(ctx, nil, pod, container.Image, c.pullSecrets, podSandboxConfig, "", container.ImagePullPolicy)
 				fakeRuntime.AssertCalls(expected.calls)
 				assert.Equal(t, expected.err, err)
-				assert.Equal(t, expected.shouldRecordStartedPullingTime, fakePodPullingTimeRecorder.startedPullingRecorded)
-				assert.Equal(t, expected.shouldRecordFinishedPullingTime, fakePodPullingTimeRecorder.finishedPullingRecorded)
+				assert.Equal(t, expected.shouldRecordStartedPullingTime, fakePodPullingTimeRecorder.startedPullingRecorded[pod.UID])
+				assert.Equal(t, expected.shouldRecordFinishedPullingTime, fakePodPullingTimeRecorder.finishedPullingRecorded[pod.UID])
 				assert.Contains(t, msg, expected.msg)
 				fakePodPullingTimeRecorder.reset()
 			}
@@ -984,8 +993,8 @@ func TestPullAndListImageWithPodAnnotations(t *testing.T) {
 		_, _, err := puller.EnsureImageExists(ctx, nil, pod, container.Image, c.pullSecrets, podSandboxConfig, "", container.ImagePullPolicy)
 		fakeRuntime.AssertCalls(c.expected[0].calls)
 		assert.Equal(t, c.expected[0].err, err, "tick=%d", 0)
-		assert.Equal(t, c.expected[0].shouldRecordStartedPullingTime, fakePodPullingTimeRecorder.startedPullingRecorded)
-		assert.Equal(t, c.expected[0].shouldRecordFinishedPullingTime, fakePodPullingTimeRecorder.finishedPullingRecorded)
+		assert.Equal(t, c.expected[0].shouldRecordStartedPullingTime, fakePodPullingTimeRecorder.startedPullingRecorded[pod.UID])
+		assert.Equal(t, c.expected[0].shouldRecordFinishedPullingTime, fakePodPullingTimeRecorder.finishedPullingRecorded[pod.UID])
 
 		images, _ := fakeRuntime.ListImages(ctx)
 		assert.Len(t, images, 1, "ListImages() count")
@@ -1048,8 +1057,8 @@ func TestPullAndListImageWithRuntimeHandlerInImageCriAPIFeatureGate(t *testing.T
 		_, _, err := puller.EnsureImageExists(ctx, nil, pod, container.Image, c.pullSecrets, podSandboxConfig, runtimeHandler, container.ImagePullPolicy)
 		fakeRuntime.AssertCalls(c.expected[0].calls)
 		assert.Equal(t, c.expected[0].err, err, "tick=%d", 0)
-		assert.Equal(t, c.expected[0].shouldRecordStartedPullingTime, fakePodPullingTimeRecorder.startedPullingRecorded)
-		assert.Equal(t, c.expected[0].shouldRecordFinishedPullingTime, fakePodPullingTimeRecorder.finishedPullingRecorded)
+		assert.Equal(t, c.expected[0].shouldRecordStartedPullingTime, fakePodPullingTimeRecorder.startedPullingRecorded[pod.UID])
+		assert.Equal(t, c.expected[0].shouldRecordFinishedPullingTime, fakePodPullingTimeRecorder.finishedPullingRecorded[pod.UID])
 
 		images, _ := fakeRuntime.ListImages(ctx)
 		assert.Len(t, images, 1, "ListImages() count")
@@ -1141,6 +1150,93 @@ func TestMaxParallelImagePullsLimit(t *testing.T) {
 
 	wg.Wait()
 	fakeRuntime.AssertCallCounts("PullImage", 7)
+}
+
+func TestParallelPodPullingTimeRecorderWithErr(t *testing.T) {
+	ctx := context.Background()
+	pod1 := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test_pod1",
+			Namespace:       "test-ns",
+			UID:             "bar1",
+			ResourceVersion: "42",
+		}}
+
+	pod2 := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test_pod2",
+			Namespace:       "test-ns",
+			UID:             "bar2",
+			ResourceVersion: "42",
+		}}
+
+	pods := [2]*v1.Pod{pod1, pod2}
+
+	testCase := &pullerTestCase{
+		containerImage: "missing_image",
+		testName:       "missing image, pull if not present",
+		policy:         v1.PullIfNotPresent,
+		inspectErr:     nil,
+		pullerErr:      nil,
+		qps:            0.0,
+		burst:          0,
+	}
+
+	useSerializedEnv := false
+	maxParallelImagePulls := 2
+	var wg sync.WaitGroup
+
+	puller, fakeClock, fakeRuntime, container, fakePodPullingTimeRecorder, _ := pullerTestEnv(t, *testCase, useSerializedEnv, ptr.To(int32(maxParallelImagePulls)))
+	fakeRuntime.BlockImagePulls = true
+	fakeRuntime.CalledFunctions = nil
+	fakeRuntime.T = t
+	fakeClock.Step(time.Second)
+
+	// First, each pod's puller calls EnsureImageExists
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func(i int) {
+			_, _, _ = puller.EnsureImageExists(ctx, nil, pods[i], container.Image, testCase.pullSecrets, nil, "", container.ImagePullPolicy)
+			wg.Done()
+		}(i)
+	}
+	time.Sleep(1 * time.Second)
+
+	// Assert the number of PullImage calls is 2
+	fakeRuntime.AssertCallCounts("PullImage", 2)
+
+	// Recording for both of the pods should be started but not finished
+	assert.True(t, fakePodPullingTimeRecorder.startedPullingRecorded[pods[0].UID])
+	assert.True(t, fakePodPullingTimeRecorder.startedPullingRecorded[pods[1].UID])
+	assert.False(t, fakePodPullingTimeRecorder.finishedPullingRecorded[pods[0].UID])
+	assert.False(t, fakePodPullingTimeRecorder.finishedPullingRecorded[pods[1].UID])
+
+	// Unblock one of the pods to pull the image
+	fakeRuntime.UnblockImagePulls(1)
+	time.Sleep(1 * time.Second)
+
+	// Introduce a pull error for the second pod and unblock it
+	fakeRuntime.SendImagePullError(errors.New("pull image error"))
+
+	wg.Wait()
+
+	// This time EnsureImageExists will return without pulling
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func(i int) {
+			_, _, err := puller.EnsureImageExists(ctx, nil, pods[i], container.Image, testCase.pullSecrets, nil, "", container.ImagePullPolicy)
+			assert.NoError(t, err)
+			wg.Done()
+		}(i)
+	}
+	wg.Wait()
+
+	// Assert the number of PullImage calls is still 2
+	fakeRuntime.AssertCallCounts("PullImage", 2)
+
+	// Both recorders should be finished
+	assert.True(t, fakePodPullingTimeRecorder.finishedPullingRecorded[pods[0].UID])
+	assert.True(t, fakePodPullingTimeRecorder.finishedPullingRecorded[pods[1].UID])
 }
 
 func TestEvalCRIPullErr(t *testing.T) {

--- a/pkg/kubelet/util/pod_startup_latency_tracker.go
+++ b/pkg/kubelet/util/pod_startup_latency_tracker.go
@@ -150,7 +150,9 @@ func (p *basicPodStartupLatencyTracker) RecordImageFinishedPulling(podUID types.
 		return
 	}
 
-	state.lastFinishedPulling = p.clock.Now() // Now is always grater than values from the past.
+	if !state.firstStartedPulling.IsZero() {
+		state.lastFinishedPulling = p.clock.Now() // Now is always grater than values from the past.
+	}
 }
 
 func (p *basicPodStartupLatencyTracker) RecordStatusUpdated(pod *v1.Pod) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
I faced an issue with the pod startup duration metric, which sometimes shows negative values. This problem is also mentioned here #130432. 

When parallel image pulling is enabled (`serializeImagePulls: false`) and the image pull policy is `IfNotPresent`, this problem may happen. When there are multiple pods concurrently pulling the image, it is possible that some of the pull requests fail (e.g., pull QPS excess). It means that some pods start recording the image pull duration, but they never stop it since they return due to an error.

https://github.com/kubernetes/kubernetes/blob/44c230bf5c321056e8bc89300b37c497f464f113/pkg/kubelet/images/image_manager.go#L284-L302

After the back-off duration, these pods retry and call `EnsureImageExists`, but this time, they don't call `pullImage` as the image already exists.

https://github.com/kubernetes/kubernetes/blob/44c230bf5c321056e8bc89300b37c497f464f113/pkg/kubelet/images/image_manager.go#L209-L246

Therefore, `state.lastFinishedPulling` never will be set.

To fix the issue, we can finish the recording by calling `RecordImageFinishedPulling` before returning from `EnsureImageExists` if there is some recording in progress (i.e., `!state.firstStartedPulling.IsZero()`). The measured pull duration is also correct, as it is the time the pod has taken to finally retrieve the image (start recording -> pull the image -> error -> retry -> image already exists -> finish recording).

I also tested the fix and couldn't reproduce the problem after that.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #130432

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
