### PR TITLE
[WIP] refactor: clean up the watch server handlers

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/apitesting/http.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/apitesting/http.go
@@ -1,0 +1,213 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apitesting
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"reflect"
+	"strings"
+
+	"github.com/google/go-cmp/cmp" //nolint:depguard // Test library
+)
+
+// errReadOnClosedResBody is returned by methods in the "http" package, when
+// reading from a response body after it's been closed.
+// Detecting this error is required because read is not cancellable.
+// From https://github.com/golang/go/blob/go1.20/src/net/http/transport.go#L2779
+var errReadOnClosedResBody = errors.New("http: read on closed response body")
+
+// errCloseOnClosedWebSocket is returned by methods in the "k8s.io/utils/net"
+// package, when accepting or closing a websocket multiListener that is already
+// closed.
+var errCloseOnClosedWebSocket = fmt.Errorf("use of closed network connection")
+
+// AssertBodyClosed fails the test if the response Body is NOT closed.
+// If not already closed, the response body will be drained and closed.
+//
+// Defer when your test is expected to close the response body before ending.
+func AssertBodyClosed(t TestingT, body io.ReadCloser) {
+	t.Helper()
+	assertEqual(t, errReadOnClosedResBody, DrainAndCloseBody(body))
+}
+
+// AssertWebSocketClosed fails the test if the WebSocket is NOT closed.
+// If not already closed, the response body will be drained and closed.
+//
+// Defer when your test is expected to close the WebSocket before ending.
+func AssertWebSocketClosed(t TestingT, ws io.ReadCloser) {
+	t.Helper()
+	// The expected error is a errors.Join of two net.OpError instances, a read
+	// and a write. But we don't know the source or destination, so we can't
+	// match the exact error.
+	AssertWebSocketClosedError(t, DrainAndCloseBody(ws))
+}
+
+// AssertWebSocketClosedError fails the test if the WebSocket error is NOT
+// errCloseOnClosedWebSocket or wrapping errCloseOnClosedWebSocket.
+//
+// Use in your test when a WebSocket operation is expected to error due to
+// having already been closed.
+func AssertWebSocketClosedError(t TestingT, err error) {
+	t.Helper()
+	// The expected error is a net.OpError instance, but we don't know the
+	// operation, source, or destination, so we can't match the exact error.
+	assertErrorContains(t, err, errCloseOnClosedWebSocket.Error())
+}
+
+// Close closes the closer and fails the test if close errors.
+//
+// Defer when your test does not need to fully read or drain the response body
+// before ending.
+func Close(t TestingT, body io.Closer) {
+	t.Helper()
+	assertNoError(t, body.Close())
+}
+
+// DrainAndCloseBody reads from the response body until EOF, discarding the
+// content, and closes the response body when finished or on error.
+// Returns an error when either Read or Close error. If both error, the errors
+// are joined and returned.
+//
+// In a defer from a test, use with t.Error or assert.NoError, NOT t.Fatal or
+// require.NoError, unless the defer also captures panics, otherwise the test
+// may not fail.
+func DrainAndCloseBody(body io.ReadCloser) error {
+	errCh := make(chan error)
+	go func() {
+		// Close after done reading
+		defer func() {
+			defer close(errCh)
+			if err := body.Close(); err != nil {
+				errCh <- err
+			}
+		}()
+		// Read until EOF and discard
+		if _, err := io.Copy(io.Discard, body); err != nil {
+			errCh <- err
+		}
+	}()
+
+	// Wait until Read and Close are both done.
+	// Combine errors, if multiple.
+	var multiErr error
+	for err := range errCh {
+		if multiErr != nil {
+			multiErr = errors.Join(multiErr, err)
+		} else {
+			multiErr = err
+		}
+	}
+	return multiErr
+}
+
+// ReadAndCloseBody reads from the response body until EOF and then
+// closing the body, returning the content and any errors.
+// Returns an error when either Read or Close error. If both error, the errors
+// are joined and returned.
+func ReadAndCloseBody(body io.ReadCloser) ([]byte, error) {
+	errCh := make(chan error)
+	bodyCh := make(chan []byte)
+	go func() {
+		// Close after done reading
+		defer func() {
+			defer close(errCh)
+			if err := body.Close(); err != nil {
+				errCh <- err
+			}
+		}()
+		defer close(bodyCh)
+		// Read until EOF and discard
+		bodyBytes, err := io.ReadAll(body)
+		if err != nil {
+			errCh <- err
+		}
+		bodyCh <- bodyBytes
+	}()
+
+	// Wait until Read and Close are both done.
+	// Combine errors, if multiple.
+	var bodyBytes []byte
+	var multiErr error
+	var errClosed, bodyClosed bool
+	for {
+		select {
+		case err, ok := <-errCh:
+			if !ok {
+				if bodyClosed {
+					return bodyBytes, multiErr
+				}
+				errClosed = true
+				continue
+			}
+			if multiErr != nil {
+				multiErr = errors.Join(multiErr, err)
+			} else {
+				multiErr = err
+			}
+		case b, ok := <-bodyCh:
+			if !ok {
+				if errClosed {
+					return bodyBytes, multiErr
+				}
+				bodyClosed = true
+				continue
+			}
+			bodyBytes = b
+		}
+	}
+}
+
+// TestingT simulates assert.TestingT and assert.tHelper without requiring an
+// extra non-test dependency.
+type TestingT interface {
+	Errorf(format string, args ...interface{})
+	Helper()
+}
+
+// assertEqual simulates assert.Equal without requiring an extra non-test
+// dependency. Use github.com/stretchr/testify/assert for tests.
+func assertEqual[T any](t TestingT, expected, actual T) {
+	t.Helper()
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("Not equal: \n"+
+			"expected: %s\n"+
+			"actual  : %s%s",
+			expected, actual, cmp.Diff(expected, actual))
+	}
+}
+
+// assertErrorContains simulates assert.ErrorContains without requiring an extra
+// non-test dependency. Use github.com/stretchr/testify/assert for tests.
+func assertErrorContains(t TestingT, err error, substr string) {
+	t.Helper()
+	if err == nil {
+		t.Errorf("An error is expected but got nil.")
+	} else if !strings.Contains(err.Error(), substr) {
+		t.Errorf("Error %#v does not contain %#v", err, substr)
+	}
+}
+
+// assertNoError simulates assert.NoError without requiring an extra non-test
+// dependency. Use github.com/stretchr/testify/assert for tests.
+func assertNoError(t TestingT, err error) {
+	t.Helper()
+	if err != nil {
+		t.Errorf("Received unexpected error:\n%+v", err)
+	}
+}

--- a/staging/src/k8s.io/apimachinery/pkg/util/net/http.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/net/http.go
@@ -92,6 +92,8 @@ func IsProbableEOF(err error) bool {
 		return true
 	case msg == "http: can't write HTTP request on broken connection":
 		return true
+	case msg == "http: read on closed response body":
+		return true
 	case strings.Contains(msg, "http2: server sent GOAWAY and closed the connection"):
 		return true
 	case strings.Contains(msg, "connection reset by peer"):

--- a/staging/src/k8s.io/client-go/rest/request.go
+++ b/staging/src/k8s.io/client-go/rest/request.go
@@ -815,7 +815,8 @@ func (r *Request) watchInternal(ctx context.Context) (watch.Interface, runtime.D
 					cancel = func() {}
 					return true, w, d, nil
 				}
-				// Cancel the request immediately
+				// Failed to create watcher, likely due to negotiation failure.
+				// Cancel the request to free up resources.
 				cancel()
 				// Handle stream error like a request error
 				err = streamErr

--- a/staging/src/k8s.io/client-go/rest/watch/decoder_test.go
+++ b/staging/src/k8s.io/client-go/rest/watch/decoder_test.go
@@ -21,8 +21,10 @@ import (
 	"fmt"
 	"io"
 	"testing"
-	"time"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -32,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes/scheme"
+	utiltesting "k8s.io/client-go/util/testing"
 )
 
 // getDecoder mimics how k8s.io/client-go/rest.createSerializers creates a decoder
@@ -45,86 +48,107 @@ func TestDecoder(t *testing.T) {
 	table := []watch.EventType{watch.Added, watch.Deleted, watch.Modified, watch.Error, watch.Bookmark}
 
 	for _, eventType := range table {
-		out, in := io.Pipe()
+		t.Run(string(eventType), func(t *testing.T) {
+			out, in := io.Pipe()
+			defer assertNoCloseError(t, in)
+			decoder := NewDecoder(streaming.NewDecoder(out, getDecoder()), getDecoder())
+			defer decoder.Close()
+			expect := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}
+			encoder := json.NewEncoder(in)
+			eType := eventType
 
-		decoder := NewDecoder(streaming.NewDecoder(out, getDecoder()), getDecoder())
-		expect := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}
-		encoder := json.NewEncoder(in)
-		eType := eventType
-		errc := make(chan error)
+			encodeErrCh := make(chan error)
+			go func() {
+				defer close(encodeErrCh)
+				data, err := runtime.Encode(scheme.Codecs.LegacyCodec(v1.SchemeGroupVersion), expect)
+				if err != nil {
+					encodeErrCh <- fmt.Errorf("encode error: %w", err)
+					return
+				}
+				event := metav1.WatchEvent{
+					Type:   string(eType),
+					Object: runtime.RawExtension{Raw: json.RawMessage(data)},
+				}
+				if err := encoder.Encode(&event); err != nil {
+					encodeErrCh <- fmt.Errorf("encode error: %w", err)
+					return
+				}
+			}()
 
-		go func() {
-			data, err := runtime.Encode(scheme.Codecs.LegacyCodec(v1.SchemeGroupVersion), expect)
-			if err != nil {
-				errc <- fmt.Errorf("Unexpected error %v", err)
-				return
-			}
-			event := metav1.WatchEvent{
-				Type:   string(eType),
-				Object: runtime.RawExtension{Raw: json.RawMessage(data)},
-			}
-			if err := encoder.Encode(&event); err != nil {
-				t.Errorf("Unexpected error %v", err)
-			}
-			in.Close()
-		}()
+			decodeErrCh := make(chan error)
+			go func() {
+				defer close(decodeErrCh)
+				action, got, err := decoder.Decode()
+				if err != nil {
+					decodeErrCh <- fmt.Errorf("decode error: %w", err)
+					return
+				}
+				assert.Equal(t, eType, action)
+				if !apiequality.Semantic.DeepDerivative(expect, got) {
+					t.Errorf("Unexpected watch event object, diff: %s", cmp.Diff(expect, got))
+				}
+			}()
 
-		done := make(chan struct{})
-		go func() {
-			action, got, err := decoder.Decode()
-			if err != nil {
-				errc <- fmt.Errorf("Unexpected error %v", err)
-				return
-			}
-			if e, a := eType, action; e != a {
-				t.Errorf("Expected %v, got %v", e, a)
-			}
-			if e, a := expect, got; !apiequality.Semantic.DeepDerivative(e, a) {
-				t.Errorf("Expected %v, got %v", e, a)
-			}
-			t.Logf("Exited read")
-			close(done)
-		}()
-		select {
-		case err := <-errc:
-			t.Fatal(err)
-		case <-done:
-		}
+			// Wait for encoder and decoder to return without error
+			err := utiltesting.WaitForAllChannelsToCloseWithTimeout(t.Context(),
+				wait.ForeverTestTimeout, encodeErrCh, decodeErrCh)
+			require.NoError(t, err)
 
-		done = make(chan struct{})
-		go func() {
-			_, _, err := decoder.Decode()
-			if err == nil {
-				t.Errorf("Unexpected nil error")
-			}
-			close(done)
-		}()
-		<-done
+			// Close the input pipe, which should cause the decoder to error
+			require.NoError(t, in.Close())
 
-		decoder.Close()
+			// Wait for decoder EOF error
+			decodeErrCh = make(chan error)
+			go func() {
+				defer close(decodeErrCh)
+				_, _, err := decoder.Decode()
+				if err != nil {
+					decodeErrCh <- err
+				}
+			}()
+
+			// Wait for decoder EOF error
+			decodeErr, err := utiltesting.WaitForChannelEventWithTimeout(t.Context(), wait.ForeverTestTimeout, decodeErrCh)
+			require.NoError(t, err)
+			require.Equal(t, io.EOF, decodeErr)
+
+			// Wait for errCh to close
+			err = utiltesting.WaitForChannelToCloseWithTimeout(t.Context(), wait.ForeverTestTimeout, decodeErrCh)
+			require.NoError(t, err)
+		})
 	}
 }
 
 func TestDecoder_SourceClose(t *testing.T) {
 	out, in := io.Pipe()
+	defer assertNoCloseError(t, in)
 	decoder := NewDecoder(streaming.NewDecoder(out, getDecoder()), getDecoder())
+	defer decoder.Close()
 
-	done := make(chan struct{})
-
+	errCh := make(chan error)
 	go func() {
+		defer close(errCh)
 		_, _, err := decoder.Decode()
-		if err == nil {
-			t.Errorf("Unexpected nil error")
+		if err != nil {
+			errCh <- err
 		}
-		close(done)
 	}()
 
-	in.Close()
+	// Close the input pipe, which should cause the decoder to error
+	require.NoError(t, in.Close())
 
-	select {
-	case <-done:
-		break
-	case <-time.After(wait.ForeverTestTimeout):
-		t.Error("Timeout")
-	}
+	// Wait for decoder EOF error
+	decodeErr, err := utiltesting.WaitForChannelEventWithTimeout(t.Context(), wait.ForeverTestTimeout, errCh)
+	require.NoError(t, err)
+	require.Equal(t, io.EOF, decodeErr)
+
+	// Wait for errCh to close
+	err = utiltesting.WaitForChannelToCloseWithTimeout(t.Context(), wait.ForeverTestTimeout, errCh)
+	require.NoError(t, err)
+}
+
+// assertNoCloseError asserts that closing the Closer doesn't error.
+// Safe to call in a defer to ensure Closer.Close is called.
+func assertNoCloseError(t *testing.T, c io.Closer) {
+	assert.NoError(t, c.Close())
 }

--- a/staging/src/k8s.io/client-go/util/testing/channels.go
+++ b/staging/src/k8s.io/client-go/util/testing/channels.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"time"
+)
+
+// WaitForChannelEvent blocks until the channel receives an event.
+// Returns an error if the channel is closed or the context is done.
+func WaitForChannelEvent[T any](ctx context.Context, ch <-chan T) (T, error) {
+	var t T // zero value
+	for {
+		select {
+		case <-ctx.Done():
+			err := ctx.Err()
+			switch err {
+			case context.DeadlineExceeded:
+				return t, fmt.Errorf("timed out waiting for channel to close: %w", err)
+			default:
+				return t, fmt.Errorf("context cancelled before channel closed: %w", err)
+			}
+		case event, ok := <-ch:
+			if !ok {
+				return t, errors.New("channel closed before receiving event")
+			}
+			return event, nil
+		}
+	}
+}
+
+// WaitForChannelToClose blocks until the channel is closed.
+// Returns an error if any events are received or the context is done.
+func WaitForChannelToClose[T any](ctx context.Context, ch <-chan T) error {
+	for {
+		select {
+		case <-ctx.Done():
+			err := ctx.Err()
+			switch err {
+			case context.DeadlineExceeded:
+				return fmt.Errorf("timed out waiting for channel to close: %w", err)
+			default:
+				return fmt.Errorf("context cancelled before channel closed: %w", err)
+			}
+		case event, ok := <-ch:
+			if !ok {
+				return nil
+			}
+			return fmt.Errorf("channel received unexpected event: %#v", event)
+		}
+	}
+}
+
+// WaitForAllChannelsToClose blocks until all the channels are closed.
+// Returns an error if any events are received or the context is done.
+func WaitForAllChannelsToClose[T any](ctx context.Context, channels ...<-chan T) error {
+	// Build a list of cases to select from
+	cases := make([]reflect.SelectCase, len(channels)+1)
+	for i, ch := range channels {
+		cases[i] = reflect.SelectCase{
+			Dir:  reflect.SelectRecv,
+			Chan: reflect.ValueOf(ch),
+		}
+	}
+	// Add the context done channel as the last case
+	contextCaseIndex := len(channels)
+	cases[contextCaseIndex] = reflect.SelectCase{
+		Dir:  reflect.SelectRecv,
+		Chan: reflect.ValueOf(ctx.Done()),
+	}
+	// Select from the cases until all channels are closed, an event is received,
+	// or the context is done.
+	channelsRemaining := len(cases)
+	for channelsRemaining > 1 {
+		// Block until one of the channels receives an event or closes
+		chosenIndex, value, ok := reflect.Select(cases)
+		if !ok {
+			// Return error immediately if the context is done
+			if chosenIndex == contextCaseIndex {
+				err := ctx.Err()
+				switch err {
+				case context.DeadlineExceeded:
+					return fmt.Errorf("timed out waiting for channel to close: %w", err)
+				default:
+					return fmt.Errorf("context cancelled before channel closed: %w", err)
+				}
+			}
+			// Remove closed channel from case to ignore it going forward
+			cases[chosenIndex].Chan = reflect.ValueOf(nil)
+			channelsRemaining--
+			continue
+		}
+		// All events received are treated as errors
+		return fmt.Errorf("channel %d received unexpected event: %#v", chosenIndex, value.Interface())
+	}
+	// All channels closed before the context was done
+	return nil
+}
+
+// WaitForChannelEventWithTimeout blocks until the channel receives an event.
+// Returns an error if the channel is closed, the context is done, or the
+// timeout is reached
+func WaitForChannelEventWithTimeout[T any](ctx context.Context, timeout time.Duration, ch <-chan T) (T, error) {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	return WaitForChannelEvent(ctx, ch)
+}
+
+// WaitForChannelToClose blocks until the channel is closed.
+// Returns an error if any events are received, the context is done, or the
+// timeout is reached
+func WaitForChannelToCloseWithTimeout[T any](ctx context.Context, timeout time.Duration, ch <-chan T) error {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	return WaitForChannelToClose(ctx, ch)
+}
+
+// WaitForAllChannelsToCloseWithTimeout blocks until all the channels are closed.
+// Returns an error if any events are received, the context is done, or the
+// timeout is reached
+func WaitForAllChannelsToCloseWithTimeout[T any](ctx context.Context, timeout time.Duration, channels ...<-chan T) error {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	return WaitForAllChannelsToClose(ctx, channels...)
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/sig api-machinery

#### What this PR does / why we need it
- Always stop the watcher when done reading events from the result
  channel. ListResource already stops the watch, but it's multiple
  layers above, which means unit tests of the internal methods need
  to replicate that behavior. So this change simplifies testing and
  ensures the watcher is stopped at least once. This should also make
  it easier to simplify the WatchServer in the future.
- Avoid calling Done & ResultChan multiple times, to reduce locking
  and memory allocations.
- Replace the TimeoutFactory with a Context, to reduce complexity.
- Use the -Ch suffix for channel variables.
- Add a done channel to the WatchServer to handle cleanup:
  stop the context and the storage watcher.
- Fix some flaky tests that were trying to use SimpleStorage.fakeWatcher
  before Watch was called.
- Validate url.Parse does not error in tests.
- Add apitesting http methods for handling response body drain, read,
  and closure.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Dependencies
- https://github.com/kubernetes/kubernetes/pull/131339
- https://github.com/kubernetes/kubernetes/pull/131457