### PR TITLE
servicecidr: only patch status if necessary

### DIFF
--- a/pkg/controller/servicecidrs/OWNERS
+++ b/pkg/controller/servicecidrs/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - sig-network-approvers
+reviewers:
+  - sig-network-reviewers
+labels:
+  - sig/network


### PR DESCRIPTION

/kind bug
/kind cleanup
```release-note
NONE
```

This is generating unnecessary work for the allocators, and network traffic between the controller manager and the apiserver, for a noop operations.
Only apply the condition if is necessary, the code is verbose on purpose for backporting, since will go in next patch release

/sig network