### PR TITLE
e2e: CreateSync: wait for all containers to run

### DIFF
--- a/test/e2e/framework/pod/pod_client.go
+++ b/test/e2e/framework/pod/pod_client.go
@@ -151,6 +151,11 @@ func (c *PodClient) CreateSync(ctx context.Context, pod *v1.Pod) *v1.Pod {
 	// Get the newest pod after it becomes running and ready, some status may change after pod created, such as pod ip.
 	p, err := c.Get(ctx, p.Name, metav1.GetOptions{})
 	framework.ExpectNoError(err)
+	// Wait for all pod containers to run.
+	for _, container := range pod.Spec.Containers {
+		err = WaitForContainerRunning(ctx, c.f.ClientSet, pod.Namespace, pod.Name, container.Name, framework.PodStartShortTimeout)
+		framework.ExpectNoError(err, "failed to wait for container %s to be running", container.Name)
+	}
 	return p
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Users of `CreateSync` assume that all pod containers are running if pod is in `Ready` state. This is not the case as described in https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase. Containers can be also [re]starting.

Adding explicit check for all pod containers to be in `Running` state should make `CreateSync` function to satisfy users assumptions.

#### Special notes for your reviewer:

This fix was proposed [here](https://github.com/kubernetes/kubernetes/pull/130178#discussion_r1957120528).

#### Does this PR introduce a user-facing change?

```release-note
NONE
```