### PR TITLE
Add `authorization-webhook-cache-size` for configuring authz webhookresponse cache

### DIFF
--- a/pkg/kubeapiserver/options/authorization.go
+++ b/pkg/kubeapiserver/options/authorization.go
@@ -44,6 +44,7 @@ const (
 	authorizationWebhookConfigFileFlag      = "authorization-webhook-config-file"
 	authorizationWebhookVersionFlag         = "authorization-webhook-version"
 	authorizationWebhookAuthorizedTTLFlag   = "authorization-webhook-cache-authorized-ttl"
+	authorizationWebhookCacheSizeFlag       = "authorization-webhook-cache-size"
 	authorizationWebhookUnauthorizedTTLFlag = "authorization-webhook-cache-unauthorized-ttl"
 	authorizationPolicyFileFlag             = "authorization-policy-file"
 	authorizationConfigFlag                 = "authorization-config"
@@ -57,6 +58,7 @@ type BuiltInAuthorizationOptions struct {
 	WebhookVersion              string
 	WebhookCacheAuthorizedTTL   time.Duration
 	WebhookCacheUnauthorizedTTL time.Duration
+	WebhookCacheSize            int
 	// WebhookRetryBackoff specifies the backoff parameters for the authorization webhook retry logic.
 	// This allows us to configure the sleep time at each iteration and the maximum number of retries allowed
 	// before we fail the webhook call in order to limit the fan out that ensues when the system is degraded.
@@ -80,6 +82,7 @@ func NewBuiltInAuthorizationOptions() *BuiltInAuthorizationOptions {
 		WebhookVersion:              "v1beta1",
 		WebhookCacheAuthorizedTTL:   5 * time.Minute,
 		WebhookCacheUnauthorizedTTL: 30 * time.Second,
+		WebhookCacheSize:            8192,
 		WebhookRetryBackoff:         genericoptions.DefaultAuthWebhookRetryBackoff(),
 	}
 }
@@ -191,6 +194,10 @@ func (o *BuiltInAuthorizationOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&o.WebhookCacheUnauthorizedTTL,
 		authorizationWebhookUnauthorizedTTLFlag, o.WebhookCacheUnauthorizedTTL,
 		"The duration to cache 'unauthorized' responses from the webhook authorizer.")
+
+	fs.IntVar(&o.WebhookCacheSize,
+		authorizationWebhookCacheSizeFlag, o.WebhookCacheSize,
+		"The size of cache for saving the responses from the webhook authorizer.")
 
 	fs.StringVar(&o.AuthorizationConfigurationFile, authorizationConfigFlag, o.AuthorizationConfigurationFile, ""+
 		"File with Authorization Configuration to configure the authorizer chain. "+

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/types.go
@@ -343,6 +343,11 @@ type WebhookConfiguration struct {
 	// Maximum allowed value is 30s.
 	// Required, no default value.
 	Timeout metav1.Duration
+	// ResponseCacheSize for the response LRU cache.
+	// The value should be a positive integer.
+	// Same as setting `--authorization-webhook-cache-size` flag
+	// Default: 8192
+	ResponseCacheSize int
 	// The API version of the authorization.k8s.io SubjectAccessReview to
 	// send to and expect from the webhook.
 	// Same as setting `--authorization-webhook-version` flag

--- a/staging/src/k8s.io/apiserver/pkg/authorization/authorizerfactory/delegating.go
+++ b/staging/src/k8s.io/apiserver/pkg/authorization/authorizerfactory/delegating.go
@@ -42,6 +42,9 @@ type DelegatingAuthorizerConfig struct {
 	// You generally want more responsive, "deny, try again" flows.
 	DenyCacheTTL time.Duration
 
+	// ResponseCacheSize is the size of the cache for saving the responses from authorizer webhook.
+	ResponseCacheSize int
+
 	// WebhookRetryBackoff specifies the backoff parameters for the authorization webhook retry logic.
 	// This allows us to configure the sleep time at each iteration and the maximum number of retries allowed
 	// before we fail the webhook call in order to limit the fan out that ensues when the system is degraded.
@@ -61,6 +64,7 @@ func (c DelegatingAuthorizerConfig) New() (authorizer.Authorizer, error) {
 		c.SubjectAccessReviewClient,
 		c.AllowCacheTTL,
 		c.DenyCacheTTL,
+		c.ResponseCacheSize,
 		*c.WebhookRetryBackoff,
 		authorizer.DecisionNoOpinion,
 		NewDelegatingAuthorizerMetrics(),

--- a/staging/src/k8s.io/apiserver/pkg/server/options/authorization.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/authorization.go
@@ -55,6 +55,9 @@ type DelegatingAuthorizationOptions struct {
 	// You generally want more responsive, "deny, try again" flows.
 	DenyCacheTTL time.Duration
 
+	// CacheSize is the size of the response cache for authorizer webhook.
+	CacheSize int
+
 	// AlwaysAllowPaths are HTTP paths which are excluded from authorization. They can be plain
 	// paths or end in * in which case prefix-match is applied. A leading / is optional.
 	AlwaysAllowPaths []string
@@ -80,6 +83,7 @@ func NewDelegatingAuthorizationOptions() *DelegatingAuthorizationOptions {
 		// very low for responsiveness, but high enough to handle storms
 		AllowCacheTTL:       10 * time.Second,
 		DenyCacheTTL:        10 * time.Second,
+		CacheSize:           8192,
 		ClientTimeout:       10 * time.Second,
 		WebhookRetryBackoff: DefaultAuthWebhookRetryBackoff(),
 		// This allows the kubelet to always get health and readiness without causing an authorization check.
@@ -153,6 +157,10 @@ func (s *DelegatingAuthorizationOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&s.DenyCacheTTL,
 		"authorization-webhook-cache-unauthorized-ttl", s.DenyCacheTTL,
 		"The duration to cache 'unauthorized' responses from the webhook authorizer.")
+
+	fs.IntVar(&s.CacheSize,
+		"authorization-webhook-cache-size", s.CacheSize,
+		"The size of the cache for saving responses from webhook authorizer.")
 
 	fs.StringSliceVar(&s.AlwaysAllowPaths, "authorization-always-allow-paths", s.AlwaysAllowPaths,
 		"A list of HTTP paths to skip during authorization, i.e. these are authorized without "+


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR adds a new flag `--authorization-webhook-cache-size` for increasing the authorizer webhook cache to a higher number.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add `authorization-webhook-cache-size` for configuring authz webhookresponse cache size.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files


