### PR TITLE
deflake intergation test: TestPersistentVolumeProvisionMultiPVCs

### DIFF
--- a/test/integration/volume/persistent_volumes_test.go
+++ b/test/integration/volume/persistent_volumes_test.go
@@ -1476,11 +1476,12 @@ func waitForSomePersistentVolumeClaimPhase(ctx context.Context, testClient clien
 				klog.Info("Recreating a watch for claims and re-checking the count of bound claims")
 				newWatchPVC, err := testClient.CoreV1().PersistentVolumeClaims(namespace).Watch(ctx, metav1.ListOptions{})
 				if err != nil {
+					klog.Errorf("Failed to recreate watch for claims: %v", err)
 					return false, err
 				}
 				watchPVC.Stop()
 				watchPVC = newWatchPVC
-				return false, waitErr
+				return false, nil
 			}
 			klog.V(1).Infof("%d claims bound", i+1)
 		}


### PR DESCRIPTION
#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

https://github.com/kubernetes/kubernetes/pull/127260 wanna fix the flaky test, but it didn't work because it returns an unexpected error after recreating the watch channel.

![image](https://github.com/user-attachments/assets/cdfee46b-eb73-4629-b749-fc62f623b1b0)


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/124136

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
