### PR TITLE
DRA: work around fake.ClientSet informer deficiency in unit test

### DIFF
--- a/pkg/controller/devicetainteviction/device_taint_eviction_test.go
+++ b/pkg/controller/devicetainteviction/device_taint_eviction_test.go
@@ -1553,6 +1553,10 @@ func testCancelEviction(tCtx ktesting.TContext, deletePod bool) {
 	}).WithTimeout(30 * time.Second).Should(gomega.BeFalseBecause("pod no longer pending eviction"))
 
 	// Whether we get an event depends on whether the pod still exists.
+	// If we expect an event, we need to wait for it.
+	if !deletePod {
+		ktesting.Eventually(tCtx, listEvents).WithTimeout(30 * time.Second).Should(matchCancellationEvent())
+	}
 	ktesting.Consistently(tCtx, func(tCtx ktesting.TContext) error {
 		matchEvents := matchCancellationEvent()
 		if deletePod {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test
/kind flake

#### What this PR does / why we need it:

fake.Clientset suffers from a race condition related to informers:
it does not implement resource version support in its Watch
implementation and instead assumes that watches are set up
before further changes are made.
    
If a test waits for caches to be synced and then immediately
adds an object, that new object will never be seen by event handlers
if the race goes wrong and the Watch call hadn't completed yet
(can be triggered by adding a sleep before https://github.com/kubernetes/kubernetes/blob/b53b9fb5573323484af9a19cf3f5bfe80760abba/staging/src/k8s.io/client-go/tools/cache/reflector.go#L431).
    
To work around this, we count all watches and only proceed when
all of them are in place. This replaces the normal watch reactor
(https://github.com/kubernetes/kubernetes/blob/b53b9fb5573323484af9a19cf3f5bfe80760abba/staging/src/k8s.io/client-go/kubernetes/fake/clientset_generated.go#L161-L173).

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubernetes/issues/131320

#### Special notes for your reviewer:

Discussed in https://kubernetes.slack.com/archives/C0EG7JC6T/p1744790432374839

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

/assign @sttts 