### PR TITLE
etcd: fix 5 second delay during shutdown

### DIFF
--- a/test/integration/framework/etcd.go
+++ b/test/integration/framework/etcd.go
@@ -153,15 +153,17 @@ func RunCustomEtcd(dataDir string, customFlags []string, output io.Writer) (url 
 			defer wg.Done()
 			select {
 			case <-ctx.Done():
-				klog.Infof("etcd exited gracefully, context cancelled")
+				klog.V(6).InfoS("etcd exited gracefully, context cancelled")
 			case <-time.After(5 * time.Second):
 				klog.Infof("etcd didn't exit in 5 seconds, killing it")
 				cancel()
 			}
 		}()
 		err := cmd.Wait()
+		klog.V(2).InfoS("etcd exited", "err", err)
+		// Tell goroutine that we are done.
+		cancel()
 		wg.Wait()
-		klog.Infof("etcd exit status: %v", err)
 		err = os.RemoveAll(etcdDataDir)
 		if err != nil {
 			klog.Warningf("error during etcd cleanup: %v", err)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The main goroutine always waited for the background goroutine, which itself only proceeded after the 5 second timeout. To tell the goroutine that it is okay to stop immediately, the main goroutine must cancel the context as soon as etcd has quit.

#### Which issue(s) this PR fixes:

```
[5 second delay after etcd has terminated]
I0417 14:29:26.503442 1494713 etcd.go:158] etcd didn't exit in 5 seconds, killing it
I0417 14:29:26.503479 1494713 etcd.go:164] etcd exit status: signal: terminated
```

#### Special notes for your reviewer:

Used to be part of https://github.com/kubernetes/kubernetes/pull/131259.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/cc @BenTheElder @aojea @serathius 