### PR TITLE
Docs: Clarify that this is a staging repository and not for direct contributions

### DIFF
--- a/staging/src/k8s.io/api/README.md
+++ b/staging/src/k8s.io/api/README.md
@@ -1,3 +1,7 @@
+> ⚠️ **This is a staging repository for Kubernetes**.  
+> Contributions, including issues and pull requests, should be made to the main Kubernetes repository: [https://github.com/kubernetes/kubernetes](https://github.com/kubernetes/kubernetes).  
+> This repository is not for direct contributions.
+
 # api
 
 Schema of the external API types that are served by the Kubernetes API server.

--- a/staging/src/k8s.io/apiextensions-apiserver/README.md
+++ b/staging/src/k8s.io/apiextensions-apiserver/README.md
@@ -1,3 +1,7 @@
+> ⚠️ **This is a staging repository for Kubernetes**.  
+> Contributions, including issues and pull requests, should be made to the main Kubernetes repository: [https://github.com/kubernetes/kubernetes](https://github.com/kubernetes/kubernetes).  
+> This repository is not for direct contributions.
+
 # apiextensions-apiserver
 
 Implements: https://github.com/kubernetes/design-proposals-archive/blob/main/api-machinery/thirdpartyresources.md

--- a/staging/src/k8s.io/apimachinery/README.md
+++ b/staging/src/k8s.io/apimachinery/README.md
@@ -1,3 +1,6 @@
+> ⚠️ **This is a staging repository for Kubernetes**.  
+> Contributions, including issues and pull requests, should be made to the main Kubernetes repository: [https://github.com/kubernetes/kubernetes](https://github.com/kubernetes/kubernetes).  
+> This repository is not for direct contributions.
 # apimachinery
 
 Scheme, typing, encoding, decoding, and conversion packages for Kubernetes and Kubernetes-like API objects.

--- a/staging/src/k8s.io/apiserver/README.md
+++ b/staging/src/k8s.io/apiserver/README.md
@@ -1,3 +1,7 @@
+> ⚠️ **This is a staging repository for Kubernetes**.  
+> Contributions, including issues and pull requests, should be made to the main Kubernetes repository: [https://github.com/kubernetes/kubernetes](https://github.com/kubernetes/kubernetes).  
+> This repository is not for direct contributions.
+
 # apiserver
 
 Generic library for building a Kubernetes aggregated API server.

--- a/staging/src/k8s.io/cli-runtime/README.md
+++ b/staging/src/k8s.io/cli-runtime/README.md
@@ -1,3 +1,7 @@
+> ⚠️ **This is a staging repository for Kubernetes**.  
+> Contributions, including issues and pull requests, should be made to the main Kubernetes repository: [https://github.com/kubernetes/kubernetes](https://github.com/kubernetes/kubernetes).  
+> This repository is not for direct contributions.
+
 # cli-runtime
 
 Set of helpers for creating kubectl commands, as well as kubectl plugins.

--- a/staging/src/k8s.io/client-go/README.md
+++ b/staging/src/k8s.io/client-go/README.md
@@ -1,3 +1,7 @@
+> ⚠️ **This is a staging repository for Kubernetes**.  
+> Contributions, including issues and pull requests, should be made to the main Kubernetes repository: [https://github.com/kubernetes/kubernetes](https://github.com/kubernetes/kubernetes).  
+> This repository is not for direct contributions.
+
 # client-go
 
 Go clients for talking to a [kubernetes](http://kubernetes.io/) cluster.

--- a/staging/src/k8s.io/cloud-provider/README.md
+++ b/staging/src/k8s.io/cloud-provider/README.md
@@ -1,3 +1,7 @@
+> ⚠️ **This is a staging repository for Kubernetes**.  
+> Contributions, including issues and pull requests, should be made to the main Kubernetes repository: [https://github.com/kubernetes/kubernetes](https://github.com/kubernetes/kubernetes).  
+> This repository is not for direct contributions.
+
 # cloud-provider
 
 This repository defines the cloud-provider interface and mechanism to initialize

--- a/staging/src/k8s.io/cluster-bootstrap/README.md
+++ b/staging/src/k8s.io/cluster-bootstrap/README.md
@@ -1,3 +1,7 @@
+> ⚠️ **This is a staging repository for Kubernetes**.  
+> Contributions, including issues and pull requests, should be made to the main Kubernetes repository: [https://github.com/kubernetes/kubernetes](https://github.com/kubernetes/kubernetes).  
+> This repository is not for direct contributions.
+
 # cluster-bootstrap
 
 Set of constants and helpers in support of

--- a/staging/src/k8s.io/code-generator/README.md
+++ b/staging/src/k8s.io/code-generator/README.md
@@ -1,3 +1,7 @@
+> ⚠️ **This is a staging repository for Kubernetes**.  
+> Contributions, including issues and pull requests, should be made to the main Kubernetes repository: [https://github.com/kubernetes/kubernetes](https://github.com/kubernetes/kubernetes).  
+> This repository is not for direct contributions.
+
 # code-generator
 
 Golang code-generators used to implement [Kubernetes-style API types](https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md).

--- a/staging/src/k8s.io/component-base/README.md
+++ b/staging/src/k8s.io/component-base/README.md
@@ -1,3 +1,7 @@
+> ⚠️ **This is a staging repository for Kubernetes**.  
+> Contributions, including issues and pull requests, should be made to the main Kubernetes repository: [https://github.com/kubernetes/kubernetes](https://github.com/kubernetes/kubernetes).  
+> This repository is not for direct contributions.
+
 ## component-base
 
 ## Purpose

--- a/staging/src/k8s.io/component-helpers/README.md
+++ b/staging/src/k8s.io/component-helpers/README.md
@@ -1,3 +1,7 @@
+> ⚠️ **This is a staging repository for Kubernetes**.  
+> Contributions, including issues and pull requests, should be made to the main Kubernetes repository: [https://github.com/kubernetes/kubernetes](https://github.com/kubernetes/kubernetes).  
+> This repository is not for direct contributions.
+
 # component-helpers
 
 This repository provides helpers primarily for core components (core components as described in [Create a k8s.io/component-base repo](https://github.com/kubernetes/enhancements/blob/master/keps/sig-cluster-lifecycle/wgs/783-component-base/README.md#component-definition)) which are required by at least two separate binaries in kubernetes org.

--- a/staging/src/k8s.io/controller-manager/README.md
+++ b/staging/src/k8s.io/controller-manager/README.md
@@ -1,3 +1,7 @@
+> ⚠️ **This is a staging repository for Kubernetes**.  
+> Contributions, including issues and pull requests, should be made to the main Kubernetes repository: [https://github.com/kubernetes/kubernetes](https://github.com/kubernetes/kubernetes).  
+> This repository is not for direct contributions.
+
 # Controller-manager
 
 ## Purpose

--- a/staging/src/k8s.io/cri-api/README.md
+++ b/staging/src/k8s.io/cri-api/README.md
@@ -1,3 +1,7 @@
+> ⚠️ **This is a staging repository for Kubernetes**.  
+> Contributions, including issues and pull requests, should be made to the main Kubernetes repository: [https://github.com/kubernetes/kubernetes](https://github.com/kubernetes/kubernetes).  
+> This repository is not for direct contributions.
+
 ## Purpose
 
 This repository contains the definitions for the Container Runtime Interface (CRI).

--- a/staging/src/k8s.io/cri-client/README.md
+++ b/staging/src/k8s.io/cri-client/README.md
@@ -1,3 +1,7 @@
+> ⚠️ **This is a staging repository for Kubernetes**.  
+> Contributions, including issues and pull requests, should be made to the main Kubernetes repository: [https://github.com/kubernetes/kubernetes](https://github.com/kubernetes/kubernetes).  
+> This repository is not for direct contributions.
+
 # cri-client
 
 Container Runtime Interface client implementation

--- a/staging/src/k8s.io/csi-translation-lib/README.md
+++ b/staging/src/k8s.io/csi-translation-lib/README.md
@@ -1,3 +1,7 @@
+> ⚠️ **This is a staging repository for Kubernetes**.  
+> Contributions, including issues and pull requests, should be made to the main Kubernetes repository: [https://github.com/kubernetes/kubernetes](https://github.com/kubernetes/kubernetes).  
+> This repository is not for direct contributions.
+
 ## Purpose
 
 This repository contains functions to be consumed by various Kubernetes and

--- a/staging/src/k8s.io/dynamic-resource-allocation/README.md
+++ b/staging/src/k8s.io/dynamic-resource-allocation/README.md
@@ -1,3 +1,7 @@
+> ⚠️ **This is a staging repository for Kubernetes**.  
+> Contributions, including issues and pull requests, should be made to the main Kubernetes repository: [https://github.com/kubernetes/kubernetes](https://github.com/kubernetes/kubernetes).  
+> This repository is not for direct contributions.
+
 # dynamic-resource-allocation
 
 ## Purpose

--- a/staging/src/k8s.io/endpointslice/README.md
+++ b/staging/src/k8s.io/endpointslice/README.md
@@ -1,3 +1,7 @@
+> ⚠️ **This is a staging repository for Kubernetes**.  
+> Contributions, including issues and pull requests, should be made to the main Kubernetes repository: [https://github.com/kubernetes/kubernetes](https://github.com/kubernetes/kubernetes).  
+> This repository is not for direct contributions.
+
 # endpointslice
 
 ## Purpose

--- a/staging/src/k8s.io/externaljwt/README.md
+++ b/staging/src/k8s.io/externaljwt/README.md
@@ -1,3 +1,7 @@
+> ⚠️ **This is a staging repository for Kubernetes**.  
+> Contributions, including issues and pull requests, should be made to the main Kubernetes repository: [https://github.com/kubernetes/kubernetes](https://github.com/kubernetes/kubernetes).  
+> This repository is not for direct contributions.
+
 # ExternalJWT
 
 This repository contains proto APIs which enable plugging external JWT signing and key management.

--- a/staging/src/k8s.io/kms/README.md
+++ b/staging/src/k8s.io/kms/README.md
@@ -1,3 +1,7 @@
+> ⚠️ **This is a staging repository for Kubernetes**.  
+> Contributions, including issues and pull requests, should be made to the main Kubernetes repository: [https://github.com/kubernetes/kubernetes](https://github.com/kubernetes/kubernetes).  
+> This repository is not for direct contributions.
+
 # KMS
 
 <!-- TODO: Placeholder README. Update with more detail and repo contents once initial implementation is in place. -->

--- a/staging/src/k8s.io/kube-aggregator/README.md
+++ b/staging/src/k8s.io/kube-aggregator/README.md
@@ -1,3 +1,7 @@
+> ⚠️ **This is a staging repository for Kubernetes**.  
+> Contributions, including issues and pull requests, should be made to the main Kubernetes repository: [https://github.com/kubernetes/kubernetes](https://github.com/kubernetes/kubernetes).  
+> This repository is not for direct contributions.
+
 # kube-aggregator
 
 Implements the [Aggregated API Servers](https://github.com/kubernetes/design-proposals-archive/blob/main/api-machinery/aggregated-api-servers.md) design proposal.

--- a/staging/src/k8s.io/kube-controller-manager/README.md
+++ b/staging/src/k8s.io/kube-controller-manager/README.md
@@ -1,3 +1,7 @@
+> ⚠️ **This is a staging repository for Kubernetes**.  
+> Contributions, including issues and pull requests, should be made to the main Kubernetes repository: [https://github.com/kubernetes/kubernetes](https://github.com/kubernetes/kubernetes).  
+> This repository is not for direct contributions.
+
 # Kube-controller-manager
 
 ## Purpose

--- a/staging/src/k8s.io/kube-proxy/README.md
+++ b/staging/src/k8s.io/kube-proxy/README.md
@@ -1,3 +1,7 @@
+> ⚠️ **This is a staging repository for Kubernetes**.  
+> Contributions, including issues and pull requests, should be made to the main Kubernetes repository: [https://github.com/kubernetes/kubernetes](https://github.com/kubernetes/kubernetes).  
+> This repository is not for direct contributions.
+
 # kube-proxy
 ## Coming Soon!
 

--- a/staging/src/k8s.io/kube-scheduler/README.md
+++ b/staging/src/k8s.io/kube-scheduler/README.md
@@ -1,3 +1,7 @@
+> ⚠️ **This is a staging repository for Kubernetes**.  
+> Contributions, including issues and pull requests, should be made to the main Kubernetes repository: [https://github.com/kubernetes/kubernetes](https://github.com/kubernetes/kubernetes).  
+> This repository is not for direct contributions.
+
 # kube-scheduler
 
 Implements [KEP 115 - Moving ComponentConfig API types to staging repos](https://git.k8s.io/enhancements/keps/sig-cluster-lifecycle/wgs/115-componentconfig#kube-scheduler-changes)

--- a/staging/src/k8s.io/kubectl/README.md
+++ b/staging/src/k8s.io/kubectl/README.md
@@ -1,3 +1,7 @@
+> ⚠️ **This is a staging repository for Kubernetes**.  
+> Contributions, including issues and pull requests, should be made to the main Kubernetes repository: [https://github.com/kubernetes/kubernetes](https://github.com/kubernetes/kubernetes).  
+> This repository is not for direct contributions.
+
 # Kubectl
 
 ![kubectl logo](./images/kubectl-logo-medium.png)

--- a/staging/src/k8s.io/kubelet/README.md
+++ b/staging/src/k8s.io/kubelet/README.md
@@ -1,3 +1,7 @@
+> ⚠️ **This is a staging repository for Kubernetes**.  
+> Contributions, including issues and pull requests, should be made to the main Kubernetes repository: [https://github.com/kubernetes/kubernetes](https://github.com/kubernetes/kubernetes).  
+> This repository is not for direct contributions.
+
 # kubelet
 
 Implements [KEP 14 - Moving ComponentConfig API types to staging repos](https://git.k8s.io/enhancements/keps/sig-cluster-lifecycle/wgs/115-componentconfig/README.md#kubelet-changes)

--- a/staging/src/k8s.io/metrics/README.md
+++ b/staging/src/k8s.io/metrics/README.md
@@ -1,3 +1,7 @@
+> ⚠️ **This is a staging repository for Kubernetes**.  
+> Contributions, including issues and pull requests, should be made to the main Kubernetes repository: [https://github.com/kubernetes/kubernetes](https://github.com/kubernetes/kubernetes).  
+> This repository is not for direct contributions.
+
 # metrics
 
 Kubernetes metrics API type definitions and clients.

--- a/staging/src/k8s.io/mount-utils/README.md
+++ b/staging/src/k8s.io/mount-utils/README.md
@@ -1,3 +1,7 @@
+> ⚠️ **This is a staging repository for Kubernetes**.  
+> Contributions, including issues and pull requests, should be made to the main Kubernetes repository: [https://github.com/kubernetes/kubernetes](https://github.com/kubernetes/kubernetes).  
+> This repository is not for direct contributions.
+
 ## Purpose
 
 This repository defines an interface to mounting filesystems to be consumed by 

--- a/staging/src/k8s.io/pod-security-admission/README.md
+++ b/staging/src/k8s.io/pod-security-admission/README.md
@@ -1,3 +1,7 @@
+> ⚠️ **This is a staging repository for Kubernetes**.  
+> Contributions, including issues and pull requests, should be made to the main Kubernetes repository: [https://github.com/kubernetes/kubernetes](https://github.com/kubernetes/kubernetes).  
+> This repository is not for direct contributions.
+
 # Pod Security Admission
 
 <!-- TODO: Placeholder README. Update with more detail and repo contents once initial implementation is in place. -->

--- a/staging/src/k8s.io/sample-apiserver/README.md
+++ b/staging/src/k8s.io/sample-apiserver/README.md
@@ -1,3 +1,7 @@
+> ⚠️ **This is a staging repository for Kubernetes**.  
+> Contributions, including issues and pull requests, should be made to the main Kubernetes repository: [https://github.com/kubernetes/kubernetes](https://github.com/kubernetes/kubernetes).  
+> This repository is not for direct contributions.
+
 # sample-apiserver
 
 Demonstration of how to use the k8s.io/apiserver library to build a functional API server.

--- a/staging/src/k8s.io/sample-cli-plugin/README.md
+++ b/staging/src/k8s.io/sample-cli-plugin/README.md
@@ -1,3 +1,7 @@
+> ⚠️ **This is a staging repository for Kubernetes**.  
+> Contributions, including issues and pull requests, should be made to the main Kubernetes repository: [https://github.com/kubernetes/kubernetes](https://github.com/kubernetes/kubernetes).  
+> This repository is not for direct contributions.
+
 # sample-cli-plugin
 
 This repository implements a single kubectl plugin for switching the namespace

--- a/staging/src/k8s.io/sample-controller/README.md
+++ b/staging/src/k8s.io/sample-controller/README.md
@@ -1,3 +1,7 @@
+> ⚠️ **This is a staging repository for Kubernetes**.  
+> Contributions, including issues and pull requests, should be made to the main Kubernetes repository: [https://github.com/kubernetes/kubernetes](https://github.com/kubernetes/kubernetes).  
+> This repository is not for direct contributions.
+
 # sample-controller
 
 This repository implements a simple controller for watching Foo resources as


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind documentation
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR updates the `README.md` file across all relevant staging repositories to clarify that these are staging repositories, and all contributions, including issues and pull requests, should be directed to the main Kubernetes repository: https://github.com/kubernetes/kubernetes.

This change is part of the broader initiative to enforce best practices for documentation across all Kubernetes staging repositories. For more context, see [kubernetes/community#8308](https://github.com/kubernetes/community/issues/8308).

#### Which issue(s) this PR fixes:
Fixes kubernetes/kubernetes#131315
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:
This is a documentation-only change aimed at aligning all staging repository documentation with the Kubernetes community standards.
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [Staging Repos Overview]: https://github.com/kubernetes/kubernetes/tree/master/staging
- [Best Practices]: https://github.com/kubernetes/community/issues/8308

```
### Affected Staging Repositories

This change applies to the following Kubernetes staging repositories:

- `k8s.io/api`
- `k8s.io/apiextensions-apiserver`
- `k8s.io/apimachinery`
- `k8s.io/apiserver`
- `k8s.io/cli-runtime`
- `k8s.io/client-go`
- `k8s.io/cloud-provider`
- `k8s.io/cluster-bootstrap`
- `k8s.io/code-generator`
- `k8s.io/component-base`
- `k8s.io/component-helpers`
- `k8s.io/controller-manager`
- `k8s.io/cri-api`
- `k8s.io/cri-client`
- `k8s.io/csi-translation-lib`
- `k8s.io/dynamic-resource-allocation`
- `k8s.io/endpointslice`
- `k8s.io/externaljwt`
- `k8s.io/kms`
- `k8s.io/kube-aggregator`
- `k8s.io/kube-controller-manager`
- `k8s.io/kube-proxy`
- `k8s.io/kube-scheduler`
- `k8s.io/kubectl`
- `k8s.io/kubelet`
- `k8s.io/metrics`
- `k8s.io/mount-utils`
- `k8s.io/pod-security-admission`
- `k8s.io/sample-apiserver`
- `k8s.io/sample-cli-plugin`
- `k8s.io/sample-controller`