### PR TITLE
kubectl: add constant reference

### DIFF
--- a/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"unicode"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	restclient "k8s.io/client-go/rest"
 	clientauth "k8s.io/client-go/tools/auth"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
@@ -415,7 +416,7 @@ func (config *DirectClientConfig) Namespace() (string, bool, error) {
 	}
 
 	if len(configContext.Namespace) == 0 {
-		return "default", false, nil
+		return metav1.NamespaceDefault, false, nil
 	}
 
 	return configContext.Namespace, false, nil
@@ -642,7 +643,7 @@ func (config *inClusterClientConfig) Namespace() (string, bool, error) {
 		}
 	}
 
-	return "default", false, nil
+	return metav1.NamespaceDefault, false, nil
 }
 
 func (config *inClusterClientConfig) ConfigAccess() ConfigAccess {


### PR DESCRIPTION
**What type of PR is this?**
/kind clenaup

**What this PR does / why we need it:**
there is a constant value 'NamespaceDefault: default' in 'k8s.io/apimachinery/pkg/apis/meta/v1'. 
but 'k8s.io/client-go/tools/clientcmd/client_config.go' does not reference the constant value, it uses a string 'default'.
when I change the constant 'NamespaceDefault' for learning and building kubectl test, it does not work ,I still have to change the string 'default'

**Which issue(s) this PR fixes:**
Fixes # NONE

**Special notes for your reviewer:**
NONE

**Does this PR introduce a user-facing change?**
NONE
**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**