### PR TITLE
Migrate BoundedFrequencyRunner to workqueue in kube-proxy

### DIFF
--- a/pkg/proxy/nftables/proxier.go
+++ b/pkg/proxy/nftables/proxier.go
@@ -36,7 +36,7 @@ import (
 
 	"golang.org/x/time/rate"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -50,7 +50,6 @@ import (
 	"k8s.io/kubernetes/pkg/proxy/metaproxier"
 	"k8s.io/kubernetes/pkg/proxy/metrics"
 	proxyutil "k8s.io/kubernetes/pkg/proxy/util"
-	"k8s.io/kubernetes/pkg/util/async"
 	utilkernel "k8s.io/kubernetes/pkg/util/kernel"
 	netutils "k8s.io/utils/net"
 	"k8s.io/utils/ptr"
@@ -164,7 +163,7 @@ type Proxier struct {
 	lastFullSync         time.Time
 	needFullSync         bool
 	initialized          int32
-	syncRunner           *async.BoundedFrequencyRunner // governs calls to syncProxyRules
+	syncRunner           *proxyutil.WorkQueueRunner // governs calls to syncProxyRules
 	syncPeriod           time.Duration
 	flushed              bool
 
@@ -273,10 +272,9 @@ func NewProxier(ctx context.Context,
 		serviceNodePorts:    newNFTElementStorage("map", serviceNodePortsMap),
 	}
 
-	burstSyncs := 2
-	logger.V(2).Info("NFTables sync params", "minSyncPeriod", minSyncPeriod, "syncPeriod", syncPeriod, "burstSyncs", burstSyncs)
-	// We need to pass *some* maxInterval to NewBoundedFrequencyRunner. time.Hour is arbitrary.
-	proxier.syncRunner = async.NewBoundedFrequencyRunner("sync-runner", proxier.syncProxyRules, minSyncPeriod, proxyutil.FullSyncPeriod, burstSyncs)
+	logger.V(2).Info("NFTables sync params", "minSyncPeriod", minSyncPeriod, "syncPeriod", syncPeriod)
+	// We need to pass *some* maxInterval to WorkQueueRunner. time.Hour is arbitrary.
+	proxier.syncRunner = proxyutil.NewWorkQueueRunner("sync-runner", proxier.syncProxyRules, minSyncPeriod, proxyutil.FullSyncPeriod)
 
 	return proxier, nil
 }

--- a/pkg/proxy/util/workqueue_runner.go
+++ b/pkg/proxy/util/workqueue_runner.go
@@ -1,0 +1,149 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"sync"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+)
+
+// WorkQueueRunner is a replacement for BoundedFrequencyRunner that uses workqueue
+// to manage runs of a user-provided function with rate limiting capabilities.
+type WorkQueueRunner struct {
+	name        string
+	fn          func()
+	minInterval time.Duration
+	maxInterval time.Duration
+	queue       workqueue.DelayingInterface
+	queueKey    string
+	stopCh      chan struct{}
+	lock        sync.Mutex
+	lastRun     time.Time
+}
+
+// NewWorkQueueRunner creates a new WorkQueueRunner instance, which will manage
+// runs of the specified function using workqueue.
+//
+// All runs will be async to the caller of WorkQueueRunner.Run, but
+// multiple runs are serialized. If the function needs to hold locks, it must
+// take them internally.
+//
+// Runs of the function will have at least minInterval between them (from
+// completion to next start). Run requests that would violate the minInterval
+// are coalesced and run at the next opportunity.
+//
+// The function will be run at least once per maxInterval. For example, this can
+// force periodic refreshes of state in the absence of anyone calling Run.
+//
+// The maxInterval must be greater than or equal to the minInterval. If the
+// caller passes a maxInterval less than minInterval, this function will panic.
+func NewWorkQueueRunner(name string, fn func(), minInterval, maxInterval time.Duration) *WorkQueueRunner {
+	if maxInterval < minInterval {
+		panic("maxInterval must be >= minInterval")
+	}
+
+	return &WorkQueueRunner{
+		name:        name,
+		fn:          fn,
+		minInterval: minInterval,
+		maxInterval: maxInterval,
+		queue:       workqueue.NewDelayingQueue(),
+		queueKey:    "sync",
+		stopCh:      make(chan struct{}),
+	}
+}
+
+// Run the function as soon as possible. If there is already a queued request to call
+// the underlying function, it may be dropped - it is just guaranteed that we will try
+// calling the underlying function as soon as possible starting from now.
+func (wqr *WorkQueueRunner) Run() {
+	wqr.queue.Add(wqr.queueKey)
+}
+
+// RetryAfter ensures that the function will run again after no later than interval.
+// This can be called from inside a run of the WorkQueueRunner's function, or
+// asynchronously.
+func (wqr *WorkQueueRunner) RetryAfter(interval time.Duration) {
+	wqr.queue.AddAfter(wqr.queueKey, interval)
+}
+
+// Loop handles the periodic timer and run requests. This is expected to be
+// called as a goroutine.
+func (wqr *WorkQueueRunner) Loop(stop <-chan struct{}) {
+	klog.V(3).Infof("%s Loop running", wqr.name)
+
+	// Start a goroutine to handle the periodic timer
+	go func() {
+		ticker := time.NewTicker(wqr.maxInterval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-stop:
+				return
+			case <-wqr.stopCh:
+				return
+			case <-ticker.C:
+				// Add to the queue to ensure we run at least once per maxInterval
+				wqr.queue.Add(wqr.queueKey)
+			}
+		}
+	}()
+
+	// Process the queue
+	wait.Until(func() {
+		for wqr.processNextWorkItem() {
+		}
+	}, time.Second, stop)
+
+	wqr.queue.ShutDown()
+	close(wqr.stopCh)
+}
+
+// processNextWorkItem processes the next item in the queue
+func (wqr *WorkQueueRunner) processNextWorkItem() bool {
+	key, quit := wqr.queue.Get()
+	if quit {
+		return false
+	}
+	defer wqr.queue.Done(key)
+
+	// Check if we need to wait for minInterval
+	wqr.lock.Lock()
+	elapsed := time.Since(wqr.lastRun)
+	if elapsed < wqr.minInterval {
+		// Not enough time has passed since the last run
+		// Re-queue with a delay
+		delay := wqr.minInterval - elapsed
+		wqr.lock.Unlock()
+		wqr.queue.AddAfter(key, delay)
+		klog.V(4).Infof("%s: Too soon to run, requeuing with delay %v", wqr.name, delay)
+		return true
+	}
+
+	// We can run now
+	klog.V(3).Infof("%s: Running function", wqr.name)
+	wqr.fn()
+	wqr.lastRun = time.Now()
+	wqr.lock.Unlock()
+
+	return true
+}

--- a/pkg/proxy/util/workqueue_runner_test.go
+++ b/pkg/proxy/util/workqueue_runner_test.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestWorkQueueRunnerBasic tests the basic functionality of WorkQueueRunner
+func TestWorkQueueRunnerBasic(t *testing.T) {
+	var callCount int
+	var callLock sync.Mutex
+	
+	fn := func() {
+		callLock.Lock()
+		defer callLock.Unlock()
+		callCount++
+	}
+	
+	minInterval := 100 * time.Millisecond
+	maxInterval := 500 * time.Millisecond
+	
+	runner := NewWorkQueueRunner("test-runner", fn, minInterval, maxInterval)
+	
+	stop := make(chan struct{})
+	defer close(stop)
+	
+	go runner.Loop(stop)
+	
+	// Wait for the first run to happen (should be immediate)
+	time.Sleep(50 * time.Millisecond)
+	
+	callLock.Lock()
+	if callCount != 1 {
+		t.Errorf("Expected 1 call, got %d", callCount)
+	}
+	callLock.Unlock()
+	
+	// Run again, should be throttled
+	runner.Run()
+	time.Sleep(50 * time.Millisecond) // Not enough time has passed
+	
+	callLock.Lock()
+	if callCount != 1 {
+		t.Errorf("Expected still 1 call (throttled), got %d", callCount)
+	}
+	callLock.Unlock()
+	
+	// Wait for minInterval to pass, should run again
+	time.Sleep(100 * time.Millisecond)
+	
+	callLock.Lock()
+	if callCount != 2 {
+		t.Errorf("Expected 2 calls after minInterval, got %d", callCount)
+	}
+	callLock.Unlock()
+	
+	// Wait for maxInterval to pass, should run again even without explicit Run() call
+	time.Sleep(500 * time.Millisecond)
+	
+	callLock.Lock()
+	if callCount != 3 {
+		t.Errorf("Expected 3 calls after maxInterval, got %d", callCount)
+	}
+	callLock.Unlock()
+}
+
+// TestWorkQueueRunnerRetryAfter tests the RetryAfter functionality
+func TestWorkQueueRunnerRetryAfter(t *testing.T) {
+	var callCount int
+	var callLock sync.Mutex
+	var shouldRetry bool
+	
+	fn := func() {
+		callLock.Lock()
+		defer callLock.Unlock()
+		callCount++
+		
+		if shouldRetry {
+			shouldRetry = false
+			// Schedule a retry after a short interval
+			go func() {
+				time.Sleep(10 * time.Millisecond)
+				runner.RetryAfter(50 * time.Millisecond)
+			}()
+		}
+	}
+	
+	minInterval := 200 * time.Millisecond
+	maxInterval := 1000 * time.Millisecond
+	
+	runner := NewWorkQueueRunner("test-runner", fn, minInterval, maxInterval)
+	
+	stop := make(chan struct{})
+	defer close(stop)
+	
+	go runner.Loop(stop)
+	
+	// Wait for the first run to happen
+	time.Sleep(50 * time.Millisecond)
+	
+	callLock.Lock()
+	if callCount != 1 {
+		t.Errorf("Expected 1 call, got %d", callCount)
+	}
+	callLock.Unlock()
+	
+	// Set up retry and run again
+	callLock.Lock()
+	shouldRetry = true
+	callLock.Unlock()
+	runner.Run()
+	
+	// Wait for minInterval to pass for the second run
+	time.Sleep(200 * time.Millisecond)
+	
+	callLock.Lock()
+	if callCount != 2 {
+		t.Errorf("Expected 2 calls after minInterval, got %d", callCount)
+	}
+	callLock.Unlock()
+	
+	// Wait for the retry to happen (50ms after the second run)
+	time.Sleep(100 * time.Millisecond)
+	
+	callLock.Lock()
+	if callCount != 3 {
+		t.Errorf("Expected 3 calls after retry, got %d", callCount)
+	}
+	callLock.Unlock()
+}


### PR DESCRIPTION
This commit migrates the BoundedFrequencyRunner in kube-proxy to use workqueue instead. The BoundedFrequencyRunner is currently in pkg/util/async, which is deprecated and will be removed in the future. This change creates a new WorkQueueRunner implementation in pkg/proxy/util that provides the same functionality using client-go's workqueue package, which is a more modern and maintained approach. All proxier implementations (iptables, ipvs, nftables, winkernel) have been updated to use the new WorkQueueRunner. This addresses issue #130518.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
