### PR TITLE
[KEP-4330] add min-compatibility-version to apiserver.

### DIFF
--- a/cmd/kube-apiserver/app/options/options_test.go
+++ b/cmd/kube-apiserver/app/options/options_test.go
@@ -128,6 +128,7 @@ func TestAddFlags(t *testing.T) {
 		"--service-cluster-ip-range=192.168.128.0/17",
 		"--lease-reuse-duration-seconds=100",
 		"--emulated-version=test=1.31",
+		"--min-compatibility-version=test=1.29",
 		"--emulation-forward-compatible=true",
 		"--runtime-config-emulation-forward-compatible=true",
 	}
@@ -351,5 +352,8 @@ func TestAddFlags(t *testing.T) {
 	testEffectiveVersion := s.GenericServerRunOptions.ComponentGlobalsRegistry.EffectiveVersionFor("test")
 	if testEffectiveVersion.EmulationVersion().String() != "1.31" {
 		t.Errorf("Got emulation version %s, wanted %s", testEffectiveVersion.EmulationVersion().String(), "1.31")
+	}
+	if testEffectiveVersion.MinCompatibilityVersion().String() != "1.29" {
+		t.Errorf("Got min compatibility version %s, wanted %s", testEffectiveVersion.MinCompatibilityVersion().String(), "1.29")
 	}
 }

--- a/cmd/kube-controller-manager/app/options/options_test.go
+++ b/cmd/kube-controller-manager/app/options/options_test.go
@@ -1544,7 +1544,7 @@ func setupControllerManagerFlagSet(t *testing.T) (*pflag.FlagSet, *KubeControlle
 	componentGlobalsRegistry := basecompatibility.NewComponentGlobalsRegistry()
 
 	verKube := basecompatibility.NewEffectiveVersionFromString("1.32", "1.31", "1.31")
-	fg := featuregate.NewVersionedFeatureGate(version.MustParse("1.32"))
+	fg := featuregate.NewVersionedFeatureGate(version.MustParse("1.32"), version.MustParse("1.31"))
 	utilruntime.Must(fg.AddVersioned(map[featuregate.Feature]featuregate.VersionedSpecs{
 		"kubeA": {
 			{Version: version.MustParse("1.30"), Default: false, PreRelease: featuregate.Beta},

--- a/pkg/controlplane/apiserver/options/options_test.go
+++ b/pkg/controlplane/apiserver/options/options_test.go
@@ -123,6 +123,7 @@ func TestAddFlags(t *testing.T) {
 		"--storage-backend=etcd3",
 		"--lease-reuse-duration-seconds=100",
 		"--emulated-version=test=1.31",
+		"--min-compatibility-version=test=1.29",
 	}
 	fs.Parse(args)
 	utilruntime.Must(componentGlobalsRegistry.Set())
@@ -315,6 +316,9 @@ func TestAddFlags(t *testing.T) {
 	testEffectiveVersion := s.GenericServerRunOptions.ComponentGlobalsRegistry.EffectiveVersionFor("test")
 	if testEffectiveVersion.EmulationVersion().String() != "1.31" {
 		t.Errorf("Got emulation version %s, wanted %s", testEffectiveVersion.EmulationVersion().String(), "1.31")
+	}
+	if testEffectiveVersion.MinCompatibilityVersion().String() != "1.29" {
+		t.Errorf("Got min compatibility version %s, wanted %s", testEffectiveVersion.MinCompatibilityVersion().String(), "1.29")
 	}
 }
 

--- a/staging/src/k8s.io/component-base/featuregate/feature_gate_test.go
+++ b/staging/src/k8s.io/component-base/featuregate/feature_gate_test.go
@@ -721,6 +721,7 @@ func TestVersionedFeatureGateFlag(t *testing.T) {
 	const testLockedFalseGate Feature = "TestLockedFalse"
 	const testAlphaGateNoVersion Feature = "TestAlphaNoVersion"
 	const testBetaGateNoVersion Feature = "TestBetaNoVersion"
+	const testCompatibilityGate Feature = "TestCompatibility"
 
 	tests := []struct {
 		arg        string
@@ -738,6 +739,7 @@ func TestVersionedFeatureGateFlag(t *testing.T) {
 				testLockedFalseGate:    false,
 				testAlphaGateNoVersion: false,
 				testBetaGateNoVersion:  false,
+				testCompatibilityGate:  false,
 			},
 		},
 		{
@@ -750,20 +752,11 @@ func TestVersionedFeatureGateFlag(t *testing.T) {
 				testLockedFalseGate:    true,
 				testAlphaGateNoVersion: false,
 				testBetaGateNoVersion:  false,
+				testCompatibilityGate:  false,
 			},
 		},
 		{
-			arg: "fooBarBaz=true",
-			expect: map[Feature]bool{
-				allAlphaGate:           false,
-				allBetaGate:            false,
-				testGAGate:             false,
-				testAlphaGate:          false,
-				testBetaGate:           false,
-				testLockedFalseGate:    false,
-				testAlphaGateNoVersion: false,
-				testBetaGateNoVersion:  false,
-			},
+			arg:        "fooBarBaz=true",
 			parseError: "unrecognized feature gate: fooBarBaz",
 		},
 		{
@@ -777,6 +770,7 @@ func TestVersionedFeatureGateFlag(t *testing.T) {
 				testLockedFalseGate:    false,
 				testAlphaGateNoVersion: false,
 				testBetaGateNoVersion:  false,
+				testCompatibilityGate:  false,
 			},
 		},
 		{
@@ -790,6 +784,7 @@ func TestVersionedFeatureGateFlag(t *testing.T) {
 				testLockedFalseGate:    false,
 				testAlphaGateNoVersion: true,
 				testBetaGateNoVersion:  false,
+				testCompatibilityGate:  false,
 			},
 		},
 		{
@@ -803,21 +798,12 @@ func TestVersionedFeatureGateFlag(t *testing.T) {
 				testLockedFalseGate:    false,
 				testAlphaGateNoVersion: false,
 				testBetaGateNoVersion:  false,
+				testCompatibilityGate:  false,
 			},
 			parseError: "invalid value of AllAlpha",
 		},
 		{
-			arg: "AllAlpha=false,TestAlpha=true,TestAlphaNoVersion=true",
-			expect: map[Feature]bool{
-				allAlphaGate:           false,
-				allBetaGate:            false,
-				testGAGate:             false,
-				testAlphaGate:          false,
-				testBetaGate:           false,
-				testLockedFalseGate:    false,
-				testAlphaGateNoVersion: true,
-				testBetaGateNoVersion:  false,
-			},
+			arg:        "AllAlpha=false,TestAlpha=true,TestAlphaNoVersion=true",
 			parseError: "cannot set feature gate TestAlpha to true, feature is PreAlpha at emulated version 1.28",
 		},
 		{
@@ -831,34 +817,15 @@ func TestVersionedFeatureGateFlag(t *testing.T) {
 				testLockedFalseGate:    false,
 				testAlphaGateNoVersion: true,
 				testBetaGateNoVersion:  false,
+				testCompatibilityGate:  false,
 			},
 		},
 		{
-			arg: "TestAlpha=true,TestAlphaNoVersion=true,AllAlpha=false",
-			expect: map[Feature]bool{
-				allAlphaGate:           false,
-				allBetaGate:            false,
-				testGAGate:             false,
-				testAlphaGate:          false,
-				testBetaGate:           false,
-				testLockedFalseGate:    false,
-				testAlphaGateNoVersion: true,
-				testBetaGateNoVersion:  false,
-			},
+			arg:        "TestAlpha=true,TestAlphaNoVersion=true,AllAlpha=false",
 			parseError: "cannot set feature gate TestAlpha to true, feature is PreAlpha at emulated version 1.28",
 		},
 		{
-			arg: "AllAlpha=true,TestAlpha=false,TestAlphaNoVersion=false",
-			expect: map[Feature]bool{
-				allAlphaGate:           true,
-				allBetaGate:            false,
-				testGAGate:             false,
-				testAlphaGate:          false,
-				testBetaGate:           true,
-				testLockedFalseGate:    false,
-				testAlphaGateNoVersion: false,
-				testBetaGateNoVersion:  false,
-			},
+			arg:        "AllAlpha=true,TestAlpha=false,TestAlphaNoVersion=false",
 			parseError: "cannot set feature gate TestAlpha to false, feature is PreAlpha at emulated version 1.28",
 		},
 		{
@@ -872,20 +839,11 @@ func TestVersionedFeatureGateFlag(t *testing.T) {
 				testLockedFalseGate:    false,
 				testAlphaGateNoVersion: false,
 				testBetaGateNoVersion:  false,
+				testCompatibilityGate:  false,
 			},
 		},
 		{
-			arg: "TestAlpha=false,TestAlphaNoVersion=false,AllAlpha=true",
-			expect: map[Feature]bool{
-				allAlphaGate:           true,
-				allBetaGate:            false,
-				testGAGate:             false,
-				testAlphaGate:          false,
-				testBetaGate:           true,
-				testLockedFalseGate:    false,
-				testAlphaGateNoVersion: false,
-				testBetaGateNoVersion:  false,
-			},
+			arg:        "TestAlpha=false,TestAlphaNoVersion=false,AllAlpha=true",
 			parseError: "cannot set feature gate TestAlpha to false, feature is PreAlpha at emulated version 1.28",
 		},
 		{
@@ -899,6 +857,7 @@ func TestVersionedFeatureGateFlag(t *testing.T) {
 				testLockedFalseGate:    false,
 				testAlphaGateNoVersion: false,
 				testBetaGateNoVersion:  true,
+				testCompatibilityGate:  false,
 			},
 		},
 
@@ -913,6 +872,7 @@ func TestVersionedFeatureGateFlag(t *testing.T) {
 				testLockedFalseGate:    false,
 				testAlphaGateNoVersion: false,
 				testBetaGateNoVersion:  false,
+				testCompatibilityGate:  false,
 			},
 		},
 		{
@@ -926,19 +886,11 @@ func TestVersionedFeatureGateFlag(t *testing.T) {
 				testLockedFalseGate:    false,
 				testAlphaGateNoVersion: false,
 				testBetaGateNoVersion:  true,
+				testCompatibilityGate:  false,
 			},
 		},
 		{
-			arg: "AllBeta=banana",
-			expect: map[Feature]bool{
-				allAlphaGate:           false,
-				allBetaGate:            false,
-				testGAGate:             false,
-				testAlphaGate:          false,
-				testBetaGate:           false,
-				testAlphaGateNoVersion: false,
-				testBetaGateNoVersion:  false,
-			},
+			arg:        "AllBeta=banana",
 			parseError: "invalid value of AllBeta",
 		},
 		{
@@ -952,6 +904,7 @@ func TestVersionedFeatureGateFlag(t *testing.T) {
 				testLockedFalseGate:    false,
 				testAlphaGateNoVersion: false,
 				testBetaGateNoVersion:  true,
+				testCompatibilityGate:  false,
 			},
 		},
 		{
@@ -965,6 +918,7 @@ func TestVersionedFeatureGateFlag(t *testing.T) {
 				testLockedFalseGate:    false,
 				testAlphaGateNoVersion: false,
 				testBetaGateNoVersion:  true,
+				testCompatibilityGate:  false,
 			},
 		},
 		{
@@ -978,6 +932,7 @@ func TestVersionedFeatureGateFlag(t *testing.T) {
 				testLockedFalseGate:    false,
 				testAlphaGateNoVersion: false,
 				testBetaGateNoVersion:  false,
+				testCompatibilityGate:  false,
 			},
 		},
 		{
@@ -991,27 +946,22 @@ func TestVersionedFeatureGateFlag(t *testing.T) {
 				testLockedFalseGate:    false,
 				testAlphaGateNoVersion: false,
 				testBetaGateNoVersion:  false,
+				testCompatibilityGate:  false,
 			},
 		},
 		{
-			arg: "TestAlpha=true,AllBeta=false",
-			expect: map[Feature]bool{
-				allAlphaGate:           false,
-				allBetaGate:            false,
-				testGAGate:             false,
-				testAlphaGate:          true,
-				testBetaGate:           false,
-				testLockedFalseGate:    false,
-				testAlphaGateNoVersion: false,
-				testBetaGateNoVersion:  false,
-			},
+			arg:        "TestAlpha=true,AllBeta=false",
 			parseError: "cannot set feature gate TestAlpha to true, feature is PreAlpha at emulated version 1.28",
+		},
+		{
+			arg:        "TestCompatibility=true",
+			parseError: "cannot set feature gate TestCompatibility to true, feature has min-compatibility-version of 1.28, higher than server min-compatibility-version 1.27, make sure you set --min-compatibility-version=1.28 at least",
 		},
 	}
 	for i, test := range tests {
 		t.Run(test.arg, func(t *testing.T) {
 			fs := pflag.NewFlagSet("testfeaturegateflag", pflag.ContinueOnError)
-			f := NewVersionedFeatureGate(version.MustParse("1.29"))
+			f := NewVersionedFeatureGate(version.MustParse("1.29"), version.MustParse("1.28"))
 			if err := f.SetEmulationVersion(version.MustParse("1.28")); err != nil {
 				t.Fatalf("failed to SetEmulationVersion: %v", err)
 			}
@@ -1031,6 +981,10 @@ func TestVersionedFeatureGateFlag(t *testing.T) {
 				testLockedFalseGate: {
 					{Version: version.MustParse("1.28"), Default: false, PreRelease: GA},
 					{Version: version.MustParse("1.29"), Default: false, PreRelease: GA, LockToDefault: true},
+				},
+				testCompatibilityGate: {
+					{Version: version.MustParse("1.28"), Default: true, PreRelease: Beta, MinCompatibilityVersion: version.MustParse("1.28")},
+					{Version: version.MustParse("1.29"), Default: true, PreRelease: GA, LockToDefault: true},
 				},
 			})
 			require.NoError(t, err)
@@ -1069,7 +1023,7 @@ func TestVersionedFeatureGateOverride(t *testing.T) {
 	const testBetaGate Feature = "TestBeta"
 
 	// Don't parse the flag, assert defaults are used.
-	f := NewVersionedFeatureGate(version.MustParse("1.29"))
+	f := NewVersionedFeatureGate(version.MustParse("1.29"), version.MustParse("1.28"))
 
 	err := f.AddVersioned(map[Feature]VersionedSpecs{
 		testAlphaGate: {
@@ -1122,7 +1076,7 @@ func TestVersionedFeatureGateFlagDefaults(t *testing.T) {
 	const testBetaGate Feature = "TestBeta"
 
 	// Don't parse the flag, assert defaults are used.
-	f := NewVersionedFeatureGate(version.MustParse("1.29"))
+	f := NewVersionedFeatureGate(version.MustParse("1.29"), version.MustParse("1.28"))
 	require.NoError(t, f.SetEmulationVersion(version.MustParse("1.28")))
 
 	err := f.AddVersioned(map[Feature]VersionedSpecs{
@@ -1190,7 +1144,7 @@ func TestVersionedFeatureGateKnownFeatures(t *testing.T) {
 	)
 
 	// Don't parse the flag, assert defaults are used.
-	f := NewVersionedFeatureGate(version.MustParse("1.29"))
+	f := NewVersionedFeatureGate(version.MustParse("1.29"), version.MustParse("1.28"))
 	require.NoError(t, f.SetEmulationVersion(version.MustParse("1.28")))
 	err := f.AddVersioned(map[Feature]VersionedSpecs{
 		testGAGate: {
@@ -1252,7 +1206,7 @@ func TestVersionedFeatureGateMetrics(t *testing.T) {
 		kubernetes_feature_enabled{name="TestBetaDisabled",stage="BETA"} 0
 `
 
-	f := NewVersionedFeatureGate(version.MustParse("1.29"))
+	f := NewVersionedFeatureGate(version.MustParse("1.29"), version.MustParse("1.28"))
 	require.NoError(t, f.SetEmulationVersion(version.MustParse("1.28")))
 	err := f.AddVersioned(map[Feature]VersionedSpecs{
 		testAlphaGate: {
@@ -1283,7 +1237,7 @@ func TestVersionedFeatureGateMetrics(t *testing.T) {
 
 func TestVersionedFeatureGateOverrideDefault(t *testing.T) {
 	t.Run("overrides take effect", func(t *testing.T) {
-		f := NewVersionedFeatureGate(version.MustParse("1.29"))
+		f := NewVersionedFeatureGate(version.MustParse("1.29"), version.MustParse("1.28"))
 		require.NoError(t, f.SetEmulationVersion(version.MustParse("1.28")))
 		if err := f.AddVersioned(map[Feature]VersionedSpecs{
 			"TestFeature1": {
@@ -1307,7 +1261,7 @@ func TestVersionedFeatureGateOverrideDefault(t *testing.T) {
 	})
 
 	t.Run("overrides at specific version take effect", func(t *testing.T) {
-		f := NewVersionedFeatureGate(version.MustParse("1.29"))
+		f := NewVersionedFeatureGate(version.MustParse("1.29"), version.MustParse("1.28"))
 		require.NoError(t, f.SetEmulationVersion(version.MustParse("1.28")))
 		if err := f.AddVersioned(map[Feature]VersionedSpecs{
 			"TestFeature1": {
@@ -1347,7 +1301,7 @@ func TestVersionedFeatureGateOverrideDefault(t *testing.T) {
 	})
 
 	t.Run("overrides are preserved across deep copies", func(t *testing.T) {
-		f := NewVersionedFeatureGate(version.MustParse("1.29"))
+		f := NewVersionedFeatureGate(version.MustParse("1.29"), version.MustParse("1.28"))
 		require.NoError(t, f.SetEmulationVersion(version.MustParse("1.28")))
 		if err := f.AddVersioned(map[Feature]VersionedSpecs{
 			"TestFeature": {
@@ -1365,7 +1319,7 @@ func TestVersionedFeatureGateOverrideDefault(t *testing.T) {
 	})
 
 	t.Run("overrides are not passed over after deep copies", func(t *testing.T) {
-		f := NewVersionedFeatureGate(version.MustParse("1.29"))
+		f := NewVersionedFeatureGate(version.MustParse("1.29"), version.MustParse("1.28"))
 		require.NoError(t, f.SetEmulationVersion(version.MustParse("1.28")))
 		if err := f.AddVersioned(map[Feature]VersionedSpecs{
 			"TestFeature": {
@@ -1393,7 +1347,7 @@ func TestVersionedFeatureGateOverrideDefault(t *testing.T) {
 	})
 
 	t.Run("reflected in known features", func(t *testing.T) {
-		f := NewVersionedFeatureGate(version.MustParse("1.29"))
+		f := NewVersionedFeatureGate(version.MustParse("1.29"), version.MustParse("1.28"))
 		require.NoError(t, f.SetEmulationVersion(version.MustParse("1.28")))
 		if err := f.AddVersioned(map[Feature]VersionedSpecs{
 			"TestFeature": {
@@ -1420,7 +1374,7 @@ func TestVersionedFeatureGateOverrideDefault(t *testing.T) {
 	})
 
 	t.Run("may not change default for specs with locked defaults", func(t *testing.T) {
-		f := NewVersionedFeatureGate(version.MustParse("1.29"))
+		f := NewVersionedFeatureGate(version.MustParse("1.29"), version.MustParse("1.28"))
 		require.NoError(t, f.SetEmulationVersion(version.MustParse("1.28")))
 		if err := f.AddVersioned(map[Feature]VersionedSpecs{
 			"LockedFeature": {
@@ -1438,7 +1392,7 @@ func TestVersionedFeatureGateOverrideDefault(t *testing.T) {
 	})
 
 	t.Run("can change default for specs without locked defaults for emulation version", func(t *testing.T) {
-		f := NewVersionedFeatureGate(version.MustParse("1.29"))
+		f := NewVersionedFeatureGate(version.MustParse("1.29"), version.MustParse("1.28"))
 		require.NoError(t, f.SetEmulationVersion(version.MustParse("1.28")))
 		if err := f.AddVersioned(map[Feature]VersionedSpecs{
 			"LockedFeature": {
@@ -1455,7 +1409,7 @@ func TestVersionedFeatureGateOverrideDefault(t *testing.T) {
 	})
 
 	t.Run("does not supersede explicitly-set value", func(t *testing.T) {
-		f := NewVersionedFeatureGate(version.MustParse("1.29"))
+		f := NewVersionedFeatureGate(version.MustParse("1.29"), version.MustParse("1.28"))
 		require.NoError(t, f.SetEmulationVersion(version.MustParse("1.28")))
 		if err := f.AddVersioned(map[Feature]VersionedSpecs{
 			"TestFeature": {
@@ -1472,7 +1426,7 @@ func TestVersionedFeatureGateOverrideDefault(t *testing.T) {
 	})
 
 	t.Run("prevents re-registration of feature spec after overriding default", func(t *testing.T) {
-		f := NewVersionedFeatureGate(version.MustParse("1.29"))
+		f := NewVersionedFeatureGate(version.MustParse("1.29"), version.MustParse("1.28"))
 		require.NoError(t, f.SetEmulationVersion(version.MustParse("1.28")))
 		if err := f.AddVersioned(map[Feature]VersionedSpecs{
 			"TestFeature": {
@@ -1493,7 +1447,7 @@ func TestVersionedFeatureGateOverrideDefault(t *testing.T) {
 	})
 
 	t.Run("does not allow override for a feature added after emulation version", func(t *testing.T) {
-		f := NewVersionedFeatureGate(version.MustParse("1.29"))
+		f := NewVersionedFeatureGate(version.MustParse("1.29"), version.MustParse("1.28"))
 		require.NoError(t, f.SetEmulationVersion(version.MustParse("1.28")))
 		if err := f.AddVersioned(map[Feature]VersionedSpecs{
 			"TestFeature": {
@@ -1508,7 +1462,7 @@ func TestVersionedFeatureGateOverrideDefault(t *testing.T) {
 	})
 
 	t.Run("does not allow override for an unknown feature", func(t *testing.T) {
-		f := NewVersionedFeatureGate(version.MustParse("1.29"))
+		f := NewVersionedFeatureGate(version.MustParse("1.29"), version.MustParse("1.28"))
 		require.NoError(t, f.SetEmulationVersion(version.MustParse("1.28")))
 		if err := f.OverrideDefault("TestFeature", true); err == nil {
 			t.Error("expected an error to be returned in attempt to override default for unregistered feature")
@@ -1516,7 +1470,7 @@ func TestVersionedFeatureGateOverrideDefault(t *testing.T) {
 	})
 
 	t.Run("returns error if already added to flag set", func(t *testing.T) {
-		f := NewVersionedFeatureGate(version.MustParse("1.29"))
+		f := NewVersionedFeatureGate(version.MustParse("1.29"), version.MustParse("1.28"))
 		require.NoError(t, f.SetEmulationVersion(version.MustParse("1.28")))
 		fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
 		f.AddFlag(fs)
@@ -1655,7 +1609,7 @@ func TestExplicitlySet(t *testing.T) {
 	for i, test := range tests {
 		t.Run(test.arg, func(t *testing.T) {
 			fs := pflag.NewFlagSet("testfeaturegateflag", pflag.ContinueOnError)
-			f := NewVersionedFeatureGate(version.MustParse("1.29"))
+			f := NewVersionedFeatureGate(version.MustParse("1.29"), version.MustParse("1.28"))
 			err := f.AddVersioned(map[Feature]VersionedSpecs{
 				testAlphaGate: {
 					{Version: version.MustParse("1.29"), Default: false, PreRelease: Alpha},
@@ -1694,7 +1648,7 @@ func TestResetFeatureValueToDefault(t *testing.T) {
 	const testAlphaGate Feature = "TestAlpha"
 	const testBetaGate Feature = "TestBeta"
 
-	f := NewVersionedFeatureGate(version.MustParse("1.29"))
+	f := NewVersionedFeatureGate(version.MustParse("1.29"), version.MustParse("1.28"))
 	err := f.AddVersioned(map[Feature]VersionedSpecs{
 		testAlphaGate: {
 			{Version: version.MustParse("1.29"), Default: false, PreRelease: Alpha},

--- a/staging/src/k8s.io/component-base/featuregate/testing/feature_gate_test.go
+++ b/staging/src/k8s.io/component-base/featuregate/testing/feature_gate_test.go
@@ -161,7 +161,7 @@ func TestSetFeatureGateInTest(t *gotest.T) {
 
 func TestSpecialGatesVersioned(t *gotest.T) {
 	originalEmulationVersion := version.MustParse("1.31")
-	gate := featuregate.NewVersionedFeatureGate(originalEmulationVersion)
+	gate := featuregate.NewVersionedFeatureGate(originalEmulationVersion, originalEmulationVersion.SubtractMinor(1))
 
 	err := gate.AddVersioned(map[featuregate.Feature]featuregate.VersionedSpecs{
 		"alpha_default_on": {
@@ -363,7 +363,7 @@ func TestDetectEmulationVersionLeakToMainTest(t *gotest.T) {
 	t.Cleanup(cleanup)
 	originalEmulationVersion := version.MustParse("1.31")
 	newEmulationVersion := version.MustParse("1.30")
-	gate := featuregate.NewVersionedFeatureGate(originalEmulationVersion)
+	gate := featuregate.NewVersionedFeatureGate(originalEmulationVersion, originalEmulationVersion.SubtractMinor(1))
 	assert.True(t, gate.EmulationVersion().EqualTo(originalEmulationVersion))
 
 	// Subtest setting feature gate and calling parallel will leak it out
@@ -386,7 +386,7 @@ func TestNoLeakFromSameEmulationVersionToMainTest(t *gotest.T) {
 	t.Cleanup(cleanup)
 	originalEmulationVersion := version.MustParse("1.31")
 	newEmulationVersion := version.MustParse("1.31")
-	gate := featuregate.NewVersionedFeatureGate(originalEmulationVersion)
+	gate := featuregate.NewVersionedFeatureGate(originalEmulationVersion, originalEmulationVersion.SubtractMinor(1))
 	assert.True(t, gate.EmulationVersion().EqualTo(originalEmulationVersion))
 
 	// Subtest setting feature gate and calling parallel will leak it out
@@ -406,7 +406,7 @@ func TestDetectEmulationVersionLeakToOtherSubtest(t *gotest.T) {
 	t.Cleanup(cleanup)
 	originalEmulationVersion := version.MustParse("1.31")
 	newEmulationVersion := version.MustParse("1.30")
-	gate := featuregate.NewVersionedFeatureGate(originalEmulationVersion)
+	gate := featuregate.NewVersionedFeatureGate(originalEmulationVersion, originalEmulationVersion.SubtractMinor(1))
 	assert.True(t, gate.EmulationVersion().EqualTo(originalEmulationVersion))
 
 	subtestName := "Subtest"

--- a/staging/src/k8s.io/sample-apiserver/pkg/cmd/server/start.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/cmd/server/start.go
@@ -142,7 +142,7 @@ func NewCommandStartWardleServer(ctx context.Context, defaults *WardleServerOpti
 	// Will skip if the component has been registered, like in the integration test.
 	_, wardleFeatureGate := defaults.ComponentGlobalsRegistry.ComponentGlobalsOrRegister(
 		apiserver.WardleComponentName, basecompatibility.NewEffectiveVersionFromString(defaultWardleVersion, "", ""),
-		featuregate.NewVersionedFeatureGate(version.MustParse(defaultWardleVersion)))
+		featuregate.NewVersionedFeatureGate(version.MustParse(defaultWardleVersion), version.MustParse(defaultWardleVersion).SubtractMinor(1)))
 
 	// Add versioned feature specifications for the "BanFlunder" feature.
 	// These specifications, together with the effective version, determine if the feature is enabled.
@@ -160,7 +160,7 @@ func NewCommandStartWardleServer(ctx context.Context, defaults *WardleServerOpti
 
 	// Set the emulation version mapping from the "Wardle" component to the kube component.
 	// This ensures that the emulation version of the latter is determined by the emulation version of the former.
-	utilruntime.Must(defaults.ComponentGlobalsRegistry.SetEmulationVersionMapping(apiserver.WardleComponentName, basecompatibility.DefaultKubeComponent, WardleVersionToKubeVersion))
+	utilruntime.Must(defaults.ComponentGlobalsRegistry.SetVersionMapping(apiserver.WardleComponentName, basecompatibility.DefaultKubeComponent, WardleVersionToKubeVersion))
 
 	defaults.ComponentGlobalsRegistry.AddFlags(flags)
 

--- a/test/integration/apiserver/apiserver_test.go
+++ b/test/integration/apiserver/apiserver_test.go
@@ -3209,6 +3209,20 @@ func TestEmulatedStorageVersion(t *testing.T) {
 				Version: "v1",
 			},
 		},
+		{
+			name:            "vap before ga release",
+			emulatedVersion: "1.30",
+			gvr: schema.GroupVersionResource{
+				Group:    "admissionregistration.k8s.io",
+				Version:  "v1beta1",
+				Resource: "validatingadmissionpolicies",
+			},
+			object: validVap,
+			expectedStorageVersion: schema.GroupVersion{
+				Group:   "admissionregistration.k8s.io",
+				Version: "v1beta1",
+			},
+		},
 	}
 
 	// Group cases by their emulated version
@@ -3228,6 +3242,175 @@ func TestEmulatedStorageVersion(t *testing.T) {
 
 			// create test namespace
 			testNamespace := "test-emulated-storage-version"
+			_, err := client.CoreV1().Namespaces().Create(context.TODO(), &v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: testNamespace,
+				},
+			}, metav1.CreateOptions{})
+			if err != nil {
+				t.Fatalf("failed to create test ns: %v", err)
+			}
+
+			restMapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(client.Discovery()))
+
+			for i, c := range cases {
+				t.Run(c.name, func(t *testing.T) {
+					gvk, err := restMapper.KindFor(c.gvr)
+					if err != nil {
+						t.Fatalf("failed to get GVK: %v", err)
+					}
+					c.object.GetObjectKind().SetGroupVersionKind(gvk)
+
+					mapping, err := restMapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+					if err != nil {
+						t.Fatalf("failed to get RESTMapping: %v", err)
+					} else if mapping.Resource != c.gvr {
+						t.Fatalf("expected resource %v, got %v", c.gvr, mapping.Resource)
+					}
+
+					asUnstructured, err := runtime.DefaultUnstructuredConverter.ToUnstructured(c.object)
+					if err != nil {
+						t.Fatalf("failed to convert object to unstructured: %v", err)
+					}
+
+					uns := &unstructured.Unstructured{
+						Object: asUnstructured,
+					}
+					uns.SetName(fmt.Sprintf("test-object%d", i))
+
+					ns := testNamespace
+					if mapping.Scope.Name() == meta.RESTScopeNameRoot {
+						ns = ""
+					}
+
+					// create object
+					created, err := dynamicClient.Resource(c.gvr).Namespace(ns).Create(context.TODO(), uns, metav1.CreateOptions{})
+					if err != nil {
+						t.Fatalf("failed to create object: %v", err)
+					}
+
+					// Fetch object from ETCD
+					// Use this poor man's way to get the etcd path. This wont
+					// work for all resources, but should work for most we want
+					// to test against
+					resourcePrefix := mapping.Resource.Resource
+					if special, ok := kubeapiserver.SpecialDefaultResourcePrefixes[c.gvr.GroupResource()]; ok {
+						resourcePrefix = special
+					}
+					etcdPathComponents := []string{
+						"/",
+						server.EtcdStoragePrefix,
+						resourcePrefix,
+					}
+
+					if len(ns) > 0 {
+						etcdPathComponents = append(etcdPathComponents, ns)
+					}
+					etcdPathComponents = append(etcdPathComponents, created.GetName())
+					etcdPath := path.Join(etcdPathComponents...)
+					fetched, err := server.EtcdClient.Get(context.TODO(), etcdPath)
+					if err != nil {
+						t.Fatalf("failed to fetch object from etcd: %v", err)
+					} else if fetched.More || fetched.Count != 1 || len(fetched.Kvs) != 1 {
+						t.Fatalf("unexpected fetched response: %v", fetched)
+					}
+
+					storedObject := &metav1.PartialObjectMetadata{}
+					err = json.Unmarshal(fetched.Kvs[0].Value, storedObject)
+
+					if err != nil {
+						t.Fatalf("failed to decode object: %v", err)
+					} else if storedObject.GroupVersionKind().GroupVersion() != c.expectedStorageVersion {
+						t.Fatalf("expected storage version %s, got %s", c.expectedStorageVersion.String(), storedObject.GroupVersionKind().GroupVersion().String())
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestMinCompatibilityStorageVersion(t *testing.T) {
+	validVap := &admissionregistrationv1.ValidatingAdmissionPolicy{
+		Spec: admissionregistrationv1.ValidatingAdmissionPolicySpec{
+			MatchConstraints: &admissionregistrationv1.MatchResources{
+				ResourceRules: []admissionregistrationv1.NamedRuleWithOperations{
+					{
+						ResourceNames: []string{"foo"},
+						RuleWithOperations: admissionregistrationv1.RuleWithOperations{
+							Operations: []admissionregistrationv1.OperationType{"CREATE"},
+							Rule: admissionregistrationv1.Rule{
+								APIGroups:   []string{"*"},
+								APIVersions: []string{"*"},
+								Resources:   []string{"*"},
+							},
+						},
+					},
+				},
+			},
+			Validations: []admissionregistrationv1.Validation{
+				{
+					Expression: "true",
+					Message:    "always valid",
+				},
+			},
+		},
+	}
+
+	type testCase struct {
+		name                    string
+		minCompatibilityVersion string
+		gvr                     schema.GroupVersionResource
+		object                  runtime.Object
+		expectedStorageVersion  schema.GroupVersion
+	}
+	cases := []testCase{
+		{
+			name:                    "vap after ga release",
+			minCompatibilityVersion: "1.31",
+			gvr: schema.GroupVersionResource{
+				Group:    "admissionregistration.k8s.io",
+				Version:  "v1beta1",
+				Resource: "validatingadmissionpolicies",
+			},
+			object: validVap,
+			expectedStorageVersion: schema.GroupVersion{
+				Group:   "admissionregistration.k8s.io",
+				Version: "v1",
+			},
+		},
+		{
+			name:                    "vap before ga release",
+			minCompatibilityVersion: "1.29",
+			gvr: schema.GroupVersionResource{
+				Group:    "admissionregistration.k8s.io",
+				Version:  "v1beta1",
+				Resource: "validatingadmissionpolicies",
+			},
+			object: validVap,
+			expectedStorageVersion: schema.GroupVersion{
+				Group:   "admissionregistration.k8s.io",
+				Version: "v1beta1",
+			},
+		},
+	}
+
+	// Group cases by their min compatibility version
+	groupedCases := map[string][]testCase{}
+	for _, c := range cases {
+		groupedCases[c.minCompatibilityVersion] = append(groupedCases[c.minCompatibilityVersion], c)
+	}
+
+	for minCompatibilityVersion, cases := range groupedCases {
+		t.Run(minCompatibilityVersion, func(t *testing.T) {
+			server := kubeapiservertesting.StartTestServerOrDie(
+				t, nil, []string{"--min-compatibility-version=kube=" + minCompatibilityVersion, `--storage-media-type=application/json`, fmt.Sprintf("--runtime-config=%s=true", admissionregistrationv1beta1.SchemeGroupVersion)}, framework.SharedEtcd())
+			defer server.TearDownFn()
+
+			client := clientset.NewForConfigOrDie(server.ClientConfig)
+			dynamicClient := dynamic.NewForConfigOrDie(server.ClientConfig)
+
+			// create test namespace
+			testNamespace := "test-min-compatibility-storage-version"
 			_, err := client.CoreV1().Namespaces().Create(context.TODO(), &v1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: testNamespace,

--- a/test/integration/examples/apiserver_test.go
+++ b/test/integration/examples/apiserver_test.go
@@ -725,7 +725,7 @@ func prepareAggregatedWardleAPIServer(ctx context.Context, t *testing.T, namespa
 	)
 	_, _ = componentGlobalsRegistry.ComponentGlobalsOrRegister(
 		apiserver.WardleComponentName, basecompatibility.NewEffectiveVersionFromString(wardleBinaryVersion, "", ""),
-		featuregate.NewVersionedFeatureGate(version.MustParse(wardleBinaryVersion)))
+		featuregate.NewVersionedFeatureGate(version.MustParse(wardleBinaryVersion), version.MustParse(wardleBinaryVersion).SubtractMinor(1)))
 
 	kubeClient := client.NewForConfigOrDie(getKubeConfig(testServer))
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Adding the `--min-compatibility-version` part of [KEP-4330](https://github.com/kubernetes/enhancements/tree/master/keps/sig-architecture/4330-compatibility-versions)
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
new `--min-compatibility-version` flag for apiserver
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: https://github.com/kubernetes/enhancements/issues/4330
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/4330
```
