### PR TITLE
Add emulation version info to client-go's user-agent

### DIFF
--- a/cmd/kube-controller-manager/app/options/options.go
+++ b/cmd/kube-controller-manager/app/options/options.go
@@ -482,6 +482,7 @@ func (s KubeControllerManagerOptions) Config(ctx context.Context, allControllers
 	kubeconfig.ContentConfig.ContentType = s.Generic.ClientConnection.ContentType
 	kubeconfig.QPS = s.Generic.ClientConnection.QPS
 	kubeconfig.Burst = int(s.Generic.ClientConnection.Burst)
+	kubeconfig.VersionInfo = s.ComponentGlobalsRegistry.EffectiveVersionFor(basecompatibility.DefaultKubeComponent)
 
 	client, err := clientset.NewForConfig(restclient.AddUserAgent(kubeconfig, KubeControllerManagerUserAgent))
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature


#### What this PR does / why we need it:
Adds Emulation Version and Min-Compat Version info to client-go's UserAgent (currently only has Binary Version) which is propagated as a request header 

```
Debug logs: 


Scheduler:
request header: map[Accept:[application/vnd.kubernetes.protobuf, */*] Content-Length:[443] Content-Type:[application/vnd.kubernetes.protobuf] User-Agent:[kube-scheduler/{BinaryVersion: 1.34.0, EmulationVersion: 1.34, MinCompatibilityVersion: 1.33}/ (linux/amd64) kubernetes/666c634/leader-election]]

Kube-controller-manager: 
request header: map[Accept:[application/vnd.kubernetes.protobuf, */*] Content-Length:[461] Content-Type:[application/vnd.kubernetes.protobuf] User-Agent:[kube-controller-manager/{BinaryVersion: 1.34.0, EmulationVersion: 1.34, MinCompatibilityVersion: 1.33}/ (linux/amd64) kubernetes/666c634/leader-election]]

Kube-probe: 
request header: map[Accept:[*/*] User-Agent:[kube-probe/1.34+]]

Kubelet: 
request header: map[Accept:[application/vnd.kubernetes.protobuf,application/json] Accept-Encoding:[gzip] Content-Length:[534] Content-Type:[application/vnd.kubernetes.protobuf] User-Agent:[kubelet/v1.34.0 (linux/amd64) kubernetes/666c634]]
```


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
This is needed to have a request level metric which tracks number of out-of-skew requests received by the apiserver. This is one of the beta requirements for https://github.com/kubernetes/enhancements/tree/master/keps/sig-architecture/4330-compatibility-versions , [ref](https://github.com/kubernetes/enhancements/tree/master/keps/sig-architecture/4330-compatibility-versions#risk-unintended-and-out-of-allowance-version-skew)

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
