### PR TITLE
e2e: set appropriate groups in SAR of kubelet authz test

### DIFF
--- a/test/e2e/framework/auth/helpers.go
+++ b/test/e2e/framework/auth/helpers.go
@@ -45,11 +45,12 @@ type bindingsGetter interface {
 
 // WaitForAuthzUpdate checks if the give user can perform named verb and action
 // on a resource or subresource.
-func WaitForAuthzUpdate(ctx context.Context, c v1authorization.SubjectAccessReviewsGetter, user string, ra *authorizationv1.ResourceAttributes, allowed bool) error {
+func WaitForAuthzUpdate(ctx context.Context, c v1authorization.SubjectAccessReviewsGetter, user string, groups []string, ra *authorizationv1.ResourceAttributes, allowed bool) error {
 	review := &authorizationv1.SubjectAccessReview{
 		Spec: authorizationv1.SubjectAccessReviewSpec{
 			ResourceAttributes: ra,
 			User:               user,
+			Groups:             groups,
 		},
 	}
 

--- a/test/e2e/node/kubelet_authz.go
+++ b/test/e2e/node/kubelet_authz.go
@@ -104,6 +104,7 @@ func runKubeletAuthzTest(ctx context.Context, f *framework.Framework, endpoint, 
 
 	err = e2eauth.WaitForAuthzUpdate(ctx, f.ClientSet.AuthorizationV1(),
 		serviceaccount.MakeUsername(ns, saName),
+		append(serviceaccount.MakeGroupNames(ns), "system:authenticated"),
 		&authorizationv1.ResourceAttributes{
 			Namespace:   ns,
 			Verb:        verb,


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:

This PR sets the appropriate groups (`system:authenticated`, `system:serviceaccounts`, `system:serviceaccounts:<ns>`) in the SAR used in `WaitForAuthzUpdate()` to accurately simulate the service account’s identity.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
