### PR TITLE
Add new unit test for LoadingRules Precedences

### DIFF
--- a/staging/src/k8s.io/client-go/tools/clientcmd/loader_test.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/loader_test.go
@@ -532,18 +532,28 @@ func TestLoadingRulesPrecedences(t *testing.T) {
 	}
 
 	oldConfigDir, _ := os.MkdirTemp("", "")
-	defer os.RemoveAll(oldConfigDir)
+	defer func() {
+		if err := os.RemoveAll(oldConfigDir); err != nil {
+			t.Errorf("Unexpected error: Failed to remove oldConfigDir: %v", err)
+		}
+	}()
 	oldConfigFile := filepath.Join(oldConfigDir, ".kubeconfig")
-	oldConfigDir, _ = filepath.Abs(oldConfigDir)
 
 	newConfigDir, _ := os.MkdirTemp("", "")
-	defer os.RemoveAll(newConfigDir)
+	defer func() {
+		if err := os.RemoveAll(newConfigDir); err != nil {
+			t.Errorf("Unexpected error: Failed to remove newConfigDir: %v", err)
+		}
+	}()
 	newConfigDir, _ = os.MkdirTemp(newConfigDir, "")
 	newConfigFile := filepath.Join(newConfigDir, ".kubeconfig")
-	newConfigDir, _ = filepath.Abs(newConfigDir)
 
-	WriteToFile(oldConfig, oldConfigFile)
-	WriteToFile(newConfig, newConfigFile)
+	if err := WriteToFile(oldConfig, oldConfigFile); err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if err := WriteToFile(newConfig, newConfigFile); err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
 
 	loadingRules := ClientConfigLoadingRules{
 		Precedence: []string{newConfigFile, oldConfigFile},


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Adding a new unit test for Precedences in LoadingRules. Not that there's a bug, just to ensure ordering of configs and how they are respected. Also, to prevent potential bugs, in case something changes in future. 

#### Which issue(s) this PR fixes:


Fixes #


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
