### PR TITLE
Check for newer fields when deciding expansion recovery feature status

### DIFF
--- a/pkg/volume/util/operationexecutor/node_expander.go
+++ b/pkg/volume/util/operationexecutor/node_expander.go
@@ -184,7 +184,7 @@ func (ne *NodeExpander) expandOnPlugin() (bool, resource.Quantity, error) {
 	}
 
 	// File system resize succeeded, now update the PVC's Capacity to match the PV's
-	ne.pvc, err = util.MarkFSResizeFinished(ne.pvc, ne.pluginResizeOpts.NewSize, ne.kubeClient)
+	ne.pvc, err = util.MarkNodeExpansionFinishedWithRecovery(ne.pvc, ne.pluginResizeOpts.NewSize, ne.kubeClient)
 	if err != nil {
 		return true, ne.pluginResizeOpts.NewSize, fmt.Errorf("mountVolume.NodeExpandVolume update pvc status failed: %w", err)
 	}

--- a/pkg/volume/util/operationexecutor/operation_generator.go
+++ b/pkg/volume/util/operationexecutor/operation_generator.go
@@ -2083,6 +2083,11 @@ func (og *operationGenerator) checkForRecoveryFromExpansion(pvc *v1.PersistentVo
 	featureGateStatus := utilfeature.DefaultFeatureGate.Enabled(features.RecoverVolumeExpansionFailure)
 
 	if !featureGateStatus {
+		// even though RecoverVolumeExpansionFailure feature-gate is disabled, we should consider it enabled
+		// if resizeStatus is not empty or allocatedresources is set
+		if resizeStatus != "" || allocatedResource != nil {
+			return true
+		}
 		return false
 	}
 

--- a/pkg/volume/util/resize_util.go
+++ b/pkg/volume/util/resize_util.go
@@ -244,7 +244,6 @@ func MarkNodeExpansionFinishedWithRecovery(
 
 	newPVC.Status.Capacity[v1.ResourceStorage] = newSize
 
-	// if RecoverVolumeExpansionFailure is enabled, we need to reset ResizeStatus back to nil
 	allocatedResourceStatusMap := newPVC.Status.AllocatedResourceStatuses
 	delete(allocatedResourceStatusMap, v1.ResourceStorage)
 	if len(allocatedResourceStatusMap) == 0 {

--- a/pkg/volume/util/resize_util.go
+++ b/pkg/volume/util/resize_util.go
@@ -236,6 +236,28 @@ func MarkFSResizeFinished(
 	return updatedPVC, err
 }
 
+func MarkNodeExpansionFinishedWithRecovery(
+	pvc *v1.PersistentVolumeClaim,
+	newSize resource.Quantity,
+	kubeClient clientset.Interface) (*v1.PersistentVolumeClaim, error) {
+	newPVC := pvc.DeepCopy()
+
+	newPVC.Status.Capacity[v1.ResourceStorage] = newSize
+
+	// if RecoverVolumeExpansionFailure is enabled, we need to reset ResizeStatus back to nil
+	allocatedResourceStatusMap := newPVC.Status.AllocatedResourceStatuses
+	delete(allocatedResourceStatusMap, v1.ResourceStorage)
+	if len(allocatedResourceStatusMap) == 0 {
+		newPVC.Status.AllocatedResourceStatuses = nil
+	} else {
+		newPVC.Status.AllocatedResourceStatuses = allocatedResourceStatusMap
+	}
+
+	newPVC = MergeResizeConditionOnPVC(newPVC, []v1.PersistentVolumeClaimCondition{}, false /* keepOldResizeConditions */)
+	updatedPVC, err := PatchPVCStatus(pvc /*oldPVC*/, newPVC, kubeClient)
+	return updatedPVC, err
+}
+
 // MarkNodeExpansionInfeasible marks a PVC for node expansion as failed. Kubelet should not retry expansion
 // of volumes which are in failed state.
 func MarkNodeExpansionInfeasible(pvc *v1.PersistentVolumeClaim, kubeClient clientset.Interface, err error) (*v1.PersistentVolumeClaim, error) {


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/131402

Apart from tests here, I have manually verified that this works as expected:

Before:

```
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  annotations:
  finalizers:
  - kubernetes.io/pvc-protection
  name: csi-pvc
  namespace: vim1
  resourceVersion: "574"
spec:
  accessModes:
  - ReadWriteOnce
  resources:
    requests:
      storage: 4Gi
  storageClassName: csi-hostpath-sc
  volumeMode: Filesystem
  volumeName: pvc-7ba4e352-5b28-494c-b68b-c2fbaf9d6221
status:
  accessModes:
  - ReadWriteOnce
  allocatedResourceStatuses:
    storage: NodeResizePending
  allocatedResources:
    storage: 4Gi
  capacity:
    storage: 4Gi
  phase: Bound
```

After:

```yaml
---
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  finalizers:
  - kubernetes.io/pvc-protection
  name: csi-pvc
  namespace: vim1
spec:
  accessModes:
  - ReadWriteOnce
  resources:
    requests:
      storage: 6Gi
  storageClassName: csi-hostpath-sc
  volumeMode: Filesystem
  volumeName: pvc-7ba4e352-5b28-494c-b68b-c2fbaf9d6221
status:
  accessModes:
  - ReadWriteOnce
  allocatedResourceStatuses:
    storage: NodeResizeInProgress
  allocatedResources:
    storage: 6Gi
  capacity:
    storage: 4Gi
  conditions:
  - lastProbeTime: null
    lastTransitionTime: "2025-04-23T20:03:23Z"
    status: "True"
    type: Resizing
  - lastProbeTime: null
    lastTransitionTime: "2025-04-23T20:03:23Z"
    message: Waiting for user to (re-)start a pod to finish file system resize of
      volume on node.
    status: "True"
    type: FileSystemResizePending
  phase: Bound
---
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  finalizers:
  - kubernetes.io/pvc-protection
  name: csi-pvc
  namespace: vim1
  resourceVersion: "763"
spec:
  accessModes:
  - ReadWriteOnce
  resources:
    requests:
      storage: 6Gi
  storageClassName: csi-hostpath-sc
  volumeMode: Filesystem
  volumeName: pvc-7ba4e352-5b28-494c-b68b-c2fbaf9d6221
status:
  accessModes:
  - ReadWriteOnce
  allocatedResources:
    storage: 6Gi
  capacity:
    storage: 6Gi
  phase: Bound
```

/sig storage

```release-note
Check for newer resize fields when deciding recovery feature's status in kubelet
```
