### PR TITLE
Fix flake in test when run with stress on pkg/kubelet/kuberuntime TestTerminationOrderingSidecarsInReverseOrder.

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_termination_order_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_termination_order_test.go
@@ -125,7 +125,7 @@ func TestTerminationOrderingSidecarsInReverseOrder(t *testing.T) {
 	waitAndExit := func(name string) {
 		delay := int64(to.waitForTurn(name, 30))
 		delays.Store(name, delay)
-		time.Sleep(1 * time.Second)
+		time.Sleep(1250 * time.Millisecond)
 		to.containerTerminated(name)
 		wg.Done()
 	}


### PR DESCRIPTION
This PR has merit: https://github.com/kubernetes/kubernetes/pull/123515

/sig node
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind flake
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Adding a few milliseconds delay to prevent a time rounding flake.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #123470

#### Special notes for your reviewer:

Reproducible steps:
```
go install golang.org/x/tools/cmd/stress@latest
go test -c ./pkg/kubelet/kuberuntime -race -count=1 -run TestTerminationOrderingSidecarsInReverseOrder
./kuberuntime.test -test.run TestTerminationOrderingSidecarsInReverseOrder
stress ./kuberuntime.test -test.run=TestTerminationOrderingSidecarsInReverseOrder
```
Test results:
```
...
22m45s: 3571 runs so far, 0 failures, 16 active
22m50s: 3584 runs so far, 0 failures, 16 active
22m55s: 3600 runs so far, 0 failures, 16 active
```
We can also consider doing the following:

```
diff --git a/pkg/kubelet/kuberuntime/kuberuntime_termination_order_test.go b/pkg/kubelet/kuberuntime/kuberuntime_termination_order_test.go
index 67a93d8ac34..7a97177a5ca 100644
--- a/pkg/kubelet/kuberuntime/kuberuntime_termination_order_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_termination_order_test.go
@@ -175,7 +175,7 @@ func TestTerminationOrderingSidecarsInReverseOrder(t *testing.T) {
                        expectedDelay: 0,
                },
        } {
-               if got := getDelay(tc.containerName); got != tc.expectedDelay {
+               if got := getDelay(tc.containerName); got > tc.expectedDelay {
                        t.Errorf("expected delay for container %s = %d, got %d", tc.containerName, tc.expectedDelay, got)
                }
        }
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
