### PR TITLE
Add more test cases to TestDescribeSecret test

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
@@ -358,15 +358,15 @@ func TestDescribeSecret(t *testing.T) {
 	}{
 		{
 			description: "alphabetical ordering",
-			data: map[string][]byte {
+			data: map[string][]byte{
 				"username": []byte("YWRtaW4="),
 				"password": []byte("MWYyZDFlMmU2N2Rm"),
 			},
-			expected:    []string{"password", "username"},
-		}, 
+			expected: []string{"password", "username"},
+		},
 		{
 			description: "uppercase comes first",
-			data: map[string][]byte {
+			data: map[string][]byte{
 				"text": []byte("a3ViZXJuZXRlcwo="),
 				"Text": []byte("dGhpcyBpcyBhIHRlc3QK"),
 				"tExt": []byte("d2VpcmQgY2FzaW5nCg=="),

--- a/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
@@ -19,6 +19,7 @@ package describe
 import (
 	"bytes"
 	"fmt"
+	"maps"
 	"reflect"
 	"strings"
 	"testing"
@@ -350,30 +351,46 @@ func TestDescribeTopologySpreadConstraints(t *testing.T) {
 }
 
 func TestDescribeSecret(t *testing.T) {
-	fake := fake.NewSimpleClientset(&corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "bar",
-			Namespace: "foo",
+	testCases := []struct {
+		description string
+		data        map[string][]byte // secret key -> secret in bytes
+		expected    []string
+	}{
+		{
+			description: "alphabetical ordering",
+			data: map[string][]byte {
+				"username": []byte("YWRtaW4="),
+				"password": []byte("MWYyZDFlMmU2N2Rm"),
+			},
+			expected:    []string{"password", "username"},
 		},
-		Data: map[string][]byte{
-			"username": []byte("YWRtaW4="),
-			"password": []byte("MWYyZDFlMmU2N2Rm"),
-		},
-	})
-	c := &describeClient{T: t, Namespace: "foo", Interface: fake}
-	d := SecretDescriber{c}
-	out, err := d.Describe("foo", "bar", DescriberSettings{})
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-	if !strings.Contains(out, "bar") || !strings.Contains(out, "foo") || !strings.Contains(out, "username") || !strings.Contains(out, "8 bytes") || !strings.Contains(out, "password") || !strings.Contains(out, "16 bytes") {
-		t.Errorf("unexpected out: %s", out)
-	}
-	if strings.Contains(out, "YWRtaW4=") || strings.Contains(out, "MWYyZDFlMmU2N2Rm") {
-		t.Errorf("sensitive data should not be shown, unexpected out: %s", out)
 	}
 
-	expectedOut := `Name:         bar
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "bar",
+					Namespace: "foo",
+				},
+				Data: testCase.data,
+			}
+			fake := fake.NewSimpleClientset(secret)
+			c := &describeClient{T: t, Namespace: "foo", Interface: fake}
+			d := SecretDescriber{c}
+
+			out, err := d.Describe("foo", "bar", DescriberSettings{})
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			for value := range maps.Values(testCase.data) {
+				if strings.Contains(out, string(value)) {
+					t.Errorf("sensitive data should not be shown, unexpected out: %s", out)
+				}
+			}
+
+			expectedOut := `Name:         bar
 Namespace:    foo
 Labels:       <none>
 Annotations:  <none>
@@ -381,12 +398,16 @@ Annotations:  <none>
 Type:  
 
 Data
-====
-password:  16 bytes
-username:  8 bytes
-`
+====`
 
-	assert.Equal(t, expectedOut, out)
+			for _, expectedKey := range testCase.expected {
+				expectedOut = fmt.Sprintf("%s\n%s:  %d bytes", expectedOut, expectedKey, len(testCase.data[expectedKey]))
+			}
+			expectedOut = fmt.Sprintf("%s\n", expectedOut)
+
+			assert.Equal(t, expectedOut, out)
+		})
+	}
 }
 
 func TestDescribeNamespace(t *testing.T) {

--- a/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
@@ -365,13 +365,21 @@ func TestDescribeSecret(t *testing.T) {
 			expected: []string{"password", "username"},
 		},
 		{
-			description: "uppercase comes first",
+			description: "uppercase takes precedence",
 			data: map[string][]byte{
 				"text": []byte("a3ViZXJuZXRlcwo="),
 				"Text": []byte("dGhpcyBpcyBhIHRlc3QK"),
 				"tExt": []byte("d2VpcmQgY2FzaW5nCg=="),
 			},
 			expected: []string{"Text", "tExt", "text"},
+		},
+		{
+			description: "numbers take precedence",
+			data: map[string][]byte{
+				"key_1": []byte("c29tZV9zZWNyZXQK"),
+				"1_key": []byte("c29tZV90ZXh0Cg=="),
+			},
+			expected: []string{"1_key", "key_1"},
 		},
 	}
 

--- a/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
@@ -363,6 +363,15 @@ func TestDescribeSecret(t *testing.T) {
 				"password": []byte("MWYyZDFlMmU2N2Rm"),
 			},
 			expected:    []string{"password", "username"},
+		}, 
+		{
+			description: "uppercase comes first",
+			data: map[string][]byte {
+				"text": []byte("a3ViZXJuZXRlcwo="),
+				"Text": []byte("dGhpcyBpcyBhIHRlc3QK"),
+				"tExt": []byte("d2VpcmQgY2FzaW5nCg=="),
+			},
+			expected: []string{"Text", "tExt", "text"},
 		},
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR is to refactor the test for sorting keys displayed through `kubectl describe secret` and add test cases to more explicitly describe the expected sorting behaviour.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes kubernetes/kubectl#1735

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
