### PR TITLE
Fix comment for default gRPC log level in DRA plugin

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/draplugin.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/draplugin.go
@@ -166,8 +166,9 @@ func DriverName(driverName string) Option {
 	}
 }
 
-// GRPCVerbosity sets the verbosity for logging gRPC calls. Default is 4. A negative
-// value disables logging.
+// GRPCVerbosity sets the verbosity for logging gRPC calls.
+// Default is 6, which includes gRPC calls and their responses.
+// A negative value disables logging.
 func GRPCVerbosity(level int) Option {
 	return func(o *options) error {
 		o.grpcVerbosity = level


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup
/kind documentation

#### What this PR does / why we need it:

While playing around with the DRA driver, I noticed a typo in the Go Doc for `GRPCVerbosity()`. It seems the documentation wasn’t updated when the default log level for gRPC calls was changed in https://github.com/kubernetes/kubernetes/pull/125163. It’s a minor fix, but since this is part of the public-facing [Go Doc](https://pkg.go.dev/k8s.io/dynamic-resource-allocation@v0.33.0/kubeletplugin), I went ahead and corrected it.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/4381
```
