### PR TITLE
Automated cherry pick of #131418: Check for newer fields when deciding expansion recovery feature status

### DIFF
--- a/pkg/volume/util/operationexecutor/node_expander.go
+++ b/pkg/volume/util/operationexecutor/node_expander.go
@@ -174,7 +174,7 @@ func (ne *NodeExpander) expandOnPlugin() (bool, error, testResponseData) {
 	}
 
 	// File system resize succeeded, now update the PVC's Capacity to match the PV's
-	ne.pvc, err = util.MarkFSResizeFinished(ne.pvc, ne.pluginResizeOpts.NewSize, ne.kubeClient)
+	ne.pvc, err = util.MarkNodeExpansionFinishedWithRecovery(ne.pvc, ne.pluginResizeOpts.NewSize, ne.kubeClient)
 	if err != nil {
 		return true, fmt.Errorf("mountVolume.NodeExpandVolume update pvc status failed: %v", err), testResponseData{true, true}
 	}

--- a/pkg/volume/util/operationexecutor/node_expander_test.go
+++ b/pkg/volume/util/operationexecutor/node_expander_test.go
@@ -49,9 +49,10 @@ func TestNodeExpander(t *testing.T) {
 
 	nodeResizePending := v1.PersistentVolumeClaimNodeResizePending
 	var tests = []struct {
-		name string
-		pvc  *v1.PersistentVolumeClaim
-		pv   *v1.PersistentVolume
+		name                          string
+		pvc                           *v1.PersistentVolumeClaim
+		pv                            *v1.PersistentVolume
+		recoverVolumeExpansionFailure bool
 
 		// desired size, defaults to pv.Spec.Capacity
 		desiredSize *resource.Quantity
@@ -67,9 +68,10 @@ func TestNodeExpander(t *testing.T) {
 		expectError              bool
 	}{
 		{
-			name: "pv.spec.cap > pvc.status.cap, resizeStatus=node_expansion_failed",
-			pvc:  getTestPVC("test-vol0", "2G", "1G", "", &nodeResizeFailed),
-			pv:   getTestPV("test-vol0", "2G"),
+			name:                          "pv.spec.cap > pvc.status.cap, resizeStatus=node_expansion_failed",
+			pvc:                           getTestPVC("test-vol0", "2G", "1G", "", &nodeResizeFailed),
+			pv:                            getTestPV("test-vol0", "2G"),
+			recoverVolumeExpansionFailure: true,
 
 			expectedResizeStatus:     nodeResizeFailed,
 			expectResizeCall:         false,
@@ -78,9 +80,11 @@ func TestNodeExpander(t *testing.T) {
 			expectedStatusSize:       resource.MustParse("1G"),
 		},
 		{
-			name:                     "pv.spec.cap > pvc.status.cap, resizeStatus=node_expansion_pending",
-			pvc:                      getTestPVC("test-vol0", "2G", "1G", "2G", &nodeResizePending),
-			pv:                       getTestPV("test-vol0", "2G"),
+			name:                          "pv.spec.cap > pvc.status.cap, resizeStatus=node_expansion_pending",
+			pvc:                           getTestPVC("test-vol0", "2G", "1G", "2G", &nodeResizePending),
+			pv:                            getTestPV("test-vol0", "2G"),
+			recoverVolumeExpansionFailure: true,
+
 			expectedResizeStatus:     "",
 			expectResizeCall:         true,
 			assumeResizeOpAsFinished: true,
@@ -88,31 +92,34 @@ func TestNodeExpander(t *testing.T) {
 			expectedStatusSize:       resource.MustParse("2G"),
 		},
 		{
-			name:                     "pv.spec.cap > pvc.status.cap, resizeStatus=node_expansion_pending, reize_op=infeasible",
-			pvc:                      getTestPVC(volumetesting.InfeasibleNodeExpansion, "2G", "1G", "2G", &nodeResizePending),
-			pv:                       getTestPV(volumetesting.InfeasibleNodeExpansion, "2G"),
-			expectError:              true,
-			expectedResizeStatus:     nodeResizeFailed,
-			expectResizeCall:         true,
-			assumeResizeOpAsFinished: true,
-			expectFinalErrors:        true,
-			expectedStatusSize:       resource.MustParse("1G"),
+			name:                          "pv.spec.cap > pvc.status.cap, resizeStatus=node_expansion_pending, reize_op=infeasible",
+			pvc:                           getTestPVC(volumetesting.InfeasibleNodeExpansion, "2G", "1G", "2G", &nodeResizePending),
+			pv:                            getTestPV(volumetesting.InfeasibleNodeExpansion, "2G"),
+			recoverVolumeExpansionFailure: false,
+			expectError:                   true,
+			expectedResizeStatus:          nodeResizeFailed,
+			expectResizeCall:              true,
+			assumeResizeOpAsFinished:      true,
+			expectFinalErrors:             true,
+			expectedStatusSize:            resource.MustParse("1G"),
 		},
 		{
-			name:                     "pv.spec.cap > pvc.status.cap, resizeStatus=node_expansion_pending, reize_op=failing",
-			pvc:                      getTestPVC(volumetesting.OtherFinalNodeExpansionError, "2G", "1G", "2G", &nodeResizePending),
-			pv:                       getTestPV(volumetesting.OtherFinalNodeExpansionError, "2G"),
-			expectError:              true,
-			expectedResizeStatus:     v1.PersistentVolumeClaimNodeResizeInProgress,
-			expectResizeCall:         true,
-			assumeResizeOpAsFinished: true,
-			expectFinalErrors:        true,
-			expectedStatusSize:       resource.MustParse("1G"),
+			name:                          "pv.spec.cap > pvc.status.cap, resizeStatus=node_expansion_pending, reize_op=failing",
+			pvc:                           getTestPVC(volumetesting.OtherFinalNodeExpansionError, "2G", "1G", "2G", &nodeResizePending),
+			pv:                            getTestPV(volumetesting.OtherFinalNodeExpansionError, "2G"),
+			recoverVolumeExpansionFailure: true,
+			expectError:                   true,
+			expectedResizeStatus:          v1.PersistentVolumeClaimNodeResizeInProgress,
+			expectResizeCall:              true,
+			assumeResizeOpAsFinished:      true,
+			expectFinalErrors:             true,
+			expectedStatusSize:            resource.MustParse("1G"),
 		},
 		{
-			name: "pv.spec.cap = pvc.status.cap, resizeStatus='', desiredSize > actualSize",
-			pvc:  getTestPVC("test-vol0", "2G", "2G", "2G", nil),
-			pv:   getTestPV("test-vol0", "2G"),
+			name:                          "pv.spec.cap > pvc.status.cap, resizeStatus=node_expansion_pending, featuregate=disabled",
+			pvc:                           getTestPVC("test-vol0", "2G", "1G", "2G", &nodeResizePending),
+			pv:                            getTestPV("test-vol0", "2G"),
+			recoverVolumeExpansionFailure: false,
 
 			expectedResizeStatus:     "",
 			expectResizeCall:         true,
@@ -125,7 +132,7 @@ func TestNodeExpander(t *testing.T) {
 	for i := range tests {
 		test := tests[i]
 		t.Run(test.name, func(t *testing.T) {
-			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.RecoverVolumeExpansionFailure, true)
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.RecoverVolumeExpansionFailure, test.recoverVolumeExpansionFailure)
 			volumePluginMgr, fakePlugin := volumetesting.GetTestKubeletVolumePluginMgr(t)
 
 			pvc := test.pvc

--- a/pkg/volume/util/operationexecutor/operation_generator.go
+++ b/pkg/volume/util/operationexecutor/operation_generator.go
@@ -2089,6 +2089,11 @@ func (og *operationGenerator) checkForRecoveryFromExpansion(pvc *v1.PersistentVo
 	featureGateStatus := utilfeature.DefaultFeatureGate.Enabled(features.RecoverVolumeExpansionFailure)
 
 	if !featureGateStatus {
+		// even though RecoverVolumeExpansionFailure feature-gate is disabled, we should consider it enabled
+		// if resizeStatus is not empty or allocatedresources is set
+		if resizeStatus != "" || allocatedResource != nil {
+			return true
+		}
 		return false
 	}
 

--- a/pkg/volume/util/resize_util.go
+++ b/pkg/volume/util/resize_util.go
@@ -244,7 +244,6 @@ func MarkNodeExpansionFinishedWithRecovery(
 
 	newPVC.Status.Capacity[v1.ResourceStorage] = newSize
 
-	// if RecoverVolumeExpansionFailure is enabled, we need to reset ResizeStatus back to nil
 	allocatedResourceStatusMap := newPVC.Status.AllocatedResourceStatuses
 	delete(allocatedResourceStatusMap, v1.ResourceStorage)
 	if len(allocatedResourceStatusMap) == 0 {

--- a/pkg/volume/util/resize_util.go
+++ b/pkg/volume/util/resize_util.go
@@ -236,6 +236,28 @@ func MarkFSResizeFinished(
 	return updatedPVC, err
 }
 
+func MarkNodeExpansionFinishedWithRecovery(
+	pvc *v1.PersistentVolumeClaim,
+	newSize resource.Quantity,
+	kubeClient clientset.Interface) (*v1.PersistentVolumeClaim, error) {
+	newPVC := pvc.DeepCopy()
+
+	newPVC.Status.Capacity[v1.ResourceStorage] = newSize
+
+	// if RecoverVolumeExpansionFailure is enabled, we need to reset ResizeStatus back to nil
+	allocatedResourceStatusMap := newPVC.Status.AllocatedResourceStatuses
+	delete(allocatedResourceStatusMap, v1.ResourceStorage)
+	if len(allocatedResourceStatusMap) == 0 {
+		newPVC.Status.AllocatedResourceStatuses = nil
+	} else {
+		newPVC.Status.AllocatedResourceStatuses = allocatedResourceStatusMap
+	}
+
+	newPVC = MergeResizeConditionOnPVC(newPVC, []v1.PersistentVolumeClaimCondition{}, false /* keepOldResizeConditions */)
+	updatedPVC, err := PatchPVCStatus(pvc /*oldPVC*/, newPVC, kubeClient)
+	return updatedPVC, err
+}
+
 // MarkNodeExpansionInfeasible marks a PVC for node expansion as failed. Kubelet should not retry expansion
 // of volumes which are in failed state.
 func MarkNodeExpansionInfeasible(pvc *v1.PersistentVolumeClaim, kubeClient clientset.Interface, err error) (*v1.PersistentVolumeClaim, error) {


### PR DESCRIPTION
Cherry pick of #131418 on release-1.31.

#131418: Check for newer fields when deciding expansion recovery feature status

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Check for newer resize fields when deciding recovery feature's status in kubelet
```