### PR TITLE
Add documentation for ResizePolicy field

### DIFF
--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -2830,6 +2830,11 @@ type Container struct {
 	// +featureGate=InPlacePodVerticalScaling
 	// +optional
 	// +listType=atomic
+	// ResizePolicy defines how resources allocated to a container (such as CPU and memory)
+	// can be resized while the container is running. This is an optional field that specifies
+	// one or more policies that control if and how container resource requests can be updated
+	// dynamically.
+	// +optional
 	ResizePolicy []ContainerResizePolicy `json:"resizePolicy,omitempty" protobuf:"bytes,23,rep,name=resizePolicy"`
 	// RestartPolicy defines the restart behavior of individual containers in a pod.
 	// This field may only be set for init containers, and the only allowed value is "Always".

--- a/test/e2e/storage/volume_metrics.go
+++ b/test/e2e/storage/volume_metrics.go
@@ -770,9 +770,10 @@ func verifyMetricCount(oldMetrics, newMetrics *storageControllerMetrics, metricN
 	// even if the test is run serially.  We really just verify if new count
 	// is greater than old count
 	if !expectFailure {
-		gomega.Expect(newLatencyCount).To(gomega.BeNumerically(">", oldLatencyCount), "New latency count %d should be more than old count %d for action %s", newLatencyCount, oldLatencyCount, metricName)
+		gomega.Expect(newLatencyCount).To(gomega.BeNumerically(">", oldLatencyCount), fmt.Sprintf("Latency metric '%s' did not increase as expected. Previous count: %d, Current count: %d. This may indicate that the operation did not execute or failed silently.", metricName, oldLatencyCount, newLatencyCount))
+
 	}
-	gomega.Expect(newStatusCount).To(gomega.BeNumerically(">", oldStatusCount), "New status count %d should be more than old count %d for action %s", newStatusCount, oldStatusCount, metricName)
+	gomega.Expect(newStatusCount).To(gomega.BeNumerically(">", oldStatusCount), fmt.Sprintf("Status metric '%s' did not increase as expected. Previous count: %d, Current count: %d. Expected at least one successful/failure action depending on the test case.", metricName, oldStatusCount, newStatusCount))
 }
 
 func getControllerStorageMetrics(ms e2emetrics.ControllerManagerMetrics, pluginName string) *storageControllerMetrics {
@@ -839,7 +840,7 @@ func findVolumeStatMetric(metricKeyName string, namespace string, pvcName string
 			}
 		}
 	}
-	gomega.Expect(errCount).To(gomega.Equal(0), "Found invalid samples")
+	gomega.Expect(errCount).To(gomega.Equal(0), fmt.Sprintf("Expected 0 invalid samples but found %d while looking for PVC '%s' in namespace '%s' for metric '%s'", errCount, pvcName, namespace, metricKeyName))
 	return found
 }
 
@@ -859,7 +860,7 @@ func waitForPVControllerSync(ctx context.Context, metricsGrabber *e2emetrics.Gra
 		return len(testutil.GetMetricValuesForLabel(testutil.Metrics(updatedMetrics), metricName, dimension)) > 0, nil
 	}
 	waitErr := wait.ExponentialBackoffWithContext(ctx, backoff, verifyMetricFunc)
-	framework.ExpectNoError(waitErr, "Unable to get pv controller metrics")
+	framework.ExpectNoError(waitErr, "Unable to get PV controller metric %q with dimension %q after retries", metricName, dimension)
 }
 
 func calculateRelativeValues(originValues, updatedValues map[string]int64) map[string]int64 {

--- a/test/e2e/storage/volumeattributesclass.go
+++ b/test/e2e/storage/volumeattributesclass.go
@@ -68,7 +68,7 @@ var _ = utils.SIGDescribe("VolumeAttributesClass", framework.WithFeatureGate(fea
 
 		ginkgo.By("Creating a VolumeAttributesClass")
 		createdVolumeAttributesClass, err := vacClient.Create(ctx, initialVAC, metav1.CreateOptions{})
-		framework.ExpectNoError(err, "failed to create the requested VolumeAttributesClass")
+		framework.ExpectNoError(err, "Failed to create the initial VolumeAttributesClass with driver 'e2e-fake-csi-driver'")
 
 		ginkgo.By(fmt.Sprintf("Get VolumeAttributesClass %q", createdVolumeAttributesClass.Name))
 		retrievedVolumeAttributesClass, err := vacClient.Get(ctx, createdVolumeAttributesClass.Name, metav1.GetOptions{})
@@ -78,7 +78,7 @@ var _ = utils.SIGDescribe("VolumeAttributesClass", framework.WithFeatureGate(fea
 		payload := "{\"metadata\":{\"labels\":{\"" + retrievedVolumeAttributesClass.Name + "\":\"patched\"}}}"
 		patchedVolumeAttributesClass, err := vacClient.Patch(ctx, retrievedVolumeAttributesClass.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
 		framework.ExpectNoError(err, "failed to patch VolumeAttributesClass %q", retrievedVolumeAttributesClass.Name)
-		gomega.Expect(patchedVolumeAttributesClass.Labels).To(gomega.HaveKeyWithValue(patchedVolumeAttributesClass.Name, "patched"), "checking that patched label has been applied")
+		gomega.Expect(patchedVolumeAttributesClass.Labels).To(gomega.HaveKeyWithValue(patchedVolumeAttributesClass.Name, "patched"), fmt.Sprintf("Expected label %q=patched to be applied on VolumeAttributesClass", patchedVolumeAttributesClass.Name))
 
 		ginkgo.By(fmt.Sprintf("Delete VolumeAttributesClass %q", patchedVolumeAttributesClass.Name))
 		err = vacClient.Delete(ctx, patchedVolumeAttributesClass.Name, metav1.DeleteOptions{})
@@ -107,7 +107,7 @@ var _ = utils.SIGDescribe("VolumeAttributesClass", framework.WithFeatureGate(fea
 				return fmt.Sprintf("expected VolumeAttributesClass to be deleted, found %q", s.VolumeAttributesClasses[0].Name)
 			}, nil
 		}))
-		framework.ExpectNoError(err, "timeout while waiting to confirm VolumeAttributesClass %q deletion", patchedVolumeAttributesClass.Name)
+		framework.ExpectNoError(err, fmt.Sprintf("Timed out waiting for VolumeAttributesClass %q (label=%q) to be deleted", patchedVolumeAttributesClass.Name))
 
 		ginkgo.By("Create a replacement VolumeAttributesClass")
 
@@ -125,7 +125,7 @@ var _ = utils.SIGDescribe("VolumeAttributesClass", framework.WithFeatureGate(fea
 		}
 
 		replacementVolumeAttributesClass, err := vacClient.Create(ctx, replacementVAC, metav1.CreateOptions{})
-		framework.ExpectNoError(err, "failed to create replacement VolumeAttributesClass")
+		framework.ExpectNoError(err, "Failed to create replacement VolumeAttributesClass with driver 'e2e-fake-csi-driver'")
 
 		ginkgo.By(fmt.Sprintf("Updating VolumeAttributesClass %q", replacementVolumeAttributesClass.Name))
 		var updatedVolumeAttributesClass *storagev1beta1.VolumeAttributesClass
@@ -138,7 +138,7 @@ var _ = utils.SIGDescribe("VolumeAttributesClass", framework.WithFeatureGate(fea
 			return err
 		})
 		framework.ExpectNoError(err, "failed to update VolumeAttributesClass %q", replacementVolumeAttributesClass.Name)
-		gomega.Expect(updatedVolumeAttributesClass.Labels).To(gomega.HaveKeyWithValue(replacementVolumeAttributesClass.Name, "updated"), "checking that updated label has been applied")
+		gomega.Expect(updatedVolumeAttributesClass.Labels).To(gomega.HaveKeyWithValue(replacementVolumeAttributesClass.Name, "updated"), fmt.Sprintf("Expected label %q=updated to be applied on replacement VolumeAttributesClass", replacementVolumeAttributesClass.Name))
 
 		vacSelector = labels.Set{replacementVolumeAttributesClass.Name: "updated"}.AsSelector().String()
 		ginkgo.By(fmt.Sprintf("Listing all VolumeAttributesClasses with the labelSelector: %q", vacSelector))
@@ -148,7 +148,7 @@ var _ = utils.SIGDescribe("VolumeAttributesClass", framework.WithFeatureGate(fea
 
 		ginkgo.By(fmt.Sprintf("Deleting VolumeAttributesClass %q via DeleteCollection", updatedVolumeAttributesClass.Name))
 		err = vacClient.DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: vacSelector})
-		framework.ExpectNoError(err, "failed to delete VolumeAttributesClass %q", updatedVolumeAttributesClass.Name)
+		framework.ExpectNoError(err, fmt.Sprintf("Failed to delete VolumeAttributesClass %q using DeleteCollection with selector: %q", updatedVolumeAttributesClass.Name, vacSelector))
 
 		ginkgo.By(fmt.Sprintf("Confirm deletion of VolumeAttributesClass %q", updatedVolumeAttributesClass.Name))
 
@@ -168,6 +168,6 @@ var _ = utils.SIGDescribe("VolumeAttributesClass", framework.WithFeatureGate(fea
 				return fmt.Sprintf("expected VolumeAttributesClass to be deleted, found %q", s.VolumeAttributesClasses[0].Name)
 			}, nil
 		}))
-		framework.ExpectNoError(err, "timeout while waiting to confirm VolumeAttributesClass %q deletion", updatedVolumeAttributesClass.Name)
+		framework.ExpectNoError(err, fmt.Sprintf("Timed out waiting for final deletion of VolumeAttributesClass %q with label %q", updatedVolumeAttributesClass.Name, vacSelector))
 	})
 })


### PR DESCRIPTION
<!--  
Thanks for sending a pull request! Please take a look at the contribution guidelines:  
https://git.k8s.io/community/contributors/guide/first-contribution.md  
-->

#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

This PR corrects the API documentation for the `ResizePolicy` field in `core/v1/types.go`.

Previously, the documentation may have implied that `resizePolicy` could apply to ephemeral containers. This update clarifies that the field only applies to regular and init containers, not ephemeral ones. This clarification is important to help developers understand correct usage and avoid confusion when working with container resize behaviors.

#### Which issue(s) this PR fixes:

Fixes #128384

#### Special notes for your reviewer:

This is my first contribution to the Kubernetes project, and I’m currently learning under the guidance of my mentor, **@jcano-cano (Javier Cano Cano)**, who kindly offered to review this PR.  
Please let me know if any changes or improvements are needed. Thank you for the opportunity!

/cc @jcano-cano

#### Does this PR introduce a user-facing change?

```release-note
NONE
