### PR TITLE
update godoc for and rename observedGeneration helpers

### DIFF
--- a/pkg/api/v1/pod/util.go
+++ b/pkg/api/v1/pod/util.go
@@ -419,20 +419,25 @@ func IsRestartableInitContainer(initContainer *v1.Container) bool {
 	return *initContainer.RestartPolicy == v1.ContainerRestartPolicyAlways
 }
 
-// We will emit status.observedGeneration if the feature is enabled OR if status.observedGeneration is already set.
+// CalculatePodStatusObservedGeneration calculates the observedGeneration for the pod status.
+// This is used to track the generation of the pod that was observed by the kubelet.
+// The observedGeneration is set to the pod's generation when the feature gate
+// PodObservedGenerationTracking is enabled OR if status.observedGeneration is already set.
 // This protects against an infinite loop of kubelet trying to clear the value after the FG is turned off, and
 // the API server preserving existing values when an incoming update tries to clear it.
-func GetPodObservedGenerationIfEnabled(pod *v1.Pod) int64 {
+func CalculatePodStatusObservedGeneration(pod *v1.Pod) int64 {
 	if pod.Status.ObservedGeneration != 0 || utilfeature.DefaultFeatureGate.Enabled(features.PodObservedGenerationTracking) {
 		return pod.Generation
 	}
 	return 0
 }
 
-// We will emit condition.observedGeneration if the feature is enabled OR if condition.observedGeneration is already set.
+// CalculatePodConditionObservedGeneration calculates the observedGeneration for a particular pod condition.
+// The observedGeneration is set to the pod's generation when the feature gate
+// PodObservedGenerationTracking is enabled OR if condition[].observedGeneration is already set.
 // This protects against an infinite loop of kubelet trying to clear the value after the FG is turned off, and
 // the API server preserving existing values when an incoming update tries to clear it.
-func GetPodObservedGenerationIfEnabledOnCondition(podStatus *v1.PodStatus, generation int64, conditionType v1.PodConditionType) int64 {
+func CalculatePodConditionObservedGeneration(podStatus *v1.PodStatus, generation int64, conditionType v1.PodConditionType) int64 {
 	if podStatus == nil {
 		return 0
 	}

--- a/pkg/controller/disruption/disruption.go
+++ b/pkg/controller/disruption/disruption.go
@@ -790,7 +790,7 @@ func (dc *DisruptionController) syncStalePodDisruption(ctx context.Context, key 
 	newPod := pod.DeepCopy()
 	updated := apipod.UpdatePodCondition(&newPod.Status, &v1.PodCondition{
 		Type:               v1.DisruptionTarget,
-		ObservedGeneration: apipod.GetPodObservedGenerationIfEnabledOnCondition(&newPod.Status, newPod.Generation, v1.DisruptionTarget),
+		ObservedGeneration: apipod.CalculatePodConditionObservedGeneration(&newPod.Status, newPod.Generation, v1.DisruptionTarget),
 		Status:             v1.ConditionFalse,
 	})
 	if !updated {

--- a/pkg/controller/podgc/gc_controller.go
+++ b/pkg/controller/podgc/gc_controller.go
@@ -247,7 +247,7 @@ func (gcc *PodGCController) gcOrphaned(ctx context.Context, pods []*v1.Pod, node
 		logger.V(2).Info("Found orphaned Pod assigned to the Node, deleting", "pod", klog.KObj(pod), "node", klog.KRef("", pod.Spec.NodeName))
 		condition := &v1.PodCondition{
 			Type:               v1.DisruptionTarget,
-			ObservedGeneration: apipod.GetPodObservedGenerationIfEnabledOnCondition(&pod.Status, pod.Generation, v1.DisruptionTarget),
+			ObservedGeneration: apipod.CalculatePodConditionObservedGeneration(&pod.Status, pod.Generation, v1.DisruptionTarget),
 			Status:             v1.ConditionTrue,
 			Reason:             "DeletionByPodGC",
 			Message:            "PodGC: node no longer exists",
@@ -349,7 +349,7 @@ func (gcc *PodGCController) markFailedAndDeletePodWithCondition(ctx context.Cont
 	if pod.Status.Phase != v1.PodSucceeded && pod.Status.Phase != v1.PodFailed {
 		newStatus := pod.Status.DeepCopy()
 		newStatus.Phase = v1.PodFailed
-		newStatus.ObservedGeneration = apipod.GetPodObservedGenerationIfEnabled(pod)
+		newStatus.ObservedGeneration = apipod.CalculatePodStatusObservedGeneration(pod)
 		if condition != nil {
 			apipod.UpdatePodCondition(newStatus, condition)
 		}

--- a/pkg/controller/tainteviction/taint_eviction.go
+++ b/pkg/controller/tainteviction/taint_eviction.go
@@ -134,7 +134,7 @@ func addConditionAndDeletePod(ctx context.Context, c clientset.Interface, name, 
 	newStatus := pod.Status.DeepCopy()
 	updated := apipod.UpdatePodCondition(newStatus, &v1.PodCondition{
 		Type:               v1.DisruptionTarget,
-		ObservedGeneration: apipod.GetPodObservedGenerationIfEnabledOnCondition(&pod.Status, pod.Generation, v1.DisruptionTarget),
+		ObservedGeneration: apipod.CalculatePodConditionObservedGeneration(&pod.Status, pod.Generation, v1.DisruptionTarget),
 		Status:             v1.ConditionTrue,
 		Reason:             "DeletionByTaintManager",
 		Message:            "Taint manager: deleting due to NoExecute taint",

--- a/pkg/kubelet/eviction/eviction_manager.go
+++ b/pkg/kubelet/eviction/eviction_manager.go
@@ -619,7 +619,7 @@ func (m *managerImpl) evictPod(pod *v1.Pod, gracePeriodOverride int64, evictMsg 
 		status.Reason = Reason
 		status.Message = evictMsg
 		if condition != nil {
-			condition.ObservedGeneration = podutil.GetPodObservedGenerationIfEnabledOnCondition(status, pod.Generation, v1.DisruptionTarget)
+			condition.ObservedGeneration = podutil.CalculatePodConditionObservedGeneration(status, pod.Generation, v1.DisruptionTarget)
 			podutil.UpdatePodCondition(status, condition)
 		}
 	})

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -1834,7 +1834,7 @@ func (kl *Kubelet) generateAPIPodStatus(pod *v1.Pod, podStatus *kubecontainer.Po
 	if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {
 		resizeStatus := kl.determinePodResizeStatus(pod, podIsTerminal)
 		for _, c := range resizeStatus {
-			c.ObservedGeneration = podutil.GetPodObservedGenerationIfEnabledOnCondition(&oldPodStatus, pod.Generation, c.Type)
+			c.ObservedGeneration = podutil.CalculatePodConditionObservedGeneration(&oldPodStatus, pod.Generation, c.Type)
 			s.Conditions = append(s.Conditions, *c)
 		}
 	}
@@ -1858,7 +1858,7 @@ func (kl *Kubelet) generateAPIPodStatus(pod *v1.Pod, podStatus *kubecontainer.Po
 	s.Conditions = append(s.Conditions, status.GenerateContainersReadyCondition(pod, &oldPodStatus, allContainerStatuses, s.Phase))
 	s.Conditions = append(s.Conditions, v1.PodCondition{
 		Type:               v1.PodScheduled,
-		ObservedGeneration: podutil.GetPodObservedGenerationIfEnabledOnCondition(&oldPodStatus, pod.Generation, v1.PodScheduled),
+		ObservedGeneration: podutil.CalculatePodConditionObservedGeneration(&oldPodStatus, pod.Generation, v1.PodScheduled),
 		Status:             v1.ConditionTrue,
 	})
 	// set HostIP/HostIPs and initialize PodIP/PodIPs for host network pods

--- a/pkg/kubelet/nodeshutdown/nodeshutdown_manager.go
+++ b/pkg/kubelet/nodeshutdown/nodeshutdown_manager.go
@@ -161,7 +161,7 @@ func (m *podManager) killPods(activePods []*v1.Pod) error {
 					status.Reason = nodeShutdownReason
 					podutil.UpdatePodCondition(status, &v1.PodCondition{
 						Type:               v1.DisruptionTarget,
-						ObservedGeneration: podutil.GetPodObservedGenerationIfEnabledOnCondition(status, pod.Generation, v1.DisruptionTarget),
+						ObservedGeneration: podutil.CalculatePodConditionObservedGeneration(status, pod.Generation, v1.DisruptionTarget),
 						Status:             v1.ConditionTrue,
 						Reason:             v1.PodReasonTerminationByKubelet,
 						Message:            nodeShutdownMessage,

--- a/pkg/kubelet/preemption/preemption.go
+++ b/pkg/kubelet/preemption/preemption.go
@@ -106,7 +106,7 @@ func (c *CriticalPodAdmissionHandler) evictPodsToFreeRequests(admitPod *v1.Pod, 
 			status.Message = message
 			podutil.UpdatePodCondition(status, &v1.PodCondition{
 				Type:               v1.DisruptionTarget,
-				ObservedGeneration: podutil.GetPodObservedGenerationIfEnabledOnCondition(status, pod.Generation, v1.DisruptionTarget),
+				ObservedGeneration: podutil.CalculatePodConditionObservedGeneration(status, pod.Generation, v1.DisruptionTarget),
 				Status:             v1.ConditionTrue,
 				Reason:             v1.PodReasonTerminationByKubelet,
 				Message:            "Pod was preempted by Kubelet to accommodate a critical pod.",

--- a/pkg/kubelet/status/generate.go
+++ b/pkg/kubelet/status/generate.go
@@ -48,7 +48,7 @@ func GenerateContainersReadyCondition(pod *v1.Pod, oldPodStatus *v1.PodStatus, c
 	if containerStatuses == nil {
 		return v1.PodCondition{
 			Type:               v1.ContainersReady,
-			ObservedGeneration: podutil.GetPodObservedGenerationIfEnabledOnCondition(oldPodStatus, pod.Generation, v1.ContainersReady),
+			ObservedGeneration: podutil.CalculatePodConditionObservedGeneration(oldPodStatus, pod.Generation, v1.ContainersReady),
 			Status:             v1.ConditionFalse,
 			Reason:             UnknownContainerStatuses,
 		}
@@ -102,7 +102,7 @@ func GenerateContainersReadyCondition(pod *v1.Pod, oldPodStatus *v1.PodStatus, c
 	if unreadyMessage != "" {
 		return v1.PodCondition{
 			Type:               v1.ContainersReady,
-			ObservedGeneration: podutil.GetPodObservedGenerationIfEnabledOnCondition(oldPodStatus, pod.Generation, v1.ContainersReady),
+			ObservedGeneration: podutil.CalculatePodConditionObservedGeneration(oldPodStatus, pod.Generation, v1.ContainersReady),
 			Status:             v1.ConditionFalse,
 			Reason:             ContainersNotReady,
 			Message:            unreadyMessage,
@@ -111,7 +111,7 @@ func GenerateContainersReadyCondition(pod *v1.Pod, oldPodStatus *v1.PodStatus, c
 
 	return v1.PodCondition{
 		Type:               v1.ContainersReady,
-		ObservedGeneration: podutil.GetPodObservedGenerationIfEnabledOnCondition(oldPodStatus, pod.Generation, v1.ContainersReady),
+		ObservedGeneration: podutil.CalculatePodConditionObservedGeneration(oldPodStatus, pod.Generation, v1.ContainersReady),
 		Status:             v1.ConditionTrue,
 	}
 }
@@ -125,7 +125,7 @@ func GeneratePodReadyCondition(pod *v1.Pod, oldPodStatus *v1.PodStatus, conditio
 	if containersReady.Status != v1.ConditionTrue {
 		return v1.PodCondition{
 			Type:               v1.PodReady,
-			ObservedGeneration: podutil.GetPodObservedGenerationIfEnabledOnCondition(oldPodStatus, pod.Generation, v1.PodReady),
+			ObservedGeneration: podutil.CalculatePodConditionObservedGeneration(oldPodStatus, pod.Generation, v1.PodReady),
 			Status:             containersReady.Status,
 			Reason:             containersReady.Reason,
 			Message:            containersReady.Message,
@@ -149,7 +149,7 @@ func GeneratePodReadyCondition(pod *v1.Pod, oldPodStatus *v1.PodStatus, conditio
 		unreadyMessage := strings.Join(unreadyMessages, ", ")
 		return v1.PodCondition{
 			Type:               v1.PodReady,
-			ObservedGeneration: podutil.GetPodObservedGenerationIfEnabledOnCondition(oldPodStatus, pod.Generation, v1.PodReady),
+			ObservedGeneration: podutil.CalculatePodConditionObservedGeneration(oldPodStatus, pod.Generation, v1.PodReady),
 			Status:             v1.ConditionFalse,
 			Reason:             ReadinessGatesNotReady,
 			Message:            unreadyMessage,
@@ -158,7 +158,7 @@ func GeneratePodReadyCondition(pod *v1.Pod, oldPodStatus *v1.PodStatus, conditio
 
 	return v1.PodCondition{
 		Type:               v1.PodReady,
-		ObservedGeneration: podutil.GetPodObservedGenerationIfEnabledOnCondition(oldPodStatus, pod.Generation, v1.PodReady),
+		ObservedGeneration: podutil.CalculatePodConditionObservedGeneration(oldPodStatus, pod.Generation, v1.PodReady),
 		Status:             v1.ConditionTrue,
 	}
 }
@@ -183,7 +183,7 @@ func GeneratePodInitializedCondition(pod *v1.Pod, oldPodStatus *v1.PodStatus, co
 	if containerStatuses == nil && len(pod.Spec.InitContainers) > 0 {
 		return v1.PodCondition{
 			Type:               v1.PodInitialized,
-			ObservedGeneration: podutil.GetPodObservedGenerationIfEnabledOnCondition(oldPodStatus, pod.Generation, v1.PodInitialized),
+			ObservedGeneration: podutil.CalculatePodConditionObservedGeneration(oldPodStatus, pod.Generation, v1.PodInitialized),
 			Status:             v1.ConditionFalse,
 			Reason:             UnknownContainerStatuses,
 		}
@@ -206,7 +206,7 @@ func GeneratePodInitializedCondition(pod *v1.Pod, oldPodStatus *v1.PodStatus, co
 	if podPhase == v1.PodSucceeded && len(unknownContainers) == 0 {
 		return v1.PodCondition{
 			Type:               v1.PodInitialized,
-			ObservedGeneration: podutil.GetPodObservedGenerationIfEnabledOnCondition(oldPodStatus, pod.Generation, v1.PodInitialized),
+			ObservedGeneration: podutil.CalculatePodConditionObservedGeneration(oldPodStatus, pod.Generation, v1.PodInitialized),
 			Status:             v1.ConditionTrue,
 			Reason:             PodCompleted,
 		}
@@ -219,7 +219,7 @@ func GeneratePodInitializedCondition(pod *v1.Pod, oldPodStatus *v1.PodStatus, co
 	if kubecontainer.HasAnyRegularContainerStarted(&pod.Spec, containerStatuses) {
 		return v1.PodCondition{
 			Type:               v1.PodInitialized,
-			ObservedGeneration: podutil.GetPodObservedGenerationIfEnabledOnCondition(oldPodStatus, pod.Generation, v1.PodInitialized),
+			ObservedGeneration: podutil.CalculatePodConditionObservedGeneration(oldPodStatus, pod.Generation, v1.PodInitialized),
 			Status:             v1.ConditionTrue,
 		}
 	}
@@ -235,7 +235,7 @@ func GeneratePodInitializedCondition(pod *v1.Pod, oldPodStatus *v1.PodStatus, co
 	if unreadyMessage != "" {
 		return v1.PodCondition{
 			Type:               v1.PodInitialized,
-			ObservedGeneration: podutil.GetPodObservedGenerationIfEnabledOnCondition(oldPodStatus, pod.Generation, v1.PodInitialized),
+			ObservedGeneration: podutil.CalculatePodConditionObservedGeneration(oldPodStatus, pod.Generation, v1.PodInitialized),
 			Status:             v1.ConditionFalse,
 			Reason:             ContainersNotInitialized,
 			Message:            unreadyMessage,
@@ -244,7 +244,7 @@ func GeneratePodInitializedCondition(pod *v1.Pod, oldPodStatus *v1.PodStatus, co
 
 	return v1.PodCondition{
 		Type:               v1.PodInitialized,
-		ObservedGeneration: podutil.GetPodObservedGenerationIfEnabledOnCondition(oldPodStatus, pod.Generation, v1.PodInitialized),
+		ObservedGeneration: podutil.CalculatePodConditionObservedGeneration(oldPodStatus, pod.Generation, v1.PodInitialized),
 		Status:             v1.ConditionTrue,
 	}
 }
@@ -258,13 +258,13 @@ func GeneratePodReadyToStartContainersCondition(pod *v1.Pod, oldPodStatus *v1.Po
 	if !newSandboxNeeded {
 		return v1.PodCondition{
 			Type:               v1.PodReadyToStartContainers,
-			ObservedGeneration: podutil.GetPodObservedGenerationIfEnabledOnCondition(oldPodStatus, pod.Generation, v1.PodReadyToStartContainers),
+			ObservedGeneration: podutil.CalculatePodConditionObservedGeneration(oldPodStatus, pod.Generation, v1.PodReadyToStartContainers),
 			Status:             v1.ConditionTrue,
 		}
 	}
 	return v1.PodCondition{
 		Type:               v1.PodReadyToStartContainers,
-		ObservedGeneration: podutil.GetPodObservedGenerationIfEnabledOnCondition(oldPodStatus, pod.Generation, v1.PodReadyToStartContainers),
+		ObservedGeneration: podutil.CalculatePodConditionObservedGeneration(oldPodStatus, pod.Generation, v1.PodReadyToStartContainers),
 		Status:             v1.ConditionFalse,
 	}
 }
@@ -272,7 +272,7 @@ func GeneratePodReadyToStartContainersCondition(pod *v1.Pod, oldPodStatus *v1.Po
 func generateContainersReadyConditionForTerminalPhase(pod *v1.Pod, oldPodStatus *v1.PodStatus, podPhase v1.PodPhase) v1.PodCondition {
 	condition := v1.PodCondition{
 		Type:               v1.ContainersReady,
-		ObservedGeneration: podutil.GetPodObservedGenerationIfEnabledOnCondition(oldPodStatus, pod.Generation, v1.ContainersReady),
+		ObservedGeneration: podutil.CalculatePodConditionObservedGeneration(oldPodStatus, pod.Generation, v1.ContainersReady),
 		Status:             v1.ConditionFalse,
 	}
 
@@ -288,7 +288,7 @@ func generateContainersReadyConditionForTerminalPhase(pod *v1.Pod, oldPodStatus 
 func generatePodReadyConditionForTerminalPhase(pod *v1.Pod, oldPodStatus *v1.PodStatus, podPhase v1.PodPhase) v1.PodCondition {
 	condition := v1.PodCondition{
 		Type:               v1.PodReady,
-		ObservedGeneration: podutil.GetPodObservedGenerationIfEnabledOnCondition(oldPodStatus, pod.Generation, v1.PodReady),
+		ObservedGeneration: podutil.CalculatePodConditionObservedGeneration(oldPodStatus, pod.Generation, v1.PodReady),
 		Status:             v1.ConditionFalse,
 	}
 

--- a/pkg/kubelet/status/status_manager.go
+++ b/pkg/kubelet/status/status_manager.go
@@ -324,7 +324,7 @@ func (m *manager) SetPodStatus(logger klog.Logger, pod *v1.Pod, status v1.PodSta
 	status = *status.DeepCopy()
 
 	// Set the observedGeneration for this pod status.
-	status.ObservedGeneration = podutil.GetPodObservedGenerationIfEnabled(pod)
+	status.ObservedGeneration = podutil.CalculatePodStatusObservedGeneration(pod)
 
 	// Force a status update if deletion timestamp is set. This is necessary
 	// because if the pod is in the non-running state, the pod worker still

--- a/pkg/scheduler/framework/preemption/preemption.go
+++ b/pkg/scheduler/framework/preemption/preemption.go
@@ -172,7 +172,7 @@ func NewEvaluator(pluginName string, fh framework.Handle, i Interface, enableAsy
 		} else {
 			condition := &v1.PodCondition{
 				Type:               v1.DisruptionTarget,
-				ObservedGeneration: apipod.GetPodObservedGenerationIfEnabledOnCondition(&victim.Status, victim.Generation, v1.DisruptionTarget),
+				ObservedGeneration: apipod.CalculatePodConditionObservedGeneration(&victim.Status, victim.Generation, v1.DisruptionTarget),
 				Status:             v1.ConditionTrue,
 				Reason:             v1.PodReasonPreemptionByScheduler,
 				Message:            fmt.Sprintf("%s: preempting to accommodate a higher priority pod", preemptor.Spec.SchedulerName),

--- a/pkg/scheduler/schedule_one.go
+++ b/pkg/scheduler/schedule_one.go
@@ -1087,7 +1087,7 @@ func (sched *Scheduler) handleSchedulingFailure(ctx context.Context, fwk framewo
 	fwk.EventRecorder().Eventf(pod, nil, v1.EventTypeWarning, "FailedScheduling", "Scheduling", msg)
 	if err := updatePod(ctx, sched.client, pod, &v1.PodCondition{
 		Type:               v1.PodScheduled,
-		ObservedGeneration: podutil.GetPodObservedGenerationIfEnabledOnCondition(&pod.Status, pod.Generation, v1.PodScheduled),
+		ObservedGeneration: podutil.CalculatePodConditionObservedGeneration(&pod.Status, pod.Generation, v1.PodScheduled),
 		Status:             v1.ConditionFalse,
 		Reason:             reason,
 		Message:            errMsg,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

Rename the helpers (and update the godoc) that calculate `observedGeneration` on pod status and pod conditions. This is a follow-up to the request in https://github.com/kubernetes/kubernetes/pull/130573#discussion_r1992138298 to clear up potential confusion.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/assign @liggitt 
