### PR TITLE
Remove alculquicondor from sig-scheduling approvers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -158,7 +158,6 @@ aliases:
   # - rootfs
   # - verult
   sig-scheduling-maintainers:
-    - alculquicondor
     - ahg-g
     - dom4ha
     - Huang-Wei
@@ -166,6 +165,7 @@ aliases:
     - macsko
     - sanposhiho
   # emeritus:
+  # - alculquicondor
   # - damemi
   # - bsalamat
   # - k82cn


### PR DESCRIPTION
/kind documentation

#### What this PR does / why we need it:

Remove alculquicondor who is stepping down from sig-scheduling approvers.

#### Which issue(s) this PR fixes:

kubernetes/community/issues/8428