### PR TITLE
enable dep-approvers for staging go.mod/go.sum

### DIFF
--- a/staging/OWNERS
+++ b/staging/OWNERS
@@ -3,23 +3,34 @@
 options:
   # make root approval non-recursive
   no_parent_owners: true
-approvers:
-  - dchen1107
-  - dims
-  - liggitt
-  - smarterclayton
-  - thockin
-  - wojtek-t
-reviewers:
-  - caesarxuchao
-  - dchen1107
-  - deads2k
-  - dims
-  - liggitt
-  - mikedanese
-  - smarterclayton
-  - sttts
-  - thockin
-  - wojtek-t
-emeritus_approvers:
-  - lavalamp
+filters:
+  # to use filters all entries must be under filters https://go.k8s.io/owners/#filters
+  # use .* for approvers that should have all files
+  ".*":
+    approvers:
+      - dchen1107
+      - dims
+      - liggitt
+      - smarterclayton
+      - thockin
+      - wojtek-t
+    reviewers:
+      - caesarxuchao
+      - dchen1107
+      - deads2k
+      - dims
+      - liggitt
+      - mikedanese
+      - smarterclayton
+      - sttts
+      - thockin
+      - wojtek-t
+    emeritus_approvers:
+      - lavalamp
+  # go.{mod,sum} files relate to go dependencies, and should be reviewed by the
+  # dep-approvers
+  "go\\.(mod|sum)$":
+    approvers:
+      - dep-approvers
+    reviewers:
+      - dep-reviewers

--- a/staging/src/k8s.io/api/OWNERS
+++ b/staging/src/k8s.io/api/OWNERS
@@ -4,11 +4,20 @@
 options:
   no_parent_owners: true
 filters:
+  # to use filters all entries must be under filters https://go.k8s.io/owners/#filters
+  # use .* for approvers that should have all files
   ".*":
     approvers:
       - api-approvers
     reviewers:
       - api-reviewers
+  # go.{mod,sum} files relate to go dependencies, and should be reviewed by the
+  # dep-approvers
+  "go\\.(mod|sum)$":
+    approvers:
+      - dep-approvers
+    reviewers:
+      - dep-reviewers
   # only auto-label go file changes as kind/api-change
   "\\.go$":
     labels:

--- a/staging/src/k8s.io/cri-api/OWNERS
+++ b/staging/src/k8s.io/cri-api/OWNERS
@@ -3,17 +3,28 @@
 # Disable inheritance as this is owned by sig-node (should mirror same contents as pkg/kubelet/OWNERS)
 options:
   no_parent_owners: true
-approvers:
-  - dims
-  - feiskyer
-  - sig-node-approvers
-  - api-approvers
-  - sig-node-cri-approvers
-reviewers:
-  - sig-node-reviewers
-  - dims
-labels:
-  - sig/node
-  - area/kubelet
-emeritus_approvers:
-  - resouer
+filters:
+  # to use filters all entries must be under filters https://go.k8s.io/owners/#filters
+  # use .* for approvers that should have all files
+  ".*":
+    approvers:
+      - dims
+      - feiskyer
+      - sig-node-approvers
+      - api-approvers
+      - sig-node-cri-approvers
+    reviewers:
+      - sig-node-reviewers
+      - dims
+    labels:
+      - sig/node
+      - area/kubelet
+    emeritus_approvers:
+      - resouer
+  # go.{mod,sum} files relate to go dependencies, and should be reviewed by the
+  # dep-approvers
+  "go\\.(mod|sum)$":
+    approvers:
+      - dep-approvers
+    reviewers:
+      - dep-reviewers

--- a/staging/src/k8s.io/cri-client/OWNERS
+++ b/staging/src/k8s.io/cri-client/OWNERS
@@ -3,12 +3,23 @@
 # Disable inheritance as this is owned by sig-node
 options:
   no_parent_owners: true
-approvers:
-  - sig-node-approvers
-  - api-approvers
-  - sig-node-cri-approvers
-reviewers:
-  - sig-node-reviewers
-labels:
-  - sig/node
-  - area/kubelet
+filters:
+  # to use filters all entries must be under filters https://go.k8s.io/owners/#filters
+  # use .* for approvers that should have all files
+  ".*":
+    approvers:
+      - sig-node-approvers
+      - api-approvers
+      - sig-node-cri-approvers
+    reviewers:
+      - sig-node-reviewers
+    labels:
+      - sig/node
+      - area/kubelet
+  # go.{mod,sum} files relate to go dependencies, and should be reviewed by the
+  # dep-approvers
+  "go\\.(mod|sum)$":
+    approvers:
+      - dep-approvers
+    reviewers:
+      - dep-reviewers


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

I think this will finally let dep-approvers that are not inherently owners of all of `staging/` actually approve dependency updates. It does not grant permission over files other than go.mod/go.sum in staging.

Follows https://github.com/kubernetes/kubernetes/pull/131452#issuecomment-2829000504
NOTE: to use filters, _all_ entries must be under filters https://go.k8s.io/owners/#filters
NOTE: we have no_parent_owners used heavily, so specfically OWNERS applying to go.mod/go.sum needed updating. Other more deeply nested or non-dependency management directories do not need this. 

I updated `staging/src/OWNERS` and `staging/src/k8s.io/*/OWNERS` (first level). Only where `no_parent_owners` is enabled. We could add it to all of `staging/src/k8s.io/*/OWNERS` but that's unnecessary unless they add no_parent_owners (which would be relative to staging/src/OWNERS which is already no_parent_owners) and I want to make sure this is working first anyhow. Only a few staging repos do this currently.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
/sig architecture
/area code-organization