### PR TITLE
[WIP] refactor: watch test cleanup

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/apiserver_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/apiserver_test.go
@@ -38,6 +38,7 @@ import (
 
 	"github.com/emicklei/go-restful/v3"
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"k8s.io/apimachinery/pkg/api/apitesting"
@@ -304,31 +305,19 @@ func testRequestInfoResolver() *request.RequestInfoFactory {
 func TestSimpleSetupRight(t *testing.T) {
 	s := &genericapitesting.Simple{ObjectMeta: metav1.ObjectMeta{Name: "aName"}}
 	wire, err := runtime.Encode(codec, s)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	s2, err := runtime.Decode(codec, wire)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !reflect.DeepEqual(s, s2) {
-		t.Fatalf("encode/decode broken:\n%#v\n%#v\n", s, s2)
-	}
+	require.NoError(t, err)
+	require.Equal(t, s, s2)
 }
 
 func TestSimpleOptionsSetupRight(t *testing.T) {
 	s := &genericapitesting.SimpleGetOptions{}
 	wire, err := runtime.Encode(codec, s)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	s2, err := runtime.Decode(codec, wire)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !reflect.DeepEqual(s, s2) {
-		t.Fatalf("encode/decode broken:\n%#v\n%#v\n", s, s2)
-	}
+	require.NoError(t, err)
+	require.Equal(t, s, s2)
 }
 
 type SimpleRESTStorage struct {
@@ -702,15 +691,6 @@ func (storage *SimpleTypedStorage) GetSingularName() string {
 	return "simple"
 }
 
-func bodyOrDie(response *http.Response) string {
-	defer response.Body.Close()
-	body, err := io.ReadAll(response.Body)
-	if err != nil {
-		panic(err)
-	}
-	return string(body)
-}
-
 func extractBody(response *http.Response, object runtime.Object) (string, error) {
 	return extractBodyDecoder(response, object, codec)
 }
@@ -811,19 +791,13 @@ func TestNotFound(t *testing.T) {
 	for testName, test := range cases {
 		t.Run(testName, func(t *testing.T) {
 			ctx := t.Context()
-			request, err := http.NewRequestWithContext(ctx, test.Method, server.URL+test.Path, nil)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
+			req, err := http.NewRequestWithContext(ctx, test.Method, server.URL+test.Path, nil)
+			require.NoError(t, err)
 
-			response, err := client.Do(request)
-			if err != nil {
-				t.Errorf("unexpected error: %v", err)
-			}
-			defer apitesting.Close(t, response.Body)
-			if response.StatusCode != test.Status {
-				t.Errorf("Expected %d for %s, Got %#v", test.Status, test.Method, response)
-			}
+			resp, err := client.Do(req)
+			require.NoError(t, err)
+			defer apitesting.Close(t, resp.Body)
+			require.Equal(t, test.Status, resp.StatusCode)
 		})
 	}
 }
@@ -885,22 +859,14 @@ func TestUnimplementedRESTStorage(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			ctx := t.Context()
 			request, err := http.NewRequestWithContext(ctx, test.Method, server.URL+test.Path, bytes.NewReader([]byte(`{"kind":"Simple","apiVersion":"version"}`)))
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
+			require.NoError(t, err)
 
 			response, err := client.Do(request)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
+			require.NoError(t, err)
 			defer apitesting.Close(t, response.Body)
 			data, err := io.ReadAll(response.Body)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if response.StatusCode != test.ErrCode {
-				t.Fatalf("expected %d for %s, Got %s", test.ErrCode, test.Method, string(data))
-			}
+			require.NoError(t, err)
+			require.Equal(t, test.ErrCode, response.StatusCode, string(data))
 		})
 	}
 }
@@ -956,22 +922,14 @@ func TestSomeUnimplementedRESTStorage(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			ctx := t.Context()
 			request, err := http.NewRequestWithContext(ctx, test.Method, server.URL+test.Path, bytes.NewReader([]byte(`{"kind":"Simple","apiVersion":"version"}`)))
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
+			require.NoError(t, err)
 
 			response, err := client.Do(request)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
+			require.NoError(t, err)
 			defer apitesting.Close(t, response.Body)
 			data, err := io.ReadAll(response.Body)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if response.StatusCode != test.ErrCode {
-				t.Fatalf("expected %d for %s, Got %s", test.ErrCode, test.Method, string(data))
-			}
+			require.NoError(t, err)
+			require.Equal(t, test.ErrCode, response.StatusCode, string(data))
 		})
 	}
 }
@@ -1129,16 +1087,12 @@ func TestList(t *testing.T) {
 			req, err := http.NewRequestWithContext(ctx, request.MethodGet, url, nil)
 			require.NoError(t, err)
 			resp, err := http.DefaultClient.Do(req)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
+			require.NoError(t, err)
 			defer apitesting.Close(t, resp.Body)
 			if resp.StatusCode != http.StatusOK {
 				t.Errorf("unexpected status: %d from url %s, Expected: %d, %#v", resp.StatusCode, test.url, http.StatusOK, resp)
 				body, err := io.ReadAll(resp.Body)
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
+				require.NoError(t, err)
 				t.Logf("body: %s", string(body))
 				return
 			}
@@ -1184,20 +1138,14 @@ func TestRequestsWithInvalidQuery(t *testing.T) {
 			baseURL := server.URL + "/" + grouplessPrefix + "/" + grouplessGroupVersion.Version + "/namespaces/default"
 			url := baseURL + test.postfix
 			r, err := http.NewRequestWithContext(ctx, test.method, url, nil)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
+			require.NoError(t, err)
 			resp, err := http.DefaultClient.Do(r)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
+			require.NoError(t, err)
 			defer apitesting.Close(t, resp.Body)
 			if resp.StatusCode != http.StatusBadRequest {
 				t.Errorf("unexpected status: %d from url %s, Expected: %d, %#v", resp.StatusCode, url, http.StatusBadRequest, resp)
 				body, err := io.ReadAll(resp.Body)
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
+				require.NoError(t, err)
 				t.Logf("body: %s", string(body))
 			}
 		})
@@ -1245,24 +1193,18 @@ func TestListCompression(t *testing.T) {
 			defer server.Close()
 
 			req, err := http.NewRequestWithContext(ctx, request.MethodGet, server.URL+test.url, nil)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
+			require.NoError(t, err)
 			// It's necessary to manually set Accept-Encoding here
 			// to prevent http.DefaultClient from automatically
 			// decoding responses
 			req.Header.Set("Accept-Encoding", test.acceptEncoding)
 			resp, err := http.DefaultClient.Do(req)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
+			require.NoError(t, err)
 			defer apitesting.Close(t, resp.Body)
 			if resp.StatusCode != http.StatusOK {
 				t.Errorf("unexpected status: %d from url %s, Expected: %d, %#v", resp.StatusCode, test.url, http.StatusOK, resp)
 				body, err := io.ReadAll(resp.Body)
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
+				require.NoError(t, err)
 				t.Logf("body: %s", string(body))
 				return
 			}
@@ -1281,18 +1223,14 @@ func TestListCompression(t *testing.T) {
 			var decoder *json.Decoder
 			if test.acceptEncoding == "gzip" {
 				gzipReader, err := gzip.NewReader(resp.Body)
-				if err != nil {
-					t.Fatalf("unexpected error creating gzip reader: %v", err)
-				}
+				require.NoError(t, err)
 				decoder = json.NewDecoder(gzipReader)
 			} else {
 				decoder = json.NewDecoder(resp.Body)
 			}
 			var itemOut genericapitesting.SimpleList
 			err = decoder.Decode(&itemOut)
-			if err != nil {
-				t.Errorf("failed to read response body as SimpleList: %v", err)
-			}
+			require.NoError(t, err)
 		})
 	}
 }
@@ -1305,20 +1243,14 @@ func TestLogs(t *testing.T) {
 	client := http.Client{}
 
 	request, err := http.NewRequestWithContext(ctx, request.MethodGet, server.URL+"/logs", nil)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
 	response, err := client.Do(request)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	defer apitesting.Close(t, response.Body)
 
 	body, err := io.ReadAll(response.Body)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	t.Logf("Data: %s", string(body))
 }
 
@@ -1337,14 +1269,10 @@ func TestErrorList(t *testing.T) {
 	req, err := http.NewRequestWithContext(ctx, request.MethodGet, url, nil)
 	require.NoError(t, err)
 	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	defer apitesting.Close(t, resp.Body)
 
-	if resp.StatusCode != http.StatusInternalServerError {
-		t.Errorf("Unexpected status: %d, Expected: %d, %#v", resp.StatusCode, http.StatusInternalServerError, resp)
-	}
+	require.Equal(t, http.StatusInternalServerError, resp.StatusCode)
 }
 
 func TestNonEmptyList(t *testing.T) {
@@ -1367,43 +1295,30 @@ func TestNonEmptyList(t *testing.T) {
 	req, err := http.NewRequestWithContext(ctx, request.MethodGet, url, nil)
 	require.NoError(t, err)
 	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	defer apitesting.Close(t, resp.Body)
 
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("Unexpected status: %d, Expected: %d, %#v", resp.StatusCode, http.StatusOK, resp)
 		body, err := io.ReadAll(resp.Body)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
+		require.NoError(t, err)
 		t.Logf("Data: %s", string(body))
 	}
 
 	var listOut genericapitesting.SimpleList
 	body, err := extractBody(resp, &listOut)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	t.Log(body)
 
-	if len(listOut.Items) != 1 {
-		t.Errorf("Unexpected response: %#v", listOut)
-		return
-	}
-	if listOut.Items[0].Other != simpleStorage.list[0].Other {
-		t.Errorf("Unexpected data: %#v, %s", listOut.Items[0], string(body))
-	}
+	require.Len(t, listOut.Items, 1, listOut)
+	require.Equal(t, simpleStorage.list[0].Other, listOut.Items[0].Other, listOut.Items[0])
 }
 
 func TestMetadata(t *testing.T) {
 	simpleStorage := &MetadataRESTStorage{&SimpleRESTStorage{}, []string{"text/plain"}}
 	h := handle(map[string]rest.Storage{"simple": simpleStorage})
 	ws := h.(*defaultAPIServer).container.RegisteredWebServices()
-	if len(ws) == 0 {
-		t.Fatal("no web services registered")
-	}
+	require.NotEmpty(t, ws, "no web services registered")
 	matches := map[string]int{}
 	for _, w := range ws {
 		for _, r := range w.Routes() {
@@ -1451,18 +1366,12 @@ func TestGet(t *testing.T) {
 	req, err := http.NewRequestWithContext(ctx, request.MethodGet, url, nil)
 	require.NoError(t, err)
 	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	defer apitesting.Close(t, resp.Body)
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("unexpected response: %#v", resp)
-	}
+	require.Equal(t, http.StatusOK, resp.StatusCode)
 	var itemOut genericapitesting.Simple
 	body, err := extractBody(resp, &itemOut)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
 	if itemOut.Name != simpleStorage.item.Name {
 		t.Errorf("Unexpected data: %#v, expected %#v (%s)", itemOut, simpleStorage.item, string(body))
@@ -1493,16 +1402,11 @@ func BenchmarkGet(b *testing.B) {
 			req, err := http.NewRequestWithContext(ctx, request.MethodGet, url, nil)
 			require.NoError(b, err)
 			resp, err := http.DefaultClient.Do(req)
-			if err != nil {
-				b.Fatalf("unexpected error: %v", err)
-			}
+			require.NoError(b, err)
 			defer apitesting.Close(b, resp.Body)
-			if resp.StatusCode != http.StatusOK {
-				b.Fatalf("unexpected response: %#v", resp)
-			}
-			if _, err := io.Copy(io.Discard, resp.Body); err != nil {
-				b.Fatalf("unable to read body")
-			}
+			require.Equal(b, http.StatusOK, resp.StatusCode)
+			_, err = io.Copy(io.Discard, resp.Body)
+			require.NoError(b, err)
 		}()
 	}
 	b.StopTimer()
@@ -1536,20 +1440,13 @@ func BenchmarkGetNoCompression(b *testing.B) {
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
 			req, err := http.NewRequestWithContext(ctx, request.MethodGet, url, nil)
-			if err != nil {
-				b.Fatalf("unexpected error: %v", err)
-			}
+			require.NoError(b, err)
 			resp, err := client.Do(req)
-			if err != nil {
-				b.Fatalf("unexpected error: %v", err)
-			}
+			require.NoError(b, err)
 			defer apitesting.Close(b, resp.Body)
-			if resp.StatusCode != http.StatusOK {
-				b.Fatalf("unexpected response: %#v", resp)
-			}
-			if _, err := io.Copy(io.Discard, resp.Body); err != nil {
-				b.Fatalf("unable to read body")
-			}
+			require.Equal(b, http.StatusOK, resp.StatusCode)
+			_, err = io.Copy(io.Discard, resp.Body)
+			require.NoError(b, err)
 		}()
 	}
 	b.StopTimer()
@@ -1580,41 +1477,30 @@ func TestGetCompression(t *testing.T) {
 		testName := fmt.Sprintf("Accept-Encoding:%s", test.acceptEncoding)
 		t.Run(testName, func(t *testing.T) {
 			ctx := t.Context()
-			req, err := http.NewRequestWithContext(ctx, request.MethodGet, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/id", nil)
-			if err != nil {
-				t.Fatalf("unexpected error creating request: %v", err)
-			}
+			url := server.URL + "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/namespaces/default/simple/id"
+			req, err := http.NewRequestWithContext(ctx, request.MethodGet, url, nil)
+			require.NoError(t, err)
 			// It's necessary to manually set Accept-Encoding here
 			// to prevent http.DefaultClient from automatically
 			// decoding responses
 			req.Header.Set("Accept-Encoding", test.acceptEncoding)
 			resp, err := http.DefaultClient.Do(req)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
+			require.NoError(t, err)
 			defer apitesting.Close(t, resp.Body)
-			if resp.StatusCode != http.StatusOK {
-				t.Fatalf("unexpected response: %#v", resp)
-			}
+			require.Equal(t, http.StatusOK, resp.StatusCode)
 			var decoder *json.Decoder
 			if test.acceptEncoding == "gzip" {
 				gzipReader, err := gzip.NewReader(resp.Body)
-				if err != nil {
-					t.Fatalf("unexpected error creating gzip reader: %v", err)
-				}
+				require.NoError(t, err)
 				decoder = json.NewDecoder(gzipReader)
 			} else {
 				decoder = json.NewDecoder(resp.Body)
 			}
 			var itemOut genericapitesting.Simple
 			err = decoder.Decode(&itemOut)
-			if err != nil {
-				t.Errorf("unexpected error: %v", err)
-			}
+			require.NoError(t, err)
 			body, err := io.ReadAll(resp.Body)
-			if err != nil {
-				t.Errorf("unexpected error reading body: %v", err)
-			}
+			require.NoError(t, err)
 
 			if itemOut.Name != simpleStorage.item.Name {
 				t.Errorf("Unexpected data: %#v, expected %#v (%s)", itemOut, simpleStorage.item, string(body))
@@ -1663,43 +1549,30 @@ func TestGetPretty(t *testing.T) {
 		}
 		t.Run(testName, func(t *testing.T) {
 			u, err := url.Parse(server.URL + "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/namespaces/default/simple/id")
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 			u.RawQuery = test.params.Encode()
 			req := &http.Request{Method: request.MethodGet, URL: u}
 			req.Header = http.Header{}
 			req.Header.Set("Accept", test.accept)
 			req.Header.Set("User-Agent", test.userAgent)
 			resp, err := http.DefaultClient.Do(req)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if resp.StatusCode != http.StatusOK {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
+			require.Equal(t, http.StatusOK, resp.StatusCode)
 			var itemOut genericapitesting.Simple
 			body, err := extractBody(resp, &itemOut)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 			// to get stable ordering we need to use a go type
 			unstructured := genericapitesting.Simple{}
-			if err := json.Unmarshal([]byte(body), &unstructured); err != nil {
-				t.Fatal(err)
-			}
+			err = json.Unmarshal([]byte(body), &unstructured)
+			require.NoError(t, err)
 			var expect string
 			if test.pretty {
 				out, err := json.MarshalIndent(unstructured, "", "  ")
-				if err != nil {
-					t.Fatal(err)
-				}
+				require.NoError(t, err)
 				expect = string(out)
 			} else {
 				out, err := json.Marshal(unstructured)
-				if err != nil {
-					t.Fatal(err)
-				}
+				require.NoError(t, err)
 				expect = string(out) + "\n"
 			}
 			if expect != body {
@@ -1717,17 +1590,13 @@ func TestGetTable(t *testing.T) {
 	}
 
 	m, err := meta.Accessor(&obj)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	var encodedV1Beta1Body []byte
 	{
 		partial := meta.AsPartialObjectMetadata(m)
 		partial.GetObjectKind().SetGroupVersionKind(metav1beta1.SchemeGroupVersion.WithKind("PartialObjectMetadata"))
 		encodedBody, err := runtime.Encode(metainternalversionscheme.Codecs.LegacyCodec(metav1beta1.SchemeGroupVersion), partial)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		// the codec includes a trailing newline that is not present during decode
 		encodedV1Beta1Body = bytes.TrimSpace(encodedBody)
 	}
@@ -1736,9 +1605,7 @@ func TestGetTable(t *testing.T) {
 		partial := meta.AsPartialObjectMetadata(m)
 		partial.GetObjectKind().SetGroupVersionKind(metav1.SchemeGroupVersion.WithKind("PartialObjectMetadata"))
 		encodedBody, err := runtime.Encode(metainternalversionscheme.Codecs.LegacyCodec(metav1.SchemeGroupVersion), partial)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		// the codec includes a trailing newline that is not present during decode
 		encodedV1Body = bytes.TrimSpace(encodedBody)
 	}
@@ -1864,39 +1731,25 @@ func TestGetTable(t *testing.T) {
 				id = "/id"
 			}
 			u, err := url.Parse(server.URL + "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/namespaces/default/simple" + id)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 			u.RawQuery = test.params.Encode()
 			req := &http.Request{Method: request.MethodGet, URL: u}
 			req.Header = http.Header{}
 			req.Header.Set("Accept", test.accept)
 			resp, err := http.DefaultClient.Do(req)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 			if test.statusCode != 0 {
-				if resp.StatusCode != test.statusCode {
-					t.Errorf("unexpected response: %#v", resp)
-				}
+				assert.Equal(t, test.statusCode, resp.StatusCode)
 				obj, _, err := extractBodyObject(resp, unstructured.UnstructuredJSONScheme)
-				if err != nil {
-					t.Fatalf("unexpected body read error: %v", err)
-				}
-				gvk := schema.GroupVersionKind{Version: "v1", Kind: "Status"}
-				if obj.GetObjectKind().GroupVersionKind() != gvk {
-					t.Fatalf("unexpected error body: %#v", obj)
-				}
+				require.NoError(t, err)
+				expectedGVK := schema.GroupVersionKind{Version: "v1", Kind: "Status"}
+				require.Equal(t, expectedGVK, obj.GetObjectKind().GroupVersionKind())
 				return
 			}
-			if resp.StatusCode != http.StatusOK {
-				t.Errorf("unexpected response: %#v", resp)
-			}
+			require.Equal(t, http.StatusOK, resp.StatusCode)
 			var itemOut metav1.Table
 			body, err := extractBody(resp, &itemOut)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 			if !reflect.DeepEqual(test.expected, &itemOut) {
 				t.Log(body)
 				t.Errorf("did not match: %s", cmp.Diff(test.expected, &itemOut))
@@ -1912,22 +1765,16 @@ func TestWatchTable(t *testing.T) {
 	}
 
 	m, err := meta.Accessor(&obj)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	partial := meta.AsPartialObjectMetadata(m)
 	partial.GetObjectKind().SetGroupVersionKind(metav1beta1.SchemeGroupVersion.WithKind("PartialObjectMetadata"))
 	encodedBody, err := runtime.Encode(metainternalversionscheme.Codecs.LegacyCodec(metav1beta1.SchemeGroupVersion), partial)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	// the codec includes a trailing newline that is not present during decode
 	encodedBody = bytes.TrimSpace(encodedBody)
 
 	encodedBodyV1, err := runtime.Encode(metainternalversionscheme.Codecs.LegacyCodec(metav1.SchemeGroupVersion), partial)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	// the codec includes a trailing newline that is not present during decode
 	encodedBodyV1 = bytes.TrimSpace(encodedBodyV1)
 
@@ -2067,9 +1914,7 @@ func TestWatchTable(t *testing.T) {
 				id = "/id"
 			}
 			u, err := url.Parse(server.URL + "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/namespaces/default/simple")
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 			if test.params == nil {
 				test.params = url.Values{}
 			}
@@ -2083,27 +1928,17 @@ func TestWatchTable(t *testing.T) {
 			req.Header = http.Header{}
 			req.Header.Set("Accept", test.accept)
 			resp, err := http.DefaultClient.Do(req)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 			defer apitesting.Close(t, resp.Body)
 			if test.statusCode != 0 {
-				if resp.StatusCode != test.statusCode {
-					t.Fatalf("unexpected response: %#v", resp)
-				}
+				assert.Equal(t, test.statusCode, resp.StatusCode)
 				obj, _, err := extractBodyObject(resp, unstructured.UnstructuredJSONScheme)
-				if err != nil {
-					t.Fatalf("unexpected body read error: %v", err)
-				}
-				gvk := schema.GroupVersionKind{Version: "v1", Kind: "Status"}
-				if obj.GetObjectKind().GroupVersionKind() != gvk {
-					t.Fatalf("unexpected error body: %#v", obj)
-				}
+				require.NoError(t, err)
+				expectedGVK := schema.GroupVersionKind{Version: "v1", Kind: "Status"}
+				require.Equal(t, expectedGVK, obj.GetObjectKind().GroupVersionKind())
 				return
 			}
-			if resp.StatusCode != http.StatusOK {
-				t.Fatalf("unexpected response: %#v", resp)
-			}
+			require.Equal(t, http.StatusOK, resp.StatusCode)
 
 			// Wait for storage watcher to start
 			var watcher *watch.FakeWatcher
@@ -2118,9 +1953,7 @@ func TestWatchTable(t *testing.T) {
 			}()
 
 			body, err := io.ReadAll(resp.Body)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 			t.Logf("Body:\n%s", string(body))
 			d := watchDecoder(resp.Header.Get("Content-Type"), io.NopCloser(bytes.NewReader(body)))
 			var actual []*metav1.WatchEvent
@@ -2130,14 +1963,10 @@ func TestWatchTable(t *testing.T) {
 				if err == io.EOF {
 					break
 				}
-				if err != nil {
-					t.Fatal(err)
-				}
+				require.NoError(t, err)
 				actual = append(actual, &event)
 			}
-			if !reflect.DeepEqual(test.expected, actual) {
-				t.Fatalf("unexpected: %s", cmp.Diff(test.expected, actual))
-			}
+			require.Equal(t, test.expected, actual)
 		})
 	}
 }
@@ -2279,59 +2108,38 @@ func TestGetPartialObjectMetadata(t *testing.T) {
 				suffix = "/namespaces/default/simple"
 			}
 			u, err := url.Parse(server.URL + "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + suffix)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 			u.RawQuery = test.params.Encode()
 			req := &http.Request{Method: request.MethodGet, URL: u}
 			req.Header = http.Header{}
 			req.Header.Set("Accept", test.accept)
 			resp, err := http.DefaultClient.Do(req)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 			defer apitesting.Close(t, resp.Body)
 			if test.statusCode != 0 {
-				if resp.StatusCode != test.statusCode {
-					t.Errorf("unexpected response: %#v", resp)
-				}
+				assert.Equal(t, test.statusCode, resp.StatusCode)
 				obj, _, err := extractBodyObject(resp, unstructured.UnstructuredJSONScheme)
-				if err != nil {
-					t.Fatalf("unexpected body read error: %v", err)
-				}
-				gvk := schema.GroupVersionKind{Version: "v1", Kind: "Status"}
-				if obj.GetObjectKind().GroupVersionKind() != gvk {
-					t.Errorf("unexpected error body: %#v", obj)
-				}
+				require.NoError(t, err)
+				expectedGVK := schema.GroupVersionKind{Version: "v1", Kind: "Status"}
+				require.Equal(t, expectedGVK, obj.GetObjectKind().GroupVersionKind())
 				return
 			}
-			if resp.StatusCode != http.StatusOK {
-				t.Fatalf("invalid status: %#v\n%s", resp, bodyOrDie(resp))
-			}
+			require.Equal(t, http.StatusOK, resp.StatusCode)
 			body := ""
 			if test.expected != nil {
 				itemOut, d, err := extractBodyObject(resp, metainternalversionscheme.Codecs.LegacyCodec(metav1beta1.SchemeGroupVersion))
-				if err != nil {
-					t.Fatal(err)
-				}
-				if !reflect.DeepEqual(test.expected, itemOut) {
-					t.Errorf("did not match: %s", cmp.Diff(test.expected, itemOut))
-				}
+				require.NoError(t, err)
+				require.Equal(t, test.expected, itemOut)
 				body = d
 			} else {
 				d, err := io.ReadAll(resp.Body)
-				if err != nil {
-					t.Fatal(err)
-				}
+				require.NoError(t, err)
 				body = string(d)
 			}
 			obj := &unstructured.Unstructured{}
-			if err := json.Unmarshal([]byte(body), obj); err != nil {
-				t.Fatal(err)
-			}
-			if obj.GetObjectKind().GroupVersionKind() != test.expectKind {
-				t.Errorf("unexpected kind: %#v", obj.GetObjectKind().GroupVersionKind())
-			}
+			err = json.Unmarshal([]byte(body), obj)
+			require.NoError(t, err)
+			require.Equal(t, test.expectKind, obj.GetObjectKind().GroupVersionKind())
 		})
 	}
 }
@@ -2348,23 +2156,16 @@ func TestGetBinary(t *testing.T) {
 	server := httptest.NewServer(handle(map[string]rest.Storage{"simple": &simpleStorage}))
 	defer server.Close()
 
-	req, err := http.NewRequestWithContext(ctx, request.MethodGet, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/binary", nil)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	url := server.URL + "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/namespaces/default/simple/binary"
+	req, err := http.NewRequestWithContext(ctx, request.MethodGet, url, nil)
+	require.NoError(t, err)
 	req.Header.Add("Accept", "text/other, */*")
 	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	defer apitesting.Close(t, resp.Body)
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("unexpected response: %#v", resp)
-	}
+	require.Equal(t, http.StatusOK, resp.StatusCode)
 	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	if !stream.closed || stream.version != testGroupVersion.String() || stream.accept != "text/other, */*" ||
 		resp.Header.Get("Content-Type") != stream.contentType || string(body) != "response data" {
 		t.Errorf("unexpected stream: %#v", stream)
@@ -2400,9 +2201,7 @@ func TestGetWithOptionsRouteParams(t *testing.T) {
 	storage["simple"] = &simpleStorage
 	handler := handle(storage)
 	ws := handler.(*defaultAPIServer).container.RegisteredWebServices()
-	if len(ws) == 0 {
-		t.Fatal("no web services registered")
-	}
+	require.NotEmpty(t, ws, "no web services registered")
 	routes := ws[0].Routes()
 	for i := range routes {
 		if routes[i].Method == request.MethodGet && routes[i].Operation == "readNamespacedSimple" {
@@ -2502,13 +2301,9 @@ func TestGetWithOptions(t *testing.T) {
 			req, err := http.NewRequestWithContext(ctx, request.MethodGet, url, nil)
 			require.NoError(t, err)
 			resp, err := http.DefaultClient.Do(req)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
+			require.NoError(t, err)
 			defer apitesting.Close(t, resp.Body)
-			if resp.StatusCode != http.StatusOK {
-				t.Fatalf("unexpected response: %#v", resp)
-			}
+			require.Equal(t, http.StatusOK, resp.StatusCode)
 
 			var itemOut runtime.Object
 			if test.rootScoped {
@@ -2517,34 +2312,22 @@ func TestGetWithOptions(t *testing.T) {
 				itemOut = &genericapitesting.Simple{}
 			}
 			body, err := extractBody(resp, itemOut)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if metadata, err := meta.Accessor(itemOut); err == nil {
-				if metadata.GetName() != simpleStorage.item.Name {
-					t.Fatalf("Unexpected data: %#v, expected %#v (%s)", itemOut, simpleStorage.item, string(body))
-				}
-			} else {
-				t.Errorf("Couldn't get name from %#v: %v", itemOut, err)
-			}
+			require.NoError(t, err)
+			metadata, err := meta.Accessor(itemOut)
+			require.NoError(t, err)
+			require.Equal(t, simpleStorage.item.Name, metadata.GetName(), string(body))
 
 			var opts *genericapitesting.SimpleGetOptions
-			var ok bool
 			if test.rootScoped {
-				opts, ok = simpleRootStorage.optionsReceived.(*genericapitesting.SimpleGetOptions)
+				require.IsType(t, &genericapitesting.SimpleGetOptions{}, simpleRootStorage.optionsReceived)
+				opts = simpleRootStorage.optionsReceived.(*genericapitesting.SimpleGetOptions)
 			} else {
-				opts, ok = simpleStorage.optionsReceived.(*genericapitesting.SimpleGetOptions)
-
+				require.IsType(t, &genericapitesting.SimpleGetOptions{}, simpleStorage.optionsReceived)
+				opts = simpleStorage.optionsReceived.(*genericapitesting.SimpleGetOptions)
 			}
-			if !ok {
-				t.Fatalf("Unexpected options object received: %#v", simpleStorage.optionsReceived)
-			}
-			if opts.Param1 != "test1" || opts.Param2 != "test2" {
-				t.Fatalf("Did not receive expected options: %#v", opts)
-			}
-			if opts.Path != test.expectedPath {
-				t.Fatalf("Unexpected path value. Expected: %s. Actual: %s.", test.expectedPath, opts.Path)
-			}
+			assert.Equal(t, "test1", opts.Param1)
+			assert.Equal(t, "test2", opts.Param2)
+			assert.Equal(t, test.expectedPath, opts.Path)
 		})
 	}
 }
@@ -2564,13 +2347,9 @@ func TestGetMissing(t *testing.T) {
 	req, err := http.NewRequestWithContext(ctx, request.MethodGet, url, nil)
 	require.NoError(t, err)
 	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	defer apitesting.Close(t, resp.Body)
-	if resp.StatusCode != http.StatusNotFound {
-		t.Errorf("Unexpected response %#v", resp)
-	}
+	require.Equal(t, http.StatusNotFound, resp.StatusCode)
 }
 
 func TestGetRetryAfter(t *testing.T) {
@@ -2588,13 +2367,9 @@ func TestGetRetryAfter(t *testing.T) {
 	req, err := http.NewRequestWithContext(ctx, request.MethodGet, url, nil)
 	require.NoError(t, err)
 	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	defer apitesting.Close(t, resp.Body)
-	if resp.StatusCode != http.StatusInternalServerError {
-		t.Errorf("Unexpected response %#v", resp)
-	}
+	require.Equal(t, http.StatusInternalServerError, resp.StatusCode)
 	if resp.Header.Get("Retry-After") != "2" {
 		t.Errorf("Unexpected Retry-After header: %v", resp.Header)
 	}
@@ -2621,17 +2396,11 @@ func TestConnect(t *testing.T) {
 	req, err := http.NewRequestWithContext(ctx, request.MethodGet, url, nil)
 	require.NoError(t, err)
 	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	defer apitesting.Close(t, resp.Body)
-	if resp.StatusCode != http.StatusOK {
-		t.Errorf("unexpected response: %#v", resp)
-	}
+	require.Equal(t, http.StatusOK, resp.StatusCode)
 	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	if connectStorage.receivedID != itemID {
 		t.Errorf("Unexpected item id. Expected: %s. Actual: %s.", itemID, connectStorage.receivedID)
 	}
@@ -2662,24 +2431,16 @@ func TestConnectResponderObject(t *testing.T) {
 	req, err := http.NewRequestWithContext(ctx, request.MethodGet, url, nil)
 	require.NoError(t, err)
 	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	defer apitesting.Close(t, resp.Body)
-	if resp.StatusCode != http.StatusCreated {
-		t.Errorf("unexpected response: %#v", resp)
-	}
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
 	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	if connectStorage.receivedID != itemID {
 		t.Errorf("Unexpected item id. Expected: %s. Actual: %s.", itemID, connectStorage.receivedID)
 	}
 	obj, err := runtime.Decode(codec, body)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if !apiequality.Semantic.DeepEqual(obj, simple) {
 		t.Errorf("Unexpected response: %#v", obj)
 	}
@@ -2706,24 +2467,16 @@ func TestConnectResponderError(t *testing.T) {
 	req, err := http.NewRequestWithContext(ctx, request.MethodGet, url, nil)
 	require.NoError(t, err)
 	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	defer apitesting.Close(t, resp.Body)
-	if resp.StatusCode != http.StatusForbidden {
-		t.Errorf("unexpected response: %#v", resp)
-	}
+	require.Equal(t, http.StatusForbidden, resp.StatusCode)
 	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	if connectStorage.receivedID != itemID {
 		t.Errorf("Unexpected item id. Expected: %s. Actual: %s.", itemID, connectStorage.receivedID)
 	}
 	obj, err := runtime.Decode(codec, body)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if obj.(*metav1.Status).Code != http.StatusForbidden {
 		t.Errorf("Unexpected response: %#v", obj)
 	}
@@ -2740,9 +2493,7 @@ func TestConnectWithOptionsRouteParams(t *testing.T) {
 	}
 	handler := handle(storage)
 	ws := handler.(*defaultAPIServer).container.RegisteredWebServices()
-	if len(ws) == 0 {
-		t.Fatal("no web services registered")
-	}
+	require.NotEmpty(t, ws, "no web services registered")
 	routes := ws[0].Routes()
 	for i := range routes {
 		switch routes[i].Operation {
@@ -2751,7 +2502,6 @@ func TestConnectWithOptionsRouteParams(t *testing.T) {
 		case "connectPutNamespacedSimpleConnect":
 		case "connectDeleteNamespacedSimpleConnect":
 			validateSimpleGetOptionsParams(t, &routes[i])
-
 		}
 	}
 }
@@ -2778,17 +2528,11 @@ func TestConnectWithOptions(t *testing.T) {
 	req, err := http.NewRequestWithContext(ctx, request.MethodGet, url, nil)
 	require.NoError(t, err)
 	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	defer apitesting.Close(t, resp.Body)
-	if resp.StatusCode != http.StatusOK {
-		t.Errorf("unexpected response: %#v", resp)
-	}
+	require.Equal(t, http.StatusOK, resp.StatusCode)
 	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	if connectStorage.receivedID != itemID {
 		t.Errorf("Unexpected item id. Expected: %s. Actual: %s.", itemID, connectStorage.receivedID)
 	}
@@ -2798,13 +2542,10 @@ func TestConnectWithOptions(t *testing.T) {
 	if connectStorage.receivedResponder == nil {
 		t.Errorf("Unexpected responder")
 	}
-	opts, ok := connectStorage.receivedConnectOptions.(*genericapitesting.SimpleGetOptions)
-	if !ok {
-		t.Fatalf("Unexpected options type: %#v", connectStorage.receivedConnectOptions)
-	}
-	if opts.Param1 != "value1" && opts.Param2 != "value2" {
-		t.Errorf("Unexpected options value: %#v", opts)
-	}
+	require.IsType(t, &genericapitesting.SimpleGetOptions{}, connectStorage.receivedConnectOptions)
+	opts := connectStorage.receivedConnectOptions.(*genericapitesting.SimpleGetOptions)
+	assert.Equal(t, "value1", opts.Param1)
+	assert.Equal(t, "value2", opts.Param2)
 }
 
 func TestConnectWithOptionsAndPath(t *testing.T) {
@@ -2831,33 +2572,18 @@ func TestConnectWithOptionsAndPath(t *testing.T) {
 	req, err := http.NewRequestWithContext(ctx, request.MethodGet, url, nil)
 	require.NoError(t, err)
 	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	defer apitesting.Close(t, resp.Body)
-	if resp.StatusCode != http.StatusOK {
-		t.Errorf("unexpected response: %#v", resp)
-	}
+	require.Equal(t, http.StatusOK, resp.StatusCode)
 	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
-	if connectStorage.receivedID != itemID {
-		t.Errorf("Unexpected item id. Expected: %s. Actual: %s.", itemID, connectStorage.receivedID)
-	}
-	if string(body) != responseText {
-		t.Errorf("Unexpected response. Expected: %s. Actual: %s.", responseText, string(body))
-	}
-	opts, ok := connectStorage.receivedConnectOptions.(*genericapitesting.SimpleGetOptions)
-	if !ok {
-		t.Fatalf("Unexpected options type: %#v", connectStorage.receivedConnectOptions)
-	}
-	if opts.Param1 != "value1" && opts.Param2 != "value2" {
-		t.Errorf("Unexpected options value: %#v", opts)
-	}
-	if opts.Path != testPath {
-		t.Errorf("Unexpected path value. Expected: %s. Actual: %s.", testPath, opts.Path)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, itemID, connectStorage.receivedID)
+	assert.Equal(t, responseText, string(body))
+	require.IsType(t, &genericapitesting.SimpleGetOptions{}, connectStorage.receivedConnectOptions)
+	opts := connectStorage.receivedConnectOptions.(*genericapitesting.SimpleGetOptions)
+	assert.Equal(t, "value1", opts.Param1)
+	assert.Equal(t, "value2", opts.Param2)
+	assert.Equal(t, testPath, opts.Path)
 }
 
 func TestDelete(t *testing.T) {
@@ -2870,22 +2596,15 @@ func TestDelete(t *testing.T) {
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
+	url := server.URL + "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/namespaces/default/simple/" + ID
 	client := http.Client{}
-	request, err := http.NewRequestWithContext(ctx, request.MethodDelete, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/"+ID, nil)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+	request, err := http.NewRequestWithContext(ctx, request.MethodDelete, url, nil)
+	require.NoError(t, err)
 	res, err := client.Do(request)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	defer apitesting.Close(t, res.Body)
-	if res.StatusCode != http.StatusOK {
-		t.Errorf("unexpected response: %#v", res)
-	}
-	if simpleStorage.deleted != ID {
-		t.Errorf("Unexpected delete: %s, expected %s", simpleStorage.deleted, ID)
-	}
+	assert.Equal(t, http.StatusOK, res.StatusCode)
+	assert.Equal(t, ID, simpleStorage.deleted)
 }
 
 func TestDeleteWithOptions(t *testing.T) {
@@ -2903,35 +2622,24 @@ func TestDeleteWithOptions(t *testing.T) {
 		GracePeriodSeconds: &grace,
 	}
 	body, err := runtime.Encode(codec, item)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
+	url := server.URL + "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/namespaces/default/simple/" + ID
 	client := http.Client{}
-	request, err := http.NewRequestWithContext(ctx, request.MethodDelete, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/"+ID, bytes.NewReader(body))
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+	request, err := http.NewRequestWithContext(ctx, request.MethodDelete, url, bytes.NewReader(body))
+	require.NoError(t, err)
 	res, err := client.Do(request)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	defer apitesting.Close(t, res.Body)
 	if res.StatusCode != http.StatusOK {
 		t.Errorf("unexpected response: %s %#v", request.URL, res)
 		s, err := io.ReadAll(res.Body)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
+		require.NoError(t, err)
 		t.Log(string(s))
 	}
-	if simpleStorage.deleted != ID {
-		t.Errorf("Unexpected delete: %s, expected %s", simpleStorage.deleted, ID)
-	}
+	assert.Equal(t, ID, simpleStorage.deleted)
 	simpleStorage.deleteOptions.GetObjectKind().SetGroupVersionKind(schema.GroupVersionKind{})
-	if !apiequality.Semantic.DeepEqual(simpleStorage.deleteOptions, item) {
-		t.Errorf("unexpected delete options: %s", cmp.Diff(simpleStorage.deleteOptions, item))
-	}
+	assert.Equal(t, item, simpleStorage.deleteOptions)
 }
 
 func TestDeleteWithOptionsQuery(t *testing.T) {
@@ -2949,31 +2657,22 @@ func TestDeleteWithOptionsQuery(t *testing.T) {
 		GracePeriodSeconds: &grace,
 	}
 
+	url := server.URL + "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/namespaces/default/simple/" + ID + "?gracePeriodSeconds=" + strconv.FormatInt(grace, 10)
 	client := http.Client{}
-	request, err := http.NewRequestWithContext(ctx, request.MethodDelete, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/"+ID+"?gracePeriodSeconds="+strconv.FormatInt(grace, 10), nil)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+	request, err := http.NewRequestWithContext(ctx, request.MethodDelete, url, nil)
+	require.NoError(t, err)
 	res, err := client.Do(request)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	defer apitesting.Close(t, res.Body)
 	if res.StatusCode != http.StatusOK {
 		t.Errorf("unexpected response: %s %#v", request.URL, res)
 		s, err := io.ReadAll(res.Body)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
+		require.NoError(t, err)
 		t.Log(string(s))
 	}
-	if simpleStorage.deleted != ID {
-		t.Fatalf("Unexpected delete: %s, expected %s", simpleStorage.deleted, ID)
-	}
+	require.Equal(t, ID, simpleStorage.deleted)
 	simpleStorage.deleteOptions.GetObjectKind().SetGroupVersionKind(schema.GroupVersionKind{})
-	if !apiequality.Semantic.DeepEqual(simpleStorage.deleteOptions, item) {
-		t.Errorf("unexpected delete options: %s", cmp.Diff(simpleStorage.deleteOptions, item))
-	}
+	require.Equal(t, item, simpleStorage.deleteOptions)
 }
 
 func TestDeleteWithOptionsQueryAndBody(t *testing.T) {
@@ -2991,34 +2690,23 @@ func TestDeleteWithOptionsQueryAndBody(t *testing.T) {
 		GracePeriodSeconds: &grace,
 	}
 	body, err := runtime.Encode(codec, item)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
+	url := server.URL + "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/namespaces/default/simple/" + ID + "?gracePeriodSeconds=" + strconv.FormatInt(grace+10, 10)
 	client := http.Client{}
-	request, err := http.NewRequestWithContext(ctx, request.MethodDelete, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/"+ID+"?gracePeriodSeconds="+strconv.FormatInt(grace+10, 10), bytes.NewReader(body))
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+	request, err := http.NewRequestWithContext(ctx, request.MethodDelete, url, bytes.NewReader(body))
+	require.NoError(t, err)
 	res, err := client.Do(request)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	defer apitesting.Close(t, res.Body)
 	if res.StatusCode != http.StatusOK {
 		t.Errorf("unexpected response: %s %#v", request.URL, res)
 		s, err := io.ReadAll(res.Body)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
+		require.NoError(t, err)
 		t.Log(string(s))
 	}
-	if simpleStorage.deleted != ID {
-		t.Errorf("Unexpected delete: %s, expected %s", simpleStorage.deleted, ID)
-	}
+	require.Equal(t, ID, simpleStorage.deleted)
 	simpleStorage.deleteOptions.GetObjectKind().SetGroupVersionKind(schema.GroupVersionKind{})
-	if !apiequality.Semantic.DeepEqual(simpleStorage.deleteOptions, item) {
-		t.Errorf("unexpected delete options: %s", cmp.Diff(simpleStorage.deleteOptions, item))
-	}
+	require.Equal(t, item, simpleStorage.deleteOptions)
 }
 
 func TestDeleteInvokesAdmissionControl(t *testing.T) {
@@ -3035,19 +2723,14 @@ func TestDeleteInvokesAdmissionControl(t *testing.T) {
 			server := httptest.NewServer(handler)
 			defer server.Close()
 
+			url := server.URL + "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/namespaces/default/simple/" + ID
 			client := http.Client{}
-			request, err := http.NewRequestWithContext(ctx, request.MethodDelete, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/"+ID, nil)
-			if err != nil {
-				t.Errorf("unexpected error: %v", err)
-			}
+			request, err := http.NewRequestWithContext(ctx, request.MethodDelete, url, nil)
+			require.NoError(t, err)
 			response, err := client.Do(request)
-			if err != nil {
-				t.Errorf("unexpected error: %v", err)
-			}
+			require.NoError(t, err)
 			defer apitesting.Close(t, response.Body)
-			if response.StatusCode != http.StatusForbidden {
-				t.Errorf("Unexpected response %#v", response)
-			}
+			require.Equal(t, http.StatusForbidden, response.StatusCode)
 		})
 	}
 }
@@ -3064,19 +2747,14 @@ func TestDeleteMissing(t *testing.T) {
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
+	url := server.URL + "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/namespaces/default/simple/" + ID
 	client := http.Client{}
-	request, err := http.NewRequestWithContext(ctx, request.MethodDelete, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/"+ID, nil)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+	request, err := http.NewRequestWithContext(ctx, request.MethodDelete, url, nil)
+	require.NoError(t, err)
 	response, err := client.Do(request)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	defer apitesting.Close(t, response.Body)
-	if response.StatusCode != http.StatusNotFound {
-		t.Errorf("Unexpected response %#v", response)
-	}
+	require.Equal(t, http.StatusNotFound, response.StatusCode)
 }
 
 func TestUpdate(t *testing.T) {
@@ -3097,27 +2775,21 @@ func TestUpdate(t *testing.T) {
 		Other: "bar",
 	}
 	body, err := runtime.Encode(testCodec, item)
-	if err != nil {
-		// The following cases will fail, so die now
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
+	url := server.URL + "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/namespaces/default/simple/" + ID
 	client := http.Client{}
-	request, err := http.NewRequestWithContext(ctx, request.MethodPut, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/"+ID, bytes.NewReader(body))
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+	request, err := http.NewRequestWithContext(ctx, request.MethodPut, url, bytes.NewReader(body))
+	require.NoError(t, err)
 	response, err := client.Do(request)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	defer apitesting.Close(t, response.Body)
-	dump, _ := httputil.DumpResponse(response, true)
+	dump, err := httputil.DumpResponse(response, true)
+	require.NoError(t, err)
 	t.Log(string(dump))
 
-	if simpleStorage.updated == nil || simpleStorage.updated.Name != item.Name {
-		t.Errorf("Unexpected update value %#v, expected %#v.", simpleStorage.updated, item)
-	}
+	require.NotNil(t, simpleStorage.updated)
+	require.Equal(t, item.Name, simpleStorage.updated.Name)
 }
 
 func TestUpdateInvokesAdmissionControl(t *testing.T) {
@@ -3142,27 +2814,19 @@ func TestUpdateInvokesAdmissionControl(t *testing.T) {
 				Other: "bar",
 			}
 			body, err := runtime.Encode(testCodec, item)
-			if err != nil {
-				// The following cases will fail, so die now
-				t.Fatalf("unexpected error: %v", err)
-			}
+			require.NoError(t, err)
 
+			url := server.URL + "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/namespaces/default/simple/" + ID
 			client := http.Client{}
-			request, err := http.NewRequestWithContext(ctx, request.MethodPut, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/"+ID, bytes.NewReader(body))
-			if err != nil {
-				t.Errorf("unexpected error: %v", err)
-			}
+			request, err := http.NewRequestWithContext(ctx, request.MethodPut, url, bytes.NewReader(body))
+			require.NoError(t, err)
 			response, err := client.Do(request)
-			if err != nil {
-				t.Errorf("unexpected error: %v", err)
-			}
+			require.NoError(t, err)
 			defer apitesting.Close(t, response.Body)
-			dump, _ := httputil.DumpResponse(response, true)
+			dump, err := httputil.DumpResponse(response, true)
+			require.NoError(t, err)
 			t.Log(string(dump))
-
-			if response.StatusCode != http.StatusForbidden {
-				t.Errorf("Unexpected response %#v", response)
-			}
+			require.Equal(t, http.StatusForbidden, response.StatusCode)
 		})
 	}
 }
@@ -3181,23 +2845,18 @@ func TestUpdateRequiresMatchingName(t *testing.T) {
 		Other: "bar",
 	}
 	body, err := runtime.Encode(testCodec, item)
-	if err != nil {
-		// The following cases will fail, so die now
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
+	url := server.URL + "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/namespaces/default/simple/" + ID
 	client := http.Client{}
-	request, err := http.NewRequestWithContext(ctx, request.MethodPut, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/"+ID, bytes.NewReader(body))
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+	request, err := http.NewRequestWithContext(ctx, request.MethodPut, url, bytes.NewReader(body))
+	require.NoError(t, err)
 	response, err := client.Do(request)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	defer apitesting.Close(t, response.Body)
 	if response.StatusCode != http.StatusBadRequest {
-		dump, _ := httputil.DumpResponse(response, true)
+		dump, err := httputil.DumpResponse(response, true)
+		require.NoError(t, err)
 		t.Log(string(dump))
 		t.Errorf("Unexpected response %#v", response)
 	}
@@ -3220,27 +2879,19 @@ func TestUpdateAllowsMissingNamespace(t *testing.T) {
 		Other: "bar",
 	}
 	body, err := runtime.Encode(testCodec, item)
-	if err != nil {
-		// The following cases will fail, so die now
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
+	url := server.URL + "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/namespaces/default/simple/" + ID
 	client := http.Client{}
-	request, err := http.NewRequestWithContext(ctx, request.MethodPut, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/"+ID, bytes.NewReader(body))
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+	request, err := http.NewRequestWithContext(ctx, request.MethodPut, url, bytes.NewReader(body))
+	require.NoError(t, err)
 	response, err := client.Do(request)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	defer apitesting.Close(t, response.Body)
-	dump, _ := httputil.DumpResponse(response, true)
+	dump, err := httputil.DumpResponse(response, true)
+	require.NoError(t, err)
 	t.Log(string(dump))
-
-	if response.StatusCode != http.StatusOK {
-		t.Errorf("Unexpected response %#v", response)
-	}
+	require.Equal(t, http.StatusOK, response.StatusCode)
 }
 
 // when the object name and namespace can't be retrieved, don't update.  It isn't safe.
@@ -3262,27 +2913,20 @@ func TestUpdateDisallowsMismatchedNamespaceOnError(t *testing.T) {
 		Other: "bar",
 	}
 	body, err := runtime.Encode(testCodec, item)
-	if err != nil {
-		// The following cases will fail, so die now
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
+	url := server.URL + "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/namespaces/default/simple/" + ID
 	client := http.Client{}
-	request, err := http.NewRequestWithContext(ctx, request.MethodPut, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/"+ID, bytes.NewReader(body))
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+	request, err := http.NewRequestWithContext(ctx, request.MethodPut, url, bytes.NewReader(body))
+	require.NoError(t, err)
 	response, err := client.Do(request)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	defer apitesting.Close(t, response.Body)
-	dump, _ := httputil.DumpResponse(response, true)
+	dump, err := httputil.DumpResponse(response, true)
+	require.NoError(t, err)
 	t.Log(string(dump))
 
-	if simpleStorage.updated != nil {
-		t.Errorf("Unexpected update value %#v.", simpleStorage.updated)
-	}
+	require.Nil(t, simpleStorage.updated)
 }
 
 func TestUpdatePreventsMismatchedNamespace(t *testing.T) {
@@ -3303,24 +2947,16 @@ func TestUpdatePreventsMismatchedNamespace(t *testing.T) {
 		Other: "bar",
 	}
 	body, err := runtime.Encode(testCodec, item)
-	if err != nil {
-		// The following cases will fail, so die now
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
+	url := server.URL + "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/namespaces/default/simple/" + ID
 	client := http.Client{}
-	request, err := http.NewRequestWithContext(ctx, request.MethodPut, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/"+ID, bytes.NewReader(body))
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+	request, err := http.NewRequestWithContext(ctx, request.MethodPut, url, bytes.NewReader(body))
+	require.NoError(t, err)
 	response, err := client.Do(request)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	defer apitesting.Close(t, response.Body)
-	if response.StatusCode != http.StatusBadRequest {
-		t.Errorf("Unexpected response %#v", response)
-	}
+	require.Equal(t, http.StatusBadRequest, response.StatusCode)
 }
 
 func TestUpdateMissing(t *testing.T) {
@@ -3343,23 +2979,16 @@ func TestUpdateMissing(t *testing.T) {
 		Other: "bar",
 	}
 	body, err := runtime.Encode(testCodec, item)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
+	url := server.URL + "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/namespaces/default/simple/" + ID
 	client := http.Client{}
-	request, err := http.NewRequestWithContext(ctx, request.MethodPut, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/"+ID, bytes.NewReader(body))
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+	request, err := http.NewRequestWithContext(ctx, request.MethodPut, url, bytes.NewReader(body))
+	require.NoError(t, err)
 	response, err := client.Do(request)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	defer apitesting.Close(t, response.Body)
-	if response.StatusCode != http.StatusNotFound {
-		t.Errorf("Unexpected response %#v", response)
-	}
+	require.Equal(t, http.StatusNotFound, response.StatusCode)
 }
 
 func TestCreateNotFound(t *testing.T) {
@@ -3377,22 +3006,15 @@ func TestCreateNotFound(t *testing.T) {
 
 	simple := &genericapitesting.Simple{Other: "foo"}
 	data, err := runtime.Encode(testCodec, simple)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-	request, err := http.NewRequestWithContext(ctx, request.MethodPost, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple", bytes.NewBuffer(data))
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
+	url := server.URL + "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/namespaces/default/simple"
+	request, err := http.NewRequestWithContext(ctx, request.MethodPost, url, bytes.NewBuffer(data))
+	require.NoError(t, err)
 
 	response, err := client.Do(request)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	defer apitesting.Close(t, response.Body)
-	if response.StatusCode != http.StatusNotFound {
-		t.Errorf("Unexpected response %#v", response)
-	}
+	require.Equal(t, http.StatusNotFound, response.StatusCode)
 }
 
 func TestCreateChecksDecode(t *testing.T) {
@@ -3404,27 +3026,17 @@ func TestCreateChecksDecode(t *testing.T) {
 
 	simple := &example.Pod{}
 	data, err := runtime.Encode(testCodec, simple)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-	request, err := http.NewRequestWithContext(ctx, request.MethodPost, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple", bytes.NewBuffer(data))
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
+	url := server.URL + "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/namespaces/default/simple"
+	request, err := http.NewRequestWithContext(ctx, request.MethodPost, url, bytes.NewBuffer(data))
+	require.NoError(t, err)
 	response, err := client.Do(request)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	defer apitesting.Close(t, response.Body)
-	if response.StatusCode != http.StatusBadRequest {
-		t.Errorf("Unexpected response %#v", response)
-	}
+	assert.Equal(t, http.StatusBadRequest, response.StatusCode)
 	b, err := io.ReadAll(response.Body)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	} else if !strings.Contains(string(b), "cannot be handled as a Simple") {
-		t.Errorf("unexpected response: %s", string(b))
-	}
+	require.NoError(t, err)
+	require.Contains(t, string(b), "cannot be handled as a Simple")
 }
 
 func TestParentResourceIsRequired(t *testing.T) {
@@ -3455,9 +3067,8 @@ func TestParentResourceIsRequired(t *testing.T) {
 		ParameterCodec: parameterCodec,
 	}
 	container := restful.NewContainer()
-	if _, _, err := group.InstallREST(container); err == nil {
-		t.Fatal("expected error")
-	}
+	_, _, err := group.InstallREST(container)
+	require.Error(t, err)
 
 	storage = &SimpleTypedStorage{
 		baseType: &genericapitesting.SimpleRoot{}, // a root scoped type
@@ -3488,28 +3099,21 @@ func TestParentResourceIsRequired(t *testing.T) {
 		ParameterCodec: parameterCodec,
 	}
 	container = restful.NewContainer()
-	if _, _, err := group.InstallREST(container); err != nil {
-		t.Fatal(err)
-	}
+	_, _, err = group.InstallREST(container)
+	require.NoError(t, err)
 
 	handler := genericapifilters.WithRequestInfo(container, newTestRequestInfoResolver())
 
 	// resource is NOT registered in the root scope
 	w := httptest.NewRecorder()
 	handler.ServeHTTP(w, &http.Request{Method: request.MethodGet, URL: &url.URL{Path: "/" + prefix + "/simple/test/sub"}})
-	if w.Code != http.StatusNotFound {
-		t.Errorf("expected not found: %#v", w)
-	}
+	assert.Equal(t, http.StatusNotFound, w.Code)
 
 	// resource is registered in the namespace scope
 	w = httptest.NewRecorder()
 	handler.ServeHTTP(w, &http.Request{Method: request.MethodGet, URL: &url.URL{Path: "/" + prefix + "/" + newGroupVersion.Group + "/" + newGroupVersion.Version + "/namespaces/test/simple/test/sub"}})
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected OK: %#v", w)
-	}
-	if storage.actualNamespace != "test" {
-		t.Errorf("namespace should be set %#v", storage)
-	}
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "test", storage.actualNamespace)
 }
 
 func TestNamedCreaterWithName(t *testing.T) {
@@ -3526,24 +3130,15 @@ func TestNamedCreaterWithName(t *testing.T) {
 
 	simple := &genericapitesting.Simple{Other: "foo"}
 	data, err := runtime.Encode(testCodec, simple)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-	request, err := http.NewRequestWithContext(ctx, request.MethodPost, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/"+pathName+"/sub", bytes.NewBuffer(data))
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
+	url := server.URL + "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/namespaces/default/simple/" + pathName + "/sub"
+	request, err := http.NewRequestWithContext(ctx, request.MethodPost, url, bytes.NewBuffer(data))
+	require.NoError(t, err)
 	response, err := client.Do(request)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	defer apitesting.Close(t, response.Body)
-	if response.StatusCode != http.StatusCreated {
-		t.Errorf("Unexpected response %#v", response)
-	}
-	if storage.createdName != pathName {
-		t.Errorf("Did not get expected name in create context. Got: %s, Expected: %s", storage.createdName, pathName)
-	}
+	assert.Equal(t, http.StatusCreated, response.StatusCode)
+	assert.Equal(t, pathName, storage.createdName)
 }
 
 func TestNamedCreaterWithoutName(t *testing.T) {
@@ -3566,30 +3161,16 @@ func TestNamedCreaterWithoutName(t *testing.T) {
 		Other: "bar",
 	}
 	data, err := runtime.Encode(testCodec, simple)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-	request, err := http.NewRequestWithContext(ctx, request.MethodPost, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/foo", bytes.NewBuffer(data))
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
+	url := server.URL + "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/namespaces/default/foo"
+	request, err := http.NewRequestWithContext(ctx, request.MethodPost, url, bytes.NewBuffer(data))
+	require.NoError(t, err)
 
-	wg := sync.WaitGroup{}
-	wg.Add(1)
-	var response *http.Response
-	go func() {
-		response, err = client.Do(request)
-		wg.Done()
-	}()
-	wg.Wait()
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+	response, err := client.Do(request)
+	require.NoError(t, err)
 	defer apitesting.Close(t, response.Body)
 	// empty name is not allowed for NamedCreater
-	if response.StatusCode != http.StatusBadRequest {
-		t.Errorf("Unexpected response %#v", response)
-	}
+	require.Equal(t, http.StatusBadRequest, response.StatusCode)
 }
 
 type namePopulatorAdmissionControl struct {
@@ -3642,44 +3223,26 @@ func TestNamedCreaterWithGenerateName(t *testing.T) {
 		Other: "bar",
 	}
 	data, err := runtime.Encode(testCodec, simple)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-	request, err := http.NewRequestWithContext(ctx, request.MethodPost, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/foo", bytes.NewBuffer(data))
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
+	url := server.URL + "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/namespaces/default/foo"
+	request, err := http.NewRequestWithContext(ctx, request.MethodPost, url, bytes.NewBuffer(data))
+	require.NoError(t, err)
 
-	wg := sync.WaitGroup{}
-	wg.Add(1)
-	var response *http.Response
-	go func() {
-		response, err = client.Do(request)
-		wg.Done()
-	}()
-	wg.Wait()
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+	response, err := client.Do(request)
+	require.NoError(t, err)
 	defer apitesting.Close(t, response.Body)
-	if response.StatusCode != http.StatusCreated {
-		t.Errorf("Unexpected status: %d, Expected: %d, %#v", response.StatusCode, http.StatusOK, response)
-	}
+	require.Equal(t, http.StatusCreated, response.StatusCode)
 
 	var itemOut genericapitesting.Simple
 	body, err := extractBody(response, &itemOut)
-	if err != nil {
-		t.Errorf("unexpected error: %v %#v", err, response)
-	}
+	require.NoError(t, err)
 
 	// Avoid comparing managed fields in expected result
 	itemOut.ManagedFields = nil
 	itemOut.GetObjectKind().SetGroupVersionKind(schema.GroupVersionKind{})
 	simple.Name = populateName
 	simple.Namespace = "default" // populated by create handler to match request URL
-	if !reflect.DeepEqual(&itemOut, simple) {
-		t.Errorf("Unexpected data: %#v, expected %#v (%s)", itemOut, simple, string(body))
-	}
+	require.Equal(t, simple, &itemOut, body)
 }
 
 func TestUpdateChecksDecode(t *testing.T) {
@@ -3691,27 +3254,17 @@ func TestUpdateChecksDecode(t *testing.T) {
 
 	simple := &example.Pod{}
 	data, err := runtime.Encode(testCodec, simple)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-	request, err := http.NewRequestWithContext(ctx, request.MethodPut, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/bar", bytes.NewBuffer(data))
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
+	url := server.URL + "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/namespaces/default/simple/bar"
+	request, err := http.NewRequestWithContext(ctx, request.MethodPut, url, bytes.NewBuffer(data))
+	require.NoError(t, err)
 	response, err := client.Do(request)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	defer apitesting.Close(t, response.Body)
-	if response.StatusCode != http.StatusBadRequest {
-		t.Errorf("Unexpected response %#v\n%s", response, readBodyOrDie(response.Body))
-	}
+	require.Equal(t, http.StatusBadRequest, response.StatusCode)
 	b, err := io.ReadAll(response.Body)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	} else if !strings.Contains(string(b), "cannot be handled as a Simple") {
-		t.Errorf("unexpected response: %s", string(b))
-	}
+	require.NoError(t, err)
+	require.Contains(t, string(b), "cannot be handled as a Simple")
 }
 
 func TestCreate(t *testing.T) {
@@ -3731,32 +3284,18 @@ func TestCreate(t *testing.T) {
 		Other: "bar",
 	}
 	data, err := runtime.Encode(testCodec, simple)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-	request, err := http.NewRequestWithContext(ctx, request.MethodPost, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/foo", bytes.NewBuffer(data))
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
+	url := server.URL + "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/namespaces/default/foo"
+	request, err := http.NewRequestWithContext(ctx, request.MethodPost, url, bytes.NewBuffer(data))
+	require.NoError(t, err)
 
-	wg := sync.WaitGroup{}
-	wg.Add(1)
-	var response *http.Response
-	go func() {
-		response, err = client.Do(request)
-		wg.Done()
-	}()
-	wg.Wait()
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+	response, err := client.Do(request)
+	require.NoError(t, err)
 	defer apitesting.Close(t, response.Body)
 
 	var itemOut genericapitesting.Simple
 	body, err := extractBody(response, &itemOut)
-	if err != nil {
-		t.Errorf("unexpected error: %v %#v", err, response)
-	}
+	require.NoError(t, err)
 
 	// Avoid comparing managed fields in expected result
 	itemOut.ManagedFields = nil
@@ -3765,9 +3304,7 @@ func TestCreate(t *testing.T) {
 	if !reflect.DeepEqual(&itemOut, simple) {
 		t.Errorf("Unexpected data: %#v, expected %#v (%s)", itemOut, simple, string(body))
 	}
-	if response.StatusCode != http.StatusCreated {
-		t.Errorf("Unexpected status: %d, Expected: %d, %#v", response.StatusCode, http.StatusOK, response)
-	}
+	require.Equal(t, http.StatusCreated, response.StatusCode)
 }
 
 func TestCreateYAML(t *testing.T) {
@@ -3795,34 +3332,20 @@ func TestCreateYAML(t *testing.T) {
 	decoder := codecs.DecoderToVersion(info.Serializer, testInternalGroupVersion)
 
 	data, err := runtime.Encode(encoder, simple)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	request, err := http.NewRequestWithContext(ctx, request.MethodPost, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/foo", bytes.NewBuffer(data))
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
+	url := server.URL + "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/namespaces/default/foo"
+	request, err := http.NewRequestWithContext(ctx, request.MethodPost, url, bytes.NewBuffer(data))
+	require.NoError(t, err)
 	request.Header.Set("Accept", "application/yaml, application/json")
 	request.Header.Set("Content-Type", "application/yaml")
 
-	wg := sync.WaitGroup{}
-	wg.Add(1)
-	var response *http.Response
-	go func() {
-		response, err = client.Do(request)
-		wg.Done()
-	}()
-	wg.Wait()
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	response, err := client.Do(request)
+	require.NoError(t, err)
 	defer apitesting.Close(t, response.Body)
 
 	var itemOut genericapitesting.Simple
 	body, err := extractBodyDecoder(response, &itemOut, decoder)
-	if err != nil {
-		t.Fatalf("unexpected error: %v %#v", err, response)
-	}
+	require.NoError(t, err)
 
 	// Avoid comparing managed fields in expected result
 	itemOut.ManagedFields = nil
@@ -3831,9 +3354,7 @@ func TestCreateYAML(t *testing.T) {
 	if !reflect.DeepEqual(&itemOut, simple) {
 		t.Errorf("Unexpected data: %#v, expected %#v (%s)", itemOut, simple, string(body))
 	}
-	if response.StatusCode != http.StatusCreated {
-		t.Errorf("Unexpected status: %d, Expected: %d, %#v", response.StatusCode, http.StatusOK, response)
-	}
+	require.Equal(t, http.StatusCreated, response.StatusCode)
 }
 
 func TestCreateInNamespace(t *testing.T) {
@@ -3853,32 +3374,18 @@ func TestCreateInNamespace(t *testing.T) {
 		Other: "bar",
 	}
 	data, err := runtime.Encode(testCodec, simple)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	request, err := http.NewRequestWithContext(ctx, request.MethodPost, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/other/foo", bytes.NewBuffer(data))
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
+	url := server.URL + "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/namespaces/other/foo"
+	request, err := http.NewRequestWithContext(ctx, request.MethodPost, url, bytes.NewBuffer(data))
+	require.NoError(t, err)
 
-	wg := sync.WaitGroup{}
-	wg.Add(1)
-	var response *http.Response
-	go func() {
-		response, err = client.Do(request)
-		wg.Done()
-	}()
-	wg.Wait()
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	response, err := client.Do(request)
+	require.NoError(t, err)
 	defer apitesting.Close(t, response.Body)
 
 	var itemOut genericapitesting.Simple
 	body, err := extractBody(response, &itemOut)
-	if err != nil {
-		t.Fatalf("unexpected error: %v\n%s", err, data)
-	}
+	require.NoError(t, err)
 
 	// Avoid comparing managed fields in expected result
 	itemOut.ManagedFields = nil
@@ -3887,9 +3394,7 @@ func TestCreateInNamespace(t *testing.T) {
 	if !reflect.DeepEqual(&itemOut, simple) {
 		t.Errorf("Unexpected data: %#v, expected %#v (%s)", itemOut, simple, string(body))
 	}
-	if response.StatusCode != http.StatusCreated {
-		t.Errorf("Unexpected status: %d, Expected: %d, %#v", response.StatusCode, http.StatusOK, response)
-	}
+	require.Equal(t, http.StatusCreated, response.StatusCode)
 }
 
 func TestCreateInvokeAdmissionControl(t *testing.T) {
@@ -3912,51 +3417,33 @@ func TestCreateInvokeAdmissionControl(t *testing.T) {
 				Other: "bar",
 			}
 			data, err := runtime.Encode(testCodec, simple)
-			if err != nil {
-				t.Errorf("unexpected error: %v", err)
-			}
-			request, err := http.NewRequestWithContext(ctx, request.MethodPost, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/other/foo", bytes.NewBuffer(data))
-			if err != nil {
-				t.Errorf("unexpected error: %v", err)
-			}
+			require.NoError(t, err)
+			url := server.URL + "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/namespaces/other/foo"
+			request, err := http.NewRequestWithContext(ctx, request.MethodPost, url, bytes.NewBuffer(data))
+			require.NoError(t, err)
 
-			var response *http.Response
-			response, err = client.Do(request)
-			if err != nil {
-				t.Errorf("unexpected error: %v", err)
-			}
+			response, err := client.Do(request)
+			require.NoError(t, err)
 			defer apitesting.Close(t, response.Body)
-			if response.StatusCode != http.StatusForbidden {
-				t.Errorf("Unexpected status: %d, Expected: %d, %#v", response.StatusCode, http.StatusForbidden, response)
-			}
+			require.Equal(t, http.StatusForbidden, response.StatusCode)
 		})
 	}
 }
 
 func expectAPIStatus(t *testing.T, method, url string, data []byte, code int) *metav1.Status {
 	t.Helper()
-	ctx := t.Context()
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
 	client := http.Client{}
 	request, err := http.NewRequestWithContext(ctx, method, url, bytes.NewBuffer(data))
-	if err != nil {
-		t.Fatalf("unexpected error %#v", err)
-		return nil
-	}
+	require.NoError(t, err)
 	response, err := client.Do(request)
-	if err != nil {
-		t.Fatalf("unexpected error on %s %s: %v", method, url, err)
-		return nil
-	}
+	require.NoError(t, err)
 	defer apitesting.Close(t, response.Body)
 	var status metav1.Status
 	body, err := extractBody(response, &status)
-	if err != nil {
-		t.Fatalf("unexpected error on %s %s: %v\nbody:\n%s", method, url, err, body)
-		return nil
-	}
-	if code != response.StatusCode {
-		t.Fatalf("Expected %s %s to return %d, Got %d: %v", method, url, code, response.StatusCode, body)
-	}
+	require.NoError(t, err)
+	require.Equalf(t, code, response.StatusCode, "method: %s, url: %s, body: %s", method, url, body)
 	return &status
 }
 
@@ -3970,7 +3457,8 @@ func TestDelayReturnsError(t *testing.T) {
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
-	status := expectAPIStatus(t, request.MethodDelete, fmt.Sprintf("%s/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/foo/bar", server.URL), nil, http.StatusConflict)
+	url := fmt.Sprintf("%s/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/foo/bar", server.URL)
+	status := expectAPIStatus(t, request.MethodDelete, url, nil, http.StatusConflict)
 	if status.Status != metav1.StatusFailure || status.Message == "" || status.Details == nil || status.Reason != metav1.StatusReasonAlreadyExists {
 		t.Errorf("Unexpected status %#v", status)
 	}
@@ -4025,13 +3513,8 @@ func TestWriteRAWJSONMarshalError(t *testing.T) {
 	defer server.Close()
 	client := http.Client{}
 	resp, err := client.Get(server.URL)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-
-	if resp.StatusCode != http.StatusInternalServerError {
-		t.Errorf("unexpected status code %d", resp.StatusCode)
-	}
+	require.NoError(t, err)
+	require.Equal(t, http.StatusInternalServerError, resp.StatusCode)
 }
 
 func TestCreateTimeout(t *testing.T) {
@@ -4052,9 +3535,7 @@ func TestCreateTimeout(t *testing.T) {
 
 	simple := &genericapitesting.Simple{Other: "foo"}
 	data, err := runtime.Encode(testCodec, simple)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	itemOut := expectAPIStatus(t, request.MethodPost, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/foo?timeout=4ms", data, http.StatusGatewayTimeout)
 	if itemOut.Status != metav1.StatusFailure || itemOut.Reason != metav1.StatusReasonTimeout {
 		t.Errorf("Unexpected status %#v", itemOut)
@@ -4071,27 +3552,17 @@ func TestCreateChecksAPIVersion(t *testing.T) {
 	simple := &genericapitesting.Simple{}
 	//using newCodec and send the request to testVersion URL shall cause a discrepancy in apiVersion
 	data, err := runtime.Encode(newCodec, simple)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-	request, err := http.NewRequestWithContext(ctx, request.MethodPost, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple", bytes.NewBuffer(data))
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
+	url := server.URL + "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/namespaces/default/simple"
+	request, err := http.NewRequestWithContext(ctx, request.MethodPost, url, bytes.NewBuffer(data))
+	require.NoError(t, err)
 	response, err := client.Do(request)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	defer apitesting.Close(t, response.Body)
-	if response.StatusCode != http.StatusBadRequest {
-		t.Errorf("Unexpected response %#v", response)
-	}
+	require.Equal(t, http.StatusBadRequest, response.StatusCode)
 	b, err := io.ReadAll(response.Body)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	} else if !strings.Contains(string(b), "does not match the expected API version") {
-		t.Errorf("unexpected response: %s", string(b))
-	}
+	require.NoError(t, err)
+	require.Contains(t, string(b), "does not match the expected API version")
 }
 
 func TestCreateDefaultsAPIVersion(t *testing.T) {
@@ -4103,32 +3574,22 @@ func TestCreateDefaultsAPIVersion(t *testing.T) {
 
 	simple := &genericapitesting.Simple{}
 	data, err := runtime.Encode(codec, simple)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
 	m := make(map[string]interface{})
-	if err := json.Unmarshal(data, &m); err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+	err = json.Unmarshal(data, &m)
+	require.NoError(t, err)
 	delete(m, "apiVersion")
 	data, err = json.Marshal(m)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
-	request, err := http.NewRequestWithContext(ctx, request.MethodPost, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple", bytes.NewBuffer(data))
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+	url := server.URL + "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/namespaces/default/simple"
+	request, err := http.NewRequestWithContext(ctx, request.MethodPost, url, bytes.NewBuffer(data))
+	require.NoError(t, err)
 	response, err := client.Do(request)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	defer apitesting.Close(t, response.Body)
-	if response.StatusCode != http.StatusCreated {
-		t.Errorf("unexpected status: %d, Expected: %d, %#v", response.StatusCode, http.StatusCreated, response)
-	}
+	require.Equal(t, http.StatusCreated, response.StatusCode)
 }
 
 func TestUpdateChecksAPIVersion(t *testing.T) {
@@ -4140,27 +3601,17 @@ func TestUpdateChecksAPIVersion(t *testing.T) {
 
 	simple := &genericapitesting.Simple{ObjectMeta: metav1.ObjectMeta{Name: "bar"}}
 	data, err := runtime.Encode(newCodec, simple)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	request, err := http.NewRequestWithContext(ctx, request.MethodPut, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/bar", bytes.NewBuffer(data))
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
+	url := server.URL + "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/namespaces/default/simple/bar"
+	request, err := http.NewRequestWithContext(ctx, request.MethodPut, url, bytes.NewBuffer(data))
+	require.NoError(t, err)
 	response, err := client.Do(request)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	defer apitesting.Close(t, response.Body)
-	if response.StatusCode != http.StatusBadRequest {
-		t.Errorf("Unexpected response %#v", response)
-	}
+	assert.Equal(t, http.StatusBadRequest, response.StatusCode)
 	b, err := io.ReadAll(response.Body)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	} else if !strings.Contains(string(b), "does not match the expected API version") {
-		t.Errorf("unexpected response: %s", string(b))
-	}
+	require.NoError(t, err)
+	require.Contains(t, string(b), "does not match the expected API version")
 }
 
 // runRequest is used by TestDryRun since it runs the test twice in a
@@ -4168,16 +3619,12 @@ func TestUpdateChecksAPIVersion(t *testing.T) {
 func runRequest(t testing.TB, path, verb string, data []byte, contentType string) *http.Response {
 	ctx := t.Context()
 	request, err := http.NewRequestWithContext(ctx, verb, path, bytes.NewBuffer(data))
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	if contentType != "" {
 		request.Header.Set("Content-Type", contentType)
 	}
 	response, err := http.DefaultClient.Do(request)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	return response
 }
 
@@ -4316,20 +3763,19 @@ unknown: baz`)
 			buf := new(bytes.Buffer)
 			buf.ReadFrom(response.Body)
 
-			if response.StatusCode != test.expectedStatusCode || !strings.Contains(buf.String(), test.expectedErr) {
-				t.Fatalf("unexpected response: %#v, expected err: %#v", response, test.expectedErr)
-			}
+			require.Equal(t, test.expectedStatusCode, response.StatusCode)
+			require.Contains(t, buf.String(), test.expectedErr)
 
-			warnings, _ := net.ParseWarningHeaders(response.Header["Warning"])
-			if len(warnings) != len(test.expectedWarns) {
-				t.Fatalf("unexpected number of warnings. Got count %d, expected %d. Got warnings %#v, expected %#v", len(warnings), len(test.expectedWarns), warnings, test.expectedWarns)
-
-			}
-			for i, warn := range warnings {
-				if warn.Text != test.expectedWarns[i] {
-					t.Fatalf("unexpected warning: %#v, expected warning: %#v", warn.Text, test.expectedWarns[i])
+			warnings, errs := net.ParseWarningHeaders(response.Header["Warning"])
+			require.Nil(t, errs)
+			var warningTexts []string
+			if len(warnings) > 0 {
+				warningTexts = make([]string, len(warnings))
+				for i, warn := range warnings {
+					warningTexts[i] = warn.Text
 				}
 			}
+			require.Equal(t, test.expectedWarns, warningTexts)
 		})
 	}
 }
@@ -4430,9 +3876,7 @@ other: bar`)
 				baseURL := server.URL + "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version
 				response := runRequest(b, baseURL+test.path+test.queryParams, test.verb, test.data, test.contentType)
 				defer apitesting.Close(b, response.Body)
-				if response.StatusCode != test.expectedStatusCode {
-					b.Fatalf("unexpected status code: %d, expected: %d", response.StatusCode, test.expectedStatusCode)
-				}
+				require.Equal(b, test.expectedStatusCode, response.StatusCode)
 			}
 		})
 	}
@@ -4509,9 +3953,8 @@ func TestXGSubresource(t *testing.T) {
 		Serializer:             codecs,
 	}
 
-	if _, _, err := (&group).InstallREST(container); err != nil {
-		panic(fmt.Sprintf("unable to install container %s: %v", group.GroupVersion, err))
-	}
+	_, _, err := (&group).InstallREST(container)
+	require.NoError(t, err)
 
 	server := newTestServer(defaultAPIServer{mux, container})
 	defer server.Close()
@@ -4520,18 +3963,12 @@ func TestXGSubresource(t *testing.T) {
 	req, err := http.NewRequestWithContext(ctx, request.MethodGet, url, nil)
 	require.NoError(t, err)
 	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	defer apitesting.Close(t, resp.Body)
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("unexpected response: %#v", resp)
-	}
+	require.Equal(t, http.StatusOK, resp.StatusCode)
 	var itemOut genericapitesting.SimpleXGSubresource
 	body, err := extractBody(resp, &itemOut)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
 	// Test if the returned object has the expected group, version and kind
 	// We are directly unmarshaling JSON here because TypeMeta cannot be decoded through the
@@ -4541,9 +3978,7 @@ func TestXGSubresource(t *testing.T) {
 	decoder := json.NewDecoder(strings.NewReader(body))
 	var itemFromBody genericapitesting.SimpleXGSubresource
 	err = decoder.Decode(&itemFromBody)
-	if err != nil {
-		t.Errorf("unexpected JSON decoding error: %v", err)
-	}
+	require.NoError(t, err)
 	if want := fmt.Sprintf("%s/%s", testGroup2Version.Group, testGroup2Version.Version); itemFromBody.APIVersion != want {
 		t.Errorf("unexpected APIVersion got: %+v want: %+v", itemFromBody.APIVersion, want)
 	}
@@ -4554,14 +3989,6 @@ func TestXGSubresource(t *testing.T) {
 	if itemOut.Name != subresourceStorage.item.Name {
 		t.Errorf("Unexpected data: %#v, expected %#v (%s)", itemOut, subresourceStorage.item, string(body))
 	}
-}
-
-func readBodyOrDie(r io.Reader) []byte {
-	body, err := io.ReadAll(r)
-	if err != nil {
-		panic(err)
-	}
-	return body
 }
 
 // BenchmarkUpdateProtobuf measures the cost of processing an update on the server in proto
@@ -4575,16 +4002,15 @@ func BenchmarkUpdateProtobuf(b *testing.B) {
 	defer server.Close()
 	client := http.Client{}
 
-	dest, _ := url.Parse(server.URL)
+	dest, err := url.Parse(server.URL)
+	require.NoError(b, err)
 	dest.Path = "/" + prefix + "/" + newGroupVersion.Group + "/" + newGroupVersion.Version + "/namespaces/foo/simples/bar"
 	dest.RawQuery = ""
 
 	info, _ := runtime.SerializerInfoForMediaType(codecs.SupportedMediaTypes(), "application/vnd.kubernetes.protobuf")
 	e := codecs.EncoderForVersion(info.Serializer, newGroupVersion)
 	data, err := runtime.Encode(e, &items[0])
-	if err != nil {
-		b.Fatal(err)
-	}
+	require.NoError(b, err)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -4593,21 +4019,19 @@ func BenchmarkUpdateProtobuf(b *testing.B) {
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
 			request, err := http.NewRequestWithContext(ctx, request.MethodPut, dest.String(), bytes.NewReader(data))
-			if err != nil {
-				b.Fatalf("unexpected error: %v", err)
-			}
+			require.NoError(b, err)
 			request.Header.Set("Accept", "application/vnd.kubernetes.protobuf")
 			request.Header.Set("Content-Type", "application/vnd.kubernetes.protobuf")
 			response, err := client.Do(request)
-			if err != nil {
-				b.Fatalf("unexpected error: %v", err)
-			}
+			require.NoError(b, err)
 			defer apitesting.Close(b, response.Body)
 			if response.StatusCode != http.StatusBadRequest {
-				body, _ := io.ReadAll(response.Body)
+				body, err := io.ReadAll(response.Body)
+				require.NoError(b, err)
 				b.Fatalf("Unexpected response %#v\n%s", response, body)
 			}
-			_, _ = io.ReadAll(response.Body)
+			_, err = io.ReadAll(response.Body)
+			require.NoError(b, err)
 		}()
 	}
 	b.StopTimer()

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/watch_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/watch_test.go
@@ -86,7 +86,7 @@ func TestWatchHTTPErrors(t *testing.T) {
 		TimeoutFactory: &fakeTimeoutFactory{timeoutCh: timeoutCh, done: doneCh},
 	}
 
-	s := httptest.NewServer(serveWatch(watcher, watchServer, nil))
+	s := httptest.NewServer(serveWatch(watchServer, nil))
 	defer s.Close()
 
 	// Setup a client
@@ -175,7 +175,7 @@ func TestWatchHTTPErrorsBeforeServe(t *testing.T) {
 	statusErr := apierrors.NewInternalError(fmt.Errorf("we got an error"))
 	errStatus := statusErr.Status()
 
-	s := httptest.NewServer(serveWatch(watcher, watchServer, statusErr))
+	s := httptest.NewServer(serveWatch(watchServer, statusErr))
 	defer s.Close()
 
 	// Setup a client
@@ -248,7 +248,7 @@ func TestWatchHTTPDynamicClientErrors(t *testing.T) {
 		TimeoutFactory: &fakeTimeoutFactory{timeoutCh: timeoutCh, done: doneCh},
 	}
 
-	s := httptest.NewServer(serveWatch(watcher, watchServer, nil))
+	s := httptest.NewServer(serveWatch(watchServer, nil))
 	defer s.Close()
 	defer s.CloseClientConnections()
 
@@ -303,7 +303,7 @@ func TestWatchHTTPTimeout(t *testing.T) {
 		TimeoutFactory: &fakeTimeoutFactory{timeoutCh: timeoutCh, done: doneCh},
 	}
 
-	s := httptest.NewServer(serveWatch(watcher, watchServer, nil))
+	s := httptest.NewServer(serveWatch(watchServer, nil))
 	defer s.Close()
 
 	// Setup a client
@@ -375,9 +375,9 @@ func (t *fakeTimeoutFactory) TimeoutCh() (<-chan time.Time, func() bool) {
 
 // serveWatch will serve a watch response according to the watcher and watchServer.
 // Before watchServer.HandleHTTP, an error may occur like k8s.io/apiserver/pkg/endpoints/handlers/watch.go#serveWatch does.
-func serveWatch(watcher watch.Interface, watchServer *WatchServer, preServeErr error) http.HandlerFunc {
+func serveWatch(watchServer *WatchServer, preServeErr error) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
-		defer watcher.Stop()
+		defer watchServer.Watching.Stop()
 
 		if preServeErr != nil {
 			responsewriters.ErrorNegotiated(preServeErr, watchServer.Scope.Serializer, watchServer.Scope.Kind.GroupVersion(), w, req)

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/watch_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/watch_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package handlers
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -39,6 +38,7 @@ import (
 	endpointstesting "k8s.io/apiserver/pkg/endpoints/testing"
 	"k8s.io/client-go/dynamic"
 	restclient "k8s.io/client-go/rest"
+	utiltesting "k8s.io/client-go/util/testing"
 )
 
 // Fake API versions, similar to api/latest.go
@@ -90,11 +90,13 @@ func TestWatchHTTPErrors(t *testing.T) {
 	defer s.Close()
 
 	// Setup a client
-	dest, _ := url.Parse(s.URL)
+	dest, err := url.Parse(s.URL)
+	require.NoError(t, err)
 	dest.Path = "/" + namedGroupPrefix + "/" + testGroupV2.Group + "/" + testGroupV2.Version + "/simple"
 	dest.RawQuery = "watch=true"
 
-	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, dest.String(), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, dest.String(), nil)
+	require.NoError(t, err)
 	client := http.Client{}
 	resp, err := client.Do(req)
 	require.NoError(t, err)
@@ -103,9 +105,8 @@ func TestWatchHTTPErrors(t *testing.T) {
 	// Send error to server from storage
 	errStatus := apierrors.NewInternalError(fmt.Errorf("we got an error")).Status()
 	watcher.Error(&errStatus)
-	watcher.Stop()
 
-	// Make sure we can actually watch an endpoint
+	// Decode error from the response
 	decoder := json.NewDecoder(resp.Body)
 	var got watchJSON
 	err = decoder.Decode(&got)
@@ -126,13 +127,27 @@ func TestWatchHTTPErrors(t *testing.T) {
 		Details: errStatus.Details,
 	}
 	require.Equal(t, expectedStatus, status)
+
+	// Close the response body to signal the server to stop serving.
+	require.NoError(t, resp.Body.Close())
+
+	// Wait for the server to call the CancelFunc returned by
+	// TimeoutFactory.TimeoutCh, closing the done channel.
+	err = utiltesting.WaitForChannelToCloseWithTimeout(ctx, wait.ForeverTestTimeout, doneCh)
+	require.NoError(t, err)
+
+	// Wait for the server to call watcher.Stop, closing the result channel.
+	err = utiltesting.WaitForChannelToCloseWithTimeout(ctx, wait.ForeverTestTimeout, watcher.ResultChan())
+	require.NoError(t, err)
+
+	// Confirm watcher.Stop was called by the server.
+	require.Truef(t, watcher.IsStopped(),
+		"Leaked watcher goroutine after request done")
 }
 
 func TestWatchHTTPErrorsBeforeServe(t *testing.T) {
 	ctx := t.Context()
 	watcher := watch.NewFake()
-	timeoutCh := make(chan time.Time)
-	doneCh := make(chan struct{})
 
 	info, ok := runtime.SerializerInfoForMediaType(codecs.SupportedMediaTypes(), runtime.ContentTypeJSON)
 	if !ok || info.StreamSerializer == nil {
@@ -153,7 +168,8 @@ func TestWatchHTTPErrorsBeforeServe(t *testing.T) {
 		Encoder:         testCodecV2,
 		EmbeddedEncoder: testCodecV2,
 
-		TimeoutFactory: &fakeTimeoutFactory{timeoutCh, doneCh},
+		// TimeoutFactory should not be needed, because the server should error
+		// before calling TimeoutFactory.TimeoutCh.
 	}
 
 	statusErr := apierrors.NewInternalError(fmt.Errorf("we got an error"))
@@ -163,11 +179,13 @@ func TestWatchHTTPErrorsBeforeServe(t *testing.T) {
 	defer s.Close()
 
 	// Setup a client
-	dest, _ := url.Parse(s.URL)
+	dest, err := url.Parse(s.URL)
+	require.NoError(t, err)
 	dest.Path = "/" + namedGroupPrefix + "/" + testGroupV2.Group + "/" + testGroupV2.Version + "/simple"
 	dest.RawQuery = "watch=true"
 
-	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, dest.String(), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, dest.String(), nil)
+	require.NoError(t, err)
 	client := http.Client{}
 	resp, err := client.Do(req)
 	require.NoError(t, err)
@@ -191,15 +209,25 @@ func TestWatchHTTPErrorsBeforeServe(t *testing.T) {
 	}
 	require.Equal(t, expectedStatus, status)
 
-	// check for leaks
+	// Close the response body to signal the server to stop serving.
+	// This isn't strictly necessary, since the test serveWatch doesn't block,
+	// but it would be if this were the real watch server.
+	require.NoError(t, resp.Body.Close())
+
+	// Wait for the server to call watcher.Stop, closing the result channel.
+	err = utiltesting.WaitForChannelToCloseWithTimeout(ctx, wait.ForeverTestTimeout, watcher.ResultChan())
+	require.NoError(t, err)
+
+	// Confirm watcher.Stop was called by the server.
 	require.Truef(t, watcher.IsStopped(),
-		"Leaked watcher goruntine after request done")
+		"Leaked watcher goroutine after request done")
 }
 
 func TestWatchHTTPDynamicClientErrors(t *testing.T) {
+	ctx := t.Context()
 	watcher := watch.NewFake()
 	timeoutCh := make(chan time.Time)
-	done := make(chan struct{})
+	doneCh := make(chan struct{})
 
 	info, ok := runtime.SerializerInfoForMediaType(codecs.SupportedMediaTypes(), runtime.ContentTypeJSON)
 	if !ok || info.StreamSerializer == nil {
@@ -217,7 +245,7 @@ func TestWatchHTTPDynamicClientErrors(t *testing.T) {
 		Encoder:         testCodecV2,
 		EmbeddedEncoder: testCodecV2,
 
-		TimeoutFactory: &fakeTimeoutFactory{timeoutCh, done},
+		TimeoutFactory: &fakeTimeoutFactory{timeoutCh: timeoutCh, done: doneCh},
 	}
 
 	s := httptest.NewServer(serveWatch(watcher, watchServer, nil))
@@ -229,15 +257,32 @@ func TestWatchHTTPDynamicClientErrors(t *testing.T) {
 		APIPath: "/" + namedGroupPrefix,
 	}).Resource(testGroupV2.WithResource("simple"))
 
-	_, err := client.Watch(context.TODO(), metav1.ListOptions{})
+	_, err := client.Watch(ctx, metav1.ListOptions{})
 	require.Equal(t, runtime.NegotiateError{Stream: true, ContentType: "testcase/json"}, err)
+
+	// The client should automatically close the connection on error.
+	//TODO(karlkfi): Fix watch client to close the response body and stop the storage watcher after a NegotiateError
+	require.False(t, watcher.IsStopped())
+
+	// Wait for the server to call the CancelFunc returned by
+	// TimeoutFactory.TimeoutCh, closing the done channel.
+	// err = utiltesting.WaitForChannelToCloseWithTimeout(ctx, wait.ForeverTestTimeout, doneCh)
+	// require.NoError(t, err)
+
+	// Wait for the server to call watcher.Stop, closing the result channel.
+	// err = utiltesting.WaitForChannelToCloseWithTimeout(ctx, wait.ForeverTestTimeout, watcher.ResultChan())
+	// require.NoError(t, err)
+
+	// Confirm watcher.Stop was called by the server.
+	// require.Truef(t, watcher.IsStopped(),
+	// 	"Leaked watcher goroutine after request done")
 }
 
 func TestWatchHTTPTimeout(t *testing.T) {
 	ctx := t.Context()
 	watcher := watch.NewFake()
 	timeoutCh := make(chan time.Time)
-	done := make(chan struct{})
+	doneCh := make(chan struct{})
 
 	info, ok := runtime.SerializerInfoForMediaType(codecs.SupportedMediaTypes(), runtime.ContentTypeJSON)
 	if !ok || info.StreamSerializer == nil {
@@ -255,18 +300,20 @@ func TestWatchHTTPTimeout(t *testing.T) {
 		Encoder:         testCodecV2,
 		EmbeddedEncoder: testCodecV2,
 
-		TimeoutFactory: &fakeTimeoutFactory{timeoutCh, done},
+		TimeoutFactory: &fakeTimeoutFactory{timeoutCh: timeoutCh, done: doneCh},
 	}
 
 	s := httptest.NewServer(serveWatch(watcher, watchServer, nil))
 	defer s.Close()
 
 	// Setup a client
-	dest, _ := url.Parse(s.URL)
+	dest, err := url.Parse(s.URL)
+	require.NoError(t, err)
 	dest.Path = "/" + namedGroupPrefix + "/" + testGroupV2.Group + "/" + testGroupV2.Version + "/simple"
 	dest.RawQuery = "watch=true"
 
-	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, dest.String(), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, dest.String(), nil)
+	require.NoError(t, err)
 	client := http.Client{}
 	resp, err := client.Do(req)
 	require.NoError(t, err)
@@ -281,29 +328,28 @@ func TestWatchHTTPTimeout(t *testing.T) {
 	err = decoder.Decode(&got)
 	require.NoError(t, err)
 
-	// Timeout and check for leaks
+	// Trigger server-side timeout.
 	close(timeoutCh)
-	select {
-	case <-done:
-		eventCh := watcher.ResultChan()
-		select {
-		case _, opened := <-eventCh:
-			if opened {
-				t.Errorf("Watcher received unexpected event")
-			}
-			if !watcher.IsStopped() {
-				t.Errorf("Watcher is not stopped")
-			}
-		case <-time.After(wait.ForeverTestTimeout):
-			t.Errorf("Leaked watch on timeout")
-		}
-	case <-time.After(wait.ForeverTestTimeout):
-		t.Errorf("Failed to stop watcher after %s of timeout signal", wait.ForeverTestTimeout.String())
-	}
 
-	// Make sure we can't receive any more events through the timeout watch
+	// Wait for the server to call the CancelFunc returned by
+	// TimeoutFactory.TimeoutCh, closing the done channel.
+	err = utiltesting.WaitForChannelToCloseWithTimeout(ctx, wait.ForeverTestTimeout, doneCh)
+	require.NoError(t, err)
+
+	// Wait for the server to call watcher.Stop, closing the result channel.
+	err = utiltesting.WaitForChannelToCloseWithTimeout(ctx, wait.ForeverTestTimeout, watcher.ResultChan())
+	require.NoError(t, err)
+
+	// Confirm watcher.Stop was called by the server.
+	require.Truef(t, watcher.IsStopped(),
+		"Leaked watcher goroutine after request done")
+
+	// Make sure we can't receive any more events after the watch timeout
 	err = decoder.Decode(&got)
 	require.Equal(t, io.EOF, err)
+
+	// Close the response body to clean up watch client resources.
+	require.NoError(t, resp.Body.Close())
 }
 
 // watchJSON defines the expected JSON wire equivalent of watch.Event.

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/watch_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/watch_test.go
@@ -25,17 +25,15 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"reflect"
 	"sync"
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/websocket"
 
 	"k8s.io/apimachinery/pkg/api/apitesting"
-	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
@@ -55,16 +53,12 @@ type watchJSON struct {
 	Object json.RawMessage `json:"object,omitempty"`
 }
 
-// roundTripOrDie round trips an object to get defaults set.
-func roundTripOrDie(codec runtime.Codec, object runtime.Object) runtime.Object {
+// requireRoundTrip round trips an object to get defaults set.
+func requireRoundTrip(t *testing.T, codec runtime.Codec, object runtime.Object) runtime.Object {
 	data, err := runtime.Encode(codec, object)
-	if err != nil {
-		panic(err)
-	}
+	require.NoError(t, err)
 	obj, err := runtime.Decode(codec, data)
-	if err != nil {
-		panic(err)
-	}
+	require.NoError(t, err)
 	return obj
 }
 
@@ -77,7 +71,7 @@ var watchTestTable = []struct {
 	{watch.Deleted, &endpointstesting.Simple{ObjectMeta: metav1.ObjectMeta{Name: "bar"}}},
 }
 
-func podWatchTestTable() []struct {
+func podWatchTestTable(t *testing.T) []struct {
 	t   watch.EventType
 	obj runtime.Object
 } {
@@ -86,9 +80,9 @@ func podWatchTestTable() []struct {
 		t   watch.EventType
 		obj runtime.Object
 	}{
-		{watch.Added, roundTripOrDie(codec, &example.Pod{ObjectMeta: metav1.ObjectMeta{Name: "foo"}})},
-		{watch.Modified, roundTripOrDie(codec, &example.Pod{ObjectMeta: metav1.ObjectMeta{Name: "bar"}})},
-		{watch.Deleted, roundTripOrDie(codec, &example.Pod{ObjectMeta: metav1.ObjectMeta{Name: "bar"}})},
+		{watch.Added, requireRoundTrip(t, codec, &example.Pod{ObjectMeta: metav1.ObjectMeta{Name: "foo"}})},
+		{watch.Modified, requireRoundTrip(t, codec, &example.Pod{ObjectMeta: metav1.ObjectMeta{Name: "bar"}})},
+		{watch.Deleted, requireRoundTrip(t, codec, &example.Pod{ObjectMeta: metav1.ObjectMeta{Name: "bar"}})},
 	}
 }
 
@@ -99,15 +93,14 @@ func TestWatchWebsocket(t *testing.T) {
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
-	dest, _ := url.Parse(server.URL)
+	dest, err := url.Parse(server.URL)
+	require.NoError(t, err)
 	dest.Scheme = "ws" // Required by websocket, though the server never sees it.
 	dest.Path = "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/watch/simples"
 	dest.RawQuery = ""
 
 	ws, err := websocket.Dial(dest.String(), "", "http://localhost")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	defer apitesting.Close(t, ws)
 
 	// Wait for storage watcher to start
@@ -123,19 +116,11 @@ func TestWatchWebsocket(t *testing.T) {
 		// Test receive
 		var got watchJSON
 		err := websocket.JSON.Receive(ws, &got)
-		if err != nil {
-			t.Fatalf("Unexpected error: %v", err)
-		}
-		if got.Type != action {
-			t.Errorf("Unexpected type: %v", got.Type)
-		}
+		require.NoError(t, err)
+		require.Equal(t, action, got.Type)
 		gotObj, err := runtime.Decode(codec, got.Object)
-		if err != nil {
-			t.Fatalf("Decode error: %v\n%v", err, got)
-		}
-		if e, a := object, gotObj; !reflect.DeepEqual(e, a) {
-			t.Errorf("Expected %#v, got %#v", e, a)
-		}
+		require.NoError(t, err)
+		require.Equal(t, object, gotObj)
 	}
 
 	for _, item := range watchTestTable {
@@ -145,9 +130,7 @@ func TestWatchWebsocket(t *testing.T) {
 
 	var got watchJSON
 	err = websocket.JSON.Receive(ws, &got)
-	if err == nil {
-		t.Errorf("Unexpected non-error")
-	}
+	require.Equal(t, io.EOF, err)
 }
 
 func TestWatchWebsocketClientClose(t *testing.T) {
@@ -157,15 +140,14 @@ func TestWatchWebsocketClientClose(t *testing.T) {
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
-	dest, _ := url.Parse(server.URL)
+	dest, err := url.Parse(server.URL)
+	require.NoError(t, err)
 	dest.Scheme = "ws" // Required by websocket, though the server never sees it.
 	dest.Path = "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/watch/simples"
 	dest.RawQuery = ""
 
 	ws, err := websocket.Dial(dest.String(), "", "http://localhost")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	// Ensure the websocket is closed without error
 	closeWebSocket := apitesting.Close
 	defer func() {
@@ -185,19 +167,11 @@ func TestWatchWebsocketClientClose(t *testing.T) {
 		// Test receive
 		var got watchJSON
 		err := websocket.JSON.Receive(ws, &got)
-		if err != nil {
-			t.Fatalf("Unexpected error: %v", err)
-		}
-		if got.Type != action {
-			t.Errorf("Unexpected type: %v", got.Type)
-		}
+		require.NoError(t, err)
+		require.Equal(t, action, got.Type)
 		gotObj, err := runtime.Decode(codec, got.Object)
-		if err != nil {
-			t.Fatalf("Decode error: %v\n%v", err, got)
-		}
-		if e, a := object, gotObj; !reflect.DeepEqual(e, a) {
-			t.Errorf("Expected %#v, got %#v", e, a)
-		}
+		require.NoError(t, err)
+		require.Equal(t, object, gotObj)
 	}
 
 	// Send/receive should work
@@ -241,25 +215,23 @@ func TestWatchClientClose(t *testing.T) {
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
-	dest, _ := url.Parse(server.URL)
+	dest, err := url.Parse(server.URL)
+	require.NoError(t, err)
 	dest.Path = "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/simples"
 	dest.RawQuery = "watch=1"
 
 	request, err := http.NewRequestWithContext(ctx, request.MethodGet, dest.String(), nil)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	request.Header.Add("Accept", "application/json")
 
 	response, err := http.DefaultClient.Do(request)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	// Ensure the response body is closed without error
 	defer apitesting.Close(t, response.Body)
 
 	if response.StatusCode != http.StatusOK {
-		b, _ := io.ReadAll(response.Body)
+		b, err := io.ReadAll(response.Body)
+		require.NoError(t, err)
 		t.Fatalf("Unexpected response: %#v\n%s", response, string(b))
 	}
 
@@ -271,9 +243,7 @@ func TestWatchClientClose(t *testing.T) {
 	}
 
 	// Close response to cause a cancel on the server
-	if err := response.Body.Close(); err != nil {
-		t.Fatalf("Unexpected close client err: %v", err)
-	}
+	require.NoError(t, response.Body.Close())
 
 	select {
 	case data, ok := <-watcher.ResultChan():
@@ -296,25 +266,23 @@ func TestWatchRead(t *testing.T) {
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
-	dest, _ := url.Parse(server.URL)
+	dest, err := url.Parse(server.URL)
+	require.NoError(t, err)
 	dest.Path = "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/simples"
 	dest.RawQuery = "watch=1"
 
 	connectHTTP := func(ctx context.Context, accept string) (io.ReadCloser, string) {
 		client := http.Client{}
 		request, err := http.NewRequestWithContext(ctx, request.MethodGet, dest.String(), nil)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
+		require.NoError(t, err)
 		request.Header.Add("Accept", accept)
 
 		response, err := client.Do(request)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
+		require.NoError(t, err)
 
 		if response.StatusCode != http.StatusOK {
-			b, _ := io.ReadAll(response.Body)
+			b, err := io.ReadAll(response.Body)
+			require.NoError(t, err)
 			t.Fatalf("Unexpected response for accept: %q: %#v\n%s", accept, response, string(b))
 		}
 		return response.Body, response.Header.Get("Content-Type")
@@ -324,14 +292,10 @@ func TestWatchRead(t *testing.T) {
 		dest := *dest
 		dest.Scheme = "ws" // Required by websocket, though the server never sees it.
 		config, err := websocket.NewConfig(dest.String(), "http://localhost")
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
+		require.NoError(t, err)
 		config.Header.Add("Accept", accept)
 		ws, err := config.DialContext(ctx)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
+		require.NoError(t, err)
 		return ws, "__default__"
 	}
 
@@ -372,10 +336,17 @@ func TestWatchRead(t *testing.T) {
 	protocols := []struct {
 		name        string
 		selfFraming bool
-		fn          func(context.Context, string) (io.ReadCloser, string)
+		openFn      func(context.Context, string) (io.ReadCloser, string)
 	}{
-		{name: "http", fn: connectHTTP},
-		{name: "websocket", selfFraming: true, fn: connectWebSocket},
+		{
+			name:   "http",
+			openFn: connectHTTP,
+		},
+		{
+			name:        "websocket",
+			selfFraming: true,
+			openFn:      connectWebSocket,
+		},
 	}
 
 	for _, protocol := range protocols {
@@ -389,7 +360,7 @@ func TestWatchRead(t *testing.T) {
 				}
 				streamSerializer := info.StreamSerializer
 
-				r, contentType := protocol.fn(ctx, test.Accept)
+				r, contentType := protocol.openFn(ctx, test.Accept)
 				closeBody := apitesting.Close
 				defer func() {
 					closeBody(t, r)
@@ -417,7 +388,7 @@ func TestWatchRead(t *testing.T) {
 					time.Sleep(time.Millisecond)
 				}
 
-				for i, item := range podWatchTestTable() {
+				for i, item := range podWatchTestTable(t) {
 					action, object := item.t, item.obj
 					name := fmt.Sprintf("%s-%s-%d", protocol.name, test.MediaType, i)
 
@@ -426,28 +397,18 @@ func TestWatchRead(t *testing.T) {
 					// Test receive
 					var got metav1.WatchEvent
 					_, _, err := d.Decode(nil, &got)
-					if err != nil {
-						t.Fatalf("%s: Unexpected error: %v", name, err)
-					}
-					if got.Type != string(action) {
-						t.Errorf("%s: Unexpected type: %v", name, got.Type)
-					}
+					require.NoError(t, err, name)
+					require.Equal(t, action, watch.EventType(got.Type), name)
 
 					gotObj, err := runtime.Decode(objectCodec, got.Object.Raw)
-					if err != nil {
-						t.Fatalf("%s: Decode error: %v", name, err)
-					}
-					if e, a := object, gotObj; !apiequality.Semantic.DeepEqual(e, a) {
-						t.Errorf("%s: different: %s", name, cmp.Diff(e, a))
-					}
+					require.NoError(t, err, name)
+					require.Equal(t, object, gotObj, name)
 				}
 				watcher.Stop()
 
 				var got metav1.WatchEvent
 				_, _, err := d.Decode(nil, &got)
-				if err == nil {
-					t.Errorf("Unexpected non-error")
-				}
+				require.Equal(t, io.EOF, err)
 			})
 		}
 	}
@@ -461,27 +422,23 @@ func TestWatchHTTPAccept(t *testing.T) {
 	defer server.Close()
 	client := http.Client{}
 
-	dest, _ := url.Parse(server.URL)
+	dest, err := url.Parse(server.URL)
+	require.NoError(t, err)
 	dest.Path = "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/watch/simples"
 	dest.RawQuery = ""
 
 	request, err := http.NewRequestWithContext(ctx, request.MethodGet, dest.String(), nil)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
 	request.Header.Set("Accept", "application/XYZ")
 	response, err := client.Do(request)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
 	// TODO: once this is fixed, this test will change
 	if response.StatusCode != http.StatusNotAcceptable {
 		t.Errorf("Unexpected response %#v", response)
 	}
 }
-
 func TestWatchParamParsing(t *testing.T) {
 	simpleStorage := &SimpleRESTStorage{}
 	handler := handle(map[string]rest.Storage{
@@ -491,7 +448,8 @@ func TestWatchParamParsing(t *testing.T) {
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
-	dest, _ := url.Parse(server.URL)
+	dest, err := url.Parse(server.URL)
+	require.NoError(t, err)
 
 	rootPath := "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/watch/simples"
 	namespacedPath := "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/watch/namespaces/other/simpleroots"
@@ -578,9 +536,7 @@ func TestWatchParamParsing(t *testing.T) {
 			req, err := http.NewRequestWithContext(ctx, request.MethodGet, dest.String(), nil)
 			require.NoError(t, err)
 			resp, err := http.DefaultClient.Do(req)
-			if err != nil {
-				t.Fatalf("%v: unexpected error: %v", test.rawQuery, err)
-			}
+			require.NoError(t, err)
 			defer apitesting.Close(t, resp.Body)
 			if e, a := test.namespace, simpleStorage.requestedResourceNamespace; e != a {
 				t.Errorf("%v: expected %v, got %v", test.rawQuery, e, a)
@@ -606,7 +562,8 @@ func TestWatchProtocolSelection(t *testing.T) {
 	defer server.CloseClientConnections()
 	client := http.Client{}
 
-	dest, _ := url.Parse(server.URL)
+	dest, err := url.Parse(server.URL)
+	require.NoError(t, err)
 	dest.Path = "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/watch/simples"
 	dest.RawQuery = ""
 
@@ -625,16 +582,12 @@ func TestWatchProtocolSelection(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			ctx := t.Context()
 			request, err := http.NewRequestWithContext(ctx, request.MethodGet, dest.String(), nil)
-			if err != nil {
-				t.Errorf("unexpected error: %v", err)
-			}
+			require.NoError(t, err)
 			request.Header.Set("Connection", test.connHeader)
 			request.Header.Set("Upgrade", "websocket")
 
 			response, err := client.Do(request)
-			if err != nil {
-				t.Errorf("unexpected error: %v", err)
-			}
+			require.NoError(t, err)
 
 			// The requests recognized as websocket requests based on connection
 			// and upgrade headers will not also have the necessary Sec-Websocket-*
@@ -694,7 +647,8 @@ func runWatchHTTPBenchmark(b *testing.B, items []runtime.Object, contentType str
 	defer server.Close()
 	client := http.Client{}
 
-	dest, _ := url.Parse(server.URL)
+	dest, err := url.Parse(server.URL)
+	require.NoError(b, err)
 	dest.Path = "/" + prefix + "/" + newGroupVersion.Group + "/" + newGroupVersion.Version + "/watch/simples"
 	dest.RawQuery = ""
 
@@ -704,13 +658,9 @@ func runWatchHTTPBenchmark(b *testing.B, items []runtime.Object, contentType str
 	}
 	req.Header.Add("Accept", contentType)
 
-	response, err := client.Do(req)
-	if err != nil {
-		b.Fatalf("unexpected error: %v", err)
-	}
-	if response.StatusCode != http.StatusOK {
-		b.Fatalf("Unexpected response %#v", response)
-	}
+	resp, err := client.Do(req)
+	require.NoError(b, err)
+	require.Equal(b, http.StatusOK, resp.StatusCode)
 
 	// Wait for storage watcher to start
 	var watcher *watch.FakeWatcher
@@ -722,10 +672,9 @@ func runWatchHTTPBenchmark(b *testing.B, items []runtime.Object, contentType str
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 	go func() {
-		defer apitesting.Close(b, response.Body)
-		if _, err := io.Copy(io.Discard, response.Body); err != nil {
-			b.Error(err)
-		}
+		defer apitesting.Close(b, resp.Body)
+		_, err := io.Copy(io.Discard, resp.Body)
+		assert.NoError(b, err)
 		wg.Done()
 	}()
 
@@ -749,15 +698,14 @@ func BenchmarkWatchWebsocket(b *testing.B) {
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
-	dest, _ := url.Parse(server.URL)
+	dest, err := url.Parse(server.URL)
+	require.NoError(b, err)
 	dest.Scheme = "ws" // Required by websocket, though the server never sees it.
 	dest.Path = "/" + prefix + "/" + newGroupVersion.Group + "/" + newGroupVersion.Version + "/watch/simples"
 	dest.RawQuery = ""
 
 	ws, err := websocket.Dial(dest.String(), "", "http://localhost")
-	if err != nil {
-		b.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(b, err)
 
 	// Wait for storage watcher to start
 	var watcher *watch.FakeWatcher
@@ -770,9 +718,8 @@ func BenchmarkWatchWebsocket(b *testing.B) {
 	wg.Add(1)
 	go func() {
 		defer apitesting.Close(b, ws)
-		if _, err := io.Copy(io.Discard, ws); err != nil {
-			b.Error(err)
-		}
+		_, err := io.Copy(io.Discard, ws)
+		assert.NoError(b, err)
 		wg.Done()
 	}()
 

--- a/staging/src/k8s.io/client-go/rest/request_test.go
+++ b/staging/src/k8s.io/client-go/rest/request_test.go
@@ -39,11 +39,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/google/go-cmp/cmp"
-
 	v1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -54,6 +52,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer/streaming"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	utilnet "k8s.io/apimachinery/pkg/util/net"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes/scheme"
 	restclientwatch "k8s.io/client-go/rest/watch"
@@ -2091,6 +2090,7 @@ func TestWatch(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			ctx := t.Context()
 			var table = []struct {
 				t   watch.EventType
 				obj runtime.Object
@@ -2132,34 +2132,41 @@ func TestWatch(t *testing.T) {
 			defer testServer.Close()
 
 			s := testRESTClient(t, testServer)
-			watching, err := s.Get().Prefix("path/to/watch/thing").
-				MaxRetries(test.maxRetries).Watch(context.Background())
-			if err != nil {
-				t.Fatalf("Unexpected error: %v", err)
-			}
+			watcher, err := s.Get().Prefix("path/to/watch/thing").
+				MaxRetries(test.maxRetries).Watch(ctx)
+			require.NoError(t, err)
+			defer watcher.Stop()
 
+			// Read the events from the result channel
+			resultCh := watcher.ResultChan()
 			for _, item := range table {
-				got, ok := <-watching.ResultChan()
+				got, ok := <-resultCh
 				if !ok {
-					t.Fatalf("Unexpected early close")
+					t.Fatal("Unexpected early close")
 				}
-				if e, a := item.t, got.Type; e != a {
-					t.Errorf("Expected %v, got %v", e, a)
-				}
-				if e, a := item.obj, got.Object; !apiequality.Semantic.DeepDerivative(e, a) {
-					t.Errorf("Expected %v, got %v", e, a)
-				}
+				assert.Equal(t, item.t, got.Type)
+				assert.Equal(t, item.obj, got.Object)
 			}
 
-			_, ok := <-watching.ResultChan()
-			if ok {
-				t.Fatal("Unexpected non-close")
+			// Stop watcher when done reading watch events
+			watcher.Stop()
+
+			// Wait for the result channel to close
+			err = utiltesting.WaitForChannelToCloseWithTimeout(ctx, wait.ForeverTestTimeout, resultCh)
+			// TODO(karlkfi): Fix race condition that causes the watch server to sometimes send an error when stopped
+			if err != nil {
+				// Extract & compare the Event so we can see  diff when it fails
+				event, unwrapErr := unwrapUnexectedWatchEvent(err)
+				require.NoError(t, unwrapErr)
+				expectedEvent := newClientWatchDecodingEvent(errReadOnClosedResBody)
+				require.Equal(t, expectedEvent, event)
 			}
 		})
 	}
 }
 
 func TestWatchNonDefaultContentType(t *testing.T) {
+	ctx := t.Context()
 	var table = []struct {
 		t   watch.EventType
 		obj runtime.Object
@@ -2195,31 +2202,37 @@ func TestWatchNonDefaultContentType(t *testing.T) {
 	contentConfig := defaultContentConfig()
 	contentConfig.ContentType = "application/vnd.kubernetes.protobuf"
 	s := testRESTClientWithConfig(t, testServer, contentConfig)
-	watching, err := s.Get().Prefix("path/to/watch/thing").Watch(context.Background())
-	if err != nil {
-		t.Fatalf("Unexpected error")
-	}
+	watcher, err := s.Get().Prefix("path/to/watch/thing").Watch(ctx)
+	require.NoError(t, err)
+	defer watcher.Stop()
 
+	resultCh := watcher.ResultChan()
 	for _, item := range table {
-		got, ok := <-watching.ResultChan()
+		got, ok := <-resultCh
 		if !ok {
 			t.Fatalf("Unexpected early close")
 		}
-		if e, a := item.t, got.Type; e != a {
-			t.Errorf("Expected %v, got %v", e, a)
-		}
-		if e, a := item.obj, got.Object; !apiequality.Semantic.DeepDerivative(e, a) {
-			t.Errorf("Expected %v, got %v", e, a)
-		}
+		assert.Equal(t, item.t, got.Type)
+		assert.Equal(t, item.obj, got.Object)
 	}
 
-	_, ok := <-watching.ResultChan()
-	if ok {
-		t.Fatal("Unexpected non-close")
+	// Stop watcher when done reading watch events
+	watcher.Stop()
+
+	// Wait for the result channel to close
+	err = utiltesting.WaitForChannelToCloseWithTimeout(ctx, wait.ForeverTestTimeout, resultCh)
+	//TODO(karlkfi): Fix race condition that causes the watch server to sometimes send an error when stopped
+	if err != nil {
+		// Extract & compare the Event so we can see  diff when it fails
+		event, unwrapErr := unwrapUnexectedWatchEvent(err)
+		require.NoError(t, unwrapErr)
+		expectedEvent := newClientWatchDecodingEvent(errReadOnClosedResBody)
+		require.Equal(t, expectedEvent, event)
 	}
 }
 
 func TestWatchUnknownContentType(t *testing.T) {
+	ctx := t.Context()
 	var table = []struct {
 		t   watch.EventType
 		obj runtime.Object
@@ -2252,10 +2265,8 @@ func TestWatchUnknownContentType(t *testing.T) {
 	defer testServer.Close()
 
 	s := testRESTClient(t, testServer)
-	_, err := s.Get().Prefix("path/to/watch/thing").Watch(context.Background())
-	if err == nil {
-		t.Fatalf("Expected to fail due to lack of known stream serialization for content type")
-	}
+	_, err := s.Get().Prefix("path/to/watch/thing").Watch(ctx)
+	require.Equal(t, runtime.NegotiateError{ContentType: "foobar", Stream: true}, err)
 }
 
 func TestStream(t *testing.T) {
@@ -4274,4 +4285,34 @@ func TestRequestWarningHandler(t *testing.T) {
 		assert.Equal(t, request, request.WarningHandlerWithContext(nil))
 		assert.Nil(t, request.warningHandler)
 	})
+}
+
+// From https://github.com/golang/go/blob/go1.20/src/net/http/transport.go#L2779
+var errReadOnClosedResBody = errors.New("http: read on closed response body")
+
+// newClientWatchDecodingEvent simulates a InternalServerError of type
+// "ClientWatchDecoding", wrapped as a watch.Event. These errors come from the
+// watch client StreamWatcher.
+func newClientWatchDecodingEvent(decodeErr error) watch.Event {
+	// From Request.newStreamWatcher
+	clientErrorReporter := apierrors.NewClientErrorReporter(http.StatusInternalServerError, "GET", "ClientWatchDecoding")
+	// From StreamWatcher.receive
+	// TODO(karlkfi): Use `%w` to format errors (errorlint) in StreamWatcher.receive
+	//nolint:errorlint // StreamWatcher.receive uses `%v`
+	serverErr := fmt.Errorf("unable to decode an event from the watch stream: %v", decodeErr)
+	return watch.Event{
+		Type:   watch.Error,
+		Object: clientErrorReporter.AsObject(serverErr),
+	}
+}
+
+// unwrapUnexectedWatchEvent unwraps a utiltesting.UnexpectedEventError to
+// extract the watch.Error.
+func unwrapUnexectedWatchEvent(err error) (watch.Event, error) {
+	var expectedErr *utiltesting.UnexpectedEventError[watch.Event]
+	if !errors.As(err, &expectedErr) {
+		return watch.Event{}, fmt.Errorf("Error expected to be of type %v, but was %v",
+			reflect.TypeOf(expectedErr), reflect.TypeOf(err))
+	}
+	return expectedErr.Event, nil
 }

--- a/staging/src/k8s.io/client-go/rest/watch/decoder_test.go
+++ b/staging/src/k8s.io/client-go/rest/watch/decoder_test.go
@@ -21,10 +21,10 @@ import (
 	"fmt"
 	"io"
 	"testing"
-	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
-	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	runtimejson "k8s.io/apimachinery/pkg/runtime/serializer/json"
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes/scheme"
+	utiltesting "k8s.io/client-go/util/testing"
 )
 
 // getDecoder mimics how k8s.io/client-go/rest.createSerializers creates a decoder
@@ -45,86 +46,103 @@ func TestDecoder(t *testing.T) {
 	table := []watch.EventType{watch.Added, watch.Deleted, watch.Modified, watch.Error, watch.Bookmark}
 
 	for _, eventType := range table {
-		out, in := io.Pipe()
+		t.Run(string(eventType), func(t *testing.T) {
+			ctx := t.Context()
+			out, in := io.Pipe()
+			defer assertNoCloseError(t, in)
+			decoder := NewDecoder(streaming.NewDecoder(out, getDecoder()), getDecoder())
+			defer decoder.Close()
+			expect := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}
+			encoder := json.NewEncoder(in)
+			eType := eventType
 
-		decoder := NewDecoder(streaming.NewDecoder(out, getDecoder()), getDecoder())
-		expect := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}
-		encoder := json.NewEncoder(in)
-		eType := eventType
-		errc := make(chan error)
+			encodeErrCh := make(chan error)
+			go func() {
+				defer close(encodeErrCh)
+				data, err := runtime.Encode(scheme.Codecs.LegacyCodec(v1.SchemeGroupVersion), expect)
+				if err != nil {
+					encodeErrCh <- fmt.Errorf("encode error: %w", err)
+					return
+				}
+				event := metav1.WatchEvent{
+					Type:   string(eType),
+					Object: runtime.RawExtension{Raw: json.RawMessage(data)},
+				}
+				if err := encoder.Encode(&event); err != nil {
+					encodeErrCh <- fmt.Errorf("encode error: %w", err)
+					return
+				}
+			}()
 
-		go func() {
-			data, err := runtime.Encode(scheme.Codecs.LegacyCodec(v1.SchemeGroupVersion), expect)
-			if err != nil {
-				errc <- fmt.Errorf("Unexpected error %v", err)
-				return
-			}
-			event := metav1.WatchEvent{
-				Type:   string(eType),
-				Object: runtime.RawExtension{Raw: json.RawMessage(data)},
-			}
-			if err := encoder.Encode(&event); err != nil {
-				t.Errorf("Unexpected error %v", err)
-			}
-			in.Close()
-		}()
+			decodeErrCh := make(chan error)
+			go func() {
+				defer close(decodeErrCh)
+				action, got, err := decoder.Decode()
+				if err != nil {
+					decodeErrCh <- fmt.Errorf("decode error: %w", err)
+					return
+				}
+				assert.Equal(t, eType, action)
+				assert.Equal(t, expect, got)
+			}()
 
-		done := make(chan struct{})
-		go func() {
-			action, got, err := decoder.Decode()
-			if err != nil {
-				errc <- fmt.Errorf("Unexpected error %v", err)
-				return
-			}
-			if e, a := eType, action; e != a {
-				t.Errorf("Expected %v, got %v", e, a)
-			}
-			if e, a := expect, got; !apiequality.Semantic.DeepDerivative(e, a) {
-				t.Errorf("Expected %v, got %v", e, a)
-			}
-			t.Logf("Exited read")
-			close(done)
-		}()
-		select {
-		case err := <-errc:
-			t.Fatal(err)
-		case <-done:
-		}
+			// Wait for encoder and decoder to return without error
+			err := utiltesting.WaitForAllChannelsToCloseWithTimeout(ctx,
+				wait.ForeverTestTimeout, encodeErrCh, decodeErrCh)
+			require.NoError(t, err)
 
-		done = make(chan struct{})
-		go func() {
-			_, _, err := decoder.Decode()
-			if err == nil {
-				t.Errorf("Unexpected nil error")
-			}
-			close(done)
-		}()
-		<-done
+			// Close the input pipe, which should cause the decoder to error
+			require.NoError(t, in.Close())
 
-		decoder.Close()
+			// Wait for decoder EOF error
+			decodeErrCh = make(chan error)
+			go func() {
+				defer close(decodeErrCh)
+				_, _, err := decoder.Decode()
+				if err != nil {
+					decodeErrCh <- err
+				}
+			}()
+
+			// Wait for decoder EOF error
+			decodeErr, err := utiltesting.WaitForChannelEventWithTimeout(ctx, wait.ForeverTestTimeout, decodeErrCh)
+			require.NoError(t, err)
+			require.Equal(t, io.EOF, decodeErr)
+		})
 	}
 }
 
 func TestDecoder_SourceClose(t *testing.T) {
+	ctx := t.Context()
 	out, in := io.Pipe()
+	defer assertNoCloseError(t, in)
 	decoder := NewDecoder(streaming.NewDecoder(out, getDecoder()), getDecoder())
+	defer decoder.Close()
 
-	done := make(chan struct{})
-
+	errCh := make(chan error)
 	go func() {
+		defer close(errCh)
 		_, _, err := decoder.Decode()
-		if err == nil {
-			t.Errorf("Unexpected nil error")
+		if err != nil {
+			errCh <- err
 		}
-		close(done)
 	}()
 
-	in.Close()
+	// Close the input pipe, which should cause the decoder to error
+	require.NoError(t, in.Close())
 
-	select {
-	case <-done:
-		break
-	case <-time.After(wait.ForeverTestTimeout):
-		t.Error("Timeout")
-	}
+	// Wait for decoder EOF error
+	decodeErr, err := utiltesting.WaitForChannelEventWithTimeout(ctx, wait.ForeverTestTimeout, errCh)
+	require.NoError(t, err)
+	require.Equal(t, io.EOF, decodeErr)
+
+	// Wait for errCh to close
+	err = utiltesting.WaitForChannelToCloseWithTimeout(ctx, wait.ForeverTestTimeout, errCh)
+	require.NoError(t, err)
+}
+
+// assertNoCloseError asserts that closing the Closer doesn't error.
+// Safe to call in a defer to ensure Closer.Close is called.
+func assertNoCloseError(t *testing.T, c io.Closer) {
+	assert.NoError(t, c.Close())
 }

--- a/staging/src/k8s.io/client-go/util/testing/channels.go
+++ b/staging/src/k8s.io/client-go/util/testing/channels.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"time"
+)
+
+// WaitForChannelEvent blocks until the channel receives an event.
+// Returns an error if the channel is closed or the context is done.
+func WaitForChannelEvent[T any](ctx context.Context, ch <-chan T) (T, error) {
+	var t T // zero value
+	for {
+		select {
+		case <-ctx.Done():
+			err := ctx.Err()
+			switch err {
+			case context.DeadlineExceeded:
+				return t, fmt.Errorf("timed out waiting for channel to close: %w", err)
+			default:
+				return t, fmt.Errorf("context cancelled before channel closed: %w", err)
+			}
+		case event, ok := <-ch:
+			if !ok {
+				return t, errors.New("channel closed before receiving event")
+			}
+			return event, nil
+		}
+	}
+}
+
+// WaitForChannelToClose blocks until the channel is closed.
+// Returns an error if any events are received or the context is done.
+func WaitForChannelToClose[T any](ctx context.Context, ch <-chan T) error {
+	for {
+		select {
+		case <-ctx.Done():
+			err := ctx.Err()
+			switch err {
+			case context.DeadlineExceeded:
+				return fmt.Errorf("timed out waiting for channel to close: %w", err)
+			default:
+				return fmt.Errorf("context cancelled before channel closed: %w", err)
+			}
+		case event, ok := <-ch:
+			if !ok {
+				return nil
+			}
+			return &UnexpectedEventError[T]{Event: event}
+		}
+	}
+}
+
+// WaitForAllChannelsToClose blocks until all the channels are closed.
+// Returns an error if any events are received or the context is done.
+func WaitForAllChannelsToClose[T any](ctx context.Context, channels ...<-chan T) error {
+	// Build a list of cases to select from
+	cases := make([]reflect.SelectCase, len(channels)+1)
+	for i, ch := range channels {
+		cases[i] = reflect.SelectCase{
+			Dir:  reflect.SelectRecv,
+			Chan: reflect.ValueOf(ch),
+		}
+	}
+	// Add the context done channel as the last case
+	contextCaseIndex := len(channels)
+	cases[contextCaseIndex] = reflect.SelectCase{
+		Dir:  reflect.SelectRecv,
+		Chan: reflect.ValueOf(ctx.Done()),
+	}
+	// Select from the cases until all channels are closed, an event is received,
+	// or the context is done.
+	channelsRemaining := len(cases)
+	for channelsRemaining > 1 {
+		// Block until one of the channels receives an event or closes
+		chosenIndex, value, ok := reflect.Select(cases)
+		if !ok {
+			// Return error immediately if the context is done
+			if chosenIndex == contextCaseIndex {
+				err := ctx.Err()
+				switch err {
+				case context.DeadlineExceeded:
+					return fmt.Errorf("timed out waiting for channel to close: %w", err)
+				default:
+					return fmt.Errorf("context cancelled before channel closed: %w", err)
+				}
+			}
+			// Remove closed channel from case to ignore it going forward
+			cases[chosenIndex].Chan = reflect.ValueOf(nil)
+			channelsRemaining--
+			continue
+		}
+		// All events received are treated as errors
+		return fmt.Errorf("channel %d: %w", chosenIndex,
+			&UnexpectedEventError[T]{Event: value.Interface().(T)})
+	}
+	// All channels closed before the context was done
+	return nil
+}
+
+// WaitForChannelEventWithTimeout blocks until the channel receives an event.
+// Returns an error if the channel is closed, the context is done, or the
+// timeout is reached
+func WaitForChannelEventWithTimeout[T any](ctx context.Context, timeout time.Duration, ch <-chan T) (T, error) {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	return WaitForChannelEvent(ctx, ch)
+}
+
+// WaitForChannelToClose blocks until the channel is closed.
+// Returns an error if any events are received, the context is done, or the
+// timeout is reached
+func WaitForChannelToCloseWithTimeout[T any](ctx context.Context, timeout time.Duration, ch <-chan T) error {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	return WaitForChannelToClose(ctx, ch)
+}
+
+// WaitForAllChannelsToCloseWithTimeout blocks until all the channels are closed.
+// Returns an error if any events are received, the context is done, or the
+// timeout is reached
+func WaitForAllChannelsToCloseWithTimeout[T any](ctx context.Context, timeout time.Duration, channels ...<-chan T) error {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	return WaitForAllChannelsToClose(ctx, channels...)
+}
+
+// UnexpectedEventError wraps an event unexpectedly received from a channel.
+type UnexpectedEventError[T any] struct {
+	Event T
+}
+
+// Error implements the error interface
+func (ue *UnexpectedEventError[T]) Error() string {
+	return fmt.Sprintf("channel received unexpected event: %#v", ue.Event)
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/kind flake

#### What this PR does / why we need it:

- Fix flaky watch tests that were not waiting for the storage watcher to be started by the server watch endpoint
- Use testify in watch tests to make the tests easier to read/debug
- Remove unnecessary test names from errors

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Dependencies
- https://github.com/kubernetes/kubernetes/pull/131505
- https://github.com/kubernetes/kubernetes/pull/131854
- https://github.com/kubernetes/kubernetes/pull/131656
- https://github.com/kubernetes/kubernetes/pull/131676
- https://github.com/kubernetes/kubernetes/pull/131680
- https://github.com/kubernetes/kubernetes/pull/131706