### PR TITLE
[kubelet] fix nil pointer panic on windows node

### DIFF
--- a/pkg/volume/volume_unsupported.go
+++ b/pkg/volume/volume_unsupported.go
@@ -27,7 +27,7 @@ import (
 
 // NewVolumeOwnership returns an interface that can be used to recursively change volume permissions and ownership
 func NewVolumeOwnership(mounter Mounter, dir string, fsGroup *int64, fsGroupChangePolicy *v1.PodFSGroupChangePolicy, completeFunc func(types.CompleteFuncParam)) VolumeOwnershipChanger {
-	return nil
+	return &VolumeOwnership{}
 }
 
 func (vo *VolumeOwnership) AddProgressNotifier(pod *v1.Pod, recorder record.EventRecorder) VolumeOwnershipChanger {


### PR DESCRIPTION

#### What type of PR is this?
/kind bug


#### What this PR does / why we need it:

This will fail kubelet on windows.
- 

```
retries permitted until 2025-04-24 19:49:18.5800049 +0000 UTC m=+6.097752901 (durationBeforeRetry 500ms). Error: recovered from panic "runtime error: invalid memory address or nil pointer dereference". (err=<nil>) Call stack:
goroutine 489 [running]:
k8s.io/apimachinery/pkg/util/runtime.RecoverFromPanic(0xc000d71e68)
	k8s.io/apimachinery/pkg/util/runtime/runtime.go:273 +0x65
panic({0x2d2c040?, 0x520abf0?})
	runtime/panic.go:792 +0x132
k8s.io/kubernetes/pkg/volume/emptydir.(*emptyDir).SetUpAt(0xc0002fc9a0, {0xc00064a280, 0x75}, {0x0, 0x0, 0x0, 0xc000be9300, {0x0, 0x0}, {0x1eb71790f80, ...}, ...})
	k8s.io/kubernetes/pkg/volume/emptydir/empty_dir.go:284 +0x59d
k8s.io/kubernetes/pkg/volume/configmap.(*configMapVolumeMounter).SetUpAt(0xc000d6aa08, {0xc00064a280, 0x75}, {0x0, 0x0, 0x0, 0xc000be9300, {0x0, 0x0}, {0x1eb71790f80, ...}, ...})
	k8s.io/kubernetes/pkg/volume/configmap/configmap.go:217 +0x8cd
k8s.io/kubernetes/pkg/volume/configmap.(*configMapVolumeMounter).SetUp(0xc000d6aa08, {0x0, 0x0, 0x0, 0xc000be9300, {0x0, 0x0}, {0x1eb71790f80, 0xc0004a5860}, {0x0, ...}})
	k8s.io/kubernetes/pkg/volume/configmap/configmap.go:177 +0x4c
k8s.io/kubernetes/pkg/volume/util/operationexecutor.(*operationGenerator).GenerateMountVolumeFunc.func1()
	k8s.io/kubernetes/pkg/volume/util/operationexecutor/operation_generator.go:582 +0xfe6
k8s.io/kubernetes/pkg/volume/util/types.(*GeneratedOperations).Run(0xc0005f0540)
	k8s.io/kubernetes/pkg/volume/util/types/types.go:79 +0x17e
k8s.io/kubernetes/pkg/volume/util/nestedpendingoperations.(*nestedPendingOperations).Run.func1()
	k8s.io/kubernetes/pkg/volume/util/nestedpendingoperations/nestedpendingoperations.go:190 +0xe8
created by k8s.io/kubernetes/pkg/volume/util/nestedpendingoperations.(*nestedPendingOperations).Run in goroutine 382
	k8s.io/kubernetes/pkg/volume/util/nestedpendingoperations/nestedpendingoperations.go:185 +0x885
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes None

#### Special notes for your reviewer:

This can be catched by https://testgrid.k8s.io/sig-release-master-informing#capz-windows-master

https://storage.googleapis.com/kubernetes-ci-logs/logs/ci-kubernetes-e2e-capz-master-windows/1915489463564242944/artifacts/clusters/capz-conf-073699/machines/capz-conf-073699-md-win-vcdqp-8zzmh/kubelet.log

#### Does this PR introduce a user-facing change?

```release-note
None
```


