### PR TITLE
Kube proxy controller

### DIFF
--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -46,9 +46,9 @@ import (
 	"k8s.io/kubernetes/pkg/proxy/healthcheck"
 	"k8s.io/kubernetes/pkg/proxy/metaproxier"
 	"k8s.io/kubernetes/pkg/proxy/metrics"
+	"k8s.io/kubernetes/pkg/proxy/util"
 	proxyutil "k8s.io/kubernetes/pkg/proxy/util"
 	"k8s.io/kubernetes/pkg/proxy/util/nfacct"
-	"k8s.io/kubernetes/pkg/util/async"
 	utiliptables "k8s.io/kubernetes/pkg/util/iptables"
 )
 
@@ -155,7 +155,7 @@ type Proxier struct {
 	lastFullSync         time.Time
 	needFullSync         bool
 	initialized          int32
-	syncRunner           *async.BoundedFrequencyRunner // governs calls to syncProxyRules
+	syncRunner           *util.BoundedFrequencyRunner // governs calls to syncProxyRules
 	syncPeriod           time.Duration
 	lastIPTablesCleanup  time.Time
 
@@ -312,7 +312,7 @@ func NewProxier(ctx context.Context,
 	// We pass syncPeriod to ipt.Monitor, which will call us only if it needs to.
 	// We need to pass *some* maxInterval to NewBoundedFrequencyRunner anyway though.
 	// time.Hour is arbitrary.
-	proxier.syncRunner = async.NewBoundedFrequencyRunner("sync-runner", proxier.syncProxyRules, minSyncPeriod, proxyutil.FullSyncPeriod, burstSyncs)
+	proxier.syncRunner = util.NewBoundedFrequencyRunner("sync-runner", proxier.syncProxyRules, minSyncPeriod, proxyutil.FullSyncPeriod, burstSyncs)
 
 	go ipt.Monitor(kubeProxyCanaryChain, []utiliptables.Table{utiliptables.TableMangle, utiliptables.TableNAT, utiliptables.TableFilter},
 		proxier.forceSyncProxyRules, syncPeriod, wait.NeverStop)

--- a/pkg/proxy/iptables/proxier_test.go
+++ b/pkg/proxy/iptables/proxier_test.go
@@ -55,9 +55,9 @@ import (
 	"k8s.io/kubernetes/pkg/proxy/conntrack"
 	"k8s.io/kubernetes/pkg/proxy/healthcheck"
 	"k8s.io/kubernetes/pkg/proxy/metrics"
+	"k8s.io/kubernetes/pkg/proxy/util"
 	proxyutil "k8s.io/kubernetes/pkg/proxy/util"
 	proxyutiltest "k8s.io/kubernetes/pkg/proxy/util/testing"
-	"k8s.io/kubernetes/pkg/util/async"
 	utiliptables "k8s.io/kubernetes/pkg/util/iptables"
 	iptablestest "k8s.io/kubernetes/pkg/util/iptables/testing"
 	netutils "k8s.io/utils/net"
@@ -144,7 +144,7 @@ func NewFakeProxier(ipt utiliptables.Interface) *Proxier {
 		},
 	}
 	p.setInitialized(true)
-	p.syncRunner = async.NewBoundedFrequencyRunner("test-sync-runner", p.syncProxyRules, 0, time.Minute, 1)
+	p.syncRunner = util.NewBoundedFrequencyRunner("test-sync-runner", p.syncProxyRules, 0, time.Minute, 1)
 	return p
 }
 

--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -49,8 +49,8 @@ import (
 	utilipvs "k8s.io/kubernetes/pkg/proxy/ipvs/util"
 	"k8s.io/kubernetes/pkg/proxy/metaproxier"
 	"k8s.io/kubernetes/pkg/proxy/metrics"
+	"k8s.io/kubernetes/pkg/proxy/util"
 	proxyutil "k8s.io/kubernetes/pkg/proxy/util"
-	"k8s.io/kubernetes/pkg/util/async"
 	utiliptables "k8s.io/kubernetes/pkg/util/iptables"
 	utilkernel "k8s.io/kubernetes/pkg/util/kernel"
 	netutils "k8s.io/utils/net"
@@ -187,7 +187,7 @@ type Proxier struct {
 	endpointSlicesSynced bool
 	servicesSynced       bool
 	initialized          int32
-	syncRunner           *async.BoundedFrequencyRunner // governs calls to syncProxyRules
+	syncRunner           *util.BoundedFrequencyRunner // governs calls to syncProxyRules
 
 	// These are effectively const and do not need the mutex to be held.
 	syncPeriod    time.Duration
@@ -402,7 +402,7 @@ func NewProxier(
 	}
 	burstSyncs := 2
 	logger.V(2).Info("ipvs sync params", "minSyncPeriod", minSyncPeriod, "syncPeriod", syncPeriod, "burstSyncs", burstSyncs)
-	proxier.syncRunner = async.NewBoundedFrequencyRunner("sync-runner", proxier.syncProxyRules, minSyncPeriod, syncPeriod, burstSyncs)
+	proxier.syncRunner = util.NewBoundedFrequencyRunner("sync-runner", proxier.syncProxyRules, minSyncPeriod, syncPeriod, burstSyncs)
 	proxier.gracefuldeleteManager.Run()
 	return proxier, nil
 }

--- a/pkg/proxy/ipvs/proxier_test.go
+++ b/pkg/proxy/ipvs/proxier_test.go
@@ -53,9 +53,9 @@ import (
 	utilipvs "k8s.io/kubernetes/pkg/proxy/ipvs/util"
 	ipvstest "k8s.io/kubernetes/pkg/proxy/ipvs/util/testing"
 	"k8s.io/kubernetes/pkg/proxy/metrics"
+	"k8s.io/kubernetes/pkg/proxy/util"
 	proxyutil "k8s.io/kubernetes/pkg/proxy/util"
 	proxyutiltest "k8s.io/kubernetes/pkg/proxy/util/testing"
-	"k8s.io/kubernetes/pkg/util/async"
 	utiliptables "k8s.io/kubernetes/pkg/util/iptables"
 	iptablestest "k8s.io/kubernetes/pkg/util/iptables/testing"
 	"k8s.io/kubernetes/test/utils/ktesting"
@@ -167,7 +167,7 @@ func NewFakeProxier(ctx context.Context, ipt utiliptables.Interface, ipvs utilip
 		ipFamily:              ipFamily,
 	}
 	p.setInitialized(true)
-	p.syncRunner = async.NewBoundedFrequencyRunner("test-sync-runner", p.syncProxyRules, 0, time.Minute, 1)
+	p.syncRunner = util.NewBoundedFrequencyRunner("test-sync-runner", p.syncProxyRules, 0, time.Minute, 1)
 	return p
 }
 

--- a/pkg/proxy/nftables/proxier.go
+++ b/pkg/proxy/nftables/proxier.go
@@ -36,7 +36,7 @@ import (
 
 	"golang.org/x/time/rate"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -49,8 +49,8 @@ import (
 	"k8s.io/kubernetes/pkg/proxy/healthcheck"
 	"k8s.io/kubernetes/pkg/proxy/metaproxier"
 	"k8s.io/kubernetes/pkg/proxy/metrics"
+	"k8s.io/kubernetes/pkg/proxy/util"
 	proxyutil "k8s.io/kubernetes/pkg/proxy/util"
-	"k8s.io/kubernetes/pkg/util/async"
 	utilkernel "k8s.io/kubernetes/pkg/util/kernel"
 	netutils "k8s.io/utils/net"
 	"k8s.io/utils/ptr"
@@ -164,7 +164,7 @@ type Proxier struct {
 	lastFullSync         time.Time
 	needFullSync         bool
 	initialized          int32
-	syncRunner           *async.BoundedFrequencyRunner // governs calls to syncProxyRules
+	syncRunner           *util.BoundedFrequencyRunner // governs calls to syncProxyRules
 	syncPeriod           time.Duration
 	flushed              bool
 
@@ -276,7 +276,7 @@ func NewProxier(ctx context.Context,
 	burstSyncs := 2
 	logger.V(2).Info("NFTables sync params", "minSyncPeriod", minSyncPeriod, "syncPeriod", syncPeriod, "burstSyncs", burstSyncs)
 	// We need to pass *some* maxInterval to NewBoundedFrequencyRunner. time.Hour is arbitrary.
-	proxier.syncRunner = async.NewBoundedFrequencyRunner("sync-runner", proxier.syncProxyRules, minSyncPeriod, proxyutil.FullSyncPeriod, burstSyncs)
+	proxier.syncRunner = util.NewBoundedFrequencyRunner("sync-runner", proxier.syncProxyRules, minSyncPeriod, proxyutil.FullSyncPeriod, burstSyncs)
 
 	return proxier, nil
 }

--- a/pkg/proxy/nftables/proxier_test.go
+++ b/pkg/proxy/nftables/proxier_test.go
@@ -46,9 +46,9 @@ import (
 	"k8s.io/kubernetes/pkg/proxy/conntrack"
 	"k8s.io/kubernetes/pkg/proxy/healthcheck"
 	"k8s.io/kubernetes/pkg/proxy/metrics"
+	"k8s.io/kubernetes/pkg/proxy/util"
 	proxyutil "k8s.io/kubernetes/pkg/proxy/util"
 	proxyutiltest "k8s.io/kubernetes/pkg/proxy/util/testing"
-	"k8s.io/kubernetes/pkg/util/async"
 	netutils "k8s.io/utils/net"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/knftables"
@@ -142,7 +142,7 @@ func NewFakeProxier(ipFamily v1.IPFamily) (*knftables.Fake, *Proxier) {
 		serviceNodePorts:    newNFTElementStorage("map", serviceNodePortsMap),
 	}
 	p.setInitialized(true)
-	p.syncRunner = async.NewBoundedFrequencyRunner("test-sync-runner", p.syncProxyRules, 0, time.Minute, 1)
+	p.syncRunner = util.NewBoundedFrequencyRunner("test-sync-runner", p.syncProxyRules, 0, time.Minute, 1)
 
 	return nft, p
 }

--- a/pkg/proxy/util/bounded_frequency_runner.go
+++ b/pkg/proxy/util/bounded_frequency_runner.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"time"
+
+	"golang.org/x/time/rate"
+	"k8s.io/klog/v2"
+)
+
+type BoundedFrequencyRunner struct {
+	maxInterval time.Duration
+	rateLimiter *rate.Limiter
+	fn          func()
+	queue       chan struct{}
+}
+
+// NewBoundedFrequencyRunner creates a new BoundedFrequencyRunner instance,
+// which will manage runs of the specified function.
+//
+// All runs will be async to the caller of BoundedFrequencyRunner.Run, but
+// multiple runs are serialized. If the function needs to hold locks, it must
+// take them internally.
+//
+// Runs of the function will have at least minInterval between them (from
+// completion to next start), except that up to bursts may be allowed.  Burst
+// runs are "accumulated" over time, one per minInterval up to burstRuns total.
+// Burst runs only occur if the previous execution of `fn` has completed.
+// This can be used, for example, to mitigate the impact of expensive operations
+// being called in response to user-initiated operations. Run requests that
+// would violate the minInterval are coalesced and run at the next opportunity.
+// The function will be run at least once per maxInterval. For example, this can
+// force periodic refreshes of state in the absence of anyone calling Run.
+//
+// Examples:
+//
+// NewBoundedFrequencyRunner("name", fn, time.Second, 5*time.Second)
+// - fn will have at least 1 second between runs
+// - fn will have no more than 5 seconds between runs
+//
+// NewBoundedFrequencyRunner("name", fn, 3*time.Second, 10*time.Second, 3)
+// - fn will have at least 3 seconds between runs, with up to 3 burst runs
+// - fn will have no more than 10 seconds between runs
+//
+// The maxInterval must be greater than or equal to the minInterval,  If the
+// caller passes a maxInterval less than minInterval, this function will panic.
+func NewBoundedFrequencyRunner(name string, fn func(), minInterval, maxInterval time.Duration, burst int) *BoundedFrequencyRunner {
+	if maxInterval < minInterval {
+		panic("maxInterval must be greater or equal than minInterval")
+	}
+
+	return &BoundedFrequencyRunner{
+		maxInterval: maxInterval,
+		rateLimiter: rate.NewLimiter(rate.Every(minInterval), burst),
+		queue:       make(chan struct{}, 1),
+		fn:          fn,
+	}
+
+}
+
+func (bfr *BoundedFrequencyRunner) Loop(stop <-chan struct{}) {
+	defer close(bfr.queue)
+	klog.V(3).Infof("Loop running")
+
+	// execute fn() at least every maxInterval
+	maxIntervalTicker := time.NewTicker(bfr.maxInterval)
+	defer maxIntervalTicker.Stop()
+
+	for {
+		select {
+		case <-stop:
+			return
+		case <-maxIntervalTicker.C:
+		case <-bfr.queue:
+		}
+		bfr.fn()
+		// reset the intervals
+		maxIntervalTicker.Reset(bfr.maxInterval)
+	}
+
+}
+
+func (bfr *BoundedFrequencyRunner) RetryAfter(interval time.Duration) {
+	go func() {
+		time.Sleep(interval)
+		bfr.Run()
+	}()
+}
+
+func (bfr *BoundedFrequencyRunner) Run() {
+	if bfr.rateLimiter.Allow() {
+		// add a token to the channel if it is empty
+		select {
+		case bfr.queue <- struct{}{}:
+		default:
+		}
+	}
+}

--- a/pkg/proxy/util/bounded_frequency_runner_test.go
+++ b/pkg/proxy/util/bounded_frequency_runner_test.go
@@ -1,0 +1,309 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestNewBoundedFrequencyRunner(t *testing.T) {
+	testFn := func() {}
+	minInterval := 100 * time.Millisecond
+	maxInterval := 500 * time.Millisecond
+	name := "test-runner"
+	burst := 3
+
+	runner := NewBoundedFrequencyRunner(name, testFn, minInterval, maxInterval, burst)
+
+	if runner.maxInterval != maxInterval {
+		t.Errorf("NewBoundedFrequencyRunner: maxInterval mismatch, got %v, want %v", runner.maxInterval, maxInterval)
+	}
+
+	if runner.fn == nil {
+		t.Errorf("NewBoundedFrequencyRunner: fn is nil, want not nil")
+	}
+	if runner.queue == nil {
+		t.Errorf("NewBoundedFrequencyRunner: queue is nil, want not nil")
+	}
+
+	// Test panic condition
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("NewBoundedFrequencyRunner: did not panic with invalid intervals")
+		}
+	}()
+	NewBoundedFrequencyRunner(name, testFn, maxInterval, minInterval, burst)
+}
+
+func TestBoundedFrequencyRunner(t *testing.T) {
+	tests := []struct {
+		name             string
+		minInterval      time.Duration
+		maxInterval      time.Duration
+		burst            int
+		runFunc          func(runner *BoundedFrequencyRunner) // Define a function type for running
+		sleepDuration    time.Duration
+		expectedRunCount int
+	}{
+		{
+			name:        "Test Run",
+			minInterval: 100 * time.Millisecond,
+			maxInterval: 500 * time.Millisecond,
+			burst:       1,
+			runFunc: func(runner *BoundedFrequencyRunner) {
+				runner.Run()
+				runner.Run()
+				runner.Run()
+			},
+			sleepDuration:    200 * time.Millisecond,
+			expectedRunCount: 1,
+		},
+		{
+			name:        "Test Run with longer sleep",
+			minInterval: 10 * time.Millisecond,
+			maxInterval: 200 * time.Millisecond,
+			burst:       1,
+			runFunc: func(runner *BoundedFrequencyRunner) {
+				runner.Run()
+			},
+			sleepDuration:    300 * time.Millisecond,
+			expectedRunCount: 2, // Should run twice because of maxInterval
+		},
+		{
+			name:        "Test RetryAfter",
+			minInterval: 50 * time.Millisecond,
+			maxInterval: 500 * time.Millisecond,
+			burst:       1,
+			runFunc: func(runner *BoundedFrequencyRunner) {
+				runner.RetryAfter(100 * time.Millisecond)
+			},
+			sleepDuration:    300 * time.Millisecond,
+			expectedRunCount: 1,
+		},
+		{
+			name:        "Test Burst",
+			minInterval: 50 * time.Millisecond,
+			maxInterval: 500 * time.Millisecond,
+			burst:       3,
+			runFunc: func(runner *BoundedFrequencyRunner) {
+				runner.Run()
+				time.Sleep(5 * time.Millisecond)
+				runner.Run()
+				time.Sleep(5 * time.Millisecond)
+				runner.Run()
+			},
+			sleepDuration:    15 * time.Millisecond,
+			expectedRunCount: 3,
+		},
+		{
+			name:        "Test Burst and minInterval",
+			minInterval: 50 * time.Millisecond,
+			maxInterval: 200 * time.Millisecond,
+			burst:       2,
+			runFunc: func(runner *BoundedFrequencyRunner) {
+				runner.Run()
+				time.Sleep(5 * time.Millisecond)
+				runner.Run()
+				time.Sleep(5 * time.Millisecond)
+				runner.Run()
+			},
+			sleepDuration:    20 * time.Millisecond, // Sleep more than minInterval
+			expectedRunCount: 2,
+		},
+		{
+			name:        "Test Burst and MaxInterval",
+			minInterval: 50 * time.Millisecond,
+			maxInterval: 200 * time.Millisecond,
+			burst:       2,
+			runFunc: func(runner *BoundedFrequencyRunner) {
+				runner.Run()
+				time.Sleep(5 * time.Millisecond)
+				runner.Run()
+				time.Sleep(5 * time.Millisecond)
+				runner.Run()
+			},
+			sleepDuration:    230 * time.Millisecond,
+			expectedRunCount: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var runCount atomic.Int32
+			testFn := func() {
+				runCount.Add(1)
+			}
+
+			runner := NewBoundedFrequencyRunner("test-runner", testFn, tt.minInterval, tt.maxInterval, tt.burst)
+			stopChan := make(chan struct{})
+			var wg sync.WaitGroup
+			wg.Add(1)
+
+			go func() {
+				defer wg.Done()
+				runner.Loop(stopChan)
+			}()
+
+			// Run the test function
+			tt.runFunc(runner)
+
+			// Wait for the specified duration
+			time.Sleep(tt.sleepDuration)
+			close(stopChan) // Signal the loop to stop
+			wg.Wait()       // Wait for the loop to finish
+
+			if int(runCount.Load()) != tt.expectedRunCount {
+				t.Errorf("%s: expected %d runs, got %d", tt.name, tt.expectedRunCount, runCount.Load())
+			}
+		})
+	}
+}
+
+func TestBoundedFrequencyRunnerRun(t *testing.T) {
+	var executionCount atomic.Int32
+	var lastExecutionTime time.Time
+	minInterval := 100 * time.Millisecond
+	maxInterval := 500 * time.Millisecond
+	burst := 1
+
+	runner := NewBoundedFrequencyRunner("test", func() {
+		executionCount.Add(1)
+		now := time.Now()
+		if !lastExecutionTime.IsZero() {
+			if now.Before(lastExecutionTime.Add(minInterval)) {
+				t.Errorf("function executed too soon: last execution at %v, current at %v, min interval %v", lastExecutionTime, now, minInterval)
+			}
+		}
+		lastExecutionTime = now
+	}, minInterval, maxInterval, burst)
+
+	stop := make(chan struct{})
+	defer close(stop)
+	go runner.Loop(stop)
+	time.Sleep(10 * time.Millisecond) // Give the loop a chance to start
+
+	// Trigger multiple runs quickly, they should be coalesced
+	runner.Run()
+	runner.Run()
+	runner.Run()
+
+	// Wait for at least one execution
+	time.Sleep(2 * minInterval)
+	if executionCount.Load() < 1 {
+		t.Errorf("function should have executed at least once")
+	}
+
+	initialCount := int(executionCount.Load())
+	time.Sleep(2 * minInterval)
+	if int(executionCount.Load()) > initialCount+burst {
+		t.Errorf("should not have executed more than burst times in this interval, got %d, expected max %d", int(executionCount.Load())-initialCount, burst)
+	}
+}
+
+func TestBoundedFrequencyRunnerRetryAfter(t *testing.T) {
+	var executionCount atomic.Int32
+	delay := 200 * time.Millisecond
+	minInterval := 100 * time.Millisecond
+	maxInterval := 500 * time.Millisecond
+	burst := 1
+
+	runner := NewBoundedFrequencyRunner("test", func() {
+		executionCount.Add(1)
+	}, minInterval, maxInterval, burst)
+
+	stop := make(chan struct{})
+	defer close(stop)
+	go runner.Loop(stop)
+	time.Sleep(10 * time.Millisecond) // Give the loop a chance to start
+
+	startTime := time.Now()
+	runner.RetryAfter(delay)
+
+	// Wait for slightly longer than the delay
+	time.Sleep(delay + 50*time.Millisecond)
+
+	if executionCount.Load() != 1 {
+		t.Errorf("function should have executed exactly once after RetryAfter, got %d", executionCount.Load())
+	}
+
+	endTime := time.Now()
+	if endTime.Before(startTime.Add(delay)) {
+		t.Errorf("function executed too early after RetryAfter, expected at least %v, got %v", delay, endTime.Sub(startTime))
+	}
+}
+
+func TestBoundedFrequencyRunnerBurst(t *testing.T) {
+	var executionCount atomic.Int32
+	minInterval := 100 * time.Millisecond
+	maxInterval := time.Minute
+	burst := 3
+
+	runner := NewBoundedFrequencyRunner("test", func() {
+		executionCount.Add(1)
+	}, minInterval, maxInterval, burst)
+
+	stop := make(chan struct{})
+	defer close(stop)
+	go runner.Loop(stop)
+	time.Sleep(10 * time.Millisecond) // Give the loop a chance to start
+
+	// Trigger more runs than the burst
+	start := time.Now()
+	for i := 0; i < burst+5; i++ {
+		runner.Run()
+		// wait for the function to finish
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	if time.Since(start) > minInterval {
+		t.Fatalf("burst functions should be executed within an interval, took %v", time.Since(start))
+	}
+
+	time.Sleep(minInterval)
+	// We expect the function to have executed up to 'burst' times relatively quickly
+	// and then throttled.
+	if int(executionCount.Load()) != burst {
+		t.Errorf("expected %d executions within the burst window, got %d", burst, executionCount.Load())
+	}
+
+}
+
+func TestBoundedFrequencyRunnerNoRunCalls(t *testing.T) {
+	var executionCount atomic.Int32
+	minInterval := 10 * time.Millisecond
+	maxInterval := 100 * time.Millisecond
+	burst := 1
+
+	runner := NewBoundedFrequencyRunner("test", func() {
+		executionCount.Add(1)
+	}, minInterval, maxInterval, burst)
+
+	stop := make(chan struct{})
+	defer close(stop)
+	go runner.Loop(stop)
+	time.Sleep(10 * time.Millisecond) // Give the loop a chance to start
+
+	// Don't call Run at all, rely solely on maxInterval
+	time.Sleep(8 * maxInterval)
+
+	if executionCount.Load() < 3 {
+		t.Errorf("function should have executed at least three times based on maxInterval, got %d", executionCount.Load())
+	}
+}

--- a/pkg/proxy/winkernel/proxier.go
+++ b/pkg/proxy/winkernel/proxier.go
@@ -48,8 +48,8 @@ import (
 	"k8s.io/kubernetes/pkg/proxy/healthcheck"
 	"k8s.io/kubernetes/pkg/proxy/metaproxier"
 	"k8s.io/kubernetes/pkg/proxy/metrics"
+	"k8s.io/kubernetes/pkg/proxy/util"
 	proxyutil "k8s.io/kubernetes/pkg/proxy/util"
-	"k8s.io/kubernetes/pkg/util/async"
 	netutils "k8s.io/utils/net"
 )
 
@@ -660,7 +660,7 @@ type Proxier struct {
 	endpointSlicesSynced bool
 	servicesSynced       bool
 	initialized          int32
-	syncRunner           *async.BoundedFrequencyRunner // governs calls to syncProxyRules
+	syncRunner           *util.BoundedFrequencyRunner // governs calls to syncProxyRules
 	// These are effectively const and do not need the mutex to be held.
 	nodeName string
 	nodeIP   net.IP
@@ -755,7 +755,7 @@ func NewProxier(
 
 	burstSyncs := 2
 	klog.V(3).InfoS("Record sync param", "minSyncPeriod", minSyncPeriod, "syncPeriod", syncPeriod, "burstSyncs", burstSyncs)
-	proxier.syncRunner = async.NewBoundedFrequencyRunner("sync-runner", proxier.syncProxyRules, minSyncPeriod, syncPeriod, burstSyncs)
+	proxier.syncRunner = util.NewBoundedFrequencyRunner("sync-runner", proxier.syncProxyRules, minSyncPeriod, syncPeriod, burstSyncs)
 	return proxier, nil
 }
 


### PR DESCRIPTION

/kind cleanup
Fixes #

```release-note
NONE
```

@danwinship @thockin  this also have some subtle different with the burst, but we really don't use burts, so we can completely remove the burst to make ti simpler

IIRC this failed because of the dependency in client go https://github.com/kubernetes/utils/pull/165 , the option is to copy the flow rate too , PTAL and let me now