### PR TITLE
docs: clarify HasClusterID purpose and usage in cloud providers

### DIFF
--- a/staging/src/k8s.io/cloud-provider/cloud.go
+++ b/staging/src/k8s.io/cloud-provider/cloud.go
@@ -65,6 +65,21 @@ type Interface interface {
 	// ProviderName returns the cloud provider ID.
 	ProviderName() string
 	// HasClusterID returns true if a ClusterID is required and set
+	// ClusterID is an identifier used by cloud providers to distinguish resources
+	// belonging to different clusters. It is particularly important when managing
+	// multiple Kubernetes clusters within the same account, region, VPC, or subnet.
+	//
+	// Some cloud providers (e.g., AWS) require ClusterID for resource tagging, load balancer
+	// naming, routing table management, etc. These cloud providers use the ClusterID to
+	// disambiguate resources when running multiple clusters within the same VPC or account.
+	//
+	// Cloud providers that don't utilize cluster IDs still need to implement this interface,
+	// and can simply implement it as 'return true' for compatibility purposes.
+	//
+	// This method is called during cloud-controller-manager initialization to verify
+	// that the current cluster is properly identified. If it returns false and the
+	// --allow-untagged-cloud flag is not set, the controller may log warnings
+	// or terminate execution to prevent resource conflicts.
 	HasClusterID() bool
 }
 

--- a/staging/src/k8s.io/cloud-provider/sample/basic_main.go
+++ b/staging/src/k8s.io/cloud-provider/sample/basic_main.go
@@ -87,6 +87,15 @@ func cloudInitializer(config *config.CompletedConfig) cloudprovider.Interface {
 		klog.Fatalf("Cloud provider is nil")
 	}
 
+	// Cloud providers may require a ClusterID to identify and manage
+	// resources (e.g., load balancers, route tables) belonging to a specific cluster.
+	// For example, AWS uses it to tag and isolate resources in shared environments.
+	//
+	// If HasClusterID() returns false and --allow-untagged-cloud is not set,
+	// the controller will exit to prevent accidental resource conflicts.
+	//
+	// Providers that don’t use tagging can bypass this by always returning true.
+	// However, long-term, supporting ClusterID is encouraged for all providers.
 	if !cloud.HasClusterID() {
 		if config.ComponentConfig.KubeCloudShared.AllowUntaggedCloud {
 			klog.Warning("detected a cluster without a ClusterID.  A ClusterID will be required in the future.  Please tag your cluster to avoid any future issues")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind documentation

#### What this PR does / why we need it:
Clarifies the purpose and expected behavior of the `HasClusterID` method in the cloud provider interface.

This PR adds detailed documentation to explain:
- Why and when a cloud provider should implement `HasClusterID`
- How this method is evaluated during cloud-controller-manager initialization
- Real-world examples of ClusterID usage (e.g., AWS resource tagging)
- Guidance for providers that do not require ClusterIDs

Improving this documentation helps cloud provider developers correctly implement the interface and avoid resource conflicts in multi-cluster environments.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
#128320

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
