### PR TITLE
kube-proxy: log errors during proxy boot

### DIFF
--- a/pkg/util/iptables/iptables.go
+++ b/pkg/util/iptables/iptables.go
@@ -654,8 +654,12 @@ func (runner *runner) ChainExists(table Table, chain Chain) (bool, error) {
 	trace := utiltrace.New("iptables ChainExists")
 	defer trace.LogIfLong(2 * time.Second)
 
-	_, err := runner.run(opListChain, fullArgs)
-	return err == nil, err
+	out, err := runner.run(opListChain, fullArgs)
+	if err != nil {
+		klog.ErrorS(err, "Failed to list chain", "chain", chain, "table", table, "output", string(out))
+		return false, err
+	}
+	return true, nil
 }
 
 type operation string


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Currently we check the existence of the default iptables chain to ensure if iptables is supported by the platform. We don't log the actual error and stdout  when the check fails.
```
I0426 10:25:33.610859       1 iptables.go:495] "Running" command="iptables" arguments=["-w","5","-W","100000","-S","POSTROUTING","-t","nat"]
I0426 10:25:33.611882       1 iptables.go:495] "Running" command="ip6tables" arguments=["-w","5","-W","100000","-S","POSTROUTING","-t","nat"]
E0426 10:25:33.612382       1 server.go:136] "Error running ProxyServer" err="iptables is not available on this host"                                                                                              
E0426 10:25:33.612393       1 run.go:72] "command failed" err="iptables is not available on this host"  
```

Logging the actual stdout/stderr will help to understand the root cause of the actual failure. It can help in covering the cases when privileges are not properly configured for the kube-proxy daemonset, removal of a deprecated flag from the user space binary and many more.

```
I0426 10:29:41.828765       1 iptables.go:495] "Running" command="iptables" arguments=["-w","5","-W","100000","-S","POSTROUTING","-t","nat"]
E0426 10:29:41.830829       1 iptables.go:659] "Failed to list chain" err="exit status 4" chain="POSTROUTING" table="nat" output=<
	Ignoring deprecated --wait-interval option.
	iptables v1.8.9 (nf_tables): Could not fetch rule set generation id: Permission denied (you must be root)
 >
I0426 10:29:41.832587       1 iptables.go:495] "Running" command="ip6tables" arguments=["-w","5","-W","100000","-S","POSTROUTING","-t","nat"]
E0426 10:29:41.834554       1 iptables.go:659] "Failed to list chain" err="exit status 4" chain="POSTROUTING" table="nat" output=<
	Ignoring deprecated --wait-interval option.
	ip6tables v1.8.9 (nf_tables): Could not fetch rule set generation id: Permission denied (you must be root)
 >
E0426 10:29:41.834608       1 server.go:136] "Error running ProxyServer" err="iptables is not available on this host"

```
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
