### PR TITLE
kubeadm: use testing.TempDir and delete helper function

### DIFF
--- a/cmd/kubeadm/app/cmd/certs_test.go
+++ b/cmd/kubeadm/app/cmd/certs_test.go
@@ -104,8 +104,7 @@ func TestCommandsGenerated(t *testing.T) {
 }
 
 func TestRunRenewCommands(t *testing.T) {
-	tmpDir := testutil.SetupTempDir(t)
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	cfg := testutil.GetDefaultInternalConfig(t)
 	cfg.CertificatesDir = tmpDir
@@ -312,8 +311,7 @@ func TestRunRenewCommands(t *testing.T) {
 }
 
 func TestRunGenCSR(t *testing.T) {
-	tmpDir := testutil.SetupTempDir(t)
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	kubeConfigDir := filepath.Join(tmpDir, "kubernetes")
 	certDir := kubeConfigDir + "/pki"
@@ -404,8 +402,7 @@ kubernetesVersion: %s`,
 		kubeadmapiv1.SchemeGroupVersion.String(),
 		kubeadmconstants.MinimumControlPlaneVersion.String())
 
-	tmpDir := testutil.SetupTempDir(t)
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	customConfigPath := tmpDir + "/kubeadm.conf"
 
@@ -489,11 +486,8 @@ kubernetesVersion: %s`,
 }
 
 func TestRunCmdCertsExpiration(t *testing.T) {
-	kdir := testutil.SetupTempDir(t)
+	kdir := t.TempDir()
 	defer func() {
-		if err := os.RemoveAll(kdir); err != nil {
-			t.Fatalf("Failed to teardown: %s", err)
-		}
 		clientSetFromFile = kubeconfigutil.ClientSetFromFile
 	}()
 

--- a/cmd/kubeadm/app/cmd/kubeconfig_test.go
+++ b/cmd/kubeadm/app/cmd/kubeconfig_test.go
@@ -78,8 +78,7 @@ func generateTestKubeadmConfig(dir, id, certDir, clusterName string) (string, er
 func TestKubeConfigSubCommandsThatWritesToOut(t *testing.T) {
 
 	// Temporary folders for the test case
-	tmpdir := testutil.SetupTempDir(t)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	// Adds a pki folder with a ca cert to the temp folder
 	pkidir := testutil.SetupPkiDirWithCertificateAuthority(t, tmpdir)

--- a/cmd/kubeadm/app/cmd/phases/init/certs_test.go
+++ b/cmd/kubeadm/app/cmd/phases/init/certs_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package phases
 
 import (
-	"os"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -44,8 +43,7 @@ func TestCreateSparseCerts(t *testing.T) {
 		t.Run(test.Name, func(t *testing.T) {
 			pkiutiltesting.Reset()
 
-			tmpdir := testutil.SetupTempDir(t)
-			defer os.RemoveAll(tmpdir)
+			tmpdir := t.TempDir()
 
 			certstestutil.WritePKIFiles(t, tmpdir, test.Files)
 

--- a/cmd/kubeadm/app/cmd/phases/reset/removeetcdmember_test.go
+++ b/cmd/kubeadm/app/cmd/phases/reset/removeetcdmember_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/lithammer/dedent"
 
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
-	testutil "k8s.io/kubernetes/cmd/kubeadm/test"
 )
 
 const (
@@ -99,8 +98,7 @@ func TestGetEtcdDataDir(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			tmpdir := testutil.SetupTempDir(t)
-			defer os.RemoveAll(tmpdir)
+			tmpdir := t.TempDir()
 
 			manifestPath := filepath.Join(tmpdir, "etcd.yaml")
 			if test.writeManifest {

--- a/cmd/kubeadm/app/cmd/upgrade/common_test.go
+++ b/cmd/kubeadm/app/cmd/upgrade/common_test.go
@@ -30,7 +30,6 @@ import (
 	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta4"
 	"k8s.io/kubernetes/cmd/kubeadm/app/preflight"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/output"
-	testutil "k8s.io/kubernetes/cmd/kubeadm/test"
 )
 
 const testConfigToken = `apiVersion: v1
@@ -55,8 +54,7 @@ users:
 `
 
 func TestEnforceRequirements(t *testing.T) {
-	tmpDir := testutil.SetupTempDir(t)
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 	fullPath := filepath.Join(tmpDir, "test-config-file")
 	f, err := os.Create(fullPath)
 	if err != nil {

--- a/cmd/kubeadm/app/phases/certs/certs_test.go
+++ b/cmd/kubeadm/app/phases/certs/certs_test.go
@@ -74,8 +74,7 @@ func TestWriteCertificateAuthorityFilesIfNotExist(t *testing.T) {
 
 	for _, test := range tests {
 		// Create temp folder for the test case
-		tmpdir := testutil.SetupTempDir(t)
-		defer os.RemoveAll(tmpdir)
+		tmpdir := t.TempDir()
 
 		// executes setup func (if necessary)
 		if test.setupFunc != nil {
@@ -179,8 +178,7 @@ func TestWriteCertificateFilesIfNotExist(t *testing.T) {
 
 	for _, test := range tests {
 		// Create temp folder for the test case
-		tmpdir := testutil.SetupTempDir(t)
-		defer os.RemoveAll(tmpdir)
+		tmpdir := t.TempDir()
 
 		// executes setup func (if necessary)
 		if test.setupFunc != nil {
@@ -252,8 +250,7 @@ func TestCreateServiceAccountKeyAndPublicKeyFiles(t *testing.T) {
 	}
 	for _, tt := range tcases {
 		t.Run(tt.name, func(t *testing.T) {
-			dir := testutil.SetupTempDir(t)
-			defer os.RemoveAll(dir)
+			dir := t.TempDir()
 
 			if tt.setupFunc != nil {
 				if err := tt.setupFunc(dir); err != nil {
@@ -383,9 +380,8 @@ func TestSharedCertificateExists(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run("", func(t *testing.T) {
-			tmpdir := testutil.SetupTempDir(t)
+			tmpdir := t.TempDir()
 			os.MkdirAll(tmpdir+"/etcd", os.ModePerm)
-			defer os.RemoveAll(tmpdir)
 
 			cfg := &kubeadmapi.ClusterConfiguration{
 				CertificatesDir: tmpdir,
@@ -415,8 +411,7 @@ func TestCreatePKIAssetsWithSparseCerts(t *testing.T) {
 		t.Run(test.Name, func(t *testing.T) {
 			pkiutiltesting.Reset()
 
-			tmpdir := testutil.SetupTempDir(t)
-			defer os.RemoveAll(tmpdir)
+			tmpdir := t.TempDir()
 
 			cfg := testutil.GetDefaultInternalConfig(t)
 			cfg.ClusterConfiguration.CertificatesDir = tmpdir
@@ -518,8 +513,7 @@ func TestUsingExternalCA(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			pkiutiltesting.Reset()
 
-			dir := testutil.SetupTempDir(t)
-			defer os.RemoveAll(dir)
+			dir := t.TempDir()
 
 			cfg := &kubeadmapi.InitConfiguration{
 				LocalAPIEndpoint: kubeadmapi.APIEndpoint{AdvertiseAddress: "1.2.3.4"},
@@ -622,8 +616,7 @@ func TestValidateMethods(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		dir := testutil.SetupTempDir(t)
-		defer os.RemoveAll(dir)
+		dir := t.TempDir()
 		test.loc.pkiDir = dir
 
 		certstestutil.WritePKIFiles(t, dir, test.files)
@@ -678,8 +671,7 @@ func TestCreateCertificateFilesMethods(t *testing.T) {
 		pkiutiltesting.Reset()
 
 		// Create temp folder for the test case
-		tmpdir := testutil.SetupTempDir(t)
-		defer os.RemoveAll(tmpdir)
+		tmpdir := t.TempDir()
 
 		cfg := &kubeadmapi.InitConfiguration{
 			LocalAPIEndpoint: kubeadmapi.APIEndpoint{AdvertiseAddress: "1.2.3.4"},

--- a/cmd/kubeadm/app/phases/certs/renewal/manager_test.go
+++ b/cmd/kubeadm/app/phases/certs/renewal/manager_test.go
@@ -37,7 +37,6 @@ import (
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
 	certtestutil "k8s.io/kubernetes/cmd/kubeadm/app/util/certs"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil"
-	testutil "k8s.io/kubernetes/cmd/kubeadm/test"
 )
 
 var (
@@ -106,8 +105,7 @@ func TestNewManager(t *testing.T) {
 }
 
 func TestRenewUsingLocalCA(t *testing.T) {
-	dir := testutil.SetupTempDir(t)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	if err := pkiutil.WriteCertAndKey(dir, "ca", testCACert, testCAKey); err != nil {
 		t.Fatalf("couldn't write out CA certificate to %s", dir)
@@ -200,8 +198,7 @@ func TestRenewUsingLocalCA(t *testing.T) {
 }
 
 func TestCreateRenewCSR(t *testing.T) {
-	dir := testutil.SetupTempDir(t)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	outdir := filepath.Join(dir, "out")
 

--- a/cmd/kubeadm/app/phases/certs/renewal/readwriter_test.go
+++ b/cmd/kubeadm/app/phases/certs/renewal/readwriter_test.go
@@ -33,13 +33,11 @@ import (
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	kubeconfigutil "k8s.io/kubernetes/cmd/kubeadm/app/util/kubeconfig"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil"
-	testutil "k8s.io/kubernetes/cmd/kubeadm/test"
 )
 
 func TestPKICertificateReadWriter(t *testing.T) {
 	// creates a tmp folder
-	dir := testutil.SetupTempDir(t)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	// creates a certificate
 	cert := writeTestCertificate(t, dir, "test", testCACert, testCAKey, testCertOrganization, time.Time{}, time.Time{})
@@ -84,10 +82,8 @@ func TestPKICertificateReadWriter(t *testing.T) {
 
 func TestKubeconfigReadWriter(t *testing.T) {
 	// creates tmp folders
-	dirKubernetes := testutil.SetupTempDir(t)
-	defer os.RemoveAll(dirKubernetes)
-	dirPKI := testutil.SetupTempDir(t)
-	defer os.RemoveAll(dirPKI)
+	dirKubernetes := t.TempDir()
+	dirPKI := t.TempDir()
 
 	// write the CA cert and key to the temporary PKI dir
 	caName := kubeadmconstants.CACertAndKeyBaseName

--- a/cmd/kubeadm/app/phases/controlplane/manifests_test.go
+++ b/cmd/kubeadm/app/phases/controlplane/manifests_test.go
@@ -169,8 +169,7 @@ func TestCreateStaticPodFilesAndWrappers(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			// Create temp folder for the test case
-			tmpdir := testutil.SetupTempDir(t)
-			defer os.RemoveAll(tmpdir)
+			tmpdir := t.TempDir()
 
 			// Creates a Cluster Configuration
 			cfg := &kubeadmapi.ClusterConfiguration{
@@ -197,8 +196,7 @@ func TestCreateStaticPodFilesAndWrappers(t *testing.T) {
 
 func TestCreateStaticPodFilesWithPatches(t *testing.T) {
 	// Create temp folder for the test case
-	tmpdir := testutil.SetupTempDir(t)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	// Creates a Cluster Configuration
 	cfg := &kubeadmapi.ClusterConfiguration{
@@ -1044,8 +1042,7 @@ func TestGetControllerManagerCommandExternalCA(t *testing.T) {
 			pkiutiltesting.Reset()
 
 			// Create temp folder for the test case
-			tmpdir := testutil.SetupTempDir(t)
-			defer os.RemoveAll(tmpdir)
+			tmpdir := t.TempDir()
 			test.cfg.CertificatesDir = tmpdir
 
 			if err := certs.CreatePKIAssets(test.cfg); err != nil {

--- a/cmd/kubeadm/app/phases/copycerts/copycerts_test.go
+++ b/cmd/kubeadm/app/phases/copycerts/copycerts_test.go
@@ -41,8 +41,7 @@ import (
 
 func TestGetDataFromInitConfig(t *testing.T) {
 	certData := []byte("cert-data")
-	tmpdir := testutil.SetupTempDir(t)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 	cfg := &kubeadmapi.InitConfiguration{}
 	cfg.CertificatesDir = tmpdir
 
@@ -159,8 +158,7 @@ func TestCertOrKeyNameToSecretName(t *testing.T) {
 }
 
 func TestUploadCerts(t *testing.T) {
-	tmpdir := testutil.SetupTempDir(t)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	secretKey, err := CreateCertificateKey()
 	if err != nil {
@@ -210,14 +208,12 @@ func TestDownloadCerts(t *testing.T) {
 	}
 
 	// Temporary directory where certificates will be generated
-	tmpdir := testutil.SetupTempDir(t)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 	initConfiguration := testutil.GetDefaultInternalConfig(t)
 	initConfiguration.ClusterConfiguration.CertificatesDir = tmpdir
 
 	// Temporary directory where certificates will be downloaded to
-	targetTmpdir := testutil.SetupTempDir(t)
-	defer os.RemoveAll(targetTmpdir)
+	targetTmpdir := t.TempDir()
 	initForDownloadConfiguration := testutil.GetDefaultInternalConfig(t)
 	initForDownloadConfiguration.ClusterConfiguration.CertificatesDir = targetTmpdir
 

--- a/cmd/kubeadm/app/phases/etcd/local_test.go
+++ b/cmd/kubeadm/app/phases/etcd/local_test.go
@@ -71,8 +71,7 @@ func TestGetEtcdPodSpec(t *testing.T) {
 
 func TestCreateLocalEtcdStaticPodManifestFile(t *testing.T) {
 	// Create temp folder for the test case
-	tmpdir := testutil.SetupTempDir(t)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	var tests = []struct {
 		cfg              *kubeadmapi.ClusterConfiguration
@@ -230,8 +229,7 @@ status: {}
 
 func TestCreateLocalEtcdStaticPodManifestFileWithPatches(t *testing.T) {
 	// Create temp folder for the test case
-	tmpdir := testutil.SetupTempDir(t)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	// Creates a Cluster Configuration
 	cfg := &kubeadmapi.ClusterConfiguration{

--- a/cmd/kubeadm/app/phases/kubeconfig/kubeconfig_test.go
+++ b/cmd/kubeadm/app/phases/kubeconfig/kubeconfig_test.go
@@ -55,8 +55,7 @@ import (
 
 func TestGetKubeConfigSpecsFailsIfCADoesntExists(t *testing.T) {
 	// Create temp folder for the test case (without a CA)
-	tmpdir := testutil.SetupTempDir(t)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	// Creates an InitConfiguration pointing to the pkidir folder
 	cfg := &kubeadmapi.InitConfiguration{
@@ -73,8 +72,7 @@ func TestGetKubeConfigSpecsFailsIfCADoesntExists(t *testing.T) {
 
 func TestGetKubeConfigSpecs(t *testing.T) {
 	// Create temp folder for the test case
-	tmpdir := testutil.SetupTempDir(t)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	// Adds a pki folder with a ca certs to the temp folder
 	pkidir := testutil.SetupPkiDirWithCertificateAuthority(t, tmpdir)
@@ -299,8 +297,7 @@ func TestCreateKubeConfigFileIfNotExists(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			// Create temp folder for the test case
-			tmpdir := testutil.SetupTempDir(t)
-			defer os.RemoveAll(tmpdir)
+			tmpdir := t.TempDir()
 
 			// Writes the existing kubeconfig file to disk
 			if test.existingKubeConfig != nil {
@@ -352,8 +349,7 @@ func TestCreateKubeconfigFilesAndWrappers(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			// Create temp folder for the test case
-			tmpdir := testutil.SetupTempDir(t)
-			defer os.RemoveAll(tmpdir)
+			tmpdir := t.TempDir()
 
 			// Adds a pki folder with a ca certs to the temp folder
 			pkidir := testutil.SetupPkiDirWithCertificateAuthority(t, tmpdir)
@@ -385,8 +381,7 @@ func TestCreateKubeconfigFilesAndWrappers(t *testing.T) {
 
 func TestWriteKubeConfigFailsIfCADoesntExists(t *testing.T) {
 	// Temporary folders for the test case (without a CA)
-	tmpdir := testutil.SetupTempDir(t)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	// Creates an InitConfiguration pointing to the tmpdir folder
 	cfg := &kubeadmapi.InitConfiguration{
@@ -429,8 +424,7 @@ func TestWriteKubeConfigFailsIfCADoesntExists(t *testing.T) {
 
 func TestWriteKubeConfig(t *testing.T) {
 	// Temporary folders for the test case
-	tmpdir := testutil.SetupTempDir(t)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	// Adds a pki folder with a ca cert to the temp folder
 	pkidir := testutil.SetupPkiDirWithCertificateAuthority(t, tmpdir)
@@ -583,8 +577,7 @@ func TestValidateKubeConfig(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			tmpdir := testutil.SetupTempDir(t)
-			defer os.RemoveAll(tmpdir)
+			tmpdir := t.TempDir()
 
 			if test.existingKubeConfig != nil {
 				if err := createKubeConfigFileIfNotExists(tmpdir, "test.conf", test.existingKubeConfig); err != nil {
@@ -607,12 +600,7 @@ func TestValidateKubeConfig(t *testing.T) {
 }
 
 func TestValidateKubeconfigsForExternalCA(t *testing.T) {
-	tmpDir := testutil.SetupTempDir(t)
-	defer func() {
-		if err := os.RemoveAll(tmpDir); err != nil {
-			t.Error(err)
-		}
-	}()
+	tmpDir := t.TempDir()
 	pkiDir := filepath.Join(tmpDir, "pki")
 
 	initConfig := &kubeadmapi.InitConfiguration{
@@ -698,12 +686,7 @@ func TestValidateKubeconfigsForExternalCA(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			tmpdir := testutil.SetupTempDir(t)
-			defer func() {
-				if err := os.RemoveAll(tmpdir); err != nil {
-					t.Error(err)
-				}
-			}()
+			tmpdir := t.TempDir()
 
 			for name, config := range test.filesToWrite {
 				if err := createKubeConfigFileIfNotExists(tmpdir, name, config); err != nil {
@@ -726,12 +709,7 @@ func TestValidateKubeconfigsForExternalCA(t *testing.T) {
 }
 
 func TestValidateKubeconfigsForExternalCAMissingRoot(t *testing.T) {
-	tmpDir := testutil.SetupTempDir(t)
-	defer func() {
-		if err := os.RemoveAll(tmpDir); err != nil {
-			t.Error(err)
-		}
-	}()
+	tmpDir := t.TempDir()
 	pkiDir := filepath.Join(tmpDir, "pki")
 
 	initConfig := &kubeadmapi.InitConfiguration{
@@ -859,12 +837,7 @@ func TestValidateKubeconfigsForExternalCAMissingRoot(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			tmpdir := testutil.SetupTempDir(t)
-			defer func() {
-				if err := os.RemoveAll(tmpdir); err != nil {
-					t.Error(err)
-				}
-			}()
+			tmpdir := t.TempDir()
 
 			for name, config := range test.filesToWrite {
 				if err := createKubeConfigFileIfNotExists(tmpdir, name, config); err != nil {
@@ -926,8 +899,7 @@ func setupKubeConfigWithTokenAuth(t *testing.T, caCert *x509.Certificate, apiSer
 }
 
 func TestEnsureAdminClusterRoleBinding(t *testing.T) {
-	dir := testutil.SetupTempDir(t)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	cfg := testutil.GetDefaultInternalConfig(t)
 	cfg.CertificatesDir = dir
@@ -1141,13 +1113,8 @@ func TestEnsureAdminClusterRoleBindingImpl(t *testing.T) {
 }
 
 func TestCreateKubeConfigAndCSR(t *testing.T) {
-	tmpDir := testutil.SetupTempDir(t)
+	tmpDir := t.TempDir()
 	testutil.SetupEmptyFiles(t, tmpDir, "testfile", "bar.csr", "bar.key")
-	defer func() {
-		if err := os.RemoveAll(tmpDir); err != nil {
-			t.Error(err)
-		}
-	}()
 	caCert, caKey := certstestutil.SetupCertificateAuthority(t)
 
 	type args struct {
@@ -1278,12 +1245,7 @@ func TestCreateKubeConfigAndCSR(t *testing.T) {
 }
 
 func TestCreateDefaultKubeConfigsAndCSRFiles(t *testing.T) {
-	tmpDir := testutil.SetupTempDir(t)
-	defer func() {
-		if err := os.RemoveAll(tmpDir); err != nil {
-			t.Error(err)
-		}
-	}()
+	tmpDir := t.TempDir()
 	type args struct {
 		kubeConfigDir string
 		kubeadmConfig *kubeadmapi.InitConfiguration

--- a/cmd/kubeadm/app/phases/upgrade/postupgrade_test.go
+++ b/cmd/kubeadm/app/phases/upgrade/postupgrade_test.go
@@ -34,13 +34,10 @@ import (
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	"k8s.io/kubernetes/cmd/kubeadm/app/componentconfigs"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
-	testutil "k8s.io/kubernetes/cmd/kubeadm/test"
 )
 
 func TestMoveFiles(t *testing.T) {
-	tmpdir := testutil.SetupTempDir(t)
-	defer os.RemoveAll(tmpdir)
-	os.Chmod(tmpdir, 0766)
+	tmpdir := t.TempDir()
 
 	certPath := filepath.Join(tmpdir, constants.APIServerCertName)
 	certFile, err := os.OpenFile(certPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0666)
@@ -72,9 +69,7 @@ func TestMoveFiles(t *testing.T) {
 }
 
 func TestRollbackFiles(t *testing.T) {
-	tmpdir := testutil.SetupTempDir(t)
-	defer os.RemoveAll(tmpdir)
-	os.Chmod(tmpdir, 0766)
+	tmpdir := t.TempDir()
 
 	subDir := filepath.Join(tmpdir, "expired")
 	if err := os.Mkdir(subDir, 0766); err != nil {

--- a/cmd/kubeadm/app/phases/upgrade/staticpods_test.go
+++ b/cmd/kubeadm/app/phases/upgrade/staticpods_test.go
@@ -789,8 +789,7 @@ func TestRenewCertsByComponent(t *testing.T) {
 			pkiutiltesting.Reset()
 
 			// Setup up basic requisites
-			tmpDir := testutil.SetupTempDir(t)
-			defer os.RemoveAll(tmpDir)
+			tmpDir := t.TempDir()
 
 			cfg := testutil.GetDefaultInternalConfig(t)
 			cfg.CertificatesDir = tmpDir

--- a/cmd/kubeadm/app/util/staticpod/utils_test.go
+++ b/cmd/kubeadm/app/util/staticpod/utils_test.go
@@ -34,7 +34,6 @@ import (
 
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
-	testutil "k8s.io/kubernetes/cmd/kubeadm/test"
 )
 
 func TestComponentResources(t *testing.T) {
@@ -671,8 +670,7 @@ func TestReadStaticPodFromDisk(t *testing.T) {
 
 	for _, rt := range tests {
 		t.Run(rt.description, func(t *testing.T) {
-			tmpdir := testutil.SetupTempDir(t)
-			defer os.RemoveAll(tmpdir)
+			tmpdir := t.TempDir()
 
 			manifestPath := filepath.Join(tmpdir, "pod.yaml")
 			if rt.writeManifest {
@@ -844,8 +842,7 @@ func TestManifestFilesAreEqual(t *testing.T) {
 
 	for _, rt := range tests {
 		t.Run(rt.description, func(t *testing.T) {
-			tmpdir := testutil.SetupTempDir(t)
-			defer os.RemoveAll(tmpdir)
+			tmpdir := t.TempDir()
 
 			// write 2 manifests
 			for i := 0; i < 2; i++ {

--- a/cmd/kubeadm/test/util.go
+++ b/cmd/kubeadm/test/util.go
@@ -28,17 +28,6 @@ import (
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil"
 )
 
-// SetupTempDir is a utility function for kubeadm testing, that creates a temporary directory
-// NB. it is up to the caller to cleanup the folder at the end of the test with defer os.RemoveAll(tmpdir)
-func SetupTempDir(t *testing.T) string {
-	tmpdir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatalf("Couldn't create tmpdir")
-	}
-
-	return tmpdir
-}
-
 // SetupEmptyFiles is a utility function for kubeadm testing that creates one or more empty files (touch)
 func SetupEmptyFiles(t *testing.T, tmpdir string, fileNames ...string) {
 	for _, fileName := range fileNames {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:

Currently, we have helper function to create tmp directory for test, but Go already publish API called testing.TemDir that also creates tmp directory, then delete at the end of test. So I replaced helper function with this. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
