### PR TITLE
Externaljwt OIDC discovery fix

### DIFF
--- a/pkg/controlplane/apiserver/config.go
+++ b/pkg/controlplane/apiserver/config.go
@@ -378,7 +378,7 @@ func CreateConfig(
 
 	if len(opts.Authentication.ServiceAccounts.KeyFiles) > 0 {
 		// Load and set the public keys.
-		var pubKeys []interface{}
+		var pubKeys []any
 		for _, f := range opts.Authentication.ServiceAccounts.KeyFiles {
 			keys, err := keyutil.PublicKeysFromFile(f)
 			if err != nil {
@@ -391,7 +391,10 @@ func CreateConfig(
 			return nil, nil, fmt.Errorf("failed to set up public service account keys: %w", err)
 		}
 		config.ServiceAccountPublicKeysGetter = keysGetter
+	} else if opts.Authentication.ServiceAccounts.ExternalPublicKeysGetter != nil {
+		config.ServiceAccountPublicKeysGetter = opts.Authentication.ServiceAccounts.ExternalPublicKeysGetter
 	}
+
 	config.ServiceAccountIssuerURL = opts.Authentication.ServiceAccounts.Issuers[0]
 	config.ServiceAccountJWKSURI = opts.Authentication.ServiceAccounts.JWKSURI
 

--- a/pkg/controlplane/apiserver/options/validation_test.go
+++ b/pkg/controlplane/apiserver/options/validation_test.go
@@ -237,7 +237,7 @@ func TestValidateOptions(t *testing.T) {
 	}
 }
 
-func TestValidateServcieAccountTokenSigningConfig(t *testing.T) {
+func TestValidateServiceAccountTokenSigningConfig(t *testing.T) {
 	tests := []struct {
 		name           string
 		featureEnabled bool

--- a/test/integration/serviceaccount/external_jwt_signer_test.go
+++ b/test/integration/serviceaccount/external_jwt_signer_test.go
@@ -77,6 +77,16 @@ func TestExternalJWTSigningAndAuth(t *testing.T) {
 	})
 	defer tearDownFn()
 
+	// Validate that OIDC discovery doc and keys are available.
+	for _, p := range []string{
+		"/.well-known/openid-configuration",
+		"/openid/v1/jwks",
+	} {
+		if _, err := client.CoreV1().RESTClient().Get().AbsPath(p).DoRaw(ctx); err != nil {
+			t.Errorf("Validating OIDC discovery failed, error getting api path %q: %v", p, err)
+		}
+	}
+
 	// Create Namesapce (ns-1) to work with.
 	if _, err := client.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:

Fix openid discovery docs with external jwt signer.
    
    If the external jwt signer is enabled, publishing
    OIDC discovery docs and keys fails because the PublicKeysGetter
    is not wired correctly.
    
    Set the public keys getter on startup so public key
    discovery works in that case as well.

```release-note
kube-apiserver: Fixes OIDC discovery document publishing when external service account token signing is enabled
```