### PR TITLE
Automated cherry pick of #130503: Unhandled panic crash on rollout_history printer.PrintObj

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/printers/managedfields.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/printers/managedfields.go
@@ -17,7 +17,6 @@ limitations under the License.
 package printers
 
 import (
-	"fmt"
 	"io"
 
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -45,7 +44,7 @@ func omitManagedFields(o runtime.Object) runtime.Object {
 // PrintObj copies the object and omits the managed fields from the copied object before printing it.
 func (p *OmitManagedFieldsPrinter) PrintObj(obj runtime.Object, w io.Writer) error {
 	if obj == nil {
-		return fmt.Errorf("error: unable to find the specified revision")
+		return p.Delegate.PrintObj(obj, w)
 	}
 
 	if meta.IsListType(obj) {

--- a/staging/src/k8s.io/cli-runtime/pkg/printers/managedfields.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/printers/managedfields.go
@@ -46,7 +46,6 @@ func (p *OmitManagedFieldsPrinter) PrintObj(obj runtime.Object, w io.Writer) err
 	if obj == nil {
 		return p.Delegate.PrintObj(obj, w)
 	}
-
 	if meta.IsListType(obj) {
 		obj = obj.DeepCopyObject()
 		_ = meta.EachListItem(obj, func(item runtime.Object) error {

--- a/staging/src/k8s.io/cli-runtime/pkg/printers/managedfields.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/printers/managedfields.go
@@ -17,6 +17,7 @@ limitations under the License.
 package printers
 
 import (
+	"fmt"
 	"io"
 
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -44,8 +45,9 @@ func omitManagedFields(o runtime.Object) runtime.Object {
 // PrintObj copies the object and omits the managed fields from the copied object before printing it.
 func (p *OmitManagedFieldsPrinter) PrintObj(obj runtime.Object, w io.Writer) error {
 	if obj == nil {
-		return p.Delegate.PrintObj(obj, w)
+		return fmt.Errorf("error: unable to find the specified revision")
 	}
+
 	if meta.IsListType(obj) {
 		obj = obj.DeepCopyObject()
 		_ = meta.EachListItem(obj, func(item runtime.Object) error {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_history.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_history.go
@@ -105,7 +105,7 @@ func NewCmdRolloutHistory(f cmdutil.Factory, streams genericiooptions.IOStreams)
 	return cmd
 }
 
-// Complete completes al the required options
+// Complete completes all the required options
 func (o *RolloutHistoryOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
 	o.Resources = args
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_history.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_history.go
@@ -177,7 +177,10 @@ func (o *RolloutHistoryOptions) Run() error {
 			}
 
 			if o.Revision > 0 {
-				return printer.PrintObj(historyInfo[o.Revision], o.Out)
+				err := printer.PrintObj(historyInfo[o.Revision], o.Out)
+				if err != nil {
+					return err
+				}
 			} else {
 				sortedKeys := make([]int64, 0, len(historyInfo))
 				for k := range historyInfo {
@@ -185,7 +188,10 @@ func (o *RolloutHistoryOptions) Run() error {
 				}
 				sort.Slice(sortedKeys, func(i, j int) bool { return sortedKeys[i] < sortedKeys[j] })
 				for _, k := range sortedKeys {
-					return printer.PrintObj(historyInfo[k], o.Out)
+					err := printer.PrintObj(historyInfo[k], o.Out)
+					if err != nil {
+						return err
+					}
 				}
 			}
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_history.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_history.go
@@ -177,10 +177,12 @@ func (o *RolloutHistoryOptions) Run() error {
 			}
 
 			if o.Revision > 0 {
-				err := printer.PrintObj(historyInfo[o.Revision], o.Out)
-				if err != nil {
-					return err
+				// Ensure the specified revision exists before printing
+				if historyInfo[o.Revision] == nil {
+					return fmt.Errorf("error: unable to find the specified revision")
 				}
+
+				printer.PrintObj(historyInfo[o.Revision], o.Out)
 			} else {
 				sortedKeys := make([]int64, 0, len(historyInfo))
 				for k := range historyInfo {
@@ -188,10 +190,7 @@ func (o *RolloutHistoryOptions) Run() error {
 				}
 				sort.Slice(sortedKeys, func(i, j int) bool { return sortedKeys[i] < sortedKeys[j] })
 				for _, k := range sortedKeys {
-					err := printer.PrintObj(historyInfo[k], o.Out)
-					if err != nil {
-						return err
-					}
+					printer.PrintObj(historyInfo[k], o.Out)
 				}
 			}
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_history.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_history.go
@@ -177,7 +177,7 @@ func (o *RolloutHistoryOptions) Run() error {
 			}
 
 			if o.Revision > 0 {
-				printer.PrintObj(historyInfo[o.Revision], o.Out)
+				return printer.PrintObj(historyInfo[o.Revision], o.Out)
 			} else {
 				sortedKeys := make([]int64, 0, len(historyInfo))
 				for k := range historyInfo {
@@ -185,7 +185,7 @@ func (o *RolloutHistoryOptions) Run() error {
 				}
 				sort.Slice(sortedKeys, func(i, j int) bool { return sortedKeys[i] < sortedKeys[j] })
 				for _, k := range sortedKeys {
-					printer.PrintObj(historyInfo[k], o.Out)
+					return printer.PrintObj(historyInfo[k], o.Out)
 				}
 			}
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_history.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_history.go
@@ -180,7 +180,7 @@ func (o *RolloutHistoryOptions) Run() error {
 				// Ensure the specified revision exists before printing
 				revision, exists := historyInfo[o.Revision]
 				if !exists {
-					return fmt.Errorf("error: unable to find the specified revision")
+					return fmt.Errorf("unable to find the specified revision")
 				}
 
 				printer.PrintObj(revision, o.Out)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_history.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_history.go
@@ -178,11 +178,12 @@ func (o *RolloutHistoryOptions) Run() error {
 
 			if o.Revision > 0 {
 				// Ensure the specified revision exists before printing
-				if historyInfo[o.Revision] == nil {
+				revision, exists := historyInfo[o.Revision]
+				if !exists {
 					return fmt.Errorf("error: unable to find the specified revision")
 				}
 
-				printer.PrintObj(historyInfo[o.Revision], o.Out)
+				printer.PrintObj(revision, o.Out)
 			} else {
 				sortedKeys := make([]int64, 0, len(historyInfo))
 				for k := range historyInfo {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_history.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_history.go
@@ -183,7 +183,9 @@ func (o *RolloutHistoryOptions) Run() error {
 					return fmt.Errorf("unable to find the specified revision")
 				}
 
-				printer.PrintObj(revision, o.Out)
+				if err := printer.PrintObj(revision, o.Out); err != nil {
+					return err
+				}
 			} else {
 				sortedKeys := make([]int64, 0, len(historyInfo))
 				for k := range historyInfo {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_history_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_history_test.go
@@ -471,7 +471,9 @@ func TestRolloutHistoryErrors(t *testing.T) {
 			o.PrintFlags = printFlags
 			o.Revision = tc.revision
 
-			o.Complete(tf, nil, []string{"deployment/foo"})
+			if err := o.Complete(tf, nil, []string{"deployment/foo"}); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
 
 			err := o.Run()
 			if err != nil && err.Error() != tc.expectedError {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_history_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_history_test.go
@@ -401,6 +401,86 @@ replicaset.apps/rev2
 	}
 }
 
+func TestRolloutHistoryErrors(t *testing.T) {
+	ns := scheme.Codecs.WithoutConversion()
+	tf := cmdtesting.NewTestFactory().WithNamespace("test")
+	defer tf.Cleanup()
+
+	info, _ := runtime.SerializerInfoForMediaType(ns.SupportedMediaTypes(), runtime.ContentTypeJSON)
+	encoder := ns.EncoderForVersion(info.Serializer, rolloutPauseGroupVersionEncoder)
+
+	tf.Client = &RolloutPauseRESTClient{
+		RESTClient: &fake.RESTClient{
+			GroupVersion:         rolloutPauseGroupVersionEncoder,
+			NegotiatedSerializer: ns,
+			Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+				switch p, m := req.URL.Path, req.Method; {
+				case p == "/namespaces/test/deployments/foo" && m == "GET":
+					responseDeployment := &appsv1.Deployment{}
+					responseDeployment.Name = "foo"
+					body := io.NopCloser(bytes.NewReader([]byte(runtime.EncodeOrDie(encoder, responseDeployment))))
+					return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: body}, nil
+				default:
+					t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+					return nil, nil
+				}
+			}),
+		},
+	}
+
+	testCases := map[string]struct {
+		revision      int64
+		outputFormat  string
+		expectedError string
+	}{
+		"get non-existing revision as yaml": {
+			revision:      999,
+			outputFormat:  "yaml",
+			expectedError: "unable to find the specified revision",
+		},
+		"get non-existing revision as json": {
+			revision:      999,
+			outputFormat:  "json",
+			expectedError: "unable to find the specified revision",
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			fhv := setupFakeHistoryViewer(t)
+			fhv.getHistoryFn = func(namespace, name string) (map[int64]runtime.Object, error) {
+				return map[int64]runtime.Object{
+					1: &appsv1.ReplicaSet{ObjectMeta: v1.ObjectMeta{Name: "rev1"}},
+					2: &appsv1.ReplicaSet{ObjectMeta: v1.ObjectMeta{Name: "rev2"}},
+				}, nil
+			}
+
+			streams := genericiooptions.NewTestIOStreamsDiscard()
+			o := NewRolloutHistoryOptions(streams)
+
+			printFlags := &genericclioptions.PrintFlags{
+				JSONYamlPrintFlags: &genericclioptions.JSONYamlPrintFlags{
+					ShowManagedFields: true,
+				},
+				OutputFormat: &tc.outputFormat,
+				OutputFlagSpecified: func() bool {
+					return true
+				},
+			}
+
+			o.PrintFlags = printFlags
+			o.Revision = tc.revision
+
+			o.Complete(tf, nil, []string{"deployment/foo"})
+
+			err := o.Run()
+			if err != nil && err.Error() != tc.expectedError {
+				t.Fatalf("expected '%s' error, but got: %v", tc.expectedError, err)
+			}
+		})
+	}
+}
+
 func TestValidate(t *testing.T) {
 	opts := RolloutHistoryOptions{
 		Revision:  0,


### PR DESCRIPTION
Cherry pick of #130503 on release-1.33.

#130503: Unhandled panic crash on rollout_history printer.PrintObj

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixed a panic issue related to kubectl revision history kubernetes/kubectl#1724 
```