### PR TITLE
kubectl: sort configmap data alphabetically to avoid random order

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/describe/describe.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe.go
@@ -4567,14 +4567,12 @@ func (d *ConfigMapDescriber) Describe(namespace, name string, describerSettings 
 		w.Write(LEVEL_0, "\nData\n====\n")
 		for _, k := range slices.Sorted(maps.Keys(configMap.Data)) {
 			v := configMap.Data[k]
-			w.Write(LEVEL_0, "%s:\n----\n", k)
-			w.Write(LEVEL_0, "%s\n", string(v))
-			w.Write(LEVEL_0, "\n")
+			w.Write(LEVEL_0, "%s:\t%s\n", k, string(v))
 		}
 		w.Write(LEVEL_0, "\nBinaryData\n====\n")
 		for _, k := range slices.Sorted(maps.Keys(configMap.BinaryData)) {
 			v := configMap.BinaryData[k]
-			w.Write(LEVEL_0, "%s: %s bytes\n", k, strconv.Itoa(len(v)))
+			w.Write(LEVEL_0, "%s:\t%s bytes\n", k, strconv.Itoa(len(v)))
 		}
 		w.Write(LEVEL_0, "\n")
 

--- a/staging/src/k8s.io/kubectl/pkg/describe/describe.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe.go
@@ -4565,13 +4565,15 @@ func (d *ConfigMapDescriber) Describe(namespace, name string, describerSettings 
 		printAnnotationsMultiline(w, "Annotations", configMap.Annotations)
 
 		w.Write(LEVEL_0, "\nData\n====\n")
-		for k, v := range configMap.Data {
+		for _, k := range slices.Sorted(maps.Keys(configMap.Data)) {
+			v := configMap.Data[k]
 			w.Write(LEVEL_0, "%s:\n----\n", k)
 			w.Write(LEVEL_0, "%s\n", string(v))
 			w.Write(LEVEL_0, "\n")
 		}
 		w.Write(LEVEL_0, "\nBinaryData\n====\n")
-		for k, v := range configMap.BinaryData {
+		for _, k := range slices.Sorted(maps.Keys(configMap.BinaryData)) {
+			v := configMap.BinaryData[k]
 			w.Write(LEVEL_0, "%s: %s bytes\n", k, strconv.Itoa(len(v)))
 		}
 		w.Write(LEVEL_0, "\n")

--- a/staging/src/k8s.io/kubectl/pkg/describe/describe.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe.go
@@ -4567,12 +4567,14 @@ func (d *ConfigMapDescriber) Describe(namespace, name string, describerSettings 
 		w.Write(LEVEL_0, "\nData\n====\n")
 		for _, k := range slices.Sorted(maps.Keys(configMap.Data)) {
 			v := configMap.Data[k]
-			w.Write(LEVEL_0, "%s:\t%s\n", k, string(v))
+			w.Write(LEVEL_0, "%s:\n----\n", k)
+			w.Write(LEVEL_0, "%s\n", string(v))
+			w.Write(LEVEL_0, "\n")
 		}
 		w.Write(LEVEL_0, "\nBinaryData\n====\n")
 		for _, k := range slices.Sorted(maps.Keys(configMap.BinaryData)) {
 			v := configMap.BinaryData[k]
-			w.Write(LEVEL_0, "%s:\t%s bytes\n", k, strconv.Itoa(len(v)))
+			w.Write(LEVEL_0, "%s: %s bytes\n", k, strconv.Itoa(len(v)))
 		}
 		w.Write(LEVEL_0, "\n")
 

--- a/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
@@ -721,13 +721,19 @@ Annotations:  <none>
 
 Data
 ====
-key1:  value1
-key2:  value2
+key1:
+----
+value1
+
+key2:
+----
+value2
+
 
 BinaryData
 ====
-binarykey1:  5 bytes
-binarykey2:  6 bytes
+binarykey1: 5 bytes
+binarykey2: 6 bytes
 
 Events:  <none>
 `

--- a/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
@@ -713,6 +713,32 @@ func TestDescribeConfigMap(t *testing.T) {
 	if !strings.Contains(out, "binarykey1") || !strings.Contains(out, "5 bytes") || !strings.Contains(out, "binarykey2") || !strings.Contains(out, "6 bytes") {
 		t.Errorf("unexpected out: %s", out)
 	}
+
+	expectedOut := `Name:         mycm
+Namespace:    foo
+Labels:       <none>
+Annotations:  <none>
+
+Data
+====
+key1:
+----
+value1
+
+key2:
+----
+value2
+
+
+BinaryData
+====
+binarykey1: 5 bytes
+binarykey2: 6 bytes
+
+Events:  <none>
+`
+
+	assert.Equal(t, expectedOut, out)
 }
 
 func TestDescribeLimitRange(t *testing.T) {

--- a/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
@@ -721,19 +721,13 @@ Annotations:  <none>
 
 Data
 ====
-key1:
-----
-value1
-
-key2:
-----
-value2
-
+key1:  value1
+key2:  value2
 
 BinaryData
 ====
-binarykey1: 5 bytes
-binarykey2: 6 bytes
+binarykey1:  5 bytes
+binarykey2:  6 bytes
 
 Events:  <none>
 `


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixed 'describe configmap' so data keys are outputted in a predictable (alphabetical) order.

`kubectl describe configmap` gives a random order of data keys. This it annoying especially when using it through k9s.

Also simplifies the display format, inspired by how env vars are shown for a pod (see https://github.com/kubernetes/kubernetes/blob/v1.33.0/staging/src/k8s.io/kubectl/pkg/describe/describe.go#L2015).

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes kubernetes/kubectl#1738

#### Special notes for your reviewer:

Follow-up to https://github.com/kubernetes/kubernetes/pull/130309.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
