### PR TITLE
kube-proxy: Fix DNAT rules for headless services with external IPs

### DIFF
--- a/pkg/proxy/serviceport_test.go
+++ b/pkg/proxy/serviceport_test.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+func TestUsesClusterEndpoints(t *testing.T) {
+	testCases := []struct {
+		name     string
+		service  *v1.Service
+		expected bool
+	}{
+		{
+			name: "normal service with external IPs",
+			service: &v1.Service{
+				Spec: v1.ServiceSpec{
+					ClusterIP:   "10.0.0.1",
+					ExternalIPs: []string{"192.168.99.11"},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "headless service with external IPs",
+			service: &v1.Service{
+				Spec: v1.ServiceSpec{
+					ClusterIP:   v1.ClusterIPNone,
+					ExternalIPs: []string{"192.168.99.11"},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "headless service without external IPs",
+			service: &v1.Service{
+				Spec: v1.ServiceSpec{
+					ClusterIP: v1.ClusterIPNone,
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			info := newBaseServiceInfo(tc.service, v1.IPv4Protocol, &v1.ServicePort{
+				Port:     80,
+				Protocol: v1.ProtocolTCP,
+			})
+			if got := info.UsesClusterEndpoints(); got != tc.expected {
+				t.Errorf("UsesClusterEndpoints() = %v, want %v", got, tc.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This commit fixes an issue where DNAT rules for external IPs are not installed by kube-proxy when a service has clusterIP: None (headless service). The issue was specific to kube-proxy's nftables mode implementation.

The fix:
1. Adds isHeadless field to BaseServicePortInfo to track headless services
2. Modifies UsesClusterEndpoints() to handle headless services consistently
3. Ensures headless services bypass cluster endpoints while still getting proper DNAT rules for external IPs

Added TestUsesClusterEndpoints to verify the behavior for:
- Normal services with external IPs
- Headless services with external IPs
- Headless services without external IPs

Fixes #131497

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
