### PR TITLE
test: validate that watchers close without error

### DIFF
--- a/staging/src/k8s.io/client-go/rest/request_test.go
+++ b/staging/src/k8s.io/client-go/rest/request_test.go
@@ -39,11 +39,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/google/go-cmp/cmp"
-
 	v1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -54,6 +52,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer/streaming"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	utilnet "k8s.io/apimachinery/pkg/util/net"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes/scheme"
 	restclientwatch "k8s.io/client-go/rest/watch"
@@ -2091,6 +2090,7 @@ func TestWatch(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			ctx := t.Context()
 			var table = []struct {
 				t   watch.EventType
 				obj runtime.Object
@@ -2132,34 +2132,41 @@ func TestWatch(t *testing.T) {
 			defer testServer.Close()
 
 			s := testRESTClient(t, testServer)
-			watching, err := s.Get().Prefix("path/to/watch/thing").
-				MaxRetries(test.maxRetries).Watch(context.Background())
-			if err != nil {
-				t.Fatalf("Unexpected error: %v", err)
-			}
+			watcher, err := s.Get().Prefix("path/to/watch/thing").
+				MaxRetries(test.maxRetries).Watch(ctx)
+			require.NoError(t, err)
+			defer watcher.Stop()
 
+			// Read the events from the result channel
+			resultCh := watcher.ResultChan()
 			for _, item := range table {
-				got, ok := <-watching.ResultChan()
+				got, ok := <-resultCh
 				if !ok {
-					t.Fatalf("Unexpected early close")
+					t.Fatal("Unexpected early close")
 				}
-				if e, a := item.t, got.Type; e != a {
-					t.Errorf("Expected %v, got %v", e, a)
-				}
-				if e, a := item.obj, got.Object; !apiequality.Semantic.DeepDerivative(e, a) {
-					t.Errorf("Expected %v, got %v", e, a)
-				}
+				assert.Equal(t, item.t, got.Type)
+				assert.Equal(t, item.obj, got.Object)
 			}
 
-			_, ok := <-watching.ResultChan()
-			if ok {
-				t.Fatal("Unexpected non-close")
+			// Stop watcher when done reading watch events
+			watcher.Stop()
+
+			// Wait for the result channel to close
+			err = utiltesting.WaitForChannelToCloseWithTimeout(ctx, wait.ForeverTestTimeout, resultCh)
+			// TODO(karlkfi): Fix race condition that causes the watch server to sometimes send an error when stopped
+			if err != nil {
+				// Extract & compare the Event so we can see  diff when it fails
+				event, unwrapErr := unwrapUnexectedWatchEvent(err)
+				require.NoError(t, unwrapErr)
+				expectedEvent := newClientWatchDecodingEvent(errReadOnClosedResBody)
+				require.Equal(t, expectedEvent, event)
 			}
 		})
 	}
 }
 
 func TestWatchNonDefaultContentType(t *testing.T) {
+	ctx := t.Context()
 	var table = []struct {
 		t   watch.EventType
 		obj runtime.Object
@@ -2195,31 +2202,37 @@ func TestWatchNonDefaultContentType(t *testing.T) {
 	contentConfig := defaultContentConfig()
 	contentConfig.ContentType = "application/vnd.kubernetes.protobuf"
 	s := testRESTClientWithConfig(t, testServer, contentConfig)
-	watching, err := s.Get().Prefix("path/to/watch/thing").Watch(context.Background())
-	if err != nil {
-		t.Fatalf("Unexpected error")
-	}
+	watcher, err := s.Get().Prefix("path/to/watch/thing").Watch(ctx)
+	require.NoError(t, err)
+	defer watcher.Stop()
 
+	resultCh := watcher.ResultChan()
 	for _, item := range table {
-		got, ok := <-watching.ResultChan()
+		got, ok := <-resultCh
 		if !ok {
 			t.Fatalf("Unexpected early close")
 		}
-		if e, a := item.t, got.Type; e != a {
-			t.Errorf("Expected %v, got %v", e, a)
-		}
-		if e, a := item.obj, got.Object; !apiequality.Semantic.DeepDerivative(e, a) {
-			t.Errorf("Expected %v, got %v", e, a)
-		}
+		assert.Equal(t, item.t, got.Type)
+		assert.Equal(t, item.obj, got.Object)
 	}
 
-	_, ok := <-watching.ResultChan()
-	if ok {
-		t.Fatal("Unexpected non-close")
+	// Stop watcher when done reading watch events
+	watcher.Stop()
+
+	// Wait for the result channel to close
+	err = utiltesting.WaitForChannelToCloseWithTimeout(ctx, wait.ForeverTestTimeout, resultCh)
+	// TODO(karlkfi): Fix race condition that causes the watch server to sometimes send an error when stopped
+	if err != nil {
+		// Extract & compare the Event so we can see  diff when it fails
+		event, unwrapErr := unwrapUnexectedWatchEvent(err)
+		require.NoError(t, unwrapErr)
+		expectedEvent := newClientWatchDecodingEvent(errReadOnClosedResBody)
+		require.Equal(t, expectedEvent, event)
 	}
 }
 
 func TestWatchUnknownContentType(t *testing.T) {
+	ctx := t.Context()
 	var table = []struct {
 		t   watch.EventType
 		obj runtime.Object
@@ -2252,10 +2265,8 @@ func TestWatchUnknownContentType(t *testing.T) {
 	defer testServer.Close()
 
 	s := testRESTClient(t, testServer)
-	_, err := s.Get().Prefix("path/to/watch/thing").Watch(context.Background())
-	if err == nil {
-		t.Fatalf("Expected to fail due to lack of known stream serialization for content type")
-	}
+	_, err := s.Get().Prefix("path/to/watch/thing").Watch(ctx)
+	require.Equal(t, runtime.NegotiateError{ContentType: "foobar", Stream: true}, err)
 }
 
 func TestStream(t *testing.T) {
@@ -4274,4 +4285,34 @@ func TestRequestWarningHandler(t *testing.T) {
 		assert.Equal(t, request, request.WarningHandlerWithContext(nil))
 		assert.Nil(t, request.warningHandler)
 	})
+}
+
+// From https://github.com/golang/go/blob/go1.20/src/net/http/transport.go#L2779
+var errReadOnClosedResBody = errors.New("http: read on closed response body")
+
+// newClientWatchDecodingEvent simulates a InternalServerError of type
+// "ClientWatchDecoding", wrapped as a watch.Event. These errors come from the
+// watch client StreamWatcher.
+func newClientWatchDecodingEvent(decodeErr error) watch.Event {
+	// From Request.newStreamWatcher
+	clientErrorReporter := apierrors.NewClientErrorReporter(http.StatusInternalServerError, "GET", "ClientWatchDecoding")
+	// From StreamWatcher.receive
+	// TODO(karlkfi): Use `%w` to format errors (errorlint) in StreamWatcher.receive
+	//nolint:errorlint // StreamWatcher.receive uses `%v`
+	serverErr := fmt.Errorf("unable to decode an event from the watch stream: %v", decodeErr)
+	return watch.Event{
+		Type:   watch.Error,
+		Object: clientErrorReporter.AsObject(serverErr),
+	}
+}
+
+// unwrapUnexectedWatchEvent unwraps a utiltesting.UnexpectedEventError to
+// extract the watch.Error.
+func unwrapUnexectedWatchEvent(err error) (watch.Event, error) {
+	var expectedErr *utiltesting.UnexpectedEventError[watch.Event]
+	if !errors.As(err, &expectedErr) {
+		return watch.Event{}, fmt.Errorf("Error expected to be of type %v, but was %v",
+			reflect.TypeOf(expectedErr), reflect.TypeOf(err))
+	}
+	return expectedErr.Event, nil
 }

--- a/staging/src/k8s.io/client-go/rest/watch/decoder_test.go
+++ b/staging/src/k8s.io/client-go/rest/watch/decoder_test.go
@@ -21,10 +21,10 @@ import (
 	"fmt"
 	"io"
 	"testing"
-	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
-	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	runtimejson "k8s.io/apimachinery/pkg/runtime/serializer/json"
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes/scheme"
+	utiltesting "k8s.io/client-go/util/testing"
 )
 
 // getDecoder mimics how k8s.io/client-go/rest.createSerializers creates a decoder
@@ -45,86 +46,103 @@ func TestDecoder(t *testing.T) {
 	table := []watch.EventType{watch.Added, watch.Deleted, watch.Modified, watch.Error, watch.Bookmark}
 
 	for _, eventType := range table {
-		out, in := io.Pipe()
+		t.Run(string(eventType), func(t *testing.T) {
+			ctx := t.Context()
+			out, in := io.Pipe()
+			defer assertNoCloseError(t, in)
+			decoder := NewDecoder(streaming.NewDecoder(out, getDecoder()), getDecoder())
+			defer decoder.Close()
+			expect := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}
+			encoder := json.NewEncoder(in)
+			eType := eventType
 
-		decoder := NewDecoder(streaming.NewDecoder(out, getDecoder()), getDecoder())
-		expect := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}
-		encoder := json.NewEncoder(in)
-		eType := eventType
-		errc := make(chan error)
+			encodeErrCh := make(chan error)
+			go func() {
+				defer close(encodeErrCh)
+				data, err := runtime.Encode(scheme.Codecs.LegacyCodec(v1.SchemeGroupVersion), expect)
+				if err != nil {
+					encodeErrCh <- fmt.Errorf("encode error: %w", err)
+					return
+				}
+				event := metav1.WatchEvent{
+					Type:   string(eType),
+					Object: runtime.RawExtension{Raw: json.RawMessage(data)},
+				}
+				if err := encoder.Encode(&event); err != nil {
+					encodeErrCh <- fmt.Errorf("encode error: %w", err)
+					return
+				}
+			}()
 
-		go func() {
-			data, err := runtime.Encode(scheme.Codecs.LegacyCodec(v1.SchemeGroupVersion), expect)
-			if err != nil {
-				errc <- fmt.Errorf("Unexpected error %v", err)
-				return
-			}
-			event := metav1.WatchEvent{
-				Type:   string(eType),
-				Object: runtime.RawExtension{Raw: json.RawMessage(data)},
-			}
-			if err := encoder.Encode(&event); err != nil {
-				t.Errorf("Unexpected error %v", err)
-			}
-			in.Close()
-		}()
+			decodeErrCh := make(chan error)
+			go func() {
+				defer close(decodeErrCh)
+				action, got, err := decoder.Decode()
+				if err != nil {
+					decodeErrCh <- fmt.Errorf("decode error: %w", err)
+					return
+				}
+				assert.Equal(t, eType, action)
+				assert.Equal(t, expect, got)
+			}()
 
-		done := make(chan struct{})
-		go func() {
-			action, got, err := decoder.Decode()
-			if err != nil {
-				errc <- fmt.Errorf("Unexpected error %v", err)
-				return
-			}
-			if e, a := eType, action; e != a {
-				t.Errorf("Expected %v, got %v", e, a)
-			}
-			if e, a := expect, got; !apiequality.Semantic.DeepDerivative(e, a) {
-				t.Errorf("Expected %v, got %v", e, a)
-			}
-			t.Logf("Exited read")
-			close(done)
-		}()
-		select {
-		case err := <-errc:
-			t.Fatal(err)
-		case <-done:
-		}
+			// Wait for encoder and decoder to return without error
+			err := utiltesting.WaitForAllChannelsToCloseWithTimeout(ctx,
+				wait.ForeverTestTimeout, encodeErrCh, decodeErrCh)
+			require.NoError(t, err)
 
-		done = make(chan struct{})
-		go func() {
-			_, _, err := decoder.Decode()
-			if err == nil {
-				t.Errorf("Unexpected nil error")
-			}
-			close(done)
-		}()
-		<-done
+			// Close the input pipe, which should cause the decoder to error
+			require.NoError(t, in.Close())
 
-		decoder.Close()
+			// Wait for decoder EOF error
+			decodeErrCh = make(chan error)
+			go func() {
+				defer close(decodeErrCh)
+				_, _, err := decoder.Decode()
+				if err != nil {
+					decodeErrCh <- err
+				}
+			}()
+
+			// Wait for decoder EOF error
+			decodeErr, err := utiltesting.WaitForChannelEventWithTimeout(ctx, wait.ForeverTestTimeout, decodeErrCh)
+			require.NoError(t, err)
+			require.Equal(t, io.EOF, decodeErr)
+		})
 	}
 }
 
 func TestDecoder_SourceClose(t *testing.T) {
+	ctx := t.Context()
 	out, in := io.Pipe()
+	defer assertNoCloseError(t, in)
 	decoder := NewDecoder(streaming.NewDecoder(out, getDecoder()), getDecoder())
+	defer decoder.Close()
 
-	done := make(chan struct{})
-
+	errCh := make(chan error)
 	go func() {
+		defer close(errCh)
 		_, _, err := decoder.Decode()
-		if err == nil {
-			t.Errorf("Unexpected nil error")
+		if err != nil {
+			errCh <- err
 		}
-		close(done)
 	}()
 
-	in.Close()
+	// Close the input pipe, which should cause the decoder to error
+	require.NoError(t, in.Close())
 
-	select {
-	case <-done:
-		break
-	case <-time.After(wait.ForeverTestTimeout):
-		t.Error("Timeout")
-	}
+	// Wait for decoder EOF error
+	decodeErr, err := utiltesting.WaitForChannelEventWithTimeout(ctx, wait.ForeverTestTimeout, errCh)
+	require.NoError(t, err)
+	require.Equal(t, io.EOF, decodeErr)
+
+	// Wait for errCh to close
+	err = utiltesting.WaitForChannelToCloseWithTimeout(ctx, wait.ForeverTestTimeout, errCh)
+	require.NoError(t, err)
+}
+
+// assertNoCloseError asserts that closing the Closer doesn't error.
+// Safe to call in a defer to ensure Closer.Close is called.
+func assertNoCloseError(t *testing.T, c io.Closer) {
+	assert.NoError(t, c.Close())
 }

--- a/staging/src/k8s.io/client-go/util/testing/channels.go
+++ b/staging/src/k8s.io/client-go/util/testing/channels.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"time"
+)
+
+// WaitForChannelEvent blocks until the channel receives an event.
+// Returns an error if the channel is closed or the context is done.
+func WaitForChannelEvent[T any](ctx context.Context, ch <-chan T) (T, error) {
+	var t T // zero value
+	for {
+		select {
+		case <-ctx.Done():
+			err := ctx.Err()
+			switch err {
+			case context.DeadlineExceeded:
+				return t, fmt.Errorf("timed out waiting for channel to close: %w", err)
+			default:
+				return t, fmt.Errorf("context cancelled before channel closed: %w", err)
+			}
+		case event, ok := <-ch:
+			if !ok {
+				return t, errors.New("channel closed before receiving event")
+			}
+			return event, nil
+		}
+	}
+}
+
+// WaitForChannelToClose blocks until the channel is closed.
+// Returns an error if any events are received or the context is done.
+func WaitForChannelToClose[T any](ctx context.Context, ch <-chan T) error {
+	for {
+		select {
+		case <-ctx.Done():
+			err := ctx.Err()
+			switch err {
+			case context.DeadlineExceeded:
+				return fmt.Errorf("timed out waiting for channel to close: %w", err)
+			default:
+				return fmt.Errorf("context cancelled before channel closed: %w", err)
+			}
+		case event, ok := <-ch:
+			if !ok {
+				return nil
+			}
+			return &UnexpectedEventError[T]{Event: event}
+		}
+	}
+}
+
+// WaitForAllChannelsToClose blocks until all the channels are closed.
+// Returns an error if any events are received or the context is done.
+func WaitForAllChannelsToClose[T any](ctx context.Context, channels ...<-chan T) error {
+	// Build a list of cases to select from
+	cases := make([]reflect.SelectCase, len(channels)+1)
+	for i, ch := range channels {
+		cases[i] = reflect.SelectCase{
+			Dir:  reflect.SelectRecv,
+			Chan: reflect.ValueOf(ch),
+		}
+	}
+	// Add the context done channel as the last case
+	contextCaseIndex := len(channels)
+	cases[contextCaseIndex] = reflect.SelectCase{
+		Dir:  reflect.SelectRecv,
+		Chan: reflect.ValueOf(ctx.Done()),
+	}
+	// Select from the cases until all channels are closed, an event is received,
+	// or the context is done.
+	channelsRemaining := len(cases)
+	for channelsRemaining > 1 {
+		// Block until one of the channels receives an event or closes
+		chosenIndex, value, ok := reflect.Select(cases)
+		if !ok {
+			// Return error immediately if the context is done
+			if chosenIndex == contextCaseIndex {
+				err := ctx.Err()
+				switch err {
+				case context.DeadlineExceeded:
+					return fmt.Errorf("timed out waiting for channel to close: %w", err)
+				default:
+					return fmt.Errorf("context cancelled before channel closed: %w", err)
+				}
+			}
+			// Remove closed channel from case to ignore it going forward
+			cases[chosenIndex].Chan = reflect.ValueOf(nil)
+			channelsRemaining--
+			continue
+		}
+		// All events received are treated as errors
+		return fmt.Errorf("channel %d: %w", chosenIndex,
+			&UnexpectedEventError[T]{Event: value.Interface().(T)})
+	}
+	// All channels closed before the context was done
+	return nil
+}
+
+// WaitForChannelEventWithTimeout blocks until the channel receives an event.
+// Returns an error if the channel is closed, the context is done, or the
+// timeout is reached
+func WaitForChannelEventWithTimeout[T any](ctx context.Context, timeout time.Duration, ch <-chan T) (T, error) {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	return WaitForChannelEvent(ctx, ch)
+}
+
+// WaitForChannelToClose blocks until the channel is closed.
+// Returns an error if any events are received, the context is done, or the
+// timeout is reached
+func WaitForChannelToCloseWithTimeout[T any](ctx context.Context, timeout time.Duration, ch <-chan T) error {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	return WaitForChannelToClose(ctx, ch)
+}
+
+// WaitForAllChannelsToCloseWithTimeout blocks until all the channels are closed.
+// Returns an error if any events are received, the context is done, or the
+// timeout is reached
+func WaitForAllChannelsToCloseWithTimeout[T any](ctx context.Context, timeout time.Duration, channels ...<-chan T) error {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	return WaitForAllChannelsToClose(ctx, channels...)
+}
+
+// UnexpectedEventError wraps an event unexpectedly received from a channel.
+type UnexpectedEventError[T any] struct {
+	Event T
+}
+
+// Error implements the error interface
+func (ue *UnexpectedEventError[T]) Error() string {
+	return fmt.Sprintf("channel received unexpected event: %#v", ue.Event)
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
- Add channel test helpers to k8s.io/client-go/util/testing
- Use the new channel test helpers in the client and server watch tests to validate that the result channels closes without error when the client stops the watcher.
- Use the new channel test helpers in the client watcher decoder tests to validate that encoded watch events can be decoded and that the decoder errors with EOF when stopped asynchronously.

These new tests uncovered existing errors (added TODOs):
1.  The watch client doesn't close the response body when it encounters a NegotiateError.
2.  The watch client sometimes sends a decode error on the result channel after the client watcher has been stopped.
3.  StreamWatcher.receive uses %v instead of %w when wrapping errors.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Dependencies
- https://github.com/kubernetes/kubernetes/pull/131706
- https://github.com/kubernetes/kubernetes/pull/131656
- https://github.com/kubernetes/kubernetes/pull/131676
- https://github.com/kubernetes/kubernetes/pull/131680
- https://github.com/kubernetes/kubernetes/pull/131706