### PR TITLE
WIP: client-go transport: allow forcing debug wrapping

### DIFF
--- a/staging/src/k8s.io/client-go/transport/config.go
+++ b/staging/src/k8s.io/client-go/transport/config.go
@@ -77,6 +77,14 @@ type Config struct {
 	//
 	// socks5 proxying does not currently support spdy streaming endpoints.
 	Proxy func(*http.Request) (*url.URL, error)
+
+	// ForceDebugWrappers enables wrapping of the final transport such that the wrapper
+	// logs information while processing a request. See [NewDebuggingRoundTripper]
+	// for details.
+	//
+	// If false, then wrapping still happens when the global klog verbosity level
+	// is >= 6. This is the traditional Kubernetes behavior.
+	ForceDebugWrappers bool
 }
 
 // DialHolder is used to make the wrapped function comparable so that it can be used as a map key.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This may be useful in consumers which do not configure klog verbosity. More work may be necessary in callers of the transport package. For example, the transports constructed here still only depend on klog verbosity:

https://github.com/kubernetes/kubernetes/blob/0abee6bd55f7274f06174d9404050c684d9f9f35/staging/src/k8s.io/client-go/rest/transport.go#L71-L8

https://github.com/kubernetes/kubernetes/blob/0abee6bd55f7274f06174d9404050c684d9f9f35/staging/src/k8s.io/client-go/transport/websocket/roundtripper.go#L179-L183

#### Which issue(s) this PR fixes:

This is an alternative to https://github.com/kubernetes/kubernetes/pull/129831.

#### Special notes for your reviewer:

Extending transport.Config with an additional boolean is backwards-compatible. If unset, the previous behavior is preserved (i.e. checking klog.V(6)).

/cc @alvaroaleman @ahmetb 