### PR TITLE
Relax external signer path validation to allow relative paths

### DIFF
--- a/pkg/controlplane/apiserver/options/validation.go
+++ b/pkg/controlplane/apiserver/options/validation.go
@@ -94,7 +94,7 @@ func validateUnknownVersionInteroperabilityProxyFlags(options *Options) []error 
 	return err
 }
 
-var pathOrSocket = regexp.MustCompile(`(^(/[^/ ]*)+/?$)|(^@([a-zA-Z0-9_-]+\.)*[a-zA-Z0-9_-]+$)`)
+var abstractSocketRegex = regexp.MustCompile(`^@([a-zA-Z0-9_-]+\.)*[a-zA-Z0-9_-]+$`)
 
 func validateServiceAccountTokenSigningConfig(options *Options) []error {
 	if len(options.ServiceAccountSigningEndpoint) == 0 {
@@ -109,9 +109,9 @@ func validateServiceAccountTokenSigningConfig(options *Options) []error {
 	if !utilfeature.DefaultFeatureGate.Enabled(features.ExternalServiceAccountTokenSigner) {
 		errors = append(errors, fmt.Errorf("setting `--service-account-signing-endpoint` requires enabling ExternalServiceAccountTokenSigner feature gate"))
 	}
-	// Check if ServiceAccountSigningEndpoint is a linux file path or an abstract socket name.
-	if !pathOrSocket.MatchString(options.ServiceAccountSigningEndpoint) {
-		errors = append(errors, fmt.Errorf("invalid value %q passed for `--service-account-signing-endpoint`, should be a valid location on the filesystem or must be prefixed with @ to name UDS in abstract namespace", options.ServiceAccountSigningEndpoint))
+	// Ensure ServiceAccountSigningEndpoint is a valid abstract socket name if prefixed with '@'.
+	if strings.HasPrefix(options.ServiceAccountSigningEndpoint, "@") && !abstractSocketRegex.MatchString(options.ServiceAccountSigningEndpoint) {
+		errors = append(errors, fmt.Errorf("invalid value %q passed for `--service-account-signing-endpoint`, when prefixed with @ must be a valid abstract socket name", options.ServiceAccountSigningEndpoint))
 	}
 
 	return errors

--- a/pkg/controlplane/apiserver/options/validation_test.go
+++ b/pkg/controlplane/apiserver/options/validation_test.go
@@ -303,11 +303,9 @@ func TestValidateServcieAccountTokenSigningConfig(t *testing.T) {
 			},
 		},
 		{
-			name:           "invalid external signer endpoint provided - 1",
+			name:           "relative external signer endpoint provided",
 			featureEnabled: true,
-			expectedErrors: []error{
-				fmt.Errorf("invalid value \"abc\" passed for `--service-account-signing-endpoint`, should be a valid location on the filesystem or must be prefixed with @ to name UDS in abstract namespace"),
-			},
+			expectedErrors: []error{},
 			options: &Options{
 				ServiceAccountSigningEndpoint: "abc",
 			},
@@ -316,7 +314,7 @@ func TestValidateServcieAccountTokenSigningConfig(t *testing.T) {
 			name:           "invalid external signer endpoint provided - 2",
 			featureEnabled: true,
 			expectedErrors: []error{
-				fmt.Errorf("invalid value \"@abc@\" passed for `--service-account-signing-endpoint`, should be a valid location on the filesystem or must be prefixed with @ to name UDS in abstract namespace"),
+				fmt.Errorf("invalid value \"@abc@\" passed for `--service-account-signing-endpoint`, when prefixed with @ must be a valid abstract socket name"),
 			},
 			options: &Options{
 				ServiceAccountSigningEndpoint: "@abc@",
@@ -326,30 +324,10 @@ func TestValidateServcieAccountTokenSigningConfig(t *testing.T) {
 			name:           "invalid external signer endpoint provided - 3",
 			featureEnabled: true,
 			expectedErrors: []error{
-				fmt.Errorf("invalid value \"@abc.abc  .ae\" passed for `--service-account-signing-endpoint`, should be a valid location on the filesystem or must be prefixed with @ to name UDS in abstract namespace"),
+				fmt.Errorf("invalid value \"@abc.abc  .ae\" passed for `--service-account-signing-endpoint`, when prefixed with @ must be a valid abstract socket name"),
 			},
 			options: &Options{
 				ServiceAccountSigningEndpoint: "@abc.abc  .ae",
-			},
-		},
-		{
-			name:           "invalid external signer endpoint provided - 4",
-			featureEnabled: true,
-			expectedErrors: []error{
-				fmt.Errorf("invalid value \"/@e_adnb/xyz /efg\" passed for `--service-account-signing-endpoint`, should be a valid location on the filesystem or must be prefixed with @ to name UDS in abstract namespace"),
-			},
-			options: &Options{
-				ServiceAccountSigningEndpoint: "/@e_adnb/xyz /efg",
-			},
-		},
-		{
-			name:           "invalid external signer endpoint provided - 5",
-			featureEnabled: true,
-			expectedErrors: []error{
-				fmt.Errorf("invalid value \"/e /xyz /efg\" passed for `--service-account-signing-endpoint`, should be a valid location on the filesystem or must be prefixed with @ to name UDS in abstract namespace"),
-			},
-			options: &Options{
-				ServiceAccountSigningEndpoint: "/e /xyz /efg",
 			},
 		},
 		{
@@ -382,10 +360,10 @@ func TestValidateServcieAccountTokenSigningConfig(t *testing.T) {
 			expectedErrors: []error{
 				fmt.Errorf("can't set `--service-account-signing-key-file` and/or `--service-account-key-file` with `--service-account-signing-endpoint` (They are mutually exclusive)"),
 				fmt.Errorf("setting `--service-account-signing-endpoint` requires enabling ExternalServiceAccountTokenSigner feature gate"),
-				fmt.Errorf("invalid value \"/e /xyz /efg\" passed for `--service-account-signing-endpoint`, should be a valid location on the filesystem or must be prefixed with @ to name UDS in abstract namespace"),
+				fmt.Errorf("invalid value \"@a@\" passed for `--service-account-signing-endpoint`, when prefixed with @ must be a valid abstract socket name"),
 			},
 			options: &Options{
-				ServiceAccountSigningEndpoint: "/e /xyz /efg",
+				ServiceAccountSigningEndpoint: "@a@",
 				ServiceAccountSigningKeyFile:  "/abc/efg",
 				Authentication: &kubeoptions.BuiltInAuthenticationOptions{
 					ServiceAccounts: &kubeoptions.ServiceAccountAuthenticationOptions{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
/kind failing-test

#### What this PR does / why we need it:

Limit structural validation of the --service-account-signing-endpoint flag to validate abstract socket names. There was no particular reason extra validation of this flag for filepaths was done... other flags like that we just attempt to use the specified path and fail if it's not found, etc ... the main intent of the validation was to make sure abstract sockets passed (starting with `@`) were valid abstract socket names.

Since relative path sockets are created by integration tests, this allows external signer integration tests to pass on all platforms (they are currently failing on darwin).

Found while testing https://github.com/kubernetes/kubernetes/pull/131493 locally.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kube-apiserver: The --service-account-signing-endpoint flag now only validates the format of abstract socket names
```

/assign @ahmedtd 
/sig auth