### PR TITLE
dependencies: github.com/client9/misspell -> github.com/golangci/misspell

### DIFF
--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -7,8 +7,8 @@ godebug default=go1.24
 require (
 	github.com/aojea/sloppy-netparser v0.0.0-20210819225411-1b3bd8b3b975
 	github.com/cespare/prettybench v0.0.0-20150116022406-03b8cfe5406c
-	github.com/client9/misspell v0.3.4
 	github.com/golangci/golangci-lint v1.64.5
+	github.com/golangci/misspell v0.6.0
 	github.com/jcchavezs/porto v0.6.0
 	github.com/vektra/mockery/v2 v2.53.3
 	go.uber.org/automaxprocs v1.6.0
@@ -86,7 +86,6 @@ require (
 	github.com/golangci/dupl v0.0.0-20180902072040-3e9179ac440a // indirect
 	github.com/golangci/go-printf-func-name v0.1.0 // indirect
 	github.com/golangci/gofmt v0.0.0-20250106114630-d62b90e6713d // indirect
-	github.com/golangci/misspell v0.6.0 // indirect
 	github.com/golangci/plugin-module-register v0.1.1 // indirect
 	github.com/golangci/revgrep v0.8.0 // indirect
 	github.com/golangci/unconvert v0.0.0-20240309020433-c5143eacb3ed // indirect

--- a/hack/tools/go.sum
+++ b/hack/tools/go.sum
@@ -128,7 +128,6 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/ckaznocha/intrange v0.3.0 h1:VqnxtK32pxgkhJgYQEeOArVidIPg+ahLP7WBOXZd5ZY=
 github.com/ckaznocha/intrange v0.3.0/go.mod h1:+I/o2d2A1FBHgGELbGxzIcyd3/9l9DuwjM8FsbSS3Lo=
-github.com/client9/misspell v0.3.4 h1:ta993UF76GwbvJcIo3Y68y/M3WxlpEHPWIGDkJYwzJI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=

--- a/hack/tools/tools.go
+++ b/hack/tools/tools.go
@@ -21,8 +21,8 @@ package tools
 import (
 	// linting tools
 	_ "github.com/aojea/sloppy-netparser"
-	_ "github.com/client9/misspell/cmd/misspell"
 	_ "github.com/golangci/golangci-lint/cmd/golangci-lint"
+	_ "github.com/golangci/misspell"
 	_ "github.com/jcchavezs/porto/cmd/porto"
 	_ "honnef.co/go/tools/cmd/staticcheck"
 	_ "sigs.k8s.io/logtools/logcheck"

--- a/hack/verify-spelling.sh
+++ b/hack/verify-spelling.sh
@@ -32,7 +32,7 @@ export GOBIN="${KUBE_OUTPUT_BIN}"
 PATH="${GOBIN}:${PATH}"
 
 # Install tools we need
-GOTOOLCHAIN="$(kube::golang::hack_tools_gotoolchain)" go -C "${KUBE_ROOT}/hack/tools" install github.com/client9/misspell/cmd/misspell
+GOTOOLCHAIN="$(kube::golang::hack_tools_gotoolchain)" go -C "${KUBE_ROOT}/hack/tools" install github.com/golangci/misspell/cmd/misspell
 
 # Spell checking
 # All the skipping files are defined in hack/.spelling_failures

--- a/pkg/kubelet/userns/userns_manager_test.go
+++ b/pkg/kubelet/userns/userns_manager_test.go
@@ -58,7 +58,7 @@ type testUserNsPodsManager struct {
 
 func (m *testUserNsPodsManager) GetPodDir(podUID types.UID) string {
 	if m.podDir == "" {
-		return "/tmp/non-existant-dir.This-is-not-used-in-tests"
+		return "/tmp/non-existent-dir.This-is-not-used-in-tests"
 	}
 	return m.podDir
 }

--- a/test/e2e/windows/eviction.go
+++ b/test/e2e/windows/eviction.go
@@ -93,7 +93,7 @@ var _ = sigDescribe(feature.Windows, "Eviction", framework.WithSerial(), framewo
 				podList, err := f.ClientSet.CoreV1().Pods(ns.Name).List(ctx, metav1.ListOptions{})
 				framework.ExpectNoError(err)
 				for _, pod := range podList.Items {
-					framework.Logf("  Deleteing pod %s", pod.Name)
+					framework.Logf("  Deleting pod %s", pod.Name)
 					err = f.ClientSet.CoreV1().Pods(ns.Name).Delete(ctx, pod.Name, metav1.DeleteOptions{})
 					framework.ExpectNoError(err)
 				}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

github.com/client9/misspell was archived by the owner on Mar 26, 2025. The golangci-lint team maintains a fork.

#### Special notes for your reviewer:

Kudos to @ldez for [pointing this out](https://github.com/kubernetes/kubernetes/pull/131477#issuecomment-2835141359).

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @dims 