### PR TITLE
Don't create extra namespaces during pod resize tests

### DIFF
--- a/test/e2e/common/node/pod_resize.go
+++ b/test/e2e/common/node/pod_resize.go
@@ -69,7 +69,7 @@ func offsetMemory(index int64, value string) string {
 	return ptr.String()
 }
 
-func doPodResizeTests() {
+func doPodResizeTests(f *framework.Framework) {
 	type testCase struct {
 		name                string
 		containers          []podresize.ResizableContainerInfo
@@ -1157,7 +1157,6 @@ func doPodResizeTests() {
 
 	for idx := range tests {
 		tc := tests[idx]
-		f := framework.NewDefaultFramework("pod-resize-tests")
 
 		ginkgo.It(tc.name, func(ctx context.Context) {
 			podClient := e2epod.NewPodClient(f)
@@ -1235,7 +1234,7 @@ func doPodResizeTests() {
 	}
 }
 
-func doPodResizeErrorTests() {
+func doPodResizeErrorTests(f *framework.Framework) {
 
 	type testCase struct {
 		name        string
@@ -1390,7 +1389,6 @@ func doPodResizeErrorTests() {
 
 	for idx := range tests {
 		tc := tests[idx]
-		f := framework.NewDefaultFramework("pod-resize-error-tests")
 
 		ginkgo.It(tc.name, func(ctx context.Context) {
 			podClient := e2epod.NewPodClient(f)
@@ -1453,6 +1451,6 @@ var _ = SIGDescribe("Pod InPlace Resize Container", framework.WithFeatureGate(fe
 		}
 	})
 
-	doPodResizeTests()
-	doPodResizeErrorTests()
+	doPodResizeTests(f)
+	doPodResizeErrorTests(f)
 })

--- a/test/e2e/node/pod_resize.go
+++ b/test/e2e/node/pod_resize.go
@@ -40,7 +40,7 @@ import (
 	"github.com/onsi/gomega"
 )
 
-func doPodResizeAdmissionPluginsTests() {
+func doPodResizeAdmissionPluginsTests(f *framework.Framework) {
 	testcases := []struct {
 		name                  string
 		enableAdmissionPlugin func(ctx context.Context, f *framework.Framework)
@@ -119,8 +119,6 @@ func doPodResizeAdmissionPluginsTests() {
 	}
 
 	for _, tc := range testcases {
-		f := framework.NewDefaultFramework(tc.name)
-
 		ginkgo.It(tc.name, func(ctx context.Context) {
 			containers := []podresize.ResizableContainerInfo{
 				{
@@ -459,7 +457,7 @@ var _ = SIGDescribe("Pod InPlace Resize Container", framework.WithFeatureGate(fe
 			e2eskipper.Skipf("runtime does not support InPlacePodVerticalScaling -- skipping")
 		}
 	})
-	doPodResizeAdmissionPluginsTests()
+	doPodResizeAdmissionPluginsTests(f)
 })
 
 func waitForResourceQuota(ctx context.Context, c clientset.Interface, ns, quotaName string) error {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind flake

#### What this PR does / why we need it:

- Modifies the pod resize tests not to create extra unused namespaces
- This reduces load on the namespace controller to help prevent timeouts when other tests are run in parallel
- This is done by pulling the test framework initialization context up so that it is only done before iterating over the test specs rather than creating a separate test framework instance for each test spec. The way the tests were previously structured caused the framework's BeforeEach function to be registered before each test, causing a significant number of extra unused namespaces to be created during these tests.

#### Which issue(s) this PR fixes:
Fixes [#131517](https://github.com/kubernetes/kubernetes/issues/131517)

#### Does this PR introduce a user-facing change?
NONE