### PR TITLE
Automated cherry pick of #131495: Handle unsupported node expansion for RWX volumes

### DIFF
--- a/pkg/volume/util/operationexecutor/node_expander_test.go
+++ b/pkg/volume/util/operationexecutor/node_expander_test.go
@@ -131,6 +131,17 @@ func TestNodeExpander(t *testing.T) {
 			expectFinalErrors:        false,
 			expectedStatusSize:       resource.MustParse("2G"),
 		},
+		{
+			name:                     "RWX pv.spec.cap = pvc.status.cap, resizeStatus='', desiredSize > actualSize, reize_op=unsupported",
+			pvc:                      addAccessMode(getTestPVC(volumetesting.FailWithUnSupportedVolumeName, "2G", "2G", "2G", nil), v1.ReadWriteMany),
+			pv:                       getTestPV(volumetesting.FailWithUnSupportedVolumeName, "2G"),
+			expectError:              false,
+			expectedResizeStatus:     "",
+			expectResizeCall:         false,
+			assumeResizeOpAsFinished: true,
+			expectFinalErrors:        false,
+			expectedStatusSize:       resource.MustParse("2G"),
+		},
 	}
 
 	for i := range tests {


### PR DESCRIPTION
Cherry pick of #131495 on release-1.32.

#131495: Handle unsupported node expansion for RWX volumes

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
kubelet: fix a bug where the unexpected NodeResizeError condition was in PVC status when the csi driver does not support node volume expansion and the pvc has the ReadWriteMany access mode.
```