### PR TITLE
Fix pod failure policy defaults does not work for cronjob

### DIFF
--- a/pkg/apis/batch/v1/defaults.go
+++ b/pkg/apis/batch/v1/defaults.go
@@ -59,17 +59,6 @@ func SetDefaults_Job(obj *batchv1.Job) {
 	if obj.Spec.Suspend == nil {
 		obj.Spec.Suspend = ptr.To(false)
 	}
-	if obj.Spec.PodFailurePolicy != nil {
-		for _, rule := range obj.Spec.PodFailurePolicy.Rules {
-			if rule.OnPodConditions != nil {
-				for i, pattern := range rule.OnPodConditions {
-					if pattern.Status == "" {
-						rule.OnPodConditions[i].Status = corev1.ConditionTrue
-					}
-				}
-			}
-		}
-	}
 	if utilfeature.DefaultFeatureGate.Enabled(features.JobPodReplacementPolicy) {
 		if obj.Spec.PodReplacementPolicy == nil {
 			if obj.Spec.PodFailurePolicy != nil {
@@ -96,5 +85,11 @@ func SetDefaults_CronJob(obj *batchv1.CronJob) {
 	}
 	if obj.Spec.FailedJobsHistoryLimit == nil {
 		obj.Spec.FailedJobsHistoryLimit = ptr.To[int32](1)
+	}
+}
+
+func SetDefaults_PodFailurePolicyOnPodConditionsPattern(obj *batchv1.PodFailurePolicyOnPodConditionsPattern) {
+	if obj.Status == "" {
+		obj.Status = corev1.ConditionTrue
 	}
 }

--- a/pkg/apis/batch/v1/zz_generated.defaults.go
+++ b/pkg/apis/batch/v1/zz_generated.defaults.go
@@ -41,6 +41,15 @@ func RegisterDefaults(scheme *runtime.Scheme) error {
 
 func SetObjectDefaults_CronJob(in *batchv1.CronJob) {
 	SetDefaults_CronJob(in)
+	if in.Spec.JobTemplate.Spec.PodFailurePolicy != nil {
+		for i := range in.Spec.JobTemplate.Spec.PodFailurePolicy.Rules {
+			a := &in.Spec.JobTemplate.Spec.PodFailurePolicy.Rules[i]
+			for j := range a.OnPodConditions {
+				b := &a.OnPodConditions[j]
+				SetDefaults_PodFailurePolicyOnPodConditionsPattern(b)
+			}
+		}
+	}
 	apiscorev1.SetDefaults_PodSpec(&in.Spec.JobTemplate.Spec.Template.Spec)
 	for i := range in.Spec.JobTemplate.Spec.Template.Spec.Volumes {
 		a := &in.Spec.JobTemplate.Spec.Template.Spec.Volumes[i]
@@ -350,6 +359,15 @@ func SetObjectDefaults_CronJobList(in *batchv1.CronJobList) {
 
 func SetObjectDefaults_Job(in *batchv1.Job) {
 	SetDefaults_Job(in)
+	if in.Spec.PodFailurePolicy != nil {
+		for i := range in.Spec.PodFailurePolicy.Rules {
+			a := &in.Spec.PodFailurePolicy.Rules[i]
+			for j := range a.OnPodConditions {
+				b := &a.OnPodConditions[j]
+				SetDefaults_PodFailurePolicyOnPodConditionsPattern(b)
+			}
+		}
+	}
 	apiscorev1.SetDefaults_PodSpec(&in.Spec.Template.Spec)
 	for i := range in.Spec.Template.Spec.Volumes {
 		a := &in.Spec.Template.Spec.Volumes[i]

--- a/pkg/apis/batch/v1beta1/zz_generated.defaults.go
+++ b/pkg/apis/batch/v1beta1/zz_generated.defaults.go
@@ -25,6 +25,7 @@ import (
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	v1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
+	batchv1 "k8s.io/kubernetes/pkg/apis/batch/v1"
 	corev1 "k8s.io/kubernetes/pkg/apis/core/v1"
 )
 
@@ -39,6 +40,15 @@ func RegisterDefaults(scheme *runtime.Scheme) error {
 
 func SetObjectDefaults_CronJob(in *batchv1beta1.CronJob) {
 	SetDefaults_CronJob(in)
+	if in.Spec.JobTemplate.Spec.PodFailurePolicy != nil {
+		for i := range in.Spec.JobTemplate.Spec.PodFailurePolicy.Rules {
+			a := &in.Spec.JobTemplate.Spec.PodFailurePolicy.Rules[i]
+			for j := range a.OnPodConditions {
+				b := &a.OnPodConditions[j]
+				batchv1.SetDefaults_PodFailurePolicyOnPodConditionsPattern(b)
+			}
+		}
+	}
 	corev1.SetDefaults_PodSpec(&in.Spec.JobTemplate.Spec.Template.Spec)
 	for i := range in.Spec.JobTemplate.Spec.Template.Spec.Volumes {
 		a := &in.Spec.JobTemplate.Spec.Template.Spec.Volumes[i]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

the default value is not applied to cronjob.

![image](https://github.com/user-attachments/assets/1ea97071-61bf-4d94-b447-ec0f714c5c33)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #131512

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kube-apiserver: cronjob objects now default empty `spec.jobTemplate.spec.podFailurePolicy.rules[*].onPodConditions[*].status` fields as documented, avoiding validation failures during write requests.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/3329
```
