### PR TITLE
DRA test: update examples

### DIFF
--- a/test/e2e/dra/test-driver/README.md
+++ b/test/e2e/dra/test-driver/README.md
@@ -15,7 +15,7 @@ testing.
 
 Valid parameters are key/value string pairs stored in a ConfigMap.
 Those get copied into the ResourceClaimStatus with "user_" and "admin_" as
-prefix, depending on whether they came from the ResourceClaim or ResourceClass.
+prefix, depending on whether they came from the ResourceClaim or DeviceClass.
 They get stored in the `ResourceHandle` field as JSON map by the controller.
 The kubelet plugin then sets these attributes as environment variables in each
 container that uses the resource.
@@ -71,7 +71,7 @@ KUBECONFIG=/var/run/kubernetes/admin.kubeconfig go run ./test/e2e/dra/test-drive
 And finally:
 ```console
 $ export KUBECONFIG=/var/run/kubernetes/admin.kubeconfig
-$ kubectl create -f test/e2e/dra/test-driver/deploy/example/resourceclass.yaml
+$ kubectl create -f test/e2e/dra/test-driver/deploy/example/deviceclass.yaml
 resourceclass/example created
 $ kubectl create -f test/e2e/dra/test-driver/deploy/example/pod-inline.yaml
 configmap/pause-claim-parameters created

--- a/test/e2e/dra/test-driver/deploy/example/pod-external.yaml
+++ b/test/e2e/dra/test-driver/deploy/example/pod-external.yaml
@@ -24,13 +24,14 @@ spec:
   containers:
   - name: with-resource
     image: registry.k8s.io/e2e-test-images/busybox:1.36.1-1
-    command: ["sh", "-c", "set && mount && ls -la /dev/"]
+    command: ["sh", "-c", "set && mount && ls -la /dev/ && sleep 10000"]
     resources:
       claims:
       - name: resource
   - name: without-resource
     image: registry.k8s.io/e2e-test-images/busybox:1.36.1-1
-    command: ["sh", "-c", "set && mount && ls -la /dev/"]
+    command: ["sh", "-c", "set && mount && ls -la /dev/ && sleep 10000"]
+  terminationGracePeriodSeconds: 0 # Shut down immediately.
   resourceClaims:
   - name: resource
     resourceClaimName: external-claim

--- a/test/e2e/dra/test-driver/deploy/example/pod-inline.yaml
+++ b/test/e2e/dra/test-driver/deploy/example/pod-inline.yaml
@@ -29,13 +29,14 @@ spec:
   containers:
   - name: with-resource
     image: registry.k8s.io/e2e-test-images/busybox:1.36.1-1
-    command: ["sh", "-c", "set && mount && ls -la /dev/"]
+    command: ["sh", "-c", "set && mount && ls -la /dev/ && sleep 10000"]
     resources:
       claims:
       - name: resource
   - name: without-resource
     image: registry.k8s.io/e2e-test-images/busybox:1.36.1-1
-    command: ["sh", "-c", "set && mount && ls -la /dev/"]
+    command: ["sh", "-c", "set && mount && ls -la /dev/ && sleep 10000"]
+  terminationGracePeriodSeconds: 0 # Shut down immediately.
   resourceClaims:
   - name: resource
     resourceClaimTemplateName: test-inline-claim-template


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Some more out-dated reference to resource class. Keeping the pod running is better for demonstrating the lifecycle of claims because it is actually possible to see a claim in the allocated state.

#### Special notes for your reviewer:

This branch can be used to reproduce https://github.com/kubernetes/kubernetes/issues/131513

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
