### PR TITLE
client-go listwatch: Add WatchWithContextFunc and deprecate WatchFuncWithContext

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/informers/externalversions/cr/v1/example.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/informers/externalversions/cr/v1/example.go
@@ -76,7 +76,7 @@ func NewFilteredExampleInformer(client versioned.Interface, namespace string, re
 				}
 				return client.CrV1().Examples(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1/customresourcedefinition.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1/customresourcedefinition.go
@@ -75,7 +75,7 @@ func NewFilteredCustomResourceDefinitionInformer(client clientset.Interface, res
 				}
 				return client.ApiextensionsV1().CustomResourceDefinitions().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1beta1/customresourcedefinition.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1beta1/customresourcedefinition.go
@@ -75,7 +75,7 @@ func NewFilteredCustomResourceDefinitionInformer(client clientset.Interface, res
 				}
 				return client.ApiextensionsV1beta1().CustomResourceDefinitions().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/dynamic/dynamicinformer/informer.go
+++ b/staging/src/k8s.io/client-go/dynamic/dynamicinformer/informer.go
@@ -167,7 +167,7 @@ func NewFilteredDynamicInformer(client dynamic.Interface, gvr schema.GroupVersio
 					}
 					return client.Resource(gvr).Namespace(namespace).List(ctx, options)
 				},
-				WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 					if tweakListOptions != nil {
 						tweakListOptions(&options)
 					}

--- a/staging/src/k8s.io/client-go/informers/admissionregistration/v1/mutatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/informers/admissionregistration/v1/mutatingwebhookconfiguration.go
@@ -75,7 +75,7 @@ func NewFilteredMutatingWebhookConfigurationInformer(client kubernetes.Interface
 				}
 				return client.AdmissionregistrationV1().MutatingWebhookConfigurations().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/admissionregistration/v1/validatingadmissionpolicy.go
+++ b/staging/src/k8s.io/client-go/informers/admissionregistration/v1/validatingadmissionpolicy.go
@@ -75,7 +75,7 @@ func NewFilteredValidatingAdmissionPolicyInformer(client kubernetes.Interface, r
 				}
 				return client.AdmissionregistrationV1().ValidatingAdmissionPolicies().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/admissionregistration/v1/validatingadmissionpolicybinding.go
+++ b/staging/src/k8s.io/client-go/informers/admissionregistration/v1/validatingadmissionpolicybinding.go
@@ -75,7 +75,7 @@ func NewFilteredValidatingAdmissionPolicyBindingInformer(client kubernetes.Inter
 				}
 				return client.AdmissionregistrationV1().ValidatingAdmissionPolicyBindings().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/admissionregistration/v1/validatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/informers/admissionregistration/v1/validatingwebhookconfiguration.go
@@ -75,7 +75,7 @@ func NewFilteredValidatingWebhookConfigurationInformer(client kubernetes.Interfa
 				}
 				return client.AdmissionregistrationV1().ValidatingWebhookConfigurations().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/admissionregistration/v1alpha1/mutatingadmissionpolicy.go
+++ b/staging/src/k8s.io/client-go/informers/admissionregistration/v1alpha1/mutatingadmissionpolicy.go
@@ -75,7 +75,7 @@ func NewFilteredMutatingAdmissionPolicyInformer(client kubernetes.Interface, res
 				}
 				return client.AdmissionregistrationV1alpha1().MutatingAdmissionPolicies().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/admissionregistration/v1alpha1/mutatingadmissionpolicybinding.go
+++ b/staging/src/k8s.io/client-go/informers/admissionregistration/v1alpha1/mutatingadmissionpolicybinding.go
@@ -75,7 +75,7 @@ func NewFilteredMutatingAdmissionPolicyBindingInformer(client kubernetes.Interfa
 				}
 				return client.AdmissionregistrationV1alpha1().MutatingAdmissionPolicyBindings().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/admissionregistration/v1alpha1/validatingadmissionpolicy.go
+++ b/staging/src/k8s.io/client-go/informers/admissionregistration/v1alpha1/validatingadmissionpolicy.go
@@ -75,7 +75,7 @@ func NewFilteredValidatingAdmissionPolicyInformer(client kubernetes.Interface, r
 				}
 				return client.AdmissionregistrationV1alpha1().ValidatingAdmissionPolicies().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/admissionregistration/v1alpha1/validatingadmissionpolicybinding.go
+++ b/staging/src/k8s.io/client-go/informers/admissionregistration/v1alpha1/validatingadmissionpolicybinding.go
@@ -75,7 +75,7 @@ func NewFilteredValidatingAdmissionPolicyBindingInformer(client kubernetes.Inter
 				}
 				return client.AdmissionregistrationV1alpha1().ValidatingAdmissionPolicyBindings().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/admissionregistration/v1beta1/mutatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/informers/admissionregistration/v1beta1/mutatingwebhookconfiguration.go
@@ -75,7 +75,7 @@ func NewFilteredMutatingWebhookConfigurationInformer(client kubernetes.Interface
 				}
 				return client.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/admissionregistration/v1beta1/validatingadmissionpolicy.go
+++ b/staging/src/k8s.io/client-go/informers/admissionregistration/v1beta1/validatingadmissionpolicy.go
@@ -75,7 +75,7 @@ func NewFilteredValidatingAdmissionPolicyInformer(client kubernetes.Interface, r
 				}
 				return client.AdmissionregistrationV1beta1().ValidatingAdmissionPolicies().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/admissionregistration/v1beta1/validatingadmissionpolicybinding.go
+++ b/staging/src/k8s.io/client-go/informers/admissionregistration/v1beta1/validatingadmissionpolicybinding.go
@@ -75,7 +75,7 @@ func NewFilteredValidatingAdmissionPolicyBindingInformer(client kubernetes.Inter
 				}
 				return client.AdmissionregistrationV1beta1().ValidatingAdmissionPolicyBindings().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/admissionregistration/v1beta1/validatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/informers/admissionregistration/v1beta1/validatingwebhookconfiguration.go
@@ -75,7 +75,7 @@ func NewFilteredValidatingWebhookConfigurationInformer(client kubernetes.Interfa
 				}
 				return client.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/apiserverinternal/v1alpha1/storageversion.go
+++ b/staging/src/k8s.io/client-go/informers/apiserverinternal/v1alpha1/storageversion.go
@@ -75,7 +75,7 @@ func NewFilteredStorageVersionInformer(client kubernetes.Interface, resyncPeriod
 				}
 				return client.InternalV1alpha1().StorageVersions().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/apps/v1/controllerrevision.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1/controllerrevision.go
@@ -76,7 +76,7 @@ func NewFilteredControllerRevisionInformer(client kubernetes.Interface, namespac
 				}
 				return client.AppsV1().ControllerRevisions(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/apps/v1/daemonset.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1/daemonset.go
@@ -76,7 +76,7 @@ func NewFilteredDaemonSetInformer(client kubernetes.Interface, namespace string,
 				}
 				return client.AppsV1().DaemonSets(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/apps/v1/deployment.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1/deployment.go
@@ -76,7 +76,7 @@ func NewFilteredDeploymentInformer(client kubernetes.Interface, namespace string
 				}
 				return client.AppsV1().Deployments(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/apps/v1/replicaset.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1/replicaset.go
@@ -76,7 +76,7 @@ func NewFilteredReplicaSetInformer(client kubernetes.Interface, namespace string
 				}
 				return client.AppsV1().ReplicaSets(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/apps/v1/statefulset.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1/statefulset.go
@@ -76,7 +76,7 @@ func NewFilteredStatefulSetInformer(client kubernetes.Interface, namespace strin
 				}
 				return client.AppsV1().StatefulSets(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/apps/v1beta1/controllerrevision.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1beta1/controllerrevision.go
@@ -76,7 +76,7 @@ func NewFilteredControllerRevisionInformer(client kubernetes.Interface, namespac
 				}
 				return client.AppsV1beta1().ControllerRevisions(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/apps/v1beta1/deployment.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1beta1/deployment.go
@@ -76,7 +76,7 @@ func NewFilteredDeploymentInformer(client kubernetes.Interface, namespace string
 				}
 				return client.AppsV1beta1().Deployments(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/apps/v1beta1/statefulset.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1beta1/statefulset.go
@@ -76,7 +76,7 @@ func NewFilteredStatefulSetInformer(client kubernetes.Interface, namespace strin
 				}
 				return client.AppsV1beta1().StatefulSets(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/apps/v1beta2/controllerrevision.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1beta2/controllerrevision.go
@@ -76,7 +76,7 @@ func NewFilteredControllerRevisionInformer(client kubernetes.Interface, namespac
 				}
 				return client.AppsV1beta2().ControllerRevisions(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/apps/v1beta2/daemonset.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1beta2/daemonset.go
@@ -76,7 +76,7 @@ func NewFilteredDaemonSetInformer(client kubernetes.Interface, namespace string,
 				}
 				return client.AppsV1beta2().DaemonSets(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/apps/v1beta2/deployment.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1beta2/deployment.go
@@ -76,7 +76,7 @@ func NewFilteredDeploymentInformer(client kubernetes.Interface, namespace string
 				}
 				return client.AppsV1beta2().Deployments(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/apps/v1beta2/replicaset.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1beta2/replicaset.go
@@ -76,7 +76,7 @@ func NewFilteredReplicaSetInformer(client kubernetes.Interface, namespace string
 				}
 				return client.AppsV1beta2().ReplicaSets(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/apps/v1beta2/statefulset.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1beta2/statefulset.go
@@ -76,7 +76,7 @@ func NewFilteredStatefulSetInformer(client kubernetes.Interface, namespace strin
 				}
 				return client.AppsV1beta2().StatefulSets(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/autoscaling/v1/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/informers/autoscaling/v1/horizontalpodautoscaler.go
@@ -76,7 +76,7 @@ func NewFilteredHorizontalPodAutoscalerInformer(client kubernetes.Interface, nam
 				}
 				return client.AutoscalingV1().HorizontalPodAutoscalers(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/autoscaling/v2/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/informers/autoscaling/v2/horizontalpodautoscaler.go
@@ -76,7 +76,7 @@ func NewFilteredHorizontalPodAutoscalerInformer(client kubernetes.Interface, nam
 				}
 				return client.AutoscalingV2().HorizontalPodAutoscalers(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/autoscaling/v2beta1/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/informers/autoscaling/v2beta1/horizontalpodautoscaler.go
@@ -76,7 +76,7 @@ func NewFilteredHorizontalPodAutoscalerInformer(client kubernetes.Interface, nam
 				}
 				return client.AutoscalingV2beta1().HorizontalPodAutoscalers(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/autoscaling/v2beta2/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/informers/autoscaling/v2beta2/horizontalpodautoscaler.go
@@ -76,7 +76,7 @@ func NewFilteredHorizontalPodAutoscalerInformer(client kubernetes.Interface, nam
 				}
 				return client.AutoscalingV2beta2().HorizontalPodAutoscalers(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/batch/v1/cronjob.go
+++ b/staging/src/k8s.io/client-go/informers/batch/v1/cronjob.go
@@ -76,7 +76,7 @@ func NewFilteredCronJobInformer(client kubernetes.Interface, namespace string, r
 				}
 				return client.BatchV1().CronJobs(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/batch/v1/job.go
+++ b/staging/src/k8s.io/client-go/informers/batch/v1/job.go
@@ -76,7 +76,7 @@ func NewFilteredJobInformer(client kubernetes.Interface, namespace string, resyn
 				}
 				return client.BatchV1().Jobs(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/batch/v1beta1/cronjob.go
+++ b/staging/src/k8s.io/client-go/informers/batch/v1beta1/cronjob.go
@@ -76,7 +76,7 @@ func NewFilteredCronJobInformer(client kubernetes.Interface, namespace string, r
 				}
 				return client.BatchV1beta1().CronJobs(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/certificates/v1/certificatesigningrequest.go
+++ b/staging/src/k8s.io/client-go/informers/certificates/v1/certificatesigningrequest.go
@@ -75,7 +75,7 @@ func NewFilteredCertificateSigningRequestInformer(client kubernetes.Interface, r
 				}
 				return client.CertificatesV1().CertificateSigningRequests().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/certificates/v1alpha1/clustertrustbundle.go
+++ b/staging/src/k8s.io/client-go/informers/certificates/v1alpha1/clustertrustbundle.go
@@ -75,7 +75,7 @@ func NewFilteredClusterTrustBundleInformer(client kubernetes.Interface, resyncPe
 				}
 				return client.CertificatesV1alpha1().ClusterTrustBundles().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/certificates/v1beta1/certificatesigningrequest.go
+++ b/staging/src/k8s.io/client-go/informers/certificates/v1beta1/certificatesigningrequest.go
@@ -75,7 +75,7 @@ func NewFilteredCertificateSigningRequestInformer(client kubernetes.Interface, r
 				}
 				return client.CertificatesV1beta1().CertificateSigningRequests().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/certificates/v1beta1/clustertrustbundle.go
+++ b/staging/src/k8s.io/client-go/informers/certificates/v1beta1/clustertrustbundle.go
@@ -75,7 +75,7 @@ func NewFilteredClusterTrustBundleInformer(client kubernetes.Interface, resyncPe
 				}
 				return client.CertificatesV1beta1().ClusterTrustBundles().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/coordination/v1/lease.go
+++ b/staging/src/k8s.io/client-go/informers/coordination/v1/lease.go
@@ -76,7 +76,7 @@ func NewFilteredLeaseInformer(client kubernetes.Interface, namespace string, res
 				}
 				return client.CoordinationV1().Leases(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/coordination/v1alpha2/leasecandidate.go
+++ b/staging/src/k8s.io/client-go/informers/coordination/v1alpha2/leasecandidate.go
@@ -76,7 +76,7 @@ func NewFilteredLeaseCandidateInformer(client kubernetes.Interface, namespace st
 				}
 				return client.CoordinationV1alpha2().LeaseCandidates(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/coordination/v1beta1/lease.go
+++ b/staging/src/k8s.io/client-go/informers/coordination/v1beta1/lease.go
@@ -76,7 +76,7 @@ func NewFilteredLeaseInformer(client kubernetes.Interface, namespace string, res
 				}
 				return client.CoordinationV1beta1().Leases(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/coordination/v1beta1/leasecandidate.go
+++ b/staging/src/k8s.io/client-go/informers/coordination/v1beta1/leasecandidate.go
@@ -76,7 +76,7 @@ func NewFilteredLeaseCandidateInformer(client kubernetes.Interface, namespace st
 				}
 				return client.CoordinationV1beta1().LeaseCandidates(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/core/v1/componentstatus.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/componentstatus.go
@@ -75,7 +75,7 @@ func NewFilteredComponentStatusInformer(client kubernetes.Interface, resyncPerio
 				}
 				return client.CoreV1().ComponentStatuses().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/core/v1/configmap.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/configmap.go
@@ -76,7 +76,7 @@ func NewFilteredConfigMapInformer(client kubernetes.Interface, namespace string,
 				}
 				return client.CoreV1().ConfigMaps(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/core/v1/endpoints.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/endpoints.go
@@ -76,7 +76,7 @@ func NewFilteredEndpointsInformer(client kubernetes.Interface, namespace string,
 				}
 				return client.CoreV1().Endpoints(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/core/v1/event.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/event.go
@@ -76,7 +76,7 @@ func NewFilteredEventInformer(client kubernetes.Interface, namespace string, res
 				}
 				return client.CoreV1().Events(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/core/v1/limitrange.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/limitrange.go
@@ -76,7 +76,7 @@ func NewFilteredLimitRangeInformer(client kubernetes.Interface, namespace string
 				}
 				return client.CoreV1().LimitRanges(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/core/v1/namespace.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/namespace.go
@@ -75,7 +75,7 @@ func NewFilteredNamespaceInformer(client kubernetes.Interface, resyncPeriod time
 				}
 				return client.CoreV1().Namespaces().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/core/v1/node.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/node.go
@@ -75,7 +75,7 @@ func NewFilteredNodeInformer(client kubernetes.Interface, resyncPeriod time.Dura
 				}
 				return client.CoreV1().Nodes().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/core/v1/persistentvolume.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/persistentvolume.go
@@ -75,7 +75,7 @@ func NewFilteredPersistentVolumeInformer(client kubernetes.Interface, resyncPeri
 				}
 				return client.CoreV1().PersistentVolumes().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/core/v1/persistentvolumeclaim.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/persistentvolumeclaim.go
@@ -76,7 +76,7 @@ func NewFilteredPersistentVolumeClaimInformer(client kubernetes.Interface, names
 				}
 				return client.CoreV1().PersistentVolumeClaims(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/core/v1/pod.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/pod.go
@@ -76,7 +76,7 @@ func NewFilteredPodInformer(client kubernetes.Interface, namespace string, resyn
 				}
 				return client.CoreV1().Pods(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/core/v1/podtemplate.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/podtemplate.go
@@ -76,7 +76,7 @@ func NewFilteredPodTemplateInformer(client kubernetes.Interface, namespace strin
 				}
 				return client.CoreV1().PodTemplates(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/core/v1/replicationcontroller.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/replicationcontroller.go
@@ -76,7 +76,7 @@ func NewFilteredReplicationControllerInformer(client kubernetes.Interface, names
 				}
 				return client.CoreV1().ReplicationControllers(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/core/v1/resourcequota.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/resourcequota.go
@@ -76,7 +76,7 @@ func NewFilteredResourceQuotaInformer(client kubernetes.Interface, namespace str
 				}
 				return client.CoreV1().ResourceQuotas(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/core/v1/secret.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/secret.go
@@ -76,7 +76,7 @@ func NewFilteredSecretInformer(client kubernetes.Interface, namespace string, re
 				}
 				return client.CoreV1().Secrets(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/core/v1/service.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/service.go
@@ -76,7 +76,7 @@ func NewFilteredServiceInformer(client kubernetes.Interface, namespace string, r
 				}
 				return client.CoreV1().Services(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/core/v1/serviceaccount.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/serviceaccount.go
@@ -76,7 +76,7 @@ func NewFilteredServiceAccountInformer(client kubernetes.Interface, namespace st
 				}
 				return client.CoreV1().ServiceAccounts(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/discovery/v1/endpointslice.go
+++ b/staging/src/k8s.io/client-go/informers/discovery/v1/endpointslice.go
@@ -76,7 +76,7 @@ func NewFilteredEndpointSliceInformer(client kubernetes.Interface, namespace str
 				}
 				return client.DiscoveryV1().EndpointSlices(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/discovery/v1beta1/endpointslice.go
+++ b/staging/src/k8s.io/client-go/informers/discovery/v1beta1/endpointslice.go
@@ -76,7 +76,7 @@ func NewFilteredEndpointSliceInformer(client kubernetes.Interface, namespace str
 				}
 				return client.DiscoveryV1beta1().EndpointSlices(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/events/v1/event.go
+++ b/staging/src/k8s.io/client-go/informers/events/v1/event.go
@@ -76,7 +76,7 @@ func NewFilteredEventInformer(client kubernetes.Interface, namespace string, res
 				}
 				return client.EventsV1().Events(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/events/v1beta1/event.go
+++ b/staging/src/k8s.io/client-go/informers/events/v1beta1/event.go
@@ -76,7 +76,7 @@ func NewFilteredEventInformer(client kubernetes.Interface, namespace string, res
 				}
 				return client.EventsV1beta1().Events(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/extensions/v1beta1/daemonset.go
+++ b/staging/src/k8s.io/client-go/informers/extensions/v1beta1/daemonset.go
@@ -76,7 +76,7 @@ func NewFilteredDaemonSetInformer(client kubernetes.Interface, namespace string,
 				}
 				return client.ExtensionsV1beta1().DaemonSets(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/extensions/v1beta1/deployment.go
+++ b/staging/src/k8s.io/client-go/informers/extensions/v1beta1/deployment.go
@@ -76,7 +76,7 @@ func NewFilteredDeploymentInformer(client kubernetes.Interface, namespace string
 				}
 				return client.ExtensionsV1beta1().Deployments(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/extensions/v1beta1/ingress.go
+++ b/staging/src/k8s.io/client-go/informers/extensions/v1beta1/ingress.go
@@ -76,7 +76,7 @@ func NewFilteredIngressInformer(client kubernetes.Interface, namespace string, r
 				}
 				return client.ExtensionsV1beta1().Ingresses(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/extensions/v1beta1/networkpolicy.go
+++ b/staging/src/k8s.io/client-go/informers/extensions/v1beta1/networkpolicy.go
@@ -76,7 +76,7 @@ func NewFilteredNetworkPolicyInformer(client kubernetes.Interface, namespace str
 				}
 				return client.ExtensionsV1beta1().NetworkPolicies(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/extensions/v1beta1/replicaset.go
+++ b/staging/src/k8s.io/client-go/informers/extensions/v1beta1/replicaset.go
@@ -76,7 +76,7 @@ func NewFilteredReplicaSetInformer(client kubernetes.Interface, namespace string
 				}
 				return client.ExtensionsV1beta1().ReplicaSets(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/flowcontrol/v1/flowschema.go
+++ b/staging/src/k8s.io/client-go/informers/flowcontrol/v1/flowschema.go
@@ -75,7 +75,7 @@ func NewFilteredFlowSchemaInformer(client kubernetes.Interface, resyncPeriod tim
 				}
 				return client.FlowcontrolV1().FlowSchemas().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/flowcontrol/v1/prioritylevelconfiguration.go
+++ b/staging/src/k8s.io/client-go/informers/flowcontrol/v1/prioritylevelconfiguration.go
@@ -75,7 +75,7 @@ func NewFilteredPriorityLevelConfigurationInformer(client kubernetes.Interface, 
 				}
 				return client.FlowcontrolV1().PriorityLevelConfigurations().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/flowcontrol/v1beta1/flowschema.go
+++ b/staging/src/k8s.io/client-go/informers/flowcontrol/v1beta1/flowschema.go
@@ -75,7 +75,7 @@ func NewFilteredFlowSchemaInformer(client kubernetes.Interface, resyncPeriod tim
 				}
 				return client.FlowcontrolV1beta1().FlowSchemas().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/flowcontrol/v1beta1/prioritylevelconfiguration.go
+++ b/staging/src/k8s.io/client-go/informers/flowcontrol/v1beta1/prioritylevelconfiguration.go
@@ -75,7 +75,7 @@ func NewFilteredPriorityLevelConfigurationInformer(client kubernetes.Interface, 
 				}
 				return client.FlowcontrolV1beta1().PriorityLevelConfigurations().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/flowcontrol/v1beta2/flowschema.go
+++ b/staging/src/k8s.io/client-go/informers/flowcontrol/v1beta2/flowschema.go
@@ -75,7 +75,7 @@ func NewFilteredFlowSchemaInformer(client kubernetes.Interface, resyncPeriod tim
 				}
 				return client.FlowcontrolV1beta2().FlowSchemas().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/flowcontrol/v1beta2/prioritylevelconfiguration.go
+++ b/staging/src/k8s.io/client-go/informers/flowcontrol/v1beta2/prioritylevelconfiguration.go
@@ -75,7 +75,7 @@ func NewFilteredPriorityLevelConfigurationInformer(client kubernetes.Interface, 
 				}
 				return client.FlowcontrolV1beta2().PriorityLevelConfigurations().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/flowcontrol/v1beta3/flowschema.go
+++ b/staging/src/k8s.io/client-go/informers/flowcontrol/v1beta3/flowschema.go
@@ -75,7 +75,7 @@ func NewFilteredFlowSchemaInformer(client kubernetes.Interface, resyncPeriod tim
 				}
 				return client.FlowcontrolV1beta3().FlowSchemas().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/flowcontrol/v1beta3/prioritylevelconfiguration.go
+++ b/staging/src/k8s.io/client-go/informers/flowcontrol/v1beta3/prioritylevelconfiguration.go
@@ -75,7 +75,7 @@ func NewFilteredPriorityLevelConfigurationInformer(client kubernetes.Interface, 
 				}
 				return client.FlowcontrolV1beta3().PriorityLevelConfigurations().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/networking/v1/ingress.go
+++ b/staging/src/k8s.io/client-go/informers/networking/v1/ingress.go
@@ -76,7 +76,7 @@ func NewFilteredIngressInformer(client kubernetes.Interface, namespace string, r
 				}
 				return client.NetworkingV1().Ingresses(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/networking/v1/ingressclass.go
+++ b/staging/src/k8s.io/client-go/informers/networking/v1/ingressclass.go
@@ -75,7 +75,7 @@ func NewFilteredIngressClassInformer(client kubernetes.Interface, resyncPeriod t
 				}
 				return client.NetworkingV1().IngressClasses().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/networking/v1/ipaddress.go
+++ b/staging/src/k8s.io/client-go/informers/networking/v1/ipaddress.go
@@ -75,7 +75,7 @@ func NewFilteredIPAddressInformer(client kubernetes.Interface, resyncPeriod time
 				}
 				return client.NetworkingV1().IPAddresses().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/networking/v1/networkpolicy.go
+++ b/staging/src/k8s.io/client-go/informers/networking/v1/networkpolicy.go
@@ -76,7 +76,7 @@ func NewFilteredNetworkPolicyInformer(client kubernetes.Interface, namespace str
 				}
 				return client.NetworkingV1().NetworkPolicies(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/networking/v1/servicecidr.go
+++ b/staging/src/k8s.io/client-go/informers/networking/v1/servicecidr.go
@@ -75,7 +75,7 @@ func NewFilteredServiceCIDRInformer(client kubernetes.Interface, resyncPeriod ti
 				}
 				return client.NetworkingV1().ServiceCIDRs().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/networking/v1alpha1/ipaddress.go
+++ b/staging/src/k8s.io/client-go/informers/networking/v1alpha1/ipaddress.go
@@ -75,7 +75,7 @@ func NewFilteredIPAddressInformer(client kubernetes.Interface, resyncPeriod time
 				}
 				return client.NetworkingV1alpha1().IPAddresses().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/networking/v1alpha1/servicecidr.go
+++ b/staging/src/k8s.io/client-go/informers/networking/v1alpha1/servicecidr.go
@@ -75,7 +75,7 @@ func NewFilteredServiceCIDRInformer(client kubernetes.Interface, resyncPeriod ti
 				}
 				return client.NetworkingV1alpha1().ServiceCIDRs().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/networking/v1beta1/ingress.go
+++ b/staging/src/k8s.io/client-go/informers/networking/v1beta1/ingress.go
@@ -76,7 +76,7 @@ func NewFilteredIngressInformer(client kubernetes.Interface, namespace string, r
 				}
 				return client.NetworkingV1beta1().Ingresses(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/networking/v1beta1/ingressclass.go
+++ b/staging/src/k8s.io/client-go/informers/networking/v1beta1/ingressclass.go
@@ -75,7 +75,7 @@ func NewFilteredIngressClassInformer(client kubernetes.Interface, resyncPeriod t
 				}
 				return client.NetworkingV1beta1().IngressClasses().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/networking/v1beta1/ipaddress.go
+++ b/staging/src/k8s.io/client-go/informers/networking/v1beta1/ipaddress.go
@@ -75,7 +75,7 @@ func NewFilteredIPAddressInformer(client kubernetes.Interface, resyncPeriod time
 				}
 				return client.NetworkingV1beta1().IPAddresses().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/networking/v1beta1/servicecidr.go
+++ b/staging/src/k8s.io/client-go/informers/networking/v1beta1/servicecidr.go
@@ -75,7 +75,7 @@ func NewFilteredServiceCIDRInformer(client kubernetes.Interface, resyncPeriod ti
 				}
 				return client.NetworkingV1beta1().ServiceCIDRs().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/node/v1/runtimeclass.go
+++ b/staging/src/k8s.io/client-go/informers/node/v1/runtimeclass.go
@@ -75,7 +75,7 @@ func NewFilteredRuntimeClassInformer(client kubernetes.Interface, resyncPeriod t
 				}
 				return client.NodeV1().RuntimeClasses().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/node/v1alpha1/runtimeclass.go
+++ b/staging/src/k8s.io/client-go/informers/node/v1alpha1/runtimeclass.go
@@ -75,7 +75,7 @@ func NewFilteredRuntimeClassInformer(client kubernetes.Interface, resyncPeriod t
 				}
 				return client.NodeV1alpha1().RuntimeClasses().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/node/v1beta1/runtimeclass.go
+++ b/staging/src/k8s.io/client-go/informers/node/v1beta1/runtimeclass.go
@@ -75,7 +75,7 @@ func NewFilteredRuntimeClassInformer(client kubernetes.Interface, resyncPeriod t
 				}
 				return client.NodeV1beta1().RuntimeClasses().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/policy/v1/poddisruptionbudget.go
+++ b/staging/src/k8s.io/client-go/informers/policy/v1/poddisruptionbudget.go
@@ -76,7 +76,7 @@ func NewFilteredPodDisruptionBudgetInformer(client kubernetes.Interface, namespa
 				}
 				return client.PolicyV1().PodDisruptionBudgets(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/policy/v1beta1/poddisruptionbudget.go
+++ b/staging/src/k8s.io/client-go/informers/policy/v1beta1/poddisruptionbudget.go
@@ -76,7 +76,7 @@ func NewFilteredPodDisruptionBudgetInformer(client kubernetes.Interface, namespa
 				}
 				return client.PolicyV1beta1().PodDisruptionBudgets(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/rbac/v1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1/clusterrole.go
@@ -75,7 +75,7 @@ func NewFilteredClusterRoleInformer(client kubernetes.Interface, resyncPeriod ti
 				}
 				return client.RbacV1().ClusterRoles().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/rbac/v1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1/clusterrolebinding.go
@@ -75,7 +75,7 @@ func NewFilteredClusterRoleBindingInformer(client kubernetes.Interface, resyncPe
 				}
 				return client.RbacV1().ClusterRoleBindings().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/rbac/v1/role.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1/role.go
@@ -76,7 +76,7 @@ func NewFilteredRoleInformer(client kubernetes.Interface, namespace string, resy
 				}
 				return client.RbacV1().Roles(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/rbac/v1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1/rolebinding.go
@@ -76,7 +76,7 @@ func NewFilteredRoleBindingInformer(client kubernetes.Interface, namespace strin
 				}
 				return client.RbacV1().RoleBindings(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/rbac/v1alpha1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1alpha1/clusterrole.go
@@ -75,7 +75,7 @@ func NewFilteredClusterRoleInformer(client kubernetes.Interface, resyncPeriod ti
 				}
 				return client.RbacV1alpha1().ClusterRoles().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/rbac/v1alpha1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1alpha1/clusterrolebinding.go
@@ -75,7 +75,7 @@ func NewFilteredClusterRoleBindingInformer(client kubernetes.Interface, resyncPe
 				}
 				return client.RbacV1alpha1().ClusterRoleBindings().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/rbac/v1alpha1/role.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1alpha1/role.go
@@ -76,7 +76,7 @@ func NewFilteredRoleInformer(client kubernetes.Interface, namespace string, resy
 				}
 				return client.RbacV1alpha1().Roles(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/rbac/v1alpha1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1alpha1/rolebinding.go
@@ -76,7 +76,7 @@ func NewFilteredRoleBindingInformer(client kubernetes.Interface, namespace strin
 				}
 				return client.RbacV1alpha1().RoleBindings(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/rbac/v1beta1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1beta1/clusterrole.go
@@ -75,7 +75,7 @@ func NewFilteredClusterRoleInformer(client kubernetes.Interface, resyncPeriod ti
 				}
 				return client.RbacV1beta1().ClusterRoles().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/rbac/v1beta1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1beta1/clusterrolebinding.go
@@ -75,7 +75,7 @@ func NewFilteredClusterRoleBindingInformer(client kubernetes.Interface, resyncPe
 				}
 				return client.RbacV1beta1().ClusterRoleBindings().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/rbac/v1beta1/role.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1beta1/role.go
@@ -76,7 +76,7 @@ func NewFilteredRoleInformer(client kubernetes.Interface, namespace string, resy
 				}
 				return client.RbacV1beta1().Roles(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/rbac/v1beta1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1beta1/rolebinding.go
@@ -76,7 +76,7 @@ func NewFilteredRoleBindingInformer(client kubernetes.Interface, namespace strin
 				}
 				return client.RbacV1beta1().RoleBindings(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/resource/v1alpha3/deviceclass.go
+++ b/staging/src/k8s.io/client-go/informers/resource/v1alpha3/deviceclass.go
@@ -75,7 +75,7 @@ func NewFilteredDeviceClassInformer(client kubernetes.Interface, resyncPeriod ti
 				}
 				return client.ResourceV1alpha3().DeviceClasses().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/resource/v1alpha3/devicetaintrule.go
+++ b/staging/src/k8s.io/client-go/informers/resource/v1alpha3/devicetaintrule.go
@@ -75,7 +75,7 @@ func NewFilteredDeviceTaintRuleInformer(client kubernetes.Interface, resyncPerio
 				}
 				return client.ResourceV1alpha3().DeviceTaintRules().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/resource/v1alpha3/resourceclaim.go
+++ b/staging/src/k8s.io/client-go/informers/resource/v1alpha3/resourceclaim.go
@@ -76,7 +76,7 @@ func NewFilteredResourceClaimInformer(client kubernetes.Interface, namespace str
 				}
 				return client.ResourceV1alpha3().ResourceClaims(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/resource/v1alpha3/resourceclaimtemplate.go
+++ b/staging/src/k8s.io/client-go/informers/resource/v1alpha3/resourceclaimtemplate.go
@@ -76,7 +76,7 @@ func NewFilteredResourceClaimTemplateInformer(client kubernetes.Interface, names
 				}
 				return client.ResourceV1alpha3().ResourceClaimTemplates(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/resource/v1alpha3/resourceslice.go
+++ b/staging/src/k8s.io/client-go/informers/resource/v1alpha3/resourceslice.go
@@ -75,7 +75,7 @@ func NewFilteredResourceSliceInformer(client kubernetes.Interface, resyncPeriod 
 				}
 				return client.ResourceV1alpha3().ResourceSlices().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/resource/v1beta1/deviceclass.go
+++ b/staging/src/k8s.io/client-go/informers/resource/v1beta1/deviceclass.go
@@ -75,7 +75,7 @@ func NewFilteredDeviceClassInformer(client kubernetes.Interface, resyncPeriod ti
 				}
 				return client.ResourceV1beta1().DeviceClasses().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/resource/v1beta1/resourceclaim.go
+++ b/staging/src/k8s.io/client-go/informers/resource/v1beta1/resourceclaim.go
@@ -76,7 +76,7 @@ func NewFilteredResourceClaimInformer(client kubernetes.Interface, namespace str
 				}
 				return client.ResourceV1beta1().ResourceClaims(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/resource/v1beta1/resourceclaimtemplate.go
+++ b/staging/src/k8s.io/client-go/informers/resource/v1beta1/resourceclaimtemplate.go
@@ -76,7 +76,7 @@ func NewFilteredResourceClaimTemplateInformer(client kubernetes.Interface, names
 				}
 				return client.ResourceV1beta1().ResourceClaimTemplates(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/resource/v1beta1/resourceslice.go
+++ b/staging/src/k8s.io/client-go/informers/resource/v1beta1/resourceslice.go
@@ -75,7 +75,7 @@ func NewFilteredResourceSliceInformer(client kubernetes.Interface, resyncPeriod 
 				}
 				return client.ResourceV1beta1().ResourceSlices().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/resource/v1beta2/deviceclass.go
+++ b/staging/src/k8s.io/client-go/informers/resource/v1beta2/deviceclass.go
@@ -75,7 +75,7 @@ func NewFilteredDeviceClassInformer(client kubernetes.Interface, resyncPeriod ti
 				}
 				return client.ResourceV1beta2().DeviceClasses().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/resource/v1beta2/resourceclaim.go
+++ b/staging/src/k8s.io/client-go/informers/resource/v1beta2/resourceclaim.go
@@ -76,7 +76,7 @@ func NewFilteredResourceClaimInformer(client kubernetes.Interface, namespace str
 				}
 				return client.ResourceV1beta2().ResourceClaims(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/resource/v1beta2/resourceclaimtemplate.go
+++ b/staging/src/k8s.io/client-go/informers/resource/v1beta2/resourceclaimtemplate.go
@@ -76,7 +76,7 @@ func NewFilteredResourceClaimTemplateInformer(client kubernetes.Interface, names
 				}
 				return client.ResourceV1beta2().ResourceClaimTemplates(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/resource/v1beta2/resourceslice.go
+++ b/staging/src/k8s.io/client-go/informers/resource/v1beta2/resourceslice.go
@@ -75,7 +75,7 @@ func NewFilteredResourceSliceInformer(client kubernetes.Interface, resyncPeriod 
 				}
 				return client.ResourceV1beta2().ResourceSlices().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/scheduling/v1/priorityclass.go
+++ b/staging/src/k8s.io/client-go/informers/scheduling/v1/priorityclass.go
@@ -75,7 +75,7 @@ func NewFilteredPriorityClassInformer(client kubernetes.Interface, resyncPeriod 
 				}
 				return client.SchedulingV1().PriorityClasses().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/scheduling/v1alpha1/priorityclass.go
+++ b/staging/src/k8s.io/client-go/informers/scheduling/v1alpha1/priorityclass.go
@@ -75,7 +75,7 @@ func NewFilteredPriorityClassInformer(client kubernetes.Interface, resyncPeriod 
 				}
 				return client.SchedulingV1alpha1().PriorityClasses().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/scheduling/v1beta1/priorityclass.go
+++ b/staging/src/k8s.io/client-go/informers/scheduling/v1beta1/priorityclass.go
@@ -75,7 +75,7 @@ func NewFilteredPriorityClassInformer(client kubernetes.Interface, resyncPeriod 
 				}
 				return client.SchedulingV1beta1().PriorityClasses().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/storage/v1/csidriver.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1/csidriver.go
@@ -75,7 +75,7 @@ func NewFilteredCSIDriverInformer(client kubernetes.Interface, resyncPeriod time
 				}
 				return client.StorageV1().CSIDrivers().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/storage/v1/csinode.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1/csinode.go
@@ -75,7 +75,7 @@ func NewFilteredCSINodeInformer(client kubernetes.Interface, resyncPeriod time.D
 				}
 				return client.StorageV1().CSINodes().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/storage/v1/csistoragecapacity.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1/csistoragecapacity.go
@@ -76,7 +76,7 @@ func NewFilteredCSIStorageCapacityInformer(client kubernetes.Interface, namespac
 				}
 				return client.StorageV1().CSIStorageCapacities(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/storage/v1/storageclass.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1/storageclass.go
@@ -75,7 +75,7 @@ func NewFilteredStorageClassInformer(client kubernetes.Interface, resyncPeriod t
 				}
 				return client.StorageV1().StorageClasses().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/storage/v1/volumeattachment.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1/volumeattachment.go
@@ -75,7 +75,7 @@ func NewFilteredVolumeAttachmentInformer(client kubernetes.Interface, resyncPeri
 				}
 				return client.StorageV1().VolumeAttachments().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/storage/v1alpha1/csistoragecapacity.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1alpha1/csistoragecapacity.go
@@ -76,7 +76,7 @@ func NewFilteredCSIStorageCapacityInformer(client kubernetes.Interface, namespac
 				}
 				return client.StorageV1alpha1().CSIStorageCapacities(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/storage/v1alpha1/volumeattachment.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1alpha1/volumeattachment.go
@@ -75,7 +75,7 @@ func NewFilteredVolumeAttachmentInformer(client kubernetes.Interface, resyncPeri
 				}
 				return client.StorageV1alpha1().VolumeAttachments().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/storage/v1alpha1/volumeattributesclass.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1alpha1/volumeattributesclass.go
@@ -75,7 +75,7 @@ func NewFilteredVolumeAttributesClassInformer(client kubernetes.Interface, resyn
 				}
 				return client.StorageV1alpha1().VolumeAttributesClasses().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/storage/v1beta1/csidriver.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1beta1/csidriver.go
@@ -75,7 +75,7 @@ func NewFilteredCSIDriverInformer(client kubernetes.Interface, resyncPeriod time
 				}
 				return client.StorageV1beta1().CSIDrivers().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/storage/v1beta1/csinode.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1beta1/csinode.go
@@ -75,7 +75,7 @@ func NewFilteredCSINodeInformer(client kubernetes.Interface, resyncPeriod time.D
 				}
 				return client.StorageV1beta1().CSINodes().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/storage/v1beta1/csistoragecapacity.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1beta1/csistoragecapacity.go
@@ -76,7 +76,7 @@ func NewFilteredCSIStorageCapacityInformer(client kubernetes.Interface, namespac
 				}
 				return client.StorageV1beta1().CSIStorageCapacities(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/storage/v1beta1/storageclass.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1beta1/storageclass.go
@@ -75,7 +75,7 @@ func NewFilteredStorageClassInformer(client kubernetes.Interface, resyncPeriod t
 				}
 				return client.StorageV1beta1().StorageClasses().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/storage/v1beta1/volumeattachment.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1beta1/volumeattachment.go
@@ -75,7 +75,7 @@ func NewFilteredVolumeAttachmentInformer(client kubernetes.Interface, resyncPeri
 				}
 				return client.StorageV1beta1().VolumeAttachments().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/storage/v1beta1/volumeattributesclass.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1beta1/volumeattributesclass.go
@@ -75,7 +75,7 @@ func NewFilteredVolumeAttributesClassInformer(client kubernetes.Interface, resyn
 				}
 				return client.StorageV1beta1().VolumeAttributesClasses().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/storagemigration/v1alpha1/storageversionmigration.go
+++ b/staging/src/k8s.io/client-go/informers/storagemigration/v1alpha1/storageversionmigration.go
@@ -75,7 +75,7 @@ func NewFilteredStorageVersionMigrationInformer(client kubernetes.Interface, res
 				}
 				return client.StoragemigrationV1alpha1().StorageVersionMigrations().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/metadata/metadatainformer/informer.go
+++ b/staging/src/k8s.io/client-go/metadata/metadatainformer/informer.go
@@ -197,7 +197,7 @@ func NewFilteredMetadataInformer(client metadata.Interface, gvr schema.GroupVers
 					}
 					return client.Resource(gvr).Namespace(namespace).List(ctx, options)
 				},
-				WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 					if tweakListOptions != nil {
 						tweakListOptions(&options)
 					}

--- a/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/informer.go
+++ b/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/informer.go
@@ -167,7 +167,7 @@ func NewFiltered$.type|public$Informer(client $.clientSetInterface|raw$$if .name
 				}
 				return client.$.group$$.version$().$.type|publicPlural$($if .namespaced$namespace$end$).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx $.contextContext|raw$, options $.v1ListOptions|raw$) ($.watchInterface|raw$, error) {
+			WatchWithContextFunc: func(ctx $.contextContext|raw$, options $.v1ListOptions|raw$) ($.watchInterface|raw$, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/code-generator/examples/HyphenGroup/informers/externalversions/example/v1/clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/examples/HyphenGroup/informers/externalversions/example/v1/clustertesttype.go
@@ -75,7 +75,7 @@ func NewFilteredClusterTestTypeInformer(client versioned.Interface, resyncPeriod
 				}
 				return client.ExampleGroupV1().ClusterTestTypes().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/code-generator/examples/HyphenGroup/informers/externalversions/example/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/HyphenGroup/informers/externalversions/example/v1/testtype.go
@@ -76,7 +76,7 @@ func NewFilteredTestTypeInformer(client versioned.Interface, namespace string, r
 				}
 				return client.ExampleGroupV1().TestTypes(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/code-generator/examples/MixedCase/informers/externalversions/example/v1/clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/examples/MixedCase/informers/externalversions/example/v1/clustertesttype.go
@@ -75,7 +75,7 @@ func NewFilteredClusterTestTypeInformer(client versioned.Interface, resyncPeriod
 				}
 				return client.ExampleV1().ClusterTestTypes().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/code-generator/examples/MixedCase/informers/externalversions/example/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/MixedCase/informers/externalversions/example/v1/testtype.go
@@ -76,7 +76,7 @@ func NewFilteredTestTypeInformer(client versioned.Interface, namespace string, r
 				}
 				return client.ExampleV1().TestTypes(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/core/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/core/v1/testtype.go
@@ -76,7 +76,7 @@ func NewFilteredTestTypeInformer(client versioned.Interface, namespace string, r
 				}
 				return client.CoreV1().TestTypes(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/example/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/example/v1/testtype.go
@@ -76,7 +76,7 @@ func NewFilteredTestTypeInformer(client versioned.Interface, namespace string, r
 				}
 				return client.ExampleV1().TestTypes(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/example2/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/example2/v1/testtype.go
@@ -76,7 +76,7 @@ func NewFilteredTestTypeInformer(client versioned.Interface, namespace string, r
 				}
 				return client.SecondExampleV1().TestTypes(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/example3.io/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/example3.io/v1/testtype.go
@@ -76,7 +76,7 @@ func NewFilteredTestTypeInformer(client versioned.Interface, namespace string, r
 				}
 				return client.ThirdExampleV1().TestTypes(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/conflicting/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/conflicting/v1/testtype.go
@@ -76,7 +76,7 @@ func NewFilteredTestTypeInformer(client versioned.Interface, namespace string, r
 				}
 				return client.ConflictingExampleV1().TestTypes(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/example/v1/clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/example/v1/clustertesttype.go
@@ -75,7 +75,7 @@ func NewFilteredClusterTestTypeInformer(client versioned.Interface, resyncPeriod
 				}
 				return client.ExampleV1().ClusterTestTypes().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/example/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/example/v1/testtype.go
@@ -76,7 +76,7 @@ func NewFilteredTestTypeInformer(client versioned.Interface, namespace string, r
 				}
 				return client.ExampleV1().TestTypes(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/example2/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/example2/v1/testtype.go
@@ -76,7 +76,7 @@ func NewFilteredTestTypeInformer(client versioned.Interface, namespace string, r
 				}
 				return client.SecondExampleV1().TestTypes(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/extensions/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/extensions/v1/testtype.go
@@ -76,7 +76,7 @@ func NewFilteredTestTypeInformer(client versioned.Interface, namespace string, r
 				}
 				return client.ExtensionsExampleV1().TestTypes(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/code-generator/examples/single/informers/externalversions/api/v1/clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/examples/single/informers/externalversions/api/v1/clustertesttype.go
@@ -75,7 +75,7 @@ func NewFilteredClusterTestTypeInformer(client versioned.Interface, resyncPeriod
 				}
 				return client.ExampleV1().ClusterTestTypes().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/code-generator/examples/single/informers/externalversions/api/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/single/informers/externalversions/api/v1/testtype.go
@@ -76,7 +76,7 @@ func NewFilteredTestTypeInformer(client versioned.Interface, namespace string, r
 				}
 				return client.ExampleV1().TestTypes(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/informers/externalversions/apiregistration/v1/apiservice.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/informers/externalversions/apiregistration/v1/apiservice.go
@@ -75,7 +75,7 @@ func NewFilteredAPIServiceInformer(client clientset.Interface, resyncPeriod time
 				}
 				return client.ApiregistrationV1().APIServices().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/informers/externalversions/apiregistration/v1beta1/apiservice.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/informers/externalversions/apiregistration/v1beta1/apiservice.go
@@ -75,7 +75,7 @@ func NewFilteredAPIServiceInformer(client clientset.Interface, resyncPeriod time
 				}
 				return client.ApiregistrationV1beta1().APIServices().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/informers/externalversions/wardle/v1alpha1/fischer.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/informers/externalversions/wardle/v1alpha1/fischer.go
@@ -75,7 +75,7 @@ func NewFilteredFischerInformer(client versioned.Interface, resyncPeriod time.Du
 				}
 				return client.WardleV1alpha1().Fischers().List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/informers/externalversions/wardle/v1alpha1/flunder.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/informers/externalversions/wardle/v1alpha1/flunder.go
@@ -76,7 +76,7 @@ func NewFilteredFlunderInformer(client versioned.Interface, namespace string, re
 				}
 				return client.WardleV1alpha1().Flunders(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/informers/externalversions/wardle/v1beta1/flunder.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/informers/externalversions/wardle/v1beta1/flunder.go
@@ -76,7 +76,7 @@ func NewFilteredFlunderInformer(client versioned.Interface, namespace string, re
 				}
 				return client.WardleV1beta1().Flunders(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/sample-controller/pkg/generated/informers/externalversions/samplecontroller/v1alpha1/foo.go
+++ b/staging/src/k8s.io/sample-controller/pkg/generated/informers/externalversions/samplecontroller/v1alpha1/foo.go
@@ -76,7 +76,7 @@ func NewFilteredFooInformer(client versioned.Interface, namespace string, resync
 				}
 				return client.SamplecontrollerV1alpha1().Foos(namespace).List(ctx, options)
 			},
-			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/test/e2e/apps/util.go
+++ b/test/e2e/apps/util.go
@@ -63,7 +63,7 @@ func (t *IndexedPodAnnotationTracker) Start(ctx context.Context, c clientset.Int
 				obj, err := c.CoreV1().Pods(t.ownerNs).List(ctx, options)
 				return runtime.Object(obj), err
 			},
-			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			WatchWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				options.LabelSelector = t.labelSelector
 				return c.CoreV1().Pods(t.ownerNs).Watch(ctx, options)
 			},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

https://github.com/kubernetes/kubernetes/blob/5be79417862d29aecfadb2735cc42da64dff3ba7/staging/src/k8s.io/client-go/tools/cache/listwatch.go#L134-L148

I noticed a slight inconsistency in naming conventions while reviewing the context-aware interfaces:

1. `ListWithContextFunc` uses `WithContext` as an infix
2. `WatchFuncWithContext` uses `WithContext` as a suffix

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
xref https://github.com/kubernetes/kubernetes/pull/129341#issuecomment-2838502893

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add WatchWithContextFunc and deprecate WatchFuncWithContext
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
