### PR TITLE
Fix: syncTracker.Finished not called when handler panics

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
+++ b/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
@@ -1074,10 +1074,10 @@ func (p *processorListener) run() {
 			case updateNotification:
 				p.handler.OnUpdate(notification.oldObj, notification.newObj)
 			case addNotification:
-				p.handler.OnAdd(notification.newObj, notification.isInInitialList)
 				if notification.isInInitialList {
-					p.syncTracker.Finished()
+					defer p.syncTracker.Finished()
 				}
+				p.handler.OnAdd(notification.newObj, notification.isInInitialList)
 			case deleteNotification:
 				p.handler.OnDelete(notification.oldObj)
 			default:


### PR DESCRIPTION
This PR ensures that `processorListener` correctly calls `syncTracker.Finished()` even when a panic occurs in the handler during initial list processing (`isInInitialList == true`).

Previously, a panic in the `AddFunc` handler prevented `Finished()` from being called, which caused `handle.HasSynced()` to remain `false` indefinitely. This resulted in controllers waiting forever for their handlers to sync, effectively stalling the system.

The fix moves the defer p.syncTracker.Finished() call to execute before
the handler invocation, ensuring it's called even when panics occur.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Fixes a bug where `syncTracker.Finished()` would not be called if the `AddFunc` handler panicked during initial list processing, leaving the informer in an unsynced state and potentially blocking controller startup.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #129024

#### Special notes for your reviewer:

- The `Finished()` call is now deferred before handler execution.
- The test `TestHandlerHasSyncedAfterPanic` confirms this fix.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix an issue where a panic in AddFunc during initial list processing could cause the informer to never report as synced.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
