### PR TITLE
kube-proxy: log iptables errors in platformCheckSupported

### DIFF
--- a/pkg/kubelet/kubelet_network_linux.go
+++ b/pkg/kubelet/kubelet_network_linux.go
@@ -37,8 +37,12 @@ const (
 )
 
 func (kl *Kubelet) initNetworkUtil() {
-	iptClients := utiliptables.NewDualStack()
-	if len(iptClients) == 0 {
+	iptClients, err := utiliptables.NewDualStack()
+	if err != nil {
+		klog.ErrorS(err, "Failed to initialize iptables")
+	}
+
+	if err != nil || len(iptClients) == 0 {
 		klog.InfoS("No iptables support on this system; not creating the KUBE-IPTABLES-HINT chain")
 		return
 	}

--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -406,7 +406,7 @@ var iptablesCleanupOnlyChains = []iptablesJumpChain{}
 // CleanupLeftovers removes all iptables rules and chains created by the Proxier
 // It returns true if an error was encountered. Errors are logged.
 func CleanupLeftovers(ctx context.Context) (encounteredError bool) {
-	ipts := utiliptables.NewDualStack()
+	ipts, _ := utiliptables.NewDualStack()
 	for _, ipt := range ipts {
 		encounteredError = cleanupLeftoversForFamily(ctx, ipt) || encounteredError
 	}

--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -706,7 +706,7 @@ func CleanupLeftovers(ctx context.Context) (encounteredError bool) {
 		return false
 	}
 
-	ipts := utiliptables.NewDualStack()
+	ipts, _ := utiliptables.NewDualStack()
 	ipsetInterface := utilipset.New()
 	ipvsInterface := utilipvs.New()
 

--- a/pkg/util/iptables/iptables.go
+++ b/pkg/util/iptables/iptables.go
@@ -654,12 +654,8 @@ func (runner *runner) ChainExists(table Table, chain Chain) (bool, error) {
 	trace := utiltrace.New("iptables ChainExists")
 	defer trace.LogIfLong(2 * time.Second)
 
-	out, err := runner.run(opListChain, fullArgs)
-	if err != nil {
-		klog.ErrorS(err, "Failed to list chain", "chain", chain, "table", table, "output", string(out))
-		return false, err
-	}
-	return true, nil
+	_, err := runner.run(opListChain, fullArgs)
+	return err == nil, err
 }
 
 type operation string

--- a/pkg/util/iptables/iptables.go
+++ b/pkg/util/iptables/iptables.go
@@ -97,7 +97,7 @@ type Interface interface {
 	HasRandomFully() bool
 
 	// Present checks if the kernel supports the iptable interface
-	Present() bool
+	Present() error
 }
 
 // Protocol defines the ip protocol either ipv4 or ipv6
@@ -250,29 +250,40 @@ func newInternal(exec utilexec.Interface, protocol Protocol, lockfilePath14x, lo
 }
 
 // New returns a new Interface which will exec iptables.
+// Note that this function will return a single iptables Interface *and* an error, if only
+// a single family is supported.
 func New(protocol Protocol) Interface {
 	return newInternal(utilexec.New(), protocol, "", "")
 }
 
-func newDualStackInternal(exec utilexec.Interface) map[v1.IPFamily]Interface {
+func newDualStackInternal(exec utilexec.Interface) (map[v1.IPFamily]Interface, error) {
+	var err error
 	interfaces := map[v1.IPFamily]Interface{}
 
 	iptv4 := newInternal(exec, ProtocolIPv4, "", "")
-	if iptv4.Present() {
+	if presentErr := iptv4.Present(); presentErr != nil {
+		err = presentErr
+	} else {
 		interfaces[v1.IPv4Protocol] = iptv4
 	}
 	iptv6 := newInternal(exec, ProtocolIPv6, "", "")
-	if iptv6.Present() {
+	if presentErr := iptv6.Present(); presentErr != nil {
+		// If we get an error for both IPv4 and IPv6 Present() calls, it's virtually guaranteed that
+		// they're going to be the same error. We ignore the error for IPv6 if IPv4 has already failed.
+		if err == nil {
+			err = presentErr
+		}
+	} else {
 		interfaces[v1.IPv6Protocol] = iptv6
 	}
 
-	return interfaces
+	return interfaces, err
 }
 
 // NewDualStack returns a map containing an IPv4 Interface (if IPv4 iptables is supported)
 // and an IPv6 Interface (if IPv6 iptables is supported). If either family is not
 // supported, no Interface will be returned for that family.
-func NewDualStack() map[v1.IPFamily]Interface {
+func NewDualStack() (map[v1.IPFamily]Interface, error) {
 	return newDualStackInternal(utilexec.New())
 }
 
@@ -654,8 +665,11 @@ func (runner *runner) ChainExists(table Table, chain Chain) (bool, error) {
 	trace := utiltrace.New("iptables ChainExists")
 	defer trace.LogIfLong(2 * time.Second)
 
-	_, err := runner.run(opListChain, fullArgs)
-	return err == nil, err
+	out, err := runner.run(opListChain, fullArgs)
+	if err != nil {
+		return false, fmt.Errorf("error listing chain %q in table %q: %w: %s", chain, table, err, out)
+	}
+	return true, nil
 }
 
 type operation string
@@ -759,12 +773,11 @@ func (runner *runner) HasRandomFully() bool {
 
 // Present tests if iptable is supported on current kernel by checking the existence
 // of default table and chain
-func (runner *runner) Present() bool {
+func (runner *runner) Present() error {
 	if _, err := runner.ChainExists(TableNAT, ChainPostrouting); err != nil {
-		return false
+		return err
 	}
-
-	return true
+	return nil
 }
 
 var iptablesNotFoundStrings = []string{

--- a/pkg/util/iptables/iptables_test.go
+++ b/pkg/util/iptables/iptables_test.go
@@ -329,7 +329,7 @@ func TestNewDualStack(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			fexec := fakeExecForCommands(tc.commands)
-			runners := newDualStackInternal(fexec)
+			runners, _ := newDualStackInternal(fexec)
 
 			if tc.ipv4 && runners[v1.IPv4Protocol] == nil {
 				t.Errorf("Expected ipv4 runner, got nil")

--- a/pkg/util/iptables/testing/fake.go
+++ b/pkg/util/iptables/testing/fake.go
@@ -327,8 +327,8 @@ func (f *FakeIPTables) HasRandomFully() bool {
 	return f.hasRandomFully
 }
 
-func (f *FakeIPTables) Present() bool {
-	return true
+func (f *FakeIPTables) Present() error {
+	return nil
 }
 
 var _ = iptables.Interface(&FakeIPTables{})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Currently we check the existence of the default iptables chain to ensure if iptables is supported by the platform. We don't log the actual error and stdout  when the check fails.
```
E0426 10:25:33.612382       1 server.go:136] "Error running ProxyServer" err="iptables is not available on this host"                                                                                              
E0426 10:25:33.612393       1 run.go:72] "command failed" err="iptables is not available on this host"  
```

Logging the actual stdout/stderr will help to understand the root cause of the actual failure. It can help in covering the cases when privileges are not properly configured for the kube-proxy daemonset, removal of a deprecated flag from the user space binary and many more.

```
E0507 16:05:47.509891       1 server.go:136] "Error running ProxyServer" err=<
	iptables is not available on this host : error listing chain "POSTROUTING" in table "nat": exit status 4: Ignoring deprecated --wait-interval option.
	iptables v1.8.9 (nf_tables): Could not fetch rule set generation id: Permission denied (you must be root)
 >
E0507 16:05:47.509907       1 run.go:72] "command failed" err=<
	iptables is not available on this host : error listing chain "POSTROUTING" in table "nat": exit status 4: Ignoring deprecated --wait-interval option.
	iptables v1.8.9 (nf_tables): Could not fetch rule set generation id: Permission denied (you must be root)
 >
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
