### PR TITLE
jwt: refactor CEL eval to drop `unstructured` and `map[string]any`

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/authentication/cel/interface.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/cel/interface.go
@@ -22,8 +22,7 @@ import (
 
 	celgo "github.com/google/cel-go/cel"
 	"github.com/google/cel-go/common/types/ref"
-
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"github.com/google/cel-go/common/types/traits"
 )
 
 // ExpressionAccessor is an interface that provides access to a CEL expression.
@@ -55,17 +54,17 @@ type Compiler interface {
 type ClaimsMapper interface {
 	// EvalClaimMapping evaluates the given claim mapping expression and returns a EvaluationResult.
 	// This is used for username, groups and uid claim mapping that contains a single expression.
-	EvalClaimMapping(ctx context.Context, claims *unstructured.Unstructured) (EvaluationResult, error)
+	EvalClaimMapping(ctx context.Context, claims traits.Mapper) (EvaluationResult, error)
 	// EvalClaimMappings evaluates the given expressions and returns a list of EvaluationResult.
 	// This is used for extra claim mapping and claim validation that contains a list of expressions.
-	EvalClaimMappings(ctx context.Context, claims *unstructured.Unstructured) ([]EvaluationResult, error)
+	EvalClaimMappings(ctx context.Context, claims traits.Mapper) ([]EvaluationResult, error)
 }
 
 // UserMapper provides a CEL expression mapper configured with the user CEL variable.
 type UserMapper interface {
 	// EvalUser evaluates the given user expressions and returns a list of EvaluationResult.
 	// This is used for user validation that contains a list of expressions.
-	EvalUser(ctx context.Context, userInfo *unstructured.Unstructured) ([]EvaluationResult, error)
+	EvalUser(ctx context.Context, userInfo traits.Mapper) ([]EvaluationResult, error)
 }
 
 var _ ExpressionAccessor = &ClaimMappingExpression{}


### PR DESCRIPTION
This prepares us to add support for distributed claims support in CEL expressions.

/kind cleanup
/assign aramase
/triage accepted

```release-note
NONE
```

- KEP: https://github.com/kubernetes/enhancements/issues/3331