### PR TITLE
e2e tests: fix in-tree plugin volume limit

### DIFF
--- a/pkg/volume/util/attach_limit.go
+++ b/pkg/volume/util/attach_limit.go
@@ -25,28 +25,6 @@ import (
 // shared between volume package and scheduler
 
 const (
-	// EBSVolumeLimitKey resource name that will store volume limits for EBS
-	EBSVolumeLimitKey = "attachable-volumes-aws-ebs"
-	// EBSNitroLimitRegex finds nitro instance types with different limit than EBS defaults
-	EBSNitroLimitRegex = "^[cmr]5.*|t3|z1d"
-	// DefaultMaxEBSVolumes is the limit for volumes attached to an instance.
-	// Amazon recommends no more than 40; the system root volume uses at least one.
-	// See http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/volume_limits.html#linux-specific-volume-limits
-	DefaultMaxEBSVolumes = 39
-	// DefaultMaxEBSNitroVolumeLimit is default EBS volume limit on m5 and c5 instances
-	DefaultMaxEBSNitroVolumeLimit = 25
-	// AzureVolumeLimitKey stores resource name that will store volume limits for Azure
-	AzureVolumeLimitKey = "attachable-volumes-azure-disk"
-	// GCEVolumeLimitKey stores resource name that will store volume limits for GCE node
-	GCEVolumeLimitKey = "attachable-volumes-gce-pd"
-
-	// CinderVolumeLimitKey contains Volume limit key for Cinder
-	CinderVolumeLimitKey = "attachable-volumes-cinder"
-	// DefaultMaxCinderVolumes defines the maximum number of PD Volumes for Cinder
-	// For Openstack we are keeping this to a high enough value so as depending on backend
-	// cluster admins can configure it.
-	DefaultMaxCinderVolumes = 256
-
 	// CSIAttachLimitPrefix defines prefix used for CSI volumes
 	CSIAttachLimitPrefix = "attachable-volumes-csi-"
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The volume limit of all in-tree plugins should obtain from csi node since https://github.com/kubernetes/kubernetes/pull/124003 and #126924 are merged.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
