### PR TITLE
Increase the number and granularity of buckets for some of kube-scheduler's alpha metrics. Make exporting flag-gated

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -685,16 +685,6 @@ const (
 	// which improves the scheduling latency when the preemption involves in.
 	SchedulerAsyncPreemption featuregate.Feature = "SchedulerAsyncPreemption"
 
-	// owner: @ania-borowiec
-	//
-	// Enables exporting some expensive metrics that monitor the latency of operations within
-	// the pod scheduling cycle with high precision and a large number of histogram buckets.
-	// Metrics enabled by this feature gate:
-	// - scheduler_event_handling_duration_seconds
-	// - scheduler_plugin_execution_duration_seconds
-	// - scheduler_queueing_hint_execution_duration_seconds
-	SchedulerHighPrecisionMetrics featuregate.Feature = "SchedulerHighPrecisionMetrics"
-
 	// owner: @macsko
 	// kep: http://kep.k8s.io/5142
 	//
@@ -1686,10 +1676,6 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 
 	SchedulerPopFromBackoffQ: {
 		{Version: version.MustParse("1.33"), Default: true, PreRelease: featuregate.Beta},
-	},
-
-	SchedulerHighPrecisionMetrics: {
-		{Version: version.MustParse("1.33"), Default: false, PreRelease: featuregate.Alpha},
 	},
 
 	SchedulerQueueingHints: {

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -685,6 +685,16 @@ const (
 	// which improves the scheduling latency when the preemption involves in.
 	SchedulerAsyncPreemption featuregate.Feature = "SchedulerAsyncPreemption"
 
+	// owner: @ania-borowiec
+	//
+	// Enables exporting some expensive metrics that monitor the latency of operations within
+	// the pod scheduling cycle with high precision and a large number of histogram buckets.
+	// Metrics enabled by this feature gate:
+	// - scheduler_event_handling_duration_seconds
+	// - scheduler_plugin_execution_duration_seconds
+	// - scheduler_queueing_hint_execution_duration_seconds
+	SchedulerHighPrecisionMetrics featuregate.Feature = "SchedulerHighPrecisionMetrics"
+
 	// owner: @macsko
 	// kep: http://kep.k8s.io/5142
 	//
@@ -1676,6 +1686,10 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 
 	SchedulerPopFromBackoffQ: {
 		{Version: version.MustParse("1.33"), Default: true, PreRelease: featuregate.Beta},
+	},
+
+	SchedulerHighPrecisionMetrics: {
+		{Version: version.MustParse("1.33"), Default: false, PreRelease: featuregate.Alpha},
 	},
 
 	SchedulerQueueingHints: {

--- a/pkg/scheduler/apis/config/types.go
+++ b/pkg/scheduler/apis/config/types.go
@@ -94,6 +94,15 @@ type KubeSchedulerConfiguration struct {
 	// failover with the benefit of lower memory overhead while waiting to become leader.
 	// Defaults to false.
 	DelayCacheUntilActive bool
+
+	// ExportHighPrecisionMetrics specifies if scheduler should export some expensive metrics that monitor
+	// the latency of operations within the pod scheduling cycle with high precision and a large number
+	// of histogram buckets.
+	// Metrics enabled by this setting:
+	// - scheduler_event_handling_duration_seconds
+	// - scheduler_plugin_execution_duration_seconds
+	// - scheduler_queueing_hint_execution_duration_seconds (if feature flag SchedulerQueueingHints is also enabled)
+	ExportHighPrecisionMetrics bool
 }
 
 // KubeSchedulerProfile is a scheduling profile.

--- a/pkg/scheduler/apis/config/v1/zz_generated.conversion.go
+++ b/pkg/scheduler/apis/config/v1/zz_generated.conversion.go
@@ -466,6 +466,7 @@ func autoConvert_config_KubeSchedulerConfiguration_To_v1_KubeSchedulerConfigurat
 	}
 	out.Extenders = *(*[]configv1.Extender)(unsafe.Pointer(&in.Extenders))
 	out.DelayCacheUntilActive = in.DelayCacheUntilActive
+	// WARNING: in.ExportHighPrecisionMetrics requires manual conversion: does not exist in peer-type
 	return nil
 }
 

--- a/pkg/scheduler/backend/cache/cache_test.go
+++ b/pkg/scheduler/backend/cache/cache_test.go
@@ -47,7 +47,7 @@ var nodeInfoCmpOpts = []cmp.Option{
 }
 
 func init() {
-	metrics.Register()
+	metrics.Register(true)
 }
 
 func deepEqualWithoutGeneration(actual *nodeInfoListItem, expected *framework.NodeInfo) error {

--- a/pkg/scheduler/backend/queue/active_queue_test.go
+++ b/pkg/scheduler/backend/queue/active_queue_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 func TestClose(t *testing.T) {
+	initMetrics(t)
 	logger, ctx := ktesting.NewTestContext(t)
 	rr := metrics.NewMetricsAsyncRecorder(10, time.Second, ctx.Done())
 	aq := newActiveQueue(heap.NewWithRecorder(podInfoKeyFunc, heap.LessFunc[*framework.QueuedPodInfo](newDefaultQueueSort()), metrics.NewActivePodsRecorder()), true, *rr, nil)

--- a/pkg/scheduler/backend/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue_test.go
@@ -111,8 +111,7 @@ var (
 // is executed, and since test are executed in random order, it needs to be done at the beginning of every test case.
 // TODO: Refactor tests to use mocks instead of a real metric registry.
 func initMetrics(t *testing.T) {
-	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.SchedulerHighPrecisionMetrics, true)
-	metrics.Register()
+	metrics.Register(true /* exportHighPrecisionMetrics */)
 }
 
 func setQueuedPodInfoGated(queuedPodInfo *framework.QueuedPodInfo) *framework.QueuedPodInfo {
@@ -1788,7 +1787,7 @@ func BenchmarkMoveAllToActiveOrBackoffQueue(b *testing.B) {
 		for _, podsInUnschedulablePods := range []int{1000, 5000} {
 			b.Run(fmt.Sprintf("%v-%v", tt.name, podsInUnschedulablePods), func(b *testing.B) {
 				logger, ctx := ktesting.NewTestContext(b)
-				metrics.Register()
+				metrics.Register(true /* exportHighPrecisionMetrics */)
 				for i := 0; i < b.N; i++ {
 					b.StopTimer()
 					c := testingclock.NewFakeClock(time.Now())

--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
@@ -99,7 +99,7 @@ var (
 )
 
 func init() {
-	metrics.Register()
+	metrics.Register(true)
 }
 
 func getDefaultDefaultPreemptionArgs() *config.DefaultPreemptionArgs {
@@ -1554,7 +1554,7 @@ func TestPodEligibleToPreemptOthers(t *testing.T) {
 }
 
 func TestPreempt(t *testing.T) {
-	metrics.Register()
+	metrics.Register(true)
 	tests := []struct {
 		name           string
 		pod            *v1.Pod

--- a/pkg/scheduler/framework/plugins/interpodaffinity/filtering_test.go
+++ b/pkg/scheduler/framework/plugins/interpodaffinity/filtering_test.go
@@ -44,7 +44,7 @@ var (
 )
 
 func init() {
-	metrics.Register()
+	metrics.Register(true)
 }
 
 func createPodWithAffinityTerms(namespace, nodeName string, labels map[string]string, affinity, antiAffinity []v1.PodAffinityTerm) *v1.Pod {

--- a/pkg/scheduler/framework/plugins/podtopologyspread/filtering_test.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/filtering_test.go
@@ -64,7 +64,7 @@ var (
 )
 
 func init() {
-	metrics.Register()
+	metrics.Register(true)
 }
 
 func (p *criticalPaths) sort() {

--- a/pkg/scheduler/framework/preemption/preemption_test.go
+++ b/pkg/scheduler/framework/preemption/preemption_test.go
@@ -64,7 +64,7 @@ var (
 )
 
 func init() {
-	metrics.Register()
+	metrics.Register(true)
 }
 
 type FakePostFilterPlugin struct {
@@ -622,7 +622,7 @@ func TestPrepareCandidate(t *testing.T) {
 	for _, asyncPreemptionEnabled := range []bool{true, false} {
 		for _, tt := range tests {
 			t.Run(fmt.Sprintf("%v (Async preemption enabled: %v)", tt.name, asyncPreemptionEnabled), func(t *testing.T) {
-				metrics.Register()
+				metrics.Register(true)
 				logger, ctx := ktesting.NewTestContext(t)
 				ctx, cancel := context.WithCancel(ctx)
 				defer cancel()
@@ -1014,7 +1014,7 @@ func TestCallExtenders(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			metrics.Register()
+			metrics.Register(true)
 			logger, ctx := ktesting.NewTestContext(t)
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()

--- a/pkg/scheduler/framework/runtime/framework_test.go
+++ b/pkg/scheduler/framework/runtime/framework_test.go
@@ -31,13 +31,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/informers"
 	clientsetfake "k8s.io/client-go/kubernetes/fake"
-	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/component-base/metrics/testutil"
 	"k8s.io/klog/v2/ktesting"
-	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 	"k8s.io/kubernetes/pkg/scheduler/backend/cache"
 	internalqueue "k8s.io/kubernetes/pkg/scheduler/backend/queue"
@@ -3100,8 +3097,7 @@ func TestRecordingMetrics(t *testing.T) {
 // is executed, and since test are executed in random order, it needs to be done at the beginning of every test case.
 // TODO: Refactor tests to use mocks instead of a real metric registry.
 func initMetrics(t *testing.T) {
-	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.SchedulerHighPrecisionMetrics, true)
-	metrics.Register()
+	metrics.Register(true /* exportHighPrecisionMetrics*/)
 	metrics.FrameworkExtensionPointDuration.Reset()
 	metrics.PluginExecutionDuration.Reset()
 	metrics.PermitWaitDuration.Reset()

--- a/pkg/scheduler/metrics/metric_recorder_test.go
+++ b/pkg/scheduler/metrics/metric_recorder_test.go
@@ -108,7 +108,7 @@ func TestClear(t *testing.T) {
 }
 
 func TestInFlightEventAsync(t *testing.T) {
-	Register()
+	Register(true)
 	r := &MetricAsyncRecorder{
 		aggregatedInflightEventMetric:              map[gaugeVecMetricKey]int{},
 		aggregatedInflightEventMetricLastFlushTime: time.Now(),

--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -127,19 +127,19 @@ var (
 var registerMetrics sync.Once
 
 // Register all metrics.
-func Register() {
+func Register(shouldRegisterHighPrecisionMetrics bool) {
 	// Register the metrics.
 	registerMetrics.Do(func() {
 		InitMetrics()
 		RegisterMetrics(metricsList...)
 		volumebindingmetrics.RegisterVolumeSchedulingMetrics()
 
-		if utilfeature.DefaultFeatureGate.Enabled(features.SchedulerHighPrecisionMetrics) {
+		if shouldRegisterHighPrecisionMetrics {
 			RegisterMetrics(EventHandlingLatency, PluginExecutionDuration)
 		}
 		if utilfeature.DefaultFeatureGate.Enabled(features.SchedulerQueueingHints) {
 			RegisterMetrics(InFlightEvents)
-			if utilfeature.DefaultFeatureGate.Enabled(features.SchedulerHighPrecisionMetrics) {
+			if shouldRegisterHighPrecisionMetrics {
 				RegisterMetrics(queueingHintExecutionDuration)
 			}
 		}

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -132,6 +132,7 @@ type schedulerOptions struct {
 	extenders                  []schedulerapi.Extender
 	frameworkCapturer          FrameworkCapturer
 	parallelism                int32
+	exportHighPrecisionMetrics bool
 	applyDefaultProfile        bool
 }
 
@@ -254,6 +255,7 @@ var defaultSchedulerOptions = schedulerOptions{
 	podMaxBackoffSeconds:              int64(internalqueue.DefaultPodMaxBackoffDuration.Seconds()),
 	podMaxInUnschedulablePodsDuration: internalqueue.DefaultPodMaxInUnschedulablePodsDuration,
 	parallelism:                       int32(parallelize.DefaultParallelism),
+	exportHighPrecisionMetrics:        false,
 	// Ideally we would statically set the default profile here, but we can't because
 	// creating the default profile may require testing feature gates, which may get
 	// set dynamically in tests. Therefore, we delay creating it until New is actually
@@ -285,6 +287,7 @@ func New(ctx context.Context,
 			return nil, err
 		}
 		options.profiles = cfg.Profiles
+		options.exportHighPrecisionMetrics = cfg.ExportHighPrecisionMetrics
 	}
 
 	registry := frameworkplugins.NewInTreeRegistry()
@@ -292,7 +295,7 @@ func New(ctx context.Context,
 		return nil, err
 	}
 
-	metrics.Register()
+	metrics.Register(options.exportHighPrecisionMetrics)
 
 	extenders, err := buildExtenders(logger, options.extenders, options.profiles)
 	if err != nil {

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -65,7 +65,7 @@ import (
 )
 
 func init() {
-	metrics.Register()
+	metrics.Register(true)
 }
 
 func TestSchedulerCreation(t *testing.T) {
@@ -252,7 +252,6 @@ func TestSchedulerCreation(t *testing.T) {
 }
 
 func TestFailureHandler(t *testing.T) {
-	metrics.Register()
 	testPod := st.MakePod().Name("test-pod").Namespace(v1.NamespaceDefault).Obj()
 	testPodUpdated := testPod.DeepCopy()
 	testPodUpdated.Labels = map[string]string{"foo": ""}


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
This is part of fixing https://github.com/kubernetes/kubernetes/issues/127384
Before this PR the values exported in the `scheduler_plugin_execution_duration_seconds_bucket` metric do not provide substantial information to kube-scheduler users or to sig-scheduling team. At the same time they tend to be a headache for cluster-admins, taking up memory.
This PR introduces more granular buckets for:
`scheduler_event_handling_duration_seconds
scheduler_plugin_execution_duration_seconds
scheduler_queueing_hint_execution_duration_seconds
scheduler_scheduling_algorithm_duration_seconds`
It also introduces a feature gate `SchedulerHighPrecisionMetrics` (disabled by default) that toggles exporting the metrics:
`scheduler_event_handling_duration_seconds
scheduler_plugin_execution_duration_seconds
scheduler_queueing_hint_execution_duration_seconds`
to help save memory in the clusters.
The values of bucket boundaries have been adjusted to fit both scheduler's performance tests and user's request.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #131209 
#### Special notes for your reviewer:
I will create issues with a very specific description for refactoring these tests to use mocks (and thus actually become unit tests). Hopefully I can phrase it clear enough to be a 'good-first-issue'.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Increased accuracy of scheduler metrics: 
- scheduler_event_handling_duration_seconds
- scheduler_plugin_execution_duration_seconds
- scheduler_queueing_hint_execution_duration_seconds
- scheduler_scheduling_algorithm_duration_seconds

Export of metrics:
- scheduler_event_handling_duration_seconds
- scheduler_plugin_execution_duration_seconds
- scheduler_queueing_hint_execution_duration_seconds
is feature gated by SchedulerHighPrecisionMetrics (disabled by default).
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
