### PR TITLE
Fix UnstructuredToVal map equality to respect nil fields

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/cel/common/values_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/common/values_test.go
@@ -319,6 +319,16 @@ func TestToValue(t *testing.T) {
 			},
 		},
 		{
+			name:       "compare: identical complex structs",
+			expression: "c1 == c2",
+			activation: map[string]typedValue{"c1": complex1, "c2": complex1Again},
+		},
+		{
+			name:       "compare: different complex structs",
+			expression: "c1 != c2",
+			activation: map[string]typedValue{"c1": complex1, "c2": complex2},
+		},
+		{
 			name:       "compare: struct and pointer to identical struct",
 			expression: "s1 == s1_ptr",
 			activation: map[string]typedValue{

--- a/staging/src/k8s.io/apiserver/pkg/cel/common/valuesunstructured.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/common/valuesunstructured.go
@@ -598,13 +598,17 @@ func (t *unstructuredMap) Equal(other ref.Val) ref.Val {
 	if t.Size() != oMap.Size() {
 		return types.False
 	}
+
 	for key, value := range t.value {
-		if propSchema, ok := t.propSchema(key); ok {
-			ov, found := oMap.Find(types.String(key))
-			if !found {
+		if _, ok := t.propSchema(key); ok {
+			v, found := t.Find(types.String(key))
+			ov, oFound := oMap.Find(types.String(key))
+			if found != oFound {
 				return types.False
 			}
-			v := UnstructuredToVal(value, propSchema)
+			if !found {
+				continue
+			}
 			vEq := v.Equal(ov)
 			if vEq != types.True {
 				return vEq // either false or error


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

This bug does NOT impact the Kubernetes API.

- CRDs normalize `null` to absent, even when `nullable:true` is set in the schema (see below verification)
- ValidatingAdmissionPolicy uses direct activations because schemas are not guaranteed to be present, and so UnstructuredToVal is not used.

#### Special notes for your reviewer:

Found while adding additional tests for https://github.com/kubernetes/kubernetes/pull/131460

#### Does this PR introduce a user-facing change?

This appears to be unreachable from user-facing API features.

```release-note
Fixed a bug in CEL's common.UnstructuredToVal where `==` evaluates to false for identical objects when a field is present but the value is null.  This bug does not impact the Kubernetes API.
```

This works as expected:

```yaml
apiVersion: apiextensions.k8s.io/v1
kind: CustomResourceDefinition
metadata:
  name: crontabs.stable.example.com
spec:
  group: stable.example.com
  versions:
    - name: v1
      served: true
      storage: true
      schema:
        openAPIV3Schema:
          type: object
          properties:
            spec:
              type: object
              x-kubernetes-validations:
                - rule: "self.list[0] == self.list[1]"
              properties:
                list:
                  type: array
                  items:
                    type: object
                    properties:
                      x:
                        type: string
                        nullable: true
  scope: Namespaced
  names:
    plural: crontabs
    singular: crontab
    kind: CronTab
    shortNames:
    - ct
 ```
 
 ```yaml
 apiVersion: stable.example.com/v1
kind: CronTab
metadata:
  name: my-cron-object
spec:
  list:
    - x: null
    - {}
 ```
 
```
kubectl apply -f equality-crd.yaml
kubectl apply -f equality.yaml
kubectl get -f equality.yaml -oyaml

apiVersion: stable.example.com/v1
kind: CronTab
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"stable.example.com/v1","kind":"CronTab","metadata":{"annotations":{},"name":"my-cron-object","namespace":"default"},"spec":{"list":[{"x":null},{"x":null}]}}
  creationTimestamp: "2025-04-30T13:44:24Z"
  generation: 2
  name: my-cron-object
  namespace: default
  resourceVersion: "244"
  uid: cd3bef5c-ff3a-4c9b-a834-75f54c11a525
spec:
  list:
  - {}
  - {}
```
 