### PR TITLE
Automated cherry pick of #131251: fix(kubelet): acquire imageRecordsLock when removing image

### DIFF
--- a/pkg/kubelet/images/image_gc_manager.go
+++ b/pkg/kubelet/images/image_gc_manager.go
@@ -494,7 +494,10 @@ func (im *realImageGCManager) freeImage(ctx context.Context, image evictionInfo,
 	if isRuntimeClassInImageCriAPIEnabled {
 		imageKey = getImageTuple(image.id, image.runtimeHandlerUsedToPullImage)
 	}
+
+	im.imageRecordsLock.Lock()
 	delete(im.imageRecords, imageKey)
+	im.imageRecordsLock.Unlock()
 
 	metrics.ImageGarbageCollectedTotal.WithLabelValues(reason).Inc()
 	return err


### PR DESCRIPTION
Cherry pick of #131251 on release-1.32.

#131251: fix(kubelet): acquire imageRecordsLock when removing image

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```