### PR TITLE
DRA e2e: avoid terminationGracePeriodSeconds

### DIFF
--- a/test/e2e/dra/test-driver/deploy/example/pod-external.yaml
+++ b/test/e2e/dra/test-driver/deploy/example/pod-external.yaml
@@ -23,15 +23,14 @@ spec:
   restartPolicy: Never
   containers:
   - name: with-resource
-    image: registry.k8s.io/e2e-test-images/busybox:1.36.1-1
-    command: ["sh", "-c", "set && mount && ls -la /dev/ && sleep 10000"]
+    image: registry.k8s.io/e2e-test-images/agnhost:2.53
+    command: ["sh", "-c", "set && mount && ls -la /dev/ && /agnhost pause"]
     resources:
       claims:
       - name: resource
   - name: without-resource
-    image: registry.k8s.io/e2e-test-images/busybox:1.36.1-1
-    command: ["sh", "-c", "set && mount && ls -la /dev/ && sleep 10000"]
-  terminationGracePeriodSeconds: 0 # Shut down immediately.
+    image: registry.k8s.io/e2e-test-images/agnhost:2.53
+    command: ["sh", "-c", "set && mount && ls -la /dev/ && /agnhost pause"]
   resourceClaims:
   - name: resource
     resourceClaimName: external-claim

--- a/test/e2e/dra/test-driver/deploy/example/pod-inline.yaml
+++ b/test/e2e/dra/test-driver/deploy/example/pod-inline.yaml
@@ -28,14 +28,14 @@ spec:
   restartPolicy: Never
   containers:
   - name: with-resource
-    image: registry.k8s.io/e2e-test-images/busybox:1.36.1-1
-    command: ["sh", "-c", "set && mount && ls -la /dev/ && sleep 10000"]
+    image: registry.k8s.io/e2e-test-images/agnhost:2.53
+    command: ["sh", "-c", "set && mount && ls -la /dev/ && /agnhost pause"]
     resources:
       claims:
       - name: resource
   - name: without-resource
-    image: registry.k8s.io/e2e-test-images/busybox:1.36.1-1
-    command: ["sh", "-c", "set && mount && ls -la /dev/ && sleep 10000"]
+    image: registry.k8s.io/e2e-test-images/agnhost:2.53
+    command: ["sh", "-c", "set && mount && ls -la /dev/ && /agnhost pause"]
   terminationGracePeriodSeconds: 0 # Shut down immediately.
   resourceClaims:
   - name: resource


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

`terminationGracePeriodSeconds: 0` was a mistake, it bypasses the normal pod shutdown in the kubelet.

The right way to shut down a pod quickly is to have it react to SIGTERM. The busybox implementation of "sleep" doesn't. `agnhost pause` does, so let's use that instead.

For E2E tests, the InfiniteSleepCommand was already change about a year ago to react to SIGTERM, so the `terminationGracePeriodSeconds: 1` workaround is no longer needed.

#### Which issue(s) this PR fixes:
Related-to: https://github.com/kubernetes/kubernetes/issues/131513#issuecomment-2842619440

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
