### PR TITLE
Continue alias creation when __completion is used to enable completion

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/kuberc/kuberc.go
+++ b/staging/src/k8s.io/kubectl/pkg/kuberc/kuberc.go
@@ -194,7 +194,7 @@ func (p *Preferences) applyAliases(rootCmd *cobra.Command, kuberc *config.Prefer
 	var commandName string // first "non-flag" arguments
 	var commandIndex int
 	for index, arg := range args[1:] {
-		if !strings.HasPrefix(arg, "-") {
+		if !strings.HasPrefix(arg, "-") && !strings.HasPrefix(arg, cobra.ShellCompRequestCmd) {
 			commandName = arg
 			commandIndex = index + 1
 			break


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This PR enables completion for the aliases defined in kuberc, as suggested https://github.com/kubernetes/kubectl/issues/1737#issuecomment-2842115936.

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubectl/issues/1737

#### Does this PR introduce a user-facing change?
```release-note
Enabling completion for aliases defined in kuberc
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
-[KEP]:  https://github.com/kubernetes/enhancements/tree/master/keps/sig-cli/3104-introduce-kuberc
```
