### PR TITLE
Expand CEL UnstructuredToVal and TypedToVal has() tests

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/cel/common/values_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/common/values_test.go
@@ -321,12 +321,12 @@ func TestToValue(t *testing.T) {
 		{
 			name:       "struct: omitzero: zero valued: does not have scalar fields",
 			expression: "!has(c.s) && !has(c.i) && !has(c.b) && !has(c.f)",
-			activation: map[string]typedValue{"c": structOmitEmpty1},
+			activation: map[string]typedValue{"c": structOmitZero1},
 		},
 		{
 			name:       "struct: omitzero: zero valued: does not have pointer to scalar fields",
 			expression: "!has(c.sp) && !has(c.ip) && !has(c.bp) && !has(c.fp)",
-			activation: map[string]typedValue{"c": structOmitEmpty1},
+			activation: map[string]typedValue{"c": structOmitZero1},
 		},
 		{
 			name:       "struct: omitzero: non-zero valued: has struct field",


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

With https://github.com/kubernetes/kubernetes/pull/130989 merged.  We need to ensure we handle both omitempty and omitzero correctly when converting data to CEL.

This adds test handling of `has()` as a way of ensuring the behavior is as expected.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

/sig api-machinery