### PR TITLE
Add TLD validation for namespace names to prevent DNS resolution issues

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/nstld/nstld.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/nstld/nstld.go
@@ -1,35 +1,49 @@
 package nstld
 
 import (
-    "fmt"
+	"fmt"
+	"os"
+	"strings"
 )
 
 // CommonTLDs contains a set of common top-level domains that should be
 // avoided when naming Kubernetes namespaces to prevent DNS resolution issues.
+// This list can be extended by setting the KUBECTL_ADDITIONAL_TLDS environment
+// variable with a comma-separated list of additional TLDs.
 var CommonTLDs = map[string]struct{}{
-    "com":  {},
-    "org":  {},
-    "net":  {},
-    "edu":  {},
-    "gov":  {},
-    "dev":  {},
-    "co":   {},
-    "info": {},
-    "biz":  {},
+	"com":  {},
+	"org":  {},
+	"net":  {},
+	"edu":  {},
+	"gov":  {},
+	"dev":  {},
+	"io": {},
+}
+
+func init() {
+	// Allow extending the TLD list via environment variable
+	if additionalTLDs := os.Getenv("KUBECTL_ADDITIONAL_TLDS"); additionalTLDs != "" {
+		for _, tld := range strings.Split(additionalTLDs, ",") {
+			tld = strings.TrimSpace(tld)
+			if tld != "" {
+				CommonTLDs[tld] = struct{}{}
+			}
+		}
+	}
 }
 
 // IsTLD checks if the provided namespace name is a common top-level domain.
 // Returns true if the namespace name matches a known TLD.
 func IsTLD(nsName string) bool {
-    _, isTLD := CommonTLDs[nsName]
-    return isTLD
+	_, isTLD := CommonTLDs[nsName]
+	return isTLD
 }
 
 // GetTLDWarningMessage returns a warning message if the namespace name
 // is a common top-level domain. If the name is not a TLD, returns an empty string.
 func GetTLDWarningMessage(nsName string) string {
-    if IsTLD(nsName) {
-        return fmt.Sprintf("Warning: Namespace name '%s' is a top-level domain (TLD). This may cause issues with DNS resolution.\n", nsName)
-    }
-    return ""
+	if IsTLD(nsName) {
+		return fmt.Sprintf("Warning: Namespace name '%s' is a top-level domain (TLD). This may cause issues with DNS resolution.\n", nsName)
+	}
+	return ""
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/nstld/nstld.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/nstld/nstld.go
@@ -1,0 +1,35 @@
+package nstld
+
+import (
+    "fmt"
+)
+
+// CommonTDLs contains a set of common top-level domains that should be
+// avoided when naming Kubernetes namespaces to prevent DNS resolution issues.
+var CommonTDLs = map[string]struct{}{
+    "com":  {},
+    "org":  {},
+    "net":  {},
+    "edu":  {},
+    "gov":  {},
+    "dev":  {},
+    "co":   {},
+    "info": {},
+    "biz":  {},
+}
+
+// IsTLD checks if the provided namespace name is a common top-level domain.
+// Returns true if the namespace name matches a known TLD.
+func IsTLD(nsName string) bool {
+    _, isTLD := CommonTDLs[nsName]
+    return isTLD
+}
+
+// GetTLDWarningMessage returns a warning message if the namespace name
+// is a common top-level domain. If the name is not a TLD, returns an empty string.
+func GetTLDWarningMessage(nsName string) string {
+    if IsTLD(nsName) {
+        return fmt.Sprintf("Warning: Namespace name '%s' is a top-level domain (TLD). This may cause issues with DNS resolution.\n", nsName)
+    }
+    return ""
+}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/nstld/nstld.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/nstld/nstld.go
@@ -4,9 +4,9 @@ import (
     "fmt"
 )
 
-// CommonTDLs contains a set of common top-level domains that should be
+// CommonTLDs contains a set of common top-level domains that should be
 // avoided when naming Kubernetes namespaces to prevent DNS resolution issues.
-var CommonTDLs = map[string]struct{}{
+var CommonTLDs = map[string]struct{}{
     "com":  {},
     "org":  {},
     "net":  {},
@@ -21,7 +21,7 @@ var CommonTDLs = map[string]struct{}{
 // IsTLD checks if the provided namespace name is a common top-level domain.
 // Returns true if the namespace name matches a known TLD.
 func IsTLD(nsName string) bool {
-    _, isTLD := CommonTDLs[nsName]
+    _, isTLD := CommonTLDs[nsName]
     return isTLD
 }
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/nstld/nstld_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/nstld/nstld_test.go
@@ -1,110 +1,271 @@
 package nstld
 
 import (
-    "strings"
-    "testing"
+	"os"
+	"strings"
+	"sync"
+	"testing"
 )
+
+var testOnce sync.Once
+
+func resetCommonTLDs() {
+	// Reset CommonTLDs to default values for testing
+	CommonTLDs = map[string]struct{}{
+		"com":  {},
+		"org":  {},
+		"net":  {},
+		"edu":  {},
+		"gov":  {},
+		"dev":  {},
+		"io":   {},
+	}
+}
 
 // TestIsTLD tests the IsTLD function which determines if a namespace name
 // is a common top-level domain (TLD).
 func TestIsTLD(t *testing.T) {
-    tests := []struct {
-        name     string
-        nsName   string
-        expected bool
-    }{
-        {
-            name:     "common TLD com",
-            nsName:   "com",
-            expected: true,
-        },
-        {
-            name:     "common TLD org",
-            nsName:   "org",
-            expected: true,
-        },
-        {
-            name:     "common TLD net",
-            nsName:   "net",
-            expected: true,
-        },
-        {
-            name:     "non TLD example",
-            nsName:   "example",
-            expected: false,
-        },
-        {
-            name:     "non TLD kubernetes",
-            nsName:   "kubernetes",
-            expected: false,
-        },
-        {
-            name:     "empty string",
-            nsName:   "",
-            expected: false,
-        },
-    }
+	testOnce.Do(resetCommonTLDs)
 
-    for _, tt := range tests {
-        t.Run(tt.name, func(t *testing.T) {
-            result := IsTLD(tt.nsName)
-            if result != tt.expected {
-                t.Errorf("IsTLD(%q) = %v, expected %v", tt.nsName, result, tt.expected)
-            }
-        })
-    }
+	tests := []struct {
+		name     string
+		nsName   string
+		expected bool
+	}{
+		{
+			name:     "common TLD com",
+			nsName:   "com",
+			expected: true,
+		},
+		{
+			name:     "common TLD org",
+			nsName:   "org",
+			expected: true,
+		},
+		{
+			name:     "common TLD net",
+			nsName:   "net",
+			expected: true,
+		},
+		{
+			name:     "non TLD example",
+			nsName:   "example",
+			expected: false,
+		},
+		{
+			name:     "non TLD kubernetes",
+			nsName:   "kubernetes",
+			expected: false,
+		},
+		{
+			name:     "empty string",
+			nsName:   "",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsTLD(tt.nsName)
+			if result != tt.expected {
+				t.Errorf("IsTLD(%q) = %v, expected %v", tt.nsName, result, tt.expected)
+			}
+		})
+	}
 }
 
 // TestGetTLDWarningMessage tests the GetTLDWarningMessage function which returns
 // a warning message if a namespace name is a common top-level domain (TLD).
 // The message warns users about potential DNS resolution issues.
 func TestGetTLDWarningMessage(t *testing.T) {
-    tests := []struct {
-        name          string
-        nsName        string
-        expectWarning bool
-    }{
-        {
-            name:          "common TLD com",
-            nsName:        "com",
-            expectWarning: true,
-        },
-        {
-            name:          "common TLD dev",
-            nsName:        "dev",
-            expectWarning: true,
-        },
-        {
-            name:          "non TLD example",
-            nsName:        "example",
-            expectWarning: false,
-        },
-        {
-            name:          "non TLD default",
-            nsName:        "default",
-            expectWarning: false,
-        },
-    }
+	testOnce.Do(resetCommonTLDs)
 
-    for _, tt := range tests {
-        t.Run(tt.name, func(t *testing.T) {
-            result := GetTLDWarningMessage(tt.nsName)
-            hasWarning := result != ""
+	tests := []struct {
+		name          string
+		nsName        string
+		expectWarning bool
+	}{
+		{
+			name:          "common TLD com",
+			nsName:        "com",
+			expectWarning: true,
+		},
+		{
+			name:          "common TLD dev",
+			nsName:        "dev",
+			expectWarning: true,
+		},
+		{
+			name:          "non TLD example",
+			nsName:        "example",
+			expectWarning: false,
+		},
+		{
+			name:          "non TLD default",
+			nsName:        "default",
+			expectWarning: false,
+		},
+	}
 
-            if hasWarning != tt.expectWarning {
-                t.Errorf("GetTLDWarningMessage(%q) warning presence = %v, expected %v", tt.nsName, hasWarning, tt.expectWarning)
-            }
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetTLDWarningMessage(tt.nsName)
+			hasWarning := result != ""
 
-            // If we expect a warning, validate the warning message content
-            if tt.expectWarning {
-                if !strings.Contains(result, tt.nsName) {
-                    t.Errorf("Warning message for %q does not contain the namespace name", tt.nsName)
-                }
+			if hasWarning != tt.expectWarning {
+				t.Errorf("GetTLDWarningMessage(%q) warning presence = %v, expected %v", tt.nsName, hasWarning, tt.expectWarning)
+			}
 
-                if !strings.Contains(result, "Warning") {
-                    t.Errorf("Warning message for %q does not contain 'Warning'", tt.nsName)
-                }
-            }
-        })
-    }
+			// If we expect a warning, validate the warning message content
+			if tt.expectWarning {
+				if !strings.Contains(result, tt.nsName) {
+					t.Errorf("Warning message for %q does not contain the namespace name", tt.nsName)
+				}
+
+				if !strings.Contains(result, "Warning") {
+					t.Errorf("Warning message for %q does not contain 'Warning'", tt.nsName)
+				}
+			}
+		})
+	}
+}
+
+// TestTLDEnvironmentVariable tests the initialization from environment variables
+func TestTLDEnvironmentVariable(t *testing.T) {
+	// Save original env and restore after test
+	originalEnv := os.Getenv("KUBECTL_ADDITIONAL_TLDS")
+	defer os.Setenv("KUBECTL_ADDITIONAL_TLDS", originalEnv)
+
+	// Reset to known state
+	resetCommonTLDs()
+
+	// Set test environment variable
+	os.Setenv("KUBECTL_ADDITIONAL_TLDS", "app,xyz,custom-tld")
+
+	// Apply environment variables directly to CommonTLDs
+	if additionalTLDs := os.Getenv("KUBECTL_ADDITIONAL_TLDS"); additionalTLDs != "" {
+		for _, tld := range strings.Split(additionalTLDs, ",") {
+			tld = strings.TrimSpace(tld)
+			if tld != "" {
+				CommonTLDs[tld] = struct{}{}
+			}
+		}
+	}
+
+	// Test custom TLDs
+	customTests := []struct {
+		name     string
+		tld      string
+		expected bool
+	}{
+		{
+			name:     "custom TLD app",
+			tld:      "app",
+			expected: true,
+		},
+		{
+			name:     "custom TLD xyz",
+			tld:      "xyz",
+			expected: true,
+		},
+		{
+			name:     "custom TLD with hyphen",
+			tld:      "custom-tld",
+			expected: true,
+		},
+		{
+			name:     "non-existent TLD",
+			tld:      "nonexistent",
+			expected: false,
+		},
+	}
+
+	for _, tt := range customTests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsTLD(tt.tld)
+			if result != tt.expected {
+				t.Errorf("After environment configuration, IsTLD(%q) = %v, expected %v",
+					tt.tld, result, tt.expected)
+			}
+
+			// Also check warning message generation
+			message := GetTLDWarningMessage(tt.tld)
+			hasWarning := message != ""
+
+			if hasWarning != tt.expected {
+				t.Errorf("GetTLDWarningMessage(%q) warning presence = %v, expected %v",
+					tt.tld, hasWarning, tt.expected)
+			}
+
+			if tt.expected && !strings.Contains(message, tt.tld) {
+				t.Errorf("Warning message for %q does not contain the TLD name", tt.tld)
+			}
+		})
+	}
+}
+
+// TestTLDEnvironmentVariableWithSpaces tests handling of spaces in the environment variable
+func TestTLDEnvironmentVariableWithSpaces(t *testing.T) {
+	// Save original env and restore after test
+	originalEnv := os.Getenv("KUBECTL_ADDITIONAL_TLDS")
+	defer os.Setenv("KUBECTL_ADDITIONAL_TLDS", originalEnv)
+
+	// Reset to known state
+	resetCommonTLDs()
+
+	// Set test environment variable with spaces
+	os.Setenv("KUBECTL_ADDITIONAL_TLDS", " space, leading,trailing ,  multiple  ")
+
+	// Apply environment variables directly to CommonTLDs
+	if additionalTLDs := os.Getenv("KUBECTL_ADDITIONAL_TLDS"); additionalTLDs != "" {
+		for _, tld := range strings.Split(additionalTLDs, ",") {
+			tld = strings.TrimSpace(tld)
+			if tld != "" {
+				CommonTLDs[tld] = struct{}{}
+			}
+		}
+	}
+
+	// Test TLDs with various spacing
+	spacingTests := []struct {
+		name     string
+		tld      string
+		expected bool
+	}{
+		{
+			name:     "TLD with spaces trimmed",
+			tld:      "space",
+			expected: true,
+		},
+		{
+			name:     "TLD with leading space trimmed",
+			tld:      "leading",
+			expected: true,
+		},
+		{
+			name:     "TLD with trailing space trimmed",
+			tld:      "trailing",
+			expected: true,
+		},
+		{
+			name:     "TLD with multiple spaces trimmed",
+			tld:      "multiple",
+			expected: true,
+		},
+		{
+			name:     "Empty TLD after trimming should be ignored",
+			tld:      "",
+			expected: false,
+		},
+	}
+
+	for _, tt := range spacingTests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsTLD(tt.tld)
+			if result != tt.expected {
+				t.Errorf("After environment configuration with spaces, IsTLD(%q) = %v, expected %v",
+					tt.tld, result, tt.expected)
+			}
+		})
+	}
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/nstld/nstld_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/nstld/nstld_test.go
@@ -1,0 +1,110 @@
+package nstld
+
+import (
+    "strings"
+    "testing"
+)
+
+// TestIsTLD tests the IsTLD function which determines if a namespace name
+// is a common top-level domain (TLD).
+func TestIsTLD(t *testing.T) {
+    tests := []struct {
+        name     string
+        nsName   string
+        expected bool
+    }{
+        {
+            name:     "common TLD com",
+            nsName:   "com",
+            expected: true,
+        },
+        {
+            name:     "common TLD org",
+            nsName:   "org",
+            expected: true,
+        },
+        {
+            name:     "common TLD net",
+            nsName:   "net",
+            expected: true,
+        },
+        {
+            name:     "non TLD example",
+            nsName:   "example",
+            expected: false,
+        },
+        {
+            name:     "non TLD kubernetes",
+            nsName:   "kubernetes",
+            expected: false,
+        },
+        {
+            name:     "empty string",
+            nsName:   "",
+            expected: false,
+        },
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            result := IsTLD(tt.nsName)
+            if result != tt.expected {
+                t.Errorf("IsTLD(%q) = %v, expected %v", tt.nsName, result, tt.expected)
+            }
+        })
+    }
+}
+
+// TestGetTLDWarningMessage tests the GetTLDWarningMessage function which returns
+// a warning message if a namespace name is a common top-level domain (TLD).
+// The message warns users about potential DNS resolution issues.
+func TestGetTLDWarningMessage(t *testing.T) {
+    tests := []struct {
+        name          string
+        nsName        string
+        expectWarning bool
+    }{
+        {
+            name:          "common TLD com",
+            nsName:        "com",
+            expectWarning: true,
+        },
+        {
+            name:          "common TLD dev",
+            nsName:        "dev",
+            expectWarning: true,
+        },
+        {
+            name:          "non TLD example",
+            nsName:        "example",
+            expectWarning: false,
+        },
+        {
+            name:          "non TLD default",
+            nsName:        "default",
+            expectWarning: false,
+        },
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            result := GetTLDWarningMessage(tt.nsName)
+            hasWarning := result != ""
+
+            if hasWarning != tt.expectWarning {
+                t.Errorf("GetTLDWarningMessage(%q) warning presence = %v, expected %v", tt.nsName, hasWarning, tt.expectWarning)
+            }
+
+            // If we expect a warning, validate the warning message content
+            if tt.expectWarning {
+                if !strings.Contains(result, tt.nsName) {
+                    t.Errorf("Warning message for %q does not contain the namespace name", tt.nsName)
+                }
+
+                if !strings.Contains(result, "Warning") {
+                    t.Errorf("Warning message for %q does not contain 'Warning'", tt.nsName)
+                }
+            }
+        })
+    }
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it:**
This PR adds validation to warn users when they attempt to create a namespace with a name that matches a common top-level domain (TLD). Using TLDs as namespace names can cause DNS resolution conflicts within the cluster, particularly with external services.

The [documentation](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/#:~:text=DNS%20labels.-,Warning,-%3A) already mentions this as a warning, but until now kubectl did not actively alert users of this problem when they create namespaces.

**Special notes for your reviewer:**
The implementation consists of:
1. A new utility package `nstld` to detect common top-level domains
2. Integration with the namespace creation workflow to display warnings
3. Support for customizing TLD list via the `KUBECTL_ADDITIONAL_TLDS` environment variable

**Does this PR introduce a user-facing change?**
```yes
Added TLD validation for namespace names to prevent DNS resolution issues

Added a warning mechanism that alerts users when creating a namespace with a name that matches 
a common top-level domain (TLD) such as "com", "org", or "net". These namespace names can cause 
DNS resolution conflicts within Kubernetes clusters, particularly when interacting with external services.

When creating a namespace with a name that matches a known TLD, kubectl now displays a warning message:

Warning: Namespace name 'com' is a top-level domain (TLD). This may cause DNS resolution conflicts in the cluster.

Users can extend the list of recognized TLDs by setting the `KUBECTL_ADDITIONAL_TLDS` environment variable
with a comma-separated list of domains (e.g., `export KUBECTL_ADDITIONAL_TLDS="app,custom,local"`).

This validation helps users avoid potential networking problems before they occur and aligns with 
the Kubernetes DNS best practices documented in the official documentation.

No action is required for existing namespaces, but users are encouraged to avoid using TLD names 
for new namespaces.