### PR TITLE
Enhance `kubectl get crd` output to include extra metadata beyond Name and Created-At

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition/etcd.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition/etcd.go
@@ -102,7 +102,7 @@ func (r *REST) Delete(ctx context.Context, name string, deleteValidation rest.Va
 		err = apierrors.NewConflict(
 			apiextensions.Resource("customresourcedefinitions"),
 			name,
-			fmt.Errorf("Precondition failed: UID in precondition: %v, UID in object meta: %v", *options.Preconditions.UID, crd.UID),
+			fmt.Errorf("precondition failed: UID in precondition: %v, UID in object meta: %v", *options.Preconditions.UID, crd.UID),
 		)
 		return nil, false, err
 	}
@@ -110,7 +110,7 @@ func (r *REST) Delete(ctx context.Context, name string, deleteValidation rest.Va
 		err = apierrors.NewConflict(
 			apiextensions.Resource("customresourcedefinitions"),
 			name,
-			fmt.Errorf("Precondition failed: ResourceVersion in precondition: %v, ResourceVersion in object meta: %v", *options.Preconditions.ResourceVersion, crd.ResourceVersion),
+			fmt.Errorf("precondition failed: ResourceVersion in precondition: %v, ResourceVersion in object meta: %v", *options.Preconditions.ResourceVersion, crd.ResourceVersion),
 		)
 		return nil, false, err
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition/etcd.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition/etcd.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
+	crdtable "k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition/tableconvertor"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -54,8 +55,7 @@ func NewREST(scheme *runtime.Scheme, optsGetter generic.RESTOptionsGetter) (*RES
 		DeleteStrategy:      strategy,
 		ResetFieldsStrategy: strategy,
 
-		// TODO: define table converter that exposes more than name/creation timestamp
-		TableConvertor: rest.NewDefaultTableConvertor(apiextensions.Resource("customresourcedefinitions")),
+		TableConvertor: crdtable.New(),
 	}
 	options := &generic.StoreOptions{RESTOptions: optsGetter, AttrFunc: GetAttrs}
 	if err := store.CompleteWithOptions(options); err != nil {

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition/strategy.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition/strategy.go
@@ -231,7 +231,7 @@ func CustomResourceDefinitionToSelectableFields(obj *apiextensions.CustomResourc
 // dropDisabledFields drops disabled fields that are not used if their associated feature gates
 // are not enabled.
 func dropDisabledFields(newCRD *apiextensions.CustomResourceDefinition, oldCRD *apiextensions.CustomResourceDefinition) {
-	if !utilfeature.DefaultFeatureGate.Enabled(apiextensionsfeatures.CRDValidationRatcheting) && (oldCRD == nil || (oldCRD != nil && !specHasOptionalOldSelf(&oldCRD.Spec))) {
+	if !utilfeature.DefaultFeatureGate.Enabled(apiextensionsfeatures.CRDValidationRatcheting) && (oldCRD == nil || !specHasOptionalOldSelf(&oldCRD.Spec)) {
 		if newCRD.Spec.Validation != nil {
 			dropOptionalOldSelfField(newCRD.Spec.Validation.OpenAPIV3Schema)
 		}
@@ -242,7 +242,7 @@ func dropDisabledFields(newCRD *apiextensions.CustomResourceDefinition, oldCRD *
 			}
 		}
 	}
-	if !utilfeature.DefaultFeatureGate.Enabled(apiextensionsfeatures.CustomResourceFieldSelectors) && (oldCRD == nil || (oldCRD != nil && !specHasSelectableFields(&oldCRD.Spec))) {
+	if !utilfeature.DefaultFeatureGate.Enabled(apiextensionsfeatures.CustomResourceFieldSelectors) && (oldCRD == nil || !specHasSelectableFields(&oldCRD.Spec)) {
 		dropSelectableFields(&newCRD.Spec)
 	}
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition/tableconvertor/tableconvertor.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition/tableconvertor/tableconvertor.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tableconvertor
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"time"
+
+	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/registry/rest"
+)
+
+var metaDocs = metav1.ObjectMeta{}.SwaggerDoc()
+
+func New() rest.TableConvertor { return &crdConvertor{} }
+
+type crdConvertor struct{}
+
+// ConvertToTable satisfies rest.TableConvertor.
+func (c *crdConvertor) ConvertToTable(ctx context.Context, obj runtime.Object, tableOpts runtime.Object) (*metav1.Table, error) {
+	table := &metav1.Table{}
+
+	if opt, _ := tableOpts.(*metav1.TableOptions); opt == nil || !opt.NoHeaders {
+		table.ColumnDefinitions = []metav1.TableColumnDefinition{
+			{Name: "Name", Type: "string", Format: "name", Description: metaDocs["name"]},
+			{Name: "Scope", Type: "string", Description: "Cluster/Namespaced"},
+			{Name: "Versions", Type: "string", Description: "Served versions"},
+			{Name: "Created At", Type: "date", Description: metaDocs["creationTimestamp"]},
+			{Name: "Group", Type: "string", Priority: 1, Description: "API group"},
+			{Name: "Kind", Type: "string", Priority: 1, Description: "CustomResource kind"},
+			{Name: "ShortNames", Type: "string", Priority: 1, Description: "Short names"},
+			{Name: "Established", Type: "boolean", Priority: 1, Description: "Established status"},
+		}
+	}
+
+	addRow := func(cr *apiextensions.CustomResourceDefinition) {
+		// versions: only served=true
+		var versions []string
+		for _, v := range cr.Spec.Versions {
+			if v.Served {
+				label := v.Name
+				if v.Storage {
+					label += "(storage)"
+				}
+				versions = append(versions, label)
+			}
+		}
+		sort.Strings(versions)
+
+		shortNames := strings.Join(cr.Spec.Names.ShortNames, ",")
+
+		table.Rows = append(table.Rows, metav1.TableRow{
+			Object: runtime.RawExtension{Object: cr},
+			Cells: []interface{}{
+				cr.Name,
+				string(cr.Spec.Scope),
+				strings.Join(versions, ","),
+				cr.CreationTimestamp.Time.UTC().Format(time.RFC3339),
+				cr.Spec.Group,
+				cr.Spec.Names.Kind,
+				shortNames,
+				isEstablished(cr),
+			},
+		})
+	}
+
+	switch {
+	case meta.IsListType(obj):
+		_ = meta.EachListItem(obj, func(item runtime.Object) error {
+			if cr, ok := item.(*apiextensions.CustomResourceDefinition); ok {
+				addRow(cr)
+			}
+			return nil
+		})
+	default:
+		if cr, ok := obj.(*apiextensions.CustomResourceDefinition); ok {
+			addRow(cr)
+		}
+	}
+
+	if l, err := meta.ListAccessor(obj); err == nil {
+		table.ResourceVersion = l.GetResourceVersion()
+		table.Continue = l.GetContinue()
+		table.RemainingItemCount = l.GetRemainingItemCount()
+	} else if m, err := meta.CommonAccessor(obj); err == nil {
+		table.ResourceVersion = m.GetResourceVersion()
+	}
+
+	return table, nil
+}
+
+// isEstablished returns true if the CRD has the Established condition with Status=True.
+func isEstablished(crd *apiextensions.CustomResourceDefinition) bool {
+	for _, cond := range crd.Status.Conditions {
+		if cond.Type == apiextensions.Established && cond.Status == apiextensions.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition/tableconvertor/tableconvertor_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition/tableconvertor/tableconvertor_test.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tableconvertor
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const Wide metav1.IncludeObjectPolicy = "wide"
+
+func TestPrintCRD(t *testing.T) {
+	tests := []struct {
+		name   string
+		crd    *apiextensions.CustomResourceDefinition
+		expect []any
+	}{
+		{
+			name: "Return table for CRD with wide options",
+			crd: &apiextensions.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "foos.sample.example.com",
+					CreationTimestamp: metav1.NewTime(time.Date(2025, 5, 3, 16, 36, 32, 0, time.UTC)),
+				},
+				Spec: apiextensions.CustomResourceDefinitionSpec{
+					Group: "sample.example.com",
+					Scope: apiextensions.NamespaceScoped,
+					Versions: []apiextensions.CustomResourceDefinitionVersion{
+						{Name: "v1", Served: true, Storage: true},
+						{Name: "v1beta1", Served: true, Storage: false},
+					},
+					Names: apiextensions.CustomResourceDefinitionNames{Kind: "Foo", ShortNames: []string{"f"}},
+				},
+				Status: apiextensions.CustomResourceDefinitionStatus{
+					Conditions: []apiextensions.CustomResourceDefinitionCondition{
+						{Type: apiextensions.Established, Status: apiextensions.ConditionTrue},
+					},
+				},
+			},
+			expect: []any{
+				"foos.sample.example.com",
+				"Namespaced",
+				"v1(storage),v1beta1",
+				"2025-05-03T16:36:32Z",
+				"sample.example.com",
+				"Foo",
+				"f",
+				true,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			table, err := New().ConvertToTable(context.Background(), tc.crd, &metav1.TableOptions{})
+			if err != nil {
+				t.Fatalf("ConvertToTable error: %v", err)
+			}
+			got := table.Rows[0].Cells
+			if len(got) != len(tc.expect) {
+				t.Fatalf("expected %d cells, got %d (%#v)", len(tc.expect), len(got), got)
+			}
+			for i, want := range tc.expect {
+				if got[i] != want {
+					t.Errorf("cell[%d] = %v, want %v", i, got[i], want)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Enhance kubectl get crd output to include extra metadata beyond Name and Created-At for better visibility of CustomResourceDefinitions.

- Before (default columns only showed `NAME` and `CREATED AT`):
```
$ kubectl get crd
NAME                      CREATED AT
foos.sample.example.com   2025-05-03T16:36:32Z
```

- After (now shows NAME, GROUP, SCOPE, VERSIONS, and CREATED AT):
```
$ kubectl get crd
NAME                      GROUP                SCOPE        VERSIONS     CREATED AT
foos.sample.example.com   sample.example.com   Namespaced   v1,v1beta1   2025-05-03T16:36:32Z
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
This PR implements a default TableConvertor for CRDs.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
`kubectl get crd` now displays additional columns—GROUP, SCOPE, VERSIONS, and CREATED AT—alongside NAME.  

This provides at-a-glance visibility into the API group, scope (Cluster‑ or Namespaced), served versions (comma‑separated), and exact creation timestamp of each CustomResourceDefinition.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
