### PR TITLE
kubeadm: bring back the klog flags removed in #125179

### DIFF
--- a/cmd/kubeadm/app/kubeadm.go
+++ b/cmd/kubeadm/app/kubeadm.go
@@ -32,16 +32,45 @@ import (
 func Run() error {
 	var allFlags flag.FlagSet
 	klog.InitFlags(&allFlags)
-	// only add the flags that are still supported for kubeadm
+	// Only add the flags that are currently supported for kubeadm. This
+	// preprevents new klog flags from being accidentally exposed.
 	allFlags.VisitAll(func(f *flag.Flag) {
 		switch f.Name {
-		case "v", "add_dir_header", "skip_headers":
+		case
+			"v",
+			"add_dir_header",
+			"skip_headers",
+			// Below are flags we support but don't expose in the help.
+			"alsologtostderr",
+			"log_backtrace_at",
+			"log_dir",
+			"logtostderr",
+			"log_file",
+			"log_file_max_size",
+			"one_output",
+			"skip_log_headers",
+			"stderrthreshold",
+			"vmodule":
 			flag.CommandLine.Var(f.Value, f.Name, f.Usage)
 		}
 	})
 
 	pflag.CommandLine.SetNormalizeFunc(cliflag.WordSepNormalizeFunc)
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
+
+	// We hide the klog flags that most users will not care about to reduce the
+	// clutter from the output. Note that these MarkHidden calls must be after
+	// the lines above.
+	pflag.CommandLine.MarkHidden("alsologtostderr")
+	pflag.CommandLine.MarkHidden("log-backtrace-at")
+	pflag.CommandLine.MarkHidden("log-dir")
+	pflag.CommandLine.MarkHidden("logtostderr")
+	pflag.CommandLine.MarkHidden("log-file")          //nolint:errcheck
+	pflag.CommandLine.MarkHidden("log-file-max-size") //nolint:errcheck
+	pflag.CommandLine.MarkHidden("one-output")        //nolint:errcheck
+	pflag.CommandLine.MarkHidden("skip-log-headers")  //nolint:errcheck
+	pflag.CommandLine.MarkHidden("stderrthreshold")
+	pflag.CommandLine.MarkHidden("vmodule")
 
 	cmd := cmd.NewKubeadmCommand(os.Stdin, os.Stdout, os.Stderr)
 	return cmd.Execute()

--- a/cmd/kubeadm/app/kubeadm.go
+++ b/cmd/kubeadm/app/kubeadm.go
@@ -61,16 +61,16 @@ func Run() error {
 	// We hide the klog flags that most users will not care about to reduce the
 	// clutter from the output. Note that these MarkHidden calls must be after
 	// the lines above.
-	pflag.CommandLine.MarkHidden("alsologtostderr")
-	pflag.CommandLine.MarkHidden("log-backtrace-at")
-	pflag.CommandLine.MarkHidden("log-dir")
-	pflag.CommandLine.MarkHidden("logtostderr")
+	pflag.CommandLine.MarkHidden("alsologtostderr")   //nolint:errcheck
+	pflag.CommandLine.MarkHidden("log-backtrace-at")  //nolint:errcheck
+	pflag.CommandLine.MarkHidden("log-dir")           //nolint:errcheck
+	pflag.CommandLine.MarkHidden("logtostderr")       //nolint:errcheck
 	pflag.CommandLine.MarkHidden("log-file")          //nolint:errcheck
 	pflag.CommandLine.MarkHidden("log-file-max-size") //nolint:errcheck
 	pflag.CommandLine.MarkHidden("one-output")        //nolint:errcheck
 	pflag.CommandLine.MarkHidden("skip-log-headers")  //nolint:errcheck
-	pflag.CommandLine.MarkHidden("stderrthreshold")
-	pflag.CommandLine.MarkHidden("vmodule")
+	pflag.CommandLine.MarkHidden("stderrthreshold")   //nolint:errcheck
+	pflag.CommandLine.MarkHidden("vmodule")           //nolint:errcheck
 
 	cmd := cmd.NewKubeadmCommand(os.Stdin, os.Stdout, os.Stderr)
 	return cmd.Execute()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
/kind regression

#### What this PR does / why we need it:

The klog flags are still useful for producing a paper trail of the execution of the kubeadm. This PR preserves the limiting of the flags kubeadm exposes added in #125179.

#### Special notes for your reviewer:

None.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: bring back the `--alsologtostderr`, `--log-backtrace-at`, `--log-dir`, `--logtostderr`, `--log-file`, `--log-file-max-size`, `--one-output`, `--skip-log-headers`, `--stderrthreshold`, `--vmodule` removed in #125179. The flags are still hidden as before to reduce clutter.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

None.
