### PR TITLE
volumezone: add single-zone detection

### DIFF
--- a/pkg/scheduler/framework/plugins/volumezone/volume_zone.go
+++ b/pkg/scheduler/framework/plugins/volumezone/volume_zone.go
@@ -234,6 +234,7 @@ func (pl *VolumeZone) Filter(ctx context.Context, cs *framework.CycleState, pod 
 	}
 	if !hasAnyNodeConstraint {
 		// Reject: multi-zone cluster but node missing zone label
+		logger.V(10).Info("Won't schedule pod onto node due to missing topology label", "pod", klog.KObj(pod), "node", klog.KObj(node), "PV", klog.KRef("", pvTopology.pvName), "PVLabelKey", pvTopology.key)
 		return framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReasonConflict)
 	}
 

--- a/pkg/scheduler/framework/plugins/volumezone/volume_zone.go
+++ b/pkg/scheduler/framework/plugins/volumezone/volume_zone.go
@@ -238,8 +238,9 @@ func (pl *VolumeZone) Filter(ctx context.Context, cs *framework.CycleState, pod 
 		return nil
 	}
 	if !hasAnyNodeConstraint {
-		// Reject: multi-zone cluster but node missing zone label
+		// Reject: multi-zone cluster but node missing zone label, but can be resolved later if zone is label is added 
 		logger.V(10).Info("Won't schedule pod onto node due to missing topology label", "pod", klog.KObj(pod), "node", klog.KObj(node))
+		return framework.NewStatus(framework.Unschedulable, "missing topology label")
 	}
 
 	for _, pvTopology := range podPVTopologies {

--- a/pkg/scheduler/framework/plugins/volumezone/volume_zone.go
+++ b/pkg/scheduler/framework/plugins/volumezone/volume_zone.go
@@ -238,9 +238,9 @@ func (pl *VolumeZone) Filter(ctx context.Context, cs *framework.CycleState, pod 
 		return nil
 	}
 	if !hasAnyNodeConstraint {
-		// Reject: multi-zone cluster but node missing zone label
+		// Mark multi-zone cluster but node missing zone label as unresolvable
 		logger.V(10).Info("Won't schedule pod onto node due to missing topology label", "pod", klog.KObj(pod), "node", klog.KObj(node))
-		return framework.NewStatus(framework.UnschedulableAndUnresolvable, "missing topology label")
+		return fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "missing topology label")
 	}
 
 	for _, pvTopology := range podPVTopologies {

--- a/pkg/scheduler/framework/plugins/volumezone/volume_zone.go
+++ b/pkg/scheduler/framework/plugins/volumezone/volume_zone.go
@@ -217,18 +217,15 @@ func (pl *VolumeZone) Filter(ctx context.Context, cs *framework.CycleState, pod 
 	}
 
 	singleZone := true
-	zoneKey := ""
+	zones := sets.New[string]()
 
-	// For each PV‐topology constraint on the pod…
+	// For each check if there exists multiple zones
 	for _, pvTopology := range podPVTopologies {
-		if _, ok := node.Labels[pvTopology.key]; !ok {
-			continue
-		}
-		if zoneKey == "" {
-			zoneKey = pvTopology.key
-		} else if zoneKey != pvTopology.key {
+		if len(pvTopology.values) > 1 || len(zones) > 1 {
 			singleZone = false
 			break
+		} else if len(pvTopology.values) == 1 {
+			zones.Union(pvTopology.values)
 		}
 	}
 

--- a/pkg/scheduler/framework/plugins/volumezone/volume_zone.go
+++ b/pkg/scheduler/framework/plugins/volumezone/volume_zone.go
@@ -238,9 +238,9 @@ func (pl *VolumeZone) Filter(ctx context.Context, cs *framework.CycleState, pod 
 		return nil
 	}
 	if !hasAnyNodeConstraint {
-		// Reject: multi-zone cluster but node missing zone label, but can be resolved later if zone is label is added 
+		// Reject: multi-zone cluster but node missing zone label
 		logger.V(10).Info("Won't schedule pod onto node due to missing topology label", "pod", klog.KObj(pod), "node", klog.KObj(node))
-		return framework.NewStatus(framework.Unschedulable, "missing topology label")
+		return framework.NewStatus(framework.UnschedulableAndUnresolvable, "missing topology label")
 	}
 
 	for _, pvTopology := range podPVTopologies {

--- a/pkg/scheduler/framework/plugins/volumezone/volume_zone_test.go
+++ b/pkg/scheduler/framework/plugins/volumezone/volume_zone_test.go
@@ -347,6 +347,7 @@ func TestMultiZone(t *testing.T) {
 					Name: "host1",
 				},
 			},
+			wantFilterStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "missing topology label"),
 		},
 		{
 			name: "beta zone label matched",


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Fixes edge case/unhandled scenario of having multi-zones, with a node missing a topology label. Currently, schedules node by default if a node has no label; can cause pod to be scheduled where PV is not available.

Addresses issue 

#### Which issue(s) this PR fixes:

Fixes #117983

#### Special notes for your reviewer:

Theres two potential solutions I thought of for fixing this issue. Either the current solution of counting each time in the filter, or using SnapshotSharedLister().NodeInfos().List() in the prefilter. However, my solution for that involves using framework.handle, which doesn't preserve the statelessness of the code.

#### Does this PR introduce a user-facing change?

```release-note
Scheduler now rejects scheduling a pod onto a node missing topology labels in multi-zone clusters.
```
