### PR TITLE
test: bump agnhost image to 2.54

### DIFF
--- a/test/e2e/dra/test-driver/deploy/example/pod-inline.yaml
+++ b/test/e2e/dra/test-driver/deploy/example/pod-inline.yaml
@@ -28,13 +28,13 @@ spec:
   restartPolicy: Never
   containers:
   - name: with-resource
-    image: registry.k8s.io/e2e-test-images/agnhost:2.53
+    image: registry.k8s.io/e2e-test-images/agnhost:2.54
     command: ["sh", "-c", "set && mount && ls -la /dev/ && /agnhost pause"]
     resources:
       claims:
       - name: resource
   - name: without-resource
-    image: registry.k8s.io/e2e-test-images/agnhost:2.53
+    image: registry.k8s.io/e2e-test-images/agnhost:2.54
     command: ["sh", "-c", "set && mount && ls -la /dev/ && /agnhost pause"]
   terminationGracePeriodSeconds: 0 # Shut down immediately.
   resourceClaims:

--- a/test/e2e/testing-manifests/ingress/gce/static-ip-2/rc.yaml
+++ b/test/e2e/testing-manifests/ingress/gce/static-ip-2/rc.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
       - name: echoheaders-https
-        image: registry.k8s.io/e2e-test-images/agnhost:2.39
+        image: registry.k8s.io/e2e-test-images/agnhost:2.54
         command:
         - /agnhost
         - netexec

--- a/test/e2e/testing-manifests/ingress/http/rc.yaml
+++ b/test/e2e/testing-manifests/ingress/http/rc.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
       - name: echoheaders
-        image: registry.k8s.io/e2e-test-images/agnhost:2.39
+        image: registry.k8s.io/e2e-test-images/agnhost:2.54
         command:
         - /agnhost
         - netexec

--- a/test/e2e/testing-manifests/ingress/http2/rc.yaml
+++ b/test/e2e/testing-manifests/ingress/http2/rc.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: echoheaders
-        image: registry.k8s.io/e2e-test-images/agnhost:2.39
+        image: registry.k8s.io/e2e-test-images/agnhost:2.54
         command:
         - /agnhost
         - netexec

--- a/test/e2e/testing-manifests/ingress/multiple-certs/rc.yaml
+++ b/test/e2e/testing-manifests/ingress/multiple-certs/rc.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
       - name: echoheaders-https
-        image: registry.k8s.io/e2e-test-images/agnhost:2.39
+        image: registry.k8s.io/e2e-test-images/agnhost:2.54
         command:
         - /agnhost
         - netexec

--- a/test/e2e/testing-manifests/ingress/neg-clusterip/rc.yaml
+++ b/test/e2e/testing-manifests/ingress/neg-clusterip/rc.yaml
@@ -15,7 +15,7 @@ spec:
         run: hostname
     spec:
       containers:
-      - image: registry.k8s.io/e2e-test-images/agnhost:2.32
+      - image: registry.k8s.io/e2e-test-images/agnhost:2.54
         command: ["/agnhost", "serve-hostname"]
         imagePullPolicy: IfNotPresent
         name: hostname

--- a/test/e2e/testing-manifests/ingress/neg-exposed/rc.yaml
+++ b/test/e2e/testing-manifests/ingress/neg-exposed/rc.yaml
@@ -14,13 +14,13 @@ spec:
         run: hostname
     spec:
       containers:
-      - image: registry.k8s.io/e2e-test-images/agnhost:2.32
+      - image: registry.k8s.io/e2e-test-images/agnhost:2.54
         name: host1
         args: ["serve-hostname", "--http=true", "--udp=false", "--port=8000"]
         ports:
         - protocol: TCP
           containerPort: 8000
-      - image: registry.k8s.io/e2e-test-images/agnhost:2.32
+      - image: registry.k8s.io/e2e-test-images/agnhost:2.54
         name: host2
         args: ["serve-hostname", "--http=true", "--udp=false", "--port=8080"]
         ports:

--- a/test/e2e/testing-manifests/ingress/neg/rc.yaml
+++ b/test/e2e/testing-manifests/ingress/neg/rc.yaml
@@ -15,7 +15,7 @@ spec:
         run: hostname
     spec:
       containers:
-      - image: registry.k8s.io/e2e-test-images/agnhost:2.32
+      - image: registry.k8s.io/e2e-test-images/agnhost:2.54
         command: ["/agnhost", "serve-hostname"]
         imagePullPolicy: IfNotPresent
         name: hostname

--- a/test/e2e/testing-manifests/ingress/pre-shared-cert/rc.yaml
+++ b/test/e2e/testing-manifests/ingress/pre-shared-cert/rc.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
       - name: echoheaders-https
-        image: registry.k8s.io/e2e-test-images/agnhost:2.39
+        image: registry.k8s.io/e2e-test-images/agnhost:2.54
         command:
         - /agnhost
         - netexec

--- a/test/e2e/testing-manifests/ingress/static-ip/rc.yaml
+++ b/test/e2e/testing-manifests/ingress/static-ip/rc.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
       - name: echoheaders-https
-        image: registry.k8s.io/e2e-test-images/agnhost:2.39
+        image: registry.k8s.io/e2e-test-images/agnhost:2.54
         command:
         - /agnhost
         - netexec

--- a/test/e2e/testing-manifests/kubectl/agnhost-primary-pod.yaml
+++ b/test/e2e/testing-manifests/kubectl/agnhost-primary-pod.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   containers:
     - name: primary
-      image: registry.k8s.io/e2e-test-images/agnhost:2.32
+      image: registry.k8s.io/e2e-test-images/agnhost:2.54
       env:
         - name: PRIMARY
           value: "true"
@@ -21,7 +21,7 @@ spec:
         - mountPath: /agnhost-primary-data
           name: data
     - name: sentinel
-      image: registry.k8s.io/e2e-test-images/agnhost:2.32
+      image: registry.k8s.io/e2e-test-images/agnhost:2.54
       env:
         - name: SENTINEL
           value: "true"

--- a/test/e2e/testing-manifests/serviceloadbalancer/netexecrc.yaml
+++ b/test/e2e/testing-manifests/serviceloadbalancer/netexecrc.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
       - name: netexec
-        image: registry.k8s.io/e2e-test-images/agnhost:2.32
+        image: registry.k8s.io/e2e-test-images/agnhost:2.54
         command: ["/agnhost", "netexec"]
         ports:
         - containerPort: 8080

--- a/test/fixtures/doc-yaml/user-guide/multi-pod.yaml
+++ b/test/fixtures/doc-yaml/user-guide/multi-pod.yaml
@@ -42,7 +42,7 @@ metadata:
 spec:
   containers:
   - name: kubernetes-serve-hostname
-    image: registry.k8s.io/e2e-test-images/agnhost:2.32
+    image: registry.k8s.io/e2e-test-images/agnhost:2.54
     command: ["/agnhost", "serve-hostname"]
     resources:
       limits:

--- a/test/fixtures/pkg/kubectl/cmd/auth/rbac-resource-plus.yaml
+++ b/test/fixtures/pkg/kubectl/cmd/auth/rbac-resource-plus.yaml
@@ -30,7 +30,7 @@ items:
   spec:
     containers:
     - name: kubernetes-serve-hostname
-      image: registry.k8s.io/e2e-test-images/agnhost:2.32
+      image: registry.k8s.io/e2e-test-images/agnhost:2.54
       command: ["/agnhost", "serve-hostname"]
       resources:
         limits:

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -216,7 +216,7 @@ const (
 
 func initImageConfigs(list RegistryList) (map[ImageID]Config, map[ImageID]Config) {
 	configs := map[ImageID]Config{}
-	configs[Agnhost] = Config{list.PromoterE2eRegistry, "agnhost", "2.53"}
+	configs[Agnhost] = Config{list.PromoterE2eRegistry, "agnhost", "2.54"}
 	configs[AgnhostPrivate] = Config{list.PrivateRegistry, "agnhost", "2.6"}
 	configs[AuthenticatedAlpine] = Config{list.GcAuthenticatedRegistry, "alpine", "3.7"}
 	configs[AuthenticatedWindowsNanoServer] = Config{list.GcAuthenticatedRegistry, "windows-nanoserver", "v1"}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Better support for signals in the pause command.

#### Special notes for your reviewer:

YAML files were patched with:

    sed -i -e 's;registry.k8s.io/e2e-test-images/agnhost:2...;registry.k8s.io/e2e-test-images/agnhost:2.54;' $(git grep -l agnhost:2 test/e2e/testing-manifests/ test/fixtures/)

The test/images/kitten and test/images/nautilus base images are still on an older agnhost because updating those is better left to the owners.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @aojea 