### PR TITLE
golangci-lint: some fixes after migration to v2

### DIFF
--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -91,6 +91,17 @@ linters:
         text: should not use Add, use AddVersioned instead
         path: _test.go$
 
+      # The Kubernetes naming convention for conversion functions uses underscores
+      # and intentionally deviates from normal Go conventions to make those function
+      # names more readable. Same for SetDefaults_*.
+      #
+      # https://github.com/kubernetes/kubernetes/issues/117288#issuecomment-1507028627
+      # https://github.com/kubernetes/kubernetes/issues/117288#issuecomment-1514201592
+      - linters:
+          - staticcheck
+          - revive
+        text: "(ST1003: should not use underscores in Go names; func ([cC]onvert_.*_To_.*|[sS]etDefaults_)|exported: exported function (Convert|SetDefaults)_.* should be of the form)"
+
       - path: (.+)\.go$
         # staticcheck: Developers tend to write in C-style with an explicit 'break' in a 'switch', so it's ok to ignore
         text: ineffective break statement. Did you mean to break out of the outer loop

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -91,6 +91,17 @@ linters:
         text: should not use Add, use AddVersioned instead
         path: _test.go$
 
+      # The Kubernetes naming convention for conversion functions uses underscores
+      # and intentionally deviates from normal Go conventions to make those function
+      # names more readable. Same for SetDefaults_*.
+      #
+      # https://github.com/kubernetes/kubernetes/issues/117288#issuecomment-1507028627
+      # https://github.com/kubernetes/kubernetes/issues/117288#issuecomment-1514201592
+      - linters:
+          - staticcheck
+          - revive
+        text: "(ST1003: should not use underscores in Go names; func ([cC]onvert_.*_To_.*|[sS]etDefaults_)|exported: exported function (Convert|SetDefaults)_.* should be of the form)"
+
       # TODO(https://github.com/kubernetes/kubernetes/issues/131475): Remove these excluded directories and fix findings. Due to large amount of findings in different components
       # with different owners it's hard to fix everything in a single pr. This will therefore be done in multiple prs.
       - path: (pkg/volume/*|test/*|azure/*|pkg/cmd/wait*|request/bearertoken/*|metrics/*|filters/*)

--- a/hack/golangci.yaml.in
+++ b/hack/golangci.yaml.in
@@ -91,6 +91,17 @@ linters:
         text: should not use Add, use AddVersioned instead
         path: _test.go$
 
+      # The Kubernetes naming convention for conversion functions uses underscores
+      # and intentionally deviates from normal Go conventions to make those function
+      # names more readable. Same for SetDefaults_*.
+      #
+      # https://github.com/kubernetes/kubernetes/issues/117288#issuecomment-1507028627
+      # https://github.com/kubernetes/kubernetes/issues/117288#issuecomment-1514201592
+      - linters:
+          - staticcheck
+          - revive
+        text: "(ST1003: should not use underscores in Go names; func ([cC]onvert_.*_To_.*|[sS]etDefaults_)|exported: exported function (Convert|SetDefaults)_.* should be of the form)"
+
       {{- if .Hints}}
 
       - path: (.+)\.go$


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test
/priority critical-urgent
/assign @aojea 

#### What this PR does / why we need it:

The v2 migration and updating of the golangci-lint invocation had some unintended side effects:

- linter issues were written to stdout asynchronously, making them invisible in the failure message (https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/127887/pull-kubernetes-linter-hints/1919016493312380928)
- the conversion and defaulting exception is still needed

#### Special notes for your reviewer:

The `> >(sed ...)` redirection runs sed in the background without waiting for it, which can be reproduced like this:
```console
$ echo hello > >(sleep 5; cat; echo done2); echo done
done
$ ps
    PID TTY          TIME CMD
   2649 pts/0    00:00:01 bash
 282417 pts/0    00:00:00 bash
 282418 pts/0    00:00:00 sleep
 282420 pts/0    00:00:00 ps
$ hello
done2
```

For the PR above, these issues should be ignored and weren't:
```
ERROR: staging/src/k8s.io/dynamic-resource-allocation/api/v1beta1/conversion.go:28:6: ST1003: should not use underscores in Go names; func Convert_v1beta1_DeviceRequest_To_v1beta2_DeviceRequest should be ConvertV1beta1DeviceRequestToV1beta2DeviceRequest (staticcheck)
ERROR: func Convert_v1beta1_DeviceRequest_To_v1beta2_DeviceRequest(in *resourcev1beta1.DeviceRequest, out *resourceapi.DeviceRequest, s conversion.Scope) error {
ERROR:      ^
ERROR: staging/src/k8s.io/dynamic-resource-allocation/api/v1beta1/conversion.go:75:6: ST1003: should not use underscores in Go names; func Convert_v1beta2_DeviceRequest_To_v1beta1_DeviceRequest should be ConvertV1beta2DeviceRequestToV1beta1DeviceRequest (staticcheck)
ERROR: func Convert_v1beta2_DeviceRequest_To_v1beta1_DeviceRequest(in *resourceapi.DeviceRequest, out *resourcev1beta1.DeviceRequest, s conversion.Scope) error {
ERROR:      ^
ERROR: staging/src/k8s.io/dynamic-resource-allocation/api/v1beta1/conversion.go:109:6: ST1003: should not use underscores in Go names; func Convert_v1beta1_ResourceSliceSpec_To_v1beta2_ResourceSliceSpec should be ConvertV1beta1ResourceSliceSpecToV1beta2ResourceSliceSpec (staticcheck)
ERROR: func Convert_v1beta1_ResourceSliceSpec_To_v1beta2_ResourceSliceSpec(in *resourcev1beta1.ResourceSliceSpec, out *resourceapi.ResourceSliceSpec, s conversion.Scope) error {
ERROR:      ^
ERROR: staging/src/k8s.io/dynamic-resource-allocation/api/v1beta1/conversion.go:126:6: ST1003: should not use underscores in Go names; func Convert_v1beta2_ResourceSliceSpec_To_v1beta1_ResourceSliceSpec should be ConvertV1beta2ResourceSliceSpecToV1beta1ResourceSliceSpec (staticcheck)
ERROR: func Convert_v1beta2_ResourceSliceSpec_To_v1beta1_ResourceSliceSpec(in *resourceapi.ResourceSliceSpec, out *resourcev1beta1.ResourceSliceSpec, s conversion.Scope) error {
ERROR:      ^
ERROR: staging/src/k8s.io/dynamic-resource-allocation/api/v1beta1/conversion.go:143:6: ST1003: should not use underscores in Go names; func Convert_v1beta1_Device_To_v1beta2_Device should be ConvertV1beta1DeviceToV1beta2Device (staticcheck)
ERROR: func Convert_v1beta1_Device_To_v1beta2_Device(in *resourcev1beta1.Device, out *resourceapi.Device, s conversion.Scope) error {
ERROR:      ^
ERROR: staging/src/k8s.io/dynamic-resource-allocation/api/v1beta1/conversion.go:188:6: ST1003: should not use underscores in Go names; func Convert_v1beta2_Device_To_v1beta1_Device should be ConvertV1beta2DeviceToV1beta1Device (staticcheck)
ERROR: func Convert_v1beta2_Device_To_v1beta1_Device(in *resourceapi.Device, out *resourcev1beta1.Device, s conversion.Scope) error {
ERROR:      ^
ERROR: staging/src/k8s.io/dynamic-resource-allocation/api/v1beta1/conversion.go:232:6: ST1003: should not use underscores in Go names; func convert_v1beta2_Attributes_To_v1beta1_Attributes should be convertV1beta2AttributesToV1beta1Attributes (staticcheck)
ERROR: func convert_v1beta2_Attributes_To_v1beta1_Attributes(in map[resourceapi.QualifiedName]resourceapi.DeviceAttribute, out map[resourcev1beta1.QualifiedName]resourcev1beta1.DeviceAttribute, s conversion.Scope) error {
ERROR:      ^
ERROR: staging/src/k8s.io/dynamic-resource-allocation/api/v1beta1/conversion.go:243:6: ST1003: should not use underscores in Go names; func convert_v1beta2_Capacity_To_v1beta1_Capacity should be convertV1beta2CapacityToV1beta1Capacity (staticcheck)
ERROR: func convert_v1beta2_Capacity_To_v1beta1_Capacity(in map[resourceapi.QualifiedName]resourceapi.DeviceCapacity, out map[resourcev1beta1.QualifiedName]resourcev1beta1.DeviceCapacity, s conversion.Scope) error {
ERROR:      ^
ERROR: staging/src/k8s.io/dynamic-resource-allocation/api/v1beta1/conversion.go:254:6: ST1003: should not use underscores in Go names; func convert_v1beta1_Attributes_To_v1beta2_Attributes should be convertV1beta1AttributesToV1beta2Attributes (staticcheck)
ERROR: func convert_v1beta1_Attributes_To_v1beta2_Attributes(in map[resourcev1beta1.QualifiedName]resourcev1beta1.DeviceAttribute, out map[resourceapi.QualifiedName]resourceapi.DeviceAttribute, s conversion.Scope) error {
ERROR:      ^
ERROR: staging/src/k8s.io/dynamic-resource-allocation/api/v1beta1/conversion.go:265:6: ST1003: should not use underscores in Go names; func convert_v1beta1_Capacity_To_v1beta2_Capacity should be convertV1beta1CapacityToV1beta2Capacity (staticcheck)
ERROR: func convert_v1beta1_Capacity_To_v1beta2_Capacity(in map[resourcev1beta1.QualifiedName]resourcev1beta1.DeviceCapacity, out map[resourceapi.QualifiedName]resourceapi.DeviceCapacity, s conversion.Scope) error {
ERROR:      ^
```

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
