### PR TITLE
Remove alculquicondor who is stepping down from sig-scheduling-api-reviewers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -487,7 +487,8 @@ aliases:
   # emeritus:
   # - mm4tt
   sig-scheduling-api-reviewers:
-    - alculquicondor
+  # emeritus:
+  # - alculquicondor
   sig-storage-api-reviewers:
     - deads2k
     - saad-ali

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -486,7 +486,7 @@ aliases:
     - wojtek-t
   # emeritus:
   # - mm4tt
-  sig-scheduling-api-reviewers:
+  # sig-scheduling-api-reviewers:
   # emeritus:
   # - alculquicondor
   sig-storage-api-reviewers:

--- a/pkg/scheduler/apis/config/OWNERS
+++ b/pkg/scheduler/apis/config/OWNERS
@@ -2,9 +2,9 @@
 
 approvers:
   - api-approvers
+  - sig-scheduling-api-approvers
 reviewers:
   - api-reviewers
-  - sig-scheduling-api-approvers
 labels:
   - kind/api-change
   - sig/scheduling

--- a/pkg/scheduler/apis/config/OWNERS
+++ b/pkg/scheduler/apis/config/OWNERS
@@ -4,7 +4,6 @@ approvers:
   - api-approvers
 reviewers:
   - api-reviewers
-  - sig-scheduling-api-reviewers
   - sig-scheduling-api-approvers
 labels:
   - kind/api-change

--- a/staging/src/k8s.io/kube-scheduler/config/OWNERS
+++ b/staging/src/k8s.io/kube-scheduler/config/OWNERS
@@ -7,7 +7,6 @@ approvers:
   - api-approvers
 reviewers:
   - api-reviewers
-  - sig-scheduling-api-reviewers
   - sig-scheduling-api-approvers
 labels:
   - kind/api-change

--- a/staging/src/k8s.io/kube-scheduler/config/OWNERS
+++ b/staging/src/k8s.io/kube-scheduler/config/OWNERS
@@ -5,8 +5,8 @@ options:
   no_parent_owners: true
 approvers:
   - api-approvers
+  - sig-scheduling-api-approvers
 reviewers:
   - api-reviewers
-  - sig-scheduling-api-approvers
 labels:
   - kind/api-change


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Remove alculquicondor who is stepping down from sig-scheduling-api-reviewers

#### Which issue(s) this PR fixes:

kubernetes/community/issues/8428


```release-note
NONE
```