### PR TITLE
update BoundedFrequencyRunner for kube-proxy

### DIFF
--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -307,12 +307,11 @@ func NewProxier(ctx context.Context,
 		},
 	}
 
-	burstSyncs := 2
-	logger.V(2).Info("Iptables sync params", "minSyncPeriod", minSyncPeriod, "syncPeriod", syncPeriod, "burstSyncs", burstSyncs)
+	logger.V(2).Info("Iptables sync params", "minSyncPeriod", minSyncPeriod, "syncPeriod", syncPeriod)
 	// We pass syncPeriod to ipt.Monitor, which will call us only if it needs to.
 	// We need to pass *some* maxInterval to NewBoundedFrequencyRunner anyway though.
 	// time.Hour is arbitrary.
-	proxier.syncRunner = runner.NewBoundedFrequencyRunner("sync-runner", proxier.syncProxyRules, minSyncPeriod, proxyutil.FullSyncPeriod, burstSyncs)
+	proxier.syncRunner = runner.NewBoundedFrequencyRunner("sync-runner", proxier.syncProxyRules, minSyncPeriod, proxyutil.FullSyncPeriod)
 
 	go ipt.Monitor(kubeProxyCanaryChain, []utiliptables.Table{utiliptables.TableMangle, utiliptables.TableNAT, utiliptables.TableFilter},
 		proxier.forceSyncProxyRules, syncPeriod, wait.NeverStop)

--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -46,9 +46,9 @@ import (
 	"k8s.io/kubernetes/pkg/proxy/healthcheck"
 	"k8s.io/kubernetes/pkg/proxy/metaproxier"
 	"k8s.io/kubernetes/pkg/proxy/metrics"
+	"k8s.io/kubernetes/pkg/proxy/runner"
 	proxyutil "k8s.io/kubernetes/pkg/proxy/util"
 	"k8s.io/kubernetes/pkg/proxy/util/nfacct"
-	"k8s.io/kubernetes/pkg/util/async"
 	utiliptables "k8s.io/kubernetes/pkg/util/iptables"
 )
 
@@ -155,7 +155,7 @@ type Proxier struct {
 	lastFullSync         time.Time
 	needFullSync         bool
 	initialized          int32
-	syncRunner           *async.BoundedFrequencyRunner // governs calls to syncProxyRules
+	syncRunner           *runner.BoundedFrequencyRunner // governs calls to syncProxyRules
 	syncPeriod           time.Duration
 	lastIPTablesCleanup  time.Time
 
@@ -312,7 +312,7 @@ func NewProxier(ctx context.Context,
 	// We pass syncPeriod to ipt.Monitor, which will call us only if it needs to.
 	// We need to pass *some* maxInterval to NewBoundedFrequencyRunner anyway though.
 	// time.Hour is arbitrary.
-	proxier.syncRunner = async.NewBoundedFrequencyRunner("sync-runner", proxier.syncProxyRules, minSyncPeriod, proxyutil.FullSyncPeriod, burstSyncs)
+	proxier.syncRunner = runner.NewBoundedFrequencyRunner("sync-runner", proxier.syncProxyRules, minSyncPeriod, proxyutil.FullSyncPeriod, burstSyncs)
 
 	go ipt.Monitor(kubeProxyCanaryChain, []utiliptables.Table{utiliptables.TableMangle, utiliptables.TableNAT, utiliptables.TableFilter},
 		proxier.forceSyncProxyRules, syncPeriod, wait.NeverStop)

--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -307,11 +307,11 @@ func NewProxier(ctx context.Context,
 		},
 	}
 
-	logger.V(2).Info("Iptables sync params", "minSyncPeriod", minSyncPeriod, "syncPeriod", syncPeriod)
+	logger.V(2).Info("Iptables sync params", "minSyncPeriod", minSyncPeriod, "syncPeriod", syncPeriod, "maxSyncPeriod", proxyutil.FullSyncPeriod)
 	// We pass syncPeriod to ipt.Monitor, which will call us only if it needs to.
 	// We need to pass *some* maxInterval to NewBoundedFrequencyRunner anyway though.
 	// time.Hour is arbitrary.
-	proxier.syncRunner = runner.NewBoundedFrequencyRunner("sync-runner", proxier.syncProxyRules, minSyncPeriod, proxyutil.FullSyncPeriod)
+	proxier.syncRunner = runner.NewBoundedFrequencyRunner("sync-runner", proxier.syncProxyRules, minSyncPeriod, syncPeriod, proxyutil.FullSyncPeriod)
 
 	go ipt.Monitor(kubeProxyCanaryChain, []utiliptables.Table{utiliptables.TableMangle, utiliptables.TableNAT, utiliptables.TableFilter},
 		proxier.forceSyncProxyRules, syncPeriod, wait.NeverStop)
@@ -783,7 +783,7 @@ func (proxier *Proxier) forceSyncProxyRules() {
 // This is where all of the iptables-save/restore calls happen.
 // The only other iptables rules are those that are setup in iptablesInit()
 // This assumes proxier.mu is NOT held
-func (proxier *Proxier) syncProxyRules() {
+func (proxier *Proxier) syncProxyRules() (retryError error) {
 	proxier.mu.Lock()
 	defer proxier.mu.Unlock()
 
@@ -817,7 +817,7 @@ func (proxier *Proxier) syncProxyRules() {
 	defer func() {
 		if !success {
 			proxier.logger.Info("Sync failed", "retryingTime", proxier.syncPeriod)
-			proxier.syncRunner.RetryAfter(proxier.syncPeriod)
+			retryError = fmt.Errorf("Sync failed")
 			if !doFullSync {
 				metrics.IPTablesPartialRestoreFailuresTotal.WithLabelValues(string(proxier.ipFamily)).Inc()
 			}
@@ -1586,6 +1586,7 @@ func (proxier *Proxier) syncProxyRules() {
 		// Finish housekeeping, clear stale conntrack entries for UDP Services
 		conntrack.CleanStaleEntries(proxier.conntrack, proxier.ipFamily, proxier.svcPortMap, proxier.endpointsMap)
 	}
+	return
 }
 
 func (proxier *Proxier) writeServiceToEndpointRules(natRules proxyutil.LineBuffer, svcPortNameString string, svcInfo proxy.ServicePort, svcChain utiliptables.Chain, endpoints []proxy.Endpoint, args []string) {

--- a/pkg/proxy/iptables/proxier_test.go
+++ b/pkg/proxy/iptables/proxier_test.go
@@ -144,7 +144,7 @@ func NewFakeProxier(ipt utiliptables.Interface) *Proxier {
 		},
 	}
 	p.setInitialized(true)
-	p.syncRunner = runner.NewBoundedFrequencyRunner("test-sync-runner", p.syncProxyRules, 0, time.Minute)
+	p.syncRunner = runner.NewBoundedFrequencyRunner("test-sync-runner", p.syncProxyRules, 0, 30*time.Second, time.Minute)
 	return p
 }
 

--- a/pkg/proxy/iptables/proxier_test.go
+++ b/pkg/proxy/iptables/proxier_test.go
@@ -144,7 +144,7 @@ func NewFakeProxier(ipt utiliptables.Interface) *Proxier {
 		},
 	}
 	p.setInitialized(true)
-	p.syncRunner = runner.NewBoundedFrequencyRunner("test-sync-runner", p.syncProxyRules, 0, time.Minute, 1)
+	p.syncRunner = runner.NewBoundedFrequencyRunner("test-sync-runner", p.syncProxyRules, 0, time.Minute)
 	return p
 }
 

--- a/pkg/proxy/iptables/proxier_test.go
+++ b/pkg/proxy/iptables/proxier_test.go
@@ -55,9 +55,9 @@ import (
 	"k8s.io/kubernetes/pkg/proxy/conntrack"
 	"k8s.io/kubernetes/pkg/proxy/healthcheck"
 	"k8s.io/kubernetes/pkg/proxy/metrics"
+	"k8s.io/kubernetes/pkg/proxy/runner"
 	proxyutil "k8s.io/kubernetes/pkg/proxy/util"
 	proxyutiltest "k8s.io/kubernetes/pkg/proxy/util/testing"
-	"k8s.io/kubernetes/pkg/util/async"
 	utiliptables "k8s.io/kubernetes/pkg/util/iptables"
 	iptablestest "k8s.io/kubernetes/pkg/util/iptables/testing"
 	netutils "k8s.io/utils/net"
@@ -144,7 +144,7 @@ func NewFakeProxier(ipt utiliptables.Interface) *Proxier {
 		},
 	}
 	p.setInitialized(true)
-	p.syncRunner = async.NewBoundedFrequencyRunner("test-sync-runner", p.syncProxyRules, 0, time.Minute, 1)
+	p.syncRunner = runner.NewBoundedFrequencyRunner("test-sync-runner", p.syncProxyRules, 0, time.Minute, 1)
 	return p
 }
 

--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -400,8 +400,10 @@ func NewProxier(
 	for _, is := range ipsetInfo {
 		proxier.ipsetList[is.name] = NewIPSet(ipset, is.name, is.setType, (ipFamily == v1.IPv6Protocol), is.comment)
 	}
-	logger.V(2).Info("ipvs sync params", "minSyncPeriod", minSyncPeriod, "syncPeriod", syncPeriod)
-	proxier.syncRunner = runner.NewBoundedFrequencyRunner("sync-runner", proxier.syncProxyRules, minSyncPeriod, syncPeriod)
+
+	logger.V(2).Info("ipvs sync params", "minSyncPeriod", minSyncPeriod, "syncPeriod", syncPeriod, "maxSyncPeriod", proxyutil.FullSyncPeriod)
+	proxier.syncRunner = runner.NewBoundedFrequencyRunner("sync-runner", proxier.syncProxyRules, minSyncPeriod, syncPeriod, proxyutil.FullSyncPeriod)
+
 	proxier.gracefuldeleteManager.Run()
 	return proxier, nil
 }
@@ -893,7 +895,7 @@ func (proxier *Proxier) OnNodeSynced() {
 func (proxier *Proxier) OnServiceCIDRsChanged(_ []string) {}
 
 // This is where all of the ipvs calls happen.
-func (proxier *Proxier) syncProxyRules() {
+func (proxier *Proxier) syncProxyRules() (retryError error) {
 	proxier.mu.Lock()
 	defer proxier.mu.Unlock()
 
@@ -1488,6 +1490,7 @@ func (proxier *Proxier) syncProxyRules() {
 		// Finish housekeeping, clear stale conntrack entries for UDP Services
 		conntrack.CleanStaleEntries(proxier.conntrack, proxier.ipFamily, proxier.svcPortMap, proxier.endpointsMap)
 	}
+	return
 }
 
 // writeIptablesRules write all iptables rules to proxier.natRules or proxier.FilterRules that ipvs proxier needed

--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -400,9 +400,8 @@ func NewProxier(
 	for _, is := range ipsetInfo {
 		proxier.ipsetList[is.name] = NewIPSet(ipset, is.name, is.setType, (ipFamily == v1.IPv6Protocol), is.comment)
 	}
-	burstSyncs := 2
-	logger.V(2).Info("ipvs sync params", "minSyncPeriod", minSyncPeriod, "syncPeriod", syncPeriod, "burstSyncs", burstSyncs)
-	proxier.syncRunner = runner.NewBoundedFrequencyRunner("sync-runner", proxier.syncProxyRules, minSyncPeriod, syncPeriod, burstSyncs)
+	logger.V(2).Info("ipvs sync params", "minSyncPeriod", minSyncPeriod, "syncPeriod", syncPeriod)
+	proxier.syncRunner = runner.NewBoundedFrequencyRunner("sync-runner", proxier.syncProxyRules, minSyncPeriod, syncPeriod)
 	proxier.gracefuldeleteManager.Run()
 	return proxier, nil
 }

--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -49,8 +49,8 @@ import (
 	utilipvs "k8s.io/kubernetes/pkg/proxy/ipvs/util"
 	"k8s.io/kubernetes/pkg/proxy/metaproxier"
 	"k8s.io/kubernetes/pkg/proxy/metrics"
+	"k8s.io/kubernetes/pkg/proxy/runner"
 	proxyutil "k8s.io/kubernetes/pkg/proxy/util"
-	"k8s.io/kubernetes/pkg/util/async"
 	utiliptables "k8s.io/kubernetes/pkg/util/iptables"
 	utilkernel "k8s.io/kubernetes/pkg/util/kernel"
 	netutils "k8s.io/utils/net"
@@ -187,7 +187,7 @@ type Proxier struct {
 	endpointSlicesSynced bool
 	servicesSynced       bool
 	initialized          int32
-	syncRunner           *async.BoundedFrequencyRunner // governs calls to syncProxyRules
+	syncRunner           *runner.BoundedFrequencyRunner // governs calls to syncProxyRules
 
 	// These are effectively const and do not need the mutex to be held.
 	syncPeriod    time.Duration
@@ -402,7 +402,7 @@ func NewProxier(
 	}
 	burstSyncs := 2
 	logger.V(2).Info("ipvs sync params", "minSyncPeriod", minSyncPeriod, "syncPeriod", syncPeriod, "burstSyncs", burstSyncs)
-	proxier.syncRunner = async.NewBoundedFrequencyRunner("sync-runner", proxier.syncProxyRules, minSyncPeriod, syncPeriod, burstSyncs)
+	proxier.syncRunner = runner.NewBoundedFrequencyRunner("sync-runner", proxier.syncProxyRules, minSyncPeriod, syncPeriod, burstSyncs)
 	proxier.gracefuldeleteManager.Run()
 	return proxier, nil
 }

--- a/pkg/proxy/ipvs/proxier_test.go
+++ b/pkg/proxy/ipvs/proxier_test.go
@@ -53,9 +53,9 @@ import (
 	utilipvs "k8s.io/kubernetes/pkg/proxy/ipvs/util"
 	ipvstest "k8s.io/kubernetes/pkg/proxy/ipvs/util/testing"
 	"k8s.io/kubernetes/pkg/proxy/metrics"
+	"k8s.io/kubernetes/pkg/proxy/runner"
 	proxyutil "k8s.io/kubernetes/pkg/proxy/util"
 	proxyutiltest "k8s.io/kubernetes/pkg/proxy/util/testing"
-	"k8s.io/kubernetes/pkg/util/async"
 	utiliptables "k8s.io/kubernetes/pkg/util/iptables"
 	iptablestest "k8s.io/kubernetes/pkg/util/iptables/testing"
 	"k8s.io/kubernetes/test/utils/ktesting"
@@ -167,7 +167,7 @@ func NewFakeProxier(ctx context.Context, ipt utiliptables.Interface, ipvs utilip
 		ipFamily:              ipFamily,
 	}
 	p.setInitialized(true)
-	p.syncRunner = async.NewBoundedFrequencyRunner("test-sync-runner", p.syncProxyRules, 0, time.Minute, 1)
+	p.syncRunner = runner.NewBoundedFrequencyRunner("test-sync-runner", p.syncProxyRules, 0, time.Minute, 1)
 	return p
 }
 

--- a/pkg/proxy/ipvs/proxier_test.go
+++ b/pkg/proxy/ipvs/proxier_test.go
@@ -167,7 +167,7 @@ func NewFakeProxier(ctx context.Context, ipt utiliptables.Interface, ipvs utilip
 		ipFamily:              ipFamily,
 	}
 	p.setInitialized(true)
-	p.syncRunner = runner.NewBoundedFrequencyRunner("test-sync-runner", p.syncProxyRules, 0, time.Minute, 1)
+	p.syncRunner = runner.NewBoundedFrequencyRunner("test-sync-runner", p.syncProxyRules, 0, time.Minute)
 	return p
 }
 

--- a/pkg/proxy/ipvs/proxier_test.go
+++ b/pkg/proxy/ipvs/proxier_test.go
@@ -167,7 +167,7 @@ func NewFakeProxier(ctx context.Context, ipt utiliptables.Interface, ipvs utilip
 		ipFamily:              ipFamily,
 	}
 	p.setInitialized(true)
-	p.syncRunner = runner.NewBoundedFrequencyRunner("test-sync-runner", p.syncProxyRules, 0, time.Minute)
+	p.syncRunner = runner.NewBoundedFrequencyRunner("test-sync-runner", p.syncProxyRules, 0, 30*time.Second, time.Minute)
 	return p
 }
 

--- a/pkg/proxy/nftables/proxier.go
+++ b/pkg/proxy/nftables/proxier.go
@@ -273,9 +273,9 @@ func NewProxier(ctx context.Context,
 		serviceNodePorts:    newNFTElementStorage("map", serviceNodePortsMap),
 	}
 
-	logger.V(2).Info("NFTables sync params", "minSyncPeriod", minSyncPeriod, "syncPeriod", syncPeriod)
+	logger.V(2).Info("NFTables sync params", "minSyncPeriod", minSyncPeriod, "syncPeriod", syncPeriod, "maxSyncPeriod", proxyutil.FullSyncPeriod)
 	// We need to pass *some* maxInterval to NewBoundedFrequencyRunner. time.Hour is arbitrary.
-	proxier.syncRunner = runner.NewBoundedFrequencyRunner("sync-runner", proxier.syncProxyRules, minSyncPeriod, proxyutil.FullSyncPeriod)
+	proxier.syncRunner = runner.NewBoundedFrequencyRunner("sync-runner", proxier.syncProxyRules, minSyncPeriod, syncPeriod, proxyutil.FullSyncPeriod)
 
 	return proxier, nil
 }
@@ -1161,7 +1161,7 @@ func (proxier *Proxier) logFailure(tx *knftables.Transaction) {
 
 // This is where all of the nftables calls happen.
 // This assumes proxier.mu is NOT held
-func (proxier *Proxier) syncProxyRules() {
+func (proxier *Proxier) syncProxyRules() (retryError error) {
 	proxier.mu.Lock()
 	defer proxier.mu.Unlock()
 
@@ -1200,7 +1200,7 @@ func (proxier *Proxier) syncProxyRules() {
 	defer func() {
 		if !success {
 			proxier.logger.Info("Sync failed", "retryingTime", proxier.syncPeriod)
-			proxier.syncRunner.RetryAfter(proxier.syncPeriod)
+			retryError = fmt.Errorf("Sync failed")
 			// proxier.serviceChanges and proxier.endpointChanges have already
 			// been flushed, so we've lost the state needed to be able to do
 			// a partial sync.
@@ -1886,6 +1886,7 @@ func (proxier *Proxier) syncProxyRules() {
 		// Finish housekeeping, clear stale conntrack entries for UDP Services
 		conntrack.CleanStaleEntries(proxier.conntrack, proxier.ipFamily, proxier.svcPortMap, proxier.endpointsMap)
 	}
+	return
 }
 
 // epChainSkipUpdate returns true if the EP chain doesn't need to be updated.

--- a/pkg/proxy/nftables/proxier.go
+++ b/pkg/proxy/nftables/proxier.go
@@ -49,8 +49,8 @@ import (
 	"k8s.io/kubernetes/pkg/proxy/healthcheck"
 	"k8s.io/kubernetes/pkg/proxy/metaproxier"
 	"k8s.io/kubernetes/pkg/proxy/metrics"
+	"k8s.io/kubernetes/pkg/proxy/runner"
 	proxyutil "k8s.io/kubernetes/pkg/proxy/util"
-	"k8s.io/kubernetes/pkg/util/async"
 	utilkernel "k8s.io/kubernetes/pkg/util/kernel"
 	netutils "k8s.io/utils/net"
 	"k8s.io/utils/ptr"
@@ -164,7 +164,7 @@ type Proxier struct {
 	lastFullSync         time.Time
 	needFullSync         bool
 	initialized          int32
-	syncRunner           *async.BoundedFrequencyRunner // governs calls to syncProxyRules
+	syncRunner           *runner.BoundedFrequencyRunner // governs calls to syncProxyRules
 	syncPeriod           time.Duration
 	flushed              bool
 
@@ -276,7 +276,7 @@ func NewProxier(ctx context.Context,
 	burstSyncs := 2
 	logger.V(2).Info("NFTables sync params", "minSyncPeriod", minSyncPeriod, "syncPeriod", syncPeriod, "burstSyncs", burstSyncs)
 	// We need to pass *some* maxInterval to NewBoundedFrequencyRunner. time.Hour is arbitrary.
-	proxier.syncRunner = async.NewBoundedFrequencyRunner("sync-runner", proxier.syncProxyRules, minSyncPeriod, proxyutil.FullSyncPeriod, burstSyncs)
+	proxier.syncRunner = runner.NewBoundedFrequencyRunner("sync-runner", proxier.syncProxyRules, minSyncPeriod, proxyutil.FullSyncPeriod, burstSyncs)
 
 	return proxier, nil
 }

--- a/pkg/proxy/nftables/proxier.go
+++ b/pkg/proxy/nftables/proxier.go
@@ -273,10 +273,9 @@ func NewProxier(ctx context.Context,
 		serviceNodePorts:    newNFTElementStorage("map", serviceNodePortsMap),
 	}
 
-	burstSyncs := 2
-	logger.V(2).Info("NFTables sync params", "minSyncPeriod", minSyncPeriod, "syncPeriod", syncPeriod, "burstSyncs", burstSyncs)
+	logger.V(2).Info("NFTables sync params", "minSyncPeriod", minSyncPeriod, "syncPeriod", syncPeriod)
 	// We need to pass *some* maxInterval to NewBoundedFrequencyRunner. time.Hour is arbitrary.
-	proxier.syncRunner = runner.NewBoundedFrequencyRunner("sync-runner", proxier.syncProxyRules, minSyncPeriod, proxyutil.FullSyncPeriod, burstSyncs)
+	proxier.syncRunner = runner.NewBoundedFrequencyRunner("sync-runner", proxier.syncProxyRules, minSyncPeriod, proxyutil.FullSyncPeriod)
 
 	return proxier, nil
 }

--- a/pkg/proxy/nftables/proxier_test.go
+++ b/pkg/proxy/nftables/proxier_test.go
@@ -142,7 +142,7 @@ func NewFakeProxier(ipFamily v1.IPFamily) (*knftables.Fake, *Proxier) {
 		serviceNodePorts:    newNFTElementStorage("map", serviceNodePortsMap),
 	}
 	p.setInitialized(true)
-	p.syncRunner = runner.NewBoundedFrequencyRunner("test-sync-runner", p.syncProxyRules, 0, time.Minute)
+	p.syncRunner = runner.NewBoundedFrequencyRunner("test-sync-runner", p.syncProxyRules, 0, 30*time.Second, time.Minute)
 
 	return nft, p
 }

--- a/pkg/proxy/nftables/proxier_test.go
+++ b/pkg/proxy/nftables/proxier_test.go
@@ -142,7 +142,7 @@ func NewFakeProxier(ipFamily v1.IPFamily) (*knftables.Fake, *Proxier) {
 		serviceNodePorts:    newNFTElementStorage("map", serviceNodePortsMap),
 	}
 	p.setInitialized(true)
-	p.syncRunner = runner.NewBoundedFrequencyRunner("test-sync-runner", p.syncProxyRules, 0, time.Minute, 1)
+	p.syncRunner = runner.NewBoundedFrequencyRunner("test-sync-runner", p.syncProxyRules, 0, time.Minute)
 
 	return nft, p
 }

--- a/pkg/proxy/nftables/proxier_test.go
+++ b/pkg/proxy/nftables/proxier_test.go
@@ -46,9 +46,9 @@ import (
 	"k8s.io/kubernetes/pkg/proxy/conntrack"
 	"k8s.io/kubernetes/pkg/proxy/healthcheck"
 	"k8s.io/kubernetes/pkg/proxy/metrics"
+	"k8s.io/kubernetes/pkg/proxy/runner"
 	proxyutil "k8s.io/kubernetes/pkg/proxy/util"
 	proxyutiltest "k8s.io/kubernetes/pkg/proxy/util/testing"
-	"k8s.io/kubernetes/pkg/util/async"
 	netutils "k8s.io/utils/net"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/knftables"
@@ -142,7 +142,7 @@ func NewFakeProxier(ipFamily v1.IPFamily) (*knftables.Fake, *Proxier) {
 		serviceNodePorts:    newNFTElementStorage("map", serviceNodePortsMap),
 	}
 	p.setInitialized(true)
-	p.syncRunner = async.NewBoundedFrequencyRunner("test-sync-runner", p.syncProxyRules, 0, time.Minute, 1)
+	p.syncRunner = runner.NewBoundedFrequencyRunner("test-sync-runner", p.syncProxyRules, 0, time.Minute, 1)
 
 	return nft, p
 }

--- a/pkg/proxy/runner/bounded_frequency_runner.go
+++ b/pkg/proxy/runner/bounded_frequency_runner.go
@@ -1,0 +1,313 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runner
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"k8s.io/client-go/util/flowcontrol"
+
+	"k8s.io/klog/v2"
+)
+
+// BoundedFrequencyRunner manages runs of a user-provided function.
+// See NewBoundedFrequencyRunner for examples.
+type BoundedFrequencyRunner struct {
+	name        string        // the name of this instance
+	minInterval time.Duration // the min time between runs, modulo bursts
+	maxInterval time.Duration // the max time between runs
+
+	run chan struct{} // try an async run
+
+	mu      sync.Mutex  // guards runs of fn and all mutations
+	fn      func()      // function to run
+	lastRun time.Time   // time of last run
+	timer   timer       // timer for deferred runs
+	limiter rateLimiter // rate limiter for on-demand runs
+
+	retry     chan struct{} // schedule a retry
+	retryMu   sync.Mutex    // guards retryTime
+	retryTime time.Time     // when to retry
+}
+
+// designed so that flowcontrol.RateLimiter satisfies
+type rateLimiter interface {
+	TryAccept() bool
+	Stop()
+}
+
+type nullLimiter struct{}
+
+func (nullLimiter) TryAccept() bool {
+	return true
+}
+
+func (nullLimiter) Stop() {}
+
+var _ rateLimiter = nullLimiter{}
+
+// for testing
+type timer interface {
+	// C returns the timer's selectable channel.
+	C() <-chan time.Time
+
+	// See time.Timer.Reset.
+	Reset(d time.Duration) bool
+
+	// See time.Timer.Stop.
+	Stop() bool
+
+	// See time.Now.
+	Now() time.Time
+
+	// Remaining returns the time until the timer will go off (if it is running).
+	Remaining() time.Duration
+
+	// See time.Since.
+	Since(t time.Time) time.Duration
+
+	// See time.Sleep.
+	Sleep(d time.Duration)
+}
+
+// implement our timer in terms of std time.Timer.
+type realTimer struct {
+	timer *time.Timer
+	next  time.Time
+}
+
+func (rt *realTimer) C() <-chan time.Time {
+	return rt.timer.C
+}
+
+func (rt *realTimer) Reset(d time.Duration) bool {
+	rt.next = time.Now().Add(d)
+	return rt.timer.Reset(d)
+}
+
+func (rt *realTimer) Stop() bool {
+	return rt.timer.Stop()
+}
+
+func (rt *realTimer) Now() time.Time {
+	return time.Now()
+}
+
+func (rt *realTimer) Remaining() time.Duration {
+	return rt.next.Sub(time.Now())
+}
+
+func (rt *realTimer) Since(t time.Time) time.Duration {
+	return time.Since(t)
+}
+
+func (rt *realTimer) Sleep(d time.Duration) {
+	time.Sleep(d)
+}
+
+var _ timer = &realTimer{}
+
+// NewBoundedFrequencyRunner creates a new BoundedFrequencyRunner instance,
+// which will manage runs of the specified function.
+//
+// All runs will be async to the caller of BoundedFrequencyRunner.Run, but
+// multiple runs are serialized. If the function needs to hold locks, it must
+// take them internally.
+//
+// Runs of the function will have at least minInterval between them (from
+// completion to next start), except that up to bursts may be allowed.  Burst
+// runs are "accumulated" over time, one per minInterval up to burstRuns total.
+// This can be used, for example, to mitigate the impact of expensive operations
+// being called in response to user-initiated operations. Run requests that
+// would violate the minInterval are coalesced and run at the next opportunity.
+//
+// The function will be run at least once per maxInterval. For example, this can
+// force periodic refreshes of state in the absence of anyone calling Run.
+//
+// Examples:
+//
+// NewBoundedFrequencyRunner("name", fn, time.Second, 5*time.Second, 1)
+// - fn will have at least 1 second between runs
+// - fn will have no more than 5 seconds between runs
+//
+// NewBoundedFrequencyRunner("name", fn, 3*time.Second, 10*time.Second, 3)
+// - fn will have at least 3 seconds between runs, with up to 3 burst runs
+// - fn will have no more than 10 seconds between runs
+//
+// The maxInterval must be greater than or equal to the minInterval,  If the
+// caller passes a maxInterval less than minInterval, this function will panic.
+func NewBoundedFrequencyRunner(name string, fn func(), minInterval, maxInterval time.Duration, burstRuns int) *BoundedFrequencyRunner {
+	timer := &realTimer{timer: time.NewTimer(0)} // will tick immediately
+	<-timer.C()                                  // consume the first tick
+	return construct(name, fn, minInterval, maxInterval, burstRuns, timer)
+}
+
+// Make an instance with dependencies injected.
+func construct(name string, fn func(), minInterval, maxInterval time.Duration, burstRuns int, timer timer) *BoundedFrequencyRunner {
+	if maxInterval < minInterval {
+		panic(fmt.Sprintf("%s: maxInterval (%v) must be >= minInterval (%v)", name, maxInterval, minInterval))
+	}
+	if timer == nil {
+		panic(fmt.Sprintf("%s: timer must be non-nil", name))
+	}
+
+	bfr := &BoundedFrequencyRunner{
+		name:        name,
+		fn:          fn,
+		minInterval: minInterval,
+		maxInterval: maxInterval,
+		run:         make(chan struct{}, 1),
+		retry:       make(chan struct{}, 1),
+		timer:       timer,
+	}
+	if minInterval == 0 {
+		bfr.limiter = nullLimiter{}
+	} else {
+		// allow burst updates in short succession
+		qps := float32(time.Second) / float32(minInterval)
+		bfr.limiter = flowcontrol.NewTokenBucketRateLimiterWithClock(qps, burstRuns, timer)
+	}
+	return bfr
+}
+
+// Loop handles the periodic timer and run requests.  This is expected to be
+// called as a goroutine.
+func (bfr *BoundedFrequencyRunner) Loop(stop <-chan struct{}) {
+	klog.V(3).Infof("%s Loop running", bfr.name)
+	bfr.timer.Reset(bfr.maxInterval)
+	for {
+		select {
+		case <-stop:
+			bfr.stop()
+			klog.V(3).Infof("%s Loop stopping", bfr.name)
+			return
+		case <-bfr.timer.C():
+			bfr.tryRun()
+		case <-bfr.run:
+			bfr.tryRun()
+		case <-bfr.retry:
+			bfr.doRetry()
+		}
+	}
+}
+
+// Run the function as soon as possible.  If this is called while Loop is not
+// running, the call may be deferred indefinitely.
+// If there is already a queued request to call the underlying function, it
+// may be dropped - it is just guaranteed that we will try calling the
+// underlying function as soon as possible starting from now.
+func (bfr *BoundedFrequencyRunner) Run() {
+	// If it takes a lot of time to run the underlying function, noone is really
+	// processing elements from <run> channel. So to avoid blocking here on the
+	// putting element to it, we simply skip it if there is already an element
+	// in it.
+	select {
+	case bfr.run <- struct{}{}:
+	default:
+	}
+}
+
+// RetryAfter ensures that the function will run again after no later than interval. This
+// can be called from inside a run of the BoundedFrequencyRunner's function, or
+// asynchronously.
+func (bfr *BoundedFrequencyRunner) RetryAfter(interval time.Duration) {
+	// This could be called either with or without bfr.mu held, so we can't grab that
+	// lock, and therefore we can't update the timer directly.
+
+	// If the Loop thread is currently running fn then it may be a while before it
+	// processes our retry request. But we want to retry at interval from now, not at
+	// interval from "whenever doRetry eventually gets called". So we convert to
+	// absolute time.
+	retryTime := bfr.timer.Now().Add(interval)
+
+	// We can't just write retryTime to a channel because there could be multiple
+	// RetryAfter calls before Loop gets a chance to read from the channel. So we
+	// record the soonest requested retry time in bfr.retryTime and then only signal
+	// the Loop thread once, just like Run does.
+	bfr.retryMu.Lock()
+	defer bfr.retryMu.Unlock()
+	if !bfr.retryTime.IsZero() && bfr.retryTime.Before(retryTime) {
+		return
+	}
+	bfr.retryTime = retryTime
+
+	select {
+	case bfr.retry <- struct{}{}:
+	default:
+	}
+}
+
+// assumes the lock is not held
+func (bfr *BoundedFrequencyRunner) stop() {
+	bfr.mu.Lock()
+	defer bfr.mu.Unlock()
+	bfr.limiter.Stop()
+	bfr.timer.Stop()
+}
+
+// assumes the lock is not held
+func (bfr *BoundedFrequencyRunner) doRetry() {
+	bfr.mu.Lock()
+	defer bfr.mu.Unlock()
+	bfr.retryMu.Lock()
+	defer bfr.retryMu.Unlock()
+
+	if bfr.retryTime.IsZero() {
+		return
+	}
+
+	// Timer wants an interval not an absolute time, so convert retryTime back now
+	retryInterval := bfr.retryTime.Sub(bfr.timer.Now())
+	bfr.retryTime = time.Time{}
+	if retryInterval < bfr.timer.Remaining() {
+		klog.V(3).Infof("%s: retrying in %v", bfr.name, retryInterval)
+		bfr.timer.Stop()
+		bfr.timer.Reset(retryInterval)
+	}
+}
+
+// assumes the lock is not held
+func (bfr *BoundedFrequencyRunner) tryRun() {
+	bfr.mu.Lock()
+	defer bfr.mu.Unlock()
+
+	if bfr.limiter.TryAccept() {
+		// We're allowed to run the function right now.
+		bfr.fn()
+		bfr.lastRun = bfr.timer.Now()
+		bfr.timer.Stop()
+		bfr.timer.Reset(bfr.maxInterval)
+		klog.V(3).Infof("%s: ran, next possible in %v, periodic in %v", bfr.name, bfr.minInterval, bfr.maxInterval)
+		return
+	}
+
+	// It can't run right now, figure out when it can run next.
+	elapsed := bfr.timer.Since(bfr.lastRun)   // how long since last run
+	nextPossible := bfr.minInterval - elapsed // time to next possible run
+	nextScheduled := bfr.timer.Remaining()    // time to next scheduled run
+	klog.V(4).Infof("%s: %v since last run, possible in %v, scheduled in %v", bfr.name, elapsed, nextPossible, nextScheduled)
+
+	// It's hard to avoid race conditions in the unit tests unless we always reset
+	// the timer here, even when it's unchanged
+	if nextPossible < nextScheduled {
+		nextScheduled = nextPossible
+	}
+	bfr.timer.Stop()
+	bfr.timer.Reset(nextScheduled)
+}

--- a/pkg/proxy/runner/bounded_frequency_runner_test.go
+++ b/pkg/proxy/runner/bounded_frequency_runner_test.go
@@ -152,6 +152,7 @@ func (ft *fakeTimer) advance(d time.Duration) {
 // return the calling line number (for printing)
 // test the timer's state
 func checkTimer(name string, t *testing.T, upd timerUpdate, active bool, next time.Duration) {
+	t.Helper()
 	if upd.active != active {
 		t.Fatalf("%s: expected timer active=%v", name, active)
 	}
@@ -162,6 +163,7 @@ func checkTimer(name string, t *testing.T, upd timerUpdate, active bool, next ti
 
 // test and reset the receiver's state
 func checkReceiver(name string, t *testing.T, receiver *receiver, expected bool) {
+	t.Helper()
 	triggered := receiver.reset()
 	if expected && !triggered {
 		t.Fatalf("%s: function should have been called", name)
@@ -175,6 +177,7 @@ var minInterval = 1 * time.Second
 var maxInterval = 10 * time.Second
 
 func waitForReset(name string, t *testing.T, timer *fakeTimer, obj *receiver, expectCall bool, expectNext time.Duration) {
+	t.Helper()
 	upd := <-timer.updated // wait for stop
 	checkReceiver(name, t, obj, expectCall)
 	checkReceiver(name, t, obj, false) // prove post-condition
@@ -184,20 +187,24 @@ func waitForReset(name string, t *testing.T, timer *fakeTimer, obj *receiver, ex
 }
 
 func waitForRun(name string, t *testing.T, timer *fakeTimer, obj *receiver) {
+	t.Helper()
 	waitForReset(name, t, timer, obj, true, maxInterval)
 }
 
 func waitForRunWithRetry(name string, t *testing.T, timer *fakeTimer, obj *receiver, expectNext time.Duration) {
+	t.Helper()
 	// It will first get reset as with a normal run, and then get set again
 	waitForRun(name, t, timer, obj)
 	waitForReset(name, t, timer, obj, false, expectNext)
 }
 
 func waitForDefer(name string, t *testing.T, timer *fakeTimer, obj *receiver, expectNext time.Duration) {
+	t.Helper()
 	waitForReset(name, t, timer, obj, false, expectNext)
 }
 
 func waitForNothing(name string, t *testing.T, timer *fakeTimer, obj *receiver) {
+	t.Helper()
 	select {
 	case <-timer.c:
 		t.Fatalf("%s: unexpected timer tick", name)

--- a/pkg/proxy/runner/bounded_frequency_runner_test.go
+++ b/pkg/proxy/runner/bounded_frequency_runner_test.go
@@ -1,0 +1,453 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runner
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// Track calls to the managed function.
+type receiver struct {
+	lock    sync.Mutex
+	run     bool
+	retryFn func()
+}
+
+func (r *receiver) F() {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	r.run = true
+
+	if r.retryFn != nil {
+		r.retryFn()
+		r.retryFn = nil
+	}
+}
+
+func (r *receiver) reset() bool {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	was := r.run
+	r.run = false
+	return was
+}
+
+func (r *receiver) setRetryFn(retryFn func()) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	r.retryFn = retryFn
+}
+
+// A single change event in the fake timer.
+type timerUpdate struct {
+	active bool
+	next   time.Duration // iff active == true
+}
+
+// Fake time.
+type fakeTimer struct {
+	c chan time.Time
+
+	lock    sync.Mutex
+	now     time.Time
+	timeout time.Time
+	active  bool
+
+	updated chan timerUpdate
+}
+
+func newFakeTimer() *fakeTimer {
+	ft := &fakeTimer{
+		now:     time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC),
+		c:       make(chan time.Time),
+		updated: make(chan timerUpdate),
+	}
+	return ft
+}
+
+func (ft *fakeTimer) C() <-chan time.Time {
+	return ft.c
+}
+
+func (ft *fakeTimer) Reset(in time.Duration) bool {
+	ft.lock.Lock()
+	defer ft.lock.Unlock()
+
+	was := ft.active
+	ft.active = true
+	ft.timeout = ft.now.Add(in)
+	ft.updated <- timerUpdate{
+		active: true,
+		next:   in,
+	}
+	return was
+}
+
+func (ft *fakeTimer) Stop() bool {
+	ft.lock.Lock()
+	defer ft.lock.Unlock()
+
+	was := ft.active
+	ft.active = false
+	ft.updated <- timerUpdate{
+		active: false,
+	}
+	return was
+}
+
+func (ft *fakeTimer) Now() time.Time {
+	ft.lock.Lock()
+	defer ft.lock.Unlock()
+
+	return ft.now
+}
+
+func (ft *fakeTimer) Remaining() time.Duration {
+	ft.lock.Lock()
+	defer ft.lock.Unlock()
+
+	return ft.timeout.Sub(ft.now)
+}
+
+func (ft *fakeTimer) Since(t time.Time) time.Duration {
+	ft.lock.Lock()
+	defer ft.lock.Unlock()
+
+	return ft.now.Sub(t)
+}
+
+func (ft *fakeTimer) Sleep(d time.Duration) {
+	// ft.advance grabs ft.lock
+	ft.advance(d)
+}
+
+// advance the current time.
+func (ft *fakeTimer) advance(d time.Duration) {
+	ft.lock.Lock()
+	defer ft.lock.Unlock()
+
+	ft.now = ft.now.Add(d)
+	if ft.active && !ft.now.Before(ft.timeout) {
+		ft.active = false
+		ft.c <- ft.timeout
+	}
+}
+
+// return the calling line number (for printing)
+// test the timer's state
+func checkTimer(name string, t *testing.T, upd timerUpdate, active bool, next time.Duration) {
+	if upd.active != active {
+		t.Fatalf("%s: expected timer active=%v", name, active)
+	}
+	if active && upd.next != next {
+		t.Fatalf("%s: expected timer to be %v, got %v", name, next, upd.next)
+	}
+}
+
+// test and reset the receiver's state
+func checkReceiver(name string, t *testing.T, receiver *receiver, expected bool) {
+	triggered := receiver.reset()
+	if expected && !triggered {
+		t.Fatalf("%s: function should have been called", name)
+	} else if !expected && triggered {
+		t.Fatalf("%s: function should not have been called", name)
+	}
+}
+
+// Durations embedded in test cases depend on these.
+var minInterval = 1 * time.Second
+var maxInterval = 10 * time.Second
+
+func waitForReset(name string, t *testing.T, timer *fakeTimer, obj *receiver, expectCall bool, expectNext time.Duration) {
+	upd := <-timer.updated // wait for stop
+	checkReceiver(name, t, obj, expectCall)
+	checkReceiver(name, t, obj, false) // prove post-condition
+	checkTimer(name, t, upd, false, 0)
+	upd = <-timer.updated // wait for reset
+	checkTimer(name, t, upd, true, expectNext)
+}
+
+func waitForRun(name string, t *testing.T, timer *fakeTimer, obj *receiver) {
+	waitForReset(name, t, timer, obj, true, maxInterval)
+}
+
+func waitForRunWithRetry(name string, t *testing.T, timer *fakeTimer, obj *receiver, expectNext time.Duration) {
+	// It will first get reset as with a normal run, and then get set again
+	waitForRun(name, t, timer, obj)
+	waitForReset(name, t, timer, obj, false, expectNext)
+}
+
+func waitForDefer(name string, t *testing.T, timer *fakeTimer, obj *receiver, expectNext time.Duration) {
+	waitForReset(name, t, timer, obj, false, expectNext)
+}
+
+func waitForNothing(name string, t *testing.T, timer *fakeTimer, obj *receiver) {
+	select {
+	case <-timer.c:
+		t.Fatalf("%s: unexpected timer tick", name)
+	case upd := <-timer.updated:
+		t.Fatalf("%s: unexpected timer update %v", name, upd)
+	default:
+	}
+	checkReceiver(name, t, obj, false)
+}
+
+func Test_BoundedFrequencyRunnerNoBurst(t *testing.T) {
+	obj := &receiver{}
+	timer := newFakeTimer()
+	runner := construct("test-runner", obj.F, minInterval, maxInterval, 1, timer)
+	stop := make(chan struct{})
+
+	var upd timerUpdate
+
+	// Start.
+	go runner.Loop(stop)
+	upd = <-timer.updated // wait for initial time to be set to max
+	checkTimer("init", t, upd, true, maxInterval)
+	checkReceiver("init", t, obj, false)
+
+	// Run once, immediately.
+	// rel=0ms
+	runner.Run()
+	waitForRun("first run", t, timer, obj)
+
+	// Run again, before minInterval expires.
+	timer.advance(500 * time.Millisecond) // rel=500ms
+	runner.Run()
+	waitForDefer("too soon after first", t, timer, obj, 500*time.Millisecond)
+
+	// Run again, before minInterval expires.
+	timer.advance(499 * time.Millisecond) // rel=999ms
+	runner.Run()
+	waitForDefer("still too soon after first", t, timer, obj, 1*time.Millisecond)
+
+	// Do the deferred run
+	timer.advance(1 * time.Millisecond) // rel=1000ms
+	waitForRun("second run", t, timer, obj)
+
+	// Try again immediately
+	runner.Run()
+	waitForDefer("too soon after second", t, timer, obj, 1*time.Second)
+
+	// Run again, before minInterval expires.
+	timer.advance(1 * time.Millisecond) // rel=1ms
+	runner.Run()
+	waitForDefer("still too soon after second", t, timer, obj, 999*time.Millisecond)
+
+	// Ensure that we don't run again early
+	timer.advance(998 * time.Millisecond) // rel=999ms
+	waitForNothing("premature", t, timer, obj)
+
+	// Do the deferred run
+	timer.advance(1 * time.Millisecond) // rel=1000ms
+	waitForRun("third run", t, timer, obj)
+
+	// Let minInterval pass, but there are no runs queued
+	timer.advance(1 * time.Second) // rel=1000ms
+	waitForNothing("minInterval", t, timer, obj)
+
+	// Let maxInterval pass
+	timer.advance(9 * time.Second) // rel=10000ms
+	waitForRun("maxInterval", t, timer, obj)
+
+	// Run again, before minInterval expires.
+	timer.advance(1 * time.Millisecond) // rel=1ms
+	runner.Run()
+	waitForDefer("too soon after maxInterval run", t, timer, obj, 999*time.Millisecond)
+
+	// Let minInterval pass
+	timer.advance(999 * time.Millisecond) // rel=1000ms
+	waitForRun("fifth run", t, timer, obj)
+
+	// Clean up.
+	stop <- struct{}{}
+	// a message is sent to time.updated in func Stop() at the end of the child goroutine
+	// to terminate the child, a receive on time.updated is needed here
+	<-timer.updated
+}
+
+func Test_BoundedFrequencyRunnerBurst(t *testing.T) {
+	obj := &receiver{}
+	timer := newFakeTimer()
+	runner := construct("test-runner", obj.F, minInterval, maxInterval, 2, timer)
+	stop := make(chan struct{})
+
+	var upd timerUpdate
+
+	// Start.
+	go runner.Loop(stop)
+	upd = <-timer.updated // wait for initial time to be set to max
+	checkTimer("init", t, upd, true, maxInterval)
+	checkReceiver("init", t, obj, false)
+
+	// Run once, immediately.
+	// abs=0ms, rel=0ms
+	runner.Run()
+	waitForRun("first run", t, timer, obj)
+
+	// Run again, before minInterval expires, with burst.
+	timer.advance(1 * time.Millisecond) // abs=1ms, rel=1ms
+	runner.Run()
+	waitForRun("second run", t, timer, obj)
+
+	// Run again, before minInterval expires.
+	timer.advance(498 * time.Millisecond) // abs=499ms, rel=498ms
+	runner.Run()
+	waitForDefer("too soon after second", t, timer, obj, 502*time.Millisecond)
+
+	// Run again, before minInterval expires.
+	timer.advance(1 * time.Millisecond) // abs=500ms, rel=499ms
+	runner.Run()
+	waitForDefer("too soon after second 2", t, timer, obj, 501*time.Millisecond)
+
+	// Run again, before minInterval expires.
+	timer.advance(1 * time.Millisecond) // abs=501ms, rel=500ms
+	runner.Run()
+	waitForDefer("too soon after second 3", t, timer, obj, 500*time.Millisecond)
+
+	// Advance timer enough to replenish bursts, but not enough to be minInterval
+	// after the last run
+	timer.advance(499 * time.Millisecond) // abs=1000ms, rel=999ms
+	waitForNothing("not minInterval", t, timer, obj)
+	runner.Run()
+	waitForRun("third run", t, timer, obj)
+
+	// Run again, before minInterval expires.
+	timer.advance(1 * time.Millisecond) // abs=1001ms, rel=1ms
+	runner.Run()
+	waitForDefer("too soon after third", t, timer, obj, 999*time.Millisecond)
+
+	// Run again, before minInterval expires.
+	timer.advance(998 * time.Millisecond) // abs=1999ms, rel=999ms
+	runner.Run()
+	waitForDefer("too soon after third 2", t, timer, obj, 1*time.Millisecond)
+
+	// Advance and do the deferred run
+	timer.advance(1 * time.Millisecond) // abs=2000ms, rel=1000ms
+	waitForRun("fourth run", t, timer, obj)
+
+	// Run again, once burst has fully replenished.
+	timer.advance(2 * time.Second) // abs=4000ms, rel=2000ms
+	runner.Run()
+	waitForRun("fifth run", t, timer, obj)
+	runner.Run()
+	waitForRun("sixth run", t, timer, obj)
+	runner.Run()
+	waitForDefer("too soon after sixth", t, timer, obj, 1*time.Second)
+
+	// Wait until minInterval after the last run
+	timer.advance(1 * time.Second) // abs=5000ms, rel=1000ms
+	waitForRun("seventh run", t, timer, obj)
+
+	// Wait for maxInterval
+	timer.advance(10 * time.Second) // abs=15000ms, rel=10000ms
+	waitForRun("maxInterval", t, timer, obj)
+
+	// Clean up.
+	stop <- struct{}{}
+	// a message is sent to time.updated in func Stop() at the end of the child goroutine
+	// to terminate the child, a receive on time.updated is needed here
+	<-timer.updated
+}
+
+func Test_BoundedFrequencyRunnerRetryAfter(t *testing.T) {
+	obj := &receiver{}
+	timer := newFakeTimer()
+	runner := construct("test-runner", obj.F, minInterval, maxInterval, 1, timer)
+	stop := make(chan struct{})
+
+	var upd timerUpdate
+
+	// Start.
+	go runner.Loop(stop)
+	upd = <-timer.updated // wait for initial time to be set to max
+	checkTimer("init", t, upd, true, maxInterval)
+	checkReceiver("init", t, obj, false)
+
+	// Run once, immediately, and queue a retry
+	// rel=0ms
+	obj.setRetryFn(func() { runner.RetryAfter(5 * time.Second) })
+	runner.Run()
+	waitForRunWithRetry("first run", t, timer, obj, 5*time.Second)
+
+	// Nothing happens...
+	timer.advance(time.Second) // rel=1000ms
+	waitForNothing("minInterval, nothing queued", t, timer, obj)
+
+	// After retryInterval, function is called
+	timer.advance(4 * time.Second) // rel=5000ms
+	waitForRun("retry", t, timer, obj)
+
+	// Run again, before minInterval expires.
+	timer.advance(499 * time.Millisecond) // rel=499ms
+	runner.Run()
+	waitForDefer("too soon after retry", t, timer, obj, 501*time.Millisecond)
+
+	// Do the deferred run, queue another retry after it returns
+	timer.advance(501 * time.Millisecond) // rel=1000ms
+	runner.RetryAfter(5 * time.Second)
+	waitForRunWithRetry("second run", t, timer, obj, 5*time.Second)
+
+	// Wait for minInterval to pass
+	timer.advance(time.Second) // rel=1000ms
+	waitForNothing("minInterval, nothing queued", t, timer, obj)
+
+	// Now do another run
+	runner.Run()
+	waitForRun("third run", t, timer, obj)
+
+	// Retry was cancelled because we already ran
+	timer.advance(4 * time.Second)
+	waitForNothing("retry cancelled", t, timer, obj)
+
+	// Run, queue a retry from a goroutine
+	obj.setRetryFn(func() {
+		go func() {
+			time.Sleep(100 * time.Millisecond)
+			runner.RetryAfter(5 * time.Second)
+		}()
+	})
+	runner.Run()
+	waitForRunWithRetry("fourth run", t, timer, obj, 5*time.Second)
+
+	// Call Run again before minInterval passes
+	timer.advance(100 * time.Millisecond) // rel=100ms
+	runner.Run()
+	waitForDefer("too soon after fourth run", t, timer, obj, 900*time.Millisecond)
+
+	// Deferred run will run after minInterval passes
+	timer.advance(900 * time.Millisecond) // rel=1000ms
+	waitForRun("fifth run", t, timer, obj)
+
+	// Retry was cancelled because we already ran
+	timer.advance(4 * time.Second) // rel=4s since run, 5s since RetryAfter
+	waitForNothing("retry cancelled", t, timer, obj)
+
+	// Rerun happens after maxInterval
+	timer.advance(5 * time.Second) // rel=9s since run, 10s since RetryAfter
+	waitForNothing("premature", t, timer, obj)
+	timer.advance(time.Second) // rel=10s since run
+	waitForRun("maxInterval", t, timer, obj)
+
+	// Clean up.
+	stop <- struct{}{}
+	// a message is sent to time.updated in func Stop() at the end of the child goroutine
+	// to terminate the child, a receive on time.updated is needed here
+	<-timer.updated
+}

--- a/pkg/proxy/winkernel/proxier.go
+++ b/pkg/proxy/winkernel/proxier.go
@@ -753,9 +753,8 @@ func NewProxier(
 		return nil, err
 	}
 
-	burstSyncs := 2
-	klog.V(3).InfoS("Record sync param", "minSyncPeriod", minSyncPeriod, "syncPeriod", syncPeriod, "burstSyncs", burstSyncs)
-	proxier.syncRunner = runner.NewBoundedFrequencyRunner("sync-runner", proxier.syncProxyRules, minSyncPeriod, syncPeriod, burstSyncs)
+	klog.V(3).InfoS("Record sync param", "minSyncPeriod", minSyncPeriod, "syncPeriod", syncPeriod)
+	proxier.syncRunner = runner.NewBoundedFrequencyRunner("sync-runner", proxier.syncProxyRules, minSyncPeriod, syncPeriod)
 	return proxier, nil
 }
 

--- a/pkg/proxy/winkernel/proxier.go
+++ b/pkg/proxy/winkernel/proxier.go
@@ -48,8 +48,8 @@ import (
 	"k8s.io/kubernetes/pkg/proxy/healthcheck"
 	"k8s.io/kubernetes/pkg/proxy/metaproxier"
 	"k8s.io/kubernetes/pkg/proxy/metrics"
+	"k8s.io/kubernetes/pkg/proxy/runner"
 	proxyutil "k8s.io/kubernetes/pkg/proxy/util"
-	"k8s.io/kubernetes/pkg/util/async"
 	netutils "k8s.io/utils/net"
 )
 
@@ -660,7 +660,7 @@ type Proxier struct {
 	endpointSlicesSynced bool
 	servicesSynced       bool
 	initialized          int32
-	syncRunner           *async.BoundedFrequencyRunner // governs calls to syncProxyRules
+	syncRunner           *runner.BoundedFrequencyRunner // governs calls to syncProxyRules
 	// These are effectively const and do not need the mutex to be held.
 	nodeName string
 	nodeIP   net.IP
@@ -755,7 +755,7 @@ func NewProxier(
 
 	burstSyncs := 2
 	klog.V(3).InfoS("Record sync param", "minSyncPeriod", minSyncPeriod, "syncPeriod", syncPeriod, "burstSyncs", burstSyncs)
-	proxier.syncRunner = async.NewBoundedFrequencyRunner("sync-runner", proxier.syncProxyRules, minSyncPeriod, syncPeriod, burstSyncs)
+	proxier.syncRunner = runner.NewBoundedFrequencyRunner("sync-runner", proxier.syncProxyRules, minSyncPeriod, syncPeriod, burstSyncs)
 	return proxier, nil
 }
 


### PR DESCRIPTION
Moves BoundedFrequencyRunner to `pkg/proxy` and rewrites it slightly; updated version of #131502.

@aojea I started this to split up the changes in more steps to make the end result easier to review. It's still against the same base commit as your PR so you can diff them against each other to see the differences, but in particular:

1. I rewrote a bunch of comments (both old and new ones), and removed some comments that seemed to be explaining obvious things (or things that had already been explained by a previous comment).
2. I shrank the `func() { ... }()` section of `Loop` since it seemed larger than it needed to be.
3. I changed `Run` to _not_ check for `bfr.ready`, since it seems to me that this would create a race condition; if you called `Run` too quickly after `Loop`, then the `Run` would be ignored. This, in turn, made it unnecessary to have the unit tests wait for `bfr.ready`, which in turn made `bfr.ready` completely unused, so I removed it.
4. I fixed a few of the Retry tests to `setReturnValue` before calling `runner.Run`, rather than after, since it seems like doing it after would create a race condition.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/kind cleanup
/sig network
/priority important-soon
/triage accepted
