### PR TITLE
Promote kuberc to beta

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go
@@ -363,7 +363,7 @@ func NewKubectlCommand(o KubectlOptions) *cobra.Command {
 	flags.BoolVar(&warningsAsErrors, "warnings-as-errors", warningsAsErrors, "Treat warnings received from the server as errors and exit with a non-zero exit code")
 
 	pref := kuberc.NewPreferences()
-	if cmdutil.KubeRC.IsEnabled() {
+	if !cmdutil.KubeRC.IsDisabled() {
 		pref.AddFlags(flags)
 	}
 
@@ -499,7 +499,7 @@ func NewKubectlCommand(o KubectlOptions) *cobra.Command {
 	// add the klog flags later.
 	cmds.SetGlobalNormalizationFunc(cliflag.WordSepNormalizeFunc)
 
-	if cmdutil.KubeRC.IsEnabled() {
+	if !cmdutil.KubeRC.IsDisabled() {
 		_, err := pref.Apply(cmds, o.Arguments, o.IOStreams.ErrOut)
 		if err != nil {
 			fmt.Fprintf(o.IOStreams.ErrOut, "error occurred while applying preferences %v\n", err)

--- a/staging/src/k8s.io/kubectl/pkg/kuberc/kuberc.go
+++ b/staging/src/k8s.io/kubectl/pkg/kuberc/kuberc.go
@@ -86,7 +86,7 @@ type aliasing struct {
 
 // AddFlags adds kuberc related flags into the command.
 func (p *Preferences) AddFlags(flags *pflag.FlagSet) {
-	flags.String("kuberc", "", "Path to the kuberc file to use for preferences. This can be disabled by exporting KUBECTL_KUBERC=false.")
+	flags.String("kuberc", "", "Path to the kuberc file to use for preferences. This can be disabled by exporting KUBECTL_KUBERC=false feature gate or turning off the feature KUBERC=off.")
 }
 
 // Apply firstly applies the aliases in the preferences file and secondly overrides

--- a/staging/src/k8s.io/kubectl/pkg/kuberc/kuberc_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/kuberc/kuberc_test.go
@@ -26,8 +26,6 @@ import (
 	"github.com/spf13/cobra"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
-	"k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/config"
 )
 
@@ -898,51 +896,49 @@ func TestApplyOverride(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			cmdtesting.WithAlphaEnvs([]util.FeatureGate{util.KubeRC}, t, func(t *testing.T) {
-				rootCmd := &cobra.Command{
-					Use: "root",
+			rootCmd := &cobra.Command{
+				Use: "root",
+			}
+			prefHandler := NewPreferences()
+			prefHandler.AddFlags(rootCmd.PersistentFlags())
+			pref, ok := prefHandler.(*Preferences)
+			if !ok {
+				t.Fatal("unexpected type. Expected *Preferences")
+			}
+			addCommands(rootCmd, test.nestedCmds)
+			pref.getPreferencesFunc = test.getPreferencesFunc
+			errWriter := &bytes.Buffer{}
+			_, err := pref.Apply(rootCmd, test.args, errWriter)
+			if test.expectedErr == nil && err != nil {
+				t.Fatalf("unexpected error %v\n", err)
+			}
+			if test.expectedErr != nil {
+				if test.expectedErr.Error() != err.Error() {
+					t.Fatalf("error %s expected but actual is %s", test.expectedErr, err)
 				}
-				prefHandler := NewPreferences()
-				prefHandler.AddFlags(rootCmd.PersistentFlags())
-				pref, ok := prefHandler.(*Preferences)
-				if !ok {
-					t.Fatal("unexpected type. Expected *Preferences")
-				}
-				addCommands(rootCmd, test.nestedCmds)
-				pref.getPreferencesFunc = test.getPreferencesFunc
-				errWriter := &bytes.Buffer{}
-				_, err := pref.Apply(rootCmd, test.args, errWriter)
-				if test.expectedErr == nil && err != nil {
-					t.Fatalf("unexpected error %v\n", err)
-				}
-				if test.expectedErr != nil {
-					if test.expectedErr.Error() != err.Error() {
-						t.Fatalf("error %s expected but actual is %s", test.expectedErr, err)
-					}
-					return
-				}
+				return
+			}
 
-				actualCmd, _, err := rootCmd.Find(test.args[1:])
-				if err != nil {
-					t.Fatalf("unable to find the command %v\n", err)
-				}
+			actualCmd, _, err := rootCmd.Find(test.args[1:])
+			if err != nil {
+				t.Fatalf("unable to find the command %v\n", err)
+			}
 
-				err = actualCmd.ParseFlags(test.args[1:])
-				if err != nil {
-					t.Fatalf("unexpected error %v\n", err)
-				}
+			err = actualCmd.ParseFlags(test.args[1:])
+			if err != nil {
+				t.Fatalf("unexpected error %v\n", err)
+			}
 
-				if errWriter.String() != "" {
-					t.Fatalf("unexpected error message %s\n", errWriter.String())
-				}
+			if errWriter.String() != "" {
+				t.Fatalf("unexpected error message %s\n", errWriter.String())
+			}
 
-				for _, expectedFlag := range test.expectedFLags {
-					actualFlag := actualCmd.Flag(expectedFlag.name)
-					if actualFlag.Value.String() != expectedFlag.value {
-						t.Fatalf("unexpected flag value expected %s actual %s", expectedFlag.value, actualFlag.Value.String())
-					}
+			for _, expectedFlag := range test.expectedFLags {
+				actualFlag := actualCmd.Flag(expectedFlag.name)
+				if actualFlag.Value.String() != expectedFlag.value {
+					t.Fatalf("unexpected flag value expected %s actual %s", expectedFlag.value, actualFlag.Value.String())
 				}
-			})
+			}
 		})
 	}
 }
@@ -1140,48 +1136,46 @@ func TestApplOverrideBool(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			cmdtesting.WithAlphaEnvs([]util.FeatureGate{util.KubeRC}, t, func(t *testing.T) {
-				rootCmd := &cobra.Command{
-					Use: "root",
-				}
-				prefHandler := NewPreferences()
-				prefHandler.AddFlags(rootCmd.PersistentFlags())
-				pref, ok := prefHandler.(*Preferences)
-				if !ok {
-					t.Fatal("unexpected type. Expected *Preferences")
-				}
-				addCommands(rootCmd, test.nestedCmds)
-				pref.getPreferencesFunc = test.getPreferencesFunc
-				errWriter := &bytes.Buffer{}
-				_, err := pref.Apply(rootCmd, test.args, errWriter)
+			rootCmd := &cobra.Command{
+				Use: "root",
+			}
+			prefHandler := NewPreferences()
+			prefHandler.AddFlags(rootCmd.PersistentFlags())
+			pref, ok := prefHandler.(*Preferences)
+			if !ok {
+				t.Fatal("unexpected type. Expected *Preferences")
+			}
+			addCommands(rootCmd, test.nestedCmds)
+			pref.getPreferencesFunc = test.getPreferencesFunc
+			errWriter := &bytes.Buffer{}
+			_, err := pref.Apply(rootCmd, test.args, errWriter)
+			if err != nil {
+				t.Fatalf("unexpected error %v\n", err)
+			}
+			actualCmd, _, err := rootCmd.Find(test.args[1:])
+			if err != nil {
+				t.Fatalf("unable to find the command %v\n", err)
+			}
+
+			err = actualCmd.ParseFlags(test.args[1:])
+			if err != nil {
+				t.Fatalf("unexpected error %v\n", err)
+			}
+
+			if errWriter.String() != "" {
+				t.Fatalf("unexpected error message %s\n", errWriter.String())
+			}
+
+			for _, expectedFlag := range test.expectedFLags {
+				actualFlag := actualCmd.Flag(expectedFlag.name)
+				actualValue, err := strconv.ParseBool(actualFlag.Value.String())
 				if err != nil {
 					t.Fatalf("unexpected error %v\n", err)
 				}
-				actualCmd, _, err := rootCmd.Find(test.args[1:])
-				if err != nil {
-					t.Fatalf("unable to find the command %v\n", err)
+				if actualValue != expectedFlag.value {
+					t.Fatalf("unexpected flag value expected %t actual %s", expectedFlag.value, actualFlag.Value.String())
 				}
-
-				err = actualCmd.ParseFlags(test.args[1:])
-				if err != nil {
-					t.Fatalf("unexpected error %v\n", err)
-				}
-
-				if errWriter.String() != "" {
-					t.Fatalf("unexpected error message %s\n", errWriter.String())
-				}
-
-				for _, expectedFlag := range test.expectedFLags {
-					actualFlag := actualCmd.Flag(expectedFlag.name)
-					actualValue, err := strconv.ParseBool(actualFlag.Value.String())
-					if err != nil {
-						t.Fatalf("unexpected error %v\n", err)
-					}
-					if actualValue != expectedFlag.value {
-						t.Fatalf("unexpected flag value expected %t actual %s", expectedFlag.value, actualFlag.Value.String())
-					}
-				}
-			})
+			}
 		})
 	}
 }
@@ -1427,72 +1421,70 @@ func TestApplyAliasBool(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			cmdtesting.WithAlphaEnvs([]util.FeatureGate{util.KubeRC}, t, func(t *testing.T) {
-				rootCmd := &cobra.Command{
-					Use: "root",
+			rootCmd := &cobra.Command{
+				Use: "root",
+			}
+			prefHandler := NewPreferences()
+			prefHandler.AddFlags(rootCmd.PersistentFlags())
+			pref, ok := prefHandler.(*Preferences)
+			if !ok {
+				t.Fatal("unexpected type. Expected *Preferences")
+			}
+			addCommands(rootCmd, test.nestedCmds)
+			pref.getPreferencesFunc = test.getPreferencesFunc
+			errWriter := &bytes.Buffer{}
+			lastArgs, err := pref.Apply(rootCmd, test.args, errWriter)
+			if test.expectedErr == nil && err != nil {
+				t.Fatalf("unexpected error %v\n", err)
+			}
+			if test.expectedErr != nil {
+				if test.expectedErr.Error() != err.Error() {
+					t.Fatalf("error %s expected but actual is %s", test.expectedErr, err)
 				}
-				prefHandler := NewPreferences()
-				prefHandler.AddFlags(rootCmd.PersistentFlags())
-				pref, ok := prefHandler.(*Preferences)
-				if !ok {
-					t.Fatal("unexpected type. Expected *Preferences")
-				}
-				addCommands(rootCmd, test.nestedCmds)
-				pref.getPreferencesFunc = test.getPreferencesFunc
-				errWriter := &bytes.Buffer{}
-				lastArgs, err := pref.Apply(rootCmd, test.args, errWriter)
-				if test.expectedErr == nil && err != nil {
+				return
+			}
+
+			actualCmd, _, err := rootCmd.Find(lastArgs[1:])
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			err = actualCmd.ParseFlags(lastArgs)
+			if err != nil {
+				t.Fatalf("unexpected error %v\n", err)
+			}
+
+			if errWriter.String() != "" {
+				t.Fatalf("unexpected error message %s\n", errWriter.String())
+			}
+
+			if test.expectedCmd != actualCmd.Name() {
+				t.Fatalf("unexpected command expected %s actual %s", test.expectedCmd, actualCmd.Name())
+			}
+
+			for _, expectedFlag := range test.expectedFLags {
+				actualFlag := actualCmd.Flag(expectedFlag.name)
+				actualValue, err := strconv.ParseBool(actualFlag.Value.String())
+				if err != nil {
 					t.Fatalf("unexpected error %v\n", err)
 				}
-				if test.expectedErr != nil {
-					if test.expectedErr.Error() != err.Error() {
-						t.Fatalf("error %s expected but actual is %s", test.expectedErr, err)
-					}
-					return
+				if actualValue != expectedFlag.value {
+					t.Fatalf("unexpected flag value expected %t actual %s", expectedFlag.value, actualFlag.Value.String())
 				}
+			}
 
-				actualCmd, _, err := rootCmd.Find(lastArgs[1:])
-				if err != nil {
-					t.Fatal(err)
-				}
-
-				err = actualCmd.ParseFlags(lastArgs)
-				if err != nil {
-					t.Fatalf("unexpected error %v\n", err)
-				}
-
-				if errWriter.String() != "" {
-					t.Fatalf("unexpected error message %s\n", errWriter.String())
-				}
-
-				if test.expectedCmd != actualCmd.Name() {
-					t.Fatalf("unexpected command expected %s actual %s", test.expectedCmd, actualCmd.Name())
-				}
-
-				for _, expectedFlag := range test.expectedFLags {
-					actualFlag := actualCmd.Flag(expectedFlag.name)
-					actualValue, err := strconv.ParseBool(actualFlag.Value.String())
-					if err != nil {
-						t.Fatalf("unexpected error %v\n", err)
-					}
-					if actualValue != expectedFlag.value {
-						t.Fatalf("unexpected flag value expected %t actual %s", expectedFlag.value, actualFlag.Value.String())
+			for _, expectedArg := range test.expectedArgs {
+				found := false
+				for _, actualArg := range lastArgs {
+					if actualArg == expectedArg {
+						found = true
+						break
 					}
 				}
-
-				for _, expectedArg := range test.expectedArgs {
-					found := false
-					for _, actualArg := range lastArgs {
-						if actualArg == expectedArg {
-							found = true
-							break
-						}
-					}
-					if !found {
-						t.Fatalf("expected arg %s can not be found", expectedArg)
-					}
+				if !found {
+					t.Fatalf("expected arg %s can not be found", expectedArg)
 				}
-			})
+			}
 		})
 	}
 }
@@ -2572,68 +2564,66 @@ func TestApplyAlias(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			cmdtesting.WithAlphaEnvs([]util.FeatureGate{util.KubeRC}, t, func(t *testing.T) {
-				rootCmd := &cobra.Command{
-					Use: "root",
+			rootCmd := &cobra.Command{
+				Use: "root",
+			}
+			prefHandler := NewPreferences()
+			prefHandler.AddFlags(rootCmd.PersistentFlags())
+			pref, ok := prefHandler.(*Preferences)
+			if !ok {
+				t.Fatal("unexpected type. Expected *Preferences")
+			}
+			addCommands(rootCmd, test.nestedCmds)
+			pref.getPreferencesFunc = test.getPreferencesFunc
+			errWriter := &bytes.Buffer{}
+			lastArgs, err := pref.Apply(rootCmd, test.args, errWriter)
+			if test.expectedErr == nil && err != nil {
+				t.Fatalf("unexpected error %v\n", err)
+			}
+			if test.expectedErr != nil {
+				if test.expectedErr.Error() != err.Error() {
+					t.Fatalf("error %s expected but actual is %s", test.expectedErr, err)
 				}
-				prefHandler := NewPreferences()
-				prefHandler.AddFlags(rootCmd.PersistentFlags())
-				pref, ok := prefHandler.(*Preferences)
-				if !ok {
-					t.Fatal("unexpected type. Expected *Preferences")
-				}
-				addCommands(rootCmd, test.nestedCmds)
-				pref.getPreferencesFunc = test.getPreferencesFunc
-				errWriter := &bytes.Buffer{}
-				lastArgs, err := pref.Apply(rootCmd, test.args, errWriter)
-				if test.expectedErr == nil && err != nil {
-					t.Fatalf("unexpected error %v\n", err)
-				}
-				if test.expectedErr != nil {
-					if test.expectedErr.Error() != err.Error() {
-						t.Fatalf("error %s expected but actual is %s", test.expectedErr, err)
-					}
-					return
-				}
+				return
+			}
 
-				actualCmd, _, err := rootCmd.Find(lastArgs[1:])
-				if err != nil {
-					t.Fatal(err)
-				}
+			actualCmd, _, err := rootCmd.Find(lastArgs[1:])
+			if err != nil {
+				t.Fatal(err)
+			}
 
-				err = actualCmd.ParseFlags(lastArgs)
-				if err != nil {
-					t.Fatalf("unexpected error %v\n", err)
-				}
+			err = actualCmd.ParseFlags(lastArgs)
+			if err != nil {
+				t.Fatalf("unexpected error %v\n", err)
+			}
 
-				if errWriter.String() != "" {
-					t.Fatalf("unexpected error message %s\n", errWriter.String())
-				}
+			if errWriter.String() != "" {
+				t.Fatalf("unexpected error message %s\n", errWriter.String())
+			}
 
-				if test.expectedCmd != actualCmd.Name() {
-					t.Fatalf("unexpected command expected %s actual %s", test.expectedCmd, actualCmd.Name())
-				}
+			if test.expectedCmd != actualCmd.Name() {
+				t.Fatalf("unexpected command expected %s actual %s", test.expectedCmd, actualCmd.Name())
+			}
 
-				for _, expectedFlag := range test.expectedFLags {
-					actualFlag := actualCmd.Flag(expectedFlag.name)
-					if actualFlag.Value.String() != expectedFlag.value {
-						t.Fatalf("unexpected flag value expected %s actual %s", expectedFlag.value, actualFlag.Value.String())
-					}
+			for _, expectedFlag := range test.expectedFLags {
+				actualFlag := actualCmd.Flag(expectedFlag.name)
+				if actualFlag.Value.String() != expectedFlag.value {
+					t.Fatalf("unexpected flag value expected %s actual %s", expectedFlag.value, actualFlag.Value.String())
 				}
+			}
 
-				for _, expectedArg := range test.expectedArgs {
-					found := false
-					for _, actualArg := range lastArgs {
-						if actualArg == expectedArg {
-							found = true
-							break
-						}
-					}
-					if !found {
-						t.Fatalf("expected arg %s can not be found", expectedArg)
+			for _, expectedArg := range test.expectedArgs {
+				found := false
+				for _, actualArg := range lastArgs {
+					if actualArg == expectedArg {
+						found = true
+						break
 					}
 				}
-			})
+				if !found {
+					t.Fatalf("expected arg %s can not be found", expectedArg)
+				}
+			}
 		})
 	}
 }

--- a/test/cmd/kuberc.sh
+++ b/test/cmd/kuberc.sh
@@ -25,9 +25,6 @@ run_kuberc_tests() {
   create_and_use_new_namespace
   kube::log::status "Testing kuberc"
 
-  # Enable KUBERC feature
-  export KUBECTL_KUBERC=true
-
   cat > "${TMPDIR:-/tmp}"/kuberc_file << EOF
 apiVersion: kubectl.config.k8s.io/v1alpha1
 kind: Preference
@@ -188,8 +185,6 @@ EOF
   # assure that explicit value supersedes
   output_message=$(kubectl delete namespace/test-kuberc-ns --interactive=false --kuberc="${TMPDIR:-/tmp}"/kuberc_file)
   kube::test::if_has_string "${output_message}" 'namespace "test-kuberc-ns" deleted'
-
-  unset KUBECTL_KUBERC
 
   set +o nounset
   set +o errexit


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This PR promotes kuberc to beta which means that it is enabled by default and can be disabled via;
* Turning off the feature gate -- `KUBECTL_KUBERC=false` (when it is promoted to GA, this flag will disappear) or
* Turning off the functionality -- `KUBERC=off`

#### Does this PR introduce a user-facing change?
```release-note
If users define a valid kuberc file in a given location, it will be functioning. 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-cli/3104-introduce-kuberc
```
