### PR TITLE
Automated cherry pick of #131609: fix(scheduler): node pre-check logic to consider NoExecute taint effect

### DIFF
--- a/pkg/scheduler/eventhandlers.go
+++ b/pkg/scheduler/eventhandlers.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/helper"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/nodeaffinity"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/nodename"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/nodeports"
@@ -610,9 +611,7 @@ func preCheckForNode(nodeInfo *framework.NodeInfo) queue.PreEnqueueCheck {
 		if len(admissionResults) != 0 {
 			return false
 		}
-		_, isUntolerated := corev1helpers.FindMatchingUntoleratedTaint(nodeInfo.Node().Spec.Taints, pod.Spec.Tolerations, func(t *v1.Taint) bool {
-			return t.Effect == v1.TaintEffectNoSchedule
-		})
+		_, isUntolerated := corev1helpers.FindMatchingUntoleratedTaint(nodeInfo.Node().Spec.Taints, pod.Spec.Tolerations, helper.DoNotScheduleTaintsFilterFunc())
 		return !isUntolerated
 	}
 }

--- a/pkg/scheduler/eventhandlers_test.go
+++ b/pkg/scheduler/eventhandlers_test.go
@@ -337,6 +337,26 @@ func TestPreCheckForNode(t *testing.T) {
 			},
 			want: []bool{false, true, false, false},
 		},
+		{
+			name: "tainted node with NoExecute effect, pods with tolerations",
+			nodeFn: func() *v1.Node {
+				node := st.MakeNode().Name("fake-node").Label("hostname", "fake-node").Capacity(cpu8).Obj()
+				node.Spec.Taints = []v1.Taint{
+					{Key: "foo", Effect: v1.TaintEffectPreferNoSchedule},
+					{Key: "baz", Effect: v1.TaintEffectNoExecute},
+				}
+				return node
+			},
+			pods: []*v1.Pod{
+				st.MakePod().Name("p1").Obj(),
+				st.MakePod().Name("p2").Obj(),
+				st.MakePod().Name("p3").Toleration("foo").Obj(),
+				st.MakePod().Name("p4").Toleration("baz").Obj(),
+				st.MakePod().Name("p5").Obj(),
+				st.MakePod().Name("p6").Toleration("bar").Toleration("baz").Obj(),
+			},
+			want: []bool{false, false, false, true, false, true},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Cherry pick of #131609 on release-1.30.

#131609: fix(scheduler): node pre-check logic to consider NoExecute taint effect

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
None
```