### PR TITLE
Update sig-network-approvers/reviewers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -267,28 +267,23 @@ aliases:
     - ffromani
     - tallclair
   sig-network-approvers:
-    - andrewsykim
     - aojea
     - bowei
-    - caseydavenport
     - danwinship
-    - dcbw
-    - freehan
-    - khenidak
-    - mrhohn
     - robscott
     - thockin
+  # emeritus:
+  # - andrewsykim
+  # - caseydavenport
+  # - dcbw
+  # - freehan
+  # - khenidak
+  # - mrhohn
   sig-network-reviewers:
-    - andrewsykim
     - aojea
     - aroradaman
     - bowei
-    - caseydavenport
     - danwinship
-    - dcbw
-    - freehan
-    - khenidak
-    - mrhohn
     - robscott
     - thockin
     - tnqn


### PR DESCRIPTION
Update sig-network-approvers/reviewers, emeritus-ing people who are no longer around (or no longer involved with sig-network really).

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/kind cleanup
/sig network
/priority important-soon
/triage accepted
/assign @thockin 