### PR TITLE
client-go remotecommand: avoid "unexpected error" log when there is no error

### DIFF
--- a/staging/src/k8s.io/client-go/tools/remotecommand/fallback.go
+++ b/staging/src/k8s.io/client-go/tools/remotecommand/fallback.go
@@ -52,7 +52,7 @@ func (f *FallbackExecutor) Stream(options StreamOptions) error {
 // initial primary call to upgrade to a websocket connection fails.
 func (f *FallbackExecutor) StreamWithContext(ctx context.Context, options StreamOptions) error {
 	err := f.primary.StreamWithContext(ctx, options)
-	if f.shouldFallback(err) {
+	if err != nil && f.shouldFallback(err) {
 		klog.V(4).Infof("RemoteCommand fallback: %v", err)
 		return f.secondary.StreamWithContext(ctx, options)
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Normal execution always started to trigger this after adding more logging in the E2E framework's exec_util.go:
    
         I0506 21:23:56.781188 6341 exec_util.go:201] unexpected error trying to use websockets for pod exec: <nil>
    
That the "should fall back" implementation gets called when there is no error
and thus no reason to even consider falling back is odd. Now the execute
implementation checks for nil first.
    
This is the same approach taken also in the portforward code:
https://github.com/kubernetes/kubernetes/blob/b35c5c0a301d326fdfa353943fca077778544ac6/staging/src/k8s.io/client-go/tools/portforward/fallback_dialer.go#L52

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/kubernetes/pull/130372/files#r2077553255

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @aojea 