### PR TITLE
 Manually read verbosity before kubectl command construction

### DIFF
--- a/cmd/kubectl/kubectl.go
+++ b/cmd/kubectl/kubectl.go
@@ -17,7 +17,10 @@ limitations under the License.
 package main
 
 import (
+	"os"
+
 	"k8s.io/component-base/cli"
+	"k8s.io/component-base/logs"
 	"k8s.io/kubectl/pkg/cmd"
 	"k8s.io/kubectl/pkg/cmd/util"
 
@@ -26,6 +29,13 @@ import (
 )
 
 func main() {
+	// We need to manually parse the arguments looking for verbosity flag and
+	// set appropriate level here, because in the normal flow the flag parsing,
+	// including the logging verbosity, happens inside cli.RunNoErrOutput.
+	// Doing it here ensures we can continue using klog during kubectl command
+	// construction, which includes handling plugins and parsing .kuberc file,
+	// for example.
+	logs.GlogSetter(cmd.GetLogVerbosity(os.Args)) // nolint:errcheck
 	command := cmd.NewDefaultKubectlCommand()
 	if err := cli.RunNoErrOutput(command); err != nil {
 		// Pretty-print the error and exit with an error.

--- a/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go
@@ -583,3 +583,29 @@ func registerCompletionFuncForGlobalFlags(cmd *cobra.Command, f cmdutil.Factory)
 			return utilcomp.ListUsersInConfig(toComplete), cobra.ShellCompDirectiveNoFileComp
 		}))
 }
+
+// GetLogVerbosity parses the provided command-line arguments to determine
+// the verbosity level for logging. Returns string representing the verbosity
+// level, or 0 if no verbosity flag is specified.
+func GetLogVerbosity(args []string) string {
+	for i, arg := range args {
+		if arg == "--" {
+			// flags after "--" does not represent any flag of
+			// the command. We should short cut the iteration in here.
+			break
+		}
+
+		if arg == "--v" || arg == "-v" {
+			if i+1 < len(args) {
+				return args[i+1]
+			}
+		} else if strings.Contains(arg, "--v=") || strings.Contains(arg, "-v=") {
+			parg := strings.Split(arg, "=")
+			if len(parg) > 1 && parg[1] != "" {
+				return parg[1]
+			}
+		}
+	}
+
+	return "0"
+}

--- a/test/cmd/kuberc.sh
+++ b/test/cmd/kuberc.sh
@@ -184,6 +184,18 @@ EOF
   # assure that warning message is also printed for the notexist kuberc version
   kube::test::if_has_string "${output_message}" "strict decoding error" "unknown"
 
+  touch "${TMPDIR:-/tmp}"/empty_kuberc_file
+  output_message=$(kubectl get namespace test-kuberc-ns 2>&1 "${kube_flags[@]:?}" --kuberc="${TMPDIR:-/tmp}"/empty_kuberc_file)
+  kube::test::if_has_not_string "${output_message}" "kuberc: no preferences found in"
+  output_message=$(kubectl get namespace test-kuberc-ns 2>&1 "${kube_flags[@]:?}" --kuberc="${TMPDIR:-/tmp}"/empty_kuberc_file -v=5)
+  kube::test::if_has_string "${output_message}" "kuberc: no preferences found in"
+  output_message=$(kubectl get namespace test-kuberc-ns 2>&1 -v 5 "${kube_flags[@]:?}" --kuberc="${TMPDIR:-/tmp}"/empty_kuberc_file)
+  kube::test::if_has_string "${output_message}" "kuberc: no preferences found in"
+  output_message=$(kubectl get namespace test-kuberc-ns 2>&1 "${kube_flags[@]:?}" --v=5 --kuberc="${TMPDIR:-/tmp}"/empty_kuberc_file)
+  kube::test::if_has_string "${output_message}" "kuberc: no preferences found in"
+  output_message=$(kubectl get --v 5 namespace test-kuberc-ns 2>&1 "${kube_flags[@]:?}" --kuberc="${TMPDIR:-/tmp}"/empty_kuberc_file)
+  kube::test::if_has_string "${output_message}" "kuberc: no preferences found in"
+
   # explicitly overwriting the value that is also defaulted in kuberc and
   # assure that explicit value supersedes
   output_message=$(kubectl delete namespace/test-kuberc-ns --interactive=false --kuberc="${TMPDIR:-/tmp}"/kuberc_file)


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/sig cli

#### What this PR does / why we need it:
kubectl command construction is slowly getting more functionality which sometimes requires to log certain actions. Currently we parse the verbosity only when actually running the command, so all of construction code is not able to use `-v=5`. This commit adds the manual parsing and loglevel setting before we even start creating the kubectl command.

The 2nd commit with tests is coming from https://github.com/kubernetes/kubernetes/pull/131290 courtesy of @ardaguclu 

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubectl/issues/1731

#### Special notes for your reviewer:
/assign @ardaguclu 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
<!--
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-cli/3104-introduce-kuberc
```
