### PR TITLE
client-go: call out WithContext inconsistency

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/listwatch.go
+++ b/staging/src/k8s.io/client-go/tools/cache/listwatch.go
@@ -154,6 +154,10 @@ type WatchFuncWithContext func(ctx context.Context, options metav1.ListOptions) 
 // ListWithContextFunc and WatchFuncWithContext are preferred if
 // a context is available, otherwise ListFunc and WatchFunc.
 //
+// Beware of the inconsistent naming of the two WithContext methods.
+// This was unintentional, but fixing it now would force the ecosystem
+// to go through a breaking Go API change and was deemed not worth it.
+//
 // NewFilteredListWatchFromClient sets all of the functions to ensure that callers
 // which only know about ListFunc and WatchFunc continue to work.
 type ListWatch struct {


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

This raises awareness so that developers hopefully get it right without having to learn about it from compile errors. It also explains that creating a PR to fix the naming is not desired.

#### Which issue(s) this PR fixes:

Related-to:  https://github.com/kubernetes/kubernetes/pull/131529#discussion_r2066565061

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/cc @wzshiming @liggitt 