### PR TITLE
Kubectl FeatureGate cleanups

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go
@@ -143,25 +143,23 @@ func NewDefaultKubectlCommandWithArgs(o KubectlOptions) *cobra.Command {
 				}
 			}
 		} else if err == nil {
-			if !cmdutil.CmdPluginAsSubcommand.IsDisabled() {
-				// Command exists(e.g. kubectl create), but it is not certain that
-				// subcommand also exists (e.g. kubectl create networkpolicy)
-				// we also have to eliminate kubectl create -f
-				if IsSubcommandPluginAllowed(foundCmd.Name()) && len(foundArgs) >= 1 && !strings.HasPrefix(foundArgs[0], "-") {
-					subcommand := foundArgs[0]
-					builtinSubcmdExist := false
-					for _, subcmd := range foundCmd.Commands() {
-						if subcmd.Name() == subcommand {
-							builtinSubcmdExist = true
-							break
-						}
+			// Command exists(e.g. kubectl create), but it is not certain that
+			// subcommand also exists (e.g. kubectl create networkpolicy)
+			// we also have to eliminate kubectl create -f
+			if IsSubcommandPluginAllowed(foundCmd.Name()) && len(foundArgs) >= 1 && !strings.HasPrefix(foundArgs[0], "-") {
+				subcommand := foundArgs[0]
+				builtinSubcmdExist := false
+				for _, subcmd := range foundCmd.Commands() {
+					if subcmd.Name() == subcommand {
+						builtinSubcmdExist = true
+						break
 					}
+				}
 
-					if !builtinSubcmdExist {
-						if err := HandlePluginCommand(o.PluginHandler, cmdPathPieces, len(cmdPathPieces)-len(foundArgs)+1); err != nil {
-							fmt.Fprintf(o.IOStreams.ErrOut, "Error: %v\n", err)
-							os.Exit(1)
-						}
+				if !builtinSubcmdExist {
+					if err := HandlePluginCommand(o.PluginHandler, cmdPathPieces, len(cmdPathPieces)-len(foundArgs)+1); err != nil {
+						fmt.Fprintf(o.IOStreams.ErrOut, "Error: %v\n", err)
+						os.Exit(1)
 					}
 				}
 			}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go
@@ -83,8 +83,6 @@ import (
 	"k8s.io/kubectl/pkg/cmd/kustomize"
 )
 
-const kubectlCmdHeaders = "KUBECTL_COMMAND_HEADERS"
-
 type KubectlOptions struct {
 	PluginHandler PluginHandler
 	Arguments     []string
@@ -522,12 +520,9 @@ func NewKubectlCommand(o KubectlOptions) *cobra.Command {
 //
 //	https://github.com/kubernetes/enhancements/tree/master/keps/sig-cli/859-kubectl-headers
 func addCmdHeaderHooks(cmds *cobra.Command, kubeConfigFlags *genericclioptions.ConfigFlags) {
-	// If the feature gate env var is set to "false", then do no add kubectl command headers.
-	if value, exists := os.LookupEnv(kubectlCmdHeaders); exists {
-		if value == "false" || value == "0" {
-			klog.V(5).Infoln("kubectl command headers turned off")
-			return
-		}
+	if cmdutil.CmdHeaders.IsDisabled() {
+		klog.V(5).Infoln("kubectl command headers turned off")
+		return
 	}
 	klog.V(5).Infoln("kubectl command headers turned on")
 	crt := &genericclioptions.CommandHeaderRoundTripper{}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/cmd_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cmd_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/kubectl/pkg/cmd/plugin"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 )
 
 func TestNormalizationFuncGlobalExistence(t *testing.T) {
@@ -381,10 +382,6 @@ func TestKubectlCommandHeadersHooks(t *testing.T) {
 			envVar:    "false",
 			addsHooks: false,
 		},
-		"zero env var value; hooks NOT added": {
-			envVar:    "0",
-			addsHooks: false,
-		},
 	}
 
 	for name, testCase := range tests {
@@ -394,7 +391,7 @@ func TestKubectlCommandHeadersHooks(t *testing.T) {
 			if kubeConfigFlags.WrapConfigFn != nil {
 				t.Fatal("expected initial nil WrapConfigFn")
 			}
-			t.Setenv(kubectlCmdHeaders, testCase.envVar)
+			t.Setenv(string(cmdutil.CmdHeaders), testCase.envVar)
 			addCmdHeaderHooks(cmds, kubeConfigFlags)
 			// Valdidate whether the hooks were added.
 			if testCase.addsHooks && kubeConfigFlags.WrapConfigFn == nil {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
@@ -427,6 +427,7 @@ type FeatureGate string
 const (
 	ApplySet                FeatureGate = "KUBECTL_APPLYSET"
 	OpenAPIV3Patch          FeatureGate = "KUBECTL_OPENAPIV3_PATCH"
+	CmdHeaders FeatureGate = "KUBECTL_COMMAND_HEADERS"
 	RemoteCommandWebsockets FeatureGate = "KUBECTL_REMOTE_COMMAND_WEBSOCKETS"
 	PortForwardWebsockets   FeatureGate = "KUBECTL_PORT_FORWARD_WEBSOCKETS"
 	KubeRC                  FeatureGate = "KUBECTL_KUBERC"

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
@@ -426,7 +426,6 @@ type FeatureGate string
 
 const (
 	ApplySet                FeatureGate = "KUBECTL_APPLYSET"
-	CmdPluginAsSubcommand   FeatureGate = "KUBECTL_ENABLE_CMD_SHADOW"
 	OpenAPIV3Patch          FeatureGate = "KUBECTL_OPENAPIV3_PATCH"
 	RemoteCommandWebsockets FeatureGate = "KUBECTL_REMOTE_COMMAND_WEBSOCKETS"
 	PortForwardWebsockets   FeatureGate = "KUBECTL_PORT_FORWARD_WEBSOCKETS"

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
@@ -425,12 +425,36 @@ func GetPodRunningTimeoutFlag(cmd *cobra.Command) (time.Duration, error) {
 type FeatureGate string
 
 const (
-	ApplySet                FeatureGate = "KUBECTL_APPLYSET"
-	OpenAPIV3Patch          FeatureGate = "KUBECTL_OPENAPIV3_PATCH"
+	// owner: @soltysh
+	// kep: https://kep.k8s.io/859
+	//
+	// HTTP headers with command name and flags used.
 	CmdHeaders FeatureGate = "KUBECTL_COMMAND_HEADERS"
+
+	// owner: @ardaguclu
+	// kep: https://kep.k8s.io/3104
+	//
+	// Separate kubectl user preferences.
+	KubeRC FeatureGate = "KUBECTL_KUBERC"
+
+	// owner: @soltysh
+	// kep: https://kep.k8s.io/3515
+	//
+	// Improved kubectl apply --prune behavior.
+	OpenAPIV3Patch FeatureGate = "KUBECTL_OPENAPIV3_PATCH"
+
+	// owner: @justinb
+	// kep: https://kep.k8s.io/3659
+	//
+	// Improved kubectl apply --prune behavior.
+	ApplySet FeatureGate = "KUBECTL_APPLYSET"
+
+	// owner: @seans
+	// kep: https://kep.k8s.io/4006
+	//
+	// Transition to WebSockets.
 	RemoteCommandWebsockets FeatureGate = "KUBECTL_REMOTE_COMMAND_WEBSOCKETS"
 	PortForwardWebsockets   FeatureGate = "KUBECTL_PORT_FORWARD_WEBSOCKETS"
-	KubeRC                  FeatureGate = "KUBECTL_KUBERC"
 )
 
 // IsEnabled returns true iff environment variable is set to true.

--- a/test/cmd/results.sh
+++ b/test/cmd/results.sh
@@ -53,6 +53,11 @@ Error from server (NotFound): pods "no-such-pod" not found
 EOF
   kube::test::results::diff "${TEMP}/actual_stdout" "${TEMP}/actual_stderr" "$res" "${TEMP}/empty" "${TEMP}/expected_stderr" 1 "kubectl get pod/no-such-pod"
 
+  output_message=$(kubectl get namespace kube-system 2>&1 "${kube_flags[@]:?}")
+  kube::test::if_has_not_string "${output_message}" "command headers turned on"
+  output_message=$(kubectl get namespace kube-system 2>&1 "${kube_flags[@]:?}" -v=5)
+  kube::test::if_has_string "${output_message}" "command headers turned on"
+
   set +o nounset
   set +o errexit
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/kind documentation
/sig cli

#### What this PR does / why we need it:
This PR brings the following 3 elements:
1. Drop KUBECTL_ENABLE_CMD_SHADOW, which was promoted to stable back in 1.32 see https://kep.k8s.io/3638
2. Swap KUBECTL_COMMAND_HEADERS to use the current FeatreGate mechanism, it also adds a test which relies on https://github.com/kubernetes/kubernetes/pull/131668 to land first
3. Adds comments to all the feature gates with links to KEPs, so it's easier to track them. 

/hold
for https://github.com/kubernetes/kubernetes/pull/131668 to land first, since that test in `test/cmd/results.sh` will fail w/o that PR. 

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
/assign @ardaguclu 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
