### PR TITLE
refactor: Use http method constants in apimachinery

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/apitesting/roundtrip/compatibility.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/apitesting/roundtrip/compatibility.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	gojson "encoding/json"
 	"io/ioutil"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -115,7 +116,7 @@ func (c *CompatibilityTestOptions) Complete(t *testing.T) *CompatibilityTestOpti
 		c.TestDataDir = "testdata"
 	}
 	if c.TestDataDirCurrentVersion == "" {
-		c.TestDataDirCurrentVersion = filepath.Join(c.TestDataDir, "HEAD")
+		c.TestDataDirCurrentVersion = filepath.Join(c.TestDataDir, http.MethodHead)
 	}
 	if c.TestDataDirsPreviousVersions == nil {
 		dirs, err := filepath.Glob(filepath.Join(c.TestDataDir, "v*"))
@@ -199,7 +200,7 @@ func (c *CompatibilityTestOptions) Run(t *testing.T) {
 	for _, gvk := range c.Kinds {
 		t.Run(makeName(gvk), func(t *testing.T) {
 
-			t.Run("HEAD", func(t *testing.T) {
+			t.Run(http.MethodHead, func(t *testing.T) {
 				c.runCurrentVersionTest(t, gvk, usedHEADFixtures)
 			})
 

--- a/staging/src/k8s.io/apimachinery/pkg/api/errors/errors.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/errors/errors.go
@@ -438,7 +438,7 @@ func NewGenericServerResponse(code int, verb string, qualifiedResource schema.Gr
 	message := fmt.Sprintf("the server responded with the status code %d but did not return more information", code)
 	switch code {
 	case http.StatusConflict:
-		if verb == "POST" {
+		if verb == http.MethodPost {
 			reason = metav1.StatusReasonAlreadyExists
 		} else {
 			reason = metav1.StatusReasonConflict

--- a/staging/src/k8s.io/apimachinery/pkg/api/errors/errors_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/errors/errors_test.go
@@ -110,13 +110,13 @@ func TestErrorNew(t *testing.T) {
 	if time, ok := SuggestsClientDelay(NewTooManyRequests("doing something", 1)); time != 1 || !ok {
 		t.Errorf("unexpected %d", time)
 	}
-	if time, ok := SuggestsClientDelay(NewGenericServerResponse(429, "get", resource("tests"), "test", "doing something", 10, true)); time != 10 || !ok {
+	if time, ok := SuggestsClientDelay(NewGenericServerResponse(429, http.MethodGet, resource("tests"), "test", "doing something", 10, true)); time != 10 || !ok {
 		t.Errorf("unexpected %d", time)
 	}
-	if time, ok := SuggestsClientDelay(NewGenericServerResponse(500, "get", resource("tests"), "test", "doing something", 10, true)); time != 10 || !ok {
+	if time, ok := SuggestsClientDelay(NewGenericServerResponse(500, http.MethodGet, resource("tests"), "test", "doing something", 10, true)); time != 10 || !ok {
 		t.Errorf("unexpected %d", time)
 	}
-	if time, ok := SuggestsClientDelay(NewGenericServerResponse(429, "get", resource("tests"), "test", "doing something", 0, true)); time != 0 || ok {
+	if time, ok := SuggestsClientDelay(NewGenericServerResponse(429, http.MethodGet, resource("tests"), "test", "doing something", 0, true)); time != 0 || ok {
 		t.Errorf("unexpected %d", time)
 	}
 }

--- a/staging/src/k8s.io/apimachinery/pkg/util/httpstream/httpstream_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/httpstream/httpstream_test.go
@@ -79,7 +79,7 @@ func TestHandshake(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		req, err := http.NewRequest("GET", "http://www.example.com/", nil)
+		req, err := http.NewRequest(http.MethodGet, "http://www.example.com/", nil)
 		if err != nil {
 			t.Fatalf("%s: error creating request: %v", name, err)
 		}

--- a/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/roundtripper.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/roundtripper.go
@@ -194,7 +194,7 @@ func (s *SpdyRoundTripper) dialWithHttpProxy(req *http.Request, proxyURL *url.UR
 
 	// proxying logic adapted from http://blog.h6t.eu/post/74098062923/golang-websocket-with-http-proxy-support
 	proxyReq := http.Request{
-		Method: "CONNECT",
+		Method: http.MethodConnect,
 		URL:    &url.URL{},
 		Host:   targetHost,
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/roundtripper_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/roundtripper_test.go
@@ -321,7 +321,7 @@ func TestRoundTripAndNewConnection(t *testing.T) {
 			if err != nil {
 				t.Fatalf("error creating request: %s", err)
 			}
-			req, err := http.NewRequest("GET", server.URL, nil)
+			req, err := http.NewRequest(http.MethodGet, server.URL, nil)
 			if err != nil {
 				t.Fatalf("error creating request: %s", err)
 			}
@@ -612,7 +612,7 @@ func TestRoundTripSocks5AndNewConnection(t *testing.T) {
 			))
 			defer server.Close()
 
-			req, err := http.NewRequest("GET", server.URL, nil)
+			req, err := http.NewRequest(http.MethodGet, server.URL, nil)
 			if err != nil {
 				t.Fatalf("error creating request: %s", err)
 			}
@@ -778,7 +778,7 @@ func TestRoundTripPassesContextToDialer(t *testing.T) {
 		t.Run(u, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
-			req, err := http.NewRequestWithContext(ctx, "GET", u, nil)
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
 			require.NoError(t, err)
 			spdyTransport, err := NewRoundTripper(&tls.Config{})
 			if err != nil {

--- a/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/upgrade_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/upgrade_test.go
@@ -68,7 +68,7 @@ func TestUpgradeResponse(t *testing.T) {
 		}))
 		defer server.Close()
 
-		req, err := http.NewRequest("GET", server.URL, nil)
+		req, err := http.NewRequest(http.MethodGet, server.URL, nil)
 		if err != nil {
 			t.Fatalf("%d: error creating request: %s", i, err)
 		}

--- a/staging/src/k8s.io/apimachinery/pkg/util/httpstream/wsstream/conn_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/httpstream/wsstream/conn_test.go
@@ -369,7 +369,7 @@ func TestIsWebSocketRequestWithStreamCloseProtocol(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		req, err := http.NewRequest("GET", "http://www.example.com/", nil)
+		req, err := http.NewRequest(http.MethodGet, "http://www.example.com/", nil)
 		require.NoError(t, err)
 		for key, value := range test.headers {
 			req.Header.Add(key, value)

--- a/staging/src/k8s.io/apimachinery/pkg/util/net/http_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/net/http_test.go
@@ -211,7 +211,7 @@ func TestProxierWithNoProxyCIDR(t *testing.T) {
 			return nil, nil
 		})
 
-		req, err := http.NewRequest("GET", test.url, nil)
+		req, err := http.NewRequest(http.MethodGet, test.url, nil)
 		if err != nil {
 			t.Errorf("%s: unexpected err: %v", test.name, err)
 			continue
@@ -444,7 +444,7 @@ func TestSourceIPs(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			req, _ := http.NewRequest("GET", "https://cluster.k8s.io/apis/foobars/v1/foo/bar", nil)
+			req, _ := http.NewRequest(http.MethodGet, "https://cluster.k8s.io/apis/foobars/v1/foo/bar", nil)
 			req.RemoteAddr = test.remoteAddr
 			if test.forwardedFor != "" {
 				req.Header.Set("X-Forwarded-For", test.forwardedFor)

--- a/staging/src/k8s.io/apimachinery/pkg/util/proxy/transport_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/proxy/transport_test.go
@@ -280,7 +280,7 @@ func TestProxyTransport(t *testing.T) {
 		item.redirect = strings.Replace(item.redirect, sourceURL.Host, serverURL.Host, -1)
 		sourceURL.Host = serverURL.Host
 
-		req, err := http.NewRequest("GET", sourceURL.String(), nil)
+		req, err := http.NewRequest(http.MethodGet, sourceURL.String(), nil)
 		if err != nil {
 			t.Errorf("%v: Unexpected error: %v", name, err)
 			return
@@ -375,7 +375,7 @@ func TestRewriteResponse(t *testing.T) {
 		t.Errorf("%s failed to read and write: %v", encode, err)
 	}
 	for _, v := range test {
-		request, _ := http.NewRequest("GET", "http://mynode.com/", nil)
+		request, _ := http.NewRequest(http.MethodGet, "http://mynode.com/", nil)
 		request.Header.Set("Content-Encoding", v.encodeType)
 		request.Header.Add("Accept-Encoding", v.encodeType)
 

--- a/staging/src/k8s.io/apimachinery/pkg/util/proxy/upgradeaware_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/proxy/upgradeaware_test.go
@@ -168,13 +168,13 @@ func TestServeHTTP(t *testing.T) {
 	}{
 		{
 			name:         "root path, simple get",
-			method:       "GET",
+			method:       http.MethodGet,
 			requestPath:  "/",
 			expectedPath: "/",
 		},
 		{
 			name:            "no upgrade header sent",
-			method:          "GET",
+			method:          http.MethodGet,
 			requestPath:     "/",
 			upgradeRequired: true,
 			expectError: func(err error) bool {
@@ -183,13 +183,13 @@ func TestServeHTTP(t *testing.T) {
 		},
 		{
 			name:         "simple path, get",
-			method:       "GET",
+			method:       http.MethodGet,
 			requestPath:  "/path/to/test",
 			expectedPath: "/path/to/test",
 		},
 		{
 			name:          "request params",
-			method:        "POST",
+			method:        http.MethodPost,
 			requestPath:   "/some/path/",
 			expectedPath:  "/some/path/",
 			requestParams: map[string]string{"param1": "value/1", "param2": "value%2"},
@@ -197,26 +197,26 @@ func TestServeHTTP(t *testing.T) {
 		},
 		{
 			name:          "request headers",
-			method:        "PUT",
+			method:        http.MethodPut,
 			requestPath:   "/some/path",
 			expectedPath:  "/some/path",
 			requestHeader: map[string]string{"Header1": "value1", "Header2": "value2"},
 		},
 		{
 			name:         "empty path - slash should be added",
-			method:       "GET",
+			method:       http.MethodGet,
 			requestPath:  "",
 			expectedPath: "/",
 		},
 		{
 			name:         "remove CORS headers",
-			method:       "GET",
+			method:       http.MethodGet,
 			requestPath:  "/some/path",
 			expectedPath: "/some/path",
 			responseHeader: map[string]string{
 				"Header1":                      "value1",
 				"Access-Control-Allow-Origin":  "some.server",
-				"Access-Control-Allow-Methods": "GET"},
+				"Access-Control-Allow-Methods": http.MethodGet},
 			expectedRespHeader: map[string]string{
 				"Header1": "value1",
 			},
@@ -227,14 +227,14 @@ func TestServeHTTP(t *testing.T) {
 		},
 		{
 			name:            "use location host",
-			method:          "GET",
+			method:          http.MethodGet,
 			requestPath:     "/some/path",
 			expectedPath:    "/some/path",
 			useLocationHost: true,
 		},
 		{
 			name:            "use location host - invalid upgrade",
-			method:          "GET",
+			method:          http.MethodGet,
 			upgradeRequired: true,
 			requestHeader: map[string]string{
 				httpstream.HeaderConnection: httpstream.HeaderUpgrade,
@@ -248,21 +248,21 @@ func TestServeHTTP(t *testing.T) {
 		},
 		{
 			name:               "append server path to request path",
-			method:             "GET",
+			method:             http.MethodGet,
 			requestPath:        "/base",
 			expectedPath:       "/base/base",
 			appendLocationPath: true,
 		},
 		{
 			name:               "append server path to request path with ending slash",
-			method:             "GET",
+			method:             http.MethodGet,
 			requestPath:        "/base/",
 			expectedPath:       "/base/base/",
 			appendLocationPath: true,
 		},
 		{
 			name:               "don't append server path to request path",
-			method:             "GET",
+			method:             http.MethodGet,
 			requestPath:        "/base",
 			expectedPath:       "/base",
 			appendLocationPath: false,
@@ -590,7 +590,7 @@ func TestProxyUpgradeConnectionErrorResponse(t *testing.T) {
 	defer proxy.Close()
 
 	// Send request to proxy server.
-	req, err := http.NewRequest("POST", "http://"+proxy.Listener.Addr().String()+"/some/path", nil)
+	req, err := http.NewRequest(http.MethodPost, "http://"+proxy.Listener.Addr().String()+"/some/path", nil)
 	require.NoError(t, err)
 	req.Header.Set(httpstream.HeaderConnection, httpstream.HeaderUpgrade)
 	resp, err := http.DefaultClient.Do(req)
@@ -633,7 +633,7 @@ func TestProxyUpgradeErrorResponseTerminates(t *testing.T) {
 			bufferedReader := bufio.NewReader(conn)
 
 			// Send upgrade request resulting in a non-101 response from the backend
-			req, _ := http.NewRequest("GET", "/", nil)
+			req, _ := http.NewRequest(http.MethodGet, "/", nil)
 			req.Header.Set(httpstream.HeaderConnection, httpstream.HeaderUpgrade)
 			require.NoError(t, req.Write(conn))
 			// Verify we get the correct response and full message body content
@@ -653,7 +653,7 @@ func TestProxyUpgradeErrorResponseTerminates(t *testing.T) {
 			}
 
 			// Send another request to another endpoint to verify it is not received
-			req, _ = http.NewRequest("GET", "/there", nil)
+			req, _ = http.NewRequest(http.MethodGet, "/there", nil)
 			req.Write(conn)
 			// wait to ensure the handler does not receive the request
 			time.Sleep(time.Second)
@@ -688,7 +688,7 @@ func TestProxyUpgradeErrorResponse(t *testing.T) {
 			bufferedReader := bufio.NewReader(conn)
 
 			// Send upgrade request resulting in a non-101 response from the backend
-			req, _ := http.NewRequest("GET", "/", nil)
+			req, _ := http.NewRequest(http.MethodGet, "/", nil)
 			req.Header.Set(httpstream.HeaderConnection, httpstream.HeaderUpgrade)
 			require.NoError(t, req.Write(conn))
 			// Verify we get the correct response and full message body content
@@ -783,7 +783,7 @@ func TestRejectForwardingRedirectsOption(t *testing.T) {
 			require.NoError(t, err)
 			bufferedReader := bufio.NewReader(conn)
 
-			req, _ := http.NewRequest("GET", proxyURL.String(), nil)
+			req, _ := http.NewRequest(http.MethodGet, proxyURL.String(), nil)
 			require.NoError(t, req.Write(conn))
 			// Verify we get the correct response and message body content
 			resp, err := http.ReadResponse(bufferedReader, nil)
@@ -1073,7 +1073,7 @@ func TestFlushIntervalHeaders(t *testing.T) {
 	frontend := httptest.NewServer(proxyHandler)
 	defer frontend.Close()
 
-	req, _ := http.NewRequest("GET", frontend.URL, nil)
+	req, _ := http.NewRequest(http.MethodGet, frontend.URL, nil)
 	req.Close = true
 
 	ctx, cancel := context.WithTimeout(req.Context(), 10*time.Second)
@@ -1118,7 +1118,7 @@ func TestErrorPropagation(t *testing.T) {
 	frontend := httptest.NewServer(proxyHandler)
 	defer frontend.Close()
 
-	req, _ := http.NewRequest("GET", frontend.URL, nil)
+	req, _ := http.NewRequest(http.MethodGet, frontend.URL, nil)
 	req.Close = true
 
 	ctx, cancel := context.WithTimeout(req.Context(), 10*time.Second)
@@ -1150,7 +1150,7 @@ func TestProxyRedirectsforRootPath(t *testing.T) {
 	}{
 		{
 			name:               "root path, simple get",
-			method:             "GET",
+			method:             http.MethodGet,
 			requestPath:        "",
 			redirect:           true,
 			expectedStatusCode: 301,
@@ -1160,14 +1160,14 @@ func TestProxyRedirectsforRootPath(t *testing.T) {
 		},
 		{
 			name:               "root path, simple put",
-			method:             "PUT",
+			method:             http.MethodPut,
 			requestPath:        "",
 			redirect:           false,
 			expectedStatusCode: 200,
 		},
 		{
 			name:               "root path, simple head",
-			method:             "HEAD",
+			method:             http.MethodHead,
 			requestPath:        "",
 			redirect:           true,
 			expectedStatusCode: 301,
@@ -1177,7 +1177,7 @@ func TestProxyRedirectsforRootPath(t *testing.T) {
 		},
 		{
 			name:               "root path, simple delete with params",
-			method:             "DELETE",
+			method:             http.MethodDelete,
 			requestPath:        "",
 			redirect:           false,
 			expectedStatusCode: 200,


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
- Linter catches this sometimes, but this change catches a few more.
- Avoids using string literals when standard constants are available.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```