### PR TITLE
test: Pass test context to http requests

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/audit_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/audit_test.go
@@ -18,6 +18,7 @@ package endpoints
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -149,15 +150,15 @@ func TestAudit(t *testing.T) {
 
 	for _, test := range []struct {
 		desc   string
-		req    func(server string) (*http.Request, error)
+		req    func(ctx context.Context, server string) (*http.Request, error)
 		code   int
 		events int
 		checks []eventCheck
 	}{
 		{
 			"get",
-			func(server string) (*http.Request, error) {
-				return http.NewRequest(request.MethodGet, server+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/other/simple/c", bytes.NewBuffer(simpleFooJSON))
+			func(ctx context.Context, server string) (*http.Request, error) {
+				return http.NewRequestWithContext(ctx, request.MethodGet, server+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/other/simple/c", bytes.NewBuffer(simpleFooJSON))
 			},
 			200,
 			2,
@@ -169,8 +170,8 @@ func TestAudit(t *testing.T) {
 		},
 		{
 			"list",
-			func(server string) (*http.Request, error) {
-				return http.NewRequest(request.MethodGet, server+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/other/simple?labelSelector=a%3Dfoobar", nil)
+			func(ctx context.Context, server string) (*http.Request, error) {
+				return http.NewRequestWithContext(ctx, request.MethodGet, server+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/other/simple?labelSelector=a%3Dfoobar", nil)
 			},
 			200,
 			2,
@@ -182,8 +183,8 @@ func TestAudit(t *testing.T) {
 		},
 		{
 			"create",
-			func(server string) (*http.Request, error) {
-				return http.NewRequest(request.MethodPost, server+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple", bytes.NewBuffer(simpleFooJSON))
+			func(ctx context.Context, server string) (*http.Request, error) {
+				return http.NewRequestWithContext(ctx, request.MethodPost, server+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple", bytes.NewBuffer(simpleFooJSON))
 			},
 			201,
 			2,
@@ -195,8 +196,8 @@ func TestAudit(t *testing.T) {
 		},
 		{
 			"not-allowed-named-create",
-			func(server string) (*http.Request, error) {
-				return http.NewRequest(request.MethodPost, server+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/named", bytes.NewBuffer(simpleFooJSON))
+			func(ctx context.Context, server string) (*http.Request, error) {
+				return http.NewRequestWithContext(ctx, request.MethodPost, server+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/named", bytes.NewBuffer(simpleFooJSON))
 			},
 			405,
 			2,
@@ -208,8 +209,8 @@ func TestAudit(t *testing.T) {
 		},
 		{
 			"delete",
-			func(server string) (*http.Request, error) {
-				return http.NewRequest(request.MethodDelete, server+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/a", nil)
+			func(ctx context.Context, server string) (*http.Request, error) {
+				return http.NewRequestWithContext(ctx, request.MethodDelete, server+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/a", nil)
 			},
 			200,
 			2,
@@ -221,8 +222,8 @@ func TestAudit(t *testing.T) {
 		},
 		{
 			"delete-with-options-in-body",
-			func(server string) (*http.Request, error) {
-				return http.NewRequest(request.MethodDelete, server+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/a", bytes.NewBuffer([]byte(`{"kind":"DeleteOptions"}`)))
+			func(ctx context.Context, server string) (*http.Request, error) {
+				return http.NewRequestWithContext(ctx, request.MethodDelete, server+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/a", bytes.NewBuffer([]byte(`{"kind":"DeleteOptions"}`)))
 			},
 			200,
 			2,
@@ -234,8 +235,8 @@ func TestAudit(t *testing.T) {
 		},
 		{
 			"update",
-			func(server string) (*http.Request, error) {
-				return http.NewRequest(request.MethodPut, server+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/other/simple/c", bytes.NewBuffer(simpleCPrimeJSON))
+			func(ctx context.Context, server string) (*http.Request, error) {
+				return http.NewRequestWithContext(ctx, request.MethodPut, server+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/other/simple/c", bytes.NewBuffer(simpleCPrimeJSON))
 			},
 			200,
 			2,
@@ -247,8 +248,8 @@ func TestAudit(t *testing.T) {
 		},
 		{
 			"update-wrong-namespace",
-			func(server string) (*http.Request, error) {
-				return http.NewRequest(request.MethodPut, server+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/c", bytes.NewBuffer(simpleCPrimeJSON))
+			func(ctx context.Context, server string) (*http.Request, error) {
+				return http.NewRequestWithContext(ctx, request.MethodPut, server+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/c", bytes.NewBuffer(simpleCPrimeJSON))
 			},
 			400,
 			2,
@@ -260,8 +261,8 @@ func TestAudit(t *testing.T) {
 		},
 		{
 			"patch",
-			func(server string) (*http.Request, error) {
-				req, _ := http.NewRequest(request.MethodPatch, server+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/other/simple/c", bytes.NewReader([]byte(`{"labels":{"foo":"bar"}}`)))
+			func(ctx context.Context, server string) (*http.Request, error) {
+				req, _ := http.NewRequestWithContext(ctx, request.MethodPatch, server+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/other/simple/c", bytes.NewReader([]byte(`{"labels":{"foo":"bar"}}`)))
 				req.Header.Set("Content-Type", "application/merge-patch+json; charset=UTF-8")
 				return req, nil
 			},
@@ -275,8 +276,8 @@ func TestAudit(t *testing.T) {
 		},
 		{
 			"watch",
-			func(server string) (*http.Request, error) {
-				return http.NewRequest(request.MethodGet, server+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/other/simple?watch=true", nil)
+			func(ctx context.Context, server string) (*http.Request, error) {
+				return http.NewRequestWithContext(ctx, request.MethodGet, server+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/other/simple?watch=true", nil)
 			},
 			200,
 			3,
@@ -288,6 +289,7 @@ func TestAudit(t *testing.T) {
 		},
 	} {
 		t.Run(test.desc, func(t *testing.T) {
+			ctx := t.Context()
 			sink := &fakeAuditSink{}
 			handler := handleInternal(map[string]rest.Storage{
 				"simple": &SimpleRESTStorage{
@@ -312,7 +314,7 @@ func TestAudit(t *testing.T) {
 			defer server.Close()
 			client := http.Client{Timeout: 2 * time.Second}
 
-			req, err := test.req(server.URL)
+			req, err := test.req(ctx, server.URL)
 			if err != nil {
 				t.Errorf("[%s] error creating the request: %v", test.desc, err)
 			}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/discovery/root_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/discovery/root_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -67,7 +68,10 @@ func decodeResponse(t *testing.T, resp *http.Response, obj interface{}) error {
 }
 
 func getGroupList(t *testing.T, server *httptest.Server) (*metav1.APIGroupList, error) {
-	resp, err := http.Get(server.URL)
+	ctx := t.Context()
+	req, err := http.NewRequestWithContext(ctx, request.MethodGet, server.URL, nil)
+	require.NoError(t, err)
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filterlatency/filterlatency_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filterlatency/filterlatency_test.go
@@ -31,6 +31,7 @@ import (
 )
 
 func TestTrackStartedWithContextAlreadyHasFilterRecord(t *testing.T) {
+	ctx := t.Context()
 	filterName := "my-filter"
 	var (
 		callCount    int
@@ -47,7 +48,7 @@ func TestTrackStartedWithContextAlreadyHasFilterRecord(t *testing.T) {
 	requestFilterStarted := time.Now()
 	wrapped := trackStarted(handler, noopoteltrace.NewTracerProvider(), filterName, testingclock.NewFakeClock(requestFilterStarted))
 
-	testRequest, err := http.NewRequest(http.MethodGet, "/api/v1/namespaces", nil)
+	testRequest, err := http.NewRequestWithContext(ctx, http.MethodGet, "/api/v1/namespaces", nil)
 	if err != nil {
 		t.Fatalf("failed to create new http request - %v", err)
 	}
@@ -74,6 +75,7 @@ func TestTrackStartedWithContextAlreadyHasFilterRecord(t *testing.T) {
 }
 
 func TestTrackStartedWithContextDoesNotHaveFilterRecord(t *testing.T) {
+	ctx := t.Context()
 	filterName := "my-filter"
 	var (
 		callCount    int
@@ -90,7 +92,7 @@ func TestTrackStartedWithContextDoesNotHaveFilterRecord(t *testing.T) {
 	requestFilterStarted := time.Now()
 	wrapped := trackStarted(handler, noopoteltrace.NewTracerProvider(), filterName, testingclock.NewFakeClock(requestFilterStarted))
 
-	testRequest, err := http.NewRequest(http.MethodGet, "/api/v1/namespaces", nil)
+	testRequest, err := http.NewRequestWithContext(ctx, http.MethodGet, "/api/v1/namespaces", nil)
 	if err != nil {
 		t.Fatalf("failed to create new http request - %v", err)
 	}
@@ -113,6 +115,7 @@ func TestTrackStartedWithContextDoesNotHaveFilterRecord(t *testing.T) {
 }
 
 func TestTrackCompletedContextHasFilterRecord(t *testing.T) {
+	ctx := t.Context()
 	var (
 		handlerCallCount     int
 		actionCallCount      int
@@ -131,7 +134,7 @@ func TestTrackCompletedContextHasFilterRecord(t *testing.T) {
 		filterCompletedAtGot = completedAt
 	})
 
-	testRequest, err := http.NewRequest(http.MethodGet, "/api/v1/namespaces", nil)
+	testRequest, err := http.NewRequestWithContext(ctx, http.MethodGet, "/api/v1/namespaces", nil)
 	if err != nil {
 		t.Fatalf("failed to create new http request - %v", err)
 	}
@@ -156,6 +159,7 @@ func TestTrackCompletedContextHasFilterRecord(t *testing.T) {
 }
 
 func TestTrackCompletedContextDoesNotHaveFilterRecord(t *testing.T) {
+	ctx := t.Context()
 	var actionCallCount, handlerCallCount int
 	handler := http.HandlerFunc(func(_ http.ResponseWriter, req *http.Request) {
 		handlerCallCount++
@@ -165,7 +169,7 @@ func TestTrackCompletedContextDoesNotHaveFilterRecord(t *testing.T) {
 		actionCallCount++
 	})
 
-	testRequest, err := http.NewRequest(http.MethodGet, "/api/v1/namespaces", nil)
+	testRequest, err := http.NewRequestWithContext(ctx, http.MethodGet, "/api/v1/namespaces", nil)
 	if err != nil {
 		t.Fatalf("failed to create new http request - %v", err)
 	}
@@ -182,6 +186,7 @@ func TestTrackCompletedContextDoesNotHaveFilterRecord(t *testing.T) {
 }
 
 func TestStartedAndCompletedOpenTelemetryTracing(t *testing.T) {
+	ctx := t.Context()
 	filterName := "my-filter"
 	// Seup OTel for testing
 	fakeRecorder := tracetest.NewSpanRecorder()
@@ -197,7 +202,7 @@ func TestStartedAndCompletedOpenTelemetryTracing(t *testing.T) {
 	wrapped := TrackCompleted(handler)
 	wrapped = TrackStarted(wrapped, tp, filterName)
 
-	testRequest, err := http.NewRequest(http.MethodGet, "/api/v1/namespaces", nil)
+	testRequest, err := http.NewRequestWithContext(ctx, http.MethodGet, "/api/v1/namespaces", nil)
 	if err != nil {
 		t.Fatalf("failed to create new http request - %v", err)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit_init_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit_init_test.go
@@ -62,6 +62,7 @@ func TestWithAuditID(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			ctx := t.Context()
 			const auditKey = "Audit-ID"
 			var (
 				innerHandlerCallCount int
@@ -83,7 +84,7 @@ func TestWithAuditID(t *testing.T) {
 				wrapped = withAuditInit(handler, test.newAuditIDFunc)
 			}
 
-			testRequest, err := http.NewRequest(http.MethodGet, "/api/v1/namespaces", nil)
+			testRequest, err := http.NewRequestWithContext(ctx, http.MethodGet, "/api/v1/namespaces", nil)
 			if err != nil {
 				t.Fatalf("failed to create new http request - %v", err)
 			}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit_test.go
@@ -670,6 +670,7 @@ func TestAudit(t *testing.T) {
 		},
 	} {
 		t.Run(test.desc, func(t *testing.T) {
+			ctx := t.Context()
 			sink := &fakeAuditSink{}
 			fakeRuleEvaluator := policy.NewFakePolicyRuleEvaluator(auditinternal.LevelRequestResponse, test.omitStages)
 			handler := WithAudit(http.HandlerFunc(test.handler), sink, fakeRuleEvaluator, func(r *http.Request, ri *request.RequestInfo) bool {
@@ -678,7 +679,7 @@ func TestAudit(t *testing.T) {
 			})
 			handler = WithAuditInit(handler)
 
-			req, _ := http.NewRequest(test.verb, test.path, nil)
+			req, _ := http.NewRequestWithContext(ctx, test.verb, test.path, nil)
 			req = withTestContext(req, &user.DefaultInfo{Name: "admin"}, nil)
 			if test.auditID != "" {
 				req.Header.Add("Audit-ID", test.auditID)
@@ -741,15 +742,17 @@ func TestAudit(t *testing.T) {
 }
 
 func TestAuditNoPanicOnNilUser(t *testing.T) {
+	ctx := t.Context()
 	fakeRuleEvaluator := policy.NewFakePolicyRuleEvaluator(auditinternal.LevelRequestResponse, nil)
 	handler := WithAudit(&fakeHTTPHandler{}, &fakeAuditSink{}, fakeRuleEvaluator, nil)
-	req, _ := http.NewRequest(request.MethodGet, "/api/v1/namespaces/default/pods", nil)
+	req, _ := http.NewRequestWithContext(ctx, request.MethodGet, "/api/v1/namespaces/default/pods", nil)
 	req = withTestContext(req, nil, nil)
 	req.RemoteAddr = "127.0.0.1"
 	handler.ServeHTTP(httptest.NewRecorder(), req)
 }
 
 func TestAuditLevelNone(t *testing.T) {
+	ctx := t.Context()
 	sink := &fakeAuditSink{}
 	var handler http.Handler
 	handler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -758,7 +761,7 @@ func TestAuditLevelNone(t *testing.T) {
 	fakeRuleEvaluator := policy.NewFakePolicyRuleEvaluator(auditinternal.LevelNone, nil)
 	handler = WithAudit(handler, sink, fakeRuleEvaluator, nil)
 
-	req, _ := http.NewRequest(request.MethodGet, "/api/v1/namespaces/default/pods", nil)
+	req, _ := http.NewRequestWithContext(ctx, request.MethodGet, "/api/v1/namespaces/default/pods", nil)
 	req.RemoteAddr = "127.0.0.1"
 	req = withTestContext(req, &user.DefaultInfo{Name: "admin"}, nil)
 
@@ -805,6 +808,7 @@ func TestAuditIDHttpHeader(t *testing.T) {
 		},
 	} {
 		t.Run(test.desc, func(t *testing.T) {
+			ctx := t.Context()
 			sink := &fakeAuditSink{}
 			var handler http.Handler
 			handler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -814,7 +818,7 @@ func TestAuditIDHttpHeader(t *testing.T) {
 			handler = WithAudit(handler, sink, fakeRuleEvaluator, nil)
 			handler = WithAuditInit(handler)
 
-			req, _ := http.NewRequest(request.MethodGet, "/api/v1/namespaces/default/pods", nil)
+			req, _ := http.NewRequestWithContext(ctx, request.MethodGet, "/api/v1/namespaces/default/pods", nil)
 			req.RemoteAddr = "127.0.0.1"
 			req = withTestContext(req, &user.DefaultInfo{Name: "admin"}, nil)
 			if test.requestHeader != "" {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authentication_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authentication_test.go
@@ -628,6 +628,7 @@ func TestUnauthenticatedHTTP2ClientConnectionClose(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			f := func(t *testing.T, nextProto string, expectConnections uint64) {
+				ctx := t.Context()
 				featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.UnauthenticatedHTTP2DOSMitigation, !tc.skipHTTP2DOSMitigation)
 
 				var localAddrs atomic.Uint64 // indicates how many TCP connection set up
@@ -671,7 +672,7 @@ func TestUnauthenticatedHTTP2ClientConnectionClose(t *testing.T) {
 				}
 
 				for i := 0; i < reqs; i++ {
-					req, err := http.NewRequest(http.MethodGet, s.URL, nil)
+					req, err := http.NewRequestWithContext(ctx, http.MethodGet, s.URL, nil)
 					if err != nil {
 						t.Fatal(err)
 					}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authn_audit_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authn_audit_test.go
@@ -30,6 +30,7 @@ import (
 )
 
 func TestFailedAuthnAudit(t *testing.T) {
+	ctx := t.Context()
 	sink := &fakeAuditSink{}
 	fakeRuleEvaluator := policy.NewFakePolicyRuleEvaluator(auditinternal.LevelRequestResponse, nil)
 	handler := WithFailedAuthenticationAudit(
@@ -37,7 +38,7 @@ func TestFailedAuthnAudit(t *testing.T) {
 			http.Error(w, "", http.StatusUnauthorized)
 		}),
 		sink, fakeRuleEvaluator)
-	req, _ := http.NewRequest(request.MethodGet, "/api/v1/namespaces/default/pods", nil)
+	req, _ := http.NewRequestWithContext(ctx, request.MethodGet, "/api/v1/namespaces/default/pods", nil)
 	req.RemoteAddr = "127.0.0.1"
 	req = withTestContext(req, nil, nil)
 	req.SetBasicAuth("username", "password")
@@ -62,6 +63,7 @@ func TestFailedAuthnAudit(t *testing.T) {
 }
 
 func TestFailedMultipleAuthnAudit(t *testing.T) {
+	ctx := t.Context()
 	sink := &fakeAuditSink{}
 	fakeRuleEvaluator := policy.NewFakePolicyRuleEvaluator(auditinternal.LevelRequestResponse, nil)
 	handler := WithFailedAuthenticationAudit(
@@ -69,7 +71,7 @@ func TestFailedMultipleAuthnAudit(t *testing.T) {
 			http.Error(w, "", http.StatusUnauthorized)
 		}),
 		sink, fakeRuleEvaluator)
-	req, _ := http.NewRequest(request.MethodGet, "/api/v1/namespaces/default/pods", nil)
+	req, _ := http.NewRequestWithContext(ctx, request.MethodGet, "/api/v1/namespaces/default/pods", nil)
 	req.RemoteAddr = "127.0.0.1"
 	req = withTestContext(req, nil, nil)
 	req.SetBasicAuth("username", "password")
@@ -95,6 +97,7 @@ func TestFailedMultipleAuthnAudit(t *testing.T) {
 }
 
 func TestFailedAuthnAuditWithoutAuthorization(t *testing.T) {
+	ctx := t.Context()
 	sink := &fakeAuditSink{}
 	fakeRuleEvaluator := policy.NewFakePolicyRuleEvaluator(auditinternal.LevelRequestResponse, nil)
 	handler := WithFailedAuthenticationAudit(
@@ -102,7 +105,7 @@ func TestFailedAuthnAuditWithoutAuthorization(t *testing.T) {
 			http.Error(w, "", http.StatusUnauthorized)
 		}),
 		sink, fakeRuleEvaluator)
-	req, _ := http.NewRequest(request.MethodGet, "/api/v1/namespaces/default/pods", nil)
+	req, _ := http.NewRequestWithContext(ctx, request.MethodGet, "/api/v1/namespaces/default/pods", nil)
 	req.RemoteAddr = "127.0.0.1"
 	req = withTestContext(req, nil, nil)
 	handler.ServeHTTP(httptest.NewRecorder(), req)
@@ -126,6 +129,7 @@ func TestFailedAuthnAuditWithoutAuthorization(t *testing.T) {
 }
 
 func TestFailedAuthnAuditOmitted(t *testing.T) {
+	ctx := t.Context()
 	sink := &fakeAuditSink{}
 	fakeRuleEvaluator := policy.NewFakePolicyRuleEvaluator(auditinternal.LevelRequestResponse, []auditinternal.Stage{auditinternal.StageResponseStarted})
 	handler := WithFailedAuthenticationAudit(
@@ -133,7 +137,7 @@ func TestFailedAuthnAuditOmitted(t *testing.T) {
 			http.Error(w, "", http.StatusUnauthorized)
 		}),
 		sink, fakeRuleEvaluator)
-	req, _ := http.NewRequest(request.MethodGet, "/api/v1/namespaces/default/pods", nil)
+	req, _ := http.NewRequestWithContext(ctx, request.MethodGet, "/api/v1/namespaces/default/pods", nil)
 	req.RemoteAddr = "127.0.0.1"
 	req = withTestContext(req, nil, nil)
 	handler.ServeHTTP(httptest.NewRecorder(), req)

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authorization_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authorization_test.go
@@ -209,11 +209,12 @@ func TestGetAuthorizerAttributes(t *testing.T) {
 
 	for k, tc := range testcases {
 		t.Run(k, func(t *testing.T) {
+			ctx := t.Context()
 			if tc.EnableAuthorizationSelector {
 				featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.AuthorizeWithSelectors, true)
 			}
 
-			req, _ := http.NewRequest(tc.Verb, tc.Path, nil)
+			req, _ := http.NewRequestWithContext(ctx, tc.Verb, tc.Path, nil)
 			req.RemoteAddr = "127.0.0.1"
 
 			var attribs authorizer.Attributes
@@ -282,10 +283,11 @@ func TestAuditAnnotation(t *testing.T) {
 	scheme := runtime.NewScheme()
 	negotiatedSerializer := serializer.NewCodecFactory(scheme).WithoutConversion()
 	for k, tc := range testcases {
+		ctx := t.Context()
 		handler := WithAuthorization(&fakeHTTPHandler{}, tc.authorizer, negotiatedSerializer)
 		// TODO: fake audit injector
 
-		req, _ := http.NewRequest(http.MethodGet, "/api/v1/namespaces/default/pods", nil)
+		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "/api/v1/namespaces/default/pods", nil)
 		req = withTestContext(req, nil, &auditinternal.Event{Level: auditinternal.LevelMetadata})
 		ae := audit.AuditEventFrom(req.Context())
 		req.RemoteAddr = "127.0.0.1"

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/cachecontrol_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/cachecontrol_test.go
@@ -50,12 +50,13 @@ func TestCacheControl(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			ctx := t.Context()
 			handler := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
 				//do nothing
 			})
 			wrapped := WithCacheControl(handler)
 
-			testRequest, err := http.NewRequest(http.MethodGet, test.path, nil)
+			testRequest, err := http.NewRequestWithContext(ctx, http.MethodGet, test.path, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/impersonation_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/impersonation_test.go
@@ -532,7 +532,7 @@ func TestImpersonationFilter(t *testing.T) {
 				ctx = request.WithUser(request.NewContext(), tc.user)
 			}()
 
-			req, err := http.NewRequest(http.MethodGet, server.URL, nil)
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, server.URL, nil)
 			if err != nil {
 				t.Errorf("%s: unexpected error: %v", tc.name, err)
 				return

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/metrics_test.go
@@ -252,13 +252,14 @@ func TestRecordAuthorizationMetricsMetrics(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.desc, func(t *testing.T) {
+			ctx := t.Context()
 			defer authorizationAttemptsCounter.Reset()
 
 			audit := &auditinternal.Event{Level: auditinternal.LevelMetadata}
 			handler := WithAuthorization(&fakeHTTPHandler{}, tt.authorizer, negotiatedSerializer)
 			// TODO: fake audit injector
 
-			req, _ := http.NewRequest(http.MethodGet, "/api/v1/namespaces/default/pods", nil)
+			req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "/api/v1/namespaces/default/pods", nil)
 			req = withTestContext(req, nil, audit)
 			req.RemoteAddr = "127.0.0.1"
 			handler.ServeHTTP(httptest.NewRecorder(), req)

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/read_write_deadline_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/read_write_deadline_test.go
@@ -1313,7 +1313,8 @@ func TestPerRequestWithSlowReader(t *testing.T) {
 
 func sendWithTrace(t *testing.T, client *http.Client, url string, f func(*testing.T, httptrace.GotConnInfo)) (*http.Response, error) {
 	t.Helper()
-	req, err := http.NewRequest(http.MethodGet, url, nil)
+	ctx := t.Context()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		t.Fatalf("failed to create new request: %v", err)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/request_deadline_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/request_deadline_test.go
@@ -71,7 +71,8 @@ func TestParseTimeout(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			request, err := http.NewRequest(http.MethodGet, test.url, nil)
+			ctx := t.Context()
+			request, err := http.NewRequestWithContext(ctx, http.MethodGet, test.url, nil)
 			if err != nil {
 				t.Fatalf("failed to create new http request - %v", err)
 			}
@@ -439,12 +440,12 @@ func TestWithFailedRequestAudit(t *testing.T) {
 }
 
 func newRequest(t *testing.T, requestURL string) *http.Request {
-	req, err := http.NewRequest(http.MethodGet, requestURL, nil)
+	ctx := t.Context()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, nil)
 	if err != nil {
 		t.Fatalf("failed to create new http request - %v", err)
 	}
-	ctx := audit.WithAuditContext(req.Context())
-	return req.WithContext(ctx)
+	return req.WithContext(audit.WithAuditContext(req.Context()))
 }
 
 func message(err error) string {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/request_received_time_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/request_received_time_test.go
@@ -27,6 +27,7 @@ import (
 )
 
 func TestWithRequestReceivedTimestamp(t *testing.T) {
+	ctx := t.Context()
 	receivedTimestampExpected := time.Now()
 
 	var (
@@ -43,7 +44,7 @@ func TestWithRequestReceivedTimestamp(t *testing.T) {
 
 	wrapped := withRequestReceivedTimestampWithClock(handler, testingclock.NewFakeClock(receivedTimestampExpected))
 
-	testRequest, err := http.NewRequest(http.MethodGet, "/api/v1/namespaces", nil)
+	testRequest, err := http.NewRequestWithContext(ctx, http.MethodGet, "/api/v1/namespaces", nil)
 	if err != nil {
 		t.Fatalf("failed to create new http request - %v", err)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/delete_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/delete_test.go
@@ -216,6 +216,7 @@ func TestDeleteCollection(t *testing.T) {
 }
 
 func TestDeleteCollectionWithNoContextDeadlineEnforced(t *testing.T) {
+	ctx := t.Context()
 	var invokedGot, hasDeadlineGot int32
 	fakeDeleterFn := func(ctx context.Context, _ rest.ValidateObjectFunc, _ *metav1.DeleteOptions, _ *metainternalversion.ListOptions) (runtime.Object, error) {
 		// we expect CollectionDeleter to be executed once
@@ -237,7 +238,7 @@ func TestDeleteCollectionWithNoContextDeadlineEnforced(t *testing.T) {
 	}
 	handler := DeleteCollection(fakeCollectionDeleterFunc(fakeDeleterFn), false, scope, nil)
 
-	request, err := http.NewRequest(request.MethodGet, "/test", nil)
+	request, err := http.NewRequestWithContext(ctx, request.MethodGet, "/test", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest_test.go
@@ -177,11 +177,12 @@ func TestLimitedReadBody(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.desc, func(t *testing.T) {
+			ctx := t.Context()
 			// reset metrics
 			defer metrics.RequestBodySizes.Reset()
 			defer legacyregistry.Reset()
 
-			req, err := http.NewRequest(request.MethodPost, "/", tc.requestBody)
+			req, err := http.NewRequestWithContext(ctx, request.MethodPost, "/", tc.requestBody)
 			if err != nil {
 				t.Errorf("err not expected: got %v", err)
 			}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/watch_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/watch_test.go
@@ -61,6 +61,7 @@ func init() {
 }
 
 func TestWatchHTTPErrors(t *testing.T) {
+	ctx := t.Context()
 	watcher := watch.NewFake()
 	timeoutCh := make(chan time.Time)
 	doneCh := make(chan struct{})
@@ -92,7 +93,7 @@ func TestWatchHTTPErrors(t *testing.T) {
 	dest.Path = "/" + namedGroupPrefix + "/" + testGroupV2.Group + "/" + testGroupV2.Version + "/simple"
 	dest.RawQuery = "watch=true"
 
-	req, _ := http.NewRequest(http.MethodGet, dest.String(), nil)
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, dest.String(), nil)
 	client := http.Client{}
 	resp, err := client.Do(req)
 	require.NoError(t, err)
@@ -124,6 +125,7 @@ func TestWatchHTTPErrors(t *testing.T) {
 }
 
 func TestWatchHTTPErrorsBeforeServe(t *testing.T) {
+	ctx := t.Context()
 	watcher := watch.NewFake()
 	timeoutCh := make(chan time.Time)
 	doneCh := make(chan struct{})
@@ -161,7 +163,7 @@ func TestWatchHTTPErrorsBeforeServe(t *testing.T) {
 	dest.Path = "/" + namedGroupPrefix + "/" + testGroupV2.Group + "/" + testGroupV2.Version + "/simple"
 	dest.RawQuery = "watch=true"
 
-	req, _ := http.NewRequest(http.MethodGet, dest.String(), nil)
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, dest.String(), nil)
 	client := http.Client{}
 	resp, err := client.Do(req)
 	require.NoError(t, err)
@@ -227,6 +229,7 @@ func TestWatchHTTPDynamicClientErrors(t *testing.T) {
 }
 
 func TestWatchHTTPTimeout(t *testing.T) {
+	ctx := t.Context()
 	watcher := watch.NewFake()
 	timeoutCh := make(chan time.Time)
 	done := make(chan struct{})
@@ -258,7 +261,7 @@ func TestWatchHTTPTimeout(t *testing.T) {
 	dest.Path = "/" + namedGroupPrefix + "/" + testGroupV2.Group + "/" + testGroupV2.Version + "/simple"
 	dest.RawQuery = "watch=true"
 
-	req, _ := http.NewRequest(http.MethodGet, dest.String(), nil)
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, dest.String(), nil)
 	client := http.Client{}
 	resp, err := client.Do(req)
 	require.NoError(t, err)

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/patchhandler_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/patchhandler_test.go
@@ -30,6 +30,7 @@ import (
 )
 
 func TestPatch(t *testing.T) {
+	ctx := t.Context()
 	storage := map[string]rest.Storage{}
 	ID := "id"
 	item := &genericapitesting.Simple{
@@ -47,7 +48,7 @@ func TestPatch(t *testing.T) {
 	defer server.Close()
 
 	client := http.Client{}
-	request, err := http.NewRequest(request.MethodPatch, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/"+ID, bytes.NewReader([]byte(`{"labels":{"foo":"bar"}}`)))
+	request, err := http.NewRequestWithContext(ctx, request.MethodPatch, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/"+ID, bytes.NewReader([]byte(`{"labels":{"foo":"bar"}}`)))
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -65,6 +66,7 @@ func TestPatch(t *testing.T) {
 }
 
 func TestForbiddenForceOnNonApply(t *testing.T) {
+	ctx := t.Context()
 	storage := map[string]rest.Storage{}
 	ID := "id"
 	item := &genericapitesting.Simple{
@@ -82,7 +84,7 @@ func TestForbiddenForceOnNonApply(t *testing.T) {
 	defer server.Close()
 
 	client := http.Client{}
-	req, err := http.NewRequest(request.MethodPatch, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/"+ID, bytes.NewReader([]byte(`{"labels":{"foo":"bar"}}`)))
+	req, err := http.NewRequestWithContext(ctx, request.MethodPatch, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/"+ID, bytes.NewReader([]byte(`{"labels":{"foo":"bar"}}`)))
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -92,7 +94,7 @@ func TestForbiddenForceOnNonApply(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	req, err = http.NewRequest(request.MethodPatch, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/"+ID+"?force=true", bytes.NewReader([]byte(`{"labels":{"foo":"bar"}}`)))
+	req, err = http.NewRequestWithContext(ctx, request.MethodPatch, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/"+ID+"?force=true", bytes.NewReader([]byte(`{"labels":{"foo":"bar"}}`)))
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -105,7 +107,7 @@ func TestForbiddenForceOnNonApply(t *testing.T) {
 		t.Errorf("Unexpected response %#v", response)
 	}
 
-	req, err = http.NewRequest(request.MethodPatch, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/"+ID+"?force=false", bytes.NewReader([]byte(`{"labels":{"foo":"bar"}}`)))
+	req, err = http.NewRequestWithContext(ctx, request.MethodPatch, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/"+ID+"?force=false", bytes.NewReader([]byte(`{"labels":{"foo":"bar"}}`)))
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -120,6 +122,7 @@ func TestForbiddenForceOnNonApply(t *testing.T) {
 }
 
 func TestPatchRequiresMatchingName(t *testing.T) {
+	ctx := t.Context()
 	storage := map[string]rest.Storage{}
 	ID := "id"
 	item := &genericapitesting.Simple{
@@ -137,7 +140,7 @@ func TestPatchRequiresMatchingName(t *testing.T) {
 	defer server.Close()
 
 	client := http.Client{}
-	request, err := http.NewRequest(request.MethodPatch, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/"+ID, bytes.NewReader([]byte(`{"metadata":{"name":"idbar"}}`)))
+	request, err := http.NewRequestWithContext(ctx, request.MethodPatch, server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/"+ID, bytes.NewReader([]byte(`{"metadata":{"name":"idbar"}}`)))
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/request/requestinfo_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/request/requestinfo_test.go
@@ -95,7 +95,8 @@ func TestGetAPIRequestInfo(t *testing.T) {
 	resolver := newTestRequestInfoResolver()
 
 	for _, successCase := range successCases {
-		req, _ := http.NewRequest(successCase.method, successCase.url, nil)
+		ctx := t.Context()
+		req, _ := http.NewRequestWithContext(ctx, successCase.method, successCase.url, nil)
 
 		apiRequestInfo, err := resolver.NewRequestInfo(req)
 		if err != nil {
@@ -136,7 +137,8 @@ func TestGetAPIRequestInfo(t *testing.T) {
 		"missing api group":           "/apis/version/resource",
 	}
 	for k, v := range errorCases {
-		req, err := http.NewRequest(MethodGet, v, nil)
+		ctx := t.Context()
+		req, err := http.NewRequestWithContext(ctx, MethodGet, v, nil)
 		if err != nil {
 			t.Errorf("Unexpected error %v", err)
 		}
@@ -174,7 +176,8 @@ func TestGetNonAPIRequestInfo(t *testing.T) {
 	resolver := newTestRequestInfoResolver()
 
 	for testName, tc := range tests {
-		req, _ := http.NewRequest(MethodGet, tc.url, nil)
+		ctx := t.Context()
+		req, _ := http.NewRequestWithContext(ctx, MethodGet, tc.url, nil)
 
 		apiRequestInfo, err := resolver.NewRequestInfo(req)
 		if err != nil {
@@ -315,7 +318,8 @@ func TestSelectorParsing(t *testing.T) {
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.AuthorizeWithSelectors, true)
 
 	for _, tc := range tests {
-		req, _ := http.NewRequest(tc.method, tc.url, nil)
+		ctx := t.Context()
+		req, _ := http.NewRequestWithContext(ctx, tc.method, tc.url, nil)
 
 		apiRequestInfo, err := resolver.NewRequestInfo(req)
 		if err != nil {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/responsewriter/wrapper_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/responsewriter/wrapper_test.go
@@ -224,7 +224,8 @@ func newServer(t *testing.T, h http.Handler, http2 bool) *httptest.Server {
 }
 
 func sendRequest(t *testing.T, server *httptest.Server) {
-	req, err := http.NewRequest(request.MethodGet, server.URL, nil)
+	ctx := t.Context()
+	req, err := http.NewRequestWithContext(ctx, request.MethodGet, server.URL, nil)
 	if err != nil {
 		t.Fatalf("error creating request: %v", err)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/watch_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/watch_test.go
@@ -31,7 +31,9 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/net/websocket"
+
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -210,6 +212,7 @@ func TestWatchWebsocketClientClose(t *testing.T) {
 }
 
 func TestWatchClientClose(t *testing.T) {
+	ctx := t.Context()
 	simpleStorage := &SimpleRESTStorage{}
 	_ = rest.Watcher(simpleStorage) // Give compile error if this doesn't work.
 	handler := handle(map[string]rest.Storage{"simples": simpleStorage})
@@ -220,7 +223,7 @@ func TestWatchClientClose(t *testing.T) {
 	dest.Path = "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/simples"
 	dest.RawQuery = "watch=1"
 
-	request, err := http.NewRequest(request.MethodGet, dest.String(), nil)
+	request, err := http.NewRequestWithContext(ctx, request.MethodGet, dest.String(), nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -252,6 +255,7 @@ func TestWatchClientClose(t *testing.T) {
 }
 
 func TestWatchRead(t *testing.T) {
+	ctx := t.Context()
 	simpleStorage := &SimpleRESTStorage{}
 	_ = rest.Watcher(simpleStorage) // Give compile error if this doesn't work.
 	handler := handle(map[string]rest.Storage{"simples": simpleStorage})
@@ -264,7 +268,7 @@ func TestWatchRead(t *testing.T) {
 
 	connectHTTP := func(accept string) (io.ReadCloser, string) {
 		client := http.Client{}
-		request, err := http.NewRequest(request.MethodGet, dest.String(), nil)
+		request, err := http.NewRequestWithContext(ctx, request.MethodGet, dest.String(), nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -406,6 +410,7 @@ func TestWatchRead(t *testing.T) {
 }
 
 func TestWatchHTTPAccept(t *testing.T) {
+	ctx := t.Context()
 	simpleStorage := &SimpleRESTStorage{}
 	handler := handle(map[string]rest.Storage{"simples": simpleStorage})
 	server := httptest.NewServer(handler)
@@ -416,7 +421,7 @@ func TestWatchHTTPAccept(t *testing.T) {
 	dest.Path = "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/watch/simples"
 	dest.RawQuery = ""
 
-	request, err := http.NewRequest(request.MethodGet, dest.String(), nil)
+	request, err := http.NewRequestWithContext(ctx, request.MethodGet, dest.String(), nil)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -516,13 +521,17 @@ func TestWatchParamParsing(t *testing.T) {
 	}
 
 	for _, item := range table {
+		ctx := t.Context()
 		simpleStorage.requestedLabelSelector = labels.Everything()
 		simpleStorage.requestedFieldSelector = fields.Everything()
 		simpleStorage.requestedResourceVersion = "5" // Prove this is set in all cases
 		simpleStorage.requestedResourceNamespace = ""
 		dest.Path = item.path
 		dest.RawQuery = item.rawQuery
-		resp, err := http.Get(dest.String())
+
+		req, err := http.NewRequestWithContext(ctx, request.MethodGet, dest.String(), nil)
+		require.NoError(t, err)
+		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
 			t.Errorf("%v: unexpected error: %v", item.rawQuery, err)
 			continue
@@ -566,7 +575,8 @@ func TestWatchProtocolSelection(t *testing.T) {
 	}
 
 	for _, item := range table {
-		request, err := http.NewRequest(request.MethodGet, dest.String(), nil)
+		ctx := t.Context()
+		request, err := http.NewRequestWithContext(ctx, request.MethodGet, dest.String(), nil)
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
@@ -628,6 +638,7 @@ func toObjectSlice(in []example.Pod) []runtime.Object {
 }
 
 func runWatchHTTPBenchmark(b *testing.B, items []runtime.Object, contentType string) {
+	ctx := b.Context()
 	simpleStorage := &SimpleRESTStorage{}
 	handler := handle(map[string]rest.Storage{"simples": simpleStorage})
 	server := httptest.NewServer(handler)
@@ -638,7 +649,7 @@ func runWatchHTTPBenchmark(b *testing.B, items []runtime.Object, contentType str
 	dest.Path = "/" + prefix + "/" + newGroupVersion.Group + "/" + newGroupVersion.Version + "/watch/simples"
 	dest.RawQuery = ""
 
-	req, err := http.NewRequest(request.MethodGet, dest.String(), nil)
+	req, err := http.NewRequestWithContext(ctx, request.MethodGet, dest.String(), nil)
 	if err != nil {
 		b.Fatalf("unexpected error: %v", err)
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
- This handles canceling the request after the test completes, cleaning up resources on the client and server. This is especially important when sharing a server between sub-tests.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```