### PR TITLE
Add container resources to crashloop backoff key

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -3005,14 +3005,14 @@ func (kl *Kubelet) handlePodResourcesResize(pod *v1.Pod, podStatus *kubecontaine
 
 		for i, container := range pod.Spec.Containers {
 			if !apiequality.Semantic.DeepEqual(container.Resources, podFromAllocation.Spec.Containers[i].Resources) {
-				key := kuberuntime.GetStableKey(pod, &container)
+				key := kuberuntime.GetBackoffKey(pod, &container)
 				kl.crashLoopBackOff.Reset(key)
 			}
 		}
 		for i, container := range pod.Spec.InitContainers {
 			if podutil.IsRestartableInitContainer(&container) {
 				if !apiequality.Semantic.DeepEqual(container.Resources, podFromAllocation.Spec.InitContainers[i].Resources) {
-					key := kuberuntime.GetStableKey(pod, &container)
+					key := kuberuntime.GetBackoffKey(pod, &container)
 					kl.crashLoopBackOff.Reset(key)
 				}
 			}

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -51,7 +51,6 @@ import (
 	"k8s.io/utils/ptr"
 
 	v1 "k8s.io/api/core/v1"
-	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
@@ -3003,20 +3002,6 @@ func (kl *Kubelet) handlePodResourcesResize(pod *v1.Pod, podStatus *kubecontaine
 		// added back as needed in the defer block, but this prevents old errors from being preserved.
 		kl.statusManager.ClearPodResizeInProgressCondition(pod.UID)
 
-		for i, container := range pod.Spec.Containers {
-			if !apiequality.Semantic.DeepEqual(container.Resources, podFromAllocation.Spec.Containers[i].Resources) {
-				key := kuberuntime.GetBackoffKey(pod, &container)
-				kl.crashLoopBackOff.Reset(key)
-			}
-		}
-		for i, container := range pod.Spec.InitContainers {
-			if podutil.IsRestartableInitContainer(&container) {
-				if !apiequality.Semantic.DeepEqual(container.Resources, podFromAllocation.Spec.InitContainers[i].Resources) {
-					key := kuberuntime.GetBackoffKey(pod, &container)
-					kl.crashLoopBackOff.Reset(key)
-				}
-			}
-		}
 		return pod, nil
 	}
 

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -3187,7 +3187,7 @@ func TestHandlePodResourcesResize(t *testing.T) {
 
 				now := kubelet.clock.Now()
 				// Put the container in backoff so we can confirm backoff is reset.
-				backoffKey := kuberuntime.GetStableKey(originalPod, originalCtr)
+				backoffKey := kuberuntime.GetBackoffKey(originalPod, originalCtr)
 				kubelet.crashLoopBackOff.Next(backoffKey, now)
 
 				updatedPod, err := kubelet.handlePodResourcesResize(newPod, podStatus)

--- a/pkg/kubelet/kuberuntime/helpers.go
+++ b/pkg/kubelet/kuberuntime/helpers.go
@@ -175,10 +175,10 @@ func isInitContainerFailed(status *kubecontainer.Status) bool {
 	return false
 }
 
-// GetStableKey generates a key (string) to uniquely identify a
+// GetBackoffKey generates a key (string) to uniquely identify a
 // (pod, container) tuple. The key should include the content of the
 // container, so that any change to the container generates a new key.
-func GetStableKey(pod *v1.Pod, container *v1.Container) string {
+func GetBackoffKey(pod *v1.Pod, container *v1.Container) string {
 	hash := strconv.FormatUint(kubecontainer.HashContainer(container), 16)
 	return fmt.Sprintf("%s_%s_%s_%s_%s", pod.Name, pod.Namespace, string(pod.UID), container.Name, hash)
 }

--- a/pkg/kubelet/kuberuntime/helpers_test.go
+++ b/pkg/kubelet/kuberuntime/helpers_test.go
@@ -122,11 +122,11 @@ func TestStableKey(t *testing.T) {
 			Containers: []v1.Container{*container},
 		},
 	}
-	oldKey := GetStableKey(pod, container)
+	oldKey := GetBackoffKey(pod, container)
 
 	// Updating the container image should change the key.
 	container.Image = "foo/image:v2"
-	newKey := GetStableKey(pod, container)
+	newKey := GetBackoffKey(pod, container)
 	assert.NotEqual(t, oldKey, newKey)
 }
 

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -1544,7 +1544,7 @@ func (m *kubeGenericRuntimeManager) doBackOff(pod *v1.Pod, container *v1.Contain
 	// Use the finished time of the latest exited container as the start point to calculate whether to do back-off.
 	ts := cStatus.FinishedAt
 	// backOff requires a unique key to identify the container.
-	key := GetStableKey(pod, container)
+	key := GetBackoffKey(pod, container)
 	if backOff.IsInBackOffSince(key, ts) {
 		if containerRef, err := kubecontainer.GenerateContainerRef(pod, container); err == nil {
 			m.recorder.Eventf(containerRef, v1.EventTypeWarning, events.BackOffStartContainer,


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Include container resources when generating the key for crashloop backoff so that the backoff doesn't need to be manually reset when the resources change.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/sig node
/priority important-soon
/assign @natasha41575 @lauralorenz 