### PR TITLE
use framework.ExpectNoError instead

### DIFF
--- a/test/e2e/framework/pod/delete.go
+++ b/test/e2e/framework/pod/delete.go
@@ -44,7 +44,7 @@ func DeletePodOrFail(ctx context.Context, c clientset.Interface, ns, name string
 		return
 	}
 
-	expectNoError(err, "failed to delete pod %s in namespace %s", name, ns)
+	framework.ExpectNoErrorWithOffset(1, err, "failed to delete pod %s in namespace %s", name, ns)
 }
 
 // DeletePodWithWait deletes the passed-in pod and waits for the pod to be terminated. Resilient to the pod

--- a/test/e2e/framework/pod/resource.go
+++ b/test/e2e/framework/pod/resource.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -42,22 +41,6 @@ import (
 // a test failure. By default, if there are no Pods with this label, only the first 5 Pods will
 // have their logs fetched.
 const LabelLogOnPodFailure = "log-on-pod-failure"
-
-// TODO: Move to its own subpkg.
-// expectNoError checks if "err" is set, and if so, fails assertion while logging the error.
-func expectNoError(err error, explain ...interface{}) {
-	expectNoErrorWithOffset(1, err, explain...)
-}
-
-// TODO: Move to its own subpkg.
-// expectNoErrorWithOffset checks if "err" is set, and if so, fails assertion while logging the error at "offset" levels above its caller
-// (for example, for call chain f -> g -> expectNoErrorWithOffset(1, ...) error would be logged for "f").
-func expectNoErrorWithOffset(offset int, err error, explain ...interface{}) {
-	if err != nil {
-		framework.Logf("Unexpected error occurred: %v", err)
-	}
-	gomega.ExpectWithOffset(1+offset, err).NotTo(gomega.HaveOccurred(), explain...)
-}
 
 // PodsCreatedByLabel returns a created pod list matched by the given label.
 func PodsCreatedByLabel(ctx context.Context, c clientset.Interface, ns, name string, replicas int32, label labels.Selector) (*v1.PodList, error) {
@@ -364,9 +347,9 @@ func CreateExecPodOrFail(ctx context.Context, client clientset.Interface, ns, ge
 		tweak(pod)
 	}
 	execPod, err := client.CoreV1().Pods(ns).Create(ctx, pod, metav1.CreateOptions{})
-	expectNoError(err, "failed to create new exec pod in namespace: %s", ns)
+	framework.ExpectNoErrorWithOffset(1, err, "failed to create new exec pod in namespace: %s", ns)
 	err = WaitForPodNameRunningInNamespace(ctx, client, execPod.Name, execPod.Namespace)
-	expectNoError(err, "failed to create new exec pod in namespace: %s", ns)
+	framework.ExpectNoErrorWithOffset(1, err, "failed to create new exec pod in namespace: %s", ns)
 	return execPod
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
