### PR TITLE
DRA E2E: revise test labeling

### DIFF
--- a/test/e2e/apimachinery/resource_quota.go
+++ b/test/e2e/apimachinery/resource_quota.go
@@ -502,7 +502,7 @@ var _ = SIGDescribe("ResourceQuota", func() {
 		Delete the ResourceClaim. Deletion MUST succeed and resource usage count against the ResourceClaim object MUST be released from ResourceQuotaStatus of the ResourceQuota.
 		[NotConformancePromotable] alpha feature
 	*/
-	f.It("should create a ResourceQuota and capture the life of a ResourceClaim", feature.DynamicResourceAllocation, func(ctx context.Context) {
+	f.It("should create a ResourceQuota and capture the life of a ResourceClaim", f.WithFeatureGate(features.DynamicResourceAllocation), f.WithLabel("DRA"), func(ctx context.Context) {
 		ginkgo.By("Counting existing ResourceQuota")
 		c, err := countResourceQuota(ctx, f.ClientSet, f.Namespace.Name)
 		framework.ExpectNoError(err)

--- a/test/e2e/dra/dra.go
+++ b/test/e2e/dra/dra.go
@@ -895,7 +895,7 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), feature.Dynami
 		b2 := newBuilder(f, driver2)
 		b2.classParameters = driver2Params
 
-		f.It("selects the first subrequest that can be satisfied", f.WithFeatureGate(features.DRAPrioritizedList), func(ctx context.Context) {
+		f.It("selects the first subrequest that can be satisfied", func(ctx context.Context) {
 			name := "external-multiclaim"
 			params := `{"a":"b"}`
 			claim := &resourceapi.ResourceClaim{
@@ -967,7 +967,7 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), feature.Dynami
 			gomega.Expect(results[1].Request).To(gomega.Equal("request-1/sub-request-2"))
 		})
 
-		f.It("uses the config for the selected subrequest", f.WithFeatureGate(features.DRAPrioritizedList), func(ctx context.Context) {
+		f.It("uses the config for the selected subrequest", func(ctx context.Context) {
 			name := "external-multiclaim"
 			parentReqParams, parentReqEnv := `{"a":"b"}`, []string{"user_a", "b"}
 			subReq1Params := `{"c":"d"}`
@@ -1049,7 +1049,7 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), feature.Dynami
 			b1.testPod(ctx, f, pod, expectedEnv...)
 		})
 
-		f.It("chooses the correct subrequest subject to constraints", f.WithFeatureGate(features.DRAPrioritizedList), func(ctx context.Context) {
+		f.It("chooses the correct subrequest subject to constraints", func(ctx context.Context) {
 			name := "external-multiclaim"
 			params := `{"a":"b"}`
 			claim := &resourceapi.ResourceClaim{
@@ -1135,7 +1135,7 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), feature.Dynami
 			gomega.Expect(results[1].Request).To(gomega.Equal("request-2"))
 		})
 
-		f.It("filters config correctly for multiple devices", f.WithFeatureGate(features.DRAPrioritizedList), func(ctx context.Context) {
+		f.It("filters config correctly for multiple devices", func(ctx context.Context) {
 			name := "external-multiclaim"
 			req1Params, req1Env := `{"a":"b"}`, []string{"user_a", "b"}
 			req1subReq1Params, _ := `{"c":"d"}`, []string{"user_d", "d"}
@@ -1360,11 +1360,7 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), feature.Dynami
 		multiNodeTests()
 	})
 
-	ginkgo.Context("with prioritized list", func() {
-		prioritizedListTests()
-	})
-
-	ginkgo.Context("with prioritized list", func() {
+	framework.Context(f.WithFeatureGate(features.DRAPrioritizedList), func() {
 		prioritizedListTests()
 	})
 
@@ -1372,7 +1368,7 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), feature.Dynami
 		v1beta2Tests()
 	})
 
-	framework.Context("with device taints", f.WithFeatureGate(features.DRADeviceTaints), func() {
+	framework.Context(f.WithFeatureGate(features.DRADeviceTaints), func() {
 		nodes := NewNodes(f, 1, 1)
 		driver := NewDriver(f, nodes, func() Resources {
 			return Resources{

--- a/test/e2e/feature/feature.go
+++ b/test/e2e/feature/feature.go
@@ -101,64 +101,23 @@ var (
 	// TODO: document the feature (owning SIG, when to use this feature for a test)
 	Downgrade = framework.WithFeature(framework.ValidFeatures.Add("Downgrade"))
 
-	// owning-sig: sig-node
-	// kep: https://kep.k8s.io/4817
-	// test-infra jobs:
-	// - "dra-alpha" in https://testgrid.k8s.io/sig-node-dynamic-resource-allocation
-	//
-	// This label is used for tests which need:
-	// - the DynamicResourceAllocation *and* DRAResourceClaimDeviceStatus feature gates
-	DRAResourceClaimDeviceStatus = framework.WithFeature(framework.ValidFeatures.Add("DRAResourceClaimDeviceStatus"))
-
-	// owning-sig: sig-node
-	// kep: https://kep.k8s.io/4381
-	// test-infra jobs:
-	// - "dra-alpha" in https://testgrid.k8s.io/sig-node-dynamic-resource-allocation
-	//
-	// This label is used for tests which need:
-	// - the DynamicResourceAllocation *and* DRAAdminAccess feature gates
-	// - the resource.k8s.io API group
-	// - a container runtime where support for CDI (https://github.com/cncf-tags/container-device-interface)
-	//   is enabled such that passing CDI device IDs through CRI fields is supported
-	DRAAdminAccess = framework.WithFeature(framework.ValidFeatures.Add("DRAAdminAccess"))
-
-	// owning-sig: sig-scheduling
-	// kep: https://kep.k8s.io/5055
-	// test-infra jobs:
-	// - "ci-kind-dra-all" in https://testgrid.k8s.io/sig-node-dynamic-resource-allocation
-	//
-	// This label is used for tests which need:
-	// - the DynamicResourceAllocation *and* DRADeviceTaints feature gates
-	// - the resource.k8s.io API group, including version v1alpha3
-	DRADeviceTaints = framework.WithFeature(framework.ValidFeatures.Add("DRADeviceTaints"))
-
 	// TODO: document the feature (owning SIG, when to use this feature for a test)
 	// OWNER: sig-node
 	// Testing downward API huge pages
 	DownwardAPIHugePages = framework.WithFeature(framework.ValidFeatures.Add("DownwardAPIHugePages"))
 
-	// owning-sig: sig-scheduling
-	// kep: https://kep.k8s.io/4816
-	// test-infra jobs:
-	// - "ci-kind-dra-all" in https://testgrid.k8s.io/sig-node-dynamic-resource-allocation
-	//
-	// This label is used for tests which need:
-	// - the DynamicResourceAllocation *and* DRAPrioritizedList feature gates
-	// - the resource.k8s.io API group
-	// - a container runtime where support for CDI (https://github.com/cncf-tags/container-device-interface)
-	//   is enabled such that passing CDI device IDs through CRI fields is supported
-	DRAPrioritizedList = framework.WithFeature(framework.ValidFeatures.Add("DRAPrioritizedList"))
-
 	// owning-sig: sig-node
 	// kep: https://kep.k8s.io/4381
 	// test-infra jobs:
-	// - the non-"classic-dra" jobs in https://testgrid.k8s.io/sig-node-dynamic-resource-allocation
+	// - https://testgrid.k8s.io/sig-node-dynamic-resource-allocation
 	//
-	// This label is used for tests which need:
-	// - *only* the DynamicResourceAllocation feature gate
-	// - the resource.k8s.io API group
+	// This feature label is used for tests which need:
+	// - kubelet support for plugins with the "usual" paths under /var/lib/kubelet
 	// - a container runtime where support for CDI (https://github.com/cncf-tags/container-device-interface)
 	//   is enabled such that passing CDI device IDs through CRI fields is supported
+	//
+	// In addition, tests must be labeled with framework.WithFeatureGate to document
+	// their dependency on specific feature gates and the corresponding API groups.
 	DynamicResourceAllocation = framework.WithFeature(framework.ValidFeatures.Add("DynamicResourceAllocation"))
 
 	// owning-sig: sig-node

--- a/test/e2e_node/dra_test.go
+++ b/test/e2e_node/dra_test.go
@@ -48,6 +48,7 @@ import (
 	admissionapi "k8s.io/pod-security-admission/api"
 	"k8s.io/utils/ptr"
 
+	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/test/e2e/feature"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
@@ -80,7 +81,9 @@ const (
 	retryTestTimeout = kubeletRetryPeriod + 30*time.Second
 )
 
-var _ = framework.SIGDescribe("node")("DRA", feature.DynamicResourceAllocation, func() {
+// Tests depend on container runtime support for CDI and the DRA feature gate.
+// The "DRA" label is used to select tests related to DRA in a Ginkgo label filter.
+var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), feature.DynamicResourceAllocation, framework.WithFeatureGate(features.DynamicResourceAllocation), func() {
 	f := framework.NewDefaultFramework("dra-node")
 	f.NamespacePodSecurityLevel = admissionapi.LevelBaseline
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

We only need one special "DynamicResourceAllocation" feature for the optional node support of DRA (plugin registration, CDI support in the container runtime). For individual features, the automatic labeling through WithFeatureGate is sufficient.

To find DRA-related tests in a label filter, instead of plain-text "DRA" a "DRA" label now gets added.

#### Which issue(s) this PR fixes:

Related-to: https://github.com/kubernetes/kubernetes/pull/130927#discussion_r2070758109

#### Special notes for your reviewer:

This change depends on an update of the DRA jobs.

Tests before:
```
    apimachinery/resource_quota.go:505: [sig-api-machinery] ResourceQuota should create a ResourceQuota and capture the life of a ResourceClaim [Feature:DynamicResourceAllocation]
    dra/dra.go:1462: [sig-node] DRA [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] ResourceSlice Controller creates slices
    dra/dra.go:1654: [sig-node] DRA [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] cluster DaemonSet with admin access [Feature:DRAAdminAccess] [FeatureGate:DRAAdminAccess] [Alpha] [Feature:OffByDefault] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault]
    dra/dra.go:1702: [sig-node] DRA [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] cluster must apply per-node permission checks
    dra/dra.go:1845: [sig-node] DRA [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] cluster must manage ResourceSlices [Slow]
    dra/dra.go:1600: [sig-node] DRA [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] cluster supports count/resourceclaims.resource.k8s.io ResourceQuota
    dra/dra.go:1590: [sig-node] DRA [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] cluster truncates the name of a generated resource claim
    dra/dra.go:1550: [sig-node] DRA [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] cluster validate ResourceClaimTemplate and ResourceClaim for admin access [Feature:DRAAdminAccess] [FeatureGate:DRAAdminAccess] [Alpha] [Feature:OffByDefault] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault]
    dra/dra.go:2009: [sig-node] DRA [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] failed update
    dra/dra.go:172: [sig-node] DRA [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] kubelet must call NodePrepareResources even if not used by any container
    dra/dra.go:184: [sig-node] DRA [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] kubelet must map configs and devices to the right containers
    dra/dra.go:126: [sig-node] DRA [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] kubelet must not run a pod if a claim is not ready
    dra/dra.go:97: [sig-node] DRA [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] kubelet must retry NodePrepareResources
    dra/dra.go:150: [sig-node] DRA [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] kubelet must unprepare resources for force-deleted pod
    dra/dra.go:93: [sig-node] DRA [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] kubelet registers plugin
    dra/dra.go:1913: [sig-node] DRA [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] multiple drivers using only drapbv1beta1 work
    dra/dra.go:652: [sig-node] DRA [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] on multiple nodes with different ResourceSlices keeps pod pending because of CEL runtime errors
    dra/dra.go:752: [sig-node] DRA [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] on multiple nodes with network-attached resources supports sharing a claim sequentially [Slow]
    dra/dra.go:710: [sig-node] DRA [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] on multiple nodes with node-local resources uses all resources
    dra/dra.go:357: [sig-node] DRA [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] on single node deletes generated claims when pod is done
    dra/dra.go:374: [sig-node] DRA [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] on single node does not delete generated claims when pod is restarting
    dra/dra.go:406: [sig-node] DRA [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] on single node must be possible for the driver to update the ResourceClaim.Status.Devices once allocated [Feature:DRAResourceClaimDeviceStatus] [FeatureGate:DRAResourceClaimDeviceStatus] [Beta] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault]
    dra/dra.go:386: [sig-node] DRA [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] on single node must deallocate after use
    dra/dra.go:343: [sig-node] DRA [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] on single node removes reservation from claim when pod is done
    dra/dra.go:552: [sig-node] DRA [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] on single node retries pod scheduling after creating device class
    dra/dra.go:573: [sig-node] DRA [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] on single node retries pod scheduling after updating device class
    dra/dra.go:604: [sig-node] DRA [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] on single node runs a pod without a generated resource claim
    dra/dra.go:491: [sig-node] DRA [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] on single node supports claim and class parameters
    dra/dra.go:320: [sig-node] DRA [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] on single node supports external claim referenced by multiple containers of multiple pods
    dra/dra.go:308: [sig-node] DRA [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] on single node supports external claim referenced by multiple pods
    dra/dra.go:332: [sig-node] DRA [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] on single node supports init containers
    dra/dra.go:295: [sig-node] DRA [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] on single node supports inline claim referenced by multiple containers
    dra/dra.go:497: [sig-node] DRA [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] on single node supports reusing resources
    dra/dra.go:525: [sig-node] DRA [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] on single node supports sharing a claim concurrently
    dra/dra.go:301: [sig-node] DRA [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] on single node supports simple pod referencing external resource claim
    dra/dra.go:289: [sig-node] DRA [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] on single node supports simple pod referencing inline resource claim
    dra/dra.go:1967: [sig-node] DRA [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] rolling update
    dra/dra.go:1942: [sig-node] DRA [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] runs pod after driver starts
    dra/dra.go:2052: [sig-node] DRA [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] sequential update with pods replacing each other [Slow]
    dra/dra.go:1380: [sig-node] DRA [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] with device taints [Feature:DRADeviceTaints] [FeatureGate:DRADeviceTaints] [Alpha] [Feature:OffByDefault] DeviceTaint keeps pod pending
    dra/dra.go:1397: [sig-node] DRA [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] with device taints [Feature:DRADeviceTaints] [FeatureGate:DRADeviceTaints] [Alpha] [Feature:OffByDefault] DeviceTaintRule evicts pod
    dra/dra.go:1386: [sig-node] DRA [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] with device taints [Feature:DRADeviceTaints] [FeatureGate:DRADeviceTaints] [Alpha] [Feature:OffByDefault] DeviceToleration enables pod scheduling
    dra/dra.go:1048: [sig-node] DRA [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] with prioritized list chooses the correct subrequest subject to constraints [Feature:DRAPrioritizedList]
    dra/dra.go:1048: [sig-node] DRA [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] with prioritized list chooses the correct subrequest subject to constraints [Feature:DRAPrioritizedList]
    dra/dra.go:1134: [sig-node] DRA [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] with prioritized list filters config correctly for multiple devices [Feature:DRAPrioritizedList]
    dra/dra.go:1134: [sig-node] DRA [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] with prioritized list filters config correctly for multiple devices [Feature:DRAPrioritizedList]
    dra/dra.go:894: [sig-node] DRA [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] with prioritized list selects the first subrequest that can be satisfied [Feature:DRAPrioritizedList]
    dra/dra.go:894: [sig-node] DRA [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] with prioritized list selects the first subrequest that can be satisfied [Feature:DRAPrioritizedList]
    dra/dra.go:966: [sig-node] DRA [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] with prioritized list uses the config for the selected subrequest [Feature:DRAPrioritizedList]
    dra/dra.go:966: [sig-node] DRA [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] with prioritized list uses the config for the selected subrequest [Feature:DRAPrioritizedList]
    dra/dra.go:1289: [sig-node] DRA [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] with v1beta2 API supports requests with alternatives [Feature:DRAPrioritizedList]
    dra/dra.go:1283: [sig-node] DRA [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] with v1beta2 API supports simple ResourceClaim
    dra_test.go:268: [sig-node] DRA [Feature:DynamicResourceAllocation] Resource Kubelet Plugin [Serial] must call NodeUnprepareResources for deleted pod
    dra_test.go:292: [sig-node] DRA [Feature:DynamicResourceAllocation] Resource Kubelet Plugin [Serial] must call NodeUnprepareResources for deleted pod after Kubelet restart
    dra_test.go:143: [sig-node] DRA [Feature:DynamicResourceAllocation] Resource Kubelet Plugin [Serial] must keep pod in pending state if NodePrepareResources times out
    dra_test.go:323: [sig-node] DRA [Feature:DynamicResourceAllocation] Resource Kubelet Plugin [Serial] must not call NodePrepareResources for deleted pod after Kubelet restart
    dra_test.go:124: [sig-node] DRA [Feature:DynamicResourceAllocation] Resource Kubelet Plugin [Serial] must process pod created when kubelet is not running
    dra_test.go:97: [sig-node] DRA [Feature:DynamicResourceAllocation] Resource Kubelet Plugin [Serial] must register after Kubelet restart
    dra_test.go:113: [sig-node] DRA [Feature:DynamicResourceAllocation] Resource Kubelet Plugin [Serial] must register after plugin restart
    dra_test.go:210: [sig-node] DRA [Feature:DynamicResourceAllocation] Resource Kubelet Plugin [Serial] must retry NodePrepareResources after Kubelet restart
    dra_test.go:241: [sig-node] DRA [Feature:DynamicResourceAllocation] Resource Kubelet Plugin [Serial] must retry NodeUnprepareResources after Kubelet restart
    dra_test.go:163: [sig-node] DRA [Feature:DynamicResourceAllocation] Resource Kubelet Plugin [Serial] must run pod if NodePrepareResources fails and then succeeds
    dra_test.go:188: [sig-node] DRA [Feature:DynamicResourceAllocation] Resource Kubelet Plugin [Serial] must run pod if NodeUnprepareResources fails and then succeeds
    dra_test.go:528: [sig-node] DRA [Feature:DynamicResourceAllocation] ResourceSlice [Serial] must be removed after plugin unregistration
    dra_test.go:499: [sig-node] DRA [Feature:DynamicResourceAllocation] ResourceSlice [Serial] must be removed on kubelet startup [Disruptive]
    dra_test.go:460: [sig-node] DRA [Feature:DynamicResourceAllocation] Two resource Kubelet Plugins [Serial] must call NodeUnprepareResources again if it's in progress for one plugin when Kubelet restarts
    dra_test.go:367: [sig-node] DRA [Feature:DynamicResourceAllocation] Two resource Kubelet Plugins [Serial] must prepare and unprepare resources
    dra_test.go:385: [sig-node] DRA [Feature:DynamicResourceAllocation] Two resource Kubelet Plugins [Serial] must run pod if NodePrepareResources fails for one plugin and then succeeds
    dra_test.go:435: [sig-node] DRA [Feature:DynamicResourceAllocation] Two resource Kubelet Plugins [Serial] must run pod if NodePrepareResources is in progress for one plugin when Kubelet restarts
    dra_test.go:410: [sig-node] DRA [Feature:DynamicResourceAllocation] Two resource Kubelet Plugins [Serial] must run pod if NodeUnprepareResources fails for one plugin and then succeeds
```

Tests after:
```
    apimachinery/resource_quota.go:505: [sig-api-machinery] ResourceQuota should create a ResourceQuota and capture the life of a ResourceClaim [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] [DRA]
    dra/dra.go:1462: [sig-node] [DRA] [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] ResourceSlice Controller creates slices
    dra/dra.go:1380: [sig-node] [DRA] [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] [FeatureGate:DRADeviceTaints] [Alpha] [Feature:OffByDefault] DeviceTaint keeps pod pending
    dra/dra.go:1397: [sig-node] [DRA] [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] [FeatureGate:DRADeviceTaints] [Alpha] [Feature:OffByDefault] DeviceTaintRule evicts pod
    dra/dra.go:1386: [sig-node] [DRA] [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] [FeatureGate:DRADeviceTaints] [Alpha] [Feature:OffByDefault] DeviceToleration enables pod scheduling
    dra/dra.go:1052: [sig-node] [DRA] [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] [FeatureGate:DRAPrioritizedList] [Alpha] [Feature:OffByDefault] chooses the correct subrequest subject to constraints
    dra/dra.go:1138: [sig-node] [DRA] [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] [FeatureGate:DRAPrioritizedList] [Alpha] [Feature:OffByDefault] filters config correctly for multiple devices
    dra/dra.go:898: [sig-node] [DRA] [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] [FeatureGate:DRAPrioritizedList] [Alpha] [Feature:OffByDefault] selects the first subrequest that can be satisfied
    dra/dra.go:970: [sig-node] [DRA] [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] [FeatureGate:DRAPrioritizedList] [Alpha] [Feature:OffByDefault] uses the config for the selected subrequest
    dra/dra.go:1654: [sig-node] [DRA] [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] cluster DaemonSet with admin access [FeatureGate:DRAAdminAccess] [Alpha] [Feature:OffByDefault]
    dra/dra.go:1702: [sig-node] [DRA] [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] cluster must apply per-node permission checks
    dra/dra.go:1845: [sig-node] [DRA] [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] cluster must manage ResourceSlices [Slow]
    dra/dra.go:1600: [sig-node] [DRA] [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] cluster supports count/resourceclaims.resource.k8s.io ResourceQuota
    dra/dra.go:1590: [sig-node] [DRA] [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] cluster truncates the name of a generated resource claim
    dra/dra.go:1550: [sig-node] [DRA] [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] cluster validate ResourceClaimTemplate and ResourceClaim for admin access [FeatureGate:DRAAdminAccess] [Alpha] [Feature:OffByDefault]
    dra/dra.go:2009: [sig-node] [DRA] [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] failed update
    dra/dra.go:176: [sig-node] [DRA] [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] kubelet must call NodePrepareResources even if not used by any container
    dra/dra.go:188: [sig-node] [DRA] [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] kubelet must map configs and devices to the right containers
    dra/dra.go:130: [sig-node] [DRA] [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] kubelet must not run a pod if a claim is not ready
    dra/dra.go:101: [sig-node] [DRA] [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] kubelet must retry NodePrepareResources
    dra/dra.go:154: [sig-node] [DRA] [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] kubelet must unprepare resources for force-deleted pod
    dra/dra.go:97: [sig-node] [DRA] [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] kubelet registers plugin
    dra/dra.go:1913: [sig-node] [DRA] [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] multiple drivers using only drapbv1beta1 work
    dra/dra.go:656: [sig-node] [DRA] [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] on multiple nodes with different ResourceSlices keeps pod pending because of CEL runtime errors
    dra/dra.go:756: [sig-node] [DRA] [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] on multiple nodes with network-attached resources supports sharing a claim sequentially [Slow]
    dra/dra.go:714: [sig-node] [DRA] [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] on multiple nodes with node-local resources uses all resources
    dra/dra.go:361: [sig-node] [DRA] [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] on single node deletes generated claims when pod is done
    dra/dra.go:378: [sig-node] [DRA] [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] on single node does not delete generated claims when pod is restarting
    dra/dra.go:410: [sig-node] [DRA] [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] on single node must be possible for the driver to update the ResourceClaim.Status.Devices once allocated [FeatureGate:DRAResourceClaimDeviceStatus] [Beta]
    dra/dra.go:390: [sig-node] [DRA] [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] on single node must deallocate after use
    dra/dra.go:347: [sig-node] [DRA] [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] on single node removes reservation from claim when pod is done
    dra/dra.go:556: [sig-node] [DRA] [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] on single node retries pod scheduling after creating device class
    dra/dra.go:577: [sig-node] [DRA] [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] on single node retries pod scheduling after updating device class
    dra/dra.go:608: [sig-node] [DRA] [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] on single node runs a pod without a generated resource claim
    dra/dra.go:495: [sig-node] [DRA] [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] on single node supports claim and class parameters
    dra/dra.go:324: [sig-node] [DRA] [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] on single node supports external claim referenced by multiple containers of multiple pods
    dra/dra.go:312: [sig-node] [DRA] [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] on single node supports external claim referenced by multiple pods
    dra/dra.go:336: [sig-node] [DRA] [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] on single node supports init containers
    dra/dra.go:299: [sig-node] [DRA] [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] on single node supports inline claim referenced by multiple containers
    dra/dra.go:501: [sig-node] [DRA] [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] on single node supports reusing resources
    dra/dra.go:529: [sig-node] [DRA] [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] on single node supports sharing a claim concurrently
    dra/dra.go:305: [sig-node] [DRA] [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] on single node supports simple pod referencing external resource claim
    dra/dra.go:293: [sig-node] [DRA] [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] on single node supports simple pod referencing inline resource claim
    dra/dra.go:1967: [sig-node] [DRA] [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] rolling update
    dra/dra.go:1942: [sig-node] [DRA] [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] runs pod after driver starts
    dra/dra.go:2052: [sig-node] [DRA] [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] sequential update with pods replacing each other [Slow]
    dra/dra.go:1293: [sig-node] [DRA] [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] with v1beta2 API supports requests with alternatives [FeatureGate:DRAPrioritizedList] [Alpha] [Feature:OffByDefault]
    dra/dra.go:1287: [sig-node] [DRA] [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] with v1beta2 API supports simple ResourceClaim
```


#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @mortent 