### PR TITLE
Remove package protected fields from ActionType

### DIFF
--- a/pkg/scheduler/framework/events.go
+++ b/pkg/scheduler/framework/events.go
@@ -68,26 +68,26 @@ func PodSchedulingPropertiesChange(newPod *v1.Pod, oldPod *v1.Pod) (events []Clu
 		r = unschedulablePod
 	}
 
-	podChangeExtracters := []podChangeExtractor{
+	podChangeExtractors := []podChangeExtractor{
 		extractPodLabelsChange,
 		extractPodScaleDown,
 		extractPodSchedulingGateEliminatedChange,
 		extractPodTolerationChange,
 	}
 	if utilfeature.DefaultFeatureGate.Enabled(features.DynamicResourceAllocation) {
-		podChangeExtracters = append(podChangeExtracters, extractPodGeneratedResourceClaimChange)
+		podChangeExtractors = append(podChangeExtractors, extractPodGeneratedResourceClaimChange)
 	}
 
-	for _, fn := range podChangeExtracters {
-		if event := fn(newPod, oldPod); event != none {
+	for _, fn := range podChangeExtractors {
+		if event := fn(newPod, oldPod); event != None {
 			events = append(events, ClusterEvent{Resource: r, ActionType: event})
 		}
 	}
 
 	if len(events) == 0 {
-		// When no specific event is found, we use AssignedPodOtherUpdate,
+		// When no specific event is found, we use the general Update action,
 		// which should only trigger plugins registering a general Pod/Update event.
-		events = append(events, ClusterEvent{Resource: r, ActionType: updatePodOther})
+		events = append(events, ClusterEvent{Resource: r, ActionType: Update})
 	}
 
 	return
@@ -116,14 +116,14 @@ func extractPodScaleDown(newPod, oldPod *v1.Pod) ActionType {
 		}
 	}
 
-	return none
+	return None
 }
 
 func extractPodLabelsChange(newPod *v1.Pod, oldPod *v1.Pod) ActionType {
 	if isLabelChanged(newPod.GetLabels(), oldPod.GetLabels()) {
 		return UpdatePodLabel
 	}
-	return none
+	return None
 }
 
 func extractPodTolerationChange(newPod *v1.Pod, oldPod *v1.Pod) ActionType {
@@ -135,7 +135,7 @@ func extractPodTolerationChange(newPod *v1.Pod, oldPod *v1.Pod) ActionType {
 		return UpdatePodToleration
 	}
 
-	return none
+	return None
 }
 
 func extractPodSchedulingGateEliminatedChange(newPod *v1.Pod, oldPod *v1.Pod) ActionType {
@@ -144,7 +144,7 @@ func extractPodSchedulingGateEliminatedChange(newPod *v1.Pod, oldPod *v1.Pod) Ac
 		return UpdatePodSchedulingGatesEliminated
 	}
 
-	return none
+	return None
 }
 
 func extractPodGeneratedResourceClaimChange(newPod *v1.Pod, oldPod *v1.Pod) ActionType {
@@ -152,7 +152,7 @@ func extractPodGeneratedResourceClaimChange(newPod *v1.Pod, oldPod *v1.Pod) Acti
 		return UpdatePodGeneratedResourceClaim
 	}
 
-	return none
+	return None
 }
 
 // NodeSchedulingPropertiesChange interprets the update of a node and returns corresponding UpdateNodeXYZ event(s).
@@ -167,7 +167,7 @@ func NodeSchedulingPropertiesChange(newNode *v1.Node, oldNode *v1.Node) (events 
 	}
 
 	for _, fn := range nodeChangeExtracters {
-		if event := fn(newNode, oldNode); event != none {
+		if event := fn(newNode, oldNode); event != None {
 			events = append(events, ClusterEvent{Resource: Node, ActionType: event})
 		}
 	}
@@ -180,14 +180,14 @@ func extractNodeAllocatableChange(newNode *v1.Node, oldNode *v1.Node) ActionType
 	if !equality.Semantic.DeepEqual(oldNode.Status.Allocatable, newNode.Status.Allocatable) {
 		return UpdateNodeAllocatable
 	}
-	return none
+	return None
 }
 
 func extractNodeLabelsChange(newNode *v1.Node, oldNode *v1.Node) ActionType {
 	if isLabelChanged(newNode.GetLabels(), oldNode.GetLabels()) {
 		return UpdateNodeLabel
 	}
-	return none
+	return None
 }
 
 func isLabelChanged(newLabels map[string]string, oldLabels map[string]string) bool {
@@ -198,7 +198,7 @@ func extractNodeTaintsChange(newNode *v1.Node, oldNode *v1.Node) ActionType {
 	if !equality.Semantic.DeepEqual(newNode.Spec.Taints, oldNode.Spec.Taints) {
 		return UpdateNodeTaint
 	}
-	return none
+	return None
 }
 
 func extractNodeConditionsChange(newNode *v1.Node, oldNode *v1.Node) ActionType {
@@ -212,7 +212,7 @@ func extractNodeConditionsChange(newNode *v1.Node, oldNode *v1.Node) ActionType 
 	if !equality.Semantic.DeepEqual(strip(oldNode.Status.Conditions), strip(newNode.Status.Conditions)) {
 		return UpdateNodeCondition
 	}
-	return none
+	return None
 }
 
 func extractNodeSpecUnschedulableChange(newNode *v1.Node, oldNode *v1.Node) ActionType {
@@ -220,12 +220,12 @@ func extractNodeSpecUnschedulableChange(newNode *v1.Node, oldNode *v1.Node) Acti
 		// TODO: create UpdateNodeSpecUnschedulable ActionType
 		return UpdateNodeTaint
 	}
-	return none
+	return None
 }
 
 func extractNodeAnnotationsChange(newNode *v1.Node, oldNode *v1.Node) ActionType {
 	if !equality.Semantic.DeepEqual(oldNode.GetAnnotations(), newNode.GetAnnotations()) {
 		return UpdateNodeAnnotation
 	}
-	return none
+	return None
 }

--- a/pkg/scheduler/framework/events_test.go
+++ b/pkg/scheduler/framework/events_test.go
@@ -60,7 +60,7 @@ func TestNodeAllocatableChange(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			oldNode := &v1.Node{Status: v1.NodeStatus{Allocatable: test.oldAllocatable}}
 			newNode := &v1.Node{Status: v1.NodeStatus{Allocatable: test.newAllocatable}}
-			changed := extractNodeAllocatableChange(newNode, oldNode) != none
+			changed := extractNodeAllocatableChange(newNode, oldNode) != None
 			if changed != test.changed {
 				t.Errorf("nodeAllocatableChanged should be %t, got %t", test.changed, changed)
 			}
@@ -93,7 +93,7 @@ func TestNodeLabelsChange(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			oldNode := &v1.Node{ObjectMeta: metav1.ObjectMeta{Labels: test.oldLabels}}
 			newNode := &v1.Node{ObjectMeta: metav1.ObjectMeta{Labels: test.newLabels}}
-			changed := extractNodeLabelsChange(newNode, oldNode) != none
+			changed := extractNodeLabelsChange(newNode, oldNode) != None
 			if changed != test.changed {
 				t.Errorf("Test case %q failed: should be %t, got %t", test.name, test.changed, changed)
 			}
@@ -125,7 +125,7 @@ func TestNodeTaintsChange(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			oldNode := &v1.Node{Spec: v1.NodeSpec{Taints: test.oldTaints}}
 			newNode := &v1.Node{Spec: v1.NodeSpec{Taints: test.newTaints}}
-			changed := extractNodeTaintsChange(newNode, oldNode) != none
+			changed := extractNodeTaintsChange(newNode, oldNode) != None
 			if changed != test.changed {
 				t.Errorf("Test case %q failed: should be %t, not %t", test.name, test.changed, changed)
 			}
@@ -180,7 +180,7 @@ func TestNodeConditionsChange(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			oldNode := &v1.Node{Status: v1.NodeStatus{Conditions: test.oldConditions}}
 			newNode := &v1.Node{Status: v1.NodeStatus{Conditions: test.newConditions}}
-			changed := extractNodeConditionsChange(newNode, oldNode) != none
+			changed := extractNodeConditionsChange(newNode, oldNode) != None
 			if changed != test.changed {
 				t.Errorf("Test case %q failed: should be %t, got %t", test.name, test.changed, changed)
 			}
@@ -377,7 +377,7 @@ func Test_podSchedulingPropertiesChange(t *testing.T) {
 			name:   "pod's resource request is scaled up",
 			oldPod: podWithSmallRequest,
 			newPod: podWithBigRequest,
-			want:   []ClusterEvent{{Resource: unschedulablePod, ActionType: updatePodOther}},
+			want:   []ClusterEvent{{Resource: unschedulablePod, ActionType: Update}},
 		},
 		{
 			name:   "both pod's resource request and label are updated",
@@ -392,7 +392,7 @@ func Test_podSchedulingPropertiesChange(t *testing.T) {
 			name:   "untracked properties of pod is updated",
 			newPod: st.MakePod().Annotation("foo", "bar").Obj(),
 			oldPod: st.MakePod().Annotation("foo", "bar2").Obj(),
-			want:   []ClusterEvent{{Resource: unschedulablePod, ActionType: updatePodOther}},
+			want:   []ClusterEvent{{Resource: unschedulablePod, ActionType: Update}},
 		},
 		{
 			name:   "scheduling gate is eliminated",
@@ -404,7 +404,7 @@ func Test_podSchedulingPropertiesChange(t *testing.T) {
 			name:   "scheduling gate is removed, but not completely eliminated",
 			newPod: st.MakePod().SchedulingGates([]string{"foo"}).Obj(),
 			oldPod: st.MakePod().SchedulingGates([]string{"foo", "bar"}).Obj(),
-			want:   []ClusterEvent{{Resource: unschedulablePod, ActionType: updatePodOther}},
+			want:   []ClusterEvent{{Resource: unschedulablePod, ActionType: Update}},
 		},
 		{
 			name:   "pod's tolerations are updated",
@@ -417,7 +417,7 @@ func Test_podSchedulingPropertiesChange(t *testing.T) {
 			draDisabled: true,
 			newPod:      st.MakePod().ResourceClaimStatuses(claimStatusA).Obj(),
 			oldPod:      st.MakePod().Obj(),
-			want:        []ClusterEvent{{Resource: unschedulablePod, ActionType: updatePodOther}},
+			want:        []ClusterEvent{{Resource: unschedulablePod, ActionType: Update}},
 		},
 		{
 			name:   "pod claim statuses change, feature enabled",

--- a/pkg/scheduler/framework/types_test.go
+++ b/pkg/scheduler/framework/types_test.go
@@ -2135,6 +2135,18 @@ func TestCloudEvent_Match(t *testing.T) {
 			comingEvent: ClusterEvent{Resource: WildCard, ActionType: UpdateNodeLabel},
 			wantResult:  false,
 		},
+		{
+			name:        "event with resource = '*' matching with coming events carrying a too broad actionType",
+			event:       ClusterEvent{Resource: WildCard, ActionType: UpdateNodeLabel},
+			comingEvent: ClusterEvent{Resource: Pod, ActionType: Update},
+			wantResult:  false,
+		},
+		{
+			name:        "event with resource = '*' matching with coming events carrying a more specific actionType",
+			event:       ClusterEvent{Resource: WildCard, ActionType: Update},
+			comingEvent: ClusterEvent{Resource: Pod, ActionType: UpdateNodeLabel},
+			wantResult:  true,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug

/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This is part of moving scheduler framework types and interfaces to staging repo.
In order to move ActionType to staging, and not need to move a significant chunk of scheduler's code at the same time, all ActionType values should be public, instead of package protected.
This PR removes the `updatePodOther` value, which seems not to be crucial for scheduler's logic, and makes the `none` value public.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #89930

#### Special notes for your reviewer:
Per what @sanposhiho said in sig-scheduling meeting (and what's in the code), the field `updatePodOther` was introduced to distinguish the cases where Pod got updated, but there is no ActionType value (yet) that would describe the updated of this particular part of Pod. So instead of a more specific type (e.g. `UpdatePodToleration`) scheduler would internally use `updatePodOther` and externally use a general `UpdatePod`.
Based on what I see in the code, the `updatePodOther` value may get exported in `scheduler_event_handling_duration_seconds` metrics (as a label). This PR would remove this behavior. If we feel that this information is actually important to scheduler's maintainers, perhaps we should consider logging this type of events, and introducing a new metric (counter?), that would count the number of events with an "other" update type? WDYT?

I decided to change the visibility of `ActionType.none` to public, I'm not sure if this may cause harm? Maybe adding a comment saying "do not use this outside of pkg/scheduler" would be sufficient here?

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
