### PR TITLE
add 'dra' folder to csi image config

### DIFF
--- a/test/utils/image/csi_manifest.go
+++ b/test/utils/image/csi_manifest.go
@@ -44,7 +44,7 @@ func appendCSIImageConfigs(configs map[ImageID]Config) {
 		}
 	}
 
-	err := fs.WalkDir(embeddedFS, "storage-csi", func(path string, d fs.DirEntry, err error) error {
+	walkDirFn := func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -97,10 +97,13 @@ func appendCSIImageConfigs(configs map[ImageID]Config) {
 
 		}
 		return nil
+	}
 
-	})
-	if err != nil {
-		panic(err)
+	for _, dir := range []string{"storage-csi", "dra"} {
+		err := fs.WalkDir(embeddedFS, dir, walkDirFn)
+		if err != nil {
+			panic(fmt.Errorf("error while extracting CSI image configs from directory: %q - %w", dir, err))
+		}
 	}
 }
 

--- a/test/utils/image/csi_manifests_test.go
+++ b/test/utils/image/csi_manifests_test.go
@@ -56,6 +56,7 @@ func TestCSIImageConfigs(t *testing.T) {
 	}
 	actualImages := sets.NewString()
 	for _, config := range configs {
+		t.Logf("found image: %s", config)
 		assert.NotEmpty(t, config.registry, "registry")
 		assert.NotEmpty(t, config.name, "name")
 		assert.NotEmpty(t, config.version, "version")

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -52,6 +52,10 @@ type Config struct {
 	version  string
 }
 
+func (i Config) String() string {
+	return fmt.Sprintf("registry: %s, name: %s, version: %s", i.registry, i.name, i.version)
+}
+
 // SetRegistry sets an image registry in a Config struct
 func (i *Config) SetRegistry(registry string) {
 	i.registry = registry


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind cleanup

#### What this PR does / why we need it:

DRA e2e tests use the `hostpathplugin:v1.7.3` image
https://github.com/kubernetes/kubernetes/blob/1b4c5b3f8605dc1c86050ae941a24556d4fbd678/test/e2e/testing-manifests/dra/dra-test-driver-proxy.yaml#L50

today the `appendCSIImageConfigs` function gathers CSI images from the `storage-csi` folder only, and the DRA tests use a separate version of the `hostpathplugin` than what is gathered from the `storage-csi` folder. As a consequence the generated image list does not include the version of the `hostpathplugin` image used by the DRA tests.

This PR adds the `dra` folder to the CSI image gathering function. The output of the test:
```
go test -v -count=1 ./test/utils/image -run=TestCSIImageConfigs
=== RUN   TestCSIImageConfigs
    csi_manifests_test.go:59: found image: registry: registry.k8s.io/sig-storage, name: csi-external-health-monitor-controller, version: v0.12.1
    csi_manifests_test.go:59: found image: registry: registry.k8s.io/sig-storage, name: csi-attacher, version: v4.8.0
    csi_manifests_test.go:59: found image: registry: registry.k8s.io/sig-storage, name: csi-provisioner, version: v5.1.0
    csi_manifests_test.go:59: found image: registry: registry.k8s.io/sig-storage, name: csi-resizer, version: v1.13.1
    csi_manifests_test.go:59: found image: registry: registry.k8s.io/sig-storage, name: csi-snapshotter, version: v8.2.0
    csi_manifests_test.go:59: found image: registry: registry.k8s.io/cloud-provider-gcp, name: gcp-compute-persistent-disk-csi-driver, version: v1.4.0
    csi_manifests_test.go:59: found image: registry: registry.k8s.io/sig-storage, name: volume-data-source-validator, version: v1.0.0
    csi_manifests_test.go:59: found image: registry: registry.k8s.io/sig-storage, name: hostpathplugin, version: v1.16.1
    csi_manifests_test.go:59: found image: registry: registry.k8s.io/sig-storage, name: csi-node-driver-registrar, version: v2.13.0
    csi_manifests_test.go:59: found image: registry: registry.k8s.io/sig-storage, name: livenessprobe, version: v2.15.0
    csi_manifests_test.go:59: found image: registry: registry.k8s.io/e2e-test-images, name: busybox, version: 1.36.1-1
    csi_manifests_test.go:59: found image: registry: registry.k8s.io/sig-storage, name: hostpathplugin, version: v1.7.3
    csi_manifests_test.go:59: found image: registry: registry.k8s.io/sig-storage, name: hello-populator, version: v1.0.1
--- PASS: TestCSIImageConfigs (0.01s)
```

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
