### PR TITLE
e2e: Fix shadowed error in reboot test and clean up containers after reboot test

### DIFF
--- a/test/e2e/windows/hybrid_network.go
+++ b/test/e2e/windows/hybrid_network.go
@@ -110,9 +110,11 @@ var (
 func assertConsistentConnectivity(ctx context.Context, f *framework.Framework, podName string, os string, cmd []string, maxTries int) {
 	connChecker := func() error {
 		var err error
+		var stdout string
+		var stderr string
 		for i := 0; i < maxTries; i++ {
 			ginkgo.By(fmt.Sprintf("checking connectivity of %s-container in %s", os, podName))
-			stdout, stderr, err := e2epod.ExecCommandInContainerWithFullOutput(f, podName, os+"-container", cmd...)
+			stdout, stderr, err = e2epod.ExecCommandInContainerWithFullOutput(f, podName, os+"-container", cmd...)
 			if err == nil {
 				break
 			}

--- a/test/e2e/windows/hybrid_network.go
+++ b/test/e2e/windows/hybrid_network.go
@@ -104,7 +104,7 @@ var (
 	timeoutSeconds = 10
 
 	externalMaxTries = 10
-	internalMaxTries = 1
+	internalMaxTries = 3
 )
 
 func assertConsistentConnectivity(ctx context.Context, f *framework.Framework, podName string, os string, cmd []string, maxTries int) {

--- a/test/e2e/windows/kubelet_stats.go
+++ b/test/e2e/windows/kubelet_stats.go
@@ -250,10 +250,6 @@ func findWindowsNodes(ctx context.Context, f *framework.Framework) ([]v1.Node, e
 		}
 	}
 
-	if len(targetNodes) == 0 {
-		e2eskipper.Skipf("Could not find and ready and schedulable Windows nodes")
-	}
-
 	return targetNodes, nil
 }
 

--- a/test/e2e/windows/kubelet_stats.go
+++ b/test/e2e/windows/kubelet_stats.go
@@ -234,6 +234,29 @@ func findWindowsNode(ctx context.Context, f *framework.Framework) (v1.Node, erro
 	return targetNode, nil
 }
 
+// findWindowsNodes finds all Windows nodes that are Ready and Schedulable
+func findWindowsNodes(ctx context.Context, f *framework.Framework) ([]v1.Node, error) {
+	selector := labels.Set{"kubernetes.io/os": "windows"}.AsSelector()
+	nodeList, err := f.ClientSet.CoreV1().Nodes().List(ctx, metav1.ListOptions{LabelSelector: selector.String()})
+
+	if err != nil {
+		return nil, err
+	}
+
+	var targetNodes []v1.Node
+	for _, n := range nodeList.Items {
+		if e2enode.IsNodeReady(&n) && e2enode.IsNodeSchedulable(&n) {
+			targetNodes = append(targetNodes, n)
+		}
+	}
+
+	if len(targetNodes) == 0 {
+		e2eskipper.Skipf("Could not find and ready and schedulable Windows nodes")
+	}
+
+	return targetNodes, nil
+}
+
 // newKubeletStatsTestPods creates a list of pods (specification) for test.
 func newKubeletStatsTestPods(numPods int, image imageutils.Config, nodeName string) []*v1.Pod {
 	var pods []*v1.Pod

--- a/test/e2e/windows/reboot_node.go
+++ b/test/e2e/windows/reboot_node.go
@@ -58,6 +58,10 @@ var _ = sigDescribe(feature.Windows, "[Excluded:WindowsDocker] [MinimumKubeletVe
 		nodes, err := findWindowsNodes(ctx, f)
 		framework.ExpectNoError(err, "Error finding Windows nodes")
 
+		if len(nodes) == 0 {
+			e2eskipper.Skipf("Could not find and ready and schedulable Windows nodes")
+		}
+
 		targetNode := nodes[0]
 		// reuse the node if find label contains "test/reboot-used" first
 		for _, node := range nodes {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind flake
/sig windows

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
- Fixed a bug in function `ExecCommandInContainerWithFullOutput` usage in `hybrid_network.go` where the `err` variable was shadowed, causing test failures to be silently ignored.

- Added cleanup logic in `eviction.go` to explicitly delete pods created by the reboot node test (e.g., `img-puller`, `reboot-host-test-windows`) before starting the eviction test.

- This improves reliability of the eviction test when the reboot test runs beforehand and leaves behind memory-consuming pods.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #(https://github.com/kubernetes/kubernetes/issues/130419)

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
