### PR TITLE
Panic in `NewYAMLToJSONDecoder`

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/yaml/decoder_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/yaml/decoder_test.go
@@ -343,6 +343,17 @@ func TestYAMLOrJSONDecoder(t *testing.T) {
 			{"foo": "bar"},
 			{"baz": "biz"},
 		}},
+		// First document is JSON, second is YAML but with smaller size.
+		{"{\"foo\": \"bar\"}\n---\na: b", 100, false, false, []generic{
+			{"foo": "bar"},
+			{"a": "b"},
+		}},
+		// First document is JSON, second is YAML,but with smaller size and
+		// trailing whitespace.
+		{"{\"foo\": \"bar\"}    \n---\na: b", 100, false, false, []generic{
+			{"foo": "bar"},
+			{"a": "b"},
+		}},
 		// First document is JSON, second is YAML, longer than the buffer
 		{"{\"foo\": \"bar\"}\n---\n{baz: biz0123456780123456780123456780123456780123456789}", 20, false, false, []generic{
 			{"foo": "bar"},


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind regression

#### What this PR does / why we need it:

This PR fixes a possible panic caused by decoding a JSON document followed by a YAML document that is shorter than the first json document.

This can cause a panic because the stream already consumed the JSON data. When we fallback to YAML reader, the YAML starts with a zero offset while the stream consumed data is non-zero. This could lead into consuming negative bytes because `d.yaml.InputOffset() - d.stream.Consumed()` is negative which will cause a panic.

#### Which issue(s) this PR fixes:

Fixes #131701

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Fixes a 1.33 regression that can cause a possible panic decoding a JSON document followed by a YAML document shorter than the first JSON document
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
