### PR TITLE
Automated cherry pick of #131702: Panic in `NewYAMLToJSONDecoder`

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/yaml/decoder_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/yaml/decoder_test.go
@@ -343,6 +343,17 @@ func TestYAMLOrJSONDecoder(t *testing.T) {
 			{"foo": "bar"},
 			{"baz": "biz"},
 		}},
+		// First document is JSON, second is YAML but with smaller size.
+		{"{\"foo\": \"bar\"}\n---\na: b", 100, false, false, []generic{
+			{"foo": "bar"},
+			{"a": "b"},
+		}},
+		// First document is JSON, second is YAML,but with smaller size and
+		// trailing whitespace.
+		{"{\"foo\": \"bar\"}    \n---\na: b", 100, false, false, []generic{
+			{"foo": "bar"},
+			{"a": "b"},
+		}},
 		// First document is JSON, second is YAML, longer than the buffer
 		{"{\"foo\": \"bar\"}\n---\n{baz: biz0123456780123456780123456780123456780123456789}", 20, false, false, []generic{
 			{"foo": "bar"},


### PR DESCRIPTION
Cherry pick of #131702 on release-1.33.

#131702: Panic in `NewYAMLToJSONDecoder`

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixes a 1.33 regression that can cause a possible panic decoding a JSON document followed by a YAML document shorter than the first JSON document
```