### PR TITLE
cleanup: Migrate deprecated function ExtractCommentTags

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/applyconfiguration-gen/generators/openapi.go
+++ b/staging/src/k8s.io/code-generator/cmd/applyconfiguration-gen/generators/openapi.go
@@ -58,7 +58,10 @@ func newTypeModels(openAPISchemaFilePath string, pkgTypes map[string]*types.Pack
 	gvkToOpenAPIType := map[clientgentypes.GroupVersionKind]string{}
 	rootDefs := map[string]spec.Schema{}
 	for _, p := range pkgTypes {
-		gv := groupVersion(p)
+		gv, err := groupVersion(p)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse comments of package %s: %w", p.Name, err)
+		}
 		for _, t := range p.Types {
 			tags := genclientTags(t)
 			hasApply := tags.HasVerb("apply") || tags.HasVerb("applyStatus")

--- a/staging/src/k8s.io/code-generator/cmd/applyconfiguration-gen/generators/targets.go
+++ b/staging/src/k8s.io/code-generator/cmd/applyconfiguration-gen/generators/targets.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/code-generator/cmd/applyconfiguration-gen/args"
 	"k8s.io/code-generator/cmd/client-gen/generators/util"
 	clientgentypes "k8s.io/code-generator/cmd/client-gen/types"
+	genutil "k8s.io/code-generator/pkg/util"
 )
 
 const (
@@ -75,7 +76,10 @@ func GetTargets(context *generator.Context, args *args.Args) []generator.Target 
 
 	var targetList []generator.Target
 	for pkg, p := range pkgTypes {
-		gv := groupVersion(p)
+		gv, err := groupVersion(p)
+		if err != nil {
+			klog.Fatalf("Failed to parse comments of package %s: %v", p.Name, err)
+		}
 
 		var toGenerate []applyConfig
 		for _, t := range p.Types {
@@ -128,7 +132,10 @@ func GetTargets(context *generator.Context, args *args.Args) []generator.Target 
 			Package: path.Clean(p.Path),
 		})
 
-		groupGoNames[groupPackageName] = goName(gv, p)
+		groupGoNames[groupPackageName], err = goName(gv, p)
+		if err != nil {
+			klog.Fatalf("Failed to parse comments of group package %s: %v", groupPackageName, err)
+		}
 		applyConfigsForGroupVersion[gv] = toGenerate
 		groupVersions[groupPackageName] = groupVersionsEntry
 	}
@@ -231,12 +238,18 @@ func targetForInternal(outputDirBase, outputPkgBase string, boilerplate []byte, 
 	}
 }
 
-func goName(gv clientgentypes.GroupVersion, p *types.Package) string {
+func goName(gv clientgentypes.GroupVersion, p *types.Package) (string, error) {
 	goName := namer.IC(strings.Split(gv.Group.NonEmpty(), ".")[0])
-	if override := gengo.ExtractCommentTags("+", p.Comments)["groupGoName"]; override != nil {
-		goName = namer.IC(override[0])
+	override, err := genutil.ExtractCommentTagsWithoutArguments("+", []string{"groupGoName"}, p.Comments)
+
+	if err != nil {
+		return goName, err
 	}
-	return goName
+	if values, ok := override["groupGoName"]; ok {
+		goName = namer.IC(values[0])
+	}
+
+	return goName, nil
 }
 
 func packageTypesForInputs(context *generator.Context, outPkgBase string) map[string]*types.Package {
@@ -259,7 +272,7 @@ func packageTypesForInputs(context *generator.Context, outPkgBase string) map[st
 	return pkgTypes
 }
 
-func groupVersion(p *types.Package) (gv clientgentypes.GroupVersion) {
+func groupVersion(p *types.Package) (gv clientgentypes.GroupVersion, err error) {
 	parts := strings.Split(p.Path, "/")
 	gv.Group = clientgentypes.Group(parts[len(parts)-2])
 	gv.Version = clientgentypes.Version(parts[len(parts)-1])
@@ -267,10 +280,16 @@ func groupVersion(p *types.Package) (gv clientgentypes.GroupVersion) {
 	// If there's a comment of the form "// +groupName=somegroup" or
 	// "// +groupName=somegroup.foo.bar.io", use the first field (somegroup) as the name of the
 	// group when generating.
-	if override := gengo.ExtractCommentTags("+", p.Comments)["groupName"]; override != nil {
-		gv.Group = clientgentypes.Group(override[0])
+	override, err := genutil.ExtractCommentTagsWithoutArguments("+", []string{"groupName"}, p.Comments)
+
+	if err != nil {
+		return gv, err
 	}
-	return gv
+	if values, ok := override["groupName"]; ok {
+		gv.Group = clientgentypes.Group(values[0])
+	}
+
+	return gv, nil
 }
 
 // isInternalPackage returns true if the package is an internal package

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/generator_for_group.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/generator_for_group.go
@@ -20,7 +20,7 @@ import (
 	"io"
 	"path"
 
-	"k8s.io/gengo/v2"
+	genutil "k8s.io/code-generator/pkg/util"
 	"k8s.io/gengo/v2/generator"
 	"k8s.io/gengo/v2/namer"
 	"k8s.io/gengo/v2/types"
@@ -73,8 +73,12 @@ func (g *genGroup) GenerateType(c *generator.Context, t *types.Type, w io.Writer
 	// allow user to define a group name that's different from the one parsed from the directory.
 	p := c.Universe.Package(g.inputPackage)
 	groupName := g.group
-	if override := gengo.ExtractCommentTags("+", p.Comments)["groupName"]; override != nil {
-		groupName = override[0]
+	override, err := genutil.ExtractCommentTagsWithoutArguments("+", []string{"groupName"}, p.Comments)
+	if err != nil {
+		return err
+	}
+	if values, ok := override["groupName"]; ok {
+		groupName = values[0]
 	}
 
 	apiPath := `"` + g.apiPath + `"`

--- a/staging/src/k8s.io/code-generator/cmd/deepcopy-gen/generators/deepcopy.go
+++ b/staging/src/k8s.io/code-generator/cmd/deepcopy-gen/generators/deepcopy.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"k8s.io/code-generator/cmd/deepcopy-gen/args"
+	genutil "k8s.io/code-generator/pkg/util"
 	"k8s.io/gengo/v2"
 	"k8s.io/gengo/v2/generator"
 	"k8s.io/gengo/v2/namer"
@@ -469,7 +470,12 @@ func extractInterfacesTag(t *types.Type) []string {
 
 func extractNonPointerInterfaces(t *types.Type) (bool, error) {
 	comments := append(append([]string{}, t.SecondClosestCommentLines...), t.CommentLines...)
-	values := gengo.ExtractCommentTags("+", comments)[interfacesNonPointerTagName]
+	tags, err := genutil.ExtractCommentTagsWithoutArguments("+", []string{interfacesNonPointerTagName}, comments)
+	if err != nil {
+		return false, fmt.Errorf("failed to parse comments: %w", err)
+	}
+
+	values := tags[interfacesNonPointerTagName]
 	if len(values) == 0 {
 		return false, nil
 	}

--- a/staging/src/k8s.io/code-generator/cmd/prerelease-lifecycle-gen/prerelease-lifecycle-generators/status.go
+++ b/staging/src/k8s.io/code-generator/cmd/prerelease-lifecycle-gen/prerelease-lifecycle-generators/status.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"k8s.io/code-generator/cmd/prerelease-lifecycle-gen/args"
+	genutil "k8s.io/code-generator/pkg/util"
 	"k8s.io/gengo/v2"
 	"k8s.io/gengo/v2/generator"
 	"k8s.io/gengo/v2/namer"
@@ -98,7 +99,11 @@ func extractRemovedTag(t *types.Type) (*tagValue, int, int, error) {
 func extractReplacementTag(t *types.Type) (group, version, kind string, hasReplacement bool, err error) {
 	comments := append(append([]string{}, t.SecondClosestCommentLines...), t.CommentLines...)
 
-	tagVals := gengo.ExtractCommentTags("+", comments)[replacementTagName]
+	tags, err := genutil.ExtractCommentTagsWithoutArguments("+", []string{replacementTagName}, comments)
+	if err != nil {
+		return "", "", "", false, fmt.Errorf("failed to parse comments: %w", err)
+	}
+	tagVals := tags[replacementTagName]
 	if len(tagVals) == 0 {
 		// No match for the tag.
 		return "", "", "", false, nil

--- a/staging/src/k8s.io/code-generator/pkg/util/comments.go
+++ b/staging/src/k8s.io/code-generator/pkg/util/comments.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+
+	"k8s.io/gengo/v2"
+)
+
+// ExtractCommentTagsWithoutArguments parses comments for special metadata tags. The
+// marker argument should be unique enough to identify the tags needed, and
+// should not be a marker for tags you don't want, or else the caller takes
+// responsibility for making that distinction.
+//
+// The tagNames argument is a list of specific tags being extracted. If this is
+// nil or empty, all lines which match the marker are considered.  If this is
+// specified, only lines with begin with marker + one of the tags will be
+// considered.  This is useful when a common marker is used which may match
+// lines which fail this syntax (e.g. which predate this definition).
+//
+// This function looks for input lines of the following forms:
+//   - 'marker' + "key=value"
+//   - 'marker' + "key()=value"
+//   - 'marker' + "key(arg)=value"
+//
+// The arg is forbidden.  This function only consider tags with no arguments specified
+// (either as "key=value" or as // "key()=value").  Finding tags with an argument will
+// result in an error.
+//
+// The value is optional.  If not specified, the resulting Tag will have "" as
+// the value.
+//
+// Tag comment-lines may have a trailing end-of-line comment.
+//
+// The map returned here is keyed by the Tag's name without args.
+//
+// A tag can be specified more than one time and all values are returned.  If
+// the resulting map has an entry for a key, the value (a slice) is guaranteed
+// to have at least 1 element.
+//
+// Example: if you pass "+" for 'marker', and the following lines are in
+// the comments:
+//
+//	+foo=val1   // foo
+//	+bar
+//	+foo=val2   // also foo
+//	+foo()=val3 // still foo
+//	+baz="qux"
+//
+// Then this function will return:
+//
+//	map[string][]string{"foo":{"val1", "val2", "val3"}, "bar": {""}, "baz": {`"qux"`}}
+func ExtractCommentTagsWithoutArguments(marker string, tagNames []string, lines []string) (map[string][]string, error) {
+	functionStyleTags, err := gengo.ExtractFunctionStyleCommentTags(marker, tagNames, lines)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make(map[string][]string)
+	for tagName, tags := range functionStyleTags {
+		values := make([]string, 0)
+
+		for _, tag := range tags {
+			if tag.Args == nil {
+				values = append(values, tag.Value)
+			} else {
+				return nil, fmt.Errorf(`failed to parse tag %s: expected no arguments, found "%s"`, tag, tag.Args[0])
+			}
+		}
+
+		if len(values) > 0 {
+			out[tagName] = values
+		}
+	}
+
+	return out, nil
+}

--- a/staging/src/k8s.io/code-generator/pkg/util/comments_test.go
+++ b/staging/src/k8s.io/code-generator/pkg/util/comments_test.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestExtractCommentTagsWithoutArguments(t *testing.T) {
+	cases := []struct {
+		tagNames    []string
+		lines       []string
+		expected    map[string][]string
+		expectedErr error
+	}{{
+		tagNames: nil,
+		lines: []string{
+			"Human comment that is ignored.",
+			"+foo=value1",
+			"+bar",
+			"+foo=value2",
+			"+foo()=value3",
+			"+baz=qux,zrb=true",
+			"+bip=\"value3\"",
+		},
+		expected: map[string][]string{
+			"foo": {"value1", "value2", "value3"},
+			"bar": {""},
+			"baz": {"qux,zrb=true"},
+			"bip": {`"value3"`},
+		},
+		expectedErr: nil,
+	}, {
+		tagNames: nil,
+		lines: []string{
+			"+foo=value1",
+			"+bar",
+			"+foo=value2",
+			"+foo()=value3",
+			"+bip(arg)=",
+			"+baz=qux,zrb=true",
+		},
+		expected:    nil,
+		expectedErr: errors.New(`failed to parse tag bip(arg): expected no arguments, found "arg"`),
+	}, {
+		tagNames: []string{"foo", "bar"},
+		lines: []string{
+			"+foo=value1",
+			"+bar",
+			"+foo=value2",
+			"+foo()=value3",
+			"+bip(arg)=",
+			"+baz=qux,zrb=true",
+		},
+		expected: map[string][]string{
+			"foo": {"value1", "value2", "value3"},
+			"bar": {""},
+		},
+		expectedErr: nil,
+	}, {
+		tagNames: []string{"lorem"},
+		lines: []string{
+			"+foo=value1",
+			"+bar",
+		},
+		expected:    map[string][]string{},
+		expectedErr: nil,
+	}}
+
+	for _, tc := range cases {
+		values, err := ExtractCommentTagsWithoutArguments("+", tc.tagNames, tc.lines)
+
+		if tc.expectedErr == nil && err != nil {
+			t.Errorf("Failed to parse comments: %v", err)
+		}
+		if tc.expectedErr != nil && tc.expectedErr.Error() != err.Error() {
+			t.Errorf("Expectng error %v, got %v", tc.expectedErr.Error(), err.Error())
+		}
+		if !reflect.DeepEqual(tc.expected, values) {
+			t.Errorf("Wrong result:\n%v", cmp.Diff(tc.expected, values))
+		}
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

[ExtractCommentTags](https://pkg.go.dev/k8s.io/gengo/v2#ExtractCommentTags) is deprecated, and we need to migrate the usages to ExtractFunctionStyleCommentTags.

This PR addresses some low-hanging fruits and introduces a utility function to facilitate further migration of the remaining usages.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #130358 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
