### PR TITLE
Add script to verify feature gates cleanup

### DIFF
--- a/hack/make-rules/verify.sh
+++ b/hack/make-rules/verify.sh
@@ -42,6 +42,7 @@ EXCLUDED_PATTERNS=(
   "verify-golangci-lint-pr-hints.sh" # Runs in a separate job for PRs.
   "verify-licenses.sh"           # runs in a separate job to monitor availability of the dependencies periodically
   "verify-openapi-docs-urls.sh"  # Spams docs URLs, don't run in CI.
+  "verify-featuregates-cleanup.sh"  # we only run this when releases are prepared
   )
 
 # Exclude typecheck in certain cases, if they're running in a separate job.

--- a/hack/verify-featuregates-cleanup.sh
+++ b/hack/verify-featuregates-cleanup.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # This script verifies that there are no feature gates that have
-# been locked to default for 5+ minor releases.
+# been locked to default for >=5 minor releases.
 # Usage: `hack/verify-featuregates-cleanup.sh`.
 
 set -o errexit
@@ -25,81 +25,6 @@ set -o pipefail
 KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 source "${KUBE_ROOT}/hack/lib/init.sh"
 
-FEATURE_LIST="${KUBE_ROOT}/test/compatibility_lifecycle/reference/versioned_feature_list.yaml"
+kube::golang::setup_env
 
-# Returns features that have been locked to their default and the versions at which they were locked.
-function extract_locked_features() {
-  # shellcheck disable=SC2016
-  # Disabled because `$name` is part of the yq expression and shouldn't be expanded by Bash.
-  yq '.[] |
-    select(.versionedSpecs != null) | 
-    .name as $name | 
-    .versionedSpecs[] | 
-    select(.lockToDefault == true) | 
-    $name + ":" + .version' "${FEATURE_LIST}"
-}
-
-# Returns 0 if the feature gate needs cleanup, 1 otherwise.
-function needs_cleanup() {
-  local locked_version="$1"
-  local current_version="$2"
-  
-  local locked_major locked_minor current_major current_minor
-  
-  IFS='.' read -r locked_major locked_minor <<< "${locked_version}"
-  IFS='.' read -r current_major current_minor <<< "${current_version}"
-
-  locked_minor=$((10#${locked_minor}))
-  # The current version passed to this function might contain a trailing "+" (e.g., "1.34+"). Strip it for numeric comparison.
-  current_minor=${current_minor%+}
-  current_minor=$((10#${current_minor}))
-  
-  # TODO: In case of a major version upgrade, when would we require feature gates to be cleaned up?
-  if [[ "${locked_major}" != "${current_major}" ]]; then
-    echo "Error: can't verify feature gate cleanup across major versions (${locked_version} vs ${current_version})" >&2
-    exit 1
-  fi
-  
-  # Check if versions are >=5 minor versions apart. 
-  # If a feature is locked to its default at version X.Y, it is still needed in the code base
-  # for version emulation until the release cycle of X.Y+3 ends. We can be certain 
-  # that the release cycle for X.Y+3 ended only once we're in the release cycle for X.Y+5 
-  # because the release cycle for X.Y+4 overlaps with the release cycle for X.Y+3.
-  if [[ $((current_minor - locked_minor)) -ge 5 ]]; then
-    return 0
-  else
-    return 1
-  fi
-}
-
-function main() {
-  kube::version::get_version_vars
-  local current_version="${KUBE_GIT_MAJOR}.${KUBE_GIT_MINOR}"
-  echo "Current version: ${current_version}"
-  
-  local locked_features
-  readarray -t locked_features < <(extract_locked_features)
-  
-  local features_needing_cleanup=()
-  for feature in "${locked_features[@]}"; do
-    local feature_name locked_version
-    IFS=':' read -r feature_name locked_version <<< "${feature}"
-    
-    if needs_cleanup "${locked_version}" "${current_version}"; then
-      features_needing_cleanup+=("${feature_name} (locked since ${locked_version})")
-    fi
-  done
-  
-  if [[ ${#features_needing_cleanup[@]} -gt 0 ]]; then
-    echo "The following feature gates have been locked to default for >=5 releases and should be cleaned up:" >&2
-    for feature in "${features_needing_cleanup[@]}"; do
-      echo "  - ${feature}" >&2
-    done
-    exit 1
-  else
-    echo "No feature gates need cleanup"
-    exit 0
-  fi
-}
-
-main "$@"
+go run test/compatibility_lifecycle/main.go feature-gates verify-cleanup

--- a/hack/verify-featuregates-cleanup.sh
+++ b/hack/verify-featuregates-cleanup.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+
+# Copyright 2025 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script verifies that there are no feature gates that have
+# been locked to default for 5+ minor releases.
+# Usage: `hack/verify-featuregates-cleanup.sh`.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+source "${KUBE_ROOT}/hack/lib/init.sh"
+
+FEATURE_LIST="${KUBE_ROOT}/test/compatibility_lifecycle/reference/versioned_feature_list.yaml"
+
+# Returns features that have been locked to their default and the versions at which they were locked.
+function extract_locked_features() {
+  # shellcheck disable=SC2016
+  # Disabled because `$name` is part of the yq expression and shouldn't be expanded by Bash.
+  yq '.[] |
+    select(.versionedSpecs != null) | 
+    .name as $name | 
+    .versionedSpecs[] | 
+    select(.lockToDefault == true) | 
+    $name + ":" + .version' "${FEATURE_LIST}"
+}
+
+# Returns 0 if the feature gate needs cleanup, 1 otherwise.
+function needs_cleanup() {
+  local locked_version="$1"
+  local current_version="$2"
+  
+  local locked_major locked_minor current_major current_minor
+  
+  IFS='.' read -r locked_major locked_minor <<< "${locked_version}"
+  IFS='.' read -r current_major current_minor <<< "${current_version}"
+
+  locked_minor=$((10#${locked_minor}))
+  # The current version passed to this function might contain a trailing "+" (e.g., "1.34+"). Strip it for numeric comparison.
+  current_minor=${current_minor%+}
+  current_minor=$((10#${current_minor}))
+  
+  # TODO: In case of a major version upgrade, when would we require feature gates to be cleaned up?
+  if [[ "${locked_major}" != "${current_major}" ]]; then
+    echo "Error: can't verify feature gate cleanup across major versions (${locked_version} vs ${current_version})" >&2
+    exit 1
+  fi
+  
+  # Check if versions are >=5 minor versions apart. 
+  # If a feature is locked to its default at version X.Y, it is still needed in the code base
+  # for version emulation until the release cycle of X.Y+3 ends. We can be certain 
+  # that the release cycle for X.Y+3 ended only once we're in the release cycle for X.Y+5 
+  # because the release cycle for X.Y+4 overlaps with the release cycle for X.Y+3.
+  if [[ $((current_minor - locked_minor)) -ge 5 ]]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+function main() {
+  kube::version::get_version_vars
+  local current_version="${KUBE_GIT_MAJOR}.${KUBE_GIT_MINOR}"
+  echo "Current version: ${current_version}"
+  
+  local locked_features
+  readarray -t locked_features < <(extract_locked_features)
+  
+  local features_needing_cleanup=()
+  for feature in "${locked_features[@]}"; do
+    local feature_name locked_version
+    IFS=':' read -r feature_name locked_version <<< "${feature}"
+    
+    if needs_cleanup "${locked_version}" "${current_version}"; then
+      features_needing_cleanup+=("${feature_name} (locked since ${locked_version})")
+    fi
+  done
+  
+  if [[ ${#features_needing_cleanup[@]} -gt 0 ]]; then
+    echo "The following feature gates have been locked to default for >=5 releases and should be cleaned up:" >&2
+    for feature in "${features_needing_cleanup[@]}"; do
+      echo "  - ${feature}" >&2
+    done
+    exit 1
+  else
+    echo "No feature gates need cleanup"
+    exit 0
+  fi
+}
+
+main "$@"

--- a/test/compatibility_lifecycle/README.md
+++ b/test/compatibility_lifecycle/README.md
@@ -7,4 +7,7 @@ go run test/compatibility_lifecycle/main.go feature-gates verify
 
 # Update feature gate list
 go run test/compatibility_lifecycle/main.go feature-gates update
+
+# Verify no feature gates need to be cleaned up
+go run test/compatibility_lifecycle/main.go feature-gates verify-cleanup
 ```

--- a/test/compatibility_lifecycle/cmd/feature_gates.go
+++ b/test/compatibility_lifecycle/cmd/feature_gates.go
@@ -37,7 +37,7 @@ import (
 
 var (
 	alphabeticalOrder        bool
-	k8RootPath               string
+	k8sRootPath              string
 	versionedFeatureListFile = "test/compatibility_lifecycle/reference/versioned_feature_list.yaml"
 	// thresholdVersion is the version after which we require emulation support for feature removal
 	// 1.31 is when we introduced emulation version support
@@ -75,7 +75,7 @@ func NewFeatureGatesCommand() *cobra.Command {
 	if err != nil {
 		panic(err)
 	}
-	cmd.Flags().StringVar(&k8RootPath, "root-path", defaultRootPath, "absolute path of the k8s repository")
+	cmd.Flags().StringVar(&k8sRootPath, "root-path", defaultRootPath, "absolute path of the k8s repository")
 
 	cmd.AddCommand(NewVerifyFeatureListCommand())
 	cmd.AddCommand(NewUpdateFeatureListCommand())
@@ -86,7 +86,7 @@ func NewFeatureGatesCommand() *cobra.Command {
 func NewVerifyFeatureListCommand() *cobra.Command {
 	cmd := cobra.Command{
 		Use:   "verify",
-		Short: "Verifies feature list files are up to date.",
+		Short: "Verify feature list files are up to date",
 		Run:   verifyFeatureListFunc,
 	}
 	cmd.Flags().BoolVar(&alphabeticalOrder, "alphabetical-order", false, "if true, verify all features in any FeatureSpec map are ordered aphabetically")
@@ -96,7 +96,7 @@ func NewVerifyFeatureListCommand() *cobra.Command {
 func NewUpdateFeatureListCommand() *cobra.Command {
 	cmd := cobra.Command{
 		Use:   "update",
-		Short: "updates feature list files.",
+		Short: "Update feature list files",
 		Run:   updateFeatureListFunc,
 	}
 	return &cmd
@@ -113,7 +113,7 @@ func NewVerifyFeatureCleanupCommand() *cobra.Command {
 
 func verifyFeatureListFunc(cmd *cobra.Command, args []string) {
 	currentVersion := version.MustParse(baseversion.DefaultKubeBinaryVersion)
-	if err := verifyOrUpdateFeatureList(k8RootPath, versionedFeatureListFile, currentVersion, false); err != nil {
+	if err := verifyOrUpdateFeatureList(k8sRootPath, versionedFeatureListFile, currentVersion, false); err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to verify versioned feature list: \n%s", err)
 		os.Exit(1)
 	}
@@ -121,14 +121,14 @@ func verifyFeatureListFunc(cmd *cobra.Command, args []string) {
 
 func updateFeatureListFunc(cmd *cobra.Command, args []string) {
 	currentVersion := version.MustParse(baseversion.DefaultKubeBinaryVersion)
-	if err := verifyOrUpdateFeatureList(k8RootPath, versionedFeatureListFile, currentVersion, true); err != nil {
+	if err := verifyOrUpdateFeatureList(k8sRootPath, versionedFeatureListFile, currentVersion, true); err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to update versioned feature list: \n%s", err)
 		os.Exit(1)
 	}
 }
 
 func verifyFeatureCleanupFunc(cmd *cobra.Command, args []string) {
-	if err := getFeaturesAndVerifyCleanup(k8RootPath); err != nil {
+	if err := getFeaturesAndVerifyCleanup(k8sRootPath); err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to verify that feature gates have been cleaned up: \n%s", err)
 		os.Exit(1)
 	}

--- a/test/compatibility_lifecycle/cmd/feature_gates_test.go
+++ b/test/compatibility_lifecycle/cmd/feature_gates_test.go
@@ -1004,10 +1004,8 @@ func TestGetFeaturesAndVerifyCleanup(t *testing.T) {
 						t.Fatalf("expected error message to not contain %q, got %q", msg, err.Error())
 					}
 				}
-			} else {
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
+			} else if err != nil {
+				t.Fatalf("unexpected error: %v", err)
 			}
 		})
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Feature gate code that has been locked to default at version X.Y is required to stay in the code base until version X.Y+3 for version emulation, but can be cleaned up afterwards. This commit adds a script checking whether any feature gates require cleanup. It is intended to be run as a release-blocking test.

#### Which issue(s) this PR fixes:
Fixes #130759

#### Special notes for your reviewer:
There are a few things I need your input on:

* Are there defined requirements for feature gate cleanup across major versions? Currently, the script errors if the current major version differs from the major version at which a feature gate was locked.
* The issue requires that this script is run in a release-blocking test. So, we need to run `make verify WHAT=featuregates-cleanup` in release pipelines. Should I open a PR to add a new job [here](https://github.com/kubernetes/test-infra/blob/master/releng/test_config.yaml#L33) once this PR is merged? I'm unsure that's the right place because all jobs there are E2E tests.
* The script depends on `yq`. As far as I see, some but not all CI images include `yq`. Is it okay to depend on `yq`? If not, it'd be possible to do the YAML parsing in pure Bash, but that'd be brittle and hard to maintain. Instead, in that case, I'd suggest I rewrite the script in Python, or add the logic to the existing `compatibility_lifecycle` tool, like this:

  ```
  go run test/compatibility_lifecycle/main.go feature-gates verify-cleanup
  ```

Thanks for your help!

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

