### PR TITLE
feat: improve the backoff calculation to O(1)

### DIFF
--- a/pkg/scheduler/backend/queue/backoff_queue.go
+++ b/pkg/scheduler/backend/queue/backoff_queue.go
@@ -239,15 +239,11 @@ func (bq *backoffQueue) calculateBackoffDuration(podInfo *framework.QueuedPodInf
 		return 0
 	}
 
-	duration := bq.podInitialBackoff
-	for i := 1; i < podInfo.Attempts; i++ {
-		// Use subtraction instead of addition or multiplication to avoid overflow.
-		if duration > bq.podMaxBackoff-duration {
-			return bq.podMaxBackoff
-		}
-		duration += duration
+	shift := podInfo.Attempts - 1
+	if bq.podInitialBackoff > bq.podMaxBackoff>>shift {
+		return bq.podMaxBackoff
 	}
-	return duration
+	return time.Duration(bq.podInitialBackoff << shift)
 }
 
 func (bq *backoffQueue) popAllBackoffCompletedWithQueue(logger klog.Logger, queue *heap.Heap[*framework.QueuedPodInfo]) []*framework.QueuedPodInfo {

--- a/pkg/scheduler/backend/queue/backoff_queue_test.go
+++ b/pkg/scheduler/backend/queue/backoff_queue_test.go
@@ -48,6 +48,13 @@ func TestBackoffQueue_calculateBackoffDuration(t *testing.T) {
 		},
 		{
 			name:                   "normal",
+			initialBackoffDuration: 3 * time.Nanosecond,
+			maxBackoffDuration:     1000 * time.Nanosecond,
+			podInfo:                &framework.QueuedPodInfo{Attempts: 5},
+			want:                   48 * time.Nanosecond, // 3 * 2^4 = 48
+		},
+		{
+			name:                   "hitting max backoff duration",
 			initialBackoffDuration: 1 * time.Nanosecond,
 			maxBackoffDuration:     32 * time.Nanosecond,
 			podInfo:                &framework.QueuedPodInfo{Attempts: 16},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Currently, we're calculating the backoff time with O(attempt), and this PR improves it to O(1).

```go
func BenchmarkBackoffQueue_calculateBackoffDuration(b *testing.B) {
	benchmarks := []struct {
		name                   string
		initialBackoffDuration time.Duration
		maxBackoffDuration     time.Duration
		attempts               int32
	}{
		{
			name:                   "10000",
			initialBackoffDuration: 1 * time.Nanosecond,
			maxBackoffDuration:     math.MaxInt64 * time.Nanosecond,
			attempts:               10000,
		},
	}

	for _, bm := range benchmarks {
		b.Run(bm.name, func(b *testing.B) {
			bq := newBackoffQueue(clock.RealClock{}, bm.initialBackoffDuration, bm.maxBackoffDuration, newDefaultQueueSort(), true)
			podInfo := &framework.QueuedPodInfo{Attempts: int(bm.attempts)}
			b.ResetTimer()
			for i := 0; i < b.N; i++ {
				_ = bq.calculateBackoffDuration(podInfo)
			}
		})
	}
}
```

**before**

```
Running tool: /usr/local/go/bin/go test -benchmem -run=^$ -bench ^BenchmarkBackoffQueue_calculateBackoffDuration$ k8s.io/kubernetes/pkg/scheduler/backend/queue

goos: darwin
goarch: arm64
pkg: k8s.io/kubernetes/pkg/scheduler/backend/queue
cpu: Apple M2 Pro
BenchmarkBackoffQueue_calculateBackoffDuration/10000-12         	57746674	        20.86 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	k8s.io/kubernetes/pkg/scheduler/backend/queue	2.027s
```

**after**

```
Running tool: /usr/local/go/bin/go test -benchmem -run=^$ -bench ^BenchmarkBackoffQueue_calculateBackoffDuration$ k8s.io/kubernetes/pkg/scheduler/backend/queue

goos: darwin
goarch: arm64
pkg: k8s.io/kubernetes/pkg/scheduler/backend/queue
cpu: Apple M2 Pro
BenchmarkBackoffQueue_calculateBackoffDuration/10000-12         	1000000000	         0.4540 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	k8s.io/kubernetes/pkg/scheduler/backend/queue	1.283s
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
