### PR TITLE
Account consumed newlines properly in YAML decoder

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/yaml/decoder.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/yaml/decoder.go
@@ -338,10 +338,10 @@ func (d *YAMLOrJSONDecoder) Decode(into interface{}) error {
 	if d.yaml != nil {
 		err := d.yaml.Decode(into)
 		if err == nil {
+			d.count++
 			consumed := int64(d.yaml.InputOffset()) - d.yamlConsumed
 			d.stream.Consume(int(consumed))
 			d.yamlConsumed += consumed
-			d.count++
 			return nil
 		}
 		if err == io.EOF { //nolint:errorlint
@@ -374,6 +374,7 @@ func (d *YAMLOrJSONDecoder) consumeWhitespace() error {
 			d.stream.Consume(consumed)
 			return nil
 		}
+		consumed += sz
 		if r == '\n' {
 			d.stream.Consume(consumed)
 			return nil
@@ -381,7 +382,6 @@ func (d *YAMLOrJSONDecoder) consumeWhitespace() error {
 		if err == io.EOF { //nolint:errorlint
 			break
 		}
-		consumed += sz
 	}
 	return io.EOF
 }


### PR DESCRIPTION
This isn't a significant functional bug in that the StreamDecoder is still offset to account for it (which is why we never saw it before). But it's a trap for future use-cases.

Also move one LOC to match a parallel-shaped block above.

/kind bug
/kind cleanup

```release-note
NONE
```
