### PR TITLE
DRA: resource quota flake

### DIFF
--- a/pkg/quota/v1/evaluator/core/registry.go
+++ b/pkg/quota/v1/evaluator/core/registry.go
@@ -22,6 +22,7 @@ import (
 	quota "k8s.io/apiserver/pkg/quota/v1"
 	"k8s.io/apiserver/pkg/quota/v1/generic"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/utils/clock"
 )
@@ -43,7 +44,7 @@ func NewEvaluators(f quota.ListerForResourceFunc) []quota.Evaluator {
 		NewPersistentVolumeClaimEvaluator(f),
 	}
 	if utilfeature.DefaultFeatureGate.Enabled(features.DynamicResourceAllocation) {
-		result = append(result, NewResourceClaimEvaluator(f))
+		result = append(result, NewResourceClaimEvaluator(klog.LoggerWithName(klog.TODO(), "resource-claim-evaluator"), f))
 	}
 
 	// these evaluators require an alias for backwards compatibility

--- a/pkg/quota/v1/evaluator/core/resource_claims_test.go
+++ b/pkg/quota/v1/evaluator/core/resource_claims_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/admission"
 	api "k8s.io/kubernetes/pkg/apis/resource"
+	"k8s.io/kubernetes/test/utils/ktesting"
 	"k8s.io/utils/ptr"
 )
 
@@ -72,7 +73,6 @@ func TestResourceClaimEvaluatorUsage(t *testing.T) {
 		},
 	})
 
-	evaluator := NewResourceClaimEvaluator(nil)
 	testCases := map[string]struct {
 		claim  *api.ResourceClaim
 		usage  corev1.ResourceList
@@ -201,6 +201,8 @@ func TestResourceClaimEvaluatorUsage(t *testing.T) {
 	}
 	for testName, testCase := range testCases {
 		t.Run(testName, func(t *testing.T) {
+			tCtx := ktesting.Init(t)
+			evaluator := NewResourceClaimEvaluator(tCtx.Logger(), nil)
 			actual, err := evaluator.Usage(testCase.claim)
 			if err != nil {
 				if testCase.errMsg == "" {
@@ -222,7 +224,6 @@ func TestResourceClaimEvaluatorUsage(t *testing.T) {
 }
 
 func TestResourceClaimEvaluatorMatchingResources(t *testing.T) {
-	evaluator := NewResourceClaimEvaluator(nil)
 	testCases := map[string]struct {
 		items []corev1.ResourceName
 		want  []corev1.ResourceName
@@ -251,6 +252,8 @@ func TestResourceClaimEvaluatorMatchingResources(t *testing.T) {
 	}
 	for testName, testCase := range testCases {
 		t.Run(testName, func(t *testing.T) {
+			tCtx := ktesting.Init(t)
+			evaluator := NewResourceClaimEvaluator(tCtx.Logger(), nil)
 			actual := evaluator.MatchingResources(testCase.items)
 
 			if diff := cmp.Diff(testCase.want, actual); diff != "" {
@@ -261,7 +264,6 @@ func TestResourceClaimEvaluatorMatchingResources(t *testing.T) {
 }
 
 func TestResourceClaimEvaluatorHandles(t *testing.T) {
-	evaluator := NewResourceClaimEvaluator(nil)
 	testCases := []struct {
 		name  string
 		attrs admission.Attributes
@@ -300,6 +302,8 @@ func TestResourceClaimEvaluatorHandles(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			tCtx := ktesting.Init(t)
+			evaluator := NewResourceClaimEvaluator(tCtx.Logger(), nil)
 			actual := evaluator.Handles(tc.attrs)
 
 			if tc.want != actual {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test
/kind flake

#### What this PR does / why we need it:

Debugging a test flake, not meant to be merged.

#### Special notes for your reviewer:

Sometimes, the ResourceQuota test fails:
```
I0509 13:26:19.961256 71380 resource_quota.go:2497] resource count/resourceclaims.resource.k8s.io, expected 0, actual 1
I0509 13:26:21.958170 71380 resource_quota.go:544] Unexpected error: 
```

I changed the assertion to be more verbose (forced here by changing the expected values):
```
[FAILED] Timed out after 300.001s.
Expected:
    <*v1.ResourceQuota | 0xc0035c3e00>: 
        metadata:
          creationTimestamp: "2025-05-09T20:00:28Z"
          managedFields:
          - apiVersion: v1
            fieldsType: FieldsV1
            fieldsV1:
              f:spec:
                f:hard:
                  .: {}
                  f:configmaps: {}
                  f:count/replicasets.apps: {}
                  f:count/resourceclaims.resource.k8s.io: {}
                  f:cpu: {}
                  f:ephemeral-storage: {}
                  f:gold.deviceclass.resource.k8s.io/devices: {}
                  f:gold.storageclass.storage.k8s.io/persistentvolumeclaims: {}
                  f:gold.storageclass.storage.k8s.io/requests.storage: {}
                  f:memory: {}
                  f:persistentvolumeclaims: {}
                  f:pods: {}
                  f:replicationcontrollers: {}
                  f:requests.example.com/dongle: {}
                  f:requests.storage: {}
                  f:resourcequotas: {}
                  f:secrets: {}
                  f:services: {}
                  f:services.loadbalancers: {}
                  f:services.nodeports: {}
            manager: e2e.test
            operation: Update
            time: "2025-05-09T20:00:28Z"
          - apiVersion: v1
            fieldsType: FieldsV1
            fieldsV1:
              f:status:
                f:hard:
                  .: {}
                  f:configmaps: {}
                  f:count/replicasets.apps: {}
                  f:count/resourceclaims.resource.k8s.io: {}
                  f:cpu: {}
                  f:ephemeral-storage: {}
                  f:gold.deviceclass.resource.k8s.io/devices: {}
                  f:gold.storageclass.storage.k8s.io/persistentvolumeclaims: {}
                  f:gold.storageclass.storage.k8s.io/requests.storage: {}
                  f:memory: {}
                  f:persistentvolumeclaims: {}
                  f:pods: {}
                  f:replicationcontrollers: {}
                  f:requests.example.com/dongle: {}
                  f:requests.storage: {}
                  f:resourcequotas: {}
                  f:secrets: {}
                  f:services: {}
                  f:services.loadbalancers: {}
                  f:services.nodeports: {}
                f:used:
                  .: {}
                  f:configmaps: {}
                  f:count/replicasets.apps: {}
                  f:count/resourceclaims.resource.k8s.io: {}
                  f:cpu: {}
                  f:ephemeral-storage: {}
                  f:gold.deviceclass.resource.k8s.io/devices: {}
                  f:gold.storageclass.storage.k8s.io/persistentvolumeclaims: {}
                  f:gold.storageclass.storage.k8s.io/requests.storage: {}
                  f:memory: {}
                  f:persistentvolumeclaims: {}
                  f:pods: {}
                  f:replicationcontrollers: {}
                  f:requests.example.com/dongle: {}
                  f:requests.storage: {}
                  f:resourcequotas: {}
                  f:secrets: {}
                  f:services: {}
                  f:services.loadbalancers: {}
                  f:services.nodeports: {}
            manager: kube-controller-manager
            operation: Update
            subresource: status
            time: "2025-05-09T20:00:28Z"
          name: test-quota
          namespace: resourcequota-4442
          resourceVersion: "2399"
          uid: 7d02e2ee-6f6a-41d4-9113-f35cfa7c8f6c
        spec:
          hard:
            configmaps: "10"
            count/replicasets.apps: "5"
            count/resourceclaims.resource.k8s.io: "1"
            cpu: "1"
            ephemeral-storage: 50Gi
            gold.deviceclass.resource.k8s.io/devices: "1"
            gold.storageclass.storage.k8s.io/persistentvolumeclaims: "10"
            gold.storageclass.storage.k8s.io/requests.storage: 10Gi
            memory: 500Mi
            persistentvolumeclaims: "10"
            pods: "5"
            replicationcontrollers: "10"
            requests.example.com/dongle: "3"
            requests.storage: 10Gi
            resourcequotas: "1"
            secrets: "10"
            services: "10"
            services.loadbalancers: "1"
            services.nodeports: "1"
        status:
          hard:
            configmaps: "10"
            count/replicasets.apps: "5"
            count/resourceclaims.resource.k8s.io: "1"
            cpu: "1"
            ephemeral-storage: 50Gi
            gold.deviceclass.resource.k8s.io/devices: "1"
            gold.storageclass.storage.k8s.io/persistentvolumeclaims: "10"
            gold.storageclass.storage.k8s.io/requests.storage: 10Gi
            memory: 500Mi
            persistentvolumeclaims: "10"
            pods: "5"
            replicationcontrollers: "10"
            requests.example.com/dongle: "3"
            requests.storage: 10Gi
            resourcequotas: "1"
            secrets: "10"
            services: "10"
            services.loadbalancers: "1"
            services.nodeports: "1"
          used:
            configmaps: "1"
            count/replicasets.apps: "0"
            count/resourceclaims.resource.k8s.io: "0"
            cpu: "0"
            ephemeral-storage: "0"
            gold.deviceclass.resource.k8s.io/devices: "0"
            gold.storageclass.storage.k8s.io/persistentvolumeclaims: "0"
            gold.storageclass.storage.k8s.io/requests.storage: "0"
            memory: "0"
            persistentvolumeclaims: "0"
            pods: "0"
            replicationcontrollers: "0"
            requests.example.com/dongle: "0"
            requests.storage: "0"
            resourcequotas: "1"
            secrets: "0"
            services: "0"
            services.loadbalancers: "0"
            services.nodeports: "0"
to have the following .status.used entries:
    count/resourceclaims.resource.k8s.io: "1"
    gold.deviceclass.resource.k8s.io/devices: "0"
    resourcequotas: "1"
In [It] at: k8s.io/kubernetes/test/e2e/apimachinery/resource_quota.go:523 @ 05/09/25 20:05:28.325
```

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

