### PR TITLE
Avoid encoding in LogResponseObject when we are not going to use it

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/audit/request.go
+++ b/staging/src/k8s.io/apiserver/pkg/audit/request.go
@@ -171,11 +171,13 @@ func LogRequestPatch(ctx context.Context, patch []byte) {
 // will be converted to the given gv.
 func LogResponseObject(ctx context.Context, obj runtime.Object, gv schema.GroupVersion, s runtime.NegotiatedSerializer) {
 	ac := AuditContextFrom(WithAuditContext(ctx))
-	if ac.GetEventLevel().Less(auditinternal.LevelRequestResponse) {
+	status, _ := obj.(*metav1.Status)
+	if ac.GetEventLevel().Less(auditinternal.LevelMetadata) {
+		return
+	} else if ac.GetEventLevel().Less(auditinternal.LevelRequestResponse) {
+		ac.LogResponseObject(status, nil)
 		return
 	}
-
-	status, _ := obj.(*metav1.Status)
 
 	if shouldOmitManagedFields(ac) {
 		copy, ok, err := copyWithoutManagedFields(obj)

--- a/staging/src/k8s.io/apiserver/pkg/audit/request.go
+++ b/staging/src/k8s.io/apiserver/pkg/audit/request.go
@@ -171,7 +171,7 @@ func LogRequestPatch(ctx context.Context, patch []byte) {
 // will be converted to the given gv.
 func LogResponseObject(ctx context.Context, obj runtime.Object, gv schema.GroupVersion, s runtime.NegotiatedSerializer) {
 	ac := AuditContextFrom(WithAuditContext(ctx))
-	if ac.GetEventLevel().Less(auditinternal.LevelMetadata) {
+	if ac.GetEventLevel().Less(auditinternal.LevelRequestResponse) {
 		return
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/audit/request_log_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/audit/request_log_test.go
@@ -1,0 +1,259 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package audit
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	auditinternal "k8s.io/apiserver/pkg/apis/audit"
+)
+
+func TestLogResponseObjectWithPod(t *testing.T) {
+	testPod := &corev1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Pod",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "test-namespace",
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "test-container",
+					Image: "test-image",
+				},
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("Failed to add core/v1 to scheme: %v", err)
+	}
+	codecs := serializer.NewCodecFactory(scheme)
+	negotiatedSerializer := codecs.WithoutConversion()
+
+	// Create audit context with RequestResponse level
+	ctx := WithAuditContext(context.Background())
+	ac := AuditContextFrom(ctx)
+
+	captureSink := &capturingAuditSink{}
+	if err := ac.Init(RequestAuditConfig{Level: auditinternal.LevelRequestResponse}, captureSink); err != nil {
+		t.Fatalf("Failed to initialize audit context: %v", err)
+	}
+
+	LogResponseObject(ctx, testPod, schema.GroupVersion{Group: "", Version: "v1"}, negotiatedSerializer)
+	ac.ProcessEventStage(ctx, auditinternal.StageResponseComplete)
+
+	if len(captureSink.events) != 1 {
+		t.Fatalf("Expected one audit event to be captured, got %d", len(captureSink.events))
+	}
+	event := captureSink.events[0]
+	if event.ResponseObject == nil {
+		t.Fatal("Expected ResponseObject to be set, but it was nil")
+	}
+	if event.ResponseObject.ContentType != runtime.ContentTypeJSON {
+		t.Errorf("Expected ContentType to be %q, got %q", runtime.ContentTypeJSON, event.ResponseObject.ContentType)
+	}
+	if len(event.ResponseObject.Raw) == 0 {
+		t.Error("Expected ResponseObject.Raw to contain data, but it was empty")
+	}
+
+	responseJSON := string(event.ResponseObject.Raw)
+	expectedFields := []string{"test-pod", "test-namespace", "test-container", "test-image"}
+	for _, field := range expectedFields {
+		if !strings.Contains(responseJSON, field) {
+			t.Errorf("Response should contain %q but didn't. Response: %s", field, responseJSON)
+		}
+	}
+
+	if event.ResponseStatus != nil {
+		t.Errorf("Expected ResponseStatus to be nil for regular object, got: %+v", event.ResponseStatus)
+	}
+}
+
+func TestLogResponseObjectWithStatus(t *testing.T) {
+	// Create a status object to test ResponseStatus handling
+	testStatus := &metav1.Status{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Status",
+		},
+		Status:  "Success",
+		Message: "Test status message",
+		Reason:  "TestReason",
+		Code:    200,
+	}
+
+	scheme := runtime.NewScheme()
+	err := metav1.AddMetaToScheme(scheme)
+	if err != nil {
+		t.Fatalf("Failed to add meta to scheme: %v", err)
+	}
+	scheme.AddKnownTypes(schema.GroupVersion{Version: "v1"}, &metav1.Status{})
+	codecs := serializer.NewCodecFactory(scheme)
+	negotiatedSerializer := codecs.WithoutConversion()
+
+	ctx := WithAuditContext(context.Background())
+	ac := AuditContextFrom(ctx)
+
+	captureSink := &capturingAuditSink{}
+	if err := ac.Init(RequestAuditConfig{Level: auditinternal.LevelRequestResponse}, captureSink); err != nil {
+		t.Fatalf("Failed to initialize audit context: %v", err)
+	}
+
+	LogResponseObject(ctx, testStatus, schema.GroupVersion{Group: "", Version: "v1"}, negotiatedSerializer)
+	ac.ProcessEventStage(ctx, auditinternal.StageResponseComplete)
+
+	if len(captureSink.events) != 1 {
+		t.Fatalf("Expected one audit event to be captured, got %d", len(captureSink.events))
+	}
+	event := captureSink.events[0]
+
+	if event.ResponseObject == nil {
+		t.Fatal("Expected ResponseObject to be set, but it was nil")
+	}
+	if event.ResponseStatus == nil {
+		t.Fatal("Expected ResponseStatus to be set for Status object, but it was nil")
+	}
+	if event.ResponseStatus.Status != "Success" {
+		t.Errorf("Expected ResponseStatus.Status to be 'Success', got %q", event.ResponseStatus.Status)
+	}
+	if event.ResponseStatus.Message != "Test status message" {
+		t.Errorf("Expected ResponseStatus.Message to be 'Test status message', got %q", event.ResponseStatus.Message)
+	}
+	if event.ResponseStatus.Reason != "TestReason" {
+		t.Errorf("Expected ResponseStatus.Reason to be 'TestReason', got %q", event.ResponseStatus.Reason)
+	}
+	if event.ResponseStatus.Code != 200 {
+		t.Errorf("Expected ResponseStatus.Code to be 200, got %d", event.ResponseStatus.Code)
+	}
+}
+
+func TestLogResponseObjectLevelCheck(t *testing.T) {
+	testCases := []struct {
+		name         string
+		level        auditinternal.Level
+		shouldEncode bool
+	}{
+		{
+			name:         "None level should not encode",
+			level:        auditinternal.LevelNone,
+			shouldEncode: false,
+		},
+		{
+			name:         "Metadata level should not encode",
+			level:        auditinternal.LevelMetadata,
+			shouldEncode: false,
+		},
+		{
+			name:         "Request level should not encode",
+			level:        auditinternal.LevelRequest,
+			shouldEncode: false,
+		},
+		{
+			name:         "RequestResponse level should encode",
+			level:        auditinternal.LevelRequestResponse,
+			shouldEncode: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create a test object
+			testObj := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "test-namespace",
+				},
+			}
+
+			// Create audit context with the specified level
+			ctx := WithAuditContext(context.Background())
+			ac := AuditContextFrom(ctx)
+			ac.Init(RequestAuditConfig{Level: tc.level}, nil)
+
+			// Create a mock serializer that tracks if encoding was attempted
+			mockSerializer := &mockNegotiatedSerializer{}
+
+			// Call the function under test
+			LogResponseObject(ctx, testObj, schema.GroupVersion{Group: "", Version: "v1"}, mockSerializer)
+
+			// Check if encoding was attempted as expected
+			if mockSerializer.encodeCalled != tc.shouldEncode {
+				t.Errorf("Expected encoding to be called: %v, but got: %v", tc.shouldEncode, mockSerializer.encodeCalled)
+			}
+		})
+	}
+}
+
+type mockNegotiatedSerializer struct {
+	encodeCalled bool
+}
+
+func (m *mockNegotiatedSerializer) SupportedMediaTypes() []runtime.SerializerInfo {
+	return []runtime.SerializerInfo{
+		{
+			MediaType:        runtime.ContentTypeJSON,
+			EncodesAsText:    true,
+			Serializer:       nil,
+			PrettySerializer: nil,
+			StreamSerializer: nil,
+		},
+	}
+}
+
+func (m *mockNegotiatedSerializer) EncoderForVersion(serializer runtime.Encoder, gv runtime.GroupVersioner) runtime.Encoder {
+	m.encodeCalled = true
+	return &mockEncoder{}
+}
+
+func (m *mockNegotiatedSerializer) DecoderToVersion(serializer runtime.Decoder, gv runtime.GroupVersioner) runtime.Decoder {
+	return nil
+}
+
+type mockEncoder struct{}
+
+func (e *mockEncoder) Encode(obj runtime.Object, w io.Writer) error {
+	return nil
+}
+
+func (e *mockEncoder) Identifier() runtime.Identifier {
+	return runtime.Identifier("mock")
+}
+
+type capturingAuditSink struct {
+	events []*auditinternal.Event
+}
+
+func (s *capturingAuditSink) ProcessEvents(events ...*auditinternal.Event) bool {
+	for _, event := range events {
+		eventCopy := event.DeepCopy()
+		s.events = append(s.events, eventCopy)
+	}
+	return true
+}


### PR DESCRIPTION
In https://github.com/kubernetes/kubernetes/pull/129472, we had a snippet where we bailed out early from `func LogResponseObject` (in request.go)

![image](https://github.com/user-attachments/assets/023cf32b-770a-43c2-b4be-c1d83553bb63)

During review, i removed this snippet by mistake so we ended up calling `encodeObject` which consumes memory. (We have the same snippet in AuditContext's LogResponseObject as well, but that is too late).

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
