### PR TITLE
Fix comments on ginkgo label functions

### DIFF
--- a/test/e2e/framework/ginkgowrapper.go
+++ b/test/e2e/framework/ginkgowrapper.go
@@ -343,7 +343,7 @@ func recordTextBug(location types.CodeLocation, message string) {
 	RecordBug(Bug{FileName: location.FileName, LineNumber: location.LineNumber, Message: message})
 }
 
-// WithEnvironment specifies that a certain test or group of tests only works
+// WithFeature specifies that a certain test or group of tests only works
 // with a feature available. The return value must be passed as additional
 // argument to [framework.It], [framework.Describe], [framework.Context].
 //
@@ -444,7 +444,7 @@ func withEnvironment(name Environment) interface{} {
 	return newLabel("Environment", string(name))
 }
 
-// WithConformace specifies that a certain test or group of tests must pass in
+// WithConformance specifies that a certain test or group of tests must pass in
 // all conformant Kubernetes clusters. The return value must be passed as
 // additional argument to [framework.It], [framework.Describe],
 // [framework.Context].
@@ -515,9 +515,10 @@ func withSerial() interface{} {
 	return newLabel("Serial")
 }
 
-// WithSlow specifies that a certain test or group of tests must not run in
-// parallel with other tests. The return value must be passed as additional
-// argument to [framework.It], [framework.Describe], [framework.Context].
+// WithSlow specifies that a certain test, or each test within a group of
+// tests, is slow (is expected to take longer than 5 minutes to run in CI).
+// The return value must be passed as additional argument to [framework.It],
+// [framework.Describe], [framework.Context].
 func WithSlow() interface{} {
 	return withSlow()
 }


### PR DESCRIPTION
Noticed in passing:
- `WithFeature`'s comment referred to `WithEnvironment`
- `WithConformance`'s comment misspelled its name
- `WithSlow`'s comment described the behavior of `WithSerial`

I think my documentation for `WithSlow` is correct? I rewrote it to be less parallel with the other comments to clarify that marking a group of tests `Slow` means that _each_ of them is slow.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/kind cleanup
/sig testing
/area e2e-test-framework