### PR TITLE
Fix two conformance tests to use EndpointSlices rather than Endpoints

### DIFF
--- a/test/e2e/network/service_latency.go
+++ b/test/e2e/network/service_latency.go
@@ -25,6 +25,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -59,8 +60,8 @@ var _ = common.SIGDescribe("Service endpoints latency", func() {
 	framework.ConformanceIt("should not be very high", func(ctx context.Context) {
 		const (
 			// These are very generous criteria. Ideally we will
-			// get this much lower in the future. See issue
-			// #10436.
+			// get this much lower in the future. See
+			// https://issues.k8s.io/10436.
 			limitMedian = time.Second * 20
 			limitTail   = time.Second * 50
 
@@ -144,7 +145,7 @@ func runServiceLatencies(ctx context.Context, f *framework.Framework, inParallel
 	framework.ExpectNoError(err)
 	// Run a single watcher, to reduce the number of API calls we have to
 	// make; this is to minimize the timing error. It's how kube-proxy
-	// consumes the endpoints data, so it seems like the right thing to
+	// consumes the endpoint data, so it seems like the right thing to
 	// test.
 	endpointQueries := newQuerier()
 	startEndpointWatcher(ctx, f, endpointQueries)
@@ -196,9 +197,9 @@ func runServiceLatencies(ctx context.Context, f *framework.Framework, inParallel
 }
 
 type endpointQuery struct {
-	endpointsName string
-	endpoints     *v1.Endpoints
-	result        chan<- struct{}
+	serviceName string
+	slice       *discoveryv1.EndpointSlice
+	result      chan<- struct{}
 }
 
 type endpointQueries struct {
@@ -206,7 +207,7 @@ type endpointQueries struct {
 
 	stop        chan struct{}
 	requestChan chan *endpointQuery
-	seenChan    chan *v1.Endpoints
+	seenChan    chan *discoveryv1.EndpointSlice
 }
 
 func newQuerier() *endpointQueries {
@@ -215,7 +216,7 @@ func newQuerier() *endpointQueries {
 
 		stop:        make(chan struct{}, 100),
 		requestChan: make(chan *endpointQuery),
-		seenChan:    make(chan *v1.Endpoints, 100),
+		seenChan:    make(chan *discoveryv1.EndpointSlice, 100),
 	}
 	go eq.join()
 	return eq
@@ -225,6 +226,9 @@ func newQuerier() *endpointQueries {
 // nice properties like:
 //   - remembering an endpoint if it happens to arrive before it is requested.
 //   - closing all outstanding requests (returning nil) if it is stopped.
+//
+// Note that this test case uses a single-stack Service with a single endpoint. Thus, it's
+// guaranteed it will have only a single endpoint IP and thus a single EndpointSlice.
 func (eq *endpointQueries) join() {
 	defer func() {
 		// Terminate all pending requests, so that no goroutine will
@@ -241,22 +245,23 @@ func (eq *endpointQueries) join() {
 		case <-eq.stop:
 			return
 		case req := <-eq.requestChan:
-			if cur, ok := eq.requests[req.endpointsName]; ok && cur.endpoints != nil {
+			if cur, ok := eq.requests[req.serviceName]; ok && cur.slice != nil {
 				// We've already gotten the result, so we can
 				// immediately satisfy this request.
-				delete(eq.requests, req.endpointsName)
-				req.endpoints = cur.endpoints
+				delete(eq.requests, req.serviceName)
+				req.slice = cur.slice
 				close(req.result)
 			} else {
 				// Save this request.
-				eq.requests[req.endpointsName] = req
+				eq.requests[req.serviceName] = req
 			}
 		case got := <-eq.seenChan:
-			if req, ok := eq.requests[got.Name]; ok {
+			serviceName := got.Labels[discoveryv1.LabelServiceName]
+			if req, ok := eq.requests[serviceName]; ok {
 				if req.result != nil {
 					// Satisfy a request.
-					delete(eq.requests, got.Name)
-					req.endpoints = got
+					delete(eq.requests, serviceName)
+					req.slice = got
 					close(req.result)
 				}
 				// We've already recorded a result, but
@@ -265,8 +270,8 @@ func (eq *endpointQueries) join() {
 			} else {
 				// We haven't gotten the corresponding request
 				// yet, save this result.
-				eq.requests[got.Name] = &endpointQuery{
-					endpoints: got,
+				eq.requests[serviceName] = &endpointQuery{
+					slice: got,
 				}
 			}
 		}
@@ -274,19 +279,19 @@ func (eq *endpointQueries) join() {
 }
 
 // request blocks until the requested endpoint is seen.
-func (eq *endpointQueries) request(endpointsName string) *v1.Endpoints {
+func (eq *endpointQueries) request(serviceName string) *discoveryv1.EndpointSlice {
 	result := make(chan struct{})
 	req := &endpointQuery{
-		endpointsName: endpointsName,
-		result:        result,
+		serviceName: serviceName,
+		result:      result,
 	}
 	eq.requestChan <- req
 	<-result
-	return req.endpoints
+	return req.slice
 }
 
 // marks e as added; does not block.
-func (eq *endpointQueries) added(e *v1.Endpoints) {
+func (eq *endpointQueries) added(e *discoveryv1.EndpointSlice) {
 	eq.seenChan <- e
 }
 
@@ -295,26 +300,26 @@ func startEndpointWatcher(ctx context.Context, f *framework.Framework, q *endpoi
 	_, controller := cache.NewInformer(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-				obj, err := f.ClientSet.CoreV1().Endpoints(f.Namespace.Name).List(ctx, options)
+				obj, err := f.ClientSet.DiscoveryV1().EndpointSlices(f.Namespace.Name).List(ctx, options)
 				return runtime.Object(obj), err
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-				return f.ClientSet.CoreV1().Endpoints(f.Namespace.Name).Watch(ctx, options)
+				return f.ClientSet.DiscoveryV1().EndpointSlices(f.Namespace.Name).Watch(ctx, options)
 			},
 		},
-		&v1.Endpoints{},
+		&discoveryv1.EndpointSlice{},
 		0,
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
-				if e, ok := obj.(*v1.Endpoints); ok {
-					if len(e.Subsets) > 0 && len(e.Subsets[0].Addresses) > 0 {
+				if e, ok := obj.(*discoveryv1.EndpointSlice); ok {
+					if len(e.Endpoints) > 0 {
 						q.added(e)
 					}
 				}
 			},
 			UpdateFunc: func(old, cur interface{}) {
-				if e, ok := cur.(*v1.Endpoints); ok {
-					if len(e.Subsets) > 0 && len(e.Subsets[0].Addresses) > 0 {
+				if e, ok := cur.(*discoveryv1.EndpointSlice); ok {
+					if len(e.Endpoints) > 0 {
 						q.added(e)
 					}
 				}


### PR DESCRIPTION
This fixes the conformance tests ~`"should proxy through a service and a pod"` and~ `"Service endpoints latency should not be very high"` to check EndpointSlices rather than Endpoints.

~For the former test, this is essentially a no-op; the test just waits for the Service's Endpoints to appear before attempting to connect to the Service, and the PR fixes it to make it wait for the EndpointSlices to appear instead. Theoretically, if this test had been flaking, then this PR might fix that, but the test wasn't flaking, so it should have no effect. (Also, there are plenty of other conformance tests that test the Endpoints controller better than this one does, so changing this one to not look at Endpoints any more does not meaningfully reduce conformance coverage of Endpoints.)~

The latency test is a slightly bigger deal: our current conformance criteria require that the Endpoints controller has reasonable latency, even though nothing uses it, and they do not require that the EndpointSlice controller has reasonable latency, even though they should. In practice, this doesn't even really matter, since the two controllers do basically the same thing and run in the same process, so it's unlikely one would have high latency when the other didn't, but for correctness (and to allow for the possibility of eventually removing the Endpoints controller), we should fix this test to check EndpointSlices instead.

In theory, if we had been paying attention, we should have had tests of both Endpoints and EndpointSlice latency, during the era when both were still used, but at this point I don't think there's any good argument for keeping the Endpoints latency test.

/kind bug
/kind cleanup
/sig network
/area conformance
/priority important-soon
/triage accepted

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/4974-deprecate-endpoints
```
