### PR TITLE
cleanup: Rename gogoproto stringer tag to avoid invalid tag arguments

### DIFF
--- a/staging/src/k8s.io/api/authentication/v1/generated.proto
+++ b/staging/src/k8s.io/api/authentication/v1/generated.proto
@@ -49,7 +49,7 @@ message BoundObjectReference {
 
 // ExtraValue masks the value so protobuf can generate
 // +protobuf.nullable=true
-// +protobuf.options.(gogoproto.goproto_stringer)=false
+// +protobuf.options.gogoproto.goproto_stringer=false
 message ExtraValue {
   // items, if empty, will result in an empty slice
 

--- a/staging/src/k8s.io/api/authentication/v1/types.go
+++ b/staging/src/k8s.io/api/authentication/v1/types.go
@@ -127,7 +127,7 @@ type UserInfo struct {
 
 // ExtraValue masks the value so protobuf can generate
 // +protobuf.nullable=true
-// +protobuf.options.(gogoproto.goproto_stringer)=false
+// +protobuf.options.gogoproto.goproto_stringer=false
 type ExtraValue []string
 
 func (t ExtraValue) String() string {

--- a/staging/src/k8s.io/api/authentication/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/authentication/v1beta1/generated.proto
@@ -31,7 +31,7 @@ option go_package = "k8s.io/api/authentication/v1beta1";
 
 // ExtraValue masks the value so protobuf can generate
 // +protobuf.nullable=true
-// +protobuf.options.(gogoproto.goproto_stringer)=false
+// +protobuf.options.gogoproto.goproto_stringer=false
 message ExtraValue {
   // items, if empty, will result in an empty slice
 

--- a/staging/src/k8s.io/api/authentication/v1beta1/types.go
+++ b/staging/src/k8s.io/api/authentication/v1beta1/types.go
@@ -111,7 +111,7 @@ type UserInfo struct {
 
 // ExtraValue masks the value so protobuf can generate
 // +protobuf.nullable=true
-// +protobuf.options.(gogoproto.goproto_stringer)=false
+// +protobuf.options.gogoproto.goproto_stringer=false
 type ExtraValue []string
 
 func (t ExtraValue) String() string {

--- a/staging/src/k8s.io/api/authorization/v1/generated.proto
+++ b/staging/src/k8s.io/api/authorization/v1/generated.proto
@@ -30,7 +30,7 @@ option go_package = "k8s.io/api/authorization/v1";
 
 // ExtraValue masks the value so protobuf can generate
 // +protobuf.nullable=true
-// +protobuf.options.(gogoproto.goproto_stringer)=false
+// +protobuf.options.gogoproto.goproto_stringer=false
 message ExtraValue {
   // items, if empty, will result in an empty slice
 

--- a/staging/src/k8s.io/api/authorization/v1/types.go
+++ b/staging/src/k8s.io/api/authorization/v1/types.go
@@ -225,7 +225,7 @@ type SubjectAccessReviewSpec struct {
 
 // ExtraValue masks the value so protobuf can generate
 // +protobuf.nullable=true
-// +protobuf.options.(gogoproto.goproto_stringer)=false
+// +protobuf.options.gogoproto.goproto_stringer=false
 type ExtraValue []string
 
 func (t ExtraValue) String() string {

--- a/staging/src/k8s.io/api/authorization/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/authorization/v1beta1/generated.proto
@@ -31,7 +31,7 @@ option go_package = "k8s.io/api/authorization/v1beta1";
 
 // ExtraValue masks the value so protobuf can generate
 // +protobuf.nullable=true
-// +protobuf.options.(gogoproto.goproto_stringer)=false
+// +protobuf.options.gogoproto.goproto_stringer=false
 message ExtraValue {
   // items, if empty, will result in an empty slice
 

--- a/staging/src/k8s.io/api/authorization/v1beta1/types.go
+++ b/staging/src/k8s.io/api/authorization/v1beta1/types.go
@@ -172,7 +172,7 @@ type SubjectAccessReviewSpec struct {
 
 // ExtraValue masks the value so protobuf can generate
 // +protobuf.nullable=true
-// +protobuf.options.(gogoproto.goproto_stringer)=false
+// +protobuf.options.gogoproto.goproto_stringer=false
 type ExtraValue []string
 
 func (t ExtraValue) String() string {

--- a/staging/src/k8s.io/api/certificates/v1/generated.proto
+++ b/staging/src/k8s.io/api/certificates/v1/generated.proto
@@ -239,7 +239,7 @@ message CertificateSigningRequestStatus {
 
 // ExtraValue masks the value so protobuf can generate
 // +protobuf.nullable=true
-// +protobuf.options.(gogoproto.goproto_stringer)=false
+// +protobuf.options.gogoproto.goproto_stringer=false
 message ExtraValue {
   // items, if empty, will result in an empty slice
 

--- a/staging/src/k8s.io/api/certificates/v1/types.go
+++ b/staging/src/k8s.io/api/certificates/v1/types.go
@@ -164,7 +164,7 @@ const (
 
 // ExtraValue masks the value so protobuf can generate
 // +protobuf.nullable=true
-// +protobuf.options.(gogoproto.goproto_stringer)=false
+// +protobuf.options.gogoproto.goproto_stringer=false
 type ExtraValue []string
 
 func (t ExtraValue) String() string {

--- a/staging/src/k8s.io/api/certificates/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/certificates/v1beta1/generated.proto
@@ -265,7 +265,7 @@ message ClusterTrustBundleSpec {
 
 // ExtraValue masks the value so protobuf can generate
 // +protobuf.nullable=true
-// +protobuf.options.(gogoproto.goproto_stringer)=false
+// +protobuf.options.gogoproto.goproto_stringer=false
 message ExtraValue {
   // items, if empty, will result in an empty slice
 

--- a/staging/src/k8s.io/api/certificates/v1beta1/types.go
+++ b/staging/src/k8s.io/api/certificates/v1beta1/types.go
@@ -163,7 +163,7 @@ const (
 
 // ExtraValue masks the value so protobuf can generate
 // +protobuf.nullable=true
-// +protobuf.options.(gogoproto.goproto_stringer)=false
+// +protobuf.options.gogoproto.goproto_stringer=false
 type ExtraValue []string
 
 func (t ExtraValue) String() string {

--- a/staging/src/k8s.io/api/resource/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1beta1/generated.proto
@@ -840,7 +840,7 @@ message DeviceSubRequest {
 // any claim which does not tolerate the taint and, through the claim,
 // to pods using the claim.
 //
-// +protobuf.options.(gogoproto.goproto_stringer)=false
+// +protobuf.options.gogoproto.goproto_stringer=false
 message DeviceTaint {
   // The taint key to be applied to a device.
   // Must be a label name.

--- a/staging/src/k8s.io/api/resource/v1beta1/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta1/types.go
@@ -450,7 +450,7 @@ const DeviceTaintsMaxLength = 4
 // any claim which does not tolerate the taint and, through the claim,
 // to pods using the claim.
 //
-// +protobuf.options.(gogoproto.goproto_stringer)=false
+// +protobuf.options.gogoproto.goproto_stringer=false
 type DeviceTaint struct {
 	// The taint key to be applied to a device.
 	// Must be a label name.

--- a/staging/src/k8s.io/api/resource/v1beta2/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1beta2/generated.proto
@@ -735,7 +735,7 @@ message DeviceSubRequest {
 // any claim which does not tolerate the taint and, through the claim,
 // to pods using the claim.
 //
-// +protobuf.options.(gogoproto.goproto_stringer)=false
+// +protobuf.options.gogoproto.goproto_stringer=false
 message DeviceTaint {
   // The taint key to be applied to a device.
   // Must be a label name.

--- a/staging/src/k8s.io/api/resource/v1beta2/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta2/types.go
@@ -446,7 +446,7 @@ const DeviceTaintsMaxLength = 4
 // any claim which does not tolerate the taint and, through the claim,
 // to pods using the claim.
 //
-// +protobuf.options.(gogoproto.goproto_stringer)=false
+// +protobuf.options.gogoproto.goproto_stringer=false
 type DeviceTaint struct {
 	// The taint key to be applied to a device.
 	// Must be a label name.

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/generated.proto
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/generated.proto
@@ -90,7 +90,7 @@ option go_package = "k8s.io/apimachinery/pkg/api/resource";
 // +protobuf=true
 // +protobuf.embed=string
 // +protobuf.options.marshal=false
-// +protobuf.options.(gogoproto.goproto_stringer)=false
+// +protobuf.options.gogoproto.goproto_stringer=false
 // +k8s:deepcopy-gen=true
 // +k8s:openapi-gen=true
 message Quantity {
@@ -103,7 +103,7 @@ message Quantity {
 // +protobuf=true
 // +protobuf.embed=string
 // +protobuf.options.marshal=false
-// +protobuf.options.(gogoproto.goproto_stringer)=false
+// +protobuf.options.gogoproto.goproto_stringer=false
 // +k8s:deepcopy-gen=true
 message QuantityValue {
   optional string string = 1;

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
@@ -96,7 +96,7 @@ import (
 // +protobuf=true
 // +protobuf.embed=string
 // +protobuf.options.marshal=false
-// +protobuf.options.(gogoproto.goproto_stringer)=false
+// +protobuf.options.gogoproto.goproto_stringer=false
 // +k8s:deepcopy-gen=true
 // +k8s:openapi-gen=true
 type Quantity struct {
@@ -856,7 +856,7 @@ func (q *Quantity) SetScaled(value int64, scale Scale) {
 // +protobuf=true
 // +protobuf.embed=string
 // +protobuf.options.marshal=false
-// +protobuf.options.(gogoproto.goproto_stringer)=false
+// +protobuf.options.gogoproto.goproto_stringer=false
 // +k8s:deepcopy-gen=true
 type QuantityValue struct {
 	Quantity

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/generated.proto
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/generated.proto
@@ -124,7 +124,7 @@ message APIResourceList {
 // APIVersions lists the versions that are available, to allow clients to
 // discover the API at /api, which is the root path of the legacy v1 API.
 //
-// +protobuf.options.(gogoproto.goproto_stringer)=false
+// +protobuf.options.gogoproto.goproto_stringer=false
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 message APIVersions {
   // versions are the api versions that are available.
@@ -369,7 +369,7 @@ message FieldSelectorRequirement {
 // If a key maps to an empty Fields value, the field that key represents is part of the set.
 //
 // The exact format is defined in sigs.k8s.io/structured-merge-diff
-// +protobuf.options.(gogoproto.goproto_stringer)=false
+// +protobuf.options.gogoproto.goproto_stringer=false
 message FieldsV1 {
   // Raw is the underlying serialization of this object.
   optional bytes Raw = 1;
@@ -389,7 +389,7 @@ message GetOptions {
 // GroupKind specifies a Group and a Kind, but does not force a version.  This is useful for identifying
 // concepts during lookup stages without having partially valid types
 //
-// +protobuf.options.(gogoproto.goproto_stringer)=false
+// +protobuf.options.gogoproto.goproto_stringer=false
 message GroupKind {
   optional string group = 1;
 
@@ -399,7 +399,7 @@ message GroupKind {
 // GroupResource specifies a Group and a Resource, but does not force a version.  This is useful for identifying
 // concepts during lookup stages without having partially valid types
 //
-// +protobuf.options.(gogoproto.goproto_stringer)=false
+// +protobuf.options.gogoproto.goproto_stringer=false
 message GroupResource {
   optional string group = 1;
 
@@ -408,7 +408,7 @@ message GroupResource {
 
 // GroupVersion contains the "group" and the "version", which uniquely identifies the API.
 //
-// +protobuf.options.(gogoproto.goproto_stringer)=false
+// +protobuf.options.gogoproto.goproto_stringer=false
 message GroupVersion {
   optional string group = 1;
 
@@ -429,7 +429,7 @@ message GroupVersionForDiscovery {
 // GroupVersionKind unambiguously identifies a kind.  It doesn't anonymously include GroupVersion
 // to avoid automatic coercion.  It doesn't use a GroupVersion to avoid custom marshalling
 //
-// +protobuf.options.(gogoproto.goproto_stringer)=false
+// +protobuf.options.gogoproto.goproto_stringer=false
 message GroupVersionKind {
   optional string group = 1;
 
@@ -441,7 +441,7 @@ message GroupVersionKind {
 // GroupVersionResource unambiguously identifies a resource.  It doesn't anonymously include GroupVersion
 // to avoid automatic coercion.  It doesn't use a GroupVersion to avoid custom marshalling
 //
-// +protobuf.options.(gogoproto.goproto_stringer)=false
+// +protobuf.options.gogoproto.goproto_stringer=false
 message GroupVersionResource {
   optional string group = 1;
 
@@ -691,7 +691,7 @@ message ManagedFieldsEntry {
 //
 // +protobuf.options.marshal=false
 // +protobuf.as=Timestamp
-// +protobuf.options.(gogoproto.goproto_stringer)=false
+// +protobuf.options.gogoproto.goproto_stringer=false
 message MicroTime {
   // Represents seconds of UTC time since Unix epoch
   // 1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
@@ -1129,7 +1129,7 @@ message TableOptions {
 //
 // +protobuf.options.marshal=false
 // +protobuf.as=Timestamp
-// +protobuf.options.(gogoproto.goproto_stringer)=false
+// +protobuf.options.gogoproto.goproto_stringer=false
 message Time {
   // Represents seconds of UTC time since Unix epoch
   // 1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
@@ -1223,7 +1223,7 @@ message UpdateOptions {
 // Verbs masks the value so protobuf can generate
 //
 // +protobuf.nullable=true
-// +protobuf.options.(gogoproto.goproto_stringer)=false
+// +protobuf.options.gogoproto.goproto_stringer=false
 message Verbs {
   // items, if empty, will result in an empty slice
 

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/group_version.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/group_version.go
@@ -27,7 +27,7 @@ import (
 // GroupResource specifies a Group and a Resource, but does not force a version.  This is useful for identifying
 // concepts during lookup stages without having partially valid types
 //
-// +protobuf.options.(gogoproto.goproto_stringer)=false
+// +protobuf.options.gogoproto.goproto_stringer=false
 type GroupResource struct {
 	Group    string `json:"group" protobuf:"bytes,1,opt,name=group"`
 	Resource string `json:"resource" protobuf:"bytes,2,opt,name=resource"`
@@ -46,7 +46,7 @@ func (gr *GroupResource) String() string {
 // GroupVersionResource unambiguously identifies a resource.  It doesn't anonymously include GroupVersion
 // to avoid automatic coercion.  It doesn't use a GroupVersion to avoid custom marshalling
 //
-// +protobuf.options.(gogoproto.goproto_stringer)=false
+// +protobuf.options.gogoproto.goproto_stringer=false
 type GroupVersionResource struct {
 	Group    string `json:"group" protobuf:"bytes,1,opt,name=group"`
 	Version  string `json:"version" protobuf:"bytes,2,opt,name=version"`
@@ -63,7 +63,7 @@ func (gvr *GroupVersionResource) String() string {
 // GroupKind specifies a Group and a Kind, but does not force a version.  This is useful for identifying
 // concepts during lookup stages without having partially valid types
 //
-// +protobuf.options.(gogoproto.goproto_stringer)=false
+// +protobuf.options.gogoproto.goproto_stringer=false
 type GroupKind struct {
 	Group string `json:"group" protobuf:"bytes,1,opt,name=group"`
 	Kind  string `json:"kind" protobuf:"bytes,2,opt,name=kind"`
@@ -82,7 +82,7 @@ func (gk *GroupKind) String() string {
 // GroupVersionKind unambiguously identifies a kind.  It doesn't anonymously include GroupVersion
 // to avoid automatic coercion.  It doesn't use a GroupVersion to avoid custom marshalling
 //
-// +protobuf.options.(gogoproto.goproto_stringer)=false
+// +protobuf.options.gogoproto.goproto_stringer=false
 type GroupVersionKind struct {
 	Group   string `json:"group" protobuf:"bytes,1,opt,name=group"`
 	Version string `json:"version" protobuf:"bytes,2,opt,name=version"`
@@ -95,7 +95,7 @@ func (gvk GroupVersionKind) String() string {
 
 // GroupVersion contains the "group" and the "version", which uniquely identifies the API.
 //
-// +protobuf.options.(gogoproto.goproto_stringer)=false
+// +protobuf.options.gogoproto.goproto_stringer=false
 type GroupVersion struct {
 	Group   string `json:"group" protobuf:"bytes,1,opt,name=group"`
 	Version string `json:"version" protobuf:"bytes,2,opt,name=version"`

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/micro_time.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/micro_time.go
@@ -29,7 +29,7 @@ const RFC3339Micro = "2006-01-02T15:04:05.000000Z07:00"
 //
 // +protobuf.options.marshal=false
 // +protobuf.as=Timestamp
-// +protobuf.options.(gogoproto.goproto_stringer)=false
+// +protobuf.options.gogoproto.goproto_stringer=false
 type MicroTime struct {
 	time.Time `protobuf:"-"`
 }

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/time.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/time.go
@@ -29,7 +29,7 @@ import (
 //
 // +protobuf.options.marshal=false
 // +protobuf.as=Timestamp
-// +protobuf.options.(gogoproto.goproto_stringer)=false
+// +protobuf.options.gogoproto.goproto_stringer=false
 type Time struct {
 	time.Time `protobuf:"-"`
 }

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
@@ -1107,7 +1107,7 @@ type List struct {
 // APIVersions lists the versions that are available, to allow clients to
 // discover the API at /api, which is the root path of the legacy v1 API.
 //
-// +protobuf.options.(gogoproto.goproto_stringer)=false
+// +protobuf.options.gogoproto.goproto_stringer=false
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type APIVersions struct {
 	TypeMeta `json:",inline"`
@@ -1223,7 +1223,7 @@ type APIResource struct {
 // Verbs masks the value so protobuf can generate
 //
 // +protobuf.nullable=true
-// +protobuf.options.(gogoproto.goproto_stringer)=false
+// +protobuf.options.gogoproto.goproto_stringer=false
 type Verbs []string
 
 func (vs Verbs) String() string {
@@ -1410,7 +1410,7 @@ const (
 // If a key maps to an empty Fields value, the field that key represents is part of the set.
 //
 // The exact format is defined in sigs.k8s.io/structured-merge-diff
-// +protobuf.options.(gogoproto.goproto_stringer)=false
+// +protobuf.options.gogoproto.goproto_stringer=false
 type FieldsV1 struct {
 	// Raw is the underlying serialization of this object.
 	Raw []byte `json:"-" protobuf:"bytes,1,opt,name=Raw"`

--- a/staging/src/k8s.io/apimachinery/pkg/util/intstr/generated.proto
+++ b/staging/src/k8s.io/apimachinery/pkg/util/intstr/generated.proto
@@ -31,7 +31,7 @@ option go_package = "k8s.io/apimachinery/pkg/util/intstr";
 // TODO: Rename to Int32OrString
 //
 // +protobuf=true
-// +protobuf.options.(gogoproto.goproto_stringer)=false
+// +protobuf.options.gogoproto.goproto_stringer=false
 // +k8s:openapi-gen=true
 message IntOrString {
   optional int64 type = 1;

--- a/staging/src/k8s.io/apimachinery/pkg/util/intstr/intstr.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/intstr/intstr.go
@@ -36,7 +36,7 @@ import (
 // TODO: Rename to Int32OrString
 //
 // +protobuf=true
-// +protobuf.options.(gogoproto.goproto_stringer)=false
+// +protobuf.options.gogoproto.goproto_stringer=false
 // +k8s:openapi-gen=true
 type IntOrString struct {
 	Type   Type   `protobuf:"varint,1,opt,name=type,casttype=Type"`

--- a/staging/src/k8s.io/code-generator/cmd/go-to-protobuf/protobuf/generator.go
+++ b/staging/src/k8s.io/code-generator/cmd/go-to-protobuf/protobuf/generator.go
@@ -322,11 +322,11 @@ func (b bodyGen) doStruct(sw *generator.SnippetWriter) error {
 					}
 				}
 			default:
-				if !b.omitGogo || !strings.HasPrefix(key, "(gogoproto.") {
-					if key == "(gogoproto.goproto_stringer)" && v[0] == "false" {
+				if !b.omitGogo || !strings.HasPrefix(key, "gogoproto.") {
+					if key == "gogoproto.goproto_stringer" && v[0] == "false" {
 						options = append(options, "(gogoproto.stringer) = false")
 					}
-					options = append(options, fmt.Sprintf("%s = %s", key, v[0]))
+					options = append(options, fmt.Sprintf("(%s) = %s", key, v[0]))
 				}
 			}
 		// protobuf.as allows a type to have the same message contents as another Go type


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

[ExtractCommentTags](https://pkg.go.dev/k8s.io/gengo/v2#ExtractCommentTags) is deprecated, and we need to migrate the usages to ExtractFunctionStyleCommentTags.

However, the migration is blocked by the existing gogoproto stringer tag. [gengo identifies](https://github.com/kubernetes/gengo/blob/1244d31929d7b7ca51aeaa1e80fdb0884a3460f9/v2/comments.go#L258-L260) `(gogoproto.goproto_stringer)` as a tag argument, but the `.` character is not a valid token in an argument.

This PR renames the tag as `+protobuf.options.gogoproto.goproto_stringer=false` to unblock further migration.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #130358

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
