### PR TITLE
Deprecate kubeconfig's preference field in favor of kuberc

### DIFF
--- a/cmd/kubeadm/app/cmd/token_test.go
+++ b/cmd/kubeadm/app/cmd/token_test.go
@@ -54,7 +54,6 @@ contexts:
   name: default
 current-context: default
 kind: Config
-preferences: {}
 users:
 - name: kubernetes-admin
   user:

--- a/cmd/kubeadm/app/cmd/upgrade/common_test.go
+++ b/cmd/kubeadm/app/cmd/upgrade/common_test.go
@@ -46,7 +46,6 @@ contexts:
   name: default
 current-context: default
 kind: Config
-preferences: {}
 users:
 - name: kubernetes-admin
   user:

--- a/cmd/kubeadm/app/discovery/token/token_test.go
+++ b/cmd/kubeadm/app/discovery/token/token_test.go
@@ -69,7 +69,6 @@ contexts:
   name: token-bootstrap-client@somecluster
 current-context: token-bootstrap-client@somecluster
 kind: Config
-preferences: {}
 users: null
 `
 	)

--- a/cmd/kubeadm/app/phases/bootstraptoken/clusterinfo/clusterinfo_test.go
+++ b/cmd/kubeadm/app/phases/bootstraptoken/clusterinfo/clusterinfo_test.go
@@ -49,7 +49,6 @@ contexts:
   name: kubernetes-admin@kubernetes
 current-context: kubernetes-admin@kubernetes
 kind: Config
-preferences: {}
 users:
 - name: kubernetes-admin`))
 

--- a/cmd/kubeadm/app/util/apiclient/dryrun.go
+++ b/cmd/kubeadm/app/util/apiclient/dryrun.go
@@ -607,7 +607,6 @@ clusters:
 contexts: null
 current-context: ""
 kind: Config
-preferences: {}
 users: null
 `)
 	data := map[string]string{

--- a/cmd/kubeadm/app/util/config/cluster_test.go
+++ b/cmd/kubeadm/app/util/config/cluster_test.go
@@ -90,7 +90,6 @@ contexts:
   name: system:node:mynode@kubernetes
 current-context: system:node:mynode@kubernetes
 kind: Config
-preferences: {}
 users:
 - name: system:node:mynode
   user:
@@ -108,7 +107,6 @@ contexts:
   name: system:node:mynode@kubernetes
 current-context: system:node:mynode@kubernetes
 kind: Config
-preferences: {}
 users:
 - name: system:node:mynode
   user:
@@ -127,7 +125,6 @@ contexts:
   name: system:node:mynode@kubernetes
 current-context: system:node:mynode@kubernetes
 kind: Config
-preferences: {}
 users:
 - name: system:node:mynode
   user:
@@ -146,7 +143,6 @@ contexts:
   name: system:node:mynode@kubernetes
 current-context: invalidContext
 kind: Config
-preferences: {}
 users:
 - name: system:node:mynode
   user:
@@ -165,7 +161,6 @@ contexts:
   name: system:node:mynode@kubernetes
 current-context: system:node:mynode@kubernetes
 kind: Config
-preferences: {}
 users:
 - name: system:node:mynode
   user:

--- a/cmd/kubeadm/app/util/kubeconfig/kubeconfig_test.go
+++ b/cmd/kubeadm/app/util/kubeconfig/kubeconfig_test.go
@@ -39,7 +39,6 @@ contexts:
   name: user1@k8s
 current-context: user1@k8s
 kind: Config
-preferences: {}
 users:
 - name: user1
   user:
@@ -57,7 +56,6 @@ contexts:
   name: user2@kubernetes
 current-context: user2@kubernetes
 kind: Config
-preferences: {}
 users:
 - name: user2
   user:

--- a/staging/src/k8s.io/client-go/tools/clientcmd/api/helpers_test.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/api/helpers_test.go
@@ -225,7 +225,6 @@ func Example_minifyAndShorten() {
 	//     cluster: cow-cluster
 	//     user: red-user
 	// current-context: federal-context
-	// preferences: {}
 	// users:
 	//   red-user:
 	//     client-certificate-data: DATA+OMITTED

--- a/staging/src/k8s.io/client-go/tools/clientcmd/api/types.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/api/types.go
@@ -40,7 +40,8 @@ type Config struct {
 	// +optional
 	APIVersion string `json:"apiVersion,omitempty"`
 	// Preferences holds general information to be use for cli interactions
-	Preferences Preferences `json:"preferences"`
+	// Deprecated: this field is deprecated in v1.34. It is not used by any of the Kubernetes components.
+	Preferences Preferences `json:"preferences,omitzero"`
 	// Clusters is a map of referencable names to cluster configs
 	Clusters map[string]*Cluster `json:"clusters"`
 	// AuthInfos is a map of referencable names to user configs
@@ -55,6 +56,7 @@ type Config struct {
 }
 
 // IMPORTANT if you add fields to this struct, please update IsConfigEmpty()
+// Deprecated: this structure is deprecated in v1.34. It is not used by any of the Kubernetes components.
 type Preferences struct {
 	// +optional
 	Colors bool `json:"colors,omitempty"`
@@ -339,11 +341,10 @@ const (
 // NewConfig is a convenience function that returns a new Config object with non-nil maps
 func NewConfig() *Config {
 	return &Config{
-		Preferences: *NewPreferences(),
-		Clusters:    make(map[string]*Cluster),
-		AuthInfos:   make(map[string]*AuthInfo),
-		Contexts:    make(map[string]*Context),
-		Extensions:  make(map[string]runtime.Object),
+		Clusters:   make(map[string]*Cluster),
+		AuthInfos:  make(map[string]*AuthInfo),
+		Contexts:   make(map[string]*Context),
+		Extensions: make(map[string]runtime.Object),
 	}
 }
 
@@ -370,6 +371,7 @@ func NewAuthInfo() *AuthInfo {
 
 // NewPreferences is a convenience function that returns a new
 // Preferences object with non-nil maps
+// Deprecated: this method is deprecated in v1.34. It is not used by any of the Kubernetes components.
 func NewPreferences() *Preferences {
 	return &Preferences{Extensions: make(map[string]runtime.Object)}
 }

--- a/staging/src/k8s.io/client-go/tools/clientcmd/api/types_test.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/api/types_test.go
@@ -35,7 +35,6 @@ func Example_emptyConfig() {
 	// clusters: {}
 	// contexts: {}
 	// current-context: ""
-	// preferences: {}
 	// users: {}
 }
 

--- a/staging/src/k8s.io/client-go/tools/clientcmd/api/v1/types.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/api/v1/types.go
@@ -37,7 +37,8 @@ type Config struct {
 	// +optional
 	APIVersion string `json:"apiVersion,omitempty"`
 	// Preferences holds general information to be use for cli interactions
-	Preferences Preferences `json:"preferences"`
+	// Deprecated: this field is deprecated in v1.34. It is not used by any of the Kubernetes components.
+	Preferences Preferences `json:"preferences,omitzero"`
 	// Clusters is a map of referencable names to cluster configs
 	Clusters []NamedCluster `json:"clusters"`
 	// AuthInfos is a map of referencable names to user configs
@@ -51,6 +52,7 @@ type Config struct {
 	Extensions []NamedExtension `json:"extensions,omitempty"`
 }
 
+// Deprecated: this structure is deprecated in v1.34. It is not used by any of the Kubernetes components.
 type Preferences struct {
 	// +optional
 	Colors bool `json:"colors,omitempty"`

--- a/staging/src/k8s.io/client-go/tools/clientcmd/loader_test.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/loader_test.go
@@ -309,7 +309,6 @@ contexts:
   name: "433e40"
 current-context: any-context-value
 kind: Config
-preferences: {}
 users: null
 `)
 	if !bytes.Equal(expected, data) {
@@ -757,7 +756,6 @@ func Example_noMergingOnExplicitPaths() {
 	//   name: federal-context
 	// current-context: ""
 	// kind: Config
-	// preferences: {}
 	// users:
 	// - name: red-user
 	//   user:
@@ -809,7 +807,6 @@ func Example_mergingSomeWithConflict() {
 	//   name: federal-context
 	// current-context: federal-context
 	// kind: Config
-	// preferences: {}
 	// users:
 	// - name: red-user
 	//   user:
@@ -887,7 +884,6 @@ func Example_mergingEverythingNoConflicts() {
 	//   name: shaker-context
 	// current-context: ""
 	// kind: Config
-	// preferences: {}
 	// users:
 	// - name: black-user
 	//   user:

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/config_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/config_test.go
@@ -69,7 +69,6 @@ func Example_view() {
 	//   name: federal-context
 	// current-context: federal-context
 	// kind: Config
-	// preferences: {}
 	// users:
 	// - name: red-user
 	//   user:

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/view_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/view_test.go
@@ -85,7 +85,6 @@ contexts:
   name: my-cluster
 current-context: minikube
 kind: Config
-preferences: {}
 users:
 - name: minikube
   user:
@@ -165,7 +164,6 @@ contexts:
   name: my-cluster
 current-context: minikube
 kind: Config
-preferences: {}
 users:
 - name: minikube
   user:
@@ -247,7 +245,6 @@ contexts:
   name: minikube
 current-context: minikube
 kind: Config
-preferences: {}
 users:
 - name: minikube
   user:
@@ -272,7 +269,6 @@ contexts:
   name: my-cluster
 current-context: my-cluster
 kind: Config
-preferences: {}
 users:
 - name: mu-cluster
   user:

--- a/test/cmd/authentication.sh
+++ b/test/cmd/authentication.sh
@@ -43,7 +43,6 @@ contexts:
   name: test
 current-context: test
 kind: Config
-preferences: {}
 users:
 - name: invalid_token_user
   user:
@@ -94,7 +93,6 @@ contexts:
   name: test
 current-context: test
 kind: Config
-preferences: {}
 users:
 - name: valid_token_user
   user:
@@ -214,7 +212,6 @@ contexts:
   name: test
 current-context: test
 kind: Config
-preferences: {}
 users:
 - name: always_interactive_token_user
   user:
@@ -287,7 +284,6 @@ contexts:
   name: test
 current-context: test
 kind: Config
-preferences: {}
 users:
 - name: missing_interactive_token_user
   user:


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/kind documentation
/kind feature
/kind api-change
/kind deprecation

#### What this PR does / why we need it:
While updating the [kuberc KEP](https://github.com/kubernetes/enhancements/pull/5300) I've noticed we explicitly said we'll deprecate the kubeconfig's preferences field. 

#### Which issue(s) this PR fixes:
Ref: https://github.com/kubernetes/enhancements/issues/3104

#### Special notes for your reviewer:
/assign @ardaguclu 
for sig-cli changes

/assign @liggitt 
for api-review

#### Does this PR introduce a user-facing change?
```release-note
Deprecate preferences field in kubeconfig in favor of kuberc
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/3104
```
