### PR TITLE
update publishing rules for rel 1.30/31/32 to use go1.23.8 and drop release-1.29 config

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -6,12 +6,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/apimachinery
-  - name: release-1.29
-    go: 1.23.6
-    source:
-      branch: release-1.29
-      dirs:
-      - staging/src/k8s.io/apimachinery
   - name: release-1.30
     go: 1.23.6
     source:
@@ -44,15 +38,6 @@ rules:
       branch: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/api
-  - name: release-1.29
-    go: 1.23.6
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.29
-    source:
-      branch: release-1.29
       dirs:
       - staging/src/k8s.io/api
   - name: release-1.30
@@ -101,21 +86,6 @@ rules:
       branch: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/client-go
-    smoke-test: |
-      # assumes GO111MODULE=on
-      go build -mod=mod ./...
-      go test -mod=mod ./...
-  - name: release-1.29
-    go: 1.23.6
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.29
-    - repository: api
-      branch: release-1.29
-    source:
-      branch: release-1.29
       dirs:
       - staging/src/k8s.io/client-go
     smoke-test: |
@@ -192,12 +162,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/code-generator
-  - name: release-1.29
-    go: 1.23.6
-    source:
-      branch: release-1.29
-      dirs:
-      - staging/src/k8s.io/code-generator
   - name: release-1.30
     go: 1.23.6
     dependencies:
@@ -245,19 +209,6 @@ rules:
       branch: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/component-base
-  - name: release-1.29
-    go: 1.23.6
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.29
-    - repository: api
-      branch: release-1.29
-    - repository: client-go
-      branch: release-1.29
-    source:
-      branch: release-1.29
       dirs:
       - staging/src/k8s.io/component-base
   - name: release-1.30
@@ -326,19 +277,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/component-helpers
-  - name: release-1.29
-    go: 1.23.6
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.29
-    - repository: api
-      branch: release-1.29
-    - repository: client-go
-      branch: release-1.29
-    source:
-      branch: release-1.29
-      dirs:
-      - staging/src/k8s.io/component-helpers
   - name: release-1.30
     go: 1.23.6
     dependencies:
@@ -401,15 +339,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/kms
-  - name: release-1.29
-    go: 1.23.6
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.29
-    source:
-      branch: release-1.29
-      dirs:
-      - staging/src/k8s.io/kms
   - name: release-1.30
     go: 1.23.6
     dependencies:
@@ -462,23 +391,6 @@ rules:
       branch: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/apiserver
-  - name: release-1.29
-    go: 1.23.6
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.29
-    - repository: api
-      branch: release-1.29
-    - repository: client-go
-      branch: release-1.29
-    - repository: component-base
-      branch: release-1.29
-    - repository: kms
-      branch: release-1.29
-    source:
-      branch: release-1.29
       dirs:
       - staging/src/k8s.io/apiserver
   - name: release-1.30
@@ -569,27 +481,6 @@ rules:
       branch: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/kube-aggregator
-  - name: release-1.29
-    go: 1.23.6
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.29
-    - repository: api
-      branch: release-1.29
-    - repository: client-go
-      branch: release-1.29
-    - repository: apiserver
-      branch: release-1.29
-    - repository: component-base
-      branch: release-1.29
-    - repository: kms
-      branch: release-1.29
-    - repository: code-generator
-      branch: release-1.29
-    source:
-      branch: release-1.29
       dirs:
       - staging/src/k8s.io/kube-aggregator
   - name: release-1.30
@@ -695,32 +586,6 @@ rules:
       branch: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/sample-apiserver
-    required-packages:
-    - k8s.io/code-generator
-    smoke-test: |
-      # assumes GO111MODULE=on
-      go build -mod=mod .
-  - name: release-1.29
-    go: 1.23.6
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.29
-    - repository: api
-      branch: release-1.29
-    - repository: client-go
-      branch: release-1.29
-    - repository: apiserver
-      branch: release-1.29
-    - repository: code-generator
-      branch: release-1.29
-    - repository: kms
-      branch: release-1.29
-    - repository: component-base
-      branch: release-1.29
-    source:
-      branch: release-1.29
       dirs:
       - staging/src/k8s.io/sample-apiserver
     required-packages:
@@ -852,26 +717,6 @@ rules:
     smoke-test: |
       # assumes GO111MODULE=on
       go build -mod=mod .
-  - name: release-1.29
-    go: 1.23.6
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.29
-    - repository: api
-      branch: release-1.29
-    - repository: client-go
-      branch: release-1.29
-    - repository: code-generator
-      branch: release-1.29
-    source:
-      branch: release-1.29
-      dirs:
-      - staging/src/k8s.io/sample-controller
-    required-packages:
-    - k8s.io/code-generator
-    smoke-test: |
-      # assumes GO111MODULE=on
-      go build -mod=mod .
   - name: release-1.30
     go: 1.23.6
     dependencies:
@@ -971,29 +816,6 @@ rules:
       branch: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/apiextensions-apiserver
-    required-packages:
-    - k8s.io/code-generator
-  - name: release-1.29
-    go: 1.23.6
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.29
-    - repository: api
-      branch: release-1.29
-    - repository: client-go
-      branch: release-1.29
-    - repository: apiserver
-      branch: release-1.29
-    - repository: code-generator
-      branch: release-1.29
-    - repository: component-base
-      branch: release-1.29
-    - repository: kms
-      branch: release-1.29
-    source:
-      branch: release-1.29
       dirs:
       - staging/src/k8s.io/apiextensions-apiserver
     required-packages:
@@ -1105,21 +927,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/metrics
-  - name: release-1.29
-    go: 1.23.6
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.29
-    - repository: api
-      branch: release-1.29
-    - repository: client-go
-      branch: release-1.29
-    - repository: code-generator
-      branch: release-1.29
-    source:
-      branch: release-1.29
-      dirs:
-      - staging/src/k8s.io/metrics
   - name: release-1.30
     go: 1.23.6
     dependencies:
@@ -1194,19 +1001,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/cli-runtime
-  - name: release-1.29
-    go: 1.23.6
-    dependencies:
-    - repository: api
-      branch: release-1.29
-    - repository: apimachinery
-      branch: release-1.29
-    - repository: client-go
-      branch: release-1.29
-    source:
-      branch: release-1.29
-      dirs:
-      - staging/src/k8s.io/cli-runtime
   - name: release-1.30
     go: 1.23.6
     dependencies:
@@ -1273,21 +1067,6 @@ rules:
       branch: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/sample-cli-plugin
-  - name: release-1.29
-    go: 1.23.6
-    dependencies:
-    - repository: api
-      branch: release-1.29
-    - repository: apimachinery
-      branch: release-1.29
-    - repository: cli-runtime
-      branch: release-1.29
-    - repository: client-go
-      branch: release-1.29
-    source:
-      branch: release-1.29
       dirs:
       - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.30
@@ -1365,21 +1144,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/kube-proxy
-  - name: release-1.29
-    go: 1.23.6
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.29
-    - repository: component-base
-      branch: release-1.29
-    - repository: api
-      branch: release-1.29
-    - repository: client-go
-      branch: release-1.29
-    source:
-      branch: release-1.29
-      dirs:
-      - staging/src/k8s.io/kube-proxy
   - name: release-1.30
     go: 1.23.6
     dependencies:
@@ -1445,12 +1209,6 @@ rules:
   - name: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/cri-api
-  - name: release-1.29
-    go: 1.23.6
-    source:
-      branch: release-1.29
       dirs:
       - staging/src/k8s.io/cri-api
   - name: release-1.30
@@ -1568,27 +1326,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/kubelet
-  - name: release-1.29
-    go: 1.23.6
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.29
-    - repository: apiserver
-      branch: release-1.29
-    - repository: api
-      branch: release-1.29
-    - repository: client-go
-      branch: release-1.29
-    - repository: cri-api
-      branch: release-1.29
-    - repository: component-base
-      branch: release-1.29
-    - repository: kms
-      branch: release-1.29
-    source:
-      branch: release-1.29
-      dirs:
-      - staging/src/k8s.io/kubelet
   - name: release-1.30
     go: 1.23.6
     dependencies:
@@ -1689,21 +1426,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/kube-scheduler
-  - name: release-1.29
-    go: 1.23.6
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.29
-    - repository: component-base
-      branch: release-1.29
-    - repository: api
-      branch: release-1.29
-    - repository: client-go
-      branch: release-1.29
-    source:
-      branch: release-1.29
-      dirs:
-      - staging/src/k8s.io/kube-scheduler
   - name: release-1.30
     go: 1.23.6
     dependencies:
@@ -1782,25 +1504,6 @@ rules:
       branch: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/controller-manager
-  - name: release-1.29
-    go: 1.23.6
-    dependencies:
-    - repository: api
-      branch: release-1.29
-    - repository: apimachinery
-      branch: release-1.29
-    - repository: client-go
-      branch: release-1.29
-    - repository: component-base
-      branch: release-1.29
-    - repository: apiserver
-      branch: release-1.29
-    - repository: kms
-      branch: release-1.29
-    source:
-      branch: release-1.29
       dirs:
       - staging/src/k8s.io/controller-manager
   - name: release-1.30
@@ -1901,29 +1604,6 @@ rules:
       branch: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/cloud-provider
-  - name: release-1.29
-    go: 1.23.6
-    dependencies:
-    - repository: api
-      branch: release-1.29
-    - repository: apimachinery
-      branch: release-1.29
-    - repository: apiserver
-      branch: release-1.29
-    - repository: client-go
-      branch: release-1.29
-    - repository: component-base
-      branch: release-1.29
-    - repository: controller-manager
-      branch: release-1.29
-    - repository: component-helpers
-      branch: release-1.29
-    - repository: kms
-      branch: release-1.29
-    source:
-      branch: release-1.29
       dirs:
       - staging/src/k8s.io/cloud-provider
   - name: release-1.30
@@ -2044,31 +1724,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/kube-controller-manager
-  - name: release-1.29
-    go: 1.23.6
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.29
-    - repository: apiserver
-      branch: release-1.29
-    - repository: component-base
-      branch: release-1.29
-    - repository: api
-      branch: release-1.29
-    - repository: client-go
-      branch: release-1.29
-    - repository: controller-manager
-      branch: release-1.29
-    - repository: cloud-provider
-      branch: release-1.29
-    - repository: component-helpers
-      branch: release-1.29
-    - repository: kms
-      branch: release-1.29
-    source:
-      branch: release-1.29
-      dirs:
-      - staging/src/k8s.io/kube-controller-manager
   - name: release-1.30
     go: 1.23.6
     dependencies:
@@ -2181,17 +1836,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/cluster-bootstrap
-  - name: release-1.29
-    go: 1.23.6
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.29
-    - repository: api
-      branch: release-1.29
-    source:
-      branch: release-1.29
-      dirs:
-      - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.30
     go: 1.23.6
     dependencies:
@@ -2248,17 +1892,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/csi-translation-lib
-  - name: release-1.29
-    go: 1.23.6
-    dependencies:
-    - repository: api
-      branch: release-1.29
-    - repository: apimachinery
-      branch: release-1.29
-    source:
-      branch: release-1.29
-      dirs:
-      - staging/src/k8s.io/csi-translation-lib
   - name: release-1.30
     go: 1.23.6
     dependencies:
@@ -2310,12 +1943,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/mount-utils
-  - name: release-1.29
-    go: 1.23.6
-    source:
-      branch: release-1.29
-      dirs:
-      - staging/src/k8s.io/mount-utils
   - name: release-1.30
     go: 1.23.6
     source:
@@ -2342,31 +1969,6 @@ rules:
   library: true
 - destination: legacy-cloud-providers
   branches:
-  - name: release-1.29
-    go: 1.23.6
-    dependencies:
-    - repository: api
-      branch: release-1.29
-    - repository: apimachinery
-      branch: release-1.29
-    - repository: client-go
-      branch: release-1.29
-    - repository: cloud-provider
-      branch: release-1.29
-    - repository: apiserver
-      branch: release-1.29
-    - repository: component-base
-      branch: release-1.29
-    - repository: controller-manager
-      branch: release-1.29
-    - repository: component-helpers
-      branch: release-1.29
-    - repository: kms
-      branch: release-1.29
-    source:
-      branch: release-1.29
-      dirs:
-      - staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.30
     go: 1.23.6
     dependencies:
@@ -2415,29 +2017,6 @@ rules:
       branch: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/kubectl
-  - name: release-1.29
-    go: 1.23.6
-    dependencies:
-    - repository: api
-      branch: release-1.29
-    - repository: apimachinery
-      branch: release-1.29
-    - repository: cli-runtime
-      branch: release-1.29
-    - repository: client-go
-      branch: release-1.29
-    - repository: code-generator
-      branch: release-1.29
-    - repository: component-base
-      branch: release-1.29
-    - repository: component-helpers
-      branch: release-1.29
-    - repository: metrics
-      branch: release-1.29
-    source:
-      branch: release-1.29
       dirs:
       - staging/src/k8s.io/kubectl
   - name: release-1.30
@@ -2552,25 +2131,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/pod-security-admission
-  - name: release-1.29
-    go: 1.23.6
-    dependencies:
-    - repository: api
-      branch: release-1.29
-    - repository: apimachinery
-      branch: release-1.29
-    - repository: apiserver
-      branch: release-1.29
-    - repository: client-go
-      branch: release-1.29
-    - repository: component-base
-      branch: release-1.29
-    - repository: kms
-      branch: release-1.29
-    source:
-      branch: release-1.29
-      dirs:
-      - staging/src/k8s.io/pod-security-admission
   - name: release-1.30
     go: 1.23.6
     dependencies:
@@ -2671,27 +2231,6 @@ rules:
       branch: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/dynamic-resource-allocation
-  - name: release-1.29
-    go: 1.23.6
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.29
-    - repository: apiserver
-      branch: release-1.29
-    - repository: api
-      branch: release-1.29
-    - repository: client-go
-      branch: release-1.29
-    - repository: cri-api
-      branch: release-1.29
-    - repository: component-base
-      branch: release-1.29
-    - repository: kubelet
-      branch: release-1.29
-    source:
-      branch: release-1.29
       dirs:
       - staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.30
@@ -2805,21 +2344,6 @@ rules:
       branch: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/endpointslice
-  - name: release-1.29
-    go: 1.23.6
-    dependencies:
-    - repository: api
-      branch: release-1.29
-    - repository: apimachinery
-      branch: release-1.29
-    - repository: client-go
-      branch: release-1.29
-    - repository: component-base
-      branch: release-1.29
-    source:
-      branch: release-1.29
       dirs:
       - staging/src/k8s.io/endpointslice
   - name: release-1.30

--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -7,13 +7,13 @@ rules:
       dirs:
       - staging/src/k8s.io/apimachinery
   - name: release-1.30
-    go: 1.23.6
+    go: 1.23.8
     source:
       branch: release-1.30
       dirs:
       - staging/src/k8s.io/apimachinery
   - name: release-1.31
-    go: 1.23.6
+    go: 1.23.8
     source:
       branch: release-1.31
       dirs:
@@ -41,7 +41,7 @@ rules:
       dirs:
       - staging/src/k8s.io/api
   - name: release-1.30
-    go: 1.23.6
+    go: 1.23.8
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -50,7 +50,7 @@ rules:
       dirs:
       - staging/src/k8s.io/api
   - name: release-1.31
-    go: 1.23.6
+    go: 1.23.8
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -93,7 +93,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.30
-    go: 1.23.6
+    go: 1.23.8
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -108,7 +108,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.31
-    go: 1.23.6
+    go: 1.23.8
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -163,7 +163,7 @@ rules:
       dirs:
       - staging/src/k8s.io/code-generator
   - name: release-1.30
-    go: 1.23.6
+    go: 1.23.8
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -172,7 +172,7 @@ rules:
       dirs:
       - staging/src/k8s.io/code-generator
   - name: release-1.31
-    go: 1.23.6
+    go: 1.23.8
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -212,7 +212,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-base
   - name: release-1.30
-    go: 1.23.6
+    go: 1.23.8
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -225,7 +225,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-base
   - name: release-1.31
-    go: 1.23.6
+    go: 1.23.8
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -278,7 +278,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-helpers
   - name: release-1.30
-    go: 1.23.6
+    go: 1.23.8
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -291,7 +291,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-helpers
   - name: release-1.31
-    go: 1.23.6
+    go: 1.23.8
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -340,7 +340,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kms
   - name: release-1.30
-    go: 1.23.6
+    go: 1.23.8
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -349,7 +349,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kms
   - name: release-1.31
-    go: 1.23.6
+    go: 1.23.8
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -394,7 +394,7 @@ rules:
       dirs:
       - staging/src/k8s.io/apiserver
   - name: release-1.30
-    go: 1.23.6
+    go: 1.23.8
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -411,7 +411,7 @@ rules:
       dirs:
       - staging/src/k8s.io/apiserver
   - name: release-1.31
-    go: 1.23.6
+    go: 1.23.8
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -484,7 +484,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-aggregator
   - name: release-1.30
-    go: 1.23.6
+    go: 1.23.8
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -505,7 +505,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-aggregator
   - name: release-1.31
-    go: 1.23.6
+    go: 1.23.8
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -594,7 +594,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.30
-    go: 1.23.6
+    go: 1.23.8
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -620,7 +620,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.31
-    go: 1.23.6
+    go: 1.23.8
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -718,7 +718,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.30
-    go: 1.23.6
+    go: 1.23.8
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -738,7 +738,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.31
-    go: 1.23.6
+    go: 1.23.8
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -821,7 +821,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.30
-    go: 1.23.6
+    go: 1.23.8
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -844,7 +844,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.31
-    go: 1.23.6
+    go: 1.23.8
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -928,7 +928,7 @@ rules:
       dirs:
       - staging/src/k8s.io/metrics
   - name: release-1.30
-    go: 1.23.6
+    go: 1.23.8
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -943,7 +943,7 @@ rules:
       dirs:
       - staging/src/k8s.io/metrics
   - name: release-1.31
-    go: 1.23.6
+    go: 1.23.8
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -1002,7 +1002,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cli-runtime
   - name: release-1.30
-    go: 1.23.6
+    go: 1.23.8
     dependencies:
     - repository: api
       branch: release-1.30
@@ -1015,7 +1015,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cli-runtime
   - name: release-1.31
-    go: 1.23.6
+    go: 1.23.8
     dependencies:
     - repository: api
       branch: release-1.31
@@ -1070,7 +1070,7 @@ rules:
       dirs:
       - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.30
-    go: 1.23.6
+    go: 1.23.8
     dependencies:
     - repository: api
       branch: release-1.30
@@ -1085,7 +1085,7 @@ rules:
       dirs:
       - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.31
-    go: 1.23.6
+    go: 1.23.8
     dependencies:
     - repository: api
       branch: release-1.31
@@ -1145,7 +1145,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-proxy
   - name: release-1.30
-    go: 1.23.6
+    go: 1.23.8
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -1160,7 +1160,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-proxy
   - name: release-1.31
-    go: 1.23.6
+    go: 1.23.8
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -1212,13 +1212,13 @@ rules:
       dirs:
       - staging/src/k8s.io/cri-api
   - name: release-1.30
-    go: 1.23.6
+    go: 1.23.8
     source:
       branch: release-1.30
       dirs:
       - staging/src/k8s.io/cri-api
   - name: release-1.31
-    go: 1.23.6
+    go: 1.23.8
     source:
       branch: release-1.31
       dirs:
@@ -1254,7 +1254,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cri-client
   - name: release-1.31
-    go: 1.23.6
+    go: 1.23.8
     dependencies:
     - repository: api
       branch: release-1.31
@@ -1327,7 +1327,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubelet
   - name: release-1.30
-    go: 1.23.6
+    go: 1.23.8
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -1348,7 +1348,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubelet
   - name: release-1.31
-    go: 1.23.6
+    go: 1.23.8
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -1427,7 +1427,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-scheduler
   - name: release-1.30
-    go: 1.23.6
+    go: 1.23.8
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -1442,7 +1442,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-scheduler
   - name: release-1.31
-    go: 1.23.6
+    go: 1.23.8
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -1507,7 +1507,7 @@ rules:
       dirs:
       - staging/src/k8s.io/controller-manager
   - name: release-1.30
-    go: 1.23.6
+    go: 1.23.8
     dependencies:
     - repository: api
       branch: release-1.30
@@ -1526,7 +1526,7 @@ rules:
       dirs:
       - staging/src/k8s.io/controller-manager
   - name: release-1.31
-    go: 1.23.6
+    go: 1.23.8
     dependencies:
     - repository: api
       branch: release-1.31
@@ -1607,7 +1607,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cloud-provider
   - name: release-1.30
-    go: 1.23.6
+    go: 1.23.8
     dependencies:
     - repository: api
       branch: release-1.30
@@ -1630,7 +1630,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cloud-provider
   - name: release-1.31
-    go: 1.23.6
+    go: 1.23.8
     dependencies:
     - repository: api
       branch: release-1.31
@@ -1725,7 +1725,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-controller-manager
   - name: release-1.30
-    go: 1.23.6
+    go: 1.23.8
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -1750,7 +1750,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-controller-manager
   - name: release-1.31
-    go: 1.23.6
+    go: 1.23.8
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -1837,7 +1837,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.30
-    go: 1.23.6
+    go: 1.23.8
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -1848,7 +1848,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.31
-    go: 1.23.6
+    go: 1.23.8
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -1893,7 +1893,7 @@ rules:
       dirs:
       - staging/src/k8s.io/csi-translation-lib
   - name: release-1.30
-    go: 1.23.6
+    go: 1.23.8
     dependencies:
     - repository: api
       branch: release-1.30
@@ -1904,7 +1904,7 @@ rules:
       dirs:
       - staging/src/k8s.io/csi-translation-lib
   - name: release-1.31
-    go: 1.23.6
+    go: 1.23.8
     dependencies:
     - repository: api
       branch: release-1.31
@@ -1944,13 +1944,13 @@ rules:
       dirs:
       - staging/src/k8s.io/mount-utils
   - name: release-1.30
-    go: 1.23.6
+    go: 1.23.8
     source:
       branch: release-1.30
       dirs:
       - staging/src/k8s.io/mount-utils
   - name: release-1.31
-    go: 1.23.6
+    go: 1.23.8
     source:
       branch: release-1.31
       dirs:
@@ -1970,7 +1970,7 @@ rules:
 - destination: legacy-cloud-providers
   branches:
   - name: release-1.30
-    go: 1.23.6
+    go: 1.23.8
     dependencies:
     - repository: api
       branch: release-1.30
@@ -2020,7 +2020,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubectl
   - name: release-1.30
-    go: 1.23.6
+    go: 1.23.8
     dependencies:
     - repository: api
       branch: release-1.30
@@ -2043,7 +2043,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubectl
   - name: release-1.31
-    go: 1.23.6
+    go: 1.23.8
     dependencies:
     - repository: api
       branch: release-1.31
@@ -2132,7 +2132,7 @@ rules:
       dirs:
       - staging/src/k8s.io/pod-security-admission
   - name: release-1.30
-    go: 1.23.6
+    go: 1.23.8
     dependencies:
     - repository: api
       branch: release-1.30
@@ -2151,7 +2151,7 @@ rules:
       dirs:
       - staging/src/k8s.io/pod-security-admission
   - name: release-1.31
-    go: 1.23.6
+    go: 1.23.8
     dependencies:
     - repository: api
       branch: release-1.31
@@ -2234,7 +2234,7 @@ rules:
       dirs:
       - staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.30
-    go: 1.23.6
+    go: 1.23.8
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -2257,7 +2257,7 @@ rules:
       dirs:
       - staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.31
-    go: 1.23.6
+    go: 1.23.8
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -2347,7 +2347,7 @@ rules:
       dirs:
       - staging/src/k8s.io/endpointslice
   - name: release-1.30
-    go: 1.23.6
+    go: 1.23.8
     dependencies:
     - repository: api
       branch: release-1.30
@@ -2362,7 +2362,7 @@ rules:
       dirs:
       - staging/src/k8s.io/endpointslice
   - name: release-1.31
-    go: 1.23.6
+    go: 1.23.8
     dependencies:
     - repository: api
       branch: release-1.31


### PR DESCRIPTION

#### What type of PR is this?


/kind cleanup

#### What this PR does / why we need it:

- update publishing rules for rel 1.30/31/32 to use go1.23.8 and drop release-1.29 config

/assign @liggitt @dims @saschagrunert @xmudrii @ameukam 
cc @kubernetes/release-managers 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
