### PR TITLE
Add ResourceSlices field to kubectl describe node

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/describe/describe.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe.go
@@ -49,6 +49,7 @@ import (
 	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	resourcev1 "k8s.io/api/resource/v1"
 	schedulingv1 "k8s.io/api/scheduling/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -3477,7 +3478,15 @@ func (d *NodeDescriber) Describe(namespace, name string, describerSettings Descr
 		}
 	}
 
-	return describeNode(node, nodeNonTerminatedPodsList, events, canViewPods, &LeaseDescriber{d})
+	// Fetch ResourceSlices exclusive to this node using indexed field selector (O(1) query)
+	var resourceSlices []resourcev1.ResourceSlice
+	if sliceList, err := d.ResourceV1().ResourceSlices().List(context.TODO(), metav1.ListOptions{
+		FieldSelector: fields.Set{resourcev1.ResourceSliceSelectorNodeName: node.Name}.AsSelector().String(),
+	}); err == nil {
+		resourceSlices = sliceList.Items
+	}
+
+	return describeNode(node, nodeNonTerminatedPodsList, events, canViewPods, &LeaseDescriber{d}, resourceSlices)
 }
 
 type LeaseDescriber struct {
@@ -3485,7 +3494,7 @@ type LeaseDescriber struct {
 }
 
 func describeNode(node *corev1.Node, nodeNonTerminatedPodsList *corev1.PodList, events *corev1.EventList,
-	canViewPods bool, ld *LeaseDescriber) (string, error) {
+	canViewPods bool, ld *LeaseDescriber, resourceSlices []resourcev1.ResourceSlice) (string, error) {
 	return tabbedString(func(out io.Writer) error {
 		w := NewPrefixWriter(out)
 		w.Write(LEVEL_0, "Name:\t%s\n", node.Name)
@@ -3547,6 +3556,9 @@ func describeNode(node *corev1.Node, nodeNonTerminatedPodsList *corev1.PodList, 
 			w.Write(LEVEL_0, "Allocatable:\n")
 			printResourceList(node.Status.Allocatable)
 		}
+		if len(resourceSlices) > 0 {
+			describeNodeResourceSlices(w, resourceSlices)
+		}
 
 		w.Write(LEVEL_0, "System Info:\n")
 		w.Write(LEVEL_0, "  Machine ID:\t%s\n", node.Status.NodeInfo.MachineID)
@@ -3580,6 +3592,58 @@ func describeNode(node *corev1.Node, nodeNonTerminatedPodsList *corev1.PodList, 
 		}
 		return nil
 	})
+}
+
+// describeNodeResourceSlices displays ResourceSlices that are exclusive to this node.
+// It aggregates slices by driver/pool and shows device counts, with output capped at 10 pools.
+func describeNodeResourceSlices(w PrefixWriter, resourceSlices []resourcev1.ResourceSlice) {
+	// Aggregate by driver/pool
+	type poolInfo struct {
+		driver      string
+		pool        string
+		sliceCount  int
+		deviceCount int
+	}
+	pools := make(map[string]*poolInfo)
+
+	for _, slice := range resourceSlices {
+		key := slice.Spec.Driver + "/" + slice.Spec.Pool.Name
+		if pools[key] == nil {
+			pools[key] = &poolInfo{
+				driver: slice.Spec.Driver,
+				pool:   slice.Spec.Pool.Name,
+			}
+		}
+		pools[key].sliceCount++
+		pools[key].deviceCount += len(slice.Spec.Devices)
+	}
+
+	if len(pools) == 0 {
+		return
+	}
+
+	// Sort pool keys for consistent output
+	sortedKeys := make([]string, 0, len(pools))
+	for k := range pools {
+		sortedKeys = append(sortedKeys, k)
+	}
+	sort.Strings(sortedKeys)
+
+	w.Write(LEVEL_0, "Node-Local ResourceSlices:\n")
+	w.Write(LEVEL_1, "Driver\tPool\tSlices\tDevices\n")
+	w.Write(LEVEL_1, "------\t----\t------\t-------\n")
+
+	const maxPoolsToShow = 10
+	shown := 0
+	for _, key := range sortedKeys {
+		if shown >= maxPoolsToShow {
+			w.Write(LEVEL_1, "...and %d more pools\n", len(sortedKeys)-maxPoolsToShow)
+			break
+		}
+		p := pools[key]
+		w.Write(LEVEL_1, "%s\t%s\t%d\t%d\n", p.driver, p.pool, p.sliceCount, p.deviceCount)
+		shown++
+	}
 }
 
 func describeNodeLease(lease *coordinationv1.Lease, w PrefixWriter) {

--- a/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
@@ -41,6 +41,7 @@ import (
 	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	resourcev1 "k8s.io/api/resource/v1"
 	schedulingv1 "k8s.io/api/scheduling/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
@@ -6690,6 +6691,156 @@ func TestDescribeNodeWithPodLevelResources(t *testing.T) {
 	}
 }
 
+func TestDescribeNodeWithResourceSlice(t *testing.T) {
+	nodeCapacity := mergeResourceLists(
+		getHugePageResourceList("2Mi", "4Gi"),
+		getResourceList("8", "24Gi"),
+		getHugePageResourceList("1Gi", "0"),
+	)
+	nodeAllocatable := mergeResourceLists(
+		getHugePageResourceList("2Mi", "2Gi"),
+		getResourceList("4", "12Gi"),
+		getHugePageResourceList("1Gi", "0"),
+	)
+
+	fake := fake.NewClientset(
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "bar",
+				UID:  "uid",
+			},
+			Spec: corev1.NodeSpec{
+				Unschedulable: true,
+			},
+			Status: corev1.NodeStatus{
+				Capacity:    nodeCapacity,
+				Allocatable: nodeAllocatable,
+			},
+		},
+		&resourcev1.ResourceSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "slice-1",
+			},
+			Spec: resourcev1.ResourceSliceSpec{
+				NodeName: ptr.To("bar"),
+				Driver:   "nvidia.com/gpu",
+				Pool: resourcev1.ResourcePool{
+					Name: "gpu-pool",
+				},
+				Devices: []resourcev1.Device{
+					{Name: "gpu-0"},
+					{Name: "gpu-1"},
+				},
+			},
+		},
+		&resourcev1.ResourceSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "slice-2",
+			},
+			Spec: resourcev1.ResourceSliceSpec{
+				NodeName: ptr.To("bar"),
+				Driver:   "nvidia.com/gpu",
+				Pool: resourcev1.ResourcePool{
+					Name: "gpu-pool",
+				},
+				Devices: []resourcev1.Device{
+					{Name: "gpu-2"},
+					{Name: "gpu-3"},
+				},
+			},
+		},
+	)
+	c := &describeClient{T: t, Namespace: "foo", Interface: fake}
+	d := NodeDescriber{c}
+	out, err := d.Describe("foo", "bar", DescriberSettings{ShowEvents: true})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// Verify node-exclusive resource slices are shown aggregated by pool
+	expectedOut := []string{
+		"Unschedulable",
+		"true",
+		"Node-Local ResourceSlices:",
+		"Driver",
+		"Pool",
+		"Slices",
+		"Devices",
+		"nvidia.com/gpu",
+		"gpu-pool",
+	}
+	for _, expected := range expectedOut {
+		if !strings.Contains(out, expected) {
+			t.Errorf("expected to find %q in output: %q", expected, out)
+		}
+	}
+}
+
+func TestDescribeNodeWithResourceSliceCapping(t *testing.T) {
+	// Create a node with more than 10 pools to test capping
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "bar",
+			UID:  "uid",
+		},
+	}
+
+	objects := []runtime.Object{node}
+
+	// Create 12 different driver/pool combinations
+	for i := range 12 {
+		objects = append(objects, &resourcev1.ResourceSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: fmt.Sprintf("slice-%d", i),
+			},
+			Spec: resourcev1.ResourceSliceSpec{
+				NodeName: ptr.To("bar"),
+				Driver:   fmt.Sprintf("driver-%d.example.com", i),
+				Pool: resourcev1.ResourcePool{
+					Name: fmt.Sprintf("pool-%d", i),
+				},
+				Devices: []resourcev1.Device{
+					{Name: "device-0"},
+				},
+			},
+		})
+	}
+
+	fake := fake.NewClientset(objects...)
+	c := &describeClient{T: t, Namespace: "foo", Interface: fake}
+	d := NodeDescriber{c}
+	out, err := d.Describe("foo", "bar", DescriberSettings{ShowEvents: true})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// Should show capping message
+	if !strings.Contains(out, "...and 2 more pools") {
+		t.Errorf("expected capping message in output: %q", out)
+	}
+}
+
+func TestDescribeNodeWithNoResourceSlices(t *testing.T) {
+	fake := fake.NewClientset(
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "bar",
+				UID:  "uid",
+			},
+		},
+	)
+	c := &describeClient{T: t, Namespace: "foo", Interface: fake}
+	d := NodeDescriber{c}
+	out, err := d.Describe("foo", "bar", DescriberSettings{ShowEvents: true})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// Should NOT show ResourceSlices section when there are none
+	if strings.Contains(out, "Node-Local ResourceSlices") {
+		t.Errorf("did not expect ResourceSlices section when there are no slices: %q", out)
+	}
+}
 func TestDescribeStatefulSet(t *testing.T) {
 	var partition int32 = 2672
 	var replicas int32 = 1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds a **ResourceSlices** section to `kubectl describe node`

#### Which issue(s) this PR fixes:

Fixes #XXXXXX <!-- Substitute with the tracking issue ID -->

#### Does this PR introduce a user-facing change?

```release-note
kubectl: `kubectl describe node` now lists aggregated **ResourceSlices** when the `ResourceSlice` API is present, detailing slice name, driver, and pool.
```
