### PR TITLE
WIP: prevent code generators adding testing imports

### DIFF
--- a/hack/verify-testing-import.sh
+++ b/hack/verify-testing-import.sh
@@ -30,7 +30,8 @@ cd "${KUBE_ROOT}"
 
 kube::golang::setup_env
 
-RELEASE_BIN_PKGS=(
+BIN_PKGS=(
+  # release binaries
   "${KUBE_ROOT}/cmd/cloud-controller-manager"
   "${KUBE_ROOT}/cmd/kube-apiserver"
   "${KUBE_ROOT}/cmd/kube-controller-manager"
@@ -40,10 +41,12 @@ RELEASE_BIN_PKGS=(
   "${KUBE_ROOT}/cmd/kubectl-convert"
   "${KUBE_ROOT}/cmd/kubelet"
   "${KUBE_ROOT}/cmd/kubeadm"
+  # code generators
+  "${KUBE_ROOT}"/staging/src/k8s.io/code-generator/cmd/*/
 )
 
 pkgs_with_testing_import=()
-for file in "${RELEASE_BIN_PKGS[@]}"
+for file in "${BIN_PKGS[@]}"
 do
   if [ "$(go list -json "${file}" | jq 'any(.Deps[]; . == "testing")')" == "true" ]
   then

--- a/hack/verify-testing-import.sh
+++ b/hack/verify-testing-import.sh
@@ -32,32 +32,32 @@ kube::golang::setup_env
 
 BIN_PKGS=(
   # release binaries
-  "${KUBE_ROOT}/cmd/cloud-controller-manager"
-  "${KUBE_ROOT}/cmd/kube-apiserver"
-  "${KUBE_ROOT}/cmd/kube-controller-manager"
-  "${KUBE_ROOT}/cmd/kube-proxy"
-  "${KUBE_ROOT}/cmd/kube-scheduler"
-  "${KUBE_ROOT}/cmd/kubectl"
-  "${KUBE_ROOT}/cmd/kubectl-convert"
-  "${KUBE_ROOT}/cmd/kubelet"
-  "${KUBE_ROOT}/cmd/kubeadm"
+  ./cmd/cloud-controller-manager
+  ./cmd/kube-apiserver
+  ./cmd/kube-controller-manager
+  ./cmd/kube-proxy
+  ./cmd/kube-scheduler
+  ./cmd/kubectl
+  ./cmd/kubectl-convert
+  ./cmd/kubelet
+  ./cmd/kubeadm
   # code generators
-  "${KUBE_ROOT}"/staging/src/k8s.io/code-generator/cmd/*/
+  ./staging/src/k8s.io/code-generator/cmd/*/
 )
 
 pkgs_with_testing_import=()
 for pkg in "${BIN_PKGS[@]}"
 do
-  if [ "$(go list -json "${pkg}" | jq 'any(.Deps[]; . == "testing")')" == "true" ]
-  then
-    pkgs_with_testing_import+=( "${pkg}" )
+  testing_deps="$(go list -json "${pkg}" | jq -r '[.Deps[] | select(endswith("testing")) ]| join(", ")')"
+  if [ -n "${testing_deps}" ]; then
+    pkgs_with_testing_import+=( "${pkg}: ${testing_deps}" )
   fi
 done
 
 if [ ${#pkgs_with_testing_import[@]} -ne 0 ]; then
-  printf "%s\n" "Testing package imported in:"
+  printf "%s\n" "Testing packages are imported in:"
   for pkg in "${pkgs_with_testing_import[@]}"; do
-    printf "\t%s\n" "${pkg}"
+    printf "  %s\n" "${pkg}"
   done
   exit 1
 fi

--- a/hack/verify-testing-import.sh
+++ b/hack/verify-testing-import.sh
@@ -62,6 +62,3 @@ if [ ${#pkgs_with_testing_import[@]} -ne 0 ]; then
   done
   exit 1
 fi
-
-exit 0
-

--- a/hack/verify-testing-import.sh
+++ b/hack/verify-testing-import.sh
@@ -29,6 +29,7 @@ source "${KUBE_ROOT}/hack/lib/init.sh"
 cd "${KUBE_ROOT}"
 
 kube::golang::setup_env
+kube::util::require-jq
 
 BIN_PKGS=(
   # release binaries

--- a/hack/verify-testing-import.sh
+++ b/hack/verify-testing-import.sh
@@ -46,18 +46,18 @@ BIN_PKGS=(
 )
 
 pkgs_with_testing_import=()
-for file in "${BIN_PKGS[@]}"
+for pkg in "${BIN_PKGS[@]}"
 do
-  if [ "$(go list -json "${file}" | jq 'any(.Deps[]; . == "testing")')" == "true" ]
+  if [ "$(go list -json "${pkg}" | jq 'any(.Deps[]; . == "testing")')" == "true" ]
   then
-    pkgs_with_testing_import+=( "${file}" )
+    pkgs_with_testing_import+=( "${pkg}" )
   fi
 done
 
 if [ ${#pkgs_with_testing_import[@]} -ne 0 ]; then
   printf "%s\n" "Testing package imported in:"
-  for file in "${pkgs_with_testing_import[@]}"; do
-    printf "\t%s\n" "${file}"
+  for pkg in "${pkgs_with_testing_import[@]}"; do
+    printf "\t%s\n" "${pkg}"
   done
   exit 1
 fi

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -307,7 +307,7 @@ func newTestKubeletWithImageList(
 	volumeStatsAggPeriod := time.Second * 10
 	kubelet.resourceAnalyzer = serverstats.NewResourceAnalyzer(kubelet, volumeStatsAggPeriod, kubelet.recorder)
 
-	fakeHostStatsProvider := stats.NewFakeHostStatsProvider()
+	fakeHostStatsProvider := stats.NewFakeHostStatsProvider(&containertest.FakeOS{})
 
 	kubelet.StatsProvider = stats.NewCadvisorStatsProvider(
 		kubelet.cadvisor,

--- a/pkg/kubelet/stats/cadvisor_stats_provider_test.go
+++ b/pkg/kubelet/stats/cadvisor_stats_provider_test.go
@@ -273,7 +273,7 @@ func TestCadvisorListPodStats(t *testing.T) {
 
 	resourceAnalyzer := &fakeResourceAnalyzer{podVolumeStats: volumeStats}
 
-	p := NewCadvisorStatsProvider(mockCadvisor, resourceAnalyzer, nil, nil, mockRuntime, mockStatus, NewFakeHostStatsProvider())
+	p := NewCadvisorStatsProvider(mockCadvisor, resourceAnalyzer, nil, nil, mockRuntime, mockStatus, NewFakeHostStatsProvider(&containertest.FakeOS{}))
 	pods, err := p.ListPodStats(ctx)
 	assert.NoError(t, err)
 
@@ -459,7 +459,7 @@ func TestCadvisorListPodCPUAndMemoryStats(t *testing.T) {
 
 	resourceAnalyzer := &fakeResourceAnalyzer{podVolumeStats: volumeStats}
 
-	p := NewCadvisorStatsProvider(mockCadvisor, resourceAnalyzer, nil, nil, nil, nil, NewFakeHostStatsProvider())
+	p := NewCadvisorStatsProvider(mockCadvisor, resourceAnalyzer, nil, nil, nil, nil, NewFakeHostStatsProvider(&containertest.FakeOS{}))
 	pods, err := p.ListPodCPUAndMemoryStats(ctx)
 	assert.NoError(t, err)
 
@@ -563,7 +563,7 @@ func TestCadvisorImagesFsStatsKubeletSeparateDiskOff(t *testing.T) {
 	mockCadvisor.EXPECT().ImagesFsInfo(ctx).Return(imageFsInfo, nil)
 	mockRuntime.EXPECT().ImageStats(ctx).Return(imageStats, nil)
 
-	provider := newCadvisorStatsProvider(mockCadvisor, &fakeResourceAnalyzer{}, mockRuntime, nil, NewFakeHostStatsProvider())
+	provider := newCadvisorStatsProvider(mockCadvisor, &fakeResourceAnalyzer{}, mockRuntime, nil, NewFakeHostStatsProvider(&containertest.FakeOS{}))
 	stats, _, err := provider.ImageFsStats(ctx)
 	assert.NoError(err)
 
@@ -644,7 +644,7 @@ func TestImageFsStatsCustomResponse(t *testing.T) {
 			mockCadvisor.EXPECT().ContainerFsInfo(ctx).Return(res, nil)
 		}
 
-		provider := newCadvisorStatsProvider(mockCadvisor, &fakeResourceAnalyzer{}, mockRuntime, nil, NewFakeHostStatsProvider())
+		provider := newCadvisorStatsProvider(mockCadvisor, &fakeResourceAnalyzer{}, mockRuntime, nil, NewFakeHostStatsProvider(&containertest.FakeOS{}))
 		stats, containerfs, err := provider.ImageFsStats(ctx)
 		if tc.shouldErr {
 			require.Error(t, err, desc)
@@ -681,7 +681,7 @@ func TestCadvisorImagesFsStats(t *testing.T) {
 	mockCadvisor.EXPECT().ImagesFsInfo(ctx).Return(imageFsInfo, nil)
 	mockRuntime.EXPECT().ImageFsInfo(ctx).Return(imageFsInfoResponse, nil)
 
-	provider := newCadvisorStatsProvider(mockCadvisor, &fakeResourceAnalyzer{}, mockRuntime, nil, NewFakeHostStatsProvider())
+	provider := newCadvisorStatsProvider(mockCadvisor, &fakeResourceAnalyzer{}, mockRuntime, nil, NewFakeHostStatsProvider(&containertest.FakeOS{}))
 	stats, containerfs, err := provider.ImageFsStats(ctx)
 	assert.NoError(err)
 
@@ -735,7 +735,7 @@ func TestCadvisorSplitImagesFsStats(t *testing.T) {
 	mockRuntime.EXPECT().ImageFsInfo(ctx).Return(imageFsInfoResponse, nil)
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.KubeletSeparateDiskGC, true)
 
-	provider := newCadvisorStatsProvider(mockCadvisor, &fakeResourceAnalyzer{}, mockRuntime, nil, NewFakeHostStatsProvider())
+	provider := newCadvisorStatsProvider(mockCadvisor, &fakeResourceAnalyzer{}, mockRuntime, nil, NewFakeHostStatsProvider(&containertest.FakeOS{}))
 	stats, containerfs, err := provider.ImageFsStats(ctx)
 	assert.NoError(err)
 
@@ -788,7 +788,7 @@ func TestCadvisorSameDiskDifferentLocations(t *testing.T) {
 	mockRuntime.EXPECT().ImageFsInfo(ctx).Return(imageFsInfoResponse, nil)
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.KubeletSeparateDiskGC, true)
 
-	provider := newCadvisorStatsProvider(mockCadvisor, &fakeResourceAnalyzer{}, mockRuntime, nil, NewFakeHostStatsProvider())
+	provider := newCadvisorStatsProvider(mockCadvisor, &fakeResourceAnalyzer{}, mockRuntime, nil, NewFakeHostStatsProvider(&containertest.FakeOS{}))
 	stats, containerfs, err := provider.ImageFsStats(ctx)
 	require.NoError(t, err, "imageFsStats should have no error")
 

--- a/pkg/kubelet/stats/cri_stats_provider_test.go
+++ b/pkg/kubelet/stats/cri_stats_provider_test.go
@@ -656,7 +656,7 @@ func TestCRIListPodCPUAndMemoryStats(t *testing.T) {
 		mockRuntimeCache,
 		fakeRuntimeService,
 		nil,
-		NewFakeHostStatsProvider(),
+		NewFakeHostStatsProvider(&kubecontainertest.FakeOS{}),
 		false,
 	)
 
@@ -791,7 +791,7 @@ func TestCRIImagesFsStats(t *testing.T) {
 		mockRuntimeCache,
 		fakeRuntimeService,
 		fakeImageService,
-		NewFakeHostStatsProvider(),
+		NewFakeHostStatsProvider(&kubecontainertest.FakeOS{}),
 		false,
 	)
 

--- a/pkg/kubelet/stats/host_stats_provider_fake.go
+++ b/pkg/kubelet/stats/host_stats_provider_fake.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	statsapi "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
-	kubecontainertest "k8s.io/kubernetes/pkg/kubelet/container/testing"
 	"k8s.io/kubernetes/pkg/kubelet/kuberuntime"
 	"k8s.io/kubernetes/pkg/volume"
 )
@@ -35,9 +34,9 @@ type fakeHostStatsProvider struct {
 }
 
 // NewFakeHostStatsProvider provides a way to test with fake host statistics
-func NewFakeHostStatsProvider() HostStatsProvider {
+func NewFakeHostStatsProvider(osInterface kubecontainer.OSInterface) HostStatsProvider {
 	return &fakeHostStatsProvider{
-		osInterface: &kubecontainertest.FakeOS{},
+		osInterface: osInterface,
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:

- adds code generators to verify-testing-import.sh
- cleans up misleading loop variable (file => pkg)
- ensures jq is actually available
- detects all `*testing` imports in non-test code, not just the stdlib "testing" package
- drops unnecessary exit 0
- ensures kubelet does not link testing package into prod packages via minor refactor

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/131646

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
/sig testing api-machinery
