### PR TITLE
[WIP]Release unallocated reusable CPUs in reconcile loop

### DIFF
--- a/pkg/kubelet/cm/cpumanager/cpu_manager.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/klog/v2"
 
 	kubefeatures "k8s.io/kubernetes/pkg/features"
+	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/kubelet/cm/containermap"
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpumanager/state"
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpumanager/topology"
@@ -445,6 +446,54 @@ func (m *manager) removeStaleState(rootLogger logr.Logger) {
 	})
 }
 
+func (m *manager) isAllInitContainerTerminated(rootLogger logr.Logger, pod *v1.Pod) bool {
+	podLogger := klog.LoggerWithValues(rootLogger, "pod", klog.KObj(pod))
+	pstatus, ok := m.podStatusProvider.GetPodStatus(pod.UID)
+	if !ok {
+		podLogger.V(5).Info("skipping pod; status not found")
+		return false
+	}
+	for _, container := range pod.Spec.InitContainers {
+		if !podutil.IsRestartableInitContainer(&container) {
+			continue
+		}
+		logger := klog.LoggerWithValues(podLogger, "containerName", container.Name)
+
+		cstatus, err := findContainerStatusByName(&pstatus, container.Name)
+		if err != nil {
+			logger.V(5).Info("skipping container; ID not found in pod status", "err", err)
+			return false
+		}
+
+		if cstatus.State.Terminated == nil {
+			return false
+		}
+	}
+	return true
+}
+
+// If there are leaked CPUs of a Pod, release them and reallocate CPUs for the InitContainer which assigned leaked CPUs.
+func (m *manager) releasePodUnallocatedCPUs(rootLogger logr.Logger) {
+	for _, pod := range m.activePods() {
+		if !m.isAllInitContainerTerminated(rootLogger, pod) {
+			continue
+		}
+
+		// 1. Calculate and release all leaked CPUs
+		leakedCPUs := m.policy.ReleaseLeakedCPUs(rootLogger, m.state, pod)
+		if leakedCPUs.Size() == 0 {
+			continue
+		}
+		// 2. Update non-restartable InitContainer CPUs
+		for _, initC := range pod.Spec.InitContainers {
+			if podutil.IsRestartableInitContainer(&initC) {
+				continue
+			}
+			m.policy.UpdateCPUsForInitC(rootLogger, m.state, pod, initC.Name, leakedCPUs)
+		}
+	}
+}
+
 func (m *manager) reconcileState(ctx context.Context) (success []reconciledContainer, failure []reconciledContainer) {
 	success = []reconciledContainer{}
 	failure = []reconciledContainer{}
@@ -452,6 +501,7 @@ func (m *manager) reconcileState(ctx context.Context) (success []reconciledConta
 	rootLogger := klog.FromContext(ctx)
 
 	m.removeStaleState(rootLogger)
+	m.releasePodUnallocatedCPUs(rootLogger)
 	for _, pod := range m.activePods() {
 		podLogger := klog.LoggerWithValues(rootLogger, "pod", klog.KObj(pod))
 

--- a/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
@@ -165,6 +165,51 @@ func (p *mockPolicy) GetAllocatableCPUs(m state.State) cpuset.CPUSet {
 	return cpuset.New()
 }
 
+func (p *mockPolicy) ReleaseLeakedCPUs(logger logr.Logger, s state.State, pod *v1.Pod) cpuset.CPUSet {
+	// If pod has no init containers, no leaked CPUs to release
+	if len(pod.Spec.InitContainers) == 0 {
+		return cpuset.New()
+	}
+
+	// Simulate releasing leaked CPUs from init containers
+	leakedCPUs := cpuset.New()
+	if assignments, exists := s.GetCPUAssignments()[string(pod.UID)]; exists {
+		for containerName, cset := range assignments {
+			// Check if this is an init container
+			for _, initC := range pod.Spec.InitContainers {
+				if initC.Name == containerName {
+					// If this is a sidecar container, keep all its CPUs
+					if initC.RestartPolicy != nil && *initC.RestartPolicy == v1.ContainerRestartPolicyAlways {
+						// Sidecar containers keep all their CPUs, no leakage
+						continue
+					}
+
+					// Simulate some leaked CPUs (remove some from the assignment)
+					if cset.Size() > 2 {
+						// Get the first 2 CPUs to keep, release the rest
+						cpus := cset.List()
+						if len(cpus) > 2 {
+							keepCPUs := cpuset.New(cpus[0], cpus[1])
+							leakedFromContainer := cset.Difference(keepCPUs)
+							leakedCPUs = leakedCPUs.Union(leakedFromContainer)
+						}
+					}
+					break
+				}
+			}
+		}
+	}
+
+	// Update default CPUSet to include leaked CPUs
+	defaultSet := s.GetDefaultCPUSet()
+	s.SetDefaultCPUSet(defaultSet.Union(leakedCPUs))
+
+	return leakedCPUs
+}
+
+func (p *mockPolicy) UpdateCPUsForInitC(logger logr.Logger, s state.State, pod *v1.Pod, containerName string, leakedCPUs cpuset.CPUSet) {
+}
+
 type mockRuntimeService struct {
 	err error
 }
@@ -1536,6 +1581,213 @@ func TestCPUManagerHandlePolicyOptions(t *testing.T) {
 			}
 		})
 
+	}
+}
+
+func TestReleasePodUnallocatedCPUs(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+
+	testCases := []struct {
+		description     string
+		activePods      []*v1.Pod
+		podStatus       v1.PodStatus
+		podStatusFound  bool
+		stAssignments   state.ContainerCPUAssignments
+		stDefaultCPUSet cpuset.CPUSet
+		expAssignments  state.ContainerCPUAssignments
+		expDefaultSet   cpuset.CPUSet
+	}{
+		{
+			description: "Pod with terminated init containers - leaked CPUs released",
+			activePods: []*v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-pod",
+						UID:  "test-pod-uid",
+					},
+					Spec: v1.PodSpec{
+						InitContainers: []v1.Container{{Name: "init-1"}},
+						Containers:     []v1.Container{{Name: "app-1"}},
+					},
+				},
+			},
+			podStatus: v1.PodStatus{
+				InitContainerStatuses: []v1.ContainerStatus{
+					{
+						Name:  "init-1",
+						State: v1.ContainerState{Terminated: &v1.ContainerStateTerminated{}},
+					},
+				},
+			},
+			podStatusFound: true,
+			stAssignments: state.ContainerCPUAssignments{
+				"test-pod-uid": {
+					"init-1": cpuset.New(0, 2, 4, 6), // 4 CPUs - has leaked CPUs
+					"app-1":  cpuset.New(1, 5),
+				},
+			},
+			stDefaultCPUSet: cpuset.New(3, 7),
+			expAssignments: state.ContainerCPUAssignments{
+				"test-pod-uid": {
+					"init-1": cpuset.New(0, 2, 4, 6), // should be updated after releasing leaked CPUs
+					"app-1":  cpuset.New(1, 5),
+				},
+			},
+			expDefaultSet: cpuset.New(3, 4, 6, 7), // leaked CPUs returned to default
+		},
+		{
+			description: "Pod with running init containers - no CPU release",
+			activePods: []*v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-pod",
+						UID:  "test-pod-uid",
+					},
+					Spec: v1.PodSpec{
+						InitContainers: []v1.Container{{Name: "init-1"}},
+						Containers:     []v1.Container{{Name: "app-1"}},
+					},
+				},
+			},
+			podStatus: v1.PodStatus{
+				InitContainerStatuses: []v1.ContainerStatus{
+					{
+						Name:  "init-1",
+						State: v1.ContainerState{Running: &v1.ContainerStateRunning{}},
+					},
+				},
+			},
+			podStatusFound: true,
+			stAssignments: state.ContainerCPUAssignments{
+				"test-pod-uid": {
+					"init-1": cpuset.New(0, 2, 4, 6),
+					"app-1":  cpuset.New(1, 5),
+				},
+			},
+			stDefaultCPUSet: cpuset.New(3, 7),
+			expAssignments: state.ContainerCPUAssignments{
+				"test-pod-uid": {
+					"init-1": cpuset.New(0, 2, 4, 6), // should remain unchanged
+					"app-1":  cpuset.New(1, 5),
+				},
+			},
+			expDefaultSet: cpuset.New(3, 7), // should remain unchanged
+		},
+		{
+			description: "Pod with restartable init containers - no CPU release",
+			activePods: []*v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-pod",
+						UID:  "test-pod-uid",
+					},
+					Spec: v1.PodSpec{
+						InitContainers: []v1.Container{
+							{
+								Name:          "init-1",
+								RestartPolicy: &[]v1.ContainerRestartPolicy{v1.ContainerRestartPolicyAlways}[0],
+							},
+						},
+						Containers: []v1.Container{{Name: "app-1"}},
+					},
+				},
+			},
+			podStatus: v1.PodStatus{
+				InitContainerStatuses: []v1.ContainerStatus{
+					{
+						Name:  "init-1",
+						State: v1.ContainerState{Terminated: &v1.ContainerStateTerminated{}},
+					},
+				},
+			},
+			podStatusFound: true,
+			stAssignments: state.ContainerCPUAssignments{
+				"test-pod-uid": {
+					"init-1": cpuset.New(0, 4, 2, 6),
+					"app-1":  cpuset.New(1, 5),
+				},
+			},
+			stDefaultCPUSet: cpuset.New(3, 7),
+			expAssignments: state.ContainerCPUAssignments{
+				"test-pod-uid": {
+					"init-1": cpuset.New(0, 2, 4, 6),
+					"app-1":  cpuset.New(1, 5),
+				},
+			},
+			expDefaultSet: cpuset.New(3, 7), // leaked CPUs returned to default
+		},
+		{
+			description: "Pod status not found - no CPU release",
+			activePods: []*v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-pod",
+						UID:  "test-pod-uid",
+					},
+					Spec: v1.PodSpec{
+						InitContainers: []v1.Container{{Name: "init-1"}},
+						Containers:     []v1.Container{{Name: "app-1"}},
+					},
+				},
+			},
+			podStatus:      v1.PodStatus{},
+			podStatusFound: false,
+			stAssignments: state.ContainerCPUAssignments{
+				"test-pod-uid": {
+					"init-1": cpuset.New(0, 4, 2, 6),
+					"app-1":  cpuset.New(1, 5),
+				},
+			},
+			stDefaultCPUSet: cpuset.New(3, 7),
+			expAssignments: state.ContainerCPUAssignments{
+				"test-pod-uid": {
+					"init-1": cpuset.New(0, 4, 2, 6), // should remain unchanged
+					"app-1":  cpuset.New(1, 5),
+				},
+			},
+			expDefaultSet: cpuset.New(3, 7), // should remain unchanged
+		},
+		{
+			description:     "No active pods - no changes",
+			activePods:      []*v1.Pod{},
+			stAssignments:   state.ContainerCPUAssignments{},
+			stDefaultCPUSet: cpuset.New(3, 7),
+			expAssignments:  state.ContainerCPUAssignments{},
+			expDefaultSet:   cpuset.New(3, 7),
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			mockState := &mockState{
+				assignments:   testCase.stAssignments.Clone(),
+				defaultCPUSet: testCase.stDefaultCPUSet.Clone(),
+			}
+
+			mgr := &manager{
+				policy: &mockPolicy{},
+				state:  mockState,
+				activePods: func() []*v1.Pod {
+					return testCase.activePods
+				},
+				podStatusProvider: mockPodStatusProvider{
+					podStatus: testCase.podStatus,
+					found:     testCase.podStatusFound,
+				},
+			}
+
+			// Call the function under test
+			mgr.releasePodUnallocatedCPUs(logger)
+
+			// Verify the results
+			if !reflect.DeepEqual(testCase.expAssignments, mgr.state.GetCPUAssignments()) {
+				t.Errorf("Expected assignments %v, but got %v", testCase.expAssignments, mgr.state.GetCPUAssignments())
+			}
+
+			if !testCase.expDefaultSet.Equals(mgr.state.GetDefaultCPUSet()) {
+				t.Errorf("Expected default CPUSet %v, but got %v", testCase.expDefaultSet, mgr.state.GetDefaultCPUSet())
+			}
+		})
 	}
 }
 

--- a/pkg/kubelet/cm/cpumanager/policy.go
+++ b/pkg/kubelet/cm/cpumanager/policy.go
@@ -45,4 +45,8 @@ type Policy interface {
 	AllocatePod(logger logr.Logger, s state.State, pod *v1.Pod) error
 	// GetAllocatableCPUs returns the total set of CPUs available for allocation.
 	GetAllocatableCPUs(m state.State) cpuset.CPUSet
+	// Release pod leaked CPUs
+	ReleaseLeakedCPUs(logger logr.Logger, s state.State, pod *v1.Pod) cpuset.CPUSet
+	// Reallocate the leaked CPUs for InitContainer
+	UpdateCPUsForInitC(logger logr.Logger, s state.State, pod *v1.Pod, containerName string, leakedCPUs cpuset.CPUSet)
 }

--- a/pkg/kubelet/cm/cpumanager/policy_none.go
+++ b/pkg/kubelet/cm/cpumanager/policy_none.go
@@ -79,3 +79,11 @@ func (p *nonePolicy) AllocatePod(_ logr.Logger, s state.State, pod *v1.Pod) erro
 func (p *nonePolicy) GetAllocatableCPUs(m state.State) cpuset.CPUSet {
 	return cpuset.New()
 }
+
+func (p *nonePolicy) ReleaseLeakedCPUs(logger logr.Logger, s state.State, pod *v1.Pod) cpuset.CPUSet {
+	return cpuset.New()
+}
+
+func (p *nonePolicy) UpdateCPUsForInitC(logger logr.Logger, s state.State, pod *v1.Pod, containerName string, leakedCPUs cpuset.CPUSet) {
+	// Do nothing
+}

--- a/pkg/kubelet/cm/cpumanager/policy_static.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static.go
@@ -622,6 +622,110 @@ func (p *staticPolicy) Allocate(logger logr.Logger, s state.State, pod *v1.Pod, 
 	return nil
 }
 
+func (p *staticPolicy) deleteCPUsInCpusToReuse(pod *v1.Pod, cpus cpuset.CPUSet) {
+	p.cpusToReuse[string(pod.UID)] = p.cpusToReuse[string(pod.UID)].Difference(cpus)
+}
+
+// getPodAssignedCPUs returns assigned cpus of given pod `podUID`.
+func getPodAssignedCPUs(s state.State, podUID string) cpuset.CPUSet {
+	assignments := s.GetCPUAssignments()
+	cset := cpuset.New()
+	for _, cpus := range assignments[podUID] {
+		cset = cset.Union(cpus)
+	}
+	return cset
+}
+
+// getPodNonUsedReusableCPUs returns the CPUs that assigned to the non-restartable InitContainers, but not assigned to the app/sideCar containers.
+func getPodNonUsedReusableCPUs(s state.State, pod *v1.Pod) cpuset.CPUSet {
+	podUID := string(pod.UID)
+	assignments := s.GetCPUAssignments()
+	initContainerCset := cpuset.New()
+	sideCarContainerCset := cpuset.New()
+	appContainerCset := cpuset.New()
+	for _, initContainer := range pod.Spec.InitContainers {
+		if podutil.IsRestartableInitContainer(&initContainer) {
+			sideCarContainerCset = sideCarContainerCset.Union(assignments[podUID][initContainer.Name])
+		}
+		initContainerCset = initContainerCset.Union(assignments[podUID][initContainer.Name])
+	}
+	for _, container := range pod.Spec.Containers {
+		appContainerCset = appContainerCset.Union(assignments[podUID][container.Name])
+	}
+	nonUsedReusableCPUs := initContainerCset.Difference(appContainerCset.Union(sideCarContainerCset))
+	return nonUsedReusableCPUs
+}
+
+// If the pod assigned CPU number is greater than the pod max request CPU number, there are leaked CPUs.
+// The leaked CPU number equal to pod assigned CPU number - pod max request CPU number.
+// Get and release these leaked CPUs into the default CPUSet.
+func (p *staticPolicy) ReleaseLeakedCPUs(logger logr.Logger, s state.State, pod *v1.Pod) cpuset.CPUSet {
+	logger = klog.LoggerWithValues(logger, "pod", klog.KObj(pod), "podUID", pod.UID)
+	leakedCPUs := cpuset.New()
+	// Get Max request CPU number of the pod
+	podCPUsNumber := p.podGuaranteedCPUs(logger, pod)
+	// Get all allocated CPUs of the pod
+	podCPUSet := getPodAssignedCPUs(s, string(pod.UID))
+	// If the number of pod allocated CPUs greater than the max request CPU number of the pod, it means have leaked CPUs.
+	if podCPUSet.Size() > podCPUsNumber {
+		// Calculate the leaked CPUs number
+		leakedCPUsNumber := podCPUSet.Size() - podCPUsNumber
+		unallocatedReusableCPUs := getPodNonUsedReusableCPUs(s, pod)
+		if unallocatedReusableCPUs.Size() < leakedCPUsNumber {
+			leakedCPUsNumber = unallocatedReusableCPUs.Size()
+		}
+		// Get the keeped CPUs in unallocatedReusableCPUs
+		keepCPUs, err := p.takeByTopology(logger, unallocatedReusableCPUs, unallocatedReusableCPUs.Size()-leakedCPUsNumber)
+		if err != nil {
+			return leakedCPUs
+		}
+		// Get the leaked CPUs
+		leakedCPUs = unallocatedReusableCPUs.Difference(keepCPUs)
+		// Release leaked CPUs into DefaultCPUSet
+		s.SetDefaultCPUSet(s.GetDefaultCPUSet().Union(leakedCPUs))
+		p.deleteCPUsInCpusToReuse(pod, leakedCPUs)
+		p.updateMetricsOnRelease(logger, s, leakedCPUs)
+		logger.Info("Static policy: ReleaseLeakedCPUs, release leaked CPUs to DefaultCPUSet", "leakedCPUsNumber", leakedCPUsNumber, "leakedCPUs", leakedCPUs)
+	}
+	return leakedCPUs
+}
+
+// Check whether the assigned CPUs of the InitContainer are released into the default cpuset,
+// if yes, reallocate the CPUs (which assigned to the pod) to the InitContainer
+func (p *staticPolicy) UpdateCPUsForInitC(logger logr.Logger, s state.State, pod *v1.Pod, containerName string, leakedCPUs cpuset.CPUSet) {
+	logger = klog.LoggerWithValues(logger, "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", containerName)
+	podCPUSet := getPodAssignedCPUs(s, string(pod.UID))
+	if cset, ok := s.GetCPUSet(string(pod.UID), containerName); ok {
+		replacedCPUs := cset.Intersection(leakedCPUs)
+		if replacedCPUs.Size() == 0 {
+			return
+		}
+		sidecarCPUsBeforeInit := p.getSidecarCPUsBeforeInit(s, pod, containerName)
+		allocatedCPUs, err := p.takeByTopology(logger, podCPUSet.Difference(leakedCPUs).Difference(sidecarCPUsBeforeInit), cset.Size())
+		if err != nil {
+			return
+		}
+		s.SetCPUSet(string(pod.UID), containerName, allocatedCPUs)
+		logger.Info("Static policy: ReplaceLeakedCPUs", "cset before update", cset, "cset after update", allocatedCPUs)
+	}
+}
+
+// Get the assigned CPU of the side-car container which running before this InitContainer. These CPUs can not be used by this InitContainer.
+func (p *staticPolicy) getSidecarCPUsBeforeInit(s state.State, pod *v1.Pod, containerName string) cpuset.CPUSet {
+	sidecarCPUs := cpuset.New()
+
+	for _, initContainer := range pod.Spec.InitContainers {
+		if containerName == initContainer.Name {
+			break
+		}
+		if podutil.IsRestartableInitContainer(&initContainer) {
+			cset, _ := s.GetCPUSet(string(pod.UID), initContainer.Name)
+			sidecarCPUs = sidecarCPUs.Union(cset)
+		}
+	}
+	return sidecarCPUs
+}
+
 // getAssignedCPUsOfSiblings returns assigned cpus of given container's siblings(all containers other than the given container) in the given pod `podUID`.
 func getAssignedCPUsOfSiblings(s state.State, podUID string, containerName string) cpuset.CPUSet {
 	assignments := s.GetCPUAssignments()

--- a/pkg/kubelet/cm/cpumanager/policy_static_test.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static_test.go
@@ -2753,3 +2753,343 @@ func getPodUncoreCacheIDs(s state.Reader, topo *topology.CPUTopology, pod *v1.Po
 	}
 	return uncoreCacheIDs, nil
 }
+
+func TestReleaseLeakedCPUs(t *testing.T) {
+	testCases := []struct {
+		description     string
+		pod             *v1.Pod
+		stAssignments   state.ContainerCPUAssignments
+		stDefaultCPUSet cpuset.CPUSet
+		expLeakedCPUs   cpuset.CPUSet
+		expDefaultSet   cpuset.CPUSet
+	}{
+		{
+			description: "No leaked CPUs",
+			pod: WithPodUID(makeMultiContainerPod(
+				[]struct{ request, limit string }{
+					{"2000m", "2000m"}, // init container
+				},
+				[]struct{ request, limit string }{
+					{"2000m", "2000m"}, // app container
+				}), "test-pod-1"),
+			stAssignments: state.ContainerCPUAssignments{
+				"test-pod-1": map[string]cpuset.CPUSet{
+					"initContainer-0": cpuset.New(0, 4),
+					"appContainer-0":  cpuset.New(1, 5),
+				},
+			},
+			stDefaultCPUSet: cpuset.New(2, 3, 6, 7),
+			expLeakedCPUs:   cpuset.New(0, 4),             // init container CPUs are released
+			expDefaultSet:   cpuset.New(0, 2, 3, 4, 6, 7), // leaked CPUs returned to default
+		},
+		{
+			description: "Leaked CPUs from init container when init containers have more CPUs",
+			pod: WithPodUID(makeMultiContainerPod(
+				[]struct{ request, limit string }{
+					{"4000m", "4000m"}, // init container - request 4 CPUs
+				},
+				[]struct{ request, limit string }{
+					{"2000m", "2000m"}, // app container - request 2 CPUs
+				}), "test-pod-2"),
+			stAssignments: state.ContainerCPUAssignments{
+				"test-pod-2": map[string]cpuset.CPUSet{
+					"initContainer-0": cpuset.New(0, 4, 2, 6),
+					"appContainer-0":  cpuset.New(1, 5),
+				},
+			},
+			stDefaultCPUSet: cpuset.New(3, 7),
+			expLeakedCPUs:   cpuset.New(2, 6),       // 2 CPUs leaked from init container
+			expDefaultSet:   cpuset.New(2, 3, 6, 7), // leaked CPUs returned to default
+		},
+		{
+			description: "No leaked CPUs when app containers have more CPUs",
+			pod: WithPodUID(makeMultiContainerPod(
+				[]struct{ request, limit string }{
+					{"2000m", "2000m"}, // init container
+				},
+				[]struct{ request, limit string }{
+					{"4000m", "4000m"}, // app container
+				}), "test-pod-4"),
+			stAssignments: state.ContainerCPUAssignments{
+				"test-pod-4": map[string]cpuset.CPUSet{
+					"initContainer-0": cpuset.New(0, 4),
+					"appContainer-0":  cpuset.New(1, 5, 2, 6),
+				},
+			},
+			stDefaultCPUSet: cpuset.New(3, 7),
+			expLeakedCPUs:   cpuset.New(0, 4),
+			expDefaultSet:   cpuset.New(0, 3, 4, 7),
+		},
+		{
+			description: "Multiple leaked CPUs from multiple init containers",
+			pod: WithPodUID(makeMultiContainerPod(
+				[]struct{ request, limit string }{
+					{"4000m", "4000m"}, // init container 1 - request 4 CPUs
+					{"2000m", "2000m"}, // init container 2 - request 2 CPUs
+				},
+				[]struct{ request, limit string }{
+					{"2000m", "2000m"}, // app container - request 2 CPUs
+				}), "test-pod-3"),
+			stAssignments: state.ContainerCPUAssignments{
+				"test-pod-3": map[string]cpuset.CPUSet{
+					"initContainer-0": cpuset.New(0, 4, 2, 6),
+					"initContainer-1": cpuset.New(3, 7),
+					"appContainer-0":  cpuset.New(1, 5),
+				},
+			},
+			stDefaultCPUSet: cpuset.New(),
+			expLeakedCPUs:   cpuset.New(2, 3, 6, 7),
+			expDefaultSet:   cpuset.New(2, 3, 6, 7),
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			logger, _ := ktesting.NewTestContext(t)
+			policy, err := NewStaticPolicy(logger, topoSingleSocketHT, 0, cpuset.New(), topologymanager.NewFakeManager(), nil)
+			if err != nil {
+				t.Fatalf("NewStaticPolicy() failed: %v", err)
+			}
+
+			st := &mockState{
+				assignments:   testCase.stAssignments,
+				defaultCPUSet: testCase.stDefaultCPUSet,
+			}
+
+			leakedCPUs := policy.ReleaseLeakedCPUs(logger, st, testCase.pod)
+
+			if !leakedCPUs.Equals(testCase.expLeakedCPUs) {
+				t.Errorf("ReleaseLeakedCPUs() error (%v). expected leaked CPUs %v but got %v",
+					testCase.description, testCase.expLeakedCPUs, leakedCPUs)
+			}
+
+			if !st.GetDefaultCPUSet().Equals(testCase.expDefaultSet) {
+				t.Errorf("ReleaseLeakedCPUs() error (%v). expected default CPUSet %v but got %v",
+					testCase.description, testCase.expDefaultSet, st.GetDefaultCPUSet())
+			}
+		})
+	}
+}
+
+func TestUpdateCPUsForInitC(t *testing.T) {
+	testCases := []struct {
+		description     string
+		pod             *v1.Pod
+		containerName   string
+		leakedCPUs      cpuset.CPUSet
+		stAssignments   state.ContainerCPUAssignments
+		stDefaultCPUSet cpuset.CPUSet
+		expCPUSet       cpuset.CPUSet
+		shouldUpdate    bool
+	}{
+		{
+			description: "Update init container with leaked CPUs",
+			pod: WithPodUID(makeMultiContainerPod(
+				[]struct{ request, limit string }{
+					{"4000m", "4000m"}, // request 4 CPUs to match allocation
+				},
+				[]struct{ request, limit string }{
+					{"2000m", "2000m"},
+				}), "test-pod-1"),
+			containerName: "init-1",
+			leakedCPUs:    cpuset.New(2, 6),
+			stAssignments: state.ContainerCPUAssignments{
+				"test-pod-1": map[string]cpuset.CPUSet{
+					"init-1": cpuset.New(0, 4, 2, 6),
+					"app-1":  cpuset.New(1, 5),
+				},
+			},
+			stDefaultCPUSet: cpuset.New(3, 7),
+			expCPUSet:       cpuset.New(0, 1, 4, 5), // should replace leaked CPU with available one
+			shouldUpdate:    true,
+		},
+		{
+			description: "No update when pod doesn't have leaked CPUs",
+			pod: WithPodUID(makeMultiContainerPod(
+				[]struct{ request, limit string }{
+					{"2000m", "2000m"},
+				},
+				[]struct{ request, limit string }{
+					{"2000m", "2000m"},
+				}), "test-pod-2"),
+			containerName: "init-1",
+			leakedCPUs:    cpuset.New(),
+			stAssignments: state.ContainerCPUAssignments{
+				"test-pod-2": map[string]cpuset.CPUSet{
+					"init-1": cpuset.New(1, 5), // doesn't contain leaked CPUs
+					"app-1":  cpuset.New(1, 5),
+				},
+			},
+			stDefaultCPUSet: cpuset.New(2, 3, 6, 7),
+			expCPUSet:       cpuset.New(1, 5), // should remain unchanged
+			shouldUpdate:    false,
+		},
+		{
+			description: "Update init container with partial leaked CPUs",
+			pod: WithPodUID(makeMultiContainerPod(
+				[]struct{ request, limit string }{
+					{"3000m", "3000m"},
+				},
+				[]struct{ request, limit string }{
+					{"2000m", "2000m"},
+				}), "test-pod-3"),
+			containerName: "init-1",
+			leakedCPUs:    cpuset.New(2, 4),
+			stAssignments: state.ContainerCPUAssignments{
+				"test-pod-3": map[string]cpuset.CPUSet{
+					"init-1": cpuset.New(0, 4, 2), // contains one leaked CPU
+					"app-1":  cpuset.New(1, 5),
+				},
+			},
+			stDefaultCPUSet: cpuset.New(3, 6, 7),
+			expCPUSet:       cpuset.New(0, 1, 5), // should replace leaked CPU with available one
+			shouldUpdate:    true,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			logger, _ := ktesting.NewTestContext(t)
+			policy, err := NewStaticPolicy(logger, topoSingleSocketHT, 0, cpuset.New(), topologymanager.NewFakeManager(), nil)
+			if err != nil {
+				t.Fatalf("NewStaticPolicy() failed: %v", err)
+			}
+			st := &mockState{
+				assignments:   testCase.stAssignments,
+				defaultCPUSet: testCase.stDefaultCPUSet,
+			}
+			policy.UpdateCPUsForInitC(logger, st, testCase.pod, testCase.containerName, testCase.leakedCPUs)
+			if testCase.shouldUpdate {
+				cset, found := st.GetCPUSet(string(testCase.pod.UID), testCase.containerName)
+				if !found {
+					t.Errorf("UpdateCPUsForInitC() error (%v). expected container %v to be present in assignments",
+						testCase.description, testCase.containerName)
+				} else if !cset.Equals(testCase.expCPUSet) {
+					t.Errorf("UpdateCPUsForInitC() error (%v). expected CPUSet %v but got %v",
+						testCase.description, testCase.expCPUSet, cset)
+				}
+			} else {
+				// If no update expected, verify the container either doesn't exist or has unchanged CPUSet
+				if cset, found := st.GetCPUSet(string(testCase.pod.UID), testCase.containerName); found {
+					if !testCase.expCPUSet.IsEmpty() && !cset.Equals(testCase.expCPUSet) {
+						t.Errorf("UpdateCPUsForInitC() error (%v). expected CPUSet %v but got %v",
+							testCase.description, testCase.expCPUSet, cset)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestGetSidecarCPUsBeforeInit(t *testing.T) {
+	testCases := []struct {
+		description    string
+		pod            *v1.Pod
+		containerName  string
+		stAssignments  state.ContainerCPUAssignments
+		expSidecarCPUs cpuset.CPUSet
+	}{
+		{
+			description: "No sidecar containers before init container",
+			pod: WithPodUID(makeMultiContainerPodWithOptions(
+				[]*containerOptions{
+					{request: "2000m", limit: "2000m"},                                                 // regular init container
+					{request: "2000m", limit: "2000m", restartPolicy: v1.ContainerRestartPolicyAlways}, // sidecar init container
+				},
+				[]*containerOptions{
+					{request: "2000m", limit: "2000m"}, // app container
+				},
+			), "test-pod"),
+			containerName: "initContainer-0",
+			stAssignments: state.ContainerCPUAssignments{
+				"test-pod": map[string]cpuset.CPUSet{
+					"initContainer-0": cpuset.New(1, 5), // current init container
+					"initContainer-1": cpuset.New(0, 4), // sidecar container
+				},
+			},
+			expSidecarCPUs: cpuset.New(), // should not get CPUs from sidecar initContainer-0
+		},
+		{
+			description: "One sidecar container before init container",
+			pod: WithPodUID(makeMultiContainerPodWithOptions(
+				[]*containerOptions{
+					{request: "1000m", limit: "1000m", restartPolicy: v1.ContainerRestartPolicyAlways},    // sidecar init container
+					{request: "1000m", limit: "1000m", restartPolicy: v1.ContainerRestartPolicyOnFailure}, // regular init container
+				},
+				[]*containerOptions{
+					{request: "1000m", limit: "1000m"}, // regular app container
+				},
+			), "test-pod"),
+			containerName: "initContainer-1",
+			stAssignments: state.ContainerCPUAssignments{
+				"test-pod": map[string]cpuset.CPUSet{
+					"initContainer-0": cpuset.New(0, 4), // sidecar container
+					"initContainer-1": cpuset.New(1, 5), // current init container
+				},
+			},
+			expSidecarCPUs: cpuset.New(0, 4), // should get CPUs from sidecar initContainer-0
+		},
+		{
+			description: "Multiple sidecar containers before init container",
+			pod: WithPodUID(makeMultiContainerPodWithOptions(
+				[]*containerOptions{
+					{request: "1000m", limit: "1000m", restartPolicy: v1.ContainerRestartPolicyAlways},    // sidecar init container 1
+					{request: "1000m", limit: "1000m", restartPolicy: v1.ContainerRestartPolicyAlways},    // sidecar init container 2
+					{request: "1000m", limit: "1000m", restartPolicy: v1.ContainerRestartPolicyOnFailure}, // regular init container
+				},
+				[]*containerOptions{
+					{request: "1000m", limit: "1000m"}, // regular app container
+				},
+			), "test-pod"),
+			containerName: "initContainer-2",
+			stAssignments: state.ContainerCPUAssignments{
+				"test-pod": map[string]cpuset.CPUSet{
+					"initContainer-0": cpuset.New(0, 4), // sidecar init container 1
+					"initContainer-1": cpuset.New(1, 5), // sidecar init container 2
+					"initContainer-2": cpuset.New(2, 6), // current init container
+				},
+			},
+			expSidecarCPUs: cpuset.New(0, 1, 4, 5), // should get CPUs from sidecar initContainer-0 and initContainer-1
+		},
+		{
+			description: "Init container after some sidecars",
+			pod: WithPodUID(makeMultiContainerPodWithOptions(
+				[]*containerOptions{
+					{request: "1000m", limit: "1000m", restartPolicy: v1.ContainerRestartPolicyAlways},    // sidecar init container 1
+					{request: "1000m", limit: "1000m", restartPolicy: v1.ContainerRestartPolicyOnFailure}, // regular init container
+					{request: "1000m", limit: "1000m", restartPolicy: v1.ContainerRestartPolicyAlways},    // sidecar init container 2
+				},
+				[]*containerOptions{
+					{request: "1000m", limit: "1000m"}, // regular app container
+				},
+			), "test-pod"),
+			containerName: "initContainer-1",
+			stAssignments: state.ContainerCPUAssignments{
+				"test-pod": map[string]cpuset.CPUSet{
+					"initContainer-0": cpuset.New(2, 6), // sidecar init container 1
+					"initContainer-1": cpuset.New(0, 4), // current init container
+					"initContainer-2": cpuset.New(3, 5), // sidecar init container 2
+				},
+			},
+			expSidecarCPUs: cpuset.New(2, 6), // should get CPUs from sidecar initContainer-0 only
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			logger, _ := ktesting.NewTestContext(t)
+			policy, err := NewStaticPolicy(logger, topoSingleSocketHT, 0, cpuset.New(), topologymanager.NewFakeManager(), nil)
+			if err != nil {
+				t.Fatalf("NewStaticPolicy() failed: %v", err)
+			}
+			st := &mockState{
+				assignments:   testCase.stAssignments,
+				defaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+			}
+			staticPolicy := policy.(*staticPolicy)
+			sidecarCPUs := staticPolicy.getSidecarCPUsBeforeInit(st, testCase.pod, testCase.containerName)
+			if !sidecarCPUs.Equals(testCase.expSidecarCPUs) {
+				t.Errorf("getSidecarCPUsBeforeInit() error (%v). expected %v but got %v",
+					testCase.description, testCase.expSidecarCPUs, sidecarCPUs)
+			}
+		})
+	}
+}

--- a/test/e2e_node/cpu_manager_test.go
+++ b/test/e2e_node/cpu_manager_test.go
@@ -18,6 +18,7 @@ package e2enode
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -36,6 +37,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/features"
 	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
@@ -1957,6 +1959,256 @@ var _ = SIGDescribe("CPU Manager", ginkgo.Ordered, ginkgo.ContinueOnFailure, fra
 			gomega.Expect(pod).ToNot(HaveContainerCPUsOverlapWith(appContainerName, nonReusableCPUs))
 		})
 	})
+
+	ginkgo.When("When checking CPU leaks in Guaranteed Pods", func() {
+		ginkgo.It("One init container(CPU number: 1) and one app container(CPU number: 2) for a pod, release leaked CPUs", func(ctx context.Context) {
+			reservedCPUs = cpuset.New(0)
+			cpuCount := 2
+			podCPUsNumber := 2
+
+			skipIfAllocatableCPUsLessThan(getLocalNode(ctx, f), cpuCount)
+
+			updateKubeletConfigIfNeeded(ctx, f, configureCPUManagerInKubelet(oldCfg, &cpuManagerKubeletArguments{
+				policyName:         string(cpumanager.PolicyStatic),
+				reservedSystemCPUs: reservedCPUs, // Not really needed for the tests but helps to make a more precise check
+			}))
+
+			pod := makeCPUManagerMultiTypeContainersPodWithRestartPolicy("gu-pod-multi-type-container", []ctnAttribute{
+				{
+					ctnName:    "init-container-1",
+					cpuRequest: "1000m",
+					cpuLimit:   "1000m",
+				},
+			}, []ctnAttribute{
+				{
+					ctnName:    "gu-container-1",
+					cpuRequest: "2000m",
+					cpuLimit:   "2000m",
+				},
+			}, v1.RestartPolicyAlways)
+			ginkgo.By("running a Gu pod with a init container and a app container")
+			pod = e2epod.NewPodClient(f).CreateSync(ctx, pod)
+			podMap[string(pod.UID)] = pod
+
+			// waiting for reconcile loop.
+			time.Sleep(1 * time.Second)
+
+			UnionCPUNumber, err := getPodContainersCPUSetUnion(ctx, f, pod)
+			framework.ExpectNoError(err, "cannot get union CPU count for pod %s/%s", pod.Namespace, pod.Name)
+			ginkgo.By(fmt.Sprintf("UnionCPUNumber = %d", UnionCPUNumber))
+
+			// have leaked CPUs
+			gomega.Expect(UnionCPUNumber).ToNot(gomega.Equal(podCPUsNumber))
+
+			// no leaked CPUs in checkpoint
+			// initcontainer cpuset could be changed after terminating if there are leaked CPUs, this change only appied to checkpoint
+			gomega.Expect(pod).To(HavePodCPUsCount(getContainerCPUSetFromCheckpoint(pod, &pod.Spec.InitContainers[0]).Union(getContainerCPUSetFromCheckpoint(pod, &pod.Spec.Containers[0])), podCPUsNumber))
+
+			ginkgo.By("checking if the no leaked cpuset was applied when pod restart")
+			// make pod restart by removing pod sandbox
+			restartPodByRemovingSandbox(ctx, f, pod)
+
+			// waiting for reconcile loop.
+			time.Sleep(1 * time.Second)
+
+			// no leaked CPUs when Pod setup
+			UnionCPUNumber, err = getPodContainersCPUSetUnion(ctx, f, pod)
+			framework.ExpectNoError(err, "cannot get union CPU count for pod %s/%s", pod.Namespace, pod.Name)
+			ginkgo.By(fmt.Sprintf("UnionCPUNumber = %d", UnionCPUNumber))
+
+			// no leaked CPUs
+			gomega.Expect(UnionCPUNumber).To(gomega.Equal(podCPUsNumber))
+			gomega.Expect(pod).To(HavePodCPUsCount(getContainerCPUSetFromCheckpoint(pod, &pod.Spec.InitContainers[0]).Union(getContainerCPUSetFromCheckpoint(pod, &pod.Spec.Containers[0])), podCPUsNumber))
+		})
+
+		ginkgo.It("One init container(CPU number: 2) and one app container(CPU number: 1) for a pod, release part of unallocated reusable CPUs", func(ctx context.Context) {
+			reservedCPUs = cpuset.New(0)
+			cpuCount := 3
+			podCPUsNumber := 2
+
+			skipIfAllocatableCPUsLessThan(getLocalNode(ctx, f), cpuCount)
+
+			updateKubeletConfigIfNeeded(ctx, f, configureCPUManagerInKubelet(oldCfg, &cpuManagerKubeletArguments{
+				policyName:         string(cpumanager.PolicyStatic),
+				reservedSystemCPUs: reservedCPUs, // Not really needed for the tests but helps to make a more precise check
+			}))
+
+			pod := makeCPUManagerMultiTypeContainersPodWithRestartPolicy("gu-pod-multi-type-container", []ctnAttribute{
+				{
+					ctnName:    "init-container-1",
+					cpuRequest: "2000m",
+					cpuLimit:   "2000m",
+				},
+			}, []ctnAttribute{
+				{
+					ctnName:    "gu-container-1",
+					cpuRequest: "1000m",
+					cpuLimit:   "1000m",
+				},
+			}, v1.RestartPolicyAlways)
+			ginkgo.By("running a Gu pod with a init container and a app container")
+			pod = e2epod.NewPodClient(f).CreateSync(ctx, pod)
+			podMap[string(pod.UID)] = pod
+
+			// waiting for reconcile loop.
+			time.Sleep(1 * time.Second)
+
+			UnionCPUNumber, err := getPodContainersCPUSetUnion(ctx, f, pod)
+			framework.ExpectNoError(err, "cannot get union CPU count for pod %s/%s", pod.Namespace, pod.Name)
+			ginkgo.By(fmt.Sprintf("UnionCPUNumber = %d", UnionCPUNumber))
+
+			// have leaked CPUs
+			gomega.Expect(UnionCPUNumber).ToNot(gomega.Equal(podCPUsNumber))
+
+			// no leaked CPUs in checkpoint
+			// initcontainer cpuset could be changed after terminating if there are leaked CPUs, this change only appied to checkpoint
+			gomega.Expect(pod).To(HavePodCPUsCount(getContainerCPUSetFromCheckpoint(pod, &pod.Spec.InitContainers[0]).Union(getContainerCPUSetFromCheckpoint(pod, &pod.Spec.Containers[0])), podCPUsNumber))
+
+			ginkgo.By("checking if the no leaked cpuset was applied when pod restart")
+			// make pod restart by removing pod sandbox
+			restartPodByRemovingSandbox(ctx, f, pod)
+
+			// waiting for reconcile loop.
+			time.Sleep(1 * time.Second)
+
+			// no leaked CPUs when Pod setup
+			UnionCPUNumber, err = getPodContainersCPUSetUnion(ctx, f, pod)
+			framework.ExpectNoError(err, "cannot get union CPU count for pod %s/%s", pod.Namespace, pod.Name)
+			ginkgo.By(fmt.Sprintf("UnionCPUNumber = %d", UnionCPUNumber))
+
+			// no leaked CPUs
+			gomega.Expect(UnionCPUNumber).To(gomega.Equal(podCPUsNumber))
+			gomega.Expect(pod).To(HavePodCPUsCount(getContainerCPUSetFromCheckpoint(pod, &pod.Spec.InitContainers[0]).Union(getContainerCPUSetFromCheckpoint(pod, &pod.Spec.Containers[0])), podCPUsNumber))
+		})
+
+		ginkgo.It("One sidecar container(CPU number:1) One init container(CPU number: 2) and one app container(CPU number: 1) for a pod, release part of unallocated reusable CPUs", func(ctx context.Context) {
+			reservedCPUs = cpuset.New(0, 2)
+			cpuCount := 4
+			podCPUsNumber := 3
+
+			skipIfAllocatableCPUsLessThan(getLocalNode(ctx, f), cpuCount)
+
+			updateKubeletConfigIfNeeded(ctx, f, configureCPUManagerInKubelet(oldCfg, &cpuManagerKubeletArguments{
+				policyName:         string(cpumanager.PolicyStatic),
+				reservedSystemCPUs: reservedCPUs, // Not really needed for the tests but helps to make a more precise check
+			}))
+
+			containerRestartPolicyAlways := v1.ContainerRestartPolicyAlways
+			pod := makeCPUManagerMultiTypeContainersPodWithRestartPolicy("gu-pod-multi-type-container", []ctnAttribute{
+				{
+					ctnName:       "sidecar-container-1",
+					cpuRequest:    "1000m",
+					cpuLimit:      "1000m",
+					restartPolicy: &containerRestartPolicyAlways,
+				},
+				{
+					ctnName:    "init-container-1",
+					cpuRequest: "2000m",
+					cpuLimit:   "2000m",
+				},
+			}, []ctnAttribute{
+				{
+					ctnName:    "gu-container-1",
+					cpuRequest: "1000m",
+					cpuLimit:   "1000m",
+				},
+			}, v1.RestartPolicyAlways)
+			ginkgo.By("running a Gu pod with a init container and a app container")
+			pod = e2epod.NewPodClient(f).CreateSync(ctx, pod)
+			podMap[string(pod.UID)] = pod
+
+			// waiting for reconcile loop.
+			time.Sleep(1 * time.Second)
+
+			UnionCPUNumber, err := getPodContainersCPUSetUnion(ctx, f, pod)
+			framework.ExpectNoError(err, "cannot get union CPU count for pod %s/%s", pod.Namespace, pod.Name)
+			ginkgo.By(fmt.Sprintf("UnionCPUNumber = %d", UnionCPUNumber))
+
+			// have leaked CPUs
+			gomega.Expect(UnionCPUNumber).ToNot(gomega.Equal(podCPUsNumber))
+
+			// no leaked CPUs in checkpoint
+			// initcontainer cpuset could be changed after terminating if there are leaked CPUs, this change only appied to checkpoint
+			gomega.Expect(pod).To(HavePodCPUsCount(getContainerCPUSetFromCheckpoint(pod, &pod.Spec.InitContainers[0]).Union(getContainerCPUSetFromCheckpoint(pod, &pod.Spec.InitContainers[1]).Union(getContainerCPUSetFromCheckpoint(pod, &pod.Spec.Containers[0]))), podCPUsNumber))
+
+			ginkgo.By("checking if the no leaked cpuset was applied when pod restart")
+			// make pod restart by removing pod sandbox
+			restartPodByRemovingSandbox(ctx, f, pod)
+
+			// waiting for reconcile loop.
+			time.Sleep(1 * time.Second)
+
+			// no leaked CPUs when Pod setup
+			UnionCPUNumber, err = getPodContainersCPUSetUnion(ctx, f, pod)
+			framework.ExpectNoError(err, "cannot get union CPU count for pod %s/%s", pod.Namespace, pod.Name)
+			ginkgo.By(fmt.Sprintf("UnionCPUNumber = %d", UnionCPUNumber))
+
+			// no leaked CPUs
+			gomega.Expect(UnionCPUNumber).To(gomega.Equal(podCPUsNumber))
+			gomega.Expect(pod).To(HavePodCPUsCount(getContainerCPUSetFromCheckpoint(pod, &pod.Spec.InitContainers[0]).Union(getContainerCPUSetFromCheckpoint(pod, &pod.Spec.InitContainers[1]).Union(getContainerCPUSetFromCheckpoint(pod, &pod.Spec.Containers[0]))), podCPUsNumber))
+
+		})
+
+		ginkgo.It("One init container(CPU number: 2) and one app container(CPU number: 1) for a pod, no leaked CPUs", func(ctx context.Context) {
+			reservedCPUs = cpuset.New(0, 10)
+			cpuCount := 2
+			podCPUsNumber := 2
+
+			skipIfAllocatableCPUsLessThan(getLocalNode(ctx, f), cpuCount)
+
+			updateKubeletConfigIfNeeded(ctx, f, configureCPUManagerInKubelet(oldCfg, &cpuManagerKubeletArguments{
+				policyName:         string(cpumanager.PolicyStatic),
+				reservedSystemCPUs: reservedCPUs, // Not really needed for the tests but helps to make a more precise check
+			}))
+
+			pod := makeCPUManagerMultiTypeContainersPodWithRestartPolicy("gu-pod-multi-type-container", []ctnAttribute{
+				{
+					ctnName:    "init-container-1",
+					cpuRequest: "2000m",
+					cpuLimit:   "2000m",
+				},
+			}, []ctnAttribute{
+				{
+					ctnName:    "gu-container-1",
+					cpuRequest: "1000m",
+					cpuLimit:   "1000m",
+				},
+			}, v1.RestartPolicyAlways)
+			ginkgo.By("running a Gu pod with a init container and a app container")
+			pod = e2epod.NewPodClient(f).CreateSync(ctx, pod)
+			podMap[string(pod.UID)] = pod
+
+			// waiting for reconcile loop.
+			time.Sleep(1 * time.Second)
+
+			UnionCPUNumber, err := getPodContainersCPUSetUnion(ctx, f, pod)
+			framework.ExpectNoError(err, "cannot get union CPU count for pod %s/%s", pod.Namespace, pod.Name)
+			ginkgo.By(fmt.Sprintf("UnionCPUNumber = %d", UnionCPUNumber))
+
+			// no leaked CPUs
+			gomega.Expect(UnionCPUNumber).To(gomega.Equal(podCPUsNumber))
+
+			// no leaked CPUs in checkpoint
+			// initcontainer cpuset could be changed after terminating if there are leaked CPUs, this change only appied to checkpoint
+			gomega.Expect(pod).To(HavePodCPUsCount(getContainerCPUSetFromCheckpoint(pod, &pod.Spec.InitContainers[0]).Union(getContainerCPUSetFromCheckpoint(pod, &pod.Spec.Containers[0])), podCPUsNumber))
+
+			ginkgo.By("checking if the no leaked cpuset was applied when pod restart")
+			// make pod restart by removing pod sandbox
+			restartPodByRemovingSandbox(ctx, f, pod)
+
+			// waiting for reconcile loop.
+			time.Sleep(1 * time.Second)
+
+			// no leaked CPUs when Pod setup
+			UnionCPUNumber, err = getPodContainersCPUSetUnion(ctx, f, pod)
+			framework.ExpectNoError(err, "cannot get union CPU count for pod %s/%s", pod.Namespace, pod.Name)
+			ginkgo.By(fmt.Sprintf("UnionCPUNumber = %d", UnionCPUNumber))
+
+			// no leaked CPUs
+			gomega.Expect(UnionCPUNumber).To(gomega.Equal(podCPUsNumber))
+			gomega.Expect(pod).To(HavePodCPUsCount(getContainerCPUSetFromCheckpoint(pod, &pod.Spec.InitContainers[0]).Union(getContainerCPUSetFromCheckpoint(pod, &pod.Spec.Containers[0])), podCPUsNumber))
+		})
+	})
 })
 
 var _ = SIGDescribe("CPU Manager Pod Level Resources", ginkgo.Ordered, ginkgo.ContinueOnFailure, framework.WithSerial(), feature.CPUManager, feature.PodLevelResources, feature.PodLevelResourceManagers, framework.WithFeatureGate(features.PodLevelResources), framework.WithFeatureGate(features.PodLevelResourceManagers), func() {
@@ -3223,6 +3475,21 @@ type msgData struct {
 	ExpectedQuota    string
 }
 
+func HavePodCPUsCount(podCPUSet cpuset.CPUSet, val int) types.GomegaMatcher {
+	md := &msgData{
+		CurrentCPUs: podCPUSet.String(),
+		Count:       val,
+	}
+	return gcustom.MakeMatcher(func(actual *v1.Pod) (bool, error) {
+		if podCPUSet.Size() == val {
+			return true, nil
+		} else if podCPUSet.Size() > val {
+			return false, fmt.Errorf("There are %d leaked CPUs", podCPUSet.Size()-val)
+		}
+		return false, fmt.Errorf("CPU not enough")
+	}).WithTemplate("Pod {{.Actual.Namespace}}/{{.Actual.Name}} UID {{.Actual.UID}} has allowed CPUs <{{.Data.CurrentCPUs}}> not matching expected count <{{.Data.Count}}> for container {{.Data.Name}}", md)
+}
+
 func HaveContainerCPUsCount(ctnName string, val int) types.GomegaMatcher {
 	md := &msgData{
 		Name:  ctnName,
@@ -4010,6 +4277,66 @@ func makeCPUManagerInitContainersPod(podName string, ctnAttributes []ctnAttribut
 	}
 }
 
+func makeCPUManagerMultiTypeContainersPodWithRestartPolicy(podName string, initCtnAttributes []ctnAttribute, ctnAttributes []ctnAttribute, restartPolicy v1.RestartPolicy) *v1.Pod {
+	var containers []v1.Container
+	var initContainers []v1.Container
+	cpusetCmd := "grep Cpus_allowed_list /proc/self/status | cut -f2"
+	cpusetAndSleepCmd := "grep Cpus_allowed_list /proc/self/status | cut -f2 && sleep 1d"
+
+	for _, ictnAttr := range initCtnAttributes {
+		ictn := v1.Container{
+			Name:  ictnAttr.ctnName,
+			Image: busyboxImage,
+			Resources: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse(ictnAttr.cpuRequest),
+					v1.ResourceMemory: resource.MustParse("100Mi"),
+				},
+				Limits: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse(ictnAttr.cpuLimit),
+					v1.ResourceMemory: resource.MustParse("100Mi"),
+				},
+			},
+			Command:       []string{"sh", "-c", cpusetCmd},
+			RestartPolicy: ictnAttr.restartPolicy,
+		}
+		if ictnAttr.restartPolicy != nil && *ictnAttr.restartPolicy == v1.ContainerRestartPolicyAlways {
+			ictn.Command = []string{"sh", "-c", cpusetAndSleepCmd}
+		}
+		initContainers = append(initContainers, ictn)
+	}
+
+	for _, ctnAttr := range ctnAttributes {
+		ctn := v1.Container{
+			Name:  ctnAttr.ctnName,
+			Image: busyboxImage,
+			Resources: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse(ctnAttr.cpuRequest),
+					v1.ResourceMemory: resource.MustParse("100Mi"),
+				},
+				Limits: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse(ctnAttr.cpuLimit),
+					v1.ResourceMemory: resource.MustParse("100Mi"),
+				},
+			},
+			Command: []string{"sh", "-c", cpusetAndSleepCmd},
+		}
+		containers = append(containers, ctn)
+	}
+
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: podName,
+		},
+		Spec: v1.PodSpec{
+			RestartPolicy:  restartPolicy,
+			InitContainers: initContainers,
+			Containers:     containers,
+		},
+	}
+}
+
 type cpuManagerKubeletArguments struct {
 	policyName                       string
 	topologyManagerPolicy            string
@@ -4083,4 +4410,102 @@ func checkAllocatableCPUs(node *v1.Node, val int, reservedCPUs cpuset.CPUSet, on
 	if nodeCPUDetails.Allocatable < cpuReq {
 		e2eskipper.Skipf("Skipping CPU Manager test: not allocatable %s", msg)
 	}
+}
+
+func getContainerCPUSetFromCheckpoint(pod *v1.Pod, container *v1.Container) cpuset.CPUSet {
+
+	// initialize empty cpuset as default return value
+	containerCPUSet := cpuset.CPUSet{}
+
+	// get the actual cpuset value from checkpoint file
+	checkpointPath := "/var/lib/kubelet/cpu_manager_state"
+	checkpointData, err := os.ReadFile(checkpointPath)
+	if err != nil {
+		fmt.Printf("Error reading checkpoint file %s: %v\n", checkpointPath, err)
+	} else {
+		// Parse the checkpoint JSON to extract CPU assignments
+		var checkpoint struct {
+			PolicyName    string                       `json:"policyName"`
+			DefaultCPUSet string                       `json:"defaultCpuSet"`
+			Entries       map[string]map[string]string `json:"entries,omitempty"`
+		}
+
+		if err := json.Unmarshal(checkpointData, &checkpoint); err != nil {
+			fmt.Printf("Error parsing checkpoint JSON: %v\n", err)
+		} else {
+			podUID := string(pod.UID)
+			if podEntries, exists := checkpoint.Entries[podUID]; exists {
+				if containerCPUs, exists := podEntries[container.Name]; exists {
+					// Parse the cpuset string and return it
+					if parsedCPUs, parseErr := cpuset.Parse(containerCPUs); parseErr == nil {
+						containerCPUSet = parsedCPUs
+					} else {
+						fmt.Printf("Error parsing cpuset string '%s': %v\n", containerCPUs, parseErr)
+					}
+				} else {
+					fmt.Printf("Container %s not found in checkpoint for pod %s\n", container.Name, podUID)
+				}
+			} else {
+				fmt.Printf("Pod %s not found in checkpoint entries\n", podUID)
+			}
+		}
+	}
+	return containerCPUSet
+}
+
+func restartPodByRemovingSandbox(ctx context.Context, f *framework.Framework, pod *v1.Pod) {
+	ginkgo.By("Getting the current pod sandbox ID")
+	rs, _, err := getCRIClient()
+	framework.ExpectNoError(err)
+	sandboxes, err := rs.ListPodSandbox(ctx, &runtimeapi.PodSandboxFilter{
+		LabelSelector: map[string]string{
+			"io.kubernetes.pod.name":      pod.Name,
+			"io.kubernetes.pod.namespace": pod.Namespace,
+		},
+	})
+	framework.ExpectNoError(err)
+	gomega.Expect(sandboxes).To(gomega.HaveLen(1))
+	podSandboxID := sandboxes[0].Id
+
+	ginkgo.By("Removing the pod sandbox")
+	err = rs.StopPodSandbox(ctx, podSandboxID)
+	framework.ExpectNoError(err)
+
+	ginkgo.By("Waiting for the pod to be restarted after sandbox removal")
+	err = e2epod.WaitForPodRunningInNamespace(ctx, f.ClientSet, pod)
+	framework.ExpectNoError(err)
+}
+
+func getPodContainersCPUSetUnion(ctx context.Context, f *framework.Framework, pod *v1.Pod) (int, error) {
+	var allCPUSets []cpuset.CPUSet
+
+	for _, initContainer := range pod.Spec.InitContainers {
+		logs, err := e2epod.GetPodLogs(ctx, f.ClientSet, pod.Namespace, pod.Name, initContainer.Name)
+		if err != nil {
+			return 0, fmt.Errorf("failed to get logs for init container %s: %w", initContainer.Name, err)
+		}
+
+		initContainerCPUs := getContainerAllowedCPUsFromLogs(pod.Name, initContainer.Name, logs)
+		allCPUSets = append(allCPUSets, initContainerCPUs)
+	}
+
+	for _, container := range pod.Spec.Containers {
+		logs, err := e2epod.GetPodLogs(ctx, f.ClientSet, pod.Namespace, pod.Name, container.Name)
+		if err != nil {
+			return 0, fmt.Errorf("failed to get logs for container %s: %w", container.Name, err)
+		}
+		containerCPUs := getContainerAllowedCPUsFromLogs(pod.Name, container.Name, logs)
+		allCPUSets = append(allCPUSets, containerCPUs)
+	}
+
+	if len(allCPUSets) == 0 {
+		return 0, nil
+	}
+
+	union := allCPUSets[0]
+	for i := 1; i < len(allCPUSets); i++ {
+		union = union.Union(allCPUSets[i])
+	}
+
+	return union.Size(), nil
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
In some cases, the app container can not reuse the CPU of InitContainer, which lead to CPU leaking.
Detail case refer to description in https://github.com/kubernetes/kubernetes/pull/131966 .

This PR implement the reconcile loop solution which is discussed with @ffromani in ( https://github.com/kubernetes/kubernetes/issues/112228#issuecomment-3066751798 and https://github.com/kubernetes/kubernetes/issues/112228#issuecomment-3088815625)

Below is the design overview:
In reconcile loop, for each pod (after all of the non-restartable initContainer terminated)
  - Calculate the leaked CPUs and release them.
  - Loop all non-restartable InitContainers (for pod restart case)
     - If InitContainer have leaked CPUs, reallocate CPUs for the InitContainer in pod other assigned CPUs (can’t use the CPUs of side-car container that runs before it).

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubernetes/issues/112228

#### Special notes for your reviewer:
Need to consider Pod restart case, when Pod restart, the non-restartable InitContainer will restart, and need exclusive CPUs.
