### PR TITLE
DRA: Add scheduler perf test for partitionable devices

### DIFF
--- a/test/integration/scheduler_perf/dra.go
+++ b/test/integration/scheduler_perf/dra.go
@@ -339,9 +339,10 @@ claims:
 		}
 
 		allocator, err := structured.NewAllocator(tCtx, structured.Features{
-			PrioritizedList: utilfeature.DefaultFeatureGate.Enabled(features.DRAPrioritizedList),
-			AdminAccess:     utilfeature.DefaultFeatureGate.Enabled(features.DRAAdminAccess),
-			DeviceTaints:    utilfeature.DefaultFeatureGate.Enabled(features.DRADeviceTaints),
+			PrioritizedList:      utilfeature.DefaultFeatureGate.Enabled(features.DRAPrioritizedList),
+			AdminAccess:          utilfeature.DefaultFeatureGate.Enabled(features.DRAAdminAccess),
+			DeviceTaints:         utilfeature.DefaultFeatureGate.Enabled(features.DRADeviceTaints),
+			PartitionableDevices: utilfeature.DefaultFeatureGate.Enabled(features.DRAPartitionableDevices),
 		}, []*resourceapi.ResourceClaim{claim}, allocatedDevices, draManager.DeviceClasses(), slices, celCache)
 		tCtx.ExpectNoError(err, "create allocator")
 

--- a/test/integration/scheduler_perf/dra/performance-config.yaml
+++ b/test/integration/scheduler_perf/dra/performance-config.yaml
@@ -415,6 +415,132 @@
       measurePods: 10
       maxClaimsPerNode: 10
 
+# SchedulingWithResourceClaimTemplatePartitionable is a variant of SchedulingWithResourceClaimTemplate.
+# It creates ResourceSlices with partitionable devices and uses a claim template referenced
+# by the test pods. It includes allocated claims that consumes counters and it sets up the devices
+# such that the allocator will have to backtrack once in order to find a working solution.
+- name: SteadyStateClusterResourceClaimTemplatePartitionable
+  featureGates:
+    DynamicResourceAllocation: true
+    DRAPartitionableDevices: true
+  workloadTemplate:
+  - opcode: createNodes
+    countParam: $nodesWithoutDRA
+  - opcode: createNodes
+    nodeTemplatePath: templates/node-with-dra-test-driver.yaml
+    countParam: $nodesWithDRA
+  - opcode: createAny
+    templatePath: templates/resourceslice-partitionable.yaml
+    countParam: $resourceSlices
+  - opcode: createAny
+    templatePath: templates/deviceclass.yaml
+  - opcode: createAny
+    templatePath: templates/resourceclaim-with-selector.yaml
+    namespace: init
+    countParam: $initClaims
+  - opcode: allocResourceClaims
+    namespace: init
+  - opcode: createAny
+    templatePath: templates/resourceclaimtemplate-for-two-devices.yaml
+    namespace: test
+  - opcode: createPods
+    namespace: test
+    countParam: $measurePods
+    steadyState: true
+    durationParam: $duration
+    podTemplatePath: templates/pod-with-claim-template.yaml
+    collectMetrics: true
+  workloads:
+  - name: fast
+    featureGates:
+      SchedulerQueueingHints: false
+    labels: [integration-test, short]
+    params:
+      # This testcase runs through all code paths without
+      # taking too long overall.
+      nodesWithDRA: 1
+      nodesWithoutDRA: 1
+      resourceSlices: 10
+      initClaims: 10
+      measurePods: 10
+      duration: 2s
+  - name: fast_QueueingHintsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
+    labels: [integration-test, short]
+    params:
+      # This testcase runs through all code paths without
+      # taking too long overall.
+      nodesWithDRA: 1
+      nodesWithoutDRA: 1
+      resourceSlices: 10
+      initClaims: 10
+      measurePods: 10
+      duration: 2s
+  - name: 2000pods_100nodes
+    params:
+      nodesWithDRA: 100
+      nodesWithoutDRA: 0
+      resourceSlices: 2000
+      initClaims: 2000
+      measurePods: 2000
+      duration: 10s
+
+# SchedulingWithResourceClaimTemplatePartitionableBacktracking is a variant of
+# SchedulingWithResourceClaimTemplate. It creates a single ResourceSlice and a
+# ResourceClaim that forces the allocator to backtrack multiple times in order
+# to find a solution.
+- name: SteadyStateClusterResourceClaimTemplatePartitionableBacktracking
+  featureGates:
+    DynamicResourceAllocation: true
+    DRAPartitionableDevices: true
+  workloadTemplate:
+  - opcode: createNodes
+    countParam: $nodesWithoutDRA
+  - opcode: createNodes
+    nodeTemplatePath: templates/node-with-dra-test-driver.yaml
+    countParam: $nodesWithDRA
+  - opcode: createAny
+    templatePath: templates/resourceslice-partitionable-backtracking.yaml
+    countParam: $resourceSlices
+  - opcode: createAny
+    templatePath: templates/deviceclass.yaml
+  - opcode: createAny
+    templatePath: templates/resourceclaimtemplate-backtracking.yaml
+    namespace: test
+  - opcode: createPods
+    namespace: test
+    countParam: $measurePods
+    steadyState: true
+    durationParam: $duration
+    podTemplatePath: templates/pod-with-claim-template.yaml
+    collectMetrics: true
+  workloads:
+  - name: fast
+    featureGates:
+      SchedulerQueueingHints: false
+    labels: [integration-test, short]
+    params:
+      # This testcase runs through all code paths without
+      # taking too long overall.
+      nodesWithDRA: 1
+      nodesWithoutDRA: 1
+      resourceSlices: 1
+      measurePods: 1
+      duration: 2s
+  - name: fast_QueueingHintsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
+    labels: [integration-test, short]
+    params:
+      # This testcase runs through all code paths without
+      # taking too long overall.
+      nodesWithDRA: 1
+      nodesWithoutDRA: 1
+      resourceSlices: 1
+      measurePods: 1
+      duration: 2s
+
 # SchedulingWithResourceClaimTemplate uses ResourceClaims
 # with deterministic names that are shared between pods.
 # There is a fixed ratio of 1:5 between claims and pods.

--- a/test/integration/scheduler_perf/dra/templates/node-with-dra-test-driver.yaml
+++ b/test/integration/scheduler_perf/dra/templates/node-with-dra-test-driver.yaml
@@ -3,6 +3,10 @@ kind: Node
 metadata:
   # The name is relevant for selecting whether the driver has resources for this node.
   generateName: scheduler-perf-dra-
+  # The label is used by the node selector in ResourceSlices to scope devices to nodes
+  # that have DRA enabled.
+  labels:
+    node-with-dra: "true"
 spec: {}
 status:
   capacity:

--- a/test/integration/scheduler_perf/dra/templates/resourceclaim-with-selector.yaml
+++ b/test/integration/scheduler_perf/dra/templates/resourceclaim-with-selector.yaml
@@ -1,0 +1,14 @@
+apiVersion: resource.k8s.io/v1alpha3
+kind: ResourceClaim
+metadata:
+  name: test-claim-with-selector-{{.Index}}
+spec:
+  devices:
+    requests:
+    - name: req-0
+      deviceClassName: test-class
+      selectors:
+      - cel:
+          expression: |-
+            device.capacity['test-driver.cdi.k8s.io'].counters.compareTo(quantity('2')) >= 0 &&
+            device.attributes['test-driver.cdi.k8s.io'].preallocate

--- a/test/integration/scheduler_perf/dra/templates/resourceclaimtemplate-backtracking.yaml
+++ b/test/integration/scheduler_perf/dra/templates/resourceclaimtemplate-backtracking.yaml
@@ -1,0 +1,11 @@
+apiVersion: resource.k8s.io/v1alpha3
+kind: ResourceClaimTemplate
+metadata:
+  name: test-claim-template
+spec:
+  spec:
+    devices:
+      requests:
+      - name: req-0
+        deviceClassName: test-class
+        count: 7

--- a/test/integration/scheduler_perf/dra/templates/resourceclaimtemplate-for-two-devices.yaml
+++ b/test/integration/scheduler_perf/dra/templates/resourceclaimtemplate-for-two-devices.yaml
@@ -1,0 +1,15 @@
+apiVersion: resource.k8s.io/v1alpha3
+kind: ResourceClaimTemplate
+metadata:
+  name: test-claim-template
+spec:
+  spec:
+    devices:
+      requests:
+      - name: req-0
+        deviceClassName: test-class
+        count: 2
+      constraints:
+      - requests:
+        - req-0
+        matchAttribute: dra.example.com/slice

--- a/test/integration/scheduler_perf/dra/templates/resourceslice-partitionable-backtracking.yaml
+++ b/test/integration/scheduler_perf/dra/templates/resourceslice-partitionable-backtracking.yaml
@@ -1,0 +1,129 @@
+kind: ResourceSlice
+apiVersion: resource.k8s.io/v1beta1
+metadata:
+  name: resourceslice-{{.Index}}
+spec:
+  pool:
+    name: resourceslice-{{.Index}}
+    generation: 1
+    resourceSliceCount: 1
+  driver: test-driver.cdi.k8s.io
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+      - key: node-with-dra
+        operator: In
+        values:
+        - "true"
+  sharedCounters:
+  - name: counter-set-for-cpu
+    counters:
+      cpu1:
+        value: "1"
+      cpu2:
+        value: "1"
+      cpu3:
+        value: "1"
+      cpu4:
+        value: "1"
+      cpu5:
+        value: "1"
+      cpu6:
+        value: "1"
+      cpu7:
+        value: "1"
+      cpu8:
+        value: "1"
+  - name: counter-set-for-mem
+    counters:
+      mem:
+        value: "70Gi"
+  devices:
+  - name: device-1
+    basic:
+      consumesCounters:
+      - counterSet: counter-set-for-cpu
+        counters:
+          cpu1:
+            value: "1"
+      - counterSet: counter-set-for-mem
+        counters:
+          mem:
+            value: "20Gi"
+  - name: device-2
+    basic:
+      consumesCounters:
+      - counterSet: counter-set-for-cpu
+        counters:
+          cpu2:
+            value: "1"
+      - counterSet: counter-set-for-mem
+        counters:
+          mem:
+            value: "10Gi"
+  - name: device-3
+    basic:
+      consumesCounters:
+      - counterSet: counter-set-for-cpu
+        counters:
+          cpu3:
+            value: "1"
+      - counterSet: counter-set-for-mem
+        counters:
+          mem:
+            value: "10Gi"
+  - name: device-4
+    basic:
+      consumesCounters:
+      - counterSet: counter-set-for-cpu
+        counters:
+          cpu4:
+            value: "1"
+      - counterSet: counter-set-for-mem
+        counters:
+          mem:
+            value: "10Gi"
+  - name: device-5
+    basic:
+      consumesCounters:
+      - counterSet: counter-set-for-cpu
+        counters:
+          cpu5:
+            value: "1"
+      - counterSet: counter-set-for-mem
+        counters:
+          mem:
+            value: "10Gi"
+  - name: device-6
+    basic:
+      consumesCounters:
+      - counterSet: counter-set-for-cpu
+        counters:
+          cpu6:
+            value: "1"
+      - counterSet: counter-set-for-mem
+        counters:
+          mem:
+            value: "10Gi"
+  - name: device-7
+    basic:
+      consumesCounters:
+      - counterSet: counter-set-for-cpu
+        counters:
+          cpu7:
+            value: "1"
+      - counterSet: counter-set-for-mem
+        counters:
+          mem:
+            value: "10Gi"
+  - name: device-8
+    basic:
+      consumesCounters:
+      - counterSet: counter-set-for-cpu
+        counters:
+          cpu8:
+            value: "1"
+      - counterSet: counter-set-for-mem
+        counters:
+          mem:
+            value: "10Gi"

--- a/test/integration/scheduler_perf/dra/templates/resourceslice-partitionable.yaml
+++ b/test/integration/scheduler_perf/dra/templates/resourceslice-partitionable.yaml
@@ -1,0 +1,125 @@
+kind: ResourceSlice
+apiVersion: resource.k8s.io/v1beta1
+metadata:
+  name: resourceslice-{{.Index}}
+spec:
+  pool:
+    name: resourceslice-{{.Index}}
+    generation: 1
+    resourceSliceCount: 1
+  driver: test-driver.cdi.k8s.io
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+      - key: node-with-dra
+        operator: In
+        values:
+        - "true"
+  sharedCounters:
+  - name: counter-set
+    counters:
+      counter1:
+        value: "1"
+      counter2:
+        value: "1"
+      counter3:
+        value: "1"
+      counter4:
+        value: "1"
+  devices:
+  # 2 counter devices
+  - name: device-2-counters-1
+    basic:
+      attributes:
+        preallocate:
+          bool: true
+        dra.example.com/slice:
+          int: {{.Index}}
+      capacity:
+        counters: 
+          value: "2"
+      consumesCounters:
+      - counterSet: counter-set
+        counters:
+          counter1:
+            value: "1"
+          counter2:
+            value: "1"
+  - name: device-2-counters-2
+    basic:
+      attributes:
+        preallocate:
+          bool: false
+        dra.example.com/slice:
+          int: {{.Index}}
+      capacity:
+        counters:
+          value: "2"
+      consumesCounters:
+      - counterSet: counter-set
+        counters:
+          counter3:
+            value: "1"
+          counter4:
+            value: "1"
+  # 1 counter devices
+  - name: device-1-counter-1
+    basic:
+      attributes:
+        preallocate:
+          bool: false
+        dra.example.com/slice:
+          int: {{.Index}}
+      capacity:
+        counters: 
+          value: "1"
+      consumesCounters:
+      - counterSet: counter-set
+        counters:
+          counter1:
+            value: "1"
+  - name: device-1-counter-2
+    basic:
+      attributes:
+        preallocate:
+          bool: false
+        dra.example.com/slice:
+          int: {{.Index}}
+      capacity:
+        counters: 
+          value: "1"
+      consumesCounters:
+      - counterSet: counter-set
+        counters:
+          counter2:
+            value: "1"
+  - name: device-1-counter-3
+    basic:
+      attributes:
+        preallocate:
+          bool: false
+        dra.example.com/slice:
+          int: {{.Index}}
+      capacity:
+        counters: 
+          value: "1"
+      consumesCounters:
+      - counterSet: counter-set
+        counters:
+          counter3:
+            value: "1"
+  - name: device-1-counter-4
+    basic:
+      attributes:
+        preallocate:
+          bool: false
+        dra.example.com/slice:
+          int: {{.Index}}
+      capacity:
+        counters:
+          value: "1"
+      consumesCounters:
+      - counterSet: counter-set
+        counters:
+          counter4:
+            value: "1"


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
This adds a scheduler perf test for the DRA Partitionable Devices feature. It lets us see the performance
impact of the feature and gives us a benchmark for performance optimizations (ref https://github.com/kubernetes/kubernetes/pull/131659).

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

