### PR TITLE
Automated cherry pick of #131623: kubelet: userns: Improve errors returned to the user

### DIFF
--- a/pkg/kubelet/kubelet_getters.go
+++ b/pkg/kubelet/kubelet_getters.go
@@ -120,8 +120,9 @@ func (kl *Kubelet) ListPodsFromDisk() ([]types.UID, error) {
 // user namespaces.
 func (kl *Kubelet) HandlerSupportsUserNamespaces(rtHandler string) (bool, error) {
 	rtHandlers := kl.runtimeState.runtimeHandlers()
-	if rtHandlers == nil {
-		return false, fmt.Errorf("runtime handlers are not set")
+	if len(rtHandlers) == 0 {
+		// The slice is empty if the runtime is old and doesn't support this message.
+		return false, nil
 	}
 	for _, h := range rtHandlers {
 		if h.Name == rtHandler {

--- a/pkg/kubelet/userns/userns_manager.go
+++ b/pkg/kubelet/userns/userns_manager.go
@@ -440,12 +440,12 @@ func (m *UsernsManager) GetOrCreateUserNamespaceMappings(pod *v1.Pod, runtimeHan
 	if string(content) != "" {
 		userNs, err = m.parseUserNsFileAndRecord(pod.UID, content)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("user namespace: %w", err)
 		}
 	} else {
 		userNs, err = m.createUserNs(pod)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("create user namespace: %w", err)
 		}
 	}
 
@@ -496,7 +496,7 @@ func (m *UsernsManager) CleanupOrphanedPodUsernsAllocations(pods []*v1.Pod, runn
 	allFound := sets.New[string]()
 	found, err := m.kl.ListPodsFromDisk()
 	if err != nil {
-		return err
+		return fmt.Errorf("user namespace: read pods from disk: %w", err)
 	}
 
 	for _, podUID := range found {


### PR DESCRIPTION
Cherry pick of #131623 on release-1.33.

#131623: kubelet: userns: Improve errors returned to the user

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Improve error message when a pod with user namespaces is created and the runtime doesn't support user namespaces.
```