### PR TITLE
Automated cherry pick of #130243: Revert userns kernel check

### DIFF
--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -138,8 +138,9 @@ func (kl *Kubelet) getKubeletMappings() (uint32, uint32, error) {
 				features.UserNamespacesSupport, err)
 		}
 		if kernelVersion != nil && !kernelVersion.AtLeast(version.MustParseGeneric(utilkernel.UserNamespacesSupportKernelVersion)) {
-			klog.InfoS("WARNING: the kernel version is incompatible with the feature gate, which needs as a minimum kernel version",
-				"kernelVersion", kernelVersion, "feature", features.UserNamespacesSupport, "minKernelVersion", utilkernel.UserNamespacesSupportKernelVersion)
+			return 0, 0, fmt.Errorf(
+				"the kernel version (%s) is incompatible with the %s feature gate, which needs %s as a minimum kernel version",
+				kernelVersion, features.UserNamespacesSupport, utilkernel.UserNamespacesSupportKernelVersion)
 		}
 	}
 

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -41,7 +41,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	utilvalidation "k8s.io/apimachinery/pkg/util/validation"
-	"k8s.io/apimachinery/pkg/util/version"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/klog/v2"
@@ -62,7 +61,6 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/status"
 	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
 	utilfs "k8s.io/kubernetes/pkg/util/filesystem"
-	utilkernel "k8s.io/kubernetes/pkg/util/kernel"
 	utilpod "k8s.io/kubernetes/pkg/util/pod"
 	volumeutil "k8s.io/kubernetes/pkg/volume/util"
 	"k8s.io/kubernetes/pkg/volume/util/hostutil"
@@ -131,17 +129,6 @@ func (kl *Kubelet) getKubeletMappings() (uint32, uint32, error) {
 
 	if !utilfeature.DefaultFeatureGate.Enabled(features.UserNamespacesSupport) {
 		return defaultFirstID, defaultLen, nil
-	} else {
-		kernelVersion, err := utilkernel.GetVersion()
-		if err != nil {
-			return 0, 0, fmt.Errorf("failed to get kernel version, unable to determine if feature %s can be supported : %w",
-				features.UserNamespacesSupport, err)
-		}
-		if kernelVersion != nil && !kernelVersion.AtLeast(version.MustParseGeneric(utilkernel.UserNamespacesSupportKernelVersion)) {
-			return 0, 0, fmt.Errorf(
-				"the kernel version (%s) is incompatible with the %s feature gate, which needs %s as a minimum kernel version",
-				kernelVersion, features.UserNamespacesSupport, utilkernel.UserNamespacesSupportKernelVersion)
-		}
 	}
 
 	_, err := user.Lookup(kubeletUser)

--- a/pkg/util/kernel/constants.go
+++ b/pkg/util/kernel/constants.go
@@ -44,10 +44,6 @@ const TCPFinTimeoutNamespacedKernelVersion = "4.6"
 // (ref: https://github.com/torvalds/linux/commit/35dfb013149f74c2be1ff9c78f14e6a3cd1539d1)
 const IPVSConnReuseModeFixedKernelVersion = "5.9"
 
-// UserNamespacesSupportKernelVersion is the kernel version where idmap for tmpfs support was added
-// (ref: https://github.com/torvalds/linux/commit/05e6295f7b5e05f09e369a3eb2882ec5b40fff20)
-const UserNamespacesSupportKernelVersion = "6.3"
-
 const TmpfsNoswapSupportKernelVersion = "6.4"
 
 // NFTablesKubeProxyKernelVersion is the lowest kernel version kube-proxy supports using


### PR DESCRIPTION
Cherry pick of #130243 on release-1.31.

This is not backported to 1.30 because it was added to 1.31
And it's nto backported to 1.33, because the change made it to 1.33

#130243: Revert userns kernel check

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixes a regression in 1.31, removing a warning around Linux user namespaces and kernel version. If the feature gate `UserNamespacesSupport` was enabled, the kubelet previously warned when detecting a Linux kernel version earlier than 6.3.0. User namespace support on Linux typically does still need kernel 6.3 or newer, but it can work in older kernels too.
```