### PR TITLE
feat: kubectl debug: add label for debugger pod for easy cleaning up the debug pods

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go
@@ -76,7 +76,7 @@ var (
 		* Node: Create a new pod that runs in the node's host namespaces and can access
 		        the node's filesystem.
 
-		Note: When a non-root user is configured for the entire target Pod, some capabilities granted 
+		Note: When a non-root user is configured for the entire target Pod, some capabilities granted
 		by debug profile may not work.
 `))
 
@@ -727,6 +727,9 @@ func (o *DebugOptions) generateNodeDebugPod(node *corev1.Node) (*corev1.Pod, err
 	p := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: pn,
+			Labels: map[string]string{
+				"app.kubernetes.io/managed-by": "kubectl-debug",
+			},
 		},
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug_test.go
@@ -1468,6 +1468,9 @@ func TestGenerateNodeDebugPod(t *testing.T) {
 			expected: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "node-debugger-node-XXX-1",
+					Labels: map[string]string{
+						"app.kubernetes.io/managed-by": "kubectl-debug",
+					},
 				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
@@ -1522,6 +1525,9 @@ func TestGenerateNodeDebugPod(t *testing.T) {
 			expected: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "node-debugger-node-XXX-1",
+					Labels: map[string]string{
+						"app.kubernetes.io/managed-by": "kubectl-debug",
+					},
 				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
@@ -1578,6 +1584,9 @@ func TestGenerateNodeDebugPod(t *testing.T) {
 			expected: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "node-debugger-node-XXX-1",
+					Labels: map[string]string{
+						"app.kubernetes.io/managed-by": "kubectl-debug",
+					},
 				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
@@ -1631,6 +1640,9 @@ func TestGenerateNodeDebugPod(t *testing.T) {
 			expected: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "node-debugger-node-XXX-1",
+					Labels: map[string]string{
+						"app.kubernetes.io/managed-by": "kubectl-debug",
+					},
 				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
@@ -1683,6 +1695,9 @@ func TestGenerateNodeDebugPod(t *testing.T) {
 			expected: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "node-debugger-node-XXX-1",
+					Labels: map[string]string{
+						"app.kubernetes.io/managed-by": "kubectl-debug",
+					},
 				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
@@ -1723,6 +1738,9 @@ func TestGenerateNodeDebugPod(t *testing.T) {
 			expected: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "node-debugger-node-XXX-1",
+					Labels: map[string]string{
+						"app.kubernetes.io/managed-by": "kubectl-debug",
+					},
 				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
@@ -1771,6 +1789,9 @@ func TestGenerateNodeDebugPod(t *testing.T) {
 			expected: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "node-debugger-node-XXX-1",
+					Labels: map[string]string{
+						"app.kubernetes.io/managed-by": "kubectl-debug",
+					},
 				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
@@ -1863,6 +1884,9 @@ func TestGenerateNodeDebugPodCustomProfile(t *testing.T) {
 			expected: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "node-debugger-node-XXX-1",
+					Labels: map[string]string{
+						"app.kubernetes.io/managed-by": "kubectl-debug",
+					},
 				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
@@ -1916,6 +1940,9 @@ func TestGenerateNodeDebugPodCustomProfile(t *testing.T) {
 			expected: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "node-debugger-node-XXX-1",
+					Labels: map[string]string{
+						"app.kubernetes.io/managed-by": "kubectl-debug",
+					},
 				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
@@ -1972,6 +1999,11 @@ func TestGenerateNodeDebugPodCustomProfile(t *testing.T) {
 				},
 			},
 			expected: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app.kubernetes.io/managed-by": "kubectl-debug",
+					},
+				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
@@ -2035,6 +2067,11 @@ func TestGenerateNodeDebugPodCustomProfile(t *testing.T) {
 				},
 			},
 			expected: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app.kubernetes.io/managed-by": "kubectl-debug",
+					},
+				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
pod created by `kubectl debug node/xxx` doesn't have any label attached to it, it is not convenience to clean up all this debug pod, this PR is to add `app.kubernetes.io/managed-by=kubectl-debug` label, so the clean up can be done by just running `kubectl delete $(kubectl get pod -l app.kubernetes.io/managed-by=kubectl-debug -o name)`

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
