### PR TITLE
DRA E2E: reduce risk of flake in ResourceSlice stress test

### DIFF
--- a/test/e2e/dra/dra.go
+++ b/test/e2e/dra/dra.go
@@ -1562,7 +1562,7 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), feature.Dynami
 			listSlices := framework.ListObjects(f.ClientSet.ResourceV1beta2().ResourceSlices().List, metav1.ListOptions{
 				FieldSelector: resourceapi.ResourceSliceSelectorDriver + "=" + driverName,
 			})
-			gomega.Eventually(ctx, listSlices).WithTimeout(time.Minute).Should(gomega.HaveField("Items", gomega.HaveLen(numSlices)))
+			gomega.Eventually(ctx, listSlices).WithTimeout(2 * time.Minute).Should(gomega.HaveField("Items", gomega.HaveLen(numSlices)))
 
 			// Verify state.
 			expectSlices, err := listSlices(ctx)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

In at least one case, the controller only got as far as creating 93 out of 100 slices in the allotted one minute:

    [FAILED] Timed out after 60.001s.
    Value for field 'Items' failed to satisfy matcher.
    Expected
        <[]v1beta2.ResourceSlice | len:93, cap:146>:
           ...
    to have length 100
    In [It] at: k8s.io/kubernetes/test/e2e/dra/dra.go:1520 @ 05/09/25 17:49:42.592


#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @bart0sh 