### PR TITLE
Automated cherry pick of #130800: Fix unit tests on windows

### DIFF
--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -132,6 +132,11 @@ func (kl *Kubelet) getKubeletMappings() (uint32, uint32, error) {
 		return defaultFirstID, defaultLen, nil
 	}
 
+	// Windows doesn't support user namespaces, let's return the default mappings.
+	if runtime.GOOS == "windows" {
+		return defaultFirstID, defaultLen, nil
+	}
+
 	_, err := user.Lookup(kubeletUser)
 	if err != nil {
 		var unknownUserErr user.UnknownUserError

--- a/pkg/kubelet/userns/types.go
+++ b/pkg/kubelet/userns/types.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package userns
+
+import "k8s.io/apimachinery/pkg/types"
+
+// Here go types that are common for all supported OS (windows, linux).
+
+type userNsPodsManager interface {
+	HandlerSupportsUserNamespaces(runtimeHandler string) (bool, error)
+	GetPodDir(podUID types.UID) string
+	ListPodsFromDisk() ([]types.UID, error)
+	GetKubeletMappings() (uint32, uint32, error)
+	GetMaxPods() int
+}

--- a/pkg/kubelet/userns/userns_manager.go
+++ b/pkg/kubelet/userns/userns_manager.go
@@ -1,3 +1,6 @@
+//go:build !windows
+// +build !windows
+
 /*
 Copyright 2022 The Kubernetes Authors.
 
@@ -42,14 +45,6 @@ const userNsLength = (1 << 16)
 // Create a new map when we removed enough pods to avoid memory leaks
 // since Go maps never free memory.
 const mapReInitializeThreshold = 1000
-
-type userNsPodsManager interface {
-	HandlerSupportsUserNamespaces(runtimeHandler string) (bool, error)
-	GetPodDir(podUID types.UID) string
-	ListPodsFromDisk() ([]types.UID, error)
-	GetKubeletMappings() (uint32, uint32, error)
-	GetMaxPods() int
-}
 
 type UsernsManager struct {
 	used    *allocator.AllocationBitmap

--- a/pkg/kubelet/userns/userns_manager.go
+++ b/pkg/kubelet/userns/userns_manager.go
@@ -127,7 +127,7 @@ func (m *UsernsManager) readMappingsFromFile(pod types.UID) ([]byte, error) {
 func MakeUserNsManager(kl userNsPodsManager) (*UsernsManager, error) {
 	kubeletMappingID, kubeletMappingLen, err := kl.GetKubeletMappings()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("kubelet mappings: %w", err)
 	}
 
 	if kubeletMappingID%userNsLength != 0 {

--- a/pkg/kubelet/userns/userns_manager_disabled_test.go
+++ b/pkg/kubelet/userns/userns_manager_disabled_test.go
@@ -1,3 +1,6 @@
+//go:build !windows
+// +build !windows
+
 /*
 Copyright 2022 The Kubernetes Authors.
 

--- a/pkg/kubelet/userns/userns_manager_switch_test.go
+++ b/pkg/kubelet/userns/userns_manager_switch_test.go
@@ -1,3 +1,6 @@
+//go:build !windows
+// +build !windows
+
 /*
 Copyright 2024 The Kubernetes Authors.
 

--- a/pkg/kubelet/userns/userns_manager_test.go
+++ b/pkg/kubelet/userns/userns_manager_test.go
@@ -1,3 +1,6 @@
+//go:build !windows
+// +build !windows
+
 /*
 Copyright 2022 The Kubernetes Authors.
 

--- a/pkg/kubelet/userns/userns_manager_windows.go
+++ b/pkg/kubelet/userns/userns_manager_windows.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package userns
+
+import (
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
+)
+
+type UsernsManager struct{}
+
+func MakeUserNsManager(kl userNsPodsManager) (*UsernsManager, error) {
+	return nil, nil
+}
+
+// Release releases the user namespace allocated to the specified pod.
+func (m *UsernsManager) Release(podUID types.UID) {
+	return
+}
+
+func (m *UsernsManager) GetOrCreateUserNamespaceMappings(pod *v1.Pod, runtimeHandler string) (*runtimeapi.UserNamespace, error) {
+	return nil, nil
+}
+
+// CleanupOrphanedPodUsernsAllocations reconciliates the state of user namespace
+// allocations with the pods actually running. It frees any user namespace
+// allocation for orphaned pods.
+func (m *UsernsManager) CleanupOrphanedPodUsernsAllocations(pods []*v1.Pod, runningPods []*kubecontainer.Pod) error {
+	return nil
+}
+
+func EnabledUserNamespacesSupport() bool {
+	return false
+}


### PR DESCRIPTION
Cherry pick of #130800 on release-1.30.

While unit tests work in this release, we want this for the userns stub implementation for windows.

#130800: Fix unit tests on windows

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```