### PR TITLE
Promote automatic_reloads of encryption config metrics to BETA

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/controller/controller_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/controller/controller_test.go
@@ -44,12 +44,12 @@ func TestController(t *testing.T) {
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.KMSv1, true)
 
 	const expectedSuccessMetricValue = `
-# HELP apiserver_encryption_config_controller_automatic_reloads_total [ALPHA] Total number of reload successes and failures of encryption configuration split by apiserver identity.
+# HELP apiserver_encryption_config_controller_automatic_reloads_total [BETA] Total number of reload successes and failures of encryption configuration split by apiserver identity.
 # TYPE apiserver_encryption_config_controller_automatic_reloads_total counter
 apiserver_encryption_config_controller_automatic_reloads_total{apiserver_id_hash="sha256:cd8a60cec6134082e9f37e7a4146b4bc14a0bf8a863237c36ec8fdb658c3e027",status="success"} 1
 `
 	const expectedFailureMetricValue = `
-# HELP apiserver_encryption_config_controller_automatic_reloads_total [ALPHA] Total number of reload successes and failures of encryption configuration split by apiserver identity.
+# HELP apiserver_encryption_config_controller_automatic_reloads_total [BETA] Total number of reload successes and failures of encryption configuration split by apiserver identity.
 # TYPE apiserver_encryption_config_controller_automatic_reloads_total counter
 apiserver_encryption_config_controller_automatic_reloads_total{apiserver_id_hash="sha256:cd8a60cec6134082e9f37e7a4146b4bc14a0bf8a863237c36ec8fdb658c3e027",status="failure"} 1
 `

--- a/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/metrics/metrics.go
@@ -38,7 +38,7 @@ var (
 			Subsystem:      subsystem,
 			Name:           "automatic_reloads_total",
 			Help:           "Total number of reload successes and failures of encryption configuration split by apiserver identity.",
-			StabilityLevel: metrics.ALPHA,
+			StabilityLevel: metrics.BETA,
 		},
 		[]string{"status", "apiserver_id_hash"},
 	)
@@ -49,7 +49,7 @@ var (
 			Subsystem:      subsystem,
 			Name:           "automatic_reload_last_timestamp_seconds",
 			Help:           "Timestamp of the last successful or failed automatic reload of encryption configuration split by apiserver identity.",
-			StabilityLevel: metrics.ALPHA,
+			StabilityLevel: metrics.BETA,
 		},
 		[]string{"status", "apiserver_id_hash"},
 	)

--- a/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/metrics/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/metrics/metrics_test.go
@@ -31,7 +31,7 @@ const (
 
 func TestRecordEncryptionConfigAutomaticReloadFailure(t *testing.T) {
 	expectedValue := `
-	# HELP apiserver_encryption_config_controller_automatic_reloads_total [ALPHA] Total number of reload successes and failures of encryption configuration split by apiserver identity.
+	# HELP apiserver_encryption_config_controller_automatic_reloads_total [BETA] Total number of reload successes and failures of encryption configuration split by apiserver identity.
     # TYPE apiserver_encryption_config_controller_automatic_reloads_total counter
     apiserver_encryption_config_controller_automatic_reloads_total {apiserver_id_hash="sha256:14f9d63e669337ac6bfda2e2162915ee6a6067743eddd4e5c374b572f951ff37",status="failure"} 1
 	`
@@ -50,7 +50,7 @@ func TestRecordEncryptionConfigAutomaticReloadFailure(t *testing.T) {
 
 func TestRecordEncryptionConfigAutomaticReloadSuccess(t *testing.T) {
 	expectedValue := `
-	# HELP apiserver_encryption_config_controller_automatic_reloads_total [ALPHA] Total number of reload successes and failures of encryption configuration split by apiserver identity.
+	# HELP apiserver_encryption_config_controller_automatic_reloads_total [BETA] Total number of reload successes and failures of encryption configuration split by apiserver identity.
     # TYPE apiserver_encryption_config_controller_automatic_reloads_total counter
     apiserver_encryption_config_controller_automatic_reloads_total {apiserver_id_hash="sha256:14f9d63e669337ac6bfda2e2162915ee6a6067743eddd4e5c374b572f951ff37",status="success"} 1
 	`
@@ -76,7 +76,7 @@ func TestEncryptionConfigAutomaticReloadLastTimestampSeconds(t *testing.T) {
 	}{
 		{
 			expectedValue: `
-                # HELP apiserver_encryption_config_controller_automatic_reload_last_timestamp_seconds [ALPHA] Timestamp of the last successful or failed automatic reload of encryption configuration split by apiserver identity.
+                # HELP apiserver_encryption_config_controller_automatic_reload_last_timestamp_seconds [BETA] Timestamp of the last successful or failed automatic reload of encryption configuration split by apiserver identity.
                 # TYPE apiserver_encryption_config_controller_automatic_reload_last_timestamp_seconds gauge
                 apiserver_encryption_config_controller_automatic_reload_last_timestamp_seconds{apiserver_id_hash="sha256:14f9d63e669337ac6bfda2e2162915ee6a6067743eddd4e5c374b572f951ff37",status="failure"} 1.689101941e+09
             `,
@@ -85,7 +85,7 @@ func TestEncryptionConfigAutomaticReloadLastTimestampSeconds(t *testing.T) {
 		},
 		{
 			expectedValue: `
-                # HELP apiserver_encryption_config_controller_automatic_reload_last_timestamp_seconds [ALPHA] Timestamp of the last successful or failed automatic reload of encryption configuration split by apiserver identity.
+                # HELP apiserver_encryption_config_controller_automatic_reload_last_timestamp_seconds [BETA] Timestamp of the last successful or failed automatic reload of encryption configuration split by apiserver identity.
                 # TYPE apiserver_encryption_config_controller_automatic_reload_last_timestamp_seconds gauge
                 apiserver_encryption_config_controller_automatic_reload_last_timestamp_seconds{apiserver_id_hash="sha256:14f9d63e669337ac6bfda2e2162915ee6a6067743eddd4e5c374b572f951ff37",status="success"} 1.689101941e+09
             `,

--- a/test/instrumentation/testdata/stable-metrics-list.yaml
+++ b/test/instrumentation/testdata/stable-metrics-list.yaml
@@ -50,6 +50,26 @@
   help: CEL evaluation time in seconds.
   type: Histogram
   stabilityLevel: BETA
+- name: automatic_reload_last_timestamp_seconds
+  subsystem: encryption_config_controller
+  namespace: apiserver
+  help: Timestamp of the last successful or failed automatic reload of encryption
+    configuration split by apiserver identity.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+  - apiserver_id_hash
+  - status
+- name: automatic_reloads_total
+  subsystem: encryption_config_controller
+  namespace: apiserver
+  help: Total number of reload successes and failures of encryption configuration
+    split by apiserver identity.
+  type: Counter
+  stabilityLevel: BETA
+  labels:
+  - apiserver_id_hash
+  - status
 - name: current_executing_requests
   subsystem: flowcontrol
   namespace: apiserver


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Promote `apiserever_encryption_config_controller_automatic_reloads_total` and `apiserver_encryption_config_controller_automatic_reload_last_timestamp_seconds` metrics to BETA. The feature has been GA since 1.29.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Promote `apiserever_encryption_config_controller_automatic_reloads_total` and `apiserver_encryption_config_controller_automatic_reload_last_timestamp_seconds` metrics to BETA. 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
[KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-auth/3299-kms-v2-improvements
```

/triage accepted
/sig auth
/priority important-soon
