### PR TITLE
future-proof csi test mocks

### DIFF
--- a/test/e2e/storage/drivers/csi-test/driver/mock.go
+++ b/test/e2e/storage/drivers/csi-test/driver/mock.go
@@ -34,19 +34,6 @@ type MockCSIDriver struct {
 	interceptor grpc.UnaryServerInterceptor
 }
 
-func NewMockCSIDriver(servers *MockCSIDriverServers, interceptor grpc.UnaryServerInterceptor) *MockCSIDriver {
-	return &MockCSIDriver{
-		CSIDriver: CSIDriver{
-			servers: &CSIDriverServers{
-				Controller: servers.Controller,
-				Node:       servers.Node,
-				Identity:   servers.Identity,
-			},
-		},
-		interceptor: interceptor,
-	}
-}
-
 // StartOnAddress starts a new gRPC server listening on given address.
 func (m *MockCSIDriver) StartOnAddress(network, address string) error {
 	l, err := net.Listen(network, address)

--- a/test/e2e/storage/drivers/csi-test/mock/service/service.go
+++ b/test/e2e/storage/drivers/csi-test/mock/service/service.go
@@ -113,6 +113,9 @@ type Service interface {
 }
 
 type service struct {
+	csi.UnimplementedControllerServer
+	csi.UnimplementedIdentityServer
+	csi.UnimplementedNodeServer
 	sync.Mutex
 	nodeID       string
 	vols         []csi.Volume


### PR DESCRIPTION
/kind cleanup

Fix for test compile failure when we switch to using `v1.11.0` of `github.com/container-storage-interface/spec`. You can see the error in:
https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-e2e-kind-dependencies/1923800045233115136

No, we don't want to switch to that version right now, but we should fix our code so it works now as well as when we do move to that version.

to recreate, do the following:
```
hack/pin-dependency.sh github.com/container-storage-interface/spec v1.11.0
hack/update-vendor.sh
```
and then compile the e2e.test:
```
❯ make WHAT=test/e2e/e2e.test
+++ [0517 20:38:42] Building go targets for darwin/arm64
    k8s.io/kubernetes/test/e2e/e2e.test (test)
# k8s.io/kubernetes/test/e2e/storage/drivers/csi-test/mock/service
test/e2e/storage/drivers/csi-test/mock/service/service.go:160:9: cannot use s (variable of type *service) as Service value in return statement: *service does not implement Service (missing method mustEmbedUnimplementedControllerServer)
# k8s.io/kubernetes/test/e2e/storage/drivers/csi-test/driver
test/e2e/storage/drivers/csi-test/driver/mock.go:41:17: cannot use servers.Controller (variable of type *MockControllerServer) as csi.ControllerServer value in struct literal: *MockControllerServer does not implement csi.ControllerServer (missing method mustEmbedUnimplementedControllerServer)
test/e2e/storage/drivers/csi-test/driver/mock.go:42:17: cannot use servers.Node (variable of type *MockNodeServer) as csi.NodeServer value in struct literal: *MockNodeServer does not implement csi.NodeServer (missing method mustEmbedUnimplementedNodeServer)
test/e2e/storage/drivers/csi-test/driver/mock.go:43:17: cannot use servers.Identity (variable of type *MockIdentityServer) as csi.IdentityServer value in struct literal: *MockIdentityServer does not implement csi.IdentityServer (missing method mustEmbedUnimplementedIdentityServer)
!!! [0517 20:39:59] Call tree:
!!! [0517 20:39:59]  1: /Users/davanum/go/src/k8s.io/kubernetes/hack/lib/golang.sh:997 kube::golang::build_binaries_for_platform(...)
!!! [0517 20:39:59]  2: hack/make-rules/build.sh:28 kube::golang::build_binaries(...)
!!! [0517 20:39:59] Call tree:
!!! [0517 20:39:59]  1: hack/make-rules/build.sh:28 kube::golang::build_binaries(...)
make: *** [all] Error 1
```

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
