### PR TITLE
Enforce structural rules in CRD OpenAPIv3 schema validation

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation.go
@@ -1483,6 +1483,18 @@ func (v *specStandardValidatorV3) validate(schema *apiextensions.JSONSchemaProps
 		allErrs = append(allErrs, field.Forbidden(fldPath.Child("items"), "items must be a schema object and not an array"))
 	}
 
+	if schema.Items != nil && schema.Type != "" && schema.Type != "array" {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("items"), schema.Type, "`items` is only valid when `type` is set to \"array\""))
+	}
+
+	if len(schema.Properties) > 0 && schema.Type != "" && schema.Type != "object" {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("properties"), schema.Type, "`properties` is only valid when `type` is set to \"object\""))
+	}
+
+	if schema.AdditionalProperties != nil && schema.Type != "" && schema.Type != "object" {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("additionalProperties"), schema.Type, "`additionalProperties` is only valid when `type` is set to \"object\""))
+	}
+
 	if v.isInsideResourceMeta && schema.XEmbeddedResource {
 		allErrs = append(allErrs, field.Forbidden(fldPath.Child("x-kubernetes-embedded-resource"), "must not be used inside of resource meta"))
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Tightens CRD OpenAPI v3 validation. A schema that sets `items`,
`properties`, or `additionalProperties` is now accepted **only** when
the owning schema declares the matching `type`:

* `items` : parent `type` **must** be `"array"`
* `properties`:  parent `type` **must** be `"object"`
* `additionalProperties`:  parent `type` **must** be `"object"`

These checks keep CRDs structurally valid, prevent runtime panics, and
align the apiserver with OpenAPI v3 constraints.

**Key changes**
* Add logic to `ValidateCustomResourceDefinitionOpenAPISchema`
* Extend unit tests to cover the new conditions
* Remove redundant expectations in existing tests

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #126273

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
CRD OpenAPI v3 validation now rejects schemas that set `items` when the parent type is not `"array"`, or `properties` / `additionalProperties` when the parent type is not `"object"`.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
