### PR TITLE
Deny pod admission for static pods referencing API objects

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -918,6 +918,11 @@ const (
 	// Enables the image volume source.
 	ImageVolume featuregate.Feature = "ImageVolume"
 
+	// owner: @sreeram-venkitesh
+	//
+	// Denies pod admission if static pods reference other API objects.
+	PreventStaticPodAPIReferences featuregate.Feature = "PreventStaticPodAPIReferences"
+
 	// owner: @zhifei92
 	//
 	// Enables the systemd watchdog for the kubelet. When enabled, the kubelet will
@@ -1753,6 +1758,10 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 		{Version: version.MustParse("1.23"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("1.27"), Default: true, PreRelease: featuregate.Beta},
 		{Version: version.MustParse("1.32"), Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // GA in 1.32, remove in 1.35
+	},
+
+	PreventStaticPodAPIReferences: {
+		{Version: version.MustParse("1.34"), Default: true, PreRelease: featuregate.Beta},
 	},
 
 	StorageCapacityScoring: {

--- a/pkg/kubelet/config/common.go
+++ b/pkg/kubelet/config/common.go
@@ -28,8 +28,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	podutil "k8s.io/kubernetes/pkg/api/pod"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/core/helper"
+	"k8s.io/kubernetes/pkg/features"
 
 	// TODO: remove this import if
 	// api.Registry.GroupOrDie(v1.GroupName).GroupVersion.String() is changed
@@ -144,19 +147,31 @@ func tryDecodeSinglePod(data []byte, defaultFn defaultFunc) (parsed bool, pod *v
 		return true, nil, err
 	}
 
-	for _, v := range v1Pod.Spec.Volumes {
-		if v.Projected == nil {
-			continue
+	if utilfeature.DefaultFeatureGate.Enabled(features.PreventStaticPodAPIReferences) {
+		// Check if pod has references to API objects
+		_, resource, err := podutil.HasAPIObjectReference(newPod)
+		if err != nil {
+			return true, nil, err
 		}
+		if resource != "" {
+			return true, nil, fmt.Errorf("static pods may not reference %s", resource)
+		}
+	} else {
+		// TODO: Remove this else block once the PreventStaticPodAPIReferences gate is GA
+		for _, v := range v1Pod.Spec.Volumes {
+			if v.Projected == nil {
+				continue
+			}
 
-		for _, s := range v.Projected.Sources {
-			if s.ClusterTrustBundle != nil {
-				return true, nil, ErrStaticPodTriedToUseClusterTrustBundle
+			for _, s := range v.Projected.Sources {
+				if s.ClusterTrustBundle != nil {
+					return true, nil, ErrStaticPodTriedToUseClusterTrustBundle
+				}
 			}
 		}
-	}
-	if len(v1Pod.Spec.ResourceClaims) > 0 {
-		return true, nil, ErrStaticPodTriedToUseResourceClaims
+		if len(v1Pod.Spec.ResourceClaims) > 0 {
+			return true, nil, ErrStaticPodTriedToUseResourceClaims
+		}
 	}
 
 	return true, v1Pod, nil
@@ -187,6 +202,16 @@ func tryDecodePodList(data []byte, defaultFn defaultFunc) (parsed bool, pods v1.
 		if errs := validation.ValidatePodCreate(newPod, validation.PodValidationOptions{}); len(errs) > 0 {
 			err = fmt.Errorf("invalid pod: %v", errs)
 			return true, pods, err
+		}
+		if utilfeature.DefaultFeatureGate.Enabled(features.PreventStaticPodAPIReferences) {
+			// Check if pod has references to API objects
+			_, resource, err := podutil.HasAPIObjectReference(newPod)
+			if err != nil {
+				return true, pods, err
+			}
+			if resource != "" {
+				return true, pods, fmt.Errorf("static pods may not reference %s", resource)
+			}
 		}
 	}
 	v1Pods := &v1.PodList{}

--- a/pkg/kubelet/config/common_test.go
+++ b/pkg/kubelet/config/common_test.go
@@ -17,8 +17,9 @@ limitations under the License.
 package config
 
 import (
-	"errors"
+	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -175,8 +176,8 @@ func TestDecodeSinglePodRejectsClusterTrustBundleVolumes(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 	_, _, err = tryDecodeSinglePod(json, noDefault)
-	if !errors.Is(err, ErrStaticPodTriedToUseClusterTrustBundle) {
-		t.Errorf("Got error %q, want %q", err, ErrStaticPodTriedToUseClusterTrustBundle)
+	if !strings.Contains(err.Error(), "may not reference clustertrustbundles") {
+		t.Errorf("Got error %q, want %q", err, fmt.Errorf("static pods may not reference clustertrustbundles API objects"))
 	}
 }
 
@@ -231,8 +232,8 @@ func TestDecodeSinglePodRejectsResourceClaims(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 	_, _, err = tryDecodeSinglePod(json, noDefault)
-	if !errors.Is(err, ErrStaticPodTriedToUseResourceClaims) {
-		t.Errorf("Got error %q, want %q", err, ErrStaticPodTriedToUseResourceClaims)
+	if !strings.Contains(err.Error(), "may not reference resourceclaims") {
+		t.Errorf("Got error %q, want %q", err, fmt.Errorf("static pods may not reference resourceclaims API objects"))
 	}
 }
 

--- a/plugin/pkg/admission/noderestriction/admission_test.go
+++ b/plugin/pkg/admission/noderestriction/admission_test.go
@@ -1032,7 +1032,7 @@ func Test_nodePlugin_Admit(t *testing.T) {
 			name:       "forbid create of pod referencing service account",
 			podsGetter: noExistingPods,
 			attributes: admission.NewAttributesRecord(sapod, nil, podKind, sapod.Namespace, sapod.Name, podResource, "", admission.Create, &metav1.CreateOptions{}, false, mynode),
-			err:        "reference a service account",
+			err:        "can not create pods that reference serviceaccounts",
 		},
 		{
 			name:       "forbid create of pod referencing secret",
@@ -1056,7 +1056,7 @@ func Test_nodePlugin_Admit(t *testing.T) {
 			name:       "forbid create of pod referencing persistentvolumeclaim",
 			podsGetter: noExistingPods,
 			attributes: admission.NewAttributesRecord(pvcpod, nil, podKind, pvcpod.Namespace, pvcpod.Name, podResource, "", admission.Create, &metav1.CreateOptions{}, false, mynode),
-			err:        "reference persistentvolumeclaims",
+			err:        "can not create pods that reference persistentvolumeclaims",
 		},
 		{
 			name:       "forbid create of pod referencing resourceclaim",

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -1107,6 +1107,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "1.34"
+- name: PreventStaticPodAPIReferences
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.34"
 - name: ProcMountType
   versionedSpecs:
   - default: false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Currently, mirror pod reconciliation for static pods which reference API objects will fail. However the pod itself is not denied admission and the node would be silently running the static pod's container. As discussed in https://github.com/kubernetes/kubernetes/issues/103587#issuecomment-2433035095, we want to tighten the validation here so that pod would not be running at all in the node. Currently the static pod would be running in the node while the mirror pod would not be created (which is enforced in the API as per https://github.com/kubernetes/kubernetes/issues/103587#issuecomment-1456581669). This PR updates the validation logic so that the pod is denied admission for static pods referencing API objects and make sure that the container is not created in the node.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/103587

#### Special notes for your reviewer:

Notes:
- I've added a new StaticPodAdmitHandler so that this validation is done from `canAdmitPod`. This is based on @gjkim42's comment https://github.com/kubernetes/kubernetes/pull/105368#issuecomment-984576615.
- The structure of the handler and the tests were inspired from the `PredicateAdmitHandler` in [pkg/kubelet/lifecycle/predicate.go](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/lifecycle/predicate.go#L116-L242)
- Only `hostPath` and `emptyDir` volume mounts are made valid for static pods based on @enj's comment: https://github.com/kubernetes/kubernetes/issues/103587#issuecomment-1448211779
- I've added a `StaticPodStrictValidation` feature gate with which we can toggle the changes to the validation.

Question:
- I wanted to add an e2e_node test. I was going through [test/e2e_node/mirror_pod_test.go](https://github.com/kubernetes/kubernetes/blob/master/test/e2e_node/mirror_pod_test.go) since it has helpers for static pod creation etc, but I'm still figuring out the failure case where we need to assert that the pod was denied admission from the kubelet logs?

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Static pods that reference API objects are now denied admission by the kubelet so that static pods would not be silently running even after the mirror pod creation fails.
ACTION REQUIRED: Prior to upgrade, ensure static pods are not referencing API objects such as ServiceAccounts, ConfigMaps, Secrets, ResourceClaims, CSIDrivers, PersistentVolumeClaims, or ClusterTrustBundles.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->

(The feature gate should be documented. I will update the docs PR here once opened.)
```docs

```
