### PR TITLE
hack/local-up-cluster.sh: remove kubelet --cloud-config

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -817,7 +817,7 @@ function start_kubelet {
     KUBELET_LOG=${LOG_DIR}/kubelet.log
     mkdir -p "${POD_MANIFEST_PATH}" &>/dev/null || sudo mkdir -p "${POD_MANIFEST_PATH}"
 
-    cloud_config_arg=("--cloud-provider=${CLOUD_PROVIDER}" "--cloud-config=${CLOUD_CONFIG}")
+    cloud_config_arg=("--cloud-provider=${CLOUD_PROVIDER}")
     if [[ "${EXTERNAL_CLOUD_PROVIDER:-}" == "true" ]]; then
        cloud_config_arg=("--cloud-provider=external")
        if [[ "${CLOUD_PROVIDER:-}" == "aws" ]]; then


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:

c0b2f341a725d4f17cf0812f6c29876f5ad37fe6 (https://github.com/kubernetes/kubernetes/pull/130161) removed that flag, which was already deprecated earlier. When passing it now, kubelet fails to come up.

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubernetes/pull/130161#discussion_r2095003487

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @carlory 