### PR TITLE
ResourceQuota: partial fix "should verify ResourceQuota with terminating scopes through scope selectors" flake

### DIFF
--- a/test/e2e/apimachinery/resource_quota.go
+++ b/test/e2e/apimachinery/resource_quota.go
@@ -1606,6 +1606,8 @@ var _ = SIGDescribe("ResourceQuota", func() {
 		usedResources[v1.ResourceLimitsMemory] = resource.MustParse("0")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaNotTerminating.Name, usedResources)
 		framework.ExpectNoError(err)
+		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaTerminating.Name, usedResources)
+		framework.ExpectNoError(err)
 
 		ginkgo.By("Creating a terminating pod")
 		_, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod2, metav1.CreateOptions{})

--- a/test/e2e/apimachinery/resource_quota.go
+++ b/test/e2e/apimachinery/resource_quota.go
@@ -61,6 +61,7 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/gcustom"
+	gomegatypes "github.com/onsi/gomega/types"
 )
 
 const (
@@ -797,7 +798,7 @@ var _ = SIGDescribe("ResourceQuota", func() {
 		usedResources[v1.ResourceRequestsMemory] = resource.MustParse("0")
 		usedResources[v1.ResourceLimitsCPU] = resource.MustParse("0")
 		usedResources[v1.ResourceLimitsMemory] = resource.MustParse("0")
-		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaTerminating.Name, usedResources)
+		err = ensureResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaTerminating.Name, usedResources)
 		framework.ExpectNoError(err)
 
 		ginkgo.By("Deleting the pod")
@@ -837,6 +838,8 @@ var _ = SIGDescribe("ResourceQuota", func() {
 		usedResources[v1.ResourceLimitsCPU] = resource.MustParse("0")
 		usedResources[v1.ResourceLimitsMemory] = resource.MustParse("0")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaNotTerminating.Name, usedResources)
+		framework.ExpectNoError(err)
+		err = ensureResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaNotTerminating.Name, usedResources)
 		framework.ExpectNoError(err)
 
 		ginkgo.By("Deleting the pod")
@@ -1559,6 +1562,12 @@ var _ = SIGDescribe("ResourceQuota", func() {
 		usedResources[v1.ResourceLimitsMemory] = resource.MustParse("0")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaTerminating.Name, usedResources)
 		framework.ExpectNoError(err)
+		// It already was like this before, so typically waitForResourceQuota returns immediately.
+		// Keep checking for a while to detect unexpected changes. There has been a test flake
+		// where updating the pod failed with:
+		//   pods "test-pod" is forbidden: exceeded quota: quota-terminating, requested: pods=1, used: pods=1, limited: pods=1
+		err = ensureResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaTerminating.Name, usedResources)
+		framework.ExpectNoError(err)
 
 		ginkgo.By("Updating the pod to have an active deadline")
 		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
@@ -1605,8 +1614,6 @@ var _ = SIGDescribe("ResourceQuota", func() {
 		usedResources[v1.ResourceLimitsCPU] = resource.MustParse("0")
 		usedResources[v1.ResourceLimitsMemory] = resource.MustParse("0")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaNotTerminating.Name, usedResources)
-		framework.ExpectNoError(err)
-		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaTerminating.Name, usedResources)
 		framework.ExpectNoError(err)
 
 		ginkgo.By("Creating a terminating pod")
@@ -2487,12 +2494,31 @@ func countResourceQuota(ctx context.Context, c clientset.Interface, namespace st
 // Wait for resource quota status to show the expected used resources value.
 // Other resources are ignored.
 func waitForResourceQuota(ctx context.Context, c clientset.Interface, ns, quotaName string, used v1.ResourceList) error {
+	var lastResourceQuota *v1.ResourceQuota
+	err := framework.Gomega().Eventually(ctx, framework.GetObject(c.CoreV1().ResourceQuotas(ns).Get, quotaName, metav1.GetOptions{})).Should(haveUsedResources(used, &lastResourceQuota))
+	if lastResourceQuota != nil && err == nil {
+		framework.Logf("Got expected ResourceQuota:\n%s", format.Object(lastResourceQuota, 1))
+	}
+	return err
+}
+
+// Ensure that the resource quota status shows the expected used resources value and does not change.
+// Other resources are ignored.
+func ensureResourceQuota(ctx context.Context, c clientset.Interface, ns, quotaName string, used v1.ResourceList) error {
+	// The longer we check the higher the confidence that it really remains the same.
+	// But we don't want to delay too long because it makes the test slower.
+	err := framework.Gomega().Consistently(ctx, framework.GetObject(c.CoreV1().ResourceQuotas(ns).Get, quotaName, metav1.GetOptions{})).WithTimeout(10 * time.Second).Should(haveUsedResources(used, nil))
+	return err
+}
+
+func haveUsedResources(used v1.ResourceList, lastResourceQuota **v1.ResourceQuota) gomegatypes.GomegaMatcher {
 	// The template emits the actual ResourceQuota object as YAML.
 	// In particular the ManagedFields are interesting because both
 	// kube-apiserver and kube-controller-manager set the status.
-	var lastResourceQuota *v1.ResourceQuota
-	haveUsedResources := gcustom.MakeMatcher(func(resourceQuota *v1.ResourceQuota) (bool, error) {
-		lastResourceQuota = resourceQuota
+	return gcustom.MakeMatcher(func(resourceQuota *v1.ResourceQuota) (bool, error) {
+		if lastResourceQuota != nil {
+			*lastResourceQuota = resourceQuota
+		}
 		// used may not yet be calculated
 		if resourceQuota.Status.Used == nil {
 			return false, nil
@@ -2505,11 +2531,6 @@ func waitForResourceQuota(ctx context.Context, c clientset.Interface, ns, quotaN
 		}
 		return true, nil
 	}).WithTemplate("Expected:\n{{.FormattedActual}}\n{{.To}} have the following .status.used entries:\n{{range $key, $value := .Data}}    {{$key}}: \"{{$value.ToUnstructured}}\"\n{{end}}").WithTemplateData(used /* Formatting of the map is done inside the template. */)
-	err := framework.Gomega().Eventually(ctx, framework.GetObject(c.CoreV1().ResourceQuotas(ns).Get, quotaName, metav1.GetOptions{})).Should(haveUsedResources)
-	if lastResourceQuota != nil && err == nil {
-		framework.Logf("Got expected ResourceQuota:\n%s", format.Object(lastResourceQuota, 1))
-	}
-	return err
 }
 
 // updateResourceQuotaUntilUsageAppears updates the resource quota object until the usage is populated


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind failing-test
/kind flake

#### What this PR does / why we need it:

As can be seen in the output of a test failure in the CI (see commit messages), the test waits for  "quota-not-terminating" to be updated, but then fails because creating the pod exceeds the "quota-terminating" quota which has not been updated yet. As both ResourceQuotas apply, it needs to wait for both of them to be updated.

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/kubernetes/issues/131834:

```
STEP: Creating a terminating pod - k8s.io/kubernetes/test/e2e/apimachinery/resource_quota.go:1609 @ 05/18/25 04:59:42.313
...
[FAILED] pods "terminating-pod" is forbidden: exceeded quota: quota-terminating, requested: pods=1, used: pods=1, limited: pods=1
In [It] at: k8s.io/kubernetes/test/e2e/apimachinery/resource_quota.go:1611 @ 05/18/25 04:59:42.337
```

It does *not* fix this one:
```
STEP: Updating the pod to have an active deadline - k8s.io/kubernetes/test/e2e/apimachinery/resource_quota.go:1563 @ 05/19/25 07:49:11.512
...
[FAILED] pods "test-pod" is forbidden: exceeded quota: quota-terminating, requested: pods=1, used: pods=1, limited: pods=1
In [It] at: k8s.io/kubernetes/test/e2e/apimachinery/resource_quota.go:1573 @ 05/19/25 07:49:11.572
```

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
