### PR TITLE
kubelet: Fix potential goroutine leak in unit tests

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1823,7 +1823,7 @@ func (kl *Kubelet) Run(updates <-chan kubetypes.PodUpdate) {
 	}
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.SystemdWatchdog) {
-		kl.healthChecker.Start()
+		kl.healthChecker.Start(ctx)
 	}
 
 	kl.syncLoop(ctx, updates, kl)

--- a/pkg/kubelet/watchdog/types.go
+++ b/pkg/kubelet/watchdog/types.go
@@ -16,11 +16,14 @@ limitations under the License.
 
 package watchdog
 
-import "net/http"
+import (
+	"context"
+	"net/http"
+)
 
 // HealthChecker defines the interface of health checkers.
 type HealthChecker interface {
-	Start()
+	Start(ctx context.Context)
 }
 
 // syncLoopHealthChecker contains the health check method for syncLoop.

--- a/pkg/kubelet/watchdog/watchdog_unsupported.go
+++ b/pkg/kubelet/watchdog/watchdog_unsupported.go
@@ -19,7 +19,10 @@ limitations under the License.
 
 package watchdog
 
-import "k8s.io/apiserver/pkg/server/healthz"
+import (
+	"context"
+	"k8s.io/apiserver/pkg/server/healthz"
+)
 
 type healthCheckerUnsupported struct{}
 
@@ -36,6 +39,6 @@ func NewHealthChecker(_ syncLoopHealthChecker, _ ...Option) (HealthChecker, erro
 	return &healthCheckerUnsupported{}, nil
 }
 
-func (ow *healthCheckerUnsupported) Start() {
+func (ow *healthCheckerUnsupported) Start(ctx context.Context) {
 	return
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
After a unit test completes, the goroutine in `healthChecker.Start` continues running and does not terminate due to the use of `wait.Forever()`. Unless the tests program stops, the goroutine will not exit, leading to two issues:

* Logs from multiple test cases may interleave with each other.
* If we use `logger` (contextual logger) instead of `klog`, since the `logger` is bound to the test case's context, the logger's resources are released after the test ends. If the goroutine continues to use the logger to output logs, it may access freed resources, potentially causing exceptions or being detected as a leak. In contrast, klog is global and does not depend on the test case context, so it does not have this issue.


This test case was fixed once in PR #128290 due to a data race (caused by simultaneous log writes from multiple test cases). However, instead of propagating context to `healthChecker.Start()` and adding a termination condition, a lock was used to prevent data races. While this fixed the data race, it did not address the issue of log interleaving and does not allow switching to **contextual logger**.

While reviewing PR #130367, I noticed this issue. The PR currently does not get merge (as it fails unit tests). Maybe
we could cherry-pick the fix from current PR into #130367, but to keep the PR's focus narrow, we could also merge it separately here.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
I ran the unit tests based on this PR 100 times, and no exceptions occurred.
```
stress ./watchdog.test -test.run TestHealthCheckerStart
5s: 0 runs so far, 0 failures, 4 active
10s: 0 runs so far, 0 failures, 4 active
15s: 0 runs so far, 0 failures, 4 active
20s: 0 runs so far, 0 failures, 4 active
25s: 0 runs so far, 0 failures, 4 active
30s: 0 runs so far, 0 failures, 4 active
35s: 0 runs so far, 0 failures, 4 active
....
15m10s: 96 runs so far, 0 failures, 4 active
15m15s: 96 runs so far, 0 failures, 4 active
15m20s: 96 runs so far, 0 failures, 4 active
15m25s: 96 runs so far, 0 failures, 4 active
15m30s: 100 runs so far, 0 failures, 4 active
15m35s: 100 runs so far, 0 failures, 4 active
15m40s: 100 runs so far, 0 failures, 4 active
15m45s: 100 runs so far, 0 failures, 4 active
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
