### PR TITLE
add mutateCachingObject

### DIFF
--- a/pkg/registry/core/service/storage/storage.go
+++ b/pkg/registry/core/service/storage/storage.go
@@ -235,6 +235,15 @@ func (r *REST) defaultOnRead(obj runtime.Object) {
 		r.defaultOnReadService(s)
 	case *api.ServiceList:
 		r.defaultOnReadServiceList(s)
+	case runtime.MutateCacheableObject:
+		obj := s.GetObject()
+		service, ok := obj.(*api.Service)
+		if !ok {
+			klog.Warningf("unexpected object type: %T", obj)
+			return
+		}
+		r.defaultOnReadService(service)
+		s.MutateObject(service)
 	default:
 		// This was not an object we can default.  This is not an error, as the
 		// caching layer can pass through here, too.

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/interfaces.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/interfaces.go
@@ -360,6 +360,14 @@ type CacheableObject interface {
 	GetObject() Object
 }
 
+// MutateCacheableObject is a superset of CacheableObject. It allows an object to
+// mutate its cached serialization.
+type MutateCacheableObject interface {
+	CacheableObject
+	// MutateObject	mutates the object to be encoded.
+	MutateObject(obj Object)
+}
+
 // Unstructured objects store values as map[string]interface{}, with only values that can be serialized
 // to JSON allowed.
 type Unstructured interface {

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/caching_object.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/caching_object.go
@@ -410,3 +410,9 @@ func (o *cachingObject) SetManagedFields(managedFields []metav1.ManagedFieldsEnt
 		func() { o.object.SetManagedFields(managedFields) },
 	)
 }
+
+func (o *cachingObject) MutateObject(obj runtime.Object) {
+	o.conditionalSet(
+		func() bool { return reflect.DeepEqual(o.object, obj) },
+		func() { o.object = obj.(metaRuntimeInterface) })
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Add a `mutateCachingObject` object, which can be used in the Service decorator to automatically add the `ipfamilies` field to Service objects that are missing this field by default. This helps to avoid the issue where `cachingObject` does not automatically add the `ipfamilies` field.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://github.com/kubernetes/kubernetes/issues/131779

#### Special notes for your reviewer:

I'm not sure if this is the most appropriate solution. If there is a better approach, please let me know.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
