### PR TITLE
test/e2e/apimachinery/namespace.go: make OrderedNamespaceDeletion test serial

### DIFF
--- a/test/e2e/apimachinery/namespace.go
+++ b/test/e2e/apimachinery/namespace.go
@@ -20,10 +20,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"k8s.io/kubernetes/pkg/features"
 	"strings"
 	"sync"
 	"time"
+
+	"k8s.io/kubernetes/pkg/features"
 
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -481,7 +482,7 @@ var _ = SIGDescribe("OrderedNamespaceDeletion", func() {
 	f := framework.NewDefaultFramework("namespacedeletion")
 	f.NamespacePodSecurityLevel = admissionapi.LevelBaseline
 
-	f.It("namespace deletion should delete pod first", feature.OrderedNamespaceDeletion, framework.WithFeatureGate(features.OrderedNamespaceDeletion), func(ctx context.Context) {
+	f.It("namespace deletion should delete pod first", framework.WithFeatureGate(features.OrderedNamespaceDeletion), framework.WithSerial(), func(ctx context.Context) {
 		ensurePodsAreRemovedFirstInOrderedNamespaceDeletion(ctx, f)
 	})
 })

--- a/test/e2e/feature/feature.go
+++ b/test/e2e/feature/feature.go
@@ -313,10 +313,6 @@ var (
 	// Tests aiming to verify oom_score functionality
 	OOMScoreAdj = framework.WithFeature(framework.ValidFeatures.Add("OOMScoreAdj"))
 
-	// Owner: sig-api-machinery
-	// Marks tests that enforce ordered namespace deletion.
-	OrderedNamespaceDeletion = framework.WithFeature(framework.ValidFeatures.Add("OrderedNamespaceDeletion"))
-
 	// Owner: sig-node
 	// Verify ProcMount feature.
 	// Used in combination with user namespaces


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test
/kind flake

#### What this PR does / why we need it:

With `OrderedNamespaceDeletion` enabled by default, the namespace controller deletes resources before deleting the namespace itself.

Some tests create many resources, and when they finish around the same time, the namespace controller can become busy (specially with the default number of workers, which is 10). This can delay the start of resource deletion, causing this test to time out. 

Initially, this patch increased the test timeout to account for that delay. However, the test still flaked in 1 out of 10 jobs, which suggests increasing the timeouts isn't enough. Once the test was made serial, no flakes were observed.

We saw this issue in our CI (OpenShift), especially in jobs that run many tests, including tests with Beta features enabled by default (as in this case). In one failure, the test was waiting for a pod to be deleted. Custom debug logs in the namespace controller (specifically in the code path handling namespace and resource deletion) showed a spike in activity at that time (see image below), suggesting the controller was under load and needed more time to process resources from the test.

![image](https://github.com/user-attachments/assets/130023d7-e06e-4846-a1bc-cf875452e33e)

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
