### PR TITLE
kubelet: Improve error handling in GeneratePodStatus function

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -1591,10 +1591,24 @@ func (m *kubeGenericRuntimeManager) killPodWithSyncResult(ctx context.Context, p
 }
 
 func (m *kubeGenericRuntimeManager) GeneratePodStatus(event *runtimeapi.ContainerEventResponse) (*kubecontainer.PodStatus, error) {
+	if event == nil {
+		return nil, errors.New("container event response is nil")
+	}
+	if event.PodSandboxStatus == nil {
+		return nil, errors.New("pod sandbox status is nil")
+	}
+	if event.PodSandboxStatus.Metadata == nil {
+		return nil, errors.New("pod sandbox metadata is nil")
+	}
+
 	podIPs := m.determinePodSandboxIPs(event.PodSandboxStatus.Metadata.Namespace, event.PodSandboxStatus.Metadata.Name, event.PodSandboxStatus)
 
 	kubeContainerStatuses := []*kubecontainer.Status{}
 	for _, status := range event.ContainersStatuses {
+		if status == nil {
+			klog.V(4).InfoS("Container status in event is nil")
+			continue
+		}
 		kubeContainerStatuses = append(kubeContainerStatuses, m.convertToKubeContainerStatus(status))
 	}
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
This PR improves error handling in the `GeneratePodStatus` function by adding nil checks for its inputs and status values. This prevents potential nil pointer dereference panics that could occur if the function receives incomplete or corrupted event data.

The changes include:
1. Adding a check for nil `event` parameter
2. Adding a check for nil `event.PodSandboxStatus`
3. Adding a check for nil `event.PodSandboxStatus.Metadata`
4. Adding a check for nil container statuses in `event.ContainersStatuses`

This is consistent with the error handling pattern used in other similar functions such as `GetPodStatus` which already includes similar nil checks.


#### Special notes for your reviewer:
The change is minimal but improves code robustness by adding proper error handling that was missing from the `GeneratePodStatus` function but present in similar functions like `GetPodStatus`.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
NONE
```