### PR TITLE
Remove superflous expansion calls if controller finished expansion

### DIFF
--- a/pkg/volume/util/operationexecutor/node_expander.go
+++ b/pkg/volume/util/operationexecutor/node_expander.go
@@ -96,12 +96,13 @@ func (ne *NodeExpander) runPreCheck() bool {
 		ne.markExpansionInfeasibleOnFailure = true
 	}
 
+	if ne.pvcStatusCap.Cmp(ne.pluginResizeOpts.NewSize) >= 0 && ne.resizeStatus == "" {
+		ne.pvcAlreadyUpdated = true
+	}
+
 	// PVC is already expanded but we are still trying to expand the volume because
 	// last recorded size in ASOW is older. This can happen for RWX volume types.
-	if ne.pvcStatusCap.Cmp(ne.pluginResizeOpts.NewSize) >= 0 &&
-		ne.resizeStatus == "" &&
-		storage.ContainsAccessMode(ne.pvc.Spec.AccessModes, v1.ReadWriteMany) {
-		ne.pvcAlreadyUpdated = true
+	if ne.pvcAlreadyUpdated && storage.ContainsAccessMode(ne.pvc.Spec.AccessModes, v1.ReadWriteMany) {
 		return true
 	}
 
@@ -124,6 +125,14 @@ func (ne *NodeExpander) runPreCheck() bool {
 func (ne *NodeExpander) expandOnPlugin() (bool, resource.Quantity, error) {
 	allowExpansion := ne.runPreCheck()
 	if !allowExpansion {
+		if ne.pvcAlreadyUpdated {
+			// if pvc is already updated, then we could be here because size stored in ASOW is smaller and controller did full
+			// expansion and hence no node expansion is needed.
+			// This will stop reconciler from retrying expansion on the node.
+			ne.testStatus = testResponseData{assumeResizeFinished: true, resizeCalledOnPlugin: false}
+			return true, ne.pluginResizeOpts.NewSize, nil
+		}
+
 		klog.V(3).Infof("NodeExpandVolume is not allowed to proceed for volume %s with resizeStatus %s", ne.vmt.VolumeName, ne.resizeStatus)
 		ne.testStatus = testResponseData{false /* resizeCalledOnPlugin */, true /* assumeResizeFinished */}
 		return false, ne.pluginResizeOpts.OldSize, nil

--- a/pkg/volume/util/operationexecutor/node_expander_test.go
+++ b/pkg/volume/util/operationexecutor/node_expander_test.go
@@ -60,10 +60,14 @@ func TestNodeExpander(t *testing.T) {
 		actualSize *resource.Quantity
 
 		// expectations of test
-		expectedResizeStatus     v1.ClaimResourceStatus
-		expectedStatusSize       resource.Quantity
-		expectResizeCall         bool
-		expectFinalErrors        bool
+		expectedResizeStatus v1.ClaimResourceStatus
+		expectedStatusSize   resource.Quantity
+		// whether resize call was made to the plugin
+		expectResizeCall    bool
+		expectFinalErrors   bool
+		expectedReturnValue bool
+
+		// whether resize operation was assumed as finished
 		assumeResizeOpAsFinished bool
 		expectError              bool
 	}{
@@ -75,6 +79,7 @@ func TestNodeExpander(t *testing.T) {
 
 			expectedResizeStatus:     nodeResizeFailed,
 			expectResizeCall:         false,
+			expectedReturnValue:      false,
 			assumeResizeOpAsFinished: true,
 			expectFinalErrors:        false,
 			expectedStatusSize:       resource.MustParse("1G"),
@@ -87,6 +92,7 @@ func TestNodeExpander(t *testing.T) {
 
 			expectedResizeStatus:     "",
 			expectResizeCall:         true,
+			expectedReturnValue:      true,
 			assumeResizeOpAsFinished: true,
 			expectFinalErrors:        false,
 			expectedStatusSize:       resource.MustParse("2G"),
@@ -100,6 +106,7 @@ func TestNodeExpander(t *testing.T) {
 			expectedResizeStatus:          nodeResizeFailed,
 			expectResizeCall:              true,
 			assumeResizeOpAsFinished:      true,
+			expectedReturnValue:           false,
 			expectFinalErrors:             true,
 			expectedStatusSize:            resource.MustParse("1G"),
 		},
@@ -111,6 +118,7 @@ func TestNodeExpander(t *testing.T) {
 			expectError:                   true,
 			expectedResizeStatus:          v1.PersistentVolumeClaimNodeResizeInProgress,
 			expectResizeCall:              true,
+			expectedReturnValue:           false,
 			assumeResizeOpAsFinished:      true,
 			expectFinalErrors:             true,
 			expectedStatusSize:            resource.MustParse("1G"),
@@ -124,6 +132,7 @@ func TestNodeExpander(t *testing.T) {
 			expectedResizeStatus:     "",
 			expectResizeCall:         false,
 			assumeResizeOpAsFinished: true,
+			expectedReturnValue:      true,
 			expectFinalErrors:        false,
 			expectedStatusSize:       resource.MustParse("2G"),
 		},
@@ -136,6 +145,7 @@ func TestNodeExpander(t *testing.T) {
 			expectedResizeStatus:     "",
 			expectResizeCall:         true,
 			assumeResizeOpAsFinished: true,
+			expectedReturnValue:      true,
 			expectFinalErrors:        false,
 			expectedStatusSize:       resource.MustParse("2G"),
 		},
@@ -148,6 +158,7 @@ func TestNodeExpander(t *testing.T) {
 			expectedResizeStatus:          "",
 			expectResizeCall:              false,
 			assumeResizeOpAsFinished:      true,
+			expectedReturnValue:           true,
 			expectFinalErrors:             false,
 			expectedStatusSize:            resource.MustParse("2G"),
 		},
@@ -160,6 +171,7 @@ func TestNodeExpander(t *testing.T) {
 			expectedResizeStatus:     "",
 			expectResizeCall:         true,
 			assumeResizeOpAsFinished: true,
+			expectedReturnValue:      true,
 			expectFinalErrors:        false,
 			expectedStatusSize:       resource.MustParse("2G"),
 		},
@@ -205,7 +217,7 @@ func TestNodeExpander(t *testing.T) {
 			ogInstance, _ := og.(*operationGenerator)
 			nodeExpander := newNodeExpander(resizeOp, ogInstance.kubeClient, ogInstance.recorder)
 
-			_, _, err := nodeExpander.expandOnPlugin()
+			returnValue, _, err := nodeExpander.expandOnPlugin()
 			expansionResponse := nodeExpander.testStatus
 
 			pvc = nodeExpander.pvc
@@ -216,6 +228,10 @@ func TestNodeExpander(t *testing.T) {
 			}
 			if test.expectError && err == nil {
 				t.Errorf("For test %s, expected error but got none", test.name)
+			}
+
+			if test.expectedReturnValue != returnValue {
+				t.Errorf("For test %s, expected return value %t, got %t", test.name, test.expectedReturnValue, returnValue)
 			}
 
 			if test.expectResizeCall != expansionResponse.resizeCalledOnPlugin {


### PR DESCRIPTION
There is a corner case if volume expansion is finished by controller and driver implements node-expansion, we could end up continuously calling node-expansion, even though node expansion is not required.

To reproduce this edge case, we could return following response from controller side of CSI driver:

```
        return &csi.ControllerExpandVolumeResponse{
                CapacityBytes:         exVol.VolSize,
               NodeExpansionRequired: false,
        }, nil
```

Now if node side doesn't handle expansion of already expanded volumes correctly and returns an error. (say, while trying to expand raw-block volume), then kubelet will perpetually try to expand the volume until pod is removed from the node or kubelet is restarted. 



```release-note
Do not expand volume on the node, if controller expansion is finished
```
