### PR TITLE
Enable the RequiredFields Kube-API-Linter rule

### DIFF
--- a/api/openapi-spec/v3/apis__coordination.k8s.io__v1alpha2_openapi.json
+++ b/api/openapi-spec/v3/apis__coordination.k8s.io__v1alpha2_openapi.json
@@ -119,6 +119,7 @@
             "description": "RenewTime is the time that the LeaseCandidate was last updated. Any time a Lease needs to do leader election, the PingTime field is updated to signal to the LeaseCandidate that they should update the RenewTime. Old LeaseCandidate objects are also garbage collected if it has been hours since the last renew. The PingTime field is updated regularly to prevent garbage collection for still active LeaseCandidates."
           },
           "strategy": {
+            "default": "",
             "description": "Strategy is the strategy that coordinated leader election will use for picking the leader. If multiple candidates for the same Lease return different strategies, the strategy provided by the candidate with the latest BinaryVersion will be used. If there is still conflict, this is a user error and coordinated leader election will not operate the Lease until resolved.",
             "type": "string"
           }

--- a/api/openapi-spec/v3/apis__coordination.k8s.io__v1beta1_openapi.json
+++ b/api/openapi-spec/v3/apis__coordination.k8s.io__v1beta1_openapi.json
@@ -119,6 +119,7 @@
             "description": "RenewTime is the time that the LeaseCandidate was last updated. Any time a Lease needs to do leader election, the PingTime field is updated to signal to the LeaseCandidate that they should update the RenewTime. Old LeaseCandidate objects are also garbage collected if it has been hours since the last renew. The PingTime field is updated regularly to prevent garbage collection for still active LeaseCandidates."
           },
           "strategy": {
+            "default": "",
             "description": "Strategy is the strategy that coordinated leader election will use for picking the leader. If multiple candidates for the same Lease return different strategies, the strategy provided by the candidate with the latest BinaryVersion will be used. If there is still conflict, this is a user error and coordinated leader election will not operate the Lease until resolved.",
             "type": "string"
           }

--- a/api/openapi-spec/v3/apis__internal.apiserver.k8s.io__v1alpha1_openapi.json
+++ b/api/openapi-spec/v3/apis__internal.apiserver.k8s.io__v1alpha1_openapi.json
@@ -97,6 +97,7 @@
             "description": "Last time the condition transitioned from one status to another."
           },
           "message": {
+            "default": "",
             "description": "A human readable message indicating details about the transition.",
             "type": "string"
           },

--- a/api/openapi-spec/v3/apis__networking.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__networking.k8s.io__v1_openapi.json
@@ -895,6 +895,7 @@
             "type": "string"
           },
           "name": {
+            "default": "",
             "description": "Name is the name of the object being referenced.",
             "type": "string"
           },
@@ -903,6 +904,7 @@
             "type": "string"
           },
           "resource": {
+            "default": "",
             "description": "Resource is the resource of the object being referenced.",
             "type": "string"
           }

--- a/api/openapi-spec/v3/apis__networking.k8s.io__v1beta1_openapi.json
+++ b/api/openapi-spec/v3/apis__networking.k8s.io__v1beta1_openapi.json
@@ -110,6 +110,7 @@
             "type": "string"
           },
           "name": {
+            "default": "",
             "description": "Name is the name of the object being referenced.",
             "type": "string"
           },
@@ -118,6 +119,7 @@
             "type": "string"
           },
           "resource": {
+            "default": "",
             "description": "Resource is the resource of the object being referenced.",
             "type": "string"
           }

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -118,6 +118,21 @@ linters:
         
       # Exceptions for kube-api-linter.
       # Exceptions are used for kube-api-linter to ignore existing issues that cannot be fixed without breaking changes.
+      
+      # All four of these files contain a variant of {Ingress}PortStatus, which has an Error field marked as optional and kubebuilder:validation:Required.
+      # Any CRD embedding this type will prefer the kubebuilder:validation:Required marker, and will have the field marked as required in the generated schema.
+      # This means the behaviour of the field is inconsistent for core types vs CRDs, and should not be fixed.
+      # It also means the requiredfield linter complains about the fields being pointers, which they must be for the core types.
+      - path: "staging/src/k8s.io/api/core/v1/types.go|staging/src/k8s.io/api/extensions/v1beta1/types.go|staging/src/k8s.io/api/networking/v1beta1/types.go|staging/src/k8s.io/api/networking/v1/types.go"
+        text: "field Error must not be marked as both optional and required"
+      - path: "staging/src/k8s.io/api/core/v1/types.go|staging/src/k8s.io/api/extensions/v1beta1/types.go|staging/src/k8s.io/api/networking/v1beta1/types.go|staging/src/k8s.io/api/networking/v1/types.go"
+        text: "field Error is marked as required, but has the omitempty tag|field Error is marked as required, should not be a pointer"
+      
+      # The ParentRef is marked required, but is a pointer and has omitempty.
+      # There is no validation checking the field is actually required (should it be optional?)
+      # but it is required per the openapi spec.
+      - path: "staging/src/k8s.io/api/networking/v1/types.go|staging/src/k8s.io/api/networking/v1beta1/types.go|staging/src/k8s.io/api/networking/v1alpha1/types.go"
+        text: "field ParentRef is marked as required, but has the omitempty tag|field ParentRef is marked as required, should not be a pointer"
 
   default: standard
   enable: # please keep this alphabetized
@@ -229,7 +244,7 @@ linters:
               # - "nomaps" # Ensure maps are not used, unless they are `map[string]string` (for labels/annotations/etc).
               # - "nophase" # Ensure field names do not have the word "phase" in them.
               # - "optionalorrequired" # Every field should be marked as `+optional` xor `+required`.
-              # - "requiredfields" # Required fields should not be pointers, and should not have `omitempty`.
+              - "requiredfields" # Required fields should not be pointers, and should not have `omitempty`.
           lintersConfig:
             # conditions:
             #   isFirstField: Warn # Require conditions to be the first field in the status struct.

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -134,6 +134,21 @@ linters:
         
       # Exceptions for kube-api-linter.
       # Exceptions are used for kube-api-linter to ignore existing issues that cannot be fixed without breaking changes.
+      
+      # All four of these files contain a variant of {Ingress}PortStatus, which has an Error field marked as optional and kubebuilder:validation:Required.
+      # Any CRD embedding this type will prefer the kubebuilder:validation:Required marker, and will have the field marked as required in the generated schema.
+      # This means the behaviour of the field is inconsistent for core types vs CRDs, and should not be fixed.
+      # It also means the requiredfield linter complains about the fields being pointers, which they must be for the core types.
+      - path: "staging/src/k8s.io/api/core/v1/types.go|staging/src/k8s.io/api/extensions/v1beta1/types.go|staging/src/k8s.io/api/networking/v1beta1/types.go|staging/src/k8s.io/api/networking/v1/types.go"
+        text: "field Error must not be marked as both optional and required"
+      - path: "staging/src/k8s.io/api/core/v1/types.go|staging/src/k8s.io/api/extensions/v1beta1/types.go|staging/src/k8s.io/api/networking/v1beta1/types.go|staging/src/k8s.io/api/networking/v1/types.go"
+        text: "field Error is marked as required, but has the omitempty tag|field Error is marked as required, should not be a pointer"
+      
+      # The ParentRef is marked required, but is a pointer and has omitempty.
+      # There is no validation checking the field is actually required (should it be optional?)
+      # but it is required per the openapi spec.
+      - path: "staging/src/k8s.io/api/networking/v1/types.go|staging/src/k8s.io/api/networking/v1beta1/types.go|staging/src/k8s.io/api/networking/v1alpha1/types.go"
+        text: "field ParentRef is marked as required, but has the omitempty tag|field ParentRef is marked as required, should not be a pointer"
 
   default: none
   enable: # please keep this alphabetized
@@ -243,7 +258,7 @@ linters:
               # - "nomaps" # Ensure maps are not used, unless they are `map[string]string` (for labels/annotations/etc).
               # - "nophase" # Ensure field names do not have the word "phase" in them.
               # - "optionalorrequired" # Every field should be marked as `+optional` xor `+required`.
-              # - "requiredfields" # Required fields should not be pointers, and should not have `omitempty`.
+              - "requiredfields" # Required fields should not be pointers, and should not have `omitempty`.
           lintersConfig:
             # conditions:
             #   isFirstField: Warn # Require conditions to be the first field in the status struct.

--- a/hack/kube-api-linter/exceptions.yaml
+++ b/hack/kube-api-linter/exceptions.yaml
@@ -1,2 +1,17 @@
 # Exceptions for kube-api-linter.
 # Exceptions are used for kube-api-linter to ignore existing issues that cannot be fixed without breaking changes.
+
+# All four of these files contain a variant of {Ingress}PortStatus, which has an Error field marked as optional and kubebuilder:validation:Required.
+# Any CRD embedding this type will prefer the kubebuilder:validation:Required marker, and will have the field marked as required in the generated schema.
+# This means the behaviour of the field is inconsistent for core types vs CRDs, and should not be fixed.
+# It also means the requiredfield linter complains about the fields being pointers, which they must be for the core types.
+- path: "staging/src/k8s.io/api/core/v1/types.go|staging/src/k8s.io/api/extensions/v1beta1/types.go|staging/src/k8s.io/api/networking/v1beta1/types.go|staging/src/k8s.io/api/networking/v1/types.go"
+  text: "field Error must not be marked as both optional and required"
+- path: "staging/src/k8s.io/api/core/v1/types.go|staging/src/k8s.io/api/extensions/v1beta1/types.go|staging/src/k8s.io/api/networking/v1beta1/types.go|staging/src/k8s.io/api/networking/v1/types.go"
+  text: "field Error is marked as required, but has the omitempty tag|field Error is marked as required, should not be a pointer"
+
+# The ParentRef is marked required, but is a pointer and has omitempty.
+# There is no validation checking the field is actually required (should it be optional?)
+# but it is required per the openapi spec.
+- path: "staging/src/k8s.io/api/networking/v1/types.go|staging/src/k8s.io/api/networking/v1beta1/types.go|staging/src/k8s.io/api/networking/v1alpha1/types.go"
+  text: "field ParentRef is marked as required, but has the omitempty tag|field ParentRef is marked as required, should not be a pointer"

--- a/hack/kube-api-linter/kube-api-linter.yaml
+++ b/hack/kube-api-linter/kube-api-linter.yaml
@@ -13,7 +13,7 @@ linters:
     # - "nomaps" # Ensure maps are not used, unless they are `map[string]string` (for labels/annotations/etc).
     # - "nophase" # Ensure field names do not have the word "phase" in them.
     # - "optionalorrequired" # Every field should be marked as `+optional` xor `+required`.
-    # - "requiredfields" # Required fields should not be pointers, and should not have `omitempty`.
+    - "requiredfields" # Required fields should not be pointers, and should not have `omitempty`.
 lintersConfig:
   # conditions:
   #   isFirstField: Warn # Require conditions to be the first field in the status struct.

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -6706,6 +6706,7 @@ func schema_k8sio_api_apiserverinternal_v1alpha1_StorageVersionCondition(ref com
 					"message": {
 						SchemaProps: spec.SchemaProps{
 							Description: "A human readable message indicating details about the transition.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -19725,6 +19726,7 @@ func schema_k8sio_api_coordination_v1alpha2_LeaseCandidateSpec(ref common.Refere
 					"strategy": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Strategy is the strategy that coordinated leader election will use for picking the leader. If multiple candidates for the same Lease return different strategies, the strategy provided by the candidate with the latest BinaryVersion will be used. If there is still conflict, this is a user error and coordinated leader election will not operate the Lease until resolved.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -19920,6 +19922,7 @@ func schema_k8sio_api_coordination_v1beta1_LeaseCandidateSpec(ref common.Referen
 					"strategy": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Strategy is the strategy that coordinated leader election will use for picking the leader. If multiple candidates for the same Lease return different strategies, the strategy provided by the candidate with the latest BinaryVersion will be used. If there is still conflict, this is a user error and coordinated leader election will not operate the Lease until resolved.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -42419,6 +42422,7 @@ func schema_k8sio_api_networking_v1_ParentReference(ref common.ReferenceCallback
 					"resource": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Resource is the resource of the object being referenced.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -42433,6 +42437,7 @@ func schema_k8sio_api_networking_v1_ParentReference(ref common.ReferenceCallback
 					"name": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Name is the name of the object being referenced.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -43457,6 +43462,7 @@ func schema_k8sio_api_networking_v1beta1_ParentReference(ref common.ReferenceCal
 					"resource": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Resource is the resource of the object being referenced.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -43471,6 +43477,7 @@ func schema_k8sio_api_networking_v1beta1_ParentReference(ref common.ReferenceCal
 					"name": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Name is the name of the object being referenced.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/staging/src/k8s.io/api/apiserverinternal/v1alpha1/types.go
+++ b/staging/src/k8s.io/api/apiserverinternal/v1alpha1/types.go
@@ -117,7 +117,7 @@ type StorageVersionCondition struct {
 	Reason string `json:"reason" protobuf:"bytes,5,opt,name=reason"`
 	// A human readable message indicating details about the transition.
 	// +required
-	Message string `json:"message,omitempty" protobuf:"bytes,6,opt,name=message"`
+	Message string `json:"message" protobuf:"bytes,6,opt,name=message"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/staging/src/k8s.io/api/coordination/v1alpha2/types.go
+++ b/staging/src/k8s.io/api/coordination/v1alpha2/types.go
@@ -74,7 +74,7 @@ type LeaseCandidateSpec struct {
 	// by the candidate with the latest BinaryVersion will be used. If there is still conflict,
 	// this is a user error and coordinated leader election will not operate the Lease until resolved.
 	// +required
-	Strategy v1.CoordinatedLeaseStrategy `json:"strategy,omitempty" protobuf:"bytes,6,opt,name=strategy"`
+	Strategy v1.CoordinatedLeaseStrategy `json:"strategy" protobuf:"bytes,6,opt,name=strategy"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/staging/src/k8s.io/api/coordination/v1beta1/types.go
+++ b/staging/src/k8s.io/api/coordination/v1beta1/types.go
@@ -147,7 +147,7 @@ type LeaseCandidateSpec struct {
 	// by the candidate with the latest BinaryVersion will be used. If there is still conflict,
 	// this is a user error and coordinated leader election will not operate the Lease until resolved.
 	// +required
-	Strategy v1.CoordinatedLeaseStrategy `json:"strategy,omitempty" protobuf:"bytes,6,opt,name=strategy"`
+	Strategy v1.CoordinatedLeaseStrategy `json:"strategy" protobuf:"bytes,6,opt,name=strategy"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/staging/src/k8s.io/api/core/v1/generated.proto
+++ b/staging/src/k8s.io/api/core/v1/generated.proto
@@ -4745,6 +4745,8 @@ message PortStatus {
   //   format foo.example.com/CamelCase.
   // ---
   // The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+  // This field is optional in core types but required in CRDs (the kubebuilder marker takes precedence when generating the CRD schema).
+  // Removing either the optional or required marker would be a breaking change for someone.
   // +optional
   // +kubebuilder:validation:Required
   // +kubebuilder:validation:Pattern=`^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$`

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -8075,6 +8075,8 @@ type PortStatus struct {
 	//   format foo.example.com/CamelCase.
 	// ---
 	// The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+	// This field is optional in core types but required in CRDs (the kubebuilder marker takes precedence when generating the CRD schema).
+	// Removing either the optional or required marker would be a breaking change for someone.
 	// +optional
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Pattern=`^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$`

--- a/staging/src/k8s.io/api/extensions/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/extensions/v1beta1/generated.proto
@@ -529,6 +529,8 @@ message IngressPortStatus {
   //   format foo.example.com/CamelCase.
   // ---
   // The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+  // This field is optional in core types but required in CRDs (the kubebuilder marker takes precedence when generating the CRD schema).
+  // Removing either the optional or required marker would be a breaking change for someone.
   // +optional
   // +kubebuilder:validation:Required
   // +kubebuilder:validation:Pattern=`^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$`

--- a/staging/src/k8s.io/api/extensions/v1beta1/types.go
+++ b/staging/src/k8s.io/api/extensions/v1beta1/types.go
@@ -741,6 +741,8 @@ type IngressPortStatus struct {
 	//   format foo.example.com/CamelCase.
 	// ---
 	// The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+	// This field is optional in core types but required in CRDs (the kubebuilder marker takes precedence when generating the CRD schema).
+	// Removing either the optional or required marker would be a breaking change for someone.
 	// +optional
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Pattern=`^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$`

--- a/staging/src/k8s.io/api/networking/v1/generated.proto
+++ b/staging/src/k8s.io/api/networking/v1/generated.proto
@@ -285,6 +285,8 @@ message IngressPortStatus {
   //   format foo.example.com/CamelCase.
   // ---
   // The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+  // This field is optional in core types but required in CRDs (the kubebuilder marker takes precedence when generating the CRD schema).
+  // Removing either the optional or required marker would be a breaking change for someone.
   // +optional
   // +kubebuilder:validation:Required
   // +kubebuilder:validation:Pattern=`^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$`

--- a/staging/src/k8s.io/api/networking/v1/types.go
+++ b/staging/src/k8s.io/api/networking/v1/types.go
@@ -378,6 +378,8 @@ type IngressPortStatus struct {
 	//   format foo.example.com/CamelCase.
 	// ---
 	// The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+	// This field is optional in core types but required in CRDs (the kubebuilder marker takes precedence when generating the CRD schema).
+	// Removing either the optional or required marker would be a breaking change for someone.
 	// +optional
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Pattern=`^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$`
@@ -675,13 +677,13 @@ type ParentReference struct {
 	Group string `json:"group,omitempty" protobuf:"bytes,1,opt,name=group"`
 	// Resource is the resource of the object being referenced.
 	// +required
-	Resource string `json:"resource,omitempty" protobuf:"bytes,2,opt,name=resource"`
+	Resource string `json:"resource" protobuf:"bytes,2,opt,name=resource"`
 	// Namespace is the namespace of the object being referenced.
 	// +optional
 	Namespace string `json:"namespace,omitempty" protobuf:"bytes,3,opt,name=namespace"`
 	// Name is the name of the object being referenced.
 	// +required
-	Name string `json:"name,omitempty" protobuf:"bytes,4,opt,name=name"`
+	Name string `json:"name" protobuf:"bytes,4,opt,name=name"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/staging/src/k8s.io/api/networking/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/networking/v1beta1/generated.proto
@@ -271,6 +271,8 @@ message IngressPortStatus {
   //   format foo.example.com/CamelCase.
   // ---
   // The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+  // This field is optional in core types but required in CRDs (the kubebuilder marker takes precedence when generating the CRD schema).
+  // Removing either the optional or required marker would be a breaking change for someone.
   // +optional
   // +kubebuilder:validation:Required
   // +kubebuilder:validation:Pattern=`^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$`

--- a/staging/src/k8s.io/api/networking/v1beta1/types.go
+++ b/staging/src/k8s.io/api/networking/v1beta1/types.go
@@ -176,6 +176,8 @@ type IngressPortStatus struct {
 	//   format foo.example.com/CamelCase.
 	// ---
 	// The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+	// This field is optional in core types but required in CRDs (the kubebuilder marker takes precedence when generating the CRD schema).
+	// Removing either the optional or required marker would be a breaking change for someone.
 	// +optional
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Pattern=`^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$`
@@ -461,13 +463,13 @@ type ParentReference struct {
 	Group string `json:"group,omitempty" protobuf:"bytes,1,opt,name=group"`
 	// Resource is the resource of the object being referenced.
 	// +required
-	Resource string `json:"resource,omitempty" protobuf:"bytes,2,opt,name=resource"`
+	Resource string `json:"resource" protobuf:"bytes,2,opt,name=resource"`
 	// Namespace is the namespace of the object being referenced.
 	// +optional
 	Namespace string `json:"namespace,omitempty" protobuf:"bytes,3,opt,name=namespace"`
 	// Name is the name of the object being referenced.
 	// +required
-	Name string `json:"name,omitempty" protobuf:"bytes,4,opt,name=name"`
+	Name string `json:"name" protobuf:"bytes,4,opt,name=name"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/staging/src/k8s.io/api/resource/v1alpha3/types.go
+++ b/staging/src/k8s.io/api/resource/v1alpha3/types.go
@@ -194,7 +194,7 @@ type CounterSet struct {
 	// The maximum number of counters is 32.
 	//
 	// +required
-	Counters map[string]Counter `json:"counters,omitempty" protobuf:"bytes,2,name=counters"`
+	Counters map[string]Counter `json:"counters" protobuf:"bytes,2,name=counters"`
 }
 
 // Counter describes a quantity associated with a device.
@@ -361,7 +361,7 @@ type DeviceCounterConsumption struct {
 	// 16 counters each).
 	//
 	// +required
-	Counters map[string]Counter `json:"counters,omitempty" protobuf:"bytes,2,opt,name=counters"`
+	Counters map[string]Counter `json:"counters" protobuf:"bytes,2,opt,name=counters"`
 }
 
 // Limit for the sum of the number of entries in both attributes and capacity.
@@ -1599,7 +1599,7 @@ type DeviceTaintRuleSpec struct {
 	// The taint that gets applied to matching devices.
 	//
 	// +required
-	Taint DeviceTaint `json:"taint,omitempty" protobuf:"bytes,2,rep,name=taint"`
+	Taint DeviceTaint `json:"taint" protobuf:"bytes,2,rep,name=taint"`
 }
 
 // DeviceTaintSelector defines which device(s) a DeviceTaintRule applies to.

--- a/staging/src/k8s.io/api/resource/v1beta1/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta1/types.go
@@ -189,7 +189,7 @@ type CounterSet struct {
 	// The maximum number of counters is 32.
 	//
 	// +required
-	Counters map[string]Counter `json:"counters,omitempty" protobuf:"bytes,2,name=counters"`
+	Counters map[string]Counter `json:"counters" protobuf:"bytes,2,name=counters"`
 }
 
 // Counter describes a quantity associated with a device.
@@ -356,7 +356,7 @@ type DeviceCounterConsumption struct {
 	// 16 counters each).
 	//
 	// +required
-	Counters map[string]Counter `json:"counters,omitempty" protobuf:"bytes,2,opt,name=counters"`
+	Counters map[string]Counter `json:"counters" protobuf:"bytes,2,opt,name=counters"`
 }
 
 // DeviceCapacity describes a quantity associated with a device.

--- a/staging/src/k8s.io/api/resource/v1beta2/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta2/types.go
@@ -189,7 +189,7 @@ type CounterSet struct {
 	// The maximum number of counters in all sets is 32.
 	//
 	// +required
-	Counters map[string]Counter `json:"counters,omitempty" protobuf:"bytes,2,name=counters"`
+	Counters map[string]Counter `json:"counters" protobuf:"bytes,2,name=counters"`
 }
 
 // DriverNameMaxLength is the maximum valid length of a driver name in the
@@ -344,7 +344,7 @@ type DeviceCounterConsumption struct {
 	// 16 counters each).
 	//
 	// +required
-	Counters map[string]Counter `json:"counters,omitempty" protobuf:"bytes,2,opt,name=counters"`
+	Counters map[string]Counter `json:"counters" protobuf:"bytes,2,opt,name=counters"`
 }
 
 // DeviceCapacity describes a quantity associated with a device.

--- a/staging/src/k8s.io/client-go/applyconfigurations/internal/internal.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/internal/internal.go
@@ -1382,6 +1382,7 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: message
       type:
         scalar: string
+      default: ""
     - name: observedGeneration
       type:
         scalar: numeric
@@ -4556,6 +4557,7 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: strategy
       type:
         scalar: string
+      default: ""
 - name: io.k8s.api.coordination.v1beta1.Lease
   map:
     fields:
@@ -4613,6 +4615,7 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: strategy
       type:
         scalar: string
+      default: ""
 - name: io.k8s.api.coordination.v1beta1.LeaseSpec
   map:
     fields:
@@ -11366,12 +11369,14 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: name
       type:
         scalar: string
+      default: ""
     - name: namespace
       type:
         scalar: string
     - name: resource
       type:
         scalar: string
+      default: ""
 - name: io.k8s.api.networking.v1.ServiceBackendPort
   map:
     fields:
@@ -11643,12 +11648,14 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: name
       type:
         scalar: string
+      default: ""
     - name: namespace
       type:
         scalar: string
     - name: resource
       type:
         scalar: string
+      default: ""
 - name: io.k8s.api.networking.v1beta1.ServiceCIDR
   map:
     fields:


### PR DESCRIPTION
#### What type of PR is this?

/kind api-change

#### What this PR does / why we need it:

This PR enables the `requiredfield` linter rule of KAL.

In short:
```
requiredFields is a linter to check that fields that are marked as required are not pointers, and do not have the omitempty tag.
The linter will check for fields that are marked as required using the +required marker, or the +kubebuilder:validation:Required marker.

The linter will suggest to remove the omitempty tag from fields that are marked as required, but have the omitempty tag.
The linter will suggest to remove the pointer type from fields that are marked as required.
```

Enabling this check on K/K flagged 19 existing issues where we have examples of fields marked `+required` but that also had omitempty, or are pointers.

```
ERROR: staging/src/k8s.io/api/networking/v1alpha1/types.go:52:2: requiredfields: field ParentRef is marked as required, but has the omitempty tag (kubeapilinter)
ERROR: staging/src/k8s.io/api/networking/v1alpha1/types.go:62:2: requiredfields: field Resource is marked as required, but has the omitempty tag (kubeapilinter)
ERROR: staging/src/k8s.io/api/networking/v1alpha1/types.go:68:2: requiredfields: field Name is marked as required, but has the omitempty tag (kubeapilinter)
ERROR: staging/src/k8s.io/api/networking/v1beta1/types.go:454:2: requiredfields: field ParentRef is marked as required, but has the omitempty tag (kubeapilinter)
ERROR: staging/src/k8s.io/api/networking/v1beta1/types.go:464:2: requiredfields: field Resource is marked as required, but has the omitempty tag (kubeapilinter)
ERROR: staging/src/k8s.io/api/networking/v1beta1/types.go:470:2: requiredfields: field Name is marked as required, but has the omitempty tag (kubeapilinter)
ERROR: staging/src/k8s.io/api/apiserverinternal/v1alpha1/types.go:120:2: requiredfields: field Message is marked as required, but has the omitempty tag (kubeapilinter)
ERROR: staging/src/k8s.io/api/coordination/v1alpha2/types.go:77:2: requiredfields: field Strategy is marked as required, but has the omitempty tag (kubeapilinter)
ERROR: staging/src/k8s.io/api/resource/v1beta1/types.go:192:2: requiredfields: field Counters is marked as required, but has the omitempty tag (kubeapilinter)
ERROR: staging/src/k8s.io/api/resource/v1beta1/types.go:359:2: requiredfields: field Counters is marked as required, but has the omitempty tag (kubeapilinter)
ERROR: staging/src/k8s.io/api/coordination/v1beta1/types.go:150:2: requiredfields: field Strategy is marked as required, but has the omitempty tag (kubeapilinter)
ERROR: staging/src/k8s.io/api/resource/v1alpha3/types.go:197:2: requiredfields: field Counters is marked as required, but has the omitempty tag (kubeapilinter)
ERROR: staging/src/k8s.io/api/resource/v1alpha3/types.go:364:2: requiredfields: field Counters is marked as required, but has the omitempty tag (kubeapilinter)
ERROR: staging/src/k8s.io/api/resource/v1alpha3/types.go:1602:2: requiredfields: field Taint is marked as required, but has the omitempty tag (kubeapilinter)
ERROR: staging/src/k8s.io/api/networking/v1/types.go:668:2: requiredfields: field ParentRef is marked as required, but has the omitempty tag (kubeapilinter)
ERROR: staging/src/k8s.io/api/networking/v1/types.go:678:2: requiredfields: field Resource is marked as required, but has the omitempty tag (kubeapilinter)
ERROR: staging/src/k8s.io/api/networking/v1/types.go:684:2: requiredfields: field Name is marked as required, but has the omitempty tag (kubeapilinter)
ERROR: staging/src/k8s.io/api/resource/v1beta2/types.go:192:2: requiredfields: field Counters is marked as required, but has the omitempty tag (kubeapilinter)
ERROR: staging/src/k8s.io/api/resource/v1beta2/types.go:347:2: requiredfields: field Counters is marked as required, but has the omitempty tag (kubeapilinter)
```

4 of these cases refer to approximately the same type, `{Ingress}PortStatus` which has fields marked as `+optional`, but also `+kubebuilder:validation:Required`. This makes them flag as required for the purpose of this linter, but, they are considered optional within Kube core types. In this case I've added an exception.

For the remaining cases:

```
ERROR: staging/src/k8s.io/api/apiserverinternal/v1alpha1/types.go:120:2: requiredfields: field Message is marked as required, but has the omitempty tag (kubeapilinter)
ERROR: staging/src/k8s.io/api/coordination/v1beta1/types.go:150:2: requiredfields: field Strategy is marked as required, but has the omitempty tag (kubeapilinter)
ERROR: staging/src/k8s.io/api/coordination/v1alpha2/types.go:77:2: requiredfields: field Strategy is marked as required, but has the omitempty tag (kubeapilinter)
ERROR: staging/src/k8s.io/api/resource/v1beta2/types.go:192:2: requiredfields: field Counters is marked as required, but has the omitempty tag (kubeapilinter)
ERROR: staging/src/k8s.io/api/resource/v1beta2/types.go:347:2: requiredfields: field Counters is marked as required, but has the omitempty tag (kubeapilinter)
ERROR: staging/src/k8s.io/api/resource/v1beta1/types.go:192:2: requiredfields: field Counters is marked as required, but has the omitempty tag (kubeapilinter)
ERROR: staging/src/k8s.io/api/resource/v1beta1/types.go:359:2: requiredfields: field Counters is marked as required, but has the omitempty tag (kubeapilinter)
ERROR: staging/src/k8s.io/api/resource/v1alpha3/types.go:197:2: requiredfields: field Counters is marked as required, but has the omitempty tag (kubeapilinter)
ERROR: staging/src/k8s.io/api/resource/v1alpha3/types.go:364:2: requiredfields: field Counters is marked as required, but has the omitempty tag (kubeapilinter)
```
For each of the above errors, the field validation that prevents the field length from being 0. So whether the JSON serialization omits the value, or marshals the zero value  (`"counters": {}`, `"strategy": ""`) doesn't appear to matter, both would be invalid. These are also all in alpha and beta API types. I believe the omitempty can be removed in these cases.

```
ERROR: staging/src/k8s.io/api/networking/v1alpha1/types.go:52:2: requiredfields: field ParentRef is marked as required, but has the omitempty tag (kubeapilinter)
ERROR: staging/src/k8s.io/api/networking/v1/types.go:668:2: requiredfields: field ParentRef is marked as required, but has the omitempty tag (kubeapilinter)
ERROR: staging/src/k8s.io/api/networking/v1beta1/types.go:454:2: requiredfields: field ParentRef is marked as required, but has the omitempty tag (kubeapilinter)

ERROR: staging/src/k8s.io/api/networking/v1/types.go:678:2: requiredfields: field Resource is marked as required, but has the omitempty tag (kubeapilinter)
ERROR: staging/src/k8s.io/api/networking/v1/types.go:684:2: requiredfields: field Name is marked as required, but has the omitempty tag (kubeapilinter)
ERROR: staging/src/k8s.io/api/networking/v1beta1/types.go:464:2: requiredfields: field Resource is marked as required, but has the omitempty tag (kubeapilinter)
ERROR: staging/src/k8s.io/api/networking/v1beta1/types.go:470:2: requiredfields: field Name is marked as required, but has the omitempty tag (kubeapilinter)
ERROR: staging/src/k8s.io/api/networking/v1alpha1/types.go:62:2: requiredfields: field Resource is marked as required, but has the omitempty tag (kubeapilinter)
ERROR: staging/src/k8s.io/api/networking/v1alpha1/types.go:68:2: requiredfields: field Name is marked as required, but has the omitempty tag (kubeapilinter)
```
The `ParentRef`, `Resource` and `Name` are all validated in [this validation](https://github.com/kubernetes/kubernetes/blob/e1cf24670f6f97063d42be0a494f4096a4ccb81e/pkg/apis/networking/validation/validation.go#L712) which checks the `ParentRef` itself is not nil, and that the Resource and Name are not empty.

Fixing Name and Resource is like the above, the difference between omitted and empty wouldn't make a difference to the validation.

For the `ParentRef`, if we removed omitempty, the JSON representation would then be `null`, since the field is a pointer. I think this one should not be fixed.

```
ERROR: staging/src/k8s.io/api/resource/v1alpha3/types.go:1602:2: requiredfields: field Taint is marked as required, but has the omitempty tag (kubeapilinter)
```

The Taint field uses a type `DeviceTaint`, which is a struct. The Taint field does not use a pointer, and so, since the Go JSON library cannot omit a struct reference, the omitempty on this field is pointless and can definitely be removed, as it doesn't change the serialization at all.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

@thockin This will be the first actual rule enabling checks from KAL. Starting with this one as it seems fairly straightforward and it hasn't got too many existing issues to look at fixing. Would appreciate if you could validate my logic on the acceptable `omitempty` removals above.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
