### PR TITLE
Add accessors for fsgroup change policy

### DIFF
--- a/pkg/securitycontext/accessors.go
+++ b/pkg/securitycontext/accessors.go
@@ -35,6 +35,7 @@ type PodSecurityContextAccessor interface {
 	SeccompProfile() *api.SeccompProfile
 	SupplementalGroups() []int64
 	FSGroup() *int64
+	FSGroupChangePolicy() *api.PodFSGroupChangePolicy
 }
 
 // PodSecurityContextMutator allows reading and writing the values of a PodSecurityContext object
@@ -52,6 +53,7 @@ type PodSecurityContextMutator interface {
 	SetSeccompProfile(*api.SeccompProfile)
 	SetSupplementalGroups([]int64)
 	SetFSGroup(*int64)
+	SetFSGroupChangePolicy(*api.PodFSGroupChangePolicy)
 
 	// PodSecurityContext returns the current PodSecurityContext object
 	PodSecurityContext() *api.PodSecurityContext
@@ -229,6 +231,23 @@ func (w *podSecurityContextWrapper) SetFSGroup(v *int64) {
 	}
 	w.ensurePodSC()
 	w.podSC.FSGroup = v
+}
+
+func (w *podSecurityContextWrapper) FSGroupChangePolicy() *api.PodFSGroupChangePolicy {
+	if w.podSC == nil {
+		return nil
+	}
+
+	return w.podSC.FSGroupChangePolicy
+}
+
+func (w *podSecurityContextWrapper) SetFSGroupChangePolicy(v *api.PodFSGroupChangePolicy) {
+	if w.podSC == nil && v == nil {
+		return
+	}
+
+	w.ensurePodSC()
+	w.podSC.FSGroupChangePolicy = v
 }
 
 // ContainerSecurityContextAccessor allows reading the values of a SecurityContext object

--- a/pkg/securitycontext/accessors_test.go
+++ b/pkg/securitycontext/accessors_test.go
@@ -31,6 +31,7 @@ func TestPodSecurityContextAccessor(t *testing.T) {
 	runAsGroup := int64(1)
 	runAsNonRoot := true
 	hostUsers := false
+	onRootMismatchPolicy := api.FSGroupChangeOnRootMismatch
 
 	testcases := []*api.PodSecurityContext{
 		nil,
@@ -46,6 +47,7 @@ func TestPodSecurityContextAccessor(t *testing.T) {
 		{SELinuxOptions: &api.SELinuxOptions{User: "bob"}},
 		{SeccompProfile: &api.SeccompProfile{Type: api.SeccompProfileTypeRuntimeDefault}},
 		{SupplementalGroups: []int64{1, 2, 3}},
+		{FSGroupChangePolicy: &onRootMismatchPolicy},
 	}
 
 	for i, tc := range testcases {
@@ -89,6 +91,9 @@ func TestPodSecurityContextAccessor(t *testing.T) {
 		if v := a.SupplementalGroups(); !reflect.DeepEqual(expected.SupplementalGroups, v) {
 			t.Errorf("%d: expected %#v, got %#v", i, expected.SupplementalGroups, v)
 		}
+		if v := a.FSGroupChangePolicy(); !reflect.DeepEqual(expected.FSGroupChangePolicy, v) {
+			t.Errorf("%d: expected %#v, got %#v", i, expected.FSGroupChangePolicy, v)
+		}
 	}
 }
 
@@ -105,17 +110,18 @@ func TestPodSecurityContextMutator(t *testing.T) {
 		"populated": {
 			newSC: func() *api.PodSecurityContext {
 				return &api.PodSecurityContext{
-					HostNetwork:        true,
-					HostIPC:            true,
-					HostPID:            true,
-					HostUsers:          nil,
-					SELinuxOptions:     &api.SELinuxOptions{},
-					RunAsUser:          nil,
-					RunAsGroup:         nil,
-					RunAsNonRoot:       nil,
-					SeccompProfile:     nil,
-					SupplementalGroups: nil,
-					FSGroup:            nil,
+					HostNetwork:         true,
+					HostIPC:             true,
+					HostPID:             true,
+					HostUsers:           nil,
+					SELinuxOptions:      &api.SELinuxOptions{},
+					RunAsUser:           nil,
+					RunAsGroup:          nil,
+					RunAsNonRoot:        nil,
+					SeccompProfile:      nil,
+					SupplementalGroups:  nil,
+					FSGroup:             nil,
+					FSGroupChangePolicy: nil,
 				}
 			},
 		},
@@ -146,6 +152,7 @@ func TestPodSecurityContextMutator(t *testing.T) {
 			m.SetSeccompProfile(m.SeccompProfile())
 			m.SetSELinuxOptions(m.SELinuxOptions())
 			m.SetSupplementalGroups(m.SupplementalGroups())
+			m.SetFSGroupChangePolicy(m.FSGroupChangePolicy())
 			if !reflect.DeepEqual(sc, originalSC) {
 				t.Errorf("%s: unexpected mutation: %#v, %#v", k, sc, originalSC)
 			}
@@ -285,6 +292,19 @@ func TestPodSecurityContextMutator(t *testing.T) {
 			m := NewPodSecurityContextMutator(tc.newSC())
 			modifiedSC.SupplementalGroups = []int64{1, 1, 2, 3}
 			m.SetSupplementalGroups([]int64{1, 1, 2, 3})
+			if !reflect.DeepEqual(m.PodSecurityContext(), modifiedSC) {
+				t.Errorf("%s: unexpected object:\n%s", k, diff.ObjectGoPrintSideBySide(modifiedSC, m.PodSecurityContext()))
+				continue
+			}
+		}
+
+		// FSGroupChangePolicy
+		{
+			onRootMismatchPolicy := api.FSGroupChangeOnRootMismatch
+			modifiedSC := nonNilSC(tc.newSC())
+			m := NewPodSecurityContextMutator(tc.newSC())
+			modifiedSC.FSGroupChangePolicy = &onRootMismatchPolicy
+			m.SetFSGroupChangePolicy(&onRootMismatchPolicy)
 			if !reflect.DeepEqual(m.PodSecurityContext(), modifiedSC) {
 				t.Errorf("%s: unexpected object:\n%s", k, diff.ObjectGoPrintSideBySide(modifiedSC, m.PodSecurityContext()))
 				continue


### PR DESCRIPTION
This brings fsgroup change policy on-par with other fields of pod security context.
