### PR TITLE
Do not expand non expnadable volumes

### DIFF
--- a/pkg/volume/util/operationexecutor/node_expander_test.go
+++ b/pkg/volume/util/operationexecutor/node_expander_test.go
@@ -163,6 +163,19 @@ func TestNodeExpander(t *testing.T) {
 			expectedStatusSize:            resource.MustParse("2G"),
 		},
 		{
+			name:                          "RWX volumes, pv.spec.cap = pvc.status.cap, resizeStatus='', desiredSize > actualSize, node-expansion-not-required",
+			pvc:                           addAnnotation(addAccessMode(getTestPVC("test-vol0", "2G", "2G", "2G", nil), v1.ReadWriteMany), volumetypes.NodeExpansionNotRequired, "true"),
+			pv:                            getTestPV("test-vol0", "2G"),
+			recoverVolumeExpansionFailure: true,
+
+			expectedResizeStatus:     "",
+			expectedReturnValue:      true,
+			expectResizeCall:         false,
+			assumeResizeOpAsFinished: true,
+			expectFinalErrors:        false,
+			expectedStatusSize:       resource.MustParse("2G"),
+		},
+		{
 			name:                          "pv.spec.cap > pvc.status.cap, resizeStatus=node_expansion_pending, featuregate=disabled",
 			pvc:                           getTestPVC("test-vol0", "2G", "1G", "2G", &nodeResizePending),
 			pv:                            getTestPV("test-vol0", "2G"),

--- a/pkg/volume/util/operationexecutor/operation_generator_test.go
+++ b/pkg/volume/util/operationexecutor/operation_generator_test.go
@@ -563,6 +563,14 @@ func addAccessMode(pvc *v1.PersistentVolumeClaim, mode v1.PersistentVolumeAccess
 	return pvc
 }
 
+func addAnnotation(pvc *v1.PersistentVolumeClaim, key, value string) *v1.PersistentVolumeClaim {
+	if pvc.Annotations == nil {
+		pvc.Annotations = make(map[string]string)
+	}
+	pvc.Annotations[key] = value
+	return pvc
+}
+
 func getTestPV(volumeName string, specSize string) *v1.PersistentVolume {
 	return &v1.PersistentVolume{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/volume/util/types/types.go
+++ b/pkg/volume/util/types/types.go
@@ -25,6 +25,10 @@ import (
 	"k8s.io/mount-utils"
 )
 
+var (
+	NodeExpansionNotRequired = "volume.kubernetes.io/node-expansion-not-required"
+)
+
 // UniquePodName defines the type to key pods off of
 type UniquePodName types.UID
 


### PR DESCRIPTION
Helps in fixing issues like - https://github.com/kubernetes/kubernetes/issues/131419 

This will be used with https://github.com/kubernetes-csi/external-resizer/pull/496

```release-note
Do not expand PVCs annotated with node-expand-not-required
```
