### PR TITLE
DRA kubelet: fix gRPC timeout flake

### DIFF
--- a/pkg/kubelet/cm/dra/manager_test.go
+++ b/pkg/kubelet/cm/dra/manager_test.go
@@ -505,7 +505,7 @@ func TestPrepareResources(t *testing.T) {
 			claim:                genTestClaim(claimName, driverName, deviceName, podUID),
 			wantTimeout:          true,
 			expectedPrepareCalls: 1,
-			expectedErrMsg:       "NodePrepareResources failed: rpc error: code = DeadlineExceeded desc = context deadline exceeded",
+			expectedErrMsg:       "NodePrepareResources failed: rpc error: code = DeadlineExceeded",
 		},
 		{
 			description:            "should prepare resource, claim not in cache",
@@ -671,7 +671,7 @@ func TestUnprepareResources(t *testing.T) {
 			claimInfo:              genTestClaimInfo(claimUID, []string{podUID}, true),
 			wantTimeout:            true,
 			expectedUnprepareCalls: 1,
-			expectedErrMsg:         "context deadline exceeded",
+			expectedErrMsg:         "NodeUnprepareResources failed: rpc error: code = DeadlineExceeded",
 		},
 		{
 			description:            "should fail when driver returns empty response",


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test
/kind flake

#### What this PR does / why we need it:

Something changed in Kubernetes such that "desc = stream terminated by RST_STREAM with error code: CANCEL" is provided as root cause description instead of "desc = context deadline exceeded".

The error code is the same, so we can test for the expected timeout by ignoring the exact description.

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubernetes/issues/131925

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
