### PR TITLE
Backport external jwt OIDC discovery fix 133

### DIFF
--- a/pkg/controlplane/apiserver/config.go
+++ b/pkg/controlplane/apiserver/config.go
@@ -378,7 +378,7 @@ func CreateConfig(
 
 	if len(opts.Authentication.ServiceAccounts.KeyFiles) > 0 {
 		// Load and set the public keys.
-		var pubKeys []interface{}
+		var pubKeys []any
 		for _, f := range opts.Authentication.ServiceAccounts.KeyFiles {
 			keys, err := keyutil.PublicKeysFromFile(f)
 			if err != nil {
@@ -391,7 +391,10 @@ func CreateConfig(
 			return nil, nil, fmt.Errorf("failed to set up public service account keys: %w", err)
 		}
 		config.ServiceAccountPublicKeysGetter = keysGetter
+	} else if opts.Authentication.ServiceAccounts.ExternalPublicKeysGetter != nil {
+		config.ServiceAccountPublicKeysGetter = opts.Authentication.ServiceAccounts.ExternalPublicKeysGetter
 	}
+
 	config.ServiceAccountIssuerURL = opts.Authentication.ServiceAccounts.Issuers[0]
 	config.ServiceAccountJWKSURI = opts.Authentication.ServiceAccounts.JWKSURI
 

--- a/pkg/controlplane/apiserver/options/validation_test.go
+++ b/pkg/controlplane/apiserver/options/validation_test.go
@@ -237,7 +237,7 @@ func TestValidateOptions(t *testing.T) {
 	}
 }
 
-func TestValidateServcieAccountTokenSigningConfig(t *testing.T) {
+func TestValidateServiceAccountTokenSigningConfig(t *testing.T) {
 	tests := []struct {
 		name           string
 		featureEnabled bool

--- a/test/integration/serviceaccount/external_jwt_signer_test.go
+++ b/test/integration/serviceaccount/external_jwt_signer_test.go
@@ -77,6 +77,16 @@ func TestExternalJWTSigningAndAuth(t *testing.T) {
 	})
 	defer tearDownFn()
 
+	// Validate that OIDC discovery doc and keys are available.
+	for _, p := range []string{
+		"/.well-known/openid-configuration",
+		"/openid/v1/jwks",
+	} {
+		if _, err := client.CoreV1().RESTClient().Get().AbsPath(p).DoRaw(ctx); err != nil {
+			t.Errorf("Validating OIDC discovery failed, error getting api path %q: %v", p, err)
+		}
+	}
+
 	// Create Namesapce (ns-1) to work with.
 	if _, err := client.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Backport https://github.com/kubernetes/kubernetes/pull/131493 into 1.33. The bug can cause OIDC discovery path return 404 with external JWT signer enabled due to key getter not wired correctly:
```
#kubectl get —raw /openid/v1/jwks
Error from server (NotFound): the server could not find the requested resource

# kubectl get --raw=/.well-known/openid-configuration
Error from server (NotFound): the server could not find the requested resource
```

The feature `ExternalServiceAccountTokenSigner ` is currently in alpha in 1.33. Tracking PR for promoting the external JWT signer feature flag to beta https://github.com/kubernetes/kubernetes/pull/131300

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kube-apiserver: Fixes OIDC discovery document publishing when external service account token signing is enabled
```

