### PR TITLE
Automated cherry pick of #131144 upstream release 1.30

### DIFF
--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -64,7 +64,7 @@ dependencies:
 
   # etcd
   - name: "etcd"
-    version: 3.5.15
+    version: 3.5.21
     refPaths:
     - path: cluster/gce/manifests/etcd.manifest
       match: etcd_docker_tag|etcd_version

--- a/cluster/gce/manifests/etcd.manifest
+++ b/cluster/gce/manifests/etcd.manifest
@@ -18,7 +18,7 @@
     {
     "name": "etcd-container",
     {{security_context}}
-    "image": "{{ pillar.get('etcd_docker_repository', 'registry.k8s.io/etcd') }}:{{ pillar.get('etcd_docker_tag', '3.5.15-0') }}",
+    "image": "{{ pillar.get('etcd_docker_repository', 'registry.k8s.io/etcd') }}:{{ pillar.get('etcd_docker_tag', '3.5.21-0') }}",
     "resources": {
       "requests": {
         "cpu": {{ cpulimit }}
@@ -34,7 +34,7 @@
         "value": "{{ pillar.get('storage_backend', 'etcd3') }}"
       },
       { "name": "TARGET_VERSION",
-        "value": "{{ pillar.get('etcd_version', '3.5.15') }}"
+        "value": "{{ pillar.get('etcd_version', '3.5.21') }}"
       },
       {
         "name": "DO_NOT_MOVE_BINARIES",

--- a/cluster/gce/upgrade-aliases.sh
+++ b/cluster/gce/upgrade-aliases.sh
@@ -170,8 +170,8 @@ export KUBE_GCE_ENABLE_IP_ALIASES=true
 export SECONDARY_RANGE_NAME="pods-default"
 export STORAGE_BACKEND="etcd3"
 export STORAGE_MEDIA_TYPE="application/vnd.kubernetes.protobuf"
-export ETCD_IMAGE=3.5.15-0
-export ETCD_VERSION=3.5.15
+export ETCD_IMAGE=3.5.21-0
+export ETCD_VERSION=3.5.21
 
 # Upgrade master with updated kube envs
 "${KUBE_ROOT}/cluster/gce/upgrade.sh" -M -l

--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -320,7 +320,7 @@ const (
 	MinExternalEtcdVersion = "3.4.13-4"
 
 	// DefaultEtcdVersion indicates the default etcd version that kubeadm uses
-	DefaultEtcdVersion = "3.5.15-0"
+	DefaultEtcdVersion = "3.5.21-0"
 
 	// Etcd defines variable used internally when referring to etcd component
 	Etcd = "etcd"
@@ -479,16 +479,16 @@ var (
 
 	// SupportedEtcdVersion lists officially supported etcd versions with corresponding Kubernetes releases
 	SupportedEtcdVersion = map[uint8]string{
-		22: "3.5.15-0",
-		23: "3.5.15-0",
-		24: "3.5.15-0",
-		25: "3.5.15-0",
-		26: "3.5.15-0",
-		27: "3.5.15-0",
-		28: "3.5.15-0",
-		29: "3.5.15-0",
-		30: "3.5.15-0",
-		31: "3.5.15-0",
+		22: "3.5.21-0",
+		23: "3.5.21-0",
+		24: "3.5.21-0",
+		25: "3.5.21-0",
+		26: "3.5.21-0",
+		27: "3.5.21-0",
+		28: "3.5.21-0",
+		29: "3.5.21-0",
+		30: "3.5.21-0",
+		31: "3.5.21-0",
 	}
 
 	// KubeadmCertsClusterRoleName sets the name for the ClusterRole that allows

--- a/hack/lib/etcd.sh
+++ b/hack/lib/etcd.sh
@@ -16,7 +16,7 @@
 
 # A set of helpers for starting/running etcd for tests
 
-ETCD_VERSION=${ETCD_VERSION:-3.5.15}
+ETCD_VERSION=${ETCD_VERSION:-3.5.21}
 ETCD_HOST=${ETCD_HOST:-127.0.0.1}
 ETCD_PORT=${ETCD_PORT:-2379}
 # This is intentionally not called ETCD_LOG_LEVEL:

--- a/staging/src/k8s.io/sample-apiserver/artifacts/example/deployment.yaml
+++ b/staging/src/k8s.io/sample-apiserver/artifacts/example/deployment.yaml
@@ -26,4 +26,4 @@ spec:
         imagePullPolicy: Never
         args: [ "--etcd-servers=http://localhost:2379" ]
       - name: etcd
-        image: gcr.io/etcd-development/etcd:v3.5.15
+        image: gcr.io/etcd-development/etcd:v3.5.21

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -238,7 +238,7 @@ func initImageConfigs(list RegistryList) (map[ImageID]Config, map[ImageID]Config
 	configs[CudaVectorAdd] = Config{list.PromoterE2eRegistry, "cuda-vector-add", "1.0"}
 	configs[CudaVectorAdd2] = Config{list.PromoterE2eRegistry, "cuda-vector-add", "2.3"}
 	configs[DistrolessIptables] = Config{list.BuildImageRegistry, "distroless-iptables", "v0.6.10"}
-	configs[Etcd] = Config{list.GcEtcdRegistry, "etcd", "3.5.15-0"}
+	configs[Etcd] = Config{list.GcEtcdRegistry, "etcd", "3.5.21-0"}
 	configs[Httpd] = Config{list.PromoterE2eRegistry, "httpd", "2.4.38-4"}
 	configs[HttpdNew] = Config{list.PromoterE2eRegistry, "httpd", "2.4.39-4"}
 	configs[InvalidRegistryImage] = Config{list.InvalidRegistry, "alpine", "3.1"}


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/blob/release-1.33/cmd/kubeadm/app/constants/constants.go#L497-L502

Cherry pick of #131144 on release-1.30.

#131144: Update etcd to 3.5.21

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Bump etcd to v3.5.21
```
/kind cleanup
