### PR TITLE
fix: allocate reusableCPUs first before allocate other available CPUs to avoid CPU leaking when cpu-manager-policy=static

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -976,6 +976,18 @@ const (
 	// operation when scheduling a Pod by setting the `metadata.labels` field on the submitted Binding,
 	// similar to how `metadata.annotations` behaves.
 	PodTopologyLabelsAdmission featuregate.Feature = "PodTopologyLabelsAdmission"
+
+	// owner: @ffromani
+	// beta: v1.34
+	//
+	// When allocating cpus to a container which need exclusive CPUs,
+	// inherit the reusable CPUs first before allocate other available CPUs.
+	// This can prevent CPU leakage, which may cause UnexpectedAdmissionError when other Pod creation.
+	// CPU leakage means that the CPU not be used by the app container, and also can
+	// not be used by other pod, because it not release to the defaultCpuSet.
+	// Reusable CPUs is the CPUs of the non-restartable InitContainer.
+	// The Feature Gate will be locked to true and then removed in +2 releases (1.36) if there are no bug reported
+	InheritReusableCPUsFirst featuregate.Feature = "InheritReusableCPUsFirst"
 )
 
 // defaultVersionedKubernetesFeatureGates consists of all known Kubernetes-specific feature keys with VersionedSpecs.
@@ -1861,6 +1873,9 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 	},
 	DisableCPUQuotaWithExclusiveCPUs: {
 		{Version: version.MustParse("1.33"), Default: true, PreRelease: featuregate.Beta},
+	},
+	InheritReusableCPUsFirst: {
+		{Version: version.MustParse("1.34"), Default: true, PreRelease: featuregate.Beta},
 	},
 }
 

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -579,6 +579,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "1.33"
+- name: InheritReusableCPUsFirst
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.34"
 - name: InPlacePodVerticalScaling
   versionedSpecs:
   - default: false

--- a/test/e2e_node/cpu_manager_test.go
+++ b/test/e2e_node/cpu_manager_test.go
@@ -294,6 +294,7 @@ type cpuManagerKubeletArguments struct {
 	policyName                       string
 	enableCPUManagerOptions          bool
 	disableCPUQuotaWithExclusiveCPUs bool
+	inheritReusableCPUsFirst         bool
 	reservedSystemCPUs               cpuset.CPUSet
 	options                          map[string]string
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
In the case of ```cpu-manager-policy=static```, when allocate CPUs to a container of a pod, the CPU manager supports reusing the CPUs which have been allocated to the non-restartable Init containers of the pod.

But In some cases, the app container can not reuse the CPU of Init containers, which lead to CPU leaking.

For example:
defaultCpuSet: {{0,10},{1,11},{2,12},{3,13},{4,14},{5,15},{6,16},{7,17},{8,18},{9,19}}
system reserved CPU: {0}
For a pod, Init container request 1 CPU, and app container request 2 CPUs.
the result in the cpu_manager_state is 
```
{
  "policyName":"static",
  "defaultCpuSet":"0,2-9,12-19",
  "entries":{
    "bc2c2aa2-ec4e-43eb-b656-a0928d92f19e":{
      "test-c-1":"1,11",
      "test-init-c-1":"10"   leaking CPU
    }
  },
  "checksum":3859770841
}
```

CPU leakage means that this CPU not be used by the app container, and also can not be used by other pod, because it not release to the defaultCpuSet. 
CPU leakage may cause the error UnexpectedAdmissionError to occur when create a new pod, because the number of available CPUs in the scheduler does not match the number of available CPUs in kubelet. The detail please refer to https://github.com/kubernetes/kubernetes/pull/129556#issuecomment-2862370289.

There are two possible solutions (https://github.com/kubernetes/kubernetes/issues/112228#issuecomment-2866126468)
```
Solution1: Allocate resuable CPUs first before allocate other available CPUs.
Solution2: Release reusable CPUs which not be used by the AppContainer after the initContainer exits.
```

If my implement correctly for Solution2 in https://github.com/kubernetes/kubernetes/pull/131764, it has been proved that it might not a good solution, because it can not cover the pod restart case.

This PR implement the **solution1**, allocate reusableCPUs first before allocate other available CPUs.

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubernetes/issues/112228
