### PR TITLE
DRA kubelet: validation pass before changing claim info cache

### DIFF
--- a/pkg/kubelet/cm/dra/claiminfo.go
+++ b/pkg/kubelet/cm/dra/claiminfo.go
@@ -115,12 +115,12 @@ func (info *ClaimInfo) isPrepared() bool {
 func newClaimInfoCache(stateDir, checkpointName string) (*claimInfoCache, error) {
 	checkpointer, err := state.NewCheckpointer(stateDir, checkpointName)
 	if err != nil {
-		return nil, fmt.Errorf("could not initialize checkpoint manager, please drain node and remove dra state file, err: %w", err)
+		return nil, fmt.Errorf("could not initialize checkpoint manager, please drain node and remove DRA state file, err: %w", err)
 	}
 
 	checkpoint, err := checkpointer.GetOrCreate()
 	if err != nil {
-		return nil, fmt.Errorf("error calling GetOrCreate() on checkpoint state: %w", err)
+		return nil, fmt.Errorf("GetOrCreate() on checkpoint state: %w", err)
 	}
 
 	cache := &claimInfoCache{
@@ -130,7 +130,7 @@ func newClaimInfoCache(stateDir, checkpointName string) (*claimInfoCache, error)
 
 	entries, err := checkpoint.GetClaimInfoStateList()
 	if err != nil {
-		return nil, fmt.Errorf("error calling GetEntries() on checkpoint: %w", err)
+		return nil, fmt.Errorf("GetEntries() on checkpoint: %w", err)
 
 	}
 	for _, entry := range entries {
@@ -156,9 +156,8 @@ func (cache *claimInfoCache) withRLock(f func() error) error {
 }
 
 // add adds a new claim info object into the claim info cache.
-func (cache *claimInfoCache) add(info *ClaimInfo) *ClaimInfo {
+func (cache *claimInfoCache) add(info *ClaimInfo) {
 	cache.claimInfo[info.Namespace+"/"+info.ClaimName] = info
-	return info
 }
 
 // contains checks to see if a specific claim info object is already in the cache.

--- a/pkg/kubelet/cm/dra/manager_test.go
+++ b/pkg/kubelet/cm/dra/manager_test.go
@@ -408,13 +408,13 @@ func TestPrepareResources(t *testing.T) {
 			description:    "claim doesn't exist",
 			driverName:     driverName,
 			pod:            genTestPod(),
-			expectedErrMsg: "failed to fetch ResourceClaim ",
+			expectedErrMsg: "fetch ResourceClaim ",
 		},
 		{
 			description:    "unknown driver",
 			pod:            genTestPod(),
-			claim:          genTestClaim(claimName, "unknown driver", deviceName, podUID),
-			expectedErrMsg: "plugin name unknown driver not found in the list of registered DRA plugins",
+			claim:          genTestClaim(claimName, "unknown.driver", deviceName, podUID),
+			expectedErrMsg: "DRA driver unknown.driver is not registered",
 		},
 		{
 			description:            "should prepare resources, driver returns nil value",
@@ -432,14 +432,14 @@ func TestPrepareResources(t *testing.T) {
 			claim:                genTestClaim(claimName, driverName, deviceName, podUID),
 			resp:                 &drapb.NodePrepareResourcesResponse{Claims: map[string]*drapb.NodePrepareResourceResponse{}},
 			expectedPrepareCalls: 1,
-			expectedErrMsg:       "NodePrepareResources left out 1 claims",
+			expectedErrMsg:       "NodePrepareResources skipped 1 ResourceClaims",
 		},
 		{
 			description:    "pod is not allowed to use resource claim",
 			driverName:     driverName,
 			pod:            genTestPod(),
 			claim:          genTestClaim(claimName, driverName, deviceName, ""),
-			expectedErrMsg: "is not allowed to use resource claim ",
+			expectedErrMsg: "is not allowed to use ResourceClaim ",
 		},
 		{
 			description: "no container uses the claim",
@@ -505,7 +505,7 @@ func TestPrepareResources(t *testing.T) {
 			claim:                genTestClaim(claimName, driverName, deviceName, podUID),
 			wantTimeout:          true,
 			expectedPrepareCalls: 1,
-			expectedErrMsg:       "NodePrepareResources failed: rpc error: code = DeadlineExceeded",
+			expectedErrMsg:       "NodePrepareResources: rpc error: code = DeadlineExceeded",
 		},
 		{
 			description:            "should prepare resource, claim not in cache",
@@ -553,7 +553,7 @@ func TestPrepareResources(t *testing.T) {
 			pod:            genTestPod(),
 			claim:          genTestClaim(claimName, driverName, deviceName, podUID),
 			claimInfo:      genTestClaimInfo(anotherClaimUID, []string{podUID}, false),
-			expectedErrMsg: fmt.Sprintf("old claim with same name %s/%s and different UID %s still exists", namespace, claimName, anotherClaimUID),
+			expectedErrMsg: fmt.Sprintf("old ResourceClaim with same name %s and different UID %s still exists", claimName, anotherClaimUID),
 		},
 	} {
 		t.Run(test.description, func(t *testing.T) {
@@ -655,7 +655,7 @@ func TestUnprepareResources(t *testing.T) {
 			pod:            genTestPod(),
 			claim:          genTestClaim(claimName, "unknown driver", deviceName, podUID),
 			claimInfo:      genTestClaimInfo(claimUID, []string{podUID}, true),
-			expectedErrMsg: "plugin name test-driver not found in the list of registered DRA plugins",
+			expectedErrMsg: "DRA driver test-driver is not registered",
 		},
 		{
 			description:         "resource claim referenced by other pod(s)",
@@ -671,7 +671,7 @@ func TestUnprepareResources(t *testing.T) {
 			claimInfo:              genTestClaimInfo(claimUID, []string{podUID}, true),
 			wantTimeout:            true,
 			expectedUnprepareCalls: 1,
-			expectedErrMsg:         "NodeUnprepareResources failed: rpc error: code = DeadlineExceeded",
+			expectedErrMsg:         "NodeUnprepareResources: rpc error: code = DeadlineExceeded",
 		},
 		{
 			description:            "should fail when driver returns empty response",
@@ -680,7 +680,7 @@ func TestUnprepareResources(t *testing.T) {
 			claimInfo:              genTestClaimInfo(claimUID, []string{podUID}, true),
 			resp:                   &drapb.NodeUnprepareResourcesResponse{Claims: map[string]*drapb.NodeUnprepareResourceResponse{}},
 			expectedUnprepareCalls: 1,
-			expectedErrMsg:         "NodeUnprepareResources left out 1 claims",
+			expectedErrMsg:         "NodeUnprepareResources skipped 1 ResourceClaims",
 		},
 		{
 			description:            "should unprepare resource",
@@ -815,7 +815,7 @@ func TestGetContainerClaimInfos(t *testing.T) {
 			description:    "should fail when claim info not found",
 			pod:            genTestPod(),
 			claimInfo:      &ClaimInfo{},
-			expectedErrMsg: "unable to get claim info for claim ",
+			expectedErrMsg: "unable to get information for ResourceClaim ",
 		},
 		{
 			description: "should fail when none of the supported fields are set",
@@ -851,7 +851,7 @@ func TestGetContainerClaimInfos(t *testing.T) {
 		{
 			description:    "should fail when claim info is not cached",
 			pod:            genTestPod(),
-			expectedErrMsg: "unable to get claim info for claim ",
+			expectedErrMsg: "unable to get information for ResourceClaim ",
 		},
 	} {
 		t.Run(test.description, func(t *testing.T) {

--- a/pkg/kubelet/cm/dra/plugin/plugin.go
+++ b/pkg/kubelet/cm/dra/plugin/plugin.go
@@ -39,17 +39,18 @@ import (
 // driver kubelet plugin which need to be called by kubelet. The wrapper
 // handles gRPC connection management and logging. Connections are reused
 // across different NewDRAPluginClient calls.
-func NewDRAPluginClient(pluginName string) (*Plugin, error) {
-	if pluginName == "" {
-		return nil, fmt.Errorf("plugin name is empty")
+//
+// It returns an informative error message including the driver name
+// with an explanation why the driver is not usable.
+func NewDRAPluginClient(driverName string) (*Plugin, error) {
+	if driverName == "" {
+		return nil, errors.New("DRA driver name is empty")
 	}
-
-	existingPlugin := draPlugins.get(pluginName)
-	if existingPlugin == nil {
-		return nil, fmt.Errorf("plugin name %s not found in the list of registered DRA plugins", pluginName)
+	client := draPlugins.get(driverName)
+	if client == nil {
+		return nil, fmt.Errorf("DRA driver %s is not registered", driverName)
 	}
-
-	return existingPlugin, nil
+	return client, nil
 }
 
 type Plugin struct {
@@ -103,6 +104,10 @@ func (p *Plugin) getOrCreateGRPCConn() (*grpc.ClientConn, error) {
 
 	p.conn = conn
 	return p.conn, nil
+}
+
+func (p *Plugin) Name() string {
+	return p.name
 }
 
 func (p *Plugin) NodePrepareResources(

--- a/test/e2e/dra/dra.go
+++ b/test/e2e/dra/dra.go
@@ -339,7 +339,7 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), feature.Dynami
 				f.ClientSet,
 				pod.Namespace,
 				expectedEvent,
-				fmt.Sprintf("old claim with same name %s and different UID %s still exists", klog.KObj(oldClaim), oldClaim.UID),
+				fmt.Sprintf("old ResourceClaim with same name %s and different UID %s still exists", oldClaim.Name, oldClaim.UID),
 				framework.PodStartTimeout*2))
 
 			driver.Fail(unprepareResources, false)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

If preparing for a pod failed because the driver was not registered, it failed after already having added the pod and claim to the claim info cache. The effect was that deletion of the pod was blocked until the driver got installed. Other errors had a similar effect. Now as many errors as possible are checked in a read-only loop before proceeding to changing the claim info cache.

The error message that was surfaced for the problem was not very readable:

     Failed to prepare dynamic resources: failed to get gRPC client for driver dra-1411.k8s.io: plugin name dra-1411.k8s.io not found in the list of registered DRA plugins

To address this, error messages and wrapping get updated according to these guidelines:

    // Most errors returned by the manager show up in the context of a pod.
    // They try to adher to the following convention:
    // - Don't include the pod.
    // - Use terms that are familiar to users.
    // - Don't include the namespace, it can be inferred from the context.
    // - Avoid repeated "failed to ...: failed to ..." when wrapping errors.
    // - Avoid wrapping when it does not provide relevant additional information to keep the user-visible error short.

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubernetes/issues/131957

#### Special notes for your reviewer:

Testing this will follow through the updated E2E tests in https://github.com/kubernetes/kubernetes/pull/131956. Those are what revealed the issue.

#### Does this PR introduce a user-facing change?
```release-note
DRA kubelet: recovery from mistakes like scheduling a pod onto a node with the required driver not running is a bit simpler now because the kubelet does not block pod deletion unnecessarily.
```

/assign @klueska 