### PR TITLE
[WIP] Added Quantity format to CRDs

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/validation/formats.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/validation/formats.go
@@ -58,6 +58,7 @@ var supportedVersionedFormats = []versionedFormats{
 			"date",         // a date string like "2006-01-02" as defined by full-date in RFC3339
 			"duration",     // a duration string like "22 ns" as parsed by Golang time.ParseDuration or compatible with Scala duration format
 			"datetime",     // a date time string like "2014-12-15T19:30:20.000Z" as defined by date-time in RFC3339
+			"quantity",     // a quantity string like "10Gi" as defined in staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
 		),
 	},
 }

--- a/staging/src/k8s.io/apiserver/pkg/cel/common/schemas.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/common/schemas.go
@@ -155,6 +155,10 @@ func SchemaDeclType(s Schema, isResourceRoot bool) *apiservercel.DeclType {
 			timestampWithMaxLength := apiservercel.NewSimpleTypeWithMinSize("timestamp", cel.TimestampType, types.Timestamp{Time: time.Time{}}, int64(apiservercel.MinDatetimeSizeJSON))
 			timestampWithMaxLength.MaxElements = estimateMaxStringLengthPerRequest(s)
 			return timestampWithMaxLength
+		case "quantity":
+			quantityWithMaxLength := apiservercel.QuantityDeclType
+			quantityWithMaxLength.MaxElements = estimateMaxStringLengthPerRequest(s)
+			return quantityWithMaxLength
 		}
 
 		strWithMaxLength := apiservercel.NewSimpleTypeWithMinSize("string", cel.StringType, types.String(""), apiservercel.MinStringSize)

--- a/staging/src/k8s.io/apiserver/pkg/cel/common/valuesunstructured.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/common/valuesunstructured.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/kube-openapi/pkg/validation/strfmt"
 
 	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apiserver/pkg/cel"
 )
 
@@ -159,6 +160,12 @@ func UnstructuredToVal(unstructured interface{}, schema Schema) ref.Val {
 				return types.NewErr("Invalid byte formatted string %s: %v", str, err)
 			}
 			return types.Bytes(base64)
+		case "quantity":
+			quantity, err := resource.ParseQuantity(str)
+			if err != nil {
+				return types.NewErr("Invalid quantity formatted string %s: %v", str, err)
+			}
+			return cel.Quantity{Quantity: &quantity}
 		}
 
 		return types.String(str)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature 
/sig api-machinery

#### What this PR does / why we need it:

This PR adds Quantity as a valid format for CRDs as well as to `SchemaDeclType` and `UnstructuredToVal` so that declarative validation of CRD fields with quantity format is possible as described in https://github.com/kubernetes/kubernetes/issues/130639.

I tested these changes locally and for this I needed to update kube-openapi to add quantity as a valid format under `pkg/validation/strfmt` as well. These changes are available in https://github.com/kubernetes/kube-openapi/pull/540. I need feedback on kube-openapi as well since I'm not sure if importing k8s.io/apimachinery to use resource.Quantity is the correct way to achieve this there.

With these changes however, fields with a format of quantity are validated and CEL expression are validated out of the box.

```yaml
memoryLimit:
  type: string
  format: quantity
```

```
- rule: "self.memoryLimit.isLessThan(quantity('10Ti'))"
  message: "memory limit cannot exceed 10Ti"
```
Find the complete CRD and CRs used [here](https://gist.github.com/sreeram-venkitesh/3202ac7692736479c367ba925317196f).

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of https://github.com/kubernetes/kubernetes/issues/130639

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
CRD field format `quantity` is now mapped to the type `Quantity` (part of the Kubernetes library for CEL), providing support for declarative validation in CEL expressions within CustomResourceDefinitions.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
