### PR TITLE
kubectl: plugin shell completion to also support cobra binaries

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/plugin/plugin_completion.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/plugin/plugin_completion.go
@@ -191,8 +191,9 @@ func pluginCompletion(cmd *cobra.Command, args []string, toComplete string) ([]s
 
 	path, found := lookupCompletionExec(pluginName)
 	if !found {
-		cobra.CompDebugln(fmt.Sprintf("Plugin %s does not provide a matching completion executable", pluginName), true)
-		return nil, cobra.ShellCompDirectiveDefault
+		// if the completion executable is not found, assume the `kubectl-<plugin> __complete <args>` is a valid call and provides completions (as cobra does).
+		path = pluginName
+		args = append([]string{"__complete"}, args...)
 	}
 
 	args = append(args, toComplete)


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
`kubectl` allows binaries to be plugged in. For shell completion of these plugins an executable `kubectl_complete-<plugin>` is required for the tab-completion to take place. Looking at the krew index, non of the projects there defines such an executable, hence no tab-completion is possible. All projects I looked at are however based on the scaffold kubectl-sample-plugin hence use the cobra library. So as a fall back if the extra executable is not present the cobra command is executed `kubectl-<plugin> __complete <args>`. This enables tab-completion of all plugins based on cobra out of the box without any additional execuatable.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
