### PR TITLE
Automated cherry pick of #131868: Remove superflous expansion calls if controller finished expansion

### DIFF
--- a/pkg/volume/util/operationexecutor/node_expander.go
+++ b/pkg/volume/util/operationexecutor/node_expander.go
@@ -96,12 +96,13 @@ func (ne *NodeExpander) runPreCheck() bool {
 		ne.markExpansionInfeasibleOnFailure = true
 	}
 
+	if ne.pvcStatusCap.Cmp(ne.pluginResizeOpts.NewSize) >= 0 && ne.resizeStatus == "" {
+		ne.pvcAlreadyUpdated = true
+	}
+
 	// PVC is already expanded but we are still trying to expand the volume because
 	// last recorded size in ASOW is older. This can happen for RWX volume types.
-	if ne.pvcStatusCap.Cmp(ne.pluginResizeOpts.NewSize) >= 0 &&
-		ne.resizeStatus == "" &&
-		storage.ContainsAccessMode(ne.pvc.Spec.AccessModes, v1.ReadWriteMany) {
-		ne.pvcAlreadyUpdated = true
+	if ne.pvcAlreadyUpdated && storage.ContainsAccessMode(ne.pvc.Spec.AccessModes, v1.ReadWriteMany) {
 		return true
 	}
 
@@ -124,6 +125,14 @@ func (ne *NodeExpander) runPreCheck() bool {
 func (ne *NodeExpander) expandOnPlugin() (bool, resource.Quantity, error) {
 	allowExpansion := ne.runPreCheck()
 	if !allowExpansion {
+		if ne.pvcAlreadyUpdated {
+			// if pvc is already updated, then we could be here because size stored in ASOW is smaller and controller did full
+			// expansion and hence no node expansion is needed.
+			// This will stop reconciler from retrying expansion on the node.
+			ne.testStatus = testResponseData{assumeResizeFinished: true, resizeCalledOnPlugin: false}
+			return true, ne.pluginResizeOpts.NewSize, nil
+		}
+
 		klog.V(3).Infof("NodeExpandVolume is not allowed to proceed for volume %s with resizeStatus %s", ne.vmt.VolumeName, ne.resizeStatus)
 		ne.testStatus = testResponseData{false /* resizeCalledOnPlugin */, true /* assumeResizeFinished */}
 		return false, ne.pluginResizeOpts.OldSize, nil


### PR DESCRIPTION
Cherry pick of #131868 on release-1.33.

#131868: Remove superflous expansion calls if controller finished expansion

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Do not expand volume on the node, if controller expansion is finished
```