### PR TITLE
Apparmor cleanup

### DIFF
--- a/pkg/api/pod/util.go
+++ b/pkg/api/pod/util.go
@@ -1532,3 +1532,29 @@ func HasAPIObjectReference(pod *api.Pod) (bool, string, error) {
 
 	return false, "", nil
 }
+
+// ApparmorFieldForAnnotation takes a pod annotation and returns the converted
+// apparmor profile field.
+func ApparmorFieldForAnnotation(annotation string) *api.AppArmorProfile {
+	if annotation == api.DeprecatedAppArmorAnnotationValueUnconfined {
+		return &api.AppArmorProfile{Type: api.AppArmorProfileTypeUnconfined}
+	}
+
+	if annotation == api.DeprecatedAppArmorAnnotationValueRuntimeDefault {
+		return &api.AppArmorProfile{Type: api.AppArmorProfileTypeRuntimeDefault}
+	}
+
+	if strings.HasPrefix(annotation, api.DeprecatedAppArmorAnnotationValueLocalhostPrefix) {
+		localhostProfile := strings.TrimPrefix(annotation, api.DeprecatedAppArmorAnnotationValueLocalhostPrefix)
+		if localhostProfile != "" {
+			return &api.AppArmorProfile{
+				Type:             api.AppArmorProfileTypeLocalhost,
+				LocalhostProfile: &localhostProfile,
+			}
+		}
+	}
+
+	// we can only reach this code path if the localhostProfile name has a zero
+	// length or if the annotation has an unrecognized value
+	return nil
+}

--- a/pkg/api/pod/util.go
+++ b/pkg/api/pod/util.go
@@ -1232,35 +1232,6 @@ func procMountInUse(podSpec *api.PodSpec) bool {
 	return inUse
 }
 
-// appArmorAnnotationsInUse returns true if the pod has apparmor annotations
-func appArmorAnnotationsInUse(podAnnotations map[string]string) bool {
-	for k := range podAnnotations {
-		if strings.HasPrefix(k, api.DeprecatedAppArmorAnnotationKeyPrefix) {
-			return true
-		}
-	}
-	return false
-}
-
-// appArmorFieldsInUse returns true if the pod has apparmor fields set
-func appArmorFieldsInUse(podSpec *api.PodSpec) bool {
-	if podSpec == nil {
-		return false
-	}
-	if podSpec.SecurityContext != nil && podSpec.SecurityContext.AppArmorProfile != nil {
-		return true
-	}
-	hasAppArmorContainer := false
-	VisitContainers(podSpec, AllContainers, func(c *api.Container, _ ContainerType) bool {
-		if c.SecurityContext != nil && c.SecurityContext.AppArmorProfile != nil {
-			hasAppArmorContainer = true
-			return false
-		}
-		return true
-	})
-	return hasAppArmorContainer
-}
-
 // restartableInitContainersInUse returns true if the pod spec is non-nil and
 // it has any init container with ContainerRestartPolicyAlways.
 func restartableInitContainersInUse(podSpec *api.PodSpec) bool {

--- a/pkg/api/pod/util_test.go
+++ b/pkg/api/pod/util_test.go
@@ -25,10 +25,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"k8s.io/component-base/featuregate"
 
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -846,103 +844,6 @@ func TestDropProcMount(t *testing.T) {
 				})
 			}
 		}
-	}
-}
-
-func TestDropAppArmor(t *testing.T) {
-	tests := []struct {
-		description    string
-		hasAnnotations bool
-		hasFields      bool
-		pod            api.Pod
-	}{{
-		description:    "with AppArmor Annotations",
-		hasAnnotations: true,
-		pod: api.Pod{
-			ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{"a": "1", v1.DeprecatedAppArmorBetaContainerAnnotationKeyPrefix + "foo": "default"}},
-			Spec:       api.PodSpec{},
-		},
-	}, {
-		description:    "with AppArmor Annotations & fields",
-		hasAnnotations: true,
-		hasFields:      true,
-		pod: api.Pod{
-			ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{"a": "1", v1.DeprecatedAppArmorBetaContainerAnnotationKeyPrefix + "foo": "default"}},
-			Spec: api.PodSpec{
-				SecurityContext: &api.PodSecurityContext{
-					AppArmorProfile: &api.AppArmorProfile{
-						Type: api.AppArmorProfileTypeRuntimeDefault,
-					},
-				},
-			},
-		},
-	}, {
-		description: "with pod AppArmor profile",
-		hasFields:   true,
-		pod: api.Pod{
-			ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{"a": "1"}},
-			Spec: api.PodSpec{
-				SecurityContext: &api.PodSecurityContext{
-					AppArmorProfile: &api.AppArmorProfile{
-						Type: api.AppArmorProfileTypeRuntimeDefault,
-					},
-				},
-			},
-		},
-	}, {
-		description: "with container AppArmor profile",
-		hasFields:   true,
-		pod: api.Pod{
-			ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{"a": "1"}},
-			Spec: api.PodSpec{
-				Containers: []api.Container{{
-					SecurityContext: &api.SecurityContext{
-						AppArmorProfile: &api.AppArmorProfile{
-							Type: api.AppArmorProfileTypeRuntimeDefault,
-						},
-					},
-				}},
-			},
-		},
-	}, {
-		description: "without AppArmor",
-		pod: api.Pod{
-			ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{"a": "1"}},
-			Spec:       api.PodSpec{},
-		},
-	}}
-
-	for _, test := range tests {
-
-		t.Run(fmt.Sprintf("%v", test.description), func(t *testing.T) {
-			newPod := test.pod.DeepCopy()
-
-			if hasAnnotations := appArmorAnnotationsInUse(newPod.Annotations); hasAnnotations != test.hasAnnotations {
-				t.Errorf("appArmorAnnotationsInUse does not match expectation: %t != %t", hasAnnotations, test.hasAnnotations)
-			}
-			if hasFields := appArmorFieldsInUse(&newPod.Spec); hasFields != test.hasFields {
-				t.Errorf("appArmorFieldsInUse does not match expectation: %t != %t", hasFields, test.hasFields)
-			}
-
-			DropDisabledPodFields(newPod, newPod)
-			require.Equal(t, &test.pod, newPod, "unchanged pod should never be mutated")
-
-			DropDisabledPodFields(newPod, nil)
-			assert.Equal(t, &test.pod, newPod, "pod should not be mutated when both feature gates are enabled")
-
-			expectAnnotations := test.hasAnnotations
-			assert.Equal(t, expectAnnotations, appArmorAnnotationsInUse(newPod.Annotations), "AppArmor annotations expectation")
-			if expectAnnotations == test.hasAnnotations {
-				assert.Equal(t, test.pod.Annotations, newPod.Annotations, "annotations should not be mutated")
-			}
-
-			expectFields := test.hasFields
-			assert.Equal(t, expectFields, appArmorFieldsInUse(&newPod.Spec), "AppArmor fields expectation")
-			if expectFields == test.hasFields {
-				assert.Equal(t, &test.pod.Spec, &newPod.Spec, "PodSpec should not be mutated")
-			}
-		})
-
 	}
 }
 

--- a/pkg/api/pod/warnings.go
+++ b/pkg/api/pod/warnings.go
@@ -224,7 +224,6 @@ func warningsForPodSpecAndMeta(fieldPath *field.Path, podSpec *api.PodSpec, meta
 			warnings = append(warnings, fmt.Sprintf(`%s: non-functional in v1.27+; use the "seccompProfile" field instead`, fieldPath.Child("metadata", "annotations").Key(api.SeccompPodAnnotationKey)))
 		}
 	}
-	hasPodAppArmorProfile := podSpec.SecurityContext != nil && podSpec.SecurityContext.AppArmorProfile != nil
 
 	pods.VisitContainersWithPath(podSpec, fieldPath.Child("spec"), func(c *api.Container, p *field.Path) bool {
 		// use of container seccomp annotation without accompanying field
@@ -237,7 +236,7 @@ func warningsForPodSpecAndMeta(fieldPath *field.Path, podSpec *api.PodSpec, meta
 		// use of container AppArmor annotation without accompanying field
 
 		isPodTemplate := fieldPath != nil // Pod warnings are emitted through applyAppArmorVersionSkew instead.
-		hasAppArmorField := hasPodAppArmorProfile || (c.SecurityContext != nil && c.SecurityContext.AppArmorProfile != nil)
+		hasAppArmorField := c.SecurityContext != nil && c.SecurityContext.AppArmorProfile != nil
 		if isPodTemplate && !hasAppArmorField {
 			key := api.DeprecatedAppArmorAnnotationKeyPrefix + c.Name
 			if _, exists := meta.Annotations[key]; exists {

--- a/pkg/api/pod/warnings_test.go
+++ b/pkg/api/pod/warnings_test.go
@@ -1852,7 +1852,7 @@ func TestTemplateOnlyWarnings(t *testing.T) {
 		expected    []string
 	}{
 		{
-			name: "annotations",
+			name: "AppArmor annotations",
 			template: &api.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
 					`container.apparmor.security.beta.kubernetes.io/foo`: `unconfined`,
@@ -1878,7 +1878,9 @@ func TestTemplateOnlyWarnings(t *testing.T) {
 					}},
 				},
 			},
-			expected: []string{},
+			expected: []string{
+				`template.metadata.annotations[container.apparmor.security.beta.kubernetes.io/foo]: deprecated since v1.30; use the "appArmorProfile" field instead`,
+			},
 		},
 		{
 			name: "AppArmor container field",

--- a/pkg/api/pod/warnings_test.go
+++ b/pkg/api/pod/warnings_test.go
@@ -1864,7 +1864,7 @@ func TestTemplateOnlyWarnings(t *testing.T) {
 			},
 		},
 		{
-			name: "AppArmor pod field",
+			name: "AppArmor matching pod field",
 			template: &api.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
 					`container.apparmor.security.beta.kubernetes.io/foo`: `unconfined`,
@@ -1872,6 +1872,23 @@ func TestTemplateOnlyWarnings(t *testing.T) {
 				Spec: api.PodSpec{
 					SecurityContext: &api.PodSecurityContext{
 						AppArmorProfile: &api.AppArmorProfile{Type: api.AppArmorProfileTypeUnconfined},
+					},
+					Containers: []api.Container{{
+						Name: "foo",
+					}},
+				},
+			},
+			expected: []string{},
+		},
+		{
+			name: "AppArmor different pod field",
+			template: &api.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+					`container.apparmor.security.beta.kubernetes.io/foo`: `localhost/foo`,
+				}},
+				Spec: api.PodSpec{
+					SecurityContext: &api.PodSecurityContext{
+						AppArmorProfile: &api.AppArmorProfile{Type: api.AppArmorProfileTypeLocalhost, LocalhostProfile: ptr.To("bar")},
 					},
 					Containers: []api.Container{{
 						Name: "foo",

--- a/pkg/registry/core/pod/strategy.go
+++ b/pkg/registry/core/pod/strategy.go
@@ -960,7 +960,7 @@ func applyAppArmorVersionSkew(ctx context.Context, pod *api.Pod) {
 
 			// Sync deprecated AppArmor annotations to fields
 			if hasAnnotation && containerProfile == nil {
-				newField := apparmorFieldForAnnotation(annotation)
+				newField := podutil.ApparmorFieldForAnnotation(annotation)
 				if errs := corevalidation.ValidateAppArmorProfileField(newField, &field.Path{}); len(errs) > 0 {
 					// Skip copying invalid value.
 					newField = nil
@@ -990,32 +990,6 @@ func applyAppArmorVersionSkew(ctx context.Context, pod *api.Pod) {
 
 			return true
 		})
-}
-
-// apparmorFieldForAnnotation takes a pod annotation and returns the converted
-// apparmor profile field.
-func apparmorFieldForAnnotation(annotation string) *api.AppArmorProfile {
-	if annotation == api.DeprecatedAppArmorAnnotationValueUnconfined {
-		return &api.AppArmorProfile{Type: api.AppArmorProfileTypeUnconfined}
-	}
-
-	if annotation == api.DeprecatedAppArmorAnnotationValueRuntimeDefault {
-		return &api.AppArmorProfile{Type: api.AppArmorProfileTypeRuntimeDefault}
-	}
-
-	if strings.HasPrefix(annotation, api.DeprecatedAppArmorAnnotationValueLocalhostPrefix) {
-		localhostProfile := strings.TrimPrefix(annotation, api.DeprecatedAppArmorAnnotationValueLocalhostPrefix)
-		if localhostProfile != "" {
-			return &api.AppArmorProfile{
-				Type:             api.AppArmorProfileTypeLocalhost,
-				LocalhostProfile: &localhostProfile,
-			}
-		}
-	}
-
-	// we can only reach this code path if the localhostProfile name has a zero
-	// length or if the annotation has an unrecognized value
-	return nil
 }
 
 // updatePodGeneration bumps metadata.generation if needed for any updates

--- a/pkg/registry/core/pod/strategy_test.go
+++ b/pkg/registry/core/pod/strategy_test.go
@@ -2400,10 +2400,8 @@ func TestApplyAppArmorVersionSkew(t *testing.T) {
 			},
 		},
 		validation: func(t *testing.T, pod *api.Pod) {
-			assert.Equal(t, map[string]string{
-				api.DeprecatedAppArmorAnnotationKeyPrefix + "init": api.DeprecatedAppArmorAnnotationValueUnconfined,
-				api.DeprecatedAppArmorAnnotationKeyPrefix + "ctr":  api.DeprecatedAppArmorAnnotationValueUnconfined,
-			}, pod.Annotations)
+			assert.Empty(t, pod.Annotations)
+			assert.Equal(t, api.AppArmorProfileTypeUnconfined, pod.Spec.SecurityContext.AppArmorProfile.Type)
 		},
 	}, {
 		description: "Pod field default and no annotation present",
@@ -2419,10 +2417,8 @@ func TestApplyAppArmorVersionSkew(t *testing.T) {
 			},
 		},
 		validation: func(t *testing.T, pod *api.Pod) {
-			assert.Equal(t, map[string]string{
-				api.DeprecatedAppArmorAnnotationKeyPrefix + "init": api.DeprecatedAppArmorAnnotationValueRuntimeDefault,
-				api.DeprecatedAppArmorAnnotationKeyPrefix + "ctr":  api.DeprecatedAppArmorAnnotationValueRuntimeDefault,
-			}, pod.Annotations)
+			assert.Empty(t, pod.Annotations)
+			assert.Equal(t, api.AppArmorProfileTypeRuntimeDefault, pod.Spec.SecurityContext.AppArmorProfile.Type)
 		},
 	}, {
 		description: "Pod field localhost and no annotation present",
@@ -2439,26 +2435,8 @@ func TestApplyAppArmorVersionSkew(t *testing.T) {
 			},
 		},
 		validation: func(t *testing.T, pod *api.Pod) {
-			assert.Equal(t, map[string]string{
-				api.DeprecatedAppArmorAnnotationKeyPrefix + "init": api.DeprecatedAppArmorAnnotationValueLocalhostPrefix + testProfile,
-				api.DeprecatedAppArmorAnnotationKeyPrefix + "ctr":  api.DeprecatedAppArmorAnnotationValueLocalhostPrefix + testProfile,
-			}, pod.Annotations)
-		},
-	}, {
-		description: "Pod field localhost but profile is nil",
-		pod: &api.Pod{
-			Spec: api.PodSpec{
-				SecurityContext: &api.PodSecurityContext{
-					AppArmorProfile: &api.AppArmorProfile{
-						Type: api.AppArmorProfileTypeLocalhost,
-					},
-				},
-				InitContainers: []api.Container{{Name: "init"}},
-				Containers:     []api.Container{{Name: "ctr"}},
-			},
-		},
-		validation: func(t *testing.T, pod *api.Pod) {
 			assert.Empty(t, pod.Annotations)
+			assert.Equal(t, api.AppArmorProfileTypeLocalhost, pod.Spec.SecurityContext.AppArmorProfile.Type)
 		},
 	}, {
 		description: "Container security context not nil",
@@ -2488,10 +2466,7 @@ func TestApplyAppArmorVersionSkew(t *testing.T) {
 			},
 		},
 		validation: func(t *testing.T, pod *api.Pod) {
-			assert.Equal(t, map[string]string{
-				api.DeprecatedAppArmorAnnotationKeyPrefix + "ctr": api.DeprecatedAppArmorAnnotationValueRuntimeDefault,
-			}, pod.Annotations)
-			assert.Nil(t, pod.Spec.SecurityContext)
+			assert.Empty(t, pod.Annotations)
 			assert.Equal(t, api.AppArmorProfileTypeRuntimeDefault, pod.Spec.Containers[0].SecurityContext.AppArmorProfile.Type)
 		},
 	}, {
@@ -2510,10 +2485,7 @@ func TestApplyAppArmorVersionSkew(t *testing.T) {
 			},
 		},
 		validation: func(t *testing.T, pod *api.Pod) {
-			assert.Equal(t, map[string]string{
-				api.DeprecatedAppArmorAnnotationKeyPrefix + "ctr": api.DeprecatedAppArmorAnnotationValueLocalhostPrefix + testProfile,
-			}, pod.Annotations)
-			assert.Nil(t, pod.Spec.SecurityContext)
+			assert.Empty(t, pod.Annotations)
 			assert.Equal(t, api.AppArmorProfileTypeLocalhost, pod.Spec.Containers[0].SecurityContext.AppArmorProfile.Type)
 		},
 	}, {
@@ -2536,9 +2508,7 @@ func TestApplyAppArmorVersionSkew(t *testing.T) {
 			},
 		},
 		validation: func(t *testing.T, pod *api.Pod) {
-			assert.Equal(t, map[string]string{
-				api.DeprecatedAppArmorAnnotationKeyPrefix + "ctr": api.DeprecatedAppArmorAnnotationValueUnconfined,
-			}, pod.Annotations)
+			assert.Empty(t, pod.Annotations)
 			assert.Equal(t, api.AppArmorProfileTypeRuntimeDefault, pod.Spec.SecurityContext.AppArmorProfile.Type)
 			assert.Equal(t, api.AppArmorProfileTypeUnconfined, pod.Spec.Containers[0].SecurityContext.AppArmorProfile.Type)
 		},
@@ -2575,11 +2545,7 @@ func TestApplyAppArmorVersionSkew(t *testing.T) {
 			},
 		},
 		validation: func(t *testing.T, pod *api.Pod) {
-			assert.Equal(t, map[string]string{
-				api.DeprecatedAppArmorAnnotationKeyPrefix + "init": api.DeprecatedAppArmorAnnotationValueLocalhostPrefix + testProfile,
-				api.DeprecatedAppArmorAnnotationKeyPrefix + "a":    api.DeprecatedAppArmorAnnotationValueUnconfined,
-				api.DeprecatedAppArmorAnnotationKeyPrefix + "c":    api.DeprecatedAppArmorAnnotationValueRuntimeDefault,
-			}, pod.Annotations)
+			assert.Empty(t, pod.Annotations)
 			assert.Nil(t, pod.Spec.SecurityContext)
 			assert.Equal(t, api.AppArmorProfileTypeLocalhost, pod.Spec.InitContainers[0].SecurityContext.AppArmorProfile.Type)
 			assert.Equal(t, api.AppArmorProfileTypeUnconfined, pod.Spec.Containers[0].SecurityContext.AppArmorProfile.Type)
@@ -2683,7 +2649,6 @@ func TestApplyAppArmorVersionSkew(t *testing.T) {
 			assert.Equal(t, map[string]string{
 				api.DeprecatedAppArmorAnnotationKeyPrefix + "init": api.DeprecatedAppArmorAnnotationValueUnconfined,
 				api.DeprecatedAppArmorAnnotationKeyPrefix + "a":    api.DeprecatedAppArmorAnnotationValueLocalhostPrefix + testProfile,
-				api.DeprecatedAppArmorAnnotationKeyPrefix + "b":    api.DeprecatedAppArmorAnnotationValueRuntimeDefault,
 				api.DeprecatedAppArmorAnnotationKeyPrefix + "c":    api.DeprecatedAppArmorAnnotationValueRuntimeDefault,
 			}, pod.Annotations)
 			assert.Equal(t, api.AppArmorProfileTypeUnconfined, pod.Spec.InitContainers[0].SecurityContext.AppArmorProfile.Type)
@@ -2806,8 +2771,6 @@ func TestApplyAppArmorVersionSkew(t *testing.T) {
 		validation: func(t *testing.T, pod *api.Pod) {
 			assert.Equal(t, map[string]string{
 				api.DeprecatedAppArmorAnnotationKeyPrefix + "unconf-annot": api.DeprecatedAppArmorAnnotationValueUnconfined,
-				api.DeprecatedAppArmorAnnotationKeyPrefix + "unconf-field": api.DeprecatedAppArmorAnnotationValueUnconfined,
-				api.DeprecatedAppArmorAnnotationKeyPrefix + "default-pod":  api.DeprecatedAppArmorAnnotationValueRuntimeDefault,
 			}, pod.Annotations)
 			assert.Equal(t, api.AppArmorProfileTypeRuntimeDefault, pod.Spec.SecurityContext.AppArmorProfile.Type)
 			assert.Equal(t, api.AppArmorProfileTypeUnconfined, pod.Spec.Containers[0].SecurityContext.AppArmorProfile.Type)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind api-change

#### What this PR does / why we need it:

Implement [phase 2 of the AppArmor field transition](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/24-apparmor/README.md#removing-annotation-support), but continue to suppress annotation warnings when there is a corresponding field. This change is consistent with the way we handle seccomp annotations.

1. Stop copying fields to annotations (but continue copying annotations -> fields)
2. Warn when using AppArmor annotations on PodTemplates without a corresponding container-level field

#### Which issue(s) this PR fixes:
For https://github.com/kubernetes/enhancements/issues/24#issuecomment-2362127159

#### Does this PR introduce a user-facing change?
```release-note
[Action Required] AppArmor profiles specified in the pod or container SecurityContext are no longer copied to deprecated AppArmor annotations (prefix `container.apparmor.security.beta.kubernetes.io/`). Anything that inspects the deprecated annotations must be migrated to use the SecurityContext fields instead.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/24-apparmor/README.md#removing-annotation-support
```

/sig node
/milestone v1.34
/priority important-longterm