### PR TITLE
DRA: Exclude individual devices when PartitionableDevices feature is disabled

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/allocator.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/allocator.go
@@ -987,8 +987,15 @@ func (alloc *allocator) allocateDevice(r deviceIndices, device deviceWithID, mus
 		return false, nil, nil
 	}
 
+	// Devices that consume counters can not be allocated if the PartitionableDevices feature
+	// is not enabled.
+	if !alloc.features.PartitionableDevices && len(device.basic.ConsumesCounters) > 0 {
+		alloc.logger.V(7).Info("Device consumes counters, but the partitionable devices feature is not enabled", "device", device.id)
+		return false, nil, nil
+	}
+
 	// The API validation logic has checked the ConsumesCounters referred should exist inside SharedCounters.
-	if alloc.features.PartitionableDevices && len(device.basic.ConsumesCounters) > 0 {
+	if len(device.basic.ConsumesCounters) > 0 {
 		// If a device consumes capacity from a capacity pool, verify that
 		// there is sufficient capacity available.
 		ok, err := alloc.checkAvailableCapacity(device)

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/pools.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/pools.go
@@ -54,7 +54,7 @@ func GatherPools(ctx context.Context, slices []*resourceapi.ResourceSlice, node 
 	pools := make(map[PoolID]*Pool)
 
 	for _, slice := range slices {
-		if !features.PartitionableDevices && (len(slice.Spec.SharedCounters) > 0 || slice.Spec.PerDeviceNodeSelection != nil) {
+		if !features.PartitionableDevices && slice.Spec.PerDeviceNodeSelection != nil {
 			continue
 		}
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Currently all devices in a ResourceSlice are excluded from the allocation process if any shared counters are defined. This change updates this to only exclude the devices that are actually consuming counters.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
