### PR TITLE
DRAAdminAccess: update label key

### DIFF
--- a/pkg/apis/resource/types.go
+++ b/pkg/apis/resource/types.go
@@ -588,7 +588,7 @@ const (
 // of adminAccess: true in any namespaced resource.k8s.io API types. Currently,
 // this permission applies to ResourceClaim and ResourceClaimTemplate objects.
 const (
-	DRAAdminNamespaceLabelKey = "resource.k8s.io/admin-access"
+	DRAAdminNamespaceLabelKey = "resource.kubernetes.io/admin-access"
 )
 
 // DeviceRequest is a request for devices required for a claim.

--- a/pkg/registry/resource/resourceclaim/strategy_test.go
+++ b/pkg/registry/resource/resourceclaim/strategy_test.go
@@ -291,7 +291,7 @@ var ns2 = &corev1.Namespace{
 	},
 }
 
-var adminAccessError = "Forbidden: admin access to devices requires the `resource.k8s.io/admin-access: true` label"
+var adminAccessError = "Forbidden: admin access to devices requires the `resource.kubernetes.io/admin-access: true` label"
 var fieldImmutableError = "field is immutable"
 var metadataError = "a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters"
 var deviceRequestError = "exactly one of `exactly` or `firstAvailable` is required"

--- a/pkg/registry/resource/resourceclaimtemplate/strategy_test.go
+++ b/pkg/registry/resource/resourceclaimtemplate/strategy_test.go
@@ -139,7 +139,7 @@ var ns2 = &corev1.Namespace{
 		Labels: map[string]string{resource.DRAAdminNamespaceLabelKey: "true"},
 	},
 }
-var adminAccessError = "Forbidden: admin access to devices requires the `resource.k8s.io/admin-access: true` label on the containing namespace"
+var adminAccessError = "Forbidden: admin access to devices requires the `resource.kubernetes.io/admin-access: true` label on the containing namespace"
 var fieldImmutableError = "field is immutable"
 var metadataError = "a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters"
 var deviceRequestError = "exactly one of `exactly` or `firstAvailable` is required"

--- a/staging/src/k8s.io/api/resource/v1alpha3/types.go
+++ b/staging/src/k8s.io/api/resource/v1alpha3/types.go
@@ -594,7 +594,7 @@ const (
 // of adminAccess: true in any namespaced resource.k8s.io API types. Currently,
 // this permission applies to ResourceClaim and ResourceClaimTemplate objects.
 const (
-	DRAAdminNamespaceLabelKey = "resource.k8s.io/admin-access"
+	DRAAdminNamespaceLabelKey = "resource.kubernetes.io/admin-access"
 )
 
 // DeviceRequest is a request for devices required for a claim.

--- a/staging/src/k8s.io/api/resource/v1beta1/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta1/types.go
@@ -600,7 +600,7 @@ const (
 // of adminAccess: true in any namespaced resource.k8s.io API types. Currently,
 // this permission applies to ResourceClaim and ResourceClaimTemplate objects.
 const (
-	DRAAdminNamespaceLabelKey = "resource.k8s.io/admin-access"
+	DRAAdminNamespaceLabelKey = "resource.kubernetes.io/admin-access"
 )
 
 // DeviceRequest is a request for devices required for a claim.

--- a/staging/src/k8s.io/api/resource/v1beta2/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta2/types.go
@@ -596,7 +596,7 @@ const (
 // of adminAccess: true in any namespaced resource.k8s.io API types. Currently,
 // this permission applies to ResourceClaim and ResourceClaimTemplate objects.
 const (
-	DRAAdminNamespaceLabelKey = "resource.k8s.io/admin-access"
+	DRAAdminNamespaceLabelKey = "resource.kubernetes.io/admin-access"
 )
 
 // DeviceRequest is a request for devices required for a claim.

--- a/test/e2e/dra/dra.go
+++ b/test/e2e/dra/dra.go
@@ -1685,7 +1685,7 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), feature.Dynami
 			claim.Spec.Devices.Requests[0].Exactly.AdminAccess = ptr.To(true)
 			_, claimTemplate := b.podInline()
 			claimTemplate.Spec.Spec.Devices.Requests[0].Exactly.AdminAccess = ptr.To(true)
-			matchValidationError := gomega.MatchError(gomega.ContainSubstring("admin access to devices requires the `resource.k8s.io/admin-access: true` label on the containing namespace"))
+			matchValidationError := gomega.MatchError(gomega.ContainSubstring("admin access to devices requires the `resource.kubernetes.io/admin-access: true` label on the containing namespace"))
 			gomega.Eventually(ctx, func(ctx context.Context) error {
 				// First delete, in case that it succeeded earlier.
 				if err := b.f.ClientSet.ResourceV1beta2().ResourceClaims(b.f.Namespace.Name).Delete(ctx, claim.Name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
@@ -1706,7 +1706,7 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), feature.Dynami
 
 			// After labeling the namespace, creation must (eventually...) succeed.
 			_, err := b.f.ClientSet.CoreV1().Namespaces().Apply(ctx,
-				applyv1.Namespace(b.f.Namespace.Name).WithLabels(map[string]string{"resource.k8s.io/admin-access": "true"}),
+				applyv1.Namespace(b.f.Namespace.Name).WithLabels(map[string]string{"resource.kubernetes.io/admin-access": "true"}),
 				metav1.ApplyOptions{FieldManager: b.f.UniqueName})
 			framework.ExpectNoError(err)
 			gomega.Eventually(ctx, func(ctx context.Context) error {
@@ -1786,7 +1786,7 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), feature.Dynami
 		f.It("DaemonSet with admin access", f.WithFeatureGate(features.DRAAdminAccess), func(ctx context.Context) {
 			// Ensure namespace has the dra admin label.
 			_, err := b.f.ClientSet.CoreV1().Namespaces().Apply(ctx,
-				applyv1.Namespace(b.f.Namespace.Name).WithLabels(map[string]string{"resource.k8s.io/admin-access": "true"}),
+				applyv1.Namespace(b.f.Namespace.Name).WithLabels(map[string]string{"resource.kubernetes.io/admin-access": "true"}),
 				metav1.ApplyOptions{FieldManager: b.f.UniqueName})
 			framework.ExpectNoError(err)
 

--- a/test/integration/dra/dra_test.go
+++ b/test/integration/dra/dra_test.go
@@ -297,14 +297,14 @@ func testAdminAccess(tCtx ktesting.TContext, adminAccessEnabled bool) {
 	if adminAccessEnabled {
 		if err != nil {
 			// should result in validation error
-			assert.ErrorContains(tCtx, err, "admin access to devices requires the `resource.k8s.io/admin-access: true` label on the containing namespace", "the error message should have contained the expected error message")
+			assert.ErrorContains(tCtx, err, "admin access to devices requires the `resource.kubernetes.io/admin-access: true` label on the containing namespace", "the error message should have contained the expected error message")
 			return
 		} else {
 			tCtx.Fatal("expected validation error(s), got none")
 		}
 
 		// create claim with AdminAccess in admin namespace
-		adminNS := createTestNamespace(tCtx, map[string]string{"resource.k8s.io/admin-access": "true"})
+		adminNS := createTestNamespace(tCtx, map[string]string{"resource.kubernetes.io/admin-access": "true"})
 		claim2 := claim.DeepCopy()
 		claim2.Namespace = adminNS
 		claim2.Name = "claim2"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR updates https://github.com/kubernetes/enhancements/tree/master/keps/sig-auth/5018-dra-adminaccess to address this: https://github.com/kubernetes/enhancements/pull/5327/files#r2103127522 
> "kubernetes.io" is the preferred form for labels and annotations, "k8s.io" should not be used for new map keys.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note-action-required
DRA: Starting with Kubernetes 1.34, the alpha-level `resource.k8s.io/admin-access` label has been updated to `resource.kubernetes.io/admin-access`. Admins using the alpha feature and updating from 1.33 can set both labels, upgrade, then remove `resource.k8s.io/admin-access` when no downgrade is going to happen anymore.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/5018
```
