### PR TITLE
ManagedFieldsObjectTracker: Reload scheme

### DIFF
--- a/staging/src/k8s.io/client-go/testing/fixture.go
+++ b/staging/src/k8s.io/client-go/testing/fixture.go
@@ -631,7 +631,7 @@ type managedFieldObjectTracker struct {
 	ObjectTracker
 	scheme          ObjectScheme
 	objectConverter runtime.ObjectConvertor
-	mapper          meta.RESTMapper
+	mapper          func() meta.RESTMapper
 	typeConverter   managedfields.TypeConverter
 }
 
@@ -644,8 +644,10 @@ func NewFieldManagedObjectTracker(scheme *runtime.Scheme, decoder runtime.Decode
 		ObjectTracker:   NewObjectTracker(scheme, decoder),
 		scheme:          scheme,
 		objectConverter: scheme,
-		mapper:          testrestmapper.TestOnlyStaticRESTMapper(scheme),
-		typeConverter:   typeConverter,
+		mapper: func() meta.RESTMapper {
+			return testrestmapper.TestOnlyStaticRESTMapper(scheme)
+		},
+		typeConverter: typeConverter,
 	}
 }
 
@@ -654,7 +656,7 @@ func (t *managedFieldObjectTracker) Create(gvr schema.GroupVersionResource, obj 
 	if err != nil {
 		return err
 	}
-	gvk, err := t.mapper.KindFor(gvr)
+	gvk, err := t.mapper().KindFor(gvr)
 	if err != nil {
 		return err
 	}
@@ -698,8 +700,9 @@ func (t *managedFieldObjectTracker) Update(gvr schema.GroupVersionResource, obj 
 	if err != nil {
 		return err
 	}
-	gvk, err := t.mapper.KindFor(gvr)
+	gvk, err := t.mapper().KindFor(gvr)
 	if err != nil {
+		println("kindfor")
 		return err
 	}
 	mgr, err := t.fieldManagerFor(gvk)
@@ -728,7 +731,7 @@ func (t *managedFieldObjectTracker) Patch(gvr schema.GroupVersionResource, patch
 	if err != nil {
 		return err
 	}
-	gvk, err := t.mapper.KindFor(gvr)
+	gvk, err := t.mapper().KindFor(gvr)
 	if err != nil {
 		return err
 	}
@@ -757,7 +760,7 @@ func (t *managedFieldObjectTracker) Apply(gvr schema.GroupVersionResource, apply
 	if err != nil {
 		return err
 	}
-	gvk, err := t.mapper.KindFor(gvr)
+	gvk, err := t.mapper().KindFor(gvr)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
In controller-runtime it is generally not expected to do any sort of scheme registration if unstructured.Unstructured is used. To make this work in the fakeclient, the fakeclient will register unstructured to the scheme if the scheme doesn't recognize the GVK.

This currently doesn't work with the `ManagedFieldsObjectTracker` as it never reloads the scheme. This change makes it reload the scheme in an inefficient but simple manner, which should be good enough for unit tests.

This change is required in order for controller-runtime to support SSA in the fakeclient, ref https://github.com/kubernetes-sigs/controller-runtime/pull/2981

/sig api-machinery
/assign @jpbetz @sttts 

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
