### PR TITLE
Increase max selectable CRD fields

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation.go
@@ -60,7 +60,7 @@ const (
 	// StaticEstimatedCRDCostLimit represents the largest-allowed total cost for the x-kubernetes-validations rules of a CRD.
 	StaticEstimatedCRDCostLimit = 100000000
 
-	MaxSelectableFields = 8
+	MaxSelectableFields = 16
 )
 
 var supportedValidationReason = sets.NewString(


### PR DESCRIPTION
#### What type of PR is this?

/kind api-change

#### What this PR does / why we need it:

Field selectors in CRDs are great. But there is a hard-coded maximum of 8. 
May we have some more? Say, 16?

#### release note
```release-note
increased maximum selectable fields for CRDs

in apiextensions validation logic

https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#crd-selectable-fields
```

#### other contributors
cc @bikramnehra @yquansah - thanks Bikram for finding the relevant line of code

#### discussion

currently, there is a hard-coded maximum on selectable fields in CRDs of 8. My understanding of why the hard limit of 8 fieldSelectors was established was to prevent slowdown of kube-apiserver, is that correct?

We love field selectors, and would like to use more of them. The max label selector limit is 64 per object, right? Would it be possible to increase the field selector limit as well?

Assumption: label selection is less computationally hazardous than field selection (otherwise why would the limit be lower?)

If the max fieldSelector limit can't safely be increased to 64 yet, then perhaps we can start with a more reasonable 16? It could even be hidden behind a feature flag if there is a need to protect unsuspecting users from performance traps.