### PR TITLE
cleanup: fix missed HandleError replacement with contextual logging

### DIFF
--- a/pkg/scheduler/schedule_one.go
+++ b/pkg/scheduler/schedule_one.go
@@ -390,8 +390,7 @@ func (sched *Scheduler) skipPodSchedule(ctx context.Context, fwk framework.Frame
 	// during its previous scheduling cycle but before getting assumed.
 	isAssumed, err := sched.Cache.IsAssumedPod(pod)
 	if err != nil {
-		// TODO(91633): pass ctx into a revised HandleError
-		utilruntime.HandleError(fmt.Errorf("failed to check whether pod %s/%s is assumed: %v", pod.Namespace, pod.Name, err))
+		utilruntime.HandleErrorWithContext(ctx, err, "Failed to check whether pod is assumed", "pod", klog.KObj(pod))
 		return false
 	}
 	return isAssumed


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR addresses a missed spot in [#116849](https://github.com/kubernetes/kubernetes/pull/116849), completing the replacement of `utilruntime.HandleError` with `HandleErrorWithContext` or `HandleErrorWithLogger` in places where contextual logging is available.

#### Which issue(s) this PR fixes:

Fixes #91633

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
