### PR TITLE
Promote two EndpointSlice e2e tests to Conformance

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -1727,6 +1727,22 @@
     MUST have Endpoints and EndpointSlices pointing to each API server instance.
   release: v1.21
   file: test/e2e/network/endpointslice.go
+- testname: EndpointSlice, multiple IPs, multiple ports
+  codename: '[sig-network] EndpointSlice should support a Service with multiple endpoint
+    IPs specified in multiple EndpointSlices [Conformance]'
+  description: Given a selector-less Service with multiple manually-created EndpointSlices
+    (and no Endpoints) where the endpoints have different IPs and different Ports,
+    the service proxy MUST allow connections to both ports.
+  release: v1.34
+  file: test/e2e/network/endpointslice.go
+- testname: EndpointSlice, single IP, multiple ports
+  codename: '[sig-network] EndpointSlice should support a Service with multiple ports
+    specified in multiple EndpointSlices [Conformance]'
+  description: Given a selector-less Service with multiple manually-created EndpointSlices
+    (and no Endpoints) where the endpoints have the same IP but different Ports, the
+    service proxy MUST allow connections to both ports.
+  release: v1.34
+  file: test/e2e/network/endpointslice.go
 - testname: EndpointSlice API
   codename: '[sig-network] EndpointSlice should support creating EndpointSlice API
     operations [Conformance]'

--- a/test/e2e/network/endpointslice.go
+++ b/test/e2e/network/endpointslice.go
@@ -528,7 +528,14 @@ var _ = common.SIGDescribe("EndpointSlice", func() {
 		gomega.Expect(epsList.Items).To(gomega.BeEmpty(), "filtered list should have 0 items")
 	})
 
-	ginkgo.It("should support a Service with multiple ports specified in multiple EndpointSlices", func(ctx context.Context) {
+	/*
+		Release: v1.34
+		Testname: EndpointSlice, single IP, multiple ports
+		Description: Given a selector-less Service with multiple manually-created
+		EndpointSlices (and no Endpoints) where the endpoints have the same IP
+		but different Ports, the service proxy MUST allow connections to both ports.
+	*/
+	framework.ConformanceIt("should support a Service with multiple ports specified in multiple EndpointSlices", func(ctx context.Context) {
 		ns := f.Namespace.Name
 		svc := createServiceReportErr(ctx, cs, f.Namespace.Name, &v1.Service{
 			ObjectMeta: metav1.ObjectMeta{
@@ -631,7 +638,14 @@ var _ = common.SIGDescribe("EndpointSlice", func() {
 
 	})
 
-	ginkgo.It("should support a Service with multiple endpoint IPs specified in multiple EndpointSlices", func(ctx context.Context) {
+	/*
+		Release: v1.34
+		Testname: EndpointSlice, multiple IPs, multiple ports
+		Description: Given a selector-less Service with multiple manually-created
+		EndpointSlices (and no Endpoints) where the endpoints have different IPs
+		and different Ports, the service proxy MUST allow connections to both ports.
+	*/
+	framework.ConformanceIt("should support a Service with multiple endpoint IPs specified in multiple EndpointSlices", func(ctx context.Context) {
 		ns := f.Namespace.Name
 		svc := createServiceReportErr(ctx, cs, f.Namespace.Name, &v1.Service{
 			ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
This promotes "`[sig-network] EndpointSlice should support a Service with multiple ports specified in multiple EndpointSlices`" and "`[sig-network] EndpointSlice should support a Service with multiple endpoint IPs specified in multiple EndpointSlices`" to conformance.

AFAICT, as of k8s 1.33, a service proxy that is based on Endpoints rather than EndpointSlices can still pass conformance. While it is unlikely that any currently-maintained service proxies actually do this (since that would imply not supporting dual-stack, topology, or terminating endpoints), we should explicitly require that they don't (since we plan to eventually allow disabling the Endpoints controller, KEP-4974).

These tests (added in #114144 in v1.27) weren't explicitly intended to test "service proxies use EndpointSlices rather than Endpoints", but they do test that as a side effect (while also ensuring that the service proxy doesn't fall victim to some easy EndpointSlice-implementing bugs).

The tests don't appear to have ever been flaky. (There are no issues reference those test names.)

#### Does this PR introduce a user-facing change?
```release-note
Promoted two EndpointSlice tests to conformance, to require that service
proxy implementations are based on EndpointSlices rather than Endpoints.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/4974-deprecate-endpoints
```

/kind cleanup
/area conformance
/sig network

/cc @aojea @thockin
@kubernetes/sig-architecture-pr-reviews @kubernetes/cncf-conformance-wg
