### PR TITLE
KEP-4427: Promote Relaxed DNS search string validation to GA

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -1657,6 +1657,7 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 	RelaxedDNSSearchValidation: {
 		{Version: version.MustParse("1.32"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("1.33"), Default: true, PreRelease: featuregate.Beta},
+		{Version: version.MustParse("1.34"), Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.37
 	},
 
 	RelaxedEnvironmentVariableValidation: {

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -1175,6 +1175,10 @@
     lockToDefault: false
     preRelease: Beta
     version: "1.33"
+  - default: true
+    lockToDefault: true
+    preRelease: GA
+    version: "1.34"
 - name: RelaxedEnvironmentVariableValidation
   versionedSpecs:
   - default: false

--- a/test/e2e/network/dns.go
+++ b/test/e2e/network/dns.go
@@ -25,8 +25,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/kubernetes/pkg/features"
-	"k8s.io/kubernetes/test/e2e/feature"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
@@ -627,11 +625,6 @@ var _ = common.SIGDescribe("DNS", func() {
 		}
 		validateDNSResults(ctx, f, pod, append(agnhostFileNames, jessieFileNames...))
 	})
-})
-
-var _ = common.SIGDescribe("DNS", feature.RelaxedDNSSearchValidation, framework.WithFeatureGate(features.RelaxedDNSSearchValidation), func() {
-	f := framework.NewDefaultFramework("dns")
-	f.NamespacePodSecurityLevel = admissionapi.LevelBaseline
 
 	ginkgo.It("should work with a search path containing an underscore and a search path with a single dot", func(ctx context.Context) {
 		// All the names we need to be able to resolve.


### PR DESCRIPTION
#### What this PR does / why we need it:

Bump `RelaxedDNSSearchValidation` to GA. 

#### Does this PR introduce a user-facing change?

```release-note
Graduated relaxed DNS search string validation to GA. For the Pod API, `.spec.dnsConfig.searches`
now allows an underscore (`_`) where a dash (`-`) would be allowed, and it allows search strings be a single dot `.`.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```
- [KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/4427-relaxed-dns-search-validation/README.md
```

/kind feature
/priority important-soon
/triage accepted
