### PR TITLE
FieldManagedObjectTracker: Fix to work with unstructured

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/managedfields/internal/skipnonapplied.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/managedfields/internal/skipnonapplied.go
@@ -80,6 +80,9 @@ func (f *skipNonAppliedManager) Apply(liveObj, appliedObj runtime.Object, manage
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to create empty object of type %v: %v", gvk, err)
 		}
+		if unstructured, isUnstructured := emptyObj.(runtime.Unstructured); isUnstructured {
+			unstructured.GetObjectKind().SetGroupVersionKind(gvk)
+		}
 		liveObj, managed, err = f.fieldManager.Update(emptyObj, liveObj, managed, f.beforeApplyManagerName)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to create manager for existing fields: %v", err)

--- a/staging/src/k8s.io/client-go/testing/fixture.go
+++ b/staging/src/k8s.io/client-go/testing/fixture.go
@@ -19,10 +19,11 @@ package testing
 import (
 	"fmt"
 	"reflect"
-	"sigs.k8s.io/yaml"
 	"sort"
 	"strings"
 	"sync"
+
+	"sigs.k8s.io/yaml"
 
 	jsonpatch "gopkg.in/evanphx/json-patch.v4"
 
@@ -702,7 +703,6 @@ func (t *managedFieldObjectTracker) Update(gvr schema.GroupVersionResource, obj 
 	}
 	gvk, err := t.mapper().KindFor(gvr)
 	if err != nil {
-		println("kindfor")
 		return err
 	}
 	mgr, err := t.fieldManagerFor(gvk)


### PR DESCRIPTION
Prior to this patch, this fails because the skipnonappliedfieldmanager uses the `objectcreater` (aka `*runtime.Scheme`) to create a new object for which it never sets the GVK. In the case of `*unstructured.Unstructured`, the GVK can not be derived from the object itself so the operation would subsequently fail [here][0] with an
```
Object 'Kind' is missing in 'unstructured object has no kind'
```

error. Fix this by explicitly setting the GVK in case of unstructured.

[0]: https://github.com/kubernetes/kubernetes/blob/02eb7d424ad5ccf4f00863fe861f165be0d491da/staging/src/k8s.io/apimachinery/pkg/util/managedfields/internal/structuredmerge.go#L98

/kind cleanup
/sig api-machinery

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug

/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
