### PR TITLE
feat: enable GPU resource overcommit for virtualized GPUs

### DIFF
--- a/pkg/apis/core/helper/helpers.go
+++ b/pkg/apis/core/helper/helpers.go
@@ -203,8 +203,17 @@ func IsNativeResource(name core.ResourceName) bool {
 // IsOvercommitAllowed returns true if the resource is in the default
 // namespace and is not hugepages.
 func IsOvercommitAllowed(name core.ResourceName) bool {
-	return IsNativeResource(name) &&
-		!IsHugePageResourceName(name)
+	// Allow overcommit for native resources (except hugepages)
+	if IsNativeResource(name) && !IsHugePageResourceName(name) {
+		return true
+	}
+
+	// Allow overcommit for NVIDIA GPU resources
+	if strings.HasPrefix(string(name), "nvidia.com/gpu") {
+		return true
+	}
+
+	return false
 }
 
 var standardLimitRangeTypes = sets.New(

--- a/pkg/apis/core/v1/helper/helpers.go
+++ b/pkg/apis/core/v1/helper/helpers.go
@@ -125,8 +125,17 @@ func HugePageSizeFromMedium(medium v1.StorageMedium) (resource.Quantity, error) 
 // IsOvercommitAllowed returns true if the resource is in the default
 // namespace and is not hugepages.
 func IsOvercommitAllowed(name v1.ResourceName) bool {
-	return IsNativeResource(name) &&
-		!IsHugePageResourceName(name)
+	// Allow overcommit for native resources (except hugepages)
+	if IsNativeResource(name) && !IsHugePageResourceName(name) {
+		return true
+	}
+
+	// Allow overcommit for NVIDIA GPU resources
+	if strings.HasPrefix(string(name), "nvidia.com/gpu") {
+		return true
+	}
+
+	return false
 }
 
 // IsAttachableVolumeResourceName returns true when the resource name is prefixed in attachable volume


### PR DESCRIPTION
# Support GPU resource overcommit for virtualized GPUs

## What type of PR is this?
/kind feature
/area gpu
/area hw-accelerators
/sig node

## What this PR does / why we need it
This PR enables GPU resource overcommit by modifying the `IsOvercommitAllowed` function to allow `nvidia.com/gpu` resources to be overcommitted. Currently, GPU resources must have equal requests and limits, which prevents leveraging GPU virtualization technologies like NVIDIA MPS, vGPU, MIG, or device plugins like HAMi that enable sharing a single physical GPU among multiple containers.

With modern GPU virtualization technologies, it's now common to share a single physical GPU among multiple containers, especially for inference workloads. This change makes it possible to overcommit GPU resources similar to how CPU and memory resources can be overcommitted.

## Which issue(s) this PR fixes
Fixes #132044 and addresses the long-standing feature request in #52757

## Special notes for your reviewer
This is a targeted change that only affects the validation logic for GPU resources, allowing them to be overcommitted while maintaining the existing behavior for other resources. The implementation pattern follows the existing pattern for native resources.

## Does this PR introduce a user-facing change?
```yaml
feature:
  title: GPU Resource Overcommit
  description: >
    Adds support for GPU resource overcommit, allowing GPU limits to be greater
    than requests. This enables better utilization of GPU resources in clusters
    that use GPU virtualization technologies.

  availability:
  - alpha: v1.33
