### PR TITLE
kubelet/windows: use CommitMemoryBytes for MemoryStats.UsageBytes in CRI stats provider

### DIFF
--- a/pkg/kubelet/stats/cri_stats_provider_windows.go
+++ b/pkg/kubelet/stats/cri_stats_provider_windows.go
@@ -146,11 +146,15 @@ func (p *criStatsProvider) makeWinContainerStats(
 		if stats.Memory.PageFaults != nil {
 			result.Memory.PageFaults = &stats.Memory.PageFaults.Value
 		}
+		if stats.Memory.CommitMemoryBytes != nil {
+			result.Memory.UsageBytes = &stats.Memory.CommitMemoryBytes.Value
+		}
 	} else {
 		result.Memory.Time = metav1.NewTime(time.Unix(0, time.Now().UnixNano()))
 		result.Memory.WorkingSetBytes = ptr.To[uint64](0)
 		result.Memory.AvailableBytes = ptr.To[uint64](0)
 		result.Memory.PageFaults = ptr.To[uint64](0)
+		result.Memory.UsageBytes = ptr.To[uint64](0)
 	}
 	if stats.WritableLayer != nil {
 		result.Rootfs.Time = metav1.NewTime(time.Unix(0, stats.WritableLayer.Timestamp))
@@ -233,6 +237,7 @@ func addCRIPodMemoryStats(ps *statsapi.PodStats, criPodStat *runtimeapi.PodSandb
 	ps.Memory = &statsapi.MemoryStats{
 		Time:            metav1.NewTime(time.Unix(0, criMemory.Timestamp)),
 		AvailableBytes:  valueOfUInt64Value(criMemory.AvailableBytes),
+		UsageBytes:      valueOfUInt64Value(criMemory.CommitMemoryBytes),
 		WorkingSetBytes: valueOfUInt64Value(criMemory.WorkingSetBytes),
 		PageFaults:      valueOfUInt64Value(criMemory.PageFaults),
 	}

--- a/pkg/kubelet/stats/cri_stats_provider_windows_test.go
+++ b/pkg/kubelet/stats/cri_stats_provider_windows_test.go
@@ -459,6 +459,7 @@ func Test_criStatsProvider_makeWinContainerStats(t *testing.T) {
 	memoryUsageTimestamp := int64(666666)
 	memoryUsageWorkingSetBytes := uint64(0x11223344)
 	memoryUsageAvailableBytes := uint64(0x55667788)
+	memoryCommitBytes := uint64(0x99AABBCC)
 	memoryUsagePageFaults := uint64(200)
 	logStatsUsed := uint64(5000)
 	logStatsInodesUsed := uint64(5050)
@@ -502,6 +503,9 @@ func Test_criStatsProvider_makeWinContainerStats(t *testing.T) {
 			WorkingSetBytes: &runtimeapi.UInt64Value{
 				Value: memoryUsageWorkingSetBytes,
 			},
+			CommitMemoryBytes: &runtimeapi.UInt64Value{
+				Value: memoryCommitBytes,
+			},
 			PageFaults: &runtimeapi.UInt64Value{
 				Value: memoryUsagePageFaults,
 			},
@@ -538,6 +542,7 @@ func Test_criStatsProvider_makeWinContainerStats(t *testing.T) {
 		Memory: &statsapi.MemoryStats{
 			Time:            v1.NewTime(time.Unix(0, memoryUsageTimestamp)),
 			AvailableBytes:  ptr.To[uint64](memoryUsageAvailableBytes),
+			UsageBytes:      ptr.To[uint64](memoryCommitBytes),
 			WorkingSetBytes: ptr.To[uint64](memoryUsageWorkingSetBytes),
 			PageFaults:      ptr.To[uint64](memoryUsagePageFaults),
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/sig windows

#### What this PR does / why we need it:
Fix Windows CRI stats provider to correctly set `MemoryStats.UsageBytes` for containers and pods

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/2371
```
