### PR TITLE
test-integration: allow enabling race detection

### DIFF
--- a/hack/make-rules/test-integration.sh
+++ b/hack/make-rules/test-integration.sh
@@ -95,7 +95,7 @@ runTests() {
       WHAT="${WHAT:-$(kube::test::find_integration_test_pkgs | paste -sd' ' -)}" \
       GOFLAGS="${GOFLAGS:-}" \
       KUBE_TIMEOUT="${KUBE_TIMEOUT}" \
-      KUBE_RACE="" \
+      KUBE_RACE=${KUBE_RACE:-""} \
       MAKEFLAGS="" \
       make -C "${KUBE_ROOT}" test
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

A job may now enable race detection via KUBE_RACE=-race.

#### Which issue(s) this PR fixes:

Related-to: https://github.com/kubernetes/test-infra/pull/34899#discussion_r2120603873

#### Special notes for your reviewer:

/hold

The pull-kubernetes-integration-race job should get created first to test this one here.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @aojea 