### PR TITLE
kuberc: add tests for DefaultGetPreferences

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/kuberc/kuberc.go
+++ b/staging/src/k8s.io/kubectl/pkg/kuberc/kuberc.go
@@ -307,9 +307,9 @@ func DefaultGetPreferences(kuberc string, errOut io.Writer) (*config.Preference,
 
 	preference, err := decodePreference(kubeRCFile)
 	switch {
-	case explicitly && preference != nil && runtime.IsStrictDecodingError(err):
-		// if explicitly requested, just warn about strict decoding errors if we got a usable Preference object back
-		fmt.Fprintf(errOut, "kuberc: ignoring strict decoding error in %s: %v", kubeRCFile, err)
+	case preference != nil && runtime.IsStrictDecodingError(err):
+		// just warn about strict decoding errors if we got a usable Preference object back
+		fmt.Fprintf(errOut, "kuberc: ignoring strict decoding error in %s: %v", kubeRCFile, err) //nolint:errcheck
 		return preference, nil
 
 	case explicitly && err != nil:
@@ -322,7 +322,7 @@ func DefaultGetPreferences(kuberc string, errOut io.Writer) (*config.Preference,
 
 	case !explicitly && err != nil:
 		// if not explicitly requested, only warn on any other error
-		fmt.Fprintf(errOut, "kuberc: no preferences loaded from %s: %v", kubeRCFile, err)
+		fmt.Fprintf(errOut, "kuberc: no preferences loaded from %s: %v", kubeRCFile, err) //nolint:errcheck
 		return nil, nil
 
 	default:


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/kind cleanup

#### What this PR does / why we need it:
This PR covers unit tests for one of the critical functions for loading kubectl preferences.

Before this PR:
```
$ go test -race -cover ./staging/src/k8s.io/kubectl/pkg/kuberc/
ok  	k8s.io/kubectl/pkg/kuberc	1.030s	coverage: 77.6% of statements
```
After:
```
$ go test -race -cover ./staging/src/k8s.io/kubectl/pkg/kuberc/
ok  	k8s.io/kubectl/pkg/kuberc	1.033s	coverage: 87.3% of statements
```

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
/assign @ardaguclu 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-cli/3104-introduce-kuberc
```