### PR TITLE
Add configurable tolerance e2e test.

### DIFF
--- a/test/e2e/autoscaling/horizontal_pod_autoscaling_behavior.go
+++ b/test/e2e/autoscaling/horizontal_pod_autoscaling_behavior.go
@@ -504,7 +504,7 @@ var _ = SIGDescribe(feature.HPAConfigurableTolerance, framework.WithFeatureGate(
 		f := framework.NewDefaultFramework("horizontal-pod-autoscaling")
 		f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 
-		waitBuffer := 1 * time.Minute
+		waitBuffer := 2 * time.Minute
 
 		ginkgo.Describe("with large configurable tolerance", func() {
 			ginkgo.It("should not scale", func(ctx context.Context) {
@@ -545,6 +545,73 @@ var _ = SIGDescribe(feature.HPAConfigurableTolerance, framework.WithFeatureGate(
 				gomega.Expect(replicas).To(gomega.BeNumerically("==", initPods), "had %s replicas, still have %s replicas after time deadline", initPods, replicas)
 			})
 		})
+
+		ginkgo.Describe("with small scale-up, large scale-down tolerances", func() {
+			ginkgo.It("should not scale", func(ctx context.Context) {
+				ginkgo.By("setting up resource consumer and HPA")
+				initPods := 10
+				podCPURequest := 200
+				targetCPUUtilizationPercent := 60
+				initCPUUsageTotal := usageForReplicasWithRequest(initPods, podCPURequest, targetCPUUtilizationPercent)
+				waitDeadline := maxHPAReactionTime + maxResourceConsumerDelay + waitBuffer
+
+				rc := e2eautoscaling.NewDynamicResourceConsumer(ctx,
+					hpaName, f.Namespace.Name, e2eautoscaling.KindDeployment, initPods,
+					initCPUUsageTotal, 0, 0, int64(podCPURequest), 200,
+					f.ClientSet, f.ScalesGetter, e2eautoscaling.Disable, e2eautoscaling.Idle,
+					nil)
+				ginkgo.DeferCleanup(rc.CleanUp)
+
+				scaleUpRule := e2eautoscaling.HPAScalingRuleWithToleranceMilli(20)    // 2%
+				scaleDownRule := e2eautoscaling.HPAScalingRuleWithToleranceMilli(300) // 30%
+				hpa := e2eautoscaling.CreateCPUHorizontalPodAutoscalerWithBehavior(ctx,
+					rc, int32(targetCPUUtilizationPercent), int32(initPods), 12,
+					e2eautoscaling.HPABehaviorWithScaleUpAndDownRules(scaleUpRule, scaleDownRule),
+				)
+				ginkgo.DeferCleanup(e2eautoscaling.DeleteHPAWithBehavior, rc, hpa.Name)
+
+				ginkgo.By("waiting for deployment to start initial pods")
+				rc.WaitForReplicas(ctx, initPods, waitDeadline)
+
+				ginkgo.By("trying to trigger scale up to 11 replicas")
+				rc.ConsumeCPU(usageForReplicasWithRequest(11, podCPURequest, targetCPUUtilizationPercent))
+
+				ginkgo.By("waiting for replicas to scale up")
+				waitStart := time.Now()
+				rc.WaitForReplicas(ctx, 11, waitDeadline)
+				timeWaited := time.Since(waitStart)
+				framework.Logf("time waited for scale up: %s", timeWaited)
+				gomega.Expect(timeWaited).To(gomega.BeNumerically("<", waitDeadline), "waited %s, wanted less than %s", timeWaited, waitDeadline)
+
+				// Increase resource usage to match 12 replicas. The difference is less
+				// than 10% (the default tolerance), but it should scale up anyway thanks
+				// to the small scale-up custom tolerance.
+
+				ginkgo.By("trying to trigger scale up to 12 replicas")
+				rc.ConsumeCPU(usageForReplicasWithRequest(12, podCPURequest, targetCPUUtilizationPercent))
+
+				ginkgo.By("waiting for replicas to scale up")
+				waitStart = time.Now()
+				rc.WaitForReplicas(ctx, 12, waitDeadline)
+				timeWaited = time.Since(waitStart)
+				framework.Logf("time waited for scale up: %s", timeWaited)
+				gomega.Expect(timeWaited).To(gomega.BeNumerically("<", waitDeadline), "waited %s, wanted less than %s", timeWaited, waitDeadline)
+
+				// Decrease resource usage to match 10 replicas. Should not scale down
+				// because of the large scale-down custom tolerance.
+
+				ginkgo.By("triggering scale down by lowering consumption")
+				waitStart = time.Now()
+				rc.ConsumeCPU(usageForReplicasWithRequest(10, podCPURequest, targetCPUUtilizationPercent))
+
+				rc.EnsureDesiredReplicasInRange(ctx, 12, 12, waitDeadline, hpa.Name)
+				timeWaited = time.Since(waitStart)
+
+				ginkgo.By("verifying time waited for a scale down")
+				framework.Logf("time waited for scale down: %s", timeWaited)
+				gomega.Expect(timeWaited).To(gomega.BeNumerically(">", waitDeadline), "waited %s, wanted to wait more than %s", timeWaited, waitDeadline)
+			})
+		})
 	})
 
 // usageForReplicas returns usage for (n - 0.5) replicas as if they would consume all CPU
@@ -553,6 +620,10 @@ var _ = SIGDescribe(feature.HPAConfigurableTolerance, framework.WithFeatureGate(
 // HPA rounds up the recommendations. So, if the usage is e.g. for 3.5 replicas,
 // the recommended replica number will be 4.
 func usageForReplicas(replicas int) int {
-	usagePerReplica := podCPURequest * targetCPUUtilizationPercent / 100
+	return usageForReplicasWithRequest(replicas, podCPURequest, targetCPUUtilizationPercent)
+}
+
+func usageForReplicasWithRequest(replicas, podRequest, targetUtilizationPercent int) int {
+	usagePerReplica := podRequest * targetUtilizationPercent / 100
 	return replicas*usagePerReplica - usagePerReplica/2
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

This provides better coverage of the 'configurable tolerance' feature ([KEP](https://github.com/kubernetes/enhancements/tree/master/keps/sig-autoscaling/4951-configurable-hpa-tolerance), [issue](https://github.com/kubernetes/kubernetes/issues/116984)).
