### PR TITLE
fix: datarace in ResolverTypeProvider

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/cel/common/typeprovider.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/common/typeprovider.go
@@ -105,23 +105,13 @@ func (p *ResolverTypeProvider) FindIdent(identName string) (ref.Val, bool) {
 	return p.underlyingTypeProvider.FindIdent(identName)
 }
 
-// ResolverEnvOption creates the ResolverTypeProvider with a given DynamicTypeResolver,
-// and also returns the CEL ResolverEnvOption to apply it to the env.
+// ResolverEnvOption creates the ResolverTypeProvider with a given DynamicTypeResolver
+// and returns the CEL ResolverEnvOption to apply it to the env.
 func ResolverEnvOption(resolver TypeResolver) cel.EnvOption {
-	_, envOpt := NewResolverTypeProviderAndEnvOption(resolver)
-	return envOpt
-}
-
-// NewResolverTypeProviderAndEnvOption creates the ResolverTypeProvider with a given DynamicTypeResolver,
-// and also returns the CEL ResolverEnvOption to apply it to the env.
-func NewResolverTypeProviderAndEnvOption(resolver TypeResolver) (*ResolverTypeProvider, cel.EnvOption) {
-	tp := &ResolverTypeProvider{typeResolver: resolver}
-	var envOption cel.EnvOption = func(e *cel.Env) (*cel.Env, error) {
-		// wrap the existing type provider (acquired from the env)
-		// and set new type provider for the env.
-		tp.underlyingTypeProvider = e.CELTypeProvider()
+	return func(e *cel.Env) (*cel.Env, error) {
+		tp := &ResolverTypeProvider{typeResolver: resolver, underlyingTypeProvider: e.CELTypeProvider()}
+		// set new type provider for the env.
 		typeProviderOption := cel.CustomTypeProvider(tp)
 		return typeProviderOption(e)
 	}
-	return tp, envOption
 }

--- a/staging/src/k8s.io/apiserver/pkg/cel/common/typeprovider_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/common/typeprovider_test.go
@@ -58,7 +58,7 @@ func TestTypeProvider(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			_, option := NewResolverTypeProviderAndEnvOption(&mockTypeResolver{})
+			option := ResolverEnvOption(&mockTypeResolver{})
 			env := mustCreateEnv(t, option)
 			ast, issues := env.Compile(tc.expression)
 			if len(tc.expectCompileError) > 0 {

--- a/staging/src/k8s.io/apiserver/pkg/cel/mutation/typeresolver_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/mutation/typeresolver_test.go
@@ -212,7 +212,7 @@ func TestTypeResolver(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			_, option := common.NewResolverTypeProviderAndEnvOption(&DynamicTypeResolver{})
+			option := common.ResolverEnvOption(&DynamicTypeResolver{})
 			env := mustCreateEnv(t, option)
 			ast, issues := env.Compile(tc.expression)
 			if len(tc.expectCompileError) > 0 {
@@ -307,7 +307,7 @@ func TestCELOptional(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			_, option := common.NewResolverTypeProviderAndEnvOption(&DynamicTypeResolver{})
+			option := common.ResolverEnvOption(&DynamicTypeResolver{})
 			env := mustCreateEnvWithOptional(t, option)
 			ast, issues := env.Compile(tc.expression)
 			if len(tc.expectedCompileError) > 0 {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
Fixes data race in the ResolverTypeProvider struct by moving the initialization of the struct inside the returned function, thus allocating a new instance on every function call.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #132024

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
