### PR TITLE
fix(metric): prevent data race in metric LabelValueAllowList initialization

### DIFF
--- a/staging/src/k8s.io/component-base/metrics/gauge.go
+++ b/staging/src/k8s.io/component-base/metrics/gauge.go
@@ -143,20 +143,22 @@ func (v *GaugeVec) WithLabelValuesChecked(lvs ...string) (GaugeMetric, error) {
 		}
 		return noop, errNotRegistered // return no-op gauge
 	}
+
+	// Initialize label allow lists if not already initialized
+	v.initializeLabelAllowListsOnce.Do(func() {
+		allowListLock.RLock()
+		if allowList, ok := labelValueAllowLists[v.FQName()]; ok {
+			v.LabelValueAllowLists = allowList
+		}
+		allowListLock.RUnlock()
+	})
+
+	// Constrain label values to allowed values
 	if v.LabelValueAllowLists != nil {
 		v.LabelValueAllowLists.ConstrainToAllowedList(v.originalLabels, lvs)
-	} else {
-		v.initializeLabelAllowListsOnce.Do(func() {
-			allowListLock.RLock()
-			if allowList, ok := labelValueAllowLists[v.FQName()]; ok {
-				v.LabelValueAllowLists = allowList
-				allowList.ConstrainToAllowedList(v.originalLabels, lvs)
-			}
-			allowListLock.RUnlock()
-		})
 	}
-	elt, err := v.GaugeVec.GetMetricWithLabelValues(lvs...)
-	return elt, err
+
+	return v.GetMetricWithLabelValues(lvs...)
 }
 
 // Default Prometheus Vec behavior is that member extraction results in creation of a new element
@@ -189,20 +191,22 @@ func (v *GaugeVec) WithChecked(labels map[string]string) (GaugeMetric, error) {
 		}
 		return noop, errNotRegistered // return no-op gauge
 	}
+
+	// Initialize label allow lists if not already initialized
+	v.initializeLabelAllowListsOnce.Do(func() {
+		allowListLock.RLock()
+		if allowList, ok := labelValueAllowLists[v.FQName()]; ok {
+			v.LabelValueAllowLists = allowList
+		}
+		allowListLock.RUnlock()
+	})
+
+	// Constrain label map to allowed values
 	if v.LabelValueAllowLists != nil {
 		v.LabelValueAllowLists.ConstrainLabelMap(labels)
-	} else {
-		v.initializeLabelAllowListsOnce.Do(func() {
-			allowListLock.RLock()
-			if allowList, ok := labelValueAllowLists[v.FQName()]; ok {
-				v.LabelValueAllowLists = allowList
-				allowList.ConstrainLabelMap(labels)
-			}
-			allowListLock.RUnlock()
-		})
 	}
-	elt, err := v.GaugeVec.GetMetricWith(labels)
-	return elt, err
+
+	return v.GetMetricWith(labels)
 }
 
 // With returns the GaugeMetric for the given Labels map (the label names

--- a/staging/src/k8s.io/component-base/metrics/histogram.go
+++ b/staging/src/k8s.io/component-base/metrics/histogram.go
@@ -181,17 +181,19 @@ func (v *HistogramVec) WithLabelValues(lvs ...string) ObserverMetric {
 	if !v.IsCreated() {
 		return noop
 	}
+
+	// Initialize label allow lists if not already initialized
+	v.initializeLabelAllowListsOnce.Do(func() {
+		allowListLock.RLock()
+		if allowList, ok := labelValueAllowLists[v.FQName()]; ok {
+			v.LabelValueAllowLists = allowList
+		}
+		allowListLock.RUnlock()
+	})
+
+	// Constrain label values to allowed values
 	if v.LabelValueAllowLists != nil {
 		v.LabelValueAllowLists.ConstrainToAllowedList(v.originalLabels, lvs)
-	} else {
-		v.initializeLabelAllowListsOnce.Do(func() {
-			allowListLock.RLock()
-			if allowList, ok := labelValueAllowLists[v.FQName()]; ok {
-				v.LabelValueAllowLists = allowList
-				allowList.ConstrainToAllowedList(v.originalLabels, lvs)
-			}
-			allowListLock.RUnlock()
-		})
 	}
 	return v.HistogramVec.WithLabelValues(lvs...)
 }
@@ -204,18 +206,21 @@ func (v *HistogramVec) With(labels map[string]string) ObserverMetric {
 	if !v.IsCreated() {
 		return noop
 	}
+
+	// Initialize label allow lists if not already initialized
+	v.initializeLabelAllowListsOnce.Do(func() {
+		allowListLock.RLock()
+		if allowList, ok := labelValueAllowLists[v.FQName()]; ok {
+			v.LabelValueAllowLists = allowList
+		}
+		allowListLock.RUnlock()
+	})
+
+	// Constrain label map to allowed values
 	if v.LabelValueAllowLists != nil {
 		v.LabelValueAllowLists.ConstrainLabelMap(labels)
-	} else {
-		v.initializeLabelAllowListsOnce.Do(func() {
-			allowListLock.RLock()
-			if allowList, ok := labelValueAllowLists[v.FQName()]; ok {
-				v.LabelValueAllowLists = allowList
-				allowList.ConstrainLabelMap(labels)
-			}
-			allowListLock.RUnlock()
-		})
 	}
+
 	return v.HistogramVec.With(labels)
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind flake

#### What this PR does / why we need it:

This PR resolves a data race in the metrics vector types (`CounterVec`, `HistogramVec`, etc.) detected by the Go race detector.

The race occurred because one goroutine could be writing to `v.LabelValueAllowLists` inside a `sync.Once` block while another goroutine was concurrently reading the same field.

Stack traces show a conflict between a write operation in `(*CounterVec).WithLabelValues.func1` and a read in `(*CounterVec).WithLabelValues`:

* **Previous Read:** `k8s.io/component-base/metrics.(*CounterVec).WithLabelValues()`
* **Concurrent Write:** `k8s.io/component-base/metrics.(*CounterVec).WithLabelValues.func1()`

This was caused by a pattern where the code would first check if `v.LabelValueAllowLists` was non-nil and only then, in an `else` block, perform the initialization within `sync.Once`. This separation of the check from the guarded initialization is what allowed the race.

The fix refactors this logic to unconditionally call `v.initializeLabelAllowListsOnce.Do()` before any access attempt. This ensures that the initialization is performed atomically and safely completes before any subsequent read of the `LabelValueAllowLists` field, thereby eliminating the data race.

The race warning log was found by running `stress` test following https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/flaky-tests.md#deflaking-integration-tests
```
 go test -c -race ./test/integration/metrics && stress --failure=".*is not allowed for label.*" --count=500 ./metrics.test -test.run TestAPIServerMetricsLabels 
```
Race warning log sample:
https://gist.github.com/yongruilin/8abb48e84a1e6a6a00cd27336257dda6

After this fix, no failure found.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/131931
Fixes https://github.com/kubernetes/kubernetes/issues/130025

#### Special notes for your reviewer:
No failure for 1000 runs.
```
~ stress --failure=".*is not allowed for label.*" --count=1000 ./metrics.test -test.run TestAPIServerMetricsLabels
...
...
23m55s: 985 runs so far, 0 failures, 15 active
24m0s: 986 runs so far, 0 failures, 14 active
24m5s: 991 runs so far, 0 failures, 9 active
24m10s: 997 runs so far, 0 failures, 3 active
24m12s: 1000 runs total, 0 failures
```
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
