### PR TITLE
e2e: node: cpumanager: require cgroup v2

### DIFF
--- a/test/e2e_node/cpumanager_test.go
+++ b/test/e2e_node/cpumanager_test.go
@@ -171,6 +171,10 @@ var _ = SIGDescribe("CPU Manager", ginkgo.Ordered, framework.WithSerial(), featu
 	})
 
 	ginkgo.JustBeforeEach(func(ctx context.Context) {
+		if !e2enodeCgroupV2Enabled {
+			e2eskipper.Skipf("Skipping since CgroupV2 not used")
+		}
+
 		// note intentionally NOT set reservedCPUs -  this must be initialized on a test-by-test basis
 
 		// use a closure to minimize the arguments, to make the usage more straightforward
@@ -966,10 +970,6 @@ var _ = SIGDescribe("CPU Manager", ginkgo.Ordered, framework.WithSerial(), featu
 
 	ginkgo.When("checking the CFS quota management", ginkgo.Label("cfs-quota"), func() {
 		ginkgo.BeforeEach(func(ctx context.Context) {
-			if !e2enodeCgroupV2Enabled {
-				e2eskipper.Skipf("Skipping since CgroupV2 not used")
-			}
-
 			// WARNING: this assumes 2-way SMT systems - we don't know how to access other SMT levels.
 			//          this means on more-than-2-way SMT systems this test will prove nothing
 			reservedCPUs = cpuset.New(0)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:

in general, the rewritten e2e cpumanager test assume cgroup v2. A limited set of these may be updated to work also with the obsolete and declining cgroup v1, but these need to be reviewed on test-by-test matter.

To fix test failures, we add a top level require for cgroup v2, skipping otherwise. This will fix the red lanes while we review the testcases and the deprecation plan of the other tests.

#### Which issue(s) this PR fixes:
Fixes https://testgrid.k8s.io/amazon-ec2-node#ci-cgroupv1-containerd-node-e2e-serial-ec2-eks&width=20

#### Special notes for your reviewer:
replaces https://github.com/kubernetes/kubernetes/pull/132076
we need to talk about the cgroup v1 support for the new testcases and implement it properly  and/or to review the deprecation plan

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
