### PR TITLE
podresources: list: sync resource managers state before listing the pod assignment

### DIFF
--- a/pkg/kubelet/apis/podresources/server_v1.go
+++ b/pkg/kubelet/apis/podresources/server_v1.go
@@ -58,6 +58,7 @@ func (p *v1PodResourcesServer) List(ctx context.Context, req *podresourcesv1.Lis
 	pods := p.podsProvider.GetPods()
 	podResources := make([]*podresourcesv1.PodResources, len(pods))
 	p.devicesProvider.UpdateAllocatedDevices()
+	p.memoryProvider.UpdateAllocatedMemory()
 
 	for i, pod := range pods {
 		pRes := podresourcesv1.PodResources{

--- a/pkg/kubelet/apis/podresources/server_v1.go
+++ b/pkg/kubelet/apis/podresources/server_v1.go
@@ -59,6 +59,7 @@ func (p *v1PodResourcesServer) List(ctx context.Context, req *podresourcesv1.Lis
 	podResources := make([]*podresourcesv1.PodResources, len(pods))
 	p.devicesProvider.UpdateAllocatedDevices()
 	p.memoryProvider.UpdateAllocatedMemory()
+	p.cpusProvider.UpdateAllocatedCPUs()
 
 	for i, pod := range pods {
 		pRes := podresourcesv1.PodResources{

--- a/pkg/kubelet/apis/podresources/testing/cpus_provider.go
+++ b/pkg/kubelet/apis/podresources/testing/cpus_provider.go
@@ -129,6 +129,38 @@ func (_c *MockCPUsProvider_GetCPUs_Call) RunAndReturn(run func(string, string) [
 	return _c
 }
 
+// UpdateAllocatedCPUs provides a mock function with no fields
+func (_m *MockCPUsProvider) UpdateAllocatedCPUs() {
+	_m.Called()
+}
+
+// MockCPUsProvider_UpdateAllocatedCPUs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateAllocatedCPUs'
+type MockCPUsProvider_UpdateAllocatedCPUs_Call struct {
+	*mock.Call
+}
+
+// UpdateAllocatedCPUs is a helper method to define mock.On call
+func (_e *MockCPUsProvider_Expecter) UpdateAllocatedCPUs() *MockCPUsProvider_UpdateAllocatedCPUs_Call {
+	return &MockCPUsProvider_UpdateAllocatedCPUs_Call{Call: _e.mock.On("UpdateAllocatedCPUs")}
+}
+
+func (_c *MockCPUsProvider_UpdateAllocatedCPUs_Call) Run(run func()) *MockCPUsProvider_UpdateAllocatedCPUs_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockCPUsProvider_UpdateAllocatedCPUs_Call) Return() *MockCPUsProvider_UpdateAllocatedCPUs_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *MockCPUsProvider_UpdateAllocatedCPUs_Call) RunAndReturn(run func()) *MockCPUsProvider_UpdateAllocatedCPUs_Call {
+	_c.Run(run)
+	return _c
+}
+
 // NewMockCPUsProvider creates a new instance of MockCPUsProvider. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewMockCPUsProvider(t interface {

--- a/pkg/kubelet/apis/podresources/testing/memory_provider.go
+++ b/pkg/kubelet/apis/podresources/testing/memory_provider.go
@@ -133,6 +133,38 @@ func (_c *MockMemoryProvider_GetMemory_Call) RunAndReturn(run func(string, strin
 	return _c
 }
 
+// UpdateAllocatedMemory provides a mock function with no fields
+func (_m *MockMemoryProvider) UpdateAllocatedMemory() {
+	_m.Called()
+}
+
+// MockMemoryProvider_UpdateAllocatedMemory_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateAllocatedMemory'
+type MockMemoryProvider_UpdateAllocatedMemory_Call struct {
+	*mock.Call
+}
+
+// UpdateAllocatedMemory is a helper method to define mock.On call
+func (_e *MockMemoryProvider_Expecter) UpdateAllocatedMemory() *MockMemoryProvider_UpdateAllocatedMemory_Call {
+	return &MockMemoryProvider_UpdateAllocatedMemory_Call{Call: _e.mock.On("UpdateAllocatedMemory")}
+}
+
+func (_c *MockMemoryProvider_UpdateAllocatedMemory_Call) Run(run func()) *MockMemoryProvider_UpdateAllocatedMemory_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockMemoryProvider_UpdateAllocatedMemory_Call) Return() *MockMemoryProvider_UpdateAllocatedMemory_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *MockMemoryProvider_UpdateAllocatedMemory_Call) RunAndReturn(run func()) *MockMemoryProvider_UpdateAllocatedMemory_Call {
+	_c.Run(run)
+	return _c
+}
+
 // NewMockMemoryProvider creates a new instance of MockMemoryProvider. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewMockMemoryProvider(t interface {

--- a/pkg/kubelet/apis/podresources/types.go
+++ b/pkg/kubelet/apis/podresources/types.go
@@ -47,6 +47,8 @@ type CPUsProvider interface {
 }
 
 type MemoryProvider interface {
+	// UpdateAllocatedMemory frees any Memory areas that are bound to terminated pods.
+	UpdateAllocatedMemory()
 	// GetMemory returns information about the memory assigned to containers
 	GetMemory(podUID, containerName string) []*podresourcesapi.ContainerMemory
 	// GetAllocatableMemory returns the allocatable memory from the node

--- a/pkg/kubelet/apis/podresources/types.go
+++ b/pkg/kubelet/apis/podresources/types.go
@@ -40,6 +40,8 @@ type PodsProvider interface {
 
 // CPUsProvider knows how to provide the cpus used by the given container
 type CPUsProvider interface {
+	// UpdateAllocatedCPUs frees any exclusive CPU that are bound to terminated pods.
+	UpdateAllocatedCPUs()
 	// GetCPUs returns information about the cpus assigned to pods and containers
 	GetCPUs(podUID, containerName string) []int64
 	// GetAllocatableCPUs returns the allocatable (not allocated) CPUs

--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -1013,6 +1013,10 @@ func (cm *containerManagerImpl) UpdateAllocatedMemory() {
 	cm.memoryManager.RemoveStaleState()
 }
 
+func (cm *containerManagerImpl) UpdateAllocatedCPUs() {
+	cm.cpuManager.RemoveStaleState()
+}
+
 func containerMemoryFromBlock(blocks []memorymanagerstate.Block) []*podresourcesapi.ContainerMemory {
 	var containerMemories []*podresourcesapi.ContainerMemory
 

--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -1009,6 +1009,10 @@ func (cm *containerManagerImpl) UpdateAllocatedDevices() {
 	cm.deviceManager.UpdateAllocatedDevices()
 }
 
+func (cm *containerManagerImpl) UpdateAllocatedMemory() {
+	cm.memoryManager.RemoveStaleState()
+}
+
 func containerMemoryFromBlock(blocks []memorymanagerstate.Block) []*podresourcesapi.ContainerMemory {
 	var containerMemories []*podresourcesapi.ContainerMemory
 

--- a/pkg/kubelet/cm/container_manager_stub.go
+++ b/pkg/kubelet/cm/container_manager_stub.go
@@ -149,7 +149,9 @@ func (cm *containerManagerStub) GetAllocateResourcesPodAdmitHandler() lifecycle.
 }
 
 func (cm *containerManagerStub) UpdateAllocatedDevices() {
-	return
+}
+
+func (cm *containerManagerStub) UpdateAllocatedMemory() {
 }
 
 func (cm *containerManagerStub) GetCPUs(_, _ string) []int64 {

--- a/pkg/kubelet/cm/container_manager_stub.go
+++ b/pkg/kubelet/cm/container_manager_stub.go
@@ -154,6 +154,9 @@ func (cm *containerManagerStub) UpdateAllocatedDevices() {
 func (cm *containerManagerStub) UpdateAllocatedMemory() {
 }
 
+func (cm *containerManagerStub) UpdateAllocatedCPUs() {
+}
+
 func (cm *containerManagerStub) GetCPUs(_, _ string) []int64 {
 	return nil
 }

--- a/pkg/kubelet/cm/container_manager_windows.go
+++ b/pkg/kubelet/cm/container_manager_windows.go
@@ -322,6 +322,15 @@ func (cm *containerManagerImpl) UpdateAllocatedDevices() {
 	return
 }
 
+func (cm *containerManagerImpl) UpdateAllocatedMemory() {
+	if utilfeature.DefaultFeatureGate.Enabled(kubefeatures.WindowsCPUAndMemoryAffinity) {
+		if cm.memoryManager != nil {
+			cm.memoryManager.RemoveStaleState()
+		}
+	}
+	return
+}
+
 func (cm *containerManagerImpl) GetCPUs(podUID, containerName string) []int64 {
 	if utilfeature.DefaultFeatureGate.Enabled(kubefeatures.WindowsCPUAndMemoryAffinity) {
 		if cm.cpuManager != nil {

--- a/pkg/kubelet/cm/container_manager_windows.go
+++ b/pkg/kubelet/cm/container_manager_windows.go
@@ -331,6 +331,15 @@ func (cm *containerManagerImpl) UpdateAllocatedMemory() {
 	return
 }
 
+func (cm *containerManagerImpl) UpdateAllocatedCPUs() {
+	if utilfeature.DefaultFeatureGate.Enabled(kubefeatures.WindowsCPUAndMemoryAffinity) {
+		if cm.cpuManager != nil {
+			cm.cpuManager.RemoveStaleState()
+		}
+	}
+	return
+}
+
 func (cm *containerManagerImpl) GetCPUs(podUID, containerName string) []int64 {
 	if utilfeature.DefaultFeatureGate.Enabled(kubefeatures.WindowsCPUAndMemoryAffinity) {
 		if cm.cpuManager != nil {

--- a/pkg/kubelet/cm/cpumanager/cpu_manager.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager.go
@@ -97,6 +97,9 @@ type Manager interface {
 	// GetAllCPUs returns all the CPUs known by cpumanager, as reported by the
 	// hardware discovery. Maps to the CPU capacity.
 	GetAllCPUs() cpuset.CPUSet
+
+	// RemoveStaleState frees any exclusive CPUs that are bound to terminated pods.
+	RemoveStaleState()
 }
 
 type manager struct {
@@ -254,7 +257,7 @@ func (m *manager) Start(activePods ActivePodsFunc, sourcesReady config.SourcesRe
 
 func (m *manager) Allocate(p *v1.Pod, c *v1.Container) error {
 	// Garbage collect any stranded resources before allocating CPUs.
-	m.removeStaleState()
+	m.RemoveStaleState()
 
 	m.Lock()
 	defer m.Unlock()
@@ -322,14 +325,14 @@ func (m *manager) State() state.Reader {
 
 func (m *manager) GetTopologyHints(pod *v1.Pod, container *v1.Container) map[string][]topologymanager.TopologyHint {
 	// Garbage collect any stranded resources before providing TopologyHints
-	m.removeStaleState()
+	m.RemoveStaleState()
 	// Delegate to active policy
 	return m.policy.GetTopologyHints(m.state, pod, container)
 }
 
 func (m *manager) GetPodTopologyHints(pod *v1.Pod) map[string][]topologymanager.TopologyHint {
 	// Garbage collect any stranded resources before providing TopologyHints
-	m.removeStaleState()
+	m.RemoveStaleState()
 	// Delegate to active policy
 	return m.policy.GetPodTopologyHints(m.state, pod)
 }
@@ -348,7 +351,7 @@ type reconciledContainer struct {
 	containerID   string
 }
 
-func (m *manager) removeStaleState() {
+func (m *manager) RemoveStaleState() {
 	// Only once all sources are ready do we attempt to remove any stale state.
 	// This ensures that the call to `m.activePods()` below will succeed with
 	// the actual active pods list.
@@ -410,7 +413,7 @@ func (m *manager) reconcileState() (success []reconciledContainer, failure []rec
 	success = []reconciledContainer{}
 	failure = []reconciledContainer{}
 
-	m.removeStaleState()
+	m.RemoveStaleState()
 	for _, pod := range m.activePods() {
 		pstatus, ok := m.podStatusProvider.GetPodStatus(pod.UID)
 		if !ok {

--- a/pkg/kubelet/cm/cpumanager/fake_cpu_manager.go
+++ b/pkg/kubelet/cm/cpumanager/fake_cpu_manager.go
@@ -90,6 +90,10 @@ func (m *fakeManager) GetAllCPUs() cpuset.CPUSet {
 	return cpuset.CPUSet{}
 }
 
+func (m *fakeManager) RemoveStaleState() {
+	klog.InfoS("RemoveStaleState")
+}
+
 // NewFakeManager creates empty/fake cpu manager
 func NewFakeManager() Manager {
 	return &fakeManager{

--- a/pkg/kubelet/cm/fake_container_manager.go
+++ b/pkg/kubelet/cm/fake_container_manager.go
@@ -213,7 +213,12 @@ func (cm *FakeContainerManager) UpdateAllocatedDevices() {
 	cm.Lock()
 	defer cm.Unlock()
 	cm.CalledFunctions = append(cm.CalledFunctions, "UpdateAllocatedDevices")
-	return
+}
+
+func (cm *FakeContainerManager) UpdateAllocatedMemory() {
+	cm.Lock()
+	defer cm.Unlock()
+	cm.CalledFunctions = append(cm.CalledFunctions, "UpdateAllocatedMemory")
 }
 
 func (cm *FakeContainerManager) GetCPUs(_, _ string) []int64 {

--- a/pkg/kubelet/cm/fake_container_manager.go
+++ b/pkg/kubelet/cm/fake_container_manager.go
@@ -221,6 +221,12 @@ func (cm *FakeContainerManager) UpdateAllocatedMemory() {
 	cm.CalledFunctions = append(cm.CalledFunctions, "UpdateAllocatedMemory")
 }
 
+func (cm *FakeContainerManager) UpdateAllocatedCPUs() {
+	cm.Lock()
+	defer cm.Unlock()
+	cm.CalledFunctions = append(cm.CalledFunctions, "UpdateAllocatedCPUs")
+}
+
 func (cm *FakeContainerManager) GetCPUs(_, _ string) []int64 {
 	cm.Lock()
 	defer cm.Unlock()

--- a/pkg/kubelet/cm/memorymanager/fake_memory_manager.go
+++ b/pkg/kubelet/cm/memorymanager/fake_memory_manager.go
@@ -86,6 +86,10 @@ func (m *fakeManager) GetMemory(podUID, containerName string) []state.Block {
 	return []state.Block{}
 }
 
+func (m *fakeManager) RemoveStaleState() {
+	klog.InfoS("RemoveStaleState")
+}
+
 // NewFakeManager creates empty/fake memory manager
 func NewFakeManager() Manager {
 	return &fakeManager{

--- a/pkg/kubelet/cm/memorymanager/memory_manager.go
+++ b/pkg/kubelet/cm/memorymanager/memory_manager.go
@@ -92,6 +92,9 @@ type Manager interface {
 
 	// GetMemory returns the memory allocated by a container from NUMA nodes
 	GetMemory(podUID, containerName string) []state.Block
+
+	// RemoveStaleState frees any Memory areas that are bound to terminated pods.
+	RemoveStaleState()
 }
 
 type manager struct {
@@ -107,7 +110,7 @@ type manager struct {
 	containerRuntime runtimeService
 
 	// activePods is a method for listing active pods on the node
-	// so all the containers can be updated during call to the removeStaleState.
+	// so all the containers can be updated during call to the RemoveStaleState.
 	activePods ActivePodsFunc
 
 	// podStatusProvider provides a method for obtaining pod statuses
@@ -260,7 +263,7 @@ func (m *manager) GetMemoryNUMANodes(pod *v1.Pod, container *v1.Container) sets.
 // Allocate is called to pre-allocate memory resources during Pod admission.
 func (m *manager) Allocate(pod *v1.Pod, container *v1.Container) error {
 	// Garbage collect any stranded resources before allocation
-	m.removeStaleState()
+	m.RemoveStaleState()
 
 	m.Lock()
 	defer m.Unlock()
@@ -298,7 +301,7 @@ func (m *manager) State() state.Reader {
 // GetPodTopologyHints returns the topology hints for the topology manager
 func (m *manager) GetPodTopologyHints(pod *v1.Pod) map[string][]topologymanager.TopologyHint {
 	// Garbage collect any stranded resources before providing TopologyHints
-	m.removeStaleState()
+	m.RemoveStaleState()
 	// Delegate to active policy
 	return m.policy.GetPodTopologyHints(m.state, pod)
 }
@@ -306,13 +309,13 @@ func (m *manager) GetPodTopologyHints(pod *v1.Pod) map[string][]topologymanager.
 // GetTopologyHints returns the topology hints for the topology manager
 func (m *manager) GetTopologyHints(pod *v1.Pod, container *v1.Container) map[string][]topologymanager.TopologyHint {
 	// Garbage collect any stranded resources before providing TopologyHints
-	m.removeStaleState()
+	m.RemoveStaleState()
 	// Delegate to active policy
 	return m.policy.GetTopologyHints(m.state, pod, container)
 }
 
 // TODO: move the method to the upper level, to re-use it under the CPU and memory managers
-func (m *manager) removeStaleState() {
+func (m *manager) RemoveStaleState() {
 	// Only once all sources are ready do we attempt to remove any stale state.
 	// This ensures that the call to `m.activePods()` below will succeed with
 	// the actual active pods list.

--- a/pkg/kubelet/cm/memorymanager/memory_manager_test.go
+++ b/pkg/kubelet/cm/memorymanager/memory_manager_test.go
@@ -909,10 +909,10 @@ func TestRemoveStaleState(t *testing.T) {
 			mgr.state.SetMemoryAssignments(testCase.assignments)
 			mgr.state.SetMachineState(testCase.machineState)
 
-			mgr.removeStaleState()
+			mgr.RemoveStaleState()
 
 			if !areContainerMemoryAssignmentsEqual(t, mgr.state.GetMemoryAssignments(), testCase.expectedAssignments) {
-				t.Errorf("Memory Manager removeStaleState() error, expected assignments %v, but got: %v",
+				t.Errorf("Memory Manager RemoveStaleState() error, expected assignments %v, but got: %v",
 					testCase.expectedAssignments, mgr.state.GetMemoryAssignments())
 			}
 			if !areMachineStatesEqual(mgr.state.GetMachineState(), testCase.expectedMachineState) {

--- a/pkg/kubelet/cm/testing/mock_container_manager.go
+++ b/pkg/kubelet/cm/testing/mock_container_manager.go
@@ -1541,6 +1541,38 @@ func (_c *MockContainerManager_UpdateAllocatedDevices_Call) RunAndReturn(run fun
 	return _c
 }
 
+// UpdateAllocatedMemory provides a mock function with no fields
+func (_m *MockContainerManager) UpdateAllocatedMemory() {
+	_m.Called()
+}
+
+// MockContainerManager_UpdateAllocatedMemory_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateAllocatedMemory'
+type MockContainerManager_UpdateAllocatedMemory_Call struct {
+	*mock.Call
+}
+
+// UpdateAllocatedMemory is a helper method to define mock.On call
+func (_e *MockContainerManager_Expecter) UpdateAllocatedMemory() *MockContainerManager_UpdateAllocatedMemory_Call {
+	return &MockContainerManager_UpdateAllocatedMemory_Call{Call: _e.mock.On("UpdateAllocatedMemory")}
+}
+
+func (_c *MockContainerManager_UpdateAllocatedMemory_Call) Run(run func()) *MockContainerManager_UpdateAllocatedMemory_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockContainerManager_UpdateAllocatedMemory_Call) Return() *MockContainerManager_UpdateAllocatedMemory_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *MockContainerManager_UpdateAllocatedMemory_Call) RunAndReturn(run func()) *MockContainerManager_UpdateAllocatedMemory_Call {
+	_c.Run(run)
+	return _c
+}
+
 // UpdateAllocatedResourcesStatus provides a mock function with given fields: pod, _a1
 func (_m *MockContainerManager) UpdateAllocatedResourcesStatus(pod *v1.Pod, _a1 *v1.PodStatus) {
 	_m.Called(pod, _a1)

--- a/pkg/kubelet/cm/testing/mock_container_manager.go
+++ b/pkg/kubelet/cm/testing/mock_container_manager.go
@@ -1509,6 +1509,38 @@ func (_c *MockContainerManager_UnprepareDynamicResources_Call) RunAndReturn(run 
 	return _c
 }
 
+// UpdateAllocatedCPUs provides a mock function with no fields
+func (_m *MockContainerManager) UpdateAllocatedCPUs() {
+	_m.Called()
+}
+
+// MockContainerManager_UpdateAllocatedCPUs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateAllocatedCPUs'
+type MockContainerManager_UpdateAllocatedCPUs_Call struct {
+	*mock.Call
+}
+
+// UpdateAllocatedCPUs is a helper method to define mock.On call
+func (_e *MockContainerManager_Expecter) UpdateAllocatedCPUs() *MockContainerManager_UpdateAllocatedCPUs_Call {
+	return &MockContainerManager_UpdateAllocatedCPUs_Call{Call: _e.mock.On("UpdateAllocatedCPUs")}
+}
+
+func (_c *MockContainerManager_UpdateAllocatedCPUs_Call) Run(run func()) *MockContainerManager_UpdateAllocatedCPUs_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockContainerManager_UpdateAllocatedCPUs_Call) Return() *MockContainerManager_UpdateAllocatedCPUs_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *MockContainerManager_UpdateAllocatedCPUs_Call) RunAndReturn(run func()) *MockContainerManager_UpdateAllocatedCPUs_Call {
+	_c.Run(run)
+	return _c
+}
+
 // UpdateAllocatedDevices provides a mock function with no fields
 func (_m *MockContainerManager) UpdateAllocatedDevices() {
 	_m.Called()

--- a/test/e2e_node/memory_manager_test.go
+++ b/test/e2e_node/memory_manager_test.go
@@ -1,6 +1,3 @@
-//go:build linux
-// +build linux
-
 /*
 Copyright 2017 The Kubernetes Authors.
 
@@ -242,7 +239,7 @@ func getAllNUMANodes() []int {
 }
 
 // Serial because the test updates kubelet configuration.
-var _ = SIGDescribe("Memory Manager", framework.WithDisruptive(), framework.WithSerial(), feature.MemoryManager, func() {
+var _ = SIGDescribe("Memory Manager", "[LinuxOnly]", framework.WithDisruptive(), framework.WithSerial(), feature.MemoryManager, func() {
 	// TODO: add more complex tests that will include interaction between CPUManager, MemoryManager and TopologyManager
 	var (
 		allNUMANodes             []int


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
The podresources API List implementation uses the internal data of the resource managers as source of truth. But, except for device manager, it never explicitly syncs their internal state before listing the assignments.

The resource manager clean up stale assignment lazily, so this leads to random (from the perspective of the consumer) return of stale wrong data.

#### Which issue(s) this PR fixes:
Fixes #132020

#### Special notes for your reviewer:
More targeted alternative to https://github.com/kubernetes/kubernetes/pull/132028 with no backward compatibility concerns

#### Does this PR introduce a user-facing change?
```release-note
NONE
```