### PR TITLE
docs: Add x-kubernetes list/map/unions docs

### DIFF
--- a/api/openapi-spec/README.md
+++ b/api/openapi-spec/README.md
@@ -58,3 +58,145 @@ For example:
 
 Some of the definitions may have these extensions. For more information about PatchStrategy and PatchMergeKey see
 [strategic-merge-patch](https://git.k8s.io/community/contributors/devel/sig-api-machinery/strategic-merge-patch.md).
+
+
+📘 Additional Kubernetes OpenAPI Extensions
+Kubernetes uses custom OpenAPI extensions to define advanced behaviors for lists and object fields in CustomResourceDefinitions (CRDs). This section documents the following extensions:
+
+x-kubernetes-list-type
+
+x-kubernetes-list-map-keys
+
+x-kubernetes-unions
+
+These extensions help the API server handle merge, patch, and validation strategies.
+
+🔹 x-kubernetes-list-type
+Defines how lists (arrays) behave when resources are merged or patched.
+
+Supported Values
+"atomic" (default): Entire list is replaced during updates.
+
+"set": Items are treated as a unique unordered set.
+
+"map": Items are treated as a map, indexed by keys defined via x-kubernetes-list-map-keys.
+
+✅ Example: Set List
+```
+finalizers:
+  type: array
+  x-kubernetes-list-type: set
+  items:
+    type: string
+```
+Ensures finalizers is treated as a set with no duplicates.
+
+Used with x-kubernetes-list-type: map to identify unique keys for merging individual items in a list.
+
+✅ Example: List Map of Containers
+```
+containers:
+  type: array
+  x-kubernetes-list-type: map
+  x-kubernetes-list-map-keys:
+    - name
+  items:
+    type: object
+    required:
+      - name
+    properties:
+      name:
+        type: string
+      image:
+        type: string
+  ```      
+Kubernetes treats the array as a map indexed by name. Useful for container specs.
+
+🔹 x-kubernetes-unions
+Declares a group of mutually exclusive fields—only one field in the union should be set at a time.
+
+✅ Example: Union of Fields
+```
+type: object
+x-kubernetes-unions:
+  - fields:
+      - stringValue
+      - intValue
+properties:
+  stringValue:
+    type: string
+  intValue:
+    type: integer
+```
+Indicates only one of stringValue or intValue should be set. Tools can enforce this during validation.
+
+🚀 Usage Instructions
+You can use these extensions in the openAPIV3Schema section of a Kubernetes CustomResourceDefinition. Kubernetes understands them automatically—no plugins or extra tools required.
+
+📄 Sample CRD Using All Three Extensions
+```
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: demos.example.com
+spec:
+  group: example.com
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                finalizers:
+                  type: array
+                  x-kubernetes-list-type: set
+                  items:
+                    type: string
+                containers:
+                  type: array
+                  x-kubernetes-list-type: map
+                  x-kubernetes-list-map-keys:
+                    - name
+                  items:
+                    type: object
+                    required:
+                      - name
+                    properties:
+                      name:
+                        type: string
+                      image:
+                        type: string
+                value:
+                  type: object
+                  x-kubernetes-unions:
+                    - fields:
+                        - stringValue
+                        - intValue
+                  properties:
+                    stringValue:
+                      type: string
+                    intValue:
+                      type: integer
+  scope: Namespaced
+  names:
+    plural: demos
+    singular: demo
+    kind: Demo
+```
+📦 Apply the CRD
+```
+kubectl apply -f demo-crd.yaml
+```
+No special flags or configurations are needed. Kubernetes understands these extensions natively when CRDs are registered.
+
+🧠 Notes
+These extensions improve patching, merging, and validation behavior for CRDs.
+
+They're especially useful for tools like kubectl apply and server-side apply.
+
+All behavior is handled by the Kubernetes API server—no external setup required.


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Adds detailed documentation for the Kubernetes OpenAPI extensions:
- `x-kubernetes-list-type`
- `x-kubernetes-list-map-keys`
- `x-kubernetes-unions`

This improves clarity for CRD authors on how to use these extensions, including YAML examples, usage instructions, and a sample CRD demonstrating all three extensions together.

#### Which issue(s) this PR fixes:

Fixes #131724

#### Special notes for your reviewer:

N/A

#### Does this PR introduce a user-facing change?

NONE

#### Additional documentation e.g., KEPs, usage docs, etc.:

N/A

<pre> ```release-note NONE ``` </pre>
