### PR TITLE
Moving Scheduler interfaces to staging: Move Code and Status from pkg/scheduler/framework to k8s.io/kube-scheduler/framework

### DIFF
--- a/cmd/kube-scheduler/app/server_test.go
+++ b/cmd/kube-scheduler/app/server_test.go
@@ -515,7 +515,7 @@ func newFoo(_ context.Context, _ runtime.Object, _ framework.Handle) (framework.
 	return &foo{}, nil
 }
 
-func (*foo) PreFilter(_ context.Context, _ fwk.CycleState, _ *v1.Pod, _ []*framework.NodeInfo) (*framework.PreFilterResult, *framework.Status) {
+func (*foo) PreFilter(_ context.Context, _ fwk.CycleState, _ *v1.Pod, _ []*framework.NodeInfo) (*framework.PreFilterResult, *fwk.Status) {
 	return nil, nil
 }
 
@@ -523,6 +523,6 @@ func (*foo) PreFilterExtensions() framework.PreFilterExtensions {
 	return nil
 }
 
-func (*foo) Filter(_ context.Context, _ fwk.CycleState, _ *v1.Pod, nodeInfo *framework.NodeInfo) *framework.Status {
+func (*foo) Filter(_ context.Context, _ fwk.CycleState, _ *v1.Pod, nodeInfo *framework.NodeInfo) *fwk.Status {
 	return nil
 }

--- a/pkg/scheduler/backend/queue/scheduling_queue.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue.go
@@ -537,7 +537,7 @@ func queueingHintToLabel(hint fwk.QueueingHint, err error) string {
 // Note: we need to associate the failed plugin to `pInfo`, so that the pod can be moved back
 // to activeQ by related cluster event.
 func (p *PriorityQueue) runPreEnqueuePlugins(ctx context.Context, pInfo *framework.QueuedPodInfo) {
-	var s *framework.Status
+	var s *fwk.Status
 	pod := pInfo.Pod
 	startTime := p.clock.Now()
 	defer func() {
@@ -572,7 +572,7 @@ func (p *PriorityQueue) runPreEnqueuePlugins(ctx context.Context, pInfo *framewo
 }
 
 // runPreEnqueuePlugin runs the PreEnqueue plugin and update pInfo's fields accordingly if needed.
-func (p *PriorityQueue) runPreEnqueuePlugin(ctx context.Context, logger klog.Logger, pl framework.PreEnqueuePlugin, pInfo *framework.QueuedPodInfo, shouldRecordMetric bool) *framework.Status {
+func (p *PriorityQueue) runPreEnqueuePlugin(ctx context.Context, logger klog.Logger, pl framework.PreEnqueuePlugin, pInfo *framework.QueuedPodInfo, shouldRecordMetric bool) *fwk.Status {
 	pod := pInfo.Pod
 	startTime := p.clock.Now()
 	s := pl.PreEnqueue(ctx, pod)
@@ -587,7 +587,7 @@ func (p *PriorityQueue) runPreEnqueuePlugin(ctx context.Context, logger klog.Log
 	metrics.UnschedulableReason(pl.Name(), pod.Spec.SchedulerName).Inc()
 	pInfo.GatingPlugin = pl.Name()
 	pInfo.GatingPluginEvents = p.pluginToEventsMap[pInfo.GatingPlugin]
-	if s.Code() == framework.Error {
+	if s.Code() == fwk.Error {
 		logger.Error(s.AsError(), "Unexpected error running PreEnqueue plugin", "pod", klog.KObj(pod), "plugin", pl.Name())
 	} else {
 		logger.V(4).Info("Status after running PreEnqueue plugin", "pod", klog.KObj(pod), "plugin", pl.Name(), "status", s)

--- a/pkg/scheduler/backend/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue_test.go
@@ -1534,7 +1534,7 @@ func (pl *preEnqueuePlugin) Name() string {
 	return "preEnqueuePlugin"
 }
 
-func (pl *preEnqueuePlugin) PreEnqueue(ctx context.Context, p *v1.Pod) *framework.Status {
+func (pl *preEnqueuePlugin) PreEnqueue(ctx context.Context, p *v1.Pod) *fwk.Status {
 	for _, allowed := range pl.allowlists {
 		for label := range p.Labels {
 			if label == allowed {
@@ -1542,7 +1542,7 @@ func (pl *preEnqueuePlugin) PreEnqueue(ctx context.Context, p *v1.Pod) *framewor
 			}
 		}
 	}
-	return framework.NewStatus(framework.UnschedulableAndUnresolvable, "pod name not in allowlists")
+	return fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "pod name not in allowlists")
 }
 
 func TestPriorityQueue_moveToActiveQ(t *testing.T) {

--- a/pkg/scheduler/framework/autoscaler_contract/framework_contract_test.go
+++ b/pkg/scheduler/framework/autoscaler_contract/framework_contract_test.go
@@ -35,9 +35,9 @@ import (
 )
 
 type frameworkContract interface {
-	RunPreFilterPlugins(ctx context.Context, state fwk.CycleState, pod *v1.Pod) (*framework.PreFilterResult, *framework.Status, sets.Set[string])
-	RunFilterPlugins(context.Context, fwk.CycleState, *v1.Pod, *framework.NodeInfo) *framework.Status
-	RunReservePluginsReserve(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeName string) *framework.Status
+	RunPreFilterPlugins(ctx context.Context, state fwk.CycleState, pod *v1.Pod) (*framework.PreFilterResult, *fwk.Status, sets.Set[string])
+	RunFilterPlugins(context.Context, fwk.CycleState, *v1.Pod, *framework.NodeInfo) *fwk.Status
+	RunReservePluginsReserve(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeName string) *fwk.Status
 }
 
 func TestFrameworkContract(t *testing.T) {

--- a/pkg/scheduler/framework/interface_test.go
+++ b/pkg/scheduler/framework/interface_test.go
@@ -24,17 +24,18 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	"k8s.io/apimachinery/pkg/util/sets"
+	fwk "k8s.io/kube-scheduler/framework"
 	st "k8s.io/kubernetes/pkg/scheduler/testing"
 )
 
-var errorStatus = NewStatus(Error, "internal error")
-var statusWithErr = AsStatus(errors.New("internal error"))
+var errorStatus = fwk.NewStatus(fwk.Error, "internal error")
+var statusWithErr = fwk.AsStatus(errors.New("internal error"))
 
 func TestStatus(t *testing.T) {
 	tests := []struct {
 		name              string
-		status            *Status
-		expectedCode      Code
+		status            *fwk.Status
+		expectedCode      fwk.Code
 		expectedMessage   string
 		expectedIsSuccess bool
 		expectedIsWait    bool
@@ -43,8 +44,8 @@ func TestStatus(t *testing.T) {
 	}{
 		{
 			name:              "success status",
-			status:            NewStatus(Success, ""),
-			expectedCode:      Success,
+			status:            fwk.NewStatus(fwk.Success, ""),
+			expectedCode:      fwk.Success,
 			expectedMessage:   "",
 			expectedIsSuccess: true,
 			expectedIsWait:    false,
@@ -53,8 +54,8 @@ func TestStatus(t *testing.T) {
 		},
 		{
 			name:              "wait status",
-			status:            NewStatus(Wait, ""),
-			expectedCode:      Wait,
+			status:            fwk.NewStatus(fwk.Wait, ""),
+			expectedCode:      fwk.Wait,
 			expectedMessage:   "",
 			expectedIsSuccess: false,
 			expectedIsWait:    true,
@@ -63,8 +64,8 @@ func TestStatus(t *testing.T) {
 		},
 		{
 			name:              "error status",
-			status:            NewStatus(Error, "unknown error"),
-			expectedCode:      Error,
+			status:            fwk.NewStatus(fwk.Error, "unknown error"),
+			expectedCode:      fwk.Error,
 			expectedMessage:   "unknown error",
 			expectedIsSuccess: false,
 			expectedIsWait:    false,
@@ -73,8 +74,8 @@ func TestStatus(t *testing.T) {
 		},
 		{
 			name:              "skip status",
-			status:            NewStatus(Skip, ""),
-			expectedCode:      Skip,
+			status:            fwk.NewStatus(fwk.Skip, ""),
+			expectedCode:      fwk.Skip,
 			expectedMessage:   "",
 			expectedIsSuccess: false,
 			expectedIsWait:    false,
@@ -84,7 +85,7 @@ func TestStatus(t *testing.T) {
 		{
 			name:              "nil status",
 			status:            nil,
-			expectedCode:      Success,
+			expectedCode:      fwk.Success,
 			expectedMessage:   "",
 			expectedIsSuccess: true,
 			expectedIsSkip:    false,
@@ -183,7 +184,7 @@ func TestPreFilterResultMerge(t *testing.T) {
 func TestIsStatusEqual(t *testing.T) {
 	tests := []struct {
 		name string
-		x, y *Status
+		x, y *fwk.Status
 		want bool
 	}{
 		{
@@ -195,13 +196,13 @@ func TestIsStatusEqual(t *testing.T) {
 		{
 			name: "nil should be equal to success status",
 			x:    nil,
-			y:    NewStatus(Success),
+			y:    fwk.NewStatus(fwk.Success),
 			want: true,
 		},
 		{
 			name: "nil should not be equal with status except success",
 			x:    nil,
-			y:    NewStatus(Error, "internal error"),
+			y:    fwk.NewStatus(fwk.Error, "internal error"),
 			want: false,
 		},
 		{
@@ -212,44 +213,44 @@ func TestIsStatusEqual(t *testing.T) {
 		},
 		{
 			name: "same type statuses without reasons should be equal",
-			x:    NewStatus(Success),
-			y:    NewStatus(Success),
+			x:    fwk.NewStatus(fwk.Success),
+			y:    fwk.NewStatus(fwk.Success),
 			want: true,
 		},
 		{
 			name: "statuses with same message should be equal",
-			x:    NewStatus(Unschedulable, "unschedulable"),
-			y:    NewStatus(Unschedulable, "unschedulable"),
+			x:    fwk.NewStatus(fwk.Unschedulable, "unschedulable"),
+			y:    fwk.NewStatus(fwk.Unschedulable, "unschedulable"),
 			want: true,
 		},
 		{
 			name: "error statuses with same message should be equal",
-			x:    NewStatus(Error, "error"),
-			y:    NewStatus(Error, "error"),
+			x:    fwk.NewStatus(fwk.Error, "error"),
+			y:    fwk.NewStatus(fwk.Error, "error"),
 			want: true,
 		},
 		{
 			name: "statuses with different reasons should not be equal",
-			x:    NewStatus(Unschedulable, "unschedulable"),
-			y:    NewStatus(Unschedulable, "unschedulable", "injected filter status"),
+			x:    fwk.NewStatus(fwk.Unschedulable, "unschedulable"),
+			y:    fwk.NewStatus(fwk.Unschedulable, "unschedulable", "injected filter status"),
 			want: false,
 		},
 		{
 			name: "statuses with different codes should not be equal",
-			x:    NewStatus(Error, "internal error"),
-			y:    NewStatus(Unschedulable, "internal error"),
+			x:    fwk.NewStatus(fwk.Error, "internal error"),
+			y:    fwk.NewStatus(fwk.Unschedulable, "internal error"),
 			want: false,
 		},
 		{
 			name: "wrap error status should be equal with original one",
 			x:    statusWithErr,
-			y:    AsStatus(fmt.Errorf("error: %w", statusWithErr.AsError())),
+			y:    fwk.AsStatus(fmt.Errorf("error: %w", statusWithErr.AsError())),
 			want: true,
 		},
 		{
 			name: "statues with different errors that have the same message shouldn't be equal",
-			x:    AsStatus(errors.New("error")),
-			y:    AsStatus(errors.New("error")),
+			x:    fwk.AsStatus(errors.New("error")),
+			y:    fwk.AsStatus(errors.New("error")),
 			want: false,
 		},
 	}
@@ -291,63 +292,63 @@ func TestNodesForStatusCode(t *testing.T) {
 	tests := []struct {
 		name          string
 		nodesStatuses *NodeToStatus
-		code          Code
+		code          fwk.Code
 		expected      sets.Set[string] // set of expected node names.
 	}{
 		{
 			name: "No node should be attempted",
-			nodesStatuses: NewNodeToStatus(map[string]*Status{
-				"node1": NewStatus(UnschedulableAndUnresolvable),
-				"node2": NewStatus(UnschedulableAndUnresolvable),
-				"node3": NewStatus(UnschedulableAndUnresolvable),
-				"node4": NewStatus(UnschedulableAndUnresolvable),
-			}, NewStatus(UnschedulableAndUnresolvable)),
-			code:     Unschedulable,
+			nodesStatuses: NewNodeToStatus(map[string]*fwk.Status{
+				"node1": fwk.NewStatus(fwk.UnschedulableAndUnresolvable),
+				"node2": fwk.NewStatus(fwk.UnschedulableAndUnresolvable),
+				"node3": fwk.NewStatus(fwk.UnschedulableAndUnresolvable),
+				"node4": fwk.NewStatus(fwk.UnschedulableAndUnresolvable),
+			}, fwk.NewStatus(fwk.UnschedulableAndUnresolvable)),
+			code:     fwk.Unschedulable,
 			expected: sets.New[string](),
 		},
 		{
 			name: "All nodes should be attempted",
-			nodesStatuses: NewNodeToStatus(map[string]*Status{
-				"node1": NewStatus(UnschedulableAndUnresolvable),
-				"node2": NewStatus(UnschedulableAndUnresolvable),
-				"node3": NewStatus(UnschedulableAndUnresolvable),
-				"node4": NewStatus(UnschedulableAndUnresolvable),
-			}, NewStatus(UnschedulableAndUnresolvable)),
-			code:     UnschedulableAndUnresolvable,
+			nodesStatuses: NewNodeToStatus(map[string]*fwk.Status{
+				"node1": fwk.NewStatus(fwk.UnschedulableAndUnresolvable),
+				"node2": fwk.NewStatus(fwk.UnschedulableAndUnresolvable),
+				"node3": fwk.NewStatus(fwk.UnschedulableAndUnresolvable),
+				"node4": fwk.NewStatus(fwk.UnschedulableAndUnresolvable),
+			}, fwk.NewStatus(fwk.UnschedulableAndUnresolvable)),
+			code:     fwk.UnschedulableAndUnresolvable,
 			expected: sets.New[string]("node1", "node2", "node3", "node4"),
 		},
 		{
 			name:          "No node should be attempted, as all are implicitly not matching the code",
 			nodesStatuses: NewDefaultNodeToStatus(),
-			code:          Unschedulable,
+			code:          fwk.Unschedulable,
 			expected:      sets.New[string](),
 		},
 		{
 			name:          "All nodes should be attempted, as all are implicitly matching the code",
 			nodesStatuses: NewDefaultNodeToStatus(),
-			code:          UnschedulableAndUnresolvable,
+			code:          fwk.UnschedulableAndUnresolvable,
 			expected:      sets.New[string]("node1", "node2", "node3", "node4"),
 		},
 		{
 			name: "UnschedulableAndUnresolvable status should be skipped but Unschedulable should be tried",
-			nodesStatuses: NewNodeToStatus(map[string]*Status{
-				"node1": NewStatus(Unschedulable),
-				"node2": NewStatus(UnschedulableAndUnresolvable),
-				"node3": NewStatus(Unschedulable),
+			nodesStatuses: NewNodeToStatus(map[string]*fwk.Status{
+				"node1": fwk.NewStatus(fwk.Unschedulable),
+				"node2": fwk.NewStatus(fwk.UnschedulableAndUnresolvable),
+				"node3": fwk.NewStatus(fwk.Unschedulable),
 				// node4 is UnschedulableAndUnresolvable by absence
-			}, NewStatus(UnschedulableAndUnresolvable)),
-			code:     Unschedulable,
+			}, fwk.NewStatus(fwk.UnschedulableAndUnresolvable)),
+			code:     fwk.Unschedulable,
 			expected: sets.New("node1", "node3"),
 		},
 		{
 			name: "Unschedulable status should be skipped but UnschedulableAndUnresolvable should be tried",
-			nodesStatuses: NewNodeToStatus(map[string]*Status{
-				"node1": NewStatus(Unschedulable),
-				"node2": NewStatus(UnschedulableAndUnresolvable),
-				"node3": NewStatus(Unschedulable),
+			nodesStatuses: NewNodeToStatus(map[string]*fwk.Status{
+				"node1": fwk.NewStatus(fwk.Unschedulable),
+				"node2": fwk.NewStatus(fwk.UnschedulableAndUnresolvable),
+				"node3": fwk.NewStatus(fwk.Unschedulable),
 				// node4 is UnschedulableAndUnresolvable by absence
-			}, NewStatus(UnschedulableAndUnresolvable)),
-			code:     UnschedulableAndUnresolvable,
+			}, fwk.NewStatus(fwk.UnschedulableAndUnresolvable)),
+			code:     fwk.UnschedulableAndUnresolvable,
 			expected: sets.New("node2", "node4"),
 		},
 	}

--- a/pkg/scheduler/framework/plugins/defaultbinder/default_binder.go
+++ b/pkg/scheduler/framework/plugins/defaultbinder/default_binder.go
@@ -49,7 +49,7 @@ func (b DefaultBinder) Name() string {
 }
 
 // Bind binds pods to nodes using the k8s client.
-func (b DefaultBinder) Bind(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodeName string) *framework.Status {
+func (b DefaultBinder) Bind(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodeName string) *fwk.Status {
 	logger := klog.FromContext(ctx)
 	logger.V(3).Info("Attempting to bind pod to node", "pod", klog.KObj(p), "node", klog.KRef("", nodeName))
 	binding := &v1.Binding{
@@ -58,7 +58,7 @@ func (b DefaultBinder) Bind(ctx context.Context, state fwk.CycleState, p *v1.Pod
 	}
 	err := b.handle.ClientSet().CoreV1().Pods(binding.Namespace).Bind(ctx, binding, metav1.CreateOptions{})
 	if err != nil {
-		return framework.AsStatus(err)
+		return fwk.AsStatus(err)
 	}
 	return nil
 }

--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
@@ -124,16 +124,16 @@ func newTestPlugin(_ context.Context, injArgs runtime.Object, f framework.Handle
 	return &TestPlugin{name: "test-plugin"}, nil
 }
 
-func (pl *TestPlugin) AddPod(ctx context.Context, state fwk.CycleState, podToSchedule *v1.Pod, podInfoToAdd *framework.PodInfo, nodeInfo *framework.NodeInfo) *framework.Status {
+func (pl *TestPlugin) AddPod(ctx context.Context, state fwk.CycleState, podToSchedule *v1.Pod, podInfoToAdd *framework.PodInfo, nodeInfo *framework.NodeInfo) *fwk.Status {
 	if nodeInfo.Node().GetLabels()["error"] == "true" {
-		return framework.AsStatus(fmt.Errorf("failed to add pod: %v", podToSchedule.Name))
+		return fwk.AsStatus(fmt.Errorf("failed to add pod: %v", podToSchedule.Name))
 	}
 	return nil
 }
 
-func (pl *TestPlugin) RemovePod(ctx context.Context, state fwk.CycleState, podToSchedule *v1.Pod, podInfoToRemove *framework.PodInfo, nodeInfo *framework.NodeInfo) *framework.Status {
+func (pl *TestPlugin) RemovePod(ctx context.Context, state fwk.CycleState, podToSchedule *v1.Pod, podInfoToRemove *framework.PodInfo, nodeInfo *framework.NodeInfo) *fwk.Status {
 	if nodeInfo.Node().GetLabels()["error"] == "true" {
-		return framework.AsStatus(fmt.Errorf("failed to remove pod: %v", podToSchedule.Name))
+		return fwk.AsStatus(fmt.Errorf("failed to remove pod: %v", podToSchedule.Name))
 	}
 	return nil
 }
@@ -146,11 +146,11 @@ func (pl *TestPlugin) PreFilterExtensions() framework.PreFilterExtensions {
 	return pl
 }
 
-func (pl *TestPlugin) PreFilter(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodes []*framework.NodeInfo) (*framework.PreFilterResult, *framework.Status) {
+func (pl *TestPlugin) PreFilter(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodes []*framework.NodeInfo) (*framework.PreFilterResult, *fwk.Status) {
 	return nil, nil
 }
 
-func (pl *TestPlugin) Filter(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) *framework.Status {
+func (pl *TestPlugin) Filter(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) *fwk.Status {
 	return nil
 }
 
@@ -172,7 +172,7 @@ func TestPostFilter(t *testing.T) {
 		filteredNodesStatuses *framework.NodeToStatus
 		extender              framework.Extender
 		wantResult            *framework.PostFilterResult
-		wantStatus            *framework.Status
+		wantStatus            *fwk.Status
 	}{
 		{
 			name: "pod with higher priority can be made schedulable",
@@ -183,11 +183,11 @@ func TestPostFilter(t *testing.T) {
 			nodes: []*v1.Node{
 				st.MakeNode().Name("node1").Capacity(onePodRes).Obj(),
 			},
-			filteredNodesStatuses: framework.NewNodeToStatus(map[string]*framework.Status{
-				"node1": framework.NewStatus(framework.Unschedulable),
-			}, framework.NewStatus(framework.UnschedulableAndUnresolvable)),
+			filteredNodesStatuses: framework.NewNodeToStatus(map[string]*fwk.Status{
+				"node1": fwk.NewStatus(fwk.Unschedulable),
+			}, fwk.NewStatus(fwk.UnschedulableAndUnresolvable)),
 			wantResult: framework.NewPostFilterResultWithNominatedNode("node1"),
-			wantStatus: framework.NewStatus(framework.Success),
+			wantStatus: fwk.NewStatus(fwk.Success),
 		},
 		{
 			name: "pod with tied priority is still unschedulable",
@@ -198,11 +198,11 @@ func TestPostFilter(t *testing.T) {
 			nodes: []*v1.Node{
 				st.MakeNode().Name("node1").Capacity(onePodRes).Obj(),
 			},
-			filteredNodesStatuses: framework.NewNodeToStatus(map[string]*framework.Status{
-				"node1": framework.NewStatus(framework.Unschedulable),
-			}, framework.NewStatus(framework.UnschedulableAndUnresolvable)),
+			filteredNodesStatuses: framework.NewNodeToStatus(map[string]*fwk.Status{
+				"node1": fwk.NewStatus(fwk.Unschedulable),
+			}, fwk.NewStatus(fwk.UnschedulableAndUnresolvable)),
 			wantResult: framework.NewPostFilterResultWithNominatedNode(""),
-			wantStatus: framework.NewStatus(framework.Unschedulable, "preemption: 0/1 nodes are available: 1 No preemption victims found for incoming pod."),
+			wantStatus: fwk.NewStatus(fwk.Unschedulable, "preemption: 0/1 nodes are available: 1 No preemption victims found for incoming pod."),
 		},
 		{
 			name: "preemption should respect filteredNodesStatuses",
@@ -213,11 +213,11 @@ func TestPostFilter(t *testing.T) {
 			nodes: []*v1.Node{
 				st.MakeNode().Name("node1").Capacity(onePodRes).Obj(),
 			},
-			filteredNodesStatuses: framework.NewNodeToStatus(map[string]*framework.Status{
-				"node1": framework.NewStatus(framework.UnschedulableAndUnresolvable),
-			}, framework.NewStatus(framework.UnschedulableAndUnresolvable)),
+			filteredNodesStatuses: framework.NewNodeToStatus(map[string]*fwk.Status{
+				"node1": fwk.NewStatus(fwk.UnschedulableAndUnresolvable),
+			}, fwk.NewStatus(fwk.UnschedulableAndUnresolvable)),
 			wantResult: framework.NewPostFilterResultWithNominatedNode(""),
-			wantStatus: framework.NewStatus(framework.Unschedulable, "preemption: 0/1 nodes are available: 1 Preemption is not helpful for scheduling."),
+			wantStatus: fwk.NewStatus(fwk.Unschedulable, "preemption: 0/1 nodes are available: 1 Preemption is not helpful for scheduling."),
 		},
 		{
 			name: "preemption should respect absent NodeToStatusMap entry meaning UnschedulableAndUnresolvable",
@@ -230,7 +230,7 @@ func TestPostFilter(t *testing.T) {
 			},
 			filteredNodesStatuses: framework.NewDefaultNodeToStatus(),
 			wantResult:            framework.NewPostFilterResultWithNominatedNode(""),
-			wantStatus:            framework.NewStatus(framework.Unschedulable, "preemption: 0/1 nodes are available: 1 Preemption is not helpful for scheduling."),
+			wantStatus:            fwk.NewStatus(fwk.Unschedulable, "preemption: 0/1 nodes are available: 1 Preemption is not helpful for scheduling."),
 		},
 		{
 			name: "pod can be made schedulable on one node",
@@ -243,12 +243,12 @@ func TestPostFilter(t *testing.T) {
 				st.MakeNode().Name("node1").Capacity(onePodRes).Obj(),
 				st.MakeNode().Name("node2").Capacity(onePodRes).Obj(),
 			},
-			filteredNodesStatuses: framework.NewNodeToStatus(map[string]*framework.Status{
-				"node1": framework.NewStatus(framework.Unschedulable),
-				"node2": framework.NewStatus(framework.Unschedulable),
-			}, framework.NewStatus(framework.UnschedulableAndUnresolvable)),
+			filteredNodesStatuses: framework.NewNodeToStatus(map[string]*fwk.Status{
+				"node1": fwk.NewStatus(fwk.Unschedulable),
+				"node2": fwk.NewStatus(fwk.Unschedulable),
+			}, fwk.NewStatus(fwk.UnschedulableAndUnresolvable)),
 			wantResult: framework.NewPostFilterResultWithNominatedNode("node2"),
-			wantStatus: framework.NewStatus(framework.Success),
+			wantStatus: fwk.NewStatus(fwk.Success),
 		},
 		{
 			name: "pod can be made schedulable on minHighestPriority node",
@@ -266,12 +266,12 @@ func TestPostFilter(t *testing.T) {
 				st.MakeNode().Name("node1").Capacity(onePodRes).Obj(),
 				st.MakeNode().Name("node2").Capacity(onePodRes).Obj(),
 			},
-			filteredNodesStatuses: framework.NewNodeToStatus(map[string]*framework.Status{
-				"node1": framework.NewStatus(framework.Unschedulable),
-				"node2": framework.NewStatus(framework.Unschedulable),
-			}, framework.NewStatus(framework.UnschedulableAndUnresolvable)),
+			filteredNodesStatuses: framework.NewNodeToStatus(map[string]*fwk.Status{
+				"node1": fwk.NewStatus(fwk.Unschedulable),
+				"node2": fwk.NewStatus(fwk.Unschedulable),
+			}, fwk.NewStatus(fwk.UnschedulableAndUnresolvable)),
 			wantResult: framework.NewPostFilterResultWithNominatedNode("node2"),
-			wantStatus: framework.NewStatus(framework.Success),
+			wantStatus: fwk.NewStatus(fwk.Success),
 		},
 		{
 			name: "preemption result filtered out by extenders",
@@ -284,16 +284,16 @@ func TestPostFilter(t *testing.T) {
 				st.MakeNode().Name("node1").Capacity(onePodRes).Obj(),
 				st.MakeNode().Name("node2").Capacity(onePodRes).Obj(),
 			},
-			filteredNodesStatuses: framework.NewNodeToStatus(map[string]*framework.Status{
-				"node1": framework.NewStatus(framework.Unschedulable),
-				"node2": framework.NewStatus(framework.Unschedulable),
-			}, framework.NewStatus(framework.UnschedulableAndUnresolvable)),
+			filteredNodesStatuses: framework.NewNodeToStatus(map[string]*fwk.Status{
+				"node1": fwk.NewStatus(fwk.Unschedulable),
+				"node2": fwk.NewStatus(fwk.Unschedulable),
+			}, fwk.NewStatus(fwk.UnschedulableAndUnresolvable)),
 			extender: &tf.FakeExtender{
 				ExtenderName: "FakeExtender1",
 				Predicates:   []tf.FitPredicate{tf.Node1PredicateExtender},
 			},
 			wantResult: framework.NewPostFilterResultWithNominatedNode("node1"),
-			wantStatus: framework.NewStatus(framework.Success),
+			wantStatus: fwk.NewStatus(fwk.Success),
 		},
 		{
 			name: "no candidate nodes found, no enough resource after removing low priority pods",
@@ -306,12 +306,12 @@ func TestPostFilter(t *testing.T) {
 				st.MakeNode().Name("node1").Capacity(nodeRes).Obj(), // no enough CPU resource
 				st.MakeNode().Name("node2").Capacity(nodeRes).Obj(), // no enough CPU resource
 			},
-			filteredNodesStatuses: framework.NewNodeToStatus(map[string]*framework.Status{
-				"node1": framework.NewStatus(framework.Unschedulable),
-				"node2": framework.NewStatus(framework.Unschedulable),
-			}, framework.NewStatus(framework.UnschedulableAndUnresolvable)),
+			filteredNodesStatuses: framework.NewNodeToStatus(map[string]*fwk.Status{
+				"node1": fwk.NewStatus(fwk.Unschedulable),
+				"node2": fwk.NewStatus(fwk.Unschedulable),
+			}, fwk.NewStatus(fwk.UnschedulableAndUnresolvable)),
 			wantResult: framework.NewPostFilterResultWithNominatedNode(""),
-			wantStatus: framework.NewStatus(framework.Unschedulable, "preemption: 0/2 nodes are available: 2 Insufficient cpu."),
+			wantStatus: fwk.NewStatus(fwk.Unschedulable, "preemption: 0/2 nodes are available: 2 Insufficient cpu."),
 		},
 		{
 			name: "no candidate nodes found with mixed reasons, no lower priority pod and no enough CPU resource",
@@ -326,13 +326,13 @@ func TestPostFilter(t *testing.T) {
 				st.MakeNode().Name("node2").Capacity(nodeRes).Obj(),   // no enough CPU resource
 				st.MakeNode().Name("node3").Capacity(onePodRes).Obj(), // no pod will be preempted
 			},
-			filteredNodesStatuses: framework.NewNodeToStatus(map[string]*framework.Status{
-				"node1": framework.NewStatus(framework.Unschedulable),
-				"node2": framework.NewStatus(framework.Unschedulable),
-				"node3": framework.NewStatus(framework.Unschedulable),
-			}, framework.NewStatus(framework.UnschedulableAndUnresolvable)),
+			filteredNodesStatuses: framework.NewNodeToStatus(map[string]*fwk.Status{
+				"node1": fwk.NewStatus(fwk.Unschedulable),
+				"node2": fwk.NewStatus(fwk.Unschedulable),
+				"node3": fwk.NewStatus(fwk.Unschedulable),
+			}, fwk.NewStatus(fwk.UnschedulableAndUnresolvable)),
 			wantResult: framework.NewPostFilterResultWithNominatedNode(""),
-			wantStatus: framework.NewStatus(framework.Unschedulable, "preemption: 0/3 nodes are available: 1 Insufficient cpu, 2 No preemption victims found for incoming pod."),
+			wantStatus: fwk.NewStatus(fwk.Unschedulable, "preemption: 0/3 nodes are available: 1 Insufficient cpu, 2 No preemption victims found for incoming pod."),
 		},
 		{
 			name: "no candidate nodes found with mixed reason, 2 UnschedulableAndUnresolvable nodes and 2 nodes don't have enough CPU resource",
@@ -347,13 +347,13 @@ func TestPostFilter(t *testing.T) {
 				st.MakeNode().Name("node3").Capacity(nodeRes).Obj(),
 				st.MakeNode().Name("node4").Capacity(nodeRes).Obj(),
 			},
-			filteredNodesStatuses: framework.NewNodeToStatus(map[string]*framework.Status{
-				"node1": framework.NewStatus(framework.Unschedulable),
-				"node2": framework.NewStatus(framework.Unschedulable),
-				"node4": framework.NewStatus(framework.UnschedulableAndUnresolvable),
-			}, framework.NewStatus(framework.UnschedulableAndUnresolvable)),
+			filteredNodesStatuses: framework.NewNodeToStatus(map[string]*fwk.Status{
+				"node1": fwk.NewStatus(fwk.Unschedulable),
+				"node2": fwk.NewStatus(fwk.Unschedulable),
+				"node4": fwk.NewStatus(fwk.UnschedulableAndUnresolvable),
+			}, fwk.NewStatus(fwk.UnschedulableAndUnresolvable)),
 			wantResult: framework.NewPostFilterResultWithNominatedNode(""),
-			wantStatus: framework.NewStatus(framework.Unschedulable, "preemption: 0/4 nodes are available: 2 Insufficient cpu, 2 Preemption is not helpful for scheduling."),
+			wantStatus: fwk.NewStatus(fwk.Unschedulable, "preemption: 0/4 nodes are available: 2 Insufficient cpu, 2 Preemption is not helpful for scheduling."),
 		},
 		{
 			name: "only one node but failed with TestPlugin",
@@ -363,11 +363,11 @@ func TestPostFilter(t *testing.T) {
 			},
 			// label the node with key as "error" so that the TestPlugin will fail with error.
 			nodes: []*v1.Node{st.MakeNode().Name("node1").Capacity(largeRes).Label("error", "true").Obj()},
-			filteredNodesStatuses: framework.NewNodeToStatus(map[string]*framework.Status{
-				"node1": framework.NewStatus(framework.Unschedulable),
-			}, framework.NewStatus(framework.UnschedulableAndUnresolvable)),
+			filteredNodesStatuses: framework.NewNodeToStatus(map[string]*fwk.Status{
+				"node1": fwk.NewStatus(fwk.Unschedulable),
+			}, fwk.NewStatus(fwk.UnschedulableAndUnresolvable)),
 			wantResult: nil,
-			wantStatus: framework.AsStatus(errors.New("preemption: running RemovePod on PreFilter plugin \"test-plugin\": failed to remove pod: p")),
+			wantStatus: fwk.AsStatus(errors.New("preemption: running RemovePod on PreFilter plugin \"test-plugin\": failed to remove pod: p")),
 		},
 		{
 			name: "one failed with TestPlugin and the other pass",
@@ -381,12 +381,12 @@ func TestPostFilter(t *testing.T) {
 				st.MakeNode().Name("node1").Capacity(largeRes).Label("error", "true").Obj(),
 				st.MakeNode().Name("node2").Capacity(largeRes).Obj(),
 			},
-			filteredNodesStatuses: framework.NewNodeToStatus(map[string]*framework.Status{
-				"node1": framework.NewStatus(framework.Unschedulable),
-				"node2": framework.NewStatus(framework.Unschedulable),
-			}, framework.NewStatus(framework.UnschedulableAndUnresolvable)),
+			filteredNodesStatuses: framework.NewNodeToStatus(map[string]*fwk.Status{
+				"node1": fwk.NewStatus(fwk.Unschedulable),
+				"node2": fwk.NewStatus(fwk.Unschedulable),
+			}, fwk.NewStatus(fwk.UnschedulableAndUnresolvable)),
 			wantResult: framework.NewPostFilterResultWithNominatedNode("node2"),
-			wantStatus: framework.NewStatus(framework.Success),
+			wantStatus: fwk.NewStatus(fwk.Success),
 		},
 	}
 
@@ -451,7 +451,7 @@ func TestPostFilter(t *testing.T) {
 
 			gotResult, gotStatus := p.PostFilter(ctx, state, tt.pod, tt.filteredNodesStatuses)
 			// As we cannot compare two errors directly due to miss the equal method for how to compare two errors, so just need to compare the reasons.
-			if gotStatus.Code() == framework.Error {
+			if gotStatus.Code() == fwk.Error {
 				if diff := cmp.Diff(tt.wantStatus.Reasons(), gotStatus.Reasons()); diff != "" {
 					t.Errorf("Unexpected status (-want, +got):\n%s", diff)
 				}
@@ -481,7 +481,7 @@ func TestDryRunPreemption(t *testing.T) {
 		initPods                []*v1.Pod
 		registerPlugins         []tf.RegisterPluginFunc
 		pdbs                    []*policy.PodDisruptionBudget
-		fakeFilterRC            framework.Code // return code for fake filter plugin
+		fakeFilterRC            fwk.Code // return code for fake filter plugin
 		disableParallelism      bool
 		expected                [][]candidate
 		expectedNumFilterCalled []int32
@@ -516,7 +516,7 @@ func TestDryRunPreemption(t *testing.T) {
 				st.MakePod().Name("p2").UID("p2").Node("node2").Priority(midPriority).Obj(),
 			},
 			expected:                [][]candidate{{}},
-			fakeFilterRC:            framework.Unschedulable,
+			fakeFilterRC:            fwk.Unschedulable,
 			expectedNumFilterCalled: []int32{2},
 		},
 		{
@@ -534,7 +534,7 @@ func TestDryRunPreemption(t *testing.T) {
 				st.MakePod().Name("p2").UID("p2").Node("node2").Priority(midPriority).Obj(),
 			},
 			expected:                [][]candidate{{}},
-			fakeFilterRC:            framework.Unschedulable,
+			fakeFilterRC:            fwk.Unschedulable,
 			expectedNumFilterCalled: []int32{2},
 		},
 		{
@@ -760,7 +760,7 @@ func TestDryRunPreemption(t *testing.T) {
 				st.MakePod().Name("p1").UID("p1").Node("node1").Priority(midPriority).Req(largeRes).Obj(),
 				st.MakePod().Name("p2").UID("p2").Node("node2").Priority(midPriority).Req(largeRes).Obj(),
 			},
-			fakeFilterRC:            framework.Unschedulable,
+			fakeFilterRC:            fwk.Unschedulable,
 			expected:                [][]candidate{{}},
 			expectedNumFilterCalled: []int32{2},
 		},
@@ -1112,7 +1112,7 @@ func TestDryRunPreemption(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			nodes := make([]*v1.Node, len(tt.nodeNames))
-			fakeFilterRCMap := make(map[string]framework.Code, len(tt.nodeNames))
+			fakeFilterRCMap := make(map[string]fwk.Code, len(tt.nodeNames))
 			for i, nodeName := range tt.nodeNames {
 				nodeWrapper := st.MakeNode().Capacity(veryLargeRes)
 				// Split node name by '/' to form labels in a format of
@@ -1825,7 +1825,7 @@ func TestPodEligibleToPreemptOthers(t *testing.T) {
 		pod                 *v1.Pod
 		pods                []*v1.Pod
 		nodes               []string
-		nominatedNodeStatus *framework.Status
+		nominatedNodeStatus *fwk.Status
 		expected            bool
 	}{
 		{
@@ -1833,7 +1833,7 @@ func TestPodEligibleToPreemptOthers(t *testing.T) {
 			pod:                 st.MakePod().Name("p_with_nominated_node").UID("p").Priority(highPriority).NominatedNodeName("node1").Obj(),
 			pods:                []*v1.Pod{st.MakePod().Name("p1").UID("p1").Priority(lowPriority).Node("node1").Terminating().Obj()},
 			nodes:               []string{"node1"},
-			nominatedNodeStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, tainttoleration.ErrReasonNotMatch),
+			nominatedNodeStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, tainttoleration.ErrReasonNotMatch),
 			expected:            true,
 		},
 		{
@@ -2172,7 +2172,7 @@ func TestPreempt(t *testing.T) {
 					extender.CachedNodeNameToInfo = cachedNodeInfoMap
 					extenders = append(extenders, extender)
 				}
-				fwk, err := tf.NewFramework(
+				schedFramework, err := tf.NewFramework(
 					ctx,
 					[]tf.RegisterPluginFunc{
 						test.registerPlugin,
@@ -2196,14 +2196,14 @@ func TestPreempt(t *testing.T) {
 
 				state := framework.NewCycleState()
 				// Some tests rely on PreFilter plugin to compute its CycleState.
-				if _, s, _ := fwk.RunPreFilterPlugins(ctx, state, testPod); !s.IsSuccess() {
+				if _, s, _ := schedFramework.RunPreFilterPlugins(ctx, state, testPod); !s.IsSuccess() {
 					t.Errorf("Unexpected preFilterStatus: %v", s)
 				}
 				// Call preempt and check the expected results.
 				features := feature.Features{
 					EnableAsyncPreemption: asyncPreemptionEnabled,
 				}
-				pl, err := New(ctx, getDefaultDefaultPreemptionArgs(), fwk, features)
+				pl, err := New(ctx, getDefaultDefaultPreemptionArgs(), schedFramework, features)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -2213,7 +2213,7 @@ func TestPreempt(t *testing.T) {
 
 				nodeToStatusMap := framework.NewDefaultNodeToStatus()
 				for _, n := range nodes {
-					nodeToStatusMap.Set(n.Name, framework.NewStatus(framework.Unschedulable))
+					nodeToStatusMap.Set(n.Name, fwk.NewStatus(fwk.Unschedulable))
 				}
 
 				res, status := pl.Evaluator.Preempt(ctx, state, testPod, nodeToStatusMap)

--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
@@ -266,7 +266,7 @@ func updateDeviceClassName(claim *resourceapi.ResourceClaim, deviceClassName str
 // result defines the expected outcome of some operation. It covers
 // operation's status and the state of the world (= objects).
 type result struct {
-	status *framework.Status
+	status *fwk.Status
 	// changes contains a mapping of name to an update function for
 	// the corresponding object. These functions apply exactly the expected
 	// changes to a copy of the object as it existed before the operation.
@@ -365,10 +365,10 @@ func TestPlugin(t *testing.T) {
 			pod: st.MakePod().Name("foo").Namespace("default").Obj(),
 			want: want{
 				prefilter: result{
-					status: framework.NewStatus(framework.Skip),
+					status: fwk.NewStatus(fwk.Skip),
 				},
 				postfilter: result{
-					status: framework.NewStatus(framework.Unschedulable),
+					status: fwk.NewStatus(fwk.Unschedulable),
 				},
 			},
 		},
@@ -411,7 +411,7 @@ func TestPlugin(t *testing.T) {
 			claims: []*resourceapi.ResourceClaim{allocatedClaim, otherClaim},
 			want: want{
 				preenqueue: result{
-					status: framework.NewStatus(framework.UnschedulableAndUnresolvable, `pod "default/my-pod": ResourceClaim not created yet`),
+					status: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, `pod "default/my-pod": ResourceClaim not created yet`),
 				},
 			},
 		},
@@ -424,7 +424,7 @@ func TestPlugin(t *testing.T) {
 			}(),
 			want: want{
 				preenqueue: result{
-					status: framework.NewStatus(framework.UnschedulableAndUnresolvable, `resourceclaim "my-pod-my-resource" is being deleted`),
+					status: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, `resourceclaim "my-pod-my-resource" is being deleted`),
 				},
 			},
 		},
@@ -437,7 +437,7 @@ func TestPlugin(t *testing.T) {
 			}(),
 			want: want{
 				preenqueue: result{
-					status: framework.NewStatus(framework.UnschedulableAndUnresolvable, `ResourceClaim default/my-pod-my-resource was not created for pod default/my-pod (pod is not owner)`),
+					status: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, `ResourceClaim default/my-pod-my-resource was not created for pod default/my-pod (pod is not owner)`),
 				},
 			},
 		},
@@ -448,11 +448,11 @@ func TestPlugin(t *testing.T) {
 			want: want{
 				filter: perNodeResult{
 					workerNode.Name: {
-						status: framework.NewStatus(framework.UnschedulableAndUnresolvable, `cannot allocate all claims`),
+						status: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, `cannot allocate all claims`),
 					},
 				},
 				postfilter: result{
-					status: framework.NewStatus(framework.Unschedulable, `still not schedulable`),
+					status: fwk.NewStatus(fwk.Unschedulable, `still not schedulable`),
 				},
 			},
 		},
@@ -612,11 +612,11 @@ func TestPlugin(t *testing.T) {
 			want: want{
 				filter: perNodeResult{
 					workerNode.Name: {
-						status: framework.NewStatus(framework.UnschedulableAndUnresolvable, `cannot allocate all claims`),
+						status: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, `cannot allocate all claims`),
 					},
 				},
 				postfilter: result{
-					status: framework.NewStatus(framework.Unschedulable, `still not schedulable`),
+					status: fwk.NewStatus(fwk.Unschedulable, `still not schedulable`),
 				},
 			},
 		},
@@ -662,11 +662,11 @@ func TestPlugin(t *testing.T) {
 			want: want{
 				filter: perNodeResult{
 					workerNode.Name: {
-						status: framework.NewStatus(framework.UnschedulableAndUnresolvable, `cannot allocate all claims`),
+						status: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, `cannot allocate all claims`),
 					},
 				},
 				postfilter: result{
-					status: framework.NewStatus(framework.Unschedulable, `still not schedulable`),
+					status: fwk.NewStatus(fwk.Unschedulable, `still not schedulable`),
 				},
 			},
 		},
@@ -713,7 +713,7 @@ func TestPlugin(t *testing.T) {
 			want: want{
 				filter: perNodeResult{
 					workerNode.Name: {
-						status: framework.NewStatus(framework.UnschedulableAndUnresolvable, `claim default/my-pod-my-resource, request req-1: admin access is requested, but the feature is disabled`),
+						status: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, `claim default/my-pod-my-resource, request req-1: admin access is requested, but the feature is disabled`),
 					},
 				},
 			},
@@ -758,7 +758,7 @@ func TestPlugin(t *testing.T) {
 			want: want{
 				filter: perNodeResult{
 					workerNode.Name: {
-						status: framework.AsStatus(errors.New(`claim default/my-pod-my-resource: selector #0: CEL runtime error: no such key: ` + string(attrName))),
+						status: fwk.AsStatus(errors.New(`claim default/my-pod-my-resource: selector #0: CEL runtime error: no such key: ` + string(attrName))),
 					},
 				},
 			},
@@ -772,7 +772,7 @@ func TestPlugin(t *testing.T) {
 			want: want{
 				filter: perNodeResult{
 					workerNode.Name: {
-						status: framework.AsStatus(errors.New(`class my-resource-class: selector #0: CEL runtime error: no such key: ` + string(attrName))),
+						status: fwk.AsStatus(errors.New(`class my-resource-class: selector #0: CEL runtime error: no such key: ` + string(attrName))),
 					},
 				},
 			},
@@ -792,7 +792,7 @@ func TestPlugin(t *testing.T) {
 			want: want{
 				filter: perNodeResult{
 					workerNode.Name: {
-						status: framework.AsStatus(errors.New(`claim default/my-pod-my-resource: selector #0: CEL runtime error: no such key: ` + string(attrName))),
+						status: fwk.AsStatus(errors.New(`claim default/my-pod-my-resource: selector #0: CEL runtime error: no such key: ` + string(attrName))),
 					},
 				},
 			},
@@ -808,12 +808,12 @@ func TestPlugin(t *testing.T) {
 			want: want{
 				filter: perNodeResult{
 					workerNode.Name: {
-						status: framework.NewStatus(framework.UnschedulableAndUnresolvable, `claim default/my-pod-my-resource: selector #0: CEL runtime error: no such key: `+string(attrName)),
+						status: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, `claim default/my-pod-my-resource: selector #0: CEL runtime error: no such key: `+string(attrName)),
 					},
 				},
 				prescore: result{
 					// This is the error found during Filter.
-					status: framework.NewStatus(framework.UnschedulableAndUnresolvable, `filter node worker: claim default/my-pod-my-resource: selector #0: CEL runtime error: no such key: healthy`),
+					status: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, `filter node worker: claim default/my-pod-my-resource: selector #0: CEL runtime error: no such key: healthy`),
 				},
 			},
 		},
@@ -823,10 +823,10 @@ func TestPlugin(t *testing.T) {
 			claims: []*resourceapi.ResourceClaim{pendingClaim},
 			want: want{
 				prefilter: result{
-					status: framework.NewStatus(framework.UnschedulableAndUnresolvable, fmt.Sprintf("request req-1: device class %s does not exist", className)),
+					status: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, fmt.Sprintf("request req-1: device class %s does not exist", className)),
 				},
 				postfilter: result{
-					status: framework.NewStatus(framework.Unschedulable, `no new claims to deallocate`),
+					status: fwk.NewStatus(fwk.Unschedulable, `no new claims to deallocate`),
 				},
 			},
 		},
@@ -838,7 +838,7 @@ func TestPlugin(t *testing.T) {
 			want: want{
 				filter: perNodeResult{
 					workerNode.Name: {
-						status: framework.NewStatus(framework.UnschedulableAndUnresolvable, `resourceclaim not available on the node`),
+						status: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, `resourceclaim not available on the node`),
 					},
 				},
 				postfilter: result{
@@ -850,7 +850,7 @@ func TestPlugin(t *testing.T) {
 								Obj()
 						},
 					},
-					status: framework.NewStatus(framework.Unschedulable, `deallocation of ResourceClaim completed`),
+					status: fwk.NewStatus(fwk.Unschedulable, `deallocation of ResourceClaim completed`),
 				},
 			},
 		},
@@ -902,10 +902,10 @@ func TestPlugin(t *testing.T) {
 			claims: []*resourceapi.ResourceClaim{inUseClaim},
 			want: want{
 				prefilter: result{
-					status: framework.NewStatus(framework.Skip),
+					status: fwk.NewStatus(fwk.Skip),
 				},
 				postfilter: result{
-					status: framework.NewStatus(framework.Unschedulable, `plugin disabled`),
+					status: fwk.NewStatus(fwk.Unschedulable, `plugin disabled`),
 				},
 			},
 			disableDRA: true,
@@ -915,10 +915,10 @@ func TestPlugin(t *testing.T) {
 			claims: []*resourceapi.ResourceClaim{updateDeviceClassName(claim, "does-not-exist")},
 			want: want{
 				prefilter: result{
-					status: framework.NewStatus(framework.Unschedulable, `request req-1: device class does-not-exist does not exist`),
+					status: fwk.NewStatus(fwk.Unschedulable, `request req-1: device class does-not-exist does not exist`),
 				},
 				postfilter: result{
-					status: framework.NewStatus(framework.Unschedulable, `no new claims to deallocate`),
+					status: fwk.NewStatus(fwk.Unschedulable, `no new claims to deallocate`),
 				},
 			},
 		},
@@ -929,10 +929,10 @@ func TestPlugin(t *testing.T) {
 			classes:                  []*resourceapi.DeviceClass{deviceClass},
 			want: want{
 				prefilter: result{
-					status: framework.NewStatus(framework.UnschedulableAndUnresolvable, `claim default/my-pod-my-resource, request req-1: has subrequests, but the DRAPrioritizedList feature is disabled`),
+					status: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, `claim default/my-pod-my-resource, request req-1: has subrequests, but the DRAPrioritizedList feature is disabled`),
 				},
 				postfilter: result{
-					status: framework.NewStatus(framework.Unschedulable, `no new claims to deallocate`),
+					status: fwk.NewStatus(fwk.Unschedulable, `no new claims to deallocate`),
 				},
 			},
 		},
@@ -942,10 +942,10 @@ func TestPlugin(t *testing.T) {
 			claims:                   []*resourceapi.ResourceClaim{updateDeviceClassName(claimWithPrioritzedList, "does-not-exist")},
 			want: want{
 				prefilter: result{
-					status: framework.NewStatus(framework.Unschedulable, `request req-1/subreq-1: device class does-not-exist does not exist`),
+					status: fwk.NewStatus(fwk.Unschedulable, `request req-1/subreq-1: device class does-not-exist does not exist`),
 				},
 				postfilter: result{
-					status: framework.NewStatus(framework.Unschedulable, `no new claims to deallocate`),
+					status: fwk.NewStatus(fwk.Unschedulable, `no new claims to deallocate`),
 				},
 			},
 		},
@@ -1007,7 +1007,7 @@ func TestPlugin(t *testing.T) {
 				assert.Equal(t, tc.want.preFilterResult, result)
 				testCtx.verify(t, tc.want.prefilter, initialObjects, result, status)
 			})
-			unschedulable := status.Code() != framework.Success
+			unschedulable := status.Code() != fwk.Success
 
 			var potentialNodes []*framework.NodeInfo
 
@@ -1021,10 +1021,10 @@ func TestPlugin(t *testing.T) {
 					t.Run(fmt.Sprintf("filter/%s", nodeInfo.Node().Name), func(t *testing.T) {
 						testCtx.verify(t, tc.want.filter.forNode(nodeName), initialObjects, nil, status)
 					})
-					if status.Code() == framework.Success {
+					if status.Code() == fwk.Success {
 						potentialNodes = append(potentialNodes, nodeInfo)
 					}
-					if status.Code() == framework.Error {
+					if status.Code() == fwk.Error {
 						// An error aborts scheduling.
 						return
 					}
@@ -1049,7 +1049,7 @@ func TestPlugin(t *testing.T) {
 				t.Run("reserve", func(t *testing.T) {
 					testCtx.verify(t, tc.want.reserve, initialObjects, nil, status)
 				})
-				if status.Code() != framework.Success {
+				if status.Code() != fwk.Success {
 					unschedulable = true
 				}
 			}
@@ -1113,7 +1113,7 @@ type testContext struct {
 	state           fwk.CycleState
 }
 
-func (tc *testContext) verify(t *testing.T, expected result, initialObjects []metav1.Object, result interface{}, status *framework.Status) {
+func (tc *testContext) verify(t *testing.T, expected result, initialObjects []metav1.Object, result interface{}, status *fwk.Status) {
 	t.Helper()
 	if expected.status == nil {
 		assert.Nil(t, status)

--- a/pkg/scheduler/framework/plugins/examples/multipoint/multipoint.go
+++ b/pkg/scheduler/framework/plugins/examples/multipoint/multipoint.go
@@ -52,9 +52,9 @@ func (s *stateData) Clone() fwk.StateData {
 }
 
 // Reserve is the function invoked by the framework at "reserve" extension point.
-func (mc CommunicatingPlugin) Reserve(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeName string) *framework.Status {
+func (mc CommunicatingPlugin) Reserve(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeName string) *fwk.Status {
 	if pod == nil {
-		return framework.NewStatus(framework.Error, "pod cannot be nil")
+		return fwk.NewStatus(fwk.Error, "pod cannot be nil")
 	}
 	if pod.Name == "my-test-pod" {
 		state.Write(fwk.StateKey(pod.Name), &stateData{data: "never bind"})
@@ -74,13 +74,13 @@ func (mc CommunicatingPlugin) Unreserve(ctx context.Context, state fwk.CycleStat
 }
 
 // PreBind is the function invoked by the framework at "prebind" extension point.
-func (mc CommunicatingPlugin) PreBind(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeName string) *framework.Status {
+func (mc CommunicatingPlugin) PreBind(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeName string) *fwk.Status {
 	if pod == nil {
-		return framework.NewStatus(framework.Error, "pod cannot be nil")
+		return fwk.NewStatus(fwk.Error, "pod cannot be nil")
 	}
 	if v, e := state.Read(fwk.StateKey(pod.Name)); e == nil {
 		if value, ok := v.(*stateData); ok && value.data == "never bind" {
-			return framework.NewStatus(framework.Unschedulable, "pod is not permitted")
+			return fwk.NewStatus(fwk.Unschedulable, "pod is not permitted")
 		}
 	}
 	return nil

--- a/pkg/scheduler/framework/plugins/examples/prebind/prebind.go
+++ b/pkg/scheduler/framework/plugins/examples/prebind/prebind.go
@@ -40,12 +40,12 @@ func (sr StatelessPreBindExample) Name() string {
 }
 
 // PreBind is the functions invoked by the framework at "prebind" extension point.
-func (sr StatelessPreBindExample) PreBind(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeName string) *framework.Status {
+func (sr StatelessPreBindExample) PreBind(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeName string) *fwk.Status {
 	if pod == nil {
-		return framework.NewStatus(framework.Error, "pod cannot be nil")
+		return fwk.NewStatus(fwk.Error, "pod cannot be nil")
 	}
 	if pod.Namespace != "foo" {
-		return framework.NewStatus(framework.Unschedulable, "only pods from 'foo' namespace are allowed")
+		return fwk.NewStatus(fwk.Unschedulable, "only pods from 'foo' namespace are allowed")
 	}
 	return nil
 }

--- a/pkg/scheduler/framework/plugins/examples/stateful/stateful.go
+++ b/pkg/scheduler/framework/plugins/examples/stateful/stateful.go
@@ -50,7 +50,7 @@ func (mp *MultipointExample) Name() string {
 // Reserve is the function invoked by the framework at "reserve" extension
 // point. In this trivial example, the Reserve method allocates an array of
 // strings.
-func (mp *MultipointExample) Reserve(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeName string) *framework.Status {
+func (mp *MultipointExample) Reserve(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeName string) *fwk.Status {
 	// Reserve is not called concurrently, and so we don't need to lock.
 	mp.executionPoints = append(mp.executionPoints, "reserve")
 	return nil
@@ -71,13 +71,13 @@ func (mp *MultipointExample) Unreserve(ctx context.Context, state fwk.CycleState
 
 // PreBind is the function invoked by the framework at "prebind" extension
 // point.
-func (mp *MultipointExample) PreBind(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeName string) *framework.Status {
+func (mp *MultipointExample) PreBind(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeName string) *fwk.Status {
 	// PreBind could be called concurrently for different pods.
 	mp.mu.Lock()
 	defer mp.mu.Unlock()
 	mp.executionPoints = append(mp.executionPoints, "pre-bind")
 	if pod == nil {
-		return framework.NewStatus(framework.Error, "pod must not be nil")
+		return fwk.NewStatus(fwk.Error, "pod must not be nil")
 	}
 	return nil
 }

--- a/pkg/scheduler/framework/plugins/helper/normalize_score.go
+++ b/pkg/scheduler/framework/plugins/helper/normalize_score.go
@@ -17,6 +17,7 @@ limitations under the License.
 package helper
 
 import (
+	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 )
 
@@ -24,7 +25,7 @@ import (
 // scores from [0, max(scores)] to [0, maxPriority]. If reverse is set to true, it
 // reverses the scores by subtracting it from maxPriority.
 // Note: The input scores are always assumed to be non-negative integers.
-func DefaultNormalizeScore(maxPriority int64, reverse bool, scores framework.NodeScoreList) *framework.Status {
+func DefaultNormalizeScore(maxPriority int64, reverse bool, scores framework.NodeScoreList) *fwk.Status {
 	var maxCount int64
 	for i := range scores {
 		if scores[i].Score > maxCount {

--- a/pkg/scheduler/framework/plugins/imagelocality/image_locality.go
+++ b/pkg/scheduler/framework/plugins/imagelocality/image_locality.go
@@ -51,10 +51,10 @@ func (pl *ImageLocality) Name() string {
 }
 
 // Score invoked at the score extension point.
-func (pl *ImageLocality) Score(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) (int64, *framework.Status) {
+func (pl *ImageLocality) Score(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) (int64, *fwk.Status) {
 	nodeInfos, err := pl.handle.SnapshotSharedLister().NodeInfos().List()
 	if err != nil {
-		return 0, framework.AsStatus(err)
+		return 0, fwk.AsStatus(err)
 	}
 	totalNumNodes := len(nodeInfos)
 

--- a/pkg/scheduler/framework/plugins/interpodaffinity/filtering.go
+++ b/pkg/scheduler/framework/plugins/interpodaffinity/filtering.go
@@ -271,27 +271,27 @@ func (pl *InterPodAffinity) getIncomingAffinityAntiAffinityCounts(ctx context.Co
 }
 
 // PreFilter invoked at the prefilter extension point.
-func (pl *InterPodAffinity) PreFilter(ctx context.Context, cycleState fwk.CycleState, pod *v1.Pod, allNodes []*framework.NodeInfo) (*framework.PreFilterResult, *framework.Status) {
+func (pl *InterPodAffinity) PreFilter(ctx context.Context, cycleState fwk.CycleState, pod *v1.Pod, allNodes []*framework.NodeInfo) (*framework.PreFilterResult, *fwk.Status) {
 	var nodesWithRequiredAntiAffinityPods []*framework.NodeInfo
 	var err error
 	if nodesWithRequiredAntiAffinityPods, err = pl.sharedLister.NodeInfos().HavePodsWithRequiredAntiAffinityList(); err != nil {
-		return nil, framework.AsStatus(fmt.Errorf("failed to list NodeInfos with pods with affinity: %w", err))
+		return nil, fwk.AsStatus(fmt.Errorf("failed to list NodeInfos with pods with affinity: %w", err))
 	}
 
 	s := &preFilterState{}
 
 	if s.podInfo, err = framework.NewPodInfo(pod); err != nil {
-		return nil, framework.NewStatus(framework.UnschedulableAndUnresolvable, fmt.Sprintf("parsing pod: %+v", err))
+		return nil, fwk.NewStatus(fwk.UnschedulableAndUnresolvable, fmt.Sprintf("parsing pod: %+v", err))
 	}
 
 	for i := range s.podInfo.RequiredAffinityTerms {
 		if err := pl.mergeAffinityTermNamespacesIfNotEmpty(&s.podInfo.RequiredAffinityTerms[i]); err != nil {
-			return nil, framework.AsStatus(err)
+			return nil, fwk.AsStatus(err)
 		}
 	}
 	for i := range s.podInfo.RequiredAntiAffinityTerms {
 		if err := pl.mergeAffinityTermNamespacesIfNotEmpty(&s.podInfo.RequiredAntiAffinityTerms[i]); err != nil {
-			return nil, framework.AsStatus(err)
+			return nil, fwk.AsStatus(err)
 		}
 	}
 	logger := klog.FromContext(ctx)
@@ -301,7 +301,7 @@ func (pl *InterPodAffinity) PreFilter(ctx context.Context, cycleState fwk.CycleS
 	s.affinityCounts, s.antiAffinityCounts = pl.getIncomingAffinityAntiAffinityCounts(ctx, s.podInfo, allNodes)
 
 	if len(s.existingAntiAffinityCounts) == 0 && len(s.podInfo.RequiredAffinityTerms) == 0 && len(s.podInfo.RequiredAntiAffinityTerms) == 0 {
-		return nil, framework.NewStatus(framework.Skip)
+		return nil, fwk.NewStatus(fwk.Skip)
 	}
 
 	cycleState.Write(preFilterStateKey, s)
@@ -314,20 +314,20 @@ func (pl *InterPodAffinity) PreFilterExtensions() framework.PreFilterExtensions 
 }
 
 // AddPod from pre-computed data in cycleState.
-func (pl *InterPodAffinity) AddPod(ctx context.Context, cycleState fwk.CycleState, podToSchedule *v1.Pod, podInfoToAdd *framework.PodInfo, nodeInfo *framework.NodeInfo) *framework.Status {
+func (pl *InterPodAffinity) AddPod(ctx context.Context, cycleState fwk.CycleState, podToSchedule *v1.Pod, podInfoToAdd *framework.PodInfo, nodeInfo *framework.NodeInfo) *fwk.Status {
 	state, err := getPreFilterState(cycleState)
 	if err != nil {
-		return framework.AsStatus(err)
+		return fwk.AsStatus(err)
 	}
 	state.updateWithPod(podInfoToAdd, nodeInfo.Node(), 1)
 	return nil
 }
 
 // RemovePod from pre-computed data in cycleState.
-func (pl *InterPodAffinity) RemovePod(ctx context.Context, cycleState fwk.CycleState, podToSchedule *v1.Pod, podInfoToRemove *framework.PodInfo, nodeInfo *framework.NodeInfo) *framework.Status {
+func (pl *InterPodAffinity) RemovePod(ctx context.Context, cycleState fwk.CycleState, podToSchedule *v1.Pod, podInfoToRemove *framework.PodInfo, nodeInfo *framework.NodeInfo) *fwk.Status {
 	state, err := getPreFilterState(cycleState)
 	if err != nil {
-		return framework.AsStatus(err)
+		return fwk.AsStatus(err)
 	}
 	state.updateWithPod(podInfoToRemove, nodeInfo.Node(), -1)
 	return nil
@@ -409,23 +409,23 @@ func satisfyPodAffinity(state *preFilterState, nodeInfo *framework.NodeInfo) boo
 
 // Filter invoked at the filter extension point.
 // It checks if a pod can be scheduled on the specified node with pod affinity/anti-affinity configuration.
-func (pl *InterPodAffinity) Filter(ctx context.Context, cycleState fwk.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) *framework.Status {
+func (pl *InterPodAffinity) Filter(ctx context.Context, cycleState fwk.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) *fwk.Status {
 
 	state, err := getPreFilterState(cycleState)
 	if err != nil {
-		return framework.AsStatus(err)
+		return fwk.AsStatus(err)
 	}
 
 	if !satisfyPodAffinity(state, nodeInfo) {
-		return framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReasonAffinityRulesNotMatch)
+		return fwk.NewStatus(fwk.UnschedulableAndUnresolvable, ErrReasonAffinityRulesNotMatch)
 	}
 
 	if !satisfyPodAntiAffinity(state, nodeInfo) {
-		return framework.NewStatus(framework.Unschedulable, ErrReasonAntiAffinityRulesNotMatch)
+		return fwk.NewStatus(fwk.Unschedulable, ErrReasonAntiAffinityRulesNotMatch)
 	}
 
 	if !satisfyExistingPodsAntiAffinity(state, nodeInfo) {
-		return framework.NewStatus(framework.Unschedulable, ErrReasonExistingAntiAffinityRulesNotMatch)
+		return fwk.NewStatus(fwk.Unschedulable, ErrReasonExistingAntiAffinityRulesNotMatch)
 	}
 
 	return nil

--- a/pkg/scheduler/framework/plugins/interpodaffinity/filtering_test.go
+++ b/pkg/scheduler/framework/plugins/interpodaffinity/filtering_test.go
@@ -84,14 +84,14 @@ func TestRequiredAffinitySingleNode(t *testing.T) {
 		pods                []*v1.Pod
 		node                *v1.Node
 		name                string
-		wantPreFilterStatus *framework.Status
-		wantFilterStatus    *framework.Status
+		wantPreFilterStatus *fwk.Status
+		wantFilterStatus    *fwk.Status
 	}{
 		{
 			name:                "A pod that has no required pod affinity scheduling rules can schedule onto a node with no existing pods",
 			pod:                 new(v1.Pod),
 			node:                &node1,
-			wantPreFilterStatus: framework.NewStatus(framework.Skip),
+			wantPreFilterStatus: fwk.NewStatus(fwk.Skip),
 		},
 		{
 			name: "satisfies with requiredDuringSchedulingIgnoredDuringExecution in PodAffinity using In operator that matches the existing pod",
@@ -124,8 +124,8 @@ func TestRequiredAffinitySingleNode(t *testing.T) {
 				}, nil),
 			pods: []*v1.Pod{st.MakePod().Namespace("ns").Label("service", "securityscan").Node("node1").Obj()},
 			node: &node1,
-			wantFilterStatus: framework.NewStatus(
-				framework.UnschedulableAndUnresolvable,
+			wantFilterStatus: fwk.NewStatus(
+				fwk.UnschedulableAndUnresolvable,
 				ErrReasonAffinityRulesNotMatch,
 			),
 		},
@@ -134,8 +134,8 @@ func TestRequiredAffinitySingleNode(t *testing.T) {
 			pod:  st.MakePod().Namespace(defaultNamespace).Labels(podLabel).PodAffinityIn("service", "", []string{"antivirusscan", "value2"}, st.PodAffinityWithRequiredReq).Obj(),
 			pods: []*v1.Pod{pod},
 			node: &node1,
-			wantFilterStatus: framework.NewStatus(
-				framework.UnschedulableAndUnresolvable,
+			wantFilterStatus: fwk.NewStatus(
+				fwk.UnschedulableAndUnresolvable,
 				ErrReasonAffinityRulesNotMatch,
 			),
 		},
@@ -212,8 +212,8 @@ func TestRequiredAffinitySingleNode(t *testing.T) {
 				}, nil),
 			pods: []*v1.Pod{pod},
 			node: &node1,
-			wantFilterStatus: framework.NewStatus(
-				framework.UnschedulableAndUnresolvable,
+			wantFilterStatus: fwk.NewStatus(
+				fwk.UnschedulableAndUnresolvable,
 				ErrReasonAffinityRulesNotMatch,
 			),
 		},
@@ -243,8 +243,8 @@ func TestRequiredAffinitySingleNode(t *testing.T) {
 				PodAntiAffinityIn("service", "zone", []string{"securityscan", "value2"}, st.PodAntiAffinityWithRequiredReq).Obj(),
 			pods: []*v1.Pod{pod},
 			node: &node1,
-			wantFilterStatus: framework.NewStatus(
-				framework.Unschedulable,
+			wantFilterStatus: fwk.NewStatus(
+				fwk.Unschedulable,
 				ErrReasonAntiAffinityRulesNotMatch,
 			),
 		},
@@ -257,8 +257,8 @@ func TestRequiredAffinitySingleNode(t *testing.T) {
 				st.MakePod().Namespace(defaultNamespace).Labels(podLabel).Node("node1").PodAntiAffinityIn("service", "zone", []string{"securityscan", "value2"}, st.PodAntiAffinityWithRequiredReq).Obj(),
 			},
 			node: &node1,
-			wantFilterStatus: framework.NewStatus(
-				framework.Unschedulable,
+			wantFilterStatus: fwk.NewStatus(
+				fwk.Unschedulable,
 				ErrReasonExistingAntiAffinityRulesNotMatch,
 			),
 		},
@@ -268,8 +268,8 @@ func TestRequiredAffinitySingleNode(t *testing.T) {
 				PodAffinityNotIn("service", "region", []string{"securityscan", "value2"}, st.PodAffinityWithRequiredReq).Obj(),
 			pods: []*v1.Pod{st.MakePod().Label("service", "securityscan").Node("node2").Obj()},
 			node: &node1,
-			wantFilterStatus: framework.NewStatus(
-				framework.UnschedulableAndUnresolvable,
+			wantFilterStatus: fwk.NewStatus(
+				fwk.UnschedulableAndUnresolvable,
 				ErrReasonAffinityRulesNotMatch,
 			),
 		},
@@ -281,8 +281,8 @@ func TestRequiredAffinitySingleNode(t *testing.T) {
 					PodAntiAffinityIn("service", "zone", []string{"securityscan", "value2"}, st.PodAntiAffinityWithRequiredReq).Obj(),
 			},
 			node: &node1,
-			wantFilterStatus: framework.NewStatus(
-				framework.Unschedulable,
+			wantFilterStatus: fwk.NewStatus(
+				fwk.Unschedulable,
 				ErrReasonExistingAntiAffinityRulesNotMatch,
 			),
 		},
@@ -294,7 +294,7 @@ func TestRequiredAffinitySingleNode(t *testing.T) {
 					PodAntiAffinityNotIn("service", "zone", []string{"securityscan", "value2"}, st.PodAntiAffinityWithRequiredReq).Obj(),
 			},
 			node:                &node1,
-			wantPreFilterStatus: framework.NewStatus(framework.Skip),
+			wantPreFilterStatus: fwk.NewStatus(fwk.Skip),
 		},
 		{
 			name: "satisfies the PodAntiAffinity with existing pod but doesn't satisfy PodAntiAffinity symmetry with incoming pod",
@@ -306,8 +306,8 @@ func TestRequiredAffinitySingleNode(t *testing.T) {
 					PodAntiAffinityExists("security", "zone", st.PodAntiAffinityWithRequiredReq).Obj(),
 			},
 			node: &node1,
-			wantFilterStatus: framework.NewStatus(
-				framework.Unschedulable,
+			wantFilterStatus: fwk.NewStatus(
+				fwk.Unschedulable,
 				ErrReasonAntiAffinityRulesNotMatch,
 			),
 		},
@@ -321,8 +321,8 @@ func TestRequiredAffinitySingleNode(t *testing.T) {
 					PodAntiAffinityExists("security", "zone", st.PodAntiAffinityWithRequiredReq).Obj(),
 			},
 			node: &node1,
-			wantFilterStatus: framework.NewStatus(
-				framework.Unschedulable,
+			wantFilterStatus: fwk.NewStatus(
+				fwk.Unschedulable,
 				ErrReasonAntiAffinityRulesNotMatch,
 			),
 		},
@@ -336,8 +336,8 @@ func TestRequiredAffinitySingleNode(t *testing.T) {
 					PodAntiAffinityExists("security", "zone", st.PodAntiAffinityWithRequiredReq).Obj(),
 			},
 			node: &node1,
-			wantFilterStatus: framework.NewStatus(
-				framework.Unschedulable,
+			wantFilterStatus: fwk.NewStatus(
+				fwk.Unschedulable,
 				ErrReasonExistingAntiAffinityRulesNotMatch,
 			),
 		},
@@ -352,8 +352,8 @@ func TestRequiredAffinitySingleNode(t *testing.T) {
 					PodAntiAffinityExists("def", "zone", st.PodAntiAffinityWithRequiredReq).Obj(),
 			},
 			node: &node1,
-			wantFilterStatus: framework.NewStatus(
-				framework.Unschedulable,
+			wantFilterStatus: fwk.NewStatus(
+				fwk.Unschedulable,
 				ErrReasonAntiAffinityRulesNotMatch,
 			),
 		},
@@ -368,8 +368,8 @@ func TestRequiredAffinitySingleNode(t *testing.T) {
 					PodAntiAffinityExists("def", "zone", st.PodAntiAffinityWithRequiredReq).Obj(),
 			},
 			node: &node1,
-			wantFilterStatus: framework.NewStatus(
-				framework.Unschedulable,
+			wantFilterStatus: fwk.NewStatus(
+				fwk.Unschedulable,
 				ErrReasonAntiAffinityRulesNotMatch,
 			),
 		},
@@ -379,8 +379,8 @@ func TestRequiredAffinitySingleNode(t *testing.T) {
 				PodAffinityIn("service", "region", []string{"{{.bad-value.}}"}, st.PodAffinityWithRequiredReq).
 				PodAffinityIn("service", "node", []string{"antivirusscan", "value2"}, st.PodAffinityWithRequiredReq).Obj(),
 			node: &node1,
-			wantPreFilterStatus: framework.NewStatus(
-				framework.UnschedulableAndUnresolvable,
+			wantPreFilterStatus: fwk.NewStatus(
+				fwk.UnschedulableAndUnresolvable,
 				`parsing pod: requiredAffinityTerms: values[0][service]: Invalid value: "{{.bad-value.}}": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')`,
 			),
 		},
@@ -390,8 +390,8 @@ func TestRequiredAffinitySingleNode(t *testing.T) {
 				PodAffinityIn("service", "region", []string{"foo"}, st.PodAffinityWithRequiredReq).
 				PodAffinityIn("service", "node", []string{"{{.bad-value.}}"}, st.PodAffinityWithRequiredReq).Obj(),
 			node: &node1,
-			wantPreFilterStatus: framework.NewStatus(
-				framework.UnschedulableAndUnresolvable,
+			wantPreFilterStatus: fwk.NewStatus(
+				fwk.UnschedulableAndUnresolvable,
 				`parsing pod: requiredAffinityTerms: values[0][service]: Invalid value: "{{.bad-value.}}": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')`,
 			),
 		},
@@ -452,8 +452,8 @@ func TestRequiredAffinitySingleNode(t *testing.T) {
 				}, nil),
 			pods: []*v1.Pod{{Spec: v1.PodSpec{NodeName: "node1"}, ObjectMeta: metav1.ObjectMeta{Namespace: "subteam1.team2", Labels: podLabel}}},
 			node: &node1,
-			wantFilterStatus: framework.NewStatus(
-				framework.UnschedulableAndUnresolvable,
+			wantFilterStatus: fwk.NewStatus(
+				fwk.UnschedulableAndUnresolvable,
 				ErrReasonAffinityRulesNotMatch,
 			),
 		},
@@ -485,8 +485,8 @@ func TestRequiredAffinitySingleNode(t *testing.T) {
 				}),
 			pods: []*v1.Pod{{Spec: v1.PodSpec{NodeName: "node1"}, ObjectMeta: metav1.ObjectMeta{Namespace: "subteam2.team1", Labels: podLabel}}},
 			node: &node1,
-			wantFilterStatus: framework.NewStatus(
-				framework.Unschedulable,
+			wantFilterStatus: fwk.NewStatus(
+				fwk.Unschedulable,
 				ErrReasonAntiAffinityRulesNotMatch,
 			),
 		},
@@ -510,8 +510,8 @@ func TestRequiredAffinitySingleNode(t *testing.T) {
 				}),
 			pods: []*v1.Pod{{Spec: v1.PodSpec{NodeName: "node1"}, ObjectMeta: metav1.ObjectMeta{Namespace: "subteam2.team1", Labels: podLabel}}},
 			node: &node1,
-			wantFilterStatus: framework.NewStatus(
-				framework.Unschedulable,
+			wantFilterStatus: fwk.NewStatus(
+				fwk.Unschedulable,
 				ErrReasonAntiAffinityRulesNotMatch,
 			),
 		},
@@ -594,8 +594,8 @@ func TestRequiredAffinityMultipleNodes(t *testing.T) {
 		pod                 *v1.Pod
 		pods                []*v1.Pod
 		nodes               []*v1.Node
-		wantFilterStatuses  []*framework.Status
-		wantPreFilterStatus *framework.Status
+		wantFilterStatuses  []*fwk.Status
+		wantPreFilterStatus *fwk.Status
 		name                string
 	}{
 		{
@@ -608,11 +608,11 @@ func TestRequiredAffinityMultipleNodes(t *testing.T) {
 				{ObjectMeta: metav1.ObjectMeta{Name: "node2", Labels: labelRgChinaAzAz1}},
 				{ObjectMeta: metav1.ObjectMeta{Name: "node3", Labels: labelRgIndia}},
 			},
-			wantFilterStatuses: []*framework.Status{
+			wantFilterStatuses: []*fwk.Status{
 				nil,
 				nil,
-				framework.NewStatus(
-					framework.UnschedulableAndUnresolvable,
+				fwk.NewStatus(
+					fwk.UnschedulableAndUnresolvable,
 					ErrReasonAffinityRulesNotMatch,
 				),
 			},
@@ -629,7 +629,7 @@ func TestRequiredAffinityMultipleNodes(t *testing.T) {
 				{ObjectMeta: metav1.ObjectMeta{Name: "nodeA", Labels: map[string]string{"zone": "az1", "hostname": "h1"}}},
 				{ObjectMeta: metav1.ObjectMeta{Name: "nodeB", Labels: map[string]string{"zone": "az2", "hostname": "h2"}}},
 			},
-			wantFilterStatuses: []*framework.Status{nil, nil},
+			wantFilterStatuses: []*fwk.Status{nil, nil},
 			name: "The affinity rule is to schedule all of the pods of this collection to the same zone. The first pod of the collection " +
 				"should not be blocked from being scheduled onto any node, even there's no existing pod that matches the rule anywhere.",
 		},
@@ -644,13 +644,13 @@ func TestRequiredAffinityMultipleNodes(t *testing.T) {
 				{ObjectMeta: metav1.ObjectMeta{Name: "nodeA", Labels: map[string]string{"zoneLabel": "az1", "hostname": "h1"}}},
 				{ObjectMeta: metav1.ObjectMeta{Name: "nodeB", Labels: map[string]string{"zoneLabel": "az2", "hostname": "h2"}}},
 			},
-			wantFilterStatuses: []*framework.Status{
-				framework.NewStatus(
-					framework.UnschedulableAndUnresolvable,
+			wantFilterStatuses: []*fwk.Status{
+				fwk.NewStatus(
+					fwk.UnschedulableAndUnresolvable,
 					ErrReasonAffinityRulesNotMatch,
 				),
-				framework.NewStatus(
-					framework.UnschedulableAndUnresolvable,
+				fwk.NewStatus(
+					fwk.UnschedulableAndUnresolvable,
 					ErrReasonAffinityRulesNotMatch,
 				),
 			},
@@ -665,13 +665,13 @@ func TestRequiredAffinityMultipleNodes(t *testing.T) {
 				{ObjectMeta: metav1.ObjectMeta{Name: "nodeA", Labels: map[string]string{"region": "r1", "hostname": "nodeA"}}},
 				{ObjectMeta: metav1.ObjectMeta{Name: "nodeB", Labels: map[string]string{"region": "r1", "hostname": "nodeB"}}},
 			},
-			wantFilterStatuses: []*framework.Status{
-				framework.NewStatus(
-					framework.Unschedulable,
+			wantFilterStatuses: []*fwk.Status{
+				fwk.NewStatus(
+					fwk.Unschedulable,
 					ErrReasonAntiAffinityRulesNotMatch,
 				),
-				framework.NewStatus(
-					framework.Unschedulable,
+				fwk.NewStatus(
+					fwk.Unschedulable,
 					ErrReasonAntiAffinityRulesNotMatch,
 				),
 			},
@@ -687,13 +687,13 @@ func TestRequiredAffinityMultipleNodes(t *testing.T) {
 				{ObjectMeta: metav1.ObjectMeta{Name: "nodeA", Labels: map[string]string{"region": "r1", "zone": "z1", "hostname": "nodeA"}}},
 				{ObjectMeta: metav1.ObjectMeta{Name: "nodeB", Labels: map[string]string{"region": "r1", "zone": "z2", "hostname": "nodeB"}}},
 			},
-			wantFilterStatuses: []*framework.Status{
-				framework.NewStatus(
-					framework.Unschedulable,
+			wantFilterStatuses: []*fwk.Status{
+				fwk.NewStatus(
+					fwk.Unschedulable,
 					ErrReasonAntiAffinityRulesNotMatch,
 				),
-				framework.NewStatus(
-					framework.Unschedulable,
+				fwk.NewStatus(
+					fwk.Unschedulable,
 					ErrReasonAntiAffinityRulesNotMatch,
 				),
 			},
@@ -709,13 +709,13 @@ func TestRequiredAffinityMultipleNodes(t *testing.T) {
 				{ObjectMeta: metav1.ObjectMeta{Name: "nodeB", Labels: labelRgChinaAzAz1}},
 				{ObjectMeta: metav1.ObjectMeta{Name: "nodeC", Labels: labelRgIndia}},
 			},
-			wantFilterStatuses: []*framework.Status{
-				framework.NewStatus(
-					framework.Unschedulable,
+			wantFilterStatuses: []*fwk.Status{
+				fwk.NewStatus(
+					fwk.Unschedulable,
 					ErrReasonAntiAffinityRulesNotMatch,
 				),
-				framework.NewStatus(
-					framework.Unschedulable,
+				fwk.NewStatus(
+					fwk.Unschedulable,
 					ErrReasonAntiAffinityRulesNotMatch,
 				),
 				nil,
@@ -733,13 +733,13 @@ func TestRequiredAffinityMultipleNodes(t *testing.T) {
 				{ObjectMeta: metav1.ObjectMeta{Name: "nodeB", Labels: labelRgChinaAzAz1}},
 				{ObjectMeta: metav1.ObjectMeta{Name: "nodeC", Labels: labelRgIndia}},
 			},
-			wantFilterStatuses: []*framework.Status{
-				framework.NewStatus(
-					framework.Unschedulable,
+			wantFilterStatuses: []*fwk.Status{
+				fwk.NewStatus(
+					fwk.Unschedulable,
 					ErrReasonAntiAffinityRulesNotMatch,
 				),
-				framework.NewStatus(
-					framework.Unschedulable,
+				fwk.NewStatus(
+					fwk.Unschedulable,
 					ErrReasonAntiAffinityRulesNotMatch,
 				),
 				nil,
@@ -755,8 +755,8 @@ func TestRequiredAffinityMultipleNodes(t *testing.T) {
 				{ObjectMeta: metav1.ObjectMeta{Name: "nodeA", Labels: map[string]string{"region": "r1", "zone": "z1", "hostname": "nodeA"}}},
 				{ObjectMeta: metav1.ObjectMeta{Name: "nodeB", Labels: map[string]string{"region": "r1", "zone": "z1", "hostname": "nodeB"}}},
 			},
-			wantPreFilterStatus: framework.NewStatus(framework.Skip),
-			wantFilterStatuses:  []*framework.Status{nil, nil},
+			wantPreFilterStatus: fwk.NewStatus(fwk.Skip),
+			wantFilterStatuses:  []*fwk.Status{nil, nil},
 			name:                "Test existing pod's anti-affinity: if an existing pod has a term with invalid topologyKey, labelSelector of the term is firstly checked, and then topologyKey of the term is also checked",
 		},
 		{
@@ -768,7 +768,7 @@ func TestRequiredAffinityMultipleNodes(t *testing.T) {
 				{ObjectMeta: metav1.ObjectMeta{Name: "nodeA", Labels: map[string]string{"region": "r1", "zone": "z1", "hostname": "nodeA"}}},
 				{ObjectMeta: metav1.ObjectMeta{Name: "nodeB", Labels: map[string]string{"region": "r1", "zone": "z1", "hostname": "nodeB"}}},
 			},
-			wantFilterStatuses: []*framework.Status{nil, nil},
+			wantFilterStatuses: []*fwk.Status{nil, nil},
 			name:               "Test incoming pod's anti-affinity: even if labelSelector matches, we still check if topologyKey matches",
 		},
 		{
@@ -781,13 +781,13 @@ func TestRequiredAffinityMultipleNodes(t *testing.T) {
 				{ObjectMeta: metav1.ObjectMeta{Name: "nodeA", Labels: map[string]string{"region": "r1", "zone": "z1", "hostname": "nodeA"}}},
 				{ObjectMeta: metav1.ObjectMeta{Name: "nodeB", Labels: map[string]string{"region": "r1", "zone": "z2", "hostname": "nodeB"}}},
 			},
-			wantFilterStatuses: []*framework.Status{
-				framework.NewStatus(
-					framework.Unschedulable,
+			wantFilterStatuses: []*fwk.Status{
+				fwk.NewStatus(
+					fwk.Unschedulable,
 					ErrReasonExistingAntiAffinityRulesNotMatch,
 				),
-				framework.NewStatus(
-					framework.Unschedulable,
+				fwk.NewStatus(
+					fwk.Unschedulable,
 					ErrReasonExistingAntiAffinityRulesNotMatch,
 				),
 			},
@@ -804,13 +804,13 @@ func TestRequiredAffinityMultipleNodes(t *testing.T) {
 				{ObjectMeta: metav1.ObjectMeta{Name: "nodeA", Labels: map[string]string{"region": "r1", "zone": "z1", "hostname": "nodeA"}}},
 				{ObjectMeta: metav1.ObjectMeta{Name: "nodeB", Labels: map[string]string{"region": "r1", "zone": "z2", "hostname": "nodeB"}}},
 			},
-			wantFilterStatuses: []*framework.Status{
-				framework.NewStatus(
-					framework.Unschedulable,
+			wantFilterStatuses: []*fwk.Status{
+				fwk.NewStatus(
+					fwk.Unschedulable,
 					ErrReasonAntiAffinityRulesNotMatch,
 				),
-				framework.NewStatus(
-					framework.Unschedulable,
+				fwk.NewStatus(
+					fwk.Unschedulable,
 					ErrReasonAntiAffinityRulesNotMatch,
 				),
 			},
@@ -826,9 +826,9 @@ func TestRequiredAffinityMultipleNodes(t *testing.T) {
 				{ObjectMeta: metav1.ObjectMeta{Name: "nodeA", Labels: map[string]string{"region": "r1", "zone": "z1", "hostname": "nodeA"}}},
 				{ObjectMeta: metav1.ObjectMeta{Name: "nodeB", Labels: map[string]string{"region": "r1", "zone": "z2", "hostname": "nodeB"}}},
 			},
-			wantFilterStatuses: []*framework.Status{
-				framework.NewStatus(
-					framework.Unschedulable,
+			wantFilterStatuses: []*fwk.Status{
+				fwk.NewStatus(
+					fwk.Unschedulable,
 					ErrReasonExistingAntiAffinityRulesNotMatch,
 				),
 				nil,
@@ -845,9 +845,9 @@ func TestRequiredAffinityMultipleNodes(t *testing.T) {
 				{ObjectMeta: metav1.ObjectMeta{Name: "nodeA", Labels: map[string]string{"region": "r1", "zone": "z1", "hostname": "nodeA"}}},
 				{ObjectMeta: metav1.ObjectMeta{Name: "nodeB", Labels: map[string]string{"region": "r1", "zone": "z2", "hostname": "nodeB"}}},
 			},
-			wantFilterStatuses: []*framework.Status{
-				framework.NewStatus(
-					framework.Unschedulable,
+			wantFilterStatuses: []*fwk.Status{
+				fwk.NewStatus(
+					fwk.Unschedulable,
 					ErrReasonAntiAffinityRulesNotMatch,
 				),
 				nil,
@@ -864,13 +864,13 @@ func TestRequiredAffinityMultipleNodes(t *testing.T) {
 				{ObjectMeta: metav1.ObjectMeta{Name: "nodeA", Labels: map[string]string{"region": "r1", "zone": "z1", "hostname": "nodeA"}}},
 				{ObjectMeta: metav1.ObjectMeta{Name: "nodeB", Labels: map[string]string{"region": "r1", "zone": "z2", "hostname": "nodeB"}}},
 			},
-			wantFilterStatuses: []*framework.Status{
-				framework.NewStatus(
-					framework.Unschedulable,
+			wantFilterStatuses: []*fwk.Status{
+				fwk.NewStatus(
+					fwk.Unschedulable,
 					ErrReasonExistingAntiAffinityRulesNotMatch,
 				),
-				framework.NewStatus(
-					framework.Unschedulable,
+				fwk.NewStatus(
+					fwk.Unschedulable,
 					ErrReasonExistingAntiAffinityRulesNotMatch,
 				),
 			},
@@ -886,13 +886,13 @@ func TestRequiredAffinityMultipleNodes(t *testing.T) {
 				{ObjectMeta: metav1.ObjectMeta{Name: "nodeA", Labels: map[string]string{"region": "r1", "zone": "z1", "hostname": "nodeA"}}},
 				{ObjectMeta: metav1.ObjectMeta{Name: "nodeB", Labels: map[string]string{"region": "r1", "zone": "z2", "hostname": "nodeB"}}},
 			},
-			wantFilterStatuses: []*framework.Status{
-				framework.NewStatus(
-					framework.Unschedulable,
+			wantFilterStatuses: []*fwk.Status{
+				fwk.NewStatus(
+					fwk.Unschedulable,
 					ErrReasonAntiAffinityRulesNotMatch,
 				),
-				framework.NewStatus(
-					framework.Unschedulable,
+				fwk.NewStatus(
+					fwk.Unschedulable,
 					ErrReasonAntiAffinityRulesNotMatch,
 				),
 			},
@@ -911,13 +911,13 @@ func TestRequiredAffinityMultipleNodes(t *testing.T) {
 				{ObjectMeta: metav1.ObjectMeta{Name: "nodeB", Labels: map[string]string{"region": "r1", "zone": "z2", "hostname": "nodeB"}}},
 				{ObjectMeta: metav1.ObjectMeta{Name: "nodeC", Labels: map[string]string{"region": "r1", "zone": "z3", "hostname": "nodeC"}}},
 			},
-			wantFilterStatuses: []*framework.Status{
-				framework.NewStatus(
-					framework.Unschedulable,
+			wantFilterStatuses: []*fwk.Status{
+				fwk.NewStatus(
+					fwk.Unschedulable,
 					ErrReasonExistingAntiAffinityRulesNotMatch,
 				),
-				framework.NewStatus(
-					framework.Unschedulable,
+				fwk.NewStatus(
+					fwk.Unschedulable,
 					ErrReasonExistingAntiAffinityRulesNotMatch,
 				),
 				nil,
@@ -934,7 +934,7 @@ func TestRequiredAffinityMultipleNodes(t *testing.T) {
 				{ObjectMeta: metav1.ObjectMeta{Name: "nodeA", Labels: map[string]string{"region": "r1", "zone": "z1", "hostname": "nodeA"}}},
 				{ObjectMeta: metav1.ObjectMeta{Name: "nodeB", Labels: map[string]string{"region": "r1", "zone": "z1", "hostname": "nodeB"}}},
 			},
-			wantFilterStatuses: []*framework.Status{nil, nil},
+			wantFilterStatuses: []*fwk.Status{nil, nil},
 			name:               "Test incoming pod's affinity: firstly check if all affinityTerms match, and then check if all topologyKeys match",
 		},
 		{
@@ -948,13 +948,13 @@ func TestRequiredAffinityMultipleNodes(t *testing.T) {
 				{ObjectMeta: metav1.ObjectMeta{Name: "nodeA", Labels: map[string]string{"region": "r1", "zone": "z1", "hostname": "nodeA"}}},
 				{ObjectMeta: metav1.ObjectMeta{Name: "nodeB", Labels: map[string]string{"region": "r1", "zone": "z2", "hostname": "nodeB"}}},
 			},
-			wantFilterStatuses: []*framework.Status{
-				framework.NewStatus(
-					framework.UnschedulableAndUnresolvable,
+			wantFilterStatuses: []*fwk.Status{
+				fwk.NewStatus(
+					fwk.UnschedulableAndUnresolvable,
 					ErrReasonAffinityRulesNotMatch,
 				),
-				framework.NewStatus(
-					framework.UnschedulableAndUnresolvable,
+				fwk.NewStatus(
+					fwk.UnschedulableAndUnresolvable,
 					ErrReasonAffinityRulesNotMatch,
 				),
 			},
@@ -1006,7 +1006,7 @@ func TestPreFilterDisabled(t *testing.T) {
 	p := plugintesting.SetupPluginWithInformers(ctx, t, schedruntime.FactoryAdapter(feature.Features{}, New), &config.InterPodAffinityArgs{}, cache.NewEmptySnapshot(), nil)
 	cycleState := framework.NewCycleState()
 	gotStatus := p.(framework.FilterPlugin).Filter(ctx, cycleState, pod, nodeInfo)
-	wantStatus := framework.AsStatus(fwk.ErrNotFound)
+	wantStatus := fwk.AsStatus(fwk.ErrNotFound)
 	if diff := cmp.Diff(gotStatus, wantStatus); diff != "" {
 		t.Errorf("Status does not match (-want,+got):\n%s", diff)
 	}

--- a/pkg/scheduler/framework/plugins/interpodaffinity/scoring_test.go
+++ b/pkg/scheduler/framework/plugins/interpodaffinity/scoring_test.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2/ktesting"
+	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 	"k8s.io/kubernetes/pkg/scheduler/backend/cache"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
@@ -380,7 +381,7 @@ func TestPreferredAffinity(t *testing.T) {
 		expectedList                       framework.NodeScoreList
 		name                               string
 		ignorePreferredTermsOfExistingPods bool
-		wantStatus                         *framework.Status
+		wantStatus                         *fwk.Status
 	}{
 		{
 			name: "all nodes are same priority as Affinity is nil",
@@ -390,7 +391,7 @@ func TestPreferredAffinity(t *testing.T) {
 				{ObjectMeta: metav1.ObjectMeta{Name: "node2", Labels: labelRgIndia}},
 				{ObjectMeta: metav1.ObjectMeta{Name: "node3", Labels: labelAzAz1}},
 			},
-			wantStatus: framework.NewStatus(framework.Skip),
+			wantStatus: fwk.NewStatus(fwk.Skip),
 		},
 		// the node(node1) that have the label {"region": "China"} (match the topology key) and that have existing pods that match the labelSelector get high score
 		// the node(node3) that don't have the label {"region": "whatever the value is"} (mismatch the topology key) but that have existing pods that match the labelSelector get low score
@@ -667,7 +668,7 @@ func TestPreferredAffinity(t *testing.T) {
 		{
 			name:       "invalid Affinity fails PreScore",
 			pod:        &v1.Pod{Spec: v1.PodSpec{NodeName: "", Affinity: invalidAffinityLabels}},
-			wantStatus: framework.NewStatus(framework.Error, `Invalid value: "{{.bad-value.}}"`),
+			wantStatus: fwk.NewStatus(fwk.Error, `Invalid value: "{{.bad-value.}}"`),
 			nodes: []*v1.Node{
 				{ObjectMeta: metav1.ObjectMeta{Name: "node1", Labels: labelRgChina}},
 				{ObjectMeta: metav1.ObjectMeta{Name: "node2", Labels: labelRgChina}},
@@ -676,7 +677,7 @@ func TestPreferredAffinity(t *testing.T) {
 		{
 			name:       "invalid AntiAffinity fails PreScore",
 			pod:        &v1.Pod{Spec: v1.PodSpec{NodeName: "", Affinity: invalidAntiAffinityLabels}},
-			wantStatus: framework.NewStatus(framework.Error, `Invalid value: "{{.bad-value.}}"`),
+			wantStatus: fwk.NewStatus(fwk.Error, `Invalid value: "{{.bad-value.}}"`),
 			nodes: []*v1.Node{
 				{ObjectMeta: metav1.ObjectMeta{Name: "node1", Labels: labelRgChina}},
 				{ObjectMeta: metav1.ObjectMeta{Name: "node2", Labels: labelRgChina}},
@@ -754,7 +755,7 @@ func TestPreferredAffinity(t *testing.T) {
 				{ObjectMeta: metav1.ObjectMeta{Name: "node2", Labels: labelRgIndia}},
 			},
 			expectedList:                       []framework.NodeScore{{Name: "node1", Score: 0}, {Name: "node2", Score: 0}},
-			wantStatus:                         framework.NewStatus(framework.Skip),
+			wantStatus:                         fwk.NewStatus(fwk.Skip),
 			ignorePreferredTermsOfExistingPods: true,
 		},
 		{
@@ -776,7 +777,7 @@ func TestPreferredAffinity(t *testing.T) {
 			pod:        &v1.Pod{Spec: v1.PodSpec{NodeName: ""}, ObjectMeta: metav1.ObjectMeta{Labels: podLabelSecurityS2}},
 			pods:       []*v1.Pod{},
 			nodes:      []*v1.Node{},
-			wantStatus: framework.NewStatus(framework.Skip),
+			wantStatus: fwk.NewStatus(fwk.Skip),
 		},
 	}
 	for _, test := range tests {
@@ -870,7 +871,7 @@ func TestPreferredAffinityWithHardPodAffinitySymmetricWeight(t *testing.T) {
 		hardPodAffinityWeight int32
 		expectedList          framework.NodeScoreList
 		name                  string
-		wantStatus            *framework.Status
+		wantStatus            *fwk.Status
 	}{
 		{
 			name: "with default weight",
@@ -900,7 +901,7 @@ func TestPreferredAffinityWithHardPodAffinitySymmetricWeight(t *testing.T) {
 				{ObjectMeta: metav1.ObjectMeta{Name: "node3", Labels: labelAzAz1}},
 			},
 			hardPodAffinityWeight: 0,
-			wantStatus:            framework.NewStatus(framework.Skip),
+			wantStatus:            fwk.NewStatus(fwk.Skip),
 		},
 		{
 			name: "with no matching namespace",
@@ -915,7 +916,7 @@ func TestPreferredAffinityWithHardPodAffinitySymmetricWeight(t *testing.T) {
 				{ObjectMeta: metav1.ObjectMeta{Name: "node3", Labels: labelAzAz1}},
 			},
 			hardPodAffinityWeight: v1.DefaultHardPodAffinitySymmetricWeight,
-			wantStatus:            framework.NewStatus(framework.Skip),
+			wantStatus:            fwk.NewStatus(fwk.Skip),
 		},
 		{
 			name: "with matching NamespaceSelector",

--- a/pkg/scheduler/framework/plugins/nodeaffinity/node_affinity_test.go
+++ b/pkg/scheduler/framework/plugins/nodeaffinity/node_affinity_test.go
@@ -44,8 +44,8 @@ func TestNodeAffinity(t *testing.T) {
 		pod                 *v1.Pod
 		labels              map[string]string
 		nodeName            string
-		wantStatus          *framework.Status
-		wantPreFilterStatus *framework.Status
+		wantStatus          *fwk.Status
+		wantPreFilterStatus *fwk.Status
 		wantPreFilterResult *framework.PreFilterResult
 		args                config.NodeAffinityArgs
 		runPreFilter        bool
@@ -55,7 +55,7 @@ func TestNodeAffinity(t *testing.T) {
 			pod: st.MakePod().NodeSelector(map[string]string{
 				"foo": "bar",
 			}).Obj(),
-			wantStatus:   framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReasonPod),
+			wantStatus:   fwk.NewStatus(fwk.UnschedulableAndUnresolvable, ErrReasonPod),
 			runPreFilter: true,
 		},
 		{
@@ -88,7 +88,7 @@ func TestNodeAffinity(t *testing.T) {
 			labels: map[string]string{
 				"foo": "bar",
 			},
-			wantStatus:   framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReasonPod),
+			wantStatus:   fwk.NewStatus(fwk.UnschedulableAndUnresolvable, ErrReasonPod),
 			runPreFilter: true,
 		},
 		{
@@ -229,7 +229,7 @@ func TestNodeAffinity(t *testing.T) {
 			labels: map[string]string{
 				"foo": "bar",
 			},
-			wantStatus:   framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReasonPod),
+			wantStatus:   fwk.NewStatus(fwk.UnschedulableAndUnresolvable, ErrReasonPod),
 			runPreFilter: true,
 		},
 		{
@@ -252,7 +252,7 @@ func TestNodeAffinity(t *testing.T) {
 			labels: map[string]string{
 				"foo": "bar",
 			},
-			wantStatus:   framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReasonPod),
+			wantStatus:   fwk.NewStatus(fwk.UnschedulableAndUnresolvable, ErrReasonPod),
 			runPreFilter: true,
 		},
 		{
@@ -261,7 +261,7 @@ func TestNodeAffinity(t *testing.T) {
 			labels: map[string]string{
 				"foo": "bar",
 			},
-			wantPreFilterStatus: framework.NewStatus(framework.Skip),
+			wantPreFilterStatus: fwk.NewStatus(fwk.Skip),
 			runPreFilter:        true,
 		},
 		{
@@ -278,7 +278,7 @@ func TestNodeAffinity(t *testing.T) {
 			labels: map[string]string{
 				"foo": "bar",
 			},
-			wantPreFilterStatus: framework.NewStatus(framework.Skip),
+			wantPreFilterStatus: fwk.NewStatus(fwk.Skip),
 			runPreFilter:        true,
 		},
 		{
@@ -341,7 +341,7 @@ func TestNodeAffinity(t *testing.T) {
 			labels: map[string]string{
 				"GPU": "NVIDIA-GRID-K1",
 			},
-			wantStatus:   framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReasonPod),
+			wantStatus:   fwk.NewStatus(fwk.UnschedulableAndUnresolvable, ErrReasonPod),
 			runPreFilter: true,
 		},
 		{
@@ -441,7 +441,7 @@ func TestNodeAffinity(t *testing.T) {
 			labels: map[string]string{
 				"foo": "barrrrrr",
 			},
-			wantStatus:   framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReasonPod),
+			wantStatus:   fwk.NewStatus(fwk.UnschedulableAndUnresolvable, ErrReasonPod),
 			runPreFilter: true,
 		},
 		{
@@ -470,7 +470,7 @@ func TestNodeAffinity(t *testing.T) {
 			labels: map[string]string{
 				"foo": "bar",
 			},
-			wantStatus:   framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReasonPod),
+			wantStatus:   fwk.NewStatus(fwk.UnschedulableAndUnresolvable, ErrReasonPod),
 			runPreFilter: true,
 		},
 		{
@@ -524,7 +524,7 @@ func TestNodeAffinity(t *testing.T) {
 				},
 			},
 			nodeName:            "node2",
-			wantStatus:          framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReasonPod),
+			wantStatus:          fwk.NewStatus(fwk.UnschedulableAndUnresolvable, ErrReasonPod),
 			wantPreFilterResult: &framework.PreFilterResult{NodeNames: sets.New("node1")},
 			runPreFilter:        true,
 		},
@@ -602,7 +602,7 @@ func TestNodeAffinity(t *testing.T) {
 			nodeName:            "node2",
 			labels:              map[string]string{"foo": "bar"},
 			wantPreFilterResult: &framework.PreFilterResult{NodeNames: sets.New("node1")},
-			wantStatus:          framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReasonPod),
+			wantStatus:          fwk.NewStatus(fwk.UnschedulableAndUnresolvable, ErrReasonPod),
 			runPreFilter:        true,
 		},
 		{
@@ -674,7 +674,7 @@ func TestNodeAffinity(t *testing.T) {
 			},
 			nodeName:     "node2",
 			labels:       map[string]string{"foo": "bar"},
-			wantStatus:   framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReasonPod),
+			wantStatus:   fwk.NewStatus(fwk.UnschedulableAndUnresolvable, ErrReasonPod),
 			runPreFilter: true,
 		},
 		{
@@ -743,8 +743,8 @@ func TestNodeAffinity(t *testing.T) {
 			},
 			nodeName:            "node2",
 			labels:              map[string]string{"foo": "bar"},
-			wantPreFilterStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, errReasonConflict),
-			wantStatus:          framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReasonPod),
+			wantPreFilterStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, errReasonConflict),
+			wantStatus:          fwk.NewStatus(fwk.UnschedulableAndUnresolvable, ErrReasonPod),
 			runPreFilter:        true,
 		},
 		{
@@ -825,7 +825,7 @@ func TestNodeAffinity(t *testing.T) {
 					},
 				},
 			},
-			wantStatus:   framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReasonPod),
+			wantStatus:   fwk.NewStatus(fwk.UnschedulableAndUnresolvable, ErrReasonPod),
 			runPreFilter: true,
 		},
 		{
@@ -848,7 +848,7 @@ func TestNodeAffinity(t *testing.T) {
 					},
 				},
 			},
-			wantStatus:   framework.NewStatus(framework.UnschedulableAndUnresolvable, errReasonEnforced),
+			wantStatus:   fwk.NewStatus(fwk.UnschedulableAndUnresolvable, errReasonEnforced),
 			runPreFilter: true,
 		},
 		{
@@ -915,7 +915,7 @@ func TestNodeAffinity(t *testing.T) {
 			}
 
 			state := framework.NewCycleState()
-			var gotStatus *framework.Status
+			var gotStatus *fwk.Status
 			if test.runPreFilter {
 				gotPreFilterResult, gotStatus := p.(framework.PreFilterPlugin).PreFilter(ctx, state, test.pod, nil)
 				if diff := cmp.Diff(test.wantPreFilterStatus, gotStatus); diff != "" {
@@ -1015,7 +1015,7 @@ func TestNodeAffinityPriority(t *testing.T) {
 		expectedList       framework.NodeScoreList
 		args               config.NodeAffinityArgs
 		runPreScore        bool
-		wantPreScoreStatus *framework.Status
+		wantPreScoreStatus *fwk.Status
 	}{
 		{
 			name: "all nodes are same priority as NodeAffinity is nil",
@@ -1043,7 +1043,7 @@ func TestNodeAffinityPriority(t *testing.T) {
 				{ObjectMeta: metav1.ObjectMeta{Name: "node1", Labels: label1}},
 			},
 			runPreScore:        true,
-			wantPreScoreStatus: framework.NewStatus(framework.Skip),
+			wantPreScoreStatus: fwk.NewStatus(fwk.Skip),
 		},
 		{
 			name: "PreScore returns error when an incoming Pod has a broken affinity",
@@ -1076,7 +1076,7 @@ func TestNodeAffinityPriority(t *testing.T) {
 				{ObjectMeta: metav1.ObjectMeta{Name: "node1", Labels: label1}},
 			},
 			runPreScore:        true,
-			wantPreScoreStatus: framework.AsStatus(fmt.Errorf(`[0].matchExpressions[0].key: Invalid value: "invalid key": name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')`)),
+			wantPreScoreStatus: fwk.AsStatus(fmt.Errorf(`[0].matchExpressions[0].key: Invalid value: "invalid key": name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')`)),
 		},
 		{
 			name: "no node matches preferred scheduling requirements in NodeAffinity of pod so all nodes' priority is zero",
@@ -1197,7 +1197,7 @@ func TestNodeAffinityPriority(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Creating plugin: %v", err)
 			}
-			var status *framework.Status
+			var status *fwk.Status
 			if test.runPreScore {
 				status = p.(framework.PreScorePlugin).PreScore(ctx, state, test.pod, tf.BuildNodeInfos(test.nodes))
 				if status.Code() != test.wantPreScoreStatus.Code() {

--- a/pkg/scheduler/framework/plugins/nodename/node_name.go
+++ b/pkg/scheduler/framework/plugins/nodename/node_name.go
@@ -69,10 +69,10 @@ func (pl *NodeName) Name() string {
 }
 
 // Filter invoked at the filter extension point.
-func (pl *NodeName) Filter(ctx context.Context, _ fwk.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) *framework.Status {
+func (pl *NodeName) Filter(ctx context.Context, _ fwk.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) *fwk.Status {
 
 	if !Fits(pod, nodeInfo) {
-		return framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReason)
+		return fwk.NewStatus(fwk.UnschedulableAndUnresolvable, ErrReason)
 	}
 	return nil
 }

--- a/pkg/scheduler/framework/plugins/nodename/node_name_test.go
+++ b/pkg/scheduler/framework/plugins/nodename/node_name_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	v1 "k8s.io/api/core/v1"
+	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/feature"
 	st "k8s.io/kubernetes/pkg/scheduler/testing"
@@ -33,7 +34,7 @@ func TestNodeName(t *testing.T) {
 		pod        *v1.Pod
 		node       *v1.Node
 		name       string
-		wantStatus *framework.Status
+		wantStatus *fwk.Status
 	}{
 		{
 			pod:  &v1.Pod{},
@@ -49,7 +50,7 @@ func TestNodeName(t *testing.T) {
 			pod:        st.MakePod().Node("bar").Obj(),
 			node:       st.MakeNode().Name("foo").Obj(),
 			name:       "host doesn't match",
-			wantStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReason),
+			wantStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, ErrReason),
 		},
 	}
 

--- a/pkg/scheduler/framework/plugins/nodeports/node_ports.go
+++ b/pkg/scheduler/framework/plugins/nodeports/node_ports.go
@@ -65,11 +65,11 @@ func (pl *NodePorts) Name() string {
 }
 
 // PreFilter invoked at the prefilter extension point.
-func (pl *NodePorts) PreFilter(ctx context.Context, cycleState fwk.CycleState, pod *v1.Pod, nodes []*framework.NodeInfo) (*framework.PreFilterResult, *framework.Status) {
+func (pl *NodePorts) PreFilter(ctx context.Context, cycleState fwk.CycleState, pod *v1.Pod, nodes []*framework.NodeInfo) (*framework.PreFilterResult, *fwk.Status) {
 	s := util.GetHostPorts(pod)
 	// Skip if a pod has no ports.
 	if len(s) == 0 {
-		return nil, framework.NewStatus(framework.Skip)
+		return nil, fwk.NewStatus(fwk.Skip)
 	}
 	cycleState.Write(preFilterStateKey, preFilterState(s))
 	return nil, nil
@@ -154,15 +154,15 @@ func (pl *NodePorts) isSchedulableAfterPodDeleted(logger klog.Logger, pod *v1.Po
 }
 
 // Filter invoked at the filter extension point.
-func (pl *NodePorts) Filter(ctx context.Context, cycleState fwk.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) *framework.Status {
+func (pl *NodePorts) Filter(ctx context.Context, cycleState fwk.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) *fwk.Status {
 	wantPorts, err := getPreFilterState(cycleState)
 	if err != nil {
-		return framework.AsStatus(err)
+		return fwk.AsStatus(err)
 	}
 
 	fits := fitsPorts(wantPorts, nodeInfo)
 	if !fits {
-		return framework.NewStatus(framework.Unschedulable, ErrReason)
+		return fwk.NewStatus(fwk.Unschedulable, ErrReason)
 	}
 
 	return nil

--- a/pkg/scheduler/framework/plugins/nodeports/node_ports_test.go
+++ b/pkg/scheduler/framework/plugins/nodeports/node_ports_test.go
@@ -53,14 +53,14 @@ func TestNodePorts(t *testing.T) {
 		pod                 *v1.Pod
 		nodeInfo            *framework.NodeInfo
 		name                string
-		wantPreFilterStatus *framework.Status
-		wantFilterStatus    *framework.Status
+		wantPreFilterStatus *fwk.Status
+		wantFilterStatus    *fwk.Status
 	}{
 		{
 			pod:                 &v1.Pod{},
 			nodeInfo:            framework.NewNodeInfo(),
 			name:                "skip filter",
-			wantPreFilterStatus: framework.NewStatus(framework.Skip),
+			wantPreFilterStatus: fwk.NewStatus(fwk.Skip),
 		},
 		{
 			pod: newPod("m1", "UDP/127.0.0.1/8080"),
@@ -73,14 +73,14 @@ func TestNodePorts(t *testing.T) {
 			nodeInfo: framework.NewNodeInfo(
 				newPod("m1", "UDP/127.0.0.1/8080")),
 			name:             "same udp port",
-			wantFilterStatus: framework.NewStatus(framework.Unschedulable, ErrReason),
+			wantFilterStatus: fwk.NewStatus(fwk.Unschedulable, ErrReason),
 		},
 		{
 			pod: newPod("m1", "TCP/127.0.0.1/8080"),
 			nodeInfo: framework.NewNodeInfo(
 				newPod("m1", "TCP/127.0.0.1/8080")),
 			name:             "same tcp port",
-			wantFilterStatus: framework.NewStatus(framework.Unschedulable, ErrReason),
+			wantFilterStatus: fwk.NewStatus(fwk.Unschedulable, ErrReason),
 		},
 		{
 			pod: newPod("m1", "TCP/127.0.0.1/8080"),
@@ -99,35 +99,35 @@ func TestNodePorts(t *testing.T) {
 			nodeInfo: framework.NewNodeInfo(
 				newPod("m1", "UDP/127.0.0.1/8080")),
 			name:             "second udp port conflict",
-			wantFilterStatus: framework.NewStatus(framework.Unschedulable, ErrReason),
+			wantFilterStatus: fwk.NewStatus(fwk.Unschedulable, ErrReason),
 		},
 		{
 			pod: newPod("m1", "TCP/127.0.0.1/8001", "UDP/127.0.0.1/8080"),
 			nodeInfo: framework.NewNodeInfo(
 				newPod("m1", "TCP/127.0.0.1/8001", "UDP/127.0.0.1/8081")),
 			name:             "first tcp port conflict",
-			wantFilterStatus: framework.NewStatus(framework.Unschedulable, ErrReason),
+			wantFilterStatus: fwk.NewStatus(fwk.Unschedulable, ErrReason),
 		},
 		{
 			pod: newPod("m1", "TCP/0.0.0.0/8001"),
 			nodeInfo: framework.NewNodeInfo(
 				newPod("m1", "TCP/127.0.0.1/8001")),
 			name:             "first tcp port conflict due to 0.0.0.0 hostIP",
-			wantFilterStatus: framework.NewStatus(framework.Unschedulable, ErrReason),
+			wantFilterStatus: fwk.NewStatus(fwk.Unschedulable, ErrReason),
 		},
 		{
 			pod: newPod("m1", "TCP/10.0.10.10/8001", "TCP/0.0.0.0/8001"),
 			nodeInfo: framework.NewNodeInfo(
 				newPod("m1", "TCP/127.0.0.1/8001")),
 			name:             "TCP hostPort conflict due to 0.0.0.0 hostIP",
-			wantFilterStatus: framework.NewStatus(framework.Unschedulable, ErrReason),
+			wantFilterStatus: fwk.NewStatus(fwk.Unschedulable, ErrReason),
 		},
 		{
 			pod: newPod("m1", "TCP/127.0.0.1/8001"),
 			nodeInfo: framework.NewNodeInfo(
 				newPod("m1", "TCP/0.0.0.0/8001")),
 			name:             "second tcp port conflict to 0.0.0.0 hostIP",
-			wantFilterStatus: framework.NewStatus(framework.Unschedulable, ErrReason),
+			wantFilterStatus: fwk.NewStatus(fwk.Unschedulable, ErrReason),
 		},
 		{
 			pod: newPod("m1", "UDP/127.0.0.1/8001"),
@@ -140,7 +140,7 @@ func TestNodePorts(t *testing.T) {
 			nodeInfo: framework.NewNodeInfo(
 				newPod("m1", "TCP/0.0.0.0/8001", "UDP/0.0.0.0/8001")),
 			name:             "UDP hostPort conflict due to 0.0.0.0 hostIP",
-			wantFilterStatus: framework.NewStatus(framework.Unschedulable, ErrReason),
+			wantFilterStatus: fwk.NewStatus(fwk.Unschedulable, ErrReason),
 		},
 		{
 			pod: st.MakePod().
@@ -154,7 +154,7 @@ func TestNodePorts(t *testing.T) {
 			nodeInfo: framework.NewNodeInfo(
 				newPod("m1", "TCP/0.0.0.0/8001")),
 			name:                "non-sidecar initContainer using hostPort",
-			wantPreFilterStatus: framework.NewStatus(framework.Skip),
+			wantPreFilterStatus: fwk.NewStatus(fwk.Skip),
 		},
 		{
 			pod: st.MakePod().
@@ -168,7 +168,7 @@ func TestNodePorts(t *testing.T) {
 			nodeInfo: framework.NewNodeInfo(
 				newPod("m1", "TCP/0.0.0.0/8001")),
 			name:             "TCP hostPort conflict from sidecar initContainer",
-			wantFilterStatus: framework.NewStatus(framework.Unschedulable, ErrReason),
+			wantFilterStatus: fwk.NewStatus(fwk.Unschedulable, ErrReason),
 		},
 	}
 
@@ -210,7 +210,7 @@ func TestPreFilterDisabled(t *testing.T) {
 	}
 	cycleState := framework.NewCycleState()
 	gotStatus := p.(framework.FilterPlugin).Filter(ctx, cycleState, pod, nodeInfo)
-	wantStatus := framework.AsStatus(fwk.ErrNotFound)
+	wantStatus := fwk.AsStatus(fwk.ErrNotFound)
 	if diff := cmp.Diff(wantStatus, gotStatus); diff != "" {
 		t.Errorf("status does not match (-want,+got):\n%s", diff)
 	}

--- a/pkg/scheduler/framework/plugins/noderesources/balanced_allocation.go
+++ b/pkg/scheduler/framework/plugins/noderesources/balanced_allocation.go
@@ -63,13 +63,13 @@ func (s *balancedAllocationPreScoreState) Clone() fwk.StateData {
 }
 
 // PreScore calculates incoming pod's resource requests and writes them to the cycle state used.
-func (ba *BalancedAllocation) PreScore(ctx context.Context, cycleState fwk.CycleState, pod *v1.Pod, nodes []*framework.NodeInfo) *framework.Status {
+func (ba *BalancedAllocation) PreScore(ctx context.Context, cycleState fwk.CycleState, pod *v1.Pod, nodes []*framework.NodeInfo) *fwk.Status {
 	podRequests := ba.calculatePodResourceRequestList(pod, ba.resources)
 	if ba.isBestEffortPod(podRequests) {
 		// Skip BalancedAllocation scoring for best-effort pods to
 		// prevent a large number of pods from being scheduled to the same node.
 		// See https://github.com/kubernetes/kubernetes/issues/129138 for details.
-		return framework.NewStatus(framework.Skip)
+		return fwk.NewStatus(fwk.Skip)
 	}
 	state := &balancedAllocationPreScoreState{
 		podRequests: podRequests,
@@ -97,7 +97,7 @@ func (ba *BalancedAllocation) Name() string {
 }
 
 // Score invoked at the score extension point.
-func (ba *BalancedAllocation) Score(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) (int64, *framework.Status) {
+func (ba *BalancedAllocation) Score(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) (int64, *fwk.Status) {
 	s, err := getBalancedAllocationPreScoreState(state)
 	if err != nil {
 		s = &balancedAllocationPreScoreState{podRequests: ba.calculatePodResourceRequestList(pod, ba.resources)}

--- a/pkg/scheduler/framework/plugins/noderesources/balanced_allocation_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/balanced_allocation_test.go
@@ -24,6 +24,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/klog/v2/ktesting"
+	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 	"k8s.io/kubernetes/pkg/scheduler/backend/cache"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
@@ -117,7 +118,7 @@ func TestNodeResourcesBalancedAllocation(t *testing.T) {
 		name                   string
 		args                   config.NodeResourcesBalancedAllocationArgs
 		runPreScore            bool
-		wantPreScoreStatusCode framework.Code
+		wantPreScoreStatusCode fwk.Code
 	}{
 		{
 			// bestEffort pods, skip in PreScore
@@ -126,7 +127,7 @@ func TestNodeResourcesBalancedAllocation(t *testing.T) {
 			name:                   "nothing scheduled, nothing requested, skip in PreScore",
 			args:                   config.NodeResourcesBalancedAllocationArgs{Resources: defaultResourceBalancedAllocationSet},
 			runPreScore:            true,
-			wantPreScoreStatusCode: framework.Skip,
+			wantPreScoreStatusCode: fwk.Skip,
 		},
 		{
 			// Node1 scores on 0-MaxNodeScore scale
@@ -306,7 +307,7 @@ func TestNodeResourcesBalancedAllocation(t *testing.T) {
 				if status.Code() != test.wantPreScoreStatusCode {
 					t.Errorf("unexpected status code, want: %v, got: %v", test.wantPreScoreStatusCode, status.Code())
 				}
-				if status.Code() == framework.Skip {
+				if status.Code() == fwk.Skip {
 					t.Log("skipping score test as PreScore returned skip")
 					return
 				}

--- a/pkg/scheduler/framework/plugins/noderesources/fit_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/fit_test.go
@@ -136,7 +136,7 @@ func TestEnoughRequests(t *testing.T) {
 		args                      config.NodeResourcesFitArgs
 		podLevelResourcesEnabled  bool
 		wantInsufficientResources []InsufficientResource
-		wantStatus                *framework.Status
+		wantStatus                *fwk.Status
 	}{
 		{
 			pod: &v1.Pod{},
@@ -150,7 +150,7 @@ func TestEnoughRequests(t *testing.T) {
 			nodeInfo: framework.NewNodeInfo(
 				newResourcePod(framework.Resource{MilliCPU: 10, Memory: 20})),
 			name:       "too many resources fails",
-			wantStatus: framework.NewStatus(framework.Unschedulable, getErrReason(v1.ResourceCPU), getErrReason(v1.ResourceMemory)),
+			wantStatus: fwk.NewStatus(fwk.Unschedulable, getErrReason(v1.ResourceCPU), getErrReason(v1.ResourceMemory)),
 			wantInsufficientResources: []InsufficientResource{
 				{ResourceName: v1.ResourceCPU, Reason: getErrReason(v1.ResourceCPU), Requested: 1, Used: 10, Capacity: 10},
 				{ResourceName: v1.ResourceMemory, Reason: getErrReason(v1.ResourceMemory), Requested: 1, Used: 20, Capacity: 20},
@@ -161,7 +161,7 @@ func TestEnoughRequests(t *testing.T) {
 			nodeInfo: framework.NewNodeInfo(
 				newResourcePod(framework.Resource{MilliCPU: 8, Memory: 19})),
 			name:       "too many resources fails due to init container cpu",
-			wantStatus: framework.NewStatus(framework.Unschedulable, getErrReason(v1.ResourceCPU)),
+			wantStatus: fwk.NewStatus(fwk.Unschedulable, getErrReason(v1.ResourceCPU)),
 			wantInsufficientResources: []InsufficientResource{
 				{ResourceName: v1.ResourceCPU, Reason: getErrReason(v1.ResourceCPU), Requested: 3, Used: 8, Capacity: 10},
 			},
@@ -171,7 +171,7 @@ func TestEnoughRequests(t *testing.T) {
 			nodeInfo: framework.NewNodeInfo(
 				newResourcePod(framework.Resource{MilliCPU: 8, Memory: 19})),
 			name:       "too many resources fails due to highest init container cpu",
-			wantStatus: framework.NewStatus(framework.Unschedulable, getErrReason(v1.ResourceCPU)),
+			wantStatus: fwk.NewStatus(fwk.Unschedulable, getErrReason(v1.ResourceCPU)),
 			wantInsufficientResources: []InsufficientResource{
 				{ResourceName: v1.ResourceCPU, Reason: getErrReason(v1.ResourceCPU), Requested: 3, Used: 8, Capacity: 10},
 			},
@@ -181,7 +181,7 @@ func TestEnoughRequests(t *testing.T) {
 			nodeInfo: framework.NewNodeInfo(
 				newResourcePod(framework.Resource{MilliCPU: 9, Memory: 19})),
 			name:       "too many resources fails due to init container memory",
-			wantStatus: framework.NewStatus(framework.Unschedulable, getErrReason(v1.ResourceMemory)),
+			wantStatus: fwk.NewStatus(fwk.Unschedulable, getErrReason(v1.ResourceMemory)),
 			wantInsufficientResources: []InsufficientResource{
 				{ResourceName: v1.ResourceMemory, Reason: getErrReason(v1.ResourceMemory), Requested: 3, Used: 19, Capacity: 20},
 			},
@@ -191,7 +191,7 @@ func TestEnoughRequests(t *testing.T) {
 			nodeInfo: framework.NewNodeInfo(
 				newResourcePod(framework.Resource{MilliCPU: 9, Memory: 19})),
 			name:       "too many resources fails due to highest init container memory",
-			wantStatus: framework.NewStatus(framework.Unschedulable, getErrReason(v1.ResourceMemory)),
+			wantStatus: fwk.NewStatus(fwk.Unschedulable, getErrReason(v1.ResourceMemory)),
 			wantInsufficientResources: []InsufficientResource{
 				{ResourceName: v1.ResourceMemory, Reason: getErrReason(v1.ResourceMemory), Requested: 3, Used: 19, Capacity: 20},
 			},
@@ -222,7 +222,7 @@ func TestEnoughRequests(t *testing.T) {
 			nodeInfo: framework.NewNodeInfo(
 				newResourcePod(framework.Resource{MilliCPU: 9, Memory: 5})),
 			name:       "one resource memory fits",
-			wantStatus: framework.NewStatus(framework.Unschedulable, getErrReason(v1.ResourceCPU)),
+			wantStatus: fwk.NewStatus(fwk.Unschedulable, getErrReason(v1.ResourceCPU)),
 			wantInsufficientResources: []InsufficientResource{
 				{ResourceName: v1.ResourceCPU, Reason: getErrReason(v1.ResourceCPU), Requested: 2, Used: 9, Capacity: 10},
 			},
@@ -232,7 +232,7 @@ func TestEnoughRequests(t *testing.T) {
 			nodeInfo: framework.NewNodeInfo(
 				newResourcePod(framework.Resource{MilliCPU: 5, Memory: 19})),
 			name:       "one resource cpu fits",
-			wantStatus: framework.NewStatus(framework.Unschedulable, getErrReason(v1.ResourceMemory)),
+			wantStatus: fwk.NewStatus(fwk.Unschedulable, getErrReason(v1.ResourceMemory)),
 			wantInsufficientResources: []InsufficientResource{
 				{ResourceName: v1.ResourceMemory, Reason: getErrReason(v1.ResourceMemory), Requested: 2, Used: 19, Capacity: 20},
 			},
@@ -269,7 +269,7 @@ func TestEnoughRequests(t *testing.T) {
 			nodeInfo: framework.NewNodeInfo(
 				newResourcePod(framework.Resource{MilliCPU: 0, Memory: 0, ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 0}})),
 			name:       "extended resource capacity enforced",
-			wantStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, getErrReason(extendedResourceA)),
+			wantStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, getErrReason(extendedResourceA)),
 			wantInsufficientResources: []InsufficientResource{
 				{ResourceName: extendedResourceA, Reason: getErrReason(extendedResourceA), Requested: 10, Used: 0, Capacity: 5, Unresolvable: true},
 			},
@@ -280,7 +280,7 @@ func TestEnoughRequests(t *testing.T) {
 			nodeInfo: framework.NewNodeInfo(
 				newResourcePod(framework.Resource{MilliCPU: 0, Memory: 0, ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 0}})),
 			name:       "extended resource capacity enforced for init container",
-			wantStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, getErrReason(extendedResourceA)),
+			wantStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, getErrReason(extendedResourceA)),
 			wantInsufficientResources: []InsufficientResource{
 				{ResourceName: extendedResourceA, Reason: getErrReason(extendedResourceA), Requested: 10, Used: 0, Capacity: 5, Unresolvable: true},
 			},
@@ -291,7 +291,7 @@ func TestEnoughRequests(t *testing.T) {
 			nodeInfo: framework.NewNodeInfo(
 				newResourcePod(framework.Resource{MilliCPU: 0, Memory: 0, ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 5}})),
 			name:       "extended resource allocatable enforced",
-			wantStatus: framework.NewStatus(framework.Unschedulable, getErrReason(extendedResourceA)),
+			wantStatus: fwk.NewStatus(fwk.Unschedulable, getErrReason(extendedResourceA)),
 			wantInsufficientResources: []InsufficientResource{
 				{ResourceName: extendedResourceA, Reason: getErrReason(extendedResourceA), Requested: 1, Used: 5, Capacity: 5},
 			},
@@ -302,7 +302,7 @@ func TestEnoughRequests(t *testing.T) {
 			nodeInfo: framework.NewNodeInfo(
 				newResourcePod(framework.Resource{MilliCPU: 0, Memory: 0, ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 5}})),
 			name:       "extended resource allocatable enforced for init container",
-			wantStatus: framework.NewStatus(framework.Unschedulable, getErrReason(extendedResourceA)),
+			wantStatus: fwk.NewStatus(fwk.Unschedulable, getErrReason(extendedResourceA)),
 			wantInsufficientResources: []InsufficientResource{
 				{ResourceName: extendedResourceA, Reason: getErrReason(extendedResourceA), Requested: 1, Used: 5, Capacity: 5},
 			},
@@ -314,7 +314,7 @@ func TestEnoughRequests(t *testing.T) {
 			nodeInfo: framework.NewNodeInfo(
 				newResourcePod(framework.Resource{MilliCPU: 0, Memory: 0, ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 2}})),
 			name:       "extended resource allocatable enforced for multiple containers",
-			wantStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, getErrReason(extendedResourceA)),
+			wantStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, getErrReason(extendedResourceA)),
 			wantInsufficientResources: []InsufficientResource{
 				{ResourceName: extendedResourceA, Reason: getErrReason(extendedResourceA), Requested: 6, Used: 2, Capacity: 5, Unresolvable: true},
 			},
@@ -335,7 +335,7 @@ func TestEnoughRequests(t *testing.T) {
 			nodeInfo: framework.NewNodeInfo(
 				newResourcePod(framework.Resource{MilliCPU: 0, Memory: 0, ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 2}})),
 			name:       "extended resource allocatable enforced for multiple init containers",
-			wantStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, getErrReason(extendedResourceA)),
+			wantStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, getErrReason(extendedResourceA)),
 			wantInsufficientResources: []InsufficientResource{
 				{ResourceName: extendedResourceA, Reason: getErrReason(extendedResourceA), Requested: 6, Used: 2, Capacity: 5, Unresolvable: true},
 			},
@@ -346,7 +346,7 @@ func TestEnoughRequests(t *testing.T) {
 			nodeInfo: framework.NewNodeInfo(
 				newResourcePod(framework.Resource{MilliCPU: 0, Memory: 0})),
 			name:       "extended resource allocatable enforced for unknown resource",
-			wantStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, getErrReason(extendedResourceB)),
+			wantStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, getErrReason(extendedResourceB)),
 			wantInsufficientResources: []InsufficientResource{
 				{ResourceName: extendedResourceB, Reason: getErrReason(extendedResourceB), Requested: 1, Used: 0, Capacity: 0, Unresolvable: true},
 			},
@@ -357,7 +357,7 @@ func TestEnoughRequests(t *testing.T) {
 			nodeInfo: framework.NewNodeInfo(
 				newResourcePod(framework.Resource{MilliCPU: 0, Memory: 0})),
 			name:       "extended resource allocatable enforced for unknown resource for init container",
-			wantStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, getErrReason(extendedResourceB)),
+			wantStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, getErrReason(extendedResourceB)),
 			wantInsufficientResources: []InsufficientResource{
 				{ResourceName: extendedResourceB, Reason: getErrReason(extendedResourceB), Requested: 1, Used: 0, Capacity: 0, Unresolvable: true},
 			},
@@ -368,7 +368,7 @@ func TestEnoughRequests(t *testing.T) {
 			nodeInfo: framework.NewNodeInfo(
 				newResourcePod(framework.Resource{MilliCPU: 0, Memory: 0})),
 			name:       "kubernetes.io resource capacity enforced",
-			wantStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, getErrReason(kubernetesIOResourceA)),
+			wantStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, getErrReason(kubernetesIOResourceA)),
 			wantInsufficientResources: []InsufficientResource{
 				{ResourceName: kubernetesIOResourceA, Reason: getErrReason(kubernetesIOResourceA), Requested: 10, Used: 0, Capacity: 0, Unresolvable: true},
 			},
@@ -379,7 +379,7 @@ func TestEnoughRequests(t *testing.T) {
 			nodeInfo: framework.NewNodeInfo(
 				newResourcePod(framework.Resource{MilliCPU: 0, Memory: 0})),
 			name:       "kubernetes.io resource capacity enforced for init container",
-			wantStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, getErrReason(kubernetesIOResourceB)),
+			wantStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, getErrReason(kubernetesIOResourceB)),
 			wantInsufficientResources: []InsufficientResource{
 				{ResourceName: kubernetesIOResourceB, Reason: getErrReason(kubernetesIOResourceB), Requested: 10, Used: 0, Capacity: 0, Unresolvable: true},
 			},
@@ -390,7 +390,7 @@ func TestEnoughRequests(t *testing.T) {
 			nodeInfo: framework.NewNodeInfo(
 				newResourcePod(framework.Resource{MilliCPU: 0, Memory: 0, ScalarResources: map[v1.ResourceName]int64{hugePageResourceA: 0}})),
 			name:       "hugepages resource capacity enforced",
-			wantStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, getErrReason(hugePageResourceA)),
+			wantStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, getErrReason(hugePageResourceA)),
 			wantInsufficientResources: []InsufficientResource{
 				{ResourceName: hugePageResourceA, Reason: getErrReason(hugePageResourceA), Requested: 10, Used: 0, Capacity: 5, Unresolvable: true},
 			},
@@ -401,7 +401,7 @@ func TestEnoughRequests(t *testing.T) {
 			nodeInfo: framework.NewNodeInfo(
 				newResourcePod(framework.Resource{MilliCPU: 0, Memory: 0, ScalarResources: map[v1.ResourceName]int64{hugePageResourceA: 0}})),
 			name:       "hugepages resource capacity enforced for init container",
-			wantStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, getErrReason(hugePageResourceA)),
+			wantStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, getErrReason(hugePageResourceA)),
 			wantInsufficientResources: []InsufficientResource{
 				{ResourceName: hugePageResourceA, Reason: getErrReason(hugePageResourceA), Requested: 10, Used: 0, Capacity: 5, Unresolvable: true},
 			},
@@ -413,7 +413,7 @@ func TestEnoughRequests(t *testing.T) {
 			nodeInfo: framework.NewNodeInfo(
 				newResourcePod(framework.Resource{MilliCPU: 0, Memory: 0, ScalarResources: map[v1.ResourceName]int64{hugePageResourceA: 2}})),
 			name:       "hugepages resource allocatable enforced for multiple containers",
-			wantStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, getErrReason(hugePageResourceA)),
+			wantStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, getErrReason(hugePageResourceA)),
 			wantInsufficientResources: []InsufficientResource{
 				{ResourceName: hugePageResourceA, Reason: getErrReason(hugePageResourceA), Requested: 6, Used: 2, Capacity: 5, Unresolvable: true},
 			},
@@ -444,7 +444,7 @@ func TestEnoughRequests(t *testing.T) {
 			),
 			nodeInfo:   framework.NewNodeInfo(newResourcePod(framework.Resource{MilliCPU: 5, Memory: 5})),
 			name:       "requests + overhead does not fit for memory",
-			wantStatus: framework.NewStatus(framework.Unschedulable, getErrReason(v1.ResourceMemory)),
+			wantStatus: fwk.NewStatus(fwk.Unschedulable, getErrReason(v1.ResourceMemory)),
 			wantInsufficientResources: []InsufficientResource{
 				{ResourceName: v1.ResourceMemory, Reason: getErrReason(v1.ResourceMemory), Requested: 16, Used: 5, Capacity: 20},
 			},
@@ -463,7 +463,7 @@ func TestEnoughRequests(t *testing.T) {
 				IgnoredResourceGroups: []string{"example.com"},
 			},
 			name:       "skip checking ignored extended resource via resource groups",
-			wantStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, getErrReason(kubernetesIOResourceA)),
+			wantStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, getErrReason(kubernetesIOResourceA)),
 			wantInsufficientResources: []InsufficientResource{
 				{
 					ResourceName: kubernetesIOResourceA,
@@ -524,7 +524,7 @@ func TestEnoughRequests(t *testing.T) {
 			nodeInfo: framework.NewNodeInfo(
 				newResourcePod(framework.Resource{MilliCPU: 5, Memory: 5})),
 			name:       "pod-level cpu resource not fit",
-			wantStatus: framework.NewStatus(framework.Unschedulable, getErrReason(v1.ResourceCPU)),
+			wantStatus: fwk.NewStatus(fwk.Unschedulable, getErrReason(v1.ResourceCPU)),
 			wantInsufficientResources: []InsufficientResource{{
 				ResourceName: v1.ResourceCPU, Reason: getErrReason(v1.ResourceCPU), Requested: 7, Used: 5, Capacity: 10},
 			},
@@ -540,7 +540,7 @@ func TestEnoughRequests(t *testing.T) {
 			nodeInfo: framework.NewNodeInfo(
 				newResourcePod(framework.Resource{MilliCPU: 5, Memory: 19})),
 			name:       "pod-level memory resource not fit",
-			wantStatus: framework.NewStatus(framework.Unschedulable, getErrReason(v1.ResourceMemory)),
+			wantStatus: fwk.NewStatus(fwk.Unschedulable, getErrReason(v1.ResourceMemory)),
 			wantInsufficientResources: []InsufficientResource{{
 				ResourceName: v1.ResourceMemory, Reason: getErrReason(v1.ResourceMemory), Requested: 2, Used: 19, Capacity: 20},
 			},
@@ -579,7 +579,7 @@ func TestEnoughRequests(t *testing.T) {
 			),
 			nodeInfo:   framework.NewNodeInfo(),
 			name:       "pod-level hugepages resource not fit",
-			wantStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, getErrReason(hugePageResourceA)),
+			wantStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, getErrReason(hugePageResourceA)),
 			wantInsufficientResources: []InsufficientResource{
 				{ResourceName: hugePageResourceA, Reason: getErrReason(hugePageResourceA), Requested: 10, Used: 0, Capacity: 5, Unresolvable: true},
 			},
@@ -597,7 +597,7 @@ func TestEnoughRequests(t *testing.T) {
 			nodeInfo: framework.NewNodeInfo(
 				newResourcePod(framework.Resource{MilliCPU: 5, Memory: 19})),
 			name:       "one pod-level cpu resource fits and all init and non-init containers resources fit",
-			wantStatus: framework.NewStatus(framework.Unschedulable, getErrReason(v1.ResourceMemory)),
+			wantStatus: fwk.NewStatus(fwk.Unschedulable, getErrReason(v1.ResourceMemory)),
 			wantInsufficientResources: []InsufficientResource{{
 				ResourceName: v1.ResourceMemory, Reason: getErrReason(v1.ResourceMemory), Requested: 2, Used: 19, Capacity: 20},
 			},
@@ -654,7 +654,7 @@ func TestPreFilterDisabled(t *testing.T) {
 	}
 	cycleState := framework.NewCycleState()
 	gotStatus := p.(framework.FilterPlugin).Filter(ctx, cycleState, pod, nodeInfo)
-	wantStatus := framework.AsStatus(fwk.ErrNotFound)
+	wantStatus := fwk.AsStatus(fwk.ErrNotFound)
 	if diff := cmp.Diff(wantStatus, gotStatus); diff != "" {
 		t.Errorf("status does not match (-want,+got):\n%s", diff)
 	}
@@ -666,31 +666,31 @@ func TestNotEnoughRequests(t *testing.T) {
 		nodeInfo   *framework.NodeInfo
 		fits       bool
 		name       string
-		wantStatus *framework.Status
+		wantStatus *fwk.Status
 	}{
 		{
 			pod:        &v1.Pod{},
 			nodeInfo:   framework.NewNodeInfo(newResourcePod(framework.Resource{MilliCPU: 10, Memory: 20})),
 			name:       "even without specified resources, predicate fails when there's no space for additional pod",
-			wantStatus: framework.NewStatus(framework.Unschedulable, "Too many pods"),
+			wantStatus: fwk.NewStatus(fwk.Unschedulable, "Too many pods"),
 		},
 		{
 			pod:        newResourcePod(framework.Resource{MilliCPU: 1, Memory: 1}),
 			nodeInfo:   framework.NewNodeInfo(newResourcePod(framework.Resource{MilliCPU: 5, Memory: 5})),
 			name:       "even if both resources fit, predicate fails when there's no space for additional pod",
-			wantStatus: framework.NewStatus(framework.Unschedulable, "Too many pods"),
+			wantStatus: fwk.NewStatus(fwk.Unschedulable, "Too many pods"),
 		},
 		{
 			pod:        newResourcePod(framework.Resource{MilliCPU: 5, Memory: 1}),
 			nodeInfo:   framework.NewNodeInfo(newResourcePod(framework.Resource{MilliCPU: 5, Memory: 19})),
 			name:       "even for equal edge case, predicate fails when there's no space for additional pod",
-			wantStatus: framework.NewStatus(framework.Unschedulable, "Too many pods"),
+			wantStatus: fwk.NewStatus(fwk.Unschedulable, "Too many pods"),
 		},
 		{
 			pod:        newResourceInitPod(newResourcePod(framework.Resource{MilliCPU: 5, Memory: 1}), framework.Resource{MilliCPU: 5, Memory: 1}),
 			nodeInfo:   framework.NewNodeInfo(newResourcePod(framework.Resource{MilliCPU: 5, Memory: 19})),
 			name:       "even for equal edge case, predicate fails when there's no space for additional pod due to init container",
-			wantStatus: framework.NewStatus(framework.Unschedulable, "Too many pods"),
+			wantStatus: fwk.NewStatus(fwk.Unschedulable, "Too many pods"),
 		},
 	}
 	for _, test := range notEnoughPodsTests {
@@ -725,7 +725,7 @@ func TestStorageRequests(t *testing.T) {
 		pod        *v1.Pod
 		nodeInfo   *framework.NodeInfo
 		name       string
-		wantStatus *framework.Status
+		wantStatus *fwk.Status
 	}{
 		{
 			pod: newResourcePod(framework.Resource{MilliCPU: 1, Memory: 1}),
@@ -738,7 +738,7 @@ func TestStorageRequests(t *testing.T) {
 			nodeInfo: framework.NewNodeInfo(
 				newResourcePod(framework.Resource{MilliCPU: 2, Memory: 2})),
 			name:       "storage ephemeral local storage request exceeds allocatable",
-			wantStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, getErrReason(v1.ResourceEphemeralStorage)),
+			wantStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, getErrReason(v1.ResourceEphemeralStorage)),
 		},
 		{
 			pod: newResourceInitPod(newResourcePod(framework.Resource{EphemeralStorage: 5})),
@@ -822,8 +822,8 @@ func TestRestartableInitContainers(t *testing.T) {
 		name                    string
 		pod                     *v1.Pod
 		enableSidecarContainers bool
-		wantPreFilterStatus     *framework.Status
-		wantFilterStatus        *framework.Status
+		wantPreFilterStatus     *fwk.Status
+		wantFilterStatus        *fwk.Status
 	}{
 		{
 			name: "allow pod without restartable init containers if sidecar containers is disabled",
@@ -832,7 +832,7 @@ func TestRestartableInitContainers(t *testing.T) {
 		{
 			name:                "not allow pod with restartable init containers if sidecar containers is disabled",
 			pod:                 newPodWithRestartableInitContainers(nil, nil),
-			wantPreFilterStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, "Pod has a restartable init container and the SidecarContainers feature is disabled"),
+			wantPreFilterStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "Pod has a restartable init container and the SidecarContainers feature is disabled"),
 		},
 		{
 			name:                    "allow pod without restartable init containers if sidecar containers is enabled",
@@ -859,7 +859,7 @@ func TestRestartableInitContainers(t *testing.T) {
 				&v1.ResourceList{v1.ResourceCPU: *resource.NewMilliQuantity(1, resource.DecimalSI)},
 				&v1.ResourceList{v1.ResourceCPU: *resource.NewMilliQuantity(2, resource.DecimalSI)},
 			),
-			wantFilterStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, getErrReason(v1.ResourceCPU)),
+			wantFilterStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, getErrReason(v1.ResourceCPU)),
 		},
 	}
 

--- a/pkg/scheduler/framework/plugins/noderesources/least_allocated_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/least_allocated_test.go
@@ -25,6 +25,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/klog/v2/ktesting"
+	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 	"k8s.io/kubernetes/pkg/scheduler/backend/cache"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
@@ -43,7 +44,7 @@ func TestLeastAllocatedScoringStrategy(t *testing.T) {
 		expectedScores framework.NodeScoreList
 		resources      []config.ResourceSpec
 		wantErrs       field.ErrorList
-		wantStatusCode framework.Code
+		wantStatusCode fwk.Code
 	}{
 		{
 			// Node1 scores (remaining resources) on 0-MaxNodeScore scale
@@ -99,7 +100,7 @@ func TestLeastAllocatedScoringStrategy(t *testing.T) {
 			existingPods:   nil,
 			expectedScores: []framework.NodeScore{{Name: "node1", Score: framework.MinNodeScore}, {Name: "node2", Score: framework.MinNodeScore}},
 			resources:      nil,
-			wantStatusCode: framework.Error,
+			wantStatusCode: fwk.Error,
 		},
 		{
 			// Node1 scores on 0-MaxNodeScore scale

--- a/pkg/scheduler/framework/plugins/noderesources/most_allocated_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/most_allocated_test.go
@@ -25,6 +25,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/klog/v2/ktesting"
+	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 	"k8s.io/kubernetes/pkg/scheduler/backend/cache"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
@@ -43,7 +44,7 @@ func TestMostAllocatedScoringStrategy(t *testing.T) {
 		expectedScores framework.NodeScoreList
 		resources      []config.ResourceSpec
 		wantErrs       field.ErrorList
-		wantStatusCode framework.Code
+		wantStatusCode fwk.Code
 	}{
 		{
 			// Node1 scores (used resources) on 0-MaxNodeScore scale
@@ -99,7 +100,7 @@ func TestMostAllocatedScoringStrategy(t *testing.T) {
 			existingPods:   nil,
 			expectedScores: []framework.NodeScore{{Name: "node1", Score: framework.MinNodeScore}, {Name: "node2", Score: framework.MinNodeScore}},
 			resources:      nil,
-			wantStatusCode: framework.Error,
+			wantStatusCode: fwk.Error,
 		},
 		{
 			// Node1 scores on 0-MaxNodeScore scale

--- a/pkg/scheduler/framework/plugins/noderesources/resource_allocation.go
+++ b/pkg/scheduler/framework/plugins/noderesources/resource_allocation.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/klog/v2"
 
 	resourcehelper "k8s.io/component-helpers/resource"
+	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	schedutil "k8s.io/kubernetes/pkg/scheduler/util"
@@ -49,13 +50,13 @@ func (r *resourceAllocationScorer) score(
 	ctx context.Context,
 	pod *v1.Pod,
 	nodeInfo *framework.NodeInfo,
-	podRequests []int64) (int64, *framework.Status) {
+	podRequests []int64) (int64, *fwk.Status) {
 	logger := klog.FromContext(ctx)
 	node := nodeInfo.Node()
 
 	// resources not set, nothing scheduled,
 	if len(r.resources) == 0 {
-		return 0, framework.NewStatus(framework.Error, "resources not found")
+		return 0, fwk.NewStatus(fwk.Error, "resources not found")
 	}
 
 	requested := make([]int64, len(r.resources))

--- a/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable.go
+++ b/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable.go
@@ -130,7 +130,7 @@ func (pl *NodeUnschedulable) Name() string {
 }
 
 // Filter invoked at the filter extension point.
-func (pl *NodeUnschedulable) Filter(ctx context.Context, _ fwk.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) *framework.Status {
+func (pl *NodeUnschedulable) Filter(ctx context.Context, _ fwk.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) *fwk.Status {
 	node := nodeInfo.Node()
 
 	if !node.Spec.Unschedulable {
@@ -143,7 +143,7 @@ func (pl *NodeUnschedulable) Filter(ctx context.Context, _ fwk.CycleState, pod *
 		Effect: v1.TaintEffectNoSchedule,
 	})
 	if !podToleratesUnschedulable {
-		return framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReasonUnschedulable)
+		return fwk.NewStatus(fwk.UnschedulableAndUnresolvable, ErrReasonUnschedulable)
 	}
 
 	return nil

--- a/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable_test.go
+++ b/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable_test.go
@@ -34,7 +34,7 @@ func TestNodeUnschedulable(t *testing.T) {
 		name       string
 		pod        *v1.Pod
 		node       *v1.Node
-		wantStatus *framework.Status
+		wantStatus *fwk.Status
 	}{
 		{
 			name: "Does not schedule pod to unschedulable node (node.Spec.Unschedulable==true)",
@@ -44,7 +44,7 @@ func TestNodeUnschedulable(t *testing.T) {
 					Unschedulable: true,
 				},
 			},
-			wantStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReasonUnschedulable),
+			wantStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, ErrReasonUnschedulable),
 		},
 		{
 			name: "Schedule pod to normal node",

--- a/pkg/scheduler/framework/plugins/nodevolumelimits/csi_test.go
+++ b/pkg/scheduler/framework/plugins/nodevolumelimits/csi_test.go
@@ -51,11 +51,11 @@ var (
 )
 
 var statusCmpOpts = []cmp.Option{
-	cmp.Comparer(func(s1 *framework.Status, s2 *framework.Status) bool {
+	cmp.Comparer(func(s1 *fwk.Status, s2 *fwk.Status) bool {
 		if s1 == nil || s2 == nil {
 			return s1.IsSuccess() && s2.IsSuccess()
 		}
-		if s1.Code() == framework.Error {
+		if s1.Code() == fwk.Error {
 			return s1.AsError().Error() == s2.AsError().Error()
 		}
 		return s1.Code() == s2.Code() && s1.Plugin() == s2.Plugin() && s1.Message() == s2.Message()
@@ -283,8 +283,8 @@ func TestCSILimits(t *testing.T) {
 		migrationEnabled    bool
 		ephemeralEnabled    bool
 		limitSource         string
-		wantStatus          *framework.Status
-		wantPreFilterStatus *framework.Status
+		wantStatus          *fwk.Status
+		wantPreFilterStatus *fwk.Status
 	}{
 		{
 			newPod:       csiEBSOneVolPod,
@@ -295,7 +295,7 @@ func TestCSILimits(t *testing.T) {
 			vaCount:      2,
 			test:         "should count VolumeAttachments towards volume limit when no pods exist",
 			limitSource:  "csinode",
-			wantStatus:   framework.NewStatus(framework.Unschedulable, ErrReasonMaxVolumeCountExceeded),
+			wantStatus:   fwk.NewStatus(fwk.Unschedulable, ErrReasonMaxVolumeCountExceeded),
 		},
 		{
 			newPod:       csiEBSOneVolPod,
@@ -324,7 +324,7 @@ func TestCSILimits(t *testing.T) {
 			driverNames:  []string{ebsCSIDriverName},
 			test:         "doesn't when node volume limit <= pods CSI volume",
 			limitSource:  "csinode",
-			wantStatus:   framework.NewStatus(framework.Unschedulable, ErrReasonMaxVolumeCountExceeded),
+			wantStatus:   fwk.NewStatus(fwk.Unschedulable, ErrReasonMaxVolumeCountExceeded),
 		},
 		{
 			newPod:       csiEBSOneVolPod,
@@ -344,7 +344,7 @@ func TestCSILimits(t *testing.T) {
 			driverNames:  []string{ebsCSIDriverName},
 			test:         "count pending PVCs towards volume limit <= pods CSI volume",
 			limitSource:  "csinode",
-			wantStatus:   framework.NewStatus(framework.Unschedulable, ErrReasonMaxVolumeCountExceeded),
+			wantStatus:   fwk.NewStatus(fwk.Unschedulable, ErrReasonMaxVolumeCountExceeded),
 		},
 		// two same pending PVCs should be counted as 1
 		{
@@ -365,7 +365,7 @@ func TestCSILimits(t *testing.T) {
 			driverNames:  []string{ebsCSIDriverName},
 			test:         "should count PVCs with invalid PV name but valid SC",
 			limitSource:  "csinode",
-			wantStatus:   framework.NewStatus(framework.Unschedulable, ErrReasonMaxVolumeCountExceeded),
+			wantStatus:   fwk.NewStatus(fwk.Unschedulable, ErrReasonMaxVolumeCountExceeded),
 		},
 		// don't count a volume which has storageclass missing
 		{
@@ -386,7 +386,7 @@ func TestCSILimits(t *testing.T) {
 			driverNames:  []string{ebsCSIDriverName, gceCSIDriverName},
 			test:         "count pvcs with the same type towards volume limit",
 			limitSource:  "csinode",
-			wantStatus:   framework.NewStatus(framework.Unschedulable, ErrReasonMaxVolumeCountExceeded),
+			wantStatus:   fwk.NewStatus(fwk.Unschedulable, ErrReasonMaxVolumeCountExceeded),
 		},
 		{
 			newPod:       gceTwoVolPod,
@@ -407,7 +407,7 @@ func TestCSILimits(t *testing.T) {
 			migrationEnabled: true,
 			limitSource:      "csinode",
 			test:             "should count in-tree volumes if migration is enabled",
-			wantStatus:       framework.NewStatus(framework.Unschedulable, ErrReasonMaxVolumeCountExceeded),
+			wantStatus:       fwk.NewStatus(fwk.Unschedulable, ErrReasonMaxVolumeCountExceeded),
 		},
 		{
 			newPod:           inTreeInlineVolPod,
@@ -426,7 +426,7 @@ func TestCSILimits(t *testing.T) {
 			migrationEnabled: true,
 			limitSource:      "csinode",
 			test:             "should count unbound in-tree volumes if migration is enabled",
-			wantStatus:       framework.NewStatus(framework.Unschedulable, ErrReasonMaxVolumeCountExceeded),
+			wantStatus:       fwk.NewStatus(fwk.Unschedulable, ErrReasonMaxVolumeCountExceeded),
 		},
 		{
 			newPod:           inTreeOneVolPod,
@@ -457,7 +457,7 @@ func TestCSILimits(t *testing.T) {
 			migrationEnabled: true,
 			limitSource:      "csinode",
 			test:             "should count in-tree inline volumes if migration is enabled",
-			wantStatus:       framework.NewStatus(framework.Unschedulable, ErrReasonMaxVolumeCountExceeded),
+			wantStatus:       fwk.NewStatus(fwk.Unschedulable, ErrReasonMaxVolumeCountExceeded),
 		},
 		// mixed volumes
 		{
@@ -469,7 +469,7 @@ func TestCSILimits(t *testing.T) {
 			migrationEnabled: true,
 			limitSource:      "csinode",
 			test:             "should count in-tree and csi volumes if migration is enabled (when scheduling in-tree volumes)",
-			wantStatus:       framework.NewStatus(framework.Unschedulable, ErrReasonMaxVolumeCountExceeded),
+			wantStatus:       fwk.NewStatus(fwk.Unschedulable, ErrReasonMaxVolumeCountExceeded),
 		},
 		{
 			newPod:           inTreeInlineVolPod,
@@ -480,7 +480,7 @@ func TestCSILimits(t *testing.T) {
 			migrationEnabled: true,
 			limitSource:      "csinode",
 			test:             "should count in-tree, inline and csi volumes if migration is enabled (when scheduling in-tree volumes)",
-			wantStatus:       framework.NewStatus(framework.Unschedulable, ErrReasonMaxVolumeCountExceeded),
+			wantStatus:       fwk.NewStatus(fwk.Unschedulable, ErrReasonMaxVolumeCountExceeded),
 		},
 		{
 			newPod:           inTreeInlineVolPodWithSameCSIVolumeID,
@@ -501,7 +501,7 @@ func TestCSILimits(t *testing.T) {
 			migrationEnabled: true,
 			limitSource:      "csinode",
 			test:             "should count in-tree and csi volumes if migration is enabled (when scheduling csi volumes)",
-			wantStatus:       framework.NewStatus(framework.Unschedulable, ErrReasonMaxVolumeCountExceeded),
+			wantStatus:       fwk.NewStatus(fwk.Unschedulable, ErrReasonMaxVolumeCountExceeded),
 		},
 		// ephemeral volumes
 		{
@@ -511,7 +511,7 @@ func TestCSILimits(t *testing.T) {
 			driverNames:      []string{ebsCSIDriverName},
 			limitSource:      "csinode-with-no-limit",
 			test:             "ephemeral volume missing",
-			wantStatus:       framework.NewStatus(framework.UnschedulableAndUnresolvable, `looking up PVC test/abc-xyz: persistentvolumeclaims "abc-xyz" not found`),
+			wantStatus:       fwk.NewStatus(fwk.UnschedulableAndUnresolvable, `looking up PVC test/abc-xyz: persistentvolumeclaims "abc-xyz" not found`),
 		},
 		{
 			newPod:           ephemeralVolumePod,
@@ -521,7 +521,7 @@ func TestCSILimits(t *testing.T) {
 			driverNames:      []string{ebsCSIDriverName},
 			limitSource:      "csinode-with-no-limit",
 			test:             "ephemeral volume not owned",
-			wantStatus:       framework.AsStatus(errors.New("PVC test/abc-xyz was not created for pod test/abc (pod is not owner)")),
+			wantStatus:       fwk.AsStatus(errors.New("PVC test/abc-xyz was not created for pod test/abc (pod is not owner)")),
 		},
 		{
 			newPod:           ephemeralVolumePod,
@@ -542,7 +542,7 @@ func TestCSILimits(t *testing.T) {
 			maxVols:          2,
 			limitSource:      "csinode",
 			test:             "ephemeral doesn't when node volume limit <= pods CSI volume",
-			wantStatus:       framework.NewStatus(framework.Unschedulable, ErrReasonMaxVolumeCountExceeded),
+			wantStatus:       fwk.NewStatus(fwk.Unschedulable, ErrReasonMaxVolumeCountExceeded),
 		},
 		{
 			newPod:           csiEBSOneVolPod,
@@ -554,7 +554,7 @@ func TestCSILimits(t *testing.T) {
 			maxVols:          2,
 			limitSource:      "csinode",
 			test:             "ephemeral doesn't when node volume limit <= pods ephemeral CSI volume",
-			wantStatus:       framework.NewStatus(framework.Unschedulable, ErrReasonMaxVolumeCountExceeded),
+			wantStatus:       fwk.NewStatus(fwk.Unschedulable, ErrReasonMaxVolumeCountExceeded),
 		},
 		{
 			newPod:           csiEBSOneVolPod,
@@ -566,7 +566,7 @@ func TestCSILimits(t *testing.T) {
 			maxVols:          3,
 			limitSource:      "csinode",
 			test:             "persistent doesn't when node volume limit <= pods ephemeral CSI volume + persistent volume, ephemeral disabled",
-			wantStatus:       framework.NewStatus(framework.Unschedulable, ErrReasonMaxVolumeCountExceeded),
+			wantStatus:       fwk.NewStatus(fwk.Unschedulable, ErrReasonMaxVolumeCountExceeded),
 		},
 		{
 			newPod:           csiEBSOneVolPod,
@@ -578,7 +578,7 @@ func TestCSILimits(t *testing.T) {
 			maxVols:          3,
 			limitSource:      "csinode",
 			test:             "persistent doesn't when node volume limit <= pods ephemeral CSI volume + persistent volume",
-			wantStatus:       framework.NewStatus(framework.Unschedulable, ErrReasonMaxVolumeCountExceeded),
+			wantStatus:       fwk.NewStatus(fwk.Unschedulable, ErrReasonMaxVolumeCountExceeded),
 		},
 		{
 			newPod:           csiEBSOneVolPod,
@@ -598,7 +598,7 @@ func TestCSILimits(t *testing.T) {
 			driverNames:         []string{ebsCSIDriverName},
 			test:                "skip Filter when the pod only uses secrets and configmaps",
 			limitSource:         "csinode",
-			wantPreFilterStatus: framework.NewStatus(framework.Skip),
+			wantPreFilterStatus: fwk.NewStatus(fwk.Skip),
 		},
 		{
 			newPod:      pvcPodWithConfigmapAndSecret,
@@ -615,7 +615,7 @@ func TestCSILimits(t *testing.T) {
 			driverNames:      []string{ebsCSIDriverName},
 			limitSource:      "csinode-with-no-limit",
 			test:             "don't skip Filter when the pod has ephemeral volumes",
-			wantStatus:       framework.NewStatus(framework.UnschedulableAndUnresolvable, `looking up PVC test/abc-xyz: persistentvolumeclaims "abc-xyz" not found`),
+			wantStatus:       fwk.NewStatus(fwk.UnschedulableAndUnresolvable, `looking up PVC test/abc-xyz: persistentvolumeclaims "abc-xyz" not found`),
 		},
 		{
 			newPod:           inlineMigratablePodWithConfigmapAndSecret,
@@ -626,7 +626,7 @@ func TestCSILimits(t *testing.T) {
 			migrationEnabled: true,
 			limitSource:      "csinode",
 			test:             "don't skip Filter when the pod has inline migratable volumes",
-			wantStatus:       framework.NewStatus(framework.Unschedulable, ErrReasonMaxVolumeCountExceeded),
+			wantStatus:       fwk.NewStatus(fwk.Unschedulable, ErrReasonMaxVolumeCountExceeded),
 		},
 	}
 
@@ -652,7 +652,7 @@ func TestCSILimits(t *testing.T) {
 			if diff := cmp.Diff(test.wantPreFilterStatus, gotPreFilterStatus, statusCmpOpts...); diff != "" {
 				t.Errorf("PreFilter status does not match (-want, +got):\n%s", diff)
 			}
-			if gotPreFilterStatus.Code() != framework.Skip {
+			if gotPreFilterStatus.Code() != fwk.Skip {
 				gotStatus := p.Filter(ctx, nil, test.newPod, node)
 				if diff := cmp.Diff(test.wantStatus, gotStatus, statusCmpOpts...); diff != "" {
 					t.Errorf("Filter status does not match (-want, +got):\n%s", diff)

--- a/pkg/scheduler/framework/plugins/podtopologyspread/filtering.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/filtering.go
@@ -137,12 +137,12 @@ func (p *criticalPaths) update(tpVal string, num int) {
 }
 
 // PreFilter invoked at the prefilter extension point.
-func (pl *PodTopologySpread) PreFilter(ctx context.Context, cycleState fwk.CycleState, pod *v1.Pod, nodes []*framework.NodeInfo) (*framework.PreFilterResult, *framework.Status) {
+func (pl *PodTopologySpread) PreFilter(ctx context.Context, cycleState fwk.CycleState, pod *v1.Pod, nodes []*framework.NodeInfo) (*framework.PreFilterResult, *fwk.Status) {
 	s, err := pl.calPreFilterState(ctx, pod, nodes)
 	if err != nil {
-		return nil, framework.AsStatus(err)
+		return nil, fwk.AsStatus(err)
 	} else if s != nil && len(s.Constraints) == 0 {
-		return nil, framework.NewStatus(framework.Skip)
+		return nil, fwk.NewStatus(fwk.Skip)
 	}
 
 	cycleState.Write(preFilterStateKey, s)
@@ -155,10 +155,10 @@ func (pl *PodTopologySpread) PreFilterExtensions() framework.PreFilterExtensions
 }
 
 // AddPod from pre-computed data in cycleState.
-func (pl *PodTopologySpread) AddPod(ctx context.Context, cycleState fwk.CycleState, podToSchedule *v1.Pod, podInfoToAdd *framework.PodInfo, nodeInfo *framework.NodeInfo) *framework.Status {
+func (pl *PodTopologySpread) AddPod(ctx context.Context, cycleState fwk.CycleState, podToSchedule *v1.Pod, podInfoToAdd *framework.PodInfo, nodeInfo *framework.NodeInfo) *fwk.Status {
 	s, err := getPreFilterState(cycleState)
 	if err != nil {
-		return framework.AsStatus(err)
+		return fwk.AsStatus(err)
 	}
 
 	pl.updateWithPod(s, podInfoToAdd.Pod, podToSchedule, nodeInfo.Node(), 1)
@@ -166,10 +166,10 @@ func (pl *PodTopologySpread) AddPod(ctx context.Context, cycleState fwk.CycleSta
 }
 
 // RemovePod from pre-computed data in cycleState.
-func (pl *PodTopologySpread) RemovePod(ctx context.Context, cycleState fwk.CycleState, podToSchedule *v1.Pod, podInfoToRemove *framework.PodInfo, nodeInfo *framework.NodeInfo) *framework.Status {
+func (pl *PodTopologySpread) RemovePod(ctx context.Context, cycleState fwk.CycleState, podToSchedule *v1.Pod, podInfoToRemove *framework.PodInfo, nodeInfo *framework.NodeInfo) *fwk.Status {
 	s, err := getPreFilterState(cycleState)
 	if err != nil {
-		return framework.AsStatus(err)
+		return fwk.AsStatus(err)
 	}
 
 	pl.updateWithPod(s, podInfoToRemove.Pod, podToSchedule, nodeInfo.Node(), -1)
@@ -308,12 +308,12 @@ func (pl *PodTopologySpread) calPreFilterState(ctx context.Context, pod *v1.Pod,
 }
 
 // Filter invoked at the filter extension point.
-func (pl *PodTopologySpread) Filter(ctx context.Context, cycleState fwk.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) *framework.Status {
+func (pl *PodTopologySpread) Filter(ctx context.Context, cycleState fwk.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) *fwk.Status {
 	node := nodeInfo.Node()
 
 	s, err := getPreFilterState(cycleState)
 	if err != nil {
-		return framework.AsStatus(err)
+		return fwk.AsStatus(err)
 	}
 
 	// However, "empty" preFilterState is legit which tolerates every toSchedule Pod.
@@ -328,7 +328,7 @@ func (pl *PodTopologySpread) Filter(ctx context.Context, cycleState fwk.CycleSta
 		tpVal, ok := node.Labels[tpKey]
 		if !ok {
 			logger.V(5).Info("Node doesn't have required topology label for spread constraint", "node", klog.KObj(node), "topologyKey", tpKey)
-			return framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReasonNodeLabelNotMatch)
+			return fwk.NewStatus(fwk.UnschedulableAndUnresolvable, ErrReasonNodeLabelNotMatch)
 		}
 
 		// judging criteria:
@@ -348,7 +348,7 @@ func (pl *PodTopologySpread) Filter(ctx context.Context, cycleState fwk.CycleSta
 		skew := matchNum + selfMatchNum - minMatchNum
 		if skew > int(c.MaxSkew) {
 			logger.V(5).Info("Node failed spreadConstraint: matchNum + selfMatchNum - minMatchNum > maxSkew", "node", klog.KObj(node), "topologyKey", tpKey, "matchNum", matchNum, "selfMatchNum", selfMatchNum, "minMatchNum", minMatchNum, "maxSkew", c.MaxSkew)
-			return framework.NewStatus(framework.Unschedulable, ErrReasonConstraintsNotMatch)
+			return fwk.NewStatus(fwk.Unschedulable, ErrReasonConstraintsNotMatch)
 		}
 	}
 

--- a/pkg/scheduler/framework/plugins/podtopologyspread/filtering_test.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/filtering_test.go
@@ -85,7 +85,7 @@ func TestPreFilterState(t *testing.T) {
 		objs                      []runtime.Object
 		defaultConstraints        []v1.TopologySpreadConstraint
 		want                      *preFilterState
-		wantPrefilterStatus       *framework.Status
+		wantPrefilterStatus       *fwk.Status
 		enableNodeInclusionPolicy bool
 		enableMatchLabelKeys      bool
 	}{
@@ -574,7 +574,7 @@ func TestPreFilterState(t *testing.T) {
 			objs: []runtime.Object{
 				&v1.Service{Spec: v1.ServiceSpec{Selector: map[string]string{"baz": "kep"}}},
 			},
-			wantPrefilterStatus: framework.NewStatus(framework.Skip),
+			wantPrefilterStatus: fwk.NewStatus(fwk.Skip),
 		},
 		{
 			name: "default constraints and a service, but pod has constraints",
@@ -612,7 +612,7 @@ func TestPreFilterState(t *testing.T) {
 			objs: []runtime.Object{
 				&v1.Service{Spec: v1.ServiceSpec{Selector: map[string]string{"foo": "bar"}}},
 			},
-			wantPrefilterStatus: framework.NewStatus(framework.Skip),
+			wantPrefilterStatus: fwk.NewStatus(fwk.Skip),
 		},
 		{
 			name: "TpKeyToDomainsNum is calculated when MinDomains is enabled",
@@ -1479,7 +1479,7 @@ func TestPreFilterState(t *testing.T) {
 			nodes: []*v1.Node{
 				st.MakeNode().Name("node-a").Label("zone", "zone1").Label("node", "node-a").Obj(),
 			},
-			wantPrefilterStatus: framework.NewStatus(framework.Skip),
+			wantPrefilterStatus: fwk.NewStatus(fwk.Skip),
 		},
 	}
 	for _, tt := range tests {
@@ -2416,7 +2416,7 @@ func TestSingleConstraint(t *testing.T) {
 		pod                       *v1.Pod
 		nodes                     []*v1.Node
 		existingPods              []*v1.Pod
-		wantStatusCode            map[string]framework.Code
+		wantStatusCode            map[string]fwk.Code
 		enableNodeInclusionPolicy bool
 	}{
 		{
@@ -2430,11 +2430,11 @@ func TestSingleConstraint(t *testing.T) {
 				st.MakeNode().Name("node-x").Label("zone", "zone2").Label("node", "node-x").Obj(),
 				st.MakeNode().Name("node-y").Label("zone", "zone2").Label("node", "node-y").Obj(),
 			},
-			wantStatusCode: map[string]framework.Code{
-				"node-a": framework.Success,
-				"node-b": framework.Success,
-				"node-x": framework.Success,
-				"node-y": framework.Success,
+			wantStatusCode: map[string]fwk.Code{
+				"node-a": fwk.Success,
+				"node-b": fwk.Success,
+				"node-x": fwk.Success,
+				"node-y": fwk.Success,
 			},
 		},
 		{
@@ -2448,11 +2448,11 @@ func TestSingleConstraint(t *testing.T) {
 				st.MakeNode().Name("node-x").Label("zone", "zone2").Label("node", "node-x").Obj(),
 				st.MakeNode().Name("node-y").Label("zone", "zone2").Label("node", "node-y").Obj(),
 			},
-			wantStatusCode: map[string]framework.Code{
-				"node-a": framework.Success,
-				"node-b": framework.Success,
-				"node-x": framework.Success,
-				"node-y": framework.Success,
+			wantStatusCode: map[string]fwk.Code{
+				"node-a": fwk.Success,
+				"node-b": fwk.Success,
+				"node-x": fwk.Success,
+				"node-y": fwk.Success,
 			},
 		},
 		{
@@ -2472,11 +2472,11 @@ func TestSingleConstraint(t *testing.T) {
 				st.MakePod().Name("p-x1").Node("node-x").Label("foo", "").Obj(),
 				st.MakePod().Name("p-y1").Node("node-y").Label("foo", "").Obj(),
 			},
-			wantStatusCode: map[string]framework.Code{
-				"node-a": framework.Success,
-				"node-b": framework.Success,
-				"node-x": framework.Unschedulable,
-				"node-y": framework.Unschedulable,
+			wantStatusCode: map[string]fwk.Code{
+				"node-a": fwk.Success,
+				"node-b": fwk.Success,
+				"node-x": fwk.Unschedulable,
+				"node-y": fwk.Unschedulable,
 			},
 		},
 		{
@@ -2494,11 +2494,11 @@ func TestSingleConstraint(t *testing.T) {
 				st.MakePod().Name("p-x1").Node("node-x").Label("foo", "").Obj(),
 				st.MakePod().Name("p-y1").Node("node-y").Label("foo", "").Obj(),
 			},
-			wantStatusCode: map[string]framework.Code{
-				"node-a": framework.Success,
-				"node-b": framework.Success,
-				"node-x": framework.Success,
-				"node-y": framework.Success,
+			wantStatusCode: map[string]fwk.Code{
+				"node-a": fwk.Success,
+				"node-b": fwk.Success,
+				"node-x": fwk.Success,
+				"node-y": fwk.Success,
 			},
 		},
 		{
@@ -2520,11 +2520,11 @@ func TestSingleConstraint(t *testing.T) {
 				st.MakePod().Name("p-y2").Node("node-y").Label("foo", "").Obj(),
 				st.MakePod().Name("p-y3").Node("node-y").Label("foo", "").Obj(),
 			},
-			wantStatusCode: map[string]framework.Code{
-				"node-a": framework.Success,
-				"node-b": framework.Success,
-				"node-x": framework.Success,
-				"node-y": framework.Success,
+			wantStatusCode: map[string]fwk.Code{
+				"node-a": fwk.Success,
+				"node-b": fwk.Success,
+				"node-x": fwk.Success,
+				"node-y": fwk.Success,
 			},
 		},
 		{
@@ -2546,11 +2546,11 @@ func TestSingleConstraint(t *testing.T) {
 				st.MakePod().Name("p-x1").Node("node-x").Label("foo", "").Obj(),
 				st.MakePod().Name("p-y1").Node("node-y").Label("foo", "").Obj(),
 			},
-			wantStatusCode: map[string]framework.Code{
-				"node-a": framework.Success,
-				"node-b": framework.UnschedulableAndUnresolvable,
-				"node-x": framework.Unschedulable,
-				"node-y": framework.Unschedulable,
+			wantStatusCode: map[string]fwk.Code{
+				"node-a": fwk.Success,
+				"node-b": fwk.UnschedulableAndUnresolvable,
+				"node-x": fwk.Unschedulable,
+				"node-y": fwk.Unschedulable,
 			},
 		},
 		{
@@ -2562,9 +2562,9 @@ func TestSingleConstraint(t *testing.T) {
 				st.MakeNode().Name("node-a").Label("zone", "zone1").Label("node", "node-a").Obj(),
 				st.MakeNode().Name("node-x").Label("zone", "zone2").Label("node", "node-x").Obj(),
 			},
-			wantStatusCode: map[string]framework.Code{
-				"node-a": framework.UnschedulableAndUnresolvable,
-				"node-x": framework.UnschedulableAndUnresolvable,
+			wantStatusCode: map[string]fwk.Code{
+				"node-a": fwk.UnschedulableAndUnresolvable,
+				"node-x": fwk.UnschedulableAndUnresolvable,
 			},
 		},
 		{
@@ -2586,11 +2586,11 @@ func TestSingleConstraint(t *testing.T) {
 				st.MakePod().Name("p-y2").Node("node-y").Label("foo", "").Obj(),
 				st.MakePod().Name("p-y3").Node("node-y").Label("foo", "").Obj(),
 			},
-			wantStatusCode: map[string]framework.Code{
-				"node-a": framework.Unschedulable,
-				"node-b": framework.Unschedulable,
-				"node-x": framework.Success,
-				"node-y": framework.Unschedulable,
+			wantStatusCode: map[string]fwk.Code{
+				"node-a": fwk.Unschedulable,
+				"node-b": fwk.Unschedulable,
+				"node-x": fwk.Success,
+				"node-y": fwk.Unschedulable,
 			},
 		},
 		{
@@ -2612,11 +2612,11 @@ func TestSingleConstraint(t *testing.T) {
 				st.MakePod().Name("p-y2").Node("node-y").Label("foo", "").Obj(),
 				st.MakePod().Name("p-y3").Node("node-y").Label("foo", "").Obj(),
 			},
-			wantStatusCode: map[string]framework.Code{
-				"node-a": framework.Unschedulable,
-				"node-b": framework.Success,
-				"node-x": framework.Success,
-				"node-y": framework.Unschedulable,
+			wantStatusCode: map[string]fwk.Code{
+				"node-a": fwk.Unschedulable,
+				"node-b": fwk.Success,
+				"node-x": fwk.Success,
+				"node-y": fwk.Unschedulable,
 			},
 		},
 		{
@@ -2642,11 +2642,11 @@ func TestSingleConstraint(t *testing.T) {
 				st.MakePod().Name("p-y2").Node("node-y").Label("foo", "").Obj(),
 				st.MakePod().Name("p-y3").Node("node-y").Label("foo", "").Obj(),
 			},
-			wantStatusCode: map[string]framework.Code{
-				"node-a": framework.Unschedulable,
-				"node-b": framework.Success,
-				"node-x": framework.Success,
-				"node-y": framework.Unschedulable,
+			wantStatusCode: map[string]fwk.Code{
+				"node-a": fwk.Unschedulable,
+				"node-b": fwk.Success,
+				"node-x": fwk.Success,
+				"node-y": fwk.Unschedulable,
 			},
 		},
 		{
@@ -2674,11 +2674,11 @@ func TestSingleConstraint(t *testing.T) {
 				st.MakePod().Name("p-y2").Node("node-y").Label("foo", "").Obj(),
 				st.MakePod().Name("p-y3").Node("node-y").Label("foo", "").Obj(),
 			},
-			wantStatusCode: map[string]framework.Code{
-				"node-a": framework.Success,
-				"node-b": framework.Success, // in real case, it's false
-				"node-x": framework.Success, // in real case, it's false
-				"node-y": framework.Unschedulable,
+			wantStatusCode: map[string]fwk.Code{
+				"node-a": fwk.Success,
+				"node-b": fwk.Success, // in real case, it's false
+				"node-x": fwk.Success, // in real case, it's false
+				"node-y": fwk.Unschedulable,
 			},
 		},
 		{
@@ -2694,9 +2694,9 @@ func TestSingleConstraint(t *testing.T) {
 				st.MakePod().Name("p-a").Node("node-a").Label("foo", "").Terminating().Obj(),
 				st.MakePod().Name("p-b").Node("node-b").Label("foo", "").Obj(),
 			},
-			wantStatusCode: map[string]framework.Code{
-				"node-a": framework.Success,
-				"node-b": framework.Unschedulable,
+			wantStatusCode: map[string]fwk.Code{
+				"node-a": fwk.Success,
+				"node-b": fwk.Unschedulable,
 			},
 		},
 		{
@@ -2717,11 +2717,11 @@ func TestSingleConstraint(t *testing.T) {
 				st.MakePod().Name("p-b2").Node("node-b").Label("foo", "").Obj(),
 				st.MakePod().Name("p-y1").Node("node-y").Label("foo", "").Obj(),
 			},
-			wantStatusCode: map[string]framework.Code{
-				"node-a": framework.Success,
-				"node-b": framework.Success, // in real case, it's Unschedulable
-				"node-x": framework.Unschedulable,
-				"node-y": framework.Unschedulable,
+			wantStatusCode: map[string]fwk.Code{
+				"node-a": fwk.Success,
+				"node-b": fwk.Success, // in real case, it's Unschedulable
+				"node-x": fwk.Unschedulable,
+				"node-y": fwk.Unschedulable,
 			},
 		},
 		{
@@ -2748,10 +2748,10 @@ func TestSingleConstraint(t *testing.T) {
 				st.MakePod().Name("p-b2").Node("node-b").Label("foo", "").Obj(),
 				st.MakePod().Name("p-c1").Node("node-c").Label("foo", "").Obj(),
 			},
-			wantStatusCode: map[string]framework.Code{
-				"node-a": framework.Unschedulable,
-				"node-b": framework.Unschedulable,
-				"node-c": framework.Success,
+			wantStatusCode: map[string]fwk.Code{
+				"node-a": fwk.Unschedulable,
+				"node-b": fwk.Unschedulable,
+				"node-c": fwk.Success,
 			},
 		},
 		{
@@ -2778,10 +2778,10 @@ func TestSingleConstraint(t *testing.T) {
 				st.MakePod().Name("p-b2").Node("node-b").Label("foo", "").Obj(),
 				st.MakePod().Name("p-c1").Node("node-c").Label("foo", "").Obj(),
 			},
-			wantStatusCode: map[string]framework.Code{
-				"node-a": framework.Success,
-				"node-b": framework.Success,
-				"node-c": framework.Success,
+			wantStatusCode: map[string]fwk.Code{
+				"node-a": fwk.Success,
+				"node-b": fwk.Success,
+				"node-c": fwk.Success,
 			},
 		},
 		{
@@ -2807,11 +2807,11 @@ func TestSingleConstraint(t *testing.T) {
 				st.MakePod().Name("p-b2").Node("node-b").Label("foo", "").Obj(),
 				st.MakePod().Name("p-y1").Node("node-y").Label("foo", "").Obj(),
 			},
-			wantStatusCode: map[string]framework.Code{
-				"node-a": framework.Unschedulable,
-				"node-b": framework.Unschedulable,
-				"node-x": framework.Success,
-				"node-y": framework.Success,
+			wantStatusCode: map[string]fwk.Code{
+				"node-a": fwk.Unschedulable,
+				"node-b": fwk.Unschedulable,
+				"node-x": fwk.Success,
+				"node-y": fwk.Success,
 			},
 		},
 		{
@@ -2837,11 +2837,11 @@ func TestSingleConstraint(t *testing.T) {
 				st.MakePod().Name("p-b2").Node("node-b").Label("foo", "").Obj(),
 				st.MakePod().Name("p-y1").Node("node-y").Label("foo", "").Obj(),
 			},
-			wantStatusCode: map[string]framework.Code{
-				"node-a": framework.Success,
-				"node-b": framework.Success,
-				"node-x": framework.Success,
-				"node-y": framework.Success,
+			wantStatusCode: map[string]fwk.Code{
+				"node-a": fwk.Success,
+				"node-b": fwk.Success,
+				"node-x": fwk.Success,
+				"node-y": fwk.Success,
 			},
 		},
 		{
@@ -2862,11 +2862,11 @@ func TestSingleConstraint(t *testing.T) {
 				st.MakePod().Name("p-b2").Node("node-b").Label("foo", "").Obj(),
 				st.MakePod().Name("p-y1").Node("node-y").Label("foo", "").Obj(),
 			},
-			wantStatusCode: map[string]framework.Code{
-				"node-a": framework.Unschedulable,
-				"node-b": framework.Unschedulable,
-				"node-x": framework.Success,
-				"node-y": framework.Success, // in real case, when we disable NodeAffinity Plugin, node-y will be success.
+			wantStatusCode: map[string]fwk.Code{
+				"node-a": fwk.Unschedulable,
+				"node-b": fwk.Unschedulable,
+				"node-x": fwk.Success,
+				"node-y": fwk.Success, // in real case, when we disable NodeAffinity Plugin, node-y will be success.
 			},
 			enableNodeInclusionPolicy: true,
 		},
@@ -2888,11 +2888,11 @@ func TestSingleConstraint(t *testing.T) {
 				st.MakePod().Name("p-b2").Node("node-b").Label("foo", "").Obj(),
 				st.MakePod().Name("p-y1").Node("node-y").Label("foo", "").Obj(),
 			},
-			wantStatusCode: map[string]framework.Code{
-				"node-a": framework.Unschedulable,
-				"node-b": framework.Unschedulable,
-				"node-x": framework.Success,
-				"node-y": framework.Unschedulable,
+			wantStatusCode: map[string]fwk.Code{
+				"node-a": fwk.Unschedulable,
+				"node-b": fwk.Unschedulable,
+				"node-x": fwk.Success,
+				"node-y": fwk.Unschedulable,
 			},
 			enableNodeInclusionPolicy: true,
 		},
@@ -2914,11 +2914,11 @@ func TestSingleConstraint(t *testing.T) {
 				st.MakePod().Name("p-b2").Node("node-b").Label("foo", "").Obj(),
 				st.MakePod().Name("p-y1").Node("node-y").Label("foo", "").Obj(),
 			},
-			wantStatusCode: map[string]framework.Code{
-				"node-a": framework.Unschedulable,
-				"node-b": framework.Unschedulable,
-				"node-x": framework.Success,
-				"node-y": framework.Success, // in real case, when we disable NodeAffinity Plugin, node-y will be success.
+			wantStatusCode: map[string]fwk.Code{
+				"node-a": fwk.Unschedulable,
+				"node-b": fwk.Unschedulable,
+				"node-x": fwk.Success,
+				"node-y": fwk.Success, // in real case, when we disable NodeAffinity Plugin, node-y will be success.
 			},
 			enableNodeInclusionPolicy: true,
 		},
@@ -2940,11 +2940,11 @@ func TestSingleConstraint(t *testing.T) {
 				st.MakePod().Name("p-b2").Node("node-b").Label("foo", "").Obj(),
 				st.MakePod().Name("p-y1").Node("node-y").Label("foo", "").Obj(),
 			},
-			wantStatusCode: map[string]framework.Code{
-				"node-a": framework.Unschedulable,
-				"node-b": framework.Unschedulable,
-				"node-x": framework.Success,
-				"node-y": framework.Unschedulable,
+			wantStatusCode: map[string]fwk.Code{
+				"node-a": fwk.Unschedulable,
+				"node-b": fwk.Unschedulable,
+				"node-x": fwk.Success,
+				"node-y": fwk.Unschedulable,
 			},
 			enableNodeInclusionPolicy: true,
 		},
@@ -2965,11 +2965,11 @@ func TestSingleConstraint(t *testing.T) {
 				st.MakePod().Name("p-b2").Node("node-b").Label("foo", "").Obj(),
 				st.MakePod().Name("p-y1").Node("node-y").Label("foo", "").Obj(),
 			},
-			wantStatusCode: map[string]framework.Code{
-				"node-a": framework.Unschedulable,
-				"node-b": framework.Unschedulable,
-				"node-x": framework.Success,
-				"node-y": framework.Success, // in real case, when we disable TaintToleration Plugin, node-y will be success.
+			wantStatusCode: map[string]fwk.Code{
+				"node-a": fwk.Unschedulable,
+				"node-b": fwk.Unschedulable,
+				"node-x": fwk.Success,
+				"node-y": fwk.Success, // in real case, when we disable TaintToleration Plugin, node-y will be success.
 			},
 			enableNodeInclusionPolicy: true,
 		},
@@ -2990,11 +2990,11 @@ func TestSingleConstraint(t *testing.T) {
 				st.MakePod().Name("p-b2").Node("node-b").Label("foo", "").Obj(),
 				st.MakePod().Name("p-y1").Node("node-y").Label("foo", "").Obj(),
 			},
-			wantStatusCode: map[string]framework.Code{
-				"node-a": framework.Unschedulable,
-				"node-b": framework.Unschedulable,
-				"node-x": framework.Success,
-				"node-y": framework.Unschedulable,
+			wantStatusCode: map[string]fwk.Code{
+				"node-a": fwk.Unschedulable,
+				"node-b": fwk.Unschedulable,
+				"node-x": fwk.Success,
+				"node-y": fwk.Unschedulable,
 			},
 			enableNodeInclusionPolicy: true,
 		},
@@ -3032,7 +3032,7 @@ func TestMultipleConstraints(t *testing.T) {
 		pod                       *v1.Pod
 		nodes                     []*v1.Node
 		existingPods              []*v1.Pod
-		wantStatusCode            map[string]framework.Code
+		wantStatusCode            map[string]fwk.Code
 		enableNodeInclusionPolicy bool
 	}{
 		{
@@ -3058,11 +3058,11 @@ func TestMultipleConstraints(t *testing.T) {
 				st.MakePod().Name("p-y2").Node("node-y").Label("foo", "").Obj(),
 				st.MakePod().Name("p-y3").Node("node-y").Label("foo", "").Obj(),
 			},
-			wantStatusCode: map[string]framework.Code{
-				"node-a": framework.Unschedulable,
-				"node-b": framework.Unschedulable,
-				"node-x": framework.Success,
-				"node-y": framework.Unschedulable,
+			wantStatusCode: map[string]fwk.Code{
+				"node-a": fwk.Unschedulable,
+				"node-b": fwk.Unschedulable,
+				"node-x": fwk.Success,
+				"node-y": fwk.Unschedulable,
 			},
 		},
 		{
@@ -3089,11 +3089,11 @@ func TestMultipleConstraints(t *testing.T) {
 				st.MakePod().Name("p-y3").Node("node-y").Label("foo", "").Obj(),
 				st.MakePod().Name("p-y4").Node("node-y").Label("foo", "").Obj(),
 			},
-			wantStatusCode: map[string]framework.Code{
-				"node-a": framework.Unschedulable,
-				"node-b": framework.Unschedulable,
-				"node-x": framework.Unschedulable,
-				"node-y": framework.Unschedulable,
+			wantStatusCode: map[string]fwk.Code{
+				"node-a": fwk.Unschedulable,
+				"node-b": fwk.Unschedulable,
+				"node-x": fwk.Unschedulable,
+				"node-y": fwk.Unschedulable,
 			},
 		},
 		{
@@ -3115,11 +3115,11 @@ func TestMultipleConstraints(t *testing.T) {
 				st.MakePod().Name("p-a1").Node("node-a").Label("foo", "").Obj(),
 				st.MakePod().Name("p-y1").Node("node-y").Label("bar", "").Obj(),
 			},
-			wantStatusCode: map[string]framework.Code{
-				"node-a": framework.Unschedulable,
-				"node-b": framework.Unschedulable,
-				"node-x": framework.Success,
-				"node-y": framework.Unschedulable,
+			wantStatusCode: map[string]fwk.Code{
+				"node-a": fwk.Unschedulable,
+				"node-b": fwk.Unschedulable,
+				"node-x": fwk.Success,
+				"node-y": fwk.Unschedulable,
 			},
 		},
 		{
@@ -3142,11 +3142,11 @@ func TestMultipleConstraints(t *testing.T) {
 				st.MakePod().Name("p-x1").Node("node-x").Label("bar", "").Obj(),
 				st.MakePod().Name("p-y1").Node("node-y").Label("bar", "").Obj(),
 			},
-			wantStatusCode: map[string]framework.Code{
-				"node-a": framework.Unschedulable,
-				"node-b": framework.Unschedulable,
-				"node-x": framework.Unschedulable,
-				"node-y": framework.Unschedulable,
+			wantStatusCode: map[string]fwk.Code{
+				"node-a": fwk.Unschedulable,
+				"node-b": fwk.Unschedulable,
+				"node-x": fwk.Unschedulable,
+				"node-y": fwk.Unschedulable,
 			},
 		},
 		{
@@ -3171,11 +3171,11 @@ func TestMultipleConstraints(t *testing.T) {
 				st.MakePod().Name("p-y2").Node("node-y").Label("foo", "").Label("bar", "").Obj(),
 				st.MakePod().Name("p-y3").Node("node-y").Label("foo", "").Obj(),
 			},
-			wantStatusCode: map[string]framework.Code{
-				"node-a": framework.Unschedulable,
-				"node-b": framework.Success,
-				"node-x": framework.Unschedulable,
-				"node-y": framework.Unschedulable,
+			wantStatusCode: map[string]fwk.Code{
+				"node-a": fwk.Unschedulable,
+				"node-b": fwk.Success,
+				"node-x": fwk.Unschedulable,
+				"node-y": fwk.Unschedulable,
 			},
 		},
 		{
@@ -3198,11 +3198,11 @@ func TestMultipleConstraints(t *testing.T) {
 				st.MakePod().Name("p-x1").Node("node-x").Label("bar", "").Obj(),
 				st.MakePod().Name("p-y1").Node("node-y").Label("bar", "").Obj(),
 			},
-			wantStatusCode: map[string]framework.Code{
-				"node-a": framework.Success,
-				"node-b": framework.Success,
-				"node-x": framework.Unschedulable,
-				"node-y": framework.Unschedulable,
+			wantStatusCode: map[string]fwk.Code{
+				"node-a": fwk.Success,
+				"node-b": fwk.Success,
+				"node-x": fwk.Unschedulable,
+				"node-y": fwk.Unschedulable,
 			},
 		},
 		{
@@ -3224,11 +3224,11 @@ func TestMultipleConstraints(t *testing.T) {
 				st.MakePod().Name("p-a1").Node("node-a").Label("foo", "").Obj(),
 				st.MakePod().Name("p-y3").Node("node-y").Label("foo", "").Obj(),
 			},
-			wantStatusCode: map[string]framework.Code{
-				"node-a": framework.Unschedulable,
-				"node-b": framework.Success,
-				"node-x": framework.UnschedulableAndUnresolvable,
-				"node-y": framework.Unschedulable,
+			wantStatusCode: map[string]fwk.Code{
+				"node-a": fwk.Unschedulable,
+				"node-b": fwk.Success,
+				"node-x": fwk.UnschedulableAndUnresolvable,
+				"node-y": fwk.Unschedulable,
 			},
 		},
 		{
@@ -3252,11 +3252,11 @@ func TestMultipleConstraints(t *testing.T) {
 				st.MakePod().Name("p-b1").Node("node-b").Label("foo", "").Obj(),
 				st.MakePod().Name("p-y1").Node("node-y").Label("foo", "").Obj(),
 			},
-			wantStatusCode: map[string]framework.Code{
-				"node-a": framework.Unschedulable,
-				"node-b": framework.Unschedulable,
-				"node-x": framework.Success,
-				"node-y": framework.Unschedulable,
+			wantStatusCode: map[string]fwk.Code{
+				"node-a": fwk.Unschedulable,
+				"node-b": fwk.Unschedulable,
+				"node-x": fwk.Success,
+				"node-y": fwk.Unschedulable,
 			},
 			enableNodeInclusionPolicy: true,
 		},
@@ -3280,11 +3280,11 @@ func TestMultipleConstraints(t *testing.T) {
 				st.MakePod().Name("p-b1").Node("node-b").Label("foo", "").Obj(),
 				st.MakePod().Name("p-y1").Node("node-y").Label("foo", "").Obj(),
 			},
-			wantStatusCode: map[string]framework.Code{
-				"node-a": framework.Unschedulable,
-				"node-b": framework.Unschedulable,
-				"node-x": framework.Success,
-				"node-y": framework.Unschedulable,
+			wantStatusCode: map[string]fwk.Code{
+				"node-a": fwk.Unschedulable,
+				"node-b": fwk.Unschedulable,
+				"node-x": fwk.Success,
+				"node-y": fwk.Unschedulable,
 			},
 			enableNodeInclusionPolicy: true,
 		},
@@ -3309,11 +3309,11 @@ func TestMultipleConstraints(t *testing.T) {
 				st.MakePod().Name("p-b1").Node("node-b").Label("foo", "").Obj(),
 				st.MakePod().Name("p-y1").Node("node-y").Label("foo", "").Obj(),
 			},
-			wantStatusCode: map[string]framework.Code{
-				"node-a": framework.Unschedulable,
-				"node-b": framework.Success,
-				"node-x": framework.Success,
-				"node-y": framework.Unschedulable,
+			wantStatusCode: map[string]fwk.Code{
+				"node-a": fwk.Unschedulable,
+				"node-b": fwk.Success,
+				"node-x": fwk.Success,
+				"node-y": fwk.Unschedulable,
 			},
 			enableNodeInclusionPolicy: true,
 		},
@@ -3338,11 +3338,11 @@ func TestMultipleConstraints(t *testing.T) {
 				st.MakePod().Name("p-b1").Node("node-b").Label("foo", "").Obj(),
 				st.MakePod().Name("p-y1").Node("node-y").Label("foo", "").Obj(),
 			},
-			wantStatusCode: map[string]framework.Code{
-				"node-a": framework.Unschedulable,
-				"node-b": framework.Unschedulable,
-				"node-x": framework.Success,
-				"node-y": framework.Unschedulable,
+			wantStatusCode: map[string]fwk.Code{
+				"node-a": fwk.Unschedulable,
+				"node-b": fwk.Unschedulable,
+				"node-x": fwk.Success,
+				"node-y": fwk.Unschedulable,
 			},
 			enableNodeInclusionPolicy: true,
 		},
@@ -3369,11 +3369,11 @@ func TestMultipleConstraints(t *testing.T) {
 				st.MakePod().Name("p-y2").Node("node-y").Label("foo", "").Label("bar", "").Obj(),
 				st.MakePod().Name("p-y3").Node("node-y").Label("foo", "").Obj(),
 			},
-			wantStatusCode: map[string]framework.Code{
-				"node-a": framework.Unschedulable,
-				"node-b": framework.Unschedulable,
-				"node-x": framework.Success,
-				"node-y": framework.Success,
+			wantStatusCode: map[string]fwk.Code{
+				"node-a": fwk.Unschedulable,
+				"node-b": fwk.Unschedulable,
+				"node-x": fwk.Success,
+				"node-y": fwk.Success,
 			},
 		},
 		{
@@ -3400,11 +3400,11 @@ func TestMultipleConstraints(t *testing.T) {
 				st.MakePod().Name("p-y3").Node("node-y").Label("foo", "").Obj(),
 				st.MakePod().Name("p-y4").Node("node-y").Label("foo", "").Obj(),
 			},
-			wantStatusCode: map[string]framework.Code{
-				"node-a": framework.Unschedulable,
-				"node-b": framework.Unschedulable,
-				"node-x": framework.Unschedulable,
-				"node-y": framework.Unschedulable,
+			wantStatusCode: map[string]fwk.Code{
+				"node-a": fwk.Unschedulable,
+				"node-b": fwk.Unschedulable,
+				"node-x": fwk.Unschedulable,
+				"node-y": fwk.Unschedulable,
 			},
 		},
 	}
@@ -3444,7 +3444,7 @@ func TestPreFilterDisabled(t *testing.T) {
 	p := plugintesting.SetupPlugin(ctx, t, topologySpreadFunc, &config.PodTopologySpreadArgs{DefaultingType: config.ListDefaulting}, cache.NewEmptySnapshot())
 	cycleState := framework.NewCycleState()
 	gotStatus := p.(*PodTopologySpread).Filter(ctx, cycleState, pod, nodeInfo)
-	wantStatus := framework.AsStatus(fwk.ErrNotFound)
+	wantStatus := fwk.AsStatus(fwk.ErrNotFound)
 	if diff := cmp.Diff(wantStatus, gotStatus); diff != "" {
 		t.Errorf("Status does not match (-want,+got):\n%s", diff)
 	}

--- a/pkg/scheduler/framework/plugins/schedulinggates/scheduling_gates.go
+++ b/pkg/scheduler/framework/plugins/schedulinggates/scheduling_gates.go
@@ -46,7 +46,7 @@ func (pl *SchedulingGates) Name() string {
 	return Name
 }
 
-func (pl *SchedulingGates) PreEnqueue(ctx context.Context, p *v1.Pod) *framework.Status {
+func (pl *SchedulingGates) PreEnqueue(ctx context.Context, p *v1.Pod) *fwk.Status {
 	if len(p.Spec.SchedulingGates) == 0 {
 		return nil
 	}
@@ -54,7 +54,7 @@ func (pl *SchedulingGates) PreEnqueue(ctx context.Context, p *v1.Pod) *framework
 	for _, gate := range p.Spec.SchedulingGates {
 		gates = append(gates, gate.Name)
 	}
-	return framework.NewStatus(framework.UnschedulableAndUnresolvable, fmt.Sprintf("waiting for scheduling gates: %v", gates))
+	return fwk.NewStatus(fwk.UnschedulableAndUnresolvable, fmt.Sprintf("waiting for scheduling gates: %v", gates))
 }
 
 // EventsToRegister returns the possible events that may make a Pod

--- a/pkg/scheduler/framework/plugins/schedulinggates/scheduling_gates_test.go
+++ b/pkg/scheduler/framework/plugins/schedulinggates/scheduling_gates_test.go
@@ -34,7 +34,7 @@ func TestPreEnqueue(t *testing.T) {
 	tests := []struct {
 		name string
 		pod  *v1.Pod
-		want *framework.Status
+		want *fwk.Status
 	}{
 		{
 			name: "pod does not carry scheduling gates",
@@ -44,7 +44,7 @@ func TestPreEnqueue(t *testing.T) {
 		{
 			name: "pod carries scheduling gates",
 			pod:  st.MakePod().Name("p").SchedulingGates([]string{"foo", "bar"}).Obj(),
-			want: framework.NewStatus(framework.UnschedulableAndUnresolvable, "waiting for scheduling gates: [foo bar]"),
+			want: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "waiting for scheduling gates: [foo bar]"),
 		},
 	}
 

--- a/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration_test.go
+++ b/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration_test.go
@@ -276,13 +276,13 @@ func TestTaintTolerationFilter(t *testing.T) {
 		name       string
 		pod        *v1.Pod
 		node       *v1.Node
-		wantStatus *framework.Status
+		wantStatus *fwk.Status
 	}{
 		{
 			name: "A pod having no tolerations can't be scheduled onto a node with nonempty taints",
 			pod:  podWithTolerations("pod1", []v1.Toleration{}),
 			node: nodeWithTaints("nodeA", []v1.Taint{{Key: "dedicated", Value: "user1", Effect: "NoSchedule"}}),
-			wantStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable,
+			wantStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable,
 				"node(s) had untolerated taint {dedicated: user1}"),
 		},
 		{
@@ -294,7 +294,7 @@ func TestTaintTolerationFilter(t *testing.T) {
 			name: "A pod which can't be scheduled on a dedicated node assigned to user2 with effect NoSchedule",
 			pod:  podWithTolerations("pod1", []v1.Toleration{{Key: "dedicated", Operator: "Equal", Value: "user2", Effect: "NoSchedule"}}),
 			node: nodeWithTaints("nodeA", []v1.Taint{{Key: "dedicated", Value: "user1", Effect: "NoSchedule"}}),
-			wantStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable,
+			wantStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable,
 				"node(s) had untolerated taint {dedicated: user1}"),
 		},
 		{
@@ -318,7 +318,7 @@ func TestTaintTolerationFilter(t *testing.T) {
 				"can't be scheduled onto the node",
 			pod:  podWithTolerations("pod1", []v1.Toleration{{Key: "foo", Operator: "Equal", Value: "bar", Effect: "PreferNoSchedule"}}),
 			node: nodeWithTaints("nodeA", []v1.Taint{{Key: "foo", Value: "bar", Effect: "NoSchedule"}}),
-			wantStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable,
+			wantStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable,
 				"node(s) had untolerated taint {foo: bar}"),
 		},
 		{

--- a/pkg/scheduler/framework/plugins/volumebinding/volume_binding_test.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/volume_binding_test.go
@@ -100,11 +100,11 @@ func TestVolumeBinding(t *testing.T) {
 		fts                     feature.Features
 		args                    *config.VolumeBindingArgs
 		wantPreFilterResult     *framework.PreFilterResult
-		wantPreFilterStatus     *framework.Status
+		wantPreFilterStatus     *fwk.Status
 		wantStateAfterPreFilter *stateData
-		wantFilterStatus        []*framework.Status
+		wantFilterStatus        []*fwk.Status
 		wantScores              []int64
-		wantPreScoreStatus      *framework.Status
+		wantPreScoreStatus      *fwk.Status
 	}{
 		{
 			name: "pod has not pvcs",
@@ -112,11 +112,11 @@ func TestVolumeBinding(t *testing.T) {
 			nodes: []*v1.Node{
 				makeNode("node-a").Node,
 			},
-			wantPreFilterStatus: framework.NewStatus(framework.Skip),
-			wantFilterStatus: []*framework.Status{
+			wantPreFilterStatus: fwk.NewStatus(fwk.Skip),
+			wantFilterStatus: []*fwk.Status{
 				nil,
 			},
-			wantPreScoreStatus: framework.NewStatus(framework.Skip),
+			wantPreScoreStatus: fwk.NewStatus(fwk.Skip),
 		},
 		{
 			name: "all bound",
@@ -140,10 +140,10 @@ func TestVolumeBinding(t *testing.T) {
 				},
 				podVolumesByNode: map[string]*PodVolumes{},
 			},
-			wantFilterStatus: []*framework.Status{
+			wantFilterStatus: []*fwk.Status{
 				nil,
 			},
-			wantPreScoreStatus: framework.NewStatus(framework.Skip),
+			wantPreScoreStatus: fwk.NewStatus(fwk.Skip),
 		},
 		{
 			name: "PVC does not exist",
@@ -152,8 +152,8 @@ func TestVolumeBinding(t *testing.T) {
 				makeNode("node-a").Node,
 			},
 			pvcs:                []*v1.PersistentVolumeClaim{},
-			wantPreFilterStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, `persistentvolumeclaim "pvc-a" not found`),
-			wantFilterStatus: []*framework.Status{
+			wantPreFilterStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, `persistentvolumeclaim "pvc-a" not found`),
+			wantFilterStatus: []*fwk.Status{
 				nil,
 			},
 			wantScores: []int64{
@@ -169,8 +169,8 @@ func TestVolumeBinding(t *testing.T) {
 			pvcs: []*v1.PersistentVolumeClaim{
 				makePVC("pvc-a", waitSC.Name).withBoundPV("pv-a").PersistentVolumeClaim,
 			},
-			wantPreFilterStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, `persistentvolumeclaim "pvc-b" not found`),
-			wantFilterStatus: []*framework.Status{
+			wantPreFilterStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, `persistentvolumeclaim "pvc-b" not found`),
+			wantFilterStatus: []*fwk.Status{
 				nil,
 			},
 			wantScores: []int64{
@@ -186,8 +186,8 @@ func TestVolumeBinding(t *testing.T) {
 			pvcs: []*v1.PersistentVolumeClaim{
 				makePVC("pvc-a", immediateSC.Name).PersistentVolumeClaim,
 			},
-			wantPreFilterStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, "pod has unbound immediate PersistentVolumeClaims"),
-			wantFilterStatus: []*framework.Status{
+			wantPreFilterStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "pod has unbound immediate PersistentVolumeClaims"),
+			wantFilterStatus: []*fwk.Status{
 				nil,
 			},
 			wantScores: []int64{
@@ -213,10 +213,10 @@ func TestVolumeBinding(t *testing.T) {
 				},
 				podVolumesByNode: map[string]*PodVolumes{},
 			},
-			wantFilterStatus: []*framework.Status{
-				framework.NewStatus(framework.UnschedulableAndUnresolvable, string(ErrReasonBindConflict)),
+			wantFilterStatus: []*fwk.Status{
+				fwk.NewStatus(fwk.UnschedulableAndUnresolvable, string(ErrReasonBindConflict)),
 			},
-			wantPreScoreStatus: framework.NewStatus(framework.Skip),
+			wantPreScoreStatus: fwk.NewStatus(fwk.Skip),
 		},
 		{
 			name: "bound and unbound unsatisfied",
@@ -251,10 +251,10 @@ func TestVolumeBinding(t *testing.T) {
 				},
 				podVolumesByNode: map[string]*PodVolumes{},
 			},
-			wantFilterStatus: []*framework.Status{
-				framework.NewStatus(framework.UnschedulableAndUnresolvable, string(ErrReasonNodeConflict), string(ErrReasonBindConflict)),
+			wantFilterStatus: []*fwk.Status{
+				fwk.NewStatus(fwk.UnschedulableAndUnresolvable, string(ErrReasonNodeConflict), string(ErrReasonBindConflict)),
 			},
-			wantPreScoreStatus: framework.NewStatus(framework.Skip),
+			wantPreScoreStatus: fwk.NewStatus(fwk.Skip),
 		},
 		{
 			name: "pv not found",
@@ -276,10 +276,10 @@ func TestVolumeBinding(t *testing.T) {
 				},
 				podVolumesByNode: map[string]*PodVolumes{},
 			},
-			wantFilterStatus: []*framework.Status{
-				framework.NewStatus(framework.UnschedulableAndUnresolvable, `node(s) unavailable due to one or more pvc(s) bound to non-existent pv(s)`),
+			wantFilterStatus: []*fwk.Status{
+				fwk.NewStatus(fwk.UnschedulableAndUnresolvable, `node(s) unavailable due to one or more pvc(s) bound to non-existent pv(s)`),
 			},
-			wantPreScoreStatus: framework.NewStatus(framework.Skip),
+			wantPreScoreStatus: fwk.NewStatus(fwk.Skip),
 		},
 		{
 			name: "pv not found claim lost",
@@ -290,8 +290,8 @@ func TestVolumeBinding(t *testing.T) {
 			pvcs: []*v1.PersistentVolumeClaim{
 				makePVC("pvc-a", waitSC.Name).withBoundPV("pv-a").withPhase(v1.ClaimLost).PersistentVolumeClaim,
 			},
-			wantPreFilterStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, `persistentvolumeclaim "pvc-a" bound to non-existent persistentvolume "pv-a"`),
-			wantFilterStatus: []*framework.Status{
+			wantPreFilterStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, `persistentvolumeclaim "pvc-a" bound to non-existent persistentvolume "pv-a"`),
+			wantFilterStatus: []*fwk.Status{
 				nil,
 			},
 			wantScores: []int64{
@@ -360,10 +360,10 @@ func TestVolumeBinding(t *testing.T) {
 				},
 				podVolumesByNode: map[string]*PodVolumes{},
 			},
-			wantFilterStatus: []*framework.Status{
+			wantFilterStatus: []*fwk.Status{
 				nil,
 				nil,
-				framework.NewStatus(framework.UnschedulableAndUnresolvable, `node(s) didn't find available persistent volumes to bind`),
+				fwk.NewStatus(fwk.UnschedulableAndUnresolvable, `node(s) didn't find available persistent volumes to bind`),
 			},
 			wantScores: []int64{
 				25,
@@ -469,10 +469,10 @@ func TestVolumeBinding(t *testing.T) {
 				},
 				podVolumesByNode: map[string]*PodVolumes{},
 			},
-			wantFilterStatus: []*framework.Status{
+			wantFilterStatus: []*fwk.Status{
 				nil,
 				nil,
-				framework.NewStatus(framework.UnschedulableAndUnresolvable, `node(s) didn't find available persistent volumes to bind`),
+				fwk.NewStatus(fwk.UnschedulableAndUnresolvable, `node(s) didn't find available persistent volumes to bind`),
 			},
 			wantScores: []int64{
 				38,
@@ -581,13 +581,13 @@ func TestVolumeBinding(t *testing.T) {
 				},
 				podVolumesByNode: map[string]*PodVolumes{},
 			},
-			wantFilterStatus: []*framework.Status{
+			wantFilterStatus: []*fwk.Status{
 				nil,
 				nil,
 				nil,
 				nil,
-				framework.NewStatus(framework.UnschedulableAndUnresolvable, `node(s) didn't find available persistent volumes to bind`),
-				framework.NewStatus(framework.UnschedulableAndUnresolvable, `node(s) didn't find available persistent volumes to bind`),
+				fwk.NewStatus(fwk.UnschedulableAndUnresolvable, `node(s) didn't find available persistent volumes to bind`),
+				fwk.NewStatus(fwk.UnschedulableAndUnresolvable, `node(s) didn't find available persistent volumes to bind`),
 			},
 			wantScores: []int64{
 				25,
@@ -717,13 +717,13 @@ func TestVolumeBinding(t *testing.T) {
 				},
 				podVolumesByNode: map[string]*PodVolumes{},
 			},
-			wantFilterStatus: []*framework.Status{
+			wantFilterStatus: []*fwk.Status{
 				nil,
 				nil,
 				nil,
 				nil,
-				framework.NewStatus(framework.UnschedulableAndUnresolvable, `node(s) didn't find available persistent volumes to bind`),
-				framework.NewStatus(framework.UnschedulableAndUnresolvable, `node(s) didn't find available persistent volumes to bind`),
+				fwk.NewStatus(fwk.UnschedulableAndUnresolvable, `node(s) didn't find available persistent volumes to bind`),
+				fwk.NewStatus(fwk.UnschedulableAndUnresolvable, `node(s) didn't find available persistent volumes to bind`),
 			},
 			wantScores: []int64{
 				15,
@@ -764,7 +764,7 @@ func TestVolumeBinding(t *testing.T) {
 				},
 				podVolumesByNode: map[string]*PodVolumes{},
 			},
-			wantFilterStatus: []*framework.Status{
+			wantFilterStatus: []*fwk.Status{
 				nil,
 				nil,
 				nil,
@@ -837,7 +837,7 @@ func TestVolumeBinding(t *testing.T) {
 				},
 				podVolumesByNode: map[string]*PodVolumes{},
 			},
-			wantFilterStatus: []*framework.Status{
+			wantFilterStatus: []*fwk.Status{
 				nil,
 				nil,
 				nil,
@@ -876,7 +876,7 @@ func TestVolumeBinding(t *testing.T) {
 				},
 				podVolumesByNode: map[string]*PodVolumes{},
 			},
-			wantFilterStatus: []*framework.Status{
+			wantFilterStatus: []*fwk.Status{
 				nil,
 			},
 			wantScores: []int64{
@@ -913,7 +913,7 @@ func TestVolumeBinding(t *testing.T) {
 				},
 				podVolumesByNode: map[string]*PodVolumes{},
 			},
-			wantFilterStatus: []*framework.Status{
+			wantFilterStatus: []*fwk.Status{
 				nil,
 				nil,
 				nil,
@@ -967,7 +967,7 @@ func TestVolumeBinding(t *testing.T) {
 				},
 				podVolumesByNode: map[string]*PodVolumes{},
 			},
-			wantFilterStatus: []*framework.Status{
+			wantFilterStatus: []*fwk.Status{
 				nil,
 				nil,
 				nil,

--- a/pkg/scheduler/framework/plugins/volumerestrictions/volume_restrictions_test.go
+++ b/pkg/scheduler/framework/plugins/volumerestrictions/volume_restrictions_test.go
@@ -54,26 +54,26 @@ func TestGCEDiskConflicts(t *testing.T) {
 		Name:         "volume with no restriction",
 		VolumeSource: v1.VolumeSource{},
 	}
-	errStatus := framework.NewStatus(framework.Unschedulable, ErrReasonDiskConflict)
+	errStatus := fwk.NewStatus(fwk.Unschedulable, ErrReasonDiskConflict)
 	tests := []struct {
 		pod                 *v1.Pod
 		nodeInfo            *framework.NodeInfo
 		name                string
-		preFilterWantStatus *framework.Status
-		wantStatus          *framework.Status
+		preFilterWantStatus *fwk.Status
+		wantStatus          *fwk.Status
 	}{
 		{
 			pod:                 &v1.Pod{},
 			nodeInfo:            framework.NewNodeInfo(),
 			name:                "nothing",
-			preFilterWantStatus: framework.NewStatus(framework.Skip),
+			preFilterWantStatus: fwk.NewStatus(fwk.Skip),
 			wantStatus:          nil,
 		},
 		{
 			pod:                 &v1.Pod{},
 			nodeInfo:            framework.NewNodeInfo(st.MakePod().Volume(volState).Obj()),
 			name:                "one state",
-			preFilterWantStatus: framework.NewStatus(framework.Skip),
+			preFilterWantStatus: fwk.NewStatus(fwk.Skip),
 			wantStatus:          nil,
 		},
 		{
@@ -94,7 +94,7 @@ func TestGCEDiskConflicts(t *testing.T) {
 			pod:                 st.MakePod().Volume(volWithNoRestriction).Obj(),
 			nodeInfo:            framework.NewNodeInfo(),
 			name:                "pod with a volume that doesn't have restrictions",
-			preFilterWantStatus: framework.NewStatus(framework.Skip),
+			preFilterWantStatus: fwk.NewStatus(fwk.Skip),
 			wantStatus:          nil,
 		},
 	}
@@ -136,27 +136,27 @@ func TestAWSDiskConflicts(t *testing.T) {
 			},
 		},
 	}
-	errStatus := framework.NewStatus(framework.Unschedulable, ErrReasonDiskConflict)
+	errStatus := fwk.NewStatus(fwk.Unschedulable, ErrReasonDiskConflict)
 	tests := []struct {
 		pod                 *v1.Pod
 		nodeInfo            *framework.NodeInfo
 		name                string
-		wantStatus          *framework.Status
-		preFilterWantStatus *framework.Status
+		wantStatus          *fwk.Status
+		preFilterWantStatus *fwk.Status
 	}{
 		{
 			pod:                 &v1.Pod{},
 			nodeInfo:            framework.NewNodeInfo(),
 			name:                "nothing",
 			wantStatus:          nil,
-			preFilterWantStatus: framework.NewStatus(framework.Skip),
+			preFilterWantStatus: fwk.NewStatus(fwk.Skip),
 		},
 		{
 			pod:                 &v1.Pod{},
 			nodeInfo:            framework.NewNodeInfo(st.MakePod().Volume(volState).Obj()),
 			name:                "one state",
 			wantStatus:          nil,
-			preFilterWantStatus: framework.NewStatus(framework.Skip),
+			preFilterWantStatus: fwk.NewStatus(fwk.Skip),
 		},
 		{
 			pod:                 st.MakePod().Volume(volState).Obj(),
@@ -217,27 +217,27 @@ func TestRBDDiskConflicts(t *testing.T) {
 			},
 		},
 	}
-	errStatus := framework.NewStatus(framework.Unschedulable, ErrReasonDiskConflict)
+	errStatus := fwk.NewStatus(fwk.Unschedulable, ErrReasonDiskConflict)
 	tests := []struct {
 		pod                 *v1.Pod
 		nodeInfo            *framework.NodeInfo
 		name                string
-		wantStatus          *framework.Status
-		preFilterWantStatus *framework.Status
+		wantStatus          *fwk.Status
+		preFilterWantStatus *fwk.Status
 	}{
 		{
 			pod:                 &v1.Pod{},
 			nodeInfo:            framework.NewNodeInfo(),
 			name:                "nothing",
 			wantStatus:          nil,
-			preFilterWantStatus: framework.NewStatus(framework.Skip),
+			preFilterWantStatus: fwk.NewStatus(fwk.Skip),
 		},
 		{
 			pod:                 &v1.Pod{},
 			nodeInfo:            framework.NewNodeInfo(st.MakePod().Volume(volState).Obj()),
 			name:                "one state",
 			wantStatus:          nil,
-			preFilterWantStatus: framework.NewStatus(framework.Skip),
+			preFilterWantStatus: fwk.NewStatus(fwk.Skip),
 		},
 		{
 			pod:                 st.MakePod().Volume(volState).Obj(),
@@ -298,27 +298,27 @@ func TestISCSIDiskConflicts(t *testing.T) {
 			},
 		},
 	}
-	errStatus := framework.NewStatus(framework.Unschedulable, ErrReasonDiskConflict)
+	errStatus := fwk.NewStatus(fwk.Unschedulable, ErrReasonDiskConflict)
 	tests := []struct {
 		pod                 *v1.Pod
 		nodeInfo            *framework.NodeInfo
 		name                string
-		wantStatus          *framework.Status
-		preFilterWantStatus *framework.Status
+		wantStatus          *fwk.Status
+		preFilterWantStatus *fwk.Status
 	}{
 		{
 			pod:                 &v1.Pod{},
 			nodeInfo:            framework.NewNodeInfo(),
 			name:                "nothing",
 			wantStatus:          nil,
-			preFilterWantStatus: framework.NewStatus(framework.Skip),
+			preFilterWantStatus: fwk.NewStatus(fwk.Skip),
 		},
 		{
 			pod:                 &v1.Pod{},
 			nodeInfo:            framework.NewNodeInfo(st.MakePod().Volume(volState).Obj()),
 			name:                "one state",
 			wantStatus:          nil,
-			preFilterWantStatus: framework.NewStatus(framework.Skip),
+			preFilterWantStatus: fwk.NewStatus(fwk.Skip),
 		},
 		{
 			pod:                 st.MakePod().Volume(volState).Obj(),
@@ -409,8 +409,8 @@ func TestAccessModeConflicts(t *testing.T) {
 		existingPods        []*v1.Pod
 		existingNodes       []*v1.Node
 		existingPVCs        []*v1.PersistentVolumeClaim
-		preFilterWantStatus *framework.Status
-		wantStatus          *framework.Status
+		preFilterWantStatus *fwk.Status
+		wantStatus          *fwk.Status
 	}{
 		{
 			name:                "nothing",
@@ -419,7 +419,7 @@ func TestAccessModeConflicts(t *testing.T) {
 			existingPods:        []*v1.Pod{},
 			existingNodes:       []*v1.Node{},
 			existingPVCs:        []*v1.PersistentVolumeClaim{},
-			preFilterWantStatus: framework.NewStatus(framework.Skip),
+			preFilterWantStatus: fwk.NewStatus(fwk.Skip),
 			wantStatus:          nil,
 		},
 		{
@@ -429,7 +429,7 @@ func TestAccessModeConflicts(t *testing.T) {
 			existingPods:        []*v1.Pod{},
 			existingNodes:       []*v1.Node{},
 			existingPVCs:        []*v1.PersistentVolumeClaim{},
-			preFilterWantStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, "persistentvolumeclaim \"claim-with-rwop-1\" not found"),
+			preFilterWantStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "persistentvolumeclaim \"claim-with-rwop-1\" not found"),
 			wantStatus:          nil,
 		},
 		{
@@ -439,7 +439,7 @@ func TestAccessModeConflicts(t *testing.T) {
 			existingPods:        []*v1.Pod{podWithReadWriteManyPVC},
 			existingNodes:       []*v1.Node{node},
 			existingPVCs:        []*v1.PersistentVolumeClaim{readWriteOncePodPVC1, readWriteManyPVC},
-			preFilterWantStatus: framework.NewStatus(framework.Skip),
+			preFilterWantStatus: fwk.NewStatus(fwk.Skip),
 			wantStatus:          nil,
 		},
 		{
@@ -450,7 +450,7 @@ func TestAccessModeConflicts(t *testing.T) {
 			existingNodes:       []*v1.Node{node},
 			existingPVCs:        []*v1.PersistentVolumeClaim{readWriteOncePodPVC1, readWriteManyPVC},
 			preFilterWantStatus: nil,
-			wantStatus:          framework.NewStatus(framework.Unschedulable, ErrReasonReadWriteOncePodConflict),
+			wantStatus:          fwk.NewStatus(fwk.Unschedulable, ErrReasonReadWriteOncePodConflict),
 		},
 		{
 			name:                "two conflicts, unschedulable",
@@ -460,7 +460,7 @@ func TestAccessModeConflicts(t *testing.T) {
 			existingNodes:       []*v1.Node{node},
 			existingPVCs:        []*v1.PersistentVolumeClaim{readWriteOncePodPVC1, readWriteOncePodPVC2, readWriteManyPVC},
 			preFilterWantStatus: nil,
-			wantStatus:          framework.NewStatus(framework.Unschedulable, ErrReasonReadWriteOncePodConflict),
+			wantStatus:          fwk.NewStatus(fwk.Unschedulable, ErrReasonReadWriteOncePodConflict),
 		},
 	}
 

--- a/pkg/scheduler/framework/plugins/volumezone/volume_zone_test.go
+++ b/pkg/scheduler/framework/plugins/volumezone/volume_zone_test.go
@@ -100,8 +100,8 @@ func TestSingleZone(t *testing.T) {
 		name                string
 		Pod                 *v1.Pod
 		Node                *v1.Node
-		wantPreFilterStatus *framework.Status
-		wantFilterStatus    *framework.Status
+		wantPreFilterStatus *fwk.Status
+		wantFilterStatus    *fwk.Status
 	}{
 		{
 			name: "pod without volume",
@@ -112,7 +112,7 @@ func TestSingleZone(t *testing.T) {
 					Labels: map[string]string{v1.LabelFailureDomainBetaZone: "us-west1-a"},
 				},
 			},
-			wantPreFilterStatus: framework.NewStatus(framework.Skip),
+			wantPreFilterStatus: fwk.NewStatus(fwk.Skip),
 		},
 		{
 			name: "node without labels",
@@ -152,7 +152,7 @@ func TestSingleZone(t *testing.T) {
 					Labels: map[string]string{v1.LabelFailureDomainBetaRegion: "no_us-west1", "uselessLabel": "none"},
 				},
 			},
-			wantFilterStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReasonConflict),
+			wantFilterStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, ErrReasonConflict),
 		},
 		{
 			name: "beta zone label doesn't match",
@@ -163,7 +163,7 @@ func TestSingleZone(t *testing.T) {
 					Labels: map[string]string{v1.LabelFailureDomainBetaZone: "no_us-west1-a", "uselessLabel": "none"},
 				},
 			},
-			wantFilterStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReasonConflict),
+			wantFilterStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, ErrReasonConflict),
 		},
 		{
 			name: "zone label matched",
@@ -194,7 +194,7 @@ func TestSingleZone(t *testing.T) {
 					Labels: map[string]string{v1.LabelTopologyRegion: "no_us-west1", "uselessLabel": "none"},
 				},
 			},
-			wantFilterStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReasonConflict),
+			wantFilterStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, ErrReasonConflict),
 		},
 		{
 			name: "zone label doesn't match",
@@ -205,7 +205,7 @@ func TestSingleZone(t *testing.T) {
 					Labels: map[string]string{v1.LabelTopologyZone: "no_us-west1-a", "uselessLabel": "none"},
 				},
 			},
-			wantFilterStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReasonConflict),
+			wantFilterStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, ErrReasonConflict),
 		},
 		{
 			name: "pv with zone and region, node with only zone",
@@ -218,7 +218,7 @@ func TestSingleZone(t *testing.T) {
 					},
 				},
 			},
-			wantFilterStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReasonConflict),
+			wantFilterStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, ErrReasonConflict),
 		},
 		{
 			name: "pv with zone,node with beta zone",
@@ -231,7 +231,7 @@ func TestSingleZone(t *testing.T) {
 					},
 				},
 			},
-			wantFilterStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReasonConflict),
+			wantFilterStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, ErrReasonConflict),
 		},
 		{
 			name: "pv with beta label,node with ga label, matched",
@@ -256,7 +256,7 @@ func TestSingleZone(t *testing.T) {
 					},
 				},
 			},
-			wantFilterStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReasonConflict),
+			wantFilterStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, ErrReasonConflict),
 		},
 	}
 
@@ -337,8 +337,8 @@ func TestMultiZone(t *testing.T) {
 		name                string
 		Pod                 *v1.Pod
 		Node                *v1.Node
-		wantPreFilterStatus *framework.Status
-		wantFilterStatus    *framework.Status
+		wantPreFilterStatus *fwk.Status
+		wantFilterStatus    *fwk.Status
 	}{
 		{
 			name: "node without labels",
@@ -368,7 +368,7 @@ func TestMultiZone(t *testing.T) {
 					Labels: map[string]string{v1.LabelFailureDomainBetaZone: "us-west1-b", "uselessLabel": "none"},
 				},
 			},
-			wantFilterStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReasonConflict),
+			wantFilterStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, ErrReasonConflict),
 		},
 		{
 			name: "zone label matched",
@@ -389,7 +389,7 @@ func TestMultiZone(t *testing.T) {
 					Labels: map[string]string{v1.LabelTopologyZone: "us-west1-b", "uselessLabel": "none"},
 				},
 			},
-			wantFilterStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReasonConflict),
+			wantFilterStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, ErrReasonConflict),
 		},
 	}
 
@@ -478,8 +478,8 @@ func TestWithBinding(t *testing.T) {
 		name                string
 		Pod                 *v1.Pod
 		Node                *v1.Node
-		wantPreFilterStatus *framework.Status
-		wantFilterStatus    *framework.Status
+		wantPreFilterStatus *fwk.Status
+		wantFilterStatus    *fwk.Status
 	}{
 		{
 			name: "label zone failure domain matched",
@@ -490,32 +490,32 @@ func TestWithBinding(t *testing.T) {
 			name: "unbound volume empty storage class",
 			Pod:  createPodWithVolume("pod_1", "PVC_EmptySC"),
 			Node: testNode,
-			wantPreFilterStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable,
+			wantPreFilterStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable,
 				"PersistentVolumeClaim had no pv name and storageClass name"),
-			wantFilterStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable,
+			wantFilterStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable,
 				"PersistentVolumeClaim had no pv name and storageClass name"),
 		},
 		{
 			name: "unbound volume no storage class",
 			Pod:  createPodWithVolume("pod_1", "PVC_NoSC"),
 			Node: testNode,
-			wantPreFilterStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable,
+			wantPreFilterStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable,
 				`storageclasses.storage.k8s.io "Class_0" not found`),
-			wantFilterStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable,
+			wantFilterStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable,
 				`storageclasses.storage.k8s.io "Class_0" not found`),
 		},
 		{
 			name:                "unbound volume immediate binding mode",
 			Pod:                 createPodWithVolume("pod_1", "PVC_ImmediateSC"),
 			Node:                testNode,
-			wantPreFilterStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, "VolumeBindingMode not set for StorageClass \"Class_Immediate\""),
-			wantFilterStatus:    framework.NewStatus(framework.UnschedulableAndUnresolvable, "VolumeBindingMode not set for StorageClass \"Class_Immediate\""),
+			wantPreFilterStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "VolumeBindingMode not set for StorageClass \"Class_Immediate\""),
+			wantFilterStatus:    fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "VolumeBindingMode not set for StorageClass \"Class_Immediate\""),
 		},
 		{
 			name:                "unbound volume wait binding mode",
 			Pod:                 createPodWithVolume("pod_1", "PVC_WaitSC"),
 			Node:                testNode,
-			wantPreFilterStatus: framework.NewStatus(framework.Skip),
+			wantPreFilterStatus: fwk.NewStatus(fwk.Skip),
 		},
 	}
 

--- a/pkg/scheduler/framework/runtime/framework_test.go
+++ b/pkg/scheduler/framework/runtime/framework_test.go
@@ -78,11 +78,11 @@ var _ framework.ScorePlugin = &TestScoreWithNormalizePlugin{}
 var _ framework.ScorePlugin = &TestScorePlugin{}
 
 var statusCmpOpts = []cmp.Option{
-	cmp.Comparer(func(s1 *framework.Status, s2 *framework.Status) bool {
+	cmp.Comparer(func(s1 *fwk.Status, s2 *fwk.Status) bool {
 		if s1 == nil || s2 == nil {
 			return s1.IsSuccess() && s2.IsSuccess()
 		}
-		if s1.Code() == framework.Error {
+		if s1.Code() == fwk.Error {
 			return s1.AsError().Error() == s2.AsError().Error()
 		}
 		return s1.Code() == s2.Code() && s1.Plugin() == s2.Plugin() && s1.Message() == s2.Message()
@@ -134,11 +134,11 @@ func (pl *TestScoreWithNormalizePlugin) Name() string {
 	return pl.name
 }
 
-func (pl *TestScoreWithNormalizePlugin) NormalizeScore(ctx context.Context, state fwk.CycleState, pod *v1.Pod, scores framework.NodeScoreList) *framework.Status {
+func (pl *TestScoreWithNormalizePlugin) NormalizeScore(ctx context.Context, state fwk.CycleState, pod *v1.Pod, scores framework.NodeScoreList) *fwk.Status {
 	return injectNormalizeRes(pl.inj, scores)
 }
 
-func (pl *TestScoreWithNormalizePlugin) Score(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodeInfo *framework.NodeInfo) (int64, *framework.Status) {
+func (pl *TestScoreWithNormalizePlugin) Score(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodeInfo *framework.NodeInfo) (int64, *fwk.Status) {
 	return setScoreRes(pl.inj)
 }
 
@@ -156,11 +156,11 @@ func (pl *TestScorePlugin) Name() string {
 	return pl.name
 }
 
-func (pl *TestScorePlugin) PreScore(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodes []*framework.NodeInfo) *framework.Status {
-	return framework.NewStatus(framework.Code(pl.inj.PreScoreStatus), injectReason)
+func (pl *TestScorePlugin) PreScore(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodes []*framework.NodeInfo) *fwk.Status {
+	return fwk.NewStatus(fwk.Code(pl.inj.PreScoreStatus), injectReason)
 }
 
-func (pl *TestScorePlugin) Score(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodeInfo *framework.NodeInfo) (int64, *framework.Status) {
+func (pl *TestScorePlugin) Score(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodeInfo *framework.NodeInfo) (int64, *fwk.Status) {
 	return setScoreRes(pl.inj)
 }
 
@@ -185,11 +185,11 @@ type TestPlugin struct {
 	inj  injectedResult
 }
 
-func (pl *TestPlugin) AddPod(ctx context.Context, state fwk.CycleState, podToSchedule *v1.Pod, podInfoToAdd *framework.PodInfo, nodeInfo *framework.NodeInfo) *framework.Status {
-	return framework.NewStatus(framework.Code(pl.inj.PreFilterAddPodStatus), injectReason)
+func (pl *TestPlugin) AddPod(ctx context.Context, state fwk.CycleState, podToSchedule *v1.Pod, podInfoToAdd *framework.PodInfo, nodeInfo *framework.NodeInfo) *fwk.Status {
+	return fwk.NewStatus(fwk.Code(pl.inj.PreFilterAddPodStatus), injectReason)
 }
-func (pl *TestPlugin) RemovePod(ctx context.Context, state fwk.CycleState, podToSchedule *v1.Pod, podInfoToRemove *framework.PodInfo, nodeInfo *framework.NodeInfo) *framework.Status {
-	return framework.NewStatus(framework.Code(pl.inj.PreFilterRemovePodStatus), injectReason)
+func (pl *TestPlugin) RemovePod(ctx context.Context, state fwk.CycleState, podToSchedule *v1.Pod, podInfoToRemove *framework.PodInfo, nodeInfo *framework.NodeInfo) *fwk.Status {
+	return fwk.NewStatus(fwk.Code(pl.inj.PreFilterRemovePodStatus), injectReason)
 }
 
 func (pl *TestPlugin) Name() string {
@@ -200,54 +200,54 @@ func (pl *TestPlugin) Less(*framework.QueuedPodInfo, *framework.QueuedPodInfo) b
 	return false
 }
 
-func (pl *TestPlugin) Score(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodeInfo *framework.NodeInfo) (int64, *framework.Status) {
-	return 0, framework.NewStatus(framework.Code(pl.inj.ScoreStatus), injectReason)
+func (pl *TestPlugin) Score(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodeInfo *framework.NodeInfo) (int64, *fwk.Status) {
+	return 0, fwk.NewStatus(fwk.Code(pl.inj.ScoreStatus), injectReason)
 }
 
 func (pl *TestPlugin) ScoreExtensions() framework.ScoreExtensions {
 	return nil
 }
 
-func (pl *TestPlugin) PreFilter(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodes []*framework.NodeInfo) (*framework.PreFilterResult, *framework.Status) {
-	return pl.inj.PreFilterResult, framework.NewStatus(framework.Code(pl.inj.PreFilterStatus), injectReason)
+func (pl *TestPlugin) PreFilter(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodes []*framework.NodeInfo) (*framework.PreFilterResult, *fwk.Status) {
+	return pl.inj.PreFilterResult, fwk.NewStatus(fwk.Code(pl.inj.PreFilterStatus), injectReason)
 }
 
 func (pl *TestPlugin) PreFilterExtensions() framework.PreFilterExtensions {
 	return pl
 }
 
-func (pl *TestPlugin) Filter(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) *framework.Status {
-	return framework.NewStatus(framework.Code(pl.inj.FilterStatus), injectFilterReason)
+func (pl *TestPlugin) Filter(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) *fwk.Status {
+	return fwk.NewStatus(fwk.Code(pl.inj.FilterStatus), injectFilterReason)
 }
 
-func (pl *TestPlugin) PostFilter(_ context.Context, _ fwk.CycleState, _ *v1.Pod, _ framework.NodeToStatusReader) (*framework.PostFilterResult, *framework.Status) {
-	return nil, framework.NewStatus(framework.Code(pl.inj.PostFilterStatus), injectReason)
+func (pl *TestPlugin) PostFilter(_ context.Context, _ fwk.CycleState, _ *v1.Pod, _ framework.NodeToStatusReader) (*framework.PostFilterResult, *fwk.Status) {
+	return nil, fwk.NewStatus(fwk.Code(pl.inj.PostFilterStatus), injectReason)
 }
 
-func (pl *TestPlugin) PreScore(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodes []*framework.NodeInfo) *framework.Status {
-	return framework.NewStatus(framework.Code(pl.inj.PreScoreStatus), injectReason)
+func (pl *TestPlugin) PreScore(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodes []*framework.NodeInfo) *fwk.Status {
+	return fwk.NewStatus(fwk.Code(pl.inj.PreScoreStatus), injectReason)
 }
 
-func (pl *TestPlugin) Reserve(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodeName string) *framework.Status {
-	return framework.NewStatus(framework.Code(pl.inj.ReserveStatus), injectReason)
+func (pl *TestPlugin) Reserve(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodeName string) *fwk.Status {
+	return fwk.NewStatus(fwk.Code(pl.inj.ReserveStatus), injectReason)
 }
 
 func (pl *TestPlugin) Unreserve(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodeName string) {
 }
 
-func (pl *TestPlugin) PreBind(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodeName string) *framework.Status {
-	return framework.NewStatus(framework.Code(pl.inj.PreBindStatus), injectReason)
+func (pl *TestPlugin) PreBind(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodeName string) *fwk.Status {
+	return fwk.NewStatus(fwk.Code(pl.inj.PreBindStatus), injectReason)
 }
 
 func (pl *TestPlugin) PostBind(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodeName string) {
 }
 
-func (pl *TestPlugin) Permit(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodeName string) (*framework.Status, time.Duration) {
-	return framework.NewStatus(framework.Code(pl.inj.PermitStatus), injectReason), time.Duration(0)
+func (pl *TestPlugin) Permit(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodeName string) (*fwk.Status, time.Duration) {
+	return fwk.NewStatus(fwk.Code(pl.inj.PermitStatus), injectReason), time.Duration(0)
 }
 
-func (pl *TestPlugin) Bind(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodeName string) *framework.Status {
-	return framework.NewStatus(framework.Code(pl.inj.BindStatus), injectReason)
+func (pl *TestPlugin) Bind(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodeName string) *fwk.Status {
+	return fwk.NewStatus(fwk.Code(pl.inj.BindStatus), injectReason)
 }
 
 func newTestCloseErrorPlugin(_ context.Context, injArgs runtime.Object, f framework.Handle) (framework.Plugin, error) {
@@ -278,7 +278,7 @@ func (pl *TestPreFilterPlugin) Name() string {
 	return preFilterPluginName
 }
 
-func (pl *TestPreFilterPlugin) PreFilter(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodes []*framework.NodeInfo) (*framework.PreFilterResult, *framework.Status) {
+func (pl *TestPreFilterPlugin) PreFilter(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodes []*framework.NodeInfo) (*framework.PreFilterResult, *fwk.Status) {
 	pl.PreFilterCalled++
 	return nil, nil
 }
@@ -298,19 +298,19 @@ func (pl *TestPreFilterWithExtensionsPlugin) Name() string {
 	return preFilterWithExtensionsPluginName
 }
 
-func (pl *TestPreFilterWithExtensionsPlugin) PreFilter(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodes []*framework.NodeInfo) (*framework.PreFilterResult, *framework.Status) {
+func (pl *TestPreFilterWithExtensionsPlugin) PreFilter(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodes []*framework.NodeInfo) (*framework.PreFilterResult, *fwk.Status) {
 	pl.PreFilterCalled++
 	return nil, nil
 }
 
 func (pl *TestPreFilterWithExtensionsPlugin) AddPod(ctx context.Context, state fwk.CycleState, podToSchedule *v1.Pod,
-	podInfoToAdd *framework.PodInfo, nodeInfo *framework.NodeInfo) *framework.Status {
+	podInfoToAdd *framework.PodInfo, nodeInfo *framework.NodeInfo) *fwk.Status {
 	pl.AddCalled++
 	return nil
 }
 
 func (pl *TestPreFilterWithExtensionsPlugin) RemovePod(ctx context.Context, state fwk.CycleState, podToSchedule *v1.Pod,
-	podInfoToRemove *framework.PodInfo, nodeInfo *framework.NodeInfo) *framework.Status {
+	podInfoToRemove *framework.PodInfo, nodeInfo *framework.NodeInfo) *fwk.Status {
 	pl.RemoveCalled++
 	return nil
 }
@@ -326,7 +326,7 @@ func (dp *TestDuplicatePlugin) Name() string {
 	return duplicatePluginName
 }
 
-func (dp *TestDuplicatePlugin) PreFilter(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodes []*framework.NodeInfo) (*framework.PreFilterResult, *framework.Status) {
+func (dp *TestDuplicatePlugin) PreFilter(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodes []*framework.NodeInfo) (*framework.PreFilterResult, *fwk.Status) {
 	return nil, nil
 }
 
@@ -348,8 +348,8 @@ type TestPermitPlugin struct {
 func (pp *TestPermitPlugin) Name() string {
 	return permitPlugin
 }
-func (pp *TestPermitPlugin) Permit(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodeName string) (*framework.Status, time.Duration) {
-	return framework.NewStatus(framework.Wait), 10 * time.Second
+func (pp *TestPermitPlugin) Permit(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodeName string) (*fwk.Status, time.Duration) {
+	return fwk.NewStatus(fwk.Wait), 10 * time.Second
 }
 
 var _ framework.PreEnqueuePlugin = &TestPreEnqueuePlugin{}
@@ -360,7 +360,7 @@ func (pl *TestPreEnqueuePlugin) Name() string {
 	return preEnqueuePlugin
 }
 
-func (pl *TestPreEnqueuePlugin) PreEnqueue(ctx context.Context, p *v1.Pod) *framework.Status {
+func (pl *TestPreEnqueuePlugin) PreEnqueue(ctx context.Context, p *v1.Pod) *fwk.Status {
 	return nil
 }
 
@@ -394,7 +394,7 @@ func (t TestBindPlugin) Name() string {
 	return bindPlugin
 }
 
-func (t TestBindPlugin) Bind(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodeName string) *framework.Status {
+func (t TestBindPlugin) Bind(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodeName string) *fwk.Status {
 	return nil
 }
 
@@ -1001,7 +1001,7 @@ func TestRunPreScorePlugins(t *testing.T) {
 		name               string
 		plugins            []*TestPlugin
 		wantSkippedPlugins sets.Set[string]
-		wantStatusCode     framework.Code
+		wantStatusCode     fwk.Code
 	}{
 		{
 			name: "all PreScorePlugins returned success",
@@ -1013,7 +1013,7 @@ func TestRunPreScorePlugins(t *testing.T) {
 					name: "success2",
 				},
 			},
-			wantStatusCode: framework.Success,
+			wantStatusCode: fwk.Success,
 		},
 		{
 			name: "one PreScore plugin returned success, but another PreScore plugin returned non-success",
@@ -1023,65 +1023,65 @@ func TestRunPreScorePlugins(t *testing.T) {
 				},
 				{
 					name: "error",
-					inj:  injectedResult{PreScoreStatus: int(framework.Error)},
+					inj:  injectedResult{PreScoreStatus: int(fwk.Error)},
 				},
 			},
-			wantStatusCode: framework.Error,
+			wantStatusCode: fwk.Error,
 		},
 		{
 			name: "one PreScore plugin returned skip, but another PreScore plugin returned non-success",
 			plugins: []*TestPlugin{
 				{
 					name: "skip",
-					inj:  injectedResult{PreScoreStatus: int(framework.Skip)},
+					inj:  injectedResult{PreScoreStatus: int(fwk.Skip)},
 				},
 				{
 					name: "error",
-					inj:  injectedResult{PreScoreStatus: int(framework.Error)},
+					inj:  injectedResult{PreScoreStatus: int(fwk.Error)},
 				},
 			},
 			wantSkippedPlugins: sets.New("skip"),
-			wantStatusCode:     framework.Error,
+			wantStatusCode:     fwk.Error,
 		},
 		{
 			name: "all PreScore plugins returned skip",
 			plugins: []*TestPlugin{
 				{
 					name: "skip1",
-					inj:  injectedResult{PreScoreStatus: int(framework.Skip)},
+					inj:  injectedResult{PreScoreStatus: int(fwk.Skip)},
 				},
 				{
 					name: "skip2",
-					inj:  injectedResult{PreScoreStatus: int(framework.Skip)},
+					inj:  injectedResult{PreScoreStatus: int(fwk.Skip)},
 				},
 				{
 					name: "skip3",
-					inj:  injectedResult{PreScoreStatus: int(framework.Skip)},
+					inj:  injectedResult{PreScoreStatus: int(fwk.Skip)},
 				},
 			},
 			wantSkippedPlugins: sets.New("skip1", "skip2", "skip3"),
-			wantStatusCode:     framework.Success,
+			wantStatusCode:     fwk.Success,
 		},
 		{
 			name: "some PreScore plugins returned skip",
 			plugins: []*TestPlugin{
 				{
 					name: "skip1",
-					inj:  injectedResult{PreScoreStatus: int(framework.Skip)},
+					inj:  injectedResult{PreScoreStatus: int(fwk.Skip)},
 				},
 				{
 					name: "success1",
 				},
 				{
 					name: "skip2",
-					inj:  injectedResult{PreScoreStatus: int(framework.Skip)},
+					inj:  injectedResult{PreScoreStatus: int(fwk.Skip)},
 				},
 				{
 					name: "success2",
 				},
 			},
 			wantSkippedPlugins: sets.New("skip1", "skip2"),
-			wantStatusCode:     framework.Success,
+			wantStatusCode:     fwk.Success,
 		},
 	}
 
@@ -1585,7 +1585,7 @@ func TestRunPreFilterPlugins(t *testing.T) {
 		plugins             []*TestPlugin
 		wantPreFilterResult *framework.PreFilterResult
 		wantSkippedPlugins  sets.Set[string]
-		wantStatusCode      framework.Code
+		wantStatusCode      fwk.Code
 	}{
 		{
 			name: "all PreFilter returned success",
@@ -1598,7 +1598,7 @@ func TestRunPreFilterPlugins(t *testing.T) {
 				},
 			},
 			wantPreFilterResult: nil,
-			wantStatusCode:      framework.Success,
+			wantStatusCode:      fwk.Success,
 		},
 		{
 			name: "one PreFilter plugin returned success, but another PreFilter plugin returned non-success",
@@ -1608,60 +1608,60 @@ func TestRunPreFilterPlugins(t *testing.T) {
 				},
 				{
 					name: "error",
-					inj:  injectedResult{PreFilterStatus: int(framework.Error)},
+					inj:  injectedResult{PreFilterStatus: int(fwk.Error)},
 				},
 			},
 			wantPreFilterResult: nil,
-			wantStatusCode:      framework.Error,
+			wantStatusCode:      fwk.Error,
 		},
 		{
 			name: "one PreFilter plugin returned skip, but another PreFilter plugin returned non-success",
 			plugins: []*TestPlugin{
 				{
 					name: "skip",
-					inj:  injectedResult{PreFilterStatus: int(framework.Skip)},
+					inj:  injectedResult{PreFilterStatus: int(fwk.Skip)},
 				},
 				{
 					name: "error",
-					inj:  injectedResult{PreFilterStatus: int(framework.Error)},
+					inj:  injectedResult{PreFilterStatus: int(fwk.Error)},
 				},
 			},
 			wantSkippedPlugins: sets.New("skip"),
-			wantStatusCode:     framework.Error,
+			wantStatusCode:     fwk.Error,
 		},
 		{
 			name: "all PreFilter plugins returned skip",
 			plugins: []*TestPlugin{
 				{
 					name: "skip1",
-					inj:  injectedResult{PreFilterStatus: int(framework.Skip)},
+					inj:  injectedResult{PreFilterStatus: int(fwk.Skip)},
 				},
 				{
 					name: "skip2",
-					inj:  injectedResult{PreFilterStatus: int(framework.Skip)},
+					inj:  injectedResult{PreFilterStatus: int(fwk.Skip)},
 				},
 				{
 					name: "skip3",
-					inj:  injectedResult{PreFilterStatus: int(framework.Skip)},
+					inj:  injectedResult{PreFilterStatus: int(fwk.Skip)},
 				},
 			},
 			wantPreFilterResult: nil,
 			wantSkippedPlugins:  sets.New("skip1", "skip2", "skip3"),
-			wantStatusCode:      framework.Success,
+			wantStatusCode:      fwk.Success,
 		},
 		{
 			name: "some PreFilter plugins returned skip",
 			plugins: []*TestPlugin{
 				{
 					name: "skip1",
-					inj:  injectedResult{PreFilterStatus: int(framework.Skip)},
+					inj:  injectedResult{PreFilterStatus: int(fwk.Skip)},
 				},
 				{
 					name: "success1",
 				},
 				{
 					name: "skip2",
-					inj:  injectedResult{PreFilterStatus: int(framework.Skip)},
+					inj:  injectedResult{PreFilterStatus: int(fwk.Skip)},
 				},
 				{
 					name: "success2",
@@ -1669,40 +1669,40 @@ func TestRunPreFilterPlugins(t *testing.T) {
 			},
 			wantPreFilterResult: nil,
 			wantSkippedPlugins:  sets.New("skip1", "skip2"),
-			wantStatusCode:      framework.Success,
+			wantStatusCode:      fwk.Success,
 		},
 		{
 			name: "one PreFilter plugin returned Unschedulable, but another PreFilter plugin should be executed",
 			plugins: []*TestPlugin{
 				{
 					name: "unschedulable",
-					inj:  injectedResult{PreFilterStatus: int(framework.Unschedulable)},
+					inj:  injectedResult{PreFilterStatus: int(fwk.Unschedulable)},
 				},
 				{
 					// to make sure this plugin is executed, this plugin return Skip and we confirm it via wantSkippedPlugins.
 					name: "skip",
-					inj:  injectedResult{PreFilterStatus: int(framework.Skip)},
+					inj:  injectedResult{PreFilterStatus: int(fwk.Skip)},
 				},
 			},
 			wantPreFilterResult: nil,
 			wantSkippedPlugins:  sets.New("skip"),
-			wantStatusCode:      framework.Unschedulable,
+			wantStatusCode:      fwk.Unschedulable,
 		},
 		{
 			name: "one PreFilter plugin returned UnschedulableAndUnresolvable, and all other plugins aren't executed",
 			plugins: []*TestPlugin{
 				{
 					name: "unresolvable",
-					inj:  injectedResult{PreFilterStatus: int(framework.UnschedulableAndUnresolvable)},
+					inj:  injectedResult{PreFilterStatus: int(fwk.UnschedulableAndUnresolvable)},
 				},
 				{
 					// to make sure this plugin is not executed, this plugin return Skip and we confirm it via wantSkippedPlugins.
 					name: "skip",
-					inj:  injectedResult{PreFilterStatus: int(framework.Skip)},
+					inj:  injectedResult{PreFilterStatus: int(fwk.Skip)},
 				},
 			},
 			wantPreFilterResult: nil,
-			wantStatusCode:      framework.UnschedulableAndUnresolvable,
+			wantStatusCode:      fwk.UnschedulableAndUnresolvable,
 		},
 		{
 			name: "all nodes are filtered out by prefilter result, but other plugins aren't executed because we consider all nodes are filtered out by UnschedulableAndUnresolvable",
@@ -1714,12 +1714,12 @@ func TestRunPreFilterPlugins(t *testing.T) {
 				{
 					// to make sure this plugin is not executed, this plugin return Skip and we confirm it via wantSkippedPlugins.
 					name: "skip",
-					inj:  injectedResult{PreFilterStatus: int(framework.Skip)},
+					inj:  injectedResult{PreFilterStatus: int(fwk.Skip)},
 				},
 			},
 			wantPreFilterResult: &framework.PreFilterResult{NodeNames: sets.New[string]()},
 			wantSkippedPlugins:  sets.New[string](), // "skip" plugin isn't executed.
-			wantStatusCode:      framework.UnschedulableAndUnresolvable,
+			wantStatusCode:      fwk.UnschedulableAndUnresolvable,
 		},
 	}
 	for _, tt := range tests {
@@ -1774,7 +1774,7 @@ func TestRunPreFilterExtensionRemovePod(t *testing.T) {
 		name               string
 		plugins            []*TestPlugin
 		skippedPluginNames sets.Set[string]
-		wantStatusCode     framework.Code
+		wantStatusCode     fwk.Code
 	}{
 		{
 			name: "no plugins are skipped and all RemovePod() returned success",
@@ -1786,7 +1786,7 @@ func TestRunPreFilterExtensionRemovePod(t *testing.T) {
 					name: "success2",
 				},
 			},
-			wantStatusCode: framework.Success,
+			wantStatusCode: fwk.Success,
 		},
 		{
 			name: "one RemovePod() returned error",
@@ -1796,10 +1796,10 @@ func TestRunPreFilterExtensionRemovePod(t *testing.T) {
 				},
 				{
 					name: "error1",
-					inj:  injectedResult{PreFilterRemovePodStatus: int(framework.Error)},
+					inj:  injectedResult{PreFilterRemovePodStatus: int(fwk.Error)},
 				},
 			},
-			wantStatusCode: framework.Error,
+			wantStatusCode: fwk.Error,
 		},
 		{
 			name: "one RemovePod() is skipped",
@@ -1810,11 +1810,11 @@ func TestRunPreFilterExtensionRemovePod(t *testing.T) {
 				{
 					name: "skipped",
 					// To confirm it's skipped, return error so that this test case will fail when it isn't skipped.
-					inj: injectedResult{PreFilterRemovePodStatus: int(framework.Error)},
+					inj: injectedResult{PreFilterRemovePodStatus: int(fwk.Error)},
 				},
 			},
 			skippedPluginNames: sets.New("skipped"),
-			wantStatusCode:     framework.Success,
+			wantStatusCode:     fwk.Success,
 		},
 	}
 	for _, tt := range tests {
@@ -1862,7 +1862,7 @@ func TestRunPreFilterExtensionAddPod(t *testing.T) {
 		name               string
 		plugins            []*TestPlugin
 		skippedPluginNames sets.Set[string]
-		wantStatusCode     framework.Code
+		wantStatusCode     fwk.Code
 	}{
 		{
 			name: "no plugins are skipped and all AddPod() returned success",
@@ -1874,7 +1874,7 @@ func TestRunPreFilterExtensionAddPod(t *testing.T) {
 					name: "success2",
 				},
 			},
-			wantStatusCode: framework.Success,
+			wantStatusCode: fwk.Success,
 		},
 		{
 			name: "one AddPod() returned error",
@@ -1884,10 +1884,10 @@ func TestRunPreFilterExtensionAddPod(t *testing.T) {
 				},
 				{
 					name: "error1",
-					inj:  injectedResult{PreFilterAddPodStatus: int(framework.Error)},
+					inj:  injectedResult{PreFilterAddPodStatus: int(fwk.Error)},
 				},
 			},
-			wantStatusCode: framework.Error,
+			wantStatusCode: fwk.Error,
 		},
 		{
 			name: "one AddPod() is skipped",
@@ -1898,11 +1898,11 @@ func TestRunPreFilterExtensionAddPod(t *testing.T) {
 				{
 					name: "skipped",
 					// To confirm it's skipped, return error so that this test case will fail when it isn't skipped.
-					inj: injectedResult{PreFilterAddPodStatus: int(framework.Error)},
+					inj: injectedResult{PreFilterAddPodStatus: int(fwk.Error)},
 				},
 			},
 			skippedPluginNames: sets.New("skipped"),
-			wantStatusCode:     framework.Success,
+			wantStatusCode:     fwk.Success,
 		},
 	}
 	for _, tt := range tests {
@@ -1950,14 +1950,14 @@ func TestFilterPlugins(t *testing.T) {
 		name           string
 		plugins        []*TestPlugin
 		skippedPlugins sets.Set[string]
-		wantStatus     *framework.Status
+		wantStatus     *fwk.Status
 	}{
 		{
 			name: "SuccessFilter",
 			plugins: []*TestPlugin{
 				{
 					name: "TestPlugin",
-					inj:  injectedResult{FilterStatus: int(framework.Success)},
+					inj:  injectedResult{FilterStatus: int(fwk.Success)},
 				},
 			},
 			wantStatus: nil,
@@ -1967,20 +1967,20 @@ func TestFilterPlugins(t *testing.T) {
 			plugins: []*TestPlugin{
 				{
 					name: "TestPlugin",
-					inj:  injectedResult{FilterStatus: int(framework.Error)},
+					inj:  injectedResult{FilterStatus: int(fwk.Error)},
 				},
 			},
-			wantStatus: framework.AsStatus(fmt.Errorf(`running "TestPlugin" filter plugin: %w`, errInjectedFilterStatus)).WithPlugin("TestPlugin"),
+			wantStatus: fwk.AsStatus(fmt.Errorf(`running "TestPlugin" filter plugin: %w`, errInjectedFilterStatus)).WithPlugin("TestPlugin"),
 		},
 		{
 			name: "UnschedulableFilter",
 			plugins: []*TestPlugin{
 				{
 					name: "TestPlugin",
-					inj:  injectedResult{FilterStatus: int(framework.Unschedulable)},
+					inj:  injectedResult{FilterStatus: int(fwk.Unschedulable)},
 				},
 			},
-			wantStatus: framework.NewStatus(framework.Unschedulable, injectFilterReason).WithPlugin("TestPlugin"),
+			wantStatus: fwk.NewStatus(fwk.Unschedulable, injectFilterReason).WithPlugin("TestPlugin"),
 		},
 		{
 			name: "UnschedulableAndUnresolvableFilter",
@@ -1988,10 +1988,10 @@ func TestFilterPlugins(t *testing.T) {
 				{
 					name: "TestPlugin",
 					inj: injectedResult{
-						FilterStatus: int(framework.UnschedulableAndUnresolvable)},
+						FilterStatus: int(fwk.UnschedulableAndUnresolvable)},
 				},
 			},
-			wantStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, injectFilterReason).WithPlugin("TestPlugin"),
+			wantStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, injectFilterReason).WithPlugin("TestPlugin"),
 		},
 		// following tests cover multiple-plugins scenarios
 		{
@@ -1999,53 +1999,53 @@ func TestFilterPlugins(t *testing.T) {
 			plugins: []*TestPlugin{
 				{
 					name: "TestPlugin1",
-					inj:  injectedResult{FilterStatus: int(framework.Error)},
+					inj:  injectedResult{FilterStatus: int(fwk.Error)},
 				},
 				{
 					name: "TestPlugin2",
-					inj:  injectedResult{FilterStatus: int(framework.Error)},
+					inj:  injectedResult{FilterStatus: int(fwk.Error)},
 				},
 			},
-			wantStatus: framework.AsStatus(fmt.Errorf(`running "TestPlugin1" filter plugin: %w`, errInjectedFilterStatus)).WithPlugin("TestPlugin1"),
+			wantStatus: fwk.AsStatus(fmt.Errorf(`running "TestPlugin1" filter plugin: %w`, errInjectedFilterStatus)).WithPlugin("TestPlugin1"),
 		},
 		{
 			name: "UnschedulableAndUnschedulableFilters",
 			plugins: []*TestPlugin{
 				{
 					name: "TestPlugin1",
-					inj:  injectedResult{FilterStatus: int(framework.Unschedulable)},
+					inj:  injectedResult{FilterStatus: int(fwk.Unschedulable)},
 				},
 				{
 					name: "TestPlugin2",
-					inj:  injectedResult{FilterStatus: int(framework.Unschedulable)},
+					inj:  injectedResult{FilterStatus: int(fwk.Unschedulable)},
 				},
 			},
-			wantStatus: framework.NewStatus(framework.Unschedulable, injectFilterReason).WithPlugin("TestPlugin1"),
+			wantStatus: fwk.NewStatus(fwk.Unschedulable, injectFilterReason).WithPlugin("TestPlugin1"),
 		},
 		{
 			name: "UnschedulableAndUnschedulableAndUnresolvableFilters",
 			plugins: []*TestPlugin{
 				{
 					name: "TestPlugin1",
-					inj:  injectedResult{FilterStatus: int(framework.UnschedulableAndUnresolvable)},
+					inj:  injectedResult{FilterStatus: int(fwk.UnschedulableAndUnresolvable)},
 				},
 				{
 					name: "TestPlugin2",
-					inj:  injectedResult{FilterStatus: int(framework.Unschedulable)},
+					inj:  injectedResult{FilterStatus: int(fwk.Unschedulable)},
 				},
 			},
-			wantStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, injectFilterReason).WithPlugin("TestPlugin1"),
+			wantStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, injectFilterReason).WithPlugin("TestPlugin1"),
 		},
 		{
 			name: "SuccessAndSuccessFilters",
 			plugins: []*TestPlugin{
 				{
 					name: "TestPlugin1",
-					inj:  injectedResult{FilterStatus: int(framework.Success)},
+					inj:  injectedResult{FilterStatus: int(fwk.Success)},
 				},
 				{
 					name: "TestPlugin2",
-					inj:  injectedResult{FilterStatus: int(framework.Success)},
+					inj:  injectedResult{FilterStatus: int(fwk.Success)},
 				},
 			},
 			wantStatus: nil,
@@ -2055,12 +2055,12 @@ func TestFilterPlugins(t *testing.T) {
 			plugins: []*TestPlugin{
 				{
 					name: "TestPlugin1",
-					inj:  injectedResult{FilterStatus: int(framework.Success)},
+					inj:  injectedResult{FilterStatus: int(fwk.Success)},
 				},
 
 				{
 					name: "TestPlugin2",
-					inj:  injectedResult{FilterStatus: int(framework.Error)}, // To make sure this plugins isn't called, set error as an injected result.
+					inj:  injectedResult{FilterStatus: int(fwk.Error)}, // To make sure this plugins isn't called, set error as an injected result.
 				},
 			},
 			wantStatus:     nil,
@@ -2071,14 +2071,14 @@ func TestFilterPlugins(t *testing.T) {
 			plugins: []*TestPlugin{
 				{
 					name: "TestPlugin1",
-					inj:  injectedResult{FilterStatus: int(framework.Error)},
+					inj:  injectedResult{FilterStatus: int(fwk.Error)},
 				},
 				{
 					name: "TestPlugin2",
-					inj:  injectedResult{FilterStatus: int(framework.Success)},
+					inj:  injectedResult{FilterStatus: int(fwk.Success)},
 				},
 			},
-			wantStatus: framework.AsStatus(fmt.Errorf(`running "TestPlugin1" filter plugin: %w`, errInjectedFilterStatus)).WithPlugin("TestPlugin1"),
+			wantStatus: fwk.AsStatus(fmt.Errorf(`running "TestPlugin1" filter plugin: %w`, errInjectedFilterStatus)).WithPlugin("TestPlugin1"),
 		},
 		{
 			name: "SuccessAndErrorFilters",
@@ -2086,28 +2086,28 @@ func TestFilterPlugins(t *testing.T) {
 				{
 
 					name: "TestPlugin1",
-					inj:  injectedResult{FilterStatus: int(framework.Success)},
+					inj:  injectedResult{FilterStatus: int(fwk.Success)},
 				},
 				{
 					name: "TestPlugin2",
-					inj:  injectedResult{FilterStatus: int(framework.Error)},
+					inj:  injectedResult{FilterStatus: int(fwk.Error)},
 				},
 			},
-			wantStatus: framework.AsStatus(fmt.Errorf(`running "TestPlugin2" filter plugin: %w`, errInjectedFilterStatus)).WithPlugin("TestPlugin2"),
+			wantStatus: fwk.AsStatus(fmt.Errorf(`running "TestPlugin2" filter plugin: %w`, errInjectedFilterStatus)).WithPlugin("TestPlugin2"),
 		},
 		{
 			name: "SuccessAndUnschedulableFilters",
 			plugins: []*TestPlugin{
 				{
 					name: "TestPlugin1",
-					inj:  injectedResult{FilterStatus: int(framework.Success)},
+					inj:  injectedResult{FilterStatus: int(fwk.Success)},
 				},
 				{
 					name: "TestPlugin2",
-					inj:  injectedResult{FilterStatus: int(framework.Unschedulable)},
+					inj:  injectedResult{FilterStatus: int(fwk.Unschedulable)},
 				},
 			},
-			wantStatus: framework.NewStatus(framework.Unschedulable, injectFilterReason).WithPlugin("TestPlugin2"),
+			wantStatus: fwk.NewStatus(fwk.Unschedulable, injectFilterReason).WithPlugin("TestPlugin2"),
 		},
 	}
 
@@ -2155,87 +2155,87 @@ func TestPostFilterPlugins(t *testing.T) {
 	tests := []struct {
 		name       string
 		plugins    []*TestPlugin
-		wantStatus *framework.Status
+		wantStatus *fwk.Status
 	}{
 		{
 			name: "a single plugin makes a Pod schedulable",
 			plugins: []*TestPlugin{
 				{
 					name: "TestPlugin",
-					inj:  injectedResult{PostFilterStatus: int(framework.Success)},
+					inj:  injectedResult{PostFilterStatus: int(fwk.Success)},
 				},
 			},
-			wantStatus: framework.NewStatus(framework.Success, injectReason),
+			wantStatus: fwk.NewStatus(fwk.Success, injectReason),
 		},
 		{
 			name: "plugin1 failed to make a Pod schedulable, followed by plugin2 which makes the Pod schedulable",
 			plugins: []*TestPlugin{
 				{
 					name: "TestPlugin1",
-					inj:  injectedResult{PostFilterStatus: int(framework.Unschedulable)},
+					inj:  injectedResult{PostFilterStatus: int(fwk.Unschedulable)},
 				},
 				{
 					name: "TestPlugin2",
-					inj:  injectedResult{PostFilterStatus: int(framework.Success)},
+					inj:  injectedResult{PostFilterStatus: int(fwk.Success)},
 				},
 			},
-			wantStatus: framework.NewStatus(framework.Success, injectReason),
+			wantStatus: fwk.NewStatus(fwk.Success, injectReason),
 		},
 		{
 			name: "plugin1 makes a Pod schedulable, followed by plugin2 which cannot make the Pod schedulable",
 			plugins: []*TestPlugin{
 				{
 					name: "TestPlugin1",
-					inj:  injectedResult{PostFilterStatus: int(framework.Success)},
+					inj:  injectedResult{PostFilterStatus: int(fwk.Success)},
 				},
 				{
 					name: "TestPlugin2",
-					inj:  injectedResult{PostFilterStatus: int(framework.Unschedulable)},
+					inj:  injectedResult{PostFilterStatus: int(fwk.Unschedulable)},
 				},
 			},
-			wantStatus: framework.NewStatus(framework.Success, injectReason),
+			wantStatus: fwk.NewStatus(fwk.Success, injectReason),
 		},
 		{
 			name: "plugin1 failed to make a Pod schedulable, followed by plugin2 which makes the Pod schedulable",
 			plugins: []*TestPlugin{
 				{
 					name: "TestPlugin1",
-					inj:  injectedResult{PostFilterStatus: int(framework.Error)},
+					inj:  injectedResult{PostFilterStatus: int(fwk.Error)},
 				},
 				{
 					name: "TestPlugin2",
-					inj:  injectedResult{PostFilterStatus: int(framework.Success)},
+					inj:  injectedResult{PostFilterStatus: int(fwk.Success)},
 				},
 			},
-			wantStatus: framework.AsStatus(fmt.Errorf(injectReason)).WithPlugin("TestPlugin1"),
+			wantStatus: fwk.AsStatus(errors.New(injectReason)).WithPlugin("TestPlugin1"),
 		},
 		{
 			name: "plugin1 failed to make a Pod schedulable, followed by plugin2 which makes the Pod unresolvable",
 			plugins: []*TestPlugin{
 				{
 					name: "TestPlugin1",
-					inj:  injectedResult{PostFilterStatus: int(framework.Unschedulable)},
+					inj:  injectedResult{PostFilterStatus: int(fwk.Unschedulable)},
 				},
 				{
 					name: "TestPlugin2",
-					inj:  injectedResult{PostFilterStatus: int(framework.UnschedulableAndUnresolvable)},
+					inj:  injectedResult{PostFilterStatus: int(fwk.UnschedulableAndUnresolvable)},
 				},
 			},
-			wantStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, injectReason).WithPlugin("TestPlugin2"),
+			wantStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, injectReason).WithPlugin("TestPlugin2"),
 		},
 		{
 			name: "both plugins failed to make a Pod schedulable",
 			plugins: []*TestPlugin{
 				{
 					name: "TestPlugin1",
-					inj:  injectedResult{PostFilterStatus: int(framework.Unschedulable)},
+					inj:  injectedResult{PostFilterStatus: int(fwk.Unschedulable)},
 				},
 				{
 					name: "TestPlugin2",
-					inj:  injectedResult{PostFilterStatus: int(framework.Unschedulable)},
+					inj:  injectedResult{PostFilterStatus: int(fwk.Unschedulable)},
 				},
 			},
-			wantStatus: framework.NewStatus(framework.Unschedulable, []string{injectReason, injectReason}...).WithPlugin("TestPlugin1"),
+			wantStatus: fwk.NewStatus(fwk.Unschedulable, []string{injectReason, injectReason}...).WithPlugin("TestPlugin1"),
 		},
 	}
 
@@ -2287,7 +2287,7 @@ func TestFilterPluginsWithNominatedPods(t *testing.T) {
 		nominatedPod    *v1.Pod
 		node            *v1.Node
 		nodeInfo        *framework.NodeInfo
-		wantStatus      *framework.Status
+		wantStatus      *fwk.Status
 	}{
 		{
 			name:            "node has no nominated pod",
@@ -2304,13 +2304,13 @@ func TestFilterPluginsWithNominatedPods(t *testing.T) {
 			preFilterPlugin: &TestPlugin{
 				name: "TestPlugin1",
 				inj: injectedResult{
-					PreFilterAddPodStatus: int(framework.Success),
+					PreFilterAddPodStatus: int(fwk.Success),
 				},
 			},
 			filterPlugin: &TestPlugin{
 				name: "TestPlugin2",
 				inj: injectedResult{
-					FilterStatus: int(framework.Success),
+					FilterStatus: int(fwk.Success),
 				},
 			},
 			pod:          lowPriorityPod,
@@ -2324,7 +2324,7 @@ func TestFilterPluginsWithNominatedPods(t *testing.T) {
 			preFilterPlugin: &TestPlugin{
 				name: "TestPlugin1",
 				inj: injectedResult{
-					PreFilterAddPodStatus: int(framework.Error),
+					PreFilterAddPodStatus: int(fwk.Error),
 				},
 			},
 			filterPlugin: nil,
@@ -2332,40 +2332,40 @@ func TestFilterPluginsWithNominatedPods(t *testing.T) {
 			nominatedPod: highPriorityPod,
 			node:         node,
 			nodeInfo:     framework.NewNodeInfo(pod),
-			wantStatus:   framework.AsStatus(fmt.Errorf(`running AddPod on PreFilter plugin "TestPlugin1": %w`, errInjectedStatus)),
+			wantStatus:   fwk.AsStatus(fmt.Errorf(`running AddPod on PreFilter plugin "TestPlugin1": %w`, errInjectedStatus)),
 		},
 		{
 			name: "node has a high-priority nominated pod and filters fail",
 			preFilterPlugin: &TestPlugin{
 				name: "TestPlugin1",
 				inj: injectedResult{
-					PreFilterAddPodStatus: int(framework.Success),
+					PreFilterAddPodStatus: int(fwk.Success),
 				},
 			},
 			filterPlugin: &TestPlugin{
 				name: "TestPlugin2",
 				inj: injectedResult{
-					FilterStatus: int(framework.Error),
+					FilterStatus: int(fwk.Error),
 				},
 			},
 			pod:          lowPriorityPod,
 			nominatedPod: highPriorityPod,
 			node:         node,
 			nodeInfo:     framework.NewNodeInfo(pod),
-			wantStatus:   framework.AsStatus(fmt.Errorf(`running "TestPlugin2" filter plugin: %w`, errInjectedFilterStatus)).WithPlugin("TestPlugin2"),
+			wantStatus:   fwk.AsStatus(fmt.Errorf(`running "TestPlugin2" filter plugin: %w`, errInjectedFilterStatus)).WithPlugin("TestPlugin2"),
 		},
 		{
 			name: "node has a low-priority nominated pod and pre filters return unschedulable",
 			preFilterPlugin: &TestPlugin{
 				name: "TestPlugin1",
 				inj: injectedResult{
-					PreFilterAddPodStatus: int(framework.Unschedulable),
+					PreFilterAddPodStatus: int(fwk.Unschedulable),
 				},
 			},
 			filterPlugin: &TestPlugin{
 				name: "TestPlugin2",
 				inj: injectedResult{
-					FilterStatus: int(framework.Success),
+					FilterStatus: int(fwk.Success),
 				},
 			},
 			pod:          highPriorityPod,
@@ -2450,7 +2450,7 @@ func TestPreBindPlugins(t *testing.T) {
 	tests := []struct {
 		name       string
 		plugins    []*TestPlugin
-		wantStatus *framework.Status
+		wantStatus *fwk.Status
 	}{
 		{
 			name:       "NoPreBindPlugin",
@@ -2462,7 +2462,7 @@ func TestPreBindPlugins(t *testing.T) {
 			plugins: []*TestPlugin{
 				{
 					name: "TestPlugin",
-					inj:  injectedResult{PreBindStatus: int(framework.Success)},
+					inj:  injectedResult{PreBindStatus: int(fwk.Success)},
 				},
 			},
 			wantStatus: nil,
@@ -2472,69 +2472,69 @@ func TestPreBindPlugins(t *testing.T) {
 			plugins: []*TestPlugin{
 				{
 					name: "TestPlugin",
-					inj:  injectedResult{PreBindStatus: int(framework.Unschedulable)},
+					inj:  injectedResult{PreBindStatus: int(fwk.Unschedulable)},
 				},
 			},
-			wantStatus: framework.NewStatus(framework.Unschedulable, injectReason).WithPlugin("TestPlugin"),
+			wantStatus: fwk.NewStatus(fwk.Unschedulable, injectReason).WithPlugin("TestPlugin"),
 		},
 		{
 			name: "ErrorPreBindPlugin",
 			plugins: []*TestPlugin{
 				{
 					name: "TestPlugin",
-					inj:  injectedResult{PreBindStatus: int(framework.Error)},
+					inj:  injectedResult{PreBindStatus: int(fwk.Error)},
 				},
 			},
-			wantStatus: framework.AsStatus(fmt.Errorf(`running PreBind plugin "TestPlugin": %w`, errInjectedStatus)),
+			wantStatus: fwk.AsStatus(fmt.Errorf(`running PreBind plugin "TestPlugin": %w`, errInjectedStatus)),
 		},
 		{
 			name: "UnschedulablePreBindPlugin",
 			plugins: []*TestPlugin{
 				{
 					name: "TestPlugin",
-					inj:  injectedResult{PreBindStatus: int(framework.UnschedulableAndUnresolvable)},
+					inj:  injectedResult{PreBindStatus: int(fwk.UnschedulableAndUnresolvable)},
 				},
 			},
-			wantStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, injectReason).WithPlugin("TestPlugin"),
+			wantStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, injectReason).WithPlugin("TestPlugin"),
 		},
 		{
 			name: "SuccessErrorPreBindPlugins",
 			plugins: []*TestPlugin{
 				{
 					name: "TestPlugin",
-					inj:  injectedResult{PreBindStatus: int(framework.Success)},
+					inj:  injectedResult{PreBindStatus: int(fwk.Success)},
 				},
 				{
 					name: "TestPlugin 1",
-					inj:  injectedResult{PreBindStatus: int(framework.Error)},
+					inj:  injectedResult{PreBindStatus: int(fwk.Error)},
 				},
 			},
-			wantStatus: framework.AsStatus(fmt.Errorf(`running PreBind plugin "TestPlugin 1": %w`, errInjectedStatus)),
+			wantStatus: fwk.AsStatus(fmt.Errorf(`running PreBind plugin "TestPlugin 1": %w`, errInjectedStatus)),
 		},
 		{
 			name: "ErrorSuccessPreBindPlugin",
 			plugins: []*TestPlugin{
 				{
 					name: "TestPlugin",
-					inj:  injectedResult{PreBindStatus: int(framework.Error)},
+					inj:  injectedResult{PreBindStatus: int(fwk.Error)},
 				},
 				{
 					name: "TestPlugin 1",
-					inj:  injectedResult{PreBindStatus: int(framework.Success)},
+					inj:  injectedResult{PreBindStatus: int(fwk.Success)},
 				},
 			},
-			wantStatus: framework.AsStatus(fmt.Errorf(`running PreBind plugin "TestPlugin": %w`, errInjectedStatus)),
+			wantStatus: fwk.AsStatus(fmt.Errorf(`running PreBind plugin "TestPlugin": %w`, errInjectedStatus)),
 		},
 		{
 			name: "SuccessSuccessPreBindPlugin",
 			plugins: []*TestPlugin{
 				{
 					name: "TestPlugin",
-					inj:  injectedResult{PreBindStatus: int(framework.Success)},
+					inj:  injectedResult{PreBindStatus: int(fwk.Success)},
 				},
 				{
 					name: "TestPlugin 1",
-					inj:  injectedResult{PreBindStatus: int(framework.Success)},
+					inj:  injectedResult{PreBindStatus: int(fwk.Success)},
 				},
 			},
 			wantStatus: nil,
@@ -2544,28 +2544,28 @@ func TestPreBindPlugins(t *testing.T) {
 			plugins: []*TestPlugin{
 				{
 					name: "TestPlugin",
-					inj:  injectedResult{PreBindStatus: int(framework.Error)},
+					inj:  injectedResult{PreBindStatus: int(fwk.Error)},
 				},
 				{
 					name: "TestPlugin 1",
-					inj:  injectedResult{PreBindStatus: int(framework.Error)},
+					inj:  injectedResult{PreBindStatus: int(fwk.Error)},
 				},
 			},
-			wantStatus: framework.AsStatus(fmt.Errorf(`running PreBind plugin "TestPlugin": %w`, errInjectedStatus)),
+			wantStatus: fwk.AsStatus(fmt.Errorf(`running PreBind plugin "TestPlugin": %w`, errInjectedStatus)),
 		},
 		{
 			name: "UnschedulableAndSuccessPreBindPlugin",
 			plugins: []*TestPlugin{
 				{
 					name: "TestPlugin",
-					inj:  injectedResult{PreBindStatus: int(framework.Unschedulable)},
+					inj:  injectedResult{PreBindStatus: int(fwk.Unschedulable)},
 				},
 				{
 					name: "TestPlugin 1",
-					inj:  injectedResult{PreBindStatus: int(framework.Success)},
+					inj:  injectedResult{PreBindStatus: int(fwk.Success)},
 				},
 			},
-			wantStatus: framework.NewStatus(framework.Unschedulable, injectReason).WithPlugin("TestPlugin"),
+			wantStatus: fwk.NewStatus(fwk.Unschedulable, injectReason).WithPlugin("TestPlugin"),
 		},
 	}
 
@@ -2612,7 +2612,7 @@ func TestReservePlugins(t *testing.T) {
 	tests := []struct {
 		name       string
 		plugins    []*TestPlugin
-		wantStatus *framework.Status
+		wantStatus *fwk.Status
 	}{
 		{
 			name:       "NoReservePlugin",
@@ -2624,7 +2624,7 @@ func TestReservePlugins(t *testing.T) {
 			plugins: []*TestPlugin{
 				{
 					name: "TestPlugin",
-					inj:  injectedResult{ReserveStatus: int(framework.Success)},
+					inj:  injectedResult{ReserveStatus: int(fwk.Success)},
 				},
 			},
 			wantStatus: nil,
@@ -2634,41 +2634,41 @@ func TestReservePlugins(t *testing.T) {
 			plugins: []*TestPlugin{
 				{
 					name: "TestPlugin",
-					inj:  injectedResult{ReserveStatus: int(framework.Unschedulable)},
+					inj:  injectedResult{ReserveStatus: int(fwk.Unschedulable)},
 				},
 			},
-			wantStatus: framework.NewStatus(framework.Unschedulable, injectReason).WithPlugin("TestPlugin"),
+			wantStatus: fwk.NewStatus(fwk.Unschedulable, injectReason).WithPlugin("TestPlugin"),
 		},
 		{
 			name: "ErrorReservePlugin",
 			plugins: []*TestPlugin{
 				{
 					name: "TestPlugin",
-					inj:  injectedResult{ReserveStatus: int(framework.Error)},
+					inj:  injectedResult{ReserveStatus: int(fwk.Error)},
 				},
 			},
-			wantStatus: framework.AsStatus(fmt.Errorf(`running Reserve plugin "TestPlugin": %w`, errInjectedStatus)),
+			wantStatus: fwk.AsStatus(fmt.Errorf(`running Reserve plugin "TestPlugin": %w`, errInjectedStatus)),
 		},
 		{
 			name: "UnschedulableReservePlugin",
 			plugins: []*TestPlugin{
 				{
 					name: "TestPlugin",
-					inj:  injectedResult{ReserveStatus: int(framework.UnschedulableAndUnresolvable)},
+					inj:  injectedResult{ReserveStatus: int(fwk.UnschedulableAndUnresolvable)},
 				},
 			},
-			wantStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, injectReason).WithPlugin("TestPlugin"),
+			wantStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, injectReason).WithPlugin("TestPlugin"),
 		},
 		{
 			name: "SuccessSuccessReservePlugins",
 			plugins: []*TestPlugin{
 				{
 					name: "TestPlugin",
-					inj:  injectedResult{ReserveStatus: int(framework.Success)},
+					inj:  injectedResult{ReserveStatus: int(fwk.Success)},
 				},
 				{
 					name: "TestPlugin 1",
-					inj:  injectedResult{ReserveStatus: int(framework.Success)},
+					inj:  injectedResult{ReserveStatus: int(fwk.Success)},
 				},
 			},
 			wantStatus: nil,
@@ -2678,56 +2678,56 @@ func TestReservePlugins(t *testing.T) {
 			plugins: []*TestPlugin{
 				{
 					name: "TestPlugin",
-					inj:  injectedResult{ReserveStatus: int(framework.Error)},
+					inj:  injectedResult{ReserveStatus: int(fwk.Error)},
 				},
 				{
 					name: "TestPlugin 1",
-					inj:  injectedResult{ReserveStatus: int(framework.Error)},
+					inj:  injectedResult{ReserveStatus: int(fwk.Error)},
 				},
 			},
-			wantStatus: framework.AsStatus(fmt.Errorf(`running Reserve plugin "TestPlugin": %w`, errInjectedStatus)),
+			wantStatus: fwk.AsStatus(fmt.Errorf(`running Reserve plugin "TestPlugin": %w`, errInjectedStatus)),
 		},
 		{
 			name: "SuccessErrorReservePlugins",
 			plugins: []*TestPlugin{
 				{
 					name: "TestPlugin",
-					inj:  injectedResult{ReserveStatus: int(framework.Success)},
+					inj:  injectedResult{ReserveStatus: int(fwk.Success)},
 				},
 				{
 					name: "TestPlugin 1",
-					inj:  injectedResult{ReserveStatus: int(framework.Error)},
+					inj:  injectedResult{ReserveStatus: int(fwk.Error)},
 				},
 			},
-			wantStatus: framework.AsStatus(fmt.Errorf(`running Reserve plugin "TestPlugin 1": %w`, errInjectedStatus)),
+			wantStatus: fwk.AsStatus(fmt.Errorf(`running Reserve plugin "TestPlugin 1": %w`, errInjectedStatus)),
 		},
 		{
 			name: "ErrorSuccessReservePlugin",
 			plugins: []*TestPlugin{
 				{
 					name: "TestPlugin",
-					inj:  injectedResult{ReserveStatus: int(framework.Error)},
+					inj:  injectedResult{ReserveStatus: int(fwk.Error)},
 				},
 				{
 					name: "TestPlugin 1",
-					inj:  injectedResult{ReserveStatus: int(framework.Success)},
+					inj:  injectedResult{ReserveStatus: int(fwk.Success)},
 				},
 			},
-			wantStatus: framework.AsStatus(fmt.Errorf(`running Reserve plugin "TestPlugin": %w`, errInjectedStatus)),
+			wantStatus: fwk.AsStatus(fmt.Errorf(`running Reserve plugin "TestPlugin": %w`, errInjectedStatus)),
 		},
 		{
 			name: "UnschedulableAndSuccessReservePlugin",
 			plugins: []*TestPlugin{
 				{
 					name: "TestPlugin",
-					inj:  injectedResult{ReserveStatus: int(framework.Unschedulable)},
+					inj:  injectedResult{ReserveStatus: int(fwk.Unschedulable)},
 				},
 				{
 					name: "TestPlugin 1",
-					inj:  injectedResult{ReserveStatus: int(framework.Success)},
+					inj:  injectedResult{ReserveStatus: int(fwk.Success)},
 				},
 			},
-			wantStatus: framework.NewStatus(framework.Unschedulable, injectReason).WithPlugin("TestPlugin"),
+			wantStatus: fwk.NewStatus(fwk.Unschedulable, injectReason).WithPlugin("TestPlugin"),
 		},
 	}
 
@@ -2774,7 +2774,7 @@ func TestPermitPlugins(t *testing.T) {
 	tests := []struct {
 		name    string
 		plugins []*TestPlugin
-		want    *framework.Status
+		want    *fwk.Status
 	}{
 		{
 			name:    "NilPermitPlugin",
@@ -2786,7 +2786,7 @@ func TestPermitPlugins(t *testing.T) {
 			plugins: []*TestPlugin{
 				{
 					name: "TestPlugin",
-					inj:  injectedResult{PermitStatus: int(framework.Success)},
+					inj:  injectedResult{PermitStatus: int(fwk.Success)},
 				},
 			},
 			want: nil,
@@ -2796,51 +2796,51 @@ func TestPermitPlugins(t *testing.T) {
 			plugins: []*TestPlugin{
 				{
 					name: "TestPlugin",
-					inj:  injectedResult{PermitStatus: int(framework.Unschedulable)},
+					inj:  injectedResult{PermitStatus: int(fwk.Unschedulable)},
 				},
 			},
-			want: framework.NewStatus(framework.Unschedulable, injectReason).WithPlugin("TestPlugin"),
+			want: fwk.NewStatus(fwk.Unschedulable, injectReason).WithPlugin("TestPlugin"),
 		},
 		{
 			name: "ErrorPermitPlugin",
 			plugins: []*TestPlugin{
 				{
 					name: "TestPlugin",
-					inj:  injectedResult{PermitStatus: int(framework.Error)},
+					inj:  injectedResult{PermitStatus: int(fwk.Error)},
 				},
 			},
-			want: framework.AsStatus(fmt.Errorf(`running Permit plugin "TestPlugin": %w`, errInjectedStatus)).WithPlugin("TestPlugin"),
+			want: fwk.AsStatus(fmt.Errorf(`running Permit plugin "TestPlugin": %w`, errInjectedStatus)).WithPlugin("TestPlugin"),
 		},
 		{
 			name: "UnschedulableAndUnresolvablePermitPlugin",
 			plugins: []*TestPlugin{
 				{
 					name: "TestPlugin",
-					inj:  injectedResult{PermitStatus: int(framework.UnschedulableAndUnresolvable)},
+					inj:  injectedResult{PermitStatus: int(fwk.UnschedulableAndUnresolvable)},
 				},
 			},
-			want: framework.NewStatus(framework.UnschedulableAndUnresolvable, injectReason).WithPlugin("TestPlugin"),
+			want: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, injectReason).WithPlugin("TestPlugin"),
 		},
 		{
 			name: "WaitPermitPlugin",
 			plugins: []*TestPlugin{
 				{
 					name: "TestPlugin",
-					inj:  injectedResult{PermitStatus: int(framework.Wait)},
+					inj:  injectedResult{PermitStatus: int(fwk.Wait)},
 				},
 			},
-			want: framework.NewStatus(framework.Wait, `one or more plugins asked to wait and no plugin rejected pod ""`),
+			want: fwk.NewStatus(fwk.Wait, `one or more plugins asked to wait and no plugin rejected pod ""`),
 		},
 		{
 			name: "SuccessSuccessPermitPlugin",
 			plugins: []*TestPlugin{
 				{
 					name: "TestPlugin",
-					inj:  injectedResult{PermitStatus: int(framework.Success)},
+					inj:  injectedResult{PermitStatus: int(fwk.Success)},
 				},
 				{
 					name: "TestPlugin 1",
-					inj:  injectedResult{PermitStatus: int(framework.Success)},
+					inj:  injectedResult{PermitStatus: int(fwk.Success)},
 				},
 			},
 			want: nil,
@@ -2850,14 +2850,14 @@ func TestPermitPlugins(t *testing.T) {
 			plugins: []*TestPlugin{
 				{
 					name: "TestPlugin",
-					inj:  injectedResult{PermitStatus: int(framework.Error)},
+					inj:  injectedResult{PermitStatus: int(fwk.Error)},
 				},
 				{
 					name: "TestPlugin 1",
-					inj:  injectedResult{PermitStatus: int(framework.Error)},
+					inj:  injectedResult{PermitStatus: int(fwk.Error)},
 				},
 			},
-			want: framework.AsStatus(fmt.Errorf(`running Permit plugin "TestPlugin": %w`, errInjectedStatus)).WithPlugin("TestPlugin"),
+			want: fwk.AsStatus(fmt.Errorf(`running Permit plugin "TestPlugin": %w`, errInjectedStatus)).WithPlugin("TestPlugin"),
 		},
 	}
 
@@ -2915,19 +2915,19 @@ func TestRecordingMetrics(t *testing.T) {
 		action             func(ctx context.Context, f framework.Framework)
 		inject             injectedResult
 		wantExtensionPoint string
-		wantStatus         framework.Code
+		wantStatus         fwk.Code
 	}{
 		{
 			name:               "PreFilter - Success",
 			action:             func(ctx context.Context, f framework.Framework) { f.RunPreFilterPlugins(ctx, state, pod) },
 			wantExtensionPoint: "PreFilter",
-			wantStatus:         framework.Success,
+			wantStatus:         fwk.Success,
 		},
 		{
 			name:               "PreScore - Success",
 			action:             func(ctx context.Context, f framework.Framework) { f.RunPreScorePlugins(ctx, state, pod, nil) },
 			wantExtensionPoint: "PreScore",
-			wantStatus:         framework.Success,
+			wantStatus:         fwk.Success,
 		},
 		{
 			name: "Score - Success",
@@ -2935,102 +2935,102 @@ func TestRecordingMetrics(t *testing.T) {
 				f.RunScorePlugins(ctx, state, pod, BuildNodeInfos(nodes))
 			},
 			wantExtensionPoint: "Score",
-			wantStatus:         framework.Success,
+			wantStatus:         fwk.Success,
 		},
 		{
 			name:               "Reserve - Success",
 			action:             func(ctx context.Context, f framework.Framework) { f.RunReservePluginsReserve(ctx, state, pod, "") },
 			wantExtensionPoint: "Reserve",
-			wantStatus:         framework.Success,
+			wantStatus:         fwk.Success,
 		},
 		{
 			name:               "Unreserve - Success",
 			action:             func(ctx context.Context, f framework.Framework) { f.RunReservePluginsUnreserve(ctx, state, pod, "") },
 			wantExtensionPoint: "Unreserve",
-			wantStatus:         framework.Success,
+			wantStatus:         fwk.Success,
 		},
 		{
 			name:               "PreBind - Success",
 			action:             func(ctx context.Context, f framework.Framework) { f.RunPreBindPlugins(ctx, state, pod, "") },
 			wantExtensionPoint: "PreBind",
-			wantStatus:         framework.Success,
+			wantStatus:         fwk.Success,
 		},
 		{
 			name:               "Bind - Success",
 			action:             func(ctx context.Context, f framework.Framework) { f.RunBindPlugins(ctx, state, pod, "") },
 			wantExtensionPoint: "Bind",
-			wantStatus:         framework.Success,
+			wantStatus:         fwk.Success,
 		},
 		{
 			name:               "PostBind - Success",
 			action:             func(ctx context.Context, f framework.Framework) { f.RunPostBindPlugins(ctx, state, pod, "") },
 			wantExtensionPoint: "PostBind",
-			wantStatus:         framework.Success,
+			wantStatus:         fwk.Success,
 		},
 		{
 			name:               "Permit - Success",
 			action:             func(ctx context.Context, f framework.Framework) { f.RunPermitPlugins(ctx, state, pod, "") },
 			wantExtensionPoint: "Permit",
-			wantStatus:         framework.Success,
+			wantStatus:         fwk.Success,
 		},
 
 		{
 			name:               "PreFilter - Error",
 			action:             func(ctx context.Context, f framework.Framework) { f.RunPreFilterPlugins(ctx, state, pod) },
-			inject:             injectedResult{PreFilterStatus: int(framework.Error)},
+			inject:             injectedResult{PreFilterStatus: int(fwk.Error)},
 			wantExtensionPoint: "PreFilter",
-			wantStatus:         framework.Error,
+			wantStatus:         fwk.Error,
 		},
 		{
 			name:               "PreScore - Error",
 			action:             func(ctx context.Context, f framework.Framework) { f.RunPreScorePlugins(ctx, state, pod, nil) },
-			inject:             injectedResult{PreScoreStatus: int(framework.Error)},
+			inject:             injectedResult{PreScoreStatus: int(fwk.Error)},
 			wantExtensionPoint: "PreScore",
-			wantStatus:         framework.Error,
+			wantStatus:         fwk.Error,
 		},
 		{
 			name: "Score - Error",
 			action: func(ctx context.Context, f framework.Framework) {
 				f.RunScorePlugins(ctx, state, pod, BuildNodeInfos(nodes))
 			},
-			inject:             injectedResult{ScoreStatus: int(framework.Error)},
+			inject:             injectedResult{ScoreStatus: int(fwk.Error)},
 			wantExtensionPoint: "Score",
-			wantStatus:         framework.Error,
+			wantStatus:         fwk.Error,
 		},
 		{
 			name:               "Reserve - Error",
 			action:             func(ctx context.Context, f framework.Framework) { f.RunReservePluginsReserve(ctx, state, pod, "") },
-			inject:             injectedResult{ReserveStatus: int(framework.Error)},
+			inject:             injectedResult{ReserveStatus: int(fwk.Error)},
 			wantExtensionPoint: "Reserve",
-			wantStatus:         framework.Error,
+			wantStatus:         fwk.Error,
 		},
 		{
 			name:               "PreBind - Error",
 			action:             func(ctx context.Context, f framework.Framework) { f.RunPreBindPlugins(ctx, state, pod, "") },
-			inject:             injectedResult{PreBindStatus: int(framework.Error)},
+			inject:             injectedResult{PreBindStatus: int(fwk.Error)},
 			wantExtensionPoint: "PreBind",
-			wantStatus:         framework.Error,
+			wantStatus:         fwk.Error,
 		},
 		{
 			name:               "Bind - Error",
 			action:             func(ctx context.Context, f framework.Framework) { f.RunBindPlugins(ctx, state, pod, "") },
-			inject:             injectedResult{BindStatus: int(framework.Error)},
+			inject:             injectedResult{BindStatus: int(fwk.Error)},
 			wantExtensionPoint: "Bind",
-			wantStatus:         framework.Error,
+			wantStatus:         fwk.Error,
 		},
 		{
 			name:               "Permit - Error",
 			action:             func(ctx context.Context, f framework.Framework) { f.RunPermitPlugins(ctx, state, pod, "") },
-			inject:             injectedResult{PermitStatus: int(framework.Error)},
+			inject:             injectedResult{PermitStatus: int(fwk.Error)},
 			wantExtensionPoint: "Permit",
-			wantStatus:         framework.Error,
+			wantStatus:         fwk.Error,
 		},
 		{
 			name:               "Permit - Wait",
 			action:             func(ctx context.Context, f framework.Framework) { f.RunPermitPlugins(ctx, state, pod, "") },
-			inject:             injectedResult{PermitStatus: int(framework.Wait)},
+			inject:             injectedResult{PermitStatus: int(fwk.Wait)},
 			wantExtensionPoint: "Permit",
-			wantStatus:         framework.Wait,
+			wantStatus:         fwk.Wait,
 		},
 	}
 
@@ -3096,68 +3096,68 @@ func TestRecordingMetrics(t *testing.T) {
 func TestRunBindPlugins(t *testing.T) {
 	tests := []struct {
 		name       string
-		injects    []framework.Code
-		wantStatus framework.Code
+		injects    []fwk.Code
+		wantStatus fwk.Code
 	}{
 		{
 			name:       "simple success",
-			injects:    []framework.Code{framework.Success},
-			wantStatus: framework.Success,
+			injects:    []fwk.Code{fwk.Success},
+			wantStatus: fwk.Success,
 		},
 		{
 			name:       "error on second",
-			injects:    []framework.Code{framework.Skip, framework.Error, framework.Success},
-			wantStatus: framework.Error,
+			injects:    []fwk.Code{fwk.Skip, fwk.Error, fwk.Success},
+			wantStatus: fwk.Error,
 		},
 		{
 			name:       "all skip",
-			injects:    []framework.Code{framework.Skip, framework.Skip, framework.Skip},
-			wantStatus: framework.Skip,
+			injects:    []fwk.Code{fwk.Skip, fwk.Skip, fwk.Skip},
+			wantStatus: fwk.Skip,
 		},
 		{
 			name:       "error on third, but not reached",
-			injects:    []framework.Code{framework.Skip, framework.Success, framework.Error},
-			wantStatus: framework.Success,
+			injects:    []fwk.Code{fwk.Skip, fwk.Success, fwk.Error},
+			wantStatus: fwk.Success,
 		},
 		{
 			name:       "no bind plugin, returns default binder",
-			injects:    []framework.Code{},
-			wantStatus: framework.Success,
+			injects:    []fwk.Code{},
+			wantStatus: fwk.Success,
 		},
 		{
 			name:       "invalid status",
-			injects:    []framework.Code{framework.Unschedulable},
-			wantStatus: framework.Unschedulable,
+			injects:    []fwk.Code{fwk.Unschedulable},
+			wantStatus: fwk.Unschedulable,
 		},
 		{
 			name:       "simple error",
-			injects:    []framework.Code{framework.Error},
-			wantStatus: framework.Error,
+			injects:    []fwk.Code{fwk.Error},
+			wantStatus: fwk.Error,
 		},
 		{
 			name:       "success on second, returns success",
-			injects:    []framework.Code{framework.Skip, framework.Success},
-			wantStatus: framework.Success,
+			injects:    []fwk.Code{fwk.Skip, fwk.Success},
+			wantStatus: fwk.Success,
 		},
 		{
 			name:       "invalid status, returns error",
-			injects:    []framework.Code{framework.Skip, framework.UnschedulableAndUnresolvable},
-			wantStatus: framework.UnschedulableAndUnresolvable,
+			injects:    []fwk.Code{fwk.Skip, fwk.UnschedulableAndUnresolvable},
+			wantStatus: fwk.UnschedulableAndUnresolvable,
 		},
 		{
 			name:       "error after success status, returns success",
-			injects:    []framework.Code{framework.Success, framework.Error},
-			wantStatus: framework.Success,
+			injects:    []fwk.Code{fwk.Success, fwk.Error},
+			wantStatus: fwk.Success,
 		},
 		{
 			name:       "success before invalid status, returns success",
-			injects:    []framework.Code{framework.Success, framework.Error},
-			wantStatus: framework.Success,
+			injects:    []fwk.Code{fwk.Success, fwk.Error},
+			wantStatus: fwk.Success,
 		},
 		{
 			name:       "success after error status, returns error",
-			injects:    []framework.Code{framework.Error, framework.Success},
-			wantStatus: framework.Error,
+			injects:    []fwk.Code{fwk.Error, fwk.Success},
+			wantStatus: fwk.Error,
 		},
 	}
 	for _, tt := range tests {
@@ -3220,7 +3220,7 @@ func TestPermitWaitDurationMetric(t *testing.T) {
 		},
 		{
 			name:    "WaitOnPermit - Wait Timeout",
-			inject:  injectedResult{PermitStatus: int(framework.Wait)},
+			inject:  injectedResult{PermitStatus: int(fwk.Wait)},
 			wantRes: "Unschedulable",
 		},
 	}
@@ -3274,14 +3274,14 @@ func TestWaitOnPermit(t *testing.T) {
 	tests := []struct {
 		name   string
 		action func(f framework.Framework)
-		want   *framework.Status
+		want   *fwk.Status
 	}{
 		{
 			name: "Reject Waiting Pod",
 			action: func(f framework.Framework) {
 				f.GetWaitingPod(pod.UID).Reject(permitPlugin, "reject message")
 			},
-			want: framework.NewStatus(framework.Unschedulable, "reject message").WithPlugin(permitPlugin),
+			want: fwk.NewStatus(fwk.Unschedulable, "reject message").WithPlugin(permitPlugin),
 		},
 		{
 			name: "Allow Waiting Pod",
@@ -3318,9 +3318,9 @@ func TestWaitOnPermit(t *testing.T) {
 			}()
 
 			runPermitPluginsStatus := f.RunPermitPlugins(ctx, state, pod, "")
-			if runPermitPluginsStatus.Code() != framework.Wait {
+			if runPermitPluginsStatus.Code() != fwk.Wait {
 				t.Fatalf("Expected RunPermitPlugins to return status %v, but got %v",
-					framework.Wait, runPermitPluginsStatus.Code())
+					fwk.Wait, runPermitPluginsStatus.Code())
 			}
 
 			go tt.action(f)
@@ -3458,16 +3458,16 @@ type injectedResult struct {
 	PermitStatus             int                        `json:"permitStatus,omitempty"`
 }
 
-func setScoreRes(inj injectedResult) (int64, *framework.Status) {
-	if framework.Code(inj.ScoreStatus) != framework.Success {
-		return 0, framework.NewStatus(framework.Code(inj.ScoreStatus), "injecting failure.")
+func setScoreRes(inj injectedResult) (int64, *fwk.Status) {
+	if fwk.Code(inj.ScoreStatus) != fwk.Success {
+		return 0, fwk.NewStatus(fwk.Code(inj.ScoreStatus), "injecting failure.")
 	}
 	return inj.ScoreRes, nil
 }
 
-func injectNormalizeRes(inj injectedResult, scores framework.NodeScoreList) *framework.Status {
-	if framework.Code(inj.NormalizeStatus) != framework.Success {
-		return framework.NewStatus(framework.Code(inj.NormalizeStatus), "injecting failure.")
+func injectNormalizeRes(inj injectedResult, scores framework.NodeScoreList) *fwk.Status {
+	if fwk.Code(inj.NormalizeStatus) != fwk.Success {
+		return fwk.NewStatus(fwk.Code(inj.NormalizeStatus), "injecting failure.")
 	}
 	for i := range scores {
 		scores[i].Score = inj.NormalizeRes
@@ -3475,7 +3475,7 @@ func injectNormalizeRes(inj injectedResult, scores framework.NodeScoreList) *fra
 	return nil
 }
 
-func collectAndComparePluginMetrics(t *testing.T, wantExtensionPoint, wantPlugin string, wantStatus framework.Code) {
+func collectAndComparePluginMetrics(t *testing.T, wantExtensionPoint, wantPlugin string, wantStatus fwk.Code) {
 	t.Helper()
 	m := metrics.PluginExecutionDuration.WithLabelValues(wantPlugin, wantExtensionPoint, wantStatus.String())
 
@@ -3493,7 +3493,7 @@ func collectAndComparePluginMetrics(t *testing.T, wantExtensionPoint, wantPlugin
 	checkLatency(t, value)
 }
 
-func collectAndCompareFrameworkMetrics(t *testing.T, wantExtensionPoint string, wantStatus framework.Code) {
+func collectAndCompareFrameworkMetrics(t *testing.T, wantExtensionPoint string, wantStatus fwk.Code) {
 	t.Helper()
 	m := metrics.FrameworkExtensionPointDuration.WithLabelValues(wantExtensionPoint, wantStatus.String(), testProfileName)
 

--- a/pkg/scheduler/framework/runtime/instrumented_plugins.go
+++ b/pkg/scheduler/framework/runtime/instrumented_plugins.go
@@ -33,7 +33,7 @@ type instrumentedFilterPlugin struct {
 
 var _ framework.FilterPlugin = &instrumentedFilterPlugin{}
 
-func (p *instrumentedFilterPlugin) Filter(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) *framework.Status {
+func (p *instrumentedFilterPlugin) Filter(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) *fwk.Status {
 	p.metric.Inc()
 	return p.FilterPlugin.Filter(ctx, state, pod, nodeInfo)
 }
@@ -46,7 +46,7 @@ type instrumentedPreFilterPlugin struct {
 
 var _ framework.PreFilterPlugin = &instrumentedPreFilterPlugin{}
 
-func (p *instrumentedPreFilterPlugin) PreFilter(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodes []*framework.NodeInfo) (*framework.PreFilterResult, *framework.Status) {
+func (p *instrumentedPreFilterPlugin) PreFilter(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodes []*framework.NodeInfo) (*framework.PreFilterResult, *fwk.Status) {
 	result, status := p.PreFilterPlugin.PreFilter(ctx, state, pod, nodes)
 	if !status.IsSkip() {
 		p.metric.Inc()
@@ -62,7 +62,7 @@ type instrumentedPreScorePlugin struct {
 
 var _ framework.PreScorePlugin = &instrumentedPreScorePlugin{}
 
-func (p *instrumentedPreScorePlugin) PreScore(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodes []*framework.NodeInfo) *framework.Status {
+func (p *instrumentedPreScorePlugin) PreScore(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodes []*framework.NodeInfo) *fwk.Status {
 	status := p.PreScorePlugin.PreScore(ctx, state, pod, nodes)
 	if !status.IsSkip() {
 		p.metric.Inc()
@@ -78,7 +78,7 @@ type instrumentedScorePlugin struct {
 
 var _ framework.ScorePlugin = &instrumentedScorePlugin{}
 
-func (p *instrumentedScorePlugin) Score(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) (int64, *framework.Status) {
+func (p *instrumentedScorePlugin) Score(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) (int64, *fwk.Status) {
 	p.metric.Inc()
 	return p.ScorePlugin.Score(ctx, state, pod, nodeInfo)
 }

--- a/pkg/scheduler/framework/types.go
+++ b/pkg/scheduler/framework/types.go
@@ -371,7 +371,7 @@ const (
 	NoNodeAvailableMsg = "0/%v nodes are available"
 )
 
-func (d *Diagnosis) AddPluginStatus(sts *Status) {
+func (d *Diagnosis) AddPluginStatus(sts *fwk.Status) {
 	if sts.Plugin() == "" {
 		return
 	}
@@ -381,7 +381,7 @@ func (d *Diagnosis) AddPluginStatus(sts *Status) {
 		}
 		d.UnschedulablePlugins.Insert(sts.Plugin())
 	}
-	if sts.Code() == Pending {
+	if sts.Code() == fwk.Pending {
 		if d.PendingPlugins == nil {
 			d.PendingPlugins = sets.New[string]()
 		}
@@ -408,7 +408,7 @@ func (f *FitError) Error() string {
 		// So, we shouldn't add the message from NodeToStatusMap when the PreFilter failed.
 		// Otherwise, we will have duplicated reasons in the error message.
 		reasons := make(map[string]int)
-		f.Diagnosis.NodeToStatus.ForEachExplicitNode(func(_ string, status *Status) {
+		f.Diagnosis.NodeToStatus.ForEachExplicitNode(func(_ string, status *fwk.Status) {
 			for _, reason := range status.Reasons() {
 				reasons[reason]++
 			}

--- a/pkg/scheduler/framework/types_test.go
+++ b/pkg/scheduler/framework/types_test.go
@@ -1496,13 +1496,13 @@ func TestFitError_Error(t *testing.T) {
 			numAllNodes: 3,
 			diagnosis: Diagnosis{
 				PreFilterMsg: "Node(s) failed PreFilter plugin FalsePreFilter",
-				NodeToStatus: NewNodeToStatus(map[string]*Status{
+				NodeToStatus: NewNodeToStatus(map[string]*fwk.Status{
 					// They're inserted by the framework.
 					// We don't include them in the reason message because they'd be just duplicates.
-					"node1": NewStatus(Unschedulable, "Node(s) failed PreFilter plugin FalsePreFilter"),
-					"node2": NewStatus(Unschedulable, "Node(s) failed PreFilter plugin FalsePreFilter"),
-					"node3": NewStatus(Unschedulable, "Node(s) failed PreFilter plugin FalsePreFilter"),
-				}, NewStatus(UnschedulableAndUnresolvable)),
+					"node1": fwk.NewStatus(fwk.Unschedulable, "Node(s) failed PreFilter plugin FalsePreFilter"),
+					"node2": fwk.NewStatus(fwk.Unschedulable, "Node(s) failed PreFilter plugin FalsePreFilter"),
+					"node3": fwk.NewStatus(fwk.Unschedulable, "Node(s) failed PreFilter plugin FalsePreFilter"),
+				}, fwk.NewStatus(fwk.UnschedulableAndUnresolvable)),
 			},
 			wantReasonMsg: "0/3 nodes are available: Node(s) failed PreFilter plugin FalsePreFilter.",
 		},
@@ -1511,13 +1511,13 @@ func TestFitError_Error(t *testing.T) {
 			numAllNodes: 3,
 			diagnosis: Diagnosis{
 				PreFilterMsg: "Node(s) failed PreFilter plugin FalsePreFilter",
-				NodeToStatus: NewNodeToStatus(map[string]*Status{
+				NodeToStatus: NewNodeToStatus(map[string]*fwk.Status{
 					// They're inserted by the framework.
 					// We don't include them in the reason message because they'd be just duplicates.
-					"node1": NewStatus(Unschedulable, "Node(s) failed PreFilter plugin FalsePreFilter"),
-					"node2": NewStatus(Unschedulable, "Node(s) failed PreFilter plugin FalsePreFilter"),
-					"node3": NewStatus(Unschedulable, "Node(s) failed PreFilter plugin FalsePreFilter"),
-				}, NewStatus(UnschedulableAndUnresolvable)),
+					"node1": fwk.NewStatus(fwk.Unschedulable, "Node(s) failed PreFilter plugin FalsePreFilter"),
+					"node2": fwk.NewStatus(fwk.Unschedulable, "Node(s) failed PreFilter plugin FalsePreFilter"),
+					"node3": fwk.NewStatus(fwk.Unschedulable, "Node(s) failed PreFilter plugin FalsePreFilter"),
+				}, fwk.NewStatus(fwk.UnschedulableAndUnresolvable)),
 				// PostFilterMsg will be included.
 				PostFilterMsg: "Error running PostFilter plugin FailedPostFilter",
 			},
@@ -1528,11 +1528,11 @@ func TestFitError_Error(t *testing.T) {
 			numAllNodes: 3,
 			diagnosis: Diagnosis{
 				PreFilterMsg: "",
-				NodeToStatus: NewNodeToStatus(map[string]*Status{
-					"node1": NewStatus(Unschedulable, "Node(s) failed Filter plugin FalseFilter-1"),
-					"node2": NewStatus(Unschedulable, "Node(s) failed Filter plugin FalseFilter-1"),
-					"node3": NewStatus(Unschedulable, "Node(s) failed Filter plugin FalseFilter-1"),
-				}, NewStatus(UnschedulableAndUnresolvable)),
+				NodeToStatus: NewNodeToStatus(map[string]*fwk.Status{
+					"node1": fwk.NewStatus(fwk.Unschedulable, "Node(s) failed Filter plugin FalseFilter-1"),
+					"node2": fwk.NewStatus(fwk.Unschedulable, "Node(s) failed Filter plugin FalseFilter-1"),
+					"node3": fwk.NewStatus(fwk.Unschedulable, "Node(s) failed Filter plugin FalseFilter-1"),
+				}, fwk.NewStatus(fwk.UnschedulableAndUnresolvable)),
 			},
 			wantReasonMsg: "0/3 nodes are available: 3 Node(s) failed Filter plugin FalseFilter-1.",
 		},
@@ -1541,11 +1541,11 @@ func TestFitError_Error(t *testing.T) {
 			numAllNodes: 3,
 			diagnosis: Diagnosis{
 				PreFilterMsg: "",
-				NodeToStatus: NewNodeToStatus(map[string]*Status{
-					"node1": NewStatus(Unschedulable, "Node(s) failed Filter plugin FalseFilter-1"),
-					"node2": NewStatus(Unschedulable, "Node(s) failed Filter plugin FalseFilter-1"),
-					"node3": NewStatus(Unschedulable, "Node(s) failed Filter plugin FalseFilter-1"),
-				}, NewStatus(UnschedulableAndUnresolvable)),
+				NodeToStatus: NewNodeToStatus(map[string]*fwk.Status{
+					"node1": fwk.NewStatus(fwk.Unschedulable, "Node(s) failed Filter plugin FalseFilter-1"),
+					"node2": fwk.NewStatus(fwk.Unschedulable, "Node(s) failed Filter plugin FalseFilter-1"),
+					"node3": fwk.NewStatus(fwk.Unschedulable, "Node(s) failed Filter plugin FalseFilter-1"),
+				}, fwk.NewStatus(fwk.UnschedulableAndUnresolvable)),
 				PostFilterMsg: "Error running PostFilter plugin FailedPostFilter",
 			},
 			wantReasonMsg: "0/3 nodes are available: 3 Node(s) failed Filter plugin FalseFilter-1. Error running PostFilter plugin FailedPostFilter",
@@ -1555,11 +1555,11 @@ func TestFitError_Error(t *testing.T) {
 			numAllNodes: 3,
 			diagnosis: Diagnosis{
 				PreFilterMsg: "",
-				NodeToStatus: NewNodeToStatus(map[string]*Status{
-					"node1": NewStatus(Unschedulable, "Node(s) failed Filter plugin FalseFilter-1"),
-					"node2": NewStatus(Unschedulable, "Node(s) failed Filter plugin FalseFilter-1"),
-					"node3": NewStatus(Unschedulable, "Node(s) failed Filter plugin FalseFilter-2"),
-				}, NewStatus(UnschedulableAndUnresolvable)),
+				NodeToStatus: NewNodeToStatus(map[string]*fwk.Status{
+					"node1": fwk.NewStatus(fwk.Unschedulable, "Node(s) failed Filter plugin FalseFilter-1"),
+					"node2": fwk.NewStatus(fwk.Unschedulable, "Node(s) failed Filter plugin FalseFilter-1"),
+					"node3": fwk.NewStatus(fwk.Unschedulable, "Node(s) failed Filter plugin FalseFilter-2"),
+				}, fwk.NewStatus(fwk.UnschedulableAndUnresolvable)),
 			},
 			wantReasonMsg: "0/3 nodes are available: 1 Node(s) failed Filter plugin FalseFilter-2, 2 Node(s) failed Filter plugin FalseFilter-1.",
 		},
@@ -1568,11 +1568,11 @@ func TestFitError_Error(t *testing.T) {
 			numAllNodes: 3,
 			diagnosis: Diagnosis{
 				PreFilterMsg: "",
-				NodeToStatus: NewNodeToStatus(map[string]*Status{
-					"node1": NewStatus(Unschedulable, "Node(s) failed Filter plugin FalseFilter-1"),
-					"node2": NewStatus(Unschedulable, "Node(s) failed Filter plugin FalseFilter-1"),
-					"node3": NewStatus(Unschedulable, "Node(s) failed Filter plugin FalseFilter-2"),
-				}, NewStatus(UnschedulableAndUnresolvable)),
+				NodeToStatus: NewNodeToStatus(map[string]*fwk.Status{
+					"node1": fwk.NewStatus(fwk.Unschedulable, "Node(s) failed Filter plugin FalseFilter-1"),
+					"node2": fwk.NewStatus(fwk.Unschedulable, "Node(s) failed Filter plugin FalseFilter-1"),
+					"node3": fwk.NewStatus(fwk.Unschedulable, "Node(s) failed Filter plugin FalseFilter-2"),
+				}, fwk.NewStatus(fwk.UnschedulableAndUnresolvable)),
 				PostFilterMsg: "Error running PostFilter plugin FailedPostFilter",
 			},
 			wantReasonMsg: "0/3 nodes are available: 1 Node(s) failed Filter plugin FalseFilter-2, 2 Node(s) failed Filter plugin FalseFilter-1. Error running PostFilter plugin FailedPostFilter",
@@ -1581,10 +1581,10 @@ func TestFitError_Error(t *testing.T) {
 			name:        "failed to Permit on node",
 			numAllNodes: 1,
 			diagnosis: Diagnosis{
-				NodeToStatus: NewNodeToStatus(map[string]*Status{
+				NodeToStatus: NewNodeToStatus(map[string]*fwk.Status{
 					// There should be only one node here.
-					"node1": NewStatus(Unschedulable, "Node failed Permit plugin Permit-1"),
-				}, NewStatus(UnschedulableAndUnresolvable)),
+					"node1": fwk.NewStatus(fwk.Unschedulable, "Node failed Permit plugin Permit-1"),
+				}, fwk.NewStatus(fwk.UnschedulableAndUnresolvable)),
 			},
 			wantReasonMsg: "0/1 nodes are available: 1 Node failed Permit plugin Permit-1.",
 		},
@@ -1592,10 +1592,10 @@ func TestFitError_Error(t *testing.T) {
 			name:        "failed to Reserve on node",
 			numAllNodes: 1,
 			diagnosis: Diagnosis{
-				NodeToStatus: NewNodeToStatus(map[string]*Status{
+				NodeToStatus: NewNodeToStatus(map[string]*fwk.Status{
 					// There should be only one node here.
-					"node1": NewStatus(Unschedulable, "Node failed Reserve plugin Reserve-1"),
-				}, NewStatus(UnschedulableAndUnresolvable)),
+					"node1": fwk.NewStatus(fwk.Unschedulable, "Node failed Reserve plugin Reserve-1"),
+				}, fwk.NewStatus(fwk.UnschedulableAndUnresolvable)),
 			},
 			wantReasonMsg: "0/1 nodes are available: 1 Node failed Reserve plugin Reserve-1.",
 		},

--- a/pkg/scheduler/profile/profile_test.go
+++ b/pkg/scheduler/profile/profile_test.go
@@ -287,7 +287,7 @@ func (p *fakePlugin) Less(*framework.QueuedPodInfo, *framework.QueuedPodInfo) bo
 	return false
 }
 
-func (p *fakePlugin) Bind(context.Context, fwk.CycleState, *v1.Pod, string) *framework.Status {
+func (p *fakePlugin) Bind(context.Context, fwk.CycleState, *v1.Pod, string) *fwk.Status {
 	return nil
 }
 

--- a/pkg/scheduler/schedule_one.go
+++ b/pkg/scheduler/schedule_one.go
@@ -142,27 +142,27 @@ var clearNominatedNode = &framework.NominatingInfo{NominatingMode: framework.Mod
 func (sched *Scheduler) schedulingCycle(
 	ctx context.Context,
 	state fwk.CycleState,
-	fwk framework.Framework,
+	schedFramework framework.Framework,
 	podInfo *framework.QueuedPodInfo,
 	start time.Time,
 	podsToActivate *framework.PodsToActivate,
-) (ScheduleResult, *framework.QueuedPodInfo, *framework.Status) {
+) (ScheduleResult, *framework.QueuedPodInfo, *fwk.Status) {
 	logger := klog.FromContext(ctx)
 	pod := podInfo.Pod
-	scheduleResult, err := sched.SchedulePod(ctx, fwk, state, pod)
+	scheduleResult, err := sched.SchedulePod(ctx, schedFramework, state, pod)
 	if err != nil {
 		defer func() {
 			metrics.SchedulingAlgorithmLatency.Observe(metrics.SinceInSeconds(start))
 		}()
 		if err == ErrNoNodesAvailable {
-			status := framework.NewStatus(framework.UnschedulableAndUnresolvable).WithError(err)
+			status := fwk.NewStatus(fwk.UnschedulableAndUnresolvable).WithError(err)
 			return ScheduleResult{nominatingInfo: clearNominatedNode}, podInfo, status
 		}
 
 		fitError, ok := err.(*framework.FitError)
 		if !ok {
 			logger.Error(err, "Error selecting node for pod", "pod", klog.KObj(pod))
-			return ScheduleResult{nominatingInfo: clearNominatedNode}, podInfo, framework.AsStatus(err)
+			return ScheduleResult{nominatingInfo: clearNominatedNode}, podInfo, fwk.AsStatus(err)
 		}
 
 		// SchedulePod() may have failed because the pod would not fit on any host, so we try to
@@ -170,16 +170,16 @@ func (sched *Scheduler) schedulingCycle(
 		// will fit due to the preemption. It is also possible that a different pod will schedule
 		// into the resources that were preempted, but this is harmless.
 
-		if !fwk.HasPostFilterPlugins() {
+		if !schedFramework.HasPostFilterPlugins() {
 			logger.V(3).Info("No PostFilter plugins are registered, so no preemption will be performed")
-			return ScheduleResult{}, podInfo, framework.NewStatus(framework.Unschedulable).WithError(err)
+			return ScheduleResult{}, podInfo, fwk.NewStatus(fwk.Unschedulable).WithError(err)
 		}
 
 		// Run PostFilter plugins to attempt to make the pod schedulable in a future scheduling cycle.
-		result, status := fwk.RunPostFilterPlugins(ctx, state, pod, fitError.Diagnosis.NodeToStatus)
+		result, status := schedFramework.RunPostFilterPlugins(ctx, state, pod, fitError.Diagnosis.NodeToStatus)
 		msg := status.Message()
 		fitError.Diagnosis.PostFilterMsg = msg
-		if status.Code() == framework.Error {
+		if status.Code() == fwk.Error {
 			logger.Error(nil, "Status after running PostFilter plugins for pod", "pod", klog.KObj(pod), "status", msg)
 		} else {
 			logger.V(5).Info("Status after running PostFilter plugins for pod", "pod", klog.KObj(pod), "status", msg)
@@ -189,7 +189,7 @@ func (sched *Scheduler) schedulingCycle(
 		if result != nil {
 			nominatingInfo = result.NominatingInfo
 		}
-		return ScheduleResult{nominatingInfo: nominatingInfo}, podInfo, framework.NewStatus(framework.Unschedulable).WithError(err)
+		return ScheduleResult{nominatingInfo: nominatingInfo}, podInfo, fwk.NewStatus(fwk.Unschedulable).WithError(err)
 	}
 
 	metrics.SchedulingAlgorithmLatency.Observe(metrics.SinceInSeconds(start))
@@ -205,13 +205,13 @@ func (sched *Scheduler) schedulingCycle(
 		// This relies on the fact that Error will check if the pod has been bound
 		// to a node and if so will not add it back to the unscheduled pods queue
 		// (otherwise this would cause an infinite loop).
-		return ScheduleResult{nominatingInfo: clearNominatedNode}, assumedPodInfo, framework.AsStatus(err)
+		return ScheduleResult{nominatingInfo: clearNominatedNode}, assumedPodInfo, fwk.AsStatus(err)
 	}
 
 	// Run the Reserve method of reserve plugins.
-	if sts := fwk.RunReservePluginsReserve(ctx, state, assumedPod, scheduleResult.SuggestedHost); !sts.IsSuccess() {
+	if sts := schedFramework.RunReservePluginsReserve(ctx, state, assumedPod, scheduleResult.SuggestedHost); !sts.IsSuccess() {
 		// trigger un-reserve to clean up state associated with the reserved Pod
-		fwk.RunReservePluginsUnreserve(ctx, state, assumedPod, scheduleResult.SuggestedHost)
+		schedFramework.RunReservePluginsUnreserve(ctx, state, assumedPod, scheduleResult.SuggestedHost)
 		if forgetErr := sched.Cache.ForgetPod(logger, assumedPod); forgetErr != nil {
 			logger.Error(forgetErr, "Scheduler cache ForgetPod failed")
 		}
@@ -226,16 +226,16 @@ func (sched *Scheduler) schedulingCycle(
 			}
 			fitErr.Diagnosis.NodeToStatus.Set(scheduleResult.SuggestedHost, sts)
 			fitErr.Diagnosis.AddPluginStatus(sts)
-			return ScheduleResult{nominatingInfo: clearNominatedNode}, assumedPodInfo, framework.NewStatus(sts.Code()).WithError(fitErr)
+			return ScheduleResult{nominatingInfo: clearNominatedNode}, assumedPodInfo, fwk.NewStatus(sts.Code()).WithError(fitErr)
 		}
 		return ScheduleResult{nominatingInfo: clearNominatedNode}, assumedPodInfo, sts
 	}
 
 	// Run "permit" plugins.
-	runPermitStatus := fwk.RunPermitPlugins(ctx, state, assumedPod, scheduleResult.SuggestedHost)
+	runPermitStatus := schedFramework.RunPermitPlugins(ctx, state, assumedPod, scheduleResult.SuggestedHost)
 	if !runPermitStatus.IsWait() && !runPermitStatus.IsSuccess() {
 		// trigger un-reserve to clean up state associated with the reserved Pod
-		fwk.RunReservePluginsUnreserve(ctx, state, assumedPod, scheduleResult.SuggestedHost)
+		schedFramework.RunReservePluginsUnreserve(ctx, state, assumedPod, scheduleResult.SuggestedHost)
 		if forgetErr := sched.Cache.ForgetPod(logger, assumedPod); forgetErr != nil {
 			logger.Error(forgetErr, "Scheduler cache ForgetPod failed")
 		}
@@ -250,7 +250,7 @@ func (sched *Scheduler) schedulingCycle(
 			}
 			fitErr.Diagnosis.NodeToStatus.Set(scheduleResult.SuggestedHost, runPermitStatus)
 			fitErr.Diagnosis.AddPluginStatus(runPermitStatus)
-			return ScheduleResult{nominatingInfo: clearNominatedNode}, assumedPodInfo, framework.NewStatus(runPermitStatus.Code()).WithError(fitErr)
+			return ScheduleResult{nominatingInfo: clearNominatedNode}, assumedPodInfo, fwk.NewStatus(runPermitStatus.Code()).WithError(fitErr)
 		}
 
 		return ScheduleResult{nominatingInfo: clearNominatedNode}, assumedPodInfo, runPermitStatus
@@ -270,17 +270,17 @@ func (sched *Scheduler) schedulingCycle(
 func (sched *Scheduler) bindingCycle(
 	ctx context.Context,
 	state fwk.CycleState,
-	fwk framework.Framework,
+	schedFramework framework.Framework,
 	scheduleResult ScheduleResult,
 	assumedPodInfo *framework.QueuedPodInfo,
 	start time.Time,
-	podsToActivate *framework.PodsToActivate) *framework.Status {
+	podsToActivate *framework.PodsToActivate) *fwk.Status {
 	logger := klog.FromContext(ctx)
 
 	assumedPod := assumedPodInfo.Pod
 
 	// Run "permit" plugins.
-	if status := fwk.WaitOnPermit(ctx, assumedPod); !status.IsSuccess() {
+	if status := schedFramework.WaitOnPermit(ctx, assumedPod); !status.IsSuccess() {
 		if status.IsRejected() {
 			fitErr := &framework.FitError{
 				NumAllNodes: 1,
@@ -291,7 +291,7 @@ func (sched *Scheduler) bindingCycle(
 				},
 			}
 			fitErr.Diagnosis.NodeToStatus.Set(scheduleResult.SuggestedHost, status)
-			return framework.NewStatus(status.Code()).WithError(fitErr)
+			return fwk.NewStatus(status.Code()).WithError(fitErr)
 		}
 		return status
 	}
@@ -305,24 +305,24 @@ func (sched *Scheduler) bindingCycle(
 	sched.SchedulingQueue.Done(assumedPod.UID)
 
 	// Run "prebind" plugins.
-	if status := fwk.RunPreBindPlugins(ctx, state, assumedPod, scheduleResult.SuggestedHost); !status.IsSuccess() {
+	if status := schedFramework.RunPreBindPlugins(ctx, state, assumedPod, scheduleResult.SuggestedHost); !status.IsSuccess() {
 		return status
 	}
 
 	// Run "bind" plugins.
-	if status := sched.bind(ctx, fwk, assumedPod, scheduleResult.SuggestedHost, state); !status.IsSuccess() {
+	if status := sched.bind(ctx, schedFramework, assumedPod, scheduleResult.SuggestedHost, state); !status.IsSuccess() {
 		return status
 	}
 
 	// Calculating nodeResourceString can be heavy. Avoid it if klog verbosity is below 2.
 	logger.V(2).Info("Successfully bound pod to node", "pod", klog.KObj(assumedPod), "node", scheduleResult.SuggestedHost, "evaluatedNodes", scheduleResult.EvaluatedNodes, "feasibleNodes", scheduleResult.FeasibleNodes)
-	metrics.PodScheduled(fwk.ProfileName(), metrics.SinceInSeconds(start))
+	metrics.PodScheduled(schedFramework.ProfileName(), metrics.SinceInSeconds(start))
 	metrics.PodSchedulingAttempts.Observe(float64(assumedPodInfo.Attempts))
 	if assumedPodInfo.InitialAttemptTimestamp != nil {
 		metrics.PodSchedulingSLIDuration.WithLabelValues(getAttemptsLabel(assumedPodInfo)).Observe(metrics.SinceInSeconds(*assumedPodInfo.InitialAttemptTimestamp))
 	}
 	// Run "postbind" plugins.
-	fwk.RunPostBindPlugins(ctx, state, assumedPod, scheduleResult.SuggestedHost)
+	schedFramework.RunPostBindPlugins(ctx, state, assumedPod, scheduleResult.SuggestedHost)
 
 	// At the end of a successful binding cycle, move up Pods if needed.
 	if len(podsToActivate.Map) != 0 {
@@ -341,7 +341,7 @@ func (sched *Scheduler) handleBindingCycleError(
 	podInfo *framework.QueuedPodInfo,
 	start time.Time,
 	scheduleResult ScheduleResult,
-	status *framework.Status) {
+	status *fwk.Status) {
 	logger := klog.FromContext(ctx)
 
 	assumedPod := podInfo.Pod
@@ -452,7 +452,7 @@ func (sched *Scheduler) schedulePod(ctx context.Context, fwk framework.Framework
 
 // Filters the nodes to find the ones that fit the pod based on the framework
 // filter plugins and filter extenders.
-func (sched *Scheduler) findNodesThatFitPod(ctx context.Context, fwk framework.Framework, state fwk.CycleState, pod *v1.Pod) ([]*framework.NodeInfo, framework.Diagnosis, error) {
+func (sched *Scheduler) findNodesThatFitPod(ctx context.Context, schedFramework framework.Framework, state fwk.CycleState, pod *v1.Pod) ([]*framework.NodeInfo, framework.Diagnosis, error) {
 	logger := klog.FromContext(ctx)
 	diagnosis := framework.Diagnosis{
 		NodeToStatus: framework.NewDefaultNodeToStatus(),
@@ -463,7 +463,7 @@ func (sched *Scheduler) findNodesThatFitPod(ctx context.Context, fwk framework.F
 		return nil, diagnosis, err
 	}
 	// Run "prefilter" plugins.
-	preRes, s, unscheduledPlugins := fwk.RunPreFilterPlugins(ctx, state, pod)
+	preRes, s, unscheduledPlugins := schedFramework.RunPreFilterPlugins(ctx, state, pod)
 	diagnosis.UnschedulablePlugins = unscheduledPlugins
 	if !s.IsSuccess() {
 		if !s.IsRejected() {
@@ -483,7 +483,7 @@ func (sched *Scheduler) findNodesThatFitPod(ctx context.Context, fwk framework.F
 	// "NominatedNodeName" can potentially be set in a previous scheduling cycle as a result of preemption.
 	// This node is likely the only candidate that will fit the pod, and hence we try it first before iterating over all nodes.
 	if len(pod.Status.NominatedNodeName) > 0 {
-		feasibleNodes, err := sched.evaluateNominatedNode(ctx, pod, fwk, state, diagnosis)
+		feasibleNodes, err := sched.evaluateNominatedNode(ctx, pod, schedFramework, state, diagnosis)
 		if err != nil {
 			logger.Error(err, "Evaluation failed on nominated node", "pod", klog.KObj(pod), "node", pod.Status.NominatedNodeName)
 		}
@@ -503,9 +503,9 @@ func (sched *Scheduler) findNodesThatFitPod(ctx context.Context, fwk framework.F
 				nodes = append(nodes, nodeInfo)
 			}
 		}
-		diagnosis.NodeToStatus.SetAbsentNodesStatus(framework.NewStatus(framework.UnschedulableAndUnresolvable, fmt.Sprintf("node(s) didn't satisfy plugin(s) %v", sets.List(unscheduledPlugins))))
+		diagnosis.NodeToStatus.SetAbsentNodesStatus(fwk.NewStatus(fwk.UnschedulableAndUnresolvable, fmt.Sprintf("node(s) didn't satisfy plugin(s) %v", sets.List(unscheduledPlugins))))
 	}
-	feasibleNodes, err := sched.findNodesThatPassFilters(ctx, fwk, state, pod, &diagnosis, nodes)
+	feasibleNodes, err := sched.findNodesThatPassFilters(ctx, schedFramework, state, pod, &diagnosis, nodes)
 	// always try to update the sched.nextStartNodeIndex regardless of whether an error has occurred
 	// this is helpful to make sure that all the nodes have a chance to be searched
 	processedNodes := len(feasibleNodes) + diagnosis.NodeToStatus.Len()
@@ -582,14 +582,14 @@ func (sched *Scheduler) hasExtenderFilters() bool {
 // findNodesThatPassFilters finds the nodes that fit the filter plugins.
 func (sched *Scheduler) findNodesThatPassFilters(
 	ctx context.Context,
-	fwk framework.Framework,
+	schedFramework framework.Framework,
 	state fwk.CycleState,
 	pod *v1.Pod,
 	diagnosis *framework.Diagnosis,
 	nodes []*framework.NodeInfo) ([]*framework.NodeInfo, error) {
 	numAllNodes := len(nodes)
-	numNodesToFind := sched.numFeasibleNodesToFind(fwk.PercentageOfNodesToScore(), int32(numAllNodes))
-	if !sched.hasExtenderFilters() && !sched.hasScoring(fwk) {
+	numNodesToFind := sched.numFeasibleNodesToFind(schedFramework.PercentageOfNodesToScore(), int32(numAllNodes))
+	if !sched.hasExtenderFilters() && !sched.hasScoring(schedFramework) {
 		numNodesToFind = 1
 	}
 
@@ -597,7 +597,7 @@ func (sched *Scheduler) findNodesThatPassFilters(
 	// and allow assigning.
 	feasibleNodes := make([]*framework.NodeInfo, numNodesToFind)
 
-	if !fwk.HasFilterPlugins() {
+	if !schedFramework.HasFilterPlugins() {
 		for i := range feasibleNodes {
 			feasibleNodes[i] = nodes[(sched.nextStartNodeIndex+i)%numAllNodes]
 		}
@@ -611,15 +611,15 @@ func (sched *Scheduler) findNodesThatPassFilters(
 
 	type nodeStatus struct {
 		node   string
-		status *framework.Status
+		status *fwk.Status
 	}
 	result := make([]*nodeStatus, numAllNodes)
 	checkNode := func(i int) {
 		// We check the nodes starting from where we left off in the previous scheduling cycle,
 		// this is to make sure all nodes have the same chance of being examined across pods.
 		nodeInfo := nodes[(sched.nextStartNodeIndex+i)%numAllNodes]
-		status := fwk.RunFilterPluginsWithNominatedPods(ctx, state, pod, nodeInfo)
-		if status.Code() == framework.Error {
+		status := schedFramework.RunFilterPluginsWithNominatedPods(ctx, state, pod, nodeInfo)
+		if status.Code() == fwk.Error {
 			errCh.SendErrorWithCancel(status.AsError(), cancel)
 			return
 		}
@@ -637,17 +637,17 @@ func (sched *Scheduler) findNodesThatPassFilters(
 	}
 
 	beginCheckNode := time.Now()
-	statusCode := framework.Success
+	statusCode := fwk.Success
 	defer func() {
 		// We record Filter extension point latency here instead of in framework.go because framework.RunFilterPlugins
 		// function is called for each node, whereas we want to have an overall latency for all nodes per scheduling cycle.
 		// Note that this latency also includes latency for `addNominatedPods`, which calls framework.RunPreFilterAddPod.
-		metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.Filter, statusCode.String(), fwk.ProfileName()).Observe(metrics.SinceInSeconds(beginCheckNode))
+		metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.Filter, statusCode.String(), schedFramework.ProfileName()).Observe(metrics.SinceInSeconds(beginCheckNode))
 	}()
 
 	// Stops searching for more nodes once the configured number of feasible nodes
 	// are found.
-	fwk.Parallelizer().Until(ctx, numAllNodes, checkNode, metrics.Filter)
+	schedFramework.Parallelizer().Until(ctx, numAllNodes, checkNode, metrics.Filter)
 	feasibleNodes = feasibleNodes[:feasibleNodesLen]
 	for _, item := range result {
 		if item == nil {
@@ -657,7 +657,7 @@ func (sched *Scheduler) findNodesThatPassFilters(
 		diagnosis.AddPluginStatus(item.status)
 	}
 	if err := errCh.ReceiveError(); err != nil {
-		statusCode = framework.Error
+		statusCode = fwk.Error
 		return feasibleNodes, err
 	}
 	return feasibleNodes, nil
@@ -722,7 +722,7 @@ func findNodesThatPassExtenders(ctx context.Context, extenders []framework.Exten
 		}
 
 		for failedNodeName, failedMsg := range failedAndUnresolvableMap {
-			statuses.Set(failedNodeName, framework.NewStatus(framework.UnschedulableAndUnresolvable, failedMsg))
+			statuses.Set(failedNodeName, fwk.NewStatus(fwk.UnschedulableAndUnresolvable, failedMsg))
 		}
 
 		for failedNodeName, failedMsg := range failedMap {
@@ -731,7 +731,7 @@ func findNodesThatPassExtenders(ctx context.Context, extenders []framework.Exten
 				// note that this only happens if the extender returns the node in both maps
 				continue
 			}
-			statuses.Set(failedNodeName, framework.NewStatus(framework.Unschedulable, failedMsg))
+			statuses.Set(failedNodeName, fwk.NewStatus(fwk.Unschedulable, failedMsg))
 		}
 
 		feasibleNodes = feasibleList
@@ -957,17 +957,17 @@ func (sched *Scheduler) assume(logger klog.Logger, assumed *v1.Pod, host string)
 // bind binds a pod to a given node defined in a binding object.
 // The precedence for binding is: (1) extenders and (2) framework plugins.
 // We expect this to run asynchronously, so we handle binding metrics internally.
-func (sched *Scheduler) bind(ctx context.Context, fwk framework.Framework, assumed *v1.Pod, targetNode string, state fwk.CycleState) (status *framework.Status) {
+func (sched *Scheduler) bind(ctx context.Context, schedFramework framework.Framework, assumed *v1.Pod, targetNode string, state fwk.CycleState) (status *fwk.Status) {
 	logger := klog.FromContext(ctx)
 	defer func() {
-		sched.finishBinding(logger, fwk, assumed, targetNode, status)
+		sched.finishBinding(logger, schedFramework, assumed, targetNode, status)
 	}()
 
 	bound, err := sched.extendersBinding(logger, assumed, targetNode)
 	if bound {
-		return framework.AsStatus(err)
+		return fwk.AsStatus(err)
 	}
-	return fwk.RunBindPlugins(ctx, state, assumed, targetNode)
+	return schedFramework.RunBindPlugins(ctx, state, assumed, targetNode)
 }
 
 // TODO(#87159): Move this to a Plugin.
@@ -989,7 +989,7 @@ func (sched *Scheduler) extendersBinding(logger klog.Logger, pod *v1.Pod, node s
 	return false, nil
 }
 
-func (sched *Scheduler) finishBinding(logger klog.Logger, fwk framework.Framework, assumed *v1.Pod, targetNode string, status *framework.Status) {
+func (sched *Scheduler) finishBinding(logger klog.Logger, fwk framework.Framework, assumed *v1.Pod, targetNode string, status *fwk.Status) {
 	if finErr := sched.Cache.FinishBinding(logger, assumed); finErr != nil {
 		logger.Error(finErr, "Scheduler cache FinishBinding failed")
 	}
@@ -1012,7 +1012,7 @@ func getAttemptsLabel(p *framework.QueuedPodInfo) string {
 
 // handleSchedulingFailure records an event for the pod that indicates the
 // pod has failed to schedule. Also, update the pod condition and nominated node name if set.
-func (sched *Scheduler) handleSchedulingFailure(ctx context.Context, fwk framework.Framework, podInfo *framework.QueuedPodInfo, status *framework.Status, nominatingInfo *framework.NominatingInfo, start time.Time) {
+func (sched *Scheduler) handleSchedulingFailure(ctx context.Context, fwk framework.Framework, podInfo *framework.QueuedPodInfo, status *fwk.Status, nominatingInfo *framework.NominatingInfo, start time.Time) {
 	calledDone := false
 	defer func() {
 		if !calledDone {

--- a/pkg/scheduler/schedule_one_test.go
+++ b/pkg/scheduler/schedule_one_test.go
@@ -171,8 +171,8 @@ func (pl *falseMapPlugin) Name() string {
 	return "FalseMap"
 }
 
-func (pl *falseMapPlugin) Score(_ context.Context, _ fwk.CycleState, _ *v1.Pod, _ *framework.NodeInfo) (int64, *framework.Status) {
-	return 0, framework.AsStatus(errPrioritize)
+func (pl *falseMapPlugin) Score(_ context.Context, _ fwk.CycleState, _ *v1.Pod, _ *framework.NodeInfo) (int64, *fwk.Status) {
+	return 0, fwk.AsStatus(errPrioritize)
 }
 
 func (pl *falseMapPlugin) ScoreExtensions() framework.ScoreExtensions {
@@ -191,11 +191,11 @@ func (pl *numericMapPlugin) Name() string {
 	return "NumericMap"
 }
 
-func (pl *numericMapPlugin) Score(_ context.Context, _ fwk.CycleState, _ *v1.Pod, nodeInfo *framework.NodeInfo) (int64, *framework.Status) {
+func (pl *numericMapPlugin) Score(_ context.Context, _ fwk.CycleState, _ *v1.Pod, nodeInfo *framework.NodeInfo) (int64, *fwk.Status) {
 	nodeName := nodeInfo.Node().Name
 	score, err := strconv.Atoi(nodeName)
 	if err != nil {
-		return 0, framework.NewStatus(framework.Error, fmt.Sprintf("Error converting nodename to int: %+v", nodeName))
+		return 0, fwk.NewStatus(fwk.Error, fmt.Sprintf("Error converting nodename to int: %+v", nodeName))
 	}
 	return int64(score), nil
 }
@@ -215,11 +215,11 @@ func (pl *reverseNumericMapPlugin) Name() string {
 	return "ReverseNumericMap"
 }
 
-func (pl *reverseNumericMapPlugin) Score(_ context.Context, _ fwk.CycleState, _ *v1.Pod, nodeInfo *framework.NodeInfo) (int64, *framework.Status) {
+func (pl *reverseNumericMapPlugin) Score(_ context.Context, _ fwk.CycleState, _ *v1.Pod, nodeInfo *framework.NodeInfo) (int64, *fwk.Status) {
 	nodeName := nodeInfo.Node().Name
 	score, err := strconv.Atoi(nodeName)
 	if err != nil {
-		return 0, framework.NewStatus(framework.Error, fmt.Sprintf("Error converting nodename to int: %+v", nodeName))
+		return 0, fwk.NewStatus(fwk.Error, fmt.Sprintf("Error converting nodename to int: %+v", nodeName))
 	}
 	return int64(score), nil
 }
@@ -228,7 +228,7 @@ func (pl *reverseNumericMapPlugin) ScoreExtensions() framework.ScoreExtensions {
 	return pl
 }
 
-func (pl *reverseNumericMapPlugin) NormalizeScore(_ context.Context, _ fwk.CycleState, _ *v1.Pod, nodeScores framework.NodeScoreList) *framework.Status {
+func (pl *reverseNumericMapPlugin) NormalizeScore(_ context.Context, _ fwk.CycleState, _ *v1.Pod, nodeScores framework.NodeScoreList) *fwk.Status {
 	var maxScore float64
 	minScore := math.MaxFloat64
 
@@ -257,7 +257,7 @@ func (pl *trueMapPlugin) Name() string {
 	return "TrueMap"
 }
 
-func (pl *trueMapPlugin) Score(_ context.Context, _ fwk.CycleState, _ *v1.Pod, _ *framework.NodeInfo) (int64, *framework.Status) {
+func (pl *trueMapPlugin) Score(_ context.Context, _ fwk.CycleState, _ *v1.Pod, _ *framework.NodeInfo) (int64, *fwk.Status) {
 	return 1, nil
 }
 
@@ -265,10 +265,10 @@ func (pl *trueMapPlugin) ScoreExtensions() framework.ScoreExtensions {
 	return pl
 }
 
-func (pl *trueMapPlugin) NormalizeScore(_ context.Context, _ fwk.CycleState, _ *v1.Pod, nodeScores framework.NodeScoreList) *framework.Status {
+func (pl *trueMapPlugin) NormalizeScore(_ context.Context, _ fwk.CycleState, _ *v1.Pod, nodeScores framework.NodeScoreList) *fwk.Status {
 	for _, host := range nodeScores {
 		if host.Name == "" {
-			return framework.NewStatus(framework.Error, "unexpected empty host name")
+			return fwk.NewStatus(fwk.Error, "unexpected empty host name")
 		}
 	}
 	return nil
@@ -288,11 +288,11 @@ func (pl *noPodsFilterPlugin) Name() string {
 }
 
 // Filter invoked at the filter extension point.
-func (pl *noPodsFilterPlugin) Filter(_ context.Context, _ fwk.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) *framework.Status {
+func (pl *noPodsFilterPlugin) Filter(_ context.Context, _ fwk.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) *fwk.Status {
 	if len(nodeInfo.Pods) == 0 {
 		return nil
 	}
-	return framework.NewStatus(framework.Unschedulable, tf.ErrReasonFake)
+	return fwk.NewStatus(fwk.Unschedulable, tf.ErrReasonFake)
 }
 
 type fakeNodeSelectorArgs struct {
@@ -307,9 +307,9 @@ func (s *fakeNodeSelector) Name() string {
 	return "FakeNodeSelector"
 }
 
-func (s *fakeNodeSelector) Filter(_ context.Context, _ fwk.CycleState, _ *v1.Pod, nodeInfo *framework.NodeInfo) *framework.Status {
+func (s *fakeNodeSelector) Filter(_ context.Context, _ fwk.CycleState, _ *v1.Pod, nodeInfo *framework.NodeInfo) *fwk.Status {
 	if nodeInfo.Node().Name != s.NodeName {
-		return framework.NewStatus(framework.UnschedulableAndUnresolvable)
+		return fwk.NewStatus(fwk.UnschedulableAndUnresolvable)
 	}
 	return nil
 }
@@ -334,7 +334,7 @@ func (f *fakeNodeSelectorDependOnPodAnnotation) Name() string {
 }
 
 // Filter selects the specified one node and rejects other non-specified nodes.
-func (f *fakeNodeSelectorDependOnPodAnnotation) Filter(_ context.Context, _ fwk.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) *framework.Status {
+func (f *fakeNodeSelectorDependOnPodAnnotation) Filter(_ context.Context, _ fwk.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) *fwk.Status {
 	resolveNodeNameFromPodAnnotation := func(pod *v1.Pod) (string, error) {
 		if pod == nil {
 			return "", fmt.Errorf("empty pod")
@@ -348,10 +348,10 @@ func (f *fakeNodeSelectorDependOnPodAnnotation) Filter(_ context.Context, _ fwk.
 
 	nodeName, err := resolveNodeNameFromPodAnnotation(pod)
 	if err != nil {
-		return framework.AsStatus(err)
+		return fwk.AsStatus(err)
 	}
 	if nodeInfo.Node().Name != nodeName {
-		return framework.NewStatus(framework.UnschedulableAndUnresolvable)
+		return fwk.NewStatus(fwk.UnschedulableAndUnresolvable)
 	}
 	return nil
 }
@@ -371,7 +371,7 @@ func (t *TestPlugin) Name() string {
 	return t.name
 }
 
-func (t *TestPlugin) Score(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodeInfo *framework.NodeInfo) (int64, *framework.Status) {
+func (t *TestPlugin) Score(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodeInfo *framework.NodeInfo) (int64, *fwk.Status) {
 	return 1, nil
 }
 
@@ -379,7 +379,7 @@ func (t *TestPlugin) ScoreExtensions() framework.ScoreExtensions {
 	return nil
 }
 
-func (t *TestPlugin) Filter(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) *framework.Status {
+func (t *TestPlugin) Filter(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) *fwk.Status {
 	return nil
 }
 
@@ -711,7 +711,7 @@ func TestSchedulerScheduleOne(t *testing.T) {
 			name:    "reserve failed with status code error",
 			sendPod: testPod,
 			registerPluginFuncs: []tf.RegisterPluginFunc{
-				tf.RegisterReservePlugin("FakeReserve", tf.NewFakeReservePlugin(framework.AsStatus(reserveErr))),
+				tf.RegisterReservePlugin("FakeReserve", tf.NewFakeReservePlugin(fwk.AsStatus(reserveErr))),
 			},
 			mockScheduleResult:  scheduleResultOk,
 			expectErrorPod:      assignedTestPod,
@@ -725,7 +725,7 @@ func TestSchedulerScheduleOne(t *testing.T) {
 			name:    "reserve failed with status code rejected",
 			sendPod: testPod,
 			registerPluginFuncs: []tf.RegisterPluginFunc{
-				tf.RegisterReservePlugin("FakeReserve", tf.NewFakeReservePlugin(framework.NewStatus(framework.UnschedulableAndUnresolvable, "rejected on reserve"))),
+				tf.RegisterReservePlugin("FakeReserve", tf.NewFakeReservePlugin(fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "rejected on reserve"))),
 			},
 			mockScheduleResult:       scheduleResultOk,
 			expectErrorPod:           assignedTestPod,
@@ -739,7 +739,7 @@ func TestSchedulerScheduleOne(t *testing.T) {
 			name:    "permit failed with status code error",
 			sendPod: testPod,
 			registerPluginFuncs: []tf.RegisterPluginFunc{
-				tf.RegisterPermitPlugin("FakePermit", tf.NewFakePermitPlugin(framework.AsStatus(permitErr), time.Minute)),
+				tf.RegisterPermitPlugin("FakePermit", tf.NewFakePermitPlugin(fwk.AsStatus(permitErr), time.Minute)),
 			},
 			mockScheduleResult:  scheduleResultOk,
 			expectErrorPod:      assignedTestPod,
@@ -753,7 +753,7 @@ func TestSchedulerScheduleOne(t *testing.T) {
 			name:    "permit failed with status code rejected",
 			sendPod: testPod,
 			registerPluginFuncs: []tf.RegisterPluginFunc{
-				tf.RegisterPermitPlugin("FakePermit", tf.NewFakePermitPlugin(framework.NewStatus(framework.Unschedulable, "rejected on permit"), time.Minute)),
+				tf.RegisterPermitPlugin("FakePermit", tf.NewFakePermitPlugin(fwk.NewStatus(fwk.Unschedulable, "rejected on permit"), time.Minute)),
 			},
 			mockScheduleResult:       scheduleResultOk,
 			expectErrorPod:           assignedTestPod,
@@ -767,7 +767,7 @@ func TestSchedulerScheduleOne(t *testing.T) {
 			name:    "prebind failed with status code rejected",
 			sendPod: testPod,
 			registerPluginFuncs: []tf.RegisterPluginFunc{
-				tf.RegisterPreBindPlugin("FakePreBind", tf.NewFakePreBindPlugin(framework.NewStatus(framework.Unschedulable, "rejected on prebind"))),
+				tf.RegisterPreBindPlugin("FakePreBind", tf.NewFakePreBindPlugin(fwk.NewStatus(fwk.Unschedulable, "rejected on prebind"))),
 			},
 			mockScheduleResult:  scheduleResultOk,
 			expectErrorPod:      assignedTestPod,
@@ -781,7 +781,7 @@ func TestSchedulerScheduleOne(t *testing.T) {
 			name:    "prebind failed with status code error",
 			sendPod: testPod,
 			registerPluginFuncs: []tf.RegisterPluginFunc{
-				tf.RegisterPreBindPlugin("FakePreBind", tf.NewFakePreBindPlugin(framework.AsStatus(preBindErr))),
+				tf.RegisterPreBindPlugin("FakePreBind", tf.NewFakePreBindPlugin(fwk.AsStatus(preBindErr))),
 			},
 			mockScheduleResult:  scheduleResultOk,
 			expectErrorPod:      assignedTestPod,
@@ -886,7 +886,7 @@ func TestSchedulerScheduleOne(t *testing.T) {
 				sched.SchedulePod = func(ctx context.Context, fwk framework.Framework, state fwk.CycleState, pod *v1.Pod) (ScheduleResult, error) {
 					return item.mockScheduleResult, item.injectSchedulingError
 				}
-				sched.FailureHandler = func(ctx context.Context, fwk framework.Framework, p *framework.QueuedPodInfo, status *framework.Status, ni *framework.NominatingInfo, start time.Time) {
+				sched.FailureHandler = func(ctx context.Context, fwk framework.Framework, p *framework.QueuedPodInfo, status *fwk.Status, ni *framework.NominatingInfo, start time.Time) {
 					gotPod = p.Pod
 					gotError = status.AsError()
 
@@ -985,8 +985,8 @@ func TestScheduleOneMarksPodAsProcessedBeforePreBind(t *testing.T) {
 		injectSchedulingError               error
 		injectBindError                     error
 		mockScheduleResult                  ScheduleResult
-		mockWaitOnPermitResult              *framework.Status
-		mockRunPreBindPluginsResult         *framework.Status
+		mockWaitOnPermitResult              *fwk.Status
+		mockRunPreBindPluginsResult         *fwk.Status
 		expectErrorPod                      *v1.Pod
 		expectAssumedPod                    *v1.Pod
 		expectError                         error
@@ -1000,7 +1000,7 @@ func TestScheduleOneMarksPodAsProcessedBeforePreBind(t *testing.T) {
 			sendPod:            testPod,
 			mockScheduleResult: scheduleResultOk,
 			registerPluginFuncs: []tf.RegisterPluginFunc{
-				tf.RegisterPermitPlugin("FakePermit", tf.NewFakePermitPlugin(framework.AsStatus(permitErr), time.Minute)),
+				tf.RegisterPermitPlugin("FakePermit", tf.NewFakePermitPlugin(fwk.AsStatus(permitErr), time.Minute)),
 			},
 			expectErrorPod:                      assignedTestPod,
 			expectAssumedPod:                    assignedTestPod,
@@ -1013,7 +1013,7 @@ func TestScheduleOneMarksPodAsProcessedBeforePreBind(t *testing.T) {
 			sendPod:            testPod,
 			mockScheduleResult: scheduleResultOk,
 			registerPluginFuncs: []tf.RegisterPluginFunc{
-				tf.RegisterPermitPlugin("FakePermit", tf.NewFakePermitPlugin(framework.NewStatus(framework.Unschedulable, "on permit"), time.Minute)),
+				tf.RegisterPermitPlugin("FakePermit", tf.NewFakePermitPlugin(fwk.NewStatus(fwk.Unschedulable, "on permit"), time.Minute)),
 			},
 			expectErrorPod:                      assignedTestPod,
 			expectAssumedPod:                    assignedTestPod,
@@ -1026,9 +1026,9 @@ func TestScheduleOneMarksPodAsProcessedBeforePreBind(t *testing.T) {
 			sendPod:            testPod,
 			mockScheduleResult: scheduleResultOk,
 			registerPluginFuncs: []tf.RegisterPluginFunc{
-				tf.RegisterPermitPlugin("FakePermit", tf.NewFakePermitPlugin(framework.NewStatus(framework.Wait), time.Minute)),
+				tf.RegisterPermitPlugin("FakePermit", tf.NewFakePermitPlugin(fwk.NewStatus(fwk.Wait), time.Minute)),
 			},
-			mockWaitOnPermitResult:              framework.AsStatus(waitOnPermitErr),
+			mockWaitOnPermitResult:              fwk.AsStatus(waitOnPermitErr),
 			expectErrorPod:                      assignedTestPod,
 			expectAssumedPod:                    assignedTestPod,
 			expectError:                         waitOnPermitErr,
@@ -1041,9 +1041,9 @@ func TestScheduleOneMarksPodAsProcessedBeforePreBind(t *testing.T) {
 			sendPod:            testPod,
 			mockScheduleResult: scheduleResultOk,
 			registerPluginFuncs: []tf.RegisterPluginFunc{
-				tf.RegisterPermitPlugin("FakePermit", tf.NewFakePermitPlugin(framework.NewStatus(framework.Wait), time.Minute)),
+				tf.RegisterPermitPlugin("FakePermit", tf.NewFakePermitPlugin(fwk.NewStatus(fwk.Wait), time.Minute)),
 			},
-			mockWaitOnPermitResult:              framework.NewStatus(framework.Unschedulable, "wait on permit"),
+			mockWaitOnPermitResult:              fwk.NewStatus(fwk.Unschedulable, "wait on permit"),
 			expectErrorPod:                      assignedTestPod,
 			expectAssumedPod:                    assignedTestPod,
 			expectError:                         makePredicateError("1 wait on permit"),
@@ -1056,10 +1056,10 @@ func TestScheduleOneMarksPodAsProcessedBeforePreBind(t *testing.T) {
 			sendPod:            testPod,
 			mockScheduleResult: scheduleResultOk,
 			registerPluginFuncs: []tf.RegisterPluginFunc{
-				tf.RegisterPreBindPlugin("FakePreBind", tf.NewFakePreBindPlugin(framework.NewStatus(framework.Unschedulable))),
+				tf.RegisterPreBindPlugin("FakePreBind", tf.NewFakePreBindPlugin(fwk.NewStatus(fwk.Unschedulable))),
 			},
-			mockWaitOnPermitResult:              framework.NewStatus(framework.Success),
-			mockRunPreBindPluginsResult:         framework.NewStatus(framework.Unschedulable, preBindErr.Error()),
+			mockWaitOnPermitResult:              fwk.NewStatus(fwk.Success),
+			mockRunPreBindPluginsResult:         fwk.NewStatus(fwk.Unschedulable, preBindErr.Error()),
 			expectErrorPod:                      assignedTestPod,
 			expectAssumedPod:                    assignedTestPod,
 			expectError:                         preBindErr,
@@ -1073,8 +1073,8 @@ func TestScheduleOneMarksPodAsProcessedBeforePreBind(t *testing.T) {
 			mockScheduleResult:                  scheduleResultOk,
 			expectBind:                          bindingOk,
 			expectAssumedPod:                    assignedTestPod,
-			mockWaitOnPermitResult:              framework.NewStatus(framework.Success),
-			mockRunPreBindPluginsResult:         framework.NewStatus(framework.Success),
+			mockWaitOnPermitResult:              fwk.NewStatus(fwk.Success),
+			mockRunPreBindPluginsResult:         fwk.NewStatus(fwk.Success),
 			eventReason:                         "Scheduled",
 			expectPodIsInFlightAtFailureHandler: false,
 			expectPodIsInFlightAtWaitOnPermit:   true,
@@ -1093,8 +1093,8 @@ func TestScheduleOneMarksPodAsProcessedBeforePreBind(t *testing.T) {
 			name:                                "error bind forget pod failed scheduling",
 			sendPod:                             testPod,
 			mockScheduleResult:                  scheduleResultOk,
-			mockWaitOnPermitResult:              framework.NewStatus(framework.Success),
-			mockRunPreBindPluginsResult:         framework.NewStatus(framework.Success),
+			mockWaitOnPermitResult:              fwk.NewStatus(fwk.Success),
+			mockRunPreBindPluginsResult:         fwk.NewStatus(fwk.Success),
 			expectBind:                          bindingOk,
 			expectAssumedPod:                    assignedTestPod,
 			injectBindError:                     bindingErr,
@@ -1173,11 +1173,11 @@ func TestScheduleOneMarksPodAsProcessedBeforePreBind(t *testing.T) {
 					t.Fatal(err)
 				}
 
-				schedFramework.waitOnPermitFn = func(_ context.Context, pod *v1.Pod) *framework.Status {
+				schedFramework.waitOnPermitFn = func(_ context.Context, pod *v1.Pod) *fwk.Status {
 					gotPodIsInFlightAtWaitOnPermit = podListContainsPod(schedFramework.queue.InFlightPods(), pod)
 					return item.mockWaitOnPermitResult
 				}
-				schedFramework.runPreBindPluginsFn = func(_ context.Context, _ fwk.CycleState, pod *v1.Pod, _ string) *framework.Status {
+				schedFramework.runPreBindPluginsFn = func(_ context.Context, _ fwk.CycleState, pod *v1.Pod, _ string) *fwk.Status {
 					gotPodIsInFlightAtRunPreBindPlugins = podListContainsPod(schedFramework.queue.InFlightPods(), pod)
 					return item.mockRunPreBindPluginsResult
 				}
@@ -1194,7 +1194,7 @@ func TestScheduleOneMarksPodAsProcessedBeforePreBind(t *testing.T) {
 				sched.SchedulePod = func(ctx context.Context, fwk framework.Framework, state fwk.CycleState, pod *v1.Pod) (ScheduleResult, error) {
 					return item.mockScheduleResult, item.injectSchedulingError
 				}
-				sched.FailureHandler = func(_ context.Context, fwk framework.Framework, p *framework.QueuedPodInfo, status *framework.Status, _ *framework.NominatingInfo, _ time.Time) {
+				sched.FailureHandler = func(_ context.Context, fwk framework.Framework, p *framework.QueuedPodInfo, status *fwk.Status, _ *framework.NominatingInfo, _ time.Time) {
 					gotCallsToFailureHandler++
 					gotPodIsInFlightAtFailureHandler = podListContainsPod(queue.InFlightPods(), p.Pod)
 
@@ -1271,8 +1271,8 @@ func TestScheduleOneMarksPodAsProcessedBeforePreBind(t *testing.T) {
 type FakeFramework struct {
 	framework.Framework
 	queue               internalqueue.SchedulingQueue
-	waitOnPermitFn      func(context.Context, *v1.Pod) *framework.Status
-	runPreBindPluginsFn func(context.Context, fwk.CycleState, *v1.Pod, string) *framework.Status
+	waitOnPermitFn      func(context.Context, *v1.Pod) *fwk.Status
+	runPreBindPluginsFn func(context.Context, fwk.CycleState, *v1.Pod, string) *fwk.Status
 }
 
 func NewFakeFramework(ctx context.Context, schedQueue internalqueue.SchedulingQueue, fns []tf.RegisterPluginFunc,
@@ -1284,11 +1284,11 @@ func NewFakeFramework(ctx context.Context, schedQueue internalqueue.SchedulingQu
 		err
 }
 
-func (ff *FakeFramework) WaitOnPermit(ctx context.Context, pod *v1.Pod) *framework.Status {
+func (ff *FakeFramework) WaitOnPermit(ctx context.Context, pod *v1.Pod) *fwk.Status {
 	return ff.waitOnPermitFn(ctx, pod)
 }
 
-func (ff *FakeFramework) RunPreBindPlugins(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeName string) *framework.Status {
+func (ff *FakeFramework) RunPreBindPlugins(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeName string) *fwk.Status {
 	return ff.runPreBindPluginsFn(ctx, state, pod, nodeName)
 }
 
@@ -1396,9 +1396,9 @@ func TestSchedulerNoPhantomPodAfterDelete(t *testing.T) {
 			Pod:         secondPod,
 			NumAllNodes: 1,
 			Diagnosis: framework.Diagnosis{
-				NodeToStatus: framework.NewNodeToStatus(map[string]*framework.Status{
-					node.Name: framework.NewStatus(framework.Unschedulable, nodeports.ErrReason).WithPlugin(nodeports.Name),
-				}, framework.NewStatus(framework.UnschedulableAndUnresolvable)),
+				NodeToStatus: framework.NewNodeToStatus(map[string]*fwk.Status{
+					node.Name: fwk.NewStatus(fwk.Unschedulable, nodeports.ErrReason).WithPlugin(nodeports.Name),
+				}, fwk.NewStatus(fwk.UnschedulableAndUnresolvable)),
 				UnschedulablePlugins: sets.New(nodeports.Name),
 			},
 		}
@@ -1484,8 +1484,8 @@ func TestSchedulerFailedSchedulingReasons(t *testing.T) {
 	// Create expected failure reasons for all the nodes. Hopefully they will get rolled up into a non-spammy summary.
 	failedNodeStatues := framework.NewDefaultNodeToStatus()
 	for _, node := range nodes {
-		failedNodeStatues.Set(node.Name, framework.NewStatus(
-			framework.UnschedulableAndUnresolvable,
+		failedNodeStatues.Set(node.Name, fwk.NewStatus(
+			fwk.UnschedulableAndUnresolvable,
 			fmt.Sprintf("Insufficient %v", v1.ResourceCPU),
 			fmt.Sprintf("Insufficient %v", v1.ResourceMemory),
 		).WithPlugin(noderesources.Name))
@@ -2084,7 +2084,7 @@ func Test_SelectHost(t *testing.T) {
 }
 
 func TestFindNodesThatPassExtenders(t *testing.T) {
-	absentStatus := framework.NewStatus(framework.UnschedulableAndUnresolvable, "node(s) didn't satisfy plugin(s) [PreFilter]")
+	absentStatus := fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "node(s) didn't satisfy plugin(s) [PreFilter]")
 
 	tests := []struct {
 		name                  string
@@ -2104,7 +2104,7 @@ func TestFindNodesThatPassExtenders(t *testing.T) {
 				},
 			},
 			nodes:                 makeNodeList([]string{"a"}),
-			filteredNodesStatuses: framework.NewNodeToStatus(make(map[string]*framework.Status), absentStatus),
+			filteredNodesStatuses: framework.NewNodeToStatus(make(map[string]*fwk.Status), absentStatus),
 			expectsErr:            true,
 		},
 		{
@@ -2116,30 +2116,30 @@ func TestFindNodesThatPassExtenders(t *testing.T) {
 				},
 			},
 			nodes:                 makeNodeList([]string{"a"}),
-			filteredNodesStatuses: framework.NewNodeToStatus(make(map[string]*framework.Status), absentStatus),
+			filteredNodesStatuses: framework.NewNodeToStatus(make(map[string]*fwk.Status), absentStatus),
 			expectsErr:            false,
 			expectedNodes:         makeNodeList([]string{"a"}),
-			expectedStatuses:      framework.NewNodeToStatus(make(map[string]*framework.Status), absentStatus),
+			expectedStatuses:      framework.NewNodeToStatus(make(map[string]*fwk.Status), absentStatus),
 		},
 		{
 			name: "unschedulable",
 			extenders: []tf.FakeExtender{
 				{
 					ExtenderName: "FakeExtender1",
-					Predicates: []tf.FitPredicate{func(pod *v1.Pod, node *framework.NodeInfo) *framework.Status {
+					Predicates: []tf.FitPredicate{func(pod *v1.Pod, node *framework.NodeInfo) *fwk.Status {
 						if node.Node().Name == "a" {
-							return framework.NewStatus(framework.Success)
+							return fwk.NewStatus(fwk.Success)
 						}
-						return framework.NewStatus(framework.Unschedulable, fmt.Sprintf("node %q is not allowed", node.Node().Name))
+						return fwk.NewStatus(fwk.Unschedulable, fmt.Sprintf("node %q is not allowed", node.Node().Name))
 					}},
 				},
 			},
 			nodes:                 makeNodeList([]string{"a", "b"}),
-			filteredNodesStatuses: framework.NewNodeToStatus(make(map[string]*framework.Status), absentStatus),
+			filteredNodesStatuses: framework.NewNodeToStatus(make(map[string]*fwk.Status), absentStatus),
 			expectsErr:            false,
 			expectedNodes:         makeNodeList([]string{"a"}),
-			expectedStatuses: framework.NewNodeToStatus(map[string]*framework.Status{
-				"b": framework.NewStatus(framework.Unschedulable, fmt.Sprintf("FakeExtender: node %q failed", "b")),
+			expectedStatuses: framework.NewNodeToStatus(map[string]*fwk.Status{
+				"b": fwk.NewStatus(fwk.Unschedulable, fmt.Sprintf("FakeExtender: node %q failed", "b")),
 			}, absentStatus),
 		},
 		{
@@ -2147,24 +2147,24 @@ func TestFindNodesThatPassExtenders(t *testing.T) {
 			extenders: []tf.FakeExtender{
 				{
 					ExtenderName: "FakeExtender1",
-					Predicates: []tf.FitPredicate{func(pod *v1.Pod, node *framework.NodeInfo) *framework.Status {
+					Predicates: []tf.FitPredicate{func(pod *v1.Pod, node *framework.NodeInfo) *fwk.Status {
 						if node.Node().Name == "a" {
-							return framework.NewStatus(framework.Success)
+							return fwk.NewStatus(fwk.Success)
 						}
 						if node.Node().Name == "b" {
-							return framework.NewStatus(framework.Unschedulable, fmt.Sprintf("node %q is not allowed", node.Node().Name))
+							return fwk.NewStatus(fwk.Unschedulable, fmt.Sprintf("node %q is not allowed", node.Node().Name))
 						}
-						return framework.NewStatus(framework.UnschedulableAndUnresolvable, fmt.Sprintf("node %q is not allowed", node.Node().Name))
+						return fwk.NewStatus(fwk.UnschedulableAndUnresolvable, fmt.Sprintf("node %q is not allowed", node.Node().Name))
 					}},
 				},
 			},
 			nodes:                 makeNodeList([]string{"a", "b", "c"}),
-			filteredNodesStatuses: framework.NewNodeToStatus(make(map[string]*framework.Status), absentStatus),
+			filteredNodesStatuses: framework.NewNodeToStatus(make(map[string]*fwk.Status), absentStatus),
 			expectsErr:            false,
 			expectedNodes:         makeNodeList([]string{"a"}),
-			expectedStatuses: framework.NewNodeToStatus(map[string]*framework.Status{
-				"b": framework.NewStatus(framework.Unschedulable, fmt.Sprintf("FakeExtender: node %q failed", "b")),
-				"c": framework.NewStatus(framework.UnschedulableAndUnresolvable, fmt.Sprintf("FakeExtender: node %q failed and unresolvable", "c")),
+			expectedStatuses: framework.NewNodeToStatus(map[string]*fwk.Status{
+				"b": fwk.NewStatus(fwk.Unschedulable, fmt.Sprintf("FakeExtender: node %q failed", "b")),
+				"c": fwk.NewStatus(fwk.UnschedulableAndUnresolvable, fmt.Sprintf("FakeExtender: node %q failed and unresolvable", "c")),
 			}, absentStatus),
 		},
 		{
@@ -2172,26 +2172,26 @@ func TestFindNodesThatPassExtenders(t *testing.T) {
 			extenders: []tf.FakeExtender{
 				{
 					ExtenderName: "FakeExtender1",
-					Predicates: []tf.FitPredicate{func(pod *v1.Pod, node *framework.NodeInfo) *framework.Status {
+					Predicates: []tf.FitPredicate{func(pod *v1.Pod, node *framework.NodeInfo) *fwk.Status {
 						if node.Node().Name == "a" {
-							return framework.NewStatus(framework.Success)
+							return fwk.NewStatus(fwk.Success)
 						}
 						if node.Node().Name == "b" {
-							return framework.NewStatus(framework.Unschedulable, fmt.Sprintf("node %q is not allowed", node.Node().Name))
+							return fwk.NewStatus(fwk.Unschedulable, fmt.Sprintf("node %q is not allowed", node.Node().Name))
 						}
-						return framework.NewStatus(framework.UnschedulableAndUnresolvable, fmt.Sprintf("node %q is not allowed", node.Node().Name))
+						return fwk.NewStatus(fwk.UnschedulableAndUnresolvable, fmt.Sprintf("node %q is not allowed", node.Node().Name))
 					}},
 				},
 			},
 			nodes: makeNodeList([]string{"a", "b"}),
-			filteredNodesStatuses: framework.NewNodeToStatus(map[string]*framework.Status{
-				"c": framework.NewStatus(framework.Unschedulable, fmt.Sprintf("FakeFilterPlugin: node %q failed", "c")),
+			filteredNodesStatuses: framework.NewNodeToStatus(map[string]*fwk.Status{
+				"c": fwk.NewStatus(fwk.Unschedulable, fmt.Sprintf("FakeFilterPlugin: node %q failed", "c")),
 			}, absentStatus),
 			expectsErr:    false,
 			expectedNodes: makeNodeList([]string{"a"}),
-			expectedStatuses: framework.NewNodeToStatus(map[string]*framework.Status{
-				"b": framework.NewStatus(framework.Unschedulable, fmt.Sprintf("FakeExtender: node %q failed", "b")),
-				"c": framework.NewStatus(framework.Unschedulable, fmt.Sprintf("FakeFilterPlugin: node %q failed", "c")),
+			expectedStatuses: framework.NewNodeToStatus(map[string]*fwk.Status{
+				"b": fwk.NewStatus(fwk.Unschedulable, fmt.Sprintf("FakeExtender: node %q failed", "b")),
+				"c": fwk.NewStatus(fwk.Unschedulable, fmt.Sprintf("FakeFilterPlugin: node %q failed", "c")),
 			}, absentStatus),
 		},
 		{
@@ -2199,33 +2199,33 @@ func TestFindNodesThatPassExtenders(t *testing.T) {
 			extenders: []tf.FakeExtender{
 				{
 					ExtenderName: "FakeExtender1",
-					Predicates: []tf.FitPredicate{func(pod *v1.Pod, node *framework.NodeInfo) *framework.Status {
+					Predicates: []tf.FitPredicate{func(pod *v1.Pod, node *framework.NodeInfo) *fwk.Status {
 						if node.Node().Name == "a" {
-							return framework.NewStatus(framework.Success)
+							return fwk.NewStatus(fwk.Success)
 						}
 						if node.Node().Name == "b" {
-							return framework.NewStatus(framework.Unschedulable, fmt.Sprintf("node %q is not allowed", node.Node().Name))
+							return fwk.NewStatus(fwk.Unschedulable, fmt.Sprintf("node %q is not allowed", node.Node().Name))
 						}
-						return framework.NewStatus(framework.UnschedulableAndUnresolvable, fmt.Sprintf("node %q is not allowed", node.Node().Name))
+						return fwk.NewStatus(fwk.UnschedulableAndUnresolvable, fmt.Sprintf("node %q is not allowed", node.Node().Name))
 					}},
 				},
 				{
 					ExtenderName: "FakeExtender1",
-					Predicates: []tf.FitPredicate{func(pod *v1.Pod, node *framework.NodeInfo) *framework.Status {
+					Predicates: []tf.FitPredicate{func(pod *v1.Pod, node *framework.NodeInfo) *fwk.Status {
 						if node.Node().Name == "a" {
-							return framework.NewStatus(framework.Success)
+							return fwk.NewStatus(fwk.Success)
 						}
-						return framework.NewStatus(framework.Unschedulable, fmt.Sprintf("node %q is not allowed", node.Node().Name))
+						return fwk.NewStatus(fwk.Unschedulable, fmt.Sprintf("node %q is not allowed", node.Node().Name))
 					}},
 				},
 			},
 			nodes:                 makeNodeList([]string{"a", "b", "c"}),
-			filteredNodesStatuses: framework.NewNodeToStatus(make(map[string]*framework.Status), absentStatus),
+			filteredNodesStatuses: framework.NewNodeToStatus(make(map[string]*fwk.Status), absentStatus),
 			expectsErr:            false,
 			expectedNodes:         makeNodeList([]string{"a"}),
-			expectedStatuses: framework.NewNodeToStatus(map[string]*framework.Status{
-				"b": framework.NewStatus(framework.Unschedulable, fmt.Sprintf("FakeExtender: node %q failed", "b")),
-				"c": framework.NewStatus(framework.UnschedulableAndUnresolvable, fmt.Sprintf("FakeExtender: node %q failed and unresolvable", "c")),
+			expectedStatuses: framework.NewNodeToStatus(map[string]*fwk.Status{
+				"b": fwk.NewStatus(fwk.Unschedulable, fmt.Sprintf("FakeExtender: node %q failed", "b")),
+				"c": fwk.NewStatus(fwk.UnschedulableAndUnresolvable, fmt.Sprintf("FakeExtender: node %q failed and unresolvable", "c")),
 			}, absentStatus),
 		},
 	}
@@ -2294,10 +2294,10 @@ func TestSchedulerSchedulePod(t *testing.T) {
 				Pod:         st.MakePod().Name("2").UID("2").Obj(),
 				NumAllNodes: 2,
 				Diagnosis: framework.Diagnosis{
-					NodeToStatus: framework.NewNodeToStatus(map[string]*framework.Status{
-						"node1": framework.NewStatus(framework.Unschedulable, tf.ErrReasonFake).WithPlugin("FalseFilter"),
-						"node2": framework.NewStatus(framework.Unschedulable, tf.ErrReasonFake).WithPlugin("FalseFilter"),
-					}, framework.NewStatus(framework.UnschedulableAndUnresolvable)),
+					NodeToStatus: framework.NewNodeToStatus(map[string]*fwk.Status{
+						"node1": fwk.NewStatus(fwk.Unschedulable, tf.ErrReasonFake).WithPlugin("FalseFilter"),
+						"node2": fwk.NewStatus(fwk.Unschedulable, tf.ErrReasonFake).WithPlugin("FalseFilter"),
+					}, fwk.NewStatus(fwk.UnschedulableAndUnresolvable)),
 					UnschedulablePlugins: sets.New("FalseFilter"),
 				},
 			},
@@ -2405,11 +2405,11 @@ func TestSchedulerSchedulePod(t *testing.T) {
 				Pod:         st.MakePod().Name("2").UID("2").Obj(),
 				NumAllNodes: 3,
 				Diagnosis: framework.Diagnosis{
-					NodeToStatus: framework.NewNodeToStatus(map[string]*framework.Status{
-						"3": framework.NewStatus(framework.Unschedulable, tf.ErrReasonFake).WithPlugin("FalseFilter"),
-						"2": framework.NewStatus(framework.Unschedulable, tf.ErrReasonFake).WithPlugin("FalseFilter"),
-						"1": framework.NewStatus(framework.Unschedulable, tf.ErrReasonFake).WithPlugin("FalseFilter"),
-					}, framework.NewStatus(framework.UnschedulableAndUnresolvable)),
+					NodeToStatus: framework.NewNodeToStatus(map[string]*fwk.Status{
+						"3": fwk.NewStatus(fwk.Unschedulable, tf.ErrReasonFake).WithPlugin("FalseFilter"),
+						"2": fwk.NewStatus(fwk.Unschedulable, tf.ErrReasonFake).WithPlugin("FalseFilter"),
+						"1": fwk.NewStatus(fwk.Unschedulable, tf.ErrReasonFake).WithPlugin("FalseFilter"),
+					}, fwk.NewStatus(fwk.UnschedulableAndUnresolvable)),
 					UnschedulablePlugins: sets.New("FalseFilter"),
 				},
 			},
@@ -2435,10 +2435,10 @@ func TestSchedulerSchedulePod(t *testing.T) {
 				Pod:         st.MakePod().Name("2").UID("2").Obj(),
 				NumAllNodes: 2,
 				Diagnosis: framework.Diagnosis{
-					NodeToStatus: framework.NewNodeToStatus(map[string]*framework.Status{
-						"1": framework.NewStatus(framework.Unschedulable, tf.ErrReasonFake).WithPlugin("MatchFilter"),
-						"2": framework.NewStatus(framework.Unschedulable, tf.ErrReasonFake).WithPlugin("NoPodsFilter"),
-					}, framework.NewStatus(framework.UnschedulableAndUnresolvable)),
+					NodeToStatus: framework.NewNodeToStatus(map[string]*fwk.Status{
+						"1": fwk.NewStatus(fwk.Unschedulable, tf.ErrReasonFake).WithPlugin("MatchFilter"),
+						"2": fwk.NewStatus(fwk.Unschedulable, tf.ErrReasonFake).WithPlugin("NoPodsFilter"),
+					}, fwk.NewStatus(fwk.UnschedulableAndUnresolvable)),
 					UnschedulablePlugins: sets.New("MatchFilter", "NoPodsFilter"),
 				},
 			},
@@ -2488,7 +2488,7 @@ func TestSchedulerSchedulePod(t *testing.T) {
 				Pod:         st.MakePod().Name("ignore").UID("ignore").PVC("unknownPVC").Obj(),
 				NumAllNodes: 2,
 				Diagnosis: framework.Diagnosis{
-					NodeToStatus:         framework.NewNodeToStatus(make(map[string]*framework.Status), framework.NewStatus(framework.UnschedulableAndUnresolvable, `persistentvolumeclaim "unknownPVC" not found`).WithPlugin("VolumeBinding")),
+					NodeToStatus:         framework.NewNodeToStatus(make(map[string]*fwk.Status), fwk.NewStatus(fwk.UnschedulableAndUnresolvable, `persistentvolumeclaim "unknownPVC" not found`).WithPlugin("VolumeBinding")),
 					PreFilterMsg:         `persistentvolumeclaim "unknownPVC" not found`,
 					UnschedulablePlugins: sets.New(volumebinding.Name),
 				},
@@ -2513,7 +2513,7 @@ func TestSchedulerSchedulePod(t *testing.T) {
 				Pod:         st.MakePod().Name("ignore").UID("ignore").Namespace(v1.NamespaceDefault).PVC("existingPVC").Obj(),
 				NumAllNodes: 2,
 				Diagnosis: framework.Diagnosis{
-					NodeToStatus:         framework.NewNodeToStatus(make(map[string]*framework.Status), framework.NewStatus(framework.UnschedulableAndUnresolvable, `persistentvolumeclaim "existingPVC" is being deleted`).WithPlugin("VolumeBinding")),
+					NodeToStatus:         framework.NewNodeToStatus(make(map[string]*fwk.Status), fwk.NewStatus(fwk.UnschedulableAndUnresolvable, `persistentvolumeclaim "existingPVC" is being deleted`).WithPlugin("VolumeBinding")),
 					PreFilterMsg:         `persistentvolumeclaim "existingPVC" is being deleted`,
 					UnschedulablePlugins: sets.New(volumebinding.Name),
 				},
@@ -2605,7 +2605,7 @@ func TestSchedulerSchedulePod(t *testing.T) {
 				tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
 				tf.RegisterFilterPlugin(
 					"FakeFilter",
-					tf.NewFakeFilterPlugin(map[string]framework.Code{"3": framework.Unschedulable}),
+					tf.NewFakeFilterPlugin(map[string]fwk.Code{"3": fwk.Unschedulable}),
 				),
 				tf.RegisterScorePlugin("NumericMap", newNumericMapPlugin(), 1),
 				tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
@@ -2619,9 +2619,9 @@ func TestSchedulerSchedulePod(t *testing.T) {
 				Pod:         st.MakePod().Name("test-filter").UID("test-filter").Obj(),
 				NumAllNodes: 1,
 				Diagnosis: framework.Diagnosis{
-					NodeToStatus: framework.NewNodeToStatus(map[string]*framework.Status{
-						"3": framework.NewStatus(framework.Unschedulable, "injecting failure for pod test-filter").WithPlugin("FakeFilter"),
-					}, framework.NewStatus(framework.UnschedulableAndUnresolvable)),
+					NodeToStatus: framework.NewNodeToStatus(map[string]*fwk.Status{
+						"3": fwk.NewStatus(fwk.Unschedulable, "injecting failure for pod test-filter").WithPlugin("FakeFilter"),
+					}, fwk.NewStatus(fwk.UnschedulableAndUnresolvable)),
 					UnschedulablePlugins: sets.New("FakeFilter"),
 				},
 			},
@@ -2632,7 +2632,7 @@ func TestSchedulerSchedulePod(t *testing.T) {
 				tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
 				tf.RegisterFilterPlugin(
 					"FakeFilter",
-					tf.NewFakeFilterPlugin(map[string]framework.Code{"3": framework.Unschedulable}),
+					tf.NewFakeFilterPlugin(map[string]fwk.Code{"3": fwk.Unschedulable}),
 				),
 				tf.RegisterScorePlugin("NumericMap", newNumericMapPlugin(), 1),
 				tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
@@ -2654,11 +2654,11 @@ func TestSchedulerSchedulePod(t *testing.T) {
 				Pod:         st.MakePod().Name("test-filter").UID("test-filter").Obj(),
 				NumAllNodes: 3,
 				Diagnosis: framework.Diagnosis{
-					NodeToStatus: framework.NewNodeToStatus(map[string]*framework.Status{
-						"1": framework.NewStatus(framework.Unschedulable, `FakeExtender: node "1" failed`),
-						"2": framework.NewStatus(framework.Unschedulable, `FakeExtender: node "2" failed`),
-						"3": framework.NewStatus(framework.Unschedulable, "injecting failure for pod test-filter").WithPlugin("FakeFilter"),
-					}, framework.NewStatus(framework.UnschedulableAndUnresolvable)),
+					NodeToStatus: framework.NewNodeToStatus(map[string]*fwk.Status{
+						"1": fwk.NewStatus(fwk.Unschedulable, `FakeExtender: node "1" failed`),
+						"2": fwk.NewStatus(fwk.Unschedulable, `FakeExtender: node "2" failed`),
+						"3": fwk.NewStatus(fwk.Unschedulable, "injecting failure for pod test-filter").WithPlugin("FakeFilter"),
+					}, fwk.NewStatus(fwk.UnschedulableAndUnresolvable)),
 					UnschedulablePlugins: sets.New("FakeFilter", framework.ExtenderName),
 				},
 			},
@@ -2669,7 +2669,7 @@ func TestSchedulerSchedulePod(t *testing.T) {
 				tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
 				tf.RegisterFilterPlugin(
 					"FakeFilter",
-					tf.NewFakeFilterPlugin(map[string]framework.Code{"3": framework.UnschedulableAndUnresolvable}),
+					tf.NewFakeFilterPlugin(map[string]fwk.Code{"3": fwk.UnschedulableAndUnresolvable}),
 				),
 				tf.RegisterScorePlugin("NumericMap", newNumericMapPlugin(), 1),
 				tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
@@ -2683,9 +2683,9 @@ func TestSchedulerSchedulePod(t *testing.T) {
 				Pod:         st.MakePod().Name("test-filter").UID("test-filter").Obj(),
 				NumAllNodes: 1,
 				Diagnosis: framework.Diagnosis{
-					NodeToStatus: framework.NewNodeToStatus(map[string]*framework.Status{
-						"3": framework.NewStatus(framework.UnschedulableAndUnresolvable, "injecting failure for pod test-filter").WithPlugin("FakeFilter"),
-					}, framework.NewStatus(framework.UnschedulableAndUnresolvable)),
+					NodeToStatus: framework.NewNodeToStatus(map[string]*fwk.Status{
+						"3": fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "injecting failure for pod test-filter").WithPlugin("FakeFilter"),
+					}, fwk.NewStatus(fwk.UnschedulableAndUnresolvable)),
 					UnschedulablePlugins: sets.New("FakeFilter"),
 				},
 			},
@@ -2696,7 +2696,7 @@ func TestSchedulerSchedulePod(t *testing.T) {
 				tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
 				tf.RegisterFilterPlugin(
 					"FakeFilter",
-					tf.NewFakeFilterPlugin(map[string]framework.Code{"1": framework.Unschedulable}),
+					tf.NewFakeFilterPlugin(map[string]fwk.Code{"1": fwk.Unschedulable}),
 				),
 				tf.RegisterScorePlugin("NumericMap", newNumericMapPlugin(), 1),
 				tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
@@ -2715,7 +2715,7 @@ func TestSchedulerSchedulePod(t *testing.T) {
 				tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
 				tf.RegisterPreFilterPlugin(
 					"FakePreFilter",
-					tf.NewFakePreFilterPlugin("FakePreFilter", nil, framework.NewStatus(framework.UnschedulableAndUnresolvable, "injected unschedulable status")),
+					tf.NewFakePreFilterPlugin("FakePreFilter", nil, fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "injected unschedulable status")),
 				),
 				tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
 			},
@@ -2729,7 +2729,7 @@ func TestSchedulerSchedulePod(t *testing.T) {
 				Pod:         st.MakePod().Name("test-prefilter").UID("test-prefilter").Obj(),
 				NumAllNodes: 2,
 				Diagnosis: framework.Diagnosis{
-					NodeToStatus:         framework.NewNodeToStatus(make(map[string]*framework.Status), framework.NewStatus(framework.UnschedulableAndUnresolvable, "injected unschedulable status").WithPlugin("FakePreFilter")),
+					NodeToStatus:         framework.NewNodeToStatus(make(map[string]*fwk.Status), fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "injected unschedulable status").WithPlugin("FakePreFilter")),
 					PreFilterMsg:         "injected unschedulable status",
 					UnschedulablePlugins: sets.New("FakePreFilter"),
 				},
@@ -2741,7 +2741,7 @@ func TestSchedulerSchedulePod(t *testing.T) {
 				tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
 				tf.RegisterPreFilterPlugin(
 					"FakePreFilter",
-					tf.NewFakePreFilterPlugin("FakePreFilter", nil, framework.NewStatus(framework.Error, "injected error status")),
+					tf.NewFakePreFilterPlugin("FakePreFilter", nil, fwk.NewStatus(fwk.Error, "injected error status")),
 				),
 				tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
 			},
@@ -2809,7 +2809,7 @@ func TestSchedulerSchedulePod(t *testing.T) {
 				Pod:         st.MakePod().Name("test-prefilter").UID("test-prefilter").Obj(),
 				NumAllNodes: 3,
 				Diagnosis: framework.Diagnosis{
-					NodeToStatus:         framework.NewNodeToStatus(make(map[string]*framework.Status), framework.NewStatus(framework.UnschedulableAndUnresolvable, "node(s) didn't satisfy plugin(s) [FakePreFilter2 FakePreFilter3] simultaneously")),
+					NodeToStatus:         framework.NewNodeToStatus(make(map[string]*fwk.Status), fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "node(s) didn't satisfy plugin(s) [FakePreFilter2 FakePreFilter3] simultaneously")),
 					UnschedulablePlugins: sets.New("FakePreFilter2", "FakePreFilter3"),
 					PreFilterMsg:         "node(s) didn't satisfy plugin(s) [FakePreFilter2 FakePreFilter3] simultaneously",
 				},
@@ -2837,7 +2837,7 @@ func TestSchedulerSchedulePod(t *testing.T) {
 				Pod:         st.MakePod().Name("test-prefilter").UID("test-prefilter").Obj(),
 				NumAllNodes: 1,
 				Diagnosis: framework.Diagnosis{
-					NodeToStatus:         framework.NewNodeToStatus(make(map[string]*framework.Status), framework.NewStatus(framework.UnschedulableAndUnresolvable, "node(s) didn't satisfy plugin FakePreFilter2")),
+					NodeToStatus:         framework.NewNodeToStatus(make(map[string]*fwk.Status), fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "node(s) didn't satisfy plugin FakePreFilter2")),
 					UnschedulablePlugins: sets.New("FakePreFilter2"),
 					PreFilterMsg:         "node(s) didn't satisfy plugin FakePreFilter2",
 				},
@@ -2853,7 +2853,7 @@ func TestSchedulerSchedulePod(t *testing.T) {
 				),
 				tf.RegisterFilterPlugin(
 					"FakeFilter",
-					tf.NewFakeFilterPlugin(map[string]framework.Code{"node2": framework.Unschedulable}),
+					tf.NewFakeFilterPlugin(map[string]fwk.Code{"node2": fwk.Unschedulable}),
 				),
 				tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
 			},
@@ -2866,9 +2866,9 @@ func TestSchedulerSchedulePod(t *testing.T) {
 				Pod:         st.MakePod().Name("test-prefilter").UID("test-prefilter").Obj(),
 				NumAllNodes: 2,
 				Diagnosis: framework.Diagnosis{
-					NodeToStatus: framework.NewNodeToStatus(map[string]*framework.Status{
-						"node2": framework.NewStatus(framework.Unschedulable, "injecting failure for pod test-prefilter").WithPlugin("FakeFilter"),
-					}, framework.NewStatus(framework.UnschedulableAndUnresolvable, "node(s) didn't satisfy plugin(s) [FakePreFilter]")),
+					NodeToStatus: framework.NewNodeToStatus(map[string]*fwk.Status{
+						"node2": fwk.NewStatus(fwk.Unschedulable, "injecting failure for pod test-prefilter").WithPlugin("FakeFilter"),
+					}, fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "node(s) didn't satisfy plugin(s) [FakePreFilter]")),
 					UnschedulablePlugins: sets.New("FakePreFilter", "FakeFilter"),
 					PreFilterMsg:         "",
 				},
@@ -2884,21 +2884,21 @@ func TestSchedulerSchedulePod(t *testing.T) {
 				),
 				tf.RegisterFilterPlugin(
 					"FakeFilter1",
-					tf.NewFakeFilterPlugin(map[string]framework.Code{
-						"node1": framework.Unschedulable,
+					tf.NewFakeFilterPlugin(map[string]fwk.Code{
+						"node1": fwk.Unschedulable,
 					}),
 				),
 				tf.RegisterPluginAsExtensions("FakeFilter2", func(_ context.Context, configuration runtime.Object, f framework.Handle) (framework.Plugin, error) {
 					return tf.FakePreFilterAndFilterPlugin{
 						FakePreFilterPlugin: &tf.FakePreFilterPlugin{
 							Result: nil,
-							Status: framework.NewStatus(framework.Skip),
+							Status: fwk.NewStatus(fwk.Skip),
 						},
 						FakeFilterPlugin: &tf.FakeFilterPlugin{
 							// This Filter plugin shouldn't be executed in the Filter extension point due to skip.
 							// To confirm that, return the status code Error to all Nodes.
-							FailedNodeReturnCodeMap: map[string]framework.Code{
-								"node1": framework.Error, "node2": framework.Error, "node3": framework.Error,
+							FailedNodeReturnCodeMap: map[string]fwk.Code{
+								"node1": fwk.Error, "node2": fwk.Error, "node3": fwk.Error,
 							},
 						},
 					}, nil
@@ -2922,8 +2922,8 @@ func TestSchedulerSchedulePod(t *testing.T) {
 				tf.RegisterFilterPlugin("TrueFilter", tf.NewTrueFilterPlugin),
 				tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
 				tf.RegisterPluginAsExtensions("FakePreScoreAndScorePlugin", tf.NewFakePreScoreAndScorePlugin("FakePreScoreAndScorePlugin", 0,
-					framework.NewStatus(framework.Skip, "fake skip"),
-					framework.NewStatus(framework.Error, "this score function shouldn't be executed because this plugin returned Skip in the PreScore"),
+					fwk.NewStatus(fwk.Skip, "fake skip"),
+					fwk.NewStatus(fwk.Error, "this score function shouldn't be executed because this plugin returned Skip in the PreScore"),
 				), "PreScore", "Score"),
 			},
 			nodes: []*v1.Node{
@@ -2991,7 +2991,7 @@ func TestSchedulerSchedulePod(t *testing.T) {
 				Pod:         st.MakePod().Name("test-prefilter").UID("test-prefilter").Obj(),
 				NumAllNodes: 2,
 				Diagnosis: framework.Diagnosis{
-					NodeToStatus:         framework.NewNodeToStatus(make(map[string]*framework.Status), framework.NewStatus(framework.UnschedulableAndUnresolvable, "node(s) didn't satisfy plugin(s) [FakePreFilter]")),
+					NodeToStatus:         framework.NewNodeToStatus(make(map[string]*fwk.Status), fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "node(s) didn't satisfy plugin(s) [FakePreFilter]")),
 					UnschedulablePlugins: sets.New("FakePreFilter"),
 				},
 			},
@@ -3130,7 +3130,7 @@ func TestFindFitAllError(t *testing.T) {
 	nodes := makeNodeList([]string{"3", "2", "1"})
 	scheduler := makeScheduler(ctx, nodes)
 
-	fwk, err := tf.NewFramework(
+	schedFramework, err := tf.NewFramework(
 		ctx,
 		[]tf.RegisterPluginFunc{
 			tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
@@ -3146,17 +3146,17 @@ func TestFindFitAllError(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, diagnosis, err := scheduler.findNodesThatFitPod(ctx, fwk, framework.NewCycleState(), &v1.Pod{})
+	_, diagnosis, err := scheduler.findNodesThatFitPod(ctx, schedFramework, framework.NewCycleState(), &v1.Pod{})
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 
 	expected := framework.Diagnosis{
-		NodeToStatus: framework.NewNodeToStatus(map[string]*framework.Status{
-			"1": framework.NewStatus(framework.Unschedulable, tf.ErrReasonFake).WithPlugin("MatchFilter"),
-			"2": framework.NewStatus(framework.Unschedulable, tf.ErrReasonFake).WithPlugin("MatchFilter"),
-			"3": framework.NewStatus(framework.Unschedulable, tf.ErrReasonFake).WithPlugin("MatchFilter"),
-		}, framework.NewStatus(framework.UnschedulableAndUnresolvable)),
+		NodeToStatus: framework.NewNodeToStatus(map[string]*fwk.Status{
+			"1": fwk.NewStatus(fwk.Unschedulable, tf.ErrReasonFake).WithPlugin("MatchFilter"),
+			"2": fwk.NewStatus(fwk.Unschedulable, tf.ErrReasonFake).WithPlugin("MatchFilter"),
+			"3": fwk.NewStatus(fwk.Unschedulable, tf.ErrReasonFake).WithPlugin("MatchFilter"),
+		}, fwk.NewStatus(fwk.UnschedulableAndUnresolvable)),
 		UnschedulablePlugins: sets.New("MatchFilter"),
 	}
 	if diff := cmp.Diff(expected, diagnosis, schedulerCmpOpts...); diff != "" {
@@ -3634,8 +3634,8 @@ func Test_prioritizeNodes(t *testing.T) {
 				tf.RegisterScorePlugin("Node2Prioritizer", tf.NewNode2PrioritizerPlugin(), 1),
 				tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
 				tf.RegisterPluginAsExtensions("FakePreScoreAndScorePlugin", tf.NewFakePreScoreAndScorePlugin("FakePreScoreAndScorePlugin", 0,
-					framework.NewStatus(framework.Skip, "fake skip"),
-					framework.NewStatus(framework.Error, "this score function shouldn't be executed because this plugin returned Skip in the PreScore"),
+					fwk.NewStatus(fwk.Skip, "fake skip"),
+					fwk.NewStatus(fwk.Error, "this score function shouldn't be executed because this plugin returned Skip in the PreScore"),
 				), "PreScore", "Score"),
 			},
 			extenders: nil,
@@ -3678,8 +3678,8 @@ func Test_prioritizeNodes(t *testing.T) {
 				tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
 				tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
 				tf.RegisterPluginAsExtensions("FakePreScoreAndScorePlugin", tf.NewFakePreScoreAndScorePlugin("FakePreScoreAndScorePlugin", 0,
-					framework.NewStatus(framework.Skip, "fake skip"),
-					framework.NewStatus(framework.Error, "this score function shouldn't be executed because this plugin returned Skip in the PreScore"),
+					fwk.NewStatus(fwk.Skip, "fake skip"),
+					fwk.NewStatus(fwk.Error, "this score function shouldn't be executed because this plugin returned Skip in the PreScore"),
 				), "PreScore", "Score"),
 			},
 			extenders: nil,
@@ -3974,7 +3974,7 @@ func TestPreferNominatedNodeFilterCallCounts(t *testing.T) {
 	tests := []struct {
 		name                  string
 		pod                   *v1.Pod
-		nodeReturnCodeMap     map[string]framework.Code
+		nodeReturnCodeMap     map[string]fwk.Code
 		expectedCount         int32
 		expectedPatchRequests int
 	}{
@@ -3991,7 +3991,7 @@ func TestPreferNominatedNodeFilterCallCounts(t *testing.T) {
 		{
 			name:              "nominated pod cannot pass the filter, filter is called for each node",
 			pod:               st.MakePod().Name("p_with_nominated_node").UID("p").Priority(highPriority).NominatedNodeName("node1").Obj(),
-			nodeReturnCodeMap: map[string]framework.Code{"node1": framework.Unschedulable},
+			nodeReturnCodeMap: map[string]fwk.Code{"node1": fwk.Unschedulable},
 			expectedCount:     4,
 		},
 	}
@@ -4180,7 +4180,7 @@ func setupTestScheduler(ctx context.Context, t *testing.T, queuedPodStore *clien
 	waitingPods := frameworkruntime.NewWaitingPodsMap()
 	snapshot := internalcache.NewEmptySnapshot()
 
-	fwk, _ := tf.NewFramework(
+	schedFramework, _ := tf.NewFramework(
 		ctx,
 		fns,
 		testSchedulerName,
@@ -4202,16 +4202,16 @@ func setupTestScheduler(ctx context.Context, t *testing.T, queuedPodStore *clien
 			return &framework.QueuedPodInfo{PodInfo: mustNewPodInfo(t, clientcache.Pop(queuedPodStore).(*v1.Pod))}, nil
 		},
 		SchedulingQueue: schedulingQueue,
-		Profiles:        profile.Map{testSchedulerName: fwk},
+		Profiles:        profile.Map{testSchedulerName: schedFramework},
 	}
 
 	sched.SchedulePod = sched.schedulePod
-	sched.FailureHandler = func(_ context.Context, _ framework.Framework, p *framework.QueuedPodInfo, status *framework.Status, _ *framework.NominatingInfo, _ time.Time) {
+	sched.FailureHandler = func(_ context.Context, _ framework.Framework, p *framework.QueuedPodInfo, status *fwk.Status, _ *framework.NominatingInfo, _ time.Time) {
 		err := status.AsError()
 		errChan <- err
 
 		msg := truncateMessage(err.Error())
-		fwk.EventRecorder().Eventf(p.Pod, nil, v1.EventTypeWarning, "FailedScheduling", "Scheduling", msg)
+		schedFramework.EventRecorder().Eventf(p.Pod, nil, v1.EventTypeWarning, "FailedScheduling", "Scheduling", msg)
 	}
 	return sched, bindingChan, errChan
 }

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -583,7 +583,7 @@ func buildExtenders(logger klog.Logger, extenders []schedulerapi.Extender, profi
 	return fExtenders, nil
 }
 
-type FailureHandlerFn func(ctx context.Context, fwk framework.Framework, podInfo *framework.QueuedPodInfo, status *framework.Status, nominatingInfo *framework.NominatingInfo, start time.Time)
+type FailureHandlerFn func(ctx context.Context, fwk framework.Framework, podInfo *framework.QueuedPodInfo, status *fwk.Status, nominatingInfo *framework.NominatingInfo, start time.Time)
 
 func unionedGVKs(queueingHintsPerProfile internalqueue.QueueingHintMapPerProfile) map[fwk.EventResource]fwk.ActionType {
 	gvkMap := make(map[fwk.EventResource]fwk.ActionType)

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -312,13 +312,13 @@ func TestFailureHandler(t *testing.T) {
 				queue.Delete(testPod)
 			}
 
-			s, fwk, err := initScheduler(ctx, schedulerCache, queue, client, informerFactory)
+			s, schedFramework, err := initScheduler(ctx, schedulerCache, queue, client, informerFactory)
 			if err != nil {
 				t.Fatal(err)
 			}
 
 			testPodInfo := &framework.QueuedPodInfo{PodInfo: mustNewPodInfo(t, testPod)}
-			s.FailureHandler(ctx, fwk, testPodInfo, framework.NewStatus(framework.Unschedulable), nil, time.Now())
+			s.FailureHandler(ctx, schedFramework, testPodInfo, fwk.NewStatus(fwk.Unschedulable), nil, time.Now())
 
 			var got *v1.Pod
 			if tt.podUpdatedDuringScheduling {
@@ -358,13 +358,13 @@ func TestFailureHandler_PodAlreadyBound(t *testing.T) {
 	// Add node to schedulerCache no matter it's deleted in API server or not.
 	schedulerCache.AddNode(logger, &nodeFoo)
 
-	s, fwk, err := initScheduler(ctx, schedulerCache, queue, client, informerFactory)
+	s, schedFramework, err := initScheduler(ctx, schedulerCache, queue, client, informerFactory)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	testPodInfo := &framework.QueuedPodInfo{PodInfo: mustNewPodInfo(t, testPod)}
-	s.FailureHandler(ctx, fwk, testPodInfo, framework.NewStatus(framework.Unschedulable).WithError(fmt.Errorf("binding rejected: timeout")), nil, time.Now())
+	s.FailureHandler(ctx, schedFramework, testPodInfo, fwk.NewStatus(fwk.Unschedulable).WithError(fmt.Errorf("binding rejected: timeout")), nil, time.Now())
 
 	pod := getPodFromPriorityQueue(queue, testPod)
 	if pod != nil {
@@ -1151,7 +1151,7 @@ func (t *fakebindPlugin) Name() string {
 	return fakeBind
 }
 
-func (t *fakebindPlugin) Bind(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodeName string) *framework.Status {
+func (t *fakebindPlugin) Bind(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodeName string) *fwk.Status {
 	return nil
 }
 
@@ -1160,7 +1160,7 @@ type filterWithoutEnqueueExtensionsPlugin struct{}
 
 func (*filterWithoutEnqueueExtensionsPlugin) Name() string { return filterWithoutEnqueueExtensions }
 
-func (*filterWithoutEnqueueExtensionsPlugin) Filter(_ context.Context, _ fwk.CycleState, _ *v1.Pod, _ *framework.NodeInfo) *framework.Status {
+func (*filterWithoutEnqueueExtensionsPlugin) Filter(_ context.Context, _ fwk.CycleState, _ *v1.Pod, _ *framework.NodeInfo) *fwk.Status {
 	return nil
 }
 
@@ -1174,7 +1174,7 @@ var fakeNodePluginQueueingFn = func(_ klog.Logger, _ *v1.Pod, _, _ interface{}) 
 
 func (*fakeNodePlugin) Name() string { return fakeNode }
 
-func (*fakeNodePlugin) Filter(_ context.Context, _ fwk.CycleState, _ *v1.Pod, _ *framework.NodeInfo) *framework.Status {
+func (*fakeNodePlugin) Filter(_ context.Context, _ fwk.CycleState, _ *v1.Pod, _ *framework.NodeInfo) *fwk.Status {
 	return nil
 }
 
@@ -1194,7 +1194,7 @@ var fakePodPluginQueueingFn = func(_ klog.Logger, _ *v1.Pod, _, _ interface{}) (
 
 func (*fakePodPlugin) Name() string { return fakePod }
 
-func (*fakePodPlugin) Filter(_ context.Context, _ fwk.CycleState, _ *v1.Pod, _ *framework.NodeInfo) *framework.Status {
+func (*fakePodPlugin) Filter(_ context.Context, _ fwk.CycleState, _ *v1.Pod, _ *framework.NodeInfo) *fwk.Status {
 	return nil
 }
 
@@ -1208,7 +1208,7 @@ type emptyEventPlugin struct{}
 
 func (*emptyEventPlugin) Name() string { return emptyEventExtensions }
 
-func (*emptyEventPlugin) Filter(_ context.Context, _ fwk.CycleState, _ *v1.Pod, _ *framework.NodeInfo) *framework.Status {
+func (*emptyEventPlugin) Filter(_ context.Context, _ fwk.CycleState, _ *v1.Pod, _ *framework.NodeInfo) *fwk.Status {
 	return nil
 }
 
@@ -1221,7 +1221,7 @@ type errorEventsToRegisterPlugin struct{}
 
 func (*errorEventsToRegisterPlugin) Name() string { return errorEventsToRegister }
 
-func (*errorEventsToRegisterPlugin) Filter(_ context.Context, _ fwk.CycleState, _ *v1.Pod, _ *framework.NodeInfo) *framework.Status {
+func (*errorEventsToRegisterPlugin) Filter(_ context.Context, _ fwk.CycleState, _ *v1.Pod, _ *framework.NodeInfo) *fwk.Status {
 	return nil
 }
 
@@ -1236,7 +1236,7 @@ type emptyEventsToRegisterPlugin struct{}
 
 func (*emptyEventsToRegisterPlugin) Name() string { return emptyEventsToRegister }
 
-func (*emptyEventsToRegisterPlugin) Filter(_ context.Context, _ fwk.CycleState, _ *v1.Pod, _ *framework.NodeInfo) *framework.Status {
+func (*emptyEventsToRegisterPlugin) Filter(_ context.Context, _ fwk.CycleState, _ *v1.Pod, _ *framework.NodeInfo) *fwk.Status {
 	return nil
 }
 
@@ -1267,13 +1267,13 @@ const (
 	permitTimeout    = 10 * time.Second
 )
 
-func (f fakePermitPlugin) Permit(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodeName string) (*framework.Status, time.Duration) {
+func (f fakePermitPlugin) Permit(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodeName string) (*fwk.Status, time.Duration) {
 	defer func() {
 		// Send event with podWaiting reason to broadcast this pod is already waiting in the permit stage.
 		f.eventRecorder.Eventf(p, nil, v1.EventTypeWarning, podWaitingReason, "", "")
 	}()
 
-	return framework.NewStatus(framework.Wait), permitTimeout
+	return fwk.NewStatus(fwk.Wait), permitTimeout
 }
 
 var _ framework.PermitPlugin = &fakePermitPlugin{}

--- a/pkg/scheduler/testing/framework/fake_extender.go
+++ b/pkg/scheduler/testing/framework/fake_extender.go
@@ -33,7 +33,7 @@ import (
 )
 
 // FitPredicate is a function type which is used in fake extender.
-type FitPredicate func(pod *v1.Pod, node *framework.NodeInfo) *framework.Status
+type FitPredicate func(pod *v1.Pod, node *framework.NodeInfo) *fwk.Status
 
 // PriorityFunc is a function type which is used in fake extender.
 type PriorityFunc func(pod *v1.Pod, nodes []*framework.NodeInfo) (*framework.NodeScoreList, error)
@@ -45,36 +45,36 @@ type PriorityConfig struct {
 }
 
 // ErrorPredicateExtender implements FitPredicate function to always return error status.
-func ErrorPredicateExtender(pod *v1.Pod, node *framework.NodeInfo) *framework.Status {
-	return framework.NewStatus(framework.Error, "some error")
+func ErrorPredicateExtender(pod *v1.Pod, node *framework.NodeInfo) *fwk.Status {
+	return fwk.NewStatus(fwk.Error, "some error")
 }
 
 // FalsePredicateExtender implements FitPredicate function to always return unschedulable status.
-func FalsePredicateExtender(pod *v1.Pod, node *framework.NodeInfo) *framework.Status {
-	return framework.NewStatus(framework.Unschedulable, fmt.Sprintf("pod is unschedulable on the node %q", node.Node().Name))
+func FalsePredicateExtender(pod *v1.Pod, node *framework.NodeInfo) *fwk.Status {
+	return fwk.NewStatus(fwk.Unschedulable, fmt.Sprintf("pod is unschedulable on the node %q", node.Node().Name))
 }
 
 // TruePredicateExtender implements FitPredicate function to always return success status.
-func TruePredicateExtender(pod *v1.Pod, node *framework.NodeInfo) *framework.Status {
-	return framework.NewStatus(framework.Success)
+func TruePredicateExtender(pod *v1.Pod, node *framework.NodeInfo) *fwk.Status {
+	return fwk.NewStatus(fwk.Success)
 }
 
 // Node1PredicateExtender implements FitPredicate function to return true
 // when the given node's name is "node1"; otherwise return false.
-func Node1PredicateExtender(pod *v1.Pod, node *framework.NodeInfo) *framework.Status {
+func Node1PredicateExtender(pod *v1.Pod, node *framework.NodeInfo) *fwk.Status {
 	if node.Node().Name == "node1" {
-		return framework.NewStatus(framework.Success)
+		return fwk.NewStatus(fwk.Success)
 	}
-	return framework.NewStatus(framework.Unschedulable, fmt.Sprintf("node %q is not allowed", node.Node().Name))
+	return fwk.NewStatus(fwk.Unschedulable, fmt.Sprintf("node %q is not allowed", node.Node().Name))
 }
 
 // Node2PredicateExtender implements FitPredicate function to return true
 // when the given node's name is "node2"; otherwise return false.
-func Node2PredicateExtender(pod *v1.Pod, node *framework.NodeInfo) *framework.Status {
+func Node2PredicateExtender(pod *v1.Pod, node *framework.NodeInfo) *fwk.Status {
 	if node.Node().Name == "node2" {
-		return framework.NewStatus(framework.Success)
+		return fwk.NewStatus(fwk.Success)
 	}
-	return framework.NewStatus(framework.Unschedulable, fmt.Sprintf("node %q is not allowed", node.Node().Name))
+	return fwk.NewStatus(fwk.Unschedulable, fmt.Sprintf("node %q is not allowed", node.Node().Name))
 }
 
 // ErrorPrioritizerExtender implements PriorityFunc function to always return error.
@@ -125,7 +125,7 @@ func (pl *node2PrioritizerPlugin) Name() string {
 }
 
 // Score return score 100 if the given nodeName is "node2"; otherwise return score 10.
-func (pl *node2PrioritizerPlugin) Score(_ context.Context, _ fwk.CycleState, _ *v1.Pod, nodeInfo *framework.NodeInfo) (int64, *framework.Status) {
+func (pl *node2PrioritizerPlugin) Score(_ context.Context, _ fwk.CycleState, _ *v1.Pod, nodeInfo *framework.NodeInfo) (int64, *fwk.Status) {
 	score := 10
 	if nodeInfo.Node().Name == "node2" {
 		score = 100
@@ -302,14 +302,14 @@ func (f *FakeExtender) selectVictimsOnNodeByExtender(logger klog.Logger, pod *v1
 
 // runPredicate run predicates of extender one by one for given pod and node.
 // Returns: fits or not.
-func (f *FakeExtender) runPredicate(pod *v1.Pod, node *framework.NodeInfo) *framework.Status {
+func (f *FakeExtender) runPredicate(pod *v1.Pod, node *framework.NodeInfo) *fwk.Status {
 	for _, predicate := range f.Predicates {
 		status := predicate(pod, node)
 		if !status.IsSuccess() {
 			return status
 		}
 	}
-	return framework.NewStatus(framework.Success)
+	return fwk.NewStatus(fwk.Success)
 }
 
 // Filter implements the extender Filter function.
@@ -321,9 +321,9 @@ func (f *FakeExtender) Filter(pod *v1.Pod, nodes []*framework.NodeInfo) ([]*fram
 		status := f.runPredicate(pod, node)
 		if status.IsSuccess() {
 			filtered = append(filtered, node)
-		} else if status.Code() == framework.Unschedulable {
+		} else if status.Code() == fwk.Unschedulable {
 			failedNodesMap[node.Node().Name] = fmt.Sprintf("FakeExtender: node %q failed", node.Node().Name)
-		} else if status.Code() == framework.UnschedulableAndUnresolvable {
+		} else if status.Code() == fwk.UnschedulableAndUnresolvable {
 			failedAndUnresolvableMap[node.Node().Name] = fmt.Sprintf("FakeExtender: node %q failed and unresolvable", node.Node().Name)
 		} else {
 			return nil, nil, nil, status.AsError()

--- a/pkg/scheduler/testing/framework/fake_plugins.go
+++ b/pkg/scheduler/testing/framework/fake_plugins.go
@@ -41,8 +41,8 @@ func (pl *FalseFilterPlugin) Name() string {
 }
 
 // Filter invoked at the filter extension point.
-func (pl *FalseFilterPlugin) Filter(_ context.Context, _ fwk.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) *framework.Status {
-	return framework.NewStatus(framework.Unschedulable, ErrReasonFake)
+func (pl *FalseFilterPlugin) Filter(_ context.Context, _ fwk.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) *fwk.Status {
+	return fwk.NewStatus(fwk.Unschedulable, ErrReasonFake)
 }
 
 // NewFalseFilterPlugin initializes a FalseFilterPlugin and returns it.
@@ -59,7 +59,7 @@ func (pl *TrueFilterPlugin) Name() string {
 }
 
 // Filter invoked at the filter extension point.
-func (pl *TrueFilterPlugin) Filter(_ context.Context, _ fwk.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) *framework.Status {
+func (pl *TrueFilterPlugin) Filter(_ context.Context, _ fwk.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) *fwk.Status {
 	return nil
 }
 
@@ -82,7 +82,7 @@ func (pl FakePreFilterAndFilterPlugin) Name() string {
 // been called, and it returns different 'Code' depending on its internal 'failedNodeReturnCodeMap'.
 type FakeFilterPlugin struct {
 	NumFilterCalled         int32
-	FailedNodeReturnCodeMap map[string]framework.Code
+	FailedNodeReturnCodeMap map[string]fwk.Code
 }
 
 // Name returns name of the plugin.
@@ -91,18 +91,18 @@ func (pl *FakeFilterPlugin) Name() string {
 }
 
 // Filter invoked at the filter extension point.
-func (pl *FakeFilterPlugin) Filter(_ context.Context, _ fwk.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) *framework.Status {
+func (pl *FakeFilterPlugin) Filter(_ context.Context, _ fwk.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) *fwk.Status {
 	atomic.AddInt32(&pl.NumFilterCalled, 1)
 
 	if returnCode, ok := pl.FailedNodeReturnCodeMap[nodeInfo.Node().Name]; ok {
-		return framework.NewStatus(returnCode, fmt.Sprintf("injecting failure for pod %v", pod.Name))
+		return fwk.NewStatus(returnCode, fmt.Sprintf("injecting failure for pod %v", pod.Name))
 	}
 
 	return nil
 }
 
 // NewFakeFilterPlugin initializes a fakeFilterPlugin and returns it.
-func NewFakeFilterPlugin(failedNodeReturnCodeMap map[string]framework.Code) frameworkruntime.PluginFactory {
+func NewFakeFilterPlugin(failedNodeReturnCodeMap map[string]fwk.Code) frameworkruntime.PluginFactory {
 	return func(_ context.Context, _ runtime.Object, _ framework.Handle) (framework.Plugin, error) {
 		return &FakeFilterPlugin{
 			FailedNodeReturnCodeMap: failedNodeReturnCodeMap,
@@ -120,15 +120,15 @@ func (pl *MatchFilterPlugin) Name() string {
 }
 
 // Filter invoked at the filter extension point.
-func (pl *MatchFilterPlugin) Filter(_ context.Context, _ fwk.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) *framework.Status {
+func (pl *MatchFilterPlugin) Filter(_ context.Context, _ fwk.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) *fwk.Status {
 	node := nodeInfo.Node()
 	if node == nil {
-		return framework.NewStatus(framework.Error, "node not found")
+		return fwk.NewStatus(fwk.Error, "node not found")
 	}
 	if pod.Name == node.Name {
 		return nil
 	}
-	return framework.NewStatus(framework.Unschedulable, ErrReasonFake)
+	return fwk.NewStatus(fwk.Unschedulable, ErrReasonFake)
 }
 
 // NewMatchFilterPlugin initializes a MatchFilterPlugin and returns it.
@@ -139,7 +139,7 @@ func NewMatchFilterPlugin(_ context.Context, _ runtime.Object, _ framework.Handl
 // FakePreFilterPlugin is a test filter plugin.
 type FakePreFilterPlugin struct {
 	Result *framework.PreFilterResult
-	Status *framework.Status
+	Status *fwk.Status
 	name   string
 }
 
@@ -149,7 +149,7 @@ func (pl *FakePreFilterPlugin) Name() string {
 }
 
 // PreFilter invoked at the PreFilter extension point.
-func (pl *FakePreFilterPlugin) PreFilter(_ context.Context, _ fwk.CycleState, pod *v1.Pod, nodes []*framework.NodeInfo) (*framework.PreFilterResult, *framework.Status) {
+func (pl *FakePreFilterPlugin) PreFilter(_ context.Context, _ fwk.CycleState, pod *v1.Pod, nodes []*framework.NodeInfo) (*framework.PreFilterResult, *fwk.Status) {
 	return pl.Result, pl.Status
 }
 
@@ -159,7 +159,7 @@ func (pl *FakePreFilterPlugin) PreFilterExtensions() framework.PreFilterExtensio
 }
 
 // NewFakePreFilterPlugin initializes a fakePreFilterPlugin and returns it.
-func NewFakePreFilterPlugin(name string, result *framework.PreFilterResult, status *framework.Status) frameworkruntime.PluginFactory {
+func NewFakePreFilterPlugin(name string, result *framework.PreFilterResult, status *fwk.Status) frameworkruntime.PluginFactory {
 	return func(_ context.Context, _ runtime.Object, _ framework.Handle) (framework.Plugin, error) {
 		return &FakePreFilterPlugin{
 			Result: result,
@@ -171,7 +171,7 @@ func NewFakePreFilterPlugin(name string, result *framework.PreFilterResult, stat
 
 // FakeReservePlugin is a test reserve plugin.
 type FakeReservePlugin struct {
-	Status *framework.Status
+	Status *fwk.Status
 }
 
 // Name returns name of the plugin.
@@ -180,7 +180,7 @@ func (pl *FakeReservePlugin) Name() string {
 }
 
 // Reserve invoked at the Reserve extension point.
-func (pl *FakeReservePlugin) Reserve(_ context.Context, _ fwk.CycleState, _ *v1.Pod, _ string) *framework.Status {
+func (pl *FakeReservePlugin) Reserve(_ context.Context, _ fwk.CycleState, _ *v1.Pod, _ string) *fwk.Status {
 	return pl.Status
 }
 
@@ -189,7 +189,7 @@ func (pl *FakeReservePlugin) Unreserve(_ context.Context, _ fwk.CycleState, _ *v
 }
 
 // NewFakeReservePlugin initializes a fakeReservePlugin and returns it.
-func NewFakeReservePlugin(status *framework.Status) frameworkruntime.PluginFactory {
+func NewFakeReservePlugin(status *fwk.Status) frameworkruntime.PluginFactory {
 	return func(_ context.Context, _ runtime.Object, _ framework.Handle) (framework.Plugin, error) {
 		return &FakeReservePlugin{
 			Status: status,
@@ -199,7 +199,7 @@ func NewFakeReservePlugin(status *framework.Status) frameworkruntime.PluginFacto
 
 // FakePreBindPlugin is a test prebind plugin.
 type FakePreBindPlugin struct {
-	Status *framework.Status
+	Status *fwk.Status
 }
 
 // Name returns name of the plugin.
@@ -208,12 +208,12 @@ func (pl *FakePreBindPlugin) Name() string {
 }
 
 // PreBind invoked at the PreBind extension point.
-func (pl *FakePreBindPlugin) PreBind(_ context.Context, _ fwk.CycleState, _ *v1.Pod, _ string) *framework.Status {
+func (pl *FakePreBindPlugin) PreBind(_ context.Context, _ fwk.CycleState, _ *v1.Pod, _ string) *fwk.Status {
 	return pl.Status
 }
 
 // NewFakePreBindPlugin initializes a fakePreBindPlugin and returns it.
-func NewFakePreBindPlugin(status *framework.Status) frameworkruntime.PluginFactory {
+func NewFakePreBindPlugin(status *fwk.Status) frameworkruntime.PluginFactory {
 	return func(_ context.Context, _ runtime.Object, _ framework.Handle) (framework.Plugin, error) {
 		return &FakePreBindPlugin{
 			Status: status,
@@ -223,7 +223,7 @@ func NewFakePreBindPlugin(status *framework.Status) frameworkruntime.PluginFacto
 
 // FakePermitPlugin is a test permit plugin.
 type FakePermitPlugin struct {
-	Status  *framework.Status
+	Status  *fwk.Status
 	Timeout time.Duration
 }
 
@@ -233,12 +233,12 @@ func (pl *FakePermitPlugin) Name() string {
 }
 
 // Permit invoked at the Permit extension point.
-func (pl *FakePermitPlugin) Permit(_ context.Context, _ fwk.CycleState, _ *v1.Pod, _ string) (*framework.Status, time.Duration) {
+func (pl *FakePermitPlugin) Permit(_ context.Context, _ fwk.CycleState, _ *v1.Pod, _ string) (*fwk.Status, time.Duration) {
 	return pl.Status, pl.Timeout
 }
 
 // NewFakePermitPlugin initializes a fakePermitPlugin and returns it.
-func NewFakePermitPlugin(status *framework.Status, timeout time.Duration) frameworkruntime.PluginFactory {
+func NewFakePermitPlugin(status *fwk.Status, timeout time.Duration) frameworkruntime.PluginFactory {
 	return func(_ context.Context, _ runtime.Object, _ framework.Handle) (framework.Plugin, error) {
 		return &FakePermitPlugin{
 			Status:  status,
@@ -250,8 +250,8 @@ func NewFakePermitPlugin(status *framework.Status, timeout time.Duration) framew
 type FakePreScoreAndScorePlugin struct {
 	name           string
 	score          int64
-	preScoreStatus *framework.Status
-	scoreStatus    *framework.Status
+	preScoreStatus *fwk.Status
+	scoreStatus    *fwk.Status
 }
 
 // Name returns name of the plugin.
@@ -259,7 +259,7 @@ func (pl *FakePreScoreAndScorePlugin) Name() string {
 	return pl.name
 }
 
-func (pl *FakePreScoreAndScorePlugin) Score(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodeInfo *framework.NodeInfo) (int64, *framework.Status) {
+func (pl *FakePreScoreAndScorePlugin) Score(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodeInfo *framework.NodeInfo) (int64, *fwk.Status) {
 	return pl.score, pl.scoreStatus
 }
 
@@ -267,11 +267,11 @@ func (pl *FakePreScoreAndScorePlugin) ScoreExtensions() framework.ScoreExtension
 	return nil
 }
 
-func (pl *FakePreScoreAndScorePlugin) PreScore(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodes []*framework.NodeInfo) *framework.Status {
+func (pl *FakePreScoreAndScorePlugin) PreScore(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodes []*framework.NodeInfo) *fwk.Status {
 	return pl.preScoreStatus
 }
 
-func NewFakePreScoreAndScorePlugin(name string, score int64, preScoreStatus, scoreStatus *framework.Status) frameworkruntime.PluginFactory {
+func NewFakePreScoreAndScorePlugin(name string, score int64, preScoreStatus, scoreStatus *fwk.Status) frameworkruntime.PluginFactory {
 	return func(_ context.Context, _ runtime.Object, _ framework.Handle) (framework.Plugin, error) {
 		return &FakePreScoreAndScorePlugin{
 			name:           name,

--- a/staging/src/k8s.io/kube-scheduler/framework/interface.go
+++ b/staging/src/k8s.io/kube-scheduler/framework/interface.go
@@ -1,0 +1,235 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file defines the scheduling framework plugin interfaces.
+
+package framework
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/google/go-cmp/cmp"         //nolint:depguard
+	"github.com/google/go-cmp/cmp/cmpopts" //nolint:depguard
+)
+
+// Code is the Status code/type which is returned from plugins.
+type Code int
+
+// These are predefined codes used in a Status.
+// Note: when you add a new status, you have to add it in `codes` slice below.
+const (
+	// Success means that plugin ran correctly and found pod schedulable.
+	// NOTE: A nil status is also considered as "Success".
+	Success Code = iota
+	// Error is one of the failures, used for internal plugin errors, unexpected input, etc.
+	// Plugin shouldn't return this code for expected failures, like Unschedulable.
+	// Since it's the unexpected failure, the scheduling queue registers the pod without unschedulable plugins.
+	// Meaning, the Pod will be requeued to activeQ/backoffQ soon.
+	Error
+	// Unschedulable is one of the failures, used when a plugin finds a pod unschedulable.
+	// If it's returned from PreFilter or Filter, the scheduler might attempt to
+	// run other postFilter plugins like preemption to get this pod scheduled.
+	// Use UnschedulableAndUnresolvable to make the scheduler skipping other postFilter plugins.
+	// The accompanying status message should explain why the pod is unschedulable.
+	//
+	// We regard the backoff as a penalty of wasting the scheduling cycle.
+	// When the scheduling queue requeues Pods, which was rejected with Unschedulable in the last scheduling,
+	// the Pod goes through backoff.
+	Unschedulable
+	// UnschedulableAndUnresolvable is used when a plugin finds a pod unschedulable and
+	// other postFilter plugins like preemption would not change anything.
+	// See the comment on PostFilter interface for more details about how PostFilter should handle this status.
+	// Plugins should return Unschedulable if it is possible that the pod can get scheduled
+	// after running other postFilter plugins.
+	// The accompanying status message should explain why the pod is unschedulable.
+	//
+	// We regard the backoff as a penalty of wasting the scheduling cycle.
+	// When the scheduling queue requeues Pods, which was rejected with UnschedulableAndUnresolvable in the last scheduling,
+	// the Pod goes through backoff.
+	UnschedulableAndUnresolvable
+	// Wait is used when a Permit plugin finds a pod scheduling should wait.
+	Wait
+	// Skip is used in the following scenarios:
+	// - when a Bind plugin chooses to skip binding.
+	// - when a PreFilter plugin returns Skip so that coupled Filter plugin/PreFilterExtensions() will be skipped.
+	// - when a PreScore plugin returns Skip so that coupled Score plugin will be skipped.
+	Skip
+	// Pending means that the scheduling process is finished successfully,
+	// but the plugin wants to stop the scheduling cycle/binding cycle here.
+	//
+	// For example, if your plugin has to notify the scheduling result to an external component,
+	// and wait for it to complete something **before** binding.
+	// It's different from when to return Unschedulable/UnschedulableAndUnresolvable,
+	// because in this case, the scheduler decides where the Pod can go successfully,
+	// but we need to wait for the external component to do something based on that scheduling result.
+	//
+	// We regard the backoff as a penalty of wasting the scheduling cycle.
+	// In the case of returning Pending, we cannot say the scheduling cycle is wasted
+	// because the scheduling result is used to proceed the Pod's scheduling forward,
+	// that particular scheduling cycle is failed though.
+	// So, Pods rejected by such reasons don't need to suffer a penalty (backoff).
+	// When the scheduling queue requeues Pods, which was rejected with Pending in the last scheduling,
+	// the Pod goes to activeQ directly ignoring backoff.
+	Pending
+)
+
+// This list should be exactly the same as the codes iota defined above in the same order.
+var codes = []string{"Success", "Error", "Unschedulable", "UnschedulableAndUnresolvable", "Wait", "Skip", "Pending"}
+
+func (c Code) String() string {
+	return codes[c]
+}
+
+// Status indicates the result of running a plugin. It consists of a code, a
+// message, (optionally) an error, and a plugin name it fails by.
+// When the status code is not Success, the reasons should explain why.
+// And, when code is Success, all the other fields should be empty.
+// NOTE: A nil Status is also considered as Success.
+type Status struct {
+	code    Code
+	reasons []string
+	err     error
+	// plugin is an optional field that records the plugin name causes this status.
+	// It's set by the framework when code is Unschedulable, UnschedulableAndUnresolvable or Pending.
+	plugin string
+}
+
+func (s *Status) WithError(err error) *Status {
+	s.err = err
+	return s
+}
+
+// Code returns code of the Status.
+func (s *Status) Code() Code {
+	if s == nil {
+		return Success
+	}
+	return s.code
+}
+
+// Message returns a concatenated message on reasons of the Status.
+func (s *Status) Message() string {
+	if s == nil {
+		return ""
+	}
+	return strings.Join(s.Reasons(), ", ")
+}
+
+// SetPlugin sets the given plugin name to s.plugin.
+func (s *Status) SetPlugin(plugin string) {
+	s.plugin = plugin
+}
+
+// WithPlugin sets the given plugin name to s.plugin,
+// and returns the given status object.
+func (s *Status) WithPlugin(plugin string) *Status {
+	s.SetPlugin(plugin)
+	return s
+}
+
+// Plugin returns the plugin name which caused this status.
+func (s *Status) Plugin() string {
+	return s.plugin
+}
+
+// Reasons returns reasons of the Status.
+func (s *Status) Reasons() []string {
+	if s.err != nil {
+		return append([]string{s.err.Error()}, s.reasons...)
+	}
+	return s.reasons
+}
+
+// AppendReason appends given reason to the Status.
+func (s *Status) AppendReason(reason string) {
+	s.reasons = append(s.reasons, reason)
+}
+
+// IsSuccess returns true if and only if "Status" is nil or Code is "Success".
+func (s *Status) IsSuccess() bool {
+	return s.Code() == Success
+}
+
+// IsWait returns true if and only if "Status" is non-nil and its Code is "Wait".
+func (s *Status) IsWait() bool {
+	return s.Code() == Wait
+}
+
+// IsSkip returns true if and only if "Status" is non-nil and its Code is "Skip".
+func (s *Status) IsSkip() bool {
+	return s.Code() == Skip
+}
+
+// IsRejected returns true if "Status" is Unschedulable (Unschedulable, UnschedulableAndUnresolvable, or Pending).
+func (s *Status) IsRejected() bool {
+	code := s.Code()
+	return code == Unschedulable || code == UnschedulableAndUnresolvable || code == Pending
+}
+
+// AsError returns nil if the status is a success, a wait or a skip; otherwise returns an "error" object
+// with a concatenated message on reasons of the Status.
+func (s *Status) AsError() error {
+	if s.IsSuccess() || s.IsWait() || s.IsSkip() {
+		return nil
+	}
+	if s.err != nil {
+		return s.err
+	}
+	return errors.New(s.Message())
+}
+
+// Equal checks equality of two statuses. This is useful for testing with
+// cmp.Equal.
+func (s *Status) Equal(x *Status) bool {
+	if s == nil || x == nil {
+		return s.IsSuccess() && x.IsSuccess()
+	}
+	if s.code != x.code {
+		return false
+	}
+	if !cmp.Equal(s.err, x.err, cmpopts.EquateErrors()) {
+		return false
+	}
+	if !cmp.Equal(s.reasons, x.reasons) {
+		return false
+	}
+	return cmp.Equal(s.plugin, x.plugin)
+}
+
+func (s *Status) String() string {
+	return s.Message()
+}
+
+// NewStatus makes a Status out of the given arguments and returns its pointer.
+func NewStatus(code Code, reasons ...string) *Status {
+	s := &Status{
+		code:    code,
+		reasons: reasons,
+	}
+	return s
+}
+
+// AsStatus wraps an error in a Status.
+func AsStatus(err error) *Status {
+	if err == nil {
+		return nil
+	}
+	return &Status{
+		code: Error,
+		err:  err,
+	}
+}

--- a/test/integration/scheduler/bind/bind_test.go
+++ b/test/integration/scheduler/bind/bind_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	st "k8s.io/kubernetes/pkg/scheduler/testing"
 	testutil "k8s.io/kubernetes/test/integration/util"
@@ -38,14 +39,14 @@ func TestDefaultBinder(t *testing.T) {
 
 	tests := map[string]struct {
 		anotherUID     bool
-		wantStatusCode framework.Code
+		wantStatusCode fwk.Code
 	}{
 		"same UID": {
-			wantStatusCode: framework.Success,
+			wantStatusCode: fwk.Success,
 		},
 		"different UID": {
 			anotherUID:     true,
-			wantStatusCode: framework.Error,
+			wantStatusCode: fwk.Error,
 		},
 	}
 	for name, tc := range tests {

--- a/test/integration/scheduler/eventhandler/eventhandler_test.go
+++ b/test/integration/scheduler/eventhandler/eventhandler_test.go
@@ -55,7 +55,7 @@ func (pl *fooPlugin) Name() string {
 	return "foo"
 }
 
-func (pl *fooPlugin) Filter(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) *framework.Status {
+func (pl *fooPlugin) Filter(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) *fwk.Status {
 	taints := nodeInfo.Node().Spec.Taints
 	if len(taints) == 0 {
 		return nil
@@ -64,7 +64,7 @@ func (pl *fooPlugin) Filter(ctx context.Context, state fwk.CycleState, pod *v1.P
 	if corev1.TolerationsTolerateTaint(pod.Spec.Tolerations, &nodeInfo.Node().Spec.Taints[0]) {
 		return nil
 	}
-	return framework.NewStatus(framework.Unschedulable)
+	return fwk.NewStatus(fwk.Unschedulable)
 }
 
 func (pl *fooPlugin) EventsToRegister(_ context.Context) ([]fwk.ClusterEventWithHint, error) {

--- a/test/integration/scheduler/plugins/plugins_test.go
+++ b/test/integration/scheduler/plugins/plugins_test.go
@@ -220,7 +220,7 @@ type BindPlugin struct {
 	mutex                 sync.Mutex
 	name                  string
 	numBindCalled         int
-	bindStatus            *framework.Status
+	bindStatus            *fwk.Status
 	client                clientset.Interface
 	pluginInvokeEventChan chan pluginInvokeEvent
 }
@@ -348,12 +348,12 @@ func (ep *PreEnqueuePlugin) Name() string {
 	return enqueuePluginName
 }
 
-func (ep *PreEnqueuePlugin) PreEnqueue(ctx context.Context, p *v1.Pod) *framework.Status {
+func (ep *PreEnqueuePlugin) PreEnqueue(ctx context.Context, p *v1.Pod) *fwk.Status {
 	ep.called++
 	if ep.admit {
 		return nil
 	}
-	return framework.NewStatus(framework.UnschedulableAndUnresolvable, "not ready for scheduling")
+	return fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "not ready for scheduling")
 }
 
 // Name returns name of the score plugin.
@@ -362,13 +362,13 @@ func (sp *ScorePlugin) Name() string {
 }
 
 // Score returns the score of scheduling a pod on a specific node.
-func (sp *ScorePlugin) Score(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodeInfo *framework.NodeInfo) (int64, *framework.Status) {
+func (sp *ScorePlugin) Score(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodeInfo *framework.NodeInfo) (int64, *fwk.Status) {
 	sp.mutex.Lock()
 	defer sp.mutex.Unlock()
 
 	sp.numScoreCalled++
 	if sp.failScore {
-		return 0, framework.NewStatus(framework.Error, fmt.Sprintf("injecting failure for pod %v", p.Name))
+		return 0, fwk.NewStatus(fwk.Error, fmt.Sprintf("injecting failure for pod %v", p.Name))
 	}
 
 	score := int64(1)
@@ -394,7 +394,7 @@ func (sp *ScoreWithNormalizePlugin) Name() string {
 }
 
 // Score returns the score of scheduling a pod on a specific node.
-func (sp *ScoreWithNormalizePlugin) Score(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodeInfo *framework.NodeInfo) (int64, *framework.Status) {
+func (sp *ScoreWithNormalizePlugin) Score(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodeInfo *framework.NodeInfo) (int64, *fwk.Status) {
 	sp.mutex.Lock()
 	defer sp.mutex.Unlock()
 
@@ -403,7 +403,7 @@ func (sp *ScoreWithNormalizePlugin) Score(ctx context.Context, state fwk.CycleSt
 	return score, nil
 }
 
-func (sp *ScoreWithNormalizePlugin) NormalizeScore(ctx context.Context, state fwk.CycleState, pod *v1.Pod, scores framework.NodeScoreList) *framework.Status {
+func (sp *ScoreWithNormalizePlugin) NormalizeScore(ctx context.Context, state fwk.CycleState, pod *v1.Pod, scores framework.NodeScoreList) *fwk.Status {
 	sp.numNormalizeScoreCalled++
 	return nil
 }
@@ -419,7 +419,7 @@ func (fp *FilterPlugin) Name() string {
 
 // Filter is a test function that returns an error or nil, depending on the
 // value of "failFilter".
-func (fp *FilterPlugin) Filter(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) *framework.Status {
+func (fp *FilterPlugin) Filter(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) *fwk.Status {
 	fp.mutex.Lock()
 	defer fp.mutex.Unlock()
 
@@ -429,10 +429,10 @@ func (fp *FilterPlugin) Filter(ctx context.Context, state fwk.CycleState, pod *v
 	}
 
 	if fp.failFilter {
-		return framework.NewStatus(framework.Error, fmt.Sprintf("injecting failure for pod %v", pod.Name))
+		return fwk.NewStatus(fwk.Error, fmt.Sprintf("injecting failure for pod %v", pod.Name))
 	}
 	if fp.rejectFilter {
-		return framework.NewStatus(framework.Unschedulable, fmt.Sprintf("reject pod %v", pod.Name))
+		return fwk.NewStatus(fwk.Unschedulable, fmt.Sprintf("reject pod %v", pod.Name))
 	}
 
 	return nil
@@ -451,10 +451,10 @@ func (rp *ReservePlugin) Name() string {
 
 // Reserve is a test function that increments an intenral counter and returns
 // an error or nil, depending on the value of "failReserve".
-func (rp *ReservePlugin) Reserve(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeName string) *framework.Status {
+func (rp *ReservePlugin) Reserve(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeName string) *fwk.Status {
 	rp.numReserveCalled++
 	if rp.failReserve {
-		return framework.NewStatus(framework.Error, fmt.Sprintf("injecting failure for pod %v", pod.Name))
+		return fwk.NewStatus(fwk.Error, fmt.Sprintf("injecting failure for pod %v", pod.Name))
 	}
 	return nil
 }
@@ -478,10 +478,10 @@ func (*PreScorePlugin) Name() string {
 }
 
 // PreScore is a test function.
-func (pfp *PreScorePlugin) PreScore(ctx context.Context, _ fwk.CycleState, pod *v1.Pod, _ []*framework.NodeInfo) *framework.Status {
+func (pfp *PreScorePlugin) PreScore(ctx context.Context, _ fwk.CycleState, pod *v1.Pod, _ []*framework.NodeInfo) *fwk.Status {
 	pfp.numPreScoreCalled++
 	if pfp.failPreScore {
-		return framework.NewStatus(framework.Error, fmt.Sprintf("injecting failure for pod %v", pod.Name))
+		return fwk.NewStatus(fwk.Error, fmt.Sprintf("injecting failure for pod %v", pod.Name))
 	}
 
 	return nil
@@ -493,7 +493,7 @@ func (pp *PreBindPlugin) Name() string {
 }
 
 // PreBind is a test function that returns (true, nil) or errors for testing.
-func (pp *PreBindPlugin) PreBind(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeName string) *framework.Status {
+func (pp *PreBindPlugin) PreBind(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeName string) *fwk.Status {
 	pp.mutex.Lock()
 	defer pp.mutex.Unlock()
 
@@ -503,10 +503,10 @@ func (pp *PreBindPlugin) PreBind(ctx context.Context, state fwk.CycleState, pod 
 	}
 	pp.podUIDs[pod.UID] = struct{}{}
 	if pp.failPreBind {
-		return framework.NewStatus(framework.Error, fmt.Sprintf("injecting failure for pod %v", pod.Name))
+		return fwk.NewStatus(fwk.Error, fmt.Sprintf("injecting failure for pod %v", pod.Name))
 	}
 	if pp.rejectPreBind {
-		return framework.NewStatus(framework.Unschedulable, fmt.Sprintf("reject pod %v", pod.Name))
+		return fwk.NewStatus(fwk.Unschedulable, fmt.Sprintf("reject pod %v", pod.Name))
 	}
 	return nil
 }
@@ -521,7 +521,7 @@ func (bp *BindPlugin) Name() string {
 	return bp.name
 }
 
-func (bp *BindPlugin) Bind(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodeName string) *framework.Status {
+func (bp *BindPlugin) Bind(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodeName string) *fwk.Status {
 	bp.mutex.Lock()
 	defer bp.mutex.Unlock()
 
@@ -540,7 +540,7 @@ func (bp *BindPlugin) Bind(ctx context.Context, state fwk.CycleState, p *v1.Pod,
 				Name: nodeName,
 			},
 		}, metav1.CreateOptions{}); err != nil {
-			return framework.NewStatus(framework.Error, fmt.Sprintf("bind failed: %v", err))
+			return fwk.NewStatus(fwk.Error, fmt.Sprintf("bind failed: %v", err))
 		}
 	}
 	return bp.bindStatus
@@ -576,13 +576,13 @@ func (pp *PreFilterPlugin) PreFilterExtensions() framework.PreFilterExtensions {
 }
 
 // PreFilter is a test function that returns (true, nil) or errors for testing.
-func (pp *PreFilterPlugin) PreFilter(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodes []*framework.NodeInfo) (*framework.PreFilterResult, *framework.Status) {
+func (pp *PreFilterPlugin) PreFilter(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodes []*framework.NodeInfo) (*framework.PreFilterResult, *fwk.Status) {
 	pp.numPreFilterCalled++
 	if pp.failPreFilter {
-		return nil, framework.NewStatus(framework.Error, fmt.Sprintf("injecting failure for pod %v", pod.Name))
+		return nil, fwk.NewStatus(fwk.Error, fmt.Sprintf("injecting failure for pod %v", pod.Name))
 	}
 	if pp.rejectPreFilter {
-		return nil, framework.NewStatus(framework.Unschedulable, fmt.Sprintf("reject pod %v", pod.Name))
+		return nil, fwk.NewStatus(fwk.Unschedulable, fmt.Sprintf("reject pod %v", pod.Name))
 	}
 	if len(pp.preFilterResultNodes) != 0 {
 		return &framework.PreFilterResult{NodeNames: pp.preFilterResultNodes}, nil
@@ -595,11 +595,11 @@ func (pp *PostFilterPlugin) Name() string {
 	return pp.name
 }
 
-func (pp *PostFilterPlugin) PostFilter(ctx context.Context, state fwk.CycleState, pod *v1.Pod, _ framework.NodeToStatusReader) (*framework.PostFilterResult, *framework.Status) {
+func (pp *PostFilterPlugin) PostFilter(ctx context.Context, state fwk.CycleState, pod *v1.Pod, _ framework.NodeToStatusReader) (*framework.PostFilterResult, *fwk.Status) {
 	pp.numPostFilterCalled++
 	nodeInfos, err := pp.fh.SnapshotSharedLister().NodeInfos().List()
 	if err != nil {
-		return nil, framework.NewStatus(framework.Error, err.Error())
+		return nil, fwk.NewStatus(fwk.Error, err.Error())
 	}
 
 	for _, nodeInfo := range nodeInfos {
@@ -608,16 +608,16 @@ func (pp *PostFilterPlugin) PostFilter(ctx context.Context, state fwk.CycleState
 	pp.fh.RunScorePlugins(ctx, state, pod, nodeInfos)
 
 	if pp.failPostFilter {
-		return nil, framework.NewStatus(framework.Error, fmt.Sprintf("injecting failure for pod %v", pod.Name))
+		return nil, fwk.NewStatus(fwk.Error, fmt.Sprintf("injecting failure for pod %v", pod.Name))
 	}
 	if pp.rejectPostFilter {
-		return nil, framework.NewStatus(framework.Unschedulable, fmt.Sprintf("injecting unschedulable for pod %v", pod.Name))
+		return nil, fwk.NewStatus(fwk.Unschedulable, fmt.Sprintf("injecting unschedulable for pod %v", pod.Name))
 	}
 	if pp.breakPostFilter {
-		return nil, framework.NewStatus(framework.UnschedulableAndUnresolvable, fmt.Sprintf("injecting unresolvable for pod %v", pod.Name))
+		return nil, fwk.NewStatus(fwk.UnschedulableAndUnresolvable, fmt.Sprintf("injecting unresolvable for pod %v", pod.Name))
 	}
 
-	return nil, framework.NewStatus(framework.Success, fmt.Sprintf("make room for pod %v to be schedulable", pod.Name))
+	return nil, fwk.NewStatus(fwk.Success, fmt.Sprintf("make room for pod %v to be schedulable", pod.Name))
 }
 
 // Name returns name of the plugin.
@@ -626,16 +626,16 @@ func (pp *PermitPlugin) Name() string {
 }
 
 // Permit implements the permit test plugin.
-func (pp *PermitPlugin) Permit(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeName string) (*framework.Status, time.Duration) {
+func (pp *PermitPlugin) Permit(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeName string) (*fwk.Status, time.Duration) {
 	pp.mutex.Lock()
 	defer pp.mutex.Unlock()
 
 	pp.numPermitCalled++
 	if pp.failPermit {
-		return framework.NewStatus(framework.Error, fmt.Sprintf("injecting failure for pod %v", pod.Name)), 0
+		return fwk.NewStatus(fwk.Error, fmt.Sprintf("injecting failure for pod %v", pod.Name)), 0
 	}
 	if pp.rejectPermit {
-		return framework.NewStatus(framework.Unschedulable, fmt.Sprintf("reject pod %v", pod.Name)), 0
+		return fwk.NewStatus(fwk.Unschedulable, fmt.Sprintf("reject pod %v", pod.Name)), 0
 	}
 	if pp.timeoutPermit {
 		go func() {
@@ -646,19 +646,19 @@ func (pp *PermitPlugin) Permit(ctx context.Context, state fwk.CycleState, pod *v
 				pp.cancelled = true
 			}
 		}()
-		return framework.NewStatus(framework.Wait, ""), 3 * time.Second
+		return fwk.NewStatus(fwk.Wait, ""), 3 * time.Second
 	}
 	if pp.waitAndRejectPermit || pp.waitAndAllowPermit {
 		if pp.waitingPod == "" || pp.waitingPod == pod.Name {
 			pp.waitingPod = pod.Name
-			return framework.NewStatus(framework.Wait, ""), 30 * time.Second
+			return fwk.NewStatus(fwk.Wait, ""), 30 * time.Second
 		}
 		if pp.waitAndRejectPermit {
 			pp.rejectingPod = pod.Name
 			pp.fh.IterateOverWaitingPods(func(wp framework.WaitingPod) {
 				wp.Reject(pp.name, fmt.Sprintf("reject pod %v", wp.GetPod().Name))
 			})
-			return framework.NewStatus(framework.Unschedulable, fmt.Sprintf("reject pod %v", pod.Name)), 0
+			return fwk.NewStatus(fwk.Unschedulable, fmt.Sprintf("reject pod %v", pod.Name)), 0
 		}
 		if pp.waitAndAllowPermit {
 			pp.allowingPod = pod.Name
@@ -1717,7 +1717,7 @@ func TestBindPlugin(t *testing.T) {
 	tests := []struct {
 		name                   string
 		enabledBindPlugins     []configv1.Plugin
-		bindPluginStatuses     []*framework.Status
+		bindPluginStatuses     []*fwk.Status
 		expectBoundByScheduler bool   // true means this test case expecting scheduler would bind pods
 		expectBoundByPlugin    bool   // true means this test case expecting a plugin would bind pods
 		expectBindFailed       bool   // true means this test case expecting a plugin binding pods with error
@@ -1727,14 +1727,14 @@ func TestBindPlugin(t *testing.T) {
 		{
 			name:                   "bind plugins skipped to bind the pod and scheduler bond the pod",
 			enabledBindPlugins:     []configv1.Plugin{{Name: bindPlugin1Name}, {Name: bindPlugin2Name}, {Name: defaultbinder.Name}},
-			bindPluginStatuses:     []*framework.Status{framework.NewStatus(framework.Skip, ""), framework.NewStatus(framework.Skip, "")},
+			bindPluginStatuses:     []*fwk.Status{fwk.NewStatus(fwk.Skip, ""), fwk.NewStatus(fwk.Skip, "")},
 			expectBoundByScheduler: true,
 			expectInvokeEvents:     []pluginInvokeEvent{{pluginName: bindPlugin1Name, val: 1}, {pluginName: bindPlugin2Name, val: 1}, {pluginName: postBindPluginName, val: 1}},
 		},
 		{
 			name:                 "bindplugin2 succeeded to bind the pod",
 			enabledBindPlugins:   []configv1.Plugin{{Name: bindPlugin1Name}, {Name: bindPlugin2Name}, {Name: defaultbinder.Name}},
-			bindPluginStatuses:   []*framework.Status{framework.NewStatus(framework.Skip, ""), framework.NewStatus(framework.Success, "")},
+			bindPluginStatuses:   []*fwk.Status{fwk.NewStatus(fwk.Skip, ""), fwk.NewStatus(fwk.Success, "")},
 			expectBoundByPlugin:  true,
 			expectBindPluginName: bindPlugin2Name,
 			expectInvokeEvents:   []pluginInvokeEvent{{pluginName: bindPlugin1Name, val: 1}, {pluginName: bindPlugin2Name, val: 1}, {pluginName: postBindPluginName, val: 1}},
@@ -1742,7 +1742,7 @@ func TestBindPlugin(t *testing.T) {
 		{
 			name:                 "bindplugin1 succeeded to bind the pod",
 			enabledBindPlugins:   []configv1.Plugin{{Name: bindPlugin1Name}, {Name: bindPlugin2Name}, {Name: defaultbinder.Name}},
-			bindPluginStatuses:   []*framework.Status{framework.NewStatus(framework.Success, ""), framework.NewStatus(framework.Success, "")},
+			bindPluginStatuses:   []*fwk.Status{fwk.NewStatus(fwk.Success, ""), fwk.NewStatus(fwk.Success, "")},
 			expectBoundByPlugin:  true,
 			expectBindPluginName: bindPlugin1Name,
 			expectInvokeEvents:   []pluginInvokeEvent{{pluginName: bindPlugin1Name, val: 1}, {pluginName: postBindPluginName, val: 1}},
@@ -1751,13 +1751,13 @@ func TestBindPlugin(t *testing.T) {
 			name:               "bind plugin fails to bind the pod",
 			enabledBindPlugins: []configv1.Plugin{{Name: bindPlugin1Name}, {Name: bindPlugin2Name}, {Name: defaultbinder.Name}},
 			expectBindFailed:   true,
-			bindPluginStatuses: []*framework.Status{framework.NewStatus(framework.Error, "failed to bind"), framework.NewStatus(framework.Success, "")},
+			bindPluginStatuses: []*fwk.Status{fwk.NewStatus(fwk.Error, "failed to bind"), fwk.NewStatus(fwk.Success, "")},
 			expectInvokeEvents: []pluginInvokeEvent{{pluginName: bindPlugin1Name, val: 1}, {pluginName: reservePluginName, val: 1}},
 		},
 		{
 			name:               "all bind plugins will be skipped(this should not happen for most of the cases)",
 			enabledBindPlugins: []configv1.Plugin{{Name: bindPlugin1Name}, {Name: bindPlugin2Name}},
-			bindPluginStatuses: []*framework.Status{framework.NewStatus(framework.Skip, ""), framework.NewStatus(framework.Skip, "")},
+			bindPluginStatuses: []*fwk.Status{fwk.NewStatus(fwk.Skip, ""), fwk.NewStatus(fwk.Skip, "")},
 			expectInvokeEvents: []pluginInvokeEvent{{pluginName: bindPlugin1Name, val: 1}, {pluginName: bindPlugin2Name, val: 1}},
 		},
 	}
@@ -2626,14 +2626,14 @@ func (j *JobPlugin) Name() string {
 	return jobPluginName
 }
 
-func (j *JobPlugin) PreFilter(_ context.Context, _ fwk.CycleState, p *v1.Pod, nodes []*framework.NodeInfo) (*framework.PreFilterResult, *framework.Status) {
+func (j *JobPlugin) PreFilter(_ context.Context, _ fwk.CycleState, p *v1.Pod, nodes []*framework.NodeInfo) (*framework.PreFilterResult, *fwk.Status) {
 	labelSelector := labels.SelectorFromSet(labels.Set{"driver": ""})
 	driverPods, err := j.podLister.Pods(p.Namespace).List(labelSelector)
 	if err != nil {
-		return nil, framework.AsStatus(err)
+		return nil, fwk.AsStatus(err)
 	}
 	if len(driverPods) == 0 {
-		return nil, framework.NewStatus(framework.UnschedulableAndUnresolvable, "unable to find driver pod")
+		return nil, fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "unable to find driver pod")
 	}
 	return nil, nil
 }
@@ -2763,7 +2763,7 @@ func (pl *SchedulingGatesPluginWithEvents) Name() string {
 	return schedulingGatesPluginWithEvents
 }
 
-func (pl *SchedulingGatesPluginWithEvents) PreEnqueue(ctx context.Context, p *v1.Pod) *framework.Status {
+func (pl *SchedulingGatesPluginWithEvents) PreEnqueue(ctx context.Context, p *v1.Pod) *fwk.Status {
 	pl.called++
 	klog.FromContext(ctx).Info("PreEnqueue is called", "pod", klog.KObj(p), "count", pl.called)
 	return pl.SchedulingGates.PreEnqueue(ctx, p)
@@ -2784,7 +2784,7 @@ func (pl *SchedulingGatesPluginWOEvents) Name() string {
 	return schedulingGatesPluginWOEvents
 }
 
-func (pl *SchedulingGatesPluginWOEvents) PreEnqueue(ctx context.Context, p *v1.Pod) *framework.Status {
+func (pl *SchedulingGatesPluginWOEvents) PreEnqueue(ctx context.Context, p *v1.Pod) *fwk.Status {
 	pl.called++
 	klog.FromContext(ctx).Info("PreEnqueue is called", "pod", klog.KObj(p), "count", pl.called)
 	return pl.SchedulingGates.PreEnqueue(ctx, p)

--- a/test/integration/scheduler/preemption/preemption_test.go
+++ b/test/integration/scheduler/preemption/preemption_test.go
@@ -105,33 +105,33 @@ func (fp *tokenFilter) Name() string {
 }
 
 func (fp *tokenFilter) Filter(ctx context.Context, state fwk.CycleState, pod *v1.Pod,
-	nodeInfo *framework.NodeInfo) *framework.Status {
+	nodeInfo *framework.NodeInfo) *fwk.Status {
 	if fp.Tokens > 0 {
 		fp.Tokens--
 		return nil
 	}
-	status := framework.Unschedulable
+	status := fwk.Unschedulable
 	if fp.Unresolvable {
-		status = framework.UnschedulableAndUnresolvable
+		status = fwk.UnschedulableAndUnresolvable
 	}
-	return framework.NewStatus(status, fmt.Sprintf("can't fit %v", pod.Name))
+	return fwk.NewStatus(status, fmt.Sprintf("can't fit %v", pod.Name))
 }
 
-func (fp *tokenFilter) PreFilter(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodes []*framework.NodeInfo) (*framework.PreFilterResult, *framework.Status) {
+func (fp *tokenFilter) PreFilter(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodes []*framework.NodeInfo) (*framework.PreFilterResult, *fwk.Status) {
 	if !fp.EnablePreFilter || fp.Tokens > 0 {
 		return nil, nil
 	}
-	return nil, framework.NewStatus(framework.Unschedulable)
+	return nil, fwk.NewStatus(fwk.Unschedulable)
 }
 
 func (fp *tokenFilter) AddPod(ctx context.Context, state fwk.CycleState, podToSchedule *v1.Pod,
-	podInfoToAdd *framework.PodInfo, nodeInfo *framework.NodeInfo) *framework.Status {
+	podInfoToAdd *framework.PodInfo, nodeInfo *framework.NodeInfo) *fwk.Status {
 	fp.Tokens--
 	return nil
 }
 
 func (fp *tokenFilter) RemovePod(ctx context.Context, state fwk.CycleState, podToSchedule *v1.Pod,
-	podInfoToRemove *framework.PodInfo, nodeInfo *framework.NodeInfo) *framework.Status {
+	podInfoToRemove *framework.PodInfo, nodeInfo *framework.NodeInfo) *fwk.Status {
 	fp.Tokens++
 	return nil
 }
@@ -1512,11 +1512,11 @@ func (af *alwaysFail) Name() string {
 	return alwaysFailPlugin
 }
 
-func (af *alwaysFail) PreBind(_ context.Context, _ fwk.CycleState, p *v1.Pod, _ string) *framework.Status {
+func (af *alwaysFail) PreBind(_ context.Context, _ fwk.CycleState, p *v1.Pod, _ string) *fwk.Status {
 	if strings.Contains(p.Name, doNotFailMe) {
 		return nil
 	}
-	return framework.NewStatus(framework.Unschedulable)
+	return fwk.NewStatus(fwk.Unschedulable)
 }
 
 func newAlwaysFail(_ context.Context, _ runtime.Object, _ framework.Handle) (framework.Plugin, error) {

--- a/test/integration/scheduler/queueing/queue_test.go
+++ b/test/integration/scheduler/queueing/queue_test.go
@@ -188,8 +188,8 @@ func (f *fakeCRPlugin) Name() string {
 	return "fakeCRPlugin"
 }
 
-func (f *fakeCRPlugin) Filter(_ context.Context, _ fwk.CycleState, _ *v1.Pod, _ *framework.NodeInfo) *framework.Status {
-	return framework.NewStatus(framework.Unschedulable, "always fail")
+func (f *fakeCRPlugin) Filter(_ context.Context, _ fwk.CycleState, _ *v1.Pod, _ *framework.NodeInfo) *fwk.Status {
+	return fwk.NewStatus(fwk.Unschedulable, "always fail")
 }
 
 // EventsToRegister returns the possible events that may make a Pod
@@ -321,17 +321,17 @@ func TestCustomResourceEnqueue(t *testing.T) {
 
 	// Pop fake-pod out. It should be unschedulable.
 	podInfo := testutils.NextPodOrDie(t, testCtx)
-	fwk, ok := testCtx.Scheduler.Profiles[podInfo.Pod.Spec.SchedulerName]
+	schedFramework, ok := testCtx.Scheduler.Profiles[podInfo.Pod.Spec.SchedulerName]
 	if !ok {
 		t.Fatalf("Cannot find the profile for Pod %v", podInfo.Pod.Name)
 	}
 	// Schedule the Pod manually.
-	_, fitError := testCtx.Scheduler.SchedulePod(ctx, fwk, framework.NewCycleState(), podInfo.Pod)
+	_, fitError := testCtx.Scheduler.SchedulePod(ctx, schedFramework, framework.NewCycleState(), podInfo.Pod)
 	// The fitError is expected to be non-nil as it failed the fakeCRPlugin plugin.
 	if fitError == nil {
 		t.Fatalf("Expect Pod %v to fail at scheduling.", podInfo.Pod.Name)
 	}
-	testCtx.Scheduler.FailureHandler(ctx, fwk, podInfo, framework.NewStatus(framework.Unschedulable).WithError(fitError), nil, time.Now())
+	testCtx.Scheduler.FailureHandler(ctx, schedFramework, podInfo, fwk.NewStatus(fwk.Unschedulable).WithError(fitError), nil, time.Now())
 
 	// Scheduling cycle is incremented from 0 to 1 after NextPod() is called, so
 	// pass a number larger than 1 to move Pod to unschedulablePods.
@@ -439,11 +439,11 @@ func (*firstFailBindPlugin) Name() string {
 	return "firstFailBindPlugin"
 }
 
-func (p *firstFailBindPlugin) Bind(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodename string) *framework.Status {
+func (p *firstFailBindPlugin) Bind(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodename string) *fwk.Status {
 	if p.counter == 0 {
 		// fail in the first Bind call.
 		p.counter++
-		return framework.NewStatus(framework.Error, "firstFailBindPlugin rejects the Pod")
+		return fwk.NewStatus(fwk.Error, "firstFailBindPlugin rejects the Pod")
 	}
 
 	return p.defaultBinderPlugin.Bind(ctx, state, pod, nodename)
@@ -569,8 +569,8 @@ func (p *fakePermitPlugin) Name() string {
 	return fakePermitPluginName
 }
 
-func (p *fakePermitPlugin) Permit(ctx context.Context, state fwk.CycleState, _ *v1.Pod, _ string) (*framework.Status, time.Duration) {
-	return framework.NewStatus(framework.Wait), wait.ForeverTestTimeout
+func (p *fakePermitPlugin) Permit(ctx context.Context, state fwk.CycleState, _ *v1.Pod, _ string) (*fwk.Status, time.Duration) {
+	return fwk.NewStatus(fwk.Wait), wait.ForeverTestTimeout
 }
 
 func (p *fakePermitPlugin) EventsToRegister(_ context.Context) ([]fwk.ClusterEventWithHint, error) {

--- a/test/integration/scheduler/rescheduling_test.go
+++ b/test/integration/scheduler/rescheduling_test.go
@@ -38,7 +38,7 @@ var _ framework.EnqueueExtensions = &ReservePlugin{}
 
 type ReservePlugin struct {
 	name               string
-	statusCode         framework.Code
+	statusCode         fwk.Code
 	numReserveCalled   int
 	numUnreserveCalled int
 }
@@ -47,16 +47,16 @@ func (rp *ReservePlugin) Name() string {
 	return rp.name
 }
 
-func (rp *ReservePlugin) Reserve(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodeName string) *framework.Status {
+func (rp *ReservePlugin) Reserve(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodeName string) *fwk.Status {
 	rp.numReserveCalled += 1
 
-	if rp.statusCode == framework.Error {
-		return framework.NewStatus(framework.Error, "failed to reserve")
+	if rp.statusCode == fwk.Error {
+		return fwk.NewStatus(fwk.Error, "failed to reserve")
 	}
 
-	if rp.statusCode == framework.Unschedulable {
+	if rp.statusCode == fwk.Unschedulable {
 		if rp.numReserveCalled <= 1 {
-			return framework.NewStatus(framework.Unschedulable, "reject to reserve")
+			return fwk.NewStatus(fwk.Unschedulable, "reject to reserve")
 		}
 	}
 
@@ -80,7 +80,7 @@ func (rp *ReservePlugin) EventsToRegister(_ context.Context) ([]fwk.ClusterEvent
 
 type PermitPlugin struct {
 	name            string
-	statusCode      framework.Code
+	statusCode      fwk.Code
 	numPermitCalled int
 }
 
@@ -88,16 +88,16 @@ func (pp *PermitPlugin) Name() string {
 	return pp.name
 }
 
-func (pp *PermitPlugin) Permit(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodeName string) (*framework.Status, time.Duration) {
+func (pp *PermitPlugin) Permit(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodeName string) (*fwk.Status, time.Duration) {
 	pp.numPermitCalled += 1
 
-	if pp.statusCode == framework.Error {
-		return framework.NewStatus(framework.Error, "failed to permit"), 0
+	if pp.statusCode == fwk.Error {
+		return fwk.NewStatus(fwk.Error, "failed to permit"), 0
 	}
 
-	if pp.statusCode == framework.Unschedulable {
+	if pp.statusCode == fwk.Unschedulable {
 		if pp.numPermitCalled <= 1 {
-			return framework.NewStatus(framework.Unschedulable, "reject to permit"), 0
+			return fwk.NewStatus(fwk.Unschedulable, "reject to permit"), 0
 		}
 	}
 
@@ -132,7 +132,7 @@ func TestReScheduling(t *testing.T) {
 		{
 			name: "Rescheduling pod rejected by Permit Plugin",
 			plugins: []framework.Plugin{
-				&PermitPlugin{name: "permit", statusCode: framework.Unschedulable},
+				&PermitPlugin{name: "permit", statusCode: fwk.Unschedulable},
 			},
 			action: func() error {
 				_, err := testutils.CreateNode(testContext.ClientSet, st.MakeNode().Name("fake-node").Obj())
@@ -143,7 +143,7 @@ func TestReScheduling(t *testing.T) {
 		{
 			name: "Rescheduling pod rejected by Permit Plugin with unrelated event",
 			plugins: []framework.Plugin{
-				&PermitPlugin{name: "permit", statusCode: framework.Unschedulable},
+				&PermitPlugin{name: "permit", statusCode: fwk.Unschedulable},
 			},
 			action: func() error {
 				_, err := testutils.CreatePausePod(testContext.ClientSet,
@@ -155,7 +155,7 @@ func TestReScheduling(t *testing.T) {
 		{
 			name: "Rescheduling pod failed by Permit Plugin",
 			plugins: []framework.Plugin{
-				&PermitPlugin{name: "permit", statusCode: framework.Error},
+				&PermitPlugin{name: "permit", statusCode: fwk.Error},
 			},
 			action: func() error {
 				_, err := testutils.CreateNode(testContext.ClientSet, st.MakeNode().Name("fake-node").Obj())
@@ -167,7 +167,7 @@ func TestReScheduling(t *testing.T) {
 		{
 			name: "Rescheduling pod rejected by Reserve Plugin",
 			plugins: []framework.Plugin{
-				&ReservePlugin{name: "reserve", statusCode: framework.Unschedulable},
+				&ReservePlugin{name: "reserve", statusCode: fwk.Unschedulable},
 			},
 			action: func() error {
 				_, err := testutils.CreateNode(testContext.ClientSet, st.MakeNode().Name("fake-node").Obj())
@@ -178,7 +178,7 @@ func TestReScheduling(t *testing.T) {
 		{
 			name: "Rescheduling pod rejected by Reserve Plugin with unrelated event",
 			plugins: []framework.Plugin{
-				&ReservePlugin{name: "reserve", statusCode: framework.Unschedulable},
+				&ReservePlugin{name: "reserve", statusCode: fwk.Unschedulable},
 			},
 			action: func() error {
 				_, err := testutils.CreatePausePod(testContext.ClientSet,
@@ -190,7 +190,7 @@ func TestReScheduling(t *testing.T) {
 		{
 			name: "Rescheduling pod failed by Reserve Plugin",
 			plugins: []framework.Plugin{
-				&ReservePlugin{name: "reserve", statusCode: framework.Error},
+				&ReservePlugin{name: "reserve", statusCode: fwk.Error},
 			},
 			action: func() error {
 				_, err := testutils.CreateNode(testContext.ClientSet, st.MakeNode().Name("fake-node").Obj())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
This is part of a larger change that moves interfaces and type and func defiinitions to the staging repo "k8s.io/kube-scheduler", to allow users for importing scheduler framework interfaces without importing k/k repo.
This PR moves structs Code and Status from k/k to the staging repo

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #89930

#### Special notes for your reviewer:
Moving this in a separate PR, since the PR moving everything is just too big to be reviewed

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Types: Code and Status moved from pkg/scheduler/framework to staging repo.
Users should update import path for these types from "k8s.io/kubernetes/pkg/scheduler/framework" to "k8s.io/kube-scheduler/framework"
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
