### PR TITLE
Remove unecessary comment since podResizeMutex no longer exist.

### DIFF
--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -2427,8 +2427,7 @@ func TestPodResourceAllocationReset(t *testing.T) {
 	defer testKubelet.Cleanup()
 	kubelet := testKubelet.kubelet
 
-	// fakePodWorkers trigger syncPodFn synchronously on update, but entering
-	// kubelet.SyncPod while holding the podResizeMutex can lead to deadlock.
+	// fakePodWorkers trigger syncPodFn synchronously on update
 	kubelet.podWorkers.(*fakePodWorkers).syncPodFn =
 		func(_ context.Context, _ kubetypes.SyncPodType, _, _ *v1.Pod, _ *kubecontainer.PodStatus) (bool, error) {
 			return false, nil

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -2427,7 +2427,8 @@ func TestPodResourceAllocationReset(t *testing.T) {
 	defer testKubelet.Cleanup()
 	kubelet := testKubelet.kubelet
 
-	// fakePodWorkers trigger syncPodFn synchronously on update
+	// fakePodWorkers triggers syncPodFn synchronously on update. We overwrite it here to
+	// avoid calling kubelet.SyncPod, which performs resize resource allocation.
 	kubelet.podWorkers.(*fakePodWorkers).syncPodFn =
 		func(_ context.Context, _ kubetypes.SyncPodType, _, _ *v1.Pod, _ *kubecontainer.PodStatus) (bool, error) {
 			return false, nil


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

With https://github.com/kubernetes/kubernetes/pull/131801 , podResizeMutex is removed.

This commit cleanup an unnecessary comment in one of test code.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```