### PR TITLE
Deprecate utilpointers and use ptr.To() in pkg/apis/admissionregistration

### DIFF
--- a/pkg/apis/admissionregistration/v1/defaults.go
+++ b/pkg/apis/admissionregistration/v1/defaults.go
@@ -20,7 +20,7 @@ import (
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func addDefaultingFuncs(scheme *runtime.Scheme) error {
@@ -90,7 +90,7 @@ func SetDefaults_Rule(obj *admissionregistrationv1.Rule) {
 // SetDefaults_ServiceReference sets defaults for Webhook's ServiceReference
 func SetDefaults_ServiceReference(obj *admissionregistrationv1.ServiceReference) {
 	if obj.Port == nil {
-		obj.Port = utilpointer.Int32(443)
+		obj.Port = ptr.To(int32(443))
 	}
 }
 

--- a/pkg/apis/admissionregistration/v1/defaults_test.go
+++ b/pkg/apis/admissionregistration/v1/defaults_test.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	_ "k8s.io/kubernetes/pkg/apis/admissionregistration/install"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestDefaultAdmissionWebhook(t *testing.T) {
@@ -107,7 +107,7 @@ func TestDefaultAdmissionWebhook(t *testing.T) {
 				Webhooks: []v1.MutatingWebhook{{
 					ClientConfig: v1.WebhookClientConfig{
 						Service: &v1.ServiceReference{
-							Port: utilpointer.Int32(443), // defaulted
+							Port: ptr.To(int32(443)), // defaulted
 						},
 					},
 					FailurePolicy:      &fail,

--- a/pkg/apis/admissionregistration/v1beta1/defaults.go
+++ b/pkg/apis/admissionregistration/v1beta1/defaults.go
@@ -20,7 +20,7 @@ import (
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func addDefaultingFuncs(scheme *runtime.Scheme) error {
@@ -124,6 +124,6 @@ func SetDefaults_MutatingWebhook(obj *admissionregistrationv1beta1.MutatingWebho
 // SetDefaults_ServiceReference sets defaults for Webhook's ServiceReference
 func SetDefaults_ServiceReference(obj *admissionregistrationv1beta1.ServiceReference) {
 	if obj.Port == nil {
-		obj.Port = utilpointer.Int32(443)
+		obj.Port = ptr.To(int32(443))
 	}
 }

--- a/pkg/apis/admissionregistration/v1beta1/defaults_test.go
+++ b/pkg/apis/admissionregistration/v1beta1/defaults_test.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	_ "k8s.io/kubernetes/pkg/apis/admissionregistration/install"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestDefaultAdmissionWebhook(t *testing.T) {
@@ -114,7 +114,7 @@ func TestDefaultAdmissionWebhook(t *testing.T) {
 				Webhooks: []v1beta1.MutatingWebhook{{
 					ClientConfig: v1beta1.WebhookClientConfig{
 						Service: &v1beta1.ServiceReference{
-							Port: utilpointer.Int32(443), // defaulted
+							Port: ptr.To(int32(443)), // defaulted
 						},
 					},
 					FailurePolicy:           &ignore,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Deprecate the use of utilpointers in pkg/apis/admissionregistration and use ptr.To() instead.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #132086

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
