### PR TITLE
Only set pod allocation if admission succeeds

### DIFF
--- a/pkg/kubelet/allocation/allocation_manager.go
+++ b/pkg/kubelet/allocation/allocation_manager.go
@@ -243,7 +243,7 @@ func (m *manager) AddPod(activePods []*v1.Pod, pod *v1.Pod) (bool, string, strin
 	allocatedPods := m.getAllocatedPods(activePods)
 	ok, reason, message := m.canAdmitPod(allocatedPods, pod)
 
-	if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {
+	if ok && utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {
 		// Checkpoint the resource values at which the Pod has been admitted or resized.
 		if err := m.SetAllocatedResources(pod); err != nil {
 			// TODO(vinaykul,InPlacePodVerticalScaling): Can we recover from this in some way? Investigate


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fix a "regression" from https://github.com/kubernetes/kubernetes/pull/131801 - allocation should be skipped if admission fails.

In practice, this probably doesn't matter. If the allocation is set on a rejected pod, it will never be used, and will be cleaned up by `RemovePod` when the Failed pod is eventually deleted.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/sig node
/priority important-soon
/assign @natasha41575 