### PR TITLE
Update PR template with more guidance around issue links

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -27,13 +27,23 @@ Optionally add one or more of the following kinds if applicable:
 
 #### What this PR does / why we need it:
 
-#### Which issue(s) this PR fixes:
+#### Which issue(s) this PR is related to:
 <!--
-*Automatically closes linked issue when PR is merged.
-Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
+Please link relevant issues to help with tracking.
+
+To automatically close the linked issue(s) when this PR is merged,
+add the word "Fixes" before the issue number or link.
+Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.
+
+Reference KEPs when applicable in addition to specific issues.
+
+Examples:
+Fixes #<issue number>
+<issue link> (issue in a different repository)
+KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>
+
+If there is no associated issue, then write "N/A".
 -->
-Fixes #
 
 #### Special notes for your reviewer:
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Update the comments around issue links in the PR template, in an effort to encourage PR authors to add issue links to make tracking easier for the Release Team.

See related [discussion here](https://github.com/kubernetes/enhancements/pull/5293#issuecomment-2864025318)

#### Which issue(s) this PR fixes:

Related to https://github.com/kubernetes/enhancements/issues/5124

#### Special notes for your reviewer:

N/A

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
