### PR TITLE
pkg/appis/apps: use utils/ptr package instead of utils/pointer

### DIFF
--- a/pkg/apis/apps/v1/conversion_test.go
+++ b/pkg/apis/apps/v1/conversion_test.go
@@ -27,11 +27,11 @@ import (
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/apis/apps"
 	api "k8s.io/kubernetes/pkg/apis/core"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestV12StatefulSetSpecConversion(t *testing.T) {
-	replicas := utilpointer.Int32(2)
+	replicas := ptr.To(int32(2))
 	selector := &metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}}
 	appsv1Template := v1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{Name: "foo"},
@@ -177,7 +177,7 @@ func TestV1StatefulSetStatusConversion(t *testing.T) {
 }
 
 func TestV1StatefulSetUpdateStrategyConversion(t *testing.T) {
-	partition := utilpointer.Int32(2)
+	partition := ptr.To(int32(2))
 	appsv1rollingUpdate := new(appsv1.RollingUpdateStatefulSetStrategy)
 	appsv1rollingUpdate.Partition = partition
 	appsrollingUpdate := new(apps.RollingUpdateStatefulSetStrategy)
@@ -259,7 +259,7 @@ func TestV1RollingUpdateDaemonSetConversion(t *testing.T) {
 }
 
 func TestV1DeploymentConversion(t *testing.T) {
-	replica := utilpointer.Int32(2)
+	replica := ptr.To(int32(2))
 	rollbackTo := new(apps.RollbackConfig)
 	rollbackTo.Revision = int64(2)
 	testcases := map[string]struct {
@@ -338,9 +338,9 @@ func TestV1DeploymentConversion(t *testing.T) {
 }
 
 func TestV1DeploymentSpecConversion(t *testing.T) {
-	replica := utilpointer.Int32(2)
-	revisionHistoryLimit := utilpointer.Int32(2)
-	progressDeadlineSeconds := utilpointer.Int32(2)
+	replica := ptr.To(int32(2))
+	revisionHistoryLimit := ptr.To(int32(2))
+	progressDeadlineSeconds := ptr.To(int32(2))
 
 	testcases := map[string]struct {
 		deploymentSpec1 *apps.DeploymentSpec

--- a/pkg/apis/apps/v1beta2/conversion_test.go
+++ b/pkg/apis/apps/v1beta2/conversion_test.go
@@ -26,14 +26,14 @@ import (
 	"k8s.io/kubernetes/pkg/apis/apps"
 	"k8s.io/kubernetes/pkg/apis/autoscaling"
 	api "k8s.io/kubernetes/pkg/apis/core"
+	"k8s.io/utils/ptr"
 
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilpointer "k8s.io/utils/pointer"
 )
 
 func TestV1beta2StatefulSetSpecConversion(t *testing.T) {
-	replicas := utilpointer.Int32(2)
+	replicas := ptr.To(int32(2))
 	selector := &metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}}
 	v1beta2Template := v1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{Name: "foo"},
@@ -104,7 +104,7 @@ func TestV1beta2StatefulSetSpecConversion(t *testing.T) {
 }
 
 func TestV1beta2StatefulSetUpdateStrategyConversion(t *testing.T) {
-	partition := utilpointer.Int32(2)
+	partition := ptr.To(int32(2))
 	v1beta2rollingUpdate := new(v1beta2.RollingUpdateStatefulSetStrategy)
 	v1beta2rollingUpdate.Partition = partition
 	appsrollingUpdate := new(apps.RollingUpdateStatefulSetStrategy)
@@ -261,7 +261,7 @@ func TestV1beta2StatefulSetStatusConversion(t *testing.T) {
 }
 
 func TestV1beta2DeploymentConversion(t *testing.T) {
-	replica := utilpointer.Int32(2)
+	replica := ptr.To(int32(2))
 	rollbackTo := new(apps.RollbackConfig)
 	rollbackTo.Revision = int64(2)
 	testcases := map[string]struct {
@@ -391,9 +391,9 @@ func TestV1beta2ScaleStatusConversion(t *testing.T) {
 }
 
 func TestV1beta2DeploymentSpecConversion(t *testing.T) {
-	replica := utilpointer.Int32(2)
-	revisionHistoryLimit := utilpointer.Int32(2)
-	progressDeadlineSeconds := utilpointer.Int32(2)
+	replica := ptr.To(int32(2))
+	revisionHistoryLimit := ptr.To(int32(2))
+	progressDeadlineSeconds := ptr.To(int32(2))
 
 	testcases := map[string]struct {
 		deploymentSpec1 *apps.DeploymentSpec


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

The new k8s.io/utils/ptr package provides generic wrapper functions, which can be used instead of type-specific pointer wrapper functions. This replaces the latter with the former, and migrates other uses of the deprecated pointer package to ptr in affacted files.

See kubernetes/utils#283 for details.

It will also reduce the friction with linter in the future

also releated:
- https://github.com/kubernetes/kubernetes/issues/132086

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
