### PR TITLE
KEP-3335: drop StatefulSetStartOrdinal feature gate

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -770,11 +770,6 @@ const (
 	// Enables policies controlling deletion of PVCs created by a StatefulSet.
 	StatefulSetAutoDeletePVC featuregate.Feature = "StatefulSetAutoDeletePVC"
 
-	// owner: @psch
-	//
-	// Enables a StatefulSet to start from an arbitrary non zero ordinal
-	StatefulSetStartOrdinal featuregate.Feature = "StatefulSetStartOrdinal"
-
 	// owner: @ahutsunshine
 	//
 	// Allows namespace indexer for namespace scope resources in apiserver cache to accelerate list operations.
@@ -1777,12 +1772,6 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 		{Version: version.MustParse("1.23"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("1.27"), Default: true, PreRelease: featuregate.Beta},
 		{Version: version.MustParse("1.32"), Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // GA in 1.32, remove in 1.35
-	},
-
-	StatefulSetStartOrdinal: {
-		{Version: version.MustParse("1.26"), Default: false, PreRelease: featuregate.Alpha},
-		{Version: version.MustParse("1.27"), Default: true, PreRelease: featuregate.Beta},
-		{Version: version.MustParse("1.31"), Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // GA in 1.31, remove in 1.33
 	},
 
 	StorageCapacityScoring: {

--- a/pkg/registry/apps/statefulset/strategy.go
+++ b/pkg/registry/apps/statefulset/strategy.go
@@ -128,12 +128,6 @@ func dropStatefulSetDisabledFields(newSS *apps.StatefulSet, oldSS *apps.Stateful
 			newSS.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable = nil
 		}
 	}
-	if !utilfeature.DefaultFeatureGate.Enabled(features.StatefulSetStartOrdinal) {
-		if oldSS == nil || oldSS.Spec.Ordinals == nil {
-			// Reset Spec.Ordinals to the default value (nil).
-			newSS.Spec.Ordinals = nil
-		}
-	}
 }
 
 // Validate validates a new StatefulSet.

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -1449,20 +1449,6 @@
     lockToDefault: true
     preRelease: GA
     version: "1.32"
-- name: StatefulSetStartOrdinal
-  versionedSpecs:
-  - default: false
-    lockToDefault: false
-    preRelease: Alpha
-    version: "1.26"
-  - default: true
-    lockToDefault: false
-    preRelease: Beta
-    version: "1.27"
-  - default: true
-    lockToDefault: true
-    preRelease: GA
-    version: "1.31"
 - name: StorageCapacityScoring
   versionedSpecs:
   - default: false

--- a/test/e2e/feature/feature.go
+++ b/test/e2e/feature/feature.go
@@ -448,9 +448,6 @@ var (
 	PodIndexLabel = framework.WithFeature(framework.ValidFeatures.Add("PodIndexLabel"))
 
 	// TODO: document the feature (owning SIG, when to use this feature for a test)
-	StatefulSetStartOrdinal = framework.WithFeature(framework.ValidFeatures.Add("StatefulSetStartOrdinal"))
-
-	// TODO: document the feature (owning SIG, when to use this feature for a test)
 	StatefulUpgrade = framework.WithFeature(framework.ValidFeatures.Add("StatefulUpgrade"))
 
 	// TODO: document the feature (owning SIG, when to use this feature for a test)


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/sig apps

#### What this PR does / why we need it:
This cleans up the StatefulSetStartOrdinal feature gate, which was promoted to GA [back in 1.31](https://github.com/kubernetes/kubernetes/pull/125374).

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
/assign @janetkuo @pwschuurman 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/3335
```
