### PR TITLE
fix the noderesourcefit plugin's nil pointer by validating RequestedToCapacityRatio config

### DIFF
--- a/pkg/scheduler/apis/config/validation/validation_pluginargs.go
+++ b/pkg/scheduler/apis/config/validation/validation_pluginargs.go
@@ -317,9 +317,17 @@ func ValidateNodeResourcesFitArgs(path *field.Path, args *config.NodeResourcesFi
 			allErrs = append(allErrs, field.NotSupported(strategyPath.Child("type"), args.ScoringStrategy.Type, sets.List(supportedScoringStrategyTypes)))
 		}
 		allErrs = append(allErrs, validateResources(args.ScoringStrategy.Resources, strategyPath.Child("resources"))...)
-		if args.ScoringStrategy.RequestedToCapacityRatio != nil {
-			allErrs = append(allErrs, validateFunctionShape(args.ScoringStrategy.RequestedToCapacityRatio.Shape, strategyPath.Child("shape"))...)
+		if args.ScoringStrategy.Type == config.RequestedToCapacityRatio {
+			if args.ScoringStrategy.RequestedToCapacityRatio == nil {
+				allErrs = append(allErrs, field.Required(strategyPath.Child("requestedToCapacityRatio"), "must be specified when type is RequestedToCapacityRatio"))
+			} else {
+				allErrs = append(allErrs, validateFunctionShape(args.ScoringStrategy.RequestedToCapacityRatio.Shape, strategyPath.Child("requestedToCapacityRatio").Child("shape"))...)
+			}
+		} else if args.ScoringStrategy.RequestedToCapacityRatio != nil {
+			allErrs = append(allErrs, field.Forbidden(strategyPath.Child("requestedToCapacityRatio"), "must be nil when type is not RequestedToCapacityRatio"))
 		}
+	} else {
+		allErrs = append(allErrs, field.Required(strategyPath, "ScoringStrategy field is required"))
 	}
 
 	if len(allErrs) == 0 {

--- a/pkg/scheduler/apis/config/validation/validation_pluginargs_test.go
+++ b/pkg/scheduler/apis/config/validation/validation_pluginargs_test.go
@@ -754,12 +754,28 @@ func TestValidateFitArgs(t *testing.T) {
 			},
 			expect: `Unsupported value: "Invalid"`,
 		},
+		{
+			name: "ScoringStrategy: requestedToCapacityRatio field is missing",
+			args: config.NodeResourcesFitArgs{
+				ScoringStrategy: &config.ScoringStrategy{
+					Type: config.RequestedToCapacityRatio,
+				},
+			},
+			expect: "must be specified when type is RequestedToCapacityRatio",
+		},
 	}
 
 	for _, test := range argsTest {
 		t.Run(test.name, func(t *testing.T) {
-			if err := ValidateNodeResourcesFitArgs(nil, &test.args); err != nil && (!strings.Contains(err.Error(), test.expect)) {
-				t.Errorf("case[%v]: error details do not include %v", test.name, err)
+			err := ValidateNodeResourcesFitArgs(nil, &test.args)
+			if err != nil {
+				if test.expect == "" {
+					t.Errorf("case[%v]: unexpected validation error %v", test.name, err)
+				} else if !strings.Contains(err.Error(), test.expect) {
+					t.Errorf("case[%v]: error details do not include %v", test.name, err)
+				}
+			} else if test.expect != "" {
+				t.Errorf("case[%v]: expected validation error", test.name)
 			}
 		})
 	}
@@ -974,7 +990,7 @@ func TestValidateRequestedToCapacityRatioScoringStrategy(t *testing.T) {
 			wantErrs: field.ErrorList{
 				{
 					Type:  field.ErrorTypeRequired,
-					Field: "scoringStrategy.shape",
+					Field: "scoringStrategy.requestedToCapacityRatio.shape",
 				},
 			},
 		},
@@ -1026,7 +1042,7 @@ func TestValidateRequestedToCapacityRatioScoringStrategy(t *testing.T) {
 			wantErrs: field.ErrorList{
 				{
 					Type:  field.ErrorTypeInvalid,
-					Field: "scoringStrategy.shape[0].utilization",
+					Field: "scoringStrategy.requestedToCapacityRatio.shape[0].utilization",
 				},
 			},
 		},
@@ -1041,7 +1057,7 @@ func TestValidateRequestedToCapacityRatioScoringStrategy(t *testing.T) {
 			wantErrs: field.ErrorList{
 				{
 					Type:  field.ErrorTypeInvalid,
-					Field: "scoringStrategy.shape[0].utilization",
+					Field: "scoringStrategy.requestedToCapacityRatio.shape[0].utilization",
 				},
 			},
 		},
@@ -1060,7 +1076,7 @@ func TestValidateRequestedToCapacityRatioScoringStrategy(t *testing.T) {
 			wantErrs: field.ErrorList{
 				{
 					Type:  field.ErrorTypeInvalid,
-					Field: "scoringStrategy.shape[1].utilization",
+					Field: "scoringStrategy.requestedToCapacityRatio.shape[1].utilization",
 				},
 			},
 		},
@@ -1101,7 +1117,7 @@ func TestValidateRequestedToCapacityRatioScoringStrategy(t *testing.T) {
 			wantErrs: field.ErrorList{
 				{
 					Type:  field.ErrorTypeInvalid,
-					Field: "scoringStrategy.shape[2].utilization",
+					Field: "scoringStrategy.requestedToCapacityRatio.shape[2].utilization",
 				},
 			},
 		},
@@ -1116,7 +1132,7 @@ func TestValidateRequestedToCapacityRatioScoringStrategy(t *testing.T) {
 			wantErrs: field.ErrorList{
 				{
 					Type:  field.ErrorTypeInvalid,
-					Field: "scoringStrategy.shape[0].score",
+					Field: "scoringStrategy.requestedToCapacityRatio.shape[0].score",
 				},
 			},
 		},
@@ -1131,7 +1147,7 @@ func TestValidateRequestedToCapacityRatioScoringStrategy(t *testing.T) {
 			wantErrs: field.ErrorList{
 				{
 					Type:  field.ErrorTypeInvalid,
-					Field: "scoringStrategy.shape[0].score",
+					Field: "scoringStrategy.requestedToCapacityRatio.shape[0].score",
 				},
 			},
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR adds validation for the `RequestedToCapacityRatio` field in the NodeResourcesFitArgs configuration. Currently, when the scoring strategy type is set to `RequestedToCapacityRatio` but the `RequestedToCapacityRatio` field is not specified, it can lead to a nil pointer dereference error.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/133346

#### Special notes for your reviewer:

The changes include:
- Adding a check for `RequestedToCapacityRatio` field when the scoring strategy type is `RequestedToCapacityRatio`
- Providing a clear error message when the field is missing
- Preventing potential nil pointer dereference errors

My Tests:

If requestedToCapacityRatio not specified, the err msg as shown:
```shell
E0605 20:43:55.061646    7252 run.go:72] "command failed" err="initializing profiles: creating profile for scheduler name default-scheduler: initializing plugin \"NodeResourcesFit\": scoringStrategy.requestedToCapacityRatio: Required value: must be specified when type is RequestedToCapacityRatio"

```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

Fixed a potential nil pointer dereference in the scheduler's NodeResourcesFitArgs validation when using RequestedToCapacityRatio scoring strategy
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
