### PR TITLE
hack: fix KUBE_RACE in benchmark-dockerized.sh

### DIFF
--- a/hack/jenkins/benchmark-dockerized.sh
+++ b/hack/jenkins/benchmark-dockerized.sh
@@ -49,8 +49,9 @@ if [ -n "${KUBE_HACK_TOOLS_GOTOOLCHAIN:-}" ]; then
 fi
 GOTOOLCHAIN="${hack_tools_gotoolchain}" go -C "${KUBE_ROOT}/hack/tools" install github.com/cespare/prettybench
 
-# Disable the Go race detector.
-export KUBE_RACE=" "
+# Disable the Go race detector by explicitly setting it to the empty string (= no argument).
+# This is also the default, but let's be explicit in case that this changes later.
+export KUBE_RACE=""
 # Disable coverage report
 export KUBE_COVER="n"
 export ARTIFACTS=${ARTIFACTS:-"${WORKSPACE}/artifacts"}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:

This fixes the following issue in ci-benchmark-scheduler-perf-master:

    malformed import path " ": invalid char ' '

    FAIL	  [setup failed]

Setting the non-empty string with just a space was broken, the right way to disable the race detector is with an empty KUBE_RACE variable. This worked before when test-integration.sh unconditionally overwrote the KUBE_RACE variable and stopped working when 6cb1488 started to keep whatever was set by the caller.

This then caused an empty string to be passed as additional parameter to "go test".

#### Which issue(s) this PR fixes:

Related-to https://github.com/kubernetes/kubernetes/issues/132089 (kept open for verification).

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
