### PR TITLE
Forbid github.com/pkg/errors in k/k

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,6 @@ require (
 	github.com/onsi/gomega v1.35.1
 	github.com/opencontainers/cgroups v0.0.1
 	github.com/opencontainers/selinux v1.11.1
-	github.com/pkg/errors v0.9.1
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/prometheus/client_golang v1.22.0
 	github.com/prometheus/client_model v0.6.1
@@ -188,6 +187,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/opencontainers/runtime-spec v1.2.0 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pquerna/cachecontrol v0.1.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -254,13 +254,6 @@ linters:
           deny:
             - pkg: "github.com/google/go-cmp/cmp"
               desc: "cmp is allowed only in test files"
-        pkg-errors:
-          files:
-            - $all
-            - "!**/cmd/kubeadm/**"
-          deny:
-            - pkg: "github.com/pkg/errors"
-              desc: "pkg/errors is allowed only in cmd/kubeadm"
     forbidigo:
       analyze-types: true
       forbid:

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -268,13 +268,6 @@ linters:
           deny:
             - pkg: "github.com/google/go-cmp/cmp"
               desc: "cmp is allowed only in test files"
-        pkg-errors:
-          files:
-            - $all
-            - "!**/cmd/kubeadm/**"
-          deny:
-            - pkg: "github.com/pkg/errors"
-              desc: "pkg/errors is allowed only in cmd/kubeadm"
     forbidigo:
       analyze-types: true
       forbid:

--- a/hack/golangci.yaml.in
+++ b/hack/golangci.yaml.in
@@ -198,13 +198,6 @@ linters:
           deny:
             - pkg: "github.com/google/go-cmp/cmp"
               desc: "cmp is allowed only in test files"
-        pkg-errors:
-          files:
-            - $all
-            - "!**/cmd/kubeadm/**"
-          deny:
-            - pkg: "github.com/pkg/errors"
-              desc: "pkg/errors is allowed only in cmd/kubeadm"
     forbidigo:
       analyze-types: true
       forbid:

--- a/hack/unwanted-dependencies.json
+++ b/hack/unwanted-dependencies.json
@@ -227,7 +227,6 @@
       "github.com/pkg/errors": [
         "github.com/Microsoft/hnslib",
         "github.com/google/cadvisor",
-        "k8s.io/kubernetes",
         "sigs.k8s.io/kustomize/api",
         "sigs.k8s.io/kustomize/kustomize/v5"
       ],


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

kubeadm has replaced pkg/errors with an internal implementation, which means that pkg/errors can be marked as unwanted (once a final straggler is replaced).

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
