### PR TITLE
KEP-3015: PreferSameTrafficDistribution to Beta

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -1629,6 +1629,7 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 
 	PreferSameTrafficDistribution: {
 		{Version: version.MustParse("1.33"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.34"), Default: true, PreRelease: featuregate.Beta},
 	},
 
 	ProcMountType: {

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -1115,6 +1115,10 @@
     lockToDefault: false
     preRelease: Alpha
     version: "1.33"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.34"
 - name: ProcMountType
   versionedSpecs:
   - default: false


### PR DESCRIPTION
Update `PreferSameTrafficDistribution` feature gate to beta.

Not doing any code/docs changes at this point; when we go to GA I'll update the docs to more clearly deprecate `PreferClose` in favor of `PreferSameZone`.

/kind feature
/sig network
/triage accepted
/priority important-soon

/hold
for enhancement update merge (https://github.com/kubernetes/enhancements/pull/5376)

#### Does this PR introduce a user-facing change?
```release-note
The PreferSameTrafficDistribution feature gate is now enabled by default,
enabling the `PreferSameNode` traffic distribution value for Services.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/3015
```
