### PR TITLE
Use named params and structured tags in declarative validation

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/ordering/structs/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/ordering/structs/doc.go
@@ -26,7 +26,7 @@ import "k8s.io/code-generator/cmd/validation-gen/testscheme"
 var localSchemeBuilder = testscheme.New()
 
 type Tother struct {
-	// +k8s:validateFalse={"flags":[], "msg":"Tother, no flags"}
+	// +k8s:validateFalse="Tother, no flags"
 	OS string `json:"os"`
 }
 
@@ -43,80 +43,80 @@ type T00 struct {
 	PT       *Tother `json:"pt"`
 }
 
-// +k8s:validateFalse={"flags":[], "msg":"T01, no flags"}
+// +k8s:validateFalse="T01, no flags"
 type T01 struct {
 	TypeMeta int
-	// +k8s:validateFalse={"flags":[], "msg":"T01.S, no flags"}
+	// +k8s:validateFalse="T01.S, no flags"
 	S string `json:"s"`
-	// +k8s:validateFalse={"flags":[], "msg":"T01.PS, no flags"}
+	// +k8s:validateFalse="T01.PS, no flags"
 	PS *string `json:"ps"`
-	// +k8s:validateFalse={"flags":[], "msg":"T01.T, no flags"}
+	// +k8s:validateFalse="T01.T, no flags"
 	T Tother `json:"t"`
-	// +k8s:validateFalse={"flags":[], "msg":"T01.PT, no flags"}
+	// +k8s:validateFalse="T01.PT, no flags"
 	PT *Tother `json:"pt"`
 }
 
-// +k8s:validateFalse={"flags":["ShortCircuit"], "msg":"T02, ShortCircuit"}
+// +k8s:validateFalse(flags: "ShortCircuit")="T02, ShortCircuit"
 type T02 struct {
 	TypeMeta int
-	// +k8s:validateFalse={"flags":["ShortCircuit"], "msg":"T02.S, ShortCircuit"}
+	// +k8s:validateFalse(flags: "ShortCircuit")="T02.S, ShortCircuit"
 	S string `json:"s"`
-	// +k8s:validateFalse={"flags":["ShortCircuit"], "msg":"T02.PS, ShortCircuit"}
+	// +k8s:validateFalse(flags: "ShortCircuit")="T02.PS, ShortCircuit"
 	PS *string `json:"ps"`
-	// +k8s:validateFalse={"flags":["ShortCircuit"], "msg":"T02.T, ShortCircuit"}
+	// +k8s:validateFalse(flags: "ShortCircuit")="T02.T, ShortCircuit"
 	T Tother `json:"t"`
-	// +k8s:validateFalse={"flags":["ShortCircuit"], "msg":"T02.PT, ShortCircuit"}
+	// +k8s:validateFalse(flags: "ShortCircuit")="T02.PT, ShortCircuit"
 	PT *Tother `json:"pt"`
 }
 
-// +k8s:validateFalse={"flags":[], "msg":"T03, no flags"}
-// +k8s:validateFalse={"flags":["ShortCircuit"], "msg":"T03, ShortCircuit"}
+// +k8s:validateFalse="T03, no flags"
+// +k8s:validateFalse(flags: "ShortCircuit")="T03, ShortCircuit"
 type T03 struct {
 	TypeMeta int
-	// +k8s:validateFalse={"flags":[], "msg":"T03.S, no flags"}
-	// +k8s:validateFalse={"flags":["ShortCircuit"], "msg":"T03.S, ShortCircuit"}
+	// +k8s:validateFalse="T03.S, no flags"
+	// +k8s:validateFalse(flags: "ShortCircuit")="T03.S, ShortCircuit"
 	S string `json:"s"`
-	// +k8s:validateFalse={"flags":[], "msg":"T03.PS, no flags"}
-	// +k8s:validateFalse={"flags":["ShortCircuit"], "msg":"T03.PS, ShortCircuit"}
+	// +k8s:validateFalse="T03.PS, no flags"
+	// +k8s:validateFalse(flags: "ShortCircuit")="T03.PS, ShortCircuit"
 	PS *string `json:"ps"`
-	// +k8s:validateFalse={"flags":[], "msg":"T03.T, no flags"}
-	// +k8s:validateFalse={"flags":["ShortCircuit"], "msg":"T03.T, ShortCircuit"}
+	// +k8s:validateFalse="T03.T, no flags"
+	// +k8s:validateFalse(flags: "ShortCircuit")="T03.T, ShortCircuit"
 	T Tother `json:"t"`
-	// +k8s:validateFalse={"flags":[], "msg":"T03.PT, no flags"}
-	// +k8s:validateFalse={"flags":["ShortCircuit"], "msg":"T03.PT, ShortCircuit"}
+	// +k8s:validateFalse="T03.PT, no flags"
+	// +k8s:validateFalse(flags: "ShortCircuit")="T03.PT, ShortCircuit"
 	PT *Tother `json:"pt"`
 }
 
 // Note: these are intentionally in the wrong final order.
-// +k8s:validateFalse={"flags":[], "msg":"TMultiple, no flags 1"}
-// +k8s:validateFalse={"flags":["ShortCircuit"], "msg":"TMultiple, ShortCircuit 1"}
+// +k8s:validateFalse="TMultiple, no flags 1"
+// +k8s:validateFalse(flags: "ShortCircuit")="TMultiple, ShortCircuit 1"
 // +k8s:validateFalse="T0, string payload"
-// +k8s:validateFalse={"flags":[], "msg":"TMultiple, no flags 2"}
-// +k8s:validateFalse={"flags":["ShortCircuit"], "msg":"TMultiple, ShortCircuit 2"}
+// +k8s:validateFalse="TMultiple, no flags 2"
+// +k8s:validateFalse(flags: "ShortCircuit")="TMultiple, ShortCircuit 2"
 type TMultiple struct {
 	TypeMeta int
-	// +k8s:validateFalse={"flags":[], "msg":"TMultiple.S, no flags 1"}
-	// +k8s:validateFalse={"flags":["ShortCircuit"], "msg":"TMultiple.S, ShortCircuit 1"}
+	// +k8s:validateFalse="TMultiple.S, no flags 1"
+	// +k8s:validateFalse(flags: "ShortCircuit")="TMultiple.S, ShortCircuit 1"
 	// +k8s:validateFalse="T0, string payload"
-	// +k8s:validateFalse={"flags":[], "msg":"TMultiple.S, no flags 2"}
-	// +k8s:validateFalse={"flags":["ShortCircuit"], "msg":"TMultiple.S, ShortCircuit 2"}
+	// +k8s:validateFalse="TMultiple.S, no flags 2"
+	// +k8s:validateFalse(flags: "ShortCircuit")="TMultiple.S, ShortCircuit 2"
 	S string `json:"s"`
-	// +k8s:validateFalse={"flags":[], "msg":"TMultiple.PS, no flags 1"}
-	// +k8s:validateFalse={"flags":["ShortCircuit"], "msg":"TMultiple.PS, ShortCircuit 1"}
+	// +k8s:validateFalse="TMultiple.PS, no flags 1"
+	// +k8s:validateFalse(flags: "ShortCircuit")="TMultiple.PS, ShortCircuit 1"
 	// +k8s:validateFalse="T0, string payload"
-	// +k8s:validateFalse={"flags":[], "msg":"TMultiple.PS, no flags 2"}
-	// +k8s:validateFalse={"flags":["ShortCircuit"], "msg":"TMultiple.PS, ShortCircuit 2"}
+	// +k8s:validateFalse="TMultiple.PS, no flags 2"
+	// +k8s:validateFalse(flags: "ShortCircuit")="TMultiple.PS, ShortCircuit 2"
 	PS *string `json:"ps"`
-	// +k8s:validateFalse={"flags":[], "msg":"TMultiple.T, no flags 1"}
-	// +k8s:validateFalse={"flags":["ShortCircuit"], "msg":"TMultiple.T, ShortCircuit 1"}
+	// +k8s:validateFalse="TMultiple.T, no flags 1"
+	// +k8s:validateFalse(flags: "ShortCircuit")="TMultiple.T, ShortCircuit 1"
 	// +k8s:validateFalse="T0, string payload"
-	// +k8s:validateFalse={"flags":[], "msg":"TMultiple.T, no flags 2"}
-	// +k8s:validateFalse={"flags":["ShortCircuit"], "msg":"TMultiple.T, ShortCircuit 2"}
+	// +k8s:validateFalse="TMultiple.T, no flags 2"
+	// +k8s:validateFalse(flags: "ShortCircuit")="TMultiple.T, ShortCircuit 2"
 	T Tother `json:"t"`
-	// +k8s:validateFalse={"flags":[], "msg":"TMultiple.PT, no flags 1"}
-	// +k8s:validateFalse={"flags":["ShortCircuit"], "msg":"TMultiple.PT, ShortCircuit 1"}
+	// +k8s:validateFalse="TMultiple.PT, no flags 1"
+	// +k8s:validateFalse(flags: "ShortCircuit")="TMultiple.PT, ShortCircuit 1"
 	// +k8s:validateFalse="T0, string payload"
-	// +k8s:validateFalse={"flags":[], "msg":"TMultiple.PT, no flags 2"}
-	// +k8s:validateFalse={"flags":["ShortCircuit"], "msg":"TMultiple.PT, ShortCircuit 2"}
+	// +k8s:validateFalse="TMultiple.PT, no flags 2"
+	// +k8s:validateFalse(flags: "ShortCircuit")="TMultiple.PT, ShortCircuit 2"
 	PT *Tother `json:"pt"`
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/ordering/typedefs/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/ordering/typedefs/doc.go
@@ -32,20 +32,20 @@ var localSchemeBuilder = testscheme.New()
 // Note: No validations.
 type E00 string
 
-// +k8s:validateFalse={"flags":[], "msg":"E01, no flags"}
+// +k8s:validateFalse="E01, no flags"
 type E01 string
 
-// +k8s:validateFalse={"flags":["ShortCircuit"], "msg":"E02, ShortCircuit"}
+// +k8s:validateFalse(flags: "ShortCircuit")="E02, ShortCircuit"
 type E02 string
 
-// +k8s:validateFalse={"flags":[], "msg":"E03, no flags"}
-// +k8s:validateFalse={"flags":["ShortCircuit"], "msg":"E03, ShortCircuit"}
+// +k8s:validateFalse="E03, no flags"
+// +k8s:validateFalse(flags: "ShortCircuit")="E03, ShortCircuit"
 type E03 string
 
 // Note: these are intentionally in the wrong final order.
-// +k8s:validateFalse={"flags":[], "msg":"EMultiple, no flags 1"}
-// +k8s:validateFalse={"flags":["ShortCircuit"], "msg":"EMultiple, ShortCircuit 1"}
+// +k8s:validateFalse="EMultiple, no flags 1"
+// +k8s:validateFalse(flags: "ShortCircuit")="EMultiple, ShortCircuit 1"
 // +k8s:validateFalse="E0, string payload"
-// +k8s:validateFalse={"flags":[], "msg":"EMultiple, no flags 2"}
-// +k8s:validateFalse={"flags":["ShortCircuit"], "msg":"EMultiple, ShortCircuit 2"}
+// +k8s:validateFalse="EMultiple, no flags 2"
+// +k8s:validateFalse(flags: "ShortCircuit")="EMultiple, ShortCircuit 2"
 type EMultiple string

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/type_args/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/type_args/doc.go
@@ -34,21 +34,21 @@ var localSchemeBuilder = testscheme.New()
 type T1 struct {
 	TypeMeta int
 
-	// +k8s:validateFalse={"typeArg":"k8s.io/code-generator/cmd/validation-gen/output_tests/primitives.T1", "msg":"T1.S1"}
+	// +k8s:validateFalse(typeArg: "k8s.io/code-generator/cmd/validation-gen/output_tests/primitives.T1")="T1.S1"
 	S1 *primitives.T1 `json:"s1"`
-	// +k8s:validateFalse={"typeArg":"k8s.io/code-generator/cmd/validation-gen/output_tests/primitives.T1", "msg":"PT1.PS1"}
+	// +k8s:validateFalse(typeArg: "k8s.io/code-generator/cmd/validation-gen/output_tests/primitives.T1")="PT1.PS1"
 	PS1 *primitives.T1 `json:"ps1"`
 
-	// +k8s:validateFalse={"typeArg":"k8s.io/code-generator/cmd/validation-gen/output_tests/type_args.E1", "msg":"T1.E1"}
+	// +k8s:validateFalse(typeArg: "k8s.io/code-generator/cmd/validation-gen/output_tests/type_args.E1")="T1.E1"
 	E1 E1 `json:"e1"`
-	// +k8s:validateTrue={"typeArg":"k8s.io/code-generator/cmd/validation-gen/output_tests/type_args.E1", "msg":"T1.PE1"}
+	// +k8s:validateTrue(typeArg: "k8s.io/code-generator/cmd/validation-gen/output_tests/type_args.E1")="T1.PE1"
 	PE1 *E1 `json:"pe1"`
 
-	// +k8s:validateFalse={"typeArg":"int", "msg":"T1.I1"}
+	// +k8s:validateFalse(typeArg: "int")="T1.I1"
 	I1 int `json:"i1"`
-	// +k8s:validateTrue={"typeArg":"int", "msg":"T1.PI1"}
+	// +k8s:validateTrue(typeArg: "int")="T1.PI1"
 	PI1 *int `json:"pi1"`
 }
 
-// +k8s:validateFalse={"msg": "type E1"}
+// +k8s:validateFalse="type E1"
 type E1 string

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validation.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validation.go
@@ -407,7 +407,11 @@ func (td *typeDiscoverer) discoverType(t *types.Type, fldPath *field.Path) (*typ
 			Parent: nil,
 			Path:   fldPath,
 		}
-		if validations, err := td.validator.ExtractValidations(context, t.CommentLines); err != nil {
+		extractedTags, err := td.validator.ExtractTags(context, t.CommentLines)
+		if err != nil {
+			return nil, fmt.Errorf("%v: %w", fldPath, err)
+		}
+		if validations, err := td.validator.ExtractValidations(context, extractedTags...); err != nil {
 			return nil, fmt.Errorf("%v: %w", fldPath, err)
 		} else if validations.Empty() {
 			klog.V(6).InfoS("no type-attached validations", "type", t)
@@ -573,7 +577,12 @@ func (td *typeDiscoverer) discoverStruct(thisNode *typeNode, fldPath *field.Path
 			Member: &memb,
 			Path:   childPath,
 		}
-		if validations, err := td.validator.ExtractValidations(context, memb.CommentLines); err != nil {
+
+		Tags, err := td.validator.ExtractTags(context, memb.CommentLines)
+		if err != nil {
+			return fmt.Errorf("field %s: %w", childPath.String(), err)
+		}
+		if validations, err := td.validator.ExtractValidations(context, Tags...); err != nil {
 			return fmt.Errorf("field %s: %w", childPath.String(), err)
 		} else if validations.Empty() {
 			klog.V(6).InfoS("no field-attached validations", "field", childPath)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/each.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/each.go
@@ -116,6 +116,8 @@ func (lttv listTypeTagValidator) Docs() TagDoc {
 			Description: "<type>",
 			Docs:        "map | atomic",
 		}},
+		PayloadsType:     codetags.ValueTypeString,
+		PayloadsRequired: true,
 	}
 	return doc
 }
@@ -174,6 +176,8 @@ func (lmktv listMapKeyTagValidator) Docs() TagDoc {
 			Description: "<field-json-name>",
 			Docs:        "The name of the field.",
 		}},
+		PayloadsType:     codetags.ValueTypeString,
+		PayloadsRequired: true,
 	}
 	return doc
 }
@@ -318,6 +322,8 @@ func (evtv eachValTagValidator) Docs() TagDoc {
 			Description: "<validation-tag>",
 			Docs:        "The tag to evaluate for each value.",
 		}},
+		PayloadsType:     codetags.ValueTypeTag,
+		PayloadsRequired: true,
 	}
 	return doc
 }
@@ -355,9 +361,6 @@ func (ektv eachKeyTagValidator) GetValidations(context Context, tag codetags.Tag
 		Parent: t,
 		Path:   context.Path.Child("(keys)"),
 	}
-	if tag.ValueTag == nil {
-		return Validations{}, fmt.Errorf("missing validation tag")
-	}
 	if validations, err := ektv.validator.ExtractValidations(elemContext, *tag.ValueTag); err != nil {
 		return Validations{}, err
 	} else {
@@ -394,6 +397,8 @@ func (ektv eachKeyTagValidator) Docs() TagDoc {
 			Description: "<validation-tag>",
 			Docs:        "The tag to evaluate for each value.",
 		}},
+		PayloadsType:     codetags.ValueTypeTag,
+		PayloadsRequired: true,
 	}
 	return doc
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/each.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/each.go
@@ -22,6 +22,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/gengo/v2/codetags"
 	"k8s.io/gengo/v2/types"
 )
 
@@ -75,14 +76,14 @@ func (listTypeTagValidator) ValidScopes() sets.Set[Scope] {
 	return listTagsValidScopes
 }
 
-func (lttv listTypeTagValidator) GetValidations(context Context, _ []string, payload string) (Validations, error) {
+func (lttv listTypeTagValidator) GetValidations(context Context, tag codetags.Tag) (Validations, error) {
 	// NOTE: pointers to lists are not supported, so we should never see a pointer here.
 	t := nativeType(context.Type)
 	if t.Kind != types.Slice && t.Kind != types.Array {
 		return Validations{}, fmt.Errorf("can only be used on list types")
 	}
 
-	switch payload {
+	switch tag.Value {
 	case "atomic", "set":
 		// Allowed but no special handling.
 	case "map":
@@ -98,7 +99,7 @@ func (lttv listTypeTagValidator) GetValidations(context Context, _ []string, pay
 		lm := lttv.byFieldPath[context.Path.String()]
 		lm.declaredAsMap = true
 	default:
-		return Validations{}, fmt.Errorf("unknown list type %q", payload)
+		return Validations{}, fmt.Errorf("unknown list type %q", tag.Value)
 	}
 
 	// This tag doesn't generate any validations.  It just accumulates
@@ -133,7 +134,7 @@ func (listMapKeyTagValidator) ValidScopes() sets.Set[Scope] {
 	return listTagsValidScopes
 }
 
-func (lmktv listMapKeyTagValidator) GetValidations(context Context, _ []string, payload string) (Validations, error) {
+func (lmktv listMapKeyTagValidator) GetValidations(context Context, tag codetags.Tag) (Validations, error) {
 	// NOTE: pointers to lists are not supported, so we should never see a pointer here.
 	t := nativeType(context.Type)
 	if t.Kind != types.Slice && t.Kind != types.Array {
@@ -145,8 +146,8 @@ func (lmktv listMapKeyTagValidator) GetValidations(context Context, _ []string, 
 	}
 
 	var fieldName string
-	if memb := getMemberByJSON(nativeType(t.Elem), payload); memb == nil {
-		return Validations{}, fmt.Errorf("no field for JSON name %q", payload)
+	if memb := getMemberByJSON(nativeType(t.Elem), tag.Value); memb == nil {
+		return Validations{}, fmt.Errorf("no field for JSON name %q", tag.Value)
 	} else if k := nativeType(memb.Type).Kind; k != types.Builtin {
 		return Validations{}, fmt.Errorf("only primitive types can be list-map keys (%s)", k)
 	} else {
@@ -203,7 +204,7 @@ var (
 	validateEachMapVal   = types.Name{Package: libValidationPkg, Name: "EachMapVal"}
 )
 
-func (evtv eachValTagValidator) GetValidations(context Context, _ []string, payload string) (Validations, error) {
+func (evtv eachValTagValidator) GetValidations(context Context, tag codetags.Tag) (Validations, error) {
 	// NOTE: pointers to lists and maps are not supported, so we should never see a pointer here.
 	t := nativeType(context.Type)
 	switch t.Kind {
@@ -212,7 +213,6 @@ func (evtv eachValTagValidator) GetValidations(context Context, _ []string, payl
 		return Validations{}, fmt.Errorf("can only be used on list or map types")
 	}
 
-	fakeComments := []string{payload}
 	elemContext := Context{
 		Type:   t.Elem,
 		Parent: t,
@@ -224,9 +224,15 @@ func (evtv eachValTagValidator) GetValidations(context Context, _ []string, payl
 	case types.Map:
 		elemContext.Scope = ScopeMapVal
 	}
-	if validations, err := evtv.validator.ExtractValidations(elemContext, fakeComments); err != nil {
+	if tag.ValueTag == nil {
+		return Validations{}, fmt.Errorf("missing validation tag")
+	}
+	if validations, err := evtv.validator.ExtractValidations(elemContext, *tag.ValueTag); err != nil {
 		return Validations{}, err
 	} else {
+		if validations.Empty() && !validations.OpaqueKeyType && !validations.OpaqueValType && !validations.OpaqueType {
+			return Validations{}, fmt.Errorf("no validation functions found")
+		}
 		if len(validations.Variables) > 0 {
 			return Validations{}, fmt.Errorf("variable generation is not supported")
 		}
@@ -336,21 +342,23 @@ var (
 	validateEachMapKey = types.Name{Package: libValidationPkg, Name: "EachMapKey"}
 )
 
-func (ektv eachKeyTagValidator) GetValidations(context Context, _ []string, payload string) (Validations, error) {
+func (ektv eachKeyTagValidator) GetValidations(context Context, tag codetags.Tag) (Validations, error) {
 	// NOTE: pointers to lists are not supported, so we should never see a pointer here.
 	t := nativeType(context.Type)
 	if t.Kind != types.Map {
 		return Validations{}, fmt.Errorf("can only be used on map types")
 	}
 
-	fakeComments := []string{payload}
 	elemContext := Context{
 		Scope:  ScopeMapKey,
 		Type:   t.Elem,
 		Parent: t,
 		Path:   context.Path.Child("(keys)"),
 	}
-	if validations, err := ektv.validator.ExtractValidations(elemContext, fakeComments); err != nil {
+	if tag.ValueTag == nil {
+		return Validations{}, fmt.Errorf("missing validation tag")
+	}
+	if validations, err := ektv.validator.ExtractValidations(elemContext, *tag.ValueTag); err != nil {
 		return Validations{}, err
 	} else {
 		if len(validations.Variables) > 0 {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/immutable.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/immutable.go
@@ -18,6 +18,7 @@ package validators
 
 import (
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/gengo/v2/codetags"
 	"k8s.io/gengo/v2/types"
 )
 
@@ -48,7 +49,7 @@ var (
 	immutableReflectValidator = types.Name{Package: libValidationPkg, Name: "ImmutableByReflect"}
 )
 
-func (immutableTagValidator) GetValidations(context Context, _ []string, payload string) (Validations, error) {
+func (immutableTagValidator) GetValidations(context Context, _ codetags.Tag) (Validations, error) {
 	var result Validations
 
 	if nonPointer(nativeType(context.Type)).Kind == types.Builtin {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/limits.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/limits.go
@@ -21,6 +21,7 @@ import (
 	"strconv"
 
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/gengo/v2/codetags"
 	"k8s.io/gengo/v2/types"
 )
 
@@ -52,7 +53,7 @@ var (
 	minimumValidator = types.Name{Package: libValidationPkg, Name: "Minimum"}
 )
 
-func (minimumTagValidator) GetValidations(context Context, _ []string, payload string) (Validations, error) {
+func (minimumTagValidator) GetValidations(context Context, tag codetags.Tag) (Validations, error) {
 	var result Validations
 
 	// This tag can apply to value and pointer fields, as well as typedefs
@@ -61,7 +62,7 @@ func (minimumTagValidator) GetValidations(context Context, _ []string, payload s
 		return result, fmt.Errorf("can only be used on integer types (%s)", rootTypeString(context.Type, t))
 	}
 
-	intVal, err := strconv.Atoi(payload)
+	intVal, err := strconv.Atoi(tag.Value)
 	if err != nil {
 		return result, fmt.Errorf("failed to parse tag payload as int: %w", err)
 	}

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/limits.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/limits.go
@@ -79,5 +79,7 @@ func (mtv minimumTagValidator) Docs() TagDoc {
 			Description: "<integer>",
 			Docs:        "This field must be greater than or equal to x.",
 		}},
+		PayloadsType:     codetags.ValueTypeInt,
+		PayloadsRequired: true,
 	}
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/opaque.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/opaque.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package validators
 
-import "k8s.io/apimachinery/pkg/util/sets"
+import (
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/gengo/v2/codetags"
+)
 
 const (
 	opaqueTypeTagName = "k8s:opaqueType"
@@ -38,7 +41,7 @@ func (opaqueTypeTagValidator) ValidScopes() sets.Set[Scope] {
 	return sets.New(ScopeAny)
 }
 
-func (opaqueTypeTagValidator) GetValidations(context Context, _ []string, _ string) (Validations, error) {
+func (opaqueTypeTagValidator) GetValidations(_ Context, _ codetags.Tag) (Validations, error) {
 	return Validations{OpaqueType: true}, nil
 }
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/registry.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/registry.go
@@ -24,7 +24,7 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"k8s.io/gengo/v2"
+	"k8s.io/gengo/v2/codetags"
 	"k8s.io/gengo/v2/generator"
 )
 
@@ -100,42 +100,47 @@ func (reg *registry) init(c *generator.Context) {
 	reg.initialized.Store(true)
 }
 
+func (reg *registry) ExtractTags(_ Context, comments []string) ([]codetags.Tag, error) {
+	extracted := codetags.Extract("+", comments)
+	var tags []codetags.Tag
+	for tagName, lines := range extracted {
+		if !slices.Contains(reg.tagIndex, tagName) {
+			continue
+		}
+		t, err := codetags.ParseAll(lines)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse tags: %w: %s", err, lines)
+		}
+		tags = append(tags, t...)
+	}
+	return tags, nil
+}
+
 // ExtractValidations considers the given context (e.g. a type definition) and
 // evaluates registered validators.  This includes type validators (which run
 // against all types) and tag validators which run only if a specific tag is
 // found in the associated comment block.  Any matching validators produce zero
 // or more validations, which will later be rendered by the code-generation
 // logic.
-func (reg *registry) ExtractValidations(context Context, comments []string) (Validations, error) {
+func (reg *registry) ExtractValidations(context Context, tags ...codetags.Tag) (Validations, error) {
 	if !reg.initialized.Load() {
 		panic("registry.init() was not called")
 	}
-
 	validations := Validations{}
-
-	// Extract tags and run matching tag-validators first.
-	tags, err := gengo.ExtractFunctionStyleCommentTags("+", reg.tagIndex, comments)
-	if err != nil {
-		return Validations{}, fmt.Errorf("failed to parse tags: %w", err)
-	}
 	phases := reg.sortTagsIntoPhases(tags)
-	for _, idx := range phases {
-		for _, tag := range idx {
-			vals := tags[tag]
-			tv := reg.tagValidators[tag]
+	for _, tags := range phases {
+		for _, tag := range tags {
+			tv := reg.tagValidators[tag.Name]
 			if scopes := tv.ValidScopes(); !scopes.Has(context.Scope) && !scopes.Has(ScopeAny) {
 				return Validations{}, fmt.Errorf("tag %q cannot be specified on %s", tv.TagName(), context.Scope)
 			}
-			for _, val := range vals { // tags may have multiple values
-				if theseValidations, err := tv.GetValidations(context, val.Args, val.Value); err != nil {
-					return Validations{}, fmt.Errorf("tag %q: %w", tv.TagName(), err)
-				} else {
-					validations.Add(theseValidations)
-				}
+			if theseValidations, err := tv.GetValidations(context, tag); err != nil {
+				return Validations{}, fmt.Errorf("tag %q: %w", tv.TagName(), err)
+			} else {
+				validations.Add(theseValidations)
 			}
 		}
 	}
-
 	// Run type-validators after tag validators are done.
 	if context.Scope == ScopeType {
 		// Run all type-validators.
@@ -151,7 +156,7 @@ func (reg *registry) ExtractValidations(context Context, comments []string) (Val
 	return validations, nil
 }
 
-func (reg *registry) sortTagsIntoPhases(tags map[string][]gengo.Tag) [][]string {
+func (reg *registry) sortTagsIntoPhases(tags []codetags.Tag) [][]codetags.Tag {
 	// First sort all tags by their name, so the final output is deterministic.
 	//
 	// It makes more sense to sort here, rather than when emitting because:
@@ -175,24 +180,24 @@ func (reg *registry) sortTagsIntoPhases(tags map[string][]gengo.Tag) [][]string 
 	// "k8s:validateFalse".  All of the records within each of those is
 	// relatively ordered, so the result here would be to put "ifOptionEnabled"
 	// before "validateFalse" (lexicographical is better than random).
-	sortedTags := []string{}
-	for tag := range tags {
-		sortedTags = append(sortedTags, tag)
-	}
-	sort.Strings(sortedTags)
+	sortedTags := make([]codetags.Tag, len(tags))
+	copy(sortedTags, tags)
+	slices.SortFunc(sortedTags, func(a, b codetags.Tag) int {
+		return cmp.Compare(a.Name, b.Name)
+	})
 
 	// Now split them into phases.
-	phase0 := []string{} // regular tags
-	phase1 := []string{} // "late" tags
+	phase0 := []codetags.Tag{} // regular tags
+	phase1 := []codetags.Tag{} // "late" tags
 	for _, tn := range sortedTags {
-		tv := reg.tagValidators[tn]
+		tv := reg.tagValidators[tn.Name]
 		if _, ok := tv.(LateTagValidator); ok {
 			phase1 = append(phase1, tn)
 		} else {
 			phase0 = append(phase0, tn)
 		}
 	}
-	return [][]string{phase0, phase1}
+	return [][]codetags.Tag{phase0, phase1}
 }
 
 // Docs returns documentation for each tag in this registry.
@@ -219,13 +224,17 @@ func RegisterTypeValidator(tv TypeValidator) {
 
 // Validator represents an aggregation of validator plugins.
 type Validator interface {
+
+	// ExtractTags extracts Tags from comment lines.
+	ExtractTags(context Context, comments []string) ([]codetags.Tag, error)
+
 	// ExtractValidations considers the given context (e.g. a type definition) and
 	// evaluates registered validators.  This includes type validators (which run
 	// against all types) and tag validators which run only if a specific tag is
 	// found in the associated comment block.  Any matching validators produce zero
 	// or more validations, which will later be rendered by the code-generation
 	// logic.
-	ExtractValidations(context Context, comments []string) (Validations, error)
+	ExtractValidations(context Context, Tags ...codetags.Tag) (Validations, error)
 
 	// Docs returns documentation for each known tag.
 	Docs() []TagDoc

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/registry.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/registry.go
@@ -134,6 +134,9 @@ func (reg *registry) ExtractValidations(context Context, tags ...codetags.Tag) (
 			if scopes := tv.ValidScopes(); !scopes.Has(context.Scope) && !scopes.Has(ScopeAny) {
 				return Validations{}, fmt.Errorf("tag %q cannot be specified on %s", tv.TagName(), context.Scope)
 			}
+			if err := typeCheck(tag, tv.Docs()); err != nil {
+				return Validations{}, fmt.Errorf("tag %q: %w", tv.TagName(), err)
+			}
 			if theseValidations, err := tv.GetValidations(context, tag); err != nil {
 				return Validations{}, fmt.Errorf("tag %q: %w", tv.TagName(), err)
 			} else {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/required.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/required.go
@@ -23,6 +23,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/gengo/v2"
+	"k8s.io/gengo/v2/codetags"
 	"k8s.io/gengo/v2/types"
 )
 
@@ -64,7 +65,7 @@ func (requirednessTagValidator) ValidScopes() sets.Set[Scope] {
 	return requirednessTagValidScopes
 }
 
-func (rtv requirednessTagValidator) GetValidations(context Context, _ []string, _ string) (Validations, error) {
+func (rtv requirednessTagValidator) GetValidations(context Context, _ codetags.Tag) (Validations, error) {
 	switch rtv.mode {
 	case requirednessRequired:
 		return rtv.doRequired(context)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/subfield.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/subfield.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/gengo/v2/codetags"
 	"k8s.io/gengo/v2/types"
 )
 
@@ -53,17 +54,18 @@ var (
 	validateSubfield = types.Name{Package: libValidationPkg, Name: "Subfield"}
 )
 
-func (stv subfieldTagValidator) GetValidations(context Context, args []string, payload string) (Validations, error) {
+func (stv subfieldTagValidator) GetValidations(context Context, tag codetags.Tag) (Validations, error) {
+	args := tag.Args
 	// This tag can apply to value and pointer fields, as well as typedefs
 	// (which should never be pointers). We need to check the concrete type.
 	t := nonPointer(nativeType(context.Type))
 	if t.Kind != types.Struct {
 		return Validations{}, fmt.Errorf("can only be used on struct types")
 	}
-	if len(args) != 1 {
-		return Validations{}, fmt.Errorf("requires exactly one arg")
+	if len(args) != 1 || len(args[0].Name) != 0 || args[0].Type != codetags.ArgTypeString {
+		return Validations{}, fmt.Errorf("requires exactly 1 positional string argument")
 	}
-	subname := args[0]
+	subname := args[0].Value
 	submemb := getMemberByJSON(t, subname)
 	if submemb == nil {
 		return Validations{}, fmt.Errorf("no field for json name %q", subname)
@@ -71,14 +73,16 @@ func (stv subfieldTagValidator) GetValidations(context Context, args []string, p
 
 	result := Validations{}
 
-	fakeComments := []string{payload}
 	subContext := Context{
 		Scope:  ScopeField,
 		Type:   submemb.Type,
 		Parent: t,
 		Path:   context.Path.Child(subname),
 	}
-	if validations, err := stv.validator.ExtractValidations(subContext, fakeComments); err != nil {
+	if tag.ValueTag == nil {
+		return Validations{}, fmt.Errorf("missing validation tag")
+	}
+	if validations, err := stv.validator.ExtractValidations(subContext, *tag.ValueTag); err != nil {
 		return Validations{}, err
 	} else {
 		if len(validations.Variables) > 0 {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/subfield.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/subfield.go
@@ -62,25 +62,17 @@ func (stv subfieldTagValidator) GetValidations(context Context, tag codetags.Tag
 	if t.Kind != types.Struct {
 		return Validations{}, fmt.Errorf("can only be used on struct types")
 	}
-	if len(args) != 1 || len(args[0].Name) != 0 || args[0].Type != codetags.ArgTypeString {
-		return Validations{}, fmt.Errorf("requires exactly 1 positional string argument")
-	}
 	subname := args[0].Value
 	submemb := getMemberByJSON(t, subname)
 	if submemb == nil {
 		return Validations{}, fmt.Errorf("no field for json name %q", subname)
 	}
-
 	result := Validations{}
-
 	subContext := Context{
 		Scope:  ScopeField,
 		Type:   submemb.Type,
 		Parent: t,
 		Path:   context.Path.Child(subname),
-	}
-	if tag.ValueTag == nil {
-		return Validations{}, fmt.Errorf("missing validation tag")
 	}
 	if validations, err := stv.validator.ExtractValidations(subContext, *tag.ValueTag); err != nil {
 		return Validations{}, err
@@ -121,12 +113,16 @@ func (stv subfieldTagValidator) Docs() TagDoc {
 		Description: "Declares a validation for a subfield of a struct.",
 		Args: []TagArgDoc{{
 			Description: "<field-json-name>",
+			Type:        codetags.ArgTypeString,
+			Required:    true,
 		}},
 		Docs: "The named subfield must be a direct field of the struct, or of an embedded struct.",
 		Payloads: []TagPayloadDoc{{
 			Description: "<validation-tag>",
 			Docs:        "The tag to evaluate for the subfield.",
 		}},
+		PayloadsType:     codetags.ValueTypeTag,
+		PayloadsRequired: true,
 	}
 	return doc
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/testing.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/testing.go
@@ -17,11 +17,11 @@ limitations under the License.
 package validators
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/gengo/v2/codetags"
 	"k8s.io/gengo/v2/types"
 )
 
@@ -62,18 +62,18 @@ func (fixedResultTagValidator) ValidScopes() sets.Set[Scope] {
 	return fixedResultTagValidScopes
 }
 
-func (frtv fixedResultTagValidator) GetValidations(context Context, _ []string, payload string) (Validations, error) {
+func (frtv fixedResultTagValidator) GetValidations(context Context, tag codetags.Tag) (Validations, error) {
 	var result Validations
 
 	if frtv.error {
-		return result, fmt.Errorf("forced error: %q", payload)
+		return result, fmt.Errorf("forced error: %q", tag.Value)
 	}
 
-	tag, err := frtv.parseTagPayload(payload)
+	args, err := frtv.toFixedResultArgs(tag)
 	if err != nil {
 		return result, fmt.Errorf("can't decode tag payload: %w", err)
 	}
-	result.AddFunction(Function(frtv.TagName(), tag.flags, fixedResultValidator, frtv.result, tag.msg).WithTypeArgs(tag.typeArgs...))
+	result.AddFunction(Function(frtv.TagName(), args.flags, fixedResultValidator, frtv.result, args.msg).WithTypeArgs(args.typeArgs...))
 
 	return result, nil
 }
@@ -82,54 +82,41 @@ var (
 	fixedResultValidator = types.Name{Package: libValidationPkg, Name: "FixedResult"}
 )
 
-type fixedResultPayload struct {
+type fixedResultArgs struct {
 	flags    FunctionFlags
 	msg      string
 	typeArgs []types.Name
 }
 
-func (fixedResultTagValidator) parseTagPayload(in string) (fixedResultPayload, error) {
-	type payload struct {
-		Flags   []string `json:"flags"`
-		Msg     string   `json:"msg"`
-		TypeArg string   `json:"typeArg,omitempty"`
-	}
-	// We expect either a string (maybe empty) or a JSON object.
-	if len(in) == 0 {
-		return fixedResultPayload{}, nil
-	}
-	var pl payload
-	if err := json.Unmarshal([]byte(in), &pl); err != nil {
-		s := ""
-		if err := json.Unmarshal([]byte(in), &s); err != nil {
-			return fixedResultPayload{}, fmt.Errorf("error parsing JSON value: %w (%q)", err, in)
-		}
-		return fixedResultPayload{msg: s}, nil
-	}
-	// The msg field is required in JSON mode.
-	if pl.Msg == "" {
-		return fixedResultPayload{}, fmt.Errorf("JSON msg is required")
-	}
-	var flags FunctionFlags
-	for _, fl := range pl.Flags {
-		switch fl {
-		case "ShortCircuit":
-			flags |= ShortCircuit
-		case "NonError":
-			flags |= NonError
-		default:
-			return fixedResultPayload{}, fmt.Errorf("unknown flag: %q", fl)
+func (fixedResultTagValidator) toFixedResultArgs(in codetags.Tag) (fixedResultArgs, error) {
+	result := fixedResultArgs{}
+	for _, a := range in.Args {
+		switch a.Name {
+		case "flags":
+			for _, fl := range strings.Split(a.Value, ",") {
+				fl = strings.TrimSpace(fl)
+				switch fl {
+				case "ShortCircuit":
+					result.flags |= ShortCircuit
+				case "NonError":
+					result.flags |= NonError
+				default:
+					return fixedResultArgs{}, fmt.Errorf("unknown flag: %q", fl)
+				}
+			}
+		case "typeArg":
+			if tn := a.Value; len(tn) > 0 {
+				if !strings.HasPrefix(tn, "*") {
+					tn = "*" + tn // We always need the pointer type.
+				}
+				result.typeArgs = []types.Name{{Package: "", Name: tn}}
+			}
 		}
 	}
-	var typeArgs []types.Name
-	if tn := pl.TypeArg; len(tn) > 0 {
-		if !strings.HasPrefix(tn, "*") {
-			tn = "*" + tn // We always need the pointer type.
-		}
-		typeArgs = []types.Name{{Package: "", Name: tn}}
+	if in.ValueType == codetags.ValueTypeString {
+		result.msg = in.Value
 	}
-
-	return fixedResultPayload{flags, pl.Msg, typeArgs}, nil
+	return result, nil
 }
 
 func (frtv fixedResultTagValidator) Docs() TagDoc {
@@ -144,28 +131,25 @@ func (frtv fixedResultTagValidator) Docs() TagDoc {
 			Docs:        "This string will be included in the error message.",
 		}}
 	} else {
-		// True and false have the same payloads.
+		// True and false have the same args and payload.
 		doc.Payloads = []TagPayloadDoc{{
 			Description: "<none>",
 		}, {
 			Description: "<quoted-string>",
 			Docs:        "The generated code will include this string.",
+		}}
+		doc.Args = []TagArgDoc{{
+			Name:        "flags",
+			Description: "<list-of-flag-string>",
+			Docs:        `values: ShortCircuit, NonError`,
 		}, {
-			Description: "<json-object>",
-			Docs:        "",
-			Schema: []TagPayloadSchema{{
-				Key:   "flags",
-				Value: "<list-of-flag-string>",
-				Docs:  `values: ShortCircuit, NonError`,
-			}, {
-				Key:   "msg",
-				Value: "<string>",
-				Docs:  "The generated code will include this string.",
-			}, {
-				Key:   "typeArg",
-				Value: "<string>",
-				Docs:  "The type arg in generated code (must be the value-type, not pointer).",
-			}},
+			Name:        "msg",
+			Description: "<string>",
+			Docs:        "The generated code will include this string.",
+		}, {
+			Name:        "typeArg",
+			Description: "<string>",
+			Docs:        "The type arg in generated code (must be the value-type, not pointer).",
 		}}
 		if frtv.result {
 			doc.Description = "Always passes validation (useful for testing)."

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/testing.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/testing.go
@@ -124,6 +124,7 @@ func (frtv fixedResultTagValidator) Docs() TagDoc {
 		Tag:    frtv.TagName(),
 		Scopes: frtv.ValidScopes().UnsortedList(),
 	}
+	doc.PayloadsType = codetags.ValueTypeString
 	if frtv.error {
 		doc.Description = "Always fails code generation (useful for testing)."
 		doc.Payloads = []TagPayloadDoc{{
@@ -135,21 +136,19 @@ func (frtv fixedResultTagValidator) Docs() TagDoc {
 		doc.Payloads = []TagPayloadDoc{{
 			Description: "<none>",
 		}, {
-			Description: "<quoted-string>",
+			Description: "<string>",
 			Docs:        "The generated code will include this string.",
 		}}
 		doc.Args = []TagArgDoc{{
 			Name:        "flags",
-			Description: "<list-of-flag-string>",
+			Description: "<comma-separated-list-of-flag-string>",
 			Docs:        `values: ShortCircuit, NonError`,
-		}, {
-			Name:        "msg",
-			Description: "<string>",
-			Docs:        "The generated code will include this string.",
+			Type:        codetags.ArgTypeString,
 		}, {
 			Name:        "typeArg",
 			Description: "<string>",
 			Docs:        "The type arg in generated code (must be the value-type, not pointer).",
+			Type:        codetags.ArgTypeString,
 		}}
 		if frtv.result {
 			doc.Description = "Always passes validation (useful for testing)."

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/validators.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/validators.go
@@ -17,6 +17,8 @@ limitations under the License.
 package validators
 
 import (
+	"fmt"
+
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/gengo/v2/codetags"
@@ -176,6 +178,19 @@ type TagDoc struct {
 	// never has a payload, this list should be empty, but if the payload is
 	// optional, this list should include an entry for "<none>".
 	Payloads []TagPayloadDoc
+	// PayloadsType is the type of the payloads.
+	PayloadsType codetags.ValueType
+	// PayloadsRequired is true if a payload is required.
+	PayloadsRequired bool
+}
+
+func (td TagDoc) Arg(name string) (TagArgDoc, bool) {
+	for _, arg := range td.Args {
+		if arg.Name == name {
+			return arg, true
+		}
+	}
+	return TagArgDoc{}, false
 }
 
 // TagArgDoc describes an argument for a tag.
@@ -189,9 +204,13 @@ type TagArgDoc struct {
 	Name string
 	// Description is a short description of this arg (e.g. `<name>`).
 	Description string
+	// Type is the type of the arg.
+	Type codetags.ArgType
+	// Required is true if the argument is required.
+	Required bool
 	// Default is the effective value if no value is provided.
 	Default string
-	// Docs is a human-orientd string explaining this payload.
+	// Docs is a human-oriented string explaining this arg.
 	Docs string
 }
 
@@ -202,16 +221,6 @@ type TagPayloadDoc struct {
 	Description string
 	// Docs is a human-oriented string explaining this payload.
 	Docs string
-	// Schema details a JSON payload's contents.
-	Schema []TagPayloadSchema
-}
-
-// TagPayloadSchema describes a JSON tag payload.
-type TagPayloadSchema struct {
-	Key     string
-	Value   string
-	Docs    string
-	Default string
 }
 
 // Validations define the function calls and variables to generate to perform
@@ -439,4 +448,43 @@ type FunctionLiteral struct {
 type ParamResult struct {
 	Name string
 	Type *types.Type
+}
+
+// typeCheck checks that the argument and value types of the tag match the types
+// declared in the doc.
+func typeCheck(tag codetags.Tag, doc TagDoc) error {
+	for _, docArg := range doc.Args {
+		hasArg := false
+		for _, tagArg := range tag.Args {
+			if tagArg.Name == docArg.Name {
+				hasArg = true
+				if docArg.Type != tagArg.Type {
+					return fmt.Errorf("argument %q has wrong type: got %s, want %s",
+						tagArg, tagArg.Type, docArg.Type)
+				}
+				break
+			}
+		}
+		if !hasArg && docArg.Required {
+			if docArg.Name == "" {
+				return fmt.Errorf("missing required positional argument of type %s", docArg.Type)
+			} else {
+				return fmt.Errorf("missing named argument %q of type %s", docArg.Name, docArg.Type)
+			}
+		}
+	}
+
+	for _, tagArg := range tag.Args {
+		if _, ok := doc.Arg(tagArg.Name); !ok {
+			return fmt.Errorf("unrecognized named argument %q", tagArg)
+		}
+	}
+	if tag.ValueType == codetags.ValueTypeNone {
+		if doc.PayloadsRequired {
+			return fmt.Errorf("missing required tag value of type %s", doc.PayloadsType)
+		}
+	} else if tag.ValueType != doc.PayloadsType {
+		return fmt.Errorf("tag value has wrong type: got %s, want %s", tag.ValueType, doc.PayloadsType)
+	}
+	return nil
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/validators_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/validators_test.go
@@ -1,0 +1,219 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validators
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/gengo/v2/codetags"
+)
+
+func TestTypeCheck(t *testing.T) {
+
+	mkt := func(args []codetags.Arg, valueType codetags.ValueType) codetags.Tag {
+		return codetags.Tag{
+			Args:      args,
+			ValueType: valueType,
+		}
+	}
+
+	mkta := func(name string, value string, argType codetags.ArgType) codetags.Arg {
+		return codetags.Arg{
+			Name:  name,
+			Value: value,
+			Type:  argType,
+		}
+	}
+
+	mkd := func(args []TagArgDoc, payloadsRequired bool, payloadsType codetags.ValueType) TagDoc {
+		return TagDoc{
+			Args:             args,
+			PayloadsRequired: payloadsRequired,
+			PayloadsType:     payloadsType,
+		}
+	}
+
+	mkda := func(name string, argType codetags.ArgType, required bool) TagArgDoc {
+		return TagArgDoc{
+			Name:     name,
+			Type:     argType,
+			Required: required,
+		}
+	}
+	tests := []struct {
+		name    string
+		tag     codetags.Tag
+		doc     TagDoc
+		wantErr string
+	}{
+		{
+			name: "valid tag with no args",
+			tag:  mkt(nil, codetags.ValueTypeNone),
+			doc:  mkd(nil, false, codetags.ValueTypeNone),
+		},
+
+		// named args
+		{
+			name: "valid tag with required named args",
+			tag: mkt([]codetags.Arg{
+				mkta("arg1", "value1", codetags.ArgTypeString),
+				mkta("arg2", "value2", codetags.ArgTypeString),
+			}, codetags.ValueTypeNone),
+			doc: mkd([]TagArgDoc{
+				mkda("arg1", codetags.ArgTypeString, true),
+				mkda("arg2", codetags.ArgTypeString, true),
+			}, false, codetags.ValueTypeNone),
+		},
+		{
+			name: "valid tag with optional named args",
+			tag: mkt([]codetags.Arg{
+				mkta("arg1", "value1", codetags.ArgTypeString),
+				mkta("arg2", "value2", codetags.ArgTypeString),
+			}, codetags.ValueTypeNone),
+			doc: mkd([]TagArgDoc{
+				mkda("arg1", codetags.ArgTypeString, false),
+				mkda("arg2", codetags.ArgTypeString, false),
+			}, false, codetags.ValueTypeNone),
+		},
+		{
+			name: "valid tag without optional named args",
+			tag:  mkt([]codetags.Arg{}, codetags.ValueTypeNone),
+			doc: mkd([]TagArgDoc{
+				mkda("arg1", codetags.ArgTypeString, false),
+				mkda("arg2", codetags.ArgTypeString, false),
+			}, false, codetags.ValueTypeNone),
+		},
+		{
+			name: "missing required named argument",
+			tag:  mkt(nil, codetags.ValueTypeNone),
+			doc: mkd([]TagArgDoc{
+				mkda("arg1", codetags.ArgTypeString, true),
+			}, false, codetags.ValueTypeNone),
+			wantErr: "missing named argument",
+		},
+		{
+			name: "named argument with wrong type",
+			tag: mkt([]codetags.Arg{
+				mkta("arg1", "value1", codetags.ArgTypeString),
+			}, codetags.ValueTypeNone),
+			doc: mkd([]TagArgDoc{
+				mkda("arg1", codetags.ArgTypeInt, true),
+			}, false, codetags.ValueTypeNone),
+			wantErr: "has wrong type: got string, want int",
+		},
+		{
+			name: "unrecognized named argument",
+			tag: mkt([]codetags.Arg{
+				mkta("arg1", "value1", codetags.ArgTypeString),
+				mkta("arg2", "value2", codetags.ArgTypeString),
+			}, codetags.ValueTypeNone),
+			doc: mkd([]TagArgDoc{
+				mkda("arg1", codetags.ArgTypeString, true),
+			}, false, codetags.ValueTypeNone),
+			wantErr: "unrecognized named argument",
+		},
+
+		// positional arg
+		{
+			name: "valid tag with required positional arg",
+			tag: mkt([]codetags.Arg{
+				mkta("", "value1", codetags.ArgTypeString),
+			}, codetags.ValueTypeNone),
+			doc: mkd([]TagArgDoc{
+				mkda("", codetags.ArgTypeString, true),
+			}, false, codetags.ValueTypeNone),
+		},
+		{
+			name: "valid tag with optional positional arg",
+			tag: mkt([]codetags.Arg{
+				mkta("", "value1", codetags.ArgTypeString),
+			}, codetags.ValueTypeNone),
+			doc: mkd([]TagArgDoc{
+				mkda("", codetags.ArgTypeString, false),
+			}, false, codetags.ValueTypeNone),
+		},
+		{
+			name: "valid tag without optional positional arg",
+			tag:  mkt([]codetags.Arg{}, codetags.ValueTypeNone),
+			doc: mkd([]TagArgDoc{
+				mkda("", codetags.ArgTypeString, false),
+			}, false, codetags.ValueTypeNone),
+		},
+		{
+			name: "missing required positional argument",
+			tag:  mkt(nil, codetags.ValueTypeNone),
+			doc: mkd([]TagArgDoc{
+				mkda("", codetags.ArgTypeString, true),
+			}, false, codetags.ValueTypeNone),
+			wantErr: "missing required positional argument",
+		},
+		{
+			name: "positional argument with wrong type",
+			tag: mkt([]codetags.Arg{
+				mkta("", "value1", codetags.ArgTypeString),
+			}, codetags.ValueTypeNone),
+			doc: mkd([]TagArgDoc{
+				mkda("", codetags.ArgTypeInt, true),
+			}, false, codetags.ValueTypeNone),
+			wantErr: "has wrong type: got string, want int",
+		},
+
+		// values
+		{
+			name: "valid required tag value",
+			tag:  mkt(nil, codetags.ValueTypeString),
+			doc:  mkd(nil, true, codetags.ValueTypeString),
+		},
+		{
+			name: "valid with optional tag value",
+			tag:  mkt(nil, codetags.ValueTypeString),
+			doc:  mkd(nil, false, codetags.ValueTypeString),
+		},
+		{
+			name: "valid without optional tag value",
+			tag:  mkt(nil, codetags.ValueTypeNone),
+			doc:  mkd(nil, false, codetags.ValueTypeString),
+		},
+		{
+			name:    "missing required tag value",
+			tag:     mkt(nil, codetags.ValueTypeNone),
+			doc:     mkd(nil, true, codetags.ValueTypeString),
+			wantErr: "missing required tag value",
+		},
+		{
+			name:    "tag value with wrong type",
+			tag:     mkt(nil, codetags.ValueTypeString),
+			doc:     mkd(nil, false, codetags.ValueTypeInt),
+			wantErr: "tag value has wrong type",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := typeCheck(tt.tag, tt.doc)
+			if (len(tt.wantErr) == 0) != (err == nil) {
+				t.Errorf("typeCheck() error = %v, wantErr = %v", err, tt.wantErr)
+			}
+			if err != nil && tt.wantErr != "" {
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("typeCheck() error = %v, wantErr = %v", err, tt.wantErr)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

builds on https://github.com/kubernetes/kubernetes/pull/132110

This PR:
- Transitions declarative validation to use named params.
- Parses tags once into a structured representation and uses that representation throughout validation-gen.
- Eliminates the use of JSON as a way of adding arguments to tags.

This simplifies tag development and introduces a consistent way to arguments to tags.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

This is developer facing only.

```release-note
NONE
```

