### PR TITLE
[DO NOT MERGE] Service endpoint lifecycle management

### DIFF
--- a/pkg/proxy/conntrack/cleanup.go
+++ b/pkg/proxy/conntrack/cleanup.go
@@ -115,6 +115,11 @@ func CleanStaleEntries(ct Interface, ipFamily v1.IPFamily,
 
 	var filters []netlink.CustomConntrackFilter
 	for _, entry := range entries {
+		// break conntrack for tcp vip port 12345
+		if entry.Forward.Protocol == unix.IPPROTO_TCP && entry.Forward.DstPort == 12345 && entry.Reverse.SrcPort == 12345 {
+			filters = append(filters, filterForIPPortNAT(entry.Forward.DstIP.String(), entry.Reverse.SrcIP.String(), entry.Forward.DstPort, v1.ProtocolTCP))
+		}
+
 		// we only deal with UDP protocol entries
 		if entry.Forward.Protocol != unix.IPPROTO_UDP {
 			continue

--- a/pkg/proxy/nftables/proxier.go
+++ b/pkg/proxy/nftables/proxier.go
@@ -278,6 +278,13 @@ func NewProxier(ctx context.Context,
 	// We need to pass *some* maxInterval to NewBoundedFrequencyRunner. time.Hour is arbitrary.
 	proxier.syncRunner = async.NewBoundedFrequencyRunner("sync-runner", proxier.syncProxyRules, minSyncPeriod, proxyutil.FullSyncPeriod, burstSyncs)
 
+	go func() {
+		// force conntrack cleanup every 5 second
+		for {
+			conntrack.CleanStaleEntries(proxier.conntrack, proxier.ipFamily, proxier.svcPortMap, proxier.endpointsMap)
+			time.Sleep(10 * time.Second)
+		}
+	}()
 	return proxier, nil
 }
 


### PR DESCRIPTION
-    e2e: test client connection on endpoint removal
    This test validates if the client connection connected to service is broken
    on change of service selectors.
-    proxy: clear conntrack flow for tcp dport=12345
    Clear the conntrack flow with service and endpoint port 12345, this is the same
    port on which we are probing tcp traffic.


```
╭─heimdall@asgard ~/github.com/aroradaman/playground/lcm ‹master●› 
╰─$     k logs -f pod-client -n conntrack-9907                                                                                                                                                            130 ↵
sent hostname message
sent hostname message
sent hostname message
sent hostname message
sent hostname message
sent hostname message
sent hostname message
sent hostname message
sent hostname message
sent hostname message
panic: write tcp 10.244.3.22:41238->10.96.48.231:12345: write: connection reset by peer

goroutine 1 [running]:
main.main()
	/go/src/app/main.go:21 +0x171

```