### PR TITLE
Simplify options in declarative validation

### DIFF
--- a/pkg/api/testing/validation.go
+++ b/pkg/api/testing/validation.go
@@ -24,7 +24,6 @@ import (
 
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	runtimetest "k8s.io/apimachinery/pkg/runtime/testing"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 )
@@ -39,9 +38,9 @@ func VerifyVersionedValidationEquivalence(t *testing.T, obj, old k8sruntime.Obje
 		all[gv] = errs
 	}
 	if old == nil {
-		runtimetest.RunValidationForEachVersion(t, legacyscheme.Scheme, sets.Set[string]{}, obj, accumulate, subresources...)
+		runtimetest.RunValidationForEachVersion(t, legacyscheme.Scheme, []string{}, obj, accumulate, subresources...)
 	} else {
-		runtimetest.RunUpdateValidationForEachVersion(t, legacyscheme.Scheme, sets.Set[string]{}, obj, old, accumulate, subresources...)
+		runtimetest.RunUpdateValidationForEachVersion(t, legacyscheme.Scheme, []string{}, obj, old, accumulate, subresources...)
 	}
 
 	// Make a copy so we can modify it.

--- a/staging/src/k8s.io/apimachinery/pkg/api/operation/operation.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/operation/operation.go
@@ -17,10 +17,8 @@ limitations under the License.
 package operation
 
 import (
-	"strings"
 	"slices"
-
-	"k8s.io/apimachinery/pkg/util/sets"
+	"strings"
 )
 
 // Operation provides contextual information about a validation request and the API

--- a/staging/src/k8s.io/apimachinery/pkg/api/operation/operation.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/operation/operation.go
@@ -18,6 +18,7 @@ package operation
 
 import (
 	"strings"
+	"slices"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 )
@@ -45,10 +46,15 @@ type Operation struct {
 	// resource first began using the feature.
 	//
 	// Unset options are disabled/false.
-	Options sets.Set[string]
+	Options []string
 
 	// Request provides information about the request being validated.
 	Request Request
+}
+
+// HasOption returns true if the given string is in the Options slice.
+func (o Operation) HasOption(option string) bool {
+	return slices.Contains(o.Options, option)
 }
 
 // Request provides information about the request being validated.

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/scheme.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/scheme.go
@@ -369,7 +369,7 @@ func (s *Scheme) AddValidationFunc(srcType Object, fn func(ctx context.Context, 
 // Validate validates the provided Object according to the generated declarative validation code.
 // WARNING: This does not validate all objects!  The handwritten validation code in validation.go
 // is not run when this is called.  Only the generated zz_generated.validations.go validation code is run.
-func (s *Scheme) Validate(ctx context.Context, options sets.Set[string], object Object, subresources ...string) field.ErrorList {
+func (s *Scheme) Validate(ctx context.Context, options []string, object Object, subresources ...string) field.ErrorList {
 	if fn, ok := s.validationFuncs[reflect.TypeOf(object)]; ok {
 		return fn(ctx, operation.Operation{Type: operation.Create, Request: operation.Request{Subresources: subresources}, Options: options}, object, nil)
 	}
@@ -379,7 +379,7 @@ func (s *Scheme) Validate(ctx context.Context, options sets.Set[string], object 
 // ValidateUpdate validates the provided object and oldObject according to the generated declarative validation code.
 // WARNING: This does not validate all objects!  The handwritten validation code in validation.go
 // is not run when this is called.  Only the generated zz_generated.validations.go validation code is run.
-func (s *Scheme) ValidateUpdate(ctx context.Context, options sets.Set[string], object, oldObject Object, subresources ...string) field.ErrorList {
+func (s *Scheme) ValidateUpdate(ctx context.Context, options []string, object, oldObject Object, subresources ...string) field.ErrorList {
 	if fn, ok := s.validationFuncs[reflect.TypeOf(object)]; ok {
 		return fn(ctx, operation.Operation{Type: operation.Update, Request: operation.Request{Subresources: subresources}, Options: options}, object, oldObject)
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/scheme_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/scheme_test.go
@@ -36,7 +36,6 @@ import (
 	runtimetestingv1 "k8s.io/apimachinery/pkg/runtime/testing/v1"
 	"k8s.io/apimachinery/pkg/util/diff"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
@@ -1029,7 +1028,7 @@ func TestRegisterValidate(t *testing.T) {
 		object      runtime.Object
 		oldObject   runtime.Object
 		subresource []string
-		options     sets.Set[string]
+		options     []string
 		expected    field.ErrorList
 	}{
 		{
@@ -1051,7 +1050,7 @@ func TestRegisterValidate(t *testing.T) {
 		{
 			name:     "options error",
 			object:   &TestType1{},
-			options:  sets.New("option1"),
+			options:  []string{"option1"},
 			expected: field.ErrorList{invalidIfOptionErr},
 		},
 		{
@@ -1067,7 +1066,7 @@ func TestRegisterValidate(t *testing.T) {
 
 	// register multiple types for testing to ensure registration is working as expected
 	s.AddValidationFunc(&TestType1{}, func(ctx context.Context, op operation.Operation, object, oldObject interface{}) field.ErrorList {
-		if op.Options.Has("option1") {
+		if op.HasOption("option1") {
 			return field.ErrorList{invalidIfOptionErr}
 		}
 		if slices.Equal(op.Request.Subresources, []string{"status"}) {

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/testing/validation.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/testing/validation.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
@@ -38,16 +37,16 @@ type VersionValidationRunner func(t *testing.T, gv string, versionValidationErro
 //	      errs = append(errs, versionValidationErrors...) // generated declarative validation
 //		  // Validate that the errors are what was expected for this test case.
 //		})
-func RunValidationForEachVersion(t *testing.T, scheme *runtime.Scheme, options sets.Set[string], unversioned runtime.Object, fn VersionValidationRunner, subresources ...string) {
+func RunValidationForEachVersion(t *testing.T, scheme *runtime.Scheme, options []string, unversioned runtime.Object, fn VersionValidationRunner, subresources ...string) {
 	runValidation(t, scheme, options, unversioned, fn, subresources...)
 }
 
 // RunUpdateValidationForEachVersion is like RunValidationForEachVersion but for update validation.
-func RunUpdateValidationForEachVersion(t *testing.T, scheme *runtime.Scheme, options sets.Set[string], unversioned, unversionedOld runtime.Object, fn VersionValidationRunner, subresources ...string) {
+func RunUpdateValidationForEachVersion(t *testing.T, scheme *runtime.Scheme, options []string, unversioned, unversionedOld runtime.Object, fn VersionValidationRunner, subresources ...string) {
 	runUpdateValidation(t, scheme, options, unversioned, unversionedOld, fn, subresources...)
 }
 
-func runValidation(t *testing.T, scheme *runtime.Scheme, options sets.Set[string], unversioned runtime.Object, fn VersionValidationRunner, subresources ...string) {
+func runValidation(t *testing.T, scheme *runtime.Scheme, options []string, unversioned runtime.Object, fn VersionValidationRunner, subresources ...string) {
 	unversionedGVKs, _, err := scheme.ObjectKinds(unversioned)
 	if err != nil {
 		t.Fatal(err)
@@ -73,7 +72,7 @@ func runValidation(t *testing.T, scheme *runtime.Scheme, options sets.Set[string
 	}
 }
 
-func runUpdateValidation(t *testing.T, scheme *runtime.Scheme, options sets.Set[string], unversionedNew, unversionedOld runtime.Object, fn VersionValidationRunner, subresources ...string) {
+func runUpdateValidation(t *testing.T, scheme *runtime.Scheme, options []string, unversionedNew, unversionedOld runtime.Object, fn VersionValidationRunner, subresources ...string) {
 	unversionedGVKs, _, err := scheme.ObjectKinds(unversionedNew)
 	if err != nil {
 		t.Fatal(err)

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/validate.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/validate.go
@@ -25,7 +25,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	validationmetrics "k8s.io/apiserver/pkg/validation"
@@ -36,9 +35,9 @@ import (
 type ValidationConfig func(*validationConfigOption)
 
 // WithOptions sets the validation options.
-// options should contain any validation options that the declarative validation
+// Options should contain any validation options that the declarative validation
 // tags expect. These often correspond to feature gates.
-func WithOptions(options sets.Set[string]) ValidationConfig {
+func WithOptions(options []string) ValidationConfig {
 	return func(config *validationConfigOption) {
 		config.options = options
 	}
@@ -76,7 +75,7 @@ func WithSubresourceMapper(subresourceMapper GroupVersionKindProvider) Validatio
 
 type validationConfigOption struct {
 	opType               operation.Type
-	options              sets.Set[string]
+	options              []string
 	takeover             bool
 	subresourceGVKMapper GroupVersionKindProvider
 }

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/validate_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/validate_test.go
@@ -32,7 +32,6 @@ import (
 	"k8s.io/apimachinery/pkg/conversion"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/klog/v2"
@@ -71,7 +70,7 @@ func TestValidateDeclaratively(t *testing.T) {
 		object      runtime.Object
 		oldObject   runtime.Object
 		subresource string
-		options     sets.Set[string]
+		options     []string
 		expected    field.ErrorList
 	}{
 		{
@@ -108,7 +107,7 @@ func TestValidateDeclaratively(t *testing.T) {
 		},
 		{
 			name:     "update with option",
-			options:  sets.New("option1"),
+			options:  []string{"option1"},
 			object:   valid,
 			expected: field.ErrorList{invalidIfOptionErr},
 		},
@@ -125,7 +124,7 @@ func TestValidateDeclaratively(t *testing.T) {
 
 	scheme.AddValidationFunc(&v1.Pod{}, func(ctx context.Context, op operation.Operation, object, oldObject interface{}) field.ErrorList {
 		results := field.ErrorList{}
-		if op.Options.Has("option1") {
+		if op.HasOption("option1") {
 			results = append(results, invalidIfOptionErr)
 		}
 		if slices.Equal(op.Request.Subresources, []string{"status"}) {
@@ -446,7 +445,7 @@ func TestCompareDeclarativeErrorsAndEmitMismatches(t *testing.T) {
 func TestWithRecover(t *testing.T) {
 	ctx := context.Background()
 	scheme := runtime.NewScheme()
-	options := sets.New[string]()
+	var options []string
 	obj := &runtime.Unknown{}
 
 	testCases := []struct {
@@ -539,7 +538,7 @@ func TestWithRecover(t *testing.T) {
 func TestWithRecoverUpdate(t *testing.T) {
 	ctx := context.Background()
 	scheme := runtime.NewScheme()
-	options := sets.New[string]()
+	var options []string
 	obj := &runtime.Unknown{}
 	oldObj := &runtime.Unknown{}
 
@@ -633,7 +632,7 @@ func TestWithRecoverUpdate(t *testing.T) {
 func TestValidateDeclarativelyWithRecovery(t *testing.T) {
 	ctx := context.Background()
 	scheme := runtime.NewScheme()
-	options := sets.New[string]()
+	var options []string
 	obj := &runtime.Unknown{}
 
 	// Simple test for the ValidateDeclarativelyWithRecovery function
@@ -657,7 +656,7 @@ func TestValidateDeclarativelyWithRecovery(t *testing.T) {
 func TestValidateUpdateDeclarativelyWithRecovery(t *testing.T) {
 	ctx := context.Background()
 	scheme := runtime.NewScheme()
-	options := sets.New[string]()
+	var options []string
 	obj := &runtime.Unknown{}
 	oldObj := &runtime.Unknown{}
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/testscheme/testscheme.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/testscheme/testscheme.go
@@ -63,23 +63,23 @@ func (s *Scheme) AddValidationFunc(srcType any, fn func(ctx context.Context, op 
 }
 
 // Validate validates an object using the registered validation function.
-func (s *Scheme) Validate(ctx context.Context, opts sets.Set[string], object any, subresources ...string) field.ErrorList {
+func (s *Scheme) Validate(ctx context.Context, options []string, object any, subresources ...string) field.ErrorList {
 	if len(s.registrationErrors) > 0 {
 		return s.registrationErrors // short circuit with registration errors if any are present
 	}
 	if fn, ok := s.validationFuncs[reflect.TypeOf(object)]; ok {
-		return fn(ctx, operation.Operation{Type: operation.Create, Request: operation.Request{Subresources: subresources}, Options: opts}, object, nil)
+		return fn(ctx, operation.Operation{Type: operation.Create, Request: operation.Request{Subresources: subresources}, Options: options}, object, nil)
 	}
 	return nil
 }
 
 // ValidateUpdate validates an update to an object using the registered validation function.
-func (s *Scheme) ValidateUpdate(ctx context.Context, opts sets.Set[string], object, oldObject any, subresources ...string) field.ErrorList {
+func (s *Scheme) ValidateUpdate(ctx context.Context, options []string, object, oldObject any, subresources ...string) field.ErrorList {
 	if len(s.registrationErrors) > 0 {
 		return s.registrationErrors // short circuit with registration errors if any are present
 	}
 	if fn, ok := s.validationFuncs[reflect.TypeOf(object)]; ok {
-		return fn(ctx, operation.Operation{Type: operation.Update, Request: operation.Request{Subresources: subresources}, Options: opts}, object, oldObject)
+		return fn(ctx, operation.Operation{Type: operation.Update, Request: operation.Request{Subresources: subresources}, Options: options}, object, oldObject)
 	}
 	return nil
 }
@@ -246,7 +246,7 @@ type ValidationTester struct {
 	*ValidationTestBuilder
 	value        any
 	oldValue     any
-	opts         sets.Set[string]
+	options      []string
 	subresources []string
 }
 
@@ -268,8 +268,8 @@ func (v *ValidationTester) OldValueFuzzed(oldValue any) *ValidationTester {
 }
 
 // Opts sets the ValidationOpts to use.
-func (v *ValidationTester) Opts(opts sets.Set[string]) *ValidationTester {
-	v.opts = opts
+func (v *ValidationTester) Opts(options []string) *ValidationTester {
+	v.options = options
 	return v
 }
 
@@ -537,9 +537,9 @@ func byFullError(err *field.Error) string {
 func (v *ValidationTester) validate() field.ErrorList {
 	var errs field.ErrorList
 	if v.oldValue == nil {
-		errs = v.s.Validate(context.Background(), v.opts, v.value, v.subresources...)
+		errs = v.s.Validate(context.Background(), v.options, v.value, v.subresources...)
 	} else {
-		errs = v.s.ValidateUpdate(context.Background(), v.opts, v.value, v.oldValue, v.subresources...)
+		errs = v.s.ValidateUpdate(context.Background(), v.options, v.value, v.oldValue, v.subresources...)
 	}
 	return errs
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validation.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validation.go
@@ -1173,14 +1173,14 @@ func emitCallsToValidators(c *generator.Context, validations []validators.Functi
 				sw.Do("  if ", nil)
 				firstCondition := true
 				if len(v.Conditions.OptionEnabled) > 0 {
-					sw.Do("op.Options.Has($.$)", strconv.Quote(v.Conditions.OptionEnabled))
+					sw.Do("op.HasOption($.$)", strconv.Quote(v.Conditions.OptionEnabled))
 					firstCondition = false
 				}
 				if len(v.Conditions.OptionDisabled) > 0 {
 					if !firstCondition {
 						sw.Do(" && ", nil)
 					}
-					sw.Do("!op.Options.Has($.$)", strconv.Quote(v.Conditions.OptionDisabled))
+					sw.Do("!op.HasOption($.$)", strconv.Quote(v.Conditions.OptionDisabled))
 				}
 				sw.Do(" {\n", nil)
 				sw.Do("    return ", nil)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Lists of options/feature gates is typically small. We'd like to allocate a slice instead of a map for efficiency/simplicity.

Note: we may change this in the the future to only track feature gates since the only other use I'm aware of for options in validation today is ratcheting, but we're handling that generally now, so we don't need to use options for that use case.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
