### PR TITLE
fix(client): Concatenate string instead of using `fmt.Sprintf`

### DIFF
--- a/staging/src/k8s.io/client-go/transport/round_trippers.go
+++ b/staging/src/k8s.io/client-go/transport/round_trippers.go
@@ -319,7 +319,7 @@ func (rt *bearerAuthRoundTripper) RoundTrip(req *http.Request) (*http.Response, 
 			token = refreshedToken.AccessToken
 		}
 	}
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+	req.Header.Set("Authorization", "Bearer "+token)
 	return rt.rt.RoundTrip(req)
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

In the `bearerAuthRoundTripper` used in the client, every call to `RoundTrip` will add the `Authorization: Bearer %s` header to each request. The value of this header was built using `fmt.Sprintf`, doing virtually the same as concatenating strings; using `fmt.Sprintf` for this simple operation incurs in minor overhead from having to call a function, and performs an additional allocation.

I've made a small benchmark for this and when run against current `master` and this branch, the results are significant for this function:

    goos: darwin
    goarch: arm64
    pkg: k8s.io/client-go/transport
    cpu: Apple M1 Pro
                              │ bart.base.log │           bart.concat.log            │
                              │    sec/op     │    sec/op     vs base                │
    BearerAuthRoundTripper-10    361.3n ± 31%   295.5n ± 11%  -18.21% (p=0.000 n=20)

                              │ bart.base.log │          bart.concat.log          │
                              │     B/op      │    B/op     vs base               │
    BearerAuthRoundTripper-10      768.0 ± 0%   752.0 ± 0%  -2.08% (p=0.000 n=20)

                              │ bart.base.log │          bart.concat.log           │
                              │   allocs/op   │ allocs/op   vs base                │
    BearerAuthRoundTripper-10      6.000 ± 0%   5.000 ± 0%  -16.67% (p=0.000 n=20)

Considering this method is likely used in many installations, the gains, while small, adds up to bigger savings.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:
Note that I mention a benchmark, this wasn't include in my changes because I couldn't find a similar one in the codebase, but I can add it in this PR. The benchmark is very simple:

```go
func BenchmarkBearerAuthRoundTripper(b *testing.B) {
	rt := &testRoundTripper{}
	req := &http.Request{}
	bart := NewBearerAuthRoundTripper("test", rt)
	b.ReportAllocs()
	for b.Loop() {
		bart.RoundTrip(req)
	}
}
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
