### PR TITLE
WIP Integration test demonstrating bug 132042 [Experiment]

### DIFF
--- a/test/integration/job/job_test.go
+++ b/test/integration/job/job_test.go
@@ -2322,7 +2322,7 @@ func TestImmediateJobRecreation(t *testing.T) {
 
 	var jobObjs []batchv1.Job
 	// create multiple Jobs we are going to recreate to make the issue more likely.
-	for i := 0; i < 6; i++ {
+	for i := 0; i < 3; i++ {
 		jobObj, err := createJobWithDefaults(ctx, clientSet, ns.Name, ptr.To(jobSpec(i)))
 		if err != nil {
 			t.Fatalf("Error %v when creating the job2 %q", err, klog.KObj(jobObj))


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
repro for issue  #132042 

#### Special notes for your reviewer:

This is just a repro test to show the problem and that https://github.com/kubernetes/kubernetes/pull/132109 is fixing it.

Locally, without the fix it fails pretty consistently (all runs so far).

Now I applied the fix and left it running in a loop with:
```
go test ./test/integration/job -timeout=10000s --count 100 -run TestImmediateJobRecreation -v 2>&1 | tee out.txt
```
so far 20 passes and not failure, indicating the fix works.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
