### PR TITLE
KEP-3715: drop ElasticIndexedJob feature gate

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -669,14 +669,6 @@ const (
 	// Adds support to pull images based on the runtime class specified.
 	RuntimeClassInImageCriAPI featuregate.Feature = "RuntimeClassInImageCriApi"
 
-	// owner: @danielvegamyhre
-	// kep: https://kep.k8s.io/2413
-	//
-	// Allows mutating spec.completions for Indexed job when done in tandem with
-	// spec.parallelism. Specifically, spec.completions is mutable iff spec.completions
-	// equals to spec.parallelism before and after the update.
-	ElasticIndexedJob featuregate.Feature = "ElasticIndexedJob"
-
 	// owner: @sanposhiho
 	// kep: http://kep.k8s.io/4247
 	//
@@ -1171,11 +1163,6 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 
 	KubeletCrashLoopBackOffMax: {
 		{Version: version.MustParse("1.32"), Default: false, PreRelease: featuregate.Alpha},
-	},
-
-	ElasticIndexedJob: {
-		{Version: version.MustParse("1.27"), Default: true, PreRelease: featuregate.Beta},
-		{Version: version.MustParse("1.31"), Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // GA in 1.31, remove in 1.32
 	},
 
 	EventedPLEG: {

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -477,16 +477,6 @@
     lockToDefault: false
     preRelease: Beta
     version: "1.32"
-- name: ElasticIndexedJob
-  versionedSpecs:
-  - default: true
-    lockToDefault: false
-    preRelease: Beta
-    version: "1.27"
-  - default: true
-    lockToDefault: true
-    preRelease: GA
-    version: "1.31"
 - name: EventedPLEG
   versionedSpecs:
   - default: false

--- a/test/integration/job/job_test.go
+++ b/test/integration/job/job_test.go
@@ -1591,7 +1591,6 @@ func TestDelayTerminalPhaseCondition(t *testing.T) {
 			}
 			featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.JobPodReplacementPolicy, test.enableJobPodReplacementPolicy)
 			featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.JobManagedBy, test.enableJobManagedBy)
-			featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.ElasticIndexedJob, true)
 			featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.JobSuccessPolicy, test.enableJobSuccessPolicy)
 
 			ctx, cancel := startJobControllerAndWaitForCaches(t, restConfig)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig apps
/wg batch

#### What this PR does / why we need it:
This cleans up the StatefulSetStartOrdinal feature gate, which was promoted to GA [back in 1.31](https://github.com/kubernetes/kubernetes/pull/125751). 

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
/assign @mimowo 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/3715
```
