### PR TITLE
KEP-3329: drop PodDisruptionConditions feature gate

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -540,13 +540,6 @@ const (
 	// Enables controlling pod ranking on replicaset scale-down.
 	PodDeletionCost featuregate.Feature = "PodDeletionCost"
 
-	// owner: @mimowo
-	// kep: https://kep.k8s.io/3329
-	//
-	// Enables support for appending a dedicated pod condition indicating that
-	// the pod is being deleted due to a disruption.
-	PodDisruptionConditions featuregate.Feature = "PodDisruptionConditions"
-
 	// owner: @danielvegamyhre
 	// kep: https://kep.k8s.io/4017
 	//
@@ -1571,12 +1564,6 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 	PodDeletionCost: {
 		{Version: version.MustParse("1.21"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("1.22"), Default: true, PreRelease: featuregate.Beta},
-	},
-
-	PodDisruptionConditions: {
-		{Version: version.MustParse("1.25"), Default: false, PreRelease: featuregate.Alpha},
-		{Version: version.MustParse("1.26"), Default: true, PreRelease: featuregate.Beta},
-		{Version: version.MustParse("1.31"), Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.33
 	},
 
 	PodIndexLabel: {

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -1007,20 +1007,6 @@
     lockToDefault: false
     preRelease: Beta
     version: "1.22"
-- name: PodDisruptionConditions
-  versionedSpecs:
-  - default: false
-    lockToDefault: false
-    preRelease: Alpha
-    version: "1.25"
-  - default: true
-    lockToDefault: false
-    preRelease: Beta
-    version: "1.26"
-  - default: true
-    lockToDefault: true
-    preRelease: GA
-    version: "1.31"
 - name: PodIndexLabel
   versionedSpecs:
   - default: true


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/sig apps
/wg batch

#### What this PR does / why we need it:
This cleans up the StatefulSetStartOrdinal feature gate, which was promoted to GA [back in 1.31](https://github.com/kubernetes/kubernetes/pull/125442).

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
/assign @mimowo 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/3329
```
