### PR TITLE
Handle consistent LIST in watch cache to avoid incorrect semantics while setting ResourceVersion on options

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
@@ -424,7 +424,7 @@ func NewCacherFromConfig(config Config) (*Cacher, error) {
 	progressRequester := progress.NewConditionalProgressRequester(config.Storage.RequestWatchProgress, config.Clock, contextMetadata)
 	watchCache := newWatchCache(
 		config.KeyFunc, cacher.processEvent, config.GetAttrsFunc, config.Versioner, config.Indexers,
-		config.Clock, eventFreshDuration, config.GroupResource, progressRequester)
+		config.Clock, eventFreshDuration, config.GroupResource, progressRequester, config.Storage.GetCurrentResourceVersion)
 	listerWatcher := NewListerWatcher(config.Storage, config.ResourcePrefix, config.NewListFunc, contextMetadata)
 	reflectorName := "storage/cacher.go:" + config.ResourcePrefix
 
@@ -694,20 +694,6 @@ func computeListLimit(opts storage.ListOptions) int64 {
 	return opts.Predicate.Limit
 }
 
-func (c *Cacher) listItems(ctx context.Context, listRV uint64, key string, opts storage.ListOptions) (listResp, string, error) {
-	if !opts.Recursive {
-		obj, exists, readResourceVersion, err := c.watchCache.WaitUntilFreshAndGet(ctx, listRV, key)
-		if err != nil {
-			return listResp{}, "", err
-		}
-		if exists {
-			return listResp{Items: []interface{}{obj}, ResourceVersion: readResourceVersion}, "", nil
-		}
-		return listResp{ResourceVersion: readResourceVersion}, "", nil
-	}
-	return c.watchCache.WaitUntilFreshAndList(ctx, listRV, key, opts)
-}
-
 type listResp struct {
 	Items           []interface{}
 	ResourceVersion uint64
@@ -723,7 +709,7 @@ func (c *Cacher) GetList(ctx context.Context, key string, opts storage.ListOptio
 	if opts.Recursive && !strings.HasSuffix(key, "/") {
 		preparedKey += "/"
 	}
-	listRV, err := c.versioner.ParseResourceVersion(opts.ResourceVersion)
+	_, err := c.versioner.ParseResourceVersion(opts.ResourceVersion)
 	if err != nil {
 		return err
 	}
@@ -759,7 +745,7 @@ func (c *Cacher) GetList(ctx context.Context, key string, opts storage.ListOptio
 		return fmt.Errorf("need a pointer to slice, got %v", listVal.Kind())
 	}
 
-	resp, indexUsed, err := c.listItems(ctx, listRV, preparedKey, opts)
+	resp, indexUsed, err := c.watchCache.WaitUntilFreshAndGetList(ctx, preparedKey, opts)
 	if err != nil {
 		return err
 	}

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
@@ -610,7 +610,7 @@ apiserver_watch_cache_consistent_read_total{fallback="true", group="", resource=
 			}
 
 			start := cacher.clock.Now()
-			err = delegator.GetList(context.TODO(), "pods/ns", storage.ListOptions{ResourceVersion: ""}, result)
+			err = delegator.GetList(context.TODO(), "pods/ns", storage.ListOptions{ResourceVersion: "", Recursive: true}, result)
 			clockStepCancelFn()
 			duration := cacher.clock.Since(start)
 			if (err != nil) != tc.expectError {
@@ -3495,7 +3495,7 @@ func TestListIndexer(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			pred := storagetesting.CreatePodPredicate(tt.fieldSelector, true, tt.indexFields)
-			_, usedIndex, err := cacher.cacher.listItems(ctx, 0, "/pods/"+tt.requestedNamespace, storage.ListOptions{Predicate: pred, Recursive: tt.recursive})
+			_, usedIndex, err := cacher.cacher.watchCache.WaitUntilFreshAndGetList(ctx, "/pods/"+tt.requestedNamespace, storage.ListOptions{Predicate: pred, Recursive: tt.recursive})
 			if err != nil {
 				t.Errorf("Unexpected error: %v", err)
 			}

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/delegator.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/delegator.go
@@ -207,36 +207,19 @@ func (c *CacheDelegator) GetList(ctx context.Context, key string, opts storage.L
 			return c.storage.GetList(ctx, key, opts, listObj)
 		}
 	}
-	fallbackOpts := opts
-	if result.ConsistentRead {
-		listRV, err = c.storage.GetCurrentResourceVersion(ctx)
-		if err != nil {
-			return err
-		}
-		// Setting resource version for consistent read in cache based on current ResourceVersion in etcd.
-		opts.ResourceVersion = strconv.FormatInt(int64(listRV), 10)
-		// If continue is not set, we need to set the resource version match to ResourceVersionMatchNotOlderThan to serve latest from cache
-		if opts.Predicate.Continue == "" {
-			opts.ResourceVersionMatch = metav1.ResourceVersionMatchNotOlderThan
-		}
-	}
 	err = c.cacher.GetList(ctx, key, opts, listObj)
 	success := "true"
 	fallback := "false"
 	if err != nil {
-		// ResourceExpired error occurs when attempting to list from cache with a specific resourceVersion
-		// that is no longer available in the cache. With ListFromCacheSnapshot feature (1.34+), we can
-		// serve exact resourceVersion requests from cache if available, falling back to storage only when
-		// the requested version is expired.
 		if errors.IsResourceExpired(err) && utilfeature.DefaultFeatureGate.Enabled(features.ListFromCacheSnapshot) {
-			return c.storage.GetList(ctx, key, fallbackOpts, listObj)
+			return c.storage.GetList(ctx, key, opts, listObj)
 		}
 		if result.ConsistentRead {
 			// IsTooLargeResourceVersion occurs when the requested RV is higher than cache's current RV
 			// and cache hasn't caught up within the timeout period. Fall back to etcd.
 			if storage.IsTooLargeResourceVersion(err) {
 				fallback = "true"
-				err = c.storage.GetList(ctx, key, fallbackOpts, listObj)
+				err = c.storage.GetList(ctx, key, opts, listObj)
 			}
 			if err != nil {
 				success = "false"

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
@@ -156,6 +156,8 @@ type watchCache struct {
 
 	// Stores previous snapshots of orderedLister to allow serving requests from previous revisions.
 	snapshots Snapshotter
+
+	getCurrentRV func(context.Context) (uint64, error)
 }
 
 func newWatchCache(
@@ -167,7 +169,9 @@ func newWatchCache(
 	clock clock.WithTicker,
 	eventFreshDuration time.Duration,
 	groupResource schema.GroupResource,
-	progressRequester *progress.ConditionalProgressRequester) *watchCache {
+	progressRequester *progress.ConditionalProgressRequester,
+	getCurrentRV func(context.Context) (uint64, error),
+) *watchCache {
 	wc := &watchCache{
 		capacity:            defaultLowerBoundCapacity,
 		keyFunc:             keyFunc,
@@ -186,6 +190,7 @@ func newWatchCache(
 		versioner:           versioner,
 		groupResource:       groupResource,
 		waitingUntilFresh:   progressRequester,
+		getCurrentRV:        getCurrentRV,
 	}
 	if utilfeature.DefaultFeatureGate.Enabled(features.ListFromCacheSnapshot) {
 		wc.snapshots = newStoreSnapshotter()
@@ -494,30 +499,48 @@ func (s sortableStoreElements) Swap(i, j int) {
 	s[i], s[j] = s[j], s[i]
 }
 
-// WaitUntilFreshAndList returns list of pointers to `storeElement` objects along
-// with their ResourceVersion and the name of the index, if any, that was used.
-func (w *watchCache) WaitUntilFreshAndList(ctx context.Context, resourceVersion uint64, key string, opts storage.ListOptions) (resp listResp, index string, err error) {
-	if delegator.ConsistentReadSupported() && w.notFresh(resourceVersion) {
-		w.waitingUntilFresh.Add()
-		err = w.waitUntilFreshAndBlock(ctx, resourceVersion)
-		w.waitingUntilFresh.Remove()
-	} else {
-		err = w.waitUntilFreshAndBlock(ctx, resourceVersion)
+func (c *watchCache) WaitUntilFreshAndGetList(ctx context.Context, key string, opts storage.ListOptions) (listResp, string, error) {
+	if opts.Recursive {
+		return c.waitUntilFreshAndList(ctx, key, opts)
 	}
+	return c.waitUntilFreshAndGetList(ctx, key, opts)
+}
 
-	defer w.RUnlock()
+func (c *watchCache) waitUntilFreshAndGetList(ctx context.Context, key string, opts storage.ListOptions) (listResp, string, error) {
+	var listRV uint64
+	var err error
+	if opts.ResourceVersionMatch == "" && opts.ResourceVersion == "" {
+		// Consistent read
+		listRV, err = c.getCurrentRV(ctx)
+		if err != nil {
+			return listResp{}, "", err
+		}
+	} else {
+		listRV, err = c.versioner.ParseResourceVersion(opts.ResourceVersion)
+		if err != nil {
+			return listResp{}, "", err
+		}
+	}
+	obj, exists, readResourceVersion, err := c.WaitUntilFreshAndGet(ctx, listRV, key)
 	if err != nil {
 		return listResp{}, "", err
 	}
-	return w.list(ctx, resourceVersion, key, opts)
+	if exists {
+		return listResp{Items: []interface{}{obj}, ResourceVersion: readResourceVersion}, "", nil
+	}
+	return listResp{ResourceVersion: readResourceVersion}, "", nil
 }
 
 // NOTICE: Structure follows the shouldDelegateList function in
 // staging/src/k8s.io/apiserver/pkg/storage/cacher/delegator.go
-func (w *watchCache) list(ctx context.Context, resourceVersion uint64, key string, opts storage.ListOptions) (resp listResp, index string, err error) {
+func (w *watchCache) waitUntilFreshAndList(ctx context.Context, key string, opts storage.ListOptions) (resp listResp, index string, err error) {
+	listRV, err := w.versioner.ParseResourceVersion(opts.ResourceVersion)
+	if err != nil {
+		return listResp{}, "", err
+	}
 	switch opts.ResourceVersionMatch {
 	case metav1.ResourceVersionMatchExact:
-		return w.listExactRV(key, "", resourceVersion)
+		return w.waitAndListExactRV(ctx, key, "", listRV)
 	case metav1.ResourceVersionMatchNotOlderThan:
 	case "":
 		// Continue
@@ -527,23 +550,36 @@ func (w *watchCache) list(ctx context.Context, resourceVersion uint64, key strin
 				return listResp{}, "", errors.NewBadRequest(fmt.Sprintf("invalid continue token: %v", err))
 			}
 			if continueRV > 0 {
-				return w.listExactRV(key, continueKey, uint64(continueRV))
+				return w.waitAndListExactRV(ctx, key, continueKey, uint64(continueRV))
 			} else {
-				// Continue with negative RV is a consistent read - already handled via waitUntilFreshAndBlock.
 				// Don't pass matchValues as they don't support continueKey
-				return w.listLatestRV(key, continueKey, nil)
+				return w.waitAndListConsistent(ctx, key, continueKey, nil)
 			}
 		}
 		// Legacy exact match
 		if opts.Predicate.Limit > 0 && len(opts.ResourceVersion) > 0 && opts.ResourceVersion != "0" {
-			return w.listExactRV(key, "", resourceVersion)
+			return w.waitAndListExactRV(ctx, key, "", listRV)
 		}
-		// Consistent Read - already handled via waitUntilFreshAndBlock
+		if opts.ResourceVersion == "" {
+			return w.waitAndListConsistent(ctx, key, "", opts.Predicate.MatcherIndex(ctx))
+		}
 	}
-	return w.listLatestRV(key, "", opts.Predicate.MatcherIndex(ctx))
+	return w.waitAndListLatestRV(ctx, listRV, key, "", opts.Predicate.MatcherIndex(ctx))
 }
 
-func (w *watchCache) listExactRV(key, continueKey string, resourceVersion uint64) (resp listResp, index string, err error) {
+func (w *watchCache) waitAndListExactRV(ctx context.Context, key, continueKey string, resourceVersion uint64) (resp listResp, index string, err error) {
+	if delegator.ConsistentReadSupported() && w.notFresh(resourceVersion) {
+		w.waitingUntilFresh.Add()
+		err = w.waitUntilFreshAndBlock(ctx, resourceVersion)
+		w.waitingUntilFresh.Remove()
+	} else {
+		err = w.waitUntilFreshAndBlock(ctx, resourceVersion)
+	}
+	defer w.RUnlock()
+	if err != nil {
+		return listResp{}, "", err
+	}
+
 	if w.snapshots == nil {
 		return listResp{}, "", errors.NewResourceExpired(fmt.Sprintf("too old resource version: %d", resourceVersion))
 	}
@@ -556,6 +592,29 @@ func (w *watchCache) listExactRV(key, continueKey string, resourceVersion uint64
 		Items:           items,
 		ResourceVersion: resourceVersion,
 	}, "", nil
+}
+
+func (w *watchCache) waitAndListConsistent(ctx context.Context, key, continueKey string, matchValues []storage.MatchValue) (resp listResp, index string, err error) {
+	resourceVersion, err := w.getCurrentRV(ctx)
+	if err != nil {
+		return listResp{}, "", err
+	}
+	return w.waitAndListLatestRV(ctx, resourceVersion, key, continueKey, matchValues)
+}
+
+func (w *watchCache) waitAndListLatestRV(ctx context.Context, resourceVersion uint64, key, continueKey string, matchValues []storage.MatchValue) (resp listResp, index string, err error) {
+	if delegator.ConsistentReadSupported() && w.notFresh(resourceVersion) {
+		w.waitingUntilFresh.Add()
+		err = w.waitUntilFreshAndBlock(ctx, resourceVersion)
+		w.waitingUntilFresh.Remove()
+	} else {
+		err = w.waitUntilFreshAndBlock(ctx, resourceVersion)
+	}
+	defer w.RUnlock()
+	if err != nil {
+		return listResp{}, "", err
+	}
+	return w.listLatestRV(key, continueKey, matchValues)
 }
 
 func (w *watchCache) listLatestRV(key, continueKey string, matchValues []storage.MatchValue) (resp listResp, index string, err error) {

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/store_tests.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/store_tests.go
@@ -697,6 +697,7 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, inc
 		{
 			name:             "rejects resource version set too high",
 			prefix:           "/pods",
+			pred:             storage.Everything,
 			rv:               strconv.FormatInt(math.MaxInt64, 10),
 			expectRVTooLarge: true,
 		},


### PR DESCRIPTION
/kind cleanup

Cleanup after discovery of https://github.com/kubernetes/kubernetes/issues/132132 and fix https://github.com/kubernetes/kubernetes/pull/132244

This PR should make the code easier to understand.

Due to Snapshots from cache feature the watch cache started classifying consistent read with limit as legacy exact read. This is because the delegator incorrectly assumed that it can transform consistent read to notOlderThan request.

```release-note
NONE
```
