### PR TITLE
Bugfix: record authentication latency before audit filter wraps up

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authentication.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authentication.go
@@ -66,9 +66,9 @@ func withAuthentication(handler http.Handler, auth authenticator.Request, failed
 		}
 		resp, ok, err := auth.AuthenticateRequest(req)
 		authenticationFinish := time.Now()
+		genericapirequest.TrackAuthenticationLatency(req.Context(), authenticationFinish.Sub(authenticationStart))
 		defer func() {
 			metrics(req.Context(), resp, ok, err, apiAuds, authenticationStart, authenticationFinish)
-			genericapirequest.TrackAuthenticationLatency(req.Context(), authenticationFinish.Sub(authenticationStart))
 		}()
 		if err != nil || !ok {
 			if err != nil {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authorization.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authorization.go
@@ -71,9 +71,9 @@ func withAuthorization(handler http.Handler, a authorizer.Authorizer, s runtime.
 		authorized, reason, err := a.Authorize(ctx, attributes)
 
 		authorizationFinish := time.Now()
+		request.TrackAuthorizationLatency(ctx, authorizationFinish.Sub(authorizationStart))
 		defer func() {
 			metrics(ctx, authorized, err, authorizationStart, authorizationFinish)
-			request.TrackAuthorizationLatency(ctx, authorizationFinish.Sub(authorizationStart))
 		}()
 
 		// an authorizer like RBAC could encounter evaluation errors and still allow the request, so authorizer decision is checked before error here.

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/webhook_duration.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/webhook_duration.go
@@ -71,9 +71,7 @@ func (wt *writeLatencyTracker) Unwrap() http.ResponseWriter {
 
 func (wt *writeLatencyTracker) Write(bs []byte) (int, error) {
 	startedAt := time.Now()
-	defer func() {
-		request.TrackResponseWriteLatency(wt.ctx, time.Since(startedAt))
-	}()
-
-	return wt.ResponseWriter.Write(bs)
+	n, err := wt.ResponseWriter.Write(bs)
+	request.TrackResponseWriteLatency(wt.ctx, time.Since(startedAt))
+	return n, err
 }


### PR DESCRIPTION
Previously https://github.com/kubernetes/kubernetes/pull/130571 added additional annotation to audit events so that we can track authn & authz latency. However it's only able to record authz latency e.g.:

> {"kind":"Event","..."annotations":{"apiserver.latency.k8s.io/authorization":"7      09ns","apiserver.latency.k8s.io/response-write":"167ns","apiserver.latency.k8s.io/serialize-response-object":"52.167µs","apiserver.latency.k8s.io/total":"52.424459ms","authorization.k8s.io/decision":"al      low","authorization.k8s.io/reason":""}}

This is because kube-apiserver's filters are chained in such order:

> authentication -> ... ->  audit -> ... -> authorization

And we recorded authentication latency in a `defer` block which works after persisting the audit log. This PR fixes this issue by recording authn latency out of the defer block. After the fix, the audit event shall look like:

> {"kind":"Event",...."annotations":{"apiserver.latency.k8s.io/authentication":"2.75µs","apiserver.latency.k8s.i      o/authorization":"500ns","apiserver.latency.k8s.io/response-write":"250ns","apiserver.latency.k8s.io/serialize-response-object":"44.417µs","apiserver.latency.k8s.io/total":"12.113ms","apiserver.latency.      k8s.io/transform-response-object":"209ns","authorization.k8s.io/decision":"allow","authorization.k8s.io/reason":""}}


/kind bug

```release-note
NONE
```

/cc @hakuna-matatah @dims @mengqiy 

