### PR TITLE
pop lock with channel

### DIFF
--- a/pkg/scheduler/backend/queue/active_queue.go
+++ b/pkg/scheduler/backend/queue/active_queue.go
@@ -177,12 +177,6 @@ type activeQueue struct {
 	// and can be used in the underLock() or underRLock().
 	unlockedQueue *unlockedActiveQueue
 
-	// cond is a condition that is notified when the pod is added to activeQ.
-	// When SchedulerPopFromBackoffQ feature is enabled,
-	// condition is also notified when the pod is added to backoffQ.
-	// It is used with lock.
-	// cond sync.Cond
-
 	// inFlightPods holds the UID of all pods which have been popped out for which Done
 	// hasn't been called yet - in other words, all pods that are currently being
 	// processed (being scheduled, in permit, or in the binding cycle).
@@ -270,9 +264,9 @@ func (aq *activeQueue) delete(pInfo *framework.QueuedPodInfo) error {
 	return aq.queue.Delete(pInfo)
 }
 
-// // pop removes the head of the queue and returns it.
-// // It blocks if the queue is empty and waits until a new item is added to the queue.
-// // It increments scheduling cycle when a pod is popped.
+// pop removes the head of the queue and returns it.
+// It blocks if the queue is empty and waits until a new item is added to the queue.
+// It increments scheduling cycle when a pod is popped.
 func (aq *activeQueue) pop(logger klog.Logger) (*framework.QueuedPodInfo, error) {
 	for {
 		aq.lock.Lock()

--- a/pkg/scheduler/backend/queue/active_queue.go
+++ b/pkg/scheduler/backend/queue/active_queue.go
@@ -181,7 +181,7 @@ type activeQueue struct {
 	// When SchedulerPopFromBackoffQ feature is enabled,
 	// condition is also notified when the pod is added to backoffQ.
 	// It is used with lock.
-	cond sync.Cond
+	// cond sync.Cond
 
 	// inFlightPods holds the UID of all pods which have been popped out for which Done
 	// hasn't been called yet - in other words, all pods that are currently being
@@ -223,6 +223,9 @@ type activeQueue struct {
 	// backoffQPopper is used to pop from backoffQ when activeQ is empty.
 	// It is non-nil only when SchedulerPopFromBackoffQ feature is enabled.
 	backoffQPopper backoffQPopper
+
+	notifyCh chan struct{}
+	closeCh  chan struct{}
 }
 
 func newActiveQueue(queue *heap.Heap[*framework.QueuedPodInfo], isSchedulingQueueHintEnabled bool, metricRecorder *metrics.MetricAsyncRecorder, backoffQPopper backoffQPopper) *activeQueue {
@@ -233,8 +236,9 @@ func newActiveQueue(queue *heap.Heap[*framework.QueuedPodInfo], isSchedulingQueu
 		isSchedulingQueueHintEnabled: isSchedulingQueueHintEnabled,
 		metricsRecorder:              metricRecorder,
 		backoffQPopper:               backoffQPopper,
+		notifyCh:                     make(chan struct{}, 1),
+		closeCh:                      make(chan struct{}),
 	}
-	aq.cond.L = &aq.lock
 	aq.unlockedQueue = newUnlockedActiveQueue(queue, aq.inFlightPods, aq.inFlightEvents, metricRecorder)
 
 	return aq
@@ -266,45 +270,62 @@ func (aq *activeQueue) delete(pInfo *framework.QueuedPodInfo) error {
 	return aq.queue.Delete(pInfo)
 }
 
-// pop removes the head of the queue and returns it.
-// It blocks if the queue is empty and waits until a new item is added to the queue.
-// It increments scheduling cycle when a pod is popped.
+// // pop removes the head of the queue and returns it.
+// // It blocks if the queue is empty and waits until a new item is added to the queue.
+// // It increments scheduling cycle when a pod is popped.
+// func (aq *activeQueue) pop(logger klog.Logger) (*framework.QueuedPodInfo, error) {
+// 	aq.lock.Lock()
+// 	defer aq.lock.Unlock()
+
+// 	return aq.unlockedPop(logger)
+// }
+
 func (aq *activeQueue) pop(logger klog.Logger) (*framework.QueuedPodInfo, error) {
-	aq.lock.Lock()
-	defer aq.lock.Unlock()
+	for {
+		aq.lock.Lock()
 
-	return aq.unlockedPop(logger)
-}
-
-func (aq *activeQueue) unlockedPop(logger klog.Logger) (*framework.QueuedPodInfo, error) {
-	var pInfo *framework.QueuedPodInfo
-	for aq.queue.Len() == 0 {
-		// backoffQPopper is non-nil only if SchedulerPopFromBackoffQ feature is enabled.
-		// In case of non-empty backoffQ, try popping from there.
-		if aq.backoffQPopper != nil && aq.backoffQPopper.lenBackoff() != 0 {
-			break
-		}
-		// When the queue is empty, invocation of Pop() is blocked until new item is enqueued.
-		// When Close() is called, the p.closed is set and the condition is broadcast,
-		// which causes this loop to continue and return from the Pop().
 		if aq.closed {
+			aq.lock.Unlock()
 			logger.V(2).Info("Scheduling queue is closed")
 			return nil, nil
 		}
-		aq.cond.Wait()
+
+		if aq.hasSomething() {
+			pInfo, err := aq.popLocked(logger)
+			aq.lock.Unlock()
+			if err != nil {
+				return nil, err
+			}
+			if pInfo == nil {
+				continue
+			}
+			return pInfo, nil
+		}
+
+		aq.lock.Unlock()
+		select {
+		case <-aq.notifyCh:
+			continue
+		case <-aq.closeCh:
+			logger.V(2).Info("Scheduling queue is closed")
+			return nil, nil
+		}
 	}
+}
+
+func (aq *activeQueue) popLocked(logger klog.Logger) (*framework.QueuedPodInfo, error) {
 	pInfo, err := aq.queue.Pop()
 	if err != nil {
 		if aq.backoffQPopper == nil {
 			return nil, err
 		}
-		// Try to pop from backoffQ when activeQ is empty.
 		pInfo, err = aq.backoffQPopper.popBackoff()
 		if err != nil {
 			return nil, err
 		}
 		metrics.SchedulerQueueIncomingPods.WithLabelValues("active", framework.PopFromBackoffQ).Inc()
 	}
+
 	pInfo.Attempts++
 	// In flight, no concurrent events yet.
 	if aq.isSchedulingQueueHintEnabled {
@@ -315,7 +336,7 @@ func (aq *activeQueue) unlockedPop(logger klog.Logger) (*framework.QueuedPodInfo
 			// because it likely doesn't cause any visible issues from the scheduling perspective.
 			utilruntime.HandleErrorWithLogger(logger, nil, "The same pod is tracked in multiple places in the scheduler, and just discard it", "pod", klog.KObj(pInfo.Pod))
 			// Just ignore/discard this duplicated pod and try to pop the next one.
-			return aq.unlockedPop(logger)
+			return nil, nil
 		}
 
 		aq.metricsRecorder.ObserveInFlightEventsAsync(metrics.PodPoppedInFlightEvent, 1, false)
@@ -334,6 +355,83 @@ func (aq *activeQueue) unlockedPop(logger klog.Logger) (*framework.QueuedPodInfo
 
 	return pInfo, nil
 }
+
+func (aq *activeQueue) hasSomething() bool {
+	if aq.queue.Len() > 0 {
+		return true
+	}
+	return aq.backoffQPopper != nil && aq.backoffQPopper.lenBackoff() > 0
+}
+
+// func (aq *activeQueue) unlockedPop(logger klog.Logger) (*framework.QueuedPodInfo, error) {
+// 	var pInfo *framework.QueuedPodInfo
+// 	for aq.queue.Len() == 0 {
+// 		// backoffQPopper is non-nil only if SchedulerPopFromBackoffQ feature is enabled.
+// 		// In case of non-empty backoffQ, try popping from there.
+// 		if aq.backoffQPopper != nil && aq.backoffQPopper.lenBackoff() != 0 {
+// 			break
+// 		}
+// 		// When the queue is empty, invocation of Pop() is blocked until new item is enqueued.
+// 		// When Close() is called, the p.closed is set and the condition is broadcast,
+// 		// which causes this loop to continue and return from the Pop().
+// 		if aq.closed {
+// 			logger.V(2).Info("Scheduling queue is closed")
+// 			return nil, nil
+// 		}
+// 		aq.cond.Wait()
+
+// 		select {
+// 		case <-aq.notifyCh:
+// 		case <-aq.closeCh:
+// 			logger.V(2).Info("Scheduling queue is closed")
+// 			return nil, nil
+// 		}
+// 	}
+// 	select {
+// 	case <-aq.notifyCh:
+// 	default:
+// 	}
+// 	pInfo, err := aq.queue.Pop()
+// 	if err != nil {
+// 		if aq.backoffQPopper == nil {
+// 			return nil, err
+// 		}
+// 		// Try to pop from backoffQ when activeQ is empty.
+// 		pInfo, err = aq.backoffQPopper.popBackoff()
+// 		if err != nil {
+// 			return nil, err
+// 		}
+// 		metrics.SchedulerQueueIncomingPods.WithLabelValues("active", framework.PopFromBackoffQ).Inc()
+// 	}
+// 	pInfo.Attempts++
+// 	// In flight, no concurrent events yet.
+// 	if aq.isSchedulingQueueHintEnabled {
+// 		// If the pod is already in the map, we shouldn't overwrite the inFlightPods otherwise it'd lead to a memory leak.
+// 		// https://github.com/kubernetes/kubernetes/pull/127016
+// 		if _, ok := aq.inFlightPods[pInfo.Pod.UID]; ok {
+// 			// Just report it as an error, but no need to stop the scheduler
+// 			// because it likely doesn't cause any visible issues from the scheduling perspective.
+// 			logger.Error(nil, "the same pod is tracked in multiple places in the scheduler, and just discard it", "pod", klog.KObj(pInfo.Pod))
+// 			// Just ignore/discard this duplicated pod and try to pop the next one.
+// 			return aq.unlockedPop(logger)
+// 		}
+
+// 		aq.metricsRecorder.ObserveInFlightEventsAsync(metrics.PodPoppedInFlightEvent, 1, false)
+// 		aq.inFlightPods[pInfo.Pod.UID] = aq.inFlightEvents.PushBack(pInfo.Pod)
+// 	}
+// 	aq.schedCycle++
+
+// 	// Update metrics and reset the set of unschedulable plugins for the next attempt.
+// 	for plugin := range pInfo.UnschedulablePlugins.Union(pInfo.PendingPlugins) {
+// 		metrics.UnschedulableReason(plugin, pInfo.Pod.Spec.SchedulerName).Dec()
+// 	}
+// 	pInfo.UnschedulablePlugins.Clear()
+// 	pInfo.PendingPlugins.Clear()
+// 	pInfo.GatingPlugin = ""
+// 	pInfo.GatingPluginEvents = nil
+
+// 	return pInfo, nil
+// }
 
 // list returns all pods that are in the queue.
 func (aq *activeQueue) list() []*v1.Pod {
@@ -504,9 +602,14 @@ func (aq *activeQueue) close() {
 		aq.unlockedDone(pod)
 	}
 	aq.closed = true
+	close(aq.closeCh)
 }
 
 // broadcast notifies the pop() operation that new pod(s) was added to the activeQueue.
 func (aq *activeQueue) broadcast() {
-	aq.cond.Broadcast()
+	// aq.cond.Broadcast()
+	select {
+	case aq.notifyCh <- struct{}{}:
+	default:
+	}
 }

--- a/pkg/scheduler/backend/queue/active_queue.go
+++ b/pkg/scheduler/backend/queue/active_queue.go
@@ -53,7 +53,6 @@ type activeQueuer interface {
 	done(pod types.UID)
 	close()
 	broadcast()
-	tryNotify()
 }
 
 // unlockedActiveQueuer defines activeQ methods that are not protected by the lock itself.
@@ -274,13 +273,6 @@ func (aq *activeQueue) delete(pInfo *framework.QueuedPodInfo) error {
 // // pop removes the head of the queue and returns it.
 // // It blocks if the queue is empty and waits until a new item is added to the queue.
 // // It increments scheduling cycle when a pod is popped.
-// func (aq *activeQueue) pop(logger klog.Logger) (*framework.QueuedPodInfo, error) {
-// 	aq.lock.Lock()
-// 	defer aq.lock.Unlock()
-
-// 	return aq.unlockedPop(logger)
-// }
-
 func (aq *activeQueue) pop(logger klog.Logger) (*framework.QueuedPodInfo, error) {
 	for {
 		aq.lock.Lock()

--- a/pkg/scheduler/backend/queue/backoff_queue.go
+++ b/pkg/scheduler/backend/queue/backoff_queue.go
@@ -75,8 +75,6 @@ type backoffQueuer interface {
 	list() []*v1.Pod
 	// len returns length of the queue.
 	len() int
-
-	setNotifyFunc(f func())
 }
 
 // backoffQueue implements backoffQueuer and wraps two queues inside,

--- a/pkg/scheduler/backend/queue/scheduling_queue.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue.go
@@ -375,6 +375,9 @@ func NewPriorityQueue(
 		backoffQPopper = backoffQ
 	}
 	pq.activeQ = newActiveQueue(heap.NewWithRecorder(podInfoKeyFunc, heap.LessFunc[*framework.QueuedPodInfo](lessConverted), metrics.NewActivePodsRecorder()), isSchedulingQueueHintEnabled, options.metricsRecorder, backoffQPopper)
+	if bq, ok := pq.backoffQ.(*backoffQueue); ok {
+		bq.setNotifyFunc(func() { pq.activeQ.tryNotify() })
+	}
 	pq.nsLister = informerFactory.Core().V1().Namespaces().Lister()
 	pq.nominator = newPodNominator(options.podLister)
 

--- a/pkg/scheduler/backend/queue/scheduling_queue.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue.go
@@ -374,9 +374,10 @@ func NewPriorityQueue(
 	if isPopFromBackoffQEnabled {
 		backoffQPopper = backoffQ
 	}
-	pq.activeQ = newActiveQueue(heap.NewWithRecorder(podInfoKeyFunc, heap.LessFunc[*framework.QueuedPodInfo](lessConverted), metrics.NewActivePodsRecorder()), isSchedulingQueueHintEnabled, options.metricsRecorder, backoffQPopper)
+	aq := newActiveQueue(heap.NewWithRecorder(podInfoKeyFunc, heap.LessFunc[*framework.QueuedPodInfo](lessConverted), metrics.NewActivePodsRecorder()), isSchedulingQueueHintEnabled, options.metricsRecorder, backoffQPopper)
+	pq.activeQ = aq
 	if bq, ok := pq.backoffQ.(*backoffQueue); ok {
-		bq.setNotifyFunc(func() { pq.activeQ.tryNotify() })
+		bq.setNotifyFunc(func() { aq.tryNotify() })
 	}
 	pq.nsLister = informerFactory.Core().V1().Namespaces().Lister()
 	pq.nominator = newPodNominator(options.podLister)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
There is a race in activeQ.pop(): in the tiny window between checking that both activeQ and backoffQ are empty and calling cond.Wait(), a pod may be added to backoffQ and broadcast() fired. The goroutine then goes to Wait() and misses the signal (lost wakeup), so the scheduler can sleep even though backoffQ has work.

This PR replaces the sync.Cond wait/notify in activeQ.pop() with a coalesced channel (cap=1) and issues notifications after unlocking on activeQ/backoffQ updates.

#### Which issue(s) this PR is related to:
Fixes #130976 
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
None
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
