### PR TITLE
bug: Fix misleading response codes in admission control metrics

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/metrics/metrics.go
@@ -305,6 +305,11 @@ func (m *AdmissionMetrics) ObserveWebhookRejection(ctx context.Context, name, st
 	m.webhookRejection.WithContext(ctx).WithLabelValues(name, stepType, operation, string(errorType), strconv.Itoa(rejectionCode)).Inc()
 }
 
+// WebhookRejectionGathererForTest exposes admission webhook rejection metric for access by unit test.
+func (m *AdmissionMetrics) WebhookRejectionGathererForTest() *metrics.CounterVec {
+	return m.webhookRejection
+}
+
 // ObserveWebhookFailOpen records validating or mutating webhook that fail open.
 func (m *AdmissionMetrics) ObserveWebhookFailOpen(ctx context.Context, name, stepType string) {
 	m.webhookFailOpen.WithContext(ctx).WithLabelValues(name, stepType).Inc()

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/dispatcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/dispatcher.go
@@ -261,7 +261,7 @@ func (a *mutatingDispatcher) callAttrMutatingHook(ctx context.Context, h *admiss
 	// Make the webhook request
 	client, err := invocation.Webhook.GetRESTClient(a.cm)
 	if err != nil {
-		return false, &webhookutil.ErrCallingWebhook{WebhookName: h.Name, Reason: fmt.Errorf("could not get REST client: %w", err), Status: apierrors.NewBadRequest("error getting REST client")}
+		return false, &webhookutil.ErrCallingWebhook{WebhookName: h.Name, Reason: fmt.Errorf("could not get REST client: %w", err), Status: apierrors.NewInternalError(err)}
 	}
 	ctx, span := tracing.Start(ctx, "Call mutating webhook",
 		attribute.String("configuration", configurationName),
@@ -305,7 +305,7 @@ func (a *mutatingDispatcher) callAttrMutatingHook(ctx context.Context, h *admiss
 		if se, ok := err.(*apierrors.StatusError); ok {
 			status = se
 		} else {
-			status = apierrors.NewBadRequest("error calling webhook")
+			status = apierrors.NewServiceUnavailable("error calling webhook")
 		}
 		return false, &webhookutil.ErrCallingWebhook{WebhookName: h.Name, Reason: fmt.Errorf("failed to call webhook: %w", err), Status: status}
 	}

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/testing/testcase.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/testing/testcase.go
@@ -508,6 +508,32 @@ func NewNonMutatingTestCases(url *url.URL) []ValidatingTest {
 			ExpectAllow:      false,
 		},
 		{
+			Name: "match & invalid client config",
+			Webhooks: []registrationv1.ValidatingWebhook{{
+				Name:                    "invalidClientConfig",
+				ClientConfig:            registrationv1.WebhookClientConfig{},
+				Rules:                   matchEverythingRules,
+				NamespaceSelector:       &metav1.LabelSelector{},
+				ObjectSelector:          &metav1.LabelSelector{},
+				AdmissionReviewVersions: []string{"v1beta1"},
+			}},
+			ExpectStatusCode: http.StatusInternalServerError,
+			ErrorContains:    "could not get REST client",
+		},
+		{
+			Name: "match & non-status error",
+			Webhooks: []registrationv1.ValidatingWebhook{{
+				Name:                    "nonStatusError",
+				ClientConfig:            ccfgSVC("nonStatusError"),
+				Rules:                   matchEverythingRules,
+				NamespaceSelector:       &metav1.LabelSelector{},
+				ObjectSelector:          &metav1.LabelSelector{},
+				AdmissionReviewVersions: []string{"v1beta1"},
+			}},
+			ExpectStatusCode: http.StatusInternalServerError,
+			ErrorContains:    "transport connection broken",
+		},
+		{
 			Name: "match & allow (url)",
 			Webhooks: []registrationv1.ValidatingWebhook{{
 				Name:                    "allow.example.com",
@@ -930,6 +956,38 @@ func NewMutatingTestCases(url *url.URL, configurationName string) []MutatingTest
 			ExpectAnnotations: map[string]string{
 				"failed-open.mutation.webhook.admission.k8s.io/round_0_index_0": "invalidPatch",
 				"mutation.webhook.admission.k8s.io/round_0_index_0":             mutationAnnotationValue(configurationName, "invalidPatch", false),
+			},
+		},
+		{
+			Name: "match & invalid client config",
+			Webhooks: []registrationv1.MutatingWebhook{{
+				Name:                    "invalidClientConfig",
+				ClientConfig:            registrationv1.WebhookClientConfig{},
+				Rules:                   matchEverythingRules,
+				NamespaceSelector:       &metav1.LabelSelector{},
+				ObjectSelector:          &metav1.LabelSelector{},
+				AdmissionReviewVersions: []string{"v1beta1"},
+			}},
+			ExpectStatusCode: http.StatusInternalServerError,
+			ErrorContains:    "could not get REST client",
+			ExpectAnnotations: map[string]string{
+				"mutation.webhook.admission.k8s.io/round_0_index_0": mutationAnnotationValue(configurationName, "invalidClientConfig", false),
+			},
+		},
+		{
+			Name: "match & non-status error",
+			Webhooks: []registrationv1.MutatingWebhook{{
+				Name:                    "nonStatusError",
+				ClientConfig:            ccfgSVC("nonStatusError"),
+				Rules:                   matchEverythingRules,
+				NamespaceSelector:       &metav1.LabelSelector{},
+				ObjectSelector:          &metav1.LabelSelector{},
+				AdmissionReviewVersions: []string{"v1beta1"},
+			}},
+			ExpectStatusCode: http.StatusInternalServerError,
+			ErrorContains:    "transport connection broken",
+			ExpectAnnotations: map[string]string{
+				"mutation.webhook.admission.k8s.io/round_0_index_0": mutationAnnotationValue(configurationName, "nonStatusError", false),
 			},
 		},
 		{

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/testing/webhook_server.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/testing/webhook_server.go
@@ -157,6 +157,11 @@ func webhookHandler(w http.ResponseWriter, r *http.Request) {
 				Patch:     []byte(`[{"op": "add", "CORRUPTED_KEY":}]`),
 			},
 		})
+	case "/nonStatusError":
+		hj, _ := w.(http.Hijacker)
+		conn, _, _ := hj.Hijack()
+		defer conn.Close()             //nolint:errcheck
+		conn.Write([]byte("bad-http")) //nolint:errcheck
 	case "/nilResponse":
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(&v1beta1.AdmissionReview{})

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/dispatcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/dispatcher.go
@@ -262,7 +262,7 @@ func (d *validatingDispatcher) callHook(ctx context.Context, h *v1.ValidatingWeb
 	// Make the webhook request
 	client, err := invocation.Webhook.GetRESTClient(d.cm)
 	if err != nil {
-		return &webhookutil.ErrCallingWebhook{WebhookName: h.Name, Reason: fmt.Errorf("could not get REST client: %w", err), Status: apierrors.NewBadRequest("error getting REST client")}
+		return &webhookutil.ErrCallingWebhook{WebhookName: h.Name, Reason: fmt.Errorf("could not get REST client: %w", err), Status: apierrors.NewInternalError(err)}
 	}
 	ctx, span := tracing.Start(ctx, "Call validating webhook",
 		attribute.String("configuration", invocation.Webhook.GetConfigurationName()),
@@ -306,7 +306,7 @@ func (d *validatingDispatcher) callHook(ctx context.Context, h *v1.ValidatingWeb
 		if se, ok := err.(*apierrors.StatusError); ok {
 			status = se
 		} else {
-			status = apierrors.NewBadRequest("error calling webhook")
+			status = apierrors.NewServiceUnavailable("error calling webhook")
 		}
 		return &webhookutil.ErrCallingWebhook{WebhookName: h.Name, Reason: fmt.Errorf("failed to call webhook: %w", err), Status: status}
 	}

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/plugin_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/plugin_test.go
@@ -24,12 +24,14 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"k8s.io/apiserver/pkg/endpoints/request"
-	clocktesting "k8s.io/utils/clock/testing"
 
 	"k8s.io/apimachinery/pkg/api/errors"
+	admissionmetrics "k8s.io/apiserver/pkg/admission/metrics"
 	webhooktesting "k8s.io/apiserver/pkg/admission/plugin/webhook/testing"
 	auditinternal "k8s.io/apiserver/pkg/apis/audit"
+	"k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/component-base/metrics/testutil"
+	clocktesting "k8s.io/utils/clock/testing"
 )
 
 // BenchmarkValidate tests that ValidatingWebhook#Validate works as expected
@@ -135,6 +137,10 @@ func TestValidate(t *testing.T) {
 			continue
 		}
 
+		if len(tt.ExpectRejectionMetrics) > 0 {
+			admissionmetrics.Metrics.WebhookRejectionGathererForTest().Reset()
+		}
+
 		attr := webhooktesting.NewAttribute(ns, nil, tt.IsDryRun)
 		err = wh.Validate(context.TODO(), attr, objectInterfaces)
 		if tt.ExpectAllow != (err == nil) {
@@ -148,6 +154,15 @@ func TestValidate(t *testing.T) {
 		}
 		if _, isStatusErr := err.(*errors.StatusError); err != nil && !isStatusErr {
 			t.Errorf("%s: expected a StatusError, got %T", tt.Name, err)
+		}
+		if len(tt.ExpectRejectionMetrics) > 0 {
+			expectedMetrics := `
+# HELP apiserver_admission_webhook_rejection_count [ALPHA] Admission webhook rejection count, identified by name and broken out for each admission type (validating or admit) and operation. Additional labels specify an error type (calling_webhook_error or apiserver_internal_error if an error occurred; no_error otherwise) and optionally a non-zero rejection code if the webhook rejects the request with an HTTP status code (honored by the apiserver when the code is greater or equal to 400). Codes greater than 600 are truncated to 600, to keep the metrics cardinality bounded.
+# TYPE apiserver_admission_webhook_rejection_count counter
+` + tt.ExpectRejectionMetrics + "\n"
+			if err := testutil.CollectAndCompare(admissionmetrics.Metrics.WebhookRejectionGathererForTest(), strings.NewReader(expectedMetrics), "apiserver_admission_webhook_rejection_count"); err != nil {
+				t.Errorf("unexpected collecting result:\n%s", err)
+			}
 		}
 		fakeAttr, ok := attr.(*webhooktesting.FakeAttributes)
 		if !ok {

--- a/staging/src/k8s.io/component-base/metrics/testutil/promlint.go
+++ b/staging/src/k8s.io/component-base/metrics/testutil/promlint.go
@@ -42,6 +42,7 @@ var exceptionMetrics = []string{
 
 	// kube-apiserver
 	"aggregator_openapi_v2_regeneration_count",
+	"apiserver_admission_webhook_rejection_count", // counter metrics should have "_total" suffix,apiserver_admission_webhook_rejection_count:non-histogram and non-summary metrics should not have "_count" suffix
 	"apiserver_admission_step_admission_duration_seconds_summary",
 	"apiserver_current_inflight_requests",
 	"apiserver_longrunning_gauge",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

The current categorization of REST client construction errors and non-status network errors is somewhat misleading.

REST client construction errors, such as those caused by invalid client configuration, are better represented as `500 Internal Server Error` instead of `400 Bad Request` because they are not caused by the client’s request. Similarly, non-status network errors like timeouts and unresolvable host names are more appropriately mapped to `503 Service Unavailable`.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Fixes #130690

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed misleading response codes in admission control metrics.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
