### PR TITLE
scheduler_perf: wait for each pod to be scheduled before deletion in churnOp

### DIFF
--- a/test/integration/scheduler_perf/executor.go
+++ b/test/integration/scheduler_perf/executor.go
@@ -377,6 +377,13 @@ func (e *WorkloadExecutor) runChurnOp(tCtx ktesting.TContext, opIndex int, op *c
 
 		churnFns = append(churnFns, func(name string) string {
 			if name != "" {
+				// Wait for pod to be scheduled before deleting
+				if op.WaitForPodsScheduledBeforeDeletion && gvk.GroupKind().String() == "Pod" {
+					if err := waitUntilPodScheduledInNamespace(tCtx, namespace, name, 100*time.Millisecond, 2*time.Minute); err != nil && !errors.Is(err, context.Canceled) {
+						tCtx.Fatalf("op %d: error waiting for pod %v to be scheduled: %v", opIndex, name, err)
+					}
+				}
+
 				if err := dynRes.Delete(tCtx, name, metav1.DeleteOptions{}); err != nil && !errors.Is(err, context.Canceled) {
 					tCtx.Errorf("op %d: unable to delete %v: %v", opIndex, name, err)
 				}
@@ -911,6 +918,28 @@ func waitUntilPodsScheduledInNamespace(tCtx ktesting.TContext, podInformer corei
 		err = fmt.Errorf("at least pod %s is not scheduled: %w", klog.KObj(pendingPod), err)
 	}
 	return err
+}
+
+// waitUntilPodScheduledInNamespace waits until the specified pod is scheduled.
+func waitUntilPodScheduledInNamespace(tCtx ktesting.TContext, namespace, name string, interval, timeout time.Duration) error {
+	return wait.PollUntilContextTimeout(tCtx, interval, timeout, true, func(ctx context.Context) (bool, error) {
+		select {
+		case <-ctx.Done():
+			return true, ctx.Err()
+		default:
+		}
+
+		pod, err := tCtx.Client().CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				// Pod already deleted, no need to wait.
+				return true, nil
+			}
+			return false, err
+		}
+
+		return pod.Spec.NodeName != "", nil
+	})
 }
 
 func getPodStrategy(cpo *createPodsOp) (TestPodCreateStrategy, error) {

--- a/test/integration/scheduler_perf/executor_test.go
+++ b/test/integration/scheduler_perf/executor_test.go
@@ -19,16 +19,19 @@ package benchmark
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/informers"
 	coreinformers "k8s.io/client-go/informers/core/v1"
@@ -516,6 +519,68 @@ func TestRunOp(t *testing.T) {
 						t.Fatalf("Verification function %d failed for test %q: %v", i, tt.name, err)
 					}
 				}
+			}
+		})
+	}
+}
+
+func TestWaitUntilPodScheduledInNamespace(t *testing.T) {
+	const (
+		targetNamespace = "test-namespace"
+		targetPodName   = "test-pod"
+	)
+
+	tests := []struct {
+		name    string
+		pod     *v1.Pod
+		wantErr error
+	}{
+		{
+			name: "scheduled pod returns nil",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: targetNamespace,
+					Name:      targetPodName,
+				},
+				Spec: v1.PodSpec{
+					NodeName: "node-1",
+				},
+			},
+		},
+		{
+			name: "unscheduled pod times out",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: targetNamespace,
+					Name:      targetPodName,
+				},
+			},
+			wantErr: context.DeadlineExceeded,
+		},
+		{
+			name:    "not found pod is treated as success",
+			wantErr: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var objs []runtime.Object
+			if tt.pod != nil {
+				objs = []runtime.Object{tt.pod}
+			}
+			client := fake.NewSimpleClientset(objs...)
+
+			tCtx := ktesting.Init(t)
+			tCtx = tCtx.WithClients(nil, nil, client, nil, nil)
+
+			err := waitUntilPodScheduledInNamespace(tCtx, targetNamespace, targetPodName, time.Millisecond, 30*time.Millisecond)
+			if tt.wantErr == nil {
+				if err != nil {
+					t.Fatalf("expected nil error, got %v", err)
+				}
+			} else if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("expected error %v, got %v", tt.wantErr, err)
 			}
 		})
 	}

--- a/test/integration/scheduler_perf/operations.go
+++ b/test/integration/scheduler_perf/operations.go
@@ -528,6 +528,9 @@ type churnOp struct {
 	Number int
 	// Intervals of churning. Defaults to 500 millisecond.
 	IntervalMilliseconds int64
+	// WaitForPodsScheduledBeforeDeletion ensures each pod is scheduled before
+	// it is deleted in Recreate mode.
+	WaitForPodsScheduledBeforeDeletion bool
 	// Namespace the churning objects should be created in. Defaults to a unique
 	// namespace of the format "namespace-<number>".
 	// Optional
@@ -545,6 +548,9 @@ func (co *churnOp) isValid(_ bool) error {
 	}
 	if co.Mode == Recreate && co.Number == 0 {
 		return fmt.Errorf("number cannot be 0 when mode is %v", Recreate)
+	}
+	if co.WaitForPodsScheduledBeforeDeletion && co.Mode != Recreate {
+		return fmt.Errorf("WaitForPodsScheduledBeforeDeletion can only be set when mode is %v", Recreate)
 	}
 	if len(co.TemplatePaths) == 0 {
 		return fmt.Errorf("at least one template spec file needs to be specified")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature
/sig scheduling

#### What this PR does / why we need it:

Fixes https://github.com/kubernetes/kubernetes/issues/125974

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
scheduler_perf: churnOp in recreate mode waits for each pod to be scheduled before deletion, so the benchmark only measures the intended scheduling code paths.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
