### PR TITLE
Fix kubelet iptables startup, clarify semantics of utiliptables calls.

### DIFF
--- a/pkg/kubelet/kubelet_network_linux.go
+++ b/pkg/kubelet/kubelet_network_linux.go
@@ -37,12 +37,13 @@ const (
 )
 
 func (kl *Kubelet) initNetworkUtil() {
-	iptClients, err := utiliptables.NewDualStack()
-	if err != nil {
-		klog.ErrorS(err, "Failed to initialize iptables")
-	}
-
-	if err != nil || len(iptClients) == 0 {
+	iptClients := utiliptables.NewBestEffort()
+	if len(iptClients) == 0 {
+		// We don't log this as an error because kubelet itself doesn't need any
+		// of this (it sets up these rules for the benefit of *other* components),
+		// and because we *expect* this to fail on hosts where only nftables is
+		// supported (in which case there can't be any other components using
+		// iptables that would need these rules anyway).
 		klog.InfoS("No iptables support on this system; not creating the KUBE-IPTABLES-HINT chain")
 		return
 	}

--- a/pkg/util/iptables/iptables.go
+++ b/pkg/util/iptables/iptables.go
@@ -275,10 +275,22 @@ func newDualStackInternal(exec utilexec.Interface) (map[v1.IPFamily]Interface, e
 }
 
 // NewDualStack returns a map containing an IPv4 Interface (if IPv4 iptables is supported)
-// and an IPv6 Interface (if IPv6 iptables is supported). If either family is not
-// supported, no Interface will be returned for that family.
+// and an IPv6 Interface (if IPv6 iptables is supported). If only one family is supported,
+// it will return a map with one Interface *and* an error (indicating the problem with the
+// other family). If neither family is supported, it will return an empty map and an
+// error.
 func NewDualStack() (map[v1.IPFamily]Interface, error) {
 	return newDualStackInternal(utilexec.New())
+}
+
+// NewBestEffort returns a map containing an IPv4 Interface (if IPv4 iptables is
+// supported) and an IPv6 Interface (if IPv6 iptables is supported). If iptables is not
+// supported, then it just returns an empty map. This function is intended to make things
+// simple for callers that just want "best-effort" iptables support, where neither partial
+// nor complete lack of iptables support is considered an error.
+func NewBestEffort() map[v1.IPFamily]Interface {
+	ipts, _ := newDualStackInternal(utilexec.New())
+	return ipts
 }
 
 // EnsureChain is part of Interface.

--- a/pkg/util/iptables/iptables_test.go
+++ b/pkg/util/iptables/iptables_test.go
@@ -329,7 +329,7 @@ func TestNewDualStack(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			fexec := fakeExecForCommands(tc.commands)
-			runners, _ := newDualStackInternal(fexec)
+			runners, err := newDualStackInternal(fexec)
 
 			if tc.ipv4 && runners[v1.IPv4Protocol] == nil {
 				t.Errorf("Expected ipv4 runner, got nil")
@@ -340,6 +340,12 @@ func TestNewDualStack(t *testing.T) {
 				t.Errorf("Expected ipv6 runner, got nil")
 			} else if !tc.ipv6 && runners[v1.IPv6Protocol] != nil {
 				t.Errorf("Expected no ipv6 runner, got one")
+			}
+
+			if len(runners) == 2 && err != nil {
+				t.Errorf("Got 2 runners but also an error (%v)", err)
+			} else if len(runners) != 2 && err == nil {
+				t.Errorf("Got %d runners but no error", len(runners))
 			}
 		})
 	}


### PR DESCRIPTION
#### What this PR does / why we need it:
#131534 was not supposed to change kubelet's behavior, but it needed to modify `kubelet_network_linux.go` to adjust to a change in the `utiliptables.NewDualStack` API. Unfortunately, a last-minute change to the PR breaks kubelet iptables startup on hosts where IPv6 is disabled, because it's misinterpreting the (unusual) error return value from `utiliptables.NewDualStack`. (Additionally, the addition of a `klog.ErrorS` ends up reverting the fix from #129826 to not log irrelevant error messages on nftables-only hosts.)

Anyway, this PR reverts kubelet back to the pre-131534 behavior but also documents things more clearly to avoid breaking it again in the future:

1. It splits out a new `utiliptables.NewBestEffort()` that has the behavior `NewDualStack` had before 131534, which is what we want here ("return either 0, 1, or 2 iptables interfaces, depending on what is supported on this host, and don't consider any of those cases to be an error").
2. It makes kubelet use that, and removes the new error log, and adds a comment explaining why that is the semantics we want there.
3. (It updates the `NewDualStack` docs and `TestNewDualStack` unit test to cover the unusual error-return behavior (that it returns both an interface and an error in the only-IPv4 and only-IPv6 cases).)

/kind bug
/kind cleanup
/sig network
/sig node
/priority important-soon
/assign @SergeyKanzhelev @thockin 
cc @aroradaman 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
