### PR TITLE
suppress git worktree status output to reduce log noise in govulncheck

### DIFF
--- a/hack/verify-govulncheck.sh
+++ b/hack/verify-govulncheck.sh
@@ -36,7 +36,7 @@ kube::util::ensure-temp-dir
 WORKTREE="${KUBE_TEMP}/worktree"
 
 # Create a copy of the repo with $BRANCH checked out
-git worktree add -f "${WORKTREE}" "${BRANCH}"
+git worktree add -f --quiet "${WORKTREE}" "${BRANCH}"
 # Clean up the copy on exit
 kube::util::trap_add "git worktree remove -f ${WORKTREE}" EXIT
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR silences the output of the `git worktree add` command in `hack/verify-govulncheck.sh` by redirecting it to `/dev/null`.

Suppressing this output helps reduce log noise during verification runs.

#### Which issue(s) this PR is related to:

Fixes #132153

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
NONE
