### PR TITLE
Remove use of html/template in apiserver to avoid disabling dead code elimination

### DIFF
--- a/cmd/kubeadm/app/cmd/util/join.go
+++ b/cmd/kubeadm/app/cmd/util/join.go
@@ -19,7 +19,7 @@ package util
 import (
 	"bytes"
 	"crypto/x509"
-	"html/template"
+	"html/template" //nolint:depguard
 	"strings"
 
 	"k8s.io/client-go/tools/clientcmd"

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -254,6 +254,8 @@ linters:
           deny:
             - pkg: "github.com/google/go-cmp/cmp"
               desc: "cmp is allowed only in test files"
+            - pkg: "html/template"
+              desc: "template is allowed only in test files as it disables dead code elimination"
     forbidigo:
       analyze-types: true
       forbid:

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -268,6 +268,8 @@ linters:
           deny:
             - pkg: "github.com/google/go-cmp/cmp"
               desc: "cmp is allowed only in test files"
+            - pkg: "html/template"
+              desc: "template is allowed only in test files as it disables dead code elimination"
     forbidigo:
       analyze-types: true
       forbid:

--- a/hack/golangci.yaml.in
+++ b/hack/golangci.yaml.in
@@ -198,6 +198,8 @@ linters:
           deny:
             - pkg: "github.com/google/go-cmp/cmp"
               desc: "cmp is allowed only in test files"
+            - pkg: "html/template"
+              desc: "template is allowed only in test files as it disables dead code elimination"
     forbidigo:
       analyze-types: true
       forbid:

--- a/staging/src/k8s.io/apiserver/pkg/server/routes/flags.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/routes/flags.go
@@ -18,7 +18,7 @@ package routes
 
 import (
 	"fmt"
-	"html/template"
+	"html/template" //nolint:depguard
 	"io"
 	"net/http"
 	"path"
@@ -56,12 +56,15 @@ func (f DebugFlags) Install(c *mux.PathRecorderMux, flag string, handler func(ht
 func (f DebugFlags) Index(w http.ResponseWriter, r *http.Request) {
 	lock.RLock()
 	defer lock.RUnlock()
-	if err := indexTmpl.Execute(w, registeredFlags); err != nil {
+	if err := indexTmpl(w, registeredFlags); err != nil {
 		klog.Error(err)
 	}
 }
 
-var indexTmpl = template.Must(template.New("index").Parse(`<html>
+func indexTmpl(w io.Writer, flags map[string]debugFlag) error {
+	// avoid using a template to avoid disabling dead code elimination
+	// https://github.com/golang/go/issues/72895
+	_, err := w.Write([]byte(`<html>
 <head>
 <title>/debug/flags/</title>
 </head>
@@ -70,15 +73,27 @@ var indexTmpl = template.Must(template.New("index").Parse(`<html>
 <br>
 flags:<br>
 <table>
-{{range .}}
-<tr>{{.Flag}}<br>
-{{end}}
-</table>
+`))
+	if err != nil {
+		return err
+	}
+
+	for _, flag := range flags {
+		_, err := fmt.Fprintf(w, `<tr>%s<br>
+`, template.HTMLEscapeString(flag.Flag))
+		if err != nil {
+			return err
+		}
+	}
+
+	_, err = w.Write([]byte(`</table>
 <br>
 full flags configurable<br>
 </body>
 </html>
 `))
+	return err
+}
 
 type debugFlag struct {
 	Flag string


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Replace the use of `html/template` in `apiserver` with direct string manipulation.

It avoids disabling dead code elimination for binaries importing this code*, in my case this single change makes a binary go from 155MiB to 117MiB (-25%).

The template is quite trivial so I don't feel like it makes the code much more complex.

_*Note that this single change doesn't enable dead code elimination in the `kube-apiserver` binary, a few other changes are needed (see https://github.com/kubernetes/kubernetes/pull/132177#issuecomment-2954136355 for details), in particular fixing or getting rid of https://github.com/google/go-cmp._

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
https://github.com/kubernetes/kubernetes/issues/130201: Not the same piece of code, but same issue.


#### Special notes for your reviewer:
Let me know if you want me to add tests around template rendering.

I believe the calls to `Write` and `Fprintf` can't fail, but I still checked the returned errors, let me know if I should remove that to simplify the code.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
```
