### PR TITLE
Iperf output parsing for v2.2.0+

### DIFF
--- a/test/e2e/network/util_iperf.go
+++ b/test/e2e/network/util_iperf.go
@@ -46,7 +46,8 @@ type IPerfCSVResult struct {
 	server        string
 	servPort      int64
 	id            string
-	interval      string
+	intervalStart string
+	intervalEnd   string
 	transferBits  int64
 	bandwidthBits int64
 }
@@ -84,9 +85,9 @@ func NewIPerf(csvLine string) (*IPerfCSVResult, error) {
 	}
 	csvLine = strings.Trim(csvLine, "\n")
 	slice := StrSlice(strings.Split(csvLine, ","))
-	// iperf 2.1.9+ reports 15 fields, before it was just 9
-	if len(slice) != 15 {
-		return nil, fmt.Errorf("incorrect fields in the output: %v (%v out of 15)", slice, len(slice))
+	// iperf 2.2.0+ reports 17 fields, before it was just 15
+	if len(slice) != 17 {
+		return nil, fmt.Errorf("incorrect fields in the output: %v (%v out of 17)", slice, len(slice))
 	}
 	i := IPerfCSVResult{}
 	i.date = slice.get(0)
@@ -95,9 +96,10 @@ func NewIPerf(csvLine string) (*IPerfCSVResult, error) {
 	i.server = slice.get(3)
 	i.servPort = intOrFail("server port", slice.get(4))
 	i.id = slice.get(5)
-	i.interval = slice.get(6)
-	i.transferBits = intOrFail("transfer port", slice.get(7))
-	i.bandwidthBits = intOrFail("bandwidth port", slice.get(8))
+	i.intervalStart = slice.get(6)
+	i.intervalEnd = slice.get(7)
+	i.transferBits = intOrFail("transfer port", slice.get(8))
+	i.bandwidthBits = intOrFail("bandwidth port", slice.get(9))
 	return &i, nil
 }
 
@@ -135,15 +137,18 @@ type IPerf2EnhancedCSVResults struct {
 // Example output with version >= 2.1.9 (agnhost >= 2.53)
 // +0000:20240908113035.128,192.168.9.3,58256,192.168.9.4,5001,1,0.0-1.0,5220466748,41763733984,-1,-1,-1,-1,0,0
 // +0000:20240908113036.128,192.168.9.3,58256,192.168.9.4,5001,1,1.0-2.0,5127667712,41021341696,-1,-1,-1,-1,0,0
-// +0000:20240908113037.128,192.168.9.3,58256,192.168.9.4,5001,1,2.0-3.0,5127405568,41019244544,-1,-1,-1,-1,0,0
-// +0000:20240908113038.128,192.168.9.3,58256,192.168.9.4,5001,1,3.0-4.0,5173018624,41384148992,-1,-1,-1,-1,0,0
-// +0000:20240908113039.128,192.168.9.3,58256,192.168.9.4,5001,1,4.0-5.0,5245894656,41967157248,-1,-1,-1,-1,0,0
-// +0000:20240908113040.128,192.168.9.3,58256,192.168.9.4,5001,1,5.0-6.0,5213257728,41706061824,-1,-1,-1,-1,0,0
-// +0000:20240908113041.128,192.168.9.3,58256,192.168.9.4,5001,1,6.0-7.0,5113118720,40904949760,-1,-1,-1,-1,0,0
-// +0000:20240908113042.128,192.168.9.3,58256,192.168.9.4,5001,1,7.0-8.0,5242748928,41941991424,-1,-1,-1,-1,0,0
+// Example output with version >= 2.2.0 (agnhost >= 2.55)
+// time,srcaddress,srcport,dstaddr,dstport,transferid,istart,iend,bytes,speed,writecnt,writeerr,tcpretry,tcpcwnd,tcppcwnd,tcprtt,tcprttvar
+// +0000:20250605191028.955,10.244.2.64,43380,10.96.223.154,6789,1,0.0,1.0,7817396288,62539170304,-1,-1,4294967295,-1,4294967295,0,0
+// +0000:20250605191029.955,10.244.2.64,43380,10.96.223.154,6789,1,1.0,2.0,7550795776,60406366208,-1,-1,4294967295,-1,4294967295,0,0
+// +0000:20250605191030.955,10.244.2.64,43380,10.96.223.154,6789,1,2.0,3.0,8703574016,69628592128,-1,-1,4294967295,-1,4294967295,0,0
 func ParseIPerf2EnhancedResultsFromCSV(output string) (*IPerf2EnhancedCSVResults, error) {
 	var parsedResults []*IPerfCSVResult
-	for _, line := range strings.Split(output, "\n") {
+	for i, line := range strings.Split(output, "\n") {
+		if i == 0 {
+			// we skip the first line, iperf 2.2.0+ returns headers as first line in output
+			continue
+		}
 		parsed, err := NewIPerf(line)
 		if err != nil {
 			return nil, err

--- a/test/e2e/network/util_iperf.go
+++ b/test/e2e/network/util_iperf.go
@@ -84,7 +84,7 @@ func NewIPerf(csvLine string) (*IPerfCSVResult, error) {
 	}
 	csvLine = strings.Trim(csvLine, "\n")
 	slice := StrSlice(strings.Split(csvLine, ","))
-	// iperf 2.19+ reports 15 fields, before it was just 9
+	// iperf 2.1.9+ reports 15 fields, before it was just 9
 	if len(slice) != 15 {
 		return nil, fmt.Errorf("incorrect fields in the output: %v (%v out of 15)", slice, len(slice))
 	}
@@ -128,11 +128,11 @@ type IPerf2EnhancedCSVResults struct {
 
 // ParseIPerf2EnhancedResultsFromCSV parses results from iperf2 when given the -e (--enhancedreports)
 // and `--reportstyle C` options.
-// Example output for version < 2.19 (agnhost < 2.53):
+// Example output for version < 2.1.9 (agnhost < 2.53):
 // 20201210141800.884,10.244.2.24,47880,10.96.114.79,6789,3,0.0-1.0,1677852672,13422821376
 // 20201210141801.881,10.244.2.24,47880,10.96.114.79,6789,3,1.0-2.0,1980760064,15846080512
 // 20201210141802.883,10.244.2.24,47880,10.96.114.79,6789,3,2.0-3.0,1886650368,15093202944
-// Example output with version >= 2.19 (agnhost >= 2.53)
+// Example output with version >= 2.1.9 (agnhost >= 2.53)
 // +0000:20240908113035.128,192.168.9.3,58256,192.168.9.4,5001,1,0.0-1.0,5220466748,41763733984,-1,-1,-1,-1,0,0
 // +0000:20240908113036.128,192.168.9.3,58256,192.168.9.4,5001,1,1.0-2.0,5127667712,41021341696,-1,-1,-1,-1,0,0
 // +0000:20240908113037.128,192.168.9.3,58256,192.168.9.4,5001,1,2.0-3.0,5127405568,41019244544,-1,-1,-1,-1,0,0


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
With agnhost update to 2.56 in https://github.com/kubernetes/kubernetes/pull/132117 iperf2 binary got updated from v2.1.9 to v2.2.0 which outputs some additional fields crashes iperf2 output parsing.
This PR fixes that.


Test output before https://github.com/kubernetes/kubernetes/pull/132117 (working)
```
I0608 11:26:38.611865 209536 networking_perf.go:277]          From               To   Bandwidth (MB/s)
I0608 11:26:38.611890 209536 networking_perf.go:279]  kind-worker2     kind-worker3               6229
I0608 11:26:38.611911 209536 networking_perf.go:279]  kind-worker3     kind-worker3               9030
I0608 11:26:38.611927 209536 networking_perf.go:279]   kind-worker     kind-worker3               6123
```


Test output after https://github.com/kubernetes/kubernetes/pull/132117
```
I0608 07:11:18.569769 76720 networking_perf.go:260] Unexpected error: unable to parse iperf2 output from client pod iperf2-clients-hwcd6 (node kind-worker): 
      <*errors.errorString | 0xc0011c35b0>: 
      incorrect fields in the output: [time srcaddress srcport dstaddr dstport transferid istart iend bytes speed writecnt writeerr tcpretry tcpcwnd tcppcwnd tcprtt tcprttvar] (17 out of 15)
      {
          s: "incorrect fields in the output: [time srcaddress srcport dstaddr dstport transferid istart iend bytes speed writecnt writeerr tcpretry tcpcwnd tcppcwnd tcprtt tcprttvar] (17 out of 15)",
      }
```



Test output now (with commits from this PR)
```
I0608 11:23:25.148840 198486 networking_perf.go:277]           From              To    Bandwidth (MB/s)
I0608 11:23:25.148870 198486 networking_perf.go:279]    kind-worker    kind-worker2                6128
I0608 11:23:25.148895 198486 networking_perf.go:279]   kind-worker3    kind-worker2                6133
I0608 11:23:25.148916 198486 networking_perf.go:279]   kind-worker2    kind-worker2                8879
```


#### Which issue(s) this PR is related to:
Fixes #[132166](https://github.com/kubernetes/kubernetes/issues/132166)
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #132166
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
