### PR TITLE
Fix incorrect logging of insufficientResources in preemption

### DIFF
--- a/pkg/kubelet/preemption/preemption.go
+++ b/pkg/kubelet/preemption/preemption.go
@@ -99,7 +99,7 @@ func (c *CriticalPodAdmissionHandler) evictPodsToFreeRequests(admitPod *v1.Pod, 
 		// record that we are evicting the pod
 		c.recorder.Eventf(pod, v1.EventTypeWarning, events.PreemptContainer, message)
 		// this is a blocking call and should only return when the pod and its containers are killed.
-		klog.V(3).InfoS("Preempting pod to free up resources", "pod", klog.KObj(pod), "podUID", pod.UID, "insufficientResources", insufficientResources)
+		klog.V(3).InfoS("Preempting pod to free up resources", "pod", klog.KObj(pod), "podUID", pod.UID, "insufficientResources", insufficientResources.toString())
 		err := c.killPodFunc(pod, true, nil, func(status *v1.PodStatus) {
 			status.Phase = v1.PodFailed
 			status.Reason = events.PreemptContainer


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes a logging issue in `pkg/kubelet/preemption/preemption.go` where the `insufficientResources` array is logged as a pointer instead of a readable value. The current log output appears as:

``` 
insufficientResources=[0xc00bfb88c0]
```

This is not informative and makes debugging difficult.

This change ensures that the contents of `insufficientResources` are printed in a human-readable format, improving debuggability and observability.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

- No functional behavior is changed.
- This is purely a logging improvement.
- The change only affects verbose log level 3 (`-v=3`) and above.

#### Does this PR introduce a user-facing change?

```release-note
Fixed an issue where `insufficientResources` was logged as a pointer during pod preemption, making logs more readable.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
